### PR TITLE
Introduce JSON-RPC

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "get-stdin": "5.0.1",
     "glob": "7.1.1",
     "jest-validate": "18.2.0",
-    "minimist": "1.2.0"
+    "minimist": "1.2.0",
+    "vscode-jsonrpc": "^3.0.4"
   },
   "devDependencies": {
+    "diff": "3.2.0",
     "jest": "18.0.0",
     "rollup": "0.41.1",
     "rollup-plugin-commonjs": "7.0.0",
@@ -35,8 +37,7 @@
     "rollup-plugin-node-builtins": "2.0.0",
     "rollup-plugin-node-globals": "1.1.0",
     "rollup-plugin-node-resolve": "2.0.0",
-    "rollup-plugin-real-babili": "1.0.0-alpha3",
-    "diff": "3.2.0"
+    "rollup-plugin-real-babili": "1.0.0-alpha3"
   },
   "scripts": {
     "test": "jest",

--- a/test-json-rpc.js
+++ b/test-json-rpc.js
@@ -1,0 +1,24 @@
+// This is a minimal example of how to communicate via json-rpc with prettier.
+
+var child_process = require('child_process');
+var rpc = require('vscode-jsonrpc');
+
+var child = child_process.spawn('bin/prettier.js', ['--json-rpc']);
+ 
+var connection = rpc.createMessageConnection(
+  new rpc.StreamMessageReader(child.stdout),
+  new rpc.StreamMessageWriter(child.stdin)
+);
+
+connection.listen();
+
+Promise.all([
+  connection.sendRequest('format', 'x=>{x()}').then(({error, formatted}) => {
+    console.log(formatted);
+  }),
+  connection.sendRequest('format', 'x(;)').then(({error, formatted}) => {
+    console.log(error);
+  })
+]).then(() => {
+  child.kill(); // Don't try this at home!
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -738,7 +738,7 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
-diff@^3.0.0:
+diff@3.2.0, diff@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.2.0.tgz#c9ce393a4b7cbd0b058a725c93df299027868ff9"
 
@@ -2379,6 +2379,10 @@ verror@1.3.6:
 vlq@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/vlq/-/vlq-0.2.1.tgz#14439d711891e682535467f8587c5630e4222a6c"
+
+vscode-jsonrpc@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-3.0.4.tgz#07fdae38e3122412faddf45756fba1d2cb1eb9c8"
 
 walker@~1.0.5:
   version "1.0.7"


### PR DESCRIPTION
In order to be avoid the startup cost of prettier which makes editor integrations feel very slow, we can keep the process alive and communicate via JSON-RPC. This is a bit more work to do on the integration side but enables <50ms response time instead of >300ms, which makes a huge difference in practice.

I'm using vscode-jsonrpc implementation which has been battle-tested inside of vscode and doesn't have any dependencies.

Fixes #730