### PR TITLE
Normalize comment types

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ function attachComments(text, ast, opts) {
   const astComments = ast.comments;
   if (astComments) {
     delete ast.comments;
-    comments.attach(astComments, ast, text);
+    comments.attach(astComments, ast, text, opts);
   }
   ast.tokens = [];
   opts.originalText = text.trimRight();

--- a/src/comments.js
+++ b/src/comments.js
@@ -123,7 +123,7 @@ function decorateComment(node, comment, text) {
   }
 }
 
-function attach(comments, ast, text) {
+function attach(comments, ast, text, options) {
   if (!isArray.check(comments)) {
     return;
   }
@@ -132,6 +132,14 @@ function attach(comments, ast, text) {
 
   comments.forEach(function(comment) {
     decorateComment(ast, comment, text);
+
+    // Workaround a bug in the flow parser where it sometimes incorrectly
+    // reports the wrong type for comments
+    if (options.parser === "flow") {
+      comment.type = text.charAt(locStart(comment) + 1) === "*"
+        ? "Block"
+        : "Line";
+    }
 
     const precedingNode = comment.precedingNode;
     const enclosingNode = comment.enclosingNode;

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1,3 +1,25 @@
+exports[`test assignment-pattern.js 1`] = `
+"const { a /* comment */ = 1 } = b;
+
+const { c = 1 /* comment */ } = d;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const { a /* comment */ = 1 } = b;
+
+const { c = 1 /* comment */ } = d;
+"
+`;
+
+exports[`test assignment-pattern.js 2`] = `
+"const { a /* comment */ = 1 } = b;
+
+const { c = 1 /* comment */ } = d;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const { a /* comment */ = 1 } = b;
+
+const { c = 1 /* comment */ } = d;
+"
+`;
+
 exports[`test blank.js 1`] = `
 "// This file only
 // has comments. This comment
@@ -103,7 +125,11 @@ expect(() => {}).toTriggerReadyStateChanges(
   ]
 );
 
-[1 /* first comment */, 2 /* second comment */, 3];
+[
+  1 /* first comment */,
+  2, // second comment
+  3
+];
 "
 `;
 
@@ -451,14 +477,14 @@ Observable.of(process)
   .takeUntil(throwOnError ? errors.flatMap(Observable.throw) : errors)
   .takeUntil(exit);
 
-/* Comments disappear inside of JSX*/
+// Comments disappear inside of JSX
 <div>
   {/* Some comment */}
 </div>;
 
-/* Comments in JSX tag are placed in a non optimal way*/
+// Comments in JSX tag are placed in a non optimal way
 <div
-/* comment*/
+// comment
 />;
 
 // Comments disappear in empty blocks
@@ -975,7 +1001,7 @@ function c() {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function a() {
   return (
-    /* Comment*/
+    // Comment
     <div />
   );
 }
@@ -1085,27 +1111,5 @@ try {
   // comment 5
   // comment 7
 }
-"
-`;
-
-exports[`test assignment-pattern.js 1`] = `
-"const { a /* comment */ = 1 } = b;
-
-const { c = 1 /* comment */ } = d;
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-const { a /* comment */ = 1 } = b;
-
-const { c = 1 /* comment */ } = d;
-"
-`;
-
-exports[`test assignment-pattern.js 2`] = `
-"const { a /* comment */ = 1 } = b;
-
-const { c = 1 /* comment */ } = d;
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-const { a /* comment */ = 1 } = b;
-
-const { c = 1 /* comment */ } = d;
 "
 `;

--- a/tests/flow/classes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/classes/__snapshots__/jsfmt.spec.js.snap
@@ -113,7 +113,7 @@ type Foo = {
   a: string, // exists in TestClass
   b: string, // doesn\'t exist
   c?: ?string, // exists in TestClass, optional
-  d?: number /* doesn\'t exist*/
+  d?: number // doesn\'t exist
 };
 
 class TestClass {

--- a/tests/flow/constructor_annots/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/constructor_annots/__snapshots__/jsfmt.spec.js.snap
@@ -42,8 +42,8 @@ interface IFooPrototype {
 }
 interface IFoo extends IFooPrototype {
   static (): void,
-  x: boolean /* error, should have declared x: number instead*/,
-  static y: boolean /* error, should have declared static y: number instead*/
+  x: boolean, // error, should have declared x: number instead
+  static y: boolean // error, should have declared static y: number instead
 }
 exports.Foo2 = (Foo: Class<IFoo>);
 "

--- a/tests/flow/disjoint-union-perf/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/disjoint-union-perf/__snapshots__/jsfmt.spec.js.snap
@@ -988,7 +988,7 @@ export type BinaryOperator =
   | \"*\"
   | \"/\"
   | \"%\"
-  | \"&\" /* TODO Missing from the Parser API.*/
+  | \"&\" // TODO Missing from the Parser API.
   | \"|\"
   | \"^\"
   | \"in\"

--- a/tests/flow/indexer/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/indexer/__snapshots__/jsfmt.spec.js.snap
@@ -99,7 +99,7 @@ let tests = [
   function() {
     ({}: {
       [k1: string]: string,
-      [k2: number]: number /* error: not supported (yet)*/
+      [k2: number]: number // error: not supported (yet)
     });
   }
 ];

--- a/tests/flow/interface/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/interface/__snapshots__/jsfmt.spec.js.snap
@@ -27,7 +27,7 @@ interface Ok {
 
 interface Bad {
   [k1: string]: string,
-  [k2: number]: number /* error: not supported (yet)*/
+  [k2: number]: number // error: not supported (yet)
 }
 "
 `;

--- a/tests/flow/jsx_intrinsics.builtin/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/jsx_intrinsics.builtin/__snapshots__/jsfmt.spec.js.snap
@@ -77,12 +77,12 @@ var Div = \"div\";
 var Bad = \"bad\";
 var Str: string = \"str\";
 
-<Div />; /* This is fine*/
-<Bad />; /* This is fine*/
+<Div />; // This is fine
+<Bad />; // This is fine
 <Str />; // This is fine
 
 React.createElement(\"div\", {}); // This is fine
-React.createElement(\"bad\", {}); /* This is fine*/
+React.createElement(\"bad\", {}); // This is fine
 
 <Div id={42} />; // This is fine
 "

--- a/tests/flow/jsx_intrinsics.custom/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/jsx_intrinsics.custom/__snapshots__/jsfmt.spec.js.snap
@@ -28,9 +28,7 @@ class CustomComponent extends React.Component {
 }
 
 var a: React.Element<{ prop: string }> = <CustomComponent prop=\"asdf\" />;
-var b: React.Element<{ prop1: string }> = (
-  <CustomComponent prop=\"asdf\" />
-); /* Error: Props<{prop}> ~> Props<{prop1}>*/
+var b: React.Element<{ prop1: string }> = <CustomComponent prop=\"asdf\" />; // Error: Props<{prop}> ~> Props<{prop1}>
 
 <div id=\"asdf\" />;
 <div id={42} />; // Error: (\`id\` prop) number ~> string
@@ -67,15 +65,15 @@ var Div = \"div\";
 var Bad = \"bad\";
 var Str: string = \"str\";
 
-<Div />; /* This is fine*/
-<Bad />; /* Error: \'bad\' not in JSXIntrinsics*/
+<Div />; // This is fine
+<Bad />; // Error: \'bad\' not in JSXIntrinsics
 <Str />; // Error: string ~> keys of JSXIntrinsics
 
 React.createElement(\"div\", {}); // This is fine
 React.createElement(\"bad\", {}); // Error: \'bad\' not in JSXIntrinsics
-React.createElement(Str, {}); /* Error: string ~> keys of JSXIntrinsics*/
+React.createElement(Str, {}); // Error: string ~> keys of JSXIntrinsics
 
-/* TODO: Make this an error*/
+// TODO: Make this an error
 <Div id={42} />; // Not an error but should be eventually
 "
 `;

--- a/tests/flow/more_react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/more_react/__snapshots__/jsfmt.spec.js.snap
@@ -173,8 +173,8 @@ var D = React.createClass({
 });
 
 <D
-  namee=\"foo\" /* error (as usual)*/
-  titlee=\"bar\" /* OK (error ignored when spread is used)*/
+  namee=\"foo\" // error (as usual)
+  titlee=\"bar\" // OK (error ignored when spread is used)
 />;
 "
 `;

--- a/tests/flow/new_react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/new_react/__snapshots__/jsfmt.spec.js.snap
@@ -415,7 +415,7 @@ class HelloMessage extends React.Component {
   props: { name: string };
 }
 
-<HelloMessage name={007} />; /* number ~/~> string error*/
+<HelloMessage name={007} />; // number ~/~> string error
 <HelloMessage name=\"Bond\" />; // ok
 "
 `;
@@ -783,7 +783,7 @@ class JDiv extends React.Component {
   };
 }
 
-/* Should be a type error (\'id\' takes a string, not a number..)*/
+// Should be a type error (\'id\' takes a string, not a number..)
 <JDiv id={42} />;
 
 class Example extends React.Component {

--- a/tests/flow/object_assign/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/object_assign/__snapshots__/jsfmt.spec.js.snap
@@ -171,7 +171,7 @@ class MyReactThing extends React.Component {
   }
 }
 
-<MyReactThing />; /* works*/
+<MyReactThing />; // works
 <MyReactThing foo={undefined} />; // also works
 "
 `;

--- a/tests/flow/react_functional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/react_functional/__snapshots__/jsfmt.spec.js.snap
@@ -16,8 +16,8 @@ var Z = 0;
 import React from \"react\";
 
 function F(props: { foo: string }) {}
-<F />; /* error: missing \`foo\`*/
-<F foo={0} />; /* error: number ~> string*/
+<F />; // error: missing \`foo\`
+<F foo={0} />; // error: number ~> string
 <F foo=\"\" />; // ok
 
 // props subtyping is property-wise covariant

--- a/tests/flow/this_type/lib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/this_type/lib/__snapshots__/jsfmt.spec.js.snap
@@ -32,10 +32,10 @@ declare class DoublyLinkedList extends LinkedList {
 
 declare module \"mini-immutable\" {
   declare class Map<K, V> {
-    set(key: K, value: V): this /* more precise than Map<K,V> (see below)*/
+    set(key: K, value: V): this // more precise than Map<K,V> (see below)
   }
   declare class OrderedMap<K, V> extends Map<K, V> {
-    /* inherits set method returning OrderedMap<K,V> instead of Map<K,V>*/
+    // inherits set method returning OrderedMap<K,V> instead of Map<K,V>
   }
 }
 "

--- a/tests/flow/traits/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/traits/__snapshots__/jsfmt.spec.js.snap
@@ -21,8 +21,8 @@ declare class Baz<T> {
 ((new Foo).z: number); // error: Qux wins
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class Foo extends Qux<string> {
-  /* KeyedCollection <: Collection*/
-  /* ...KeyedIterable*/
+  // KeyedCollection <: Collection
+  // ...KeyedIterable
 }
 declare class Bar<T> extends Baz<T> {
   // KeyedIterable <: Iterable


### PR DESCRIPTION
There's a bug in the flow parser where it incorrectly reports some comments to be the wrong type. By reading from the source we can fix most of those issues.

Fixes #755