### PR TITLE
Do not attach comments to EmptyStatements in try/catch

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -291,10 +291,11 @@ function addTrailingComment(node, comment) {
 }
 
 function addBlockStatementFirstComment(node, comment) {
-  if (node.body.length === 0) {
+  const body = node.body.filter(n => n.type !== "EmptyStatement");
+  if (body.length === 0) {
     addDanglingComment(node, comment);
   } else {
-    addLeadingComment(node.body[0], comment);
+    addLeadingComment(body[0], comment);
   }
 }
 

--- a/tests/try/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/try/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`try.js 1`] = `
+"try
+/* missing comment */
+{;}
+finally {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+try {
+  /* missing comment */
+} finally {
+}
+"
+`;

--- a/tests/try/jsfmt.spec.js
+++ b/tests/try/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/try/try.js
+++ b/tests/try/try.js
@@ -1,0 +1,4 @@
+try
+/* missing comment */
+{;}
+finally {}


### PR DESCRIPTION
We skip EmptyStatement when generating the list of preceding/enclosing/following nodes but didn't do the same for the exceptions.

Fixes #695