### PR TITLE
Remove extra parens around ternary arguments of a new call

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -419,11 +419,11 @@ FPp.needsParens = function(assumeExpressionContext) {
         case "BinaryExpression":
         case "LogicalExpression":
         case "LogicalExpression":
-        case "NewExpression":
         case "ExportDefaultDeclaration":
         case "AwaitExpression":
           return true;
 
+        case "NewExpression":
         case "CallExpression":
           return name === "callee" && parent.callee === node;
 

--- a/tests/conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/conditional/__snapshots__/jsfmt.spec.js.snap
@@ -78,3 +78,14 @@ const { configureStore } = process.env.NODE_ENV === \\"production\\"
   : require(\\"./configureDevStore\\"); // b
 "
 `;
+
+exports[`new-expression.js 1`] = `
+"const testConsole = new TestConsole(
+  config.useStderr ? process.stderr : process.stdout
+);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const testConsole = new TestConsole(
+  config.useStderr ? process.stderr : process.stdout
+);
+"
+`;

--- a/tests/conditional/new-expression.js
+++ b/tests/conditional/new-expression.js
@@ -1,0 +1,3 @@
+const testConsole = new TestConsole(
+  config.useStderr ? process.stderr : process.stdout
+);


### PR DESCRIPTION
Fixes #771.