### PR TITLE
[RFC] Add parenthesis around && inside of ||

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -319,6 +319,10 @@ FPp.needsParens = function(assumeExpressionContext) {
           var no = node.operator;
           var np = util.getPrecedence(no);
 
+          if (po === "||" && no === "&&") {
+            return true;
+          }
+
           if (pp > np) {
             return true;
           }

--- a/tests/binary-expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/binary-expressions/__snapshots__/jsfmt.spec.js.snap
@@ -128,9 +128,9 @@ const x = longVariable &&
   longVariable &&
   longVariable &&
   longVariable;
-const x = longVariable && longVariable ||
-  longVariable && longVariable ||
-  longVariable && longVariable;
+const x = (longVariable && longVariable) ||
+  (longVariable && longVariable) ||
+  (longVariable && longVariable);
 
 const x = longVariable * longint &&
   longVariable >> 0 &&

--- a/tests/flow/logical/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/logical/__snapshots__/jsfmt.spec.js.snap
@@ -721,35 +721,35 @@ function logical6f(): number {
  */
 function logical7a(): number {
   var x: ?number = null;
-  return x != null && x || 0;
+  return (x != null && x) || 0;
 }
 
 /**
  * A composite && and || where the truthiness is unknown
  */
 function logical7b(x: boolean, y: number): number {
-  return x && y || 0;
+  return (x && y) || 0;
 }
 
 /**
  * A composite && and ||
  */
 function logical7c(x: string): number {
-  return x && 1 || 0;
+  return (x && 1) || 0;
 }
 
 /**
  * A composite && and ||
  */
 function logical7d(x: number): string {
-  return x && \\"foo\\" || \\"bar\\";
+  return (x && \\"foo\\") || \\"bar\\";
 }
 
 /**
  * A composite && and ||
  */
 function logical7e(x: number): string {
-  return false && x || \\"bar\\";
+  return (false && x) || \\"bar\\";
 }
 
 /**
@@ -788,7 +788,7 @@ function logical8c(): string {
  */
 function logical8d(): number {
   var x = false;
-  return x || 0 && \\"foo\\";
+  return x || (0 && \\"foo\\");
 }
 
 /**
@@ -796,7 +796,7 @@ function logical8d(): number {
  */
 function logical8e(): string {
   var x = false;
-  return x || 1 && \\"foo\\";
+  return x || (1 && \\"foo\\");
 }
 
 /**
@@ -805,7 +805,7 @@ function logical8e(): string {
 function logical8f(): string {
   // expected \`: boolean\`
   var x = true;
-  return x || 1 && \\"foo\\";
+  return x || (1 && \\"foo\\");
 }
 
 /**

--- a/tests/flow/predicates-inferred/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/predicates-inferred/__snapshots__/jsfmt.spec.js.snap
@@ -126,7 +126,7 @@ function dotAccess(head, create) {
   const stack = path.split(\\".\\");
   do {
     const key = stack.shift();
-    head = head[key] || create && (head[key] = {});
+    head = head[key] || (create && (head[key] = {}));
   } while (stack.length && head);
   return head;
 }

--- a/tests/flow/refinements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/refinements/__snapshots__/jsfmt.spec.js.snap
@@ -436,15 +436,15 @@ declare class Foo {
 }
 
 function foo0(x: ?string): string {
-  return x && x || \\"\\";
+  return (x && x) || \\"\\";
 }
 
 function foo1(x: ?Foo): string {
-  return x && x.foo || \\"\\";
+  return (x && x.foo) || \\"\\";
 }
 
 function foo2(x: ?Class<Foo>): string {
-  return x && new x().foo || \\"\\";
+  return (x && new x().foo) || \\"\\";
 }
 "
 `;


### PR DESCRIPTION
It seems like precedence for this combination of operators is very unclear to people (myself included) and consistently adding parenthesis there would be good.

Fixes #773