### PR TITLE
Add `this` for Member factory whitelist and remove softline

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2309,11 +2309,12 @@ function printMemberChain(path, options, print) {
   //
   // In order to detect those cases, we use an heuristic: if the first
   // node is just an identifier with the name starting with a capital
-  // letter or just a sequence of _$. The rationale is that they are
+  // letter, just a sequence of _$ or this. The rationale is that they are
   // likely to be factories.
   const shouldMerge = groups[0].length === 1 &&
-    groups[0][0].node.type === "Identifier" &&
-    groups[0][0].node.name.match(/(^[A-Z])|^[_$]+$/) &&
+    (groups[0][0].node.type === "ThisExpression" ||
+      groups[0][0].node.type === "Identifier" &&
+      groups[0][0].node.name.match(/(^[A-Z])|^[_$]+$/)) &&
     groups.length >= 2;
 
   function printGroup(printedGroup) {
@@ -2339,7 +2340,7 @@ function printMemberChain(path, options, print) {
 
   const expanded = concat([
     printGroup(groups[0]),
-    shouldMerge ? printIndentedGroup(groups.slice(1, 2), softline) : "",
+    shouldMerge ? printIndentedGroup(groups.slice(1, 2), "") : "",
     printIndentedGroup(groups.slice(shouldMerge ? 2 : 1), hardline)
   ]);
 

--- a/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
@@ -169,8 +169,7 @@ const render10 = props => (
 );
 
 const notJSX = (aaaaaaaaaaaaaaaaa, bbbbbbbbbbb) =>
-  this
-    .someLongCallWithParams(aaaaaa, bbbbbbb)
+  this.someLongCallWithParams(aaaaaa, bbbbbbb)
     .anotherLongCallWithParams(cccccccccccc, dddddddddddddddddddddd);
 
 React.render(

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -150,10 +150,28 @@ exports[`first_long.js 1`] = `
     .map(({ theType, ...data }) => theMap(theType, data))
     .retryWhen(errors => errors));
 }
+
+function f() {
+  return this._getWorker(workerOptions)({
+    filePath,
+    hasteImplModulePath: this._options.hasteImplModulePath,
+  }).then(
+    metadata => {
+      // \`1\` for truthy values instead of \`true\` to save cache space.
+      fileMetadata[H.VISITED] = 1;
+      const metadataId = metadata.id;
+      const metadataModule = metadata.module;
+      if (metadataId && metadataModule) {
+        fileMetadata[H.ID] = metadataId;
+        setModule(metadataId, metadataModule);
+      }
+      fileMetadata[H.DEPENDENCIES] = metadata.dependencies || [];
+    }
+  );
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 export default function theFunction(action$, store) {
-  return action$.ofType(THE_ACTION).switchMap(action => Observable
-    .webSocket({
+  return action$.ofType(THE_ACTION).switchMap(action => Observable.webSocket({
       url: THE_URL,
       more: stuff(),
       evenMore: stuff({
@@ -165,6 +183,24 @@ export default function theFunction(action$, store) {
     .filter(data => theFilter(data))
     .map(({ theType, ...data }) => theMap(theType, data))
     .retryWhen(errors => errors));
+}
+
+function f() {
+  return this._getWorker(workerOptions)({
+      filePath,
+      hasteImplModulePath: this._options.hasteImplModulePath
+    })
+    .then(metadata => {
+      // \`1\` for truthy values instead of \`true\` to save cache space.
+      fileMetadata[H.VISITED] = 1;
+      const metadataId = metadata.id;
+      const metadataModule = metadata.module;
+      if (metadataId && metadataModule) {
+        fileMetadata[H.ID] = metadataId;
+        setModule(metadataId, metadataModule);
+      }
+      fileMetadata[H.DEPENDENCIES] = metadata.dependencies || [];
+    });
 }
 "
 `;

--- a/tests/method-chain/first_long.js
+++ b/tests/method-chain/first_long.js
@@ -13,3 +13,22 @@ export default function theFunction(action$, store) {
     .map(({ theType, ...data }) => theMap(theType, data))
     .retryWhen(errors => errors));
 }
+
+function f() {
+  return this._getWorker(workerOptions)({
+    filePath,
+    hasteImplModulePath: this._options.hasteImplModulePath,
+  }).then(
+    metadata => {
+      // `1` for truthy values instead of `true` to save cache space.
+      fileMetadata[H.VISITED] = 1;
+      const metadataId = metadata.id;
+      const metadataModule = metadata.module;
+      if (metadataId && metadataModule) {
+        fileMetadata[H.ID] = metadataId;
+        setModule(metadataId, metadataModule);
+      }
+      fileMetadata[H.DEPENDENCIES] = metadata.dependencies || [];
+    }
+  );
+}


### PR DESCRIPTION
In addition to Observable, $ or _, we should also add `this` to the list of things that are likely factory and not objects you want to apply things on directly.

I added a way to make the function call break on its own line when it doesn't fit in one line and indent. But I think that only having the indentation is enough, having the call on its own line feels weird.

Fixes #777