### PR TITLE
Do not expand empty catch

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -555,6 +555,7 @@ function genericPrintNoParens(path, options, print) {
       const hasDirectives = n.directives && n.directives.length > 0;
 
       var parent = path.getParentNode();
+      const parentParent = path.getParentNode(1);
       if (
         !hasContent &&
         !hasDirectives &&
@@ -563,7 +564,8 @@ function genericPrintNoParens(path, options, print) {
           parent.type === "FunctionExpression" ||
           parent.type === "FunctionDeclaration" ||
           parent.type === "ObjectMethod" ||
-          parent.type === "ClassMethod")
+          parent.type === "ClassMethod" ||
+          (parent.type === "CatchClause" && !parentParent.finalizer))
       ) {
         return "{}";
       }

--- a/tests/flow/try/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/try/__snapshots__/jsfmt.spec.js.snap
@@ -205,8 +205,7 @@ function f() {
   try {
     var x: number = 0;
     var y: number = x;
-  } catch (e) {
-  }
+  } catch (e) {}
 }
 
 // and within catch
@@ -311,16 +310,14 @@ function f() {
   var y: number = x; // error
   try {
     var x: number = 0;
-  } catch (e) {
-  }
+  } catch (e) {}
 }
 
 // another non-dominated post
 function f() {
   try {
     var x: number = 0;
-  } catch (e) {
-  }
+  } catch (e) {}
   var y: number = x; // error
 }
 
@@ -341,8 +338,7 @@ function f(b) {
       throw new Error();
     }
     x = 0;
-  } catch (e) {
-  }
+  } catch (e) {}
   var y: number = x; // error
 }
 "
@@ -448,8 +444,7 @@ function baz(): string {
 function qux(): string {
   try {
     throw new Error(\\"foo\\");
-  } catch (e) {
-  }
+  } catch (e) {}
   console.log();
   return \\"bar\\";
 }
@@ -457,8 +452,7 @@ function qux(): string {
 function quux(): string {
   try {
     return qux();
-  } catch (e) {
-  }
+  } catch (e) {}
   return \\"bar\\";
 }
 

--- a/tests/flow/type-at-pos/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type-at-pos/__snapshots__/jsfmt.spec.js.snap
@@ -280,7 +280,6 @@ try {
 
 try {
   throw \\"foo\\";
-} catch (e) {
-}
+} catch (e) {}
 "
 `;

--- a/tests/try/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/try/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`empty.js 1`] = `
+"try {
+} catch (e) {
+}
+finally {
+}
+
+try {
+} catch (e) {
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+try {
+} catch (e) {
+} finally {
+}
+
+try {
+} catch (e) {}
+"
+`;
+
 exports[`try.js 1`] = `
 "try
 /* missing comment */

--- a/tests/try/empty.js
+++ b/tests/try/empty.js
@@ -1,0 +1,9 @@
+try {
+} catch (e) {
+}
+finally {
+}
+
+try {
+} catch (e) {
+}


### PR DESCRIPTION
I originally wanted to expand it but I think that it may not be a good decision because it's very common for them to be empty and you want it to take as little space as possible.

I tried to remove all those conditions but I think that there are valid places where we always want to expand like empty if/for/while loops.

Fixes #778