### PR TITLE
[WIP] Group TypeCastExpression

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1660,12 +1660,22 @@ function genericPrintNoParens(path, options, print) {
       return concat(parts);
     }
     case "TypeCastExpression":
-      return concat([
-        "(",
-        path.call(print, "expression"),
-        path.call(print, "typeAnnotation"),
-        ")"
-      ]);
+      return group(
+        concat([
+          "(",
+          indent(
+            options.tabWidth,
+            concat([
+              softline,
+              path.call(print, "expression"),
+              path.call(print, "typeAnnotation"),
+            ])
+          ),
+          ifBreak(shouldPrintComma(options, "all") ? "," : ""),
+          softline,
+          ")"
+        ])
+      )
     case "TypeParameterDeclaration":
     case "TypeParameterInstantiation":
       return concat(["<", join(", ", path.map(print, "params")), ">"]);

--- a/tests/flow/facebookisms/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/facebookisms/__snapshots__/jsfmt.spec.js.snap
@@ -62,11 +62,13 @@ let tests = [
   function(copyProperties: Object$Assign) {
     let result = {};
     result.baz = false;
-    (copyProperties(result, { foo: \\"a\\" }, { bar: 123 }): {
-      foo: string,
-      bar: number,
-      baz: boolean
-    });
+    (
+      copyProperties(result, { foo: \\"a\\" }, { bar: 123 }): {
+        foo: string,
+        bar: number,
+        baz: boolean
+      }
+    );
   },
 
   // module from lib

--- a/tests/flow/indexer/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/indexer/__snapshots__/jsfmt.spec.js.snap
@@ -99,10 +99,12 @@ let tests = [
 
 let tests = [
   function() {
-    ({}: {
-      [k1: string]: string,
-      [k2: number]: number /* error: not supported (yet)*/
-    });
+    (
+      {}: {
+        [k1: string]: string,
+        [k2: number]: number /* error: not supported (yet)*/
+      }
+    );
   }
 ];
 "

--- a/tests/flow/object_assign/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/object_assign/__snapshots__/jsfmt.spec.js.snap
@@ -108,10 +108,12 @@ exports[`apply.js 1`] = `
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // @flow
 
-(Object.assign.apply(null, [{}, { a: 1 }, { b: \\"foo\\" }]): {
-  a: number,
-  b: string
-});
+(
+  Object.assign.apply(null, [{}, { a: 1 }, { b: \\"foo\\" }]): {
+    a: number,
+    b: string
+  }
+);
 (Object.assign({}, ...[{ a: 1 }, { b: \\"foo\\" }]): { a: number, b: string });
 "
 `;

--- a/tests/flow/sealed_objects/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/sealed_objects/__snapshots__/jsfmt.spec.js.snap
@@ -39,9 +39,8 @@ var s5: string = o5.y; // ok (spreads make object types extensible)
 var o6: { [_: any]: any, x: number } = { x: 0 };
 var s6: string = o6.y; // ok  (indexers make object types extensible)
 
-var o7: { x: number, y?: string } = ({ x: 0, y: 0 }: {
-  [_: any]: number,
-  x: number
-}); // error
+var o7: { x: number, y?: string } = (
+  { x: 0, y: 0 }: { [_: any]: number, x: number }
+); // error
 "
 `;

--- a/tests/flow/union_new/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/union_new/__snapshots__/jsfmt.spec.js.snap
@@ -1357,15 +1357,17 @@ exports[`test13.js 1`] = `
 
 /* ensure there are no unintended side effects when trying branches */
 
-({ type: \\"B\\", id: \\"hi\\" }:
-  | {
-      type: \\"A\\",
-      id: ?string
-    }
-  | {
-      type: \\"B\\",
-      id: string
-    });
+(
+  { type: \\"B\\", id: \\"hi\\" }:
+    | {
+        type: \\"A\\",
+        id: ?string
+      }
+    | {
+        type: \\"B\\",
+        id: string
+      }
+);
 "
 `;
 


### PR DESCRIPTION
This is an attempt to fix #772, although it targets `TypeCastExpression` instead of empty objects directly, so I think https://github.com/prettier/prettier/issues/772#issuecomment-281800180 could be addressed separately.

@vjeux @cpojer let me know what do you think of it and how can we improve it.
Personally I only like this change:
```diff
-var o7: { x: number, y?: string } = ({ x: 0, y: 0 }: {
-  [_: any]: number,
-  x: number
-}); // error
+var o7: { x: number, y?: string } = (
+  { x: 0, y: 0 }: { [_: any]: number, x: number }
+); // error
```
