### PR TITLE
Eagerly evaluate `ifBreak` when processing template literals (fixes #795)

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1388,6 +1388,9 @@ function genericPrintNoParens(path, options, print) {
           if (d.type === "line" && !d.hard) {
             return d.soft ? "" : " ";
           }
+          else if(d.type === "if-break") {
+            return d.flatContents || "";
+          }
           return d;
         });
       }

--- a/tests/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/strings/__snapshots__/jsfmt.spec.js.snap
@@ -26,16 +26,6 @@ exports[`strings.js 1`] = `
 
   '\\\\uD801\\\\uDC28',
 ];
-
-foo(\`a long string \${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 } with expr\`);
-
-const x = \`a long string \${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + ( function() {return 3 })() + 3 + 2 + 3 + 2 + 3 } with expr\`;
-
-foo(\`a long string \${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + ( function() {
-  const x = 5;
-
-  return x;
- })() + 3 + 2 + 3 + 2 + 3 } with expr\`);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [
   \\"abc\\",
@@ -61,17 +51,133 @@ foo(\`a long string \${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + ( functi
   \\"🐶\\",
   '\\\\uD801\\\\uDC28'
 ];
+"
+`;
+
+exports[`strings.js 2`] = `
+"[
+  \\"abc\\",
+  'abc',
+
+  '\\\\'',
+
+  '\\"',
+  '\\\\\\"',
+  '\\\\\\\\\\"',
+
+  \\"'\\",
+  \\"\\\\'\\",
+  \\"\\\\\\\\'\\",
+
+  \\"'\\\\\\"\\",
+  '\\\\'\\"',
+
+  '\\\\\\\\',
+  \\"\\\\\\\\\\",
+
+  '\\\\0',
+  '🐶',
+
+  '\\\\uD801\\\\uDC28',
+];
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[
+  \\"abc\\",
+  \\"abc\\",
+
+  \\"'\\",
+
+  '\\"',
+  '\\"',
+  '\\\\\\\\\\"',
+
+  \\"'\\",
+  \\"'\\",
+  \\"\\\\\\\\'\\",
+
+  \\"'\\\\\\"\\",
+  \\"'\\\\\\"\\",
+
+  \\"\\\\\\\\\\",
+  \\"\\\\\\\\\\",
+
+  \\"\\\\0\\",
+  \\"🐶\\",
+  '\\\\uD801\\\\uDC28',
+];
+"
+`;
+
+exports[`template-literals.js 1`] = `
+"foo(\`a long string \${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 } with expr\`);
+
+const x = \`a long string \${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + ( function() {return 3 })() + 3 + 2 + 3 + 2 + 3 } with expr\`;
+
+foo(\`a long string \${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + ( function() {
+  const x = 5;
+
+  return x;
+ })() + 3 + 2 + 3 + 2 + 3 } with expr\`);
+
+pipe.write(
+  \`\\\\n  \${chalk.dim(\`\\\\u203A and \${more} more \${more} more \${more} more \${more}\`)}\`,
+);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 foo(
   \`a long string \${1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3} with expr\`
 );
+
 const x = \`a long string \${1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + (function() {
     return 3;
   })() + 3 + 2 + 3 + 2 + 3} with expr\`;
+
 foo(
   \`a long string \${1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + (function() {
       const x = 5;
+
       return x;
     })() + 3 + 2 + 3 + 2 + 3} with expr\`
+);
+
+pipe.write(
+  \`\\\\n  \${chalk.dim(\`\\\\u203A and \${more} more \${more} more \${more} more \${more}\`)}\`
+);
+"
+`;
+
+exports[`template-literals.js 2`] = `
+"foo(\`a long string \${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 } with expr\`);
+
+const x = \`a long string \${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + ( function() {return 3 })() + 3 + 2 + 3 + 2 + 3 } with expr\`;
+
+foo(\`a long string \${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + ( function() {
+  const x = 5;
+
+  return x;
+ })() + 3 + 2 + 3 + 2 + 3 } with expr\`);
+
+pipe.write(
+  \`\\\\n  \${chalk.dim(\`\\\\u203A and \${more} more \${more} more \${more} more \${more}\`)}\`,
+);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+foo(
+  \`a long string \${1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3} with expr\`,
+);
+
+const x = \`a long string \${1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + (function() {
+    return 3;
+  })() + 3 + 2 + 3 + 2 + 3} with expr\`;
+
+foo(
+  \`a long string \${1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + (function() {
+      const x = 5;
+
+      return x;
+    })() + 3 + 2 + 3 + 2 + 3} with expr\`,
+);
+
+pipe.write(
+  \`\\\\n  \${chalk.dim(\`\\\\u203A and \${more} more \${more} more \${more} more \${more}\`)}\`,
 );
 "
 `;

--- a/tests/strings/jsfmt.spec.js
+++ b/tests/strings/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(__dirname);
+run_spec(__dirname, { trailingComma: "all" });

--- a/tests/strings/strings.js
+++ b/tests/strings/strings.js
@@ -23,13 +23,3 @@
 
   '\uD801\uDC28',
 ];
-
-foo(`a long string ${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 } with expr`);
-
-const x = `a long string ${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + ( function() {return 3 })() + 3 + 2 + 3 + 2 + 3 } with expr`;
-
-foo(`a long string ${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + ( function() {
-  const x = 5;
-
-  return x;
- })() + 3 + 2 + 3 + 2 + 3 } with expr`);

--- a/tests/strings/template-literals.js
+++ b/tests/strings/template-literals.js
@@ -1,0 +1,13 @@
+foo(`a long string ${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 } with expr`);
+
+const x = `a long string ${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + ( function() {return 3 })() + 3 + 2 + 3 + 2 + 3 } with expr`;
+
+foo(`a long string ${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + ( function() {
+  const x = 5;
+
+  return x;
+ })() + 3 + 2 + 3 + 2 + 3 } with expr`);
+
+pipe.write(
+  `\n  ${chalk.dim(`\u203A and ${more} more ${more} more ${more} more ${more}`)}`,
+);


### PR DESCRIPTION
This should fix the problem with commas, but I wonder if we're going to run into anything else.