### PR TITLE
Fix empty options

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -21,10 +21,12 @@ var exampleConfig = Object.assign({}, defaults, {
 
 // Copy options and fill in default values.
 function normalize(options) {
-  if (typeof options.trailingComma === "boolean") {
+  const normalized = Object.assign({}, options || {});
+
+  if (typeof normalized.trailingComma === "boolean") {
     // Support a deprecated boolean type for the trailing comma config
     // for a few versions. This code can be removed later.
-    options.trailingComma = "es5";
+    normalized.trailingComma = "es5";
 
     console.warn(
       "Warning: `trailingComma` without any argument is deprecated. " +
@@ -32,8 +34,7 @@ function normalize(options) {
     );
   }
 
-  validate(options, { exampleConfig, deprecatedConfig });
-  const normalized = Object.assign({}, options || {});
+  validate(normalized, { exampleConfig, deprecatedConfig });
 
   // For backward compatibility. Deprecated in 0.0.10
   if ("useFlowParser" in normalized) {


### PR DESCRIPTION
```js
// test.js
var prettier = require('./');
prettier.format('a=1');
```

```js
node test.js
// doesn't crash
```

Fixes #801