### PR TITLE
Properly support `do`

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1093,13 +1093,7 @@ function genericPrintNoParens(path, options, print) {
 
       return concat(parts);
     case "DoExpression":
-      var statements = path.call(
-        function(bodyPath) {
-          return printStatementSequence(bodyPath, options, print);
-        },
-        "body"
-      );
-      return concat(["do {\n", statements.indent(options.tabWidth), "\n}"]);
+      return concat(["do ", path.call(print, "body")]);
     case "BreakStatement":
       parts.push("break");
 

--- a/tests/do/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/do/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`do.js 1`] = `
+"const envSpecific = {
+  domain:
+    do {
+      if(env === 'production') 'https://abc.mno.com/';
+      else if(env === 'development') 'http://localhost:4000';
+    }
+};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const envSpecific = {
+  domain: do {
+    if (env === \\"production\\") (\\"https://abc.mno.com/\\");
+    else if (env === \\"development\\") (\\"http://localhost:4000\\");
+  }
+};
+"
+`;

--- a/tests/do/do.js
+++ b/tests/do/do.js
@@ -1,0 +1,7 @@
+const envSpecific = {
+  domain:
+    do {
+      if(env === 'production') 'https://abc.mno.com/';
+      else if(env === 'development') 'http://localhost:4000';
+    }
+};

--- a/tests/do/jsfmt.spec.js
+++ b/tests/do/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, {parser: 'babylon'});


### PR DESCRIPTION
The code that supported `do` was likely from some recast time and didn't work anymore.

Fixes #810