### PR TITLE
Do not put parenthesis around not named default export

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -451,9 +451,16 @@ FPp.needsParens = function(assumeExpressionContext) {
           if (parent.test === node) {
             return true;
           }
+          return false;
 
         case "ExportDefaultDeclaration":
-          return node.type !== "ArrowFunctionExpression";
+          if (node.type === "ArrowFunctionExpression") {
+            return false;
+          }
+          if (node.type === "FunctionExpression" && !node.id) {
+            return false;
+          }
+          return true;
 
         case "ExpressionStatement":
         case "MemberExpression":

--- a/tests/conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/conditional/__snapshots__/jsfmt.spec.js.snap
@@ -41,23 +41,23 @@ const { configureStore } = process.env.NODE_ENV === \\"production\\"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var inspect = 4 === util.inspect.length
   ? // node <= 0.8.x
-    (function(v, colors) {
+    function(v, colors) {
       return util.inspect(v, void 0, void 0, colors);
-    })
+    }
   : // node > 0.8.x
-    (function(v, colors) {
+    function(v, colors) {
       return util.inspect(v, { colors: colors });
-    });
+    };
 
 var inspect = 4 === util.inspect.length
   ? // node <= 0.8.x
-    (function(v, colors) {
+    function(v, colors) {
       return util.inspect(v, void 0, void 0, colors);
-    })
+    }
   : // node > 0.8.x
-    (function(v, colors) {
+    function(v, colors) {
       return util.inspect(v, { colors: colors });
-    });
+    };
 
 const extractTextPluginOptions = shouldUseRelativeAssetPaths
   ? // Making sure that the publicPath goes back to to build folder.

--- a/tests/es6modules/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/es6modules/__snapshots__/jsfmt.spec.js.snap
@@ -101,14 +101,14 @@ export default function f() {}
 exports[`export_default_function_expression.js 1`] = `
 "export default (function() {});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-export default (function() {});
+export default function() {};
 "
 `;
 
 exports[`export_default_function_expression.js 2`] = `
 "export default (function() {});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-export default (function() {});
+export default function() {};
 "
 `;
 


### PR DESCRIPTION
We need to add parenthesis around function expressions if they are named otherwise the name leak, but if the function is not named then it's just superfluous.

The conditional change is due to a bad use of switch case where it would fall through the next one. We don't want parenthesis there.