### PR TITLE
Allow breaking for logical expressions in member chains

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2394,7 +2394,10 @@ function printMemberChain(path, options, print) {
 
   // If we only have a single `.`, we shouldn't do anything fancy and just
   // render everything concatenated together.
-  if (groups.length <= (shouldMerge ? 3 : 2) && !hasComment) {
+  if (groups.length <= (shouldMerge ? 3 : 2) &&
+      !hasComment &&
+      // (a || b).map() should be break before .map() instead of ||
+      groups[0][0].node.type !== "LogicalExpression") {
     return group(oneLine);
   }
 

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -224,6 +224,15 @@ Object.keys(
 "
 `;
 
+exports[`logical.js 1`] = `
+"(veryLongVeryLongVeryLong || e).map(tickets =>
+  TicketRecord.createFromSomeLongString());
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+(veryLongVeryLongVeryLong || e)
+  .map(tickets => TicketRecord.createFromSomeLongString());
+"
+`;
+
 exports[`multiple-members.js 1`] = `
 "if (testConfig.ENABLE_ONLINE_TESTS === \\"true\\") {
   describe(\\"POST /users/me/pet\\", function() {

--- a/tests/method-chain/logical.js
+++ b/tests/method-chain/logical.js
@@ -1,0 +1,2 @@
+(veryLongVeryLongVeryLong || e).map(tickets =>
+  TicketRecord.createFromSomeLongString());


### PR DESCRIPTION
I'm not really sure what a general rule is for those, but starting with LogicalExpressions should be good. Outside of identifiers, function calls and logical expressions, there aren't a lot of things you'd put there in real code anyway.

Fixes #822