### PR TITLE
Fix indentation of a merged group

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2371,10 +2371,10 @@ function printMemberChain(path, options, print) {
     return concat(printedGroup.map(tuple => tuple.printed));
   }
 
-  function printIndentedGroup(groups, lineType) {
+  function printIndentedGroup(groups) {
     return indent(
       options.tabWidth,
-      group(concat([lineType, join(lineType, groups.map(printGroup))]))
+      group(concat([hardline, join(hardline, groups.map(printGroup))]))
     );
   }
 
@@ -2384,14 +2384,14 @@ function printMemberChain(path, options, print) {
 
   // If we only have a single `.`, we shouldn't do anything fancy and just
   // render everything concatenated together.
-  if (groups.length <= 2 && !hasComment) {
+  if (groups.length <= (shouldMerge ? 3 : 2) && !hasComment) {
     return group(oneLine);
   }
 
   const expanded = concat([
     printGroup(groups[0]),
-    shouldMerge ? printIndentedGroup(groups.slice(1, 2), "") : "",
-    printIndentedGroup(groups.slice(shouldMerge ? 2 : 1), hardline)
+    shouldMerge ? concat(groups.slice(1, 2).map(printGroup)) : "",
+    printIndentedGroup(groups.slice(shouldMerge ? 2 : 1))
   ]);
 
   // If there's a comment, we don't want to print in one line.

--- a/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
@@ -169,8 +169,10 @@ const render10 = props => (
 );
 
 const notJSX = (aaaaaaaaaaaaaaaaa, bbbbbbbbbbb) =>
-  this.someLongCallWithParams(aaaaaa, bbbbbbb)
-    .anotherLongCallWithParams(cccccccccccc, dddddddddddddddddddddd);
+  this.someLongCallWithParams(aaaaaa, bbbbbbb).anotherLongCallWithParams(
+    cccccccccccc,
+    dddddddddddddddddddddd
+  );
 
 React.render(
   <BaseForm

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -172,14 +172,14 @@ function f() {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 export default function theFunction(action$, store) {
   return action$.ofType(THE_ACTION).switchMap(action => Observable.webSocket({
-      url: THE_URL,
-      more: stuff(),
-      evenMore: stuff({
-        value1: true,
-        value2: false,
-        value3: false
-      })
+    url: THE_URL,
+    more: stuff(),
+    evenMore: stuff({
+      value1: true,
+      value2: false,
+      value3: false
     })
+  })
     .filter(data => theFilter(data))
     .map(({ theType, ...data }) => theMap(theType, data))
     .retryWhen(errors => errors));
@@ -187,21 +187,40 @@ export default function theFunction(action$, store) {
 
 function f() {
   return this._getWorker(workerOptions)({
-      filePath,
-      hasteImplModulePath: this._options.hasteImplModulePath
-    })
-    .then(metadata => {
-      // \`1\` for truthy values instead of \`true\` to save cache space.
-      fileMetadata[H.VISITED] = 1;
-      const metadataId = metadata.id;
-      const metadataModule = metadata.module;
-      if (metadataId && metadataModule) {
-        fileMetadata[H.ID] = metadataId;
-        setModule(metadataId, metadataModule);
-      }
-      fileMetadata[H.DEPENDENCIES] = metadata.dependencies || [];
-    });
+    filePath,
+    hasteImplModulePath: this._options.hasteImplModulePath
+  }).then(metadata => {
+    // \`1\` for truthy values instead of \`true\` to save cache space.
+    fileMetadata[H.VISITED] = 1;
+    const metadataId = metadata.id;
+    const metadataModule = metadata.module;
+    if (metadataId && metadataModule) {
+      fileMetadata[H.ID] = metadataId;
+      setModule(metadataId, metadataModule);
+    }
+    fileMetadata[H.DEPENDENCIES] = metadata.dependencies || [];
+  });
 }
+"
+`;
+
+exports[`inline_merge.js 1`] = `
+"Object.keys(
+  availableLocales({
+    test: true
+  })
+)
+.forEach(locale => {
+  // ...
+});
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Object.keys(
+  availableLocales({
+    test: true
+  })
+).forEach(locale => {
+  // ...
+});
 "
 `;
 

--- a/tests/method-chain/inline_merge.js
+++ b/tests/method-chain/inline_merge.js
@@ -1,0 +1,8 @@
+Object.keys(
+  availableLocales({
+    test: true
+  })
+)
+.forEach(locale => {
+  // ...
+});


### PR DESCRIPTION
Printing a merged group indented was actually not the right fix. The right fix was to print them in a single line. It used to have this behavior when I was mutating the first group but now that I don't anymore I need to reproduce this condition.

Fixes #823