### PR TITLE
Put short body of arrow functions on the same line

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -353,7 +353,7 @@ function genericPrintNoParens(path, options, print) {
           collapsed,
           concat([
             concat(parts),
-            indent(options.tabWidth, concat([line, body]))
+            group(indent(options.tabWidth, concat([line, body])))
           ])
         ]),
         { shouldBreak: willBreak(body) }

--- a/tests/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -52,3 +52,20 @@ const foo = () => {
 };
 "
 `;
+
+exports[`short_body.js 1`] = `
+"const initializeSnapshotState = (
+  testFile: Path,
+  update: boolean,
+  testPath: string,
+  expand: boolean,
+) => new SnapshotState(testFile, update, testPath, expand);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const initializeSnapshotState = (
+  testFile: Path,
+  update: boolean,
+  testPath: string,
+  expand: boolean
+) => new SnapshotState(testFile, update, testPath, expand);
+"
+`;

--- a/tests/arrows/short_body.js
+++ b/tests/arrows/short_body.js
@@ -1,0 +1,6 @@
+const initializeSnapshotState = (
+  testFile: Path,
+  update: boolean,
+  testPath: string,
+  expand: boolean,
+) => new SnapshotState(testFile, update, testPath, expand);


### PR DESCRIPTION
By adding a group, we can avoid adding a newline if the expression fits in a single line.

Fixes #800