### PR TITLE
Preserve new lines for comments after `=`

### DIFF
--- a/tests/assignment_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/assignment_comments/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,90 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`assignment_comments.js 1`] = `
+"fnString =
+  // Comment
+  'some' + 'long' + 'string';
+
+var fnString =
+  // Comment
+  'some' + 'long' + 'string';
+
+var fnString =
+  // Comment
+
+  'some' + 'long' + 'string';
+
+var fnString =
+
+  // Comment
+
+  'some' + 'long' + 'string';
+
+var fnString =
+  /* comment */
+  'some' + 'long' + 'string';
+
+var fnString =
+  /**
+   * multi-line
+   */
+  'some' + 'long' + 'string';
+
+var fnString =
+  /* inline */ 'some' + 'long' + 'string' + 'some' + 'long' + 'string' + 'some' + 'long' + 'string' + 'some' + 'long' + 'string';
+
+var fnString = // Comment
+  // Comment
+  'some' + 'long' + 'string';
+
+var fnString = // Comment
+  'some' + 'long' + 'string';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+fnString =
+  // Comment
+  \\"some\\" + \\"long\\" + \\"string\\";
+
+var fnString =
+  // Comment
+  \\"some\\" + \\"long\\" + \\"string\\";
+
+var fnString =
+  // Comment
+
+  \\"some\\" + \\"long\\" + \\"string\\";
+
+var fnString =
+  // Comment
+
+  \\"some\\" + \\"long\\" + \\"string\\";
+
+var fnString =
+  /* comment */
+  \\"some\\" + \\"long\\" + \\"string\\";
+
+var fnString =
+  /**
+   * multi-line
+   */
+  \\"some\\" + \\"long\\" + \\"string\\";
+
+var fnString = /* inline */ \\"some\\" +
+  \\"long\\" +
+  \\"string\\" +
+  \\"some\\" +
+  \\"long\\" +
+  \\"string\\" +
+  \\"some\\" +
+  \\"long\\" +
+  \\"string\\" +
+  \\"some\\" +
+  \\"long\\" +
+  \\"string\\";
+
+var fnString = // Comment
+  // Comment
+  \\"some\\" + \\"long\\" + \\"string\\";
+
+var fnString = \\"some\\" + \\"long\\" + \\"string\\"; // Comment
+"
+`;

--- a/tests/assignment_comments/assignment_comments.js
+++ b/tests/assignment_comments/assignment_comments.js
@@ -1,0 +1,38 @@
+fnString =
+  // Comment
+  'some' + 'long' + 'string';
+
+var fnString =
+  // Comment
+  'some' + 'long' + 'string';
+
+var fnString =
+  // Comment
+
+  'some' + 'long' + 'string';
+
+var fnString =
+
+  // Comment
+
+  'some' + 'long' + 'string';
+
+var fnString =
+  /* comment */
+  'some' + 'long' + 'string';
+
+var fnString =
+  /**
+   * multi-line
+   */
+  'some' + 'long' + 'string';
+
+var fnString =
+  /* inline */ 'some' + 'long' + 'string' + 'some' + 'long' + 'string' + 'some' + 'long' + 'string' + 'some' + 'long' + 'string';
+
+var fnString = // Comment
+  // Comment
+  'some' + 'long' + 'string';
+
+var fnString = // Comment
+  'some' + 'long' + 'string';

--- a/tests/assignment_comments/jsfmt.spec.js
+++ b/tests/assignment_comments/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);


### PR DESCRIPTION
The `hasLeadingOwnLineComment` helper is going to be useful for other places where we just used `n.comments` as a proxy for it.

Fixes #660