### PR TITLE
Migrate class comments to the beginning

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -145,7 +145,8 @@ function attach(comments, ast, text, options) {
       if (
         handleMemberExpressionComments(enclosingNode, followingNode, comment) ||
         handleIfStatementComments(enclosingNode, followingNode, comment) ||
-        handleTryStatementComments(enclosingNode, followingNode, comment)
+        handleTryStatementComments(enclosingNode, followingNode, comment) ||
+        handleClassComments(enclosingNode, comment)
       ) {
         // We're good
       } else if (followingNode) {
@@ -168,7 +169,8 @@ function attach(comments, ast, text, options) {
           comment,
           text
         ) ||
-        handleTemplateLiteralComments(enclosingNode, comment)
+        handleTemplateLiteralComments(enclosingNode, comment) ||
+        handleClassComments(enclosingNode, comment)
       ) {
         // We're good
       } else if (precedingNode) {
@@ -449,6 +451,16 @@ function handleFunctionDeclarationComments(enclosingNode, comment) {
     enclosingNode.params.length === 0
   ) {
     addDanglingComment(enclosingNode, comment);
+    return true;
+  }
+  return false;
+}
+
+function handleClassComments(enclosingNode, comment) {
+  if (enclosingNode &&
+      (enclosingNode.type === "ClassDeclaration" ||
+        enclosingNode.type === "ClassExpression")) {
+    addLeadingComment(enclosingNode, comment);
     return true;
   }
   return false;

--- a/tests/class_comment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/class_comment/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`comments.js 1`] = `
+"class A // comment 1
+  // comment 2
+  extends B {}
+
+class A extends B // comment1
+// comment2
+// comment3
+{}
+
+class A /* a */ extends B {}
+class A extends B /* a */ {}
+class A extends /* a */ B {}
+
+(class A // comment 1
+  // comment 2
+  extends B {});
+
+(class A extends B // comment1
+// comment2
+// comment3
+{});
+
+(class A /* a */ extends B {});
+(class A extends B /* a */ {});
+(class A extends /* a */ B {});
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// comment 1
+// comment 2
+class A extends B {}
+
+// comment1
+// comment2
+// comment3
+class A extends B {}
+
+class A /* a */ extends B {}
+class A extends B /* a */ {
+}
+class A extends /* a */ B {}
+
+// comment 1
+// comment 2
+(class A extends B {});
+
+// comment1
+// comment2
+// comment3
+(class A extends B {});
+
+(class A /* a */ extends B {});
+(class A extends B /* a */ {
+});
+(class A extends /* a */ B {});
+"
+`;

--- a/tests/class_comment/comments.js
+++ b/tests/class_comment/comments.js
@@ -1,0 +1,25 @@
+class A // comment 1
+  // comment 2
+  extends B {}
+
+class A extends B // comment1
+// comment2
+// comment3
+{}
+
+class A /* a */ extends B {}
+class A extends B /* a */ {}
+class A extends /* a */ B {}
+
+(class A // comment 1
+  // comment 2
+  extends B {});
+
+(class A extends B // comment1
+// comment2
+// comment3
+{});
+
+(class A /* a */ extends B {});
+(class A extends B /* a */ {});
+(class A extends /* a */ B {});

--- a/tests/class_comment/jsfmt.spec.js
+++ b/tests/class_comment/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);


### PR DESCRIPTION
Instead of trying to figure out a complicated way to preserve their correct position, it's easier to just migrate those comments before the class.

Fixes #693
Fixes #694