### PR TITLE
Do not break long it calls

### DIFF
--- a/tests/it/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/it/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`it.js 1`] = `
+"// Shouldn't break
+
+it(\\"does something really long and complicated so I have to write a very long name for the test\\", () => {
+  console.log(\\"hello!\\");
+});
+
+it(\\"does something really long and complicated so I have to write a very long name for the test\\", function() {
+  console.log(\\"hello!\\");
+});
+
+test(\\"does something really long and complicated so I have to write a very long name for the test\\", (done) => {
+  console.log(\\"hello!\\");
+});
+
+// Should break
+
+it.only(\\"does something really long and complicated so I have to write a very long name for the test\\", () => {
+  console.log(\\"hello!\\");
+});
+
+it.only(\\"does something really long and complicated so I have to write a very long name for the test\\", 10, () => {
+  console.log(\\"hello!\\");
+});
+
+it.only.only(\\"does something really long and complicated so I have to write a very long name for the test\\", () => {
+  console.log(\\"hello!\\");
+});
+
+it.only.only(\\"does something really long and complicated so I have to write a very long name for the test\\", (a, b, c) => {
+  console.log(\\"hello!\\");
+});
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Shouldn't break
+
+it(\\"does something really long and complicated so I have to write a very long name for the test\\", () => {
+  console.log(\\"hello!\\");
+});
+
+it(\\"does something really long and complicated so I have to write a very long name for the test\\", function() {
+  console.log(\\"hello!\\");
+});
+
+test(\\"does something really long and complicated so I have to write a very long name for the test\\", done => {
+  console.log(\\"hello!\\");
+});
+
+// Should break
+
+it.only(
+  \\"does something really long and complicated so I have to write a very long name for the test\\",
+  () => {
+    console.log(\\"hello!\\");
+  }
+);
+
+it.only(
+  \\"does something really long and complicated so I have to write a very long name for the test\\",
+  10,
+  () => {
+    console.log(\\"hello!\\");
+  }
+);
+
+it.only.only(
+  \\"does something really long and complicated so I have to write a very long name for the test\\",
+  () => {
+    console.log(\\"hello!\\");
+  }
+);
+
+it.only.only(
+  \\"does something really long and complicated so I have to write a very long name for the test\\",
+  (a, b, c) => {
+    console.log(\\"hello!\\");
+  }
+);
+"
+`;

--- a/tests/it/it.js
+++ b/tests/it/it.js
@@ -1,0 +1,31 @@
+// Shouldn't break
+
+it("does something really long and complicated so I have to write a very long name for the test", () => {
+  console.log("hello!");
+});
+
+it("does something really long and complicated so I have to write a very long name for the test", function() {
+  console.log("hello!");
+});
+
+test("does something really long and complicated so I have to write a very long name for the test", (done) => {
+  console.log("hello!");
+});
+
+// Should break
+
+it.only("does something really long and complicated so I have to write a very long name for the test", () => {
+  console.log("hello!");
+});
+
+it.only("does something really long and complicated so I have to write a very long name for the test", 10, () => {
+  console.log("hello!");
+});
+
+it.only.only("does something really long and complicated so I have to write a very long name for the test", () => {
+  console.log("hello!");
+});
+
+it.only.only("does something really long and complicated so I have to write a very long name for the test", (a, b, c) => {
+  console.log("hello!");
+});

--- a/tests/it/jsfmt.spec.js
+++ b/tests/it/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);


### PR DESCRIPTION
This happens very frequently that naming a test makes the entire line go > 80 columns and requires to indent everything which takes a lot more space. We've had this being reported multiple times and it also affects a lot of tests inside of fb.

Fixes #159

(Note, this is built on-top of #841 but github doesn't handle stacked pull requests well... You want to look at the second commit here: https://github.com/prettier/prettier/pull/842/commits/a4bab0c64e2a765b9968dcd49b6829b643235adc )