### PR TITLE
Keep parenthesis on export default function

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -454,10 +454,10 @@ FPp.needsParens = function(assumeExpressionContext) {
           return false;
 
         case "ExportDefaultDeclaration":
-          if (node.type === "ArrowFunctionExpression") {
-            return false;
-          }
-          if (node.type === "FunctionExpression" && !node.id) {
+          if (
+            node.type === "ArrowFunctionExpression" ||
+            node.type === "FunctionDeclaration"
+          ) {
             return false;
           }
           return true;

--- a/tests/es6modules/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/es6modules/__snapshots__/jsfmt.spec.js.snap
@@ -101,14 +101,14 @@ export default function f() {}
 exports[`export_default_function_expression.js 1`] = `
 "export default (function() {});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-export default function() {};
+export default (function() {});
 "
 `;
 
 exports[`export_default_function_expression.js 2`] = `
 "export default (function() {});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-export default function() {};
+export default (function() {});
 "
 `;
 


### PR DESCRIPTION
It turns out that my fix was not correct. We should not add parenthesis for FunctionDeclaration instead of checking if the function expression is named.

Fixes #819