### PR TITLE
[JSX] Don't wrap JSX Elements in parentheses if they are inside JSX Expression Containers

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2677,6 +2677,7 @@ function maybeWrapJSXElementInParens(path, elem, options) {
 
   const NO_WRAP_PARENTS = {
     JSXElement: true,
+    JSXExpressionContainer: true,
     ExpressionStatement: true,
     CallExpression: true,
     ConditionalExpression: true,

--- a/tests/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -60,7 +60,13 @@ exports[`expression.js 1`] = `
     this.props.veryBigItemImageViewFunc(option)}
   heading={this.props.displayTextFunc(option)}
   value={option}
-/>
+/>;
+
+<ParentComponent prop={
+  <Child>
+    test
+  </Child>
+}/>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <View
   style={{
@@ -121,6 +127,14 @@ exports[`expression.js 1`] = `
   }
   heading={this.props.displayTextFunc(option)}
   value={option}
+/>;
+
+<ParentComponent
+  prop={
+    <Child>
+      test
+    </Child>
+  }
 />;
 "
 `;

--- a/tests/jsx/expression.js
+++ b/tests/jsx/expression.js
@@ -57,4 +57,10 @@
     this.props.veryBigItemImageViewFunc(option)}
   heading={this.props.displayTextFunc(option)}
   value={option}
-/>
+/>;
+
+<ParentComponent prop={
+  <Child>
+    test
+  </Child>
+}/>;


### PR DESCRIPTION
Fixes https://github.com/prettier/prettier/issues/843