### PR TITLE
Fix jsx expression comment that break

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1316,10 +1316,7 @@ function genericPrintNoParens(path, options, print) {
     case "JSXText":
       throw new Error("JSXTest should be handled by JSXElement");
     case "JSXEmptyExpression":
-      return concat([
-        comments.printDanglingComments(path, options, /* sameIndent */ true),
-        softline
-      ]);
+      return comments.printDanglingComments(path, options, /* sameIndent */ true);
     case "TypeAnnotatedIdentifier":
       return concat([
         path.call(print, "annotation"),

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -793,6 +793,8 @@ exports[`jsx.js 1`] = `
 <div>
   {/* comment */}
 </div>;
+
+<div>{/*<div>  Some very v  ery very very long line to break line width limit </div>*/}</div>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <div>
   {/* comment */}
@@ -826,6 +828,10 @@ exports[`jsx.js 1`] = `
 
 <div>
   {/* comment */}
+</div>;
+
+<div>
+  {/*<div>  Some very v  ery very very long line to break line width limit </div>*/}
 </div>;
 "
 `;
@@ -869,6 +875,8 @@ exports[`jsx.js 2`] = `
 <div>
   {/* comment */}
 </div>;
+
+<div>{/*<div>  Some very v  ery very very long line to break line width limit </div>*/}</div>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <div>
   {/* comment */}
@@ -902,6 +910,10 @@ exports[`jsx.js 2`] = `
 
 <div>
   {/* comment */}
+</div>;
+
+<div>
+  {/*<div>  Some very v  ery very very long line to break line width limit </div>*/}
 </div>;
 "
 `;

--- a/tests/comments/jsx.js
+++ b/tests/comments/jsx.js
@@ -36,3 +36,5 @@
 <div>
   {/* comment */}
 </div>;
+
+<div>{/*<div>  Some very v  ery very very long line to break line width limit </div>*/}</div>;


### PR DESCRIPTION
In #596, I fixed a bunch of jsx expression comment edge cases and happened to add a softline there. But it turns out that it's not needed and is actually harmful :)

Fixes #712