### PR TITLE
Fix flow union comments

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -148,7 +148,8 @@ function attach(comments, ast, text, options) {
         handleIfStatementComments(enclosingNode, followingNode, comment) ||
         handleTryStatementComments(enclosingNode, followingNode, comment) ||
         handleImportSpecifierComments(enclosingNode, comment) ||
-        handleClassComments(enclosingNode, comment)
+        handleClassComments(enclosingNode, comment) ||
+        handleUnionTypeComments(precedingNode, enclosingNode, followingNode, comment)
       ) {
         // We're good
       } else if (followingNode) {
@@ -507,6 +508,16 @@ function handleCallExpressionComments(precedingNode, enclosingNode, comment) {
       precedingNode && enclosingNode.callee === precedingNode &&
       enclosingNode.arguments.length > 0) {
     addLeadingComment(enclosingNode.arguments[0], comment);
+    return true;
+  }
+  return false;
+}
+
+function handleUnionTypeComments(precedingNode, enclosingNode, followingNode, comment) {
+  if (enclosingNode && enclosingNode.type === 'UnionTypeAnnotation' &&
+      precedingNode && precedingNode.type === 'ObjectTypeAnnotation' &&
+      followingNode && followingNode.type === 'ObjectTypeAnnotation') {
+    addTrailingComment(precedingNode, comment);
     return true;
   }
   return false;

--- a/src/printer.js
+++ b/src/printer.js
@@ -1622,12 +1622,19 @@ function genericPrintNoParens(path, options, print) {
         return join(" & ", types);
       }
 
+      const parent = path.getParentNode();
+      // If there's a leading comment, the parent is doing the indentation
+      const shouldIndent = !(parent.type === 'TypeAlias' &&
+        hasLeadingOwnLineComment(options.originalText, n));
+
+      const token = isIntersection ? "&" : "|";
+
       return group(
         indent(
-          options.tabWidth,
+          shouldIndent ? options.tabWidth : 0,
           concat([
-            ifBreak(concat([line, isIntersection ? "&" : "|", " "])),
-            join(concat([line, isIntersection ? "&" : "|", " "]), types)
+            ifBreak(concat([shouldIndent ? line : "", token, " "])),
+            join(concat([line, token, " "]), types)
           ])
         )
       );
@@ -1710,8 +1717,13 @@ function genericPrintNoParens(path, options, print) {
         "type ",
         path.call(print, "id"),
         path.call(print, "typeParameters"),
-        " = ",
-        path.call(print, "right"),
+        " =",
+        hasLeadingOwnLineComment(options.originalText, n.right)
+          ? indent(
+              options.tabWidth,
+              concat([hardline, path.call(print, "right")])
+            )
+          : concat([" ", path.call(print, "right")]),
         ";"
       );
 

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -244,6 +244,52 @@ b;
 "
 `;
 
+exports[`flow_union.js 1`] = `
+"type UploadState<E, EM, D>
+  // The upload hasnt begun yet
+  = {type: \\"Not_begun\\"}
+  // The upload timed out
+  | {type: \\"Timed_out\\"}
+  // Failed somewhere on the line
+  | {type: \\"Failed\\", error: E, errorMsg: EM}
+  // Uploading to aws3 and CreatePostMutation succeeded
+  | {type: \\"Success\\", data: D};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+type UploadState<E, EM, D> =
+  // The upload hasnt begun yet
+  | { type: \\"Not_begun\\" }
+  // The upload timed out
+  | { type: \\"Timed_out\\" }
+  // Failed somewhere on the line
+  | { type: \\"Failed\\", error: E, errorMsg: EM }
+  // Uploading to aws3 and CreatePostMutation succeeded
+  | { type: \\"Success\\", data: D };
+"
+`;
+
+exports[`flow_union.js 2`] = `
+"type UploadState<E, EM, D>
+  // The upload hasnt begun yet
+  = {type: \\"Not_begun\\"}
+  // The upload timed out
+  | {type: \\"Timed_out\\"}
+  // Failed somewhere on the line
+  | {type: \\"Failed\\", error: E, errorMsg: EM}
+  // Uploading to aws3 and CreatePostMutation succeeded
+  | {type: \\"Success\\", data: D};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+type UploadState<E, EM, D> =
+  // The upload hasnt begun yet
+  | { type: \\"Not_begun\\" }
+  // The upload timed out
+  | { type: \\"Timed_out\\" }
+  // Failed somewhere on the line
+  | { type: \\"Failed\\", error: E, errorMsg: EM }
+  // Uploading to aws3 and CreatePostMutation succeeded
+  | { type: \\"Success\\", data: D };
+"
+`;
+
 exports[`function-declaration.js 1`] = `
 "function a(/* comment */) {} // comment
 function b() {} // comment

--- a/tests/comments/flow_union.js
+++ b/tests/comments/flow_union.js
@@ -1,0 +1,9 @@
+type UploadState<E, EM, D>
+  // The upload hasnt begun yet
+  = {type: "Not_begun"}
+  // The upload timed out
+  | {type: "Timed_out"}
+  // Failed somewhere on the line
+  | {type: "Failed", error: E, errorMsg: EM}
+  // Uploading to aws3 and CreatePostMutation succeeded
+  | {type: "Success", data: D};


### PR DESCRIPTION
The comments infra has been architected with trailing operators and fails for leading `|`. Instead of having leading comments, we can put trailing comments on the previous one and use the same technique as assignment to deal with the indentation.

Fixes #849