### PR TITLE
Stabilize `import as` comments

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -146,6 +146,7 @@ function attach(comments, ast, text, options) {
         handleMemberExpressionComments(enclosingNode, followingNode, comment) ||
         handleIfStatementComments(enclosingNode, followingNode, comment) ||
         handleTryStatementComments(enclosingNode, followingNode, comment) ||
+        handleImportSpecifierComments(enclosingNode, comment) ||
         handleClassComments(enclosingNode, comment)
       ) {
         // We're good
@@ -169,6 +170,7 @@ function attach(comments, ast, text, options) {
           comment,
           text
         ) ||
+        handleImportSpecifierComments(enclosingNode, comment) ||
         handleTemplateLiteralComments(enclosingNode, comment) ||
         handleClassComments(enclosingNode, comment)
       ) {
@@ -463,6 +465,14 @@ function handleClassComments(enclosingNode, comment) {
     (enclosingNode.type === "ClassDeclaration" ||
       enclosingNode.type === "ClassExpression")
   ) {
+    addLeadingComment(enclosingNode, comment);
+    return true;
+  }
+  return false;
+}
+
+function handleImportSpecifierComments(enclosingNode, comment) {
+  if (enclosingNode && enclosingNode.type === "ImportSpecifier") {
     addLeadingComment(enclosingNode, comment);
     return true;
   }

--- a/tests/import/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/import/__snapshots__/jsfmt.spec.js.snap
@@ -54,6 +54,108 @@ import {fitsIn, oneLine} from \\".\\";
 "
 `;
 
+exports[`comments.js 1`] = `
+"import { a //comment1
+//comment2
+//comment3
+as b} from \\"\\";
+
+import {
+  a as //comment1
+  //comment2
+  //comment3
+  b
+} from \\"\\";
+
+import {
+  a as //comment2 //comment1
+  //comment3
+  b
+} from \\"\\";
+
+import {
+  a as //comment3 //comment2 //comment1
+  b
+} from \\"\\";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import {
+  //comment1
+  //comment2
+  //comment3
+  a as b
+} from \\"\\";
+
+import {
+  //comment1
+  //comment2
+  //comment3
+  a as b
+} from \\"\\";
+
+import {
+  //comment2 //comment1
+  //comment3
+  a as b
+} from \\"\\";
+
+import {
+  //comment3 //comment2 //comment1
+  a as b
+} from \\"\\";
+"
+`;
+
+exports[`comments.js 2`] = `
+"import { a //comment1
+//comment2
+//comment3
+as b} from \\"\\";
+
+import {
+  a as //comment1
+  //comment2
+  //comment3
+  b
+} from \\"\\";
+
+import {
+  a as //comment2 //comment1
+  //comment3
+  b
+} from \\"\\";
+
+import {
+  a as //comment3 //comment2 //comment1
+  b
+} from \\"\\";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import {
+  //comment1
+  //comment2
+  //comment3
+  a as b
+} from \\"\\";
+
+import {
+  //comment1
+  //comment2
+  //comment3
+  a as b
+} from \\"\\";
+
+import {
+  //comment2 //comment1
+  //comment3
+  a as b
+} from \\"\\";
+
+import {
+  //comment3 //comment2 //comment1
+  a as b
+} from \\"\\";
+"
+`;
+
 exports[`long-line.js 1`] = `
 "import someCoolUtilWithARatherLongName from '../../../../utils/someCoolUtilWithARatherLongName';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/import/comments.js
+++ b/tests/import/comments.js
@@ -1,0 +1,22 @@
+import { a //comment1
+//comment2
+//comment3
+as b} from "";
+
+import {
+  a as //comment1
+  //comment2
+  //comment3
+  b
+} from "";
+
+import {
+  a as //comment2 //comment1
+  //comment3
+  b
+} from "";
+
+import {
+  a as //comment3 //comment2 //comment1
+  b
+} from "";


### PR DESCRIPTION
Since this is extremely rare, I just took the easy way out and if you are adding a comment inside the "as" node, I just move it outside. We could be more fancy but that works.

Fixes #620