### PR TITLE
Fix comment after the last argument of a function

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -143,6 +143,7 @@ function attach(comments, ast, text, options) {
       // If a comment exists on its own line, prefer a leading comment.
       // We also need to check if it's the first line of the file.
       if (
+        handleLastFunctionArgComments(precedingNode, enclosingNode, followingNode, comment) ||
         handleMemberExpressionComments(enclosingNode, followingNode, comment) ||
         handleIfStatementComments(enclosingNode, followingNode, comment) ||
         handleTryStatementComments(enclosingNode, followingNode, comment) ||
@@ -452,6 +453,27 @@ function handleFunctionDeclarationComments(enclosingNode, comment) {
     enclosingNode.params.length === 0
   ) {
     addDanglingComment(enclosingNode, comment);
+    return true;
+  }
+  return false;
+}
+
+function handleLastFunctionArgComments(precedingNode, enclosingNode, followingNode, comment) {
+  // Type definitions functions
+  if (precedingNode && precedingNode.type === 'FunctionTypeParam' &&
+    enclosingNode && enclosingNode.type === 'FunctionTypeAnnotation' &&
+    followingNode && followingNode.type !== 'FunctionTypeParam') {
+    addTrailingComment(precedingNode, comment);
+    return true;
+  }
+
+  // Real functions
+  if (precedingNode && precedingNode.type === 'Identifier' &&
+    enclosingNode && (
+      enclosingNode.type === 'ArrowFunctionExpression' ||
+      enclosingNode.type === 'FunctionExpression') &&
+    followingNode && followingNode.type !== 'Identifier') {
+    addTrailingComment(precedingNode, comment);
     return true;
   }
   return false;

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -906,6 +906,92 @@ exports[`jsx.js 2`] = `
 "
 `;
 
+exports[`last-arg.js 1`] = `
+"type f = (
+  currentRequest: {a: number},
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+) => number;
+
+f = (
+  currentRequest: {a: number},
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+): number => {};
+
+f = (
+  currentRequest: {a: number},
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+) => {};
+
+f = function(
+  currentRequest: {a: number},
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+) {};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+type f = (
+  currentRequest: { a: number }
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+) => number;
+
+f = (
+  currentRequest: { a: number }
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+): number => {};
+
+f = (
+  currentRequest: { a: number }
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+) => {};
+
+f = function(
+  currentRequest: { a: number }
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+) {};
+"
+`;
+
+exports[`last-arg.js 2`] = `
+"type f = (
+  currentRequest: {a: number},
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+) => number;
+
+f = (
+  currentRequest: {a: number},
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+): number => {};
+
+f = (
+  currentRequest: {a: number},
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+) => {};
+
+f = function(
+  currentRequest: {a: number},
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+) {};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+type f = (
+  currentRequest: { a: number }
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+) => number;
+
+f = (
+  currentRequest: { a: number }
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+): number => {};
+
+f = (
+  currentRequest: { a: number }
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+) => {};
+
+f = function(
+  currentRequest: { a: number }
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+) {};
+"
+`;
+
 exports[`preserve-new-line-last.js 1`] = `
 "function f() {
   a

--- a/tests/comments/last-arg.js
+++ b/tests/comments/last-arg.js
@@ -1,0 +1,19 @@
+type f = (
+  currentRequest: {a: number},
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+) => number;
+
+f = (
+  currentRequest: {a: number},
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+): number => {};
+
+f = (
+  currentRequest: {a: number},
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+) => {};
+
+f = function(
+  currentRequest: {a: number},
+  // TODO this is a very very very very long comment that makes it go > 80 columns
+) {};


### PR DESCRIPTION
The issue is that the comment algorithm attaches it to the return type / value but we want to attach it to the previous one.

Fixes #612