### PR TITLE
Add parenthesis around assignments

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -407,11 +407,21 @@ FPp.needsParens = function(assumeExpressionContext) {
     case "AssignmentExpression":
       if (
         parent.type === "ArrowFunctionExpression" &&
-        parent.body === node &&
-        node.left.type === "ObjectPattern"
+        parent.body === node
       ) {
-        return true;
+        return node.left.type === "ObjectPattern";
       }
+      if (parent.type === "ForStatement" &&
+        (parent.init === node || parent.update === node)) {
+        return false;
+      }
+      if (parent.type === "ExpressionStatement") {
+        if (node.left.type === "ObjectPattern") {
+          return true;
+        }
+        return false;
+      }
+      return true;
 
     case "ConditionalExpression":
       switch (parent.type) {

--- a/tests/flow/iter/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/iter/__snapshots__/jsfmt.spec.js.snap
@@ -55,12 +55,12 @@ for (var j in b) {
 }
 
 var c;
-for (var m in c = b) {
+for (var m in (c = b)) {
   foo(c[m]);
 }
 
 var d;
-for (var n in d = a) {
+for (var n in (d = a)) {
   foo(d[n]); // d is a string, which shouldn't be used for array access
 }
 

--- a/tests/flow/missing_annotation/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/missing_annotation/__snapshots__/jsfmt.spec.js.snap
@@ -153,6 +153,6 @@ var Bar = {
   d: Foo.d(\\"bar\\") // no annotation required
 };
 
-module.exports = Foo, Bar;
+(module.exports = Foo), Bar;
 "
 `;

--- a/tests/flow/predicates-declared/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/predicates-declared/__snapshots__/jsfmt.spec.js.snap
@@ -203,7 +203,7 @@ var n = r(s) || 1;
 (n: number);
 
 var x = \\"\\";
-if (x = r(s) || 1) {
+if ((x = r(s) || 1)) {
   (x: number);
 }
 

--- a/tests/flow/refinements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/refinements/__snapshots__/jsfmt.spec.js.snap
@@ -38,7 +38,7 @@ function bar2(x : Bar) {
 
 function foo(x: ?number) {
   var y;
-  if (y = x) {
+  if ((y = x)) {
     var z = y * 1000;
   }
 }
@@ -49,14 +49,14 @@ type Bar = {
 };
 
 function bar0(x: Bar) {
-  while (x = x.parent) {
+  while ((x = x.parent)) {
     // can't assign x to ?Bar
     x.doStuff();
   }
 }
 
 function bar1(x: ?Bar) {
-  while (x = x.parent) {
+  while ((x = x.parent)) {
     // x.parent might be null
     x.doStuff();
   }
@@ -64,7 +64,7 @@ function bar1(x: ?Bar) {
 
 function bar2(x: Bar) {
   var y = x;
-  while (y = y.parent) {
+  while ((y = y.parent)) {
     y.doStuff();
   }
 }


### PR DESCRIPTION
This is a neat trick from the React codebase. It helps highlight the fact that this is an assignment and not a comparison which is subtle to realize.

Fixes #861