### PR TITLE
Fix switch case spacing

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2926,7 +2926,7 @@ function hasBreakOrReturn (node) {
 
 function hasBreakOrReturnBefore (path, node) {
   const parent = path.getParentNode(0);
-  let breakOrReturnBefore = false
+  let breakOrReturnBefore = false;
   for (let i = 0; i < parent.cases.length; ++i) {
     if (
       node === parent.cases[i] && parent.cases[i - 1] &&

--- a/tests/flow/binding/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/binding/__snapshots__/jsfmt.spec.js.snap
@@ -586,6 +586,7 @@ function switch_scope(x: string) {
       let a = \\"\\"; // ok: local to switch
       var b = \\"\\"; // error: string ~> number
       break;
+
     case \\"bar\\":
       let a = \\"\\"; // error: a already bound in switch
       break;
@@ -600,15 +601,19 @@ function switch_scope2(x: number) {
     case 0:
       a = \\"\\"; // error: assign before declaration
       break;
+
     case 1:
       var b = a; // error: use before declaration
       break;
+
     case 2:
       let a = \\"\\";
       break;
+
     case 3:
       a = \\"\\"; // error: skipped initializer
       break;
+
     case 4:
       var c: string = a; // error: skipped initializer
       break;

--- a/tests/flow/break/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/break/__snapshots__/jsfmt.spec.js.snap
@@ -93,6 +93,7 @@ function bar(b) {
     case 1:
       var z: number = x; // 2 errors: (boolean | string) !~> number
       break;
+
     case 2:
   }
   var w: number = x; // 2 errors: (boolean | string) !~> number

--- a/tests/flow/disjoint-union-perf/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/disjoint-union-perf/__snapshots__/jsfmt.spec.js.snap
@@ -245,12 +245,16 @@ function getBinaryOp(
   switch (op) {
     case \\"plus\\":
       return \\"+\\";
+
     case \\"minus\\":
       return \\"-\\";
+
     case \\"divide\\":
       return \\"/\\";
+
     case \\"multiply\\":
       return \\"*\\";
+
     default:
       throw new Error(\\"Invalid binary operator: \\" + op);
   }
@@ -261,12 +265,14 @@ export function emitExpression(node: TypedNode): t.Expression {
     case \\"string_literal\\": // FALLTHROUGH
     case \\"number\\":
       return b.literal(node.value);
+
     case \\"variable\\":
       return b.memberExpression(
         b.identifier(\\"vars\\"),
         b.identifier(node.name),
         false
       );
+
     case \\"binary_op\\": {
       const lhs = emitExpression(node.lhs);
       const rhs = emitExpression(node.rhs);

--- a/tests/flow/init/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/init/__snapshots__/jsfmt.spec.js.snap
@@ -456,6 +456,7 @@ function switch_partial_post_init(i) {
     case 0:
       x = 0;
       break;
+
     case 1:
       x = 1;
       break;
@@ -470,9 +471,11 @@ function switch_post_init(i) {
     case 0:
       x = 0;
       break;
+
     case 1:
       x = 1;
       break;
+
     default:
       x = 2;
   }
@@ -850,6 +853,7 @@ function switch_partial_post_init(i) {
     case 0:
       x = 0;
       break;
+
     case 1:
       x = 1;
       break;
@@ -864,9 +868,11 @@ function switch_post_init(i) {
     case 0:
       x = 0;
       break;
+
     case 1:
       x = 1;
       break;
+
     default:
       x = 2;
   }
@@ -926,6 +932,7 @@ function switch_post_init2(i): number {
     case 1:
       bar = 3;
       break;
+
     default:
       throw new Error(\\"Invalid state\\");
   }
@@ -939,6 +946,7 @@ function switch_post_init2(i): number {
     case 1:
       bar = 3;
       break;
+
     default:
       throw new Error(\\"Invalid state\\");
   }

--- a/tests/flow/react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/react/__snapshots__/jsfmt.spec.js.snap
@@ -269,6 +269,7 @@ var React = React.createClass({
     switch (this.props.name) {
       case \\"a\\":
         return \\"Bob\\";
+
       default:
         return \\"Alice\\";
     }

--- a/tests/flow/refi/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/refi/__snapshots__/jsfmt.spec.js.snap
@@ -1248,6 +1248,7 @@ function foo(a, b, c) {
     case a.x.y: // OK
     case b.x.y: // OK
       return;
+
     default:
       return;
   }
@@ -1262,6 +1263,7 @@ function exhaustion1(x): number {
     case 1:
       foo = 3;
       break;
+
     default:
       throw new Error(\\"Invalid state\\");
   }
@@ -1287,6 +1289,7 @@ function exhaustion2(x, y): number {
     case 1:
       foo = 3;
       break;
+
     default:
       throw new Error(\\"Invalid state\\");
   }
@@ -1300,6 +1303,7 @@ function exhaustion3(x): number {
     case 1:
       foo = 3;
       break;
+
     default:
       throw new Error(\\"Invalid state\\");
   }

--- a/tests/flow/refinements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/refinements/__snapshots__/jsfmt.spec.js.snap
@@ -2190,8 +2190,10 @@ function foo(text: string | number): string {
   switch (typeof text) {
     case \\"string\\":
       return text;
+
     case \\"number\\":
       return text; // error, should return string
+
     default:
       return \\"wat\\";
   }
@@ -2200,6 +2202,7 @@ function bar(text: string | number): string {
   switch (typeof text) {
     case \\"string\\":
       return text[0];
+
     default:
       return text++ + \\"\\";
   }
@@ -2210,6 +2213,7 @@ function baz1(text: string | number): string {
     case \\"string\\":
       return text[0];
     // error, [0] on number
+
     default:
       return \\"wat\\";
   }
@@ -2219,6 +2223,7 @@ function baz2(text: string | number): string {
     case \\"string\\":
     case \\"number\\":
       return text[0]; // error, [0] on number
+
     default:
       return \\"wat\\";
   }
@@ -2227,9 +2232,11 @@ function corge(text: string | number | Array<string>): string {
   switch (typeof text) {
     case \\"object\\":
       return text[0];
+
     case \\"string\\":
     case \\"number\\": // using ++ since it isn't valid on arrays or strings. // should only error for string since Array was filtered out.
       return text++ + \\"\\";
+
     default:
       return \\"wat\\";
   }
@@ -2527,6 +2534,7 @@ function length(l) {
   switch (l.kind) {
     case \\"cons\\":
       return 1 + length(l.next);
+
     default:
       return 0;
   }
@@ -2545,8 +2553,10 @@ function kind(x: A | B | C): number {
   switch (x.kind) {
     case EnumKind.A:
       return x.A;
+
     case EnumKind.B:
       return x.B;
+
     default:
       return x.A; // error, x: C and property A not found in type C
   }
@@ -2779,6 +2789,7 @@ function handleStatus(status: Success | Error) {
     case SUCCESS:
       console.log(\`Successful: \${status.message}\`);
       break;
+
     default:
       console.log(\`Errored: \${status.error}\`);
   }

--- a/tests/flow/switch/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/switch/__snapshots__/jsfmt.spec.js.snap
@@ -35,6 +35,7 @@ function foo(x): number {
     case 0:
     case 1:
       return 1;
+
     default:
       throw new Error(\\"hi\\");
   }
@@ -44,6 +45,7 @@ function bar(x) {
   switch (x) {
     case 0:
       break;
+
     default:
       return;
   }
@@ -54,8 +56,10 @@ function baz(x): number {
   switch (x) {
     case 0:
       break;
+
     case 1:
       return 1;
+
     default:
       throw new Error(\\"hi\\");
   }
@@ -111,6 +115,7 @@ function bar() {
   switch (\\"bar\\") {
     case \\"bar\\":
       break;
+
     default:
       break;
   }
@@ -208,6 +213,7 @@ function baz(x: mixed): number {
     case \\"baz\\":
       a = 0;
       break;
+
     case \\"bar\\":
       a = \\"\\";
     default:
@@ -320,12 +326,15 @@ function f1(i) {
     case 0:
       x = 0;
       break;
+
     case 1:
       x = 1;
       break;
+
     default:
       x = -1;
       break;
+
     case 2:
       x = \\"2\\";
       break;
@@ -343,6 +352,7 @@ function f2(i) {
     default:
       x = 1;
       break;
+
     case 2:
     // does not fall through default
   }
@@ -379,6 +389,7 @@ function bar(x) {
   switch (x) {
     default:
       return;
+
     case 0:
       break;
   }
@@ -389,6 +400,7 @@ function baz(x): number {
   switch (x) {
     case 0:
       break;
+
     default:
       throw new Error(\\"hi\\");
     case 1:


### PR DESCRIPTION
This PR fixes #814 & #805. As you can see, it introduces a very opinionated heuristic but I think it's a good way to avoid future issues in switch statements. One future improvement could be to detect enclosed break or return statements in cases in order to apply the same logic, but that involves going through each descendant nodes to find them.