### PR TITLE
Add parens around return for binaryish expressions

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -202,6 +202,7 @@ function genericPrintNoParens(path, options, print) {
         parent.type === "AssignmentExpression" ||
         parent.type === "VariableDeclarator" ||
         shouldInlineLogicalExpression(n) ||
+        parent.type === "ReturnStatement" ||
         (n !== parent.body &&
           (parent.type === "IfStatement" ||
             parent.type === "WhileStatement" ||
@@ -605,6 +606,21 @@ function genericPrintNoParens(path, options, print) {
               line,
               ")"
             ])
+          );
+        } else if (
+          n.argument.type === 'LogicalExpression' ||
+          n.argument.type === 'BinaryExpression'
+        ) {
+          parts.push(
+            group(concat([
+              ifBreak(" (", " "),
+              indent(
+                options.tabWidth,
+                concat([softline, path.call(print, "argument")])
+              ),
+              softline,
+              ifBreak(")")
+            ]))
           );
         } else {
           parts.push(" ", path.call(print, "argument"));

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1587,7 +1587,7 @@ function binaryInBinaryLeft() {
     // Reason for 42
     42 *
       84 +
-      2
+    2
   );
 }
 
@@ -1595,7 +1595,7 @@ function binaryInBinaryRight() {
   return (
     // Reason for 42
     42 +
-      84 * 2
+    84 * 2
   );
 }
 
@@ -1827,7 +1827,7 @@ function binaryInBinaryLeft() {
     // Reason for 42
     42 *
       84 +
-      2
+    2
   );
 }
 
@@ -1835,7 +1835,7 @@ function binaryInBinaryRight() {
   return (
     // Reason for 42
     42 +
-      84 * 2
+    84 * 2
   );
 }
 

--- a/tests/flow/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -46,8 +46,10 @@ function selectBestEffortImageForWidth(
   var maxPixelWidth = maxWidth;
   //images = images.sort(function (a, b) { return a.width - b.width });
   images = images.sort((a, b) => a.width - b.width + \\"\\");
-  return images.find(image => image.width >= maxPixelWidth) ||
-    images[images.length - 1];
+  return (
+    images.find(image => image.width >= maxPixelWidth) ||
+    images[images.length - 1]
+  );
 }
 "
 `;

--- a/tests/flow/intersection/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/intersection/__snapshots__/jsfmt.spec.js.snap
@@ -86,9 +86,11 @@ type DuplexStreamOptions = ReadableStreamOptions & WritableStreamOptions & {
 };
 
 function hasObjectMode_bad(options: DuplexStreamOptions): boolean {
-  return options.objectMode ||
+  return (
+    options.objectMode ||
     options.readableObjectMode ||
-    options.writableObjectMode; // error, undefined ~> boolean
+    options.writableObjectMode
+  ); // error, undefined ~> boolean
 }
 
 function hasObjectMode_ok(options: DuplexStreamOptions): boolean {

--- a/tests/return/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/return/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`binaryish.js 1`] = `
+"function f() {
+  return (
+    property.isIdentifier() &&
+     FUNCTIONS[property.node.name] &&
+     (object.isIdentifier(JEST_GLOBAL) ||
+       (callee.isMemberExpression() && shouldHoistExpression(object))) &&
+    FUNCTIONS[property.node.name](expr.get('arguments'))
+  );
+
+  return (
+    chalk.bold(
+      'No tests found related to files changed since last commit.\\\\n',
+    ) +
+    chalk.dim(
+      patternInfo.watch ?
+        'Press \`a\` to run all tests, or run Jest with \`--watchAll\`.' :
+        'Run Jest without \`-o\` to run all tests.',
+    )
+  );
+
+  return !filePath.includes(coverageDirectory) &&
+    !filePath.endsWith(\`.\${SNAPSHOT_EXTENSION}\`);
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+function f() {
+  return (
+    property.isIdentifier() &&
+    FUNCTIONS[property.node.name] &&
+    (object.isIdentifier(JEST_GLOBAL) ||
+      (callee.isMemberExpression() && shouldHoistExpression(object))) &&
+    FUNCTIONS[property.node.name](expr.get(\\"arguments\\"))
+  );
+
+  return (
+    chalk.bold(\\"No tests found related to files changed since last commit.\\\\n\\") +
+    chalk.dim(
+      patternInfo.watch
+        ? \\"Press \`a\` to run all tests, or run Jest with \`--watchAll\`.\\"
+        : \\"Run Jest without \`-o\` to run all tests.\\"
+    )
+  );
+
+  return (
+    !filePath.includes(coverageDirectory) &&
+    !filePath.endsWith(\`.\${SNAPSHOT_EXTENSION}\`)
+  );
+}
+"
+`;

--- a/tests/return/binaryish.js
+++ b/tests/return/binaryish.js
@@ -1,0 +1,23 @@
+function f() {
+  return (
+    property.isIdentifier() &&
+     FUNCTIONS[property.node.name] &&
+     (object.isIdentifier(JEST_GLOBAL) ||
+       (callee.isMemberExpression() && shouldHoistExpression(object))) &&
+    FUNCTIONS[property.node.name](expr.get('arguments'))
+  );
+
+  return (
+    chalk.bold(
+      'No tests found related to files changed since last commit.\n',
+    ) +
+    chalk.dim(
+      patternInfo.watch ?
+        'Press `a` to run all tests, or run Jest with `--watchAll`.' :
+        'Run Jest without `-o` to run all tests.',
+    )
+  );
+
+  return !filePath.includes(coverageDirectory) &&
+    !filePath.endsWith(`.${SNAPSHOT_EXTENSION}`);
+}

--- a/tests/return/jsfmt.spec.js
+++ b/tests/return/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);


### PR DESCRIPTION
It looks better when the first element is aligned with the rest and this is consistent with the way we render `if` test.

Fixes #866