### PR TITLE
[RFC] Do not indent calls with a single template literal argument

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -667,6 +667,8 @@ function genericPrintNoParens(path, options, print, args) {
       if (
         // We want to keep require calls as a unit
         (n.callee.type === "Identifier" && n.callee.name === "require") ||
+        // Template literals as single arguments
+        n.arguments.length === 1 && n.arguments[0].type === "TemplateLiteral" ||
         // Keep test declarations on a single line
         // e.g. `it('long name', () => {`
         (n.callee.type === "Identifier" &&

--- a/tests/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/strings/__snapshots__/jsfmt.spec.js.snap
@@ -123,25 +123,19 @@ pipe.write(
   \`\\n  \${chalk.dim(\`\\u203A and \${more} more \${more} more \${more} more \${more}\`)}\`,
 );
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-foo(
-  \`a long string \${1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3} with expr\`
-);
+foo(\`a long string \${1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3} with expr\`);
 
 const x = \`a long string \${1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + (function() {
     return 3;
   })() + 3 + 2 + 3 + 2 + 3} with expr\`;
 
-foo(
-  \`a long string \${1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + (function() {
-      const x = 5;
+foo(\`a long string \${1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + (function() {
+    const x = 5;
 
-      return x;
-    })() + 3 + 2 + 3 + 2 + 3} with expr\`
-);
+    return x;
+  })() + 3 + 2 + 3 + 2 + 3} with expr\`);
 
-pipe.write(
-  \`\\n  \${chalk.dim(\`\\u203A and \${more} more \${more} more \${more} more \${more}\`)}\`
-);
+pipe.write(\`\\n  \${chalk.dim(\`\\u203A and \${more} more \${more} more \${more} more \${more}\`)}\`);
 
 `;
 
@@ -160,24 +154,18 @@ pipe.write(
   \`\\n  \${chalk.dim(\`\\u203A and \${more} more \${more} more \${more} more \${more}\`)}\`,
 );
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-foo(
-  \`a long string \${1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3} with expr\`,
-);
+foo(\`a long string \${1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3} with expr\`);
 
 const x = \`a long string \${1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + (function() {
     return 3;
   })() + 3 + 2 + 3 + 2 + 3} with expr\`;
 
-foo(
-  \`a long string \${1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + (function() {
-      const x = 5;
+foo(\`a long string \${1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + (function() {
+    const x = 5;
 
-      return x;
-    })() + 3 + 2 + 3 + 2 + 3} with expr\`,
-);
+    return x;
+  })() + 3 + 2 + 3 + 2 + 3} with expr\`);
 
-pipe.write(
-  \`\\n  \${chalk.dim(\`\\u203A and \${more} more \${more} more \${more} more \${more}\`)}\`,
-);
+pipe.write(\`\\n  \${chalk.dim(\`\\u203A and \${more} more \${more} more \${more} more \${more}\`)}\`);
 
 `;

--- a/tests/template/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/template/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`call.js 1`] = `
+insertRule(\`*, *:before, *:after {
+  box-sizing: inherit;
+}\`);
+
+insertRule\`*, *:before, *:after {
+  box-sizing: inherit;
+}\`;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+insertRule(\`*, *:before, *:after {
+  box-sizing: inherit;
+}\`);
+
+insertRule\`*, *:before, *:after {
+  box-sizing: inherit;
+}\`;
+
+`;
+
 exports[`comment.js 1`] = `
 \`
 (?:\${escapeChar}[\\\\S\\\\s]|(?:(?!\${// Using \`XRegExp.union\` safely rewrites backreferences in \`left\` and \`right\`.

--- a/tests/template/call.js
+++ b/tests/template/call.js
@@ -1,0 +1,7 @@
+insertRule(`*, *:before, *:after {
+  box-sizing: inherit;
+}`);
+
+insertRule`*, *:before, *:after {
+  box-sizing: inherit;
+}`;


### PR DESCRIPTION
I'm not sure that this is a good idea. A current workaround is to remove the parenthesis.

Fixes #786