### PR TITLE
Expand first argument if it is an inline function

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1952,6 +1952,15 @@ function shouldGroupLastArg(args) {
     (!penultimateArg || penultimateArg.type !== lastArg.type);
 }
 
+function shouldGroupFirstArg(args) {
+  if (args.length < 1) return false;
+  const firstArg = args[0];
+  return (firstArg.type === 'FunctionExpression' ||
+    (firstArg.type === 'ArrowFunctionExpression' &&
+      firstArg.body.type === 'BlockStatement')) &&
+    args.slice(1).every(a => !typeIsFunction(a.type));
+}
+
 function printArgumentsList(path, options, print) {
   var printed = path.map(print, "arguments");
 
@@ -1963,20 +1972,31 @@ function printArgumentsList(path, options, print) {
   // This is just an optimization; I think we could return the
   // conditional group for all function calls, but it's more expensive
   // so only do it for specific forms.
-  if (shouldGroupLastArg(args)) {
-    const shouldBreak = printed.slice(0, -1).some(willBreak);
+  const shouldGroupFirst = shouldGroupFirstArg(args);
+  if (shouldGroupFirst || shouldGroupLastArg(args)) {
+    const shouldBreak = shouldGroupFirst
+      ? printed.slice(1).some(willBreak)
+      : printed.slice(0, -1).some(willBreak);
     return concat([
       printed.some(willBreak) ? breakParent : "",
       conditionalGroup(
         [
           concat(["(", join(concat([", "]), printed), ")"]),
-          concat([
-            "(",
-            join(concat([",", line]), printed.slice(0, -1)),
-            printed.length > 1 ? ", " : "",
-            group(util.getLast(printed), { shouldBreak: true }),
-            ")"
-          ]),
+          shouldGroupFirst
+            ? concat([
+                "(",
+                group(printed[0], { shouldBreak: true }),
+                printed.length > 1 ? ", " : "",
+                join(concat([",", line]), printed.slice(1)),
+                ")"
+              ])
+            : concat([
+                "(",
+                join(concat([",", line]), printed.slice(0, -1)),
+                printed.length > 1 ? ", " : "",
+                group(util.getLast(printed), { shouldBreak: true }),
+                ")"
+              ]),
           group(
             concat([
               "(",
@@ -2046,8 +2066,8 @@ function printFunctionParams(path, print, options) {
   const canHaveTrailingComma = !(lastParam &&
     lastParam.type === "RestElement") && !fun.rest;
 
-  // If the parent is a call with the last argument expansion and this is the
-  // params of the last argument, we dont want the arguments to break and instead
+  // If the parent is a call with the first/last argument expansion and this is the
+  // params of the first/last argument, we dont want the arguments to break and instead
   // want the whole expression to be on a new line.
   //
   // Good:                 Bad:
@@ -2059,8 +2079,10 @@ function printFunctionParams(path, print, options) {
   const parent = path.getParentNode();
   if (
     (parent.type === "CallExpression" || parent.type === "NewExpression") &&
-    util.getLast(parent.arguments) === path.getValue() &&
-    shouldGroupLastArg(parent.arguments)
+    ((util.getLast(parent.arguments) === path.getValue() &&
+      shouldGroupLastArg(parent.arguments)) ||
+      (parent.arguments[0] === path.getValue() &&
+        shouldGroupFirstArg(parent.arguments)))
   ) {
     return concat(["(", join(", ", printed), ")"]);
   }

--- a/tests/first_argument_expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/first_argument_expansion/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test.js 1`] = `
+"setInterval(() => {
+  thing();
+}, 500);
+
+setTimeout(function() {
+  thing();
+}, 500);
+
+reallyLongLongLongLongLongLongLongLongLongLongLongLongLongLongMethod((f, g, h) => {
+  return f.pop();
+}, true);
+
+compose((a) => { return a.thing; }, b => { return b + \\"\\"; });
+
+renderThing(a => <div>Content. So much to say. Oh my. Are we done yet?</div>, args)
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+setInterval(() => {
+  thing();
+}, 500);
+
+setTimeout(function() {
+  thing();
+}, 500);
+
+reallyLongLongLongLongLongLongLongLongLongLongLongLongLongLongMethod(
+  (f, g, h) => {
+    return f.pop();
+  },
+  true
+);
+
+compose(
+  a => {
+    return a.thing;
+  },
+  b => {
+    return b + \\"\\";
+  }
+);
+
+renderThing(
+  a => <div>Content. So much to say. Oh my. Are we done yet?</div>,
+  args
+);
+"
+`;

--- a/tests/first_argument_expansion/jsfmt.spec.js
+++ b/tests/first_argument_expansion/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/first_argument_expansion/test.js
+++ b/tests/first_argument_expansion/test.js
@@ -1,0 +1,16 @@
+setInterval(() => {
+  thing();
+}, 500);
+
+setTimeout(function() {
+  thing();
+}, 500);
+
+reallyLongLongLongLongLongLongLongLongLongLongLongLongLongLongMethod((f, g, h) => {
+  return f.pop();
+}, true);
+
+compose((a) => { return a.thing; }, b => { return b + ""; });
+
+renderThing(a => <div>Content. So much to say. Oh my. Are we done yet?</div>, args)
+

--- a/tests/flow/arraylib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/arraylib/__snapshots__/jsfmt.spec.js.snap
@@ -94,12 +94,9 @@ function reduce_test() {
     return previousValue + currentValue + array[index];
   });
 
-  [0, 1, 2, 3, 4].reduce(
-    function(previousValue, currentValue, index, array) {
-      return previousValue + currentValue + array[index];
-    },
-    10
-  );
+  [0, 1, 2, 3, 4].reduce(function(previousValue, currentValue, index, array) {
+    return previousValue + currentValue + array[index];
+  }, 10);
 
   var total = [0, 1, 2, 3].reduce(function(a, b) {
     return a + b;

--- a/tests/flow/union_new/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/union_new/__snapshots__/jsfmt.spec.js.snap
@@ -1597,12 +1597,9 @@ exports[`test20.js 1`] = `
 
 [0, 1].reduce((x, y, i) => y);
 
-[\\"a\\", \\"b\\"].reduce(
-  (regex, representation, index) => {
-    return regex + (index ? \\"|\\" : \\"\\") + \\"(\\" + representation + \\")\\";
-  },
-  \\"\\"
-);
+[\\"a\\", \\"b\\"].reduce((regex, representation, index) => {
+  return regex + (index ? \\"|\\" : \\"\\") + \\"(\\" + representation + \\")\\";
+}, \\"\\");
 
 [\\"\\"].reduce((acc, str) => acc * str.length);
 "


### PR DESCRIPTION
Addresses #888

```javascript
setInterval(function() {
  thing();
}, 500);
```
No longer produces.
```javascript
setInterval(
  function() {
    thing();
  },
  500
);
```