### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ and add this config to your `package.json`:
       "git add"
     ]
   },
-  "pre-commit": "lint:staged"
+  "pre-commit": "lint-staged"
 }
 ```
 


### PR DESCRIPTION
I believe that the instructions for pre-commit config are off by a character.