### PR TITLE
Add newline for bracket-less arrow functions that return calls

### DIFF
--- a/tests/arrow-call/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/arrow-call/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,171 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`arrow_call.js 1`] = `
+"const testResults = results.testResults.map(testResult =>
+  formatResult(testResult, formatter, reporter)
+);
+
+it('mocks regexp instances', () => {
+  expect(
+    () => moduleMocker.generateFromMetadata(moduleMocker.getMetadata(/a/)),
+  ).not.toThrow();
+});
+
+expect(() => asyncRequest({ url: \\"/test-endpoint\\" }))
+  .toThrowError(/Required parameter/);
+
+expect(() => asyncRequest({ url: \\"/test-endpoint-but-with-a-long-url\\" }))
+  .toThrowError(/Required parameter/);
+
+expect(() => asyncRequest({ url: \\"/test-endpoint-but-with-a-suuuuuuuuper-long-url\\" }))
+  .toThrowError(/Required parameter/);
+
+expect(() => asyncRequest({ type: \\"foo\\", url: \\"/test-endpoint\\" }))
+  .not.toThrowError();
+
+expect(() => asyncRequest({ type: \\"foo\\", url: \\"/test-endpoint-but-with-a-long-url\\" }))
+  .not.toThrowError();
+
+const a = Observable
+  .fromPromise(axiosInstance.post('/carts/mine'))
+  .map((response) => response.data)
+
+const b = Observable.fromPromise(axiosInstance.get(url))
+  .map((response) => response.data)
+
+func(
+  veryLoooooooooooooooooooooooongName,
+  veryLooooooooooooooooooooooooongName =>
+    veryLoooooooooooooooongName.something()
+);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const testResults = results.testResults.map(testResult =>
+  formatResult(testResult, formatter, reporter)
+);
+
+it(\\"mocks regexp instances\\", () => {
+  expect(() =>
+    moduleMocker.generateFromMetadata(moduleMocker.getMetadata(/a/))
+  ).not.toThrow();
+});
+
+expect(() => asyncRequest({ url: \\"/test-endpoint\\" })).toThrowError(
+  /Required parameter/
+);
+
+expect(() =>
+  asyncRequest({ url: \\"/test-endpoint-but-with-a-long-url\\" })
+).toThrowError(/Required parameter/);
+
+expect(() =>
+  asyncRequest({ url: \\"/test-endpoint-but-with-a-suuuuuuuuper-long-url\\" })
+).toThrowError(/Required parameter/);
+
+expect(() =>
+  asyncRequest({ type: \\"foo\\", url: \\"/test-endpoint\\" })
+).not.toThrowError();
+
+expect(() =>
+  asyncRequest({ type: \\"foo\\", url: \\"/test-endpoint-but-with-a-long-url\\" })
+).not.toThrowError();
+
+const a = Observable.fromPromise(axiosInstance.post(\\"/carts/mine\\")).map(
+  response => response.data
+);
+
+const b = Observable.fromPromise(axiosInstance.get(url)).map(
+  response => response.data
+);
+
+func(
+  veryLoooooooooooooooooooooooongName,
+  veryLooooooooooooooooooooooooongName =>
+    veryLoooooooooooooooongName.something()
+);
+"
+`;
+
+exports[`arrow_call.js 2`] = `
+"const testResults = results.testResults.map(testResult =>
+  formatResult(testResult, formatter, reporter)
+);
+
+it('mocks regexp instances', () => {
+  expect(
+    () => moduleMocker.generateFromMetadata(moduleMocker.getMetadata(/a/)),
+  ).not.toThrow();
+});
+
+expect(() => asyncRequest({ url: \\"/test-endpoint\\" }))
+  .toThrowError(/Required parameter/);
+
+expect(() => asyncRequest({ url: \\"/test-endpoint-but-with-a-long-url\\" }))
+  .toThrowError(/Required parameter/);
+
+expect(() => asyncRequest({ url: \\"/test-endpoint-but-with-a-suuuuuuuuper-long-url\\" }))
+  .toThrowError(/Required parameter/);
+
+expect(() => asyncRequest({ type: \\"foo\\", url: \\"/test-endpoint\\" }))
+  .not.toThrowError();
+
+expect(() => asyncRequest({ type: \\"foo\\", url: \\"/test-endpoint-but-with-a-long-url\\" }))
+  .not.toThrowError();
+
+const a = Observable
+  .fromPromise(axiosInstance.post('/carts/mine'))
+  .map((response) => response.data)
+
+const b = Observable.fromPromise(axiosInstance.get(url))
+  .map((response) => response.data)
+
+func(
+  veryLoooooooooooooooooooooooongName,
+  veryLooooooooooooooooooooooooongName =>
+    veryLoooooooooooooooongName.something()
+);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const testResults = results.testResults.map(testResult =>
+  formatResult(testResult, formatter, reporter),
+);
+
+it(\\"mocks regexp instances\\", () => {
+  expect(() =>
+    moduleMocker.generateFromMetadata(moduleMocker.getMetadata(/a/)),
+  ).not.toThrow();
+});
+
+expect(() => asyncRequest({ url: \\"/test-endpoint\\" })).toThrowError(
+  /Required parameter/,
+);
+
+expect(() =>
+  asyncRequest({ url: \\"/test-endpoint-but-with-a-long-url\\" }),
+).toThrowError(/Required parameter/);
+
+expect(() =>
+  asyncRequest({ url: \\"/test-endpoint-but-with-a-suuuuuuuuper-long-url\\" }),
+).toThrowError(/Required parameter/);
+
+expect(() =>
+  asyncRequest({ type: \\"foo\\", url: \\"/test-endpoint\\" }),
+).not.toThrowError();
+
+expect(() =>
+  asyncRequest({ type: \\"foo\\", url: \\"/test-endpoint-but-with-a-long-url\\" }),
+).not.toThrowError();
+
+const a = Observable.fromPromise(axiosInstance.post(\\"/carts/mine\\")).map(
+  response => response.data,
+);
+
+const b = Observable.fromPromise(axiosInstance.get(url)).map(
+  response => response.data,
+);
+
+func(
+  veryLoooooooooooooooooooooooongName,
+  veryLooooooooooooooooooooooooongName =>
+    veryLoooooooooooooooongName.something(),
+);
+"
+`;

--- a/tests/arrow-call/arrow_call.js
+++ b/tests/arrow-call/arrow_call.js
@@ -1,0 +1,37 @@
+const testResults = results.testResults.map(testResult =>
+  formatResult(testResult, formatter, reporter)
+);
+
+it('mocks regexp instances', () => {
+  expect(
+    () => moduleMocker.generateFromMetadata(moduleMocker.getMetadata(/a/)),
+  ).not.toThrow();
+});
+
+expect(() => asyncRequest({ url: "/test-endpoint" }))
+  .toThrowError(/Required parameter/);
+
+expect(() => asyncRequest({ url: "/test-endpoint-but-with-a-long-url" }))
+  .toThrowError(/Required parameter/);
+
+expect(() => asyncRequest({ url: "/test-endpoint-but-with-a-suuuuuuuuper-long-url" }))
+  .toThrowError(/Required parameter/);
+
+expect(() => asyncRequest({ type: "foo", url: "/test-endpoint" }))
+  .not.toThrowError();
+
+expect(() => asyncRequest({ type: "foo", url: "/test-endpoint-but-with-a-long-url" }))
+  .not.toThrowError();
+
+const a = Observable
+  .fromPromise(axiosInstance.post('/carts/mine'))
+  .map((response) => response.data)
+
+const b = Observable.fromPromise(axiosInstance.get(url))
+  .map((response) => response.data)
+
+func(
+  veryLoooooooooooooooooooooooongName,
+  veryLooooooooooooooooooooooooongName =>
+    veryLoooooooooooooooongName.something()
+);

--- a/tests/arrow-call/jsfmt.spec.js
+++ b/tests/arrow-call/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname);
+run_spec(__dirname, { trailingComma: 'all' });

--- a/tests/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -156,14 +156,17 @@ Seq(typeDef.interface.groups).forEach(group =>
     markdownDoc(member.doc, {
       typePath: typePath.concat(memberName.slice(1)),
       signatures: member.signatures
-    })));
+    })
+  )
+);
 
 const promiseFromCallback = fn =>
   new Promise((resolve, reject) =>
     fn((err, result) => {
       if (err) return reject(err);
       return resolve(result);
-    }));
+    })
+  );
 
 runtimeAgent.getProperties(
   objectId,

--- a/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
@@ -32,7 +32,9 @@ export default function searchUsers(action$) {
               .getJSON(\`https://api.github.com/search/users?q=\${q}\`)
               .map(res => res.items)
               .map(receiveUsers)
-          )));
+          )
+        )
+    );
 }
 "
 `;

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -212,7 +212,8 @@ export default function theFunction(action$, store) {
     })
       .filter(data => theFilter(data))
       .map(({ theType, ...data }) => theMap(theType, data))
-      .retryWhen(errors => errors));
+      .retryWhen(errors => errors)
+  );
 }
 
 function f() {


### PR DESCRIPTION
I've tried a lot of places where to fix this and this is the only one that gives correct results. This is likely not exhaustive but works for that use case. It's been reported twice in issues and I've seen it happen a few other times so we probably want to get it fixed.

Fixes #922
Fixes #797
Fixes #974