### PR TITLE
[RFC] Omit space before empty anonymous function body

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -281,7 +281,7 @@ function genericPrintNoParens(path, options, print) {
         path.call(print, "typeAnnotation")
       ]);
     case "FunctionDeclaration":
-    case "FunctionExpression":
+    case "FunctionExpression": {
       if (n.async) parts.push("async ");
 
       parts.push("function");
@@ -299,12 +299,26 @@ function genericPrintNoParens(path, options, print) {
             printFunctionParams(path, print, options),
             printReturnType(path, print)
           ])
-        ),
-        " ",
-        path.call(print, "body")
+        )
       );
 
+      const body = path.call(print, "body");
+
+      if (
+        n.id ||
+        n.predicate ||
+        n.returnType ||
+        body.type !== "concat" ||
+        body.parts.length !== 1 ||
+        body.parts[0] !== "{}"
+      ) {
+        parts.push(" ");
+      }
+
+      parts.push(body);
+
       return concat(parts);
+    }
     case "ArrowFunctionExpression":
       if (n.async) parts.push("async ");
 

--- a/tests/class_extends/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/class_extends/__snapshots__/jsfmt.spec.js.snap
@@ -83,7 +83,7 @@ class a extends class {} {}
 class a extends (b ? c : d) {}
 
 // \\"FunctionExpression\\"
-class a extends function() {} {}
+class a extends function(){} {}
 
 // \\"LogicalExpression\\"
 class a extends (b || c) {}

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1151,7 +1151,7 @@ f = (
 f = function(
   currentRequest: { a: number }
   // TODO this is a very very very very long comment that makes it go > 80 columns
-) {};
+){};
 "
 `;
 
@@ -1194,7 +1194,7 @@ f = (
 f = function(
   currentRequest: { a: number }
   // TODO this is a very very very very long comment that makes it go > 80 columns
-) {};
+){};
 "
 `;
 

--- a/tests/es6modules/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/es6modules/__snapshots__/jsfmt.spec.js.snap
@@ -59,14 +59,14 @@ export default (class foobar {});
 exports[`export_default_function_declaration.js 1`] = `
 "export default function() {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-export default function() {}
+export default function(){}
 "
 `;
 
 exports[`export_default_function_declaration.js 2`] = `
 "export default function() {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-export default function() {}
+export default function(){}
 "
 `;
 
@@ -101,14 +101,14 @@ export default function f() {}
 exports[`export_default_function_expression.js 1`] = `
 "export default (function() {});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-export default (function() {});
+export default (function(){});
 "
 `;
 
 exports[`export_default_function_expression.js 2`] = `
 "export default (function() {});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-export default (function() {});
+export default (function(){});
 "
 `;
 

--- a/tests/flow/async/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/async/__snapshots__/jsfmt.spec.js.snap
@@ -186,10 +186,10 @@ class C {
   static async mt<T>(a: T) {}
 }
 
-var e = async function() {};
-var et = async function<T>(a: T) {};
+var e = async function(){};
+var et = async function<T>(a: T){};
 
-var n = new async function() {}();
+var n = new async function(){}();
 
 var o = { async m() {} };
 var ot = { async m<T>(a: T) {} };

--- a/tests/flow/call_properties/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/call_properties/__snapshots__/jsfmt.spec.js.snap
@@ -108,11 +108,11 @@ var d: { (): string } = function(x: number): string {
 };
 
 // ...but subtyping rules still apply
-var e: { (x: any): void } = function() {}; // arity
+var e: { (x: any): void } = function(){}; // arity
 var f: { (): mixed } = function(): string {
   return \\"hi\\";
 }; // return type
-var g: { (x: string): void } = function(x: mixed) {}; // param type
+var g: { (x: string): void } = function(x: mixed){}; // param type
 
 // A function can be an object
 var y: {} = function(x: number): string {
@@ -261,13 +261,13 @@ f.myProp = 123;
 var c : { myProp: number } = f;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Expecting properties that don't exist should be an error
-var a: { someProp: number } = function() {};
+var a: { someProp: number } = function(){};
 
 // Expecting properties that do exist should be fine
-var b: { apply: Function } = function() {};
+var b: { apply: Function } = function(){};
 
 // Expecting properties in the functions statics should be fine
-var f = function() {};
+var f = function(){};
 f.myProp = 123;
 var c: { myProp: number } = f;
 "

--- a/tests/flow/class_statics/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/class_statics/__snapshots__/jsfmt.spec.js.snap
@@ -69,7 +69,7 @@ class A {
   static foo(x: number) {}
   static bar(y: string) {}
 }
-A.qux = function(x: string) {}; // error?
+A.qux = function(x: string){}; // error?
 
 class B extends A {
   static x: string; // error?

--- a/tests/flow/closure/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/closure/__snapshots__/jsfmt.spec.js.snap
@@ -133,7 +133,7 @@ function local_func() {
 var global_y = \\"hello\\";
 
 var global_o = {
-  f: function() {},
+  f: function(){},
   g: function() {
     global_y = 42;
   }
@@ -154,7 +154,7 @@ function local_meth() {
   var local_y = \\"hello\\";
 
   var local_o = {
-    f: function() {},
+    f: function(){},
     g: function() {
       local_y = 42;
     }

--- a/tests/flow/init/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/init/__snapshots__/jsfmt.spec.js.snap
@@ -55,42 +55,42 @@ function _for_of(arr: Array<number>) {
 
 function _if(b: () => boolean) {
   if (b()) {
-    var f = function() {};
+    var f = function(){};
   }
   f(); // error, possibly undefined
 }
 
 function _while(b: () => boolean) {
   while (b()) {
-    var f = function() {};
+    var f = function(){};
   }
   f(); // error, possibly undefined
 }
 
 function _do_while(b: () => boolean) {
   do {
-    var f = function() {};
+    var f = function(){};
   } while (b());
   f(); // ok
 }
 
 function _for(n: number) {
   for (var i = 0; i < n; i++) {
-    var f = function() {};
+    var f = function(){};
   }
   f(); // error, possibly undefined
 }
 
 function _for_in(obj: Object) {
   for (var p in obj) {
-    var f = function() {};
+    var f = function(){};
   }
   f(); // error, possibly undefined
 }
 
 function _for_of(arr: Array<number>) {
   for (var x of arr) {
-    var f = function() {};
+    var f = function(){};
   }
   f(); // error, possibly undefined
 }

--- a/tests/flow/more_annot/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/more_annot/__snapshots__/jsfmt.spec.js.snap
@@ -45,7 +45,7 @@ var o2: Foo = new Foo();
 function Foo() {
   this.x = 0;
 }
-Foo.prototype.m = function() {};
+Foo.prototype.m = function(){};
 
 var o1: { x: number, m(): void } = new Foo();
 

--- a/tests/flow/new_react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/new_react/__snapshots__/jsfmt.spec.js.snap
@@ -87,7 +87,7 @@ module.exports = {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /* @providesModule Mixin */
 module.exports = {
-  success: function() {}
+  success: function(){}
 };
 "
 `;

--- a/tests/flow/object_api/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/object_api/__snapshots__/jsfmt.spec.js.snap
@@ -454,7 +454,7 @@ takesAString(y.toString());
 // ... on a primitive
 (123).toString();
 (123).toString;
-(123).toString = function() {}; // error
+(123).toString = function(){}; // error
 (123).toString(2);
 (123).toString(\\"foo\\"); // error
 (123).toString(null); // error

--- a/tests/flow/object_freeze/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/object_freeze/__snapshots__/jsfmt.spec.js.snap
@@ -35,7 +35,7 @@ bliffl.bar = \\"23456\\"; // error
 bliffl.baz = 3456; // error
 bliffl.corge; // error
 bliffl.constructor = baz; // error
-bliffl.toString = function() {}; // error
+bliffl.toString = function(){}; // error
 
 baz.baz = 0;
 

--- a/tests/flow/optional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/optional/__snapshots__/jsfmt.spec.js.snap
@@ -266,7 +266,7 @@ function testOptionalNullableProperty(obj: { x?: ?string }): string {
 }
 
 function testOptionalNullableFlowingToNullable(x?: ?string): ?string {
-  var f = function(y: ?string) {};
+  var f = function(y: ?string){};
   f(x);
 }
 "

--- a/tests/flow/promises/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/promises/__snapshots__/jsfmt.spec.js.snap
@@ -589,7 +589,7 @@ Promise.reject(0)
   });
 
 // TODO: resolvedPromise<T> -> catch() -> then():T
-Promise.resolve(0).catch(function(err) {}).then(function(num) {
+Promise.resolve(0).catch(function(err){}).then(function(num) {
   var a: number = num;
 
   // TODO

--- a/tests/flow/refinements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/refinements/__snapshots__/jsfmt.spec.js.snap
@@ -797,7 +797,7 @@ function foo5() {
     o.p();
   }
   function _foo5() {
-    o.p = function() {};
+    o.p = function(){};
   }
 }
 

--- a/tests/flow/requireLazy/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/requireLazy/__snapshots__/jsfmt.spec.js.snap
@@ -90,7 +90,7 @@ var notA: Object = A;
 var notB: Object = B;
 
 requireLazy(); // Error: No args
-requireLazy([nope], function() {}); // Error: Non-stringliteral args
+requireLazy([nope], function(){}); // Error: Non-stringliteral args
 requireLazy([\\"A\\"]); // Error: No calback expression
 "
 `;

--- a/tests/flow/union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/union/__snapshots__/jsfmt.spec.js.snap
@@ -114,8 +114,8 @@ declare class Myclass {
 }
 declare var myclass: Myclass;
 
-myclass.myfun([\\"1\\", \\"2\\", \\"3\\", \\"4\\", \\"5\\", \\"6\\", function(ar) {}]);
-myclass.myfun([\\"1\\", \\"2\\", \\"3\\", \\"4\\", \\"5\\", \\"6\\", \\"7\\", function(ar) {}]);
+myclass.myfun([\\"1\\", \\"2\\", \\"3\\", \\"4\\", \\"5\\", \\"6\\", function(ar){}]);
+myclass.myfun([\\"1\\", \\"2\\", \\"3\\", \\"4\\", \\"5\\", \\"6\\", \\"7\\", function(ar){}]);
 "
 `;
 

--- a/tests/function/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/function/__snapshots__/jsfmt.spec.js.snap
@@ -13,16 +13,16 @@ a = function f() {} || b;
 a + function() {};
 new function() {};
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-(function() {}.length);
-typeof function() {};
-export default (function() {})();
-(function() {})()\`\`;
-(function() {})\`\`;
-new function() {}();
-(function() {});
+(function(){}.length);
+typeof function(){};
+export default (function(){})();
+(function(){})()\`\`;
+(function(){})\`\`;
+new function(){}();
+(function(){});
 a = function f() {} || b;
-(function() {} && a);
-a + function() {};
-new function() {}();
+(function(){} && a);
+a + function(){};
+new function(){}();
 "
 `;

--- a/tests/template/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/template/__snapshots__/jsfmt.spec.js.snap
@@ -113,7 +113,7 @@ b()\`\`;
 (b ? c : d)\`\`;
 
 // \\"FunctionExpression\\"
-(function() {})\`\`;
+(function(){})\`\`;
 
 // \\"LogicalExpression\\"
 (b || c)\`\`;


### PR DESCRIPTION
This is purely stylistic, but when I'm writing anonymous function expressions with no body, I do not include a space before the body.

For example, the space looks weird to me in
```js
a.catch(function() {});
```
or
```js
return function() {};
```

This PR removes that space, giving
```js
a.catch(function(){});
```
and
```js
return function(){};
```

I've only applied removed the space when there would not otherwise be a space in the function literal. For example, all of these are untouched:
```js
(function f() {});
(function(): void {});
(function() {
  foo;
});
```
