### PR TITLE
Recursively find leading comments inside ReturnStatements

### DIFF
--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1293,79 +1293,481 @@ function name() {
 `;
 
 exports[`return-statement.js 1`] = `
-"function a() {
+"function jsx() {
   return (
     // Comment
     <div />
   );
 }
 
-function b() {
+function unary() {
   return (
     // Comment
     !!x
   );
 }
 
-function c() {
+function numericLiteralNoParen() {
   return 1337; // Comment
+}
+
+function logical() {
+  return (
+    // Reason for 42
+    42
+  ) && 84
+}
+
+function binary() {
+  return (
+    // Reason for 42
+    42
+  ) * 84
+}
+
+function binaryInBinaryLeft() {
+  return (
+    // Reason for 42
+    42
+  ) * 84 + 2
+}
+
+function binaryInBinaryRight() {
+  return (
+    // Reason for 42
+    42
+  ) + 84 * 2
+}
+
+function conditional() {
+  return (
+    // Reason for 42
+    42
+  ) ? 1 : 2
+}
+
+function binaryInConditional() {
+  return (
+    // Reason for 42
+    42
+  ) * 3 ? 1 : 2
+}
+
+function call() {
+  return (
+    // Reason for a
+    a
+  )()
+}
+
+function memberInside() {
+  return (
+    // Reason for a.b
+    a.b
+  ).c
+}
+
+function memberOutside() {
+  return (
+    // Reason for a
+    a
+  ).b.c
+}
+
+function memberInAndOutWithCalls() {
+  return (
+    // Reason for a
+    a.b()
+  ).c.d()
+}
+
+function excessiveEverything() {
+  return (
+    // Reason for stuff
+    a.b() * 3 + 4 ? (a\`hi\`, 1) ? 1 : 1 : 1
+  )
+}
+
+function sequenceExpression() {
+  return (
+    // Reason for a
+    a
+  ), b
+}
+
+function taggedTemplate() {
+  return (
+    // Reason for a
+    a
+  )\`b\`
+}
+
+function inlineComment() {
+  return (
+    /* hi */ 42
+  ) || 42
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-function a() {
+function jsx() {
   return (
     // Comment
     <div />
   );
 }
 
-function b() {
+function unary() {
   return (
     // Comment
     !!x
   );
 }
 
-function c() {
+function numericLiteralNoParen() {
   return 1337; // Comment
+}
+
+function logical() {
+  return (
+    // Reason for 42
+    42 && 84
+  );
+}
+
+function binary() {
+  return (
+    // Reason for 42
+    42 * 84
+  );
+}
+
+function binaryInBinaryLeft() {
+  return (
+    // Reason for 42
+    42 *
+      84 +
+      2
+  );
+}
+
+function binaryInBinaryRight() {
+  return (
+    // Reason for 42
+    42 +
+      84 * 2
+  );
+}
+
+function conditional() {
+  return (
+    // Reason for 42
+    42
+      ? 1
+      : 2
+  );
+}
+
+function binaryInConditional() {
+  return (
+    // Reason for 42
+    42 * 3
+      ? 1
+      : 2
+  );
+}
+
+function call() {
+  return (
+    // Reason for a
+    a()
+  );
+}
+
+function memberInside() {
+  return (
+    // Reason for a.b
+    a.b.c
+  );
+}
+
+function memberOutside() {
+  return (
+    // Reason for a
+    a.b.c
+  );
+}
+
+function memberInAndOutWithCalls() {
+  return (
+    a
+      .b// Reason for a
+      ()
+      .c.d()
+  );
+}
+
+function excessiveEverything() {
+  return (
+    // Reason for stuff
+    a.b() * 3 + 4 ? (a\`hi\`, 1) ? 1 : 1 : 1
+  );
+}
+
+function sequenceExpression() {
+  return (
+    // Reason for a
+    a, b
+  );
+}
+
+function taggedTemplate() {
+  return (
+    // Reason for a
+    a\`b\`
+  );
+}
+
+function inlineComment() {
+  return /* hi */ 42 || 42;
 }
 "
 `;
 
 exports[`return-statement.js 2`] = `
-"function a() {
+"function jsx() {
   return (
     // Comment
     <div />
   );
 }
 
-function b() {
+function unary() {
   return (
     // Comment
     !!x
   );
 }
 
-function c() {
+function numericLiteralNoParen() {
   return 1337; // Comment
+}
+
+function logical() {
+  return (
+    // Reason for 42
+    42
+  ) && 84
+}
+
+function binary() {
+  return (
+    // Reason for 42
+    42
+  ) * 84
+}
+
+function binaryInBinaryLeft() {
+  return (
+    // Reason for 42
+    42
+  ) * 84 + 2
+}
+
+function binaryInBinaryRight() {
+  return (
+    // Reason for 42
+    42
+  ) + 84 * 2
+}
+
+function conditional() {
+  return (
+    // Reason for 42
+    42
+  ) ? 1 : 2
+}
+
+function binaryInConditional() {
+  return (
+    // Reason for 42
+    42
+  ) * 3 ? 1 : 2
+}
+
+function call() {
+  return (
+    // Reason for a
+    a
+  )()
+}
+
+function memberInside() {
+  return (
+    // Reason for a.b
+    a.b
+  ).c
+}
+
+function memberOutside() {
+  return (
+    // Reason for a
+    a
+  ).b.c
+}
+
+function memberInAndOutWithCalls() {
+  return (
+    // Reason for a
+    a.b()
+  ).c.d()
+}
+
+function excessiveEverything() {
+  return (
+    // Reason for stuff
+    a.b() * 3 + 4 ? (a\`hi\`, 1) ? 1 : 1 : 1
+  )
+}
+
+function sequenceExpression() {
+  return (
+    // Reason for a
+    a
+  ), b
+}
+
+function taggedTemplate() {
+  return (
+    // Reason for a
+    a
+  )\`b\`
+}
+
+function inlineComment() {
+  return (
+    /* hi */ 42
+  ) || 42
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-function a() {
+function jsx() {
   return (
     // Comment
     <div />
   );
 }
 
-function b() {
+function unary() {
   return (
     // Comment
     !!x
   );
 }
 
-function c() {
+function numericLiteralNoParen() {
   return 1337; // Comment
+}
+
+function logical() {
+  return (
+    // Reason for 42
+    42 && 84
+  );
+}
+
+function binary() {
+  return (
+    // Reason for 42
+    42 * 84
+  );
+}
+
+function binaryInBinaryLeft() {
+  return (
+    // Reason for 42
+    42 *
+      84 +
+      2
+  );
+}
+
+function binaryInBinaryRight() {
+  return (
+    // Reason for 42
+    42 +
+      84 * 2
+  );
+}
+
+function conditional() {
+  return (
+    // Reason for 42
+    42
+      ? 1
+      : 2
+  );
+}
+
+function binaryInConditional() {
+  return (
+    // Reason for 42
+    42 * 3
+      ? 1
+      : 2
+  );
+}
+
+function call() {
+  return (
+    // Reason for a
+    a()
+  );
+}
+
+function memberInside() {
+  return (
+    // Reason for a.b
+    a.b.c
+  );
+}
+
+function memberOutside() {
+  return (
+    // Reason for a
+    a.b.c
+  );
+}
+
+function memberInAndOutWithCalls() {
+  return (
+    a
+      .b// Reason for a
+      ()
+      .c.d()
+  );
+}
+
+function excessiveEverything() {
+  return (
+    // Reason for stuff
+    a.b() * 3 + 4 ? (a\`hi\`, 1) ? 1 : 1 : 1
+  );
+}
+
+function sequenceExpression() {
+  return (
+    // Reason for a
+    a, b
+  );
+}
+
+function taggedTemplate() {
+  return (
+    // Reason for a
+    a\`b\`
+  );
+}
+
+function inlineComment() {
+  return /* hi */ 42 || 42;
 }
 "
 `;

--- a/tests/comments/return-statement.js
+++ b/tests/comments/return-statement.js
@@ -1,17 +1,114 @@
-function a() {
+function jsx() {
   return (
     // Comment
     <div />
   );
 }
 
-function b() {
+function unary() {
   return (
     // Comment
     !!x
   );
 }
 
-function c() {
+function numericLiteralNoParen() {
   return 1337; // Comment
+}
+
+function logical() {
+  return (
+    // Reason for 42
+    42
+  ) && 84
+}
+
+function binary() {
+  return (
+    // Reason for 42
+    42
+  ) * 84
+}
+
+function binaryInBinaryLeft() {
+  return (
+    // Reason for 42
+    42
+  ) * 84 + 2
+}
+
+function binaryInBinaryRight() {
+  return (
+    // Reason for 42
+    42
+  ) + 84 * 2
+}
+
+function conditional() {
+  return (
+    // Reason for 42
+    42
+  ) ? 1 : 2
+}
+
+function binaryInConditional() {
+  return (
+    // Reason for 42
+    42
+  ) * 3 ? 1 : 2
+}
+
+function call() {
+  return (
+    // Reason for a
+    a
+  )()
+}
+
+function memberInside() {
+  return (
+    // Reason for a.b
+    a.b
+  ).c
+}
+
+function memberOutside() {
+  return (
+    // Reason for a
+    a
+  ).b.c
+}
+
+function memberInAndOutWithCalls() {
+  return (
+    // Reason for a
+    a.b()
+  ).c.d()
+}
+
+function excessiveEverything() {
+  return (
+    // Reason for stuff
+    a.b() * 3 + 4 ? (a`hi`, 1) ? 1 : 1 : 1
+  )
+}
+
+function sequenceExpression() {
+  return (
+    // Reason for a
+    a
+  ), b
+}
+
+function taggedTemplate() {
+  return (
+    // Reason for a
+    a
+  )`b`
+}
+
+function inlineComment() {
+  return (
+    /* hi */ 42
+  ) || 42
 }

--- a/tests/flow/generics/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/generics/__snapshots__/jsfmt.spec.js.snap
@@ -74,9 +74,7 @@ class E<X> extends C<X> {
   //x:X;
   set(x: X): X {
     /*return x;*/ this.x = x;
-    return (
-      /*this.x; */ this.get()
-    );
+    return /*this.x; */ this.get();
   }
 }
 

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -126,10 +126,12 @@ exports[`comment.js 1`] = `
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function f() {
-  return observableFromSubscribeFunction()
-    // Debounce manually rather than using editor.onDidStopChanging so that the debounce time is
-    // configurable.
-    .debounceTime(debounceInterval);
+  return (
+    observableFromSubscribeFunction()
+      // Debounce manually rather than using editor.onDidStopChanging so that the debounce time is
+      // configurable.
+      .debounceTime(debounceInterval)
+  );
 }
 "
 `;


### PR DESCRIPTION
Fixes https://github.com/prettier/prettier/issues/916

What a beast! Code ended up being reasonably concise but was pretty hard for me to figure out. 

I'm pretty sure this is comprehensive, but my confidence has been higher. I also don't love my approach; open to suggestions!!

I went through every node type in [the spec](https://github.com/babel/babylon/blob/master/ast/spec.md) and tested every kind that I thought might have a leading sub-node to which a comment might be attached (eg; in binaryexpression, the "left" attribute can get the comment without the binaryexpression getting the comment as leading). 

Pretty much all the test cases are significant and fail without something in here; the only exception I think is a kitchen sink I threw in. 