### PR TITLE
Make comments around empty parenthesis be inside

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1959,7 +1959,11 @@ function printArgumentsList(path, options, print) {
   var printed = path.map(print, "arguments");
 
   if (printed.length === 0) {
-    return "()";
+    return concat([
+      "(",
+      comments.printDanglingComments(path, options, /* sameIndent */ true),
+      ")"
+    ]);
   }
 
   const args = path.getValue().arguments;

--- a/tests/empty_paren_comment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/empty_paren_comment/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,111 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`empty_paren_comment.js 1`] = `
+"let f = (/* ... */) => {}
+(function (/* ... */) {})(/* ... */)
+function f(/* ... */) {}
+
+const obj = {
+  f(/* ... */) {},
+  f: (/* ... */) => {},
+  f: function(/* ... */) {},
+  f: function f(/* ... */) {}
+}
+
+class Foo {
+  f(/* ... */) {}
+  f = (/* ... */) => {};
+  static f(/* ... */) {};
+  static f = (/* ... */) => {};
+  static f = function(/* ... */) {};
+  static f = function f(/* ... */) {};
+  static f /* ... */() {};
+}
+
+f(/* ... */);
+f(a, /* ... */);
+f(a, /* ... */ b);
+f(/* ... */ a, b);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+let f = (/* ... */) => {};
+(function(/* ... */) {})(/* ... */);
+function f(/* ... */) {}
+
+const obj = {
+  f(/* ... */) {},
+  f: (/* ... */) => {},
+  f: function(/* ... */) {},
+  f: function f(/* ... */) {}
+};
+
+class Foo {
+  f(/* ... */) {}
+  f = (/* ... */) => {};
+  static f(/* ... */) {}
+  static f = (/* ... */) => {};
+  static f = function(/* ... */) {};
+  static f = function f(/* ... */) {};
+  static f(/* ... */) {}
+}
+
+f(/* ... */);
+f(a /* ... */);
+f(a, /* ... */ b);
+f(/* ... */ a, b);
+"
+`;
+
+exports[`empty_paren_comment.js 2`] = `
+"let f = (/* ... */) => {}
+(function (/* ... */) {})(/* ... */)
+function f(/* ... */) {}
+
+const obj = {
+  f(/* ... */) {},
+  f: (/* ... */) => {},
+  f: function(/* ... */) {},
+  f: function f(/* ... */) {}
+}
+
+class Foo {
+  f(/* ... */) {}
+  f = (/* ... */) => {};
+  static f(/* ... */) {};
+  static f = (/* ... */) => {};
+  static f = function(/* ... */) {};
+  static f = function f(/* ... */) {};
+  static f /* ... */() {};
+}
+
+f(/* ... */);
+f(a, /* ... */);
+f(a, /* ... */ b);
+f(/* ... */ a, b);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+let f = (/* ... */) => {};
+(function(/* ... */) {})(/* ... */);
+function f(/* ... */) {}
+
+const obj = {
+  f(/* ... */) {},
+  f: (/* ... */) => {},
+  f: function(/* ... */) {},
+  f: function f(/* ... */) {}
+};
+
+class Foo {
+  f(/* ... */) {}
+  f = (/* ... */) => {};
+  static f(/* ... */) {}
+  static f = (/* ... */) => {};
+  static f = function(/* ... */) {};
+  static f = function f(/* ... */) {};
+  static f(/* ... */) {}
+}
+
+f(/* ... */);
+f(a /* ... */);
+f(a, /* ... */ b);
+f(/* ... */ a, b);
+"
+`;

--- a/tests/empty_paren_comment/empty_paren_comment.js
+++ b/tests/empty_paren_comment/empty_paren_comment.js
@@ -1,0 +1,25 @@
+let f = (/* ... */) => {}
+(function (/* ... */) {})(/* ... */)
+function f(/* ... */) {}
+
+const obj = {
+  f(/* ... */) {},
+  f: (/* ... */) => {},
+  f: function(/* ... */) {},
+  f: function f(/* ... */) {}
+}
+
+class Foo {
+  f(/* ... */) {}
+  f = (/* ... */) => {};
+  static f(/* ... */) {};
+  static f = (/* ... */) => {};
+  static f = function(/* ... */) {};
+  static f = function f(/* ... */) {};
+  static f /* ... */() {};
+}
+
+f(/* ... */);
+f(a, /* ... */);
+f(a, /* ... */ b);
+f(/* ... */ a, b);

--- a/tests/empty_paren_comment/jsfmt.spec.js
+++ b/tests/empty_paren_comment/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname);
+run_spec(__dirname, {parser: 'babylon'});


### PR DESCRIPTION
The logic was already implemented in #802 but for a single case. I just added all the cases added in the awesome @umidbekkarimov

Fixes #956