### PR TITLE
Stabilize comment after object label

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -156,6 +156,7 @@ function attach(comments, ast, text, options) {
         handleTryStatementComments(enclosingNode, followingNode, comment) ||
         handleClassComments(enclosingNode, comment) ||
         handleImportSpecifierComments(enclosingNode, comment) ||
+        handleObjectPropertyComments(enclosingNode, comment) ||
         handleUnionTypeComments(
           precedingNode,
           enclosingNode,
@@ -209,7 +210,7 @@ function attach(comments, ast, text, options) {
     } else {
       if (
         handleIfStatementComments(enclosingNode, followingNode, comment) ||
-        handleObjectProperty(enclosingNode, precedingNode, comment) ||
+        handleObjectPropertyAssignment(enclosingNode, precedingNode, comment) ||
         handleTemplateLiteralComments(enclosingNode, comment) ||
         handleFunctionDeclarationComments(enclosingNode, comment) ||
         handleOnlyComments(enclosingNode, ast, comment, isLastComment)
@@ -436,7 +437,7 @@ function handleConditionalExpressionComments(
   return false;
 }
 
-function handleObjectProperty(enclosingNode, precedingNode, comment) {
+function handleObjectPropertyAssignment(enclosingNode, precedingNode, comment) {
   if (
     enclosingNode &&
     (enclosingNode.type === "ObjectProperty" ||
@@ -528,6 +529,14 @@ function handleClassComments(enclosingNode, comment) {
 
 function handleImportSpecifierComments(enclosingNode, comment) {
   if (enclosingNode && enclosingNode.type === "ImportSpecifier") {
+    addLeadingComment(enclosingNode, comment);
+    return true;
+  }
+  return false;
+}
+
+function handleObjectPropertyComments(enclosingNode, comment) {
+  if (enclosingNode && enclosingNode.type === "ObjectProperty") {
     addLeadingComment(enclosingNode, comment);
     return true;
   }

--- a/tests/object_property_comment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/object_property_comment/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`comment.js 1`] = `
+"o = {
+  name:
+    // Comment A
+    // Comment B
+    (({id: type}: any): CreativeConcept),
+};
+
+o = {
+  name: // Comment A
+  // Comment B
+  (({ id: type }: any): CreativeConcept)
+};
+
+o = {
+  name: // Comment B // Comment A
+  (({ id: type }: any): CreativeConcept)
+};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+o = {
+  name: // Comment A
+  // Comment B
+  (({ id: type }: any): CreativeConcept)
+};
+
+o = {
+  // Comment A
+  name: // Comment B
+  (({ id: type }: any): CreativeConcept)
+};
+
+o = {
+  // Comment B // Comment A
+  name: (({ id: type }: any): CreativeConcept)
+};
+"
+`;

--- a/tests/object_property_comment/comment.js
+++ b/tests/object_property_comment/comment.js
@@ -1,0 +1,17 @@
+o = {
+  name:
+    // Comment A
+    // Comment B
+    (({id: type}: any): CreativeConcept),
+};
+
+o = {
+  name: // Comment A
+  // Comment B
+  (({ id: type }: any): CreativeConcept)
+};
+
+o = {
+  name: // Comment B // Comment A
+  (({ id: type }: any): CreativeConcept)
+};

--- a/tests/object_property_comment/jsfmt.spec.js
+++ b/tests/object_property_comment/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);


### PR DESCRIPTION
This is the largest firing unstability on the Facebook codebase.

Fixes #906