### PR TITLE
WIP - avoid wrapping parens around returns that dont need them

### DIFF
--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1409,6 +1409,14 @@ function inlineComment() {
     /* hi */ 42
   ) || 42
 }
+
+function iosOpen(url: string) {
+  return SafariView.isAvailable()
+    // if it's around, open in safari
+    .then(() => SafariView.show({url}))
+    // fall back to opening in default browser
+    .catch(() => genericOpen(url))
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function jsx() {
   return (
@@ -1492,10 +1500,8 @@ function memberInside() {
 }
 
 function memberOutside() {
-  return (
-    // Reason for a
-    a.b.c
-  );
+  return // Reason for a
+  a.b.c;
 }
 
 function memberInAndOutWithCalls() {
@@ -1530,6 +1536,14 @@ function taggedTemplate() {
 
 function inlineComment() {
   return /* hi */ 42 || 42;
+}
+
+function iosOpen(url: string) {
+  return SafariView.isAvailable()
+    // if it's around, open in safari
+    .then(() => SafariView.show({ url }))
+    // fall back to opening in default browser
+    .catch(() => genericOpen(url));
 }
 "
 `;
@@ -1649,6 +1663,14 @@ function inlineComment() {
     /* hi */ 42
   ) || 42
 }
+
+function iosOpen(url: string) {
+  return SafariView.isAvailable()
+    // if it's around, open in safari
+    .then(() => SafariView.show({url}))
+    // fall back to opening in default browser
+    .catch(() => genericOpen(url))
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function jsx() {
   return (
@@ -1732,10 +1754,8 @@ function memberInside() {
 }
 
 function memberOutside() {
-  return (
-    // Reason for a
-    a.b.c
-  );
+  return // Reason for a
+  a.b.c;
 }
 
 function memberInAndOutWithCalls() {
@@ -1770,6 +1790,14 @@ function taggedTemplate() {
 
 function inlineComment() {
   return /* hi */ 42 || 42;
+}
+
+function iosOpen(url: string) {
+  return SafariView.isAvailable()
+    // if it's around, open in safari
+    .then(() => SafariView.show({ url }))
+    // fall back to opening in default browser
+    .catch(() => genericOpen(url));
 }
 "
 `;

--- a/tests/comments/return-statement.js
+++ b/tests/comments/return-statement.js
@@ -112,3 +112,11 @@ function inlineComment() {
     /* hi */ 42
   ) || 42
 }
+
+function iosOpen(url: string) {
+  return SafariView.isAvailable()
+    // if it's around, open in safari
+    .then(() => SafariView.show({url}))
+    // fall back to opening in default browser
+    .catch(() => genericOpen(url))
+}

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -128,12 +128,10 @@ exports[`comment.js 1`] = `
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function f() {
-  return (
-    observableFromSubscribeFunction()
-      // Debounce manually rather than using editor.onDidStopChanging so that the debounce time is
-      // configurable.
-      .debounceTime(debounceInterval)
-  );
+  return observableFromSubscribeFunction()
+    // Debounce manually rather than using editor.onDidStopChanging so that the debounce time is
+    // configurable.
+    .debounceTime(debounceInterval);
 }
 "
 `;


### PR DESCRIPTION
This doesn't quiiite work (see a regression in the tests) but I thought I'd put it up for posterity. 

Attempts to address https://github.com/prettier/prettier/issues/968