### PR TITLE
Do not respect newlines for object destructuring pattern

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -700,11 +700,12 @@ function genericPrintNoParens(path, options, print) {
       const canHaveTrailingComma = !(lastElem &&
         lastElem.type === "RestProperty");
 
-      const shouldBreak = util.hasNewlineInRange(
-        options.originalText,
-        util.locStart(n),
-        util.locEnd(n)
-      );
+      const shouldBreak = n.type !== "ObjectPattern" &&
+        util.hasNewlineInRange(
+          options.originalText,
+          util.locStart(n),
+          util.locEnd(n)
+        );
 
       if (props.length === 0) {
         return group(

--- a/tests/objects/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/objects/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`expand.js 1`] = `
+"const Component1 = ({ props }) => (
+  <Text>Test</Text>
+);
+
+const Component2 = ({
+  props
+}) => (
+  <Text>Test</Text>
+);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const Component1 = ({ props }) => <Text>Test</Text>;
+
+const Component2 = ({ props }) => <Text>Test</Text>;
+"
+`;
+
 exports[`expression.js 1`] = `
 "() => ({}\`\`);
 ({})\`\`;

--- a/tests/objects/expand.js
+++ b/tests/objects/expand.js
@@ -1,0 +1,9 @@
+const Component1 = ({ props }) => (
+  <Text>Test</Text>
+);
+
+const Component2 = ({
+  props
+}) => (
+  <Text>Test</Text>
+);


### PR DESCRIPTION
This was intended for object expressions. I tried to remove it for ObjectTypeAnnotation but it changes a ton of stuff as it's used all over the place in many different contexts. We should clean it up but in a later PR :)

Fixes part of #975