### PR TITLE
Update repo links

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,15 +5,9 @@
   "bin": {
     "prettier": "./bin/prettier.js"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/jlongster/prettier.git"
-  },
+  "repository": "prettier/prettier",
   "author": "James Long",
   "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/jlongster/prettier/issues"
-  },
   "main": "./index.js",
   "dependencies": {
     "ast-types": "0.9.4",


### PR DESCRIPTION
GH redirects, but no reason not to link directly to the org 😄 