### PR TITLE
Use correct print-width argument

### DIFF
--- a/editors/emacs/prettier-js.el
+++ b/editors/emacs/prettier-js.el
@@ -186,9 +186,9 @@ function."
           (width-args
            (cond
             ((equal prettier-width-mode 'window)
-             (list "--width" (number-to-string (window-body-width))))
+             (list "--print-width" (number-to-string (window-body-width))))
             ((equal prettier-width-mode 'fill)
-             (list "--width" (number-to-string fill-column)))
+             (list "--print-width" (number-to-string fill-column)))
             (t
              '()))))
      (unwind-protect


### PR DESCRIPTION
Use print-width instead of width, bringing prettier-js.el in line with https://github.com/prettier/prettier/blob/205458a8d12ab39a8ad0bb0e815e017481108f2e/bin/prettier.js#L33