### PR TITLE
Enable yarn caching in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - 6
   - stable
 cache:
+  yarn: true
   directories:
   - node_modules
 script: npm test -- --runInBand


### PR DESCRIPTION
This enables yarn caching during Travis CI builds
https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#Caching-with-yarn