### PR TITLE
Special logic for flow intersection

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1630,14 +1630,29 @@ function genericPrintNoParens(path, options, print) {
         path.call(print, "id"),
         path.call(print, "typeParameters")
       ]);
-    case "IntersectionTypeAnnotation":
+    case "IntersectionTypeAnnotation": {
+      const types = path.map(print, "types");
+      const result = [];
+      for (let i = 0; i < types.length; ++i) {
+        if (i === 0) {
+          result.push(types[i]);
+        } else if (
+          (n.types[i - 1].type === "ObjectTypeAnnotation" &&
+            n.types[i].type !== "ObjectTypeAnnotation") ||
+          (n.types[i - 1].type !== "ObjectTypeAnnotation" &&
+            n.types[i].type === "ObjectTypeAnnotation")
+        ) {
+          // If you go from object to non-object or vis-versa, then inline it
+          result.push(" & ", types[i]);
+        } else {
+          // Otherwise go to the next line and indent
+          result.push(indent(options.tabWidth, concat([" &", line, types[i]])));
+        }
+      }
+      return group(concat(result));
+    }
     case "TSUnionType":
     case "UnionTypeAnnotation": {
-      const types = path.map(print, "types");
-      const isIntersection = n.type === "IntersectionTypeAnnotation";
-      const shouldInline = isIntersection &&
-        !(n.types.length > 1 && n.types[0].type === "ObjectTypeAnnotation");
-
       // single-line variation
       // A | B | C
 
@@ -1646,24 +1661,17 @@ function genericPrintNoParens(path, options, print) {
       // | B
       // | C
 
-      // We want & operators to be inlined.
-      if (shouldInline) {
-        return join(" & ", types);
-      }
-
       const parent = path.getParentNode();
       // If there's a leading comment, the parent is doing the indentation
       const shouldIndent = !(parent.type === "TypeAlias" &&
         hasLeadingOwnLineComment(options.originalText, n));
 
-      const token = isIntersection ? "&" : "|";
-
       return group(
         indent(
           shouldIndent ? options.tabWidth : 0,
           concat([
-            ifBreak(concat([shouldIndent ? line : "", token, " "])),
-            join(concat([line, token, " "]), types)
+            ifBreak(concat([shouldIndent ? line : "", "| "])),
+            join(concat([line, "| "]), path.map(print, "types"))
           ])
         )
       );

--- a/tests/flow/intersection/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/intersection/__snapshots__/jsfmt.spec.js.snap
@@ -79,7 +79,8 @@ function hasObjectMode_ok(options: DuplexStreamOptions): boolean {
  * @flow
  */
 
-type DuplexStreamOptions = ReadableStreamOptions & WritableStreamOptions & {
+type DuplexStreamOptions = ReadableStreamOptions &
+  WritableStreamOptions & {
   allowHalfOpen?: boolean,
   readableObjectMode?: boolean,
   writableObjectMode?: boolean

--- a/tests/flow/union_new/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/union_new/__snapshots__/jsfmt.spec.js.snap
@@ -260,19 +260,15 @@ function printAll(val: MyType) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 type Common = {};
 
-type A =
-  & {
-    type: \\"A\\",
-    foo: number
-  }
-  & Common;
+type A = {
+  type: \\"A\\",
+  foo: number
+} & Common;
 
-type B =
-  & {
-    type: \\"B\\",
-    foo: Array<number>
-  }
-  & Common;
+type B = {
+  type: \\"B\\",
+  foo: Array<number>
+} & Common;
 
 type MyType = A | B;
 
@@ -1684,11 +1680,9 @@ type Success = {
   result: string
 };
 
-type Error =
-  & {
-    type: \\"ERROR\\"
-  }
-  & Empty;
+type Error = {
+  type: \\"ERROR\\"
+} & Empty;
 
 export type T = Success | Error;
 

--- a/tests/intersection/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/intersection/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`intersection.js 1`] = `
+"export type ReallyBigSocketServer = ReallyBigSocketServerInterface & ReallyBigSocketServerStatics;
+
+type Props = {
+  focusedChildren?: React.Children,
+  onClick: () => void,
+  overlayChildren?: React.Children,
+  style?: Object,
+  thumbnail: ImageSource,
+} & FooterProps;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export type ReallyBigSocketServer = ReallyBigSocketServerInterface &
+  ReallyBigSocketServerStatics;
+
+type Props = {
+  focusedChildren?: React.Children,
+  onClick: () => void,
+  overlayChildren?: React.Children,
+  style?: Object,
+  thumbnail: ImageSource
+} & FooterProps;
+"
+`;

--- a/tests/intersection/intersection.js
+++ b/tests/intersection/intersection.js
@@ -1,0 +1,9 @@
+export type ReallyBigSocketServer = ReallyBigSocketServerInterface & ReallyBigSocketServerStatics;
+
+type Props = {
+  focusedChildren?: React.Children,
+  onClick: () => void,
+  overlayChildren?: React.Children,
+  style?: Object,
+  thumbnail: ImageSource,
+} & FooterProps;

--- a/tests/intersection/jsfmt.spec.js
+++ b/tests/intersection/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);


### PR DESCRIPTION
We started using the same logic for union and intersection but then added a special case for `a & {}`. It turns out that they should be handled completely differently in practice.

The heuristic i'm using is if you go from object to non-object or vis-versa, then inline, otherwise go to the next line and indent (like &&).

Fixes #864
Fixes #1017