### PR TITLE
Hug on single object destructuring function

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2200,9 +2200,25 @@ function printFunctionParams(path, print, options) {
     return concat(["(", join(", ", printed), ")"]);
   }
 
+  // Single object destructuring should hug
+  //
+  // function({
+  //   a,
+  //   b,
+  //   c
+  // }) {}
+  if (fun.params.length === 1 &&
+    !fun.params[0].comments &&
+    (fun.params[0].type === "ObjectPattern" ||
+      fun.params[0].type === "FunctionTypeParam" &&
+        fun.params[0].typeAnnotation.type === "ObjectTypeAnnotation") &&
+    !fun.rest) {
+    return concat(["(", join(", ", printed), ")"]);
+  }
+
   const isFlowShorthandWithOneArg = (isObjectTypePropertyAFunction(parent) ||
     isTypeAnnotationAFunction(parent) || parent.type === "TypeAlias") &&
-    fun[paramsField].length === 1 && fun[paramsField][0].name === null && fun.rest === null;
+    fun[paramsField].length === 1 && fun[paramsField][0].name === null && !fun.rest;
 
   return concat([
     isFlowShorthandWithOneArg ? "" : "(",

--- a/tests/function_single_destructuring/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/function_single_destructuring/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,126 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test.js 1`] = `
+"function StatelessFunctionalComponent({
+  isActive,
+  onFiltersUpdated,
+  onSelect,
+  onSubmitAndDeselect,
+  onCancel,
+  searchFilters,
+  title,
+  items,
+}) {
+  return <div />
+}
+
+const StatelessFunctionalComponent = ({
+  isActive,
+  onFiltersUpdated,
+  onSelect,
+  onSubmitAndDeselect,
+  onCancel,
+  searchFilters,
+  title,
+  items,
+}: {
+  isActive: number,
+  onFiltersUpdated: number,
+  onSelect: number,
+  onSubmitAndDeselect: number,
+  onCancel: number,
+  searchFilters: number,
+  title: number,
+  items: number,
+}) => {
+  return <div />
+};
+
+class C {
+  StatelessFunctionalComponent({
+    isActive,
+    onFiltersUpdated,
+    onSelect,
+    onSubmitAndDeselect,
+    onCancel,
+    searchFilters,
+    title,
+    items,
+  }) {
+    return <div />
+  }
+}
+
+type T = ({
+  isActive: number,
+  onFiltersUpdated: number,
+  onSelect: number,
+  onSubmitAndDeselect: number,
+  onCancel: number,
+  searchFilters: number,
+  title: number,
+  items: number,
+}) => void;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+function StatelessFunctionalComponent({
+  isActive,
+  onFiltersUpdated,
+  onSelect,
+  onSubmitAndDeselect,
+  onCancel,
+  searchFilters,
+  title,
+  items
+}) {
+  return <div />;
+}
+
+const StatelessFunctionalComponent = ({
+  isActive,
+  onFiltersUpdated,
+  onSelect,
+  onSubmitAndDeselect,
+  onCancel,
+  searchFilters,
+  title,
+  items
+}: {
+  isActive: number,
+  onFiltersUpdated: number,
+  onSelect: number,
+  onSubmitAndDeselect: number,
+  onCancel: number,
+  searchFilters: number,
+  title: number,
+  items: number
+}) => {
+  return <div />;
+};
+
+class C {
+  StatelessFunctionalComponent({
+    isActive,
+    onFiltersUpdated,
+    onSelect,
+    onSubmitAndDeselect,
+    onCancel,
+    searchFilters,
+    title,
+    items
+  }) {
+    return <div />;
+  }
+}
+
+type T = ({
+  isActive: number,
+  onFiltersUpdated: number,
+  onSelect: number,
+  onSubmitAndDeselect: number,
+  onCancel: number,
+  searchFilters: number,
+  title: number,
+  items: number
+}) => void;
+"
+`;

--- a/tests/function_single_destructuring/jsfmt.spec.js
+++ b/tests/function_single_destructuring/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/function_single_destructuring/test.js
+++ b/tests/function_single_destructuring/test.js
@@ -1,0 +1,60 @@
+function StatelessFunctionalComponent({
+  isActive,
+  onFiltersUpdated,
+  onSelect,
+  onSubmitAndDeselect,
+  onCancel,
+  searchFilters,
+  title,
+  items,
+}) {
+  return <div />
+}
+
+const StatelessFunctionalComponent = ({
+  isActive,
+  onFiltersUpdated,
+  onSelect,
+  onSubmitAndDeselect,
+  onCancel,
+  searchFilters,
+  title,
+  items,
+}: {
+  isActive: number,
+  onFiltersUpdated: number,
+  onSelect: number,
+  onSubmitAndDeselect: number,
+  onCancel: number,
+  searchFilters: number,
+  title: number,
+  items: number,
+}) => {
+  return <div />
+};
+
+class C {
+  StatelessFunctionalComponent({
+    isActive,
+    onFiltersUpdated,
+    onSelect,
+    onSubmitAndDeselect,
+    onCancel,
+    searchFilters,
+    title,
+    items,
+  }) {
+    return <div />
+  }
+}
+
+type T = ({
+  isActive: number,
+  onFiltersUpdated: number,
+  onSelect: number,
+  onSubmitAndDeselect: number,
+  onCancel: number,
+  searchFilters: number,
+  title: number,
+  items: number,
+}) => void;


### PR DESCRIPTION
This is very common for stateful react functional components. It also matches last object expansion. I think that we should only do that for a single argument in function definitions though, unlike the last for function calls.

Fixes #1019