### PR TITLE
Inline class expressions for bracket-less arrow functions

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -337,7 +337,8 @@ function genericPrintNoParens(path, options, print) {
         n.body.type === "JSXElement" ||
         n.body.type === "BlockStatement" ||
         n.body.type === "TaggedTemplateExpression" ||
-        n.body.type === "TemplateElement"
+        n.body.type === "TemplateElement" ||
+        n.body.type === "ClassExpression"
       ) {
         return group(collapsed);
       }

--- a/tests/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -140,7 +140,17 @@ function render() {
       />
     </View>
   );
-}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+}
+
+jest.mock(
+  '../SearchSource',
+  () => class {
+    findMatchingTests(pattern) {
+      return {paths: []};
+    }
+  },
+);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Seq(typeDef.interface.groups).forEach(group =>
   Seq(group.members).forEach((member, memberName) =>
     markdownDoc(member.doc, {
@@ -209,6 +219,15 @@ function render() {
     </View>
   );
 }
+
+jest.mock(
+  \\"../SearchSource\\",
+  () => class {
+    findMatchingTests(pattern) {
+      return { paths: [] };
+    }
+  }
+);
 "
 `;
 

--- a/tests/arrows/call.js
+++ b/tests/arrows/call.js
@@ -65,3 +65,12 @@ function render() {
     </View>
   );
 }
+
+jest.mock(
+  '../SearchSource',
+  () => class {
+    findMatchingTests(pattern) {
+      return {paths: []};
+    }
+  },
+);


### PR DESCRIPTION
I could go either way but it doesn't seem a big deal to inline them. I don't expect it to be very common anyway

Fixes #990