### PR TITLE
Hide typescript parser from static analysis

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -55,16 +55,19 @@ function parseWithBabylon(text) {
 }
 
 function parseWithTypeScript(text) {
-    const parser = require('typescript-eslint-parser')
-    return parser.parse(text, {
-        loc: true,
-        range: true,
-        tokens: true,
-        attachComment: true,
-        ecmaFeatures: {
-            jsx: true,
-        }
-    })
+  // While we are working on typescript, we are putting it in devDependencies
+  // so it shouldn't be picked up by static analysis
+  const r = require;
+  const parser = r('typescript-eslint-parser')
+  return parser.parse(text, {
+    loc: true,
+    range: true,
+    tokens: true,
+    attachComment: true,
+    ecmaFeatures: {
+      jsx: true,
+    }
+  })
 }
 
 module.exports = { parseWithFlow, parseWithBabylon, parseWithTypeScript };


### PR DESCRIPTION
Adding typescript broke the docs build and is causing issues with create-react-app bundler. Let's use a small hack to hide it from static analysis, but still works in node.

Fixes #986