### PR TITLE
Preserve comment position for last arg or method

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -518,7 +518,8 @@ function handleLastFunctionArgComments(
     precedingNode.type === "Identifier" &&
     enclosingNode &&
     (enclosingNode.type === "ArrowFunctionExpression" ||
-      enclosingNode.type === "FunctionExpression") &&
+      enclosingNode.type === "FunctionExpression" ||
+      enclosingNode.type === "ClassMethod") &&
     followingNode &&
     followingNode.type !== "Identifier"
   ) {

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1246,6 +1246,13 @@ f = function(
   currentRequest: {a: number},
   // TODO this is a very very very very long comment that makes it go > 80 columns
 ) {};
+
+class X {
+  f(
+    currentRequest: {a: number},
+    // TODO this is a very very very very long comment that makes it go > 80 columns
+  ) {}
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 type f = (
   currentRequest: { a: number }
@@ -1266,6 +1273,13 @@ f = function(
   currentRequest: { a: number }
   // TODO this is a very very very very long comment that makes it go > 80 columns
 ) {};
+
+class X {
+  f(
+    currentRequest: { a: number }
+    // TODO this is a very very very very long comment that makes it go > 80 columns
+  ) {}
+}
 "
 `;
 
@@ -1289,6 +1303,13 @@ f = function(
   currentRequest: {a: number},
   // TODO this is a very very very very long comment that makes it go > 80 columns
 ) {};
+
+class X {
+  f(
+    currentRequest: {a: number},
+    // TODO this is a very very very very long comment that makes it go > 80 columns
+  ) {}
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 type f = (
   currentRequest: { a: number }
@@ -1309,6 +1330,13 @@ f = function(
   currentRequest: { a: number }
   // TODO this is a very very very very long comment that makes it go > 80 columns
 ) {};
+
+class X {
+  f(
+    currentRequest: { a: number }
+    // TODO this is a very very very very long comment that makes it go > 80 columns
+  ) {}
+}
 "
 `;
 

--- a/tests/comments/last-arg.js
+++ b/tests/comments/last-arg.js
@@ -17,3 +17,10 @@ f = function(
   currentRequest: {a: number},
   // TODO this is a very very very very long comment that makes it go > 80 columns
 ) {};
+
+class X {
+  f(
+    currentRequest: {a: number},
+    // TODO this is a very very very very long comment that makes it go > 80 columns
+  ) {}
+}


### PR DESCRIPTION
In #856, it handled a bunch of cases but missed class methods

Fixes #905