### PR TITLE
Remove unused code.

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -100,7 +100,6 @@ function getIntOption(optionName) {
 }
 
 function getTrailingComma() {
-  let trailingComma;
   switch (argv["trailing-comma"]) {
     case undefined:
     case "none":

--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -272,7 +272,7 @@ FPp.needsParens = function(assumeExpressionContext) {
 
         case "NewExpression":
         case "CallExpression":
-          return name === "callee" && parent.callee == node;
+          return name === "callee" && parent.callee === node;
 
         case "BinaryExpression":
           return parent.operator === "**" && name === "left";
@@ -437,7 +437,6 @@ FPp.needsParens = function(assumeExpressionContext) {
         case "SpreadProperty":
         case "BinaryExpression":
         case "LogicalExpression":
-        case "LogicalExpression":
         case "ExportDefaultDeclaration":
         case "AwaitExpression":
         case "JSXSpreadAttribute":
@@ -482,7 +481,7 @@ FPp.needsParens = function(assumeExpressionContext) {
 
         case "BindExpression":
         case "TaggedTemplateExpression":
-        case "UnaryExpression":  
+        case "UnaryExpression":
         case "LogicalExpression":
         case "BinaryExpression":
           return true;

--- a/src/printer.js
+++ b/src/printer.js
@@ -652,7 +652,6 @@ function genericPrintNoParens(path, options, print) {
     case "ObjectExpression":
     case "ObjectPattern":
     case "ObjectTypeAnnotation":
-      var allowBreak = false;
       var isTypeAnnotation = n.type === "ObjectTypeAnnotation";
       // Leave this here because we *might* want to make this
       // configurable later -- flow accepts ";" for type separators
@@ -1309,7 +1308,7 @@ function genericPrintNoParens(path, options, print) {
         comments.printDanglingComments(
           path,
           options,
-          /* sameIndent */ requiresHardline ? false : true
+          /* sameIndent */ !requiresHardline
         ),
         requiresHardline ? hardline : ""
       ]);
@@ -1819,13 +1818,12 @@ function genericPrintNoParens(path, options, print) {
       debugger;
       throw new Error("unknown type: " + JSON.stringify(n.type));
   }
-  return p;
 }
 
 function printStatementSequence(path, options, print) {
   let printed = [];
 
-  path.map(function(stmtPath, i) {
+  path.map(stmtPath => {
     var stmt = stmtPath.getValue();
 
     // Just in case the AST has been modified to contain falsy
@@ -2903,15 +2901,6 @@ function isCurlyBracket(doc) {
 function isEmptyBlock(doc) {
   const str = getFirstString(doc);
   return str === "{}";
-}
-
-function lastNonSpaceCharacter(lines) {
-  var pos = lines.lastPos();
-  do {
-    var ch = lines.charAt(pos);
-
-    if (/\S/.test(ch)) return ch;
-  } while (lines.prevPos(pos));
 }
 
 function nodeStr(node, options) {

--- a/src/util.js
+++ b/src/util.js
@@ -1,6 +1,5 @@
 "use strict";
 
-var assert = require("assert");
 var types = require("ast-types");
 var n = types.namedTypes;
 


### PR DESCRIPTION
A follow-up to @vjeux 's https://github.com/prettier/prettier/pull/936#discussion_r106489469. There are other functions declared in `printer.js` that are actually unused but I guess we want to keep them available.