### PR TITLE
Add ability to break for top member expression

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -232,9 +232,22 @@ function genericPrintNoParens(path, options, print, args) {
         path.call(print, "right")
       ]);
     case "MemberExpression": {
+      const parent = path.getParentNode();
+      const shouldInline =
+        n.computed ||
+        (n.object.type === "Identifier" &&
+          n.property.type === "Identifier" &&
+          parent.type !== "MemberExpression");
+
       return concat([
         path.call(print, "object"),
-        printMemberLookup(path, options, print)
+        shouldInline
+          ? printMemberLookup(path, options, print)
+          : group(
+              indent(
+                concat([softline, printMemberLookup(path, options, print)])
+              )
+            )
       ]);
     }
     case "MetaProperty":

--- a/tests/flow/declare_export/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declare_export/__snapshots__/jsfmt.spec.js.snap
@@ -1117,7 +1117,8 @@ var numberValue6 = require(\\"ES6_ExportFrom_Intermediary2\\").numberValue1;
 var ap1: number = numberValue6;
 var ap2: string = numberValue6; // Error: number ~> string
 
-var numberValue2_renamed2 = require(\\"ES6_ExportFrom_Intermediary2\\").numberValue2_renamed2;
+var numberValue2_renamed2 = require(\\"ES6_ExportFrom_Intermediary2\\")
+  .numberValue2_renamed2;
 var aq1: number = numberValue2_renamed2;
 var aq2: string = numberValue2_renamed2; // Error: number ~> string
 

--- a/tests/flow/es6modules/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/es6modules/__snapshots__/jsfmt.spec.js.snap
@@ -1246,7 +1246,8 @@ var numberValue6 = require(\\"ES6_ExportFrom_Intermediary2\\").numberValue1;
 var ap1: number = numberValue6;
 var ap2: string = numberValue6; // Error: number ~> string
 
-var numberValue2_renamed2 = require(\\"ES6_ExportFrom_Intermediary2\\").numberValue2_renamed2;
+var numberValue2_renamed2 = require(\\"ES6_ExportFrom_Intermediary2\\")
+  .numberValue2_renamed2;
 var aq1: number = numberValue2_renamed2;
 var aq2: string = numberValue2_renamed2; // Error: number ~> string
 

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -119,6 +119,32 @@ it(\\"should group messages with same created time\\", () => {
 "
 `;
 
+exports[`break-last-member.js 1`] = `
+"SomeVeryLongUpperCaseConstant.someVeryLongCallExpression().some_very_long_member_expression
+weNeedToReachTheEightyCharacterLimitXXXXXXXXXXXXXXXXX.someNode
+  .childrenInAnArray[0];
+superSupersuperSupersuperSupersuperSupersuperSuperLong.exampleOfOrderOfGetterAndSetterReordered;
+superSupersuperSupersuperSupersuperSupersuperSuperLong.exampleOfOrderOfGetterAndSetterReordered[0];
+
+expect(
+  findDOMNode(component.instance()).getElementsByClassName(styles.inner)[0].style.paddingRight
+).toBe('1000px');
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+SomeVeryLongUpperCaseConstant.someVeryLongCallExpression()
+  .some_very_long_member_expression;
+weNeedToReachTheEightyCharacterLimitXXXXXXXXXXXXXXXXX.someNode
+  .childrenInAnArray[0];
+superSupersuperSupersuperSupersuperSupersuperSuperLong.exampleOfOrderOfGetterAndSetterReordered;
+superSupersuperSupersuperSupersuperSupersuperSuperLong
+  .exampleOfOrderOfGetterAndSetterReordered[0];
+
+expect(
+  findDOMNode(component.instance()).getElementsByClassName(styles.inner)[0]
+    .style.paddingRight
+).toBe(\\"1000px\\");
+"
+`;
+
 exports[`comment.js 1`] = `
 "function f() {
   return observableFromSubscribeFunction()

--- a/tests/method-chain/break-last-member.js
+++ b/tests/method-chain/break-last-member.js
@@ -1,0 +1,9 @@
+SomeVeryLongUpperCaseConstant.someVeryLongCallExpression().some_very_long_member_expression
+weNeedToReachTheEightyCharacterLimitXXXXXXXXXXXXXXXXX.someNode
+  .childrenInAnArray[0];
+superSupersuperSupersuperSupersuperSupersuperSuperLong.exampleOfOrderOfGetterAndSetterReordered;
+superSupersuperSupersuperSupersuperSupersuperSuperLong.exampleOfOrderOfGetterAndSetterReordered[0];
+
+expect(
+  findDOMNode(component.instance()).getElementsByClassName(styles.inner)[0].style.paddingRight
+).toBe('1000px');


### PR DESCRIPTION
It turns out that the top member expression doesn't go through the member chain logic. Let's give it the ability to break for now.

Fixes #1031
Fixes #1100