### PR TITLE
Fix comment sorting location

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -36,7 +36,8 @@ function getSortedChildNodes(node, text, resultArray) {
       // time because we almost always (maybe always?) append the
       // nodes in order anyway.
       for (var i = resultArray.length - 1; i >= 0; --i) {
-        if (locEnd(resultArray[i]) - locStart(node) <= 0) {
+        if (locStart(resultArray[i]) <= locStart(node) &&
+            locEnd(resultArray[i]) <= locEnd(node)) {
           break;
         }
       }

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -13,8 +13,7 @@ const { a /* comment */ = 1 } = b;
 const { c = 1 /* comment */ } = d;
 
 let {
-  //comment
-  a = b
+  a = b //comment
 } = c;
 "
 `;
@@ -32,8 +31,7 @@ const { a /* comment */ = 1 } = b;
 const { c = 1 /* comment */ } = d;
 
 let {
-  //comment
-  a = b
+  a = b //comment
 } = c;
 "
 `;

--- a/tests/flow/coverage/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/coverage/__snapshots__/jsfmt.spec.js.snap
@@ -13,15 +13,14 @@ declare module bar {
 
 // TODO
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-declare module foo {
-}
-
-// TODO
 // This file triggers a violation of the \\"disjoint-or-nested ranges invariant\\"
 // that we implicitly assume in type-at-pos and coverage implementations. In
 // particular, when unchecked it causes a crash with coverage --color.
 
+declare module foo {
+}
 declare module bar {
+  // TODO
 }
 "
 `;
@@ -64,16 +63,15 @@ declare module bar {
 declare class qux {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-declare module foo {
-}
 // This file triggers a violation of the \\"disjoint-or-nested ranges invariant\\"
 // that we implicitly assume in type-at-pos and coverage implementations. In
 // particular, when unchecked it causes non-termination with coverage --color.
 
-declare module bar {
+declare module foo {
 }
-// TODO
-
+declare module bar {
+  // TODO
+}
 declare class qux {}
 "
 `;

--- a/tests/flow/declare_module_exports/flow-typed/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declare_module_exports/flow-typed/__snapshots__/jsfmt.spec.js.snap
@@ -42,12 +42,12 @@ declare module \\"declare_m_e_with_other_value_declares\\" {
 declare module \\"declare_m_e_with_other_type_declares\\" {
   declare module.exports: number;
   declare type str2 = string;
-}
-/**
+
+  /**
  * \`declare var exports\` is deprecated, so we have a grace period where both
  * syntaxes will work.
  */
-
+}
 declare module \\"DEPRECATED__declare_var_exports\\" {
   declare var exports: number;
 

--- a/tests/flow_method/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_method/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`comment.js 1`] = `
+"type Foo = {
+  method(
+    arg: number, // I belong with baz
+    qux: string
+  ) : void
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+type Foo = {
+  method(
+    arg: number, // I belong with baz
+    qux: string
+  ): void
+};
+"
+`;
+
 exports[`method.js 1`] = `
 "type T = { method: () => void };
 type T = { method(): void };

--- a/tests/flow_method/comment.js
+++ b/tests/flow_method/comment.js
@@ -1,0 +1,6 @@
+type Foo = {
+  method(
+    arg: number, // I belong with baz
+    qux: string
+  ) : void
+}


### PR DESCRIPTION
Right now it's only doing one test for begin/end, but in the issue #1037, we have two nodes that have the same start but different end. The current implementation incorrectly sorts them and the identifier ends up being before the container and therefore the comment search doesn't recurse into it.

Fixes #1037
Fixes #938