### PR TITLE
Stabilize comment on member chain with three elements

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2466,7 +2466,9 @@ function printMemberChain(path, options, print) {
 
   const printedGroups = groups.map(printGroup);
   const oneLine = concat(printedGroups);
-  const hasComment = groups.length >= 2 && groups[1][0].node.comments;
+  const hasComment =
+    (groups.length >= 2 && groups[1][0].node.comments) ||
+    (groups.length >= 3 && groups[2][0].node.comments);
 
   // If we only have a single `.`, we shouldn't do anything fancy and just
   // render everything concatenated together.

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -126,6 +126,19 @@ exports[`comment.js 1`] = `
     // configurable.
     .debounceTime(debounceInterval);
 }
+
+_.a(a)
+  /* very very very very very very very long such that it is longer than 80 columns */
+  .a()
+
+_.a(
+  a
+)/* very very very very very very very long such that it is longer than 80 columns */
+.a();
+
+_.a(
+  a
+) /* very very very very very very very long such that it is longer than 80 columns */.a();
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function f() {
   return (
@@ -135,6 +148,18 @@ function f() {
       .debounceTime(debounceInterval)
   );
 }
+
+_.a(a)
+  /* very very very very very very very long such that it is longer than 80 columns */
+  .a();
+
+_.a(
+  a
+) /* very very very very very very very long such that it is longer than 80 columns */.a();
+
+_.a(
+  a
+) /* very very very very very very very long such that it is longer than 80 columns */.a();
 "
 `;
 

--- a/tests/method-chain/comment.js
+++ b/tests/method-chain/comment.js
@@ -4,3 +4,16 @@ function f() {
     // configurable.
     .debounceTime(debounceInterval);
 }
+
+_.a(a)
+  /* very very very very very very very long such that it is longer than 80 columns */
+  .a()
+
+_.a(
+  a
+)/* very very very very very very very long such that it is longer than 80 columns */
+.a();
+
+_.a(
+  a
+) /* very very very very very very very long such that it is longer than 80 columns */.a();


### PR DESCRIPTION
We already had a special case for it for a group of 2 elements but now that we are also going in this codepath for 3 if we merge, then we need to do the same here.

Fixes #930