### PR TITLE
Add ability for flow generics to break

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1547,7 +1547,7 @@ function genericPrintNoParens(path, options, print) {
 
       parts.push(path.call(print, "typeParameters"));
 
-      parts.push(group(printFunctionParams(path, print, options)));
+      parts.push(printFunctionParams(path, print, options));
 
       // The returnType is not wrapped in a TypeAnnotation, so the colon
       // needs to be added separately.
@@ -1559,7 +1559,7 @@ function genericPrintNoParens(path, options, print) {
         );
       }
 
-      return concat(parts);
+      return group(concat(parts));
     case "FunctionTypeParam":
       return concat([
         path.call(print, "name"),
@@ -1737,8 +1737,28 @@ function genericPrintNoParens(path, options, print) {
         ")"
       ]);
     case "TypeParameterDeclaration":
-    case "TypeParameterInstantiation":
-      return concat(["<", join(", ", path.map(print, "params")), ">"]);
+    case "TypeParameterInstantiation": {
+      const shouldInline =
+        n.params.length === 1 &&
+        n.params[0].type === "ObjectTypeAnnotation";
+
+      if (shouldInline) {
+        return concat(["<", join(", ", path.map(print, "params")), ">"]);
+      }
+
+      return group(concat([
+        "<",
+        indent(
+          options.tabWidth,
+          concat([
+            softline,
+            join(concat([",", line]), path.map(print, "params")),
+          ])
+        ),
+        softline,
+        ">"
+      ]));
+    }
     case "TypeParameter":
       switch (n.variance) {
         case "plus":

--- a/tests/flow/new_react/fakelib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/new_react/fakelib/__snapshots__/jsfmt.spec.js.snap
@@ -12,7 +12,12 @@ declare var $React: $Exports<\\"react\\">; // fake import
 // Strawman: revised definition of $jsx (alternatively, React.Element).
 // Using bounded poly to specify a constraint on a type parameter, and
 // existentials to elide type arguments.
-type _ReactElement<DefaultProps, Props, Config: $Diff<Props, DefaultProps>, C: $React.Component<DefaultProps, Props, any>> = $React.Element<Config>;
+type _ReactElement<
+  DefaultProps,
+  Props,
+  Config: $Diff<Props, DefaultProps>,
+  C: $React.Component<DefaultProps, Props, any>
+> = $React.Element<Config>;
 type $jsx<C> = _ReactElement<*, *, *, C>;
 "
 `;

--- a/tests/flow/type_param_variance2/libs/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type_param_variance2/libs/__snapshots__/jsfmt.spec.js.snap
@@ -88,9 +88,9 @@ declare class Promise<R> {
   static all<T>(promises: Array<?Promise<T> | T>): Promise<Array<T>>,
   static race<T>(promises: Array<Promise<T>>): Promise<T>,
 
-  static allObject<T: Object>(promisesByKey: T): Promise<{
-    [key: $Keys<T>]: any
-  }>
+  static allObject<T: Object>(
+    promisesByKey: T
+  ): Promise<{ [key: $Keys<T>]: any }>
 }
 "
 `;

--- a/tests/flow_generic/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_generic/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`break.js 1`] = `
+"var X = {
+  perform: function<    
+     A, B, C, D, E, F, G,     
+     T: (a: A, b: B, c: C, d: D, e: E, f: F) => G // eslint-disable-line space-before-function-paren
+   >(     
+     method: T, scope: any,     
+     a: A, b: B, c: C, d: D, e: E, f: F,    
+   ): G {
+  }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+var X = {
+  perform: function<
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    T: (a: A, b: B, c: C, d: D, e: E, f: F) => G // eslint-disable-line space-before-function-paren
+  >(method: T, scope: any, a: A, b: B, c: C, d: D, e: E, f: F): G {}
+};
+"
+`;

--- a/tests/flow_generic/break.js
+++ b/tests/flow_generic/break.js
@@ -1,0 +1,10 @@
+var X = {
+  perform: function<    
+     A, B, C, D, E, F, G,     
+     T: (a: A, b: B, c: C, d: D, e: E, f: F) => G // eslint-disable-line space-before-function-paren
+   >(     
+     method: T, scope: any,     
+     a: A, b: B, c: C, d: D, e: E, f: F,    
+   ): G {
+  }
+}

--- a/tests/flow_generic/jsfmt.spec.js
+++ b/tests/flow_generic/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);


### PR DESCRIPTION
While looking at an instability on the React codebase ( https://github.com/sebmarkbage/react/commit/ba1299acc2c3b66ec1e093c201bcede421a8caa0#diff-2550aa3d377452ae29361f5e53c51c10 ), I realized that we don't let them break which makes the code look weird.

So I added the ability for them to break :)