### PR TITLE
[RFC] Fix comment location for binary expressions

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2843,7 +2843,11 @@ function printBinaryishExpressions(path, parts, print, options, isNested) {
     // the other ones since we don't call the normal print on BinaryExpression,
     // only for the left and right parts
     if (isNested && node.comments) {
-      parts.push(comments.printComments(path, p => "", options));
+      parts.splice(
+        0,
+        parts.length,
+        comments.printComments(path, p => concat(parts.slice()), options)
+      );
     }
   } else {
     // Our stopping case. Simply print the node normally.

--- a/tests/binary-expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/binary-expressions/__snapshots__/jsfmt.spec.js.snap
@@ -19,6 +19,21 @@ function f() {
 "
 `;
 
+exports[`comment.js 1`] = `
+"a = (
+  // Commment 1
+  (Math.random() * (yRange * (1 - minVerticalFraction)))
+  + (minVerticalFraction * yRange)
+) - offset;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+a =
+  // Commment 1
+  Math.random() * (yRange * (1 - minVerticalFraction)) +
+  minVerticalFraction * yRange -
+  offset;
+"
+`;
+
 exports[`exp.js 1`] = `
 "a ** b ** c;
 (a ** b) ** c;

--- a/tests/binary-expressions/comment.js
+++ b/tests/binary-expressions/comment.js
@@ -1,0 +1,5 @@
+a = (
+  // Commment 1
+  (Math.random() * (yRange * (1 - minVerticalFraction)))
+  + (minVerticalFraction * yRange)
+) - offset;

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -674,10 +674,10 @@ export type AsyncExecuteOptions = child_process$execFileOpts & {
 // optional trailing comma gets moved all the way to the beginning
 const regex = new RegExp(
   \\"^\\\\\\\\s*\\" + // beginning of the line
-    \\"name\\\\\\\\s*=\\\\\\\\s*\\" + // name =
-    \\"['\\\\\\"]\\" + // opening quotation mark
-    escapeStringRegExp(target.name) + // target name
-    \\"['\\\\\\"]\\" + // closing quotation mark
+  \\"name\\\\\\\\s*=\\\\\\\\s*\\" + // name =
+  \\"['\\\\\\"]\\" + // opening quotation mark
+  escapeStringRegExp(target.name) + // target name
+  \\"['\\\\\\"]\\" + // closing quotation mark
     \\",?$\\" // optional trailing comma
 );
 
@@ -900,10 +900,10 @@ export type AsyncExecuteOptions = child_process$execFileOpts & {
 // optional trailing comma gets moved all the way to the beginning
 const regex = new RegExp(
   \\"^\\\\\\\\s*\\" + // beginning of the line
-    \\"name\\\\\\\\s*=\\\\\\\\s*\\" + // name =
-    \\"['\\\\\\"]\\" + // opening quotation mark
-    escapeStringRegExp(target.name) + // target name
-    \\"['\\\\\\"]\\" + // closing quotation mark
+  \\"name\\\\\\\\s*=\\\\\\\\s*\\" + // name =
+  \\"['\\\\\\"]\\" + // opening quotation mark
+  escapeStringRegExp(target.name) + // target name
+  \\"['\\\\\\"]\\" + // closing quotation mark
     \\",?$\\" // optional trailing comma
 );
 


### PR DESCRIPTION
The root cause is that we're calling `printComments` with an empty string, meaning that the leading/trailing comments are not correctly inserted at the right location.

So, the way to fix it is to call `p => concat(parts)` but because we're mutating the array in place, it doesn't work. We need to mutate it and create a copy. But, the root call is actually checking the shape of the parts array which our code is now breaking...

```js
          // Don't include the initial expression in the indentation
          // level. The first item is guaranteed to be the first
          // left-most expression.
          parts.length > 0 ? parts[0] : "",
```

The consequence is that binary expressions are no longer indented correctly if expressions have a comment (but now it places the comment properly!), which seems like an okay trade-off.

I'm not sure if we should merge this one or instead refactor this code such that it doesn't rely on mutation and looking at the shape of the printed tree. `printMemberChain` is a good thing to reference for inspiration.

Fixes #946