### PR TITLE
Ability for interface to break

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1612,17 +1612,28 @@ function genericPrintNoParens(path, options, print) {
       parts.push(
         "interface ",
         path.call(print, "id"),
-        path.call(print, "typeParameters"),
-        " "
+        path.call(print, "typeParameters")
       );
 
       if (n["extends"].length > 0) {
-        parts.push("extends ", join(", ", path.map(print, "extends")), " ");
+        parts.push(
+          group(
+            indent(
+              options.tabWidth,
+              concat([
+                line,
+                "extends ",
+                join(", ", path.map(print, "extends")),
+              ])
+            )
+          )
+        );
       }
 
+      parts.push(" ");
       parts.push(path.call(print, "body"));
 
-      return concat(parts);
+      return group(concat(parts));
     }
     case "ClassImplements":
     case "InterfaceExtends":

--- a/tests/interface/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/interface/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`break.js 1`] = `
+"export interface Environment1 extends GenericEnvironment<
+  SomeType,
+  AnotherType,
+  YetAnotherType,
+> {
+  m(): void;
+};
+export class Environment2 extends GenericEnvironment<
+  SomeType,
+  AnotherType,
+  YetAnotherType,
+> {
+  m() {};
+};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export interface Environment1
+  extends GenericEnvironment<SomeType, AnotherType, YetAnotherType> {
+  m(): void
+}
+export class Environment2
+  extends GenericEnvironment<SomeType, AnotherType, YetAnotherType> {
+  m() {}
+}
+"
+`;
+
 exports[`module.js 1`] = `
 "declare module X {
   declare interface Y { x: number; }

--- a/tests/interface/break.js
+++ b/tests/interface/break.js
@@ -1,0 +1,14 @@
+export interface Environment1 extends GenericEnvironment<
+  SomeType,
+  AnotherType,
+  YetAnotherType,
+> {
+  m(): void;
+};
+export class Environment2 extends GenericEnvironment<
+  SomeType,
+  AnotherType,
+  YetAnotherType,
+> {
+  m() {};
+};


### PR DESCRIPTION
We break on `class` before `extends` but didn't for `interface`. Now we do in the same way. Also TIL that `interface` was an actual keyword in JavaScript :P