### PR TITLE
Add support for currying

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -318,7 +318,8 @@ function genericPrintNoParens(path, options, print) {
         n.body.type === "BlockStatement" ||
         n.body.type === "TaggedTemplateExpression" ||
         n.body.type === "TemplateElement" ||
-        n.body.type === "ClassExpression"
+        n.body.type === "ClassExpression" ||
+        n.body.type === "ArrowFunctionExpression"
       ) {
         return group(collapsed);
       }

--- a/tests/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -231,6 +231,33 @@ jest.mock(
 "
 `;
 
+exports[`currying.js 1`] = `
+"const fn = b => c => d => {
+  return 3;
+};
+
+const mw = store => next => action => {
+  return next(action)
+}
+
+const middleware = options => (req, res, next) => {
+  // ...
+};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const fn = b => c => d => {
+  return 3;
+};
+
+const mw = store => next => action => {
+  return next(action);
+};
+
+const middleware = options => (req, res, next) => {
+  // ...
+};
+"
+`;
+
 exports[`long-call-no-args.js 1`] = `
 "veryLongCall(VERY_VERY_VERY_VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_CONSTANT, () => {})
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/arrows/currying.js
+++ b/tests/arrows/currying.js
@@ -1,0 +1,11 @@
+const fn = b => c => d => {
+  return 3;
+};
+
+const mw = store => next => action => {
+  return next(action)
+}
+
+const middleware = options => (req, res, next) => {
+  // ...
+};


### PR DESCRIPTION
If you write your code in a functional way where you have an arrow function for each argument, it looks better for them to be inline. I can't imagine any case where it would be used in a different way if we limit to a single argument.

Fixes #1065