### PR TITLE
Remove a few node types

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1494,7 +1494,6 @@ function genericPrintNoParens(path, options, print) {
         ])
       );
 
-    case "ExistentialTypeParam":
     case "ExistsTypeAnnotation":
       return "*";
     case "EmptyTypeAnnotation":

--- a/src/printer.js
+++ b/src/printer.js
@@ -132,10 +132,10 @@ function genericPrintNoParens(path, options, print) {
     return n;
   }
 
-  // TODO: For some reason NumericLiteralTypeAnnotation is not
-  // printable so this throws, but I think that's a bug in ast-types.
+  // TODO: Investigate types that return not printable.
   // This assert isn't very useful though.
   // namedTypes.Printable.assert(n);
+
   var parts = [];
   switch (n.type) {
     case "File":
@@ -1507,7 +1507,6 @@ function genericPrintNoParens(path, options, print) {
       return concat([path.call(print, "elementType"), "[]"]);
     case "BooleanTypeAnnotation":
       return "boolean";
-    case "NumericLiteralTypeAnnotation":
     case "BooleanLiteralTypeAnnotation":
       return "" + n.value;
     case "DeclareClass":


### PR DESCRIPTION
A couple node types were renamed in Babylon 7 to match their Flow counterparts.

NumericLiteralTypeAnnotation:
https://github.com/babel/babylon/pull/332

ExistsTypeAnnotation:
https://github.com/babel/babylon/pull/322