### PR TITLE
Change the suggested emacs config

### DIFF
--- a/editors/emacs/README.md
+++ b/editors/emacs/README.md
@@ -2,7 +2,10 @@ Add this to your init:
 
 ```elisp
 (require 'prettier-js)
-(add-hook 'js-mode-hook
-          (lambda ()
-            (add-hook 'before-save-hook 'prettier-before-save)))
+(add-hook 'before-save-hook
+  (lambda ()
+    (if
+      (member (car (last (split-string buffer-file-name "\\."))) '("jsx" "js"))
+      (prettier)
+      ())))
 ```


### PR DESCRIPTION
I've had some problems with running the suggested `before-save-hook` with js2-mode. This config should be mode-agnostic.