### PR TITLE
Add check method to Prettier Node API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ exit 1
 
 ### API
 
-The API is a single function exported as `format`. The options
+The API has two functions, exported as `format` and `check`. The options
 argument is optional, and all of the defaults are shown below:
 
 ```js
@@ -211,6 +211,9 @@ prettier.format(source, {
   parser: 'babylon'
 });
 ```
+
+`check` checks to see if the file has been formatted with prettier given the those options and returns a Boolean.
+This is similar to the `--list-different` parameter in the CLI and is useful for running Prettier in CI scenarios.
 
 ### Excluding code from formatting
 

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -232,6 +232,21 @@ if (stdin) {
 
     let output;
 
+    if (argv["list-different"]) {
+      try {
+        if (!prettier.check(input, options)) {
+          console.log(filename);
+          process.exitCode = 1;
+        }
+      } catch (e) {
+        // Add newline to split errors from filename line.
+        process.stdout.write("\n");
+        handleError(filename, e);
+      } finally {
+        return;
+      }
+    }
+
     try {
       output = format(input);
     } catch (e) {
@@ -266,11 +281,6 @@ if (stdin) {
       process.stdout.write("\n");
       if (output) {
         console.log(output);
-      }
-    } else if (argv["list-different"]) {
-      if (input !== output) {
-        console.log(filename);
-        process.exitCode = 1;
       }
     } else {
       // Don't use `console.log` here since it adds an extra newline at the end.

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -239,9 +239,7 @@ if (stdin) {
           process.exitCode = 1;
         }
       } catch (e) {
-        // Add newline to split errors from filename line.
-        process.stdout.write("\n");
-        handleError(filename, e);
+        // should never hit this block since check catches errors before it returns
       } finally {
         return;
       }

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -228,22 +228,20 @@ if (stdin) {
       return;
     }
 
-    const start = Date.now();
-
-    let output;
-
     if (argv["list-different"]) {
       try {
         if (!prettier.check(input, options)) {
           console.log(filename);
           process.exitCode = 1;
         }
-      } catch (e) {
-        // should never hit this block since check catches errors before it returns
       } finally {
         return;
       }
     }
+
+    const start = Date.now();
+
+    let output;
 
     try {
       output = format(input);

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -229,14 +229,11 @@ if (stdin) {
     }
 
     if (argv["list-different"]) {
-      try {
-        if (!prettier.check(input, options)) {
-          console.log(filename);
-          process.exitCode = 1;
-        }
-      } finally {
-        return;
+      if (!prettier.check(input, options)) {
+        console.log(filename);
+        process.exitCode = 1;
       }
+      return;
     }
 
     const start = Date.now();

--- a/index.js
+++ b/index.js
@@ -96,7 +96,12 @@ module.exports = {
     return formatWithShebang(text, normalizeOptions(opts));
   },
   check: function(text, opts) {
-    return this.format(text, opts) === text;
+    try {
+      const formatted = this.format(text, opts);
+      return formatted === text;
+    } catch (e) {
+      return false;
+    }
   },
   version: version,
   __debug: {

--- a/index.js
+++ b/index.js
@@ -95,6 +95,9 @@ module.exports = {
   format: function(text, opts) {
     return formatWithShebang(text, normalizeOptions(opts));
   },
+  check: function(text, opts) {
+    return this.format(text, opts) === text;
+  },
   version: version,
   __debug: {
     formatAST: function(ast, opts) {


### PR DESCRIPTION
Hi friends!

I figured this was better as a PR instead of an issue. We'd like to adopt Prettier and part of that is build it into our continuous integration. We run everything through Gulp (hence why I also forked btholt/gulp-prettier too) which makes use of the Node API. The `list-different` which is available to the CLI is precisely what we need but since that lives in the bin and not in the Node library it can't be used. This moves this logic back into the library exported from `index.js` as a tiny function that just makes use of the `format` function.

Is it very hard to keep ahold of the old string and compare it with the new string from Prettier? No, definitely not. This is what I did with my fork of gulp-prettier (which I borrowed the idea from facebook/react#9187). But I figured if my use case needed this as well as there's that it may be useful to support this use case in Prettier.

Let me know what you think and/or what I can fix!