### PR TITLE
Support "// prettier-ignore" in comment blocks

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -65,7 +65,7 @@ function genericPrint(path, options, printPath) {
   if (
     node.comments &&
     node.comments.length > 0 &&
-    node.comments[0].value.trim() === "prettier-ignore"
+    node.comments[node.comments.length - 1].value.trim() === "prettier-ignore"
   ) {
     return options.originalText.slice(util.locStart(node), util.locEnd(node));
   }

--- a/tests/ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ignore/__snapshots__/jsfmt.spec.js.snap
@@ -18,6 +18,14 @@ exports[`ignore.js 1`] = `
     0, 0, 0
   );
 
+  // Let's make sure that this comment doesn't interfere
+
+  // prettier-ignore
+  const commentsWithPrettierIgnore =   {
+    \\"ewww\\":
+            \\"gross-formatting\\",
+  };
+
   // prettier-ignore
   console.error(
     'In order to use ' + prompt + ', you need to configure a ' +
@@ -68,6 +76,14 @@ function a() {
     0, 1, 0,
     0, 0, 0
   );
+
+  // Let's make sure that this comment doesn't interfere
+
+  // prettier-ignore
+  const commentsWithPrettierIgnore =   {
+    \\"ewww\\":
+            \\"gross-formatting\\",
+  };
 
   // prettier-ignore
   console.error(

--- a/tests/ignore/ignore.js
+++ b/tests/ignore/ignore.js
@@ -15,6 +15,14 @@ function a() {
     0, 0, 0
   );
 
+  // Let's make sure that this comment doesn't interfere
+
+  // prettier-ignore
+  const commentsWithPrettierIgnore =   {
+    "ewww":
+            "gross-formatting",
+  };
+
   // prettier-ignore
   console.error(
     'In order to use ' + prompt + ', you need to configure a ' +


### PR DESCRIPTION
Pretty much took the example from #1109.

The important caveat is that `// prettier-ignore` has to be the only or _last_ comment attached to a node.

I could update this to use a `.filter(...).length` check so it can exist _anywhere_ in the comments, but felt that doesn't really make sense cosmetically to warrant it.