### PR TITLE
"// prettier-ignore" position within comments doesn't matter

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -65,7 +65,7 @@ function genericPrint(path, options, printPath) {
   if (
     node.comments &&
     node.comments.length > 0 &&
-    node.comments[node.comments.length - 1].value.trim() === "prettier-ignore"
+    node.comments.some(comment => comment.value.trim() === "prettier-ignore")
   ) {
     return options.originalText.slice(util.locStart(node), util.locEnd(node));
   }

--- a/tests/ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ignore/__snapshots__/jsfmt.spec.js.snap
@@ -26,6 +26,11 @@ exports[`ignore.js 1`] = `
             \\"gross-formatting\\",
   };
 
+  function giveMeSome() {
+    a(  a  ); // prettier-ignore
+    // shouldn't I return something?  :shrug:
+  }
+
   // prettier-ignore
   console.error(
     'In order to use ' + prompt + ', you need to configure a ' +
@@ -84,6 +89,11 @@ function a() {
     \\"ewww\\":
             \\"gross-formatting\\",
   };
+
+  function giveMeSome() {
+    a(  a  ); // prettier-ignore
+    // shouldn't I return something?  :shrug:
+  }
 
   // prettier-ignore
   console.error(

--- a/tests/ignore/ignore.js
+++ b/tests/ignore/ignore.js
@@ -23,6 +23,11 @@ function a() {
             "gross-formatting",
   };
 
+  function giveMeSome() {
+    a(  a  ); // prettier-ignore
+    // shouldn't I return something?  :shrug:
+  }
+
   // prettier-ignore
   console.error(
     'In order to use ' + prompt + ', you need to configure a ' +


### PR DESCRIPTION
Per @vjeux's comment:
> https://github.com/prettier/prettier/pull/1125#issuecomment-291930315

This now supports:

```js
  function giveMeSome() {
    a(  a  ); // prettier-ignore
    // shouldn't I return something?  :shrug:
  }
```

I'm using `comment.value.trim() === "prettier-ignore"`, as that is what property is what was there before.  @vjeux mentioned `comment.text === "prettier-ignore"`, but I don't know if this was pseudo-code or the "right way" now.
