### PR TITLE
Fix comment detection before comma

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -214,10 +214,10 @@ function isPreviousLineEmpty(text, node) {
 function isNextLineEmpty(text, node) {
   let oldIdx = null;
   let idx = locEnd(node);
-  idx = skipToLineEnd(text, idx);
   while (idx !== oldIdx) {
     // We need to skip all the potential trailing inline comments
     oldIdx = idx;
+    idx = skipToLineEnd(text, idx);
     idx = skipInlineComment(text, idx);
     idx = skipSpaces(text, idx);
   }

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -18,6 +18,23 @@ let {
 "
 `;
 
+exports[`before-comma.js 1`] = `
+"const foo = {
+  a: 'a' /* comment for this line */,
+
+  /* Section B */
+  b: 'b',
+};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const foo = {
+  a: \\"a\\" /* comment for this line */,
+
+  /* Section B */
+  b: \\"b\\"
+};
+"
+`;
+
 exports[`blank.js 1`] = `
 "// This file only
 // has comments. This comment

--- a/tests/comments/before-comma.js
+++ b/tests/comments/before-comma.js
@@ -1,0 +1,6 @@
+const foo = {
+  a: 'a' /* comment for this line */,
+
+  /* Section B */
+  b: 'b',
+};


### PR DESCRIPTION
We need to call the `skipToLineEnd` which skips `,` after an inline comment. So we have to put it inside of the while loop as you can have many comments, a comma and then many more comments.

Fixes #964