### PR TITLE
Fix trailing comment on switch case

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1178,7 +1178,7 @@ function genericPrintNoParens(path, options, print) {
       const isFirstCase = path.getNode() === path.getParentNode().cases[0];
 
       if (!isFirstCase && util.isPreviousLineEmpty(options.originalText, path.getValue())) {
-        parts.splice(0, 0, hardline);
+        parts.unshift(hardline);
       }
 
       if (n.consequent.find(node => node.type !== "EmptyStatement")) {

--- a/src/printer.js
+++ b/src/printer.js
@@ -1175,15 +1175,15 @@ function genericPrintNoParens(path, options, print) {
       if (n.test) parts.push("case ", path.call(print, "test"), ":");
       else parts.push("default:");
 
+      const isFirstCase = path.getNode() === path.getParentNode().cases[0];
+
+      if (!isFirstCase && util.isPreviousLineEmpty(options.originalText, path.getValue())) {
+        parts.splice(0, 0, hardline);
+      }
+
       if (n.consequent.find(node => node.type !== "EmptyStatement")) {
-        const parent = path.getParentNode();
-        const lastCase = util.getLast(parent.cases);
         const cons = path.call(consequentPath => {
-          return join(hardline, consequentPath.map(p => {
-            const shouldAddLine = p.getParentNode() !== lastCase &&
-              util.isNextLineEmpty(options.originalText, p.getValue());
-            return concat([print(p), shouldAddLine ? hardline : ""]);
-          }));
+          return join(hardline, consequentPath.map(print));
         }, "consequent");
         parts.push(
           isCurlyBracket(cons)

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1009,6 +1009,14 @@ switch (foo) {
 
   // no default
 }
+
+switch (foo) {
+  case \\"bar\\": //comment
+    doThing(); //comment
+
+  case \\"baz\\":
+    doOtherThing();
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 switch (node && node.type) {
   case \\"Property\\":
@@ -1028,6 +1036,14 @@ switch (foo) {
     doThing();
 
   // no default
+}
+
+switch (foo) {
+  case \\"bar\\": //comment
+    doThing(); //comment
+
+  case \\"baz\\":
+    doOtherThing();
 }
 "
 `;

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1015,7 +1015,18 @@ switch (foo) {
     doThing(); //comment
 
   case \\"baz\\":
-    doOtherThing();
+    doOtherThing(); //comment
+
+}
+
+switch (foo) {
+  case \\"bar\\": {
+    doThing();
+  } //comment
+
+  case \\"baz\\": {
+    doThing();
+  } //comment
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 switch (node && node.type) {
@@ -1043,7 +1054,17 @@ switch (foo) {
     doThing(); //comment
 
   case \\"baz\\":
-    doOtherThing();
+    doOtherThing(); //comment
+}
+
+switch (foo) {
+  case \\"bar\\": {
+    doThing();
+  } //comment
+
+  case \\"baz\\": {
+    doThing();
+  } //comment
 }
 "
 `;

--- a/tests/comments/switch.js
+++ b/tests/comments/switch.js
@@ -17,3 +17,11 @@ switch (foo) {
 
   // no default
 }
+
+switch (foo) {
+  case "bar": //comment
+    doThing(); //comment
+
+  case "baz":
+    doOtherThing();
+}

--- a/tests/comments/switch.js
+++ b/tests/comments/switch.js
@@ -23,5 +23,16 @@ switch (foo) {
     doThing(); //comment
 
   case "baz":
-    doOtherThing();
+    doOtherThing(); //comment
+
+}
+
+switch (foo) {
+  case "bar": {
+    doThing();
+  } //comment
+
+  case "baz": {
+    doThing();
+  } //comment
 }

--- a/tests/switch/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/switch/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,76 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`empty_lines.js 1`] = `
+"switch (foo) {
+  case \\"bar\\":
+    doSomething();
+
+  case \\"baz\\":
+    doOtherThing();
+}
+
+switch (foo) {
+
+  case \\"bar\\":
+    doSomething();
+
+  case \\"baz\\":
+    doOtherThing();
+}
+
+switch (foo) {
+  case \\"bar\\":
+    doSomething();
+
+  case \\"baz\\":
+    doOtherThing();
+
+}
+
+switch (foo) {
+  case \\"bar\\":
+    doSomething();
+
+
+
+  case \\"baz\\":
+    doOtherThing();
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+switch (foo) {
+  case \\"bar\\":
+    doSomething();
+
+  case \\"baz\\":
+    doOtherThing();
+}
+
+switch (foo) {
+  case \\"bar\\":
+    doSomething();
+
+  case \\"baz\\":
+    doOtherThing();
+}
+
+switch (foo) {
+  case \\"bar\\":
+    doSomething();
+
+  case \\"baz\\":
+    doOtherThing();
+}
+
+switch (foo) {
+  case \\"bar\\":
+    doSomething();
+
+  case \\"baz\\":
+    doOtherThing();
+}
+"
+`;
+
 exports[`empty_switch.js 1`] = `
 "switch (1) { default:; }
 switch (1) {}

--- a/tests/switch/empty_lines.js
+++ b/tests/switch/empty_lines.js
@@ -1,0 +1,35 @@
+switch (foo) {
+  case "bar":
+    doSomething();
+
+  case "baz":
+    doOtherThing();
+}
+
+switch (foo) {
+
+  case "bar":
+    doSomething();
+
+  case "baz":
+    doOtherThing();
+}
+
+switch (foo) {
+  case "bar":
+    doSomething();
+
+  case "baz":
+    doOtherThing();
+
+}
+
+switch (foo) {
+  case "bar":
+    doSomething();
+
+
+
+  case "baz":
+    doOtherThing();
+}


### PR DESCRIPTION
This changes how we print new lines between switch cases, thus fixing #945.

Instead of inserting lines after a case, this inserts before.