### PR TITLE
Improve jsx output for style components

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2877,8 +2877,23 @@ function printJSXElement(path, options, print) {
     delete n.closingElement;
   }
 
-  // If no children, just print the opening element
   const openingLines = path.call(print, "openingElement");
+  const closingLines = path.call(print, "closingElement");
+
+  if (
+    n.children.length === 1 &&
+    n.children[0].type === "JSXExpressionContainer" &&
+    (n.children[0].expression.type === "TemplateLiteral" ||
+      n.children[0].expression.type === "TaggedTemplateExpression")
+  ) {
+    return concat([
+      openingLines,
+      concat(path.map(print, "children")),
+      closingLines
+    ]);
+  }
+
+  // If no children, just print the opening element
   if (n.openingElement.selfClosing) {
     assert.ok(!n.closingElement);
     return openingLines;
@@ -2964,8 +2979,6 @@ function printJSXElement(path, options, print) {
       )
     )
   ];
-
-  const closingLines = path.call(print, "closingElement");
 
   const multiLineElem = group(
     concat([

--- a/src/printer.js
+++ b/src/printer.js
@@ -1253,6 +1253,8 @@ function genericPrintNoParens(path, options, print) {
         n.expression.type === "CallExpression" ||
         n.expression.type === "FunctionExpression" ||
         n.expression.type === "JSXEmptyExpression" ||
+        n.expression.type === "TemplateLiteral" ||
+        n.expression.type === "TaggedTemplateExpression" ||
         (parent.type === "JSXElement" &&
           (n.expression.type === "ConditionalExpression" ||
             isBinaryish(n.expression)));

--- a/tests/jsx_template/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx_template/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`styled-components.js 1`] = `
+"<style jsx>{\`
+  p {
+    color: red;
+  }
+\`}</style>;
+
+<style jsx>{tpl\`
+  p {
+    color: red;
+  }
+\`}</style>;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<style jsx>
+  {\`
+  p {
+    color: red;
+  }
+\`}
+</style>;
+
+<style jsx>
+  {tpl\`
+  p {
+    color: red;
+  }
+\`}
+</style>;
+"
+`;

--- a/tests/jsx_template/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx_template/__snapshots__/jsfmt.spec.js.snap
@@ -12,21 +12,31 @@ exports[`styled-components.js 1`] = `
     color: red;
   }
 \`}</style>;
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-<style jsx>
-  {\`
-  p {
-    color: red;
-  }
-\`}
-</style>;
 
 <style jsx>
-  {tpl\`
+  {\`p {
+     color: red;
+     }
+  \`}
+</style>;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<style jsx>{\`
   p {
     color: red;
   }
-\`}
+\`}</style>;
+
+<style jsx>{tpl\`
+  p {
+    color: red;
+  }
+\`}</style>;
+
+<style jsx>
+  {\`p {
+     color: red;
+     }
+  \`}
 </style>;
 "
 `;

--- a/tests/jsx_template/jsfmt.spec.js
+++ b/tests/jsx_template/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/jsx_template/styled-components.js
+++ b/tests/jsx_template/styled-components.js
@@ -9,3 +9,10 @@
     color: red;
   }
 `}</style>;
+
+<style jsx>
+  {`p {
+     color: red;
+     }
+  `}
+</style>;

--- a/tests/jsx_template/styled-components.js
+++ b/tests/jsx_template/styled-components.js
@@ -1,0 +1,11 @@
+<style jsx>{`
+  p {
+    color: red;
+  }
+`}</style>;
+
+<style jsx>{tpl`
+  p {
+    color: red;
+  }
+`}</style>;


### PR DESCRIPTION
There are two commits in this PR:

## Hug template literals inside of JSXExpressionContainer
We already hug a bunch of things inside of `{}`. It seems that it's a good idea to do it for template literals as well. I don't think I've seen anyone actually indent them.

## Inline jsx elements with single template literal expression

If there is a single expression and a single template literal, then a lot of people in the jsx-style world inline it. I've also myself used this for markdown and printed it that way. So we probably should print it that way.

Note that I'm checking for children.length === 1, this means that if there's any whitespace, this is not going to be true and will not enter this case. So it WON'T reformat

```js
<style>
  {`
     color: red;
  `}
</style>
```

into

```js
<style>{`
    color: red;
`}</style>
```

which is great. You have to opt-in to the second style in order to get it.


Fixes for #1090