### PR TITLE
Add parens around arrow function return type

### DIFF
--- a/tests/flow_return_arrow/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_return_arrow/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parens.js 1`] = `
+"const f = (): (string => string) => {};
+const f = (): (a | string => string) => {};
+const f = (): (a & string => string) => {};
+function f(): string => string {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const f = (): (string => string) => {};
+const f = (): a | ((string) => string) => {};
+const f = (): a & ((string) => string) => {};
+function f(): string => string {}
+"
+`;

--- a/tests/flow_return_arrow/jsfmt.spec.js
+++ b/tests/flow_return_arrow/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/flow_return_arrow/parens.js
+++ b/tests/flow_return_arrow/parens.js
@@ -1,0 +1,4 @@
+const f = (): (string => string) => {};
+const f = (): (a | string => string) => {};
+const f = (): (a & string => string) => {};
+function f(): string => string {}


### PR DESCRIPTION
Fixes #1151