### PR TITLE
Improve printing of chained intersections

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1639,16 +1639,14 @@ function genericPrintNoParens(path, options, print) {
         if (i === 0) {
           result.push(types[i]);
         } else if (
-          (n.types[i - 1].type === "ObjectTypeAnnotation" &&
-            n.types[i].type !== "ObjectTypeAnnotation") ||
-          (n.types[i - 1].type !== "ObjectTypeAnnotation" &&
-            n.types[i].type === "ObjectTypeAnnotation")
+          n.types[i - 1].type !== "ObjectTypeAnnotation" &&
+          n.types[i].type !== "ObjectTypeAnnotation"
         ) {
-          // If you go from object to non-object or vis-versa, then inline it
-          result.push(" & ", types[i]);
-        } else {
-          // Otherwise go to the next line and indent
+          // If no object is involved, go to the next line if it breaks
           result.push(indent(concat([" &", line, types[i]])));
+        } else {
+          // If you go from object to non-object or vis-versa, then inline it
+          result.push(" & ", i > 1 ? indent(types[i]) : types[i]);
         }
       }
       return group(concat(result));

--- a/tests/flow/intersection/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/intersection/__snapshots__/jsfmt.spec.js.snap
@@ -81,10 +81,10 @@ function hasObjectMode_ok(options: DuplexStreamOptions): boolean {
 
 type DuplexStreamOptions = ReadableStreamOptions &
   WritableStreamOptions & {
-  allowHalfOpen?: boolean,
-  readableObjectMode?: boolean,
-  writableObjectMode?: boolean
-};
+    allowHalfOpen?: boolean,
+    readableObjectMode?: boolean,
+    writableObjectMode?: boolean
+  };
 
 function hasObjectMode_bad(options: DuplexStreamOptions): boolean {
   return (

--- a/tests/intersection/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/intersection/__snapshots__/jsfmt.spec.js.snap
@@ -10,6 +10,34 @@ type Props = {
   style?: Object,
   thumbnail: ImageSource,
 } & FooterProps;
+
+type DuplexStreamOptions = ReadableStreamOptions & {
+  allowHalfOpen?: boolean,
+  readableObjectMode?: boolean
+};
+
+type DuplexStreamOptions = {
+  allowHalfOpen?: boolean,
+  readableObjectMode?: boolean
+} & {
+  allowHalfOpen?: boolean,
+  readableObjectMode?: boolean
+};
+
+type DuplexStreamOptions = ReadableStreamOptions &
+  WritableStreamOptions & {
+    allowHalfOpen?: boolean,
+    readableObjectMode?: boolean
+  };
+
+type DuplexStreamOptions = ReadableStreamOptions &
+  WritableStreamOptions & {
+    allowHalfOpen?: boolean,
+    readableObjectMode?: boolean
+  } & {
+    allowHalfOpen?: boolean,
+    readableObjectMode?: boolean
+  };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 export type ReallyBigSocketServer = ReallyBigSocketServerInterface &
   ReallyBigSocketServerStatics;
@@ -21,5 +49,33 @@ type Props = {
   style?: Object,
   thumbnail: ImageSource
 } & FooterProps;
+
+type DuplexStreamOptions = ReadableStreamOptions & {
+  allowHalfOpen?: boolean,
+  readableObjectMode?: boolean
+};
+
+type DuplexStreamOptions = {
+  allowHalfOpen?: boolean,
+  readableObjectMode?: boolean
+} & {
+  allowHalfOpen?: boolean,
+  readableObjectMode?: boolean
+};
+
+type DuplexStreamOptions = ReadableStreamOptions &
+  WritableStreamOptions & {
+    allowHalfOpen?: boolean,
+    readableObjectMode?: boolean
+  };
+
+type DuplexStreamOptions = ReadableStreamOptions &
+  WritableStreamOptions & {
+    allowHalfOpen?: boolean,
+    readableObjectMode?: boolean
+  } & {
+    allowHalfOpen?: boolean,
+    readableObjectMode?: boolean
+  };
 "
 `;

--- a/tests/intersection/intersection.js
+++ b/tests/intersection/intersection.js
@@ -7,3 +7,31 @@ type Props = {
   style?: Object,
   thumbnail: ImageSource,
 } & FooterProps;
+
+type DuplexStreamOptions = ReadableStreamOptions & {
+  allowHalfOpen?: boolean,
+  readableObjectMode?: boolean
+};
+
+type DuplexStreamOptions = {
+  allowHalfOpen?: boolean,
+  readableObjectMode?: boolean
+} & {
+  allowHalfOpen?: boolean,
+  readableObjectMode?: boolean
+};
+
+type DuplexStreamOptions = ReadableStreamOptions &
+  WritableStreamOptions & {
+    allowHalfOpen?: boolean,
+    readableObjectMode?: boolean
+  };
+
+type DuplexStreamOptions = ReadableStreamOptions &
+  WritableStreamOptions & {
+    allowHalfOpen?: boolean,
+    readableObjectMode?: boolean
+  } & {
+    allowHalfOpen?: boolean,
+    readableObjectMode?: boolean
+  };


### PR DESCRIPTION
Now properly indents all the combinations of objects and non objects.

Fixes #1076