### PR TITLE
Fix switch new lines

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1178,7 +1178,11 @@ function genericPrintNoParens(path, options, print) {
 
       if (n.consequent.find(node => node.type !== "EmptyStatement")) {
         const cons = path.call(consequentPath => {
-          return join(hardline, consequentPath.map(print));
+          return join(hardline, consequentPath.map((p, i) => {
+            const shouldAddLine = i !== n.consequent.length - 1 &&
+              util.isNextLineEmpty(options.originalText, p.getValue());
+            return concat([print(p), shouldAddLine ? hardline : ""]);
+          }));
         }, "consequent");
         parts.push(
           isCurlyBracket(cons)

--- a/tests/switch/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/switch/__snapshots__/jsfmt.spec.js.snap
@@ -36,6 +36,18 @@ switch (foo) {
   case \\"baz\\":
     doOtherThing();
 }
+
+switch (x) {
+  case y:
+    call();
+
+    break;
+
+  case z:
+    call();
+
+    break;
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 switch (foo) {
   case \\"bar\\":
@@ -67,6 +79,18 @@ switch (foo) {
 
   case \\"baz\\":
     doOtherThing();
+}
+
+switch (x) {
+  case y:
+    call();
+
+    break;
+
+  case z:
+    call();
+
+    break;
 }
 "
 `;

--- a/tests/switch/empty_lines.js
+++ b/tests/switch/empty_lines.js
@@ -33,3 +33,15 @@ switch (foo) {
   case "baz":
     doOtherThing();
 }
+
+switch (x) {
+  case y:
+    call();
+
+    break;
+
+  case z:
+    call();
+
+    break;
+}


### PR DESCRIPTION
#1136 accidentally removed all the empty lines between statements inside of switch cases. I just brought back the logic and made sure to only use it for everything but the last line.