### PR TITLE
Add doc debug printing for line-suffix-boundary

### DIFF
--- a/src/doc-debug.js
+++ b/src/doc-debug.js
@@ -99,6 +99,10 @@ function printDoc(doc) {
     return "lineSuffix(" + printDoc(doc.contents) + ")";
   }
 
+  if (doc.type === "line-suffix-boundary") {
+    return "lineSuffixBoundary";
+  }
+
   throw new Error("Unknown doc type " + doc.type);
 }
 


### PR DESCRIPTION
This fixes a bug where you are unable to print the doc representation for a doc that contains a `line-suffix-boundary`.

For example:

```
<a>{}</a>
```

(I imagine this was accidentally missed in https://github.com/prettier/prettier/pull/750)

https://prettier.github.io/prettier/#%7B%22content%22%3A%22%3Ca%3E%7B%7D%3C%2Fa%3E%22%2C%22options%22%3A%7B%22printWidth%22%3A80%2C%22tabWidth%22%3A2%2C%22singleQuote%22%3Afalse%2C%22trailingComma%22%3A%22none%22%2C%22bracketSpacing%22%3Atrue%2C%22jsxBracketSameLine%22%3Afalse%2C%22parser%22%3A%22babylon%22%2C%22doc%22%3Atrue%7D%7D