### PR TITLE
Make comments in JSX valid

### DIFF
--- a/tests/flow/more_react/App.react.js
+++ b/tests/flow/more_react/App.react.js
@@ -33,7 +33,7 @@ var App = React.createClass({
     return (
       <div>
         {foo(x,y)}
-        {foo(z,x)} // error, since z: number
+        {foo(z,x) /* error, since z: number */}
       </div>
     );
   }

--- a/tests/flow/more_react/JSX.js
+++ b/tests/flow/more_react/JSX.js
@@ -5,7 +5,7 @@ var React = require('react');
 var App = require('App.react');
 
 var app =
-  <App y={42}> // error, y: number but foo expects string in App.react
+  <App y={42}> {/* error, y: number but foo expects string in App.react */}
     Some text.
   </App>;
 

--- a/tests/flow/more_react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/more_react/__snapshots__/jsfmt.spec.js.snap
@@ -56,7 +56,7 @@ var App = React.createClass({
     return (
       <div>
         {foo(x,y)}
-        {foo(z,x)} // error, since z: number
+        {foo(z,x) /* error, since z: number */}
       </div>
     );
   }
@@ -100,7 +100,7 @@ var App = React.createClass({
     return (
       <div>
         {foo(x, y)}
-        {foo(z, x)} // error, since z: number
+        {foo(z, x) /* error, since z: number */}
       </div>
     );
   }
@@ -118,7 +118,7 @@ var React = require('react');
 var App = require('App.react');
 
 var app =
-  <App y={42}> // error, y: number but foo expects string in App.react
+  <App y={42}> {/* error, y: number but foo expects string in App.react */}
     Some text.
   </App>;
 
@@ -131,7 +131,7 @@ var App = require(\\"App.react\\");
 
 var app = (
   <App y={42}>
-    {\\" \\"}// error, y: number but foo expects string in App.react
+    {\\" \\"}{/* error, y: number but foo expects string in App.react */}
     Some text.
   </App>
 );


### PR DESCRIPTION
There are two places in the tests where we have `// comment` comments in JSX.

These are not actually valid comments in JSX and wouldn't behave as expected in a real program. This PR changes them to valid JSX comments (use the nearest thing JSX has to comments: `{/* comment */}`).

This doesn't really effect Prettier or the tests, it was just a small tidy up I came across while working on the new `fill` primitive for JSX.