### PR TITLE
Flatten nested ternaries

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -883,7 +883,20 @@ function genericPrintNoParens(path, options, print) {
       if (n.prefix) parts.reverse();
 
       return concat(parts);
-    case "ConditionalExpression":
+    case "ConditionalExpression": {
+      const parent = path.getParentNode(0);
+      if (parent.type === "ConditionalExpression" && parent.alternate === n) {
+        return concat([
+          path.call(print, "test"),
+          line,
+          "? ",
+          path.call(print, "consequent"),
+          line,
+          ": ",
+          path.call(print, "alternate")
+        ]);
+      }
+
       return group(
         concat([
           path.call(print, "test"),
@@ -894,11 +907,14 @@ function genericPrintNoParens(path, options, print) {
               align(2, path.call(print, "consequent")),
               line,
               ": ",
-              align(2, path.call(print, "alternate"))
+              n.alternate.type === "ConditionalExpression"
+                ? path.call(print, "alternate")
+                : align(2, path.call(print, "alternate")),
             ])
           )
         ])
       );
+    }
     case "NewExpression":
       parts.push("new ", path.call(print, "callee"));
 

--- a/tests/conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/conditional/__snapshots__/jsfmt.spec.js.snap
@@ -79,6 +79,25 @@ const { configureStore } = process.env.NODE_ENV === \\"production\\"
 "
 `;
 
+exports[`nested.js 1`] = `
+"const value = condition1
+  ? value1
+  : condition2
+      ? value2
+      : condition3
+          ? value3
+          : value4;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const value = condition1
+  ? value1
+  : condition2
+  ? value2
+  : condition3
+  ? value3
+  : value4;
+"
+`;
+
 exports[`new-expression.js 1`] = `
 "const testConsole = new TestConsole(
   config.useStderr ? process.stderr : process.stdout

--- a/tests/conditional/nested.js
+++ b/tests/conditional/nested.js
@@ -1,0 +1,7 @@
+const value = condition1
+  ? value1
+  : condition2
+      ? value2
+      : condition3
+          ? value3
+          : value4;


### PR DESCRIPTION
This keeps coming up that the way prettier prints nested ternaries is not good. Here's an attempt at solving the situation. A good compromise is to
- keep printing ternaries the way they are but do not indent nested ones
- have a single group for chained ternaries, this way the last ones also break instead of awkwardly being fitting in a single line

The implementation is pretty straightforward, just look at the parent and print it differently if it's a ternary and we are in the second group.

Before:
```js
const value = condition1
  ? value1
  : condition2 ? value2 : condition3 ? value3 : value4;
```

After:
```js
const value = condition1
  ? value1
  : condition2
  ? value2
  : condition3
  ? value3
  : value4;
```

Fixes #737 