### PR TITLE
Enhance prettier-js.el README

### DIFF
--- a/editors/emacs/README.md
+++ b/editors/emacs/README.md
@@ -6,3 +6,13 @@ Add this to your init:
           (lambda ()
             (add-hook 'before-save-hook 'prettier-before-save)))
 ```
+
+If you don't use `js-mode`, which is what Prettier targets by default, you'll need to first set your major-mode of choice:
+
+```elisp
+(require 'prettier-js)
+(setq prettier-target-mode "js2-mode")
+(add-hook 'js2-mode-hook
+          (lambda ()
+            (add-hook 'before-save-hook 'prettier-before-save)))
+```


### PR DESCRIPTION
Provide documentation for users who aren't using `js-mode` as their default JS major-mode.