### PR TITLE
Add parenthesis for no-confusing-arrow rule

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -443,6 +443,7 @@ FPp.needsParens = function(assumeExpressionContext) {
         case "ExportDefaultDeclaration":
         case "AwaitExpression":
         case "JSXSpreadAttribute":
+        case "ArrowFunctionExpression":
           return true;
 
         case "NewExpression":

--- a/tests/break-calls/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/break-calls/__snapshots__/jsfmt.spec.js.snap
@@ -70,7 +70,7 @@ function someFunction(url) {
 }
 
 const mapChargeItems = fp.flow(
-  l => l < 10 ? l : 1,
+  l => (l < 10 ? l : 1),
   l => Immutable.Range(l).toMap()
 );
 

--- a/tests/conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/conditional/__snapshots__/jsfmt.spec.js.snap
@@ -89,3 +89,14 @@ const testConsole = new TestConsole(
 );
 "
 `;
+
+exports[`no-confusing-arrow.js 1`] = `
+"// no-confusing-arrow
+var x = a => 1 ? 2 : 3;
+var x = a <= 1 ? 2 : 3;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// no-confusing-arrow
+var x = a => (1 ? 2 : 3);
+var x = a <= 1 ? 2 : 3;
+"
+`;

--- a/tests/conditional/no-confusing-arrow.js
+++ b/tests/conditional/no-confusing-arrow.js
@@ -1,0 +1,3 @@
+// no-confusing-arrow
+var x = a => 1 ? 2 : 3;
+var x = a <= 1 ? 2 : 3;

--- a/tests/flow/dump-types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/dump-types/__snapshots__/jsfmt.spec.js.snap
@@ -49,7 +49,7 @@ function unannotated(x) {
 }
 
 // test deduping of inferred types
-const nullToUndefined = val => val === null ? undefined : val;
+const nullToUndefined = val => (val === null ? undefined : val);
 
 function f0(x: ?Object) {
   return nullToUndefined(x);

--- a/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
@@ -71,7 +71,7 @@ true
     }),
     require(\\"postcss-url\\")({
       url: url =>
-        url.startsWith(\\"/\\") || /^[a-z]+:/.test(url) ? url : \`/static/\${url}\`
+        (url.startsWith(\\"/\\") || /^[a-z]+:/.test(url) ? url : \`/static/\${url}\`)
     })
   ]
 });


### PR DESCRIPTION
I'm unclear whether anyone was ever confused by this but the eslint page is kind of compelling

```js
// The intent is not clear
var x = a => 1 ? 2 : 3;
// Did the author mean this
var x = function (a) { return 1 ? 2 : 3 };
// Or this
var x = a <= 1 ? 2 : 3;
```

Adding a parenthesis makes it valid with `{"allowParens": true}` rule. Note that if this option is not enabled, the code would not pass lint in the first place.