### PR TITLE
Allow to break for member expressions after =

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3109,7 +3109,8 @@ function printAssignment(printedLeft, operator, rightNode, printedRight, options
     (isBinaryish(rightNode) && !shouldInlineLogicalExpression(rightNode)) ||
     rightNode.type === "StringLiteral" ||
     (rightNode.type === "Literal" &&
-      typeof rightNode.value === "string")
+      typeof rightNode.value === "string") ||
+    isMemberExpressionChain(rightNode)
   ) {
     printed = indent(
       concat([line, printedRight])
@@ -3316,6 +3317,16 @@ function returnArgumentHasLeadingComment(options, argument) {
   }
 
   return false;
+}
+
+function isMemberExpressionChain(node) {
+  if (node.type !== "MemberExpression") {
+    return false;
+  }
+  if (node.object.type === "Identifier") {
+    return true;
+  }
+  return isMemberExpressionChain(node.object);
 }
 
 // Hack to differentiate between the following two which have the same ast

--- a/tests/flow/getters_and_setters_enabled/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/getters_and_setters_enabled/__snapshots__/jsfmt.spec.js.snap
@@ -384,7 +384,8 @@ var testSubtypingGetterAndSetter: number = obj.propWithSubtypingGetterAndSetter;
 obj.exampleOfOrderOfGetterAndSetter = new C(); // Error C ~> B
 
 // And this example shows the danger of using the setter's type.
-var testExampleOrOrderOfGetterAndSetterReordered: number = obj.exampleOfOrderOfGetterAndSetterReordered; // Error A ~> B
+var testExampleOrOrderOfGetterAndSetterReordered: number =
+  obj.exampleOfOrderOfGetterAndSetterReordered; // Error A ~> B
 "
 `;
 
@@ -480,7 +481,8 @@ function test(obj: T) {
 
   obj.goodSetterWithAnnotation = \\"hello\\"; // Error string ~> number
 
-  var testSubtypingGetterAndSetter: number = obj.propWithSubtypingGetterAndSetter; // Error ?number ~> number
+  var testSubtypingGetterAndSetter: number =
+    obj.propWithSubtypingGetterAndSetter; // Error ?number ~> number
 
   // When building this feature, it was tempting to flow the setter into the
   // getter and then use either the getter or setter as the type of the
@@ -488,7 +490,8 @@ function test(obj: T) {
   obj.exampleOfOrderOfGetterAndSetter = new C(); // Error C ~> B
 
   // And this example shows the danger of using the setter's type.
-  var testExampleOrOrderOfGetterAndSetterReordered: number = obj.exampleOfOrderOfGetterAndSetterReordered; // Error A ~> B
+  var testExampleOrOrderOfGetterAndSetterReordered: number =
+    obj.exampleOfOrderOfGetterAndSetterReordered; // Error A ~> B
 }
 "
 `;

--- a/tests/member/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/member/__snapshots__/jsfmt.spec.js.snap
@@ -3,9 +3,8 @@
 exports[`expand.js 1`] = `
 "const veryVeryVeryVeryVeryVeryVeryLong = doc.expandedStates[doc.expandedStates.length - 1];
 const small = doc.expandedStates[doc.expandedStates.length - 1];~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-const veryVeryVeryVeryVeryVeryVeryLong = doc.expandedStates[
-  doc.expandedStates.length - 1
-];
+const veryVeryVeryVeryVeryVeryVeryLong =
+  doc.expandedStates[doc.expandedStates.length - 1];
 const small = doc.expandedStates[doc.expandedStates.length - 1];
 "
 `;


### PR DESCRIPTION
This should address a concern of #1036