### PR TITLE
Propagate hard breaks within member expressions (fixes #1117)

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2827,7 +2827,13 @@ function printMemberChain(path, options, print) {
     return group(expanded);
   }
 
-  return conditionalGroup([oneLine, expanded]);
+  return concat([
+    // We only need to check `oneLine` because if `expanded` is chosen
+    // that means that the parent group has already been broken
+    // naturally
+    willBreak(oneLine) ? breakParent : "",
+    conditionalGroup([oneLine, expanded])
+  ])
 }
 
 function isEmptyJSXElement(node) {

--- a/tests/member/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/member/__snapshots__/jsfmt.spec.js.snap
@@ -2,9 +2,51 @@
 
 exports[`expand.js 1`] = `
 "const veryVeryVeryVeryVeryVeryVeryLong = doc.expandedStates[doc.expandedStates.length - 1];
-const small = doc.expandedStates[doc.expandedStates.length - 1];~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const small = doc.expandedStates[doc.expandedStates.length - 1];
+
+const promises = [
+  promise.resolve().then(console.log).catch(err => {
+    console.log(err)
+    return null
+  }),
+  redis.fetch(),
+  other.fetch(),
+];
+
+const promises = [
+  promise.resolve().veryLongFunctionCall().veryLongFunctionCall().then(console.log).catch(err => {
+    console.log(err)
+    return null
+  }),
+  redis.fetch(),
+  other.fetch(),
+];
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const veryVeryVeryVeryVeryVeryVeryLong =
   doc.expandedStates[doc.expandedStates.length - 1];
 const small = doc.expandedStates[doc.expandedStates.length - 1];
+
+const promises = [
+  promise.resolve().then(console.log).catch(err => {
+    console.log(err);
+    return null;
+  }),
+  redis.fetch(),
+  other.fetch()
+];
+
+const promises = [
+  promise
+    .resolve()
+    .veryLongFunctionCall()
+    .veryLongFunctionCall()
+    .then(console.log)
+    .catch(err => {
+      console.log(err);
+      return null;
+    }),
+  redis.fetch(),
+  other.fetch()
+];
 "
 `;

--- a/tests/member/expand.js
+++ b/tests/member/expand.js
@@ -1,2 +1,20 @@
 const veryVeryVeryVeryVeryVeryVeryLong = doc.expandedStates[doc.expandedStates.length - 1];
 const small = doc.expandedStates[doc.expandedStates.length - 1];
+
+const promises = [
+  promise.resolve().then(console.log).catch(err => {
+    console.log(err)
+    return null
+  }),
+  redis.fetch(),
+  other.fetch(),
+];
+
+const promises = [
+  promise.resolve().veryLongFunctionCall().veryLongFunctionCall().then(console.log).catch(err => {
+    console.log(err)
+    return null
+  }),
+  redis.fetch(),
+  other.fetch(),
+];


### PR DESCRIPTION
The problem actually isn't in the last arg printing logic. We already appropriately propagate breaks [here](https://github.com/prettier/prettier/blob/master/src/printer.js#L2202) in that logic.

The problem is that member expressions are using `conditionalGroup` but not manually propagating breaks. This logic was suppressing it, so we need to propagate it.