### PR TITLE
Fix function trailing comment location

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -152,6 +152,7 @@ function attach(comments, ast, text, options) {
       // We also need to check if it's the first line of the file.
       if (
         handleLastFunctionArgComments(
+          text,
           precedingNode,
           enclosingNode,
           followingNode,
@@ -544,6 +545,7 @@ function handleCommentInEmptyParens(enclosingNode, comment) {
 }
 
 function handleLastFunctionArgComments(
+  text,
   precedingNode,
   enclosingNode,
   followingNode,
@@ -571,8 +573,7 @@ function handleLastFunctionArgComments(
       enclosingNode.type === "FunctionExpression" ||
       enclosingNode.type === "FunctionDeclaration" ||
       enclosingNode.type === "ClassMethod") &&
-    followingNode &&
-    followingNode.type !== "Identifier"
+    getNextNonSpaceNonCommentCharacter(text, comment) === ")"
   ) {
     addTrailingComment(precedingNode, comment);
     return true;

--- a/tests/trailing_comma/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/trailing_comma/__snapshots__/jsfmt.spec.js.snap
@@ -387,6 +387,14 @@ function supersupersupersuperLongF(
 ) {
   a
 }
+
+this.getAttribute(function(s)
+  /*string*/ {
+  console.log()
+});
+this.getAttribute(function(s) /*string*/ {
+  console.log()
+});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 let example = [
   "FOO",
@@ -424,6 +432,13 @@ function supersupersupersuperLongF(
 ) {
   a;
 }
+
+this.getAttribute(function(s) /*string*/ {
+  console.log();
+});
+this.getAttribute(function(s) /*string*/ {
+  console.log();
+});
 
 `;
 
@@ -463,6 +478,14 @@ function supersupersupersuperLongF(
 ) {
   a
 }
+
+this.getAttribute(function(s)
+  /*string*/ {
+  console.log()
+});
+this.getAttribute(function(s) /*string*/ {
+  console.log()
+});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 let example = [
   "FOO",
@@ -500,6 +523,13 @@ function supersupersupersuperLongF(
 ) {
   a;
 }
+
+this.getAttribute(function(s) /*string*/ {
+  console.log();
+});
+this.getAttribute(function(s) /*string*/ {
+  console.log();
+});
 
 `;
 
@@ -539,6 +569,14 @@ function supersupersupersuperLongF(
 ) {
   a
 }
+
+this.getAttribute(function(s)
+  /*string*/ {
+  console.log()
+});
+this.getAttribute(function(s) /*string*/ {
+  console.log()
+});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 let example = [
   "FOO",
@@ -576,5 +614,12 @@ function supersupersupersuperLongF(
 ) {
   a;
 }
+
+this.getAttribute(function(s) /*string*/ {
+  console.log();
+});
+this.getAttribute(function(s) /*string*/ {
+  console.log();
+});
 
 `;

--- a/tests/trailing_comma/trailing_whitespace.js
+++ b/tests/trailing_comma/trailing_whitespace.js
@@ -33,3 +33,11 @@ function supersupersupersuperLongF(
 ) {
   a
 }
+
+this.getAttribute(function(s)
+  /*string*/ {
+  console.log()
+});
+this.getAttribute(function(s) /*string*/ {
+  console.log()
+});


### PR DESCRIPTION
It turns out that we can't reliably detect with the ast if a comment is before or after the ). In order to fix this same problem with `if` I added the `getNextNonSpaceNonCommentCharacter` function. We can use the same here to fix the problem.

Fixes #933