### PR TITLE
Fix overflow for last argument expansion

### DIFF
--- a/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
@@ -172,6 +172,38 @@ func(one, two, three, four, five, six, seven, eig, is, this, too, long, yes, {
   // Comments
 });
 
+foo(
+  (
+    one,
+    two,
+    three,
+    four,
+    five,
+    six,
+    seven,
+    eight,
+    nine,
+    ten,
+    eleven,
+    twelve,
+    thirteen,
+    fourteen,
+  ) => {},
+);
+
+const contentTypes = function(tile, singleSelection) {
+  return compute(
+    function contentTypesContentTypes(
+      tile,
+      searchString = '',
+      filteredContentTypes = [],
+      contentTypesArray = [],
+      selectedGroup,
+      singleSelection) {
+      selectedGroup = (tile.state && tile.state.group) || selectedGroup;
+    }
+  );
+};
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 SuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLongCall(
   (err, result) => {
@@ -264,5 +296,37 @@ func(
     // Comments
   }
 );
+
+foo(
+  (
+    one,
+    two,
+    three,
+    four,
+    five,
+    six,
+    seven,
+    eight,
+    nine,
+    ten,
+    eleven,
+    twelve,
+    thirteen,
+    fourteen
+  ) => {}
+);
+
+const contentTypes = function(tile, singleSelection) {
+  return compute(function contentTypesContentTypes(
+    tile,
+    searchString = "",
+    filteredContentTypes = [],
+    contentTypesArray = [],
+    selectedGroup,
+    singleSelection
+  ) {
+    selectedGroup = (tile.state && tile.state.group) || selectedGroup;
+  });
+};
 
 `;

--- a/tests/last_argument_expansion/overflow.js
+++ b/tests/last_argument_expansion/overflow.js
@@ -17,3 +17,35 @@ func(one, two, three, four, five, six, seven, eig, is, this, too, long, yes, {
   // Comments
 });
 
+foo(
+  (
+    one,
+    two,
+    three,
+    four,
+    five,
+    six,
+    seven,
+    eight,
+    nine,
+    ten,
+    eleven,
+    twelve,
+    thirteen,
+    fourteen,
+  ) => {},
+);
+
+const contentTypes = function(tile, singleSelection) {
+  return compute(
+    function contentTypesContentTypes(
+      tile,
+      searchString = '',
+      filteredContentTypes = [],
+      contentTypesArray = [],
+      selectedGroup,
+      singleSelection) {
+      selectedGroup = (tile.state && tile.state.group) || selectedGroup;
+    }
+  );
+};


### PR DESCRIPTION
In #847, I used a heuristic to find if the element was going to be expanded. But, it wasn't 100% accurate because we couldn't know in which conditionalGroup we would land. We added a way for the parent to tell that function if we should be in `expandLastArg`. By replacing the condition by this variable, it now fixes the issues!

This is so good that adding the right abstraction fixes problems across the board :)

Fixes #997