### PR TITLE
Fix trailing comma for rest element in Babylon

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -706,8 +706,11 @@ function genericPrintNoParens(path, options, print, args) {
       });
 
       const lastElem = util.getLast(n[propertiesField]);
-      const canHaveTrailingComma = !(lastElem &&
-        lastElem.type === "RestProperty");
+
+      const canHaveTrailingComma = !(
+        lastElem &&
+        (lastElem.type === "RestProperty" || lastElem.type === "RestElement")
+      );
 
       const shouldBreak =
         n.type !== "ObjectPattern" &&

--- a/tests/rest/jsfmt.spec.js
+++ b/tests/rest/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, { trailingComma: "all" });
+run_spec(__dirname, { trailingComma: "all" }, ["babylon"]);


### PR DESCRIPTION
We changed RestProperty/SpreadProperty to RestElement/SpreadElement in https://github.com/babel/babylon/pull/384.