### PR TITLE
Fixing n.comments check in printer

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1334,7 +1334,7 @@ function genericPrintNoParens(path, options, print, args) {
     case "JSXText":
       throw new Error("JSXTest should be handled by JSXElement");
     case "JSXEmptyExpression":
-      const requiresHardline = n.comments.some(
+      const requiresHardline = n.comments && n.comments.some(
         comment => comment.type === "Line" || comment.type === "CommentLine"
       );
 


### PR DESCRIPTION
This is in line with similar checks in printer.js

Fixes #1237 