### PR TITLE
Get rid of fixFaultyLocations code

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -15,7 +15,6 @@ var align = docBuilders.align;
 var lineSuffix = docBuilders.lineSuffix;
 var join = docBuilders.join;
 var util = require("./util");
-var comparePos = util.comparePos;
 var childNodesCacheKey = Symbol("child-nodes");
 var locStart = util.locStart;
 var locEnd = util.locEnd;
@@ -28,10 +27,6 @@ function getSortedChildNodes(node, text, resultArray) {
   if (!node) {
     return;
   }
-
-  // The loc checks below are sensitive to some of the problems that
-  // are fixed by this utility function.
-  util.fixFaultyLocations(node, text);
 
   if (resultArray) {
     if (n.Node.check(node) && node.type !== "EmptyStatement") {

--- a/src/util.js
+++ b/src/util.js
@@ -3,57 +3,6 @@
 var types = require("ast-types");
 var n = types.namedTypes;
 
-function comparePos(pos1, pos2) {
-  return pos1.line - pos2.line || pos1.column - pos2.column;
-}
-
-function expandLoc(parentNode, childNode) {
-  if (locStart(childNode) - locStart(parentNode) < 0) {
-    setLocStart(parentNode, locStart(childNode));
-  }
-
-  if (locEnd(parentNode) - locEnd(childNode) < 0) {
-    setLocEnd(parentNode, locEnd(childNode));
-  }
-}
-
-function fixFaultyLocations(node, text) {
-  if (node.decorators) {
-    // Expand the loc of the node responsible for printing the decorators
-    // (here, the decorated node) so that it includes node.decorators.
-    node.decorators.forEach(function(decorator) {
-      expandLoc(node, decorator);
-    });
-  } else if (node.declaration && isExportDeclaration(node)) {
-    // Expand the loc of the node responsible for printing the decorators
-    // (here, the export declaration) so that it includes node.decorators.
-    var decorators = node.declaration.decorators;
-    if (decorators) {
-      decorators.forEach(function(decorator) {
-        expandLoc(node, decorator);
-      });
-    }
-  } else if (
-    (n.MethodDefinition && n.MethodDefinition.check(node)) ||
-    (n.Property.check(node) && (node.method || node.shorthand))
-  ) {
-    if (n.FunctionExpression.check(node.value)) {
-      // FunctionExpression method values should be anonymous,
-      // because their .id fields are ignored anyway.
-      node.value.id = null;
-    }
-  } else if (node.type === "ObjectTypeProperty") {
-    var end = skipSpaces(text, locEnd(node), true);
-    if (end !== false && text.charAt(end) === ",") {
-      // Some parsers accidentally include trailing commas in the
-      // end information for ObjectTypeProperty nodes.
-      if ((end = skipSpaces(text, end - 1, true)) !== false) {
-        setLocEnd(node, end);
-      }
-    }
-  }
-}
-
 function isExportDeclaration(node) {
   if (node)
     switch (node.type) {
@@ -322,9 +271,7 @@ function getPrecedence(op) {
 }
 
 module.exports = {
-  comparePos,
   getPrecedence,
-  fixFaultyLocations,
   isExportDeclaration,
   getParentExportDeclaration,
   getPenultimate,

--- a/tests/flow/getters_and_setters_enabled/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/getters_and_setters_enabled/__snapshots__/jsfmt.spec.js.snap
@@ -457,15 +457,20 @@ class C extends A {}
 type T = {
   goodGetterWithAnnotation: () => number,
   goodSetterWithAnnotation: (x: number) => void,
+
   propWithMatchingGetterAndSetter: () => number,
   propWithMatchingGetterAndSetter: (x: number) => void,
+
   // The getter and setter need not have the same type
   propWithSubtypingGetterAndSetter: () => ?number, // OK
   propWithSubtypingGetterAndSetter: (x: number) => void,
+
   propWithSubtypingGetterAndSetterReordered: (x: number) => void, // OK
   propWithSubtypingGetterAndSetterReordered: () => ?number,
+
   exampleOfOrderOfGetterAndSetter: () => A,
   exampleOfOrderOfGetterAndSetter: (x: B) => void,
+
   exampleOfOrderOfGetterAndSetterReordered: (x: B) => void,
   exampleOfOrderOfGetterAndSetterReordered: () => A
 };


### PR DESCRIPTION
As I was debugging #1248, I found out that the code to fix was actually making things worse. The other two branches are for decorators and deleting some random value of a function. I ran all the tests and the flow object is actually now preserving empty lines and didn't change anything else.

I'd rather remove all those and if something comes up then fix it properly upstream than having those crutches that we don't know why they exist anymore.