### PR TITLE
Add `--init` command

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -26,6 +26,7 @@ const argv = minimist(process.argv.slice(2), {
     "color",
     "list-different",
     "help",
+    "init",
     "version",
     "debug-print-doc",
     "debug-check",
@@ -177,7 +178,21 @@ function handleError(filename, e) {
   process.exitCode = 2;
 }
 
-if (argv["help"] || (!filepatterns.length && !stdin)) {
+let init = false;
+if (argv["init"]) {
+  init = true;
+  prettier.init()
+    .then(() => {
+      console.log('Successfully initialized prettier with npm script: `npm run prettier`.');
+      process.exit(0);
+    })
+    .catch(err => {
+      console.error(err);
+      process.exit(1);
+    });
+}
+
+if (argv["help"] || (!init && !filepatterns.length && !stdin)) {
   console.log(
     "Usage: prettier [opts] [filename ...]\n\n" +
       "Available options:\n" +
@@ -195,6 +210,7 @@ if (argv["help"] || (!filepatterns.length && !stdin)) {
       "                           Print trailing commas wherever possible. Defaults to none.\n" +
       "  --parser <flow|babylon>  Specify which parse to use. Defaults to babylon.\n" +
       "  --color                  Colorize error messages. Defaults to true.\n" +
+      "  --init                   Initialize prettier in the current working directory.\n" +
       "  --version or -v          Print prettier version.\n" +
       "\n" +
       "Boolean options can be turned off like this:\n" +
@@ -204,7 +220,7 @@ if (argv["help"] || (!filepatterns.length && !stdin)) {
   process.exit(argv["help"] ? 0 : 1);
 }
 
-if (stdin) {
+if (!init && stdin) {
   getStdin().then(input => {
     try {
       // Don't use `console.log` here since it adds an extra newline at the end.
@@ -214,7 +230,7 @@ if (stdin) {
       return;
     }
   });
-} else {
+} else if (!init) {
   eachFilename(filepatterns, filename => {
     if (write || argv["debug-check"]) {
       // Don't use `console.log` here since we need to replace this line.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const path = require('path');
+const fs = require('fs');
 const codeFrame = require("babel-code-frame");
 const comments = require("./src/comments");
 const version = require("./package.json").version;
@@ -92,6 +94,21 @@ function formatWithShebang(text, opts) {
   return shebang + newLine + format(programText, opts);
 }
 
+function init() {
+  const file = path.resolve(process.cwd(), "package.json");
+  const data = fs.readFileSync(file, "utf8");
+  try {
+    const pkg = JSON.parse(data);
+    if (!pkg.scripts || !pkg.scripts.prettier) {
+      pkg.scripts.prettier = "prettier --write \"{**/*.js}\"";
+    }
+    fs.writeFileSync(file, JSON.stringify(pkg, null, "  "));
+    return Promise.resolve(true);
+  } catch (err) {
+    return Promise.reject("Error trying to parse package.json");
+  }
+}
+
 module.exports = {
   format: function(text, opts) {
     return formatWithShebang(text, normalizeOptions(opts));
@@ -104,6 +121,7 @@ module.exports = {
       return false;
     }
   },
+  init: init,
   version: version,
   __debug: {
     formatAST: function(ast, opts) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "flow-parser": "0.43.0",
     "get-stdin": "5.0.1",
     "glob": "7.1.1",
+    "ini": "^1.3.4",
     "jest-validate": "19.0.0",
     "minimist": "1.2.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -928,6 +928,10 @@ inherits@2, inherits@^2.0.1:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.3.tgz#633c2c83e3da42a502f52466022480f4208261de"
 
+ini@^1.3.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.4.tgz#0537cb79daf59b59a1a517dff706c86ec039162e"
+
 invariant@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"


### PR DESCRIPTION
**Issue:** Having to create new projects and copy/paste the same `prettier` into a `package.json` on each new project becomes very tedious.

This PR will add a simple `--init` command that will initialize the current working directory with `prettier`. This will make it really easy for beginners to get started with `prettier`.

In addition, it will attempt to read from an existing `.editorconfig` (#42) file in the directory in which the script is ran. This will void our need to have a custom config file (#62) just for prettier since there's no shortage of dot/rc files.

- Updates `package.json` in cwd with a `prettier` npm script.
  - Default: `prettier --write '{**/*.js}'"`
  - Optionally reads from an `.editorconfig` and specify the indentation width/style.
    - `indent_style` -> `--use-tabs`
    - `indent_size` --> `--tab-width`

### Usage:

```bash
$ cd myproject

$ prettier --init
```