### PR TITLE
Remove trailing whitespace

### DIFF
--- a/src/doc-printer.js
+++ b/src/doc-printer.js
@@ -267,6 +267,13 @@ function printDocToString(doc, options) {
               } else {
                 if (out.length > 0) {
                   // Trim whitespace at the end of line
+                  while (
+                    out.length > 0 &&
+                    out[out.length - 1].match(/^[^\S\n]*$/)
+                  ) {
+                    out.pop();
+                  }
+
                   out[out.length - 1] = out[out.length - 1].replace(
                     /[^\S\n]*$/,
                     ""

--- a/tests/typescript/conformance/types/functions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/functions/__snapshots__/jsfmt.spec.js.snap
@@ -507,7 +507,7 @@ function f(x: string): void {
     return;
 } 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-function f(x: string): number 
+function f(x: string): number
 function f(x: string): void {
   return;
 }
@@ -520,7 +520,7 @@ function f(x: string): number {
     return 0;
 } 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-function f(x: string): void 
+function f(x: string): void
 function f(x: string): number {
   return 0;
 }
@@ -533,7 +533,7 @@ function f(x: string): void {
     return;
 } 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-function f(x: string): void 
+function f(x: string): void
 function f(x: string): void {
   return;
 }
@@ -553,14 +553,14 @@ function fn5(x: string, ...y: any[], z: string);
 function fn5() { }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //Function overload signature with optional parameter followed by non-optional parameter
-function fn4a(x?: number, y: string) 
+function fn4a(x?: number, y: string)
 function fn4a() {}
 
-function fn4b(n: string, x?: number, y: string) 
+function fn4b(n: string, x?: number, y: string)
 function fn4b() {}
 
 //Function overload signature with rest param followed by non-optional parameter
-function fn5(x: string, ...y: any[], z: string) 
+function fn5(x: string, ...y: any[], z: string)
 function fn5() {}
 
 `;

--- a/tests/typescript/conformance/types/tuple/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/tuple/__snapshots__/jsfmt.spec.js.snap
@@ -212,7 +212,7 @@ var y = foo([undefined]);
 y = [""];
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //@noImplicitAny: true
-declare function foo<T extends [any]>(x: T): T 
+declare function foo<T extends [any]>(x: T): T
 
 var y = foo([undefined]);
 y = [""];


### PR DESCRIPTION
In #1257, I discovered that if there's a `""` doc at the end, it's not going to trim the previous one correctly. It also happens to fix a few existing things.