### PR TITLE
Fix isPreviousLineEmpty on Windows

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -119,6 +119,9 @@ function skipNewline(text, index, opts) {
 
   const atIndex = text.charAt(index);
   if (backwards) {
+    if (text.charAt(index - 1) === "\r" && atIndex === "\n") {
+      return index - 2;
+    }
     if (
       atIndex === "\n" ||
       atIndex === "\r" ||
@@ -126,9 +129,6 @@ function skipNewline(text, index, opts) {
       atIndex === "\u2029"
     ) {
       return index - 1;
-    }
-    if (text.charAt(index - 1) === "\r" && atIndex === "\n") {
-      return index - 2;
     }
   } else {
     if (atIndex === "\r" && text.charAt(index + 1) === "\n") {

--- a/tests/switch/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/switch/__snapshots__/jsfmt.spec.js.snap
@@ -54,6 +54,23 @@ switch (a) {
     if (1) {};
     c;
 }
+
+switch (a) {
+  case x:
+  case y:
+    call();
+
+  case z:
+    call();
+}
+
+switch (a) {
+  case x: case y:
+    call();
+
+  case z:
+    call();
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 switch (foo) {
   case "bar":
@@ -104,6 +121,24 @@ switch (a) {
     if (1) {
     }
     c;
+}
+
+switch (a) {
+  case x:
+  case y:
+    call();
+
+  case z:
+    call();
+}
+
+switch (a) {
+  case x:
+  case y:
+    call();
+
+  case z:
+    call();
 }
 
 `;

--- a/tests/switch/empty_lines.js
+++ b/tests/switch/empty_lines.js
@@ -51,3 +51,20 @@ switch (a) {
     if (1) {};
     c;
 }
+
+switch (a) {
+  case x:
+  case y:
+    call();
+
+  case z:
+    call();
+}
+
+switch (a) {
+  case x: case y:
+    call();
+
+  case z:
+    call();
+}


### PR DESCRIPTION
Fixes #1262

```js
switch (a) {
  case x:

  case y:
    call();

  case z:
    call();
}
```
becomes
```js
switch (a) {
  case x:
  case y:
    call();

  case z:
    call();
}
```