### PR TITLE
Match jsx files in pre-commit hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Alternately you can just save this script as `.git/hooks/pre-commit` and give it
 
 ```bash
 #!/bin/sh
-jsfiles=$(git diff --cached --name-only --diff-filter=ACM | grep '\.js$' | tr '\n' ' ')
+jsfiles=$(git diff --cached --name-only --diff-filter=ACM | grep '\.jsx\?$' | tr '\n' ' ')
 [ -z "$jsfiles" ] && exit 0
 
 diffs=$(node_modules/.bin/prettier -l $jsfiles)


### PR DESCRIPTION
per Rahul Sethi on twitter: https://twitter.com/rahul1sethi/status/852811834964836352

I should have matched jsx as well as js with my pre-commit hook, I don't use
react myself so I didn't think about it.