### PR TITLE
Use regexp-tree to optimize regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "get-stdin": "5.0.1",
     "glob": "7.1.1",
     "jest-validate": "19.0.0",
-    "minimist": "1.2.0"
+    "minimist": "1.2.0",
+    "regexp-tree": "^0.0.38"
   },
   "devDependencies": {
     "diff": "3.2.0",

--- a/src/printer.js
+++ b/src/printer.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var assert = require("assert");
+var regexpTree = require('regexp-tree');
 var comments = require("./comments");
 var FastPath = require("./fast-path");
 var util = require("./util");
@@ -880,7 +881,7 @@ function genericPrintNoParens(path, options, print, args) {
     case "NullLiteral":
       return "null"; // Babel 6 Literal split
     case "RegExpLiteral":
-      return n.extra.raw;
+      return regexpTree.optimize(n.extra.raw).toString();
     // Babel 6 Literal split
     case "NumericLiteral":
       return printNumber(n.extra.raw);

--- a/tests/regex/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/regex/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`regex.js 1`] = `
+const standardRegex = /cookie/;
+const optimizableRegex = /[a-zA-Z_0-9][A-Z_\\da-z]*\\e{1,}/;
+const invalidRegex = /![a-zA-Z0-9,\\\\.\\']!🍪/;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const standardRegex = /cookie/;
+const optimizableRegex = /[a-zA-Z_0-9][A-Z_\\da-z]*\\e{1,}/;
+const invalidRegex = /![a-zA-Z0-9,\\\\.\\']!🍪/;
+
+`;

--- a/tests/regex/jsfmt.spec.js
+++ b/tests/regex/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/regex/regex.js
+++ b/tests/regex/regex.js
@@ -1,0 +1,3 @@
+const standardRegex = /cookie/;
+const optimizableRegex = /[a-zA-Z_0-9][A-Z_\da-z]*\e{1,}/;
+const invalidRegex = /![a-zA-Z0-9,\\.\']!🍪/;

--- a/yarn.lock
+++ b/yarn.lock
@@ -46,6 +46,10 @@ ansi-styles@^3.0.0:
   dependencies:
     color-convert "^1.0.0"
 
+ansi-styles@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
+
 anymatch@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-1.3.0.tgz#a3e52fa39168c825ff57b0248126ce5a8ff95507"
@@ -424,6 +428,14 @@ chalk@1.1.3, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+chalk@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
+  dependencies:
+    ansi-styles "~1.0.0"
+    has-color "~0.1.0"
+    strip-ansi "~0.1.0"
 
 ci-info@^1.0.0:
   version "1.0.0"
@@ -864,6 +876,10 @@ has-ansi@^2.0.0:
   resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
   dependencies:
     ansi-regex "^2.0.0"
+
+has-color@~0.1.0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
 
 has-flag@^1.0.0:
   version "1.0.0"
@@ -1570,6 +1586,13 @@ node-notifier@^5.0.1:
     shellwords "^0.1.0"
     which "^1.2.12"
 
+nomnom@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
+  dependencies:
+    chalk "~0.4.0"
+    underscore "~1.6.0"
+
 normalize-package-data@^2.3.2:
   version "2.3.5"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.3.5.tgz#8d924f142960e1777e7ffe170543631cc7cb02df"
@@ -1809,6 +1832,12 @@ regex-cache@^0.4.2:
   dependencies:
     is-equal-shallow "^0.1.3"
     is-primitive "^2.0.0"
+
+regexp-tree@^0.0.38:
+  version "0.0.38"
+  resolved "https://registry.yarnpkg.com/regexp-tree/-/regexp-tree-0.0.38.tgz#d45f0a7a6dce88b2329957bd5915533d6fb4dd26"
+  dependencies:
+    nomnom "^1.8.1"
 
 repeat-element@^1.1.2:
   version "1.1.2"
@@ -2060,6 +2089,10 @@ strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   dependencies:
     ansi-regex "^2.0.0"
 
+strip-ansi@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
+
 strip-bom@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
@@ -2153,6 +2186,10 @@ uglify-js@^2.6:
 uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
+
+underscore@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
 
 uuid@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Using [regexp-tree](https://www.npmjs.com/package/regexp-tree#using-optimizer-apir) to optimize regexp expression.

Example:
```js
// Before

const standardRegex = /cookie/;
const optimizableRegex = /[a-zA-Z_0-9][A-Z_\da-z]*\e{1,}/;
const invalidRegex = /![a-zA-Z0-9,\.']!🍪/;
```
```js
// After

const standardRegex = /cookie/;
const optimizableRegex = /\w+e+/;
const invalidRegex = /![a-zA-Z\d,\.']!🍪/;
```
I'm not sure what your policy is on using an external dependency as optimizer. 