### PR TITLE
Do not print the sub-tree when using prettier-ignore

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,6 +56,14 @@ function attachComments(text, ast, opts) {
 }
 
 function ensureAllCommentsPrinted(astComments) {
+  for (let i = 0; i < astComments.length; ++i) {
+    if (astComments[i].value.trim() === "prettier-ignore") {
+      // If there's a prettier-ignore, we're not printing that sub-tree so we
+      // don't know if the comments was printed or not.
+      return;
+    }
+  }
+
   astComments.forEach(comment => {
     if (!comment.printed) {
       throw new Error(

--- a/src/printer.js
+++ b/src/printer.js
@@ -53,21 +53,23 @@ function genericPrint(path, options, printPath, args) {
   assert.ok(path instanceof FastPath);
 
   var node = path.getValue();
+
+  // Escape hatch
+  if (
+    node &&
+    node.comments &&
+    node.comments.length > 0 &&
+    node.comments.some(comment => comment.value.trim() === "prettier-ignore")
+  ) {
+    return options.originalText.slice(util.locStart(node), util.locEnd(node));
+  }
+
   var parts = [];
   var needsParens = false;
   var linesWithoutParens = genericPrintNoParens(path, options, printPath, args);
 
   if (!node || isEmpty(linesWithoutParens)) {
     return linesWithoutParens;
-  }
-
-  // Escape hatch
-  if (
-    node.comments &&
-    node.comments.length > 0 &&
-    node.comments.some(comment => comment.value.trim() === "prettier-ignore")
-  ) {
-    return options.originalText.slice(util.locStart(node), util.locEnd(node));
   }
 
   if (


### PR DESCRIPTION
In #1250, @jeresig reported that adding // prettier-ignore on a file that has a ton of conditional group still took 1.7s. The issue is that we're printing before checking for the comment. Swaping the two had the unfortunate side effect of not marking the comments as being printed, so I had to skip that safety check if there's a prettier-ignore.

With this change, adding prettier-ignore makes the file be printed instantly!