### PR TITLE
Write out change CLI changes synchronously. Fixes #1287.

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -268,13 +268,13 @@ if (stdin) {
       } else {
         console.log("%s %dms", filename, Date.now() - start);
 
-        fs.writeFile(filename, output, "utf8", err => {
-          if (err) {
-            console.error("Unable to write file: " + filename + "\n" + err);
-            // Don't exit the process if one file failed
-            process.exitCode = 2;
-          }
-        });
+        try {
+          fs.writeFileSync(filename, output, "utf8");
+        } catch (err) {
+          console.error("Unable to write file: " + filename + "\n" + err);
+          // Don't exit the process if one file failed
+          process.exitCode = 2;
+        }
       }
     } else if (argv["debug-check"]) {
       process.stdout.write("\n");


### PR DESCRIPTION
This fixes the issue mentioned in #1287. To test it I I modified a single file (to introduce a linting mistake) and ran it across 100+ files. After I saw that that particular file had been fix I hit `Ctrl+C` to abort the process. I looked at the output of the files and saw that they had all been written and there were no empty files.