### PR TITLE
Search expression.leadingComments in findExpressionIndexForComment()

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -796,7 +796,7 @@ function findExpressionIndexForComment(expressions, comment) {
       break;
     }
 
-    if ((expressions[i].leadingComments || []).includes(comment)) {
+    if ((expressions[i].leadingComments || []).indexOf(comment) !== -1) {
       match = i;
       break;
     }

--- a/src/comments.js
+++ b/src/comments.js
@@ -795,6 +795,11 @@ function findExpressionIndexForComment(expressions, comment) {
       match = i;
       break;
     }
+
+    if ((expressions[i].leadingComments || []).includes(comment)) {
+      match = i;
+      break;
+    }
   }
 
   return match;

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1160,6 +1160,14 @@ exports[`template-literal.js 1`] = `
 d //comment
 };
 \`
+
+\`
+(?:\${escapeChar}[\\\\S\\\\s]|(?:(?!\${// Using \`XRegExp.union\` safely rewrites backreferences in \`left\` and \`right\`.
+// Intentionally not passing \`basicFlags\` to \`XRegExp.union\` since any syntax
+// transformation resulting from those flags was already applied to \`left\` and
+// \`right\` when they were passed through the XRegExp constructor above.
+XRegExp.union([left, right], '', {conjunction: 'or'}).source})[^\${escapeChar}])+)+
+\`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 \`
 \${/* comment*/
@@ -1172,6 +1180,14 @@ a}
 \${/* comment*/
 /*comment*/
 d};
+\`\`
+(?:\${escapeChar}[\\\\S\\\\s]|(?:(?!\${/* Using \`XRegExp.union\` safely rewrites backreferences in \`left\` and \`right\`.*/
+// Intentionally not passing \`basicFlags\` to \`XRegExp.union\` since any syntax
+// transformation resulting from those flags was already applied to \`left\` and
+// \`right\` when they were passed through the XRegExp constructor above.
+XRegExp.union([left, right], "", {
+  conjunction: "or"
+}).source})[^\${escapeChar}])+)+
 \`;
 
 `;

--- a/tests/comments/jsfmt.spec.js
+++ b/tests/comments/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, null, ["babylon"]);
+run_spec(__dirname, { parser: 'babylon' })

--- a/tests/comments/template-literal.js
+++ b/tests/comments/template-literal.js
@@ -10,3 +10,11 @@ ${// comment
 d //comment
 };
 `
+
+`
+(?:${escapeChar}[\\S\\s]|(?:(?!${// Using `XRegExp.union` safely rewrites backreferences in `left` and `right`.
+// Intentionally not passing `basicFlags` to `XRegExp.union` since any syntax
+// transformation resulting from those flags was already applied to `left` and
+// `right` when they were passed through the XRegExp constructor above.
+XRegExp.union([left, right], '', {conjunction: 'or'}).source})[^${escapeChar}])+)+
+`


### PR DESCRIPTION
This fixes https://github.com/prettier/prettier/issues/1293, but note that
the Flow parser doesn't yet work in this case.