### PR TITLE
Remove emoji part from lint-staged's name

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ In the future we will have better support for formatting whole projects.
 
 #### Pre-commit hook for changed files
 
-[🚫💩 lint-staged](https://github.com/okonet/lint-staged) can re-format your files that are marked as "staged" via `git add`  before you commit.
+[lint-staged](https://github.com/okonet/lint-staged) can re-format your files that are marked as "staged" via `git add`  before you commit.
 
 Install it along with [husky](https://github.com/typicode/husky):
 
@@ -181,7 +181,7 @@ and add this config to your `package.json`:
 }
 ```
 
-See https://github.com/okonet/lint-staged#configuration for more details about how you can configure 🚫💩 lint-staged.
+See https://github.com/okonet/lint-staged#configuration for more details about how you can configure lint-staged.
 
 Alternately you can just save this script as `.git/hooks/pre-commit` and give it execute permission:
 


### PR DESCRIPTION
When I read "🚫💩 lint-staged" in the list of possible pre-commit hooks my brains reads the emoji part as "not good, don't use it". For this reason, the first time I read the README I just skipped it as an option. It may be that I'm weird but maybe there are others like me 😉 

If you check [lint-staged's repo](https://github.com/okonet/lint-staged) they also don't use the emoji for the title so I don't think it would be a big problem if gets removed from the README.