### PR TITLE
Avoid breaking arguments for last arg expansion

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1435,21 +1435,6 @@ function genericPrintNoParens(path, options, print, args) {
     case "TemplateLiteral":
       var expressions = path.map(print, "expressions");
 
-      function removeLines(doc) {
-        // Force this doc into flat mode by statically converting all
-        // lines into spaces (or soft lines into nothing). Hard lines
-        // should still output because there's too great of a chance
-        // of breaking existing assumptions otherwise.
-        return docUtils.mapDoc(doc, d => {
-          if (d.type === "line" && !d.hard) {
-            return d.soft ? "" : " ";
-          } else if (d.type === "if-break") {
-            return d.flatContents || "";
-          }
-          return d;
-        });
-      }
-
       parts.push("`");
 
       path.each(function(childPath) {
@@ -2289,7 +2274,7 @@ function printFunctionParams(path, print, options, expandArg) {
   //   })                    ) => {
   //                         })
   if (expandArg) {
-    return group(concat(["(", join(", ", printed), ")"]));
+    return group(concat(["(", join(", ", printed.map(removeLines)), ")"]));
   }
 
   // Single object destructuring should hug
@@ -3575,6 +3560,21 @@ function printArrayItems(path, options, printPath, print) {
   }, printPath);
 
   return concat(printedElements);
+}
+
+function removeLines(doc) {
+  // Force this doc into flat mode by statically converting all
+  // lines into spaces (or soft lines into nothing). Hard lines
+  // should still output because there's too great of a chance
+  // of breaking existing assumptions otherwise.
+  return docUtils.mapDoc(doc, d => {
+    if (d.type === "line" && !d.hard) {
+      return d.soft ? "" : " ";
+    } else if (d.type === "if-break") {
+      return d.flatContents || "";
+    }
+    return d;
+  });
 }
 
 function printAstToDoc(ast, options) {

--- a/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
@@ -39,6 +39,37 @@ export default function searchUsers(action$) {
 
 `;
 
+exports[`break.js 1`] = `
+export default class AddAssetHtmlPlugin {
+  apply(compiler: WebpackCompilerType) {
+    compiler.plugin('compilation', (compilation: WebpackCompilationType) => {
+      compilation.plugin('html-webpack-plugin-before-html', (callback: Callback<any>) => {
+        addAllAssetsToCompilation(this.assets, compilation, htmlPluginData, callback);
+      });
+    });
+  }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export default class AddAssetHtmlPlugin {
+  apply(compiler: WebpackCompilerType) {
+    compiler.plugin("compilation", (compilation: WebpackCompilationType) => {
+      compilation.plugin(
+        "html-webpack-plugin-before-html",
+        (callback: Callback<any>) => {
+          addAllAssetsToCompilation(
+            this.assets,
+            compilation,
+            htmlPluginData,
+            callback
+          );
+        }
+      );
+    });
+  }
+}
+
+`;
+
 exports[`break-parent.js 1`] = `
 ({
   processors: [

--- a/tests/last_argument_expansion/break.js
+++ b/tests/last_argument_expansion/break.js
@@ -1,0 +1,9 @@
+export default class AddAssetHtmlPlugin {
+  apply(compiler: WebpackCompilerType) {
+    compiler.plugin('compilation', (compilation: WebpackCompilationType) => {
+      compilation.plugin('html-webpack-plugin-before-html', (callback: Callback<any>) => {
+        addAllAssetsToCompilation(this.assets, compilation, htmlPluginData, callback);
+      });
+    });
+  }
+}


### PR DESCRIPTION
We've had this issue since the beginning and I tagged it as 1.0 but haven't managed to fix it by then. We shouldn't allow things to break in the argument list if we are in the last argument expansion mode. It turns out that we now have all the building blocks needed to fix this:
- have a special way to flag when we are printing the last argument expansion in the code that prints the argument list
- have a way to remove all the softlines from the argument list

Fixes #1301