### PR TITLE
Skip globbing filenames with node-glob when the filename is not a glob

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -290,6 +290,10 @@ if (stdin) {
 
 function eachFilename(patterns, callback) {
   patterns.forEach(pattern => {
+    if (!glob.hasMagic(pattern)) {
+      callback(pattern)
+    }
+
     glob(pattern, (err, filenames) => {
       if (err) {
         console.error("Unable to expand glob pattern: " + pattern + "\n" + err);

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -291,7 +291,8 @@ if (stdin) {
 function eachFilename(patterns, callback) {
   patterns.forEach(pattern => {
     if (!glob.hasMagic(pattern)) {
-      callback(pattern)
+      callback(pattern);
+      return;
     }
 
     glob(pattern, (err, filenames) => {


### PR DESCRIPTION
Closes #1246 

@vjeux:
> For this issue, I can see two things:
>
> 1. Use fs.readFileSync instead of going through glob is there is no special patterns. If you give the actual name of a file, we should throw if it's not there.
> […]

It turns out that`node-glob` has a handy function `.hasMagic`, which tells you if a given string has any globbable patterns in it. All I had to do was call it when we iterate over the filenames.

I tested this manually; I'm not sure how to add tests for the prettier cli.

```bash
# before
$ stat non-existent-file.js
stat: cannot stat 'non-existent-file.js': No such file or directory
$ prettier non-existent-file.js; echo $?
0
```

```bash
# after
$ stat non-existent-file.js
stat: cannot stat 'non-existent-file.js': No such file or directory
$ node bin/prettier.js non-existent-file.js; echo $?

Unable to read file: non-existent-file.js
Error: ENOENT: no such file or directory, open 'non-existent-file.js'
2
```