### PR TITLE
Add multi-node ignore

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,17 @@ matrix(
 )
 ```
 
+If you'd like to ignore multiple nodes in the abstract syntax tree in a row, you can wrap them with a starting comment of `// prettier-start-ignore` and an ending comment of `//prettier-end-ignore`, like so:
+
+```js
+// prettier-start-ignore
+var n             = 1;
+var number        = 2;
+var anotherNumber = 3;
+// prettier-end-ignore
+```
+
+
 ## Editor Integration
 
 ### Atom

--- a/README.md
+++ b/README.md
@@ -283,14 +283,14 @@ matrix(
 )
 ```
 
-If you'd like to ignore multiple nodes in the abstract syntax tree in a row, you can wrap them with a starting comment of `// prettier-start-ignore` and an ending comment of `//prettier-end-ignore`, like so:
+If you'd like to ignore multiple nodes in the abstract syntax tree in a row, you can wrap them with a starting comment of `// prettier-ignore-start` and an ending comment of `//prettier-ignore-end`, like so:
 
 ```js
-// prettier-start-ignore
+// prettier-ignore-start
 var n             = 1;
 var number        = 2;
 var anotherNumber = 3;
-// prettier-end-ignore
+// prettier-ignore-end
 ```
 
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -33,8 +33,8 @@ var isObject = types.builtInTypes.object;
 
 // Resources for a multi-node ignore state.
 var shouldIgnore = false;
-var START_IGNORE_DIRECTIVE = "prettier-start-ignore";
-var END_IGNORE_DIRECTIVE = "prettier-end-ignore";
+var START_IGNORE_DIRECTIVE = "prettier-ignore-start";
+var END_IGNORE_DIRECTIVE = "prettier-ignore-end";
 var IGNORE_DIRECTIVE = "prettier-ignore";
 
 


### PR DESCRIPTION
Hi!

There are some cases where I'd like to purposefully stray from the usual style for a chunk of lines (usually for organizational purposes) like this:

```js
var thing           = 1;
var otherThing      = 2;
var anotherThing    = 3;
var omgSoManyThings = 4;
```

I know there are probably mixed feelings about the above example, but either way it would be nice to have the option. I'm sure there are other use cases, too, where it becomes impractical to add the `// prettier-ignore` comment before every single AST node.

Anyway, so this was why I would *love* to get multi-node ignore directives added. It's a simple, risk-free change that just switches a `shouldIgnore` state on/off. I wasn't sure how you'd like it to be stored but you get the gist. :)

It would be used like this:
```js
// prettier-ignore-start
var thing           = 1;
var otherThing      = 2;
var anotherThing    = 3;
var omgSoManyThings = 4;
// prettier-ignore-end
```

Let me know what you think!

-- Christine