### PR TITLE
Add typescript as a valid parser value

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -66,19 +66,27 @@ function getParserOption() {
     return "flow";
   }
 
-  if (value === "flow" || value === "babylon") {
+  const defaultParser = "babylon";
+  const supportedParsers = ["babylon", "flow"];
+  const experimentalParsers = ["typescript"];
+  if (supportedParsers.indexOf(value) >= 0) {
+    return value;
+  }
+  if(experimentalParsers.indexOf(value) >= 0) {
+    console.warn("WARNING: " + value + " parser is experimental!");
     return value;
   }
 
+  const allParsers = supportedParsers.concat(experimentalParsers);
   console.warn(
     "Ignoring unknown --" +
       optionName +
-      ' value, falling back to "babylon":\n' +
-      '  Expected "flow" or "babylon", but received: ' +
+      ' value, falling back to "' + defaultParser + '":\n' +
+      '  Expected one of [' + allParsers.join(", ") + '] but received: ' +
       JSON.stringify(value)
   );
 
-  return "babylon";
+  return defaultParser;
 }
 
 function getIntOption(optionName) {

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -66,27 +66,19 @@ function getParserOption() {
     return "flow";
   }
 
-  const defaultParser = "babylon";
-  const supportedParsers = ["babylon", "flow"];
-  const experimentalParsers = ["typescript"];
-  if (supportedParsers.indexOf(value) >= 0) {
-    return value;
-  }
-  if(experimentalParsers.indexOf(value) >= 0) {
-    console.warn("WARNING: " + value + " parser is experimental!");
+  if (value === "flow" || value === "babylon" || value === "typescript") {
     return value;
   }
 
-  const allParsers = supportedParsers.concat(experimentalParsers);
   console.warn(
     "Ignoring unknown --" +
       optionName +
-      ' value, falling back to "' + defaultParser + '":\n' +
-      '  Expected one of [' + allParsers.join(", ") + '] but received: ' +
+      ' value, falling back to "babylon":\n' +
+      '  Expected "flow" or "babylon", but received: ' +
       JSON.stringify(value)
   );
 
-  return defaultParser;
+  return "babylon";
 }
 
 function getIntOption(optionName) {


### PR DESCRIPTION
Now that typescript development has started, each contributor has been adding this as a supported flag themselves.

This just adds it as an allowed option, with a warning that support for this parser is experimental.

I also tried to structure this a bit future proof, in case other experimental parsers come along.

(This came up in pursuit of @vjeux's #1306)