### PR TITLE
Add prettier_d to Related Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ passes `prettier` output to `standard --fix`
 - [`prettier-miscellaneous`](https://github.com/arijs/prettier-miscellaneous)
 `prettier` with a few minor extra options
 - [`neutrino-preset-prettier`](https://github.com/SpencerCDixon/neutrino-preset-prettier) allows you to use Prettier as a Neutrino preset
+- [`prettier_d`](https://github.com/josephfrazier/prettier_d.js) runs Prettier as a server to avoid Node.js startup delay
 
 
 ## Technical Details


### PR DESCRIPTION
[prettier_d](https://github.com/josephfrazier/prettier_d.js) is like [eslint_d], but it runs `prettier` instead of`eslint`. This eliminates the Node.js startup delay from all but the first run of `prettier_d`, making it a snappier experience.

[eslint_d]: https://github.com/mantoni/eslint_d.js

Related discussion:
* https://github.com/prettier/prettier/issues/575#issuecomment-277368389
* https://github.com/prettier/prettier/issues/918#issuecomment-294130268
* https://github.com/prettier/prettier/pull/753#issuecomment-294339207