### PR TITLE
add printer branches for some TypeScript nodes

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1953,6 +1953,8 @@ function genericPrintNoParens(path, options, print, args) {
       ]);
     case "TSFirstTypeNode":
       return concat([n.parameterName.name, " is ", path.call(print, "typeAnnotation")])
+    case "TSNeverKeyword":
+      return "never";
     // TODO
     case "ClassHeritage":
     // TODO

--- a/src/printer.js
+++ b/src/printer.js
@@ -1959,6 +1959,8 @@ function genericPrintNoParens(path, options, print, args) {
       return "undefined";
     case "TSSymbolKeyword":
       return "symbol";
+    case "TSNonNullExpression":
+      return concat([path.call(print, "expression"), "!"]);
     // TODO
     case "ClassHeritage":
     // TODO

--- a/src/printer.js
+++ b/src/printer.js
@@ -1955,6 +1955,8 @@ function genericPrintNoParens(path, options, print, args) {
       return concat([n.parameterName.name, " is ", path.call(print, "typeAnnotation")])
     case "TSNeverKeyword":
       return "never";
+    case "TSUndefinedKeyword":
+      return "undefined";
     // TODO
     case "ClassHeritage":
     // TODO

--- a/src/printer.js
+++ b/src/printer.js
@@ -1961,6 +1961,8 @@ function genericPrintNoParens(path, options, print, args) {
       return "symbol";
     case "TSNonNullExpression":
       return concat([path.call(print, "expression"), "!"]);
+    case "TSThisType":
+      return "this";
     // TODO
     case "ClassHeritage":
     // TODO

--- a/src/printer.js
+++ b/src/printer.js
@@ -1957,6 +1957,8 @@ function genericPrintNoParens(path, options, print, args) {
       return "never";
     case "TSUndefinedKeyword":
       return "undefined";
+    case "TSSymbolKeyword":
+      return "symbol";
     // TODO
     case "ClassHeritage":
     // TODO

--- a/tests/typescript/conformance/types/never/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/never/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`never.ts 1`] = `
+var x: never
+var x: never | string
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+var x: never;
+var x: never | string;
+
+`;

--- a/tests/typescript/conformance/types/never/jsfmt.spec.js
+++ b/tests/typescript/conformance/types/never/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });

--- a/tests/typescript/conformance/types/never/never.ts
+++ b/tests/typescript/conformance/types/never/never.ts
@@ -1,0 +1,2 @@
+var x: never
+var x: never | string

--- a/tests/typescript/conformance/types/nonNullExpression/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/nonNullExpression/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`nonNullExpression.ts 1`] = `
+var xx = (xx!, xx);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+var xx = (xx!, xx);
+
+`;

--- a/tests/typescript/conformance/types/nonNullExpression/jsfmt.spec.js
+++ b/tests/typescript/conformance/types/nonNullExpression/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });

--- a/tests/typescript/conformance/types/nonNullExpression/nonNullExpression.ts
+++ b/tests/typescript/conformance/types/nonNullExpression/nonNullExpression.ts
@@ -1,0 +1,1 @@
+var xx = (xx!, xx);

--- a/tests/typescript/conformance/types/symbol/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/symbol/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`symbol.ts 1`] = `
+var x: symbol
+var x: symbol | string
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+var x: symbol;
+var x: symbol | string;
+
+`;

--- a/tests/typescript/conformance/types/symbol/jsfmt.spec.js
+++ b/tests/typescript/conformance/types/symbol/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });

--- a/tests/typescript/conformance/types/symbol/symbol.ts
+++ b/tests/typescript/conformance/types/symbol/symbol.ts
@@ -1,0 +1,2 @@
+var x: symbol
+var x: symbol | string

--- a/tests/typescript/conformance/types/thisType/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/thisType/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`thisType.ts 1`] = `
+declare class MyArray<T> extends Array<T> {
+    sort(compareFn?: (a: T, b: T) => number): this;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class MyArray<T> extends Array {
+  sort(compareFn?: (a: T, b: T) => number): this
+}
+
+`;

--- a/tests/typescript/conformance/types/thisType/jsfmt.spec.js
+++ b/tests/typescript/conformance/types/thisType/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });

--- a/tests/typescript/conformance/types/thisType/thisType.ts
+++ b/tests/typescript/conformance/types/thisType/thisType.ts
@@ -1,0 +1,3 @@
+declare class MyArray<T> extends Array<T> {
+    sort(compareFn?: (a: T, b: T) => number): this;
+}

--- a/tests/typescript/conformance/types/undefined/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/undefined/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`undefined.ts 1`] = `
+var x: undefined
+var x: undefined | string
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+var x: undefined;
+var x: undefined | string;
+
+`;

--- a/tests/typescript/conformance/types/undefined/jsfmt.spec.js
+++ b/tests/typescript/conformance/types/undefined/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });

--- a/tests/typescript/conformance/types/undefined/undefined.ts
+++ b/tests/typescript/conformance/types/undefined/undefined.ts
@@ -1,0 +1,2 @@
+var x: undefined
+var x: undefined | string


### PR DESCRIPTION
This adds the printer implementation for some of the simpler TypeScript nodes mentioned in #1306.

It does not add tests since I haven't come around writing them (copy 'n pasting them from the TypeScript repo), maybe tomorrow though my week is pretty full.

Just thought I'd share this before someone else puts in the effort for this.