### PR TITLE
add printer branch for TSFirstTypeNode

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1487,7 +1487,11 @@ function genericPrintNoParens(path, options, print, args) {
           !shouldTypeScriptTypeAvoidColon(path) &&
           // TypeScript should not have a colon before type parameter constraints
           !(path.getParentNode().type === "TypeParameter" &&
-            path.getParentNode().constraint)
+            path.getParentNode().constraint) && 
+          // TypeScript should not have a colon in TSFirstTypeNode nodes
+          // `a is number`
+          !(path.getParentNode().type === "TypeAnnotation" &&
+           path.getParentNode().typeAnnotation.type === 'TSFirstTypeNode')
         ) {
           parts.push(": ");
         }
@@ -1922,6 +1926,8 @@ function genericPrintNoParens(path, options, print, args) {
         "]: ",
         path.call(print, "typeAnnotation")
       ]);
+    case "TSFirstTypeNode":
+      return concat([n.parameterName.name, " is ", path.call(print, "typeAnnotation")])
     // TODO
     case "ClassHeritage":
     // TODO

--- a/tests/typescript/conformance/types/firstTypeNode/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/firstTypeNode/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`firstTypeNode.ts 1`] = `
+export function fooWithTypePredicate(a: any): a is number {
+    return true;
+}
+export function fooWithTypePredicateAndMulitpleParams(a: any, b: any, c: any): a is number {
+    return true;
+}
+export function fooWithTypeTypePredicateAndGeneric<T>(a: any): a is T {
+    return true;
+}
+export function fooWithTypeTypePredicateAndRestParam(a: any, ...rest): a is number {
+    return true;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export function fooWithTypePredicate(a: any): a is number {
+  return true;
+}
+export function fooWithTypePredicateAndMulitpleParams(
+  a: any,
+  b: any,
+  c: any
+): a is number {
+  return true;
+}
+export function fooWithTypeTypePredicateAndGeneric<T>(a: any): a is T {
+  return true;
+}
+export function fooWithTypeTypePredicateAndRestParam(
+  a: any,
+  ...rest
+): a is number {
+  return true;
+}
+
+`;

--- a/tests/typescript/conformance/types/firstTypeNode/firstTypeNode.ts
+++ b/tests/typescript/conformance/types/firstTypeNode/firstTypeNode.ts
@@ -1,0 +1,12 @@
+export function fooWithTypePredicate(a: any): a is number {
+    return true;
+}
+export function fooWithTypePredicateAndMulitpleParams(a: any, b: any, c: any): a is number {
+    return true;
+}
+export function fooWithTypeTypePredicateAndGeneric<T>(a: any): a is T {
+    return true;
+}
+export function fooWithTypeTypePredicateAndRestParam(a: any, ...rest): a is number {
+    return true;
+}

--- a/tests/typescript/conformance/types/firstTypeNode/jsfmt.spec.js
+++ b/tests/typescript/conformance/types/firstTypeNode/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });


### PR DESCRIPTION
This adds the printer implementation for the `TSFirstTypeNode`. I'm not sure this is correct, since I call `path.getParentNode()` in the `TypeAnnotation` branch but instead of getting the direct parent (which would be `TSFirstTypeNode`) I actually get the parent's parent, thus I have to walk down that path one node again.

When looking for the parent node it probably just skips unknown nodes. I'll take a look at`path.getParentNode`'s implementation later this week. 