### PR TITLE
Fix arrow function parenthesis with comments in flow

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2357,8 +2357,7 @@ function canPrintParamsWithoutParens(node) {
     !node.rest &&
     node.params[0].type === "Identifier" &&
     !node.params[0].typeAnnotation &&
-    !node.params[0].leadingComments &&
-    !node.params[0].trailingComments &&
+    !node.params[0].comments &&
     !node.params[0].optional &&
     !node.predicate &&
     !node.returnType

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -234,10 +234,12 @@ exports[`function-declaration.js 1`] = `
 function a(/* comment */) {} // comment
 function b() {} // comment
 function c(/* comment */ argA, argB, argC) {} // comment
+call((/*object*/ row) => {});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function a(/* comment */) {} // comment
 function b() {} // comment
 function c(/* comment */ argA, argB, argC) {} // comment
+call((/*object*/ row) => {});
 
 `;
 

--- a/tests/comments/function-declaration.js
+++ b/tests/comments/function-declaration.js
@@ -1,3 +1,4 @@
 function a(/* comment */) {} // comment
 function b() {} // comment
 function c(/* comment */ argA, argB, argC) {} // comment
+call((/*object*/ row) => {});


### PR DESCRIPTION
`leadingComment` and `trailingComment` are babylon-specific, we should use `comments` which is what prettier adds.

Fixes #1335