### PR TITLE
Fix duplicate comments in classes

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2119,11 +2119,7 @@ function printMethod(path, options, print) {
     group(
       concat([
         path.call(function(valuePath) {
-          return comments.printComments(
-            path,
-            p => printFunctionParams(valuePath, print, options),
-            options
-          )
+          return printFunctionParams(valuePath, print, options);
         }, "value"),
         path.call(p => printReturnType(p, print), "value")
       ])

--- a/tests/empty_paren_comment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/empty_paren_comment/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`class.js 1`] = `
+class x {
+  /**
+  * Set of default settings to be applied to model fetch calls in DAO layer.
+  */
+  static get defaultSettings() {
+  }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class x {
+  /**
+  * Set of default settings to be applied to model fetch calls in DAO layer.
+  */
+  static get defaultSettings() {}
+}
+
+`;
+
 exports[`empty_paren_comment.js 1`] = `
 let f = (/* ... */) => {}
 (function (/* ... */) {})(/* ... */)

--- a/tests/empty_paren_comment/class.js
+++ b/tests/empty_paren_comment/class.js
@@ -1,0 +1,7 @@
+class x {
+  /**
+  * Set of default settings to be applied to model fetch calls in DAO layer.
+  */
+  static get defaultSettings() {
+  }
+}


### PR DESCRIPTION
Turns out, you can't blindly print this node. We need a deeper fix but let's revert this fix for now.

Fixes #1348