### PR TITLE
Only break for conditionals

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3205,7 +3205,7 @@ function printBinaryishExpressions(path, print, options, isNested, isInsideParen
     // in order to avoid having a small right part like -1 be on its own line.
     const parent = path.getParentNode();
     const shouldGroup =
-      !isInsideParenthesis &&
+      !(isInsideParenthesis && node.type === "LogicalExpression") &&
       parent.type !== node.type &&
       node.left.type !== node.type &&
       node.right.type !== node.type;

--- a/tests/binary-expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/binary-expressions/__snapshots__/jsfmt.spec.js.snap
@@ -61,6 +61,9 @@ if (this.hasPlugin("dynamicImports") && this.lookahead().type) {}
 if (this.hasPlugin("dynamicImports") && this.lookahead().type === tt.parenLeft) {}
 
 if (this.hasPlugin("dynamicImports") && this.lookahead().type === tt.parenLeft.right) {}
+
+if (VeryVeryVeryVeryVeryVeryVeryVeryLong === VeryVeryVeryVeryVeryVeryVeryVeryLong) {
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 if (this.hasPlugin("dynamicImports") && this.lookahead().type) {
 }
@@ -74,6 +77,11 @@ if (
 if (
   this.hasPlugin("dynamicImports") &&
   this.lookahead().type === tt.parenLeft.right
+) {
+}
+
+if (
+  VeryVeryVeryVeryVeryVeryVeryVeryLong === VeryVeryVeryVeryVeryVeryVeryVeryLong
 ) {
 }
 

--- a/tests/binary-expressions/if.js
+++ b/tests/binary-expressions/if.js
@@ -3,3 +3,6 @@ if (this.hasPlugin("dynamicImports") && this.lookahead().type) {}
 if (this.hasPlugin("dynamicImports") && this.lookahead().type === tt.parenLeft) {}
 
 if (this.hasPlugin("dynamicImports") && this.lookahead().type === tt.parenLeft.right) {}
+
+if (VeryVeryVeryVeryVeryVeryVeryVeryLong === VeryVeryVeryVeryVeryVeryVeryVeryLong) {
+}


### PR DESCRIPTION
We only want to break for && and ||, not for ===.

Used to print

```js
if (
  VeryVeryVeryVeryVeryVeryVeryVeryLong ===
  VeryVeryVeryVeryVeryVeryVeryVeryLong
) {
}
```

This is a side effect of #1344. 