### PR TITLE
Remove parens around variable assignment JSX expressions

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -362,7 +362,6 @@ function genericPrintNoParens(path, options, print, args) {
       if (
         n.body.type === "ArrayExpression" ||
         n.body.type === "ObjectExpression" ||
-        n.body.type === "JSXElement" ||
         n.body.type === "BlockStatement" ||
         n.body.type === "TaggedTemplateExpression" ||
         n.body.type === "TemplateElement" ||
@@ -3154,6 +3153,7 @@ function maybeWrapJSXElementInParens(path, elem, options) {
 
   const NO_WRAP_PARENTS = {
     ArrayExpression: true,
+    ArrowFunctionExpression: true,
     JSXElement: true,
     JSXExpressionContainer: true,
     ExpressionStatement: true,
@@ -3161,6 +3161,7 @@ function maybeWrapJSXElementInParens(path, elem, options) {
     ConditionalExpression: true,
     LogicalExpression: true
   };
+
   if (NO_WRAP_PARENTS[parent.type]) {
     return elem;
   }

--- a/src/printer.js
+++ b/src/printer.js
@@ -3154,12 +3154,14 @@ function maybeWrapJSXElementInParens(path, elem, options) {
   const NO_WRAP_PARENTS = {
     ArrayExpression: true,
     ArrowFunctionExpression: true,
+    AssignmentExpression: true,
     JSXElement: true,
     JSXExpressionContainer: true,
     ExpressionStatement: true,
     CallExpression: true,
     ConditionalExpression: true,
-    LogicalExpression: true
+    LogicalExpression: true,
+    VariableDeclarator: true,
   };
 
   if (NO_WRAP_PARENTS[parent.type]) {
@@ -3284,7 +3286,8 @@ function printAssignment(
     (leftNode.type === "Identifier" || leftNode.type === "MemberExpression") &&
       (rightNode.type === "StringLiteral" ||
         (rightNode.type === "Literal" && typeof rightNode.value === "string") ||
-        isMemberExpressionChain(rightNode))
+        isMemberExpressionChain(rightNode) ||
+        rightNode.type === "JSXElement")
   ) {
     printed = indent(concat([line, printedRight]));
   } else {

--- a/tests/flow/jsx_intrinsics.builtin/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/jsx_intrinsics.builtin/__snapshots__/jsfmt.spec.js.snap
@@ -43,9 +43,8 @@ var c: React.Element<any> = <div not_a_real_attr="asdf" />;
 // different attributes.
 var d: React.Element<{ doesntmatch: string }> = <div not_a_real_attr="asdf" />;
 // No error as long as expectations are consistent, though.
-var e: React.Element<{ not_a_real_attr: string }> = (
-  <div not_a_real_attr="asdf" />
-);
+var e: React.Element<{ not_a_real_attr: string }> =
+  <div not_a_real_attr="asdf" />;
 
 `;
 

--- a/tests/flow/more_react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/more_react/__snapshots__/jsfmt.spec.js.snap
@@ -162,12 +162,11 @@ module.exports = app;
 var React = require("react");
 var App = require("App.react");
 
-var app = (
+var app =
   <App y={42}>
     {" "}// error, y: number but foo expects string in App.react
     Some text.
-  </App>
-);
+  </App>;
 
 module.exports = app;
 

--- a/tests/jsx-multiline-assign/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-multiline-assign/__snapshots__/jsfmt.spec.js.snap
@@ -21,33 +21,28 @@ const comp4 = <div style={styles} key="something">Create wrapping parens and ind
 
 const comp5 = <div>Keep it on one line.</div>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-const comp1 = (
+const comp1 =
   <div style={styles} key="something">
     Keep the wrapping parens.
-  </div>
-);
+  </div>;
 
-const comp2 = (
+const comp2 =
   <div style={styles} key="something">
     Create wrapping parens.
-  </div>
-);
+  </div>;
 
-comp2A = (
+comp2A =
   <div style={styles} key="something">
     Create wrapping parens.
-  </div>
-);
+  </div>;
 
-const comp3 = (
-  <div style={styles} key="something">Bump to next line without parens</div>
-);
+const comp3 =
+  <div style={styles} key="something">Bump to next line without parens</div>;
 
-const comp4 = (
+const comp4 =
   <div style={styles} key="something">
     Create wrapping parens and indent <strong>all the things</strong>.
-  </div>
-);
+  </div>;
 
 const comp5 = <div>Keep it on one line.</div>;
 

--- a/tests/jsx-newlines/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-newlines/__snapshots__/jsfmt.spec.js.snap
@@ -96,15 +96,14 @@ regression_extra_newline_2 = (
   </div>
 );
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-keep = (
+keep =
   <p>
     Welcome to the <strong>Universal React Starter-kyt</strong>.
     This starter kyt should serve as the base for an advanced,
     server-rendered React app.
-  </p>
-);
+  </p>;
 
-newlines_text = (
+newlines_text =
   <div>
     hi
     there
@@ -113,30 +112,27 @@ newlines_text = (
     are you
 
     are you fine today?
-  </div>
-);
+  </div>;
 
-newlines_text_spaced = (
+newlines_text_spaced =
   <div>
 
     space above
 
     space below
 
-  </div>
-);
+  </div>;
 
-newlines_elems_spaced = (
+newlines_elems_spaced =
   <div>
 
     <span>space above</span>
 
     <span>space below</span>
 
-  </div>
-);
+  </div>;
 
-newlines_mixed = (
+newlines_mixed =
   <div>
     hi
     <span>there</span>
@@ -146,10 +142,9 @@ newlines_mixed = (
     are <strong>you</strong>
 
     are you fine today?
-  </div>
-);
+  </div>;
 
-newlines_elems = (
+newlines_elems =
   <div>
     <div>
 
@@ -165,17 +160,15 @@ newlines_elems = (
 
     <Big />
 
-  </div>
-);
+  </div>;
 
-regression_extra_newline = (
+regression_extra_newline =
   <div>
     <span className="nuclide-console-new-messages-notification-icon icon icon-nuclicon-arrow-down" />
     New Messages
-  </div>
-);
+  </div>;
 
-regression_extra_newline_2 = (
+regression_extra_newline_2 =
   <div>
     (
     <FormattedMessage
@@ -183,8 +176,7 @@ regression_extra_newline_2 = (
       defaultMessage="some loooooooooooooooooooooooooooong default"
     />
     )
-  </div>
-);
+  </div>;
 
 `;
 

--- a/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
@@ -76,117 +76,102 @@ not_broken_begin =
     <br /> long text long text long text long text long text long text long text long text<link>url</link> long text long text
   </div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-after = (
+after =
   <span>
     foo <span>bar</span>
-  </span>
-);
+  </span>;
 
-before = (
+before =
   <span>
     <span>bar</span> foo
-  </span>
-);
+  </span>;
 
-before_break1 = (
+before_break1 =
   <span>
     <span barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar />
     {" "}
     foo
-  </span>
-);
+  </span>;
 
-before_break2 = (
+before_break2 =
   <span>
     <span
       barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar
     />
     {" "}
     foo
-  </span>
-);
+  </span>;
 
-after_break = (
+after_break =
   <span>
     foo
     {" "}
     <span barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar />
-  </span>
-);
+  </span>;
 
-within = (
+within =
   <span>
     foo <span> bar </span>
-  </span>
-);
+  </span>;
 
-break_components = (
+break_components =
   <div>
     <Foo />
     <Bar>
       <p>foo<span>bar bar bar</span></p><h1><span><em>yep</em></span></h1>
     </Bar>
     <h2>nope</h2>
-  </div>
-);
+  </div>;
 
-var x = (
+var x =
   <div>
     hello <strong>hi</strong> <foo>sdkflsdfjk</foo>
-  </div>
-);
+  </div>;
 
-nest_plz = (
+nest_plz =
   <div>
     <div>
       <div />
     </div>
-  </div>
-);
+  </div>;
 
-regression_not_transformed_1 = (
+regression_not_transformed_1 =
   <span>
     {" "}<Icon icon="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" />
-  </span>
-);
+  </span>;
 
-regression_not_transformed_2 = (
+regression_not_transformed_2 =
   <span>
     <Icon icon="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" />{" "}
-  </span>
-);
+  </span>;
 
-similar_1 = (
+similar_1 =
   <span>
     {" "}
     <Icon icon="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" />
-  </span>
-);
+  </span>;
 
-similar_2 = (
+similar_2 =
   <span>
     <Icon icon="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" />
     {" "}
-  </span>
-);
+  </span>;
 
-similar_3 = (
+similar_3 =
   <span>
     <Icon icon="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" /> <Icon icon="" />
-  </span>
-);
+  </span>;
 
-not_broken_end = (
+not_broken_end =
   <div>
     long text long text long text long text long text long text long text long text
     {" "}
     <link>url</link>
     {" "}
     long text long text
-  </div>
-);
+  </div>;
 
-not_broken_begin = (
+not_broken_begin =
   <div>
     <br />
     {" "}
@@ -194,7 +179,6 @@ not_broken_begin = (
     <link>url</link>
     {" "}
     long text long text
-  </div>
-);
+  </div>;
 
 `;

--- a/tests/jsx-split-attrs/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-split-attrs/__snapshots__/jsfmt.spec.js.snap
@@ -50,17 +50,16 @@ long_string_with_extra_param =
 long_obj =
   <div style={{ i: 'dont', use: 'bootstrap', and: 'instead', use: 'massive', objects }}>hello world</div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-long_closed = (
+long_closed =
   <BaseForm
     url="/auth/google"
     method="GET"
     colour="blue"
     size="large"
     submitLabel="Sign in with Google"
-  />
-);
+  />;
 
-long_open = (
+long_open =
   <BaseForm
     url="/auth/google"
     method="GET"
@@ -69,10 +68,9 @@ long_open = (
     submitLabel="Sign in with Google"
   >
     hello
-  </BaseForm>
-);
+  </BaseForm>;
 
-long_open_long_children = (
+long_open_long_children =
   <BaseForm
     url="/auth/google"
     method="GET"
@@ -140,18 +138,16 @@ long_open_long_children = (
         submitLabel="Sign in with Google"
       />
     </BaseForm>
-  </BaseForm>
-);
+  </BaseForm>;
 
 short_closed = <BaseForm url="/auth/google" method="GET" />;
 
-short_open = (
+short_open =
   <BaseForm url="/auth/google" method="GET">
     hello
-  </BaseForm>
-);
+  </BaseForm>;
 
-make_self_closing = (
+make_self_closing =
   <div>
     <BaseForm
       url="/auth/google"
@@ -167,10 +163,9 @@ make_self_closing = (
       size="large"
       submitLabel="Sign in with Google"
     />
-  </div>
-);
+  </div>;
 
-leave_opening = (
+leave_opening =
   <BaseForm
     url="/auth/google"
     method="GET"
@@ -179,25 +174,22 @@ leave_opening = (
     submitLabel="Sign in with Google"
   >
     {" "}
-  </BaseForm>
-);
+  </BaseForm>;
 
-long_string = (
+long_string =
   <div className="i use bootstrap and just put loooaads of classnames in here all the time">
     hello world
-  </div>
-);
+  </div>;
 
-long_string_with_extra_param = (
+long_string_with_extra_param =
   <div
     className="i use bootstrap and just put loooaads of classnames in here all the time"
     blah="3"
   >
     hello world
-  </div>
-);
+  </div>;
 
-long_obj = (
+long_obj =
   <div
     style={{
       i: "dont",
@@ -208,7 +200,6 @@ long_obj = (
     }}
   >
     hello world
-  </div>
-);
+  </div>;
 
 `;

--- a/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
@@ -75,31 +75,27 @@ const renderTernary = (props) =>
     {props.showTheOtherThing ? <div>I am here!!</div> : null}
   </BaseForm>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-const render1 = ({ styles }) => (
+const render1 = ({ styles }) =>
   <div style={styles} key="something">
     Keep the wrapping parens. Put each key on its own line.
-  </div>
-);
+  </div>;
 
-const render2 = ({ styles }) => (
+const render2 = ({ styles }) =>
   <div style={styles} key="something">
     Create wrapping parens.
-  </div>
-);
+  </div>;
 
-const render3 = ({ styles }) => (
-  <div style={styles} key="something">Bump to next line without parens</div>
-);
+const render3 = ({ styles }) =>
+  <div style={styles} key="something">Bump to next line without parens</div>;
 
-const render4 = ({ styles }) => (
+const render4 = ({ styles }) =>
   <div style={styles} key="something">
     Create wrapping parens and indent <strong>all the things</strong>.
-  </div>
-);
+  </div>;
 
 const render5 = ({ styles }) => <div>Keep it on one line.</div>;
 
-const render6 = ({ styles }) => (
+const render6 = ({ styles }) =>
   <div attr1="aaaaaaaaaaaaaaaaa" attr2="bbbbbbbbbbb" attr3="cccccccccccc">
     <div
       attr1="aaaaaaaaaaaaaaaaa"
@@ -134,39 +130,33 @@ const render6 = ({ styles }) => (
       {" "}
       <strong>hello</strong>
     </div>
-  </div>
-);
+  </div>;
 
-const render7 = () => (
+const render7 = () =>
   <div>
     <span /><span>Dont break each elem onto its own line.</span> <span />
     <div /> <div />
-  </div>
-);
+  </div>;
 
-const render7A = () => (
+const render7A = () =>
   <div>
     <div /><div /><div />
-  </div>
-);
+  </div>;
 
-const render7B = () => (
+const render7B = () =>
   <div>
     <span> <span /> Dont break plz</span>
     <span><span />Dont break plz</span>
     <span>Dont break plz<span /></span>
-  </div>
-);
+  </div>;
 
 const render8 = props => <div>{props.text}</div>;
-const render9 = props => (
-  <div>{props.looooooooooooooooooooooooooooooong_text}</div>
-);
-const render10 = props => (
+const render9 = props =>
+  <div>{props.looooooooooooooooooooooooooooooong_text}</div>;
+const render10 = props =>
   <div>
     {props.even_looooooooooooooooooooooooooooooooooooooooooonger_contents}
-  </div>
-);
+  </div>;
 
 const notJSX = (aaaaaaaaaaaaaaaaa, bbbbbbbbbbb) =>
   this.someLongCallWithParams(aaaaaa, bbbbbbb).anotherLongCallWithParams(
@@ -185,7 +175,7 @@ React.render(
   document.querySelector("#react-root")
 );
 
-const renderTernary = props => (
+const renderTernary = props =>
   <BaseForm
     url="/auth/google"
     method="GET"
@@ -228,7 +218,6 @@ const renderTernary = props => (
         </BaseForm>}
     {props.showTheOtherThing ? <div>I am here</div> : <div attr="blah" />}
     {props.showTheOtherThing ? <div>I am here!!</div> : null}
-  </BaseForm>
-);
+  </BaseForm>;
 
 `;

--- a/tests/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -89,19 +89,18 @@ exports[`expression.js 1`] = `
 />;
 
 <Something>
-  {() => (
+  {() =>
+    <SomethingElse>
+      <span />
+    </SomethingElse>}
+</Something>;
+
+<Something>
+  {items.map(item =>
     <SomethingElse>
       <span />
     </SomethingElse>
   )}
-</Something>;
-
-<Something>
-  {items.map(item => (
-    <SomethingElse>
-      <span />
-    </SomethingElse>
-  ))}
 </Something>;
 
 <Something>
@@ -188,28 +187,28 @@ exports[`hug.js 1`] = `
   {__DEV__
     ? this.renderDevApp()
     : <div>
-        {routes.map(route => (
+        {routes.map(route =>
           <MatchAsync
             key={\`\${route.to}-async\`}
             pattern={route.to}
             exactly={route.to === "/"}
             getComponent={routeES6Modules[route.value]}
           />
-        ))}
+        )}
       </div>}
 </div>;
 
 <div>
   {__DEV__ &&
     <div>
-      {routes.map(route => (
+      {routes.map(route =>
         <MatchAsync
           key={\`\${route.to}-async\`}
           pattern={route.to}
           exactly={route.to === "/"}
           getComponent={routeES6Modules[route.value]}
         />
-      ))}
+      )}
     </div>}
 </div>;
 

--- a/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
@@ -282,11 +282,11 @@ const els = items.map(item => (
   </div>
 ));
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-const els = items.map(item => (
+const els = items.map(item =>
   <div className="whatever">
     <span>{children}</span>
   </div>
-));
+);
 
 `;
 


### PR DESCRIPTION
Should be stacked on top of #1382 (Github...).

Fixes the related issue of wrapping JSX which are RHS of a variable assignment.