### PR TITLE
Add parenthesis for unusual nested ternaries

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -954,7 +954,9 @@ function genericPrintNoParens(path, options, print, args) {
             concat([
               line,
               "? ",
+              n.consequent.type === "ConditionalExpression" ? ifBreak("", "(") : "",
               align(2, path.call(print, "consequent")),
+              n.consequent.type === "ConditionalExpression" ? ifBreak("", ")") : "",
               line,
               ": ",
               align(2, path.call(print, "alternate"))

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1038,7 +1038,7 @@ function memberInAndOutWithCalls() {
 function excessiveEverything() {
   return (
     // Reason for stuff
-    a.b() * 3 + 4 ? (a\`hi\`, 1) ? 1 : 1 : 1
+    a.b() * 3 + 4 ? ((a\`hi\`, 1) ? 1 : 1) : 1
   );
 }
 

--- a/tests/ternaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ternaries/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`parenthesis.js 1`] = `
+debug ? this.state.isVisible ? "partially visible" : "hidden" : null;
+debug ? this.state.isVisible && somethingComplex ? "partially visible" : "hidden" : null;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
+debug
+  ? this.state.isVisible && somethingComplex ? "partially visible" : "hidden"
+  : null;
+
+`;
+
+exports[`parenthesis.js 2`] = `
+debug ? this.state.isVisible ? "partially visible" : "hidden" : null;
+debug ? this.state.isVisible && somethingComplex ? "partially visible" : "hidden" : null;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
+debug
+    ? this.state.isVisible && somethingComplex ? "partially visible" : "hidden"
+    : null;
+
+`;
+
 exports[`test.js 1`] = `
 const obj0 = conditionIsTruthy ? shortThing : otherShortThing
 

--- a/tests/ternaries/parenthesis.js
+++ b/tests/ternaries/parenthesis.js
@@ -1,0 +1,2 @@
+debug ? this.state.isVisible ? "partially visible" : "hidden" : null;
+debug ? this.state.isVisible && somethingComplex ? "partially visible" : "hidden" : null;


### PR DESCRIPTION
All of the discussions around ternaries are for the form

```js
cond1 ? elem1_if : cond2 ? elem2_if : elem_else
```

but some of them are for the form

```js
cond1 ? cond2 ? elem2_if : elem2_else : elem1_else
```

which is more rare and would be good to call out by adding parenthesis.

```js
cond1 ? (cond2 ? elem2_if : elem2_else) : elem1_else
```

Note that we only want parenthesis if it's written inline, otherwise the indentation is good enough to understand the flow:

```js
cond1
  ? cond2 ? elem2_if : elem2_else
  : elem1_else
```