### PR TITLE
[WIP] Allow for multiple member expressions to be merged

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2802,10 +2802,14 @@ function printMemberChain(path, options, print) {
   const shouldMerge =
     groups.length >= 2 &&
     !groups[1][0].node.comments &&
-    groups[0].length === 1 &&
     (groups[0][0].node.type === "ThisExpression" ||
       (groups[0][0].node.type === "Identifier" &&
-        groups[0][0].node.name.match(/(^[A-Z])|^[_$]+$/)));
+        groups[0][0].node.name.match(/(^[A-Z])|^[_$]+$/))) &&
+    (groups[0].length === 1 ||
+      (groups[0].length > 1 &&
+        (groups[1][0].node.computed ||
+          (groups[1][0].node.property.type === "Identifier" &&
+            groups[1][0].node.property.name.match(/^[A-Z]/)))));
 
   function printGroup(printedGroup) {
     return concat(printedGroup.map(tuple => tuple.printed));

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -316,6 +316,14 @@ Object.keys(
 .forEach(locale => {
   // ...
 });
+
+DraftSelectors.fragmentsNotPublishing[level]()
+  .map(fragment => getRequiredSelectionInfoForFragment(fragment))
+  .toSet();
+
+Immutable.Seq.Keyed(
+  segments.map(segment => [segment.id, segment])
+).toOrderedMap();
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Object.keys(
   availableLocales({
@@ -324,6 +332,14 @@ Object.keys(
 ).forEach(locale => {
   // ...
 });
+
+DraftSelectors.fragmentsNotPublishing[level]()
+  .map(fragment => getRequiredSelectionInfoForFragment(fragment))
+  .toSet();
+
+Immutable.Seq.Keyed(
+  segments.map(segment => [segment.id, segment])
+).toOrderedMap();
 
 `;
 

--- a/tests/method-chain/inline_merge.js
+++ b/tests/method-chain/inline_merge.js
@@ -6,3 +6,11 @@ Object.keys(
 .forEach(locale => {
   // ...
 });
+
+DraftSelectors.fragmentsNotPublishing[level]()
+  .map(fragment => getRequiredSelectionInfoForFragment(fragment))
+  .toSet();
+
+Immutable.Seq.Keyed(
+  segments.map(segment => [segment.id, segment])
+).toOrderedMap();


### PR DESCRIPTION
If there are multiple member expressions and the last one is either a computed property or capitalized, then it doesn't make sense to have them on their own line: they should be in a single line with the call.

This is nice that we're down to such level of detail, the member expression chain printing has become really good :)

Fixes #1374