### PR TITLE
Preserve inline comment as last argument

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -194,6 +194,13 @@ function attach(comments, ast, text, options) {
       }
     } else if (util.hasNewline(text, locEnd(comment))) {
       if (
+        handleLastFunctionArgComments(
+          text,
+          precedingNode,
+          enclosingNode,
+          followingNode,
+          comment
+        ) ||
         handleConditionalExpressionComments(
           enclosingNode,
           precedingNode,

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -714,6 +714,47 @@ class X {
   ): $Enum<SectionMode> {
   }
 }
+
+class Foo {
+  a(lol /*string*/) {}
+
+  b(lol /*string*/
+  ) {}
+
+  d(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) {}
+
+  d(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) /*string*/ {}
+
+  // prettier-ignore
+  c(lol /*string*/
+  ) {}
+
+  // prettier-ignore
+  d(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) {}
+
+  // prettier-ignore
+  e(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) {} /* string*/
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 type f = (
   currentRequest: { a: number }
@@ -765,6 +806,42 @@ class X {
     /* $FlowFixMe This error was exposed while converting keyMirror
      * to keyMirrorRecursive */
   ): $Enum<SectionMode> {}
+}
+
+class Foo {
+  a(lol /*string*/) {}
+
+  b(lol /*string*/) {}
+
+  d(lol /*string*/, lol2 /*string*/, lol3 /*string*/, lol4 /*string*/) {}
+
+  d(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) /*string*/ {
+  }
+
+  // prettier-ignore
+  c(lol /*string*/
+  ) {}
+
+  // prettier-ignore
+  d(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) {}
+
+  // prettier-ignore
+  e(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) {} /* string*/
 }
 
 `;

--- a/tests/comments/last-arg.js
+++ b/tests/comments/last-arg.js
@@ -51,3 +51,44 @@ class X {
   ): $Enum<SectionMode> {
   }
 }
+
+class Foo {
+  a(lol /*string*/) {}
+
+  b(lol /*string*/
+  ) {}
+
+  d(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) {}
+
+  d(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) /*string*/ {}
+
+  // prettier-ignore
+  c(lol /*string*/
+  ) {}
+
+  // prettier-ignore
+  d(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) {}
+
+  // prettier-ignore
+  e(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) {} /* string*/
+}


### PR DESCRIPTION
We already had the logic but only applied it for comments on their own line, we should also do it if they are inline.

Fixes #1380