### PR TITLE
parent decides how to print type annotations

### DIFF
--- a/tests/flow/objectTypeProperty/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/objectTypeProperty/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`objectTypeProperty.js 1`] = `
+/* @flow */
+
+declare var BAZ: {stuff?: (x: number) => void} | void;
+
+declare class Foo<T> {
+  constructor(): void;
+  foo: () => void;
+}
+
+let x: { x?: number }
+
+type T = {
+  get goodGetterWithAnnotation(): number,
+  set goodSetterWithAnnotation(x: number): void,
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/* @flow */
+
+declare var BAZ: { stuff?: (x: number) => void } | void;
+
+declare class Foo<T> {
+  constructor(): void,
+  foo: () => void
+}
+
+let x: { x?: number };
+
+type T = {
+  goodGetterWithAnnotation: () => number,
+  goodSetterWithAnnotation: (x: number) => void
+};
+
+`;

--- a/tests/flow/objectTypeProperty/jsfmt.spec.js
+++ b/tests/flow/objectTypeProperty/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/flow/objectTypeProperty/objectTypeProperty.js
+++ b/tests/flow/objectTypeProperty/objectTypeProperty.js
@@ -1,0 +1,15 @@
+/* @flow */
+
+declare var BAZ: {stuff?: (x: number) => void} | void;
+
+declare class Foo<T> {
+  constructor(): void;
+  foo: () => void;
+}
+
+let x: { x?: number }
+
+type T = {
+  get goodGetterWithAnnotation(): number,
+  set goodSetterWithAnnotation(x: number): void,
+}


### PR DESCRIPTION
Following up the discussion on #1367.

This PR separates the `TypeAnnotation` from the preceding colon that may or may not be there depending on the context. Instead of leaving it up to the `TypeAnnotation` to find out what the context is, it's now the `TypeAnnotation`'s parent's job.

I also added a test containing multiple `ObjectTypeProperties` since they were hard to get right.