### PR TITLE
fix VariableDeclarator not printing type parameters

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1015,7 +1015,7 @@ function genericPrintNoParens(path, options, print, args) {
     case "VariableDeclarator":
       return printAssignment(
         n.id,
-        path.call(print, "id"),
+        concat([path.call(print, "id"), path.call(print, "typeParameters")]),
         "=",
         n.init,
         n.init && path.call(print, "init"),

--- a/tests/typescript/conformance/types/variableDeclarator/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/variableDeclarator/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`variableDeclarator.ts 1`] = `
+type MyMap<T, P> = Map<T, P>;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+type MyMap<T, P> = Map<T, P>;
+
+`;

--- a/tests/typescript/conformance/types/variableDeclarator/jsfmt.spec.js
+++ b/tests/typescript/conformance/types/variableDeclarator/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });

--- a/tests/typescript/conformance/types/variableDeclarator/variableDeclarator.ts
+++ b/tests/typescript/conformance/types/variableDeclarator/variableDeclarator.ts
@@ -1,0 +1,1 @@
+type MyMap<T, P> = Map<T, P>;


### PR DESCRIPTION
Before the change it would have printed this:
```ts
type MyMap = Map<T, P>;
```