### PR TITLE
Add TypeScript delcare modifier support for variables, classes and functions

### DIFF
--- a/tests/typescript/conformance/ambient/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/ambient/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,58 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ambientDeclarations.ts 1`] = `
+declare var n;
+
+declare var m: string;
+
+declare function fn1();
+
+declare function fn2(n: string): number;
+
+declare function fn3(n: string): number;
+declare function fn4(n: number, y: number): string;
+
+declare function fn5(x, y?);
+declare function fn6(e?);
+declare function fn7(x, y?, ...z);
+declare function fn8(y?, ...z: number[]);
+declare function fn9(...q: {}[]);
+declare function fn10<T>(...q: T[]);
+
+declare class cls {
+    constructor();
+    method(): cls;
+    static static(p): number;
+    static q;
+    private fn();
+    private static fns();
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+declare var n;
+
+declare var m: string;
+
+declare function fn1()
+
+declare function fn2(n: string): number
+
+declare function fn3(n: string): number
+declare function fn4(n: number, y: number): string
+
+declare function fn5(x, y?)
+declare function fn6(e?)
+declare function fn7(x, y?, ...z)
+declare function fn8(y?, ...z: number[])
+declare function fn9(...q: {}[])
+declare function fn10<T>(...q: T[])
+
+declare class cls {
+  constructor();
+  method(): cls;
+  static static(p): number;
+  static q;
+  private fn();
+  static private fns();
+}
+
+`;

--- a/tests/typescript/conformance/ambient/ambientDeclarations.ts
+++ b/tests/typescript/conformance/ambient/ambientDeclarations.ts
@@ -1,0 +1,26 @@
+declare var n;
+
+declare var m: string;
+
+declare function fn1();
+
+declare function fn2(n: string): number;
+
+declare function fn3(n: string): number;
+declare function fn4(n: number, y: number): string;
+
+declare function fn5(x, y?);
+declare function fn6(e?);
+declare function fn7(x, y?, ...z);
+declare function fn8(y?, ...z: number[]);
+declare function fn9(...q: {}[]);
+declare function fn10<T>(...q: T[]);
+
+declare class cls {
+    constructor();
+    method(): cls;
+    static static(p): number;
+    static q;
+    private fn();
+    private static fns();
+}

--- a/tests/typescript/conformance/ambient/jsfmt.spec.js
+++ b/tests/typescript/conformance/ambient/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });

--- a/tests/typescript/conformance/types/thisType/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/thisType/__snapshots__/jsfmt.spec.js.snap
@@ -5,7 +5,7 @@ declare class MyArray<T> extends Array<T> {
     sort(compareFn?: (a: T, b: T) => number): this;
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-class MyArray<T> extends Array {
+declare class MyArray<T> extends Array {
   sort(compareFn?: (a: T, b: T) => number): this;
 }
 

--- a/tests/typescript/custom/declare/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/custom/declare/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`declareModifier.d.ts 1`] = `
+
+declare function a();
+
+declare const b: string;
+
+declare var c: number;
+
+declare let d: any;
+
+declare class e {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+declare function a()
+
+declare const b: string;
+
+declare var c: number;
+
+declare let d: any;
+
+declare class e {}
+
+`;

--- a/tests/typescript/custom/declare/declareModifier.d.ts
+++ b/tests/typescript/custom/declare/declareModifier.d.ts
@@ -1,0 +1,10 @@
+
+declare function a();
+
+declare const b: string;
+
+declare var c: number;
+
+declare let d: any;
+
+declare class e {}

--- a/tests/typescript/custom/declare/jsfmt.spec.js
+++ b/tests/typescript/custom/declare/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });


### PR DESCRIPTION
Also (accidentally) fixed a bug with flow `declare class`.

Declare modifier support for `enum` and `namespace` is obviously blocked on their respective implementations. 