### PR TITLE
Don't break on empty arrays and objects

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -666,11 +666,7 @@ function genericPrintNoParens(path, options, print, args) {
         }
       }
 
-      const hasDanglingComments =
-        n.comments &&
-        n.comments.some(comment => !comment.leading && !comment.trailing);
-
-      if (hasDanglingComments) {
+      if (hasDanglingComments(n)) {
         parts.push(
           " ",
           comments.printDanglingComments(path, options, /* sameIndent */ true)
@@ -777,6 +773,10 @@ function genericPrintNoParens(path, options, print, args) {
         );
 
       if (props.length === 0) {
+        if (!hasDanglingComments(n)) {
+          return concat([leftBrace, rightBrace]);
+        }
+
         return group(
           concat([
             leftBrace,
@@ -852,16 +852,20 @@ function genericPrintNoParens(path, options, print, args) {
     case "ArrayExpression":
     case "ArrayPattern":
       if (n.elements.length === 0) {
-        parts.push(
-          group(
-            concat([
-              "[",
-              comments.printDanglingComments(path, options),
-              softline,
-              "]"
-            ])
-          )
-        );
+        if (!hasDanglingComments(n)) {
+          parts.push("[]");
+        } else {
+          parts.push(
+            group(
+              concat([
+                "[",
+                comments.printDanglingComments(path, options),
+                softline,
+                "]"
+              ])
+            )
+          );
+        }
       } else {
         const lastElem = util.getLast(n.elements);
         const canHaveTrailingComma = !(lastElem &&
@@ -3696,6 +3700,11 @@ function printArrayItems(path, options, printPath, print) {
   }, printPath);
 
   return concat(printedElements);
+}
+
+function hasDanglingComments(node) {
+  return node.comments &&
+    node.comments.some(comment => !comment.leading && !comment.trailing);
 }
 
 function removeLines(doc) {

--- a/tests/arrays/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/arrays/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`empty.js 1`] = `
+const a = someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || [];
+const a = someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || {};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const a = someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || [];
+const a = someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || {};
+
+`;
+
 exports[`last.js 1`] = `
 [,];
 [,,];

--- a/tests/arrays/empty.js
+++ b/tests/arrays/empty.js
@@ -1,0 +1,2 @@
+const a = someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || [];
+const a = someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || {};


### PR DESCRIPTION
We never want to break on those at it looks very weird. The reason why I didn't add this yet is because whenever it triggered in the past, the root cause was something else and it helped identify things to fix. But now the remaining ones I'm seeing are no longer underlying issues and they're just about this breaking unnecessarily, so we should just fix it.