### PR TITLE
Require '(a || b).c++' to have a preceding ; in no-semi style

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3528,7 +3528,8 @@ function hasNakedLeftSide(node) {
     node.type === "CallExpression" ||
     node.type === "MemberExpression" ||
     node.type === "SequenceExpression" ||
-    node.type === "TaggedTemplateExpression"
+    node.type === "TaggedTemplateExpression" ||
+    (node.type === "UpdateExpression" && !node.prefix)
   );
 }
 
@@ -3536,7 +3537,7 @@ function getLeftSide(node) {
   if (node.expressions) {
     return node.expressions[0];
   }
-  return node.left || node.test || node.callee || node.object || node.tag;
+  return node.left || node.test || node.callee || node.object || node.tag || node.argument;
 }
 
 function exprNeedsASIProtection(node) {

--- a/tests/no-semi/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/no-semi/__snapshots__/jsfmt.spec.js.snap
@@ -229,6 +229,10 @@ tag
 
 x; x => x
 
+x; (a || b).c++
+
+x; ++(a || b).c
+
 while (false)
   (function(){}())
 
@@ -394,6 +398,12 @@ tag\`string\`;
 x;
 x => x;
 
+x;
+(a || b).c++;
+
+x;
+++(a || b).c;
+
 while (false)
   (function() {})();
 
@@ -549,6 +559,10 @@ tag
 \`string\`
 
 x; x => x
+
+x; (a || b).c++
+
+x; ++(a || b).c
 
 while (false)
   (function(){}())
@@ -714,6 +728,12 @@ tag\`string\`
 
 x
 x => x
+
+x
+;(a || b).c++
+
+x
+++(a || b).c
 
 while (false)
   (function() {})()
@@ -871,6 +891,10 @@ tag
 
 x; x => x
 
+x; (a || b).c++
+
+x; ++(a || b).c
+
 while (false)
   (function(){}())
 
@@ -1036,6 +1060,12 @@ tag\`string\`
 
 x
 x => x
+
+x
+;(a || b).c++
+
+x
+++(a || b).c
 
 while (false)
   (function() {})()

--- a/tests/no-semi/no-semi.js
+++ b/tests/no-semi/no-semi.js
@@ -145,6 +145,10 @@ tag
 
 x; x => x
 
+x; (a || b).c++
+
+x; ++(a || b).c
+
 while (false)
   (function(){}())
 


### PR DESCRIPTION
Sorry I missed this [earlier](https://github.com/prettier/prettier/pull/1129#issuecomment-291997555).