### PR TITLE
add indentation to unary expressions

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -954,10 +954,23 @@ function genericPrintNoParens(path, options, print, args) {
       parts.push(n.operator);
 
       if (/[a-z]$/.test(n.operator)) parts.push(" ");
+	  
+	  var expression = path.call(print, "argument");
+	  var expParts = expression.parts;
+	  var multipleParams = ((expParts[0] === "(") && (expParts[expParts.length-1] === ")"));
+	  if (multipleParams){
+		 expParts.shift();
+		 expParts.unshift(indent(softline));
+		 expParts.unshift("(");
+		 expParts.pop();
+		 expParts.push(softline);
+		 expParts.push(")"); 
+	  }
+	  expression.parts = expParts;
 
-      parts.push(path.call(print, "argument"));
+      parts.push(group(expression));
 
-      return concat(parts);
+	 return concat(parts);
     case "UpdateExpression":
       parts.push(path.call(print, "argument"), n.operator);
 

--- a/tests/flow/intersection/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/intersection/__snapshots__/jsfmt.spec.js.snap
@@ -95,9 +95,11 @@ function hasObjectMode_bad(options: DuplexStreamOptions): boolean {
 }
 
 function hasObjectMode_ok(options: DuplexStreamOptions): boolean {
-  return !!(options.objectMode ||
+  return !!(
+    options.objectMode ||
     options.readableObjectMode ||
-    options.writableObjectMode);
+    options.writableObjectMode
+  );
 }
 
 `;


### PR DESCRIPTION
issue #774 
unary expressions now create new lines after parenthesis if there are more than one nested expressions