### PR TITLE
Don't break for unparenthesised single argument flow function

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2466,19 +2466,22 @@ function printFunctionParams(path, print, options, expandArg) {
     flowTypeAnnotations.indexOf(fun[paramsField][0].typeAnnotation.type) !== -1 &&
     !fun.rest;
 
+  if (isFlowShorthandWithOneArg) {
+    return concat(printed);
+  }
+
   const canHaveTrailingComma =
-    !isFlowShorthandWithOneArg &&
     !(lastParam && lastParam.type === "RestElement") &&
     !fun.rest;
 
   return concat([
-    isFlowShorthandWithOneArg ? "" : "(",
+    "(",
     indent(concat([softline, join(concat([",", line]), printed)])),
     ifBreak(
       canHaveTrailingComma && shouldPrintComma(options, "all") ? "," : ""
     ),
     softline,
-    isFlowShorthandWithOneArg ? "" : ")"
+    ")"
   ]);
 }
 

--- a/tests/flow_function_parentheses/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_function_parentheses/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`single.js 1`] = `
+const selectorByPath:
+  Path
+ => SomethingSelector<
+  SomethingUEditorContextType,
+  SomethingUEditorContextType,
+  SomethingBulkValue<string>
+> = memoizeWithArgs(/* ... */)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const selectorByPath: Path => SomethingSelector<
+  SomethingUEditorContextType,
+  SomethingUEditorContextType,
+  SomethingBulkValue<string>
+> = memoizeWithArgs(/* ... */);
+
+`;
+
+exports[`single.js 2`] = `
+const selectorByPath:
+  Path
+ => SomethingSelector<
+  SomethingUEditorContextType,
+  SomethingUEditorContextType,
+  SomethingBulkValue<string>
+> = memoizeWithArgs(/* ... */)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const selectorByPath: Path => SomethingSelector<
+  SomethingUEditorContextType,
+  SomethingUEditorContextType,
+  SomethingBulkValue<string>,
+> = memoizeWithArgs(/* ... */);
+
+`;
+
 exports[`test.js 1`] = `
 type Banana = {
   eat: string => boolean,
@@ -79,16 +113,12 @@ type f = (?arg) => void;
 
 class X {
   constructor(
-    ideConnectionFactory:
-      child_process$ChildProcess
-     => FlowIDEConnection = defaultIDEConnectionFactory
+    ideConnectionFactory: child_process$ChildProcess => FlowIDEConnection = defaultIDEConnectionFactory
   ) {}
 }
 
 interface F {
-  ideConnectionFactoryLongLongLong:
-    child_process$ChildProcess
-   => FlowIDEConnection
+  ideConnectionFactoryLongLongLong: child_process$ChildProcess => FlowIDEConnection
 }
 
 `;
@@ -172,16 +202,12 @@ type f = (?arg) => void;
 
 class X {
   constructor(
-    ideConnectionFactory:
-      child_process$ChildProcess
-     => FlowIDEConnection = defaultIDEConnectionFactory,
+    ideConnectionFactory: child_process$ChildProcess => FlowIDEConnection = defaultIDEConnectionFactory,
   ) {}
 }
 
 interface F {
-  ideConnectionFactoryLongLongLong:
-    child_process$ChildProcess
-   => FlowIDEConnection,
+  ideConnectionFactoryLongLongLong: child_process$ChildProcess => FlowIDEConnection,
 }
 
 `;

--- a/tests/flow_function_parentheses/single.js
+++ b/tests/flow_function_parentheses/single.js
@@ -1,0 +1,7 @@
+const selectorByPath:
+  Path
+ => SomethingSelector<
+  SomethingUEditorContextType,
+  SomethingUEditorContextType,
+  SomethingBulkValue<string>
+> = memoizeWithArgs(/* ... */)


### PR DESCRIPTION
This has been reported internally. It looks --very-- weird to have it indented the way it was.