### PR TITLE
Break inline object first in function arguments

### DIFF
--- a/tests/function/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/function/__snapshots__/jsfmt.spec.js.snap
@@ -26,3 +26,34 @@ a + function() {};
 new function() {}();
 
 `;
+
+exports[`single_expand.js 1`] = `
+function onDidInsertSuggestion({
+  editor,
+  triggerPosition,
+  re
+}): Promise<void> {
+}
+
+class X {
+  async onDidInsertSuggestion({editor, triggerPosition, suggestion}): Promise<
+    void
+  > {
+  }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+function onDidInsertSuggestion({
+  editor,
+  triggerPosition,
+  re
+}): Promise<void> {}
+
+class X {
+  async onDidInsertSuggestion({
+    editor,
+    triggerPosition,
+    suggestion
+  }): Promise<void> {}
+}
+
+`;

--- a/tests/function/single_expand.js
+++ b/tests/function/single_expand.js
@@ -1,0 +1,13 @@
+function onDidInsertSuggestion({
+  editor,
+  triggerPosition,
+  re
+}): Promise<void> {
+}
+
+class X {
+  async onDidInsertSuggestion({editor, triggerPosition, suggestion}): Promise<
+    void
+  > {
+  }
+}


### PR DESCRIPTION
This is getting subtle where the groups need to be in a precise position but that works :)

Fixes #1409