### PR TITLE
Add space around `=` for flow generics default arguments

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1903,7 +1903,7 @@ function genericPrintNoParens(path, options, print, args) {
       }
 
       if (n["default"]) {
-        parts.push("=", path.call(print, "default"));
+        parts.push(" = ", path.call(print, "default"));
       }
 
       return concat(parts);

--- a/tests/flow/react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/react/__snapshots__/jsfmt.spec.js.snap
@@ -1118,7 +1118,7 @@ var PolyExample = React.createClass({
 <PolyExample x={(new Poly(): Poly<string>)} />; // OK
 <PolyExample x={(new Poly(): Poly<number>)} />; // OK
 
-class PolyDefault<T=string> {
+class PolyDefault<T = string> {
   x: T;
 }
 var PolyDefaultExample = React.createClass({

--- a/tests/flow/type_args_nonstrict/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type_args_nonstrict/__snapshots__/jsfmt.spec.js.snap
@@ -99,7 +99,7 @@ var c: MyClass = new MyClass(0); // no error
 
 // no arity error in type annotation using polymorphic class with defaulting
 
-class MyClass2<T, U=string> {
+class MyClass2<T, U = string> {
   x: T;
   y: U;
   constructor(x: T, y: U) {

--- a/tests/flow/type_args_strict/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type_args_strict/__snapshots__/jsfmt.spec.js.snap
@@ -97,7 +97,7 @@ var c: MyClass = new MyClass(0); // error, missing argument list (1)
 
 // arity error in type annotation using polymorphic class with defaulting
 
-class MyClass2<T, U=string> {
+class MyClass2<T, U = string> {
   x: T;
   y: U;
   constructor(x: T, y: U) {

--- a/tests/flow/type_param_defaults/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type_param_defaults/__snapshots__/jsfmt.spec.js.snap
@@ -77,7 +77,7 @@ class A<T> {
 }
 
 // Test out simple defaults
-class B<T=string> extends A<T> {}
+class B<T = string> extends A<T> {}
 
 var b_number: B<number> = new B(123);
 var b_void: B<void> = new B();
@@ -91,7 +91,7 @@ var b_star: B<*> = new B(123);
 
 (b_star.p: boolean); // Error number ~> boolean
 
-class C<T: ?string=string> extends A<T> {}
+class C<T: ?string = string> extends A<T> {}
 
 var c_number: C<number> = new C(123); // Error number ~> ?string
 var c_void: C<void> = new C();
@@ -102,7 +102,7 @@ var c_star: C<*> = new C("hello");
 (c_default.p: boolean); // Error string ~> boolean
 (c_star.p: boolean); // Error string ~> boolean
 
-class D<S, T=string> extends A<T> {}
+class D<S, T = string> extends A<T> {}
 var d_number: D<mixed, number> = new D(123);
 var d_void: D<mixed, void> = new D();
 var d_default: D<mixed> = new D("hello");
@@ -115,18 +115,18 @@ var d_star: D<*> = new D(10); // error, number ~> string
 (d_default.p: boolean); // Error string ~> boolean
 (d_star.p: boolean); // Error number ~> boolean
 
-class E<S: string, T: number=S> {} // Error: string ~> number
-class F<S: string, T: S=number> {} // Error: number ~> string
+class E<S: string, T: number = S> {} // Error: string ~> number
+class F<S: string, T: S = number> {} // Error: number ~> string
 
-class G<S: string, T=S> extends A<T> {}
+class G<S: string, T = S> extends A<T> {}
 
 var g_default: G<string> = new G("hello");
 
 (g_default.p: boolean); // Error string ~> boolean
 
-class H<S=T, T=string> {} // Error - can't refer to T before it's defined
+class H<S = T, T = string> {} // Error - can't refer to T before it's defined
 
-class I<T: ?string=*> extends A<T> {}
+class I<T: ?string = *> extends A<T> {}
 
 var i_number: I<number> = new I(123); // Error number ~> ?string
 var i_void: I<void> = new I();


### PR DESCRIPTION
We have a space for function arguments and it looks weird without.