### PR TITLE
Implement TypeScript keywords, namespace functions and class heritage

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -334,7 +334,7 @@ function genericPrintNoParens(path, options, print, args) {
     case "FunctionExpression":
     case "TSNamespaceFunctionDeclaration":
       if (isNodeStartingWithDeclare(n, options)) {
-        parts.push(hardline, "declare ");
+        parts.push("declare ");
       }
       parts.push(printFunctionDeclaration(path, print, options));
       return concat(parts);
@@ -835,7 +835,7 @@ function genericPrintNoParens(path, options, print, args) {
       let content;
       if (props.length === 0 && !n.typeAnnotation) {
         if (!hasDanglingComments(n)) {
-          return concat([prefix, leftBrace, rightBrace]);
+          return concat([concat(prefix), leftBrace, rightBrace]);
         }
 
         content = group(

--- a/src/printer.js
+++ b/src/printer.js
@@ -755,26 +755,34 @@ function genericPrintNoParens(path, options, print, args) {
       var propertiesField = isTypeScriptType
         ? "members"
         : "properties";
-      var prefix = ""
+      var prefix = []
 
       if (isTypeAnnotation) {
         fields.push("indexers", "callProperties");
       }
 
       if (isTypeScriptInterfaceDeclaration) {
-        prefix = concat([
+        prefix.push(
+          printTypeScriptModifiers(path, options, print),
           "interface ",
           path.call(print, "name"),
           " "
-        ]);
+        );
+
+        if (n.typeParameters) {
+          prefix.push(
+            "<",
+            join(", ", path.map(print, "typeParameters")),
+            ">"
+          );
+        }
 
         if (n.heritageClauses) {
-          prefix = concat([
-            prefix,
+          prefix.push(
             "extends ",
             join(", ", path.map(print, "heritageClauses")),
             " "
-          ]);
+          );
         }
       }
 
@@ -824,7 +832,7 @@ function genericPrintNoParens(path, options, print, args) {
 
         content = group(
           concat([
-            prefix,
+            concat(prefix),
             leftBrace,
             comments.printDanglingComments(path, options),
             softline,
@@ -833,7 +841,7 @@ function genericPrintNoParens(path, options, print, args) {
         );
       } else {
         content = concat([
-          prefix,
+          concat(prefix),
           leftBrace,
           indent(
             align(

--- a/src/printer.js
+++ b/src/printer.js
@@ -339,7 +339,9 @@ function genericPrintNoParens(path, options, print, args) {
       parts.push(printFunctionDeclaration(path, print, options));
       return concat(parts);
     case "ArrowFunctionExpression": {
-      if (n.async) parts.push("async ");
+      if (n.async) {
+        parts.push("async ");
+      }
 
       if (n.typeParameters) {
         parts.push(path.call(print, "typeParameters"));
@@ -439,17 +441,23 @@ function genericPrintNoParens(path, options, print, args) {
     case "YieldExpression":
       parts.push("yield");
 
-      if (n.delegate) parts.push("*");
-
-      if (n.argument) parts.push(" ", path.call(print, "argument"));
+      if (n.delegate) {
+        parts.push("*");
+      }
+      if (n.argument) {
+        parts.push(" ", path.call(print, "argument"));
+      }
 
       return concat(parts);
     case "AwaitExpression":
       parts.push("await");
 
-      if (n.all) parts.push("*");
-
-      if (n.argument) parts.push(" ", path.call(print, "argument"));
+      if (n.all) {
+        parts.push("*");
+      }
+      if (n.argument) {
+        parts.push(" ", path.call(print, "argument"));
+      }
 
       return concat(parts);
     case "ModuleDeclaration":
@@ -994,7 +1002,9 @@ function genericPrintNoParens(path, options, print, args) {
         );
       }
 
-      if (n.typeAnnotation) parts.push(": ", path.call(print, "typeAnnotation"));
+      if (n.typeAnnotation) {
+        parts.push(": ", path.call(print, "typeAnnotation"));
+      }
 
       return concat(parts);
     case "SequenceExpression":
@@ -1017,10 +1027,15 @@ function genericPrintNoParens(path, options, print, args) {
     // Babel 6 Literal split
     case "StringLiteral":
     case "Literal":
-      if (typeof n.value === "number") return printNumber(n.raw);
-      if (n.regex) return printRegex(n.regex);
-      if (typeof n.value !== "string") return "" + n.value;
-
+      if (typeof n.value === "number") {
+        return printNumber(n.raw);
+      }
+      if (n.regex) {
+        return printRegex(n.regex);
+      }
+      if (typeof n.value !== "string") {
+        return "" + n.value;
+      }
       return nodeStr(n, options); // Babel 6
     case "Directive":
       return path.call(print, "value"); // Babel 6
@@ -1037,7 +1052,9 @@ function genericPrintNoParens(path, options, print, args) {
     case "UnaryExpression":
       parts.push(n.operator);
 
-      if (/[a-z]$/.test(n.operator)) parts.push(" ");
+      if (/[a-z]$/.test(n.operator)) {
+        parts.push(" ");
+      }
 
       parts.push(path.call(print, "argument"));
 
@@ -1045,7 +1062,9 @@ function genericPrintNoParens(path, options, print, args) {
     case "UpdateExpression":
       parts.push(path.call(print, "argument"), n.operator);
 
-      if (n.prefix) parts.reverse();
+      if (n.prefix) {
+        parts.reverse();
+      }
 
       return concat(parts);
     case "ConditionalExpression":
@@ -1270,7 +1289,9 @@ function genericPrintNoParens(path, options, print, args) {
     case "BreakStatement":
       parts.push("break");
 
-      if (n.label) parts.push(" ", path.call(print, "label"));
+      if (n.label) {
+        parts.push(" ", path.call(print, "label"));
+      }
 
       parts.push(semi);
 
@@ -1278,7 +1299,9 @@ function genericPrintNoParens(path, options, print, args) {
     case "ContinueStatement":
       parts.push("continue");
 
-      if (n.label) parts.push(" ", path.call(print, "label"));
+      if (n.label) {
+        parts.push(" ", path.call(print, "label"));
+      }
 
       parts.push(semi);
 
@@ -1334,8 +1357,11 @@ function genericPrintNoParens(path, options, print, args) {
         "}"
       ]);
     case "SwitchCase":
-      if (n.test) parts.push("case ", path.call(print, "test"), ":");
-      else parts.push("default:");
+      if (n.test) {
+        parts.push("case ", path.call(print, "test"), ":");
+      } else {
+        parts.push("default:");
+      }
 
       const isFirstCase = path.getNode() === path.getParentNode().cases[0];
 
@@ -1529,29 +1555,37 @@ function genericPrintNoParens(path, options, print, args) {
     case "ClassPropertyDefinition":
       parts.push("static ", path.call(print, "definition"));
 
-      if (!namedTypes.MethodDefinition.check(n.definition)) parts.push(semi);
+      if (!namedTypes.MethodDefinition.check(n.definition)) {
+        parts.push(semi);
+      }
 
       return concat(parts);
     case "ClassProperty":
     case "TSAbstractClassProperty":
-      if (n.static) parts.push("static ");
-
+      if (n.static) {
+        parts.push("static ");
+      }
       var variance = getFlowVariance(n, options);
-      if (variance) parts.push(variance);
-
-      if (n.accessibility) parts.push(n.accessibility + " ");
-
-      if (n.type === "TSAbstractClassProperty") parts.push("abstract ");
-
+      if (variance) {
+        parts.push(variance);
+      }
+      if (n.accessibility) {
+        parts.push(n.accessibility + " ");
+      }
+      if (n.type === "TSAbstractClassProperty") {
+        parts.push("abstract ");
+      }
       if (n.computed) {
         parts.push("[", path.call(print, "key"), "]");
       } else {
         parts.push(printPropertyKey(path, options, print));
       }
-
-      if (n.typeAnnotation) parts.push(": ", path.call(print, "typeAnnotation"));
-
-      if (n.value) parts.push(" = ", path.call(print, "value"));
+      if (n.typeAnnotation) {
+        parts.push(": ", path.call(print, "typeAnnotation"));
+      }
+      if (n.value) {
+        parts.push(" = ", path.call(print, "value"));
+      }
 
       parts.push(semi);
 
@@ -2752,12 +2786,15 @@ function printFunctionDeclaration(path, print, options) {
   var n = path.getValue();
   var parts = [];
 
-  if (n.async) parts.push("async ");
+  if (n.async) {
+    parts.push("async ");
+  }
 
   parts.push("function");
 
-  if (n.generator) parts.push("*");
-
+  if (n.generator) {
+    parts.push("*");
+  }
   if (n.id) {
     parts.push(" ", path.call(print, "id"));
   }
@@ -2781,10 +2818,12 @@ function printObjectMethod(path, options, print) {
   var objMethod = path.getValue();
   var parts = [];
 
-  if (objMethod.async) parts.push("async ");
-
-  if (objMethod.generator) parts.push("*");
-
+  if (objMethod.async) {
+    parts.push("async ");
+  }
+  if (objMethod.generator) {
+    parts.push("*");
+  }
   if (
     objMethod.method || objMethod.kind === "get" || objMethod.kind === "set"
   ) {
@@ -3254,8 +3293,12 @@ function printMemberChain(path, options, print) {
 }
 
 function isEmptyJSXElement(node) {
-  if (node.children.length === 0) return true;
-  if (node.children.length > 1) return false;
+  if (node.children.length === 0) {
+    return true;
+  }
+  if (node.children.length > 1) {
+    return false;
+  }
 
   // if there is one child but it's just a newline, treat as empty
   const value = node.children[0].value;
@@ -3506,7 +3549,9 @@ function printJSXElement(path, options, print) {
 
 function maybeWrapJSXElementInParens(path, elem) {
   const parent = path.getParentNode();
-  if (!parent) return elem;
+  if (!parent) {
+    return elem;
+  }
 
   const NO_WRAP_PARENTS = {
     ArrayExpression: true,
@@ -3763,7 +3808,9 @@ function printNumber(rawNumber) {
 
 function isLastStatement(path) {
   const parent = path.getParentNode();
-  if (!parent) return true;
+  if (!parent) {
+    return true;
+  }
   const node = path.getValue();
   const body = parent.body.filter(stmt => stmt.type !== "EmptyStatement");
   return body && body[body.length - 1] === node;
@@ -3833,7 +3880,9 @@ function exprNeedsASIProtection(node) {
 }
 
 function stmtNeedsASIProtection(path) {
-  if (!path) return false;
+  if (!path) {
+    return false;
+  }
   const node = path.getNode();
 
   if (node.type !== "ExpressionStatement") {
@@ -3863,7 +3912,9 @@ function classPropMayCauseASIProblems(path) {
 }
 
 function classChildNeedsASIProtection(node) {
-  if (!node) return;
+  if (!node) {
+    return;
+  }
 
   switch (node.type) {
     case "ClassProperty":

--- a/tests/typescript/conformance/internalModules/importDeclarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/internalModules/importDeclarations/__snapshots__/jsfmt.spec.js.snap
@@ -117,7 +117,7 @@ module A {
   export class Point {
     constructor(public x: number, public y: number) {}
   }export module B {
-    interface Id {
+    export interface Id {
       name: string
     }
   }
@@ -158,7 +158,7 @@ module K {
   export class L {
     constructor(public name: string) {}
   }export module L {
-    export var y = 12;interface Point {
+    export var y = 12;export interface Point {
       x: number,
       y: number
     }
@@ -241,7 +241,7 @@ class clodule {
 }
 
 module clodule {
-  interface Point {
+  export interface Point {
     x: number,
     y: number
   }var Point: Point = { x: 0, y: 0 };
@@ -257,7 +257,7 @@ function fundule() {
 }
 
 module fundule {
-  interface Point {
+  export interface Point {
     x: number,
     y: number
   }var Point: Point = { x: 0, y: 0 };
@@ -353,7 +353,7 @@ module Z {
 // all errors imported modules conflict with local variables
 
 module A {
-  export var Point = { x: 0, y: 0 };interface Point {
+  export var Point = { x: 0, y: 0 };export interface Point {
     x: number,
     y: number
   }
@@ -365,7 +365,7 @@ module B {
 
 module X {
   export module Y {
-    interface Point {
+    export interface Point {
       x: number,
       y: number
     }

--- a/tests/typescript/conformance/internalModules/importDeclarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/internalModules/importDeclarations/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,382 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`circularImportAlias.ts 1`] = `
+// expected no error
+
+module B {
+    export import a = A;
+    export class D extends a.C {
+        id: number;
+    }
+}
+
+module A {
+    export class C { name: string }
+    export import b = B;
+}
+
+var c: { name: string };
+var c = new B.a.C();
+
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// expected no error
+
+module B {
+  export import a = A;
+  export class D extends a.C {
+    id: number;
+  }
+}
+
+module A {
+
+  export class C {
+    name: string;
+  }export import b = B;
+}
+
+var c: { name: string };
+var c = new B.a.C();
+
+`;
+
+exports[`exportImportAlias.ts 1`] = `
+// expect no errors here
+
+module A {
+
+    export var x = 'hello world'
+    export class Point {
+        constructor(public x: number, public y: number) { }
+    }
+    export module B {
+        export interface Id {
+            name: string;
+        }
+    }
+}
+
+module C {
+    export import a = A;
+}
+
+var a: string = C.a.x;
+var b: { x: number; y: number; } = new C.a.Point(0, 0);
+var c: { name: string };
+var c: C.a.B.Id;
+
+module X {
+    export function Y() {
+        return 42;
+    }
+
+    export module Y {
+        export class Point {
+            constructor(public x: number, public y: number) { }
+        }
+    }
+}
+
+module Z {
+
+    // 'y' should be a fundule here
+    export import y = X.Y;
+}
+
+var m: number = Z.y();
+var n: { x: number; y: number; } = new Z.y.Point(0, 0);
+
+module K {
+    export class L {
+        constructor(public name: string) { }
+    }
+
+    export module L {
+        export var y = 12;
+        export interface Point {
+            x: number;
+            y: number;
+        }
+    }
+}
+
+module M {
+    export import D = K.L;
+}
+
+var o: { name: string };
+var o = new M.D('Hello');
+
+var p: { x: number; y: number; }
+var p: M.D.Point;~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// expect no errors here
+
+module A {
+  export var x = "hello world";
+  export class Point {
+    constructor(public x: number, public y: number) {}
+  }export module B {
+    interface Id {
+      name: string
+    }
+  }
+}
+
+module C {
+  export import a = A;
+}
+
+var a: string = C.a.x;
+var b: { x: number, y: number } = new C.a.Point(0, 0);
+var c: { name: string };
+var c: undefined.Id;
+
+module X {
+
+  export function Y() {
+    return 42;
+  }export module Y {
+
+    export class Point {
+      constructor(public x: number, public y: number) {}
+    }
+  }
+}
+
+module Z {
+
+// 'y' should be a fundule here
+  export import y = X.Y;
+}
+
+var m: number = Z.y();
+var n: { x: number, y: number } = new Z.y.Point(0, 0);
+
+module K {
+
+  export class L {
+    constructor(public name: string) {}
+  }export module L {
+    export var y = 12;interface Point {
+      x: number,
+      y: number
+    }
+  }
+}
+
+module M {
+  export import D = K.L;
+}
+
+var o: { name: string };
+var o = new M.D("Hello");
+
+var p: { x: number, y: number };
+var p: undefined.Point;
+
+`;
+
+exports[`importAliasIdentifiers.ts 1`] = `
+module moduleA {
+    export class Point {
+        constructor(public x: number, public y: number) { }
+    }
+}
+
+import alias = moduleA;
+
+var p: alias.Point;
+var p: moduleA.Point;
+var p: { x: number; y: number; };
+
+class clodule {
+    name: string;
+}
+
+module clodule {
+    export interface Point {
+        x: number; y: number;
+    }
+    var Point: Point = { x: 0, y: 0 };
+}
+
+import clolias = clodule;
+
+var p: clolias.Point;
+var p: clodule.Point;
+var p: { x: number; y: number; };
+
+
+function fundule() {
+    return { x: 0, y: 0 };
+}
+
+module fundule {
+    export interface Point {
+        x: number; y: number;
+    }
+    var Point: Point = { x: 0, y: 0 };
+}
+
+import funlias = fundule;
+
+var p: funlias.Point;
+var p: fundule.Point;
+var p: { x: number; y: number; };~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+module moduleA {
+
+  export class Point {
+    constructor(public x: number, public y: number) {}
+  }
+}
+
+import alias = moduleA;
+var p: alias.Point;
+var p: moduleA.Point;
+var p: { x: number, y: number };
+
+class clodule {
+  name: string;
+}
+
+module clodule {
+  interface Point {
+    x: number,
+    y: number
+  }var Point: Point = { x: 0, y: 0 };
+}
+
+import clolias = clodule;
+var p: clolias.Point;
+var p: clodule.Point;
+var p: { x: number, y: number };
+
+function fundule() {
+  return { x: 0, y: 0 };
+}
+
+module fundule {
+  interface Point {
+    x: number,
+    y: number
+  }var Point: Point = { x: 0, y: 0 };
+}
+
+import funlias = fundule;
+var p: funlias.Point;
+var p: fundule.Point;
+var p: { x: number, y: number };
+
+`;
+
+exports[`invalidImportAliasIdentifiers.ts 1`] = `
+// none of these should work, since non are actually modules
+
+var V = 12;
+
+import v = V;
+
+class C {
+    name: string;
+}
+
+import c = C;
+
+enum E {
+    Red, Blue
+}
+
+import e = E;
+
+interface I {
+    id: number;
+}
+
+import i = I;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// none of these should work, since non are actually modules
+
+var V = 12;
+
+import v = V;
+class C {
+  name: string;
+}
+
+import c = C;
+enum E { Red, Blue }
+
+import e = E;
+interface I {
+  id: number
+}
+
+import i = I;
+
+`;
+
+exports[`shadowedInternalModule.ts 1`] = `
+// all errors imported modules conflict with local variables
+
+module A {
+    export var Point = { x: 0, y: 0 }
+    export interface Point {
+        x: number;
+        y: number;
+    }
+} 
+
+module B {
+    var A = { x: 0, y: 0 };
+    import Point = A;
+}
+
+module X {
+    export module Y {
+        export interface Point{
+            x: number;
+            y: number
+        }
+    }
+
+    export class Y {
+        name: string;
+    }
+}
+
+module Z {
+    import Y = X.Y;
+
+    var Y = 12;
+}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// all errors imported modules conflict with local variables
+
+module A {
+  export var Point = { x: 0, y: 0 };interface Point {
+    x: number,
+    y: number
+  }
+}
+
+module B {
+  var A = { x: 0, y: 0 };import Point = A;
+}
+
+module X {
+  export module Y {
+    interface Point {
+      x: number,
+      y: number
+    }
+  }
+  export class Y {
+    name: string;
+  }
+}
+
+module Z {
+  import Y = X.Y;var Y = 12;
+}
+
+`;

--- a/tests/typescript/conformance/internalModules/importDeclarations/circularImportAlias.ts
+++ b/tests/typescript/conformance/internalModules/importDeclarations/circularImportAlias.ts
@@ -1,0 +1,18 @@
+// expected no error
+
+module B {
+    export import a = A;
+    export class D extends a.C {
+        id: number;
+    }
+}
+
+module A {
+    export class C { name: string }
+    export import b = B;
+}
+
+var c: { name: string };
+var c = new B.a.C();
+
+

--- a/tests/typescript/conformance/internalModules/importDeclarations/exportImportAlias.ts
+++ b/tests/typescript/conformance/internalModules/importDeclarations/exportImportAlias.ts
@@ -1,0 +1,68 @@
+// expect no errors here
+
+module A {
+
+    export var x = 'hello world'
+    export class Point {
+        constructor(public x: number, public y: number) { }
+    }
+    export module B {
+        export interface Id {
+            name: string;
+        }
+    }
+}
+
+module C {
+    export import a = A;
+}
+
+var a: string = C.a.x;
+var b: { x: number; y: number; } = new C.a.Point(0, 0);
+var c: { name: string };
+var c: C.a.B.Id;
+
+module X {
+    export function Y() {
+        return 42;
+    }
+
+    export module Y {
+        export class Point {
+            constructor(public x: number, public y: number) { }
+        }
+    }
+}
+
+module Z {
+
+    // 'y' should be a fundule here
+    export import y = X.Y;
+}
+
+var m: number = Z.y();
+var n: { x: number; y: number; } = new Z.y.Point(0, 0);
+
+module K {
+    export class L {
+        constructor(public name: string) { }
+    }
+
+    export module L {
+        export var y = 12;
+        export interface Point {
+            x: number;
+            y: number;
+        }
+    }
+}
+
+module M {
+    export import D = K.L;
+}
+
+var o: { name: string };
+var o = new M.D('Hello');
+
+var p: { x: number; y: number; }
+var p: M.D.Point;

--- a/tests/typescript/conformance/internalModules/importDeclarations/importAliasIdentifiers.ts
+++ b/tests/typescript/conformance/internalModules/importDeclarations/importAliasIdentifiers.ts
@@ -1,0 +1,46 @@
+module moduleA {
+    export class Point {
+        constructor(public x: number, public y: number) { }
+    }
+}
+
+import alias = moduleA;
+
+var p: alias.Point;
+var p: moduleA.Point;
+var p: { x: number; y: number; };
+
+class clodule {
+    name: string;
+}
+
+module clodule {
+    export interface Point {
+        x: number; y: number;
+    }
+    var Point: Point = { x: 0, y: 0 };
+}
+
+import clolias = clodule;
+
+var p: clolias.Point;
+var p: clodule.Point;
+var p: { x: number; y: number; };
+
+
+function fundule() {
+    return { x: 0, y: 0 };
+}
+
+module fundule {
+    export interface Point {
+        x: number; y: number;
+    }
+    var Point: Point = { x: 0, y: 0 };
+}
+
+import funlias = fundule;
+
+var p: funlias.Point;
+var p: fundule.Point;
+var p: { x: number; y: number; };

--- a/tests/typescript/conformance/internalModules/importDeclarations/invalidImportAliasIdentifiers.ts
+++ b/tests/typescript/conformance/internalModules/importDeclarations/invalidImportAliasIdentifiers.ts
@@ -1,0 +1,23 @@
+// none of these should work, since non are actually modules
+
+var V = 12;
+
+import v = V;
+
+class C {
+    name: string;
+}
+
+import c = C;
+
+enum E {
+    Red, Blue
+}
+
+import e = E;
+
+interface I {
+    id: number;
+}
+
+import i = I;

--- a/tests/typescript/conformance/internalModules/importDeclarations/jsfmt.spec.js
+++ b/tests/typescript/conformance/internalModules/importDeclarations/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });

--- a/tests/typescript/conformance/internalModules/importDeclarations/shadowedInternalModule.ts
+++ b/tests/typescript/conformance/internalModules/importDeclarations/shadowedInternalModule.ts
@@ -1,0 +1,33 @@
+// all errors imported modules conflict with local variables
+
+module A {
+    export var Point = { x: 0, y: 0 }
+    export interface Point {
+        x: number;
+        y: number;
+    }
+} 
+
+module B {
+    var A = { x: 0, y: 0 };
+    import Point = A;
+}
+
+module X {
+    export module Y {
+        export interface Point{
+            x: number;
+            y: number
+        }
+    }
+
+    export class Y {
+        name: string;
+    }
+}
+
+module Z {
+    import Y = X.Y;
+
+    var Y = 12;
+}

--- a/tests/typescript/conformance/types/moduleDeclaration/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/moduleDeclaration/__snapshots__/jsfmt.spec.js.snap
@@ -11,8 +11,12 @@ declare module "B" {
     }
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-module A {export class A {}}
+module A {
+  export class A {}
+}
 
-declare module "B" {export class B {}}
+declare module "B" {
+  export class B {}
+}
 
 `;


### PR DESCRIPTION
Adding the last big batch of TypeScript nodes:

* `TSAsyncKeyword`
* `TSExportKeyword`
* `TSNamespaceFunctionDeclaration`
* `TSProtectedKeyword`
* `TSPublicKeyword`
* `TSHeritageClause`
* `TSExpressionWithTypeArguments`

Some of the formatting is far from pretty at this point though.

#1480 #13