### PR TITLE
fix #1484

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -809,7 +809,7 @@ function genericPrintNoParens(path, options, print, args) {
       let content;
       if (props.length === 0 && !n.typeAnnotation) {
         if (!hasDanglingComments(n)) {
-          return concat([leftBrace, rightBrace]);
+          return concat([prefix, leftBrace, rightBrace]);
         }
 
         content = group(
@@ -2052,8 +2052,11 @@ function genericPrintNoParens(path, options, print, args) {
       return concat([path.call(print, "elementType"), "[]"]);
     case "TSPropertySignature":
       parts.push(path.call(print, "name"));
-      parts.push(": ");
-      parts.push(path.call(print, "typeAnnotation"));
+      
+      if (n.typeAnnotation) {
+        parts.push(": ");
+        parts.push(path.call(print, "typeAnnotation"));
+      }
 
       return concat(parts);
     case "TSParameterProperty":

--- a/tests/typescript/conformance/types/interfaceDeclaration/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/interfaceDeclaration/__snapshots__/jsfmt.spec.js.snap
@@ -5,10 +5,22 @@ interface abstract {
     abstract(): void,
     concrete(): number
 }
+
+interface X {
+  x
+}
+
+interface nil {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 interface abstract {
   abstract(): void,
   concrete(): number
 }
+
+interface X {
+  x
+}
+
+interface nil {}
 
 `;

--- a/tests/typescript/conformance/types/interfaceDeclaration/interfaceDeclaration.ts
+++ b/tests/typescript/conformance/types/interfaceDeclaration/interfaceDeclaration.ts
@@ -2,3 +2,9 @@ interface abstract {
     abstract(): void,
     concrete(): number
 }
+
+interface X {
+  x
+}
+
+interface nil {}


### PR DESCRIPTION
* don't print colon if there is no `typeAnnotation`
* print prefix also for empty interfaces