### PR TITLE
[Editor support] Make prettier into a global minor mode that can be toggled on and off

### DIFF
--- a/editors/emacs/README.md
+++ b/editors/emacs/README.md
@@ -2,9 +2,7 @@ Add this to your init:
 
 ```elisp
 (require 'prettier-js)
-(add-hook 'js-mode-hook
-          (lambda ()
-            (add-hook 'before-save-hook 'prettier-before-save)))
+(prettier-mode)
 ```
 
 If you don't use `js-mode`, which is what Prettier targets by default, you'll need to first set your major-mode of choice:
@@ -12,9 +10,7 @@ If you don't use `js-mode`, which is what Prettier targets by default, you'll ne
 ```elisp
 (require 'prettier-js)
 (setq prettier-target-mode "js2-mode")
-(add-hook 'js2-mode-hook
-          (lambda ()
-            (add-hook 'before-save-hook 'prettier-before-save)))
+(prettier-mode)
 ```
 
 To adjust the CLI args used for the prettier command, you can customize the `prettier-args` variable:

--- a/editors/emacs/prettier-js.el
+++ b/editors/emacs/prettier-js.el
@@ -219,4 +219,13 @@ function."
      (delete-file bufferfile)
      (delete-file outputfile)))
 
+;;;###autoload
+(define-minor-mode prettier-mode
+  "Runs prettier on file save when this mode is turned on"
+  :lighter " prettier"
+  :global t
+  (if prettier-mode
+      (add-hook 'before-save-hook 'prettier-before-save)
+    (remove-hook 'before-save-hook 'prettier-before-save)))
+
 (provide 'prettier-js)


### PR DESCRIPTION
Prettier would cause great havoc on some older projects that I work on. Disabling prettier when I work on these projects was really painful (modify init file, then restart emacs). This PR adds a new `prettier-mode` global minor mode that lets you quickly enable or disable prettier by just toggling the mode.

I am by no means an elisp guru, so it would be great if someone who has more experience writing emacs modes could review this change.