### PR TITLE
Print empty member lookup

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -775,7 +775,7 @@ function genericPrintNoParens(path, options, print, args) {
           path.call(print, "name"),
           printTypeParameters(path, options, print, "typeParameters"),
           " "
-        ); 
+        );
       }
       if (n.heritageClauses) {
         prefix.push(
@@ -2149,7 +2149,7 @@ function genericPrintNoParens(path, options, print, args) {
       if (n.type !== "TSCallSignature") {
         parts.push("new ");
       }
-      var isType = n.type === "TSConstructorType";      
+      var isType = n.type === "TSConstructorType";
       parts.push(
         printTypeParameters(path, options, print, "typeParameters"),
         "(",
@@ -3059,6 +3059,7 @@ function printMemberLookup(path, options, print) {
   }
 
   if (
+    !n.property ||
     (n.property.type === "Literal" && typeof n.property.value === "number") ||
       n.property.type === "NumericLiteral"
   ) {

--- a/tests/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`badArrayIndex.ts 1`] = `
+var results = number[];
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+var results = number[];
+
+`;

--- a/tests/typescript/compiler/badArrayIndex.ts
+++ b/tests/typescript/compiler/badArrayIndex.ts
@@ -1,0 +1,1 @@
+var results = number[];

--- a/tests/typescript/compiler/jsfmt.spec.js
+++ b/tests/typescript/compiler/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });


### PR DESCRIPTION
I have no idea if it's even valid but it threw on 8 typescript tests, now it doesn't.

```js
TypeError: Cannot read property 'type' of null
at printMemberLookup (prettier/src/printer.js:3062:16)
```