### PR TITLE
Less aggressive parenthesization of await

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -395,10 +395,12 @@ FPp.needsParens = function() {
         case "LogicalExpression":
         case "SpreadElement":
         case "SpreadProperty":
-        case "NewExpression":
-        case "MemberExpression":
           return true;
 
+        case "MemberExpression":
+          return parent.object === node;
+
+        case "NewExpression":
         case "CallExpression":
           return parent.callee === node;
 

--- a/tests/async/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/async/__snapshots__/jsfmt.spec.js.snap
@@ -13,6 +13,10 @@ function *f(){
 async function f() {
   a = !(await f());
 }
+async () => {
+  new A(await x);
+  obj[await x];
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 async function f() {
   (await f()).length;
@@ -26,6 +30,10 @@ function* f() {
 async function f() {
   a = !await f();
 }
+async () => {
+  new A(await x);
+  obj[await x];
+};
 
 `;
 

--- a/tests/async/await_parse.js
+++ b/tests/async/await_parse.js
@@ -10,3 +10,7 @@ function *f(){
 async function f() {
   a = !(await f());
 }
+async () => {
+  new A(await x);
+  obj[await x];
+}


### PR DESCRIPTION
Fixes #1512.

Also removes parentheses which were being inserted in `x[(await a)]`.

This is actually still too aggressive; `await` has the precedence of a unary operator, and needs parenthesization in exactly the cases a unary operator does. You can compare its case in fast-path with that of UnaryExpression to see the excess.

In particular, prettier inserts all of the parentheses below, none of which are necessary:

```js
async a => {
  a + (await b);
  a || (await b);
  [...(await a)];
  !{ ...(await a) };
  (await a) ? b : c;
};
```

I'm going to leave those cases alone in this PR, since they're less obviously dumb.