### PR TITLE
WIP: expand single-chained methods with very long definition

### DIFF
--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -294,6 +294,8 @@ function f() {
     }
   );
 }
+
+const result = aReallyLongMethodCall(withSomeParameters, andAnother).chained({ nothing });
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 export default function theFunction(action$, store) {
   return action$.ofType(THE_ACTION).switchMap(action =>
@@ -328,6 +330,9 @@ function f() {
     fileMetadata[H.DEPENDENCIES] = metadata.dependencies || [];
   });
 }
+
+const result = aReallyLongMethodCall(withSomeParameters, andAnother)
+  .chained({ nothing });
 
 `;
 

--- a/tests/method-chain/first_long.js
+++ b/tests/method-chain/first_long.js
@@ -32,3 +32,5 @@ function f() {
     }
   );
 }
+
+const result = aReallyLongMethodCall(withSomeParameters, andAnother).chained({ nothing });


### PR DESCRIPTION
Fixes #1516 

Hi, It's my very first try to contribute here, and I immediately stuck in one thing.
If you can help, I'll glad to continue work on this task. If no, feel free to close this PR :)
The problem:
I have an exact group which can be broken on a new line (`firstIndentedGroup`, the last group in a single-method chain). And I couldn't figure out how to correctly check if this line will have a line break.

P.S. This solution can break the current behavior with long comments, in:
```
_.a(
  a
) /* very very very very very very very long such that it is longer than 80 columns */.a();
```
`.a()` will be moved to new line.