### PR TITLE
TypeScript: print typeParameters on TSMethodSignature

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2185,9 +2185,8 @@ function genericPrintNoParens(path, options, print, args) {
     case "TSMethodSignature":
       parts.push(
         path.call(print, 'name'),
-        "(",
-        join(", ", path.map(print, "parameters")),
-        ")"
+        printTypeParameters(path, options, print, "typeParameters"),
+        printFunctionParams(path, print, options)
       )
 
       if (n.typeAnnotation) {
@@ -2636,7 +2635,11 @@ function printFunctionTypeParameters(path, options, print) {
 function printFunctionParams(path, print, options, expandArg) {
   var fun = path.getValue();
   // namedTypes.Function.assert(fun);
-  var paramsField = fun.type === "TSFunctionType" ? "parameters" : "params";
+  var paramsField = (fun.type === "TSFunctionType" ||
+    fun.type === "TSMethodSignature")
+      ? "parameters"
+      : "params";
+
   var printed = path.map(print, paramsField);
 
   if (fun.defaults) {

--- a/tests/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
@@ -6,3 +6,30 @@ var results = number[];
 var results = number[];
 
 `;
+
+exports[`functionOverloadsOnGenericArity1.ts 1`] = `
+// overloading on arity not allowed
+interface C {
+   f<T>(): string;
+   f<T, U>(): string; 
+ 
+   <T>(): string;
+   <T, U>(): string; 
+ 
+  new <T>(): string;
+  new <T, U>(): string; 
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// overloading on arity not allowed
+interface C {
+  f<T>(): string,
+  f<T, U>(): string,
+
+  <T>(): string,
+  <T, U>(): string,
+
+  new <T>(): string,
+  new <T, U>(): string
+}
+
+`;

--- a/tests/typescript/compiler/functionOverloadsOnGenericArity1.ts
+++ b/tests/typescript/compiler/functionOverloadsOnGenericArity1.ts
@@ -1,0 +1,11 @@
+// overloading on arity not allowed
+interface C {
+   f<T>(): string;
+   f<T, U>(): string; 
+ 
+   <T>(): string;
+   <T, U>(): string; 
+ 
+  new <T>(): string;
+  new <T, U>(): string; 
+}


### PR DESCRIPTION
Previously,
```ts
interface C {
  f<T>(): string;
}
```

was printed as:

```ts
interface C {
  f(): string;
}
```
#1480