### PR TITLE
Add parens around `as`

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -313,6 +313,7 @@ FPp.needsParens = function() {
         return true;
       }
     // else fall through
+    case "TSAsExpression":
     case "LogicalExpression":
       switch (parent.type) {
         case "CallExpression":

--- a/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`as.js 1`] = `
+const name = (description as DescriptionObject).name || (description as string);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const name = (description as DescriptionObject).name || description as string;
+
+`;

--- a/tests/typescript_as/as.js
+++ b/tests/typescript_as/as.js
@@ -1,0 +1,1 @@
+const name = (description as DescriptionObject).name || (description as string);

--- a/tests/typescript_as/jsfmt.spec.js
+++ b/tests/typescript_as/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, {parser: "typescript"});


### PR DESCRIPTION
I put it at the same place where `a in b` is handled.

Fixes #1524