### PR TITLE
TypeScript: define TSFunctionType AST node

### DIFF
--- a/src/typescript-ast-nodes.js
+++ b/src/typescript-ast-nodes.js
@@ -62,7 +62,9 @@ module.exports = function(fork) {
   // Types
   def("TSConstructorType").bases("TSType");
 
-  def("TSFunctionType").bases("TSType");
+  def("TSFunctionType")
+    .bases("TSSignature")
+    .build("typeParameters", "parameters", "typeAnnotation");
 
   def("TSIntersectionType")
     .bases("TSType")
@@ -169,10 +171,7 @@ module.exports = function(fork) {
     .field("expression", def("Identifier"))
     .bases("Node");
 
-  def("TSTypeParameter")
-    .build("name")
-    .field("name", def("Identifier"))
+  def("TSTypeParameter").build("name").field("name", def("Identifier"));
 
-  def("TSParameterProperty")
-    .build("accessibility", "isReadonly", "parameters")
+  def("TSParameterProperty").build("accessibility", "isReadonly", "parameters");
 };

--- a/tests/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
@@ -7,6 +7,17 @@ var results = number[];
 
 `;
 
+exports[`commentsInterface.ts 1`] = `
+interface i2 {
+    foo: (/**param help*/b: number) => string;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+interface i2 {
+  foo: (/**param help*/ b: number) => string
+}
+
+`;
+
 exports[`functionOverloadsOnGenericArity1.ts 1`] = `
 // overloading on arity not allowed
 interface C {

--- a/tests/typescript/compiler/commentsInterface.ts
+++ b/tests/typescript/compiler/commentsInterface.ts
@@ -1,0 +1,3 @@
+interface i2 {
+    foo: (/**param help*/b: number) => string;
+}


### PR DESCRIPTION
#1480

- defines `TSFunctionType` AST nodes
- fixes printing of comments inside function type node
- test is based on TypeScript's test `compiler/commentsInterface.ts` which was failing

fixes that:
```
../TypeScript/tests/cases/compiler/commentsInterface.ts
../TypeScript/tests/cases/compiler/commentsInterface.ts: Error: Comment "*param help" was not printed. Please report this error!
    at astComments.forEach.comment (/mnt/c/Users/Lucas Azzola/Code/prettier/index.js:69:13)
    at Array.forEach (native)
    at ensureAllCommentsPrinted (/mnt/c/Users/Lucas Azzola/Code/prettier/index.js:67:15)
    at format (/mnt/c/Users/Lucas Azzola/Code/prettier/index.js:85:3)
    at formatWithShebang (/mnt/c/Users/Lucas Azzola/Code/prettier/index.js:91:12)
    at Object.module.exports.format (/mnt/c/Users/Lucas Azzola/Code/prettier/index.js:105:12)
    at format (/mnt/c/Users/Lucas Azzola/Code/prettier/bin/prettier.js:214:25)
    at err (/mnt/c/Users/Lucas Azzola/Code/prettier/bin/prettier.js:328:16)
    at patterns.forEach.pattern (/mnt/c/Users/Lucas Azzola/Code/prettier/bin/prettier.js:372:7)
    at Array.forEach (native)
```