### PR TITLE
TypeScript: workaround eslint/typescript-eslint-parser#257

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1411,6 +1411,14 @@ function genericPrintNoParens(path, options, print, args) {
 
       return concat(parts);
     case "JSXIdentifier":
+      // Can be removed when this is fixed:
+      // https://github.com/eslint/typescript-eslint-parser/issues/257
+      if (n.object && n.property) {
+        return join(".", [
+          path.call(print, "object"),
+          path.call(print, "property")
+        ]);
+      }
       return "" + n.name;
     case "JSXNamespacedName":
       return join(":", [

--- a/tests/typescript/conformance/internalModules/importDeclarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/internalModules/importDeclarations/__snapshots__/jsfmt.spec.js.snap
@@ -134,7 +134,7 @@ namespace C {
 var a: string = C.a.x;
 var b: { x: number, y: number } = new C.a.Point(0, 0);
 var c: { name: string };
-var c: undefined.Id;
+var c: C.a.B.Id;
 
 namespace X {
 
@@ -182,7 +182,7 @@ var o: { name: string };
 var o = new M.D("Hello");
 
 var p: { x: number, y: number };
-var p: undefined.Point;
+var p: M.D.Point;
 
 `;
 


### PR DESCRIPTION
A large proportion of the `ast(prettier(input)) !== ast(input)` failures with the TypeScript parser are caused by this issue.

I've opened an issue (eslint/typescript-eslint-parser#257) on the parser side, but the workaround is simple enough for now.