### PR TITLE
TypeScript: ArrowFunctionExpression needs parens in TSAsExpression

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -515,6 +515,7 @@ FPp.needsParens = function() {
         case "MemberExpression":
           return name === "object";
 
+        case "TSAsExpression":
         case "BindExpression":
         case "TaggedTemplateExpression":
         case "UnaryExpression":

--- a/tests/typescript/conformance/expressions/asOperator/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/expressions/asOperator/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`asOperatorContextualType.ts 1`] = `
+// should error
+var x = (v => v) as (x: number) => string;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// should error
+var x = (v => v) as (x: number) => string;
+
+`;

--- a/tests/typescript/conformance/expressions/asOperator/asOperatorContextualType.ts
+++ b/tests/typescript/conformance/expressions/asOperator/asOperatorContextualType.ts
@@ -1,0 +1,2 @@
+// should error
+var x = (v => v) as (x: number) => string;

--- a/tests/typescript/conformance/expressions/asOperator/jsfmt.spec.js
+++ b/tests/typescript/conformance/expressions/asOperator/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });


### PR DESCRIPTION
Fixes this case:

```ts
-var x = (v => v) as (x: number) => string;
+var x = v => v as (x: number) => string;
```

#1480 
