### PR TITLE
TypeScript: remove extraneous newline with namespace exports

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2268,7 +2268,7 @@ function genericPrintNoParens(path, options, print, args) {
         }
       }
 
-      return group(concat([softline, concat(parts)]));
+      return group(concat(parts));
     case "TSEnumDeclaration":
       if (n.modifiers) {
         parts.push(printTypeScriptModifiers(path, options, print));

--- a/tests/typescript/conformance/internalModules/importDeclarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/internalModules/importDeclarations/__snapshots__/jsfmt.spec.js.snap
@@ -24,14 +24,12 @@ var c = new B.a.C();
 
 namespace B {
   export import a = A;
-
   export class D extends a.C {
     id: number;
   }
 }
 
 namespace A {
-
   export class C {
     name: string;
   }
@@ -116,7 +114,6 @@ var p: M.D.Point;~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 namespace A {
   export var x = "hello world";
-
   export class Point {
     constructor(public x: number, public y: number) {}
   }
@@ -137,13 +134,11 @@ var c: { name: string };
 var c: C.a.B.Id;
 
 namespace X {
-
   export function Y() {
     return 42;
   }
 
   export namespace Y {
-
     export class Point {
       constructor(public x: number, public y: number) {}
     }
@@ -160,7 +155,6 @@ var m: number = Z.y();
 var n: { x: number, y: number } = new Z.y.Point(0, 0);
 
 namespace K {
-
   export class L {
     constructor(public name: string) {}
   }
@@ -234,7 +228,6 @@ var p: funlias.Point;
 var p: fundule.Point;
 var p: { x: number; y: number; };~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 namespace moduleA {
-
   export class Point {
     constructor(public x: number, public y: number) {}
   }
@@ -389,7 +382,6 @@ namespace X {
       y: number
     }
   }
-
 
   export class Y {
     name: string;

--- a/tests/typescript/custom/stability/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/custom/stability/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`moduleBlock.ts 1`] = `
+module m2 {
+    function fn() {
+        return 1;
+    }
+    export function exports() {
+        return 1;
+    }
+    export function require() {
+        return "require";
+    }
+}
+
+module m2 {
+
+    export function exports() {
+        return 1;
+    }
+
+    export function require() {
+        return "require";
+    }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+namespace m2 {
+  function fn() {
+    return 1;
+  }
+  export function exports() {
+    return 1;
+  }
+  export function require() {
+    return "require";
+  }
+}
+
+namespace m2 {
+  export function exports() {
+    return 1;
+  }
+
+  export function require() {
+    return "require";
+  }
+}
+
+`;

--- a/tests/typescript/custom/stability/jsfmt.spec.js
+++ b/tests/typescript/custom/stability/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });

--- a/tests/typescript/custom/stability/moduleBlock.ts
+++ b/tests/typescript/custom/stability/moduleBlock.ts
@@ -1,0 +1,22 @@
+module m2 {
+    function fn() {
+        return 1;
+    }
+    export function exports() {
+        return 1;
+    }
+    export function require() {
+        return "require";
+    }
+}
+
+module m2 {
+
+    export function exports() {
+        return 1;
+    }
+
+    export function require() {
+        return "require";
+    }
+}


### PR DESCRIPTION
This one was easier than I thought it would be 👍 

#1480 