### PR TITLE
TypeScript: fix a handful of ast(prettier(input)) issues

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -189,7 +189,9 @@ function format(input) {
 
         // We change {'key': value} into {key: value}
         if (
-          (ast.type === "Property" || ast.type === "MethodDefinition") &&
+          (ast.type === "Property" ||
+            ast.type === "MethodDefinition" ||
+              ast.type === "ClassProperty") &&
           typeof ast.key === "object" &&
           ast.key &&
           (ast.key.type === "Literal" || ast.key.type === "Identifier")

--- a/src/printer.js
+++ b/src/printer.js
@@ -2084,8 +2084,6 @@ function genericPrintNoParens(path, options, print, args) {
       return "private";
     case "TSPublicKeyword":
       return "public";
-    case "TSQuestionToken":
-      return "?";
     case "TSReadonlyKeyword":
       return "readonly";
     case "TSSymbolKeyword":
@@ -2122,9 +2120,18 @@ function genericPrintNoParens(path, options, print, args) {
         parts.push("]");
       }
 
+      if (n.questionToken && !n.name.optional) {
+        parts.push("?");
+      }
+
       if (n.typeAnnotation) {
         parts.push(": ");
         parts.push(path.call(print, "typeAnnotation"));
+      }
+
+      // This isn't valid semantically, but it's in the AST so we can print it.
+      if (n.initializer) {
+          parts.push(" = ", path.call(print, "initializer"));
       }
 
       return concat(parts);
@@ -2212,7 +2219,7 @@ function genericPrintNoParens(path, options, print, args) {
               "[",
               path.call(print, "typeParameter"),
               "]",
-              n.questionToken ? path.call(print, "questionToken") : "",
+              n.questionToken ? "?" : "",
               ": ",
               path.call(print, "typeAnnotation")
             ])
@@ -3051,8 +3058,7 @@ function printTypeScriptModifiers(path, options, print) {
 function printTypeParameters(path, options, print, paramsKey) {
     const n = path.getValue();
 
-    // In flow, Foo<> is acceptable. In TypeScript, it's a syntax error.
-    if (!n[paramsKey] || (n.type.startsWith("TS") && !n[paramsKey].length)) {
+    if (!n[paramsKey]) {
       return "";
     }
 

--- a/tests/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
@@ -68,6 +68,26 @@ interface i2 {
 
 `;
 
+exports[`emptyGenericParamList.ts 1`] = `
+class I<T> {}
+var x: I<>;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class I<T> {}
+var x: I<>;
+
+`;
+
+exports[`errorOnInitializerInInterfaceProperty.ts 1`] = `
+interface Foo {
+    bar: number = 5;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+interface Foo {
+  bar: number = 5
+}
+
+`;
+
 exports[`functionOverloadsOnGenericArity1.ts 1`] = `
 // overloading on arity not allowed
 interface C {

--- a/tests/typescript/compiler/emptyGenericParamList.ts
+++ b/tests/typescript/compiler/emptyGenericParamList.ts
@@ -1,0 +1,2 @@
+class I<T> {}
+var x: I<>;

--- a/tests/typescript/compiler/errorOnInitializerInInterfaceProperty.ts
+++ b/tests/typescript/compiler/errorOnInitializerInInterfaceProperty.ts
@@ -1,0 +1,3 @@
+interface Foo {
+    bar: number = 5;
+}

--- a/tests/typescript/conformance/es6/Symbols/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/es6/Symbols/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`symbolProperty15.ts 1`] = `
+//@target: ES6
+class C { }
+interface I {
+    [Symbol.iterator]?: { x };
+}
+
+declare function foo(i: I): I;
+declare function foo(a: any): any;
+
+declare function bar(i: C): C;
+declare function bar(a: any): any;
+
+foo(new C);
+var i: I;
+bar(i);~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//@target: ES6
+class C {}
+interface I {
+  [Symbol.iterator]?: { x }
+}
+
+declare function foo(i: I): I
+declare function foo(a: any): any
+
+declare function bar(i: C): C
+declare function bar(a: any): any
+
+foo(new C());
+var i: I;
+bar(i);
+
+`;

--- a/tests/typescript/conformance/es6/Symbols/jsfmt.spec.js
+++ b/tests/typescript/conformance/es6/Symbols/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });

--- a/tests/typescript/conformance/es6/Symbols/symbolProperty15.ts
+++ b/tests/typescript/conformance/es6/Symbols/symbolProperty15.ts
@@ -1,0 +1,15 @@
+//@target: ES6
+class C { }
+interface I {
+    [Symbol.iterator]?: { x };
+}
+
+declare function foo(i: I): I;
+declare function foo(a: any): any;
+
+declare function bar(i: C): C;
+declare function bar(a: any): any;
+
+foo(new C);
+var i: I;
+bar(i);

--- a/tests/typescript/conformance/interfaces/interfaceDeclarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/interfaces/interfaceDeclarations/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`interfaceWithMultipleBaseTypes2.ts 1`] = `
+interface Base {
+    x: {
+        a?: string; b: string;
+    }
+}
+
+interface Base2 {
+    x: {
+        b: string; c?: number;
+    }
+}
+
+interface Derived extends Base, Base2 {
+    x: { b: string }
+}
+
+interface Derived2 extends Base, Base2 { // error
+    x: { a: number; b: string }
+}
+
+interface Derived3 extends Base, Base2 {
+    x: { a: string; b: string }
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+interface Base {
+  x: {
+    a?: string,
+    b: string
+  }
+}
+
+interface Base2 {
+  x: {
+    b: string,
+    c?: number
+  }
+}
+
+interface Derived extends Base, Base2 {
+  x: { b: string }
+}
+
+interface Derived2 extends Base, Base2 { // error
+  x: { a: number, b: string }
+}
+
+interface Derived3 extends Base, Base2 {
+  x: { a: string, b: string }
+}
+
+`;

--- a/tests/typescript/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBaseTypes2.ts
+++ b/tests/typescript/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBaseTypes2.ts
@@ -1,0 +1,24 @@
+interface Base {
+    x: {
+        a?: string; b: string;
+    }
+}
+
+interface Base2 {
+    x: {
+        b: string; c?: number;
+    }
+}
+
+interface Derived extends Base, Base2 {
+    x: { b: string }
+}
+
+interface Derived2 extends Base, Base2 { // error
+    x: { a: number; b: string }
+}
+
+interface Derived3 extends Base, Base2 {
+    x: { a: string; b: string }
+}
+

--- a/tests/typescript/conformance/interfaces/interfaceDeclarations/jsfmt.spec.js
+++ b/tests/typescript/conformance/interfaces/interfaceDeclarations/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });


### PR DESCRIPTION
1.
```
-var x: I<>;
+var x: I;
```
2.
```
 interface Foo {
-    bar: number = 5;
+  bar: number
 }
```

3. (ignored in debug-check)
```
             "type": "ClassProperty",
             "key": {
-              "type": "Literal",
-              "value": "prop1"
+              "type": "Identifier",
+              "name": "prop1"
             },
```

4.
```
 interface I {
-    [Symbol.iterator]?: { x };
+  [Symbol.iterator]: { x }
 }
```

5.
```
 interface I {
-  3?<T>();
+  3<T>()
```

#1480