### PR TITLE
TypeScript: add fallback for JSX detection

### DIFF
--- a/tests/typescript_tsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_tsx/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`not-react.ts 1`] = `
+/// <reference types="node" />
+
+type ul = any;
+const somethingElse = 1;
+const thing = <ul>somethingElse;
+const div = "<div></div>";
+const h1 = \`<h1>Hi</h1>\`;
+const footer = '<footer></footer>';
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/// <reference types="node" />
+
+type ul = any;
+const somethingElse = 1;
+const thing = <ul>somethingElse;
+const div = "<div></div>";
+const h1 = \`<h1>Hi</h1>\`;
+const footer = "<footer></footer>";
+
+`;
+
+exports[`react.tsx 1`] = `
+const MyCoolList = ({ things }) =>
+    <ul>
+        {things.map(MyCoolThing)}
+    </ul>;
+
+const MyCoolThing = ({ thingo }) => <li>{thingo}</li>;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const MyCoolList = ({ things }) => (
+  <ul>
+    {things.map(MyCoolThing)}
+  </ul>
+);
+
+const MyCoolThing = ({ thingo }) => <li>{thingo}</li>;
+
+`;

--- a/tests/typescript_tsx/jsfmt.spec.js
+++ b/tests/typescript_tsx/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, {parser: "typescript"});

--- a/tests/typescript_tsx/not-react.ts
+++ b/tests/typescript_tsx/not-react.ts
@@ -1,0 +1,8 @@
+/// <reference types="node" />
+
+type ul = any;
+const somethingElse = 1;
+const thing = <ul>somethingElse;
+const div = "<div></div>";
+const h1 = `<h1>Hi</h1>`;
+const footer = '<footer></footer>';

--- a/tests/typescript_tsx/react.tsx
+++ b/tests/typescript_tsx/react.tsx
@@ -1,0 +1,6 @@
+const MyCoolList = ({ things }) =>
+    <ul>
+        {things.map(MyCoolThing)}
+    </ul>;
+
+const MyCoolThing = ({ thingo }) => <li>{thingo}</li>;

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const fs = require("fs");
+const extname = require("path").extname;
 const prettier = require("../");
 const types = require("../src/ast-types");
 const parser = require("../src/parser");
@@ -25,10 +26,8 @@ function removeEmptyStatements(ast) {
 
 function run_spec(dirname, options, additionalParsers) {
   fs.readdirSync(dirname).forEach(filename => {
-    if (
-      (filename.endsWith(".js") || filename.endsWith(".ts")) &&
-      filename !== "jsfmt.spec.js"
-    ) {
+    const extension = extname(filename);
+    if (/^\.[jt]sx?$/.test(extension) && filename !== "jsfmt.spec.js") {
       const path = dirname + "/" + filename;
 
       if (!RUN_AST_TESTS) {


### PR DESCRIPTION
Improves the existing JSX detection by making a naive guess, parsing in the guessed JSX mode, and falling back to the opposite if the code fails to parse.

#1538