### PR TITLE
Mention --debug-check in CLI section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ expands the globs rather than your shell, for cross-platform usage.)
 
 In the future we will have better support for formatting whole projects.
 
+If you're worried that Prettier will change the correctness of your code, add `--debug-check` to the command.
+This will cause Prettier to print an error message if it detects that code correctness might have changed.
+Note that `--write` cannot be used with `--debug-check`.
+
 #### Pre-commit hook for changed files
 
 You can use this with a pre-commit tool. This can re-format your files that are marked as "staged" via `git add`  before you commit.  

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -156,6 +156,7 @@ function format(input) {
       process.stdout.write("\n");
       console.error('prettier(input) !== prettier(prettier(input))');
       console.error(diff(pp, pppp));
+      process.exitCode = 2;
     } else {
       const ast = cleanAST(prettier.__debug.parse(input, options));
       const past = cleanAST(prettier.__debug.parse(pp, options));
@@ -165,6 +166,7 @@ function format(input) {
         console.error('ast(input) !== ast(prettier(input))');
         console.error(diff(ast, past));
         console.error(diff(input, pp));
+        process.exitCode = 2;
       }
     }
     return;
@@ -297,6 +299,8 @@ if (stdin) {
       process.stdout.write("\n");
       if (output) {
         console.log(output);
+      } else {
+        process.exitCode = 2;
       }
     } else {
       // Don't use `console.log` here since it adds an extra newline at the end.

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -53,6 +53,11 @@ const filepatterns = argv["_"];
 const write = argv["write"];
 const stdin = argv["stdin"] || (!filepatterns.length && !process.stdin.isTTY);
 
+if (write && argv["debug-check"]) {
+  console.error("Cannot use --write and --debug-check together.");
+  process.exit(1);
+}
+
 function getParserOption() {
   const optionName = "parser";
   const value = argv[optionName];


### PR DESCRIPTION
This addresses https://github.com/prettier/prettier/issues/1552#issuecomment-300043294

As described in the comment linked above, these changes also prevent
using `--write` with `--debug-check`. Additionally, a `--debug-check`
failure causes the process to exit with a non-zero code.