### PR TITLE
(Babylon) Allow `return` outside function

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -63,7 +63,7 @@ function parseWithBabylon(text) {
   const babylonOptions = {
     sourceType: "module",
     allowImportExportEverywhere: false,
-    allowReturnOutsideFunction: false,
+    allowReturnOutsideFunction: true,
     plugins: [
       "jsx",
       "flow",

--- a/tests/return-outside-function/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/return-outside-function/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`return-outside-function.js 1`] = `
+return someVeryLongStringA && someVeryLongStringB && someVeryLongStringC && someVeryLongStringD
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+return (
+  someVeryLongStringA &&
+  someVeryLongStringB &&
+  someVeryLongStringC &&
+  someVeryLongStringD
+);
+
+`;

--- a/tests/return-outside-function/jsfmt.spec.js
+++ b/tests/return-outside-function/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "babylon" }, ["typescript"]);

--- a/tests/return-outside-function/return-outside-function.js
+++ b/tests/return-outside-function/return-outside-function.js
@@ -1,0 +1,1 @@
+return someVeryLongStringA && someVeryLongStringB && someVeryLongStringC && someVeryLongStringD


### PR DESCRIPTION
This makes it easier to format code snippets including a `return`
statement, without having to format the entire function. For example,
given the following code:

```js
function f() {
    return someVeryLongStringA && someVeryLongStringB && someVeryLongStringC && someVeryLongStringD
}
```

a developer could select the line containing `return`, then use
prettier to format the code to:

```js
function f() {
return (
  someVeryLongStringA &&
  someVeryLongStringB &&
  someVeryLongStringC &&
  someVeryLongStringD
);
}
```

which can then be reindented by the editor.

---

Related to https://github.com/prettier/prettier/issues/593