### PR TITLE
Always run prettier if prettier-mode is active

### DIFF
--- a/editors/emacs/README.md
+++ b/editors/emacs/README.md
@@ -2,15 +2,13 @@ Add this to your init:
 
 ```elisp
 (require 'prettier-js)
-(prettier-mode)
 ```
 
-If you don't use `js-mode`, which is what Prettier targets by default, you'll need to first set your major-mode of choice:
-
+Then you can hook to your favorite javascript mode:
 ```elisp
-(require 'prettier-js)
-(setq prettier-target-mode "js2-mode")
-(prettier-mode)
+(add-hook 'js2-mode-hook 'prettier-mode)
+(add-hook 'web-mode-hook 'prettier-mode)
+...
 ```
 
 To adjust the CLI args used for the prettier command, you can customize the `prettier-args` variable:

--- a/editors/emacs/prettier-js.el
+++ b/editors/emacs/prettier-js.el
@@ -223,9 +223,9 @@ function."
 (define-minor-mode prettier-mode
   "Runs prettier on file save when this mode is turned on"
   :lighter " prettier"
-  :global t
+  :global nil
   (if prettier-mode
-      (add-hook 'before-save-hook 'prettier-before-save)
-    (remove-hook 'before-save-hook 'prettier-before-save)))
+      (add-hook 'before-save-hook 'prettier nil 'local)
+    (remove-hook 'before-save-hook 'prettier 'local)))
 
 (provide 'prettier-js)


### PR DESCRIPTION
Prettier should always run when prettier-mode is active. Also, disabling prettier as a global minor mode allows its users to hook prettier-mode to their favorite javascript mode(s) like this:

```
(require 'prettier-js)
(add-hook 'js2-mode-hook 'prettier-mode)
(add-hook 'web-mode-hook 'prettier-mode)
...
```

I believe this is how most of minor modes work, what do you think?

Cheers and thanks for this awesome tool! 😄 