### PR TITLE
TypeScript: do not report SyntaxErrors as errors when running external tests

### DIFF
--- a/scripts/run-external-typescript-tests.js
+++ b/scripts/run-external-typescript-tests.js
@@ -1,3 +1,17 @@
+/**
+ * There's an issue with this script's assumption that each run of prettier
+ * will result in one output to stderr or stdout.
+ *
+ * On Mac this seems not to hold for stderr, where multiple errors are buffered
+ * into one emit on the stderr stream.
+ *
+ * If you have any ideas on how to fix this, please send a PR!
+ */
+if (process.platform !== "win32") {
+  console.error("Error: this script currently only works on windows.");
+  process.exit(1);
+}
+
 const fs = require("fs");
 const path = require("path");
 const spawn = require("child_process").spawn;
@@ -17,6 +31,9 @@ if (!fs.existsSync(tsRoot) || !fs.existsSync(testsDir)) {
 const badFiles = [];
 const errorTypes = {};
 let good = 0;
+let skipped = 0;
+
+rimraf.sync(errorsPath);
 
 const cp = spawn("node", [
   "./bin/prettier.js",
@@ -30,30 +47,39 @@ cp.stdout.on("data", out => {
   good++;
   printStatus();
 });
+
 cp.stderr.on("data", err => {
   const error = err.toString();
   const { file, errorType } = splitFileAndError(error);
-  badFiles.push({ file, errorType, error });
-  errorTypes[errorType] = (errorTypes[errorType] || 0) + 1;
+  if (errorType.startsWith("SyntaxError:")) {
+    skipped++;
+  } else {
+    badFiles.push({ file, errorType, error });
+    errorTypes[errorType] = (errorTypes[errorType] || 0) + 1;
+  }
   printStatus();
 });
 
 cp.on("close", code => {
-  const total = badFiles.length + good;
-  console.log(`\n${good}/${total} files printed without errors.`);
-  console.log("");
+  const total = badFiles.length + good + skipped;
+  const percentNoError = (100 * (good + skipped) / total).toFixed(0);
+  console.log(
+    `\n${percentNoError}% of ${total} files processed without errors.\n`
+  );
   Object.keys(errorTypes)
     .sort((a, b) => errorTypes[b] - errorTypes[a])
     .forEach(errorType => {
       console.log(`${errorTypes[errorType]}\t${errorType}`);
     });
 
-  console.log(`Writing errors to '${errorsPath}' directory`);
+  console.log(`\nWriting errors to '${errorsPath}' directory`);
   writeErrorsToFiles();
 });
 
 function printStatus() {
-  process.stdout.write(`\r${good} good, ${badFiles.length} bad`);
+  process.stdout.write(
+    `\r${good} good, ${skipped} skipped, ${badFiles.length} bad`
+  );
 }
 
 function splitFileAndError(err) {
@@ -79,17 +105,18 @@ function splitFileAndError(err) {
 
 function writeErrorsToFiles() {
   const splitter = "@".repeat(80);
-  rimraf.sync(errorsPath);
   fs.mkdirSync(errorsPath);
   Object.keys(errorTypes).forEach(errorType => {
     const files = badFiles.filter(f => f.errorType === errorType);
-    const contents = files.map(({ file, error }) => {
-      // Trim file name from error.
-      if (error.startsWith(file)) {
-        error = error.substring(file.length);
-      }
-      return `\n\n${file}\n${error}\n${splitter}\n`;
-    }).join("\n");
+    const contents = files
+      .map(({ file, error }) => {
+        // Trim file name from error.
+        if (error.startsWith(file)) {
+          error = error.substring(file.length);
+        }
+        return `\n\n${file}\n${error}\n${splitter}\n`;
+      })
+      .join("\n");
     fs.writeFileSync(
       path.join(errorsPath, sanitize(errorType) + ".log"),
       contents
@@ -98,5 +125,5 @@ function writeErrorsToFiles() {
 }
 
 function sanitize(string) {
-  return string.replace(/[^A-Z0-9_.\-]/gi, "_");
+  return string.replace(/[^A-Z0-9_.\(\) \-]/gi, "_").replace(/\.$/, "");
 }


### PR DESCRIPTION
Output:
```
12873 good, 573 skipped, 314 bad
98% of 13760 files processed without errors.

83      TypeError: Cannot read property 'type' of undefined
62      Error: Value undefined is not a valid document
58      prettier(input) !== prettier(prettier(input))
56      Error: did not recognize object of type "TSInterfaceHeritage"
42      ast(input) !== ast(prettier(input))
6       TypeError: Cannot read property 'some' of undefined
4       Error: Comment "<omitted>" was not printed. Please report this error!
3       Error: Comment location overlaps with node location

Writing errors to './errors/' directory
```