### PR TITLE
TypeScript: isReadonly changed to readonly

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "rollup-plugin-node-globals": "1.1.0",
     "rollup-plugin-node-resolve": "2.0.0",
     "typescript": "2.3.2",
-    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#f5fcc879b493138eb97b9bdfb39afc4d210b1ddf"
+    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#b06ac2d98db6928fb9ec2fae103a490a635647dd"
   },
   "scripts": {
     "test": "jest",

--- a/src/printer.js
+++ b/src/printer.js
@@ -2180,7 +2180,7 @@ function genericPrintNoParens(path, options, print, args) {
       if (n.accessibility) {
         parts.push(n.accessibility + " ");
       }
-      if (n.isReadonly) {
+      if (n.readonly) {
         parts.push("readonly ");
       }
 

--- a/src/typescript-ast-nodes.js
+++ b/src/typescript-ast-nodes.js
@@ -183,7 +183,7 @@ module.exports = function(fork) {
 
   def("TSTypeParameter").build("name").field("name", def("Identifier"));
 
-  def("TSParameterProperty").build("accessibility", "isReadonly", "parameters");
+  def("TSParameterProperty").build("accessibility", "readonly", "parameters");
 
   def("TSTypeAssertionExpression")
     .build("expression", "typeAnnotation")

--- a/yarn.lock
+++ b/yarn.lock
@@ -2156,9 +2156,9 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#f5fcc879b493138eb97b9bdfb39afc4d210b1ddf":
-  version "2.1.0"
-  resolved "git://github.com/eslint/typescript-eslint-parser.git#f5fcc879b493138eb97b9bdfb39afc4d210b1ddf"
+"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#b06ac2d98db6928fb9ec2fae103a490a635647dd":
+  version "3.0.0"
+  resolved "git://github.com/eslint/typescript-eslint-parser.git#b06ac2d98db6928fb9ec2fae103a490a635647dd"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.3.0"


### PR DESCRIPTION
DO NOT MERGE, currently using a commit hash from a PR branch.

Once the PR in typescript-eslint-parser (https://github.com/eslint/typescript-eslint-parser/pull/285) officially lands, I will update the commit hash.