### PR TITLE
Add instruction on how to set up key binding in vim

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   * [Vim](#vim)
     + [Other `autocmd` events](#other-autocmd-events)
     + [Customizing Prettier in Vim](#customizing-prettier-in-vim)
+    + [Running Prettier manually in Vim](#running-prettier-manually-in-vim)
   * [Visual Studio Code](#visual-studio-code)
   * [Visual Studio](#visual-studio)
   * [Sublime Text](#sublime-text)
@@ -348,6 +349,16 @@ let g:neoformat_try_formatprg = 1
 ```
 
 Each option needs to be escaped with `\`.
+
+#### Running Prettier manually in Vim
+
+If you need a little more control over when prettier is run, you can create a
+custom key binding. In this example, `gp` (mnemonic: "get pretty") is used to
+run prettier (with options) in the currently active buffer:
+
+```vim
+nnoremap gp :silent %!prettier --stdin --trailing-comma all --single-quote<CR>
+```
 
 ### Visual Studio Code
 


### PR DESCRIPTION
I'm a vim user, and I use prettier on a few of my projects, but not all.
The Prettier docs listed ways to make prettier run automatically on save
(and other autocmd events), but I needed a way to invoke it manually.
After spending some time finding the right vim config, I decided it
could be useful to others as well.

Fixes #1615