### PR TITLE
Make emacs package summary clearer

### DIFF
--- a/editors/emacs/prettier-js.el
+++ b/editors/emacs/prettier-js.el
@@ -1,4 +1,4 @@
-;;; prettier-js.el --- utility functions to format reason code
+;;; prettier-js.el --- Emacs minor mode to format JS code on file save
 
 ;; Version: 0.1.0
 


### PR DESCRIPTION
Currently the package summary makes no sense when viewed from Emacs's package manager, this fixes it.