### PR TITLE
Upgrade typescript parser, fix and run AST tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ cache:
   - node_modules
 script:
   - yarn lint
-  - yarn test -- --runInBand
+  - AST_COMPARE=1 yarn test -- --runInBand

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "rollup-plugin-node-globals": "1.1.0",
     "rollup-plugin-node-resolve": "2.0.0",
     "typescript": "2.3.2",
-    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#3f9f41c7d8bcdaa3fbd68767e390f07f05555c3a"
+    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#b7220fdbf5a923c64bb6e5bbbfc2ad689ec779eb"
   },
   "scripts": {
     "test": "jest",

--- a/src/parser.js
+++ b/src/parser.js
@@ -118,6 +118,7 @@ function tryParseTypeScript(text, jsx) {
     range: true,
     tokens: true,
     comment: true,
+    useJSXTextNode: true,
     ecmaFeatures: { jsx }
   });
 }

--- a/src/printer.js
+++ b/src/printer.js
@@ -1456,6 +1456,8 @@ function genericPrintNoParens(path, options, print, args) {
         path.call(print, "object"),
         path.call(print, "property")
       ]);
+    case "TSQualifiedName":
+      return join(".", [path.call(print, "left"), path.call(print, "right")]);
     case "JSXSpreadAttribute":
       return concat(["{...", path.call(print, "argument"), "}"]);
     case "JSXExpressionContainer": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1529,11 +1529,7 @@ jest-diff@^20.0.0:
     jest-matcher-utils "^20.0.0"
     pretty-format "^20.0.0"
 
-jest-docblock@^20.0.0:
-  version "20.0.0"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.0.tgz#5b647c4af36f52dae74df1949a8cb418d146ad3a"
-
-jest-docblock@^20.0.1:
+jest-docblock@^20.0.0, jest-docblock@^20.0.1:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.3.tgz#17bea984342cc33d83c50fbe1545ea0efaa44712"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2688,9 +2688,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#3f9f41c7d8bcdaa3fbd68767e390f07f05555c3a":
+"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#b7220fdbf5a923c64bb6e5bbbfc2ad689ec779eb":
   version "3.0.0"
-  resolved "git://github.com/eslint/typescript-eslint-parser.git#3f9f41c7d8bcdaa3fbd68767e390f07f05555c3a"
+  resolved "git://github.com/eslint/typescript-eslint-parser.git#b7220fdbf5a923c64bb6e5bbbfc2ad689ec779eb"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.3.0"


### PR DESCRIPTION
This fixes https://github.com/prettier/prettier/issues/1558
and uses `AST_COMPARE=1` on Travis tests, so we can make sure those
don't break going forward.