### PR TITLE
Preserve unusual unicode whitespace

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3410,7 +3410,8 @@ function printJSXChildren(path, options, print, jsxWhitespace) {
     if (isLiteral && typeof child.value === "string") {
       const value = child.raw || child.extra.raw;
 
-      if (/\S/.test(value)) {
+      // Contains a non-whitespace character
+      if (/[^ \n\r\t]/.test(value)) {
         // treat each line of text as its own entity
         value.split(/(\r?\n\s*)/).forEach(textLine => {
           const newlines = textLine.match(/\n/g);
@@ -3428,18 +3429,18 @@ function printJSXChildren(path, options, print, jsxWhitespace) {
             return;
           }
 
-          const beginSpace = /^\s+/.test(textLine);
+          const beginSpace = /^[ \n\r\t]+/.test(textLine);
           if (beginSpace) {
             children.push(jsxWhitespace);
           } else {
             children.push(softline);
           }
 
-          const stripped = textLine.replace(/^\s+|\s+$/g, "");
+          const stripped = textLine.replace(/^[ \n\r\t]+|[ \n\r\t]+$/g, "");
           if (stripped) {
             // Split text into words separated by "line"s.
-            stripped.split(/(\s+)/).forEach(word => {
-              const space = /\s+/.test(word);
+            stripped.split(/([ \n\r\t]+)/).forEach(word => {
+              const space = /[ \n\r\t]+/.test(word);
               if (space) {
                 children.push(line);
               } else {
@@ -3448,7 +3449,7 @@ function printJSXChildren(path, options, print, jsxWhitespace) {
             });
           }
 
-          const endSpace = /\s+$/.test(textLine);
+          const endSpace = /[ \n\r\t]+$/.test(textLine);
           if (endSpace) {
             children.push(jsxWhitespace);
           } else {
@@ -3462,7 +3463,7 @@ function printJSXChildren(path, options, print, jsxWhitespace) {
         if (value.match(/\n/g).length > 1) {
           children.push(hardline);
         }
-      } else if (/\s/.test(value)) {
+      } else if (/[ \n\r\t]/.test(value)) {
         // whitespace(s)-only without newlines,
         // eg; one or more spaces separating two elements
         for (let i = 0; i < value.length; ++i) {

--- a/tests/jsx-whitespace/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-whitespace/__snapshots__/jsfmt.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`test.js 1`] = `
-// Should collapse
+// Treated as whitespace in JSX
 spaces = <div>]   [</div>
 tabs = <div>]      [</div>
 slash_n = <div>]
@@ -14,7 +14,7 @@ slash_r = <div>]
 [</div>
 
 
-// Should not collapse
+// Not treated as whitespace in JSX
 // NOTE: Some of the space characters here won't show up in an editor,
 // but they are there!
 slash_f = <div>][</div>
@@ -24,7 +24,7 @@ em_space = <div>]   [</div>
 hair_space = <div>]  [</div>
 zero_width_space = <div>]​​​[</div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// Should collapse
+// Treated as whitespace in JSX
 spaces = <div>] [</div>;
 tabs = <div>] [</div>;
 slash_n = (
@@ -42,7 +42,7 @@ slash_r = (
   </div>
 );
 
-// Should not collapse
+// Not treated as whitespace in JSX
 // NOTE: Some of the space characters here won't show up in an editor,
 // but they are there!
 slash_f = <div>][</div>;

--- a/tests/jsx-whitespace/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-whitespace/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test.js 1`] = `
+// Should collapse
+spaces = <div>]   [</div>
+tabs = <div>]      [</div>
+slash_n = <div>]
+
+
+[</div>
+slash_r = <div>]
+
+
+[</div>
+
+
+// Should not collapse
+// NOTE: Some of the space characters here won't show up in an editor,
+// but they are there!
+slash_f = <div>][</div>
+slash_v = <div>][</div>
+non_breaking_spaces = <div>]   [</div>
+em_space = <div>]   [</div>
+hair_space = <div>]  [</div>
+zero_width_space = <div>]​​​[</div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Should collapse
+spaces = <div>] [</div>;
+tabs = <div>] [</div>;
+slash_n = (
+  <div>
+    ]
+
+    [
+  </div>
+);
+slash_r = (
+  <div>
+    ]
+
+    [
+  </div>
+);
+
+// Should not collapse
+// NOTE: Some of the space characters here won't show up in an editor,
+// but they are there!
+slash_f = <div>][</div>;
+slash_v = <div>][</div>;
+non_breaking_spaces = <div>]   [</div>;
+em_space = <div>]   [</div>;
+hair_space = <div>]  [</div>;
+zero_width_space = <div>]​​​[</div>;
+
+`;

--- a/tests/jsx-whitespace/jsfmt.spec.js
+++ b/tests/jsx-whitespace/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, null, ["typescript"]);

--- a/tests/jsx-whitespace/test.js
+++ b/tests/jsx-whitespace/test.js
@@ -1,4 +1,4 @@
-// Should collapse
+// Treated as whitespace in JSX
 spaces = <div>]   [</div>
 tabs = <div>]      [</div>
 slash_n = <div>]
@@ -11,7 +11,7 @@ slash_r = <div>]
 [</div>
 
 
-// Should not collapse
+// Not treated as whitespace in JSX
 // NOTE: Some of the space characters here won't show up in an editor,
 // but they are there!
 slash_f = <div>][</div>

--- a/tests/jsx-whitespace/test.js
+++ b/tests/jsx-whitespace/test.js
@@ -1,0 +1,22 @@
+// Should collapse
+spaces = <div>]   [</div>
+tabs = <div>]      [</div>
+slash_n = <div>]
+
+
+[</div>
+slash_r = <div>]
+
+
+[</div>
+
+
+// Should not collapse
+// NOTE: Some of the space characters here won't show up in an editor,
+// but they are there!
+slash_f = <div>][</div>
+slash_v = <div>][</div>
+non_breaking_spaces = <div>]   [</div>
+em_space = <div>]   [</div>
+hair_space = <div>]  [</div>
+zero_width_space = <div>]​​​[</div>

--- a/tests/jsx_escape/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx_escape/__snapshots__/jsfmt.spec.js.snap
@@ -26,7 +26,7 @@ raw_amp = <span>foo & bar</span>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 many_nbsp = <div>&nbsp; &nbsp; </div>;
 single_nbsp = <div>&nbsp;</div>;
-many_raw_nbsp = <div>   </div>;
+many_raw_nbsp = <div>   </div>;
 many_raw_spaces = <div>   </div>;
 
 amp = <span>foo &amp; bar</span>;
@@ -46,7 +46,7 @@ raw_amp = <span>foo & bar</span>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 many_nbsp = <div>&nbsp; &nbsp; </div>;
 single_nbsp = <div>&nbsp;</div>;
-many_raw_nbsp = <div>   </div>;
+many_raw_nbsp = <div>   </div>;
 many_raw_spaces = <div>   </div>;
 
 amp = <span>foo &amp; bar</span>;


### PR DESCRIPTION
This PR preserves unusual unicode whitespace characters.

Currently any whitespace that matches a unicode whitespace character gets converted to a normal space. This means we lose whitespace characters with special meanings (such as non-breaking spaces and zero width spaces).

In this PR we no longer treat anything other than newline, tab, and space characters as whitespace. This allows us to preserve these unusual unicode whitespace characters as is.

With this change I believe we no longer need to preserve multiple space characters when formatting JSX, because they can no longer contain unusual whitespace we know that they will collapse down to a single space when rendering so it is safe to do that in Prettier.