### PR TITLE
Fix fill wrapping when text starts with whitespace

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3585,6 +3585,11 @@ function printJSXElement(path, options, print) {
         multilineChildren.push(rawJsxWhitespace);
         return;
       } else if (i === 0) {
+        // Fill expects alternating content & whitespace parts
+        // always starting with content.
+        // So we add a dummy content element if we would otherwise start
+        // with whitespace.
+        multilineChildren.push("");
         multilineChildren.push(concat([rawJsxWhitespace, hardline]));
         return;
       } else if (i === children.length - 1) {

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -96,6 +96,12 @@ x =
       Second
     </div> Third
   </div>
+
+leading_whitespace =
+  <div> First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth</div>
+
+no_leading_whitespace =
+  <div>First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth</div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Wrapping text
 x = (
@@ -238,6 +244,21 @@ x = (
     </div>
     {" "}
     Third
+  </div>
+);
+
+leading_whitespace = (
+  <div>
+    {" "}
+    First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh
+    Twelfth Thirteenth Fourteenth
+  </div>
+);
+
+no_leading_whitespace = (
+  <div>
+    First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh
+    Twelfth Thirteenth Fourteenth
   </div>
 );
 

--- a/tests/jsx-text-wrap/test.js
+++ b/tests/jsx-text-wrap/test.js
@@ -93,3 +93,9 @@ x =
       Second
     </div> Third
   </div>
+
+leading_whitespace =
+  <div> First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth</div>
+
+no_leading_whitespace =
+  <div>First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth</div>


### PR DESCRIPTION
There is a bug in the fill implementation in #1120 when text starts with a whitespace.

Input:
```javascript
leading_whitespace =
  <div> First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth</div>
```

Output on master:
```javascript
leading_whitespace = (
  <div>
    {" "}
    First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth
  </div>
);
```

The `fill` algorithm expects to be passed alternating content and whitespace parts, starting with content. Before this PR it was possible for it to start with a whitespace, throwing off the algorithm.

Output with this PR:
```javascript
leading_whitespace = (
  <div>
    {" "}
    First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh
    Twelfth Thirteenth Fourteenth
  </div>
);
```