### PR TITLE
Add test for flow class field override

### DIFF
--- a/tests/flow_class_field/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_class_field/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`override.js 1`] = `
+class Foo {
+  constructor: () => this;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class Foo {
+  constructor: () => this;
+}
+
+`;

--- a/tests/flow_class_field/jsfmt.spec.js
+++ b/tests/flow_class_field/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, null, ["babylon"]);

--- a/tests/flow_class_field/override.js
+++ b/tests/flow_class_field/override.js
@@ -1,0 +1,3 @@
+class Foo {
+  constructor: () => this;
+}


### PR DESCRIPTION
Fixed in latest Babylon, but forgot to add a test in https://github.com/prettier/prettier/pull/1668!

Fixes #1481.