### PR TITLE
Extend custom testing framework style behaviour to function calls

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -737,9 +737,10 @@ function genericPrintNoParens(path, options, print, args) {
             n.arguments[0].type === "TemplateLiteral" ||
             (n.arguments[0].type === "Literal" &&
               typeof n.arguments[0].value === "string")) &&
-          (n.arguments[1].type === "FunctionExpression" ||
+          (((n.arguments[1].type === "FunctionExpression" ||
             n.arguments[1].type === "ArrowFunctionExpression") &&
-          n.arguments[1].params.length <= 1)
+            n.arguments[1].params.length <= 1) ||
+            n.arguments[1].type === "CallExpression"))
       ) {
         return concat([
           path.call(print, "callee"),

--- a/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
@@ -46,6 +46,10 @@ describe(\`does something really long and complicated so I have to write a very 
   });
 });
 
+describe("does something really long and complicated so I have to write a very long name for the describe block", willResolve(() => {
+  console.log("hello!");
+}));
+
 // Should break
 
 it.only("does something really long and complicated so I have to write a very long name for the test", () => {
@@ -112,6 +116,12 @@ describe(\`does something really long and complicated so I have to write a very 
     console.log("hello!");
   });
 });
+
+describe("does something really long and complicated so I have to write a very long name for the describe block", willResolve(
+  () => {
+    console.log("hello!");
+  }
+));
 
 // Should break
 

--- a/tests/test_declarations/test_declarations.js
+++ b/tests/test_declarations/test_declarations.js
@@ -43,6 +43,10 @@ describe(`does something really long and complicated so I have to write a very l
   });
 });
 
+describe("does something really long and complicated so I have to write a very long name for the describe block", willResolve(() => {
+  console.log("hello!");
+}));
+
 // Should break
 
 it.only("does something really long and complicated so I have to write a very long name for the test", () => {


### PR DESCRIPTION
We have a number of tests using [`jasmine-promise-tools`](https://www.npmjs.com/package/jasmine-promise-tools)'s `willResolve` to decorate the function:

    describe("does something really long and complicated so I have to write a very long name for the describe block", willResolve(() => {
      console.log("hello!");
    }));

However, this doesn't currently get the special treatment added in #159, and ends up split:

    describe(
      "does something really long and complicated so I have to write a very long name for the describe block",
      willResolve(() => {
        console.log("hello!");
      })
    );

This PR extends the treatment so that the top-level arguments are kept on the same line:

    describe("does something really long and complicated so I have to write a very long name for the describe block", willResolve(
      () => {
        console.log("hello!");
      }
    ));

Ideally, we'd keep the arrow function on the same line to match the original formatting, but this initial change is already an improvement.

Are you open to a change here? I'm keen to figure out if I should put my effort into improving the rules for this case or learning to love the split lines.
