### PR TITLE
Hug JSX text after multi line tags

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3432,7 +3432,16 @@ function printJSXChildren(path, options, print, jsxWhitespace) {
           if (beginSpace) {
             children.push(jsxWhitespace);
           } else {
-            children.push(softline);
+            // Ideally this would be a `softline` to allow a break between
+            // tags and text.
+            // Unfortunately Facebook have a custom translation pipeline
+            // (https://github.com/prettier/prettier/issues/1581#issuecomment-300975032)
+            // that uses the JSX syntax, but does not follow the JSX whitespace
+            // rules.
+            // Ensuring that we never have a break between tags and text in JSX
+            // will allow Facebook to adopt Prettier without too much of an
+            // adverse effect on formatting algorithm.
+            children.push("");
           }
 
           const stripped = textLine.replace(/^[ \n\r\t]+|[ \n\r\t]+$/g, "");
@@ -3561,9 +3570,9 @@ function printJSXElement(path, options, print) {
     children.push(hardline);
   }
 
-  // Trim leading lines, recording if there was a hardline
+  // Trim leading lines (or empty strings), recording if there was a hardline
   let numLeadingHard = 0;
-  while (children.length && isLineNext(children[0])) {
+  while (children.length && (isLineNext(children[0]) || isEmpty(children[0]))) {
     if (willBreak(children[0])) {
       ++numLeadingHard;
       forcedBreak = true;

--- a/src/printer.js
+++ b/src/printer.js
@@ -3436,7 +3436,7 @@ function printJSXChildren(path, options, print, jsxWhitespace) {
             // tags and text.
             // Unfortunately Facebook have a custom translation pipeline
             // (https://github.com/prettier/prettier/issues/1581#issuecomment-300975032)
-            // that uses the JSX syntax, but does not follow the JSX whitespace
+            // that uses the JSX syntax, but does not follow the React whitespace
             // rules.
             // Ensuring that we never have a break between tags and text in JSX
             // will allow Facebook to adopt Prettier without too much of an
@@ -3461,7 +3461,8 @@ function printJSXChildren(path, options, print, jsxWhitespace) {
           if (endSpace) {
             children.push(jsxWhitespace);
           } else {
-            children.push(softline);
+            // As above this would ideally be a `softline`.
+            children.push("");
           }
         });
       } else if (/\n/.test(value)) {

--- a/tests/jsx-split-attrs/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-split-attrs/__snapshots__/jsfmt.spec.js.snap
@@ -122,8 +122,7 @@ long_open_long_children = (
         colour="blue"
         size="large"
         submitLabel="Sign in with Google"
-      />
-      d
+      />d
     </BaseForm>
     <BaseForm
       url="/auth/google"

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -103,14 +103,19 @@ leading_whitespace =
 no_leading_whitespace =
   <div>First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth</div>
 
-facebook_translation_leave_text_after_tag =
+facebook_translation_leave_text_around_tag =
   <div>
     <span>
       First
     </span>,
-    <span>
+    (<span>
       Second
-    </span>
+    </span>)
+  </div>
+
+this_really_should_split_across_lines =
+  <div>
+    before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after
   </div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Wrapping text
@@ -159,8 +164,7 @@ x = (
 
 x = (
   <div>
-    before
-    <div>
+    before<div>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur at
       mollis lorem.
     </div>after
@@ -272,14 +276,20 @@ no_leading_whitespace = (
   </div>
 );
 
-facebook_translation_leave_text_after_tag = (
+facebook_translation_leave_text_around_tag = (
   <div>
     <span>
       First
     </span>,
-    <span>
+    (<span>
       Second
-    </span>
+    </span>)
+  </div>
+);
+
+this_really_should_split_across_lines = (
+  <div>
+    before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after
   </div>
 );
 

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -102,6 +102,16 @@ leading_whitespace =
 
 no_leading_whitespace =
   <div>First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth</div>
+
+facebook_translation_leave_text_after_tag =
+  <div>
+    <span>
+      First
+    </span>,
+    <span>
+      Second
+    </span>
+  </div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Wrapping text
 x = (
@@ -153,8 +163,7 @@ x = (
     <div>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur at
       mollis lorem.
-    </div>
-    after
+    </div>after
   </div>
 );
 
@@ -188,8 +197,9 @@ function DiffOverview(props) {
       <div className="alert alert-info">
         <p>
           This diff overview is computed against the current list of records in
-          this collection and the list it contained on <b>{humanDate(since)}</b>
-          .
+          this collection and the list it contained on <b>
+            {humanDate(since)}
+          </b>.
         </p>
         <p>
           <b>Note:</b> <code>last_modified</code> and <code>schema</code> record
@@ -259,6 +269,17 @@ no_leading_whitespace = (
   <div>
     First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh
     Twelfth Thirteenth Fourteenth
+  </div>
+);
+
+facebook_translation_leave_text_after_tag = (
+  <div>
+    <span>
+      First
+    </span>,
+    <span>
+      Second
+    </span>
   </div>
 );
 

--- a/tests/jsx-text-wrap/test.js
+++ b/tests/jsx-text-wrap/test.js
@@ -99,3 +99,13 @@ leading_whitespace =
 
 no_leading_whitespace =
   <div>First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth</div>
+
+facebook_translation_leave_text_after_tag =
+  <div>
+    <span>
+      First
+    </span>,
+    <span>
+      Second
+    </span>
+  </div>

--- a/tests/jsx-text-wrap/test.js
+++ b/tests/jsx-text-wrap/test.js
@@ -100,12 +100,17 @@ leading_whitespace =
 no_leading_whitespace =
   <div>First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth</div>
 
-facebook_translation_leave_text_after_tag =
+facebook_translation_leave_text_around_tag =
   <div>
     <span>
       First
     </span>,
-    <span>
+    (<span>
       Second
-    </span>
+    </span>)
+  </div>
+
+this_really_should_split_across_lines =
+  <div>
+    before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after
   </div>


### PR DESCRIPTION
A fix for https://github.com/prettier/prettier/issues/1581

This PR no longer allows a line break between tags and text in JSX. This fixes an issue that was blocking adoption at Facebook (https://github.com/prettier/prettier/issues/1581#issuecomment-300975032) with little adverse effects for our standard formatting.