### PR TITLE
Fix last comment of import

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -173,6 +173,7 @@ function attach(comments, ast, text) {
         ) ||
         handleOnlyComments(enclosingNode, ast, comment, isLastComment) ||
         handleImportDeclarationComments(
+          text,
           enclosingNode,
           precedingNode,
           comment
@@ -726,6 +727,7 @@ function handleForComments(enclosingNode, precedingNode, comment) {
 }
 
 function handleImportDeclarationComments(
+  text,
   enclosingNode,
   precedingNode,
   comment
@@ -734,7 +736,7 @@ function handleImportDeclarationComments(
     precedingNode &&
     enclosingNode &&
     enclosingNode.type === "ImportDeclaration" &&
-    !util.isBlockComment(comment)
+    util.hasNewline(text, util.locEnd(comment))
   ) {
     addTrailingComment(precedingNode, comment);
     return true;

--- a/tests/import/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/import/__snapshots__/jsfmt.spec.js.snap
@@ -87,6 +87,14 @@ import {
   // FN4,
   // FN5
 } from "./module";
+
+import {
+  ExecutionResult,
+  DocumentNode,
+  /* tslint:disable */
+  SelectionSetNode,
+  /* tslint:enable */
+} from 'graphql';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import {
   //comment1
@@ -122,6 +130,14 @@ import {
   // FN4,
   // FN5
 } from "./module";
+
+import {
+  ExecutionResult,
+  DocumentNode,
+  /* tslint:disable */
+  SelectionSetNode
+  /* tslint:enable */
+} from "graphql";
 
 `;
 
@@ -158,6 +174,14 @@ import {
   // FN4,
   // FN5
 } from "./module";
+
+import {
+  ExecutionResult,
+  DocumentNode,
+  /* tslint:disable */
+  SelectionSetNode,
+  /* tslint:enable */
+} from 'graphql';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import {
   //comment1
@@ -193,6 +217,14 @@ import {
   // FN4,
   // FN5
 } from "./module";
+
+import {
+  ExecutionResult,
+  DocumentNode,
+  /* tslint:disable */
+  SelectionSetNode
+  /* tslint:enable */
+} from "graphql";
 
 `;
 

--- a/tests/import/comments.js
+++ b/tests/import/comments.js
@@ -30,3 +30,11 @@ import {
   // FN4,
   // FN5
 } from "./module";
+
+import {
+  ExecutionResult,
+  DocumentNode,
+  /* tslint:disable */
+  SelectionSetNode,
+  /* tslint:enable */
+} from 'graphql';


### PR DESCRIPTION
We used to use isBlock as a heuristic but the real thing we want is to know if the comment is on its own line. Now it works with both :)

Before it was printing

```js
import {
  ExecutionResult,
  DocumentNode,
  /* tslint:disable */
  SelectionSetNode,
} /* tslint:enable */ from 'graphql';
```

and was not stable.

This fixes the last issue for apollo-client.