### PR TITLE
Handle TypeScript decorators

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -87,13 +87,24 @@ function genericPrint(path, options, printPath, args) {
     // responsible for printing node.decorators.
     !util.getParentExportDeclaration(path)
   ) {
-    const separator = node.decorators.length === 1 &&
-      (node.decorators[0].expression.type === "Identifier" ||
-        node.decorators[0].expression.type === "MemberExpression")
-      ? " "
-      : hardline;
+    let separator = hardline;
     path.each(decoratorPath => {
-      parts.push(printPath(decoratorPath), separator);
+      let prefix = "@";
+      let decorator = decoratorPath.getValue();
+      if (decorator.expression) {
+        decorator = decorator.expression;
+        prefix = "";
+      }
+
+      if (
+        node.decorators.length === 1 &&
+        (decorator.type === "Identifier" ||
+          decorator.type === "MemberExpression")
+      ) {
+        separator = " ";
+      }
+
+      parts.push(prefix, printPath(decoratorPath), separator);
     }, "decorators");
   } else if (
     util.isExportDeclaration(node) &&
@@ -104,7 +115,12 @@ function genericPrint(path, options, printPath, args) {
     // that logically apply to node.declaration.
     path.each(
       decoratorPath => {
-        parts.push(printPath(decoratorPath), line);
+        const decorator = decoratorPath.getValue();
+        const prefix = decorator.type === "Decorator" ||
+          decorator.type === "TSDecorator"
+          ? ""
+          : "@";
+        parts.push(prefix, printPath(decoratorPath), line);
       },
       "declaration",
       "decorators"

--- a/tests/typescript_decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_decorators/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`decorators.js 1`] = `
+export class TestTextFileService {
+	constructor(
+		@ILifecycleService lifecycleService,
+	) {
+	}
+}
+
+@commonEditorContribution
+export class TabCompletionController {
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export class TestTextFileService {
+  constructor(@ILifecycleService lifecycleService) {}
+}
+
+@commonEditorContribution
+export class TabCompletionController {}
+
+`;

--- a/tests/typescript_decorators/decorators.js
+++ b/tests/typescript_decorators/decorators.js
@@ -1,0 +1,10 @@
+export class TestTextFileService {
+	constructor(
+		@ILifecycleService lifecycleService,
+	) {
+	}
+}
+
+@commonEditorContribution
+export class TabCompletionController {
+}

--- a/tests/typescript_decorators/jsfmt.spec.js
+++ b/tests/typescript_decorators/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });


### PR DESCRIPTION
See this issue for creating the same decorators as babylon ( https://github.com/eslint/typescript-eslint-parser/issues/250 ), in the meantime, this is making a ton of files in vscode crash. So we can just support both :)