### PR TITLE
Make the comment chain comment detection more robust

### DIFF
--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -244,6 +244,12 @@ measure() // Warm-up first
 
 const configModel = this.baseConfigurationService.getCache().consolidated		// global/default values (do NOT modify)
   .merge(this.cachedWorkspaceConfig);
+
+this.doWriteConfiguration(target, value, options) // queue up writes to prevent race conditions
+  .then(() => null,
+  error => {
+    return options.donotNotifyError ? TPromise.wrapError(error) : this.onError(error, target, value);
+  });
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function f() {
   return (
@@ -260,11 +266,13 @@ _.a(a)
 
 _.a(
   a
-) /* very very very very very very very long such that it is longer than 80 columns */.a();
+) /* very very very very very very very long such that it is longer than 80 columns */
+  .a();
 
 _.a(
   a
-) /* very very very very very very very long such that it is longer than 80 columns */.a();
+) /* very very very very very very very long such that it is longer than 80 columns */
+  .a();
 
 Something
   // $FlowFixMe(>=0.41.0)
@@ -285,6 +293,16 @@ const configModel = this.baseConfigurationService
   .getCache()
   .consolidated // global/default values (do NOT modify)
   .merge(this.cachedWorkspaceConfig);
+
+this.doWriteConfiguration(target, value, options) // queue up writes to prevent race conditions
+  .then(
+    () => null,
+    error => {
+      return options.donotNotifyError
+        ? TPromise.wrapError(error)
+        : this.onError(error, target, value);
+    }
+  );
 
 `;
 

--- a/tests/method-chain/comment.js
+++ b/tests/method-chain/comment.js
@@ -36,3 +36,9 @@ measure() // Warm-up first
 
 const configModel = this.baseConfigurationService.getCache().consolidated		// global/default values (do NOT modify)
   .merge(this.cachedWorkspaceConfig);
+
+this.doWriteConfiguration(target, value, options) // queue up writes to prevent race conditions
+  .then(() => null,
+  error => {
+    return options.donotNotifyError ? TPromise.wrapError(error) : this.onError(error, target, value);
+  });


### PR DESCRIPTION
I kept adding places where comments could be but more use cases kept creeping in. So now this is a holistical approach, we check all the comments that can be between two nodes. This way we should be good to go :)