### PR TITLE
Properly add parenthesis for as inside of binary expression

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -340,6 +340,10 @@ FPp.needsParens = function() {
 
         case "BinaryExpression":
         case "LogicalExpression": {
+          if (!node.operator) {
+            return true;
+          }
+
           const po = parent.operator;
           const pp = util.getPrecedence(po);
           const no = node.operator;

--- a/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
@@ -4,11 +4,17 @@ exports[`as.js 1`] = `
 const name = (description as DescriptionObject).name || (description as string);
 this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
 (originalError ? wrappedError(errMsg, originalError) : Error(errMsg)) as InjectionError;
+'current' in (props.pagination as Object)
+start + (yearSelectTotal as number)
+scrollTop > (visibilityHeight as number)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-const name = (description as DescriptionObject).name || description as string;
+const name = (description as DescriptionObject).name || (description as string);
 this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
 (originalError
   ? wrappedError(errMsg, originalError)
   : Error(errMsg)) as InjectionError;
+"current" in (props.pagination as Object);
+start + (yearSelectTotal as number);
+scrollTop > (visibilityHeight as number);
 
 `;

--- a/tests/typescript_as/as.js
+++ b/tests/typescript_as/as.js
@@ -1,3 +1,6 @@
 const name = (description as DescriptionObject).name || (description as string);
 this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
 (originalError ? wrappedError(errMsg, originalError) : Error(errMsg)) as InjectionError;
+'current' in (props.pagination as Object)
+start + (yearSelectTotal as number)
+scrollTop > (visibilityHeight as number)


### PR DESCRIPTION
The binary logic doesn't work if the node isn't a binary or logical expression