### PR TITLE
Add parenthesis for as inside of class extends

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -326,6 +326,8 @@ FPp.needsParens = function() {
         case "NewExpression":
           return name === "callee" && parent.callee === node;
 
+        case "ClassDeclaration":
+          return name === "superClass" && parent.superClass === node;
         case "TSTypeAssertionExpression":
         case "TaggedTemplateExpression":
         case "UnaryExpression":

--- a/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
@@ -7,6 +7,7 @@ this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
 'current' in (props.pagination as Object)
 start + (yearSelectTotal as number)
 scrollTop > (visibilityHeight as number)
+export default class Column<T> extends (RcTable.Column as React.ComponentClass<ColumnProps<T>>) {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const name = (description as DescriptionObject).name || (description as string);
 this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
@@ -16,5 +17,7 @@ this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
 "current" in (props.pagination as Object);
 start + (yearSelectTotal as number);
 scrollTop > (visibilityHeight as number);
+export default class Column<T>
+  extends (RcTable.Column as React.ComponentClass<ColumnProps<T>>) {}
 
 `;

--- a/tests/typescript_as/as.js
+++ b/tests/typescript_as/as.js
@@ -4,3 +4,4 @@ this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
 'current' in (props.pagination as Object)
 start + (yearSelectTotal as number)
 scrollTop > (visibilityHeight as number)
+export default class Column<T> extends (RcTable.Column as React.ComponentClass<ColumnProps<T>>) {}


### PR DESCRIPTION
Looks like we didn't properly support it for all the binary operators :p