### PR TITLE
Extract contributing guide into separate document

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to Prettier
+
+To get up and running, install the dependencies and run the tests:
+
+```
+yarn
+yarn lint
+yarn test
+```
+
+Here's what you need to know about the tests:
+
+* The tests uses [Jest](https://facebook.github.io/jest/) snapshots.
+* You can make changes and run `jest -u` (or `yarn test -- -u`) to update the
+  snapshots. Then run `git diff` to take a look at what changed. Always update
+  the snapshots when opening a PR.
+* You can run `AST_COMPARE=1 jest` for a more robust test run. That formats each
+  file, re-parses it, and compares the new AST with the original one and makes
+  sure they are semantically equivalent.
+* Each test folder has a `jsfmt.spec.js` that runs the tests. Normally you can
+  just put `run_spec(__dirname);` there. You can also pass options and
+  additional parsers, like this:
+  `run_spec(__dirname, { trailingComma: "es5" }, ["babylon"]);`
+* `tests/flow/` contains the Flow test suite, and is not supposed to be edited
+  by hand. To update it, clone the Flow repo next to the Prettier repo and run:
+  `node scripts/sync-flow-tests.js ../flow/tests/`.
+* If you would like to debug prettier locally, you can either debug it in node
+  or the browser. The easiest way to debug it in the browser is to run the
+  interactive `docs` REPL locally. The easiest way to debug it in node, is to
+  create a local test file and run it in an editor like VS Code.
+
+Run `yarn lint -- --fix` to automatically format files.
+
+If you can, take look at [commands.md](commands.md) and check out [Wadler's
+paper](http://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf) to
+understand how Prettier works.

--- a/README.md
+++ b/README.md
@@ -456,37 +456,4 @@ Show the world you're using *Prettier* → [![styled with prettier](https://img.
 
 ## Contributing
 
-To get up and running, install the dependencies and run the tests:
-
-```
-yarn
-yarn lint
-yarn test
-```
-
-Here's what you need to know about the tests:
-
-* The tests uses [Jest](https://facebook.github.io/jest/) snapshots.
-* You can make changes and run `jest -u` (or `yarn test -- -u`) to update the
-  snapshots. Then run `git diff` to take a look at what changed. Always update
-  the snapshots when opening a PR.
-* You can run `AST_COMPARE=1 jest` for a more robust test run. That formats each
-  file, re-parses it, and compares the new AST with the original one and makes
-  sure they are semantically equivalent.
-* Each test folder has a `jsfmt.spec.js` that runs the tests. Normally you can
-  just put `run_spec(__dirname);` there. You can also pass options and
-  additional parsers, like this:
-  `run_spec(__dirname, { trailingComma: "es5" }, ["babylon"]);`
-* `tests/flow/` contains the Flow test suite, and is not supposed to be edited
-  by hand. To update it, clone the Flow repo next to the Prettier repo and run:
-  `node scripts/sync-flow-tests.js ../flow/tests/`.
-* If you would like to debug prettier locally, you can either debug it in node
-  or the browser. The easiest way to debug it in the browser is to run the
-  interactive `docs` REPL locally. The easiest way to debug it in node, is to
-  create a local test file and run it in an editor like VS Code.
-
-Run `yarn lint -- --fix` to automatically format files.
-
-If you can, take look at [commands.md](commands.md) and check out [Wadler's
-paper](http://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf) to
-understand how Prettier works.
+See [CONTRIBUTING.md](CONTRIBUTING.md).


### PR DESCRIPTION
It's easier to find it this way, and it's pretty popular convention to have a `CONTRIBUTING.md` file in repo root.