### PR TITLE
[WIP] fix comment printing in decorators

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -52,6 +52,10 @@ function getSortedChildNodes(node, text, resultArray) {
     names = Object.keys(node);
   } else if (isObject.check(node)) {
     names = types.getFieldNames(node);
+
+    if (node.decorators) {
+      names.push("decorators");
+    }
   } else {
     return;
   }
@@ -161,6 +165,7 @@ function attach(comments, ast, text) {
           comment
         ) ||
         handleTryStatementComments(enclosingNode, followingNode, comment) ||
+        handleDecoratorComments(enclosingNode, comment) ||
         handleClassComments(enclosingNode, comment) ||
         handleImportSpecifierComments(enclosingNode, comment) ||
         handleObjectPropertyComments(enclosingNode, comment) ||
@@ -603,6 +608,21 @@ function handleLastFunctionArgComments(
     return true;
   }
   return false;
+}
+
+function handleDecoratorComments(enclosingNode, comment) {
+  if (
+    enclosingNode &&
+    enclosingNode.type === "ClassDeclaration" &&
+    enclosingNode.decorators &&
+    enclosingNode.decorators.length
+  ) {
+    addTrailingComment(
+      enclosingNode.decorators[enclosingNode.decorators.length - 1],
+      comment
+    );
+    return true;
+  }
 }
 
 function handleClassComments(enclosingNode, comment) {

--- a/src/printer.js
+++ b/src/printer.js
@@ -97,6 +97,7 @@ function genericPrint(path, options, printPath, args) {
       }
 
       if (
+        node.type !== "ClassDeclaration" &&
         node.decorators.length === 1 &&
         (decorator.type === "Identifier" ||
           decorator.type === "MemberExpression")

--- a/tests/decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators/__snapshots__/jsfmt.spec.js.snap
@@ -22,7 +22,8 @@ import {observable} from "mobx";
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import { observable } from "mobx";
 
-@observer class OrderLine {
+@observer
+class OrderLine {
   @observable price: number = 0;
   @observable amount: number = 1;
 

--- a/tests/typescript_decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_decorators/__snapshots__/jsfmt.spec.js.snap
@@ -11,6 +11,19 @@ export class TestTextFileService {
 @commonEditorContribution
 export class TabCompletionController {
 }
+
+@Decorarte
+class Foo {}
+
+@AutoSubscribeStore
+//store in resub, is a class extends from StoreBase.
+class HelloStore extends StoreBase {
+    @autoSubscribe
+    // this method should return a string type
+    getHello():string {
+        return this._helloString;
+    }
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 export class TestTextFileService {
   constructor(@ILifecycleService lifecycleService) {}
@@ -18,5 +31,17 @@ export class TestTextFileService {
 
 @commonEditorContribution
 export class TabCompletionController {}
+
+@Decorarte
+class Foo {}
+
+@AutoSubscribeStore
+//store in resub, is a class extends from StoreBase.
+class HelloStore extends StoreBase {
+  @autoSubscribe // this method should return a string type
+  getHello(): string {
+    return this._helloString;
+  }
+}
 
 `;

--- a/tests/typescript_decorators/decorators.js
+++ b/tests/typescript_decorators/decorators.js
@@ -8,3 +8,16 @@ export class TestTextFileService {
 @commonEditorContribution
 export class TabCompletionController {
 }
+
+@Decorarte
+class Foo {}
+
+@AutoSubscribeStore
+//store in resub, is a class extends from StoreBase.
+class HelloStore extends StoreBase {
+    @autoSubscribe
+    // this method should return a string type
+    getHello():string {
+        return this._helloString;
+    }
+}


### PR DESCRIPTION
fix #1460 

This still needs some work. The hack in `getSortedChildNodes` needs to be fixed properly, probably in `ast-types` or via forking.

This also still fails for things like: 

```ts
@AutoSubscribeStore
//store in resub, is a class extends from StoreBase.
class HelloStore extends StoreBase {
    getHello():string {
        return this._helloString;
    }
}
```
:arrow_down: 
```ts
@AutoSubscribeStore
@SomeOtherMagic
//store in resub, is a class extends from StoreBase.
// apply differnet magic
class HelloStore extends StoreBase {
  getHello(): string {
    return this._helloString;
  }
}
```