### PR TITLE
Fix empty lines with comments between switch cases

### DIFF
--- a/tests/switch/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/switch/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`comments.js 1`] = `
+switch (true) {
+  case true:
+  // Good luck getting here
+
+  case false:
+}
+
+switch (true) {
+  case true:
+
+  // Good luck getting here
+  case false:
+}
+
+switch(x) {
+  case x: {
+  }
+
+  // other
+
+  case y: {
+  }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+switch (true) {
+  case true:
+  // Good luck getting here
+
+  case false:
+}
+
+switch (true) {
+  case true:
+
+  // Good luck getting here
+  case false:
+}
+
+switch (x) {
+  case x: {
+  }
+
+  // other
+
+  case y: {
+  }
+}
+
+`;
+
 exports[`empty_lines.js 1`] = `
 switch (foo) {
   case "bar":

--- a/tests/switch/comments.js
+++ b/tests/switch/comments.js
@@ -1,0 +1,23 @@
+switch (true) {
+  case true:
+  // Good luck getting here
+
+  case false:
+}
+
+switch (true) {
+  case true:
+
+  // Good luck getting here
+  case false:
+}
+
+switch(x) {
+  case x: {
+  }
+
+  // other
+
+  case y: {
+  }
+}


### PR DESCRIPTION
The function isPreviousLineEmpty comment doesn't skip comments (on purpose, see comment above that method :P) so the detection is messed up. Turns out, it's easier to just use isNextLineEmpty like everywhere else.

Fixes #1708