### PR TITLE
[RFC] Add `astTransform` option

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -36,7 +36,7 @@ const argv = minimist(process.argv.slice(2), {
     "flow-parser"
   ],
   string: [
-    "ast-transform",
+    "transform",
     "print-width",
     "tab-width",
     "parser",
@@ -148,8 +148,8 @@ function getTrailingComma() {
 
 const r = require;
 const options = {
-  astTransform: argv["ast-transform"] &&
-    r(path.resolve(process.cwd(), argv["ast-transform"])),
+  transform: argv["transform"] &&
+    r(path.resolve(process.cwd(), argv["transform"])),
   rangeStart: getIntOption("range-start"),
   rangeEnd: getIntOption("range-end"),
   useTabs: argv["use-tabs"],

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -146,9 +146,10 @@ function getTrailingComma() {
   }
 }
 
+const r = require;
 const options = {
   astTransform: argv["ast-transform"] &&
-    require(path.resolve(process.cwd(), argv["ast-transform"])),
+    r(path.resolve(process.cwd(), argv["ast-transform"])),
   rangeStart: getIntOption("range-start"),
   rangeEnd: getIntOption("range-end"),
   useTabs: argv["use-tabs"],

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -36,6 +36,7 @@ const argv = minimist(process.argv.slice(2), {
     "flow-parser"
   ],
   string: [
+    "ast-transform",
     "print-width",
     "tab-width",
     "parser",
@@ -146,6 +147,8 @@ function getTrailingComma() {
 }
 
 const options = {
+  astTransform: argv["ast-transform"] &&
+    require(path.resolve(process.cwd(), argv["ast-transform"])),
   rangeStart: getIntOption("range-start"),
   rangeEnd: getIntOption("range-end"),
   useTabs: argv["use-tabs"],

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function ensureAllCommentsPrinted(astComments) {
 function format(text, opts, addAlignmentSize) {
   addAlignmentSize = addAlignmentSize || 0;
 
-  const ast = parser.parse(text, opts);
+  const ast = opts.astTransform(parser.parse(text, opts));
 
   const formattedRangeOnly = formatRange(text, opts, ast);
   if (formattedRangeOnly) {

--- a/index.js
+++ b/index.js
@@ -52,7 +52,7 @@ function ensureAllCommentsPrinted(astComments) {
 function format(text, opts, addAlignmentSize) {
   addAlignmentSize = addAlignmentSize || 0;
 
-  const ast = opts.astTransform(parser.parse(text, opts));
+  const ast = opts.transform(parser.parse(text, opts));
 
   const formattedRangeOnly = formatRange(text, opts, ast);
   if (formattedRangeOnly) {

--- a/src/options.js
+++ b/src/options.js
@@ -4,6 +4,7 @@ const validate = require("jest-validate").validate;
 const deprecatedConfig = require("./deprecated");
 
 const defaults = {
+  astTransform: ast => ast,
   rangeStart: 0,
   rangeEnd: Infinity,
   useTabs: false,

--- a/src/options.js
+++ b/src/options.js
@@ -4,7 +4,7 @@ const validate = require("jest-validate").validate;
 const deprecatedConfig = require("./deprecated");
 
 const defaults = {
-  astTransform: ast => ast,
+  transform: ast => ast,
   rangeStart: 0,
   rangeEnd: Infinity,
   useTabs: false,


### PR DESCRIPTION
This doesn't have tests yet, but I wanted to get some feedback on the
API before fleshing it out further.

---

As suggested in https://github.com/prettier/prettier/issues/1684#issuecomment-303547552 (also relevant to https://github.com/prettier/prettier/issues/1020),
this adds a way for users to transform their AST before formatting,
without having to do so as a separate step before `prettier`. They
simply provide a function that takes an AST and returns an AST.

For example:

```js
require("./").format("// this won't show up in the output", {
  astTransform: () => require("./src/parser").parse("0", { parser: "babylon" })
});
```

The option is also available in the CLI, by specifying a path (resolved
relative to the current working directory) to a module that exports the
transform function. For example, given `transform.js` containing:

```js
module.exports = () =>
  require("./src/parser").parse("0", { parser: "babylon" });
```

the following is equivalent to the API example above:

```bash
echo "// this won't show up in the output" | ./bin/prettier.js --stdin --ast-transform transform.js
```