### PR TITLE
Add .flowconfig

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,3 @@
+[ignore]
+.*/tests/.*
+.*/node_modules/.*


### PR DESCRIPTION
I have no intention of using flow to type prettier but adding this file makes Nuclide run flow and get jump to definition and some datatips for what it can infer.