### PR TITLE
Fix comments inside of template literals

### DIFF
--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1245,13 +1245,15 @@ d //comment
 \`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 \`
-\${a /* comment*/}
+\${a // comment
+}
 
 \${b /* comment */}
 
-\${c /* comment */ /* comment */}
+\${/* comment */ c /* comment */}
 
-\${d /*comment*/ // comment
+\${// comment
+d //comment
 };
 \`;
 

--- a/tests/line_suffix_boundary/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/line_suffix_boundary/__snapshots__/jsfmt.spec.js.snap
@@ -29,17 +29,19 @@ ExampleStory.getFragment('story')}
 \`\${a + a // a
 }
 
-\${a /* comment*/}
+\${a // comment
+}
 
 \${b /* comment */}
 
-\${c /* comment */ /* comment */}
+\${/* comment */ c /* comment */}
 
-\${d /*comment*/ // comment
+\${// comment
+d //comment
 }
 
-\${ExampleStory.getFragment("story") // $FlowFixMe found when converting React.createClass to ES6
-}
+\${// $FlowFixMe found when converting React.createClass to ES6
+ExampleStory.getFragment("story")}
 \`;
 
 <div>

--- a/tests/template/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/template/__snapshots__/jsfmt.spec.js.snap
@@ -53,17 +53,17 @@ g
 }\`;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 \`
-(?:\${escapeChar}[\\\\S\\\\s]|(?:(?!\${XRegExp.union([left, right], "", {
-  conjunction: "or"
-}).source // Using \`XRegExp.union\` safely rewrites backreferences in \`left\` and \`right\`.
+(?:\${escapeChar}[\\\\S\\\\s]|(?:(?!\${// Using \`XRegExp.union\` safely rewrites backreferences in \`left\` and \`right\`.
 // Intentionally not passing \`basicFlags\` to \`XRegExp.union\` since any syntax
 // transformation resulting from those flags was already applied to \`left\` and
 // \`right\` when they were passed through the XRegExp constructor above.
-})[^\${escapeChar}])+)+
+XRegExp.union([left, right], "", { conjunction: "or" })
+  .source})[^\${escapeChar}])+)+
 \`;
 
-\`a\${c /* b */ /* d */}e\${g // f
-/* h*/
+\`a\${/* b */ c /* d */}e\${// f
+g
+// h
 }\`;
 
 `;


### PR DESCRIPTION
We completely butcher comments inside of template literals. The fix is to not be able to attach comments to TemplateElement nodes and to avoid comments that are in one expression to be moved to another expression. We now have the boundary to prevent outputting invalid code.

Fixes #1617