### PR TITLE
Ignore docs/prettier.min.js when searching with ag/ripgrep/sift

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,1 @@
+docs/prettier.min.js


### PR DESCRIPTION
This makes it easier to search through the code without getting
irrelevant results. It uses a .ignore file in order to cover at least
the three tools mentioned in the title. See the discussion here:

https://news.ycombinator.com/item?id=12568822