### PR TITLE
Pass entire text through formatWithShebang() to format()

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,11 +235,10 @@ function formatWithShebang(text, opts) {
 
   const index = text.indexOf("\n");
   const shebang = text.slice(0, index + 1);
-  const programText = text.slice(index + 1);
   const nextChar = text.charAt(index + 1);
   const newLine = nextChar === "\n" ? "\n" : nextChar === "\r" ? "\r\n" : "";
 
-  return shebang + newLine + format(programText, opts);
+  return shebang + newLine + format(text, opts);
 }
 
 module.exports = {

--- a/src/comments.js
+++ b/src/comments.js
@@ -802,8 +802,9 @@ function printComment(commentPath, options) {
     case "CommentLine":
     case "Line":
       // Don't print the shebang, it's taken care of in index.js
-      if (options.originalText.slice(util.locStart(comment)).startsWith("#!"))
+      if (options.originalText.slice(util.locStart(comment)).startsWith("#!")) {
         return "";
+      }
       return "//" + comment.value;
     default:
       throw new Error("Not a comment: " + JSON.stringify(comment));

--- a/tests/shebang/jsfmt.spec.js
+++ b/tests/shebang/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, null, ["typescript"]);
+run_spec(__dirname, null, ["typescript", "babylon"]);


### PR DESCRIPTION
That way, we won't have to do any arithmetic on range and cursor locations
when there is a shebang. See here for details:
                                                                           
https://github.com/prettier/prettier/pull/1637#issuecomment-303846507
                                                                           
This required changing comment printing such that comments that are
actually shebangs are just ignored.