### PR TITLE
Use expandLast for nested arrow functions

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -402,7 +402,7 @@ function genericPrintNoParens(path, options, print, args) {
 
       parts.push(" =>");
 
-      const body = path.call(print, "body");
+      const body = path.call(bodyPath => print(bodyPath, args), "body");
       const collapsed = concat([concat(parts), " ", body]);
 
       // We want to always keep these types of nodes on the same line

--- a/tests/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -154,6 +154,10 @@ jest.mock(
     }
   },
 );
+
+fooooooooooooooooooooooooooooooooooooooooooooooooooo(action => next =>
+    dispatch(action),
+);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Seq(typeDef.interface.groups).forEach(group =>
   Seq(group.members).forEach((member, memberName) =>
@@ -235,6 +239,10 @@ jest.mock(
         return { paths: [] };
       }
     }
+);
+
+fooooooooooooooooooooooooooooooooooooooooooooooooooo(action => next =>
+  dispatch(action)
 );
 
 `;

--- a/tests/arrows/call.js
+++ b/tests/arrows/call.js
@@ -74,3 +74,7 @@ jest.mock(
     }
   },
 );
+
+fooooooooooooooooooooooooooooooooooooooooooooooooooo(action => next =>
+    dispatch(action),
+);


### PR DESCRIPTION
We don't always want to automatically forward this option but we can always forward it to `n.body`. If it's an arrow function, it's doing the intended behavior, otherwise, it's not going to ignore it and not forward it. What we don't want is for arrow -> blockStatement -> arrow to get it, but we're good.

Fixes #1652