### PR TITLE
Force \n for multiple variable declarations

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1134,11 +1134,19 @@ function genericPrintNoParens(path, options, print, args) {
         return print(childPath);
       }, "declarations");
 
+      const hasValue = n.declarations.some(decl => decl.init);
+
       parts = [
         isNodeStartingWithDeclare(n, options) ? "declare " : "",
         n.kind,
         printed.length ? concat([" ", printed[0]]) : "",
-        indent(concat(printed.slice(1).map(p => concat([",", line, p]))))
+        indent(
+          concat(
+            printed
+              .slice(1)
+              .map(p => concat([",", hasValue ? hardline : line, p]))
+          )
+        )
       ];
 
       // We generally want to terminate all variable declarations with a

--- a/tests/flow/es6modules/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/es6modules/__snapshots__/jsfmt.spec.js.snap
@@ -473,7 +473,8 @@ export var numberValue1 = 1, numberValue2 = 2;
  * @flow
  */
 
-export var numberValue1 = 1, numberValue2 = 2;
+export var numberValue1 = 1,
+  numberValue2 = 2;
 
 `;
 
@@ -490,7 +491,8 @@ export var numberValue1 = 1, numberValue2 = 2;
  * @flow
  */
 
-export var numberValue1 = 1, numberValue2 = 2;
+export var numberValue1 = 1,
+  numberValue2 = 2;
 
 `;
 
@@ -543,7 +545,8 @@ export class NumberGenerator {
   }
 }
 
-export var varDeclNumber1 = 1, varDeclNumber2 = 2;
+export var varDeclNumber1 = 1,
+  varDeclNumber2 = 2;
 export var { destructuredObjNumber } = { destructuredObjNumber: 1 };
 export var [destructuredArrNumber] = [1];
 
@@ -594,7 +597,8 @@ export class NumberGenerator2 {
   }
 }
 
-export var varDeclNumber3 = 1, varDeclNumber4 = 2;
+export var varDeclNumber3 = 1,
+  varDeclNumber4 = 2;
 export var { destructuredObjNumber2 } = { destructuredObjNumber2: 1 };
 export var [destructuredArrNumber2] = [1];
 

--- a/tests/flow/unreachable/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/unreachable/__snapshots__/jsfmt.spec.js.snap
@@ -100,7 +100,10 @@ function foo(x, y) {
   var x, y, z;
 
   // assignments are not hoisted, should generate 2 warnings
-  var t, u = 5, v, w = 7;
+  var t,
+    u = 5,
+    v,
+    w = 7;
 }
 
 foo(1, 2);

--- a/tests/variable_declarator/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/variable_declarator/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`multiple.js 1`] = `
+var assert = require('assert'),
+  lookup = require('../lookup');
+
+const eloBar     = require("elo-bar")
+  , foo        = require("foo")
+  , otherThing = require("other-thing");
+
+var a, b, c;
+
+let superSuperSuperLong1, superSuperSuperLong2, superSuperSuperLong3, superSuperSuperLong4;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+var assert = require("assert"),
+  lookup = require("../lookup");
+
+const eloBar = require("elo-bar"),
+  foo = require("foo"),
+  otherThing = require("other-thing");
+
+var a, b, c;
+
+let superSuperSuperLong1,
+  superSuperSuperLong2,
+  superSuperSuperLong3,
+  superSuperSuperLong4;
+
+`;
+
 exports[`string.js 1`] = `
 elements[0].innerHTML = '<div></div><div></div><div></div><div></div><div></div><div></div>';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/variable_declarator/multiple.js
+++ b/tests/variable_declarator/multiple.js
@@ -1,0 +1,10 @@
+var assert = require('assert'),
+  lookup = require('../lookup');
+
+const eloBar     = require("elo-bar")
+  , foo        = require("foo")
+  , otherThing = require("other-thing");
+
+var a, b, c;
+
+let superSuperSuperLong1, superSuperSuperLong2, superSuperSuperLong3, superSuperSuperLong4;


### PR DESCRIPTION
This keeps being requested and we're not using it at Facebook, so I don't particularly care which way it should be printed. We now force multiline if there's at least one declaration with a value. We don't want to break all the variables that are just declared.

Fixes #1607