### PR TITLE
Inline import type

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -581,8 +581,6 @@ function genericPrintNoParens(path, options, print, args) {
     case "ImportDeclaration": {
       parts.push("import ");
 
-      const fromParts = [];
-
       if (n.importKind && n.importKind !== "value") {
         parts.push(n.importKind + " ");
       }
@@ -610,7 +608,21 @@ function genericPrintNoParens(path, options, print, args) {
           parts.push(", ");
         }
 
-        if (grouped.length > 0) {
+        if (
+          grouped.length === 1 &&
+          n.specifiers &&
+          !n.specifiers.some(node => node.comments)
+        ) {
+          parts.push(
+            concat([
+              "{",
+              options.bracketSpacing ? " " : "",
+              concat(grouped),
+              options.bracketSpacing ? " " : "",
+              "}"
+            ])
+          );
+        } else if (grouped.length >= 1) {
           parts.push(
             group(
               concat([
@@ -629,25 +641,14 @@ function genericPrintNoParens(path, options, print, args) {
           );
         }
 
-        fromParts.push(grouped.length === 0 ? line : " ", "from ");
+        parts.push(" ", "from ");
       } else if (n.importKind && n.importKind === "type") {
         parts.push("{} from ");
       }
 
-      fromParts.push(path.call(print, "source"), semi);
+      parts.push(path.call(print, "source"), semi);
 
-      // If there's a very long import, break the following way:
-      //
-      //   import veryLong
-      //     from 'verylong'
-      //
-      // In case there are grouped elements, they will already break the way
-      // we want and this break would take precedence instead.
-      if (grouped.length === 0) {
-        return group(concat([concat(parts), indent(concat(fromParts))]));
-      }
-
-      return concat([concat(parts), concat(fromParts)]);
+      return concat(parts);
     }
 
     case "Import":

--- a/tests/flow_import_type_specifier/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_import_type_specifier/__snapshots__/jsfmt.spec.js.snap
@@ -7,6 +7,9 @@ exports[`test.js 1`] = `
 
 import { Foo, type Baz } from "../module";
 import type {} from 'foo';
+
+import type {somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import type {a, somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /**
  * @flow
@@ -14,5 +17,11 @@ import type {} from 'foo';
 
 import { Foo, type Baz } from "../module";
 import type {} from "foo";
+
+import type { somethingSuperLongsomethingSuperLong } from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
+import type {
+  a,
+  somethingSuperLongsomethingSuperLong
+} from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
 
 `;

--- a/tests/flow_import_type_specifier/test.js
+++ b/tests/flow_import_type_specifier/test.js
@@ -4,3 +4,6 @@
 
 import { Foo, type Baz } from "../module";
 import type {} from 'foo';
+
+import type {somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import type {a, somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'

--- a/tests/import/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/import/__snapshots__/jsfmt.spec.js.snap
@@ -228,19 +228,49 @@ import {
 
 `;
 
+exports[`inline.js 1`] = `
+import somethingSuperLongsomethingSuperLong from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import {somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import a, {somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import {a, somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import somethingSuperLongsomethingSuperLong from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
+import { somethingSuperLongsomethingSuperLong } from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
+import a, { somethingSuperLongsomethingSuperLong } from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
+import {
+  a,
+  somethingSuperLongsomethingSuperLong
+} from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
+
+`;
+
+exports[`inline.js 2`] = `
+import somethingSuperLongsomethingSuperLong from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import {somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import a, {somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import {a, somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import somethingSuperLongsomethingSuperLong from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
+import {somethingSuperLongsomethingSuperLong} from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
+import a, {somethingSuperLongsomethingSuperLong} from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
+import {
+  a,
+  somethingSuperLongsomethingSuperLong
+} from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
+
+`;
+
 exports[`long-line.js 1`] = `
 import someCoolUtilWithARatherLongName from '../../../../utils/someCoolUtilWithARatherLongName';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-import someCoolUtilWithARatherLongName
-  from "../../../../utils/someCoolUtilWithARatherLongName";
+import someCoolUtilWithARatherLongName from "../../../../utils/someCoolUtilWithARatherLongName";
 
 `;
 
 exports[`long-line.js 2`] = `
 import someCoolUtilWithARatherLongName from '../../../../utils/someCoolUtilWithARatherLongName';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-import someCoolUtilWithARatherLongName
-  from "../../../../utils/someCoolUtilWithARatherLongName";
+import someCoolUtilWithARatherLongName from "../../../../utils/someCoolUtilWithARatherLongName";
 
 `;
 

--- a/tests/import/inline.js
+++ b/tests/import/inline.js
@@ -1,0 +1,4 @@
+import somethingSuperLongsomethingSuperLong from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import {somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import a, {somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import {a, somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'


### PR DESCRIPTION
A long time ago I introduced the ability to break for import statements. Then, later on, we removed the ability for require to break and go over the 80 column mark. In order to be consistent, we should do the same for import statements as well.