### PR TITLE
Break on implements instead of extends

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3371,21 +3371,20 @@ function printClass(path, options, print) {
 
   const partsGroup = [];
   if (n.superClass) {
-    partsGroup.push(
-      line,
-      "extends ",
+    parts.push(
+      " extends ",
       path.call(print, "superClass"),
       path.call(print, "superTypeParameters")
     );
   } else if (n.extends && n.extends.length > 0) {
-    partsGroup.push(line, "extends ", join(", ", path.map(print, "extends")));
+    parts.push(" extends ", join(", ", path.map(print, "extends")));
   }
 
   if (n["implements"] && n["implements"].length > 0) {
     partsGroup.push(
       line,
       "implements ",
-      join(", ", path.map(print, "implements"))
+      indent(join(concat([",", line]), path.map(print, "implements")))
     );
   }
 

--- a/tests/classes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/classes/__snapshots__/jsfmt.spec.js.snap
@@ -17,11 +17,61 @@ exports[`break.js 1`] = `
 class MyContractSelectionWidget extends React.Component<void,  MyContractSelectionWidgetPropsType, void> implements SomethingLarge {
   method() {}
 }
+
+class DisplayObject
+  extends utils.EventEmitter
+  implements interaction_InteractiveTarget {
+}
+
+class DisplayObject extends utils.EventEmitter
+  implements interaction_InteractiveTarget {
+}
+
+class DisplayObject extends utils.EventEmitter
+  implements interaction_InteractiveTarget,
+    somethingElse_SomeOtherThing,
+    somethingElseAgain_RunningOutOfNames {
+}
+
+class DisplayObject extends utils.EventEmitter implements interaction_InteractiveTarget {}
+class Readable extends events.EventEmitter implements NodeJS_ReadableStream {}
+class InMemoryAppender extends log4javascript.Appender implements ICachedLogMessageProvider {}
+
+class Foo extends Immutable.Record({
+  ipaddress: '',
+}) {
+  ipaddress: string;
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-class MyContractSelectionWidget
-  extends React.Component<void, MyContractSelectionWidgetPropsType, void>
-  implements SomethingLarge {
+class MyContractSelectionWidget extends React.Component<
+  void,
+  MyContractSelectionWidgetPropsType,
+  void
+> implements SomethingLarge {
   method() {}
+}
+
+class DisplayObject extends utils.EventEmitter
+  implements interaction_InteractiveTarget {}
+
+class DisplayObject extends utils.EventEmitter
+  implements interaction_InteractiveTarget {}
+
+class DisplayObject extends utils.EventEmitter
+  implements interaction_InteractiveTarget,
+    somethingElse_SomeOtherThing,
+    somethingElseAgain_RunningOutOfNames {}
+
+class DisplayObject extends utils.EventEmitter
+  implements interaction_InteractiveTarget {}
+class Readable extends events.EventEmitter implements NodeJS_ReadableStream {}
+class InMemoryAppender extends log4javascript.Appender
+  implements ICachedLogMessageProvider {}
+
+class Foo extends Immutable.Record({
+  ipaddress: ""
+}) {
+  ipaddress: string;
 }
 
 `;

--- a/tests/classes/break.js
+++ b/tests/classes/break.js
@@ -1,3 +1,28 @@
 class MyContractSelectionWidget extends React.Component<void,  MyContractSelectionWidgetPropsType, void> implements SomethingLarge {
   method() {}
 }
+
+class DisplayObject
+  extends utils.EventEmitter
+  implements interaction_InteractiveTarget {
+}
+
+class DisplayObject extends utils.EventEmitter
+  implements interaction_InteractiveTarget {
+}
+
+class DisplayObject extends utils.EventEmitter
+  implements interaction_InteractiveTarget,
+    somethingElse_SomeOtherThing,
+    somethingElseAgain_RunningOutOfNames {
+}
+
+class DisplayObject extends utils.EventEmitter implements interaction_InteractiveTarget {}
+class Readable extends events.EventEmitter implements NodeJS_ReadableStream {}
+class InMemoryAppender extends log4javascript.Appender implements ICachedLogMessageProvider {}
+
+class Foo extends Immutable.Record({
+  ipaddress: '',
+}) {
+  ipaddress: string;
+}

--- a/tests/flow/union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/union/__snapshots__/jsfmt.spec.js.snap
@@ -71,20 +71,30 @@ export class BinaryExpression<
 
 export type ArithmeticExpression = PlusOp | MinusOp | MulOp | DivOp | ModOp;
 
-export class PlusOp
-  extends BinaryExpression<ArithmeticExpression, ArithmeticExpression> {}
+export class PlusOp extends BinaryExpression<
+  ArithmeticExpression,
+  ArithmeticExpression
+> {}
 
-export class MinusOp
-  extends BinaryExpression<ArithmeticExpression, ArithmeticExpression> {}
+export class MinusOp extends BinaryExpression<
+  ArithmeticExpression,
+  ArithmeticExpression
+> {}
 
-export class MulOp
-  extends BinaryExpression<ArithmeticExpression, ArithmeticExpression> {}
+export class MulOp extends BinaryExpression<
+  ArithmeticExpression,
+  ArithmeticExpression
+> {}
 
-export class DivOp
-  extends BinaryExpression<ArithmeticExpression, ArithmeticExpression> {}
+export class DivOp extends BinaryExpression<
+  ArithmeticExpression,
+  ArithmeticExpression
+> {}
 
-export class ModOp
-  extends BinaryExpression<ArithmeticExpression, ArithmeticExpression> {}
+export class ModOp extends BinaryExpression<
+  ArithmeticExpression,
+  ArithmeticExpression
+> {}
 
 `;
 

--- a/tests/interface/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/interface/__snapshots__/jsfmt.spec.js.snap
@@ -20,8 +20,11 @@ export interface Environment1
   extends GenericEnvironment<SomeType, AnotherType, YetAnotherType> {
   m(): void
 }
-export class Environment2
-  extends GenericEnvironment<SomeType, AnotherType, YetAnotherType> {
+export class Environment2 extends GenericEnvironment<
+  SomeType,
+  AnotherType,
+  YetAnotherType
+> {
   m() {}
 }
 

--- a/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
@@ -17,7 +17,8 @@ this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
 "current" in (props.pagination as Object);
 start + (yearSelectTotal as number);
 scrollTop > (visibilityHeight as number);
-export default class Column<T>
-  extends (RcTable.Column as React.ComponentClass<ColumnProps<T>>) {}
+export default class Column<T> extends (RcTable.Column as React.ComponentClass<
+  ColumnProps<T>
+>) {}
 
 `;


### PR DESCRIPTION
There can often be something that breaks inside of `extends` so it's looking weird to break twice. It now only breaks on `implements` and make sure to put each element on its own line.

Fixes #1520