### PR TITLE
Inline | null and | void

### DIFF
--- a/tests/flow_union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_union/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,32 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`union.js 1`] = `
+interface RelayProps {
+  articles: Array<{
+    __id: string,
+  } | null> | null | void | 1,
+}
+
+interface RelayProps {
+  articles: Array<{
+    __id: string,
+  } | null> | null | void,
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+interface RelayProps {
+  articles:
+    | Array<{
+        __id: string
+      } | null>
+    | null
+    | void
+    | 1
+}
+
+interface RelayProps {
+  articles: Array<{
+    __id: string
+  } | null> | null | void
+}
+
+`;

--- a/tests/flow_union/jsfmt.spec.js
+++ b/tests/flow_union/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, null, ["babylon"]);

--- a/tests/flow_union/union.js
+++ b/tests/flow_union/union.js
@@ -1,0 +1,11 @@
+interface RelayProps {
+  articles: Array<{
+    __id: string,
+  } | null> | null | void | 1,
+}
+
+interface RelayProps {
+  articles: Array<{
+    __id: string,
+  } | null> | null | void,
+}


### PR DESCRIPTION
TypeScript doesn't have the concept of `?` for nullable options and instead you have to write `| null` and `| void`. This is annoying to have it use the long form, so we're now inlining them.

While working on this, I found out a few issues with the way we deal with those:
- We only align objects if the parent is a union. This means that if you have `Array<{ object }>`, the object is not aligned properly. The fix is to move the alignment logic to the union, and not the child.
- When doing so, it messes up with the comment alignment, so we have to manually handle children comment printing in the union code.

It doesn't yet fix #1727 because the hardcoded type names are different, i'll follow up in a PR.