### PR TITLE
Cleanup fast-path

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -164,10 +164,6 @@ function genericPrintNoParens(path, options, print, args) {
     return n;
   }
 
-  // TODO: Investigate types that return not printable.
-  // This assert isn't very useful though.
-  // namedTypes.Printable.assert(n);
-
   let parts = [];
   switch (n.type) {
     case "File":
@@ -4618,7 +4614,7 @@ function printAstToDoc(ast, options, addAlignmentSize) {
     );
   }
 
-  let doc = printGenerically(FastPath.from(ast));
+  let doc = printGenerically(new FastPath(ast));
   if (addAlignmentSize > 0) {
     // Add a hardline to make the indents take effect
     // It should be removed in index.js format()


### PR DESCRIPTION
- I want to get to a place where we don't use ast-types in order to do the traversal. This almost removes it from fast-path.
- Remove FastPath.from and copy
- Use .prototype instead of the weird Fpp
- Remove unused TODO
- Remove unused needsParen condition with a bunch of associated code