### PR TITLE
Remove ast-types from comments traversal

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -81,8 +81,9 @@ function parseWithBabylon(text) {
     ]
   };
 
+  let ast;
   try {
-    return babylon.parse(text, babylonOptions);
+    ast = babylon.parse(text, babylonOptions);
   } catch (originalError) {
     try {
       return babylon.parse(
@@ -93,21 +94,27 @@ function parseWithBabylon(text) {
       throw originalError;
     }
   }
+  delete ast.tokens;
+  return ast;
 }
 
 function parseWithTypeScript(text) {
   const jsx = isProbablyJsx(text);
+  let ast;
   try {
     try {
       // Try passing with our best guess first.
-      return tryParseTypeScript(text, jsx);
+      ast = tryParseTypeScript(text, jsx);
     } catch (e) {
       // But if we get it wrong, try the opposite.
-      return tryParseTypeScript(text, !jsx);
+      ast = tryParseTypeScript(text, !jsx);
     }
   } catch (e) {
     throw createError(e.message, e.lineNumber, e.column);
   }
+
+  delete ast.tokens;
+  return ast;
 }
 
 function tryParseTypeScript(text, jsx) {

--- a/tests/typescript/conformance/internalModules/importDeclarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/internalModules/importDeclarations/__snapshots__/jsfmt.spec.js.snap
@@ -146,8 +146,7 @@ namespace X {
 }
 
 namespace Z {
-
-// 'y' should be a fundule here
+  // 'y' should be a fundule here
   export import y = X.Y;
 }
 

--- a/tests/typescript/webhost/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/webhost/__snapshots__/jsfmt.spec.js.snap
@@ -108,18 +108,14 @@ namespace TypeScript.WebTsc {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /// <reference path='..\\..\\src\\compiler\\tsc.ts'/>
 
-namespace TypeScript /*text*/.WebTsc {
-// Load file and read the first two bytes into a string with no interpretation
-// Position must be at 0 before encoding can be changed
-// [0xFF,0xFE] and [0xFE,0xFF] mean utf-16 (little or big endian), otherwise default to utf-8
-// ReadText method always strips byte order mark from resulting string
+namespace TypeScript.WebTsc {
   declare var RealActiveXObject: { new (s: string): any };
 
   function getWScriptSystem() {
     const fso = new RealActiveXObject("Scripting.FileSystemObject");
 
     const fileStream = new ActiveXObject("ADODB.Stream");
-    fileStream.Type = 2;
+    fileStream.Type = 2 /*text*/;
 
     const args: string[] = [];
     for (let i = 0; i < WScript.Arguments.length; i++) {
@@ -144,16 +140,20 @@ namespace TypeScript /*text*/.WebTsc {
             fileStream.Charset = encoding;
             fileStream.LoadFromFile(fileName);
           } else {
+            // Load file and read the first two bytes into a string with no interpretation
             fileStream.Charset = "x-ansi";
             fileStream.LoadFromFile(fileName);
             const bom = fileStream.ReadText(2) || "";
+            // Position must be at 0 before encoding can be changed
             fileStream.Position = 0;
+            // [0xFF,0xFE] and [0xFE,0xFF] mean utf-16 (little or big endian), otherwise default to utf-8
             fileStream.Charset = bom.length >= 2 &&
               ((bom.charCodeAt(0) === 0xff && bom.charCodeAt(1) === 0xfe) ||
                 (bom.charCodeAt(0) === 0xfe && bom.charCodeAt(1) === 0xff))
               ? "unicode"
               : "utf-8";
           }
+          // ReadText method always strips byte order mark from resulting string
           return fileStream.ReadText();
         } catch (e) {
           throw e;


### PR DESCRIPTION
It's very annoying to have to have a static definition of the ast, we should instead just traverse the objects to discover it. We just need to make sure not to have any cycles, but it's also good for debugging anyway.

This fixed a few comments already :)