### PR TITLE
Also add the stack for postcss errors

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -341,7 +341,7 @@ function parseWithPostCSS(text) {
     return parsedResult;
   } catch (e) {
     if (typeof e.line !== "number") {
-      throw e;
+      throw e.stack;
     }
     throw createError(e.name + " " + e.reason, e.line, e.column);
   }


### PR DESCRIPTION
Before

```js
test.css: SyntaxError: Unexpected token
```

After

```js
test.css: SyntaxError: Unexpected token
    at Object.parse (native)
    at new SourceMapConsumer (/Users/vjeux/random/prettier/node_modules/source-map/lib/source-map-consumer.js:17:22)
    at PreviousMap.consumer (/Users/vjeux/random/prettier/node_modules/postcss-less/node_modules/postcss/lib/previous-map.js:69:34)
    at new Input (/Users/vjeux/random/prettier/node_modules/postcss-less/node_modules/postcss/lib/input.js:84:28)
    at Object.lessParse [as parse] (/Users/vjeux/random/prettier/node_modules/postcss-less/dist/less-parse.js:19:15)
    at parseWithPostCSS (/Users/vjeux/random/prettier/src/parser.js:346:27)
    at Object.parse (/Users/vjeux/random/prettier/src/parser.js:24:12)
    at format (/Users/vjeux/random/prettier/index.js:59:22)
    at formatWithShebang (/Users/vjeux/random/prettier/index.js:233:12)
    at Object.module.exports.format (/Users/vjeux/random/prettier/index.js:246:12)
```