### PR TITLE
TypeScript: handle ExperimentalSpreadOperator, optional method, and abstract interface

### DIFF
--- a/src/clean-ast.js
+++ b/src/clean-ast.js
@@ -65,6 +65,21 @@ function massageAST(ast) {
       delete newObj.params;
     }
 
+    // (TypeScript) Ignore `static` in `constructor(static p) {}`
+    // and `export` in `constructor(export p) {}`
+    if (
+      ast.type === "TSParameterProperty" &&
+      ast.accessibility === null &&
+      !ast.readonly
+    ) {
+      return {
+        type: "Identifier",
+        name: ast.parameter.name,
+        typeAnnotation: newObj.parameter.typeAnnotation,
+        decorators: newObj.decorators
+      };
+    }
+
     // We convert <div></div> to <div />
     if (ast.type === "JSXOpeningElement") {
       delete newObj.selfClosing;

--- a/src/printer.js
+++ b/src/printer.js
@@ -356,6 +356,7 @@ function genericPrintNoParens(path, options, print, args) {
     case "SpreadElementPattern":
     case "RestProperty":
     case "ExperimentalRestProperty":
+    case "ExperimentalSpreadProperty":
     case "SpreadProperty":
     case "SpreadPropertyPattern":
     case "RestElement":
@@ -779,6 +780,7 @@ function genericPrintNoParens(path, options, print, args) {
     }
     case "TSInterfaceDeclaration":
       parts.push(
+        n.abstract ? "abstract " : "",
         printTypeScriptModifiers(path, options, print),
         "interface ",
         path.call(print, "id"),
@@ -2352,6 +2354,7 @@ function genericPrintNoParens(path, options, print, args) {
     case "TSMethodSignature":
       parts.push(
         path.call(print, "name"),
+        n.questionToken ? "?" : "",
         printFunctionTypeParameters(path, options, print),
         printFunctionParams(path, print, options)
       );

--- a/tests/typescript_class/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_class/__snapshots__/jsfmt.spec.js.snap
@@ -14,3 +14,14 @@ interface AudioBufferList {
 }
 
 `;
+
+exports[`methods.ts 1`] = `
+class X {
+    optionalMethod?() {}
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class X {
+  optionalMethod?() {}
+}
+
+`;

--- a/tests/typescript_class/methods.ts
+++ b/tests/typescript_class/methods.ts
@@ -1,0 +1,3 @@
+class X {
+    optionalMethod?() {}
+}

--- a/tests/typescript_interface/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_interface/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`abstract.ts 1`] = `
+abstract interface I {
+
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+abstract interface I {}
+
+`;

--- a/tests/typescript_interface/abstract.ts
+++ b/tests/typescript_interface/abstract.ts
@@ -1,0 +1,3 @@
+abstract interface I {
+
+}

--- a/tests/typescript_interface/jsfmt.spec.js
+++ b/tests/typescript_interface/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });


### PR DESCRIPTION
Who are we to say no to completely nonsensical `abstract interface`s? 😉 

Fixes Some `ast(prettier(input)) !== ast(input)` checks by:
 * ignoring `export` and `static` in constructor properties (massageAST).
 * print `abstract interface` 
 * print optional methods `method?() {}`

#1643 