### PR TITLE
TypeScript: allow parens with TSFunctionType and ignore empty specifiers

### DIFF
--- a/src/clean-ast.js
+++ b/src/clean-ast.js
@@ -81,6 +81,24 @@ function massageAST(ast) {
       };
     }
 
+    // (TypeScript) ignore empty `specifiers` array
+    if (
+      ast.type === "TSNamespaceExportDeclaration" &&
+      ast.specifiers &&
+      ast.specifiers.length === 0
+    ) {
+      delete newObj.specifiers;
+    }
+
+    // (TypeScript) allow parenthesization of TSFunctionType
+    if (
+      ast.type === "TSParenthesizedType" &&
+      ast.typeAnnotation.type === "TypeAnnotation" &&
+      ast.typeAnnotation.typeAnnotation.type === "TSFunctionType"
+    ) {
+      return newObj.typeAnnotation.typeAnnotation;
+    }
+
     // We convert <div></div> to <div />
     if (ast.type === "JSXOpeningElement") {
       delete newObj.selfClosing;

--- a/tests/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
@@ -214,6 +214,21 @@ interface i2 {
 
 `;
 
+exports[`contextualSignatureInstantiation2.ts 1`] = `
+// dot f g x = f(g(x))
+var dot: <T, S>(f: (_: T) => S) => <U>(g: (_: U) => T) => (_: U) => S;
+dot = <T, S>(f: (_: T) => S) => <U>(g: (_: U) => T): (r:U) => S => (x) => f(g(x));
+var id: <T>(x:T) => T;
+var r23 = dot(id)(id);~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// dot f g x = f(g(x))
+var dot: <T, S>(f: (_: T) => S) => <U>(g: (_: U) => T) => (_: U) => S;
+dot = <T, S>(f: (_: T) => S) => <U>(g: (_: U) => T): ((r: U) => S) => x =>
+  f(g(x));
+var id: <T>(x: T) => T;
+var r23 = dot(id)(id);
+
+`;
+
 exports[`decrementAndIncrementOperators.ts 1`] = `
 var x = 0;
 
@@ -306,6 +321,42 @@ interface Foo {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 interface Foo {
   bar: number = 5;
+}
+
+`;
+
+exports[`es5ExportDefaultClassDeclaration4.ts 1`] = `
+// @target: es5
+// @module: commonjs
+// @declaration: true
+
+declare module "foo" {
+    export var before: C;
+
+    export default class C {
+        method(): C;
+    }
+
+    export var after: C;
+
+    export var t: typeof C;
+}
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// @target: es5
+// @module: commonjs
+// @declaration: true
+
+declare module "foo" {
+  export var before: C;
+
+  export class C {
+    method(): C;
+  }
+
+  export var after: C;
+
+  export var t: typeof C;
 }
 
 `;

--- a/tests/typescript/compiler/contextualSignatureInstantiation2.ts
+++ b/tests/typescript/compiler/contextualSignatureInstantiation2.ts
@@ -1,0 +1,5 @@
+// dot f g x = f(g(x))
+var dot: <T, S>(f: (_: T) => S) => <U>(g: (_: U) => T) => (_: U) => S;
+dot = <T, S>(f: (_: T) => S) => <U>(g: (_: U) => T): (r:U) => S => (x) => f(g(x));
+var id: <T>(x:T) => T;
+var r23 = dot(id)(id);

--- a/tests/typescript/compiler/es5ExportDefaultClassDeclaration4.ts
+++ b/tests/typescript/compiler/es5ExportDefaultClassDeclaration4.ts
@@ -1,0 +1,16 @@
+// @target: es5
+// @module: commonjs
+// @declaration: true
+
+declare module "foo" {
+    export var before: C;
+
+    export default class C {
+        method(): C;
+    }
+
+    export var after: C;
+
+    export var t: typeof C;
+}
+


### PR DESCRIPTION
Fixes remaining failing AST checks.