### PR TITLE
TypeScript: fix unstable optional method

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2354,7 +2354,7 @@ function genericPrintNoParens(path, options, print, args) {
     case "TSMethodSignature":
       parts.push(
         path.call(print, "name"),
-        n.questionToken ? "?" : "",
+        n.questionToken && !n.name.optional ? "?" : "",
         printFunctionTypeParameters(path, options, print),
         printFunctionParams(path, print, options)
       );

--- a/tests/typescript_method/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_method/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`type_literal_optional_method.ts 1`] = `
+var v: { e?(): number };
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+var v: { e?(): number };
+
+`;

--- a/tests/typescript_method/jsfmt.spec.js
+++ b/tests/typescript_method/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });

--- a/tests/typescript_method/type_literal_optional_method.ts
+++ b/tests/typescript_method/type_literal_optional_method.ts
@@ -1,0 +1,1 @@
+var v: { e?(): number };


### PR DESCRIPTION
Might need to go through and figure out all the combinations of `optional` and `questionToken`, but this holds for now.

