### PR TITLE
Remove many spaces from media query

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2568,7 +2568,7 @@ function genericPrintNoParens(path, options, print, args) {
       return concat(["(", concat(path.map(print, "nodes")), ")"]);
     }
     case "media-feature": {
-      return n.value;
+      return n.value.replace(/ +/g, ' ');
     }
     case "media-colon": {
       return concat([n.value, " "]);

--- a/tests/stylefmt/at-media/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/stylefmt/at-media/__snapshots__/jsfmt.spec.js.snap
@@ -26,10 +26,10 @@ exports[`at-media.css 1`] = `
 @media not all and (monochrome) {
 
 }
-@media (not     all) and (monochrome) {
+@media (not all) and (monochrome) {
 
 }
-@media (not (   screen     and   (  color  )  )), print and (color) {
+@media (not ( screen and ( color ) )), print and (color) {
 
 }
 @media screen and (device-aspect-ratio: 16/9), screen and (device-aspect-ratio: 16/10) {

--- a/tests/stylefmt/media-queries-ranges/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/stylefmt/media-queries-ranges/__snapshots__/jsfmt.spec.js.snap
@@ -13,7 +13,7 @@ exports[`media-queries-ranges.css 1`] = `
     color: red;
   }
 }
-@custom-media --only-medium-screen (width    >=500px) and (width<=    1200px);
+@custom-media --only-medium-screen (width >=500px) and (width<= 1200px);
 @media (--only-medium-screen) {
   .rule {
     color: blue;


### PR DESCRIPTION
The issue is really that the media query parser fails to parse the inner queries and just gives a raw string for the expression, but it should be safe to remove extra spaces. I can't make it rmeove spaces inside () that way unfortunately :(