### PR TITLE
Fix decorators location

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -206,6 +206,9 @@ function hasSpaces(text, index, opts) {
 }
 
 function locStart(node) {
+  if (node.decorators && node.decorators.length > 0) {
+    return locStart(node.decorators[0]);
+  }
   if (node.range) {
     return node.range[0];
   }

--- a/tests/decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`comments.js 1`] = `
+var x = 100
+
+@Hello({
+  a: 'a', // Comment is in the wrong place
+  // test
+  b: '2'
+})
+class X {
+
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+var x = 100;
+
+@Hello({
+  a: "a", // Comment is in the wrong place
+  // test
+  b: "2"
+})
+class X {}
+
+`;
+
 exports[`mobx.js 1`] = `
 import {observable} from "mobx";
 

--- a/tests/decorators/comments.js
+++ b/tests/decorators/comments.js
@@ -1,0 +1,10 @@
+var x = 100
+
+@Hello({
+  a: 'a', // Comment is in the wrong place
+  // test
+  b: '2'
+})
+class X {
+
+}


### PR DESCRIPTION
Babylon has a bug (I guess) with locations for classes where decorators are involved. Instead of the class starting at the first decorator, it starts at the beginning of the `class` keyword. By moving the location to the first comment, it solves --some-- of the issues with decorator comments.