### PR TITLE
TypeScript: upgrade typescript-eslint-parser to 992f1fa

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "rollup-plugin-node-globals": "1.1.0",
     "rollup-plugin-node-resolve": "2.0.0",
     "typescript": "2.3.2",
-    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#31ad3c4c3e59ad3290aeb1a04d8f2683de55fbde"
+    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#992f1fa940c5679c8a509059665146f717da58cb"
   },
   "scripts": {
     "test": "jest",

--- a/tests/async/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/async/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`async-iteration.js 1`] = `
+
+async function * a() {
+    yield* b();
+}
+
+class X {
+    async * b() {
+        yield* a();
+    }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+async function* a() {
+  yield* b();
+}
+
+class X {
+  async *b() {
+    yield* a();
+  }
+}
+
+`;
+
 exports[`await_parse.js 1`] = `
 async function f() { (await f()).length }
 async function g() {

--- a/tests/async/async-iteration.js
+++ b/tests/async/async-iteration.js
@@ -1,0 +1,10 @@
+
+async function * a() {
+    yield* b();
+}
+
+class X {
+    async * b() {
+        yield* a();
+    }
+}

--- a/tests/typescript_class/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_class/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`dunder.ts 1`] = `
+// eslint/typescript-eslint-parser#296
+class F<__T> {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// eslint/typescript-eslint-parser#296
+class F<__T> {}
+
+`;
+
 exports[`generics.ts 1`] = `
 class<T> implements Map<T> {}
 

--- a/tests/typescript_class/dunder.ts
+++ b/tests/typescript_class/dunder.ts
@@ -1,0 +1,2 @@
+// eslint/typescript-eslint-parser#296
+class F<__T> {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2808,9 +2808,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#31ad3c4c3e59ad3290aeb1a04d8f2683de55fbde":
+"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#992f1fa940c5679c8a509059665146f717da58cb":
   version "3.0.0"
-  resolved "git://github.com/eslint/typescript-eslint-parser.git#31ad3c4c3e59ad3290aeb1a04d8f2683de55fbde"
+  resolved "git://github.com/eslint/typescript-eslint-parser.git#992f1fa940c5679c8a509059665146f717da58cb"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.3.0"


### PR DESCRIPTION
Fixes #1769.

Reduces total errors to 16 in #1643.

```
13      prettier(input) !== prettier(prettier(input))
3       Error: Comment location overlaps with node location
```