### PR TITLE
Build the dist/ with rollup

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,5 @@
 !/tests/**/jsfmt.spec.js
 !/**/.eslintrc.js
 /test.js
+/dist/
+/scripts/build/

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,3 +1,4 @@
 [ignore]
 .*/tests/.*
 .*/node_modules/.*
+.*/dist/.*

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 /test.ts
 /test.css
 /.vscode
+/dist

--- a/.ignore
+++ b/.ignore
@@ -1,1 +1,2 @@
 docs/prettier.min.js
+dist

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -9,7 +9,7 @@ const glob = require("glob");
 const chalk = require("chalk");
 const minimist = require("minimist");
 const readline = require("readline");
-const prettier = require("../index");
+const prettier = eval("require")("../index");
 const cleanAST = require("../src/clean-ast.js").cleanAST;
 
 const argv = minimist(process.argv.slice(2), {

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const printAstToDoc = require("./src/printer").printAstToDoc;
 const util = require("./src/util");
 const printDocToString = require("./src/doc-printer").printDocToString;
 const normalizeOptions = require("./src/options").normalize;
-const parser = require("./src/parser");
+const parser = require("./parser");
 const printDocToDebug = require("./src/doc-debug").printDocToDebug;
 
 function guessLineEnding(text) {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,10 @@
     "rollup-plugin-node-builtins": "2.0.0",
     "rollup-plugin-node-globals": "1.1.0",
     "rollup-plugin-node-resolve": "2.0.0",
+    "rollup-plugin-replace": "1.1.1",
     "typescript": "2.3.2",
-    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#87445776fce9dbc67139890b18143e767ab19c7d"
+    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#87445776fce9dbc67139890b18143e767ab19c7d",
+    "uglify-es": "mishoo/UglifyJS2#harmony"
   },
   "scripts": {
     "test": "jest",

--- a/parser.js
+++ b/parser.js
@@ -4,15 +4,13 @@ function parse(text, opts) {
   let parseFunction;
 
   if (opts.parser === "flow") {
-    parseFunction = require("./parser-flow");
+    parseFunction = eval("require")("./src/parser-flow");
   } else if (opts.parser === "typescript") {
-    const r = require;
-    parseFunction = r("./parser-typescript");
+    parseFunction = eval("require")("./src/parser-typescript");
   } else if (opts.parser === "postcss") {
-    const r = require;
-    parseFunction = r("./parser-postcss");
+    parseFunction = eval("require")("./src/parser-postcss");
   } else {
-    parseFunction = require("./parser-babylon");
+    parseFunction = eval("require")("./src/parser-babylon");
   }
 
   try {

--- a/scripts/build/build.sh
+++ b/scripts/build/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+cd "$(dirname "$0")";
+cd ../..;
+
+rm -Rf dist/
+
+echo 'The warning about eval being strongly discouraged is normal.'
+
+echo 'Bundling index...';
+node_modules/.bin/rollup -c scripts/build/rollup.index.config.js
+
+echo 'Bundling bin...';
+node_modules/.bin/rollup -c scripts/build/rollup.bin.config.js
+chmod +x ./dist/bin/prettier.js
+
+echo 'Bundling babylon...';
+node_modules/.bin/rollup -c scripts/build/rollup.parser.config.js --environment parser:babylon
+
+echo 'Bundling flow...';
+node_modules/.bin/rollup -c scripts/build/rollup.parser.config.js --environment parser:flow
+
+echo 'Bundling typescript...';
+node_modules/.bin/rollup -c scripts/build/rollup.parser.config.js --environment parser:typescript
+
+echo 'Bundling postcss...';
+node_modules/.bin/rollup -c scripts/build/rollup.parser.config.js --environment parser:postcss

--- a/scripts/build/rollup.bin.config.js
+++ b/scripts/build/rollup.bin.config.js
@@ -1,0 +1,22 @@
+import resolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+import json from 'rollup-plugin-json';
+import replace from 'rollup-plugin-replace';
+
+const parser = process.env.parser;
+
+export default {
+  entry: 'bin/prettier.js',
+  dest: 'dist/bin/prettier.js',
+  format: 'cjs',
+  banner: '#!/usr/bin/env node',
+  plugins: [
+    replace({
+      '#!/usr/bin/env node': ''
+    }),
+    json(),
+    resolve(),
+    commonjs(),
+  ],
+  external: ['fs', 'readline', 'path', 'module', 'assert', 'util', 'events'],
+};

--- a/scripts/build/rollup.index.config.js
+++ b/scripts/build/rollup.index.config.js
@@ -1,0 +1,15 @@
+import resolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+import json from 'rollup-plugin-json';
+
+export default {
+  entry: 'index.js',
+  dest: 'dist/index.js',
+  format: 'cjs',
+  plugins: [
+    json(),
+    resolve(),
+    commonjs(),
+  ],
+  external: ['assert'],
+};

--- a/scripts/build/rollup.parser.config.js
+++ b/scripts/build/rollup.parser.config.js
@@ -1,0 +1,32 @@
+import resolve from 'rollup-plugin-node-resolve';
+import commonjs from 'rollup-plugin-commonjs';
+import json from 'rollup-plugin-json';
+import replace from 'rollup-plugin-replace';
+import uglify from 'uglify-es';
+
+const parser = process.env.parser;
+
+export default {
+  entry: 'src/parser-' + parser + '.js',
+  dest: 'dist/src/parser-' + parser + '.js',
+  format: 'cjs',
+  plugins: [
+    parser === 'typescript' ? replace({
+      'exports\.Syntax =': '1,',
+      include: 'node_modules/typescript-eslint-parser/parser.js',
+    }) : {},
+    json(),
+    resolve(),
+    commonjs(),
+    {
+      transformBundle(code) {
+        const result = uglify.minify(code, {});
+        if (result.error) throw result.error;
+        return result;
+      }
+    }
+  ],
+  external: ['fs', 'buffer', 'path', 'module', 'assert', 'util', 'os', 'crypto'],
+  useStrict: parser === "flow" ? false : true,
+};
+

--- a/src/parser-postcss.js
+++ b/src/parser-postcss.js
@@ -3,8 +3,7 @@
 const createError = require("./parser-create-error");
 
 function parseSelector(selector) {
-  const r = require;
-  const selectorParser = r("postcss-selector-parser");
+  const selectorParser = require("postcss-selector-parser");
   let result;
   selectorParser(result_ => {
     result = result_;
@@ -139,16 +138,14 @@ function parseNestedValue(node) {
 }
 
 function parseValue(value) {
-  const r = require;
-  const valueParser = r("postcss-values-parser");
+  const valueParser = require("postcss-values-parser");
   const result = valueParser(value, { loose: true }).parse();
   const parsedResult = parseNestedValue(result);
   return addTypePrefix(parsedResult, "value-");
 }
 
 function parseMediaQuery(value) {
-  const r = require;
-  const mediaParser = r("postcss-media-query-parser").default;
+  const mediaParser = require("postcss-media-query-parser").default;
   const result = addMissingType(mediaParser(value));
   return addTypePrefix(result, "media-");
 }
@@ -206,20 +203,21 @@ function parseWithParser(parser, text) {
   return parsedResult;
 }
 
+function requireParser(isSCSS) {
+  if (isSCSS) {
+    return require("postcss-scss");
+  } else {
+    return require("postcss-less");
+  }
+}
+
 function parse(text) {
-  const r = require;
   const isLikelySCSS = !!text.match(/(\w\s*: [^}:]+|#){/);
   try {
-    return parseWithParser(
-      r(isLikelySCSS ? "postcss-scss" : "postcss-less"),
-      text
-    );
+    return parseWithParser(requireParser(isLikelySCSS), text);
   } catch (e) {
     try {
-      return parseWithParser(
-        r(isLikelySCSS ? "postcss-less" : "postcss-scss"),
-        text
-      );
+      return parseWithParser(requireParser(!isLikelySCSS), text);
     } catch (e2) {
       throw e;
     }

--- a/src/parser-typescript.js
+++ b/src/parser-typescript.js
@@ -24,8 +24,7 @@ function parse(text) {
 function tryParseTypeScript(text, jsx) {
   // While we are working on typescript, we are putting it in devDependencies
   // so it shouldn't be picked up by static analysis
-  const r = require;
-  const parser = r("typescript-eslint-parser");
+  const parser = require("typescript-eslint-parser");
   return parser.parse(text, {
     loc: true,
     range: true,

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -2,8 +2,8 @@
 
 const fs = require("fs");
 const extname = require("path").extname;
-const prettier = require("../");
-const parser = require("../src/parser");
+const prettier = require("../"); // change to ../dist/ to "test in prod"
+const parser = require("../parser");
 const massageAST = require("../src/clean-ast.js").massageAST;
 
 const AST_COMPARE = process.env["AST_COMPARE"];

--- a/yarn.lock
+++ b/yarn.lock
@@ -541,6 +541,12 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@~2.9.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.9.0.tgz#9c99094176e12240cb22d6c5146098400fe0f7d4"
+  dependencies:
+    graceful-readlink ">= 1.0.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -1150,6 +1156,10 @@ globby@^5.0.0:
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
+
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -1894,6 +1904,12 @@ lru-cache@^4.0.1:
     pseudomap "^1.0.1"
     yallist "^2.0.0"
 
+magic-string@^0.15.2:
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.15.2.tgz#0681d7388741bbc3addaa65060992624c6c09e9c"
+  dependencies:
+    vlq "^0.2.1"
+
 magic-string@^0.16.0:
   version "0.16.0"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.16.0.tgz#970ebb0da7193301285fb1aa650f39bdd81eb45a"
@@ -2522,7 +2538,15 @@ rollup-plugin-node-resolve@2.0.0:
     builtin-modules "^1.1.0"
     resolve "^1.1.6"
 
-rollup-pluginutils@^1.5.1, rollup-pluginutils@^1.5.2:
+rollup-plugin-replace@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/rollup-plugin-replace/-/rollup-plugin-replace-1.1.1.tgz#396315ded050a6ce43b9518a886a3f60efb1ea33"
+  dependencies:
+    magic-string "^0.15.2"
+    minimatch "^3.0.2"
+    rollup-pluginutils "^1.5.0"
+
+rollup-pluginutils@^1.5.0, rollup-pluginutils@^1.5.1, rollup-pluginutils@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-1.5.2.tgz#1e156e778f94b7255bfa1b3d0178be8f5c552408"
   dependencies:
@@ -2814,13 +2838,6 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#2d09fb183e36a3b4089509c67cd256cd5f8871b0":
-  version "3.0.0"
-  resolved "git://github.com/eslint/typescript-eslint-parser.git#2d09fb183e36a3b4089509c67cd256cd5f8871b0"
-  dependencies:
-    lodash.unescape "4.0.1"
-    semver "5.3.0"
-
 "typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#87445776fce9dbc67139890b18143e767ab19c7d":
   version "3.0.0"
   resolved "git://github.com/eslint/typescript-eslint-parser.git#87445776fce9dbc67139890b18143e767ab19c7d"
@@ -2831,6 +2848,13 @@ typedarray@^0.0.6:
 typescript@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.2.tgz#f0f045e196f69a72f06b25fd3bd39d01c3ce9984"
+
+uglify-es@mishoo/UglifyJS2#harmony:
+  version "3.0.12"
+  resolved "https://codeload.github.com/mishoo/UglifyJS2/tar.gz/e5e0ce0b42307fe7d535376c39caa02d5d823fe2"
+  dependencies:
+    commander "~2.9.0"
+    source-map "~0.5.1"
 
 uglify-js@^2.6:
   version "2.8.27"


### PR DESCRIPTION
This is my least favorite part of the job, but well, someone needs to do it :)

So, this PR has a script `scripts/build/build.sh` that generates the following output:

<img width="178" alt="screen shot 2017-05-28 at 8 56 31 pm" src="https://cloud.githubusercontent.com/assets/197597/26536282/49d1bc34-43ea-11e7-80b7-1422786c9f17.png">

This way we can `npm publish` the `dist/` folder and have exactly 0 dependencies, yay!

The eval trick is a bit gross and throws big warnings when running the release script but I couldn't find a better way: https://github.com/rollup/rollup/issues/1418

Running `./dist/bin/prettier.js` works without parsers, with flow, babylon and typescript. For postcss, there's currently an issue with the output

```js
test.js: TypeError: Super expression must either be null or a function, not undefined
    at i (/Users/vjeux/random/prettier/dist/src/parser-postcss.js:1:116352)
    at /Users/vjeux/random/prettier/dist/src/parser-postcss.js:1:117024
    at /Users/vjeux/random/prettier/dist/src/parser-postcss.js:1:117252
    at createCommonjsModule (/Users/vjeux/random/prettier/dist/src/parser-postcss.js:1:324)
    at Object.<anonymous> (/Users/vjeux/random/prettier/dist/src/parser-postcss.js:1:115953)
    at Module._compile (module.js:425:26)
    at Object.Module._extensions..js (module.js:432:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:311:12)
    at Module.require (module.js:366:17)
```

I haven't found why yet, but I think it's better to merge this before.

I tweaked `run_spec` to use the dist folder and all the tests (but the css ones) are passing, yay!

The binary is taking ~15ms more to run (~120ms without minification) so it's okay to ship.

This PR will break the docs/ build. I need to figure out how to fix it next.