### PR TITLE
Update tsep to latest master, reenable abstract interface test

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "rollup-plugin-node-resolve": "2.0.0",
     "rollup-plugin-replace": "1.1.1",
     "typescript": "2.3.2",
-    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#87445776fce9dbc67139890b18143e767ab19c7d",
+    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#3dcba7d53f61f51069ed84b57e053802c014d703",
     "uglify-es": "mishoo/UglifyJS2#harmony"
   },
   "scripts": {
@@ -62,9 +62,7 @@
     "testRegex": "jsfmt\\.spec\\.js$|__tests__/.*\\.js$",
     "testPathIgnorePatterns": [
       "tests/new_react",
-      "tests/more_react",
-      "see https://github.com/eslint/typescript-eslint-parser/issues/269",
-      "tests/typescript/conformance/types/abstractKeyword/jsfmt.spec.js"
+      "tests/more_react"
     ]
   }
 }

--- a/src/printer.js
+++ b/src/printer.js
@@ -2269,7 +2269,7 @@ function genericPrintNoParens(path, options, print, args) {
       if (n.static) {
         parts.push("static ");
       }
-      if (n.isReadonly) {
+      if (n.readonly) {
         parts.push("readonly ");
       }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2838,9 +2838,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#87445776fce9dbc67139890b18143e767ab19c7d":
+"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#3dcba7d53f61f51069ed84b57e053802c014d703":
   version "3.0.0"
-  resolved "git://github.com/eslint/typescript-eslint-parser.git#87445776fce9dbc67139890b18143e767ab19c7d"
+  resolved "git://github.com/eslint/typescript-eslint-parser.git#3dcba7d53f61f51069ed84b57e053802c014d703"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.3.0"


### PR DESCRIPTION
This updates `typescript-eslint-parser` to latest master (currently #3dcba7d53f61f51069ed84b57e053802c014d703) and reenables the abstract interface test which was unblocked.

@vjeux Should we be updating the `docs/prettier.min.js` file by hand in this PR too, or does that get auto-generated as part of a build process?