### PR TITLE
Workaround bug with comment ending in */

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2537,13 +2537,14 @@ function genericPrintNoParens(path, options, print, args) {
         return n.raws.content;
       }
       const text = options.originalText.slice(util.locStart(n), util.locEnd(n));
+      const rawText = n.raws.text || n.text;
       // Workaround a bug where the location is off.
       // https://github.com/postcss/postcss-scss/issues/63
-      if (text.indexOf(n.text) === -1) {
+      if (text.indexOf(rawText) === -1) {
         if (n.raws.inline) {
-          return concat(["// ", n.text]);
+          return concat(["// ", rawText]);
         }
-        return concat(["/* ", n.text, " */"]);
+        return concat(["/* ", rawText, " */"]);
       }
       return text;
     }

--- a/tests/css_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_comments/__snapshots__/jsfmt.spec.js.snap
@@ -82,3 +82,17 @@ exports[`selector.css 1`] = `
 }
 
 `;
+
+exports[`trailing_star_slash.css 1`] = `
+@media (max-width: 1) {}
+a {
+  // element.style */
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@media (max-width: 1) {
+}
+a {
+  // element.style */
+}
+
+`;

--- a/tests/css_comments/trailing_star_slash.css
+++ b/tests/css_comments/trailing_star_slash.css
@@ -1,0 +1,4 @@
+@media (max-width: 1) {}
+a {
+  // element.style */
+}


### PR DESCRIPTION
Reported in the original repo: https://github.com/postcss/postcss-scss/issues/64