### PR TITLE
Do not indent nested ternaries

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1114,28 +1114,26 @@ function genericPrintNoParens(path, options, print, args) {
       }
 
       return concat(parts);
-    case "ConditionalExpression":
+    case "ConditionalExpression": {
+      const parent = path.getParentNode();
+      const printed = concat([
+        line,
+        "? ",
+        n.consequent.type === "ConditionalExpression" ? ifBreak("", "(") : "",
+        align(2, path.call(print, "consequent")),
+        n.consequent.type === "ConditionalExpression" ? ifBreak("", ")") : "",
+        line,
+        ": ",
+        align(2, path.call(print, "alternate"))
+      ]);
+
       return group(
         concat([
           path.call(print, "test"),
-          indent(
-            concat([
-              line,
-              "? ",
-              n.consequent.type === "ConditionalExpression"
-                ? ifBreak("", "(")
-                : "",
-              align(2, path.call(print, "consequent")),
-              n.consequent.type === "ConditionalExpression"
-                ? ifBreak("", ")")
-                : "",
-              line,
-              ": ",
-              align(2, path.call(print, "alternate"))
-            ])
-          )
+          parent.type === "ConditionalExpression" ? printed : indent(printed)
         ])
       );
+    }
     case "NewExpression":
       parts.push(
         "new ",

--- a/tests/ternaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ternaries/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`indent.js 1`] = `
+aaaaaaaaaaaaaaa ? bbbbbbbbbbbbbbbbbb : ccccccccccccccc ? ddddddddddddddd : eeeeeeeeeeeeeee ? fffffffffffffff : gggggggggggggggg
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+aaaaaaaaaaaaaaa
+  ? bbbbbbbbbbbbbbbbbb
+  : ccccccccccccccc
+    ? ddddddddddddddd
+    : eeeeeeeeeeeeeee ? fffffffffffffff : gggggggggggggggg;
+
+`;
+
+exports[`indent.js 2`] = `
+aaaaaaaaaaaaaaa ? bbbbbbbbbbbbbbbbbb : ccccccccccccccc ? ddddddddddddddd : eeeeeeeeeeeeeee ? fffffffffffffff : gggggggggggggggg
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+aaaaaaaaaaaaaaa
+    ? bbbbbbbbbbbbbbbbbb
+    : ccccccccccccccc
+      ? ddddddddddddddd
+      : eeeeeeeeeeeeeee ? fffffffffffffff : gggggggggggggggg;
+
+`;
+
 exports[`parenthesis.js 1`] = `
 debug ? this.state.isVisible ? "partially visible" : "hidden" : null;
 debug ? this.state.isVisible && somethingComplex ? "partially visible" : "hidden" : null;

--- a/tests/ternaries/indent.js
+++ b/tests/ternaries/indent.js
@@ -1,0 +1,1 @@
+aaaaaaaaaaaaaaa ? bbbbbbbbbbbbbbbbbb : ccccccccccccccc ? ddddddddddddddd : eeeeeeeeeeeeeee ? fffffffffffffff : gggggggggggggggg


### PR DESCRIPTION
This avoids making it seems like it is indented by 4 characters instead of two. The downside is that if the condition is multi-line it's not going to be properly aligned, but I feel it's a better trade-offs. If you are doing nested ternaries, you usually have small conditions.