### PR TITLE
JSX whitespace on the same line as text

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -4018,10 +4018,7 @@ function printJSXElement(path, options, print) {
   let forcedBreak = willBreak(openingLines);
 
   const rawJsxWhitespace = options.singleQuote ? "{' '}" : '{" "}';
-  const jsxWhitespace = ifBreak(
-    concat([softline, rawJsxWhitespace, softline]),
-    " "
-  );
+  const jsxWhitespace = ifBreak(concat([softline, rawJsxWhitespace]), " ");
 
   const children = printJSXChildren(path, options, print, jsxWhitespace);
 
@@ -4079,14 +4076,17 @@ function printJSXElement(path, options, print) {
     // `{" "}` when outputting this element over multiple lines.
     if (child === jsxWhitespace) {
       if (i === 1 && children[i - 1] === "") {
-        if (children.length === 2) {
-          multilineChildren.push(rawJsxWhitespace);
-          return;
-        }
-        multilineChildren.push(concat([rawJsxWhitespace, hardline]));
+        multilineChildren.push(rawJsxWhitespace);
         return;
       } else if (i === children.length - 1) {
         multilineChildren.push(concat([hardline, rawJsxWhitespace]));
+        return;
+      } else if (willBreak(children[i - 1]) || willBreak(children[i + 1])) {
+        // If we come before or after a JSX element that is multiline
+        // ensure the JSX whitespace appears on a line by itself.
+        // NOTE: Currently this only detects elements that are already
+        // multiline before formatting!
+        multilineChildren.push(concat([hardline, rawJsxWhitespace, hardline]));
         return;
       }
     }

--- a/tests/flow/more_react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/more_react/__snapshots__/jsfmt.spec.js.snap
@@ -164,8 +164,7 @@ var App = require("App.react");
 
 var app = (
   <App y={42}>
-    {" "}
-    // error, y: number but foo expects string in App.react
+    {" "}// error, y: number but foo expects string in App.react
     Some text.
   </App>
 );

--- a/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
@@ -91,8 +91,7 @@ before = (
 before_break1 = (
   <span>
     <span barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar />
-    {" "}
-    foo
+    {" "}foo
   </span>
 );
 
@@ -101,16 +100,16 @@ before_break2 = (
     <span
       barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar
     />
-    {" "}
-    foo
+    {" "}foo
   </span>
 );
 
 after_break = (
   <span>
     foo
-    {" "}
-    <span barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar />
+    {" "}<span
+      barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar
+    />
   </span>
 );
 
@@ -146,8 +145,7 @@ nest_plz = (
 
 regression_not_transformed_1 = (
   <span>
-    {" "}
-    <Icon icon="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" />
+    {" "}<Icon icon="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" />
   </span>
 );
 
@@ -160,8 +158,7 @@ regression_not_transformed_2 = (
 
 similar_1 = (
   <span>
-    {" "}
-    <Icon icon="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" />
+    {" "}<Icon icon="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" />
   </span>
 );
 

--- a/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
@@ -127,8 +127,7 @@ const render6 = ({ styles }) =>
       >
         ddd d dd d d dddd dddd <strong>hello</strong>
       </div>
-      {" "}
-      <strong>hello</strong>
+      {" "}<strong>hello</strong>
     </div>
   </div>;
 

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -100,7 +100,10 @@ x =
 leading_whitespace =
   <div> First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth</div>
 
-no_leading_whitespace =
+trailing_whitespace =
+  <div>First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth </div>
+
+no_leading_or_trailing_whitespace =
   <div>First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth</div>
 
 facebook_translation_leave_text_around_tag =
@@ -118,7 +121,6 @@ this_really_should_split_across_lines =
     before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after
   </div>
 
-
 unstable_before =
   <div className="yourScore">
     Your score: <span className="score">{\`\${mini.crosstable.users[sessionUserId]} - \${mini.crosstable.users[user.id]}\`}</span>
@@ -135,6 +137,32 @@ unstable_after_first_run = (
 
 solitary_whitespace =
   <div first="first" second="second" third="third" fourth="fourth" fifth="fifth" sixth="sixth"> </div>
+
+jsx_whitespace_on_newline =
+  <div>
+    <div>
+      First
+    </div> <div>
+      Second
+    </div> <div>
+      Third
+    </div>
+  </div>
+
+jsx_around_multiline_element =
+  <div>Before <div>{"Enough text to make this element wrap on to multiple lines when formatting"}</div> After</div>
+
+jsx_around_multiline_element_second_pass = (
+  <div>
+    Before
+    {" "}<div>
+      {
+        "Enough text to make this element wrap on to multiple lines when formatting"
+      }
+    </div>
+    {" "}After
+  </div>
+);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Wrapping text
 x = (
@@ -148,8 +176,7 @@ x = (
 x = (
   <div>
     <first>f</first> <first>f</first> <first>f</first> <first>f</first>
-    {" "}
-    <first>f</first> <first>f</first>
+    {" "}<first>f</first> <first>f</first>
   </div>
 );
 
@@ -166,8 +193,7 @@ x = (
   <div>
     <a /><b /><c />
     <first>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</first>
-    {" "}
-    <first>f</first>
+    {" "}<first>f</first>
   </div>
 );
 
@@ -175,8 +201,7 @@ x = (
 x = (
   <div>
     <sadashdkjahsdkjhaskjdhaksjdhkashdkashdkasjhdkajshdkashdkashd />
-    {" "}
-    <first>f</first>
+    {" "}<first>f</first>
   </div>
 );
 
@@ -199,16 +224,14 @@ x = (
 x = (
   <div>
     before {stuff} after {stuff} after {stuff} after {stuff} after {stuff} after
-    {" "}
-    {stuff}  {stuff}  {stuff} after {stuff} after
+    {" "}{stuff}  {stuff}  {stuff} after {stuff} after
   </div>
 );
 
 x = (
   <div>
     Please state your <b>name</b> and <b>occupation</b> for the board of
-    {" "}
-    <b>school</b> directors.
+    {" "}<b>school</b> directors.
   </div>
 );
 
@@ -238,10 +261,8 @@ x = (
   <font size={-3}>
     <i>
       Starting at minute {graphActivity.startTime}, running for
-      {" "}
-      {graphActivity.length} to minute
-      {" "}
-      {graphActivity.startTime + graphActivity.length}
+      {" "}{graphActivity.length} to minute
+      {" "}{graphActivity.startTime + graphActivity.length}
     </i>
   </font>
 );
@@ -281,13 +302,20 @@ x = (
 
 leading_whitespace = (
   <div>
-    {" "}
-    First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh
-    Twelfth Thirteenth Fourteenth
+    {" "}First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth
+    Eleventh Twelfth Thirteenth Fourteenth
   </div>
 );
 
-no_leading_whitespace = (
+trailing_whitespace = (
+  <div>
+    First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh
+    Twelfth Thirteenth Fourteenth
+    {" "}
+  </div>
+);
+
+no_leading_or_trailing_whitespace = (
   <div>
     First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh
     Twelfth Thirteenth Fourteenth
@@ -314,9 +342,9 @@ this_really_should_split_across_lines = (
 unstable_before = (
   <div className="yourScore">
     Your score:
-    {" "}
-    <span className="score">{\`\${mini.crosstable.users[sessionUserId]} - \${mini
-      .crosstable.users[user.id]}\`}</span>
+    {" "}<span className="score">{\`\${mini.crosstable.users[
+      sessionUserId
+    ]} - \${mini.crosstable.users[user.id]}\`}</span>
   </div>
 );
 
@@ -339,6 +367,47 @@ solitary_whitespace = (
     sixth="sixth"
   >
     {" "}
+  </div>
+);
+
+jsx_whitespace_on_newline = (
+  <div>
+    <div>
+      First
+    </div>
+    {" "}
+    <div>
+      Second
+    </div>
+    {" "}
+    <div>
+      Third
+    </div>
+  </div>
+);
+
+jsx_around_multiline_element = (
+  <div>
+    Before
+    {" "}<div>
+      {
+        "Enough text to make this element wrap on to multiple lines when formatting"
+      }
+    </div>
+    {" "}After
+  </div>
+);
+
+jsx_around_multiline_element_second_pass = (
+  <div>
+    Before
+    {" "}
+    <div>
+      {
+        "Enough text to make this element wrap on to multiple lines when formatting"
+      }
+    </div>
+    {" "}After
   </div>
 );
 

--- a/tests/jsx-text-wrap/test.js
+++ b/tests/jsx-text-wrap/test.js
@@ -97,7 +97,10 @@ x =
 leading_whitespace =
   <div> First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth</div>
 
-no_leading_whitespace =
+trailing_whitespace =
+  <div>First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth </div>
+
+no_leading_or_trailing_whitespace =
   <div>First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth</div>
 
 facebook_translation_leave_text_around_tag =
@@ -115,7 +118,6 @@ this_really_should_split_across_lines =
     before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after
   </div>
 
-
 unstable_before =
   <div className="yourScore">
     Your score: <span className="score">{`${mini.crosstable.users[sessionUserId]} - ${mini.crosstable.users[user.id]}`}</span>
@@ -132,3 +134,29 @@ unstable_after_first_run = (
 
 solitary_whitespace =
   <div first="first" second="second" third="third" fourth="fourth" fifth="fifth" sixth="sixth"> </div>
+
+jsx_whitespace_on_newline =
+  <div>
+    <div>
+      First
+    </div> <div>
+      Second
+    </div> <div>
+      Third
+    </div>
+  </div>
+
+jsx_around_multiline_element =
+  <div>Before <div>{"Enough text to make this element wrap on to multiple lines when formatting"}</div> After</div>
+
+jsx_around_multiline_element_second_pass = (
+  <div>
+    Before
+    {" "}<div>
+      {
+        "Enough text to make this element wrap on to multiple lines when formatting"
+      }
+    </div>
+    {" "}After
+  </div>
+);


### PR DESCRIPTION
A potential fix for https://github.com/prettier/prettier/issues/1582

This tweaks our JSX formatting to only put a JSX whitespace `{" "}` on a line by itself when it comes before or after a multiline element.

When preceding a text or single line element it appear on the same line as that element.

With this input:

```javascript
x = <font size={-3}><i>Starting at minute {graphActivity.startTime}, running for {graphActivity.length} to minute {graphActivity.startTime + graphActivity.length}</i></font>
```

We used to output:

```javascript
x = (
  <font size={-3}>
    <i>
      Starting at minute {graphActivity.startTime}, running for
      {" "}
      {graphActivity.length} to minute
      {" "}
      {graphActivity.startTime + graphActivity.length}
    </i>
  </font>
);
```

After this PR we will output:

```javascript
x = (
  <font size={-3}>
    <i>
      Starting at minute {graphActivity.startTime}, running for
      {" "}{graphActivity.length} to minute
      {" "}{graphActivity.startTime + graphActivity.length}
    </i>
  </font>
);
```