### PR TITLE
Allow JSX lines to be recombined

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3861,17 +3861,26 @@ function printJSXElement(path, options, print) {
 
   const children = printJSXChildren(path, options, print, jsxWhitespace);
 
+  const containsText =
+    n.children.filter(child => isMeaningfulJSXText(child)).length > 0;
+
   // We can end up we multiple whitespace elements with empty string
   // content between them.
   // We need to remove empty whitespace and softlines before JSX whitespace
   // to get the correct output.
   for (let i = children.length - 2; i >= 0; i--) {
-    const pairOfEmptyString = children[i] === "" && children[i + 1] === "";
-    const softlineFollowedByJSXWhitespace =
+    const isPairOfEmptyStrings = children[i] === "" && children[i + 1] === "";
+    const isSoftlineFollowedByJSXWhitespace =
       children[i] === softline &&
       children[i + 1] === "" &&
       children[i + 2] === jsxWhitespace;
-    if (pairOfEmptyString || softlineFollowedByJSXWhitespace) {
+    const isEmptyFollowedByHardline =
+      children[i] === "" && children[i + 1] === hardline;
+    if (
+      isPairOfEmptyStrings ||
+      isSoftlineFollowedByJSXWhitespace ||
+      (isEmptyFollowedByHardline && containsText)
+    ) {
       children.splice(i, 2);
     }
   }
@@ -3942,9 +3951,6 @@ function printJSXElement(path, options, print) {
       forcedBreak = true;
     }
   });
-
-  const containsText =
-    n.children.filter(child => isMeaningfulJSXText(child)).length > 0;
 
   // If there is text we use `fill` to fit as much onto each line as possible.
   // When there is no text (just tags and expressions) we use `group`

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -495,9 +495,7 @@ Observable.of(process)
   .takeUntil(exit);
 
 // Comments disappear inside of JSX
-<div>
-  {/* Some comment */}
-</div>;
+<div>{/* Some comment */}</div>;
 
 // Comments in JSX tag are placed in a non optimal way
 <div
@@ -596,23 +594,15 @@ exports[`jsx.js 1`] = `
 
 <div>{/*<div>  Some very v  ery very very long line to break line width limit </div>*/}</div>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-<div>
-  {/* comment */}
-</div>;
+<div>{/* comment */}</div>;
 
-<div>
-  {/* comment */}
-</div>;
+<div>{/* comment */}</div>;
 
-<div>
-  {/* comment
-*/}
-</div>;
+<div>{/* comment
+*/}</div>;
 
-<div>
-  {a /* comment
-*/}
-</div>;
+<div>{a /* comment
+*/}</div>;
 
 <div>
   {
@@ -622,13 +612,9 @@ exports[`jsx.js 1`] = `
   }
 </div>;
 
-<div>
-  {/* comment */}
-</div>;
+<div>{/* comment */}</div>;
 
-<div>
-  {/* comment */}
-</div>;
+<div>{/* comment */}</div>;
 
 <div>
   {

--- a/tests/flow/more_react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/more_react/__snapshots__/jsfmt.spec.js.snap
@@ -99,8 +99,7 @@ var App = React.createClass({
 
     return (
       <div>
-        {foo(x, y)}
-        {foo(z, x)} // error, since z: number
+        {foo(x, y)}{foo(z, x)} // error, since z: number
       </div>
     );
   }
@@ -164,8 +163,7 @@ var App = require("App.react");
 
 var app = (
   <App y={42}>
-    {" "}// error, y: number but foo expects string in App.react
-    Some text.
+    {" "}// error, y: number but foo expects string in App.react Some text.
   </App>
 );
 

--- a/tests/flow/new_react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/new_react/__snapshots__/jsfmt.spec.js.snap
@@ -865,11 +865,7 @@ var ReactClass = React.createClass({
   render: function(): any {
     // Any state access here seems to make state any
     this.state;
-    return (
-      <div>
-        {this.state.bar.qux}
-      </div>
-    );
+    return <div>{this.state.bar.qux}</div>;
   }
 });
 

--- a/tests/flow/react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/react/__snapshots__/jsfmt.spec.js.snap
@@ -741,11 +741,7 @@ class Bar extends React.Component {
     test: number
   };
   render() {
-    return (
-      <div>
-        {this.props.test}
-      </div>
-    );
+    return <div>{this.props.test}</div>;
   }
 }
 

--- a/tests/jsx-multiline-assign/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-multiline-assign/__snapshots__/jsfmt.spec.js.snap
@@ -40,7 +40,9 @@ comp2A = (
 );
 
 const comp3 = (
-  <div style={styles} key="something">Bump to next line without parens</div>
+  <div style={styles} key="something">
+    Bump to next line without parens
+  </div>
 );
 
 const comp4 = (

--- a/tests/jsx-newlines/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-newlines/__snapshots__/jsfmt.spec.js.snap
@@ -126,9 +126,7 @@ newlines_elems = (
     <div>
       <div />
     </div>
-    hi<div />
-    <span />
-    <Big />
+    hi<div /><span /><Big />
   </div>
 );
 

--- a/tests/jsx-newlines/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-newlines/__snapshots__/jsfmt.spec.js.snap
@@ -98,73 +98,37 @@ regression_extra_newline_2 = (
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 keep = (
   <p>
-    Welcome to the <strong>Universal React Starter-kyt</strong>.
-    This starter kyt should serve as the base for an advanced,
-    server-rendered React app.
+    Welcome to the <strong>Universal React Starter-kyt</strong>. This starter
+    kyt should serve as the base for an advanced, server-rendered React app.
   </p>
 );
 
-newlines_text = (
-  <div>
-    hi
-    there
-    how
+newlines_text = <div>hi there how are you are you fine today?</div>;
 
-    are you
-
-    are you fine today?
-  </div>
-);
-
-newlines_text_spaced = (
-  <div>
-
-    space above
-
-    space below
-
-  </div>
-);
+newlines_text_spaced = <div>space above space below</div>;
 
 newlines_elems_spaced = (
   <div>
-
     <span>space above</span>
 
     <span>space below</span>
-
   </div>
 );
 
 newlines_mixed = (
   <div>
-    hi
-    <span>there</span>
-
-    how
-
-    are <strong>you</strong>
-
-    are you fine today?
+    hi<span>there</span>how are <strong>you</strong>are you fine today?
   </div>
 );
 
 newlines_elems = (
   <div>
     <div>
-
       <div />
-
     </div>
-
-    hi
-
-    <div />
-
+    hi<div />
     <span />
-
     <Big />
-
   </div>
 );
 
@@ -193,8 +157,6 @@ exports[`windows.js 1`] = `
 Text
 </div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-<div>
-  Text
-</div>;
+<div>Text</div>;
 
 `;

--- a/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
@@ -123,7 +123,14 @@ break_components = (
   <div>
     <Foo />
     <Bar>
-      <p>foo<span>bar bar bar</span></p><h1><span><em>yep</em></span></h1>
+      <p>
+        foo<span>bar bar bar</span>
+      </p>
+      <h1>
+        <span>
+          <em>yep</em>
+        </span>
+      </h1>
     </Bar>
     <h2>nope</h2>
   </div>
@@ -182,7 +189,8 @@ not_broken_end = (
 
 not_broken_begin = (
   <div>
-    <br /> long text long text long text long text long text long text long text
+    <br />
+    {" "}long text long text long text long text long text long text long text
     long text<link>url</link> long text long text
   </div>
 );

--- a/tests/jsx-split-attrs/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-split-attrs/__snapshots__/jsfmt.spec.js.snap
@@ -90,11 +90,21 @@ long_open_long_children = (
       Hello world
     </BaseForm>
     <div>
-      <div><div><div><div><div>hey hiya how are ya</div></div></div></div></div>
+      <div>
+        <div>
+          <div>
+            <div>
+              <div>hey hiya how are ya</div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
     <div>
       <div>
-        <div><div attr="long" attr2="also long" attr3="gonna break" /></div>
+        <div>
+          <div attr="long" attr2="also long" attr3="gonna break" />
+        </div>
       </div>
     </div>
     <div>

--- a/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
@@ -86,7 +86,9 @@ const render2 = ({ styles }) =>
   </div>;
 
 const render3 = ({ styles }) =>
-  <div style={styles} key="something">Bump to next line without parens</div>;
+  <div style={styles} key="something">
+    Bump to next line without parens
+  </div>;
 
 const render4 = ({ styles }) =>
   <div style={styles} key="something">
@@ -133,20 +135,28 @@ const render6 = ({ styles }) =>
 
 const render7 = () =>
   <div>
-    <span /><span>Dont break each elem onto its own line.</span> <span />
-    <div /> <div />
+    <span /><span>Dont break each elem onto its own line.</span> <span /><div />{" "}
+    <div />
   </div>;
 
 const render7A = () =>
   <div>
-    <div /><div /><div />
+    <div />
+    <div />
+    <div />
   </div>;
 
 const render7B = () =>
   <div>
-    <span> <span /> Dont break plz</span>
-    <span><span />Dont break plz</span>
-    <span>Dont break plz<span /></span>
+    <span>
+      {" "}<span /> Dont break plz
+    </span>
+    <span>
+      <span />Dont break plz
+    </span>
+    <span>
+      Dont break plz<span />
+    </span>
   </div>;
 
 const render8 = props => <div>{props.text}</div>;

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -228,6 +228,8 @@ br_followed_by_whitespace = <div><br /> text</div>
 dont_preserve_blank_lines_when_jsx_contains_text =
   <div>
 
+    <div>Zeroth</div>
+
     <div>First</div>
 
     Second
@@ -551,7 +553,7 @@ br_followed_by_whitespace = (
 
 dont_preserve_blank_lines_when_jsx_contains_text = (
   <div>
-    <div>First</div>Second
+    <div>Zeroth</div><div>First</div>Second
   </div>
 );
 

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -252,6 +252,15 @@ expression_does_not_break =
 // FIXME
 br_triggers_expression_break =
   <div><br />text text text text text text text text text text text {this.props.type} </div>
+
+jsx_whitespace_after_tag =
+  <div>
+    <span a="a" b="b">
+      {variable}
+    </span>
+    {" "}
+    ({variable})
+  </div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Wrapping text
 x = (
@@ -575,6 +584,15 @@ br_triggers_expression_break = (
     text text text text text text text text text text text {
       this.props.type
     }{" "}
+  </div>
+);
+
+jsx_whitespace_after_tag = (
+  <div>
+    <span a="a" b="b">
+      {variable}
+    </span>{" "}
+    ({variable})
   </div>
 );
 

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -246,7 +246,12 @@ single_expression_child_tags =
     You currently have <strong>{dashboardStr}</strong> and <strong>{userStr}</strong>
   </div>
 
+expression_does_not_break =
+  <div>texty text text text text text text text text text text text {this.props.type} </div>
 
+// FIXME
+br_triggers_expression_break =
+  <div><br />text text text text text text text text text text text {this.props.type} </div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Wrapping text
 x = (
@@ -553,6 +558,23 @@ single_expression_child_tags = (
   <div>
     You currently have <strong>{dashboardStr}</strong> and{" "}
     <strong>{userStr}</strong>
+  </div>
+);
+
+expression_does_not_break = (
+  <div>
+    texty text text text text text text text text text text text{" "}
+    {this.props.type}{" "}
+  </div>
+);
+
+// FIXME
+br_triggers_expression_break = (
+  <div>
+    <br />
+    text text text text text text text text text text text {
+      this.props.type
+    }{" "}
   </div>
 );
 

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -162,6 +162,91 @@ jsx_around_multiline_element_second_pass = (
     After
   </div>
 );
+
+convert_space_expressions =
+  <div>{" "}</div>
+
+x =
+  <div>
+    <first />
+    <second />
+    <third />
+    <fourth />
+    <fifth />
+    <sixth />
+  </div>
+
+const Abc = () => {
+  return (
+    <div>
+      Please state your
+      {" "}
+      <b>name</b>
+      {" "}
+      and
+      {" "}
+      <b>occupation</b>
+      {" "}
+      for the board of directors.
+    </div>
+  );
+};
+
+x = <div id="moo">Some stuff here</div>
+
+headers_and_paragraphs = (
+  <div>
+    <h2>First</h2>
+    <p>The first paragraph.</p>
+
+    <h2>Second</h2>
+    <p>The second paragraph.</p>
+  </div>
+);
+
+no_text_one_tag_per_line =
+  <div>
+    <first /><second />
+  </div>
+
+with_text_fill_line =
+  <div>
+    Text <first /><second />
+  </div>
+
+line_after_br =
+  <div>
+    Text<br />
+    More text <br />
+    And more<br />
+  </div>
+
+line_after_br_2 = <div>A<br />B<br />C</div>
+
+br_followed_by_whitespace = <div><br /> text</div>
+
+dont_preserve_blank_lines_when_jsx_contains_text =
+  <div>
+
+    <div>First</div>
+
+    Second
+
+  </div>
+
+multiple_expressions =
+  <div>
+    {header}
+    {body}
+    {footer}
+  </div>
+
+single_expression_child_tags =
+  <div>
+    You currently have <strong>{dashboardStr}</strong> and <strong>{userStr}</strong>
+  </div>
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Wrapping text
 x = (
@@ -182,8 +267,12 @@ x = (
 // Wrapping tags
 x = (
   <div>
-    <first>f</first><first>f</first><first>f</first><first>f</first>
-    <first>f</first><first>f</first>
+    <first>f</first>
+    <first>f</first>
+    <first>f</first>
+    <first>f</first>
+    <first>f</first>
+    <first>f</first>
   </div>
 );
 
@@ -223,7 +312,7 @@ x = (
 x = (
   <div>
     before {stuff} after {stuff} after {stuff} after {stuff} after {stuff} after{" "}
-    {stuff}  {stuff}  {stuff} after {stuff} after
+    {stuff} {stuff} {stuff} after {stuff} after
   </div>
 );
 
@@ -241,14 +330,11 @@ function DiffOverview(props) {
       <div className="alert alert-info">
         <p>
           This diff overview is computed against the current list of records in
-          this collection and the list it contained on <b>
-            {humanDate(since)}
-          </b>.
+          this collection and the list it contained on <b>{humanDate(since)}</b>.
         </p>
         <p>
           <b>Note:</b> <code>last_modified</code> and <code>schema</code> record
-          metadata
-          are omitted for easier review.
+          metadata are omitted for easier review.
         </p>
       </div>
       <Diff source={source} target={target} />
@@ -277,23 +363,13 @@ x = (
 
 x = (
   <div>
-    <div>
-      First
-    </div>
-    Second
-    <div>
-      Third
-    </div>
+    <div>First</div>Second<div>Third</div>
   </div>
 );
 
 x = (
   <div>
-    First{" "}
-    <div>
-      Second
-    </div>{" "}
-    Third
+    First <div>Second</div> Third
   </div>
 );
 
@@ -320,12 +396,7 @@ no_leading_or_trailing_whitespace = (
 
 facebook_translation_leave_text_around_tag = (
   <div>
-    <span>
-      First
-    </span>,
-    (<span>
-      Second
-    </span>)
+    <span>First</span>, (<span>Second</span>)
   </div>
 );
 
@@ -366,15 +437,7 @@ solitary_whitespace = (
 
 jsx_whitespace_on_newline = (
   <div>
-    <div>
-      First
-    </div>{" "}
-    <div>
-      Second
-    </div>{" "}
-    <div>
-      Third
-    </div>
+    <div>First</div> <div>Second</div> <div>Third</div>
   </div>
 );
 
@@ -399,6 +462,97 @@ jsx_around_multiline_element_second_pass = (
       }
     </div>{" "}
     After
+  </div>
+);
+
+convert_space_expressions = <div> </div>;
+
+x = (
+  <div>
+    <first />
+    <second />
+    <third />
+    <fourth />
+    <fifth />
+    <sixth />
+  </div>
+);
+
+const Abc = () => {
+  return (
+    <div>
+      Please state your <b>name</b> and <b>occupation</b> for the board of
+      directors.
+    </div>
+  );
+};
+
+x = <div id="moo">Some stuff here</div>;
+
+headers_and_paragraphs = (
+  <div>
+    <h2>First</h2>
+    <p>The first paragraph.</p>
+
+    <h2>Second</h2>
+    <p>The second paragraph.</p>
+  </div>
+);
+
+no_text_one_tag_per_line = (
+  <div>
+    <first />
+    <second />
+  </div>
+);
+
+with_text_fill_line = (
+  <div>
+    Text <first /><second />
+  </div>
+);
+
+line_after_br = (
+  <div>
+    Text<br />
+    More text <br />
+    And more<br />
+  </div>
+);
+
+line_after_br_2 = (
+  <div>
+    A<br />
+    B<br />
+    C
+  </div>
+);
+
+br_followed_by_whitespace = (
+  <div>
+    <br />
+    {" "}text
+  </div>
+);
+
+dont_preserve_blank_lines_when_jsx_contains_text = (
+  <div>
+    <div>First</div>Second
+  </div>
+);
+
+multiple_expressions = (
+  <div>
+    {header}
+    {body}
+    {footer}
+  </div>
+);
+
+single_expression_child_tags = (
+  <div>
+    You currently have <strong>{dashboardStr}</strong> and{" "}
+    <strong>{userStr}</strong>
   </div>
 );
 

--- a/tests/jsx-text-wrap/test.js
+++ b/tests/jsx-text-wrap/test.js
@@ -249,3 +249,12 @@ expression_does_not_break =
 // FIXME
 br_triggers_expression_break =
   <div><br />text text text text text text text text text text text {this.props.type} </div>
+
+jsx_whitespace_after_tag =
+  <div>
+    <span a="a" b="b">
+      {variable}
+    </span>
+    {" "}
+    ({variable})
+  </div>

--- a/tests/jsx-text-wrap/test.js
+++ b/tests/jsx-text-wrap/test.js
@@ -159,3 +159,88 @@ jsx_around_multiline_element_second_pass = (
     After
   </div>
 );
+
+convert_space_expressions =
+  <div>{" "}</div>
+
+x =
+  <div>
+    <first />
+    <second />
+    <third />
+    <fourth />
+    <fifth />
+    <sixth />
+  </div>
+
+const Abc = () => {
+  return (
+    <div>
+      Please state your
+      {" "}
+      <b>name</b>
+      {" "}
+      and
+      {" "}
+      <b>occupation</b>
+      {" "}
+      for the board of directors.
+    </div>
+  );
+};
+
+x = <div id="moo">Some stuff here</div>
+
+headers_and_paragraphs = (
+  <div>
+    <h2>First</h2>
+    <p>The first paragraph.</p>
+
+    <h2>Second</h2>
+    <p>The second paragraph.</p>
+  </div>
+);
+
+no_text_one_tag_per_line =
+  <div>
+    <first /><second />
+  </div>
+
+with_text_fill_line =
+  <div>
+    Text <first /><second />
+  </div>
+
+line_after_br =
+  <div>
+    Text<br />
+    More text <br />
+    And more<br />
+  </div>
+
+line_after_br_2 = <div>A<br />B<br />C</div>
+
+br_followed_by_whitespace = <div><br /> text</div>
+
+dont_preserve_blank_lines_when_jsx_contains_text =
+  <div>
+
+    <div>First</div>
+
+    Second
+
+  </div>
+
+multiple_expressions =
+  <div>
+    {header}
+    {body}
+    {footer}
+  </div>
+
+single_expression_child_tags =
+  <div>
+    You currently have <strong>{dashboardStr}</strong> and <strong>{userStr}</strong>
+  </div>
+
+

--- a/tests/jsx-text-wrap/test.js
+++ b/tests/jsx-text-wrap/test.js
@@ -225,6 +225,8 @@ br_followed_by_whitespace = <div><br /> text</div>
 dont_preserve_blank_lines_when_jsx_contains_text =
   <div>
 
+    <div>Zeroth</div>
+
     <div>First</div>
 
     Second

--- a/tests/jsx-text-wrap/test.js
+++ b/tests/jsx-text-wrap/test.js
@@ -243,4 +243,9 @@ single_expression_child_tags =
     You currently have <strong>{dashboardStr}</strong> and <strong>{userStr}</strong>
   </div>
 
+expression_does_not_break =
+  <div>texty text text text text text text text text text text text {this.props.type} </div>
 
+// FIXME
+br_triggers_expression_break =
+  <div><br />text text text text text text text text text text text {this.props.type} </div>

--- a/tests/jsx-whitespace/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-whitespace/__snapshots__/jsfmt.spec.js.snap
@@ -27,20 +27,8 @@ zero_width_space = <div>]​​​[</div>
 // Treated as whitespace in JSX
 spaces = <div>] [</div>;
 tabs = <div>] [</div>;
-slash_n = (
-  <div>
-    ]
-
-    [
-  </div>
-);
-slash_r = (
-  <div>
-    ]
-
-    [
-  </div>
-);
+slash_n = <div>] [</div>;
+slash_r = <div>] [</div>;
 
 // Not treated as whitespace in JSX
 // NOTE: Some of the space characters here won't show up in an editor,

--- a/tests/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -128,13 +128,7 @@ exports[`expression.js 1`] = `
   value={option}
 />;
 
-<ParentComponent
-  prop={
-    <Child>
-      test
-    </Child>
-  }
-/>;
+<ParentComponent prop={<Child>test</Child>} />;
 
 `;
 
@@ -148,9 +142,7 @@ const aDiv = (
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const aDiv = (
   /* $FlowFixMe */
-  <div className="foo">
-    Foo bar
-  </div>
+  <div className="foo">Foo bar</div>
 );
 
 `;
@@ -283,7 +275,8 @@ onClick={() => {
     a;
   }}
 >
-  {header}{showSort}
+  {header}
+  {showSort}
 </td>;
 
 <td
@@ -359,23 +352,11 @@ const Labels = {
 };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const Labels = {
-  label1: (
-    <fbt>
-      Label 1
-    </fbt>
-  ),
+  label1: <fbt>Label 1</fbt>,
 
-  label2: (
-    <fbt>
-      Label 2
-    </fbt>
-  ),
+  label2: <fbt>Label 2</fbt>,
 
-  label3: (
-    <fbt>
-      Label 3
-    </fbt>
-  )
+  label3: <fbt>Label 3</fbt>
 };
 
 `;

--- a/tests/jsx_escape/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx_escape/__snapshots__/jsfmt.spec.js.snap
@@ -31,14 +31,10 @@ raw_amp = <span>foo & bar</span>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 many_nbsp = <div>&nbsp; &nbsp; </div>;
 single_nbsp = <div>&nbsp;</div>;
-nbsp_with_newline = (
-  <div>
-    &nbsp;
-  </div>
-);
+nbsp_with_newline = <div>&nbsp;</div>;
 
 many_raw_nbsp = <div>   </div>;
-many_raw_spaces = <div>   </div>;
+many_raw_spaces = <div> </div>;
 
 amp = <span>foo &amp; bar</span>;
 raw_amp = <span>foo & bar</span>;
@@ -62,14 +58,10 @@ raw_amp = <span>foo & bar</span>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 many_nbsp = <div>&nbsp; &nbsp; </div>;
 single_nbsp = <div>&nbsp;</div>;
-nbsp_with_newline = (
-  <div>
-    &nbsp;
-  </div>
-);
+nbsp_with_newline = <div>&nbsp;</div>;
 
 many_raw_nbsp = <div>   </div>;
-many_raw_spaces = <div>   </div>;
+many_raw_spaces = <div> </div>;
 
 amp = <span>foo &amp; bar</span>;
 raw_amp = <span>foo & bar</span>;

--- a/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
@@ -30,17 +30,9 @@ var example2 = <div>
 	/*test*/
 </div>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-var example1 = (
-  <div>
-    https://test
-  </div>
-);
+var example1 = <div>https://test</div>;
 
-var example2 = (
-  <div>
-    /*test*/
-  </div>
-);
+var example2 = <div>/*test*/</div>;
 
 `;
 

--- a/tests/typescript_tsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_tsx/__snapshots__/jsfmt.spec.js.snap
@@ -38,10 +38,7 @@ const MyCoolList = ({ things }) =>
 
 const MyCoolThing = ({ thingo }) => <li>{thingo}</li>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-const MyCoolList = ({ things }) =>
-  <ul>
-    {things.map(MyCoolThing)}
-  </ul>;
+const MyCoolList = ({ things }) => <ul>{things.map(MyCoolThing)}</ul>;
 
 const MyCoolThing = ({ thingo }) => <li>{thingo}</li>;
 


### PR DESCRIPTION
This PR is an initial investigation into the feasibility to having Prettier recombine JSX lines that have already been split.

Inspired by: https://github.com/prettier/prettier/issues/1583

This still has a number of edge cases that need to be handled, but the basics are there.

For example:

```javascript
const Abc = () => {
  return (
    <div>
      Please state your
      {" "}
      <b>name</b>
      {" "}
      and
      {" "}
      <b>occupation</b>
      {" "}
      for the board of directors.
    </div>
  );
};
```

Would become:

```javascript
const Abc = () => {
  return (
    <div>
      Please state your <b>name</b> and <b>occupation</b> for the board of
      directors.
    </div>
  );
}
```

Allowing lines of JSX to be recombined is a big change from our current approach where we always retain newlines in JSX.

Issue https://github.com/prettier/prettier/issues/1583 mentions just recombining lines split with `{" "}` whereas this PR takes the approach of allowing any lines to be recombined.

I'd be interested in people's opinions on this. Do we think allowing lines to be recombined, as we do with JS, is a good idea for JSX?

P.S. I've based this PR on top of some other PRs I've been working on, only the last commit contains logic for recombining lines.