### PR TITLE
Adding --stdin-filepath option in order to enable filetype inference …

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ Prettier ships with a handful of customizable format options, usable in both the
 | **JSX Brackets on Same Line** - Put the `>` of a multi-line JSX element at the end of the last line instead of being alone on the next line | `false` | `--jsx-bracket-same-line` | `jsxBracketSameLine: <bool>` |
 | **Range Start** - Format code starting at a given character offset. The range will extend backwards to the start of the first line containing the selected statement. | `0` | `--range-start <int>` | `rangeStart: <int>` |
 | **Range End** - Format code ending at a given character offset (exclusive). The range will extend forwards to the end of the selected statement. | `Infinity` | `--range-end <int>` | `rangeEnd: <int>` |
-| **Parser** - Specify which parser to use. Both parsers support the same set of JavaScript features (including Flow). You shouldn't have to change this setting. | `babylon` | <code>--parser <flow&#124;babylon></code> | <code>parser: "<flow&#124;babylon&#124;postcss>"</code> |
+| **Parser** - Specify which parser to use. Both parsers support the same set of JavaScript features (including Flow). You shouldn't have to change this setting. | `babylon` | <code>--parser <flow&#124;babylon></code> | <code>parser: "<flow&#124;babylon&#124;postcss&#124;typescript>"</code> |
 | **Filepath** - Specify the input filepath this will be used to do parser inference.<br /><br /> Example: <br />`cat foo \| prettier --stdin-filepath foo.css`<br /> will default to use `postcss` parser |  | `--stdin-filepath` | `filepath: <string>` |
 
 ### Excluding code from formatting

--- a/README.md
+++ b/README.md
@@ -271,7 +271,8 @@ Prettier ships with a handful of customizable format options, usable in both the
 | **JSX Brackets on Same Line** - Put the `>` of a multi-line JSX element at the end of the last line instead of being alone on the next line | `false` | `--jsx-bracket-same-line` | `jsxBracketSameLine: <bool>` |
 | **Range Start** - Format code starting at a given character offset. The range will extend backwards to the start of the first line containing the selected statement. | `0` | `--range-start <int>` | `rangeStart: <int>` |
 | **Range End** - Format code ending at a given character offset (exclusive). The range will extend forwards to the end of the selected statement. | `Infinity` | `--range-end <int>` | `rangeEnd: <int>` |
-| **Parser** - Specify which parser to use. Both parsers support the same set of JavaScript features (including Flow). You shouldn't have to change this setting. | `babylon` | <code>--parser <flow&#124;babylon></code> | <code>parser: "<flow&#124;babylon>"</code> |
+| **Parser** - Specify which parser to use. Both parsers support the same set of JavaScript features (including Flow). You shouldn't have to change this setting. | `babylon` | <code>--parser <flow&#124;babylon></code> | <code>parser: "<flow&#124;babylon&#124;postcss>"</code> |
+| **Filepath** - Specify the input filepath this will be used to do parser inference.<br /><br /> Example: <br />`cat foo \| prettier --stdin-filepath foo.css`<br /> will default to use `postcss` parser |  | `--stdin-filepath` | `filepath: <string>` |
 
 ### Excluding code from formatting
 

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -41,7 +41,8 @@ const argv = minimist(process.argv.slice(2), {
     "parser",
     "trailing-comma",
     "range-start",
-    "range-end"
+    "range-end",
+    "stdin-filepath"
   ],
   default: {
     semi: true,
@@ -160,6 +161,7 @@ const options = {
   bracketSpacing: argv["bracket-spacing"],
   singleQuote: argv["single-quote"],
   jsxBracketSameLine: argv["jsx-bracket-same-line"],
+  filepath: argv["stdin-filepath"],
   trailingComma: getTrailingComma(),
   parser: getParserOption()
 };
@@ -233,6 +235,7 @@ if (argv["help"] || (!filepatterns.length && !stdin)) {
       "  --write                  Edit the file in-place. (Beware!)\n" +
       "  --list-different or -l   Print filenames of files that are different from Prettier formatting.\n" +
       "  --stdin                  Read input from stdin.\n" +
+      "  --stdin-filepath         Path to the file used to read from stdin.\n" +
       "  --print-width <int>      Specify the length of line that the printer will wrap on. Defaults to 80.\n" +
       "  --tab-width <int>        Specify the number of spaces per indentation-level. Defaults to 2.\n" +
       "  --use-tabs               Indent lines with tabs instead of spaces.\n" +

--- a/src/options.js
+++ b/src/options.js
@@ -26,12 +26,16 @@ const exampleConfig = Object.assign({}, defaults, {
 // Copy options and fill in default values.
 function normalize(options) {
   const normalized = Object.assign({}, options || {});
+  const filepath = normalized.filepath;
 
   if (
-    "filepath" in normalized &&
-    /\.(css|less|scss)$/.test(normalized.filepath)
+    /\.(css|less|scss)$/.test(filepath)
   ) {
     normalized.parser = "postcss";
+  } else if (
+    /\.(ts|tsx)$/.test(filepath)
+  ) {
+    normalized.parser = "typescript";
   }
 
   if (typeof normalized.trailingComma === "boolean") {

--- a/src/options.js
+++ b/src/options.js
@@ -28,13 +28,9 @@ function normalize(options) {
   const normalized = Object.assign({}, options || {});
   const filepath = normalized.filepath;
 
-  if (
-    /\.(css|less|scss)$/.test(filepath)
-  ) {
+  if (/\.(css|less|scss)$/.test(filepath)) {
     normalized.parser = "postcss";
-  } else if (
-    /\.(ts|tsx)$/.test(filepath)
-  ) {
+  } else if (/\.(ts|tsx)$/.test(filepath)) {
     normalized.parser = "typescript";
   }
 

--- a/src/options.js
+++ b/src/options.js
@@ -18,7 +18,7 @@ const defaults = {
 };
 
 const exampleConfig = Object.assign({}, defaults, {
-  filename: "testFilename",
+  filepath: "path/to/Filename",
   printWidth: 80,
   originalText: "text"
 });
@@ -26,6 +26,13 @@ const exampleConfig = Object.assign({}, defaults, {
 // Copy options and fill in default values.
 function normalize(options) {
   const normalized = Object.assign({}, options || {});
+
+  if (
+    "filepath" in normalized &&
+    /\.(css|less|scss)$/.test(normalized.filepath)
+  ) {
+    normalized.parser = "postcss";
+  }
 
   if (typeof normalized.trailingComma === "boolean") {
     // Support a deprecated boolean type for the trailing comma config


### PR DESCRIPTION
By including a new CLI option to go along with the existing `--stdin`  will allow the parser to be infered making integrations to other editors a lot easier.