### PR TITLE
Add an option to include "dot" directories.

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -32,6 +32,7 @@ const argv = minimist(process.argv.slice(2), {
     "debug-print-doc",
     "debug-check",
     "with-node-modules",
+    "include-dot-directories",
     // Deprecated in 0.0.10
     "flow-parser"
   ],
@@ -68,8 +69,10 @@ const filepatterns = argv["_"];
 const write = argv["write"];
 const stdin = argv["stdin"] || (!filepatterns.length && !process.stdin.isTTY);
 const ignoreNodeModules = argv["with-node-modules"] === false;
+const includeDotDirectories = argv["include-dot-directories"] === true;
 const globOptions = {
-  ignore: ignoreNodeModules && "**/node_modules/**"
+  ignore: ignoreNodeModules && "**/node_modules/**",
+  dot: includeDotDirectories
 };
 
 if (write && argv["debug-check"]) {

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -32,7 +32,6 @@ const argv = minimist(process.argv.slice(2), {
     "debug-print-doc",
     "debug-check",
     "with-node-modules",
-    "include-dot-directories",
     // Deprecated in 0.0.10
     "flow-parser"
   ],
@@ -69,10 +68,9 @@ const filepatterns = argv["_"];
 const write = argv["write"];
 const stdin = argv["stdin"] || (!filepatterns.length && !process.stdin.isTTY);
 const ignoreNodeModules = argv["with-node-modules"] === false;
-const includeDotDirectories = argv["include-dot-directories"] === true;
 const globOptions = {
   ignore: ignoreNodeModules && "**/node_modules/**",
-  dot: includeDotDirectories
+  dot: true
 };
 
 if (write && argv["debug-check"]) {


### PR DESCRIPTION
We have some files in directories that start with a `.` that we want prettified. This PR adds the `include-dot-directories` flag to let the glob match dot directories.