### PR TITLE
Use `filepath` option instead of `filename` in tests

### DIFF
--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -113,7 +113,7 @@ function prettyprint(src, filename, options) {
     src,
     Object.assign(
       {
-        filename
+        filepath: filename
       },
       options
     )


### PR DESCRIPTION
This silences the validation warnings like:

    Unknown option "filename" with value "/home/travis/build/prettier/prettier/tests/flow/es_declare_module/flow-typed/declares.js" was found.

See here for an example:
https://travis-ci.org/prettier/prettier/jobs/238474756#L397

Related to commit 0d9b04b (https://github.com/prettier/prettier/pull/1835)