### PR TITLE
Ignore docs/index.js when searching with ag/ripgrep/sift

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,2 +1,3 @@
 docs/prettier.min.js
+docs/index.js
 dist

--- a/.ignore
+++ b/.ignore
@@ -1,3 +1,6 @@
-docs/prettier.min.js
 docs/index.js
+docs/parser-babylon.js
+docs/parser-flow.js
+docs/parser-postcss.js
+docs/parser-typescript.js
 dist


### PR DESCRIPTION
This makes it easier to search through the code without getting
irrelevant results.