### PR TITLE
TypeScript: do not print trailing comma in TS tuple type

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1802,7 +1802,10 @@ function genericPrintNoParens(path, options, print, args) {
               printArrayItems(path, options, typesField, print)
             ])
           ),
-          ifBreak(shouldPrintComma(options) ? "," : ""),
+          // TypeScript doesn't support trailing commas in tuple types
+          n.type === "TSTupleType"
+            ? ""
+            : ifBreak(shouldPrintComma(options) ? "," : ""),
           comments.printDanglingComments(path, options, /* sameIndent */ true),
           softline,
           "]"

--- a/tests/typescript_tuple/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_tuple/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`trailing-comma.ts 1`] = `
+export interface ShopQueryResult {
+  chic: boolean;
+  location: number[];
+  menus: Menu[];
+  openingDays: number[];
+  closingDays: [
+    {
+      from: string,
+      to: string,
+    }, // <== this one
+  ];
+  shop: string;
+  distance: number;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export interface ShopQueryResult {
+  chic: boolean;
+  location: number[];
+  menus: Menu[];
+  openingDays: number[];
+  closingDays: [
+    {
+      from: string,
+      to: string
+    } // <== this one
+  ];
+  shop: string;
+  distance: number;
+}
+
+`;
+
 exports[`tuple.ts 1`] = `
 
 export type SCMRawResource = [

--- a/tests/typescript_tuple/trailing-comma.ts
+++ b/tests/typescript_tuple/trailing-comma.ts
@@ -1,0 +1,14 @@
+export interface ShopQueryResult {
+  chic: boolean;
+  location: number[];
+  menus: Menu[];
+  openingDays: number[];
+  closingDays: [
+    {
+      from: string,
+      to: string,
+    }, // <== this one
+  ];
+  shop: string;
+  distance: number;
+}


### PR DESCRIPTION
Fixes #1858