### PR TITLE
Require semicolons before class props named 'in' or 'instanceof'

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -4591,6 +4591,10 @@ function classChildNeedsASIProtection(node) {
     return;
   }
 
+  if (!node.computed) {
+    const name = node.key && node.key.name;
+    if (name === "in" || name === "instanceof") return true;
+  }
   switch (node.type) {
     case "ClassProperty":
     case "TSAbstractClassProperty":

--- a/tests/no-semi-babylon-extensions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/no-semi-babylon-extensions/__snapshots__/jsfmt.spec.js.snap
@@ -3,17 +3,53 @@
 exports[`no-semi.js 1`] = `
 a
 ;::b.c
+
+class A {
+  a = b;
+  in
+  c
+
+  a = b;
+  instanceof(){}
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 a;
 ::b.c;
+
+class A {
+  a = b;
+  in;
+  c;
+
+  a = b;
+  instanceof() {}
+}
 
 `;
 
 exports[`no-semi.js 2`] = `
 a
 ;::b.c
+
+class A {
+  a = b;
+  in
+  c
+
+  a = b;
+  instanceof(){}
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 a
 ;::b.c
+
+class A {
+  a = b;
+  in
+  c
+
+  a = b;
+  instanceof() {}
+}
 
 `;

--- a/tests/no-semi-babylon-extensions/no-semi.js
+++ b/tests/no-semi-babylon-extensions/no-semi.js
@@ -1,2 +1,11 @@
 a
 ;::b.c
+
+class A {
+  a = b;
+  in
+  c
+
+  a = b;
+  instanceof(){}
+}


### PR DESCRIPTION
Fixes #1875.

(Man, class properties with no-semi are *so edge-case-y*. Ugh.)