### PR TITLE
Add shebang comment nodes to Flow/TypeScript ASTs

### DIFF
--- a/index.js
+++ b/index.js
@@ -252,33 +252,16 @@ function formatRange(text, opts, ast) {
   }
 }
 
-function fixShebang(text, formatted) {
-  if (!text.startsWith("#!")) {
-    return formatted;
-  }
-
-  const index = text.indexOf("\n");
-  const shebang = text.slice(0, index + 1);
-  const nextChar = text.charAt(index + 1);
-  const newLine = nextChar === "\n" ? "\n" : nextChar === "\r" ? "\r\n" : "";
-
-  return shebang + newLine + formatted;
-}
-
 module.exports = {
   formatWithCursor: function(text, opts) {
-    const result = formatWithCursor(text, normalizeOptions(opts));
-    return {
-      formatted: fixShebang(text, result.formatted),
-      cursorOffset: result.cursorOffset
-    };
+    return formatWithCursor(text, normalizeOptions(opts));
   },
   format: function(text, opts) {
-    return fixShebang(text, format(text, normalizeOptions(opts)));
+    return format(text, normalizeOptions(opts));
   },
   check: function(text, opts) {
     try {
-      const formatted = fixShebang(text, format(text, normalizeOptions(opts)));
+      const formatted = format(text, normalizeOptions(opts));
       return formatted === text;
     } catch (e) {
       return false;

--- a/src/comments.js
+++ b/src/comments.js
@@ -812,9 +812,9 @@ function printComment(commentPath, options) {
       return "/*" + comment.value + "*/";
     case "CommentLine":
     case "Line":
-      // Don't print the shebang, it's taken care of in index.js
+      // Print shebangs with the proper comment characters
       if (options.originalText.slice(util.locStart(comment)).startsWith("#!")) {
-        return "";
+        return "#!" + comment.value;
       }
       return "//" + comment.value;
     default:

--- a/src/parser-flow.js
+++ b/src/parser-flow.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const createError = require("./parser-create-error");
+const includeShebang = require("./parser-include-shebang");
 
 function parse(text) {
   // Inline the require to avoid loading all the JS if we don't use it
@@ -20,30 +21,7 @@ function parse(text) {
     );
   }
 
-  if (!text.startsWith("#!")) {
-    return ast;
-  }
-
-  const index = text.indexOf("\n");
-  const shebang = text.slice(2, index);
-  const comment = {
-    type: "Line",
-    loc: {
-      source: null,
-      start: {
-        line: 1,
-        column: 0
-      },
-      end: {
-        line: 1,
-        column: index
-      }
-    },
-    range: [0, index],
-    value: shebang
-  };
-  ast.comments = [comment].concat(ast.comments);
-
+  includeShebang(text, ast);
   return ast;
 }
 module.exports = parse;

--- a/src/parser-flow.js
+++ b/src/parser-flow.js
@@ -20,7 +20,30 @@ function parse(text) {
     );
   }
 
+  if (!text.startsWith("#!")) {
+    return ast;
+  }
+
+  const index = text.indexOf("\n");
+  const shebang = text.slice(2, index);
+  const comment = {
+    type: "Line",
+    loc: {
+      source: null,
+      start: {
+        line: 1,
+        column: 0
+      },
+      end: {
+        line: 1,
+        column: index
+      }
+    },
+    range: [0, index],
+    value: shebang
+  };
+  ast.comments = [comment].concat(ast.comments);
+
   return ast;
 }
-
 module.exports = parse;

--- a/src/parser-include-shebang.js
+++ b/src/parser-include-shebang.js
@@ -1,0 +1,30 @@
+"use strict";
+
+function includeShebang(text, ast) {
+  if (!text.startsWith("#!")) {
+    return;
+  }
+
+  const index = text.indexOf("\n");
+  const shebang = text.slice(2, index);
+  const comment = {
+    type: "Line",
+    value: shebang,
+    range: [0, index],
+    loc: {
+      source: null,
+      start: {
+        line: 1,
+        column: 0
+      },
+      end: {
+        line: 1,
+        column: index
+      }
+    }
+  };
+
+  ast.comments = [comment].concat(ast.comments);
+}
+
+module.exports = includeShebang;

--- a/src/parser-typescript.js
+++ b/src/parser-typescript.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const createError = require("./parser-create-error");
+const includeShebang = require("./parser-include-shebang");
 
 function parse(text) {
   const jsx = isProbablyJsx(text);
@@ -18,30 +19,7 @@ function parse(text) {
   }
 
   delete ast.tokens;
-
-  if (!text.startsWith("#!")) {
-    return ast;
-  }
-
-  const index = text.indexOf("\n");
-  const shebang = text.slice(2, index);
-  const comment = {
-    type: "Line",
-    value: shebang,
-    range: [0, index],
-    loc: {
-      start: {
-        line: 1,
-        column: 0
-      },
-      end: {
-        line: 1,
-        column: index
-      }
-    }
-  };
-  ast.comments = [comment].concat(ast.comments);
-
+  includeShebang(text, ast);
   return ast;
 }
 

--- a/src/parser-typescript.js
+++ b/src/parser-typescript.js
@@ -18,6 +18,30 @@ function parse(text) {
   }
 
   delete ast.tokens;
+
+  if (!text.startsWith("#!")) {
+    return ast;
+  }
+
+  const index = text.indexOf("\n");
+  const shebang = text.slice(2, index);
+  const comment = {
+    type: "Line",
+    value: shebang,
+    range: [0, index],
+    loc: {
+      start: {
+        line: 1,
+        column: 0
+      },
+      end: {
+        line: 1,
+        column: index
+      }
+    }
+  };
+  ast.comments = [comment].concat(ast.comments);
+
   return ast;
 }
 


### PR DESCRIPTION
Now we handle actually printing the shebang in `printComment`, rather than
lopping it off beforehand and reattaching it afterward, as suggested in
https://github.com/prettier/prettier/pull/1718#issuecomment-303876792