### PR TITLE
Move accessibility before static

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1661,15 +1661,15 @@ function genericPrintNoParens(path, options, print, args) {
       return concat(parts);
     case "ClassProperty":
     case "TSAbstractClassProperty": {
-      if (n.static) {
-        parts.push("static ");
-      }
       const variance = getFlowVariance(n);
       if (variance) {
         parts.push(variance);
       }
       if (n.accessibility) {
         parts.push(n.accessibility + " ");
+      }
+      if (n.static) {
+        parts.push("static ");
       }
       if (n.type === "TSAbstractClassProperty") {
         parts.push("abstract ");

--- a/tests/typescript/conformance/classes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/classes/__snapshots__/jsfmt.spec.js.snap
@@ -149,25 +149,25 @@ class Private2 {
 class Protected {
   constructor(...args: any[]) {}
   protected p: string;
-  static protected s: string;
+  protected static s: string;
 }
 
 class Protected2 {
   constructor(...args: any[]) {}
   protected p: string;
-  static protected s: string;
+  protected static s: string;
 }
 
 class Public {
   constructor(...args: any[]) {}
   public p: string;
-  static public s: string;
+  public static s: string;
 }
 
 class Public2 {
   constructor(...args: any[]) {}
   public p: string;
-  static public s: string;
+  public static s: string;
 }
 
 function f1(x: Private & Private2) {

--- a/tests/typescript_class/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_class/__snapshots__/jsfmt.spec.js.snap
@@ -51,6 +51,10 @@ class X {
 interface Iterable<T> {
   export [Symbol.iterator](): Iterator<T>;
 }
+
+export class Check {
+  private static property = 'test';
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class X {
   optionalMethod?() {}
@@ -58,6 +62,10 @@ class X {
 
 interface Iterable<T> {
   export [Symbol.iterator](): Iterator<T>;
+}
+
+export class Check {
+  private static property = "test";
 }
 
 `;

--- a/tests/typescript_class/methods.ts
+++ b/tests/typescript_class/methods.ts
@@ -5,3 +5,7 @@ class X {
 interface Iterable<T> {
   export [Symbol.iterator](): Iterator<T>;
 }
+
+export class Check {
+  private static property = 'test';
+}


### PR DESCRIPTION
I looked through all the places where we display accessibility and all of them now have a consistent way of printing all those modifiers.

Fixes #1877