### PR TITLE
Fix strictEqual throwing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,7 +7,7 @@ global = window;
 Buffer = {isBuffer: function() { return false; }};
 fs = module$1 = module = path = os = crypto = {};
 process = {argv: [], env: {}}
-assert = {ok: function() {}};
+assert = {ok: function() {}, strictEqual: function() {}};
 function require(path) { return window[path.replace(/.+-/, '')]; }
 </script>
 


### PR DESCRIPTION
I looked at what is being called with assert and couldn't find anything but `ok` and `strictEqual`.

Fixes #1903