### PR TITLE
Use semi-colon for object separator

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -812,18 +812,14 @@ function genericPrintNoParens(path, options, print, args) {
       return concat(parts);
     case "ObjectExpression":
     case "ObjectPattern":
-    case "TSInterfaceBody":
     case "ObjectTypeAnnotation":
+    case "TSInterfaceBody":
     case "TSTypeLiteral": {
       const isTypeAnnotation = n.type === "ObjectTypeAnnotation";
-      const isTypeScriptInterfaceBody = n.type === "TSInterfaceBody";
-      // Leave this here because we *might* want to make this
-      // configurable later -- flow accepts ";" for type separators,
-      // typescript accepts ";" and newlines
-      let separator = isTypeAnnotation ? "," : ",";
-      if (isTypeScriptInterfaceBody) {
-        separator = semi;
-      }
+      const separator = n.type === "TSInterfaceBody" ||
+        n.type === "TSTypeLiteral"
+        ? semi
+        : ",";
       const fields = [];
       const leftBrace = n.exact ? "{|" : "{";
       const rightBrace = n.exact ? "|}" : "}";

--- a/tests/template/jsfmt.spec.js
+++ b/tests/template/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, null, ["typescript"]);
+run_spec(__dirname, null);

--- a/tests/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
@@ -499,9 +499,9 @@ const shouldFail: { important: boolean } = output.x.children;
 
 type Meta<T, A> = {
   [P in keyof T]: {
-    value: T[P],
-    also: A,
-    readonly children: Meta<T[P], A>
+    value: T[P];
+    also: A;
+    readonly children: Meta<T[P], A>;
   }
 };
 

--- a/tests/typescript/conformance/interfaces/interfaceDeclarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/interfaces/interfaceDeclarations/__snapshots__/jsfmt.spec.js.snap
@@ -27,15 +27,15 @@ interface Derived3 extends Base, Base2 {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 interface Base {
   x: {
-    a?: string,
-    b: string
+    a?: string;
+    b: string;
   };
 }
 
 interface Base2 {
   x: {
-    b: string,
-    c?: number
+    b: string;
+    c?: number;
   };
 }
 
@@ -44,11 +44,11 @@ interface Derived extends Base, Base2 {
 }
 
 interface Derived2 extends Base, Base2 {
-  x: { a: number, b: string };
+  x: { a: number; b: string };
 }
 
 interface Derived3 extends Base, Base2 {
-  x: { a: string, b: string };
+  x: { a: string; b: string };
 }
 
 `;

--- a/tests/typescript/conformance/internalModules/importDeclarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/internalModules/importDeclarations/__snapshots__/jsfmt.spec.js.snap
@@ -129,7 +129,7 @@ namespace C {
 }
 
 var a: string = C.a.x;
-var b: { x: number, y: number } = new C.a.Point(0, 0);
+var b: { x: number; y: number } = new C.a.Point(0, 0);
 var c: { name: string };
 var c: C.a.B.Id;
 
@@ -151,7 +151,7 @@ namespace Z {
 }
 
 var m: number = Z.y();
-var n: { x: number, y: number } = new Z.y.Point(0, 0);
+var n: { x: number; y: number } = new Z.y.Point(0, 0);
 
 namespace K {
   export class L {
@@ -174,7 +174,7 @@ namespace M {
 var o: { name: string };
 var o = new M.D("Hello");
 
-var p: { x: number, y: number };
+var p: { x: number; y: number };
 var p: M.D.Point;
 
 `;
@@ -242,7 +242,7 @@ import alias = moduleA;
 
 var p: alias.Point;
 var p: moduleA.Point;
-var p: { x: number, y: number };
+var p: { x: number; y: number };
 
 class clodule {
   name: string;
@@ -260,7 +260,7 @@ import clolias = clodule;
 
 var p: clolias.Point;
 var p: clodule.Point;
-var p: { x: number, y: number };
+var p: { x: number; y: number };
 
 function fundule() {
   return { x: 0, y: 0 };
@@ -278,7 +278,7 @@ import funlias = fundule;
 
 var p: funlias.Point;
 var p: fundule.Point;
-var p: { x: number, y: number };
+var p: { x: number; y: number };
 
 `;
 

--- a/tests/typescript/conformance/types/functions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/functions/__snapshots__/jsfmt.spec.js.snap
@@ -438,7 +438,7 @@ function opt1(n = 4) {
 // Function signature with optional parameter, no type annotation and initializer has initializer's widened type
 function opt2(n = { x: null, y: undefined }) {
   var m = n;
-  var m: { x: any, y: any };
+  var m: { x: any; y: any };
 }
 
 // Function signature with initializer referencing other parameter to the left

--- a/tests/typescript/conformance/types/methodSignature/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/methodSignature/__snapshots__/jsfmt.spec.js.snap
@@ -7,8 +7,8 @@ var logger: {
 };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var logger: {
-  log(val: any, val2: any),
-  error(val: any)
+  log(val: any, val2: any);
+  error(val: any);
 };
 
 `;

--- a/tests/typescript/conformance/types/union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/union/__snapshots__/jsfmt.spec.js.snap
@@ -88,8 +88,8 @@ strOrBoolean = unionOfDifferentReturnType("hello"); // error
 unionOfDifferentReturnType1(true); // error in type of parameter
 
 var unionOfDifferentReturnType1:
-  | { (a: number): number, (a: string): string }
-  | { (a: number): Date, (a: string): boolean };
+  | { (a: number): number; (a: string): string }
+  | { (a: number): Date; (a: string): boolean };
 numOrDate = unionOfDifferentReturnType1(10);
 strOrBoolean = unionOfDifferentReturnType1("hello");
 unionOfDifferentReturnType1(true); // error in type of parameter
@@ -104,7 +104,7 @@ unionOfDifferentParameterTypes(); // error - no call signatures
 
 var unionOfDifferentNumberOfSignatures:
   | { (a: number): number }
-  | { (a: number): Date, (a: string): boolean };
+  | { (a: number): Date; (a: string): boolean };
 unionOfDifferentNumberOfSignatures(); // error - no call signatures
 unionOfDifferentNumberOfSignatures(10); // error - no call signatures
 unionOfDifferentNumberOfSignatures("hello"); // error - no call signatures
@@ -350,8 +350,8 @@ strOrBoolean = new unionOfDifferentReturnType("hello"); // error
 new unionOfDifferentReturnType1(true); // error in type of parameter
 
 var unionOfDifferentReturnType1:
-  | { new (a: number): number, new (a: string): string }
-  | { new (a: number): Date, new (a: string): boolean };
+  | { new (a: number): number; new (a: string): string }
+  | { new (a: number): Date; new (a: string): boolean };
 numOrDate = new unionOfDifferentReturnType1(10);
 strOrBoolean = new unionOfDifferentReturnType1("hello");
 new unionOfDifferentReturnType1(true); // error in type of parameter
@@ -366,7 +366,7 @@ new unionOfDifferentParameterTypes(); // error - no call signatures
 
 var unionOfDifferentNumberOfSignatures:
   | { new (a: number): number }
-  | { new (a: number): Date, new (a: string): boolean };
+  | { new (a: number): Date; new (a: string): boolean };
 new unionOfDifferentNumberOfSignatures(); // error - no call signatures
 new unionOfDifferentNumberOfSignatures(10); // error - no call signatures
 new unionOfDifferentNumberOfSignatures("hello"); // error - no call signatures
@@ -510,8 +510,8 @@ var arr3Tuple: [number, string] = [3, "three"]; // [number, string]
 var arr4Tuple: [number, string] = [3, "three", "hello"]; // [number, string, string]
 var arrEmpty = [];
 var arr5Tuple: {
-  0: string,
-  5: number
+  0: string;
+  5: number;
 } = ["hello", true, false, " hello", true, 10, "any"]; // Tuple
 class C {
   foo() {}

--- a/tests/typescript/custom/computedProperties/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/custom/computedProperties/__snapshots__/jsfmt.spec.js.snap
@@ -14,7 +14,7 @@ interface I {
 }
 
 type T = {
-  "string": "T"
+  "string": "T";
 };
 
 `;
@@ -33,7 +33,7 @@ interface I {
 }
 
 type T = {
-  [Symbol.toStringTag]: "T"
+  [Symbol.toStringTag]: "T";
 };
 
 `;

--- a/tests/typescript_array/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_array/__snapshots__/jsfmt.spec.js.snap
@@ -15,7 +15,7 @@ export class ViewTokensChangedEvent {
     /**
      * Start line number of range
      */
-    readonly fromLineNumber: number
+    readonly fromLineNumber: number;
   }[];
 }
 

--- a/tests/typescript_interface/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_interface/__snapshots__/jsfmt.spec.js.snap
@@ -8,3 +8,38 @@ abstract interface I {
 abstract interface I {}
 
 `;
+
+exports[`separator.ts 1`] = `
+declare module 'selenium-webdriver' {
+  export const until: {
+    ableToSwitchToFrame(frame: number | WebElement | By): Condition<boolean>;
+    alertIsPresent(): Condition<Alert>;
+  };
+}
+
+export interface Edge {
+  cursor: {};
+  node: {
+    id: {};
+  };
+}
+
+interface Test { one: string, two: any[] }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+declare module "selenium-webdriver" {
+  export const until: {
+    ableToSwitchToFrame(frame: number | WebElement | By): Condition<boolean>;
+    alertIsPresent(): Condition<Alert>;
+  };
+}
+
+export interface Edge {
+  cursor: {};
+  node: {
+    id: {};
+  };
+}
+
+interface Test { one: string; two: any[] }
+
+`;

--- a/tests/typescript_interface/separator.ts
+++ b/tests/typescript_interface/separator.ts
@@ -1,0 +1,15 @@
+declare module 'selenium-webdriver' {
+  export const until: {
+    ableToSwitchToFrame(frame: number | WebElement | By): Condition<boolean>;
+    alertIsPresent(): Condition<Alert>;
+  };
+}
+
+export interface Edge {
+  cursor: {};
+  node: {
+    id: {};
+  };
+}
+
+interface Test { one: string, two: any[] }

--- a/tests/typescript_tuple/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_tuple/__snapshots__/jsfmt.spec.js.snap
@@ -23,8 +23,8 @@ export interface ShopQueryResult {
   openingDays: number[];
   closingDays: [
     {
-      from: string,
-      to: string
+      from: string;
+      to: string;
     } // <== this one
   ];
   shop: string;

--- a/tests/typescript_union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_union/__snapshots__/jsfmt.spec.js.snap
@@ -35,7 +35,7 @@ interface RelayProps {
 }
 interface RelayProps {
   articles: Array<{
-    __id: string
+    __id: string;
   } | null> | null | void;
 }
 
@@ -45,9 +45,9 @@ type UploadState<E, EM, D> =
   // The upload timed out
   | { type: "Timed_out" }
   // Failed somewhere on the line
-  | { type: "Failed", error: E, errorMsg: EM }
+  | { type: "Failed"; error: E; errorMsg: EM }
   // Uploading to aws3 and CreatePostMutation succeeded
-  | { type: "Success", data: D };
+  | { type: "Success"; data: D };
 
 type UploadState<E, EM, D> =
   // The upload hasnt begun yet


### PR DESCRIPTION
Looks like the convention for typescript separator is `;` whereas for flow it's `,`. Let's migrate to that.

Fixes #1896
Fixes #1879
Fixes #1874