### PR TITLE
Fix leading comment

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3836,7 +3836,7 @@ function printMemberChain(path, options, print) {
     .reduce((res, group) => res.concat(group), []);
 
   const hasComment =
-    flatGroups.slice(1).some(node => hasLeadingComment(node.node)) ||
+    flatGroups.slice(1, -1).some(node => hasLeadingComment(node.node)) ||
     flatGroups.slice(0, -1).some(node => hasTrailingComment(node.node));
 
   // If we only have a single `.`, we shouldn't do anything fancy and just

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -250,6 +250,11 @@ this.doWriteConfiguration(target, value, options) // queue up writes to prevent 
   error => {
     return options.donotNotifyError ? TPromise.wrapError(error) : this.onError(error, target, value);
   });
+
+ret = __DEV__ ?
+  // $FlowFixMe: this type differs according to the env
+vm.runInContext(source, ctx)
+: a
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function f() {
   return (
@@ -303,6 +308,11 @@ this.doWriteConfiguration(target, value, options) // queue up writes to prevent 
         : this.onError(error, target, value);
     }
   );
+
+ret = __DEV__
+  ? // $FlowFixMe: this type differs according to the env
+    vm.runInContext(source, ctx)
+  : a;
 
 `;
 

--- a/tests/method-chain/comment.js
+++ b/tests/method-chain/comment.js
@@ -42,3 +42,8 @@ this.doWriteConfiguration(target, value, options) // queue up writes to prevent 
   error => {
     return options.donotNotifyError ? TPromise.wrapError(error) : this.onError(error, target, value);
   });
+
+ret = __DEV__ ?
+  // $FlowFixMe: this type differs according to the env
+vm.runInContext(source, ctx)
+: a


### PR DESCRIPTION
It turns out that leading comment is attached to the CallExpression which is the last one and not the first one if they fit in a single line, so we want to not check that one.

Fixes #1892