### PR TITLE
Fix As parenthesis for real

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -521,9 +521,6 @@ FastPath.prototype.needsParens = function() {
           return false;
       }
 
-    case "ObjectExpression":
-      return parent.type === "TSAsExpression";
-
     case "ClassExpression":
       return parent.type === "ExportDefaultDeclaration";
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -4519,7 +4519,8 @@ function getLeftSide(node) {
     node.callee ||
     node.object ||
     node.tag ||
-    node.argument
+    node.argument ||
+    node.expression
   );
 }
 

--- a/src/util.js
+++ b/src/util.js
@@ -324,6 +324,11 @@ function startsWithNoLookaheadToken(node, forbidFunctionAndClass) {
         node.expressions[0],
         forbidFunctionAndClass
       );
+    case "TSAsExpression":
+      return startsWithNoLookaheadToken(
+        node.expression,
+        forbidFunctionAndClass
+      );
     default:
       return false;
   }

--- a/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
@@ -15,6 +15,12 @@ function*g() {
 async function g() {
   const test = (await 'foo') as number;
 }
+({}) as X;
+() => ({}) as X;
+const state = JSON.stringify({
+  next: window.location.href,
+  nonce,
+} as State);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const name = (description as DescriptionObject).name || (description as string);
 this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
@@ -27,12 +33,20 @@ scrollTop > (visibilityHeight as number);
 export default class Column<T> extends (RcTable.Column as React.ComponentClass<
   ColumnProps<T>
 >) {}
-({}) as {};
+({} as {});
 function* g() {
   const test = (yield "foo") as number;
 }
 async function g() {
   const test = (await "foo") as number;
 }
+({} as X);
+() => ({} as X);
+const state = JSON.stringify(
+  {
+    next: window.location.href,
+    nonce
+  } as State
+);
 
 `;

--- a/tests/typescript_as/as.js
+++ b/tests/typescript_as/as.js
@@ -12,3 +12,9 @@ function*g() {
 async function g() {
   const test = (await 'foo') as number;
 }
+({}) as X;
+() => ({}) as X;
+const state = JSON.stringify({
+  next: window.location.href,
+  nonce,
+} as State);


### PR DESCRIPTION
Instead of doing it inside of object, we need to have them use the existing mechanism that checks if the left-most character is a paren.