### PR TITLE
Update typescript-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "rollup-plugin-node-resolve": "2.0.0",
     "rollup-plugin-replace": "1.1.1",
     "typescript": "2.3.2",
-    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#32634f10b8c9bc4622762867d9d00e79ea1092fe",
+    "typescript-eslint-parser": "git://github.com/vjeux/typescript-eslint-parser.git#488ba4f273f52ee6ef8d951d7ae84d28231e2fe9",
     "uglify-es": "3.0.15",
     "webpack": "2.6.1"
   },

--- a/tests/typescript_rest/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_rest/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rest.ts 1`] = `
+function test([first, ...rest]) {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+function test([first, ...rest]) {}
+
+`;

--- a/tests/typescript_rest/jsfmt.spec.js
+++ b/tests/typescript_rest/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });

--- a/tests/typescript_rest/rest.ts
+++ b/tests/typescript_rest/rest.ts
@@ -1,0 +1,1 @@
+function test([first, ...rest]) {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3210,6 +3210,13 @@ typedarray@^0.0.6:
     lodash.unescape "4.0.1"
     semver "5.3.0"
 
+"typescript-eslint-parser@git://github.com/vjeux/typescript-eslint-parser.git#488ba4f273f52ee6ef8d951d7ae84d28231e2fe9":
+  version "3.0.0"
+  resolved "git://github.com/vjeux/typescript-eslint-parser.git#488ba4f273f52ee6ef8d951d7ae84d28231e2fe9"
+  dependencies:
+    lodash.unescape "4.0.1"
+    semver "5.3.0"
+
 typescript@2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.2.tgz#f0f045e196f69a72f06b25fd3bd39d01c3ce9984"


### PR DESCRIPTION
This applies https://github.com/eslint/typescript-eslint-parser/pull/308 and https://github.com/eslint/typescript-eslint-parser/pull/303 to fix issues on prettier.

When they are merged upstream, we should stop using my fork ;)

Fixes #1870