### PR TITLE
Decorators: do not inline methods with decorators with babylon

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -97,6 +97,7 @@ function genericPrint(path, options, printPath, args) {
         node.decorators.length === 1 &&
         node.type !== "ClassDeclaration" &&
         node.type !== "MethodDefinition" &&
+        node.type !== "ClassMethod" &&
         (decorator.type === "Identifier" ||
           decorator.type === "MemberExpression" ||
           (decorator.type === "CallExpression" &&

--- a/tests/decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators/__snapshots__/jsfmt.spec.js.snap
@@ -23,6 +23,26 @@ class X {}
 
 `;
 
+exports[`methods.js 1`] = `
+
+class Yo {
+  @foo("hello")
+  async plop() {}
+
+  @anotherDecoratorWithALongName("and a very long string as a first argument")
+  async plip() {}
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class Yo {
+  @foo("hello")
+  async plop() {}
+
+  @anotherDecoratorWithALongName("and a very long string as a first argument")
+  async plip() {}
+}
+
+`;
+
 exports[`mobx.js 1`] = `
 import {observable} from "mobx";
 
@@ -54,11 +74,13 @@ class OrderLine {
     this.price = price;
   }
 
-  @computed get total() {
+  @computed
+  get total() {
     return this.price * this.amount;
   }
 
-  @action.bound setPrice(price) {
+  @action.bound
+  setPrice(price) {
     this.price = price;
   }
 }

--- a/tests/decorators/methods.js
+++ b/tests/decorators/methods.js
@@ -1,0 +1,8 @@
+
+class Yo {
+  @foo("hello")
+  async plop() {}
+
+  @anotherDecoratorWithALongName("and a very long string as a first argument")
+  async plip() {}
+}


### PR DESCRIPTION
Missed babylon using "ClassMethod" instead of "MethodDefinition".

Fixes #1933