### PR TITLE
TypeScript: fix trailing comma in enum

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2461,7 +2461,7 @@ function genericPrintNoParens(path, options, print, args) {
                 concat([
                   hardline,
                   printArrayItems(path, options, "members", print),
-                  shouldPrintComma(options, "all") ? "," : ""
+                  shouldPrintComma(options, "es5") ? "," : ""
                 ])
               ),
               comments.printDanglingComments(

--- a/src/printer.js
+++ b/src/printer.js
@@ -2460,7 +2460,8 @@ function genericPrintNoParens(path, options, print, args) {
               indent(
                 concat([
                   hardline,
-                  printArrayItems(path, options, "members", print)
+                  printArrayItems(path, options, "members", print),
+                  shouldPrintComma(options, "all") ? "," : ""
                 ])
               ),
               comments.printDanglingComments(

--- a/tests/typescript_trailing_comma/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_trailing_comma/__snapshots__/jsfmt.spec.js.snap
@@ -5,9 +5,19 @@ export class BaseSingleLevelProfileTargeting<
 	T extends ValidSingleLevelProfileNode,
 > {
 }
+
+enum Enum {
+	x = 1,
+	y = 2,
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 export class BaseSingleLevelProfileTargeting<
   T extends ValidSingleLevelProfileNode
 > {}
+
+enum Enum {
+  x = 1,
+  y = 2,
+}
 
 `;

--- a/tests/typescript_trailing_comma/trailing.ts
+++ b/tests/typescript_trailing_comma/trailing.ts
@@ -2,3 +2,8 @@ export class BaseSingleLevelProfileTargeting<
 	T extends ValidSingleLevelProfileNode,
 > {
 }
+
+enum Enum {
+	x = 1,
+	y = 2,
+}


### PR DESCRIPTION
With `--trailing-comma all` and `es5` we can safely add a trailing comma in `enum`s.

Fixes #1932