### PR TITLE
Enable estree mode of babylon

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -197,7 +197,6 @@ function attach(comments, ast, text) {
         handleTryStatementComments(enclosingNode, followingNode, comment) ||
         handleClassComments(enclosingNode, comment) ||
         handleImportSpecifierComments(enclosingNode, comment) ||
-        handleObjectPropertyComments(enclosingNode, comment) ||
         handleForComments(enclosingNode, precedingNode, comment) ||
         handleUnionTypeComments(
           precedingNode,
@@ -256,7 +255,6 @@ function attach(comments, ast, text) {
         handlePropertyComments(enclosingNode, comment) ||
         handleExportNamedDeclarationComments(enclosingNode, comment) ||
         handleOnlyComments(enclosingNode, ast, comment, isLastComment) ||
-        handleClassMethodComments(enclosingNode, comment) ||
         handleTypeAliasComments(enclosingNode, followingNode, comment) ||
         handleVariableDeclaratorComments(enclosingNode, followingNode, comment)
       ) {
@@ -534,8 +532,7 @@ function handleConditionalExpressionComments(
 function handleObjectPropertyAssignment(enclosingNode, precedingNode, comment) {
   if (
     enclosingNode &&
-    (enclosingNode.type === "ObjectProperty" ||
-      enclosingNode.type === "Property") &&
+    enclosingNode.type === "Property" &&
     enclosingNode.shorthand &&
     enclosingNode.key === precedingNode &&
     enclosingNode.value.type === "AssignmentPattern"
@@ -557,9 +554,7 @@ function handleCommentInEmptyParens(text, enclosingNode, comment) {
     enclosingNode &&
     (((enclosingNode.type === "FunctionDeclaration" ||
       enclosingNode.type === "FunctionExpression" ||
-      enclosingNode.type === "ArrowFunctionExpression" ||
-      enclosingNode.type === "ClassMethod" ||
-      enclosingNode.type === "ObjectMethod") &&
+      enclosingNode.type === "ArrowFunctionExpression") &&
       enclosingNode.params.length === 0) ||
       (enclosingNode.type === "CallExpression" &&
         enclosingNode.arguments.length === 0))
@@ -606,9 +601,7 @@ function handleLastFunctionArgComments(
     enclosingNode &&
     (enclosingNode.type === "ArrowFunctionExpression" ||
       enclosingNode.type === "FunctionExpression" ||
-      enclosingNode.type === "FunctionDeclaration" ||
-      enclosingNode.type === "ObjectMethod" ||
-      enclosingNode.type === "ClassMethod") &&
+      enclosingNode.type === "FunctionDeclaration") &&
     getNextNonSpaceNonCommentCharacter(text, comment) === ")"
   ) {
     addTrailingComment(precedingNode, comment);
@@ -631,14 +624,6 @@ function handleClassComments(enclosingNode, comment) {
 
 function handleImportSpecifierComments(enclosingNode, comment) {
   if (enclosingNode && enclosingNode.type === "ImportSpecifier") {
-    addLeadingComment(enclosingNode, comment);
-    return true;
-  }
-  return false;
-}
-
-function handleObjectPropertyComments(enclosingNode, comment) {
-  if (enclosingNode && enclosingNode.type === "ObjectProperty") {
     addLeadingComment(enclosingNode, comment);
     return true;
   }
@@ -685,11 +670,7 @@ function handleUnionTypeComments(
 }
 
 function handlePropertyComments(enclosingNode, comment) {
-  if (
-    enclosingNode &&
-    (enclosingNode.type === "Property" ||
-      enclosingNode.type === "ObjectProperty")
-  ) {
+  if (enclosingNode && enclosingNode.type === "Property") {
     addLeadingComment(enclosingNode, comment);
     return true;
   }
@@ -716,9 +697,7 @@ function handleOnlyComments(enclosingNode, ast, comment, isLastComment) {
   } else if (
     enclosingNode &&
     enclosingNode.type === "Program" &&
-    enclosingNode.body.length === 0 &&
-    enclosingNode.directives &&
-    enclosingNode.directives.length === 0
+    enclosingNode.body.length === 0
   ) {
     if (isLastComment) {
       addDanglingComment(enclosingNode, comment);
@@ -763,14 +742,6 @@ function handleImportDeclarationComments(
 function handleAssignmentPatternComments(enclosingNode, comment) {
   if (enclosingNode && enclosingNode.type === "AssignmentPattern") {
     addLeadingComment(enclosingNode, comment);
-    return true;
-  }
-  return false;
-}
-
-function handleClassMethodComments(enclosingNode, comment) {
-  if (enclosingNode && enclosingNode.type === "ClassMethod") {
-    addTrailingComment(enclosingNode, comment);
     return true;
   }
   return false;

--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -405,7 +405,6 @@ FastPath.prototype.needsParens = function() {
         parent.type === "IntersectionTypeAnnotation"
       );
 
-    case "NumericLiteral":
     case "Literal":
       return (
         parent.type === "MemberExpression" &&
@@ -523,9 +522,6 @@ FastPath.prototype.needsParens = function() {
 
     case "ClassExpression":
       return parent.type === "ExportDefaultDeclaration";
-
-    case "StringLiteral":
-      return parent.type === "ExpressionStatement"; // To avoid becoming a directive
   }
 
   return false;
@@ -537,7 +533,6 @@ function isStatement(node) {
     node.type === "BreakStatement" ||
     node.type === "ClassBody" ||
     node.type === "ClassDeclaration" ||
-    node.type === "ClassMethod" ||
     node.type === "ClassProperty" ||
     node.type === "ContinueStatement" ||
     node.type === "DebuggerStatement" ||

--- a/src/parser-babylon.js
+++ b/src/parser-babylon.js
@@ -11,6 +11,7 @@ function parse(text) {
     allowImportExportEverywhere: false,
     allowReturnOutsideFunction: true,
     plugins: [
+      "estree",
       "jsx",
       "flow",
       "doExpressions",

--- a/tests/do/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/do/__snapshots__/jsfmt.spec.js.snap
@@ -11,8 +11,8 @@ const envSpecific = {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const envSpecific = {
   domain: do {
-    if (env === "production") ("https://abc.mno.com/");
-    else if (env === "development") ("http://localhost:4000");
+    if (env === "production") "https://abc.mno.com/";
+    else if (env === "development") "http://localhost:4000";
   }
 };
 

--- a/tests/expression_statement/jsfmt.spec.js
+++ b/tests/expression_statement/jsfmt.spec.js
@@ -1,2 +1,1 @@
-// TODO: Re-enable Flow when the following fix is merged facebook/flow#3234.
-run_spec(__dirname, { parser: "babylon" } /*, ["typescript"] */);
+run_spec(__dirname, { parser: "babylon" }, ["flow"]);


### PR DESCRIPTION
Babylon as of 6.16.0 has a plugin called `estree`. This plugin changes the output AST of babylon to conform to estree.

By enabling this in prettier, there is no need anymore to have special cases for babylon nodes, which allowed me to remove a bunch of code.

On the downside on thing is now broken (but it is also broken when using flow as parser)
```js
("use strict");
```
This will get reformatted without parens. I tried to figure out how this is fixed in flow, until I figured out that this is currently broken with parser flow.

I'm not yet sure how to fix this for all cases. 

- Either always add parens around string literals in an ExpressionStatement if they are not marked as directive. (Maybe a little ugly. I tried this but a lot of tests where afterwards complaining)
- Somehow detect if at the current position in the code directives can be placed (Every `ExpressionStatement` before the first non-`ExpressionStatement` in body of `Program` or a `Block`) and if this is the case then add parens to all non directives and following

I will try to implement the second approach.