### PR TITLE
Position JSX whitespace (`{" "}`) at the end of lines

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3998,7 +3998,13 @@ function printJSXChildren(path, options, print, jsxWhitespace) {
 
       const next = n.children[i + 1];
       const followedByJSXElement = next && !isLiteral(next);
-      if (followedByJSXElement) {
+      const followedByJSXWhitespace =
+        next &&
+        next.type === "JSXExpressionContainer" &&
+        next.expression.type === "Literal" &&
+        next.expression.value === " ";
+
+      if (followedByJSXElement && !followedByJSXWhitespace) {
         children.push(softline);
       } else {
         // Ideally this would be a softline as well.
@@ -4061,7 +4067,7 @@ function printJSXElement(path, options, print) {
   let forcedBreak = willBreak(openingLines);
 
   const rawJsxWhitespace = options.singleQuote ? "{' '}" : '{" "}';
-  const jsxWhitespace = ifBreak(concat([softline, rawJsxWhitespace]), " ");
+  const jsxWhitespace = ifBreak(concat([rawJsxWhitespace, softline]), " ");
 
   const children = printJSXChildren(path, options, print, jsxWhitespace);
 
@@ -4122,14 +4128,7 @@ function printJSXElement(path, options, print) {
         multilineChildren.push(rawJsxWhitespace);
         return;
       } else if (i === children.length - 1) {
-        multilineChildren.push(concat([hardline, rawJsxWhitespace]));
-        return;
-      } else if (willBreak(children[i - 1]) || willBreak(children[i + 1])) {
-        // If we come before or after a JSX element that is multiline
-        // ensure the JSX whitespace appears on a line by itself.
-        // NOTE: Currently this only detects elements that are already
-        // multiline before formatting!
-        multilineChildren.push(concat([hardline, rawJsxWhitespace, hardline]));
+        multilineChildren.push(rawJsxWhitespace);
         return;
       }
     }

--- a/src/printer.js
+++ b/src/printer.js
@@ -4001,7 +4001,7 @@ function printJSXChildren(path, options, print, jsxWhitespace) {
       const followedByJSXWhitespace =
         next &&
         next.type === "JSXExpressionContainer" &&
-        next.expression.type === "Literal" &&
+        isLiteral(next.expression) &&
         next.expression.value === " ";
 
       if (followedByJSXElement && !followedByJSXWhitespace) {

--- a/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
@@ -90,8 +90,10 @@ before = (
 
 before_break1 = (
   <span>
-    <span barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar />
-    {" "}foo
+    <span
+      barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar
+    />{" "}
+    foo
   </span>
 );
 
@@ -99,17 +101,15 @@ before_break2 = (
   <span>
     <span
       barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar
-    />
-    {" "}foo
+    />{" "}
+    foo
   </span>
 );
 
 after_break = (
   <span>
-    foo
-    {" "}<span
-      barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar
-    />
+    foo{" "}
+    <span barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar />
   </span>
 );
 
@@ -151,8 +151,7 @@ regression_not_transformed_1 = (
 
 regression_not_transformed_2 = (
   <span>
-    <Icon icon="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" />
-    {" "}
+    <Icon icon="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" />{" "}
   </span>
 );
 
@@ -164,8 +163,7 @@ similar_1 = (
 
 similar_2 = (
   <span>
-    <Icon icon="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" />
-    {" "}
+    <Icon icon="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" />{" "}
   </span>
 );
 

--- a/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
@@ -126,8 +126,8 @@ const render6 = ({ styles }) =>
         attr4
       >
         ddd d dd d d dddd dddd <strong>hello</strong>
-      </div>
-      {" "}<strong>hello</strong>
+      </div>{" "}
+      <strong>hello</strong>
     </div>
   </div>;
 

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -128,8 +128,7 @@ unstable_before =
 
 unstable_after_first_run = (
   <div className="yourScore">
-    Your score:
-    {" "}
+    Your score:{" "}
     <span className="score">{\`\${mini.crosstable.users[sessionUserId]} - \${mini
       .crosstable.users[user.id]}\`}</span>
   </div>
@@ -154,13 +153,13 @@ jsx_around_multiline_element =
 
 jsx_around_multiline_element_second_pass = (
   <div>
-    Before
-    {" "}<div>
+    Before{" "}
+    <div>
       {
         "Enough text to make this element wrap on to multiple lines when formatting"
       }
-    </div>
-    {" "}After
+    </div>{" "}
+    After
   </div>
 );
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -175,8 +174,8 @@ x = (
 // Wrapping tags
 x = (
   <div>
-    <first>f</first> <first>f</first> <first>f</first> <first>f</first>
-    {" "}<first>f</first> <first>f</first>
+    <first>f</first> <first>f</first> <first>f</first> <first>f</first>{" "}
+    <first>f</first> <first>f</first>
   </div>
 );
 
@@ -192,16 +191,16 @@ x = (
 x = (
   <div>
     <a /><b /><c />
-    <first>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</first>
-    {" "}<first>f</first>
+    <first>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</first>{" "}
+    <first>f</first>
   </div>
 );
 
 // Wrapping tags
 x = (
   <div>
-    <sadashdkjahsdkjhaskjdhaksjdhkashdkashdkasjhdkajshdkashdkashd />
-    {" "}<first>f</first>
+    <sadashdkjahsdkjhaskjdhaksjdhkashdkashdkasjhdkajshdkashdkashd />{" "}
+    <first>f</first>
   </div>
 );
 
@@ -223,15 +222,15 @@ x = (
 
 x = (
   <div>
-    before {stuff} after {stuff} after {stuff} after {stuff} after {stuff} after
-    {" "}{stuff}  {stuff}  {stuff} after {stuff} after
+    before {stuff} after {stuff} after {stuff} after {stuff} after {stuff} after{" "}
+    {stuff}  {stuff}  {stuff} after {stuff} after
   </div>
 );
 
 x = (
   <div>
-    Please state your <b>name</b> and <b>occupation</b> for the board of
-    {" "}<b>school</b> directors.
+    Please state your <b>name</b> and <b>occupation</b> for the board of{" "}
+    <b>school</b> directors.
   </div>
 );
 
@@ -260,9 +259,9 @@ function DiffOverview(props) {
 x = (
   <font size={-3}>
     <i>
-      Starting at minute {graphActivity.startTime}, running for
-      {" "}{graphActivity.length} to minute
-      {" "}{graphActivity.startTime + graphActivity.length}
+      Starting at minute {graphActivity.startTime}, running for{" "}
+      {graphActivity.length} to minute{" "}
+      {graphActivity.startTime + graphActivity.length}
     </i>
   </font>
 );
@@ -290,12 +289,10 @@ x = (
 
 x = (
   <div>
-    First
-    {" "}
+    First{" "}
     <div>
       Second
-    </div>
-    {" "}
+    </div>{" "}
     Third
   </div>
 );
@@ -310,8 +307,7 @@ leading_whitespace = (
 trailing_whitespace = (
   <div>
     First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh
-    Twelfth Thirteenth Fourteenth
-    {" "}
+    Twelfth Thirteenth Fourteenth{" "}
   </div>
 );
 
@@ -341,17 +337,15 @@ this_really_should_split_across_lines = (
 
 unstable_before = (
   <div className="yourScore">
-    Your score:
-    {" "}<span className="score">{\`\${mini.crosstable.users[
-      sessionUserId
-    ]} - \${mini.crosstable.users[user.id]}\`}</span>
+    Your score:{" "}
+    <span className="score">{\`\${mini.crosstable.users[sessionUserId]} - \${mini
+      .crosstable.users[user.id]}\`}</span>
   </div>
 );
 
 unstable_after_first_run = (
   <div className="yourScore">
-    Your score:
-    {" "}
+    Your score:{" "}
     <span className="score">{\`\${mini.crosstable.users[sessionUserId]} - \${mini
       .crosstable.users[user.id]}\`}</span>
   </div>
@@ -374,12 +368,10 @@ jsx_whitespace_on_newline = (
   <div>
     <div>
       First
-    </div>
-    {" "}
+    </div>{" "}
     <div>
       Second
-    </div>
-    {" "}
+    </div>{" "}
     <div>
       Third
     </div>
@@ -388,26 +380,25 @@ jsx_whitespace_on_newline = (
 
 jsx_around_multiline_element = (
   <div>
-    Before
-    {" "}<div>
+    Before{" "}
+    <div>
       {
         "Enough text to make this element wrap on to multiple lines when formatting"
       }
-    </div>
-    {" "}After
+    </div>{" "}
+    After
   </div>
 );
 
 jsx_around_multiline_element_second_pass = (
   <div>
-    Before
-    {" "}
+    Before{" "}
     <div>
       {
         "Enough text to make this element wrap on to multiple lines when formatting"
       }
-    </div>
-    {" "}After
+    </div>{" "}
+    After
   </div>
 );
 

--- a/tests/jsx-text-wrap/test.js
+++ b/tests/jsx-text-wrap/test.js
@@ -125,8 +125,7 @@ unstable_before =
 
 unstable_after_first_run = (
   <div className="yourScore">
-    Your score:
-    {" "}
+    Your score:{" "}
     <span className="score">{`${mini.crosstable.users[sessionUserId]} - ${mini
       .crosstable.users[user.id]}`}</span>
   </div>
@@ -151,12 +150,12 @@ jsx_around_multiline_element =
 
 jsx_around_multiline_element_second_pass = (
   <div>
-    Before
-    {" "}<div>
+    Before{" "}
+    <div>
       {
         "Enough text to make this element wrap on to multiple lines when formatting"
       }
-    </div>
-    {" "}After
+    </div>{" "}
+    After
   </div>
 );


### PR DESCRIPTION
Currently we place JSX whitespace (`{" "}`) at the beginning of lines, this PR is an exploration of placing JSX whitespace at the end of lines instead.

It was inspired by @SimenB's comment in https://github.com/prettier/prettier/pull/1831#discussion_r119909463.

It works nicely, although with one drawback that it is now possible for a line ending with `{" "}` to be longer than the max line length.

I'd be interested in people's opinions on this. If people prefer this way of outputting whitespace I'm happy to have it merged and reviewed.