### PR TITLE
[RFC] Force break when argument list contains function call.

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3062,6 +3062,10 @@ function shouldGroupFirstArg(args) {
   );
 }
 
+function shouldBreakArgs(args) {
+  return args.length > 1 && args.some(arg => arg.type === "CallExpression");
+}
+
 function printArgumentsList(path, options, print) {
   const printed = path.map(print, "arguments");
   if (printed.length === 0) {
@@ -3076,6 +3080,7 @@ function printArgumentsList(path, options, print) {
   // This is just an optimization; I think we could return the
   // conditional group for all function calls, but it's more expensive
   // so only do it for specific forms.
+
   const shouldGroupFirst = shouldGroupFirstArg(args);
   const shouldGroupLast = shouldGroupLastArg(args);
   if (shouldGroupFirst || shouldGroupLast) {
@@ -3138,16 +3143,18 @@ function printArgumentsList(path, options, print) {
     ]);
   }
 
-  return group(
-    concat([
-      "(",
-      indent(concat([softline, join(concat([",", line]), printed)])),
-      ifBreak(shouldPrintComma(options, "all") ? "," : ""),
-      softline,
-      ")"
-    ]),
-    { shouldBreak: printed.some(willBreak) }
-  );
+  const children = [
+    "(",
+    indent(concat([softline, join(concat([",", line]), printed)])),
+    ifBreak(shouldPrintComma(options, "all") ? "," : ""),
+    softline,
+    ")"
+  ];
+
+  if (shouldBreakArgs(args)) {
+    children.push(breakParent);
+  }
+  return group(concat(children), { shouldBreak: printed.some(willBreak) });
 }
 
 function printFunctionTypeParameters(path, options, print) {

--- a/tests/flow/call_caching1/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/call_caching1/__snapshots__/jsfmt.spec.js.snap
@@ -20,7 +20,10 @@ const tasksPerStatusMap = new Map(
   [].map(taskStatus => [taskStatus, new Map()])
 );
 for (let [taskStatus, tasksMap] of tasksPerStatusMap) {
-  tasksPerStatusMap.set(taskStatus, Immutable.Map(tasksMap));
+  tasksPerStatusMap.set(
+    taskStatus,
+    Immutable.Map(tasksMap)
+  );
 }
 
 `;

--- a/tests/flow/fixpoint/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/fixpoint/__snapshots__/jsfmt.spec.js.snap
@@ -60,7 +60,10 @@ function mk_factorial() {
       if (eq(n, 1)) {
         return 1;
       }
-      return mul(factorial(sub(n, 1)), n);
+      return mul(
+        factorial(sub(n, 1)),
+        n
+      );
     };
   });
 }

--- a/tests/flow/get-def/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/get-def/__snapshots__/jsfmt.spec.js.snap
@@ -28,7 +28,10 @@ function add(a: number, b: number): number {
 var re = /^keynote (talk){2} (lightning){3,5} (talk){2} closing partytime!!!/;
 
 // t123456
-add(lib.iTakeAString(42), 7);
+add(
+  lib.iTakeAString(42),
+  7
+);
 
 // D123456
 lib.bar();

--- a/tests/function_composition/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/function_composition/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,50 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`compose.js 1`] = `
+const a = compose(
+  b(),
+  c,
+)(d);
+
+const b = compose(c, d)(e);
+const c = compose(
+  d(),
+  e("thing1", "thing2")(),
+)(f);
+
+const d = compose(
+  d(),
+  e("thing1", "thing2")(),
+);
+
+const mapStateToProps = state => ({
+  users: R.compose(
+    R.filter(R.propEq('status', 'active')),
+    R.values
+  )(state.users)
+});
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const a = compose(
+  b(),
+  c
+)(d);
+
+const b = compose(c, d)(e);
+const c = compose(
+  d(),
+  e("thing1", "thing2")()
+)(f);
+
+const d = compose(
+  d(),
+  e("thing1", "thing2")()
+);
+
+const mapStateToProps = state => ({
+  users: R.compose(
+    R.filter(R.propEq("status", "active")),
+    R.values
+  )(state.users)
+});
+
+`;

--- a/tests/function_composition/compose.js
+++ b/tests/function_composition/compose.js
@@ -1,0 +1,22 @@
+const a = compose(
+  b(),
+  c,
+)(d);
+
+const b = compose(c, d)(e);
+const c = compose(
+  d(),
+  e("thing1", "thing2")(),
+)(f);
+
+const d = compose(
+  d(),
+  e("thing1", "thing2")(),
+);
+
+const mapStateToProps = state => ({
+  users: R.compose(
+    R.filter(R.propEq('status', 'active')),
+    R.values
+  )(state.users)
+});

--- a/tests/function_composition/jsfmt.spec.js
+++ b/tests/function_composition/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, null, ["typescript"]);

--- a/tests/objects/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/objects/__snapshots__/jsfmt.spec.js.snap
@@ -67,7 +67,13 @@ group(
     "(",
     indent(
       options.tabWidth,
-      concat([line, join(concat([",", line]), printed)])
+      concat([
+        line,
+        join(
+          concat([",", line]),
+          printed
+        )
+      ])
     ),
     options.trailingComma ? "," : "",
     line,

--- a/tests/performance/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/performance/__snapshots__/jsfmt.spec.js.snap
@@ -132,13 +132,20 @@ tap.test("RecordImport.advance", t => {
   const checkStates = (batches, states) => {
     t.equal(batches.length, states.length);
     for (const batch of batches) {
-      t.equal(batch.state, states.shift());
+      t.equal(
+        batch.state,
+        states.shift()
+      );
       t.ok(batch.getCurState().name(i18n));
     }
   };
 
   const batch = init.getRecordBatch();
-  const dataFile = path.resolve(process.cwd(), "testData", "default.json");
+  const dataFile = path.resolve(
+    process.cwd(),
+    "testData",
+    "default.json"
+  );
 
   const getBatches = callback => {
     RecordImport.find({}, "", {}, (err, batches) => {


### PR DESCRIPTION
This came out of a discussion on #1420, but it does not fix that issue. It attempts to improve readability when using function composition, when all code could technically fit on one line. I'm not convinced this is the best way to handle this - it seems too aggressive in many cases - but maybe it'll help find a better solution.

Change: Force a parentBreak when a call expression contains a call expression and at least two arguments.

With current behavior:
```js
const c = compose(d(e(), g()), e("thing1", "thing2")())(f);
```
With this change:
```js
const c = compose(
  d(
    e(),
    g()
  ),
  e("thing1", "thing2")()
)(f);
```
Real code looks more like this (from the issue):
```js
const mapStateToProps = state => ({
  users: R.compose(
    R.filter(R.propEq('status', 'active')),
    R.values
  )(state.users)
});
```