### PR TITLE
Keep translated cursor inside formatted node

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,6 +79,7 @@ function formatWithCursor(text, opts, addAlignmentSize) {
   const toStringResult = printDocToString(doc, opts);
   const str = toStringResult.formatted;
   const cursorOffsetResult = toStringResult.cursor;
+  const cursorNodeEnd = toStringResult.cursorNodeEnd;
   ensureAllCommentsPrinted(astComments);
   // Remove extra leading indentation as well as the added indentation after last newline
   if (addAlignmentSize > 0) {
@@ -88,7 +89,7 @@ function formatWithCursor(text, opts, addAlignmentSize) {
   if (cursorOffset !== undefined) {
     return {
       formatted: str,
-      cursorOffset: cursorOffsetResult + cursorOffset
+      cursorOffset: Math.min(cursorOffsetResult + cursorOffset, cursorNodeEnd)
     };
   }
 

--- a/index.js
+++ b/index.js
@@ -64,11 +64,13 @@ function formatWithCursor(text, opts, addAlignmentSize) {
   }
 
   let cursorOffset;
+  let cursorOffsetEnd;
   if (opts.cursorOffset >= 0) {
     const cursorNodeAndParents = findNodeAtOffset(ast, opts.cursorOffset);
     const cursorNode = cursorNodeAndParents.node;
     if (cursorNode) {
       cursorOffset = opts.cursorOffset - util.locStart(cursorNode);
+      cursorOffsetEnd = opts.cursorOffset - util.locEnd(cursorNode);
       opts.cursorNode = cursorNode;
     }
   }
@@ -87,10 +89,20 @@ function formatWithCursor(text, opts, addAlignmentSize) {
   }
 
   if (cursorOffset !== undefined) {
-    return {
-      formatted: str,
-      cursorOffset: Math.min(cursorOffsetResult + cursorOffset, cursorNodeEnd)
-    };
+    if (cursorOffsetResult + cursorOffset < cursorNodeEnd) {
+      return {
+        formatted: str,
+        cursorOffset: cursorOffsetResult + cursorOffset
+      };
+    } else {
+      return {
+        formatted: str,
+        cursorOffset: Math.max(
+          cursorNodeEnd + cursorOffsetEnd,
+          cursorOffsetResult
+        )
+      };
+    }
   }
 
   return { formatted: str };

--- a/src/comments.js
+++ b/src/comments.js
@@ -9,6 +9,7 @@ const indent = docBuilders.indent;
 const lineSuffix = docBuilders.lineSuffix;
 const join = docBuilders.join;
 const cursor = docBuilders.cursor;
+const cursorNodeEnd = docBuilders.cursorNodeEnd;
 const util = require("./util");
 const childNodesCacheKey = Symbol("child-nodes");
 const locStart = util.locStart;
@@ -931,9 +932,9 @@ function printDanglingComments(path, options, sameIndent) {
   return indent(concat([hardline, join(hardline, parts)]));
 }
 
-function prependCursorPlaceholder(path, options, printed) {
+function addCursorPlaceholders(path, options, printed) {
   if (path.getNode() === options.cursorNode) {
-    return concat([cursor, printed]);
+    return concat([cursor, printed, cursorNodeEnd]);
   }
   return printed;
 }
@@ -944,7 +945,7 @@ function printComments(path, print, options, needsSemi) {
   const comments = value && value.comments;
 
   if (!comments || comments.length === 0) {
-    return prependCursorPlaceholder(path, options, printed);
+    return addCursorPlaceholders(path, options, printed);
   }
 
   const leadingParts = [];
@@ -971,7 +972,7 @@ function printComments(path, print, options, needsSemi) {
     }
   }, "comments");
 
-  return prependCursorPlaceholder(
+  return addCursorPlaceholders(
     path,
     options,
     concat(leadingParts.concat(trailingParts))

--- a/src/doc-builders.js
+++ b/src/doc-builders.js
@@ -86,6 +86,7 @@ const literalline = concat([
   breakParent
 ]);
 const cursor = { type: "cursor", placeholder: Symbol() };
+const cursorNodeEnd = { type: "cursorNodeEnd", placeholder: Symbol() };
 
 function join(sep, arr) {
   const res = [];
@@ -130,6 +131,7 @@ module.exports = {
   lineSuffix,
   lineSuffixBoundary,
   cursor,
+  cursorNodeEnd,
   breakParent,
   ifBreak,
   indent,

--- a/src/doc-printer.js
+++ b/src/doc-printer.js
@@ -4,6 +4,7 @@ const docBuilders = require("./doc-builders");
 const concat = docBuilders.concat;
 const fill = docBuilders.fill;
 const cursor = docBuilders.cursor;
+const cursorNodeEnd = docBuilders.cursorNodeEnd;
 
 const MODE_BREAK = 1;
 const MODE_FLAT = 2;
@@ -159,6 +160,10 @@ function printDocToString(doc, options) {
       switch (doc.type) {
         case "cursor":
           out.push(cursor.placeholder);
+
+          break;
+        case "cursorNodeEnd":
+          out.push(cursorNodeEnd.placeholder);
 
           break;
         case "concat":
@@ -387,12 +392,13 @@ function printDocToString(doc, options) {
                   // Trim whitespace at the end of line
                   while (
                     out.length > 0 &&
+                    out[out.length - 1].match &&
                     out[out.length - 1].match(/^[^\S\n]*$/)
                   ) {
                     out.pop();
                   }
 
-                  if (out.length) {
+                  if (out.length && out[out.length - 1].replace) {
                     out[out.length - 1] = out[out.length - 1].replace(
                       /[^\S\n]*$/,
                       ""
@@ -416,13 +422,18 @@ function printDocToString(doc, options) {
   }
 
   const cursorPlaceholderIndex = out.indexOf(cursor.placeholder);
+  const cursorNodeEndPlaceholderIndex = out.indexOf(cursorNodeEnd.placeholder);
   if (cursorPlaceholderIndex !== -1) {
     const beforeCursor = out.slice(0, cursorPlaceholderIndex).join("");
-    const afterCursor = out.slice(cursorPlaceholderIndex + 1).join("");
+    const cursorNode = out
+      .slice(cursorPlaceholderIndex + 1, cursorNodeEndPlaceholderIndex)
+      .join("");
+    const afterCursor = out.slice(cursorNodeEndPlaceholderIndex + 1).join("");
 
     return {
-      formatted: beforeCursor + afterCursor,
-      cursor: beforeCursor.length
+      formatted: beforeCursor + cursorNode + afterCursor,
+      cursor: beforeCursor.length,
+      cursorNodeEnd: beforeCursor.length + cursorNode.length
     };
   }
 

--- a/tests/cursor/jsfmt.spec.js
+++ b/tests/cursor/jsfmt.spec.js
@@ -6,3 +6,11 @@ test("translates cursor correctly in basic case", () => {
     cursorOffset: 1
   });
 });
+
+test("keeps cursor inside formatted node", () => {
+  const code = "return         15";
+  expect(prettier.formatWithCursor(code, { cursorOffset: 15 })).toEqual({
+    formatted: "return 15;\n",
+    cursorOffset: 15
+  });
+});

--- a/tests/cursor/jsfmt.spec.js
+++ b/tests/cursor/jsfmt.spec.js
@@ -11,6 +11,6 @@ test("keeps cursor inside formatted node", () => {
   const code = "return         15";
   expect(prettier.formatWithCursor(code, { cursorOffset: 15 })).toEqual({
     formatted: "return 15;\n",
-    cursorOffset: 10
+    cursorOffset: 8
   });
 });

--- a/tests/cursor/jsfmt.spec.js
+++ b/tests/cursor/jsfmt.spec.js
@@ -11,6 +11,6 @@ test("keeps cursor inside formatted node", () => {
   const code = "return         15";
   expect(prettier.formatWithCursor(code, { cursorOffset: 15 })).toEqual({
     formatted: "return 15;\n",
-    cursorOffset: 15
+    cursorOffset: 10
   });
 });


### PR DESCRIPTION
This partially addresses
https://github.com/prettier/prettier/issues/1981 by ensuring that the
cursor cannot jump outside of its node upon formatting. It could be
improved upon by keeping track of the offset relative to the end of the
node as well.