### PR TITLE
Parse CSS in template literals (styled-jsx)

### DIFF
--- a/src/clean-ast.js
+++ b/src/clean-ast.js
@@ -125,6 +125,28 @@ function massageAST(ast) {
       delete newObj.key;
     }
 
+    // Remove raw and cooked values from TemplateElement when it's CSS
+    if (
+      ast.type === "JSXElement" &&
+      ast.openingElement.name.name === "style" &&
+      ast.openingElement.attributes.some(attr => attr.name.name === "jsx")
+    ) {
+      const templateLiterals = newObj.children
+        .filter(
+          child =>
+            child.type === "JSXExpressionContainer" &&
+            child.expression.type === "TemplateLiteral"
+        )
+        .map(container => container.expression);
+
+      const quasis = templateLiterals.reduce(
+        (quasis, templateLiteral) => quasis.concat(templateLiteral.quasis),
+        []
+      );
+
+      quasis.forEach(q => delete q.value);
+    }
+
     return newObj;
   }
   return ast;

--- a/src/printer.js
+++ b/src/printer.js
@@ -1743,17 +1743,18 @@ function genericPrintNoParens(path, options, print, args) {
       /* Subtree parsing PoC */
       const parent = path.getParentNode();
       const parentParent = path.getParentNode(1);
-      const isStyledJsx =
+      const isCSS =
         n.quasis &&
         n.quasis.length === 1 &&
         parent.type === "JSXExpressionContainer" &&
         parentParent.type === "JSXElement" &&
+        parentParent.openingElement.name.name === "style" &&
         parentParent.openingElement.attributes.some(
           attribute => attribute.name.name === "jsx"
         );
 
-      if (isStyledJsx) {
-        const parseCss = require("./parser-postcss");
+      if (isCSS) {
+        const parseCss = eval("require")("./parser-postcss");
 
         const text = n.quasis[0].value.raw;
         const ast = parseCss(text, options);

--- a/src/printer.js
+++ b/src/printer.js
@@ -1740,7 +1740,6 @@ function genericPrintNoParens(path, options, print, args) {
     case "TemplateElement":
       return join(literalline, n.value.raw.split(/\r?\n/g));
     case "TemplateLiteral": {
-      /* Subtree parsing PoC */
       const parent = path.getParentNode();
       const parentParent = path.getParentNode(1);
       const isCSS =
@@ -1755,16 +1754,15 @@ function genericPrintNoParens(path, options, print, args) {
 
       if (isCSS) {
         const parseCss = eval("require")("./parser-postcss");
-
+        const newOptions = Object.assign({}, options, { parser: "postcss" });
         const text = n.quasis[0].value.raw;
-        const ast = parseCss(text, options);
-        let subtree = printAstToDoc(ast, options);
-        //HACK remove ending hardline
+        const ast = parseCss(text, newOptions);
+        let subtree = printAstToDoc(ast, newOptions);
+        // HACK remove ending hardline
         subtree = subtree.parts[0].parts[0];
         parts.push("`", indent(concat([line, subtree])), line, "`");
-        return concat(parts);
+        return group(concat(parts));
       }
-      /* Subtree parsing PoC */
 
       const expressions = path.map(print, "expressions");
 

--- a/tests/jsx_template/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx_template/__snapshots__/jsfmt.spec.js.snap
@@ -33,9 +33,10 @@ exports[`styled-components.js 1`] = `
 \`}</style>;
 
 <style jsx>
-  {\`p {
-     color: red;
-     }
+  {\`
+    p {
+      color: red;
+    }
   \`}
 </style>;
 

--- a/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`styled-jsx.js 1`] = `
+<style jsx>{\`
+	/* a comment */
+	div :global(.react-select) {
+		color: red; display: none
+	}
+\`}</style>;
+
+<div>
+<style jsx>{\`
+/* a comment */
+div :global(.react-select) {
+color: red; display: none
+}\`}</style>
+</div>;
+
+<div>
+<style jsx>{\`div{color:red}\`}</style>
+</div>;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<style jsx>{\`
+  /* a comment */
+  div :global(.react-select) {
+    color: red;
+    display: none;
+  }
+\`}</style>;
+
+<div>
+  <style jsx>{\`
+    /* a comment */
+    div :global(.react-select) {
+      color: red;
+      display: none;
+    }
+  \`}</style>
+</div>;
+
+<div>
+  <style jsx>{\`
+    div {
+      color: red;
+    }
+  \`}</style>
+</div>;
+
+`;

--- a/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
@@ -10,7 +10,7 @@ exports[`styled-jsx.js 1`] = `
 
 <div>
 <style jsx>{\`
-/* a comment */
+	/* a comment */
 div :global(.react-select) {
 color: red; display: none
 }\`}</style>
@@ -18,6 +18,12 @@ color: red; display: none
 
 <div>
 <style jsx>{\`div{color:red}\`}</style>
+</div>;
+
+<div>
+<style jsx>{\`This is invalid css. 
+      Shouldn't fail.
+            Shouldn't be formatted.\`}</style>
 </div>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <style jsx>{\`
@@ -44,6 +50,12 @@ color: red; display: none
       color: red;
     }
   \`}</style>
+</div>;
+
+<div>
+  <style jsx>{\`This is invalid css. 
+      Shouldn't fail.
+            Shouldn't be formatted.\`}</style>
 </div>;
 
 `;

--- a/tests/template_literals/jsfmt.spec.js
+++ b/tests/template_literals/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, null);

--- a/tests/template_literals/styled-jsx.js
+++ b/tests/template_literals/styled-jsx.js
@@ -7,7 +7,7 @@
 
 <div>
 <style jsx>{`
-/* a comment */
+	/* a comment */
 div :global(.react-select) {
 color: red; display: none
 }`}</style>
@@ -15,4 +15,10 @@ color: red; display: none
 
 <div>
 <style jsx>{`div{color:red}`}</style>
+</div>;
+
+<div>
+<style jsx>{`This is invalid css. 
+      Shouldn't fail.
+            Shouldn't be formatted.`}</style>
 </div>;

--- a/tests/template_literals/styled-jsx.js
+++ b/tests/template_literals/styled-jsx.js
@@ -1,0 +1,18 @@
+<style jsx>{`
+	/* a comment */
+	div :global(.react-select) {
+		color: red; display: none
+	}
+`}</style>;
+
+<div>
+<style jsx>{`
+/* a comment */
+div :global(.react-select) {
+color: red; display: none
+}`}</style>
+</div>;
+
+<div>
+<style jsx>{`div{color:red}`}</style>
+</div>;


### PR DESCRIPTION
New PR because I broke the other one (#1965)

Adding support for CSS formatting in template literals (for #1948).  
Right now it is only formatting styled-jsx without expressions.  

From this:
```jsx
<div>
<style jsx>{`
/* a comment */
div :global(.react-select) {
color: red; display: none
}`}</style>
</div>;
```  

To this:
```jsx
<div>
  <style jsx>{`
    /* a comment */
    div :global(.react-select) {
      color: red;
      display: none;
    }
  `}</style>
</div>;
```

The current version of the code is pretty ugly, the idea is to refactor it in a way that makes adding new "sub tree formatters" easier.

