### PR TITLE
Use var to fix SyntaxError on Node@4

### DIFF
--- a/src/parser-flow.js
+++ b/src/parser-flow.js
@@ -4,6 +4,8 @@ const createError = require("./parser-create-error");
 const includeShebang = require("./parser-include-shebang");
 
 function parse(text) {
+  // Fixes Node 4 issue (#1986)
+  "use strict"; // eslint-disable-line
   // Inline the require to avoid loading all the JS if we don't use it
   const flowParser = require("flow-parser");
 


### PR DESCRIPTION
Closes https://github.com/prettier/prettier/issues/1986

I think ideally this should be addressed in `uglify-es` but this is more expedient.