### PR TITLE
GraphQL: Add support for formatting fields in selection sets

### DIFF
--- a/src/printer-graphql.js
+++ b/src/printer-graphql.js
@@ -53,7 +53,7 @@ function genericPrint(path, options, print) {
                     ])
                   ),
                   softline,
-                  ") "
+                  ")"
                 ])
               )
             : "",

--- a/src/printer-graphql.js
+++ b/src/printer-graphql.js
@@ -28,7 +28,9 @@ function genericPrint(path, options, print) {
     case "SelectionSet": {
       return concat([
         "{",
-        indent(concat([hardline, concat(path.map(print, "selections"))])),
+        indent(
+          concat([hardline, join(hardline, path.map(print, "selections"))])
+        ),
         hardline,
         "}"
       ]);
@@ -55,6 +57,7 @@ function genericPrint(path, options, print) {
                 ])
               )
             : "",
+          n.selectionSet ? " " : "",
           path.call(print, "selectionSet")
         ])
       );

--- a/tests/graphql_fields/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_fields/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fields.graphql 1`] = `
+{
+  posts {, title, votes, author {,   firstName,   posts {, author { firstName } }
+    }}
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{
+  posts {
+    title
+    votes
+    author {
+      firstName
+      posts {
+        author {
+          firstName
+        }
+      }
+    }
+  }
+}
+
+`;

--- a/tests/graphql_fields/fields.graphql
+++ b/tests/graphql_fields/fields.graphql
@@ -1,0 +1,4 @@
+{
+  posts {, title, votes, author {,   firstName,   posts {, author { firstName } }
+    }}
+}

--- a/tests/graphql_fields/jsfmt.spec.js
+++ b/tests/graphql_fields/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "graphql" });


### PR DESCRIPTION
This doesn't yet handle arguments or directives, and takes the opinion that fields should always be on separate lines. @jnwng 