### PR TITLE
GraphQL: Add support for printing operation names

### DIFF
--- a/src/printer-graphql.js
+++ b/src/printer-graphql.js
@@ -20,10 +20,7 @@ function genericPrint(path, options, print) {
 
   switch (n.kind) {
     case "Document": {
-      return concat([
-        join(concat([hardline, hardline]), path.map(print, "definitions")),
-        hardline
-      ]);
+      return join(concat([hardline, hardline]), path.map(print, "definitions"));
     }
     case "OperationDefinition": {
       return concat([

--- a/src/printer-graphql.js
+++ b/src/printer-graphql.js
@@ -20,10 +20,18 @@ function genericPrint(path, options, print) {
 
   switch (n.kind) {
     case "Document": {
-      return concat([join(hardline, path.map(print, "definitions")), hardline]);
+      return concat([
+        join(concat([hardline, hardline]), path.map(print, "definitions")),
+        hardline
+      ]);
     }
     case "OperationDefinition": {
-      return path.call(print, "selectionSet");
+      return concat([
+        n.name === null ? "" : concat([n.operation, " "]),
+        path.call(print, "name"),
+        n.name ? " " : "",
+        path.call(print, "selectionSet")
+      ]);
     }
     case "SelectionSet": {
       return concat([

--- a/tests/graphql_definitions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_definitions/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fields.graphql 1`] = `
+query MyFirstQuery {
+  hello
+}
+
+mutation
+MyFirstMutation {
+  world
+}
+
+subscription, ThisIsASub, {
+  excellent
+}
+
+, query, ThisIsASub, {
+  excellent
+}
+
+query {
+  noName
+}
+
+{
+  noOperationType
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+query MyFirstQuery {
+  hello
+}
+
+mutation MyFirstMutation {
+  world
+}
+
+subscription ThisIsASub {
+  excellent
+}
+
+query ThisIsASub {
+  excellent
+}
+
+query {
+  noName
+}
+
+{
+  noOperationType
+}
+
+`;

--- a/tests/graphql_definitions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_definitions/__snapshots__/jsfmt.spec.js.snap
@@ -49,5 +49,4 @@ query {
 {
   noOperationType
 }
-
 `;

--- a/tests/graphql_definitions/fields.graphql
+++ b/tests/graphql_definitions/fields.graphql
@@ -1,0 +1,24 @@
+query MyFirstQuery {
+  hello
+}
+
+mutation
+MyFirstMutation {
+  world
+}
+
+subscription, ThisIsASub, {
+  excellent
+}
+
+, query, ThisIsASub, {
+  excellent
+}
+
+query {
+  noName
+}
+
+{
+  noOperationType
+}

--- a/tests/graphql_definitions/jsfmt.spec.js
+++ b/tests/graphql_definitions/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "graphql" });

--- a/tests/graphql_hello/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_hello/__snapshots__/jsfmt.spec.js.snap
@@ -12,5 +12,4 @@ exports[`hello.graphql 1`] = `
     tagline
   }
 }
-
 `;


### PR DESCRIPTION
This currently comes with the opinion that if someone didn't put the `query` keyword in front of an anonymous query, we shouldn't add it for them. It uses a hack that currently the GraphQL parser returns an operation name of `null` if there was no operation type, and `undefined` if there was. 😨 