### PR TITLE
GraphQL: Add support for arguments with soft line break

### DIFF
--- a/src/printer-graphql.js
+++ b/src/printer-graphql.js
@@ -7,6 +7,7 @@ const hardline = docBuilders.hardline;
 const softline = docBuilders.softline;
 const group = docBuilders.group;
 const indent = docBuilders.indent;
+const ifBreak = docBuilders.ifBreak;
 
 function genericPrint(path, options, print) {
   const n = path.getValue();
@@ -45,7 +46,7 @@ function genericPrint(path, options, print) {
                     concat([
                       softline,
                       join(
-                        concat([",", softline]),
+                        concat([",", ifBreak("", " "), softline]),
                         path.map(print, "arguments")
                       )
                     ])
@@ -64,6 +65,18 @@ function genericPrint(path, options, print) {
     }
     case "StringValue": {
       return concat(['"', n.value, '"']);
+    }
+    case "IntValue": {
+      return n.value;
+    }
+    case "FloatValue": {
+      return n.value;
+    }
+    case "BooleanValue": {
+      return n.value ? 'true' : 'false';
+    }
+    case "Variable": {
+      return concat(["$", path.call(print, "name")])
     }
     case "Argument": {
       return concat([

--- a/tests/graphql_arguments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_arguments/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`hello.graphql 1`] = `
+{
+  short(var: $var, int: 5, float: 5.6, bool: true, string: "hello world!")
+  long(var: $thisIsAReallyLongVariableNameRight, int: 52342342342, float: 5.6, bool: true, string: "hello world this is a very long string!")
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{
+  short(var: $var, int: 5, float: 5.6, bool: true, string: "hello world!") long(
+    var: $thisIsAReallyLongVariableNameRight,
+    int: 52342342342,
+    float: 5.6,
+    bool: true,
+    string: "hello world this is a very long string!"
+  )
+}
+
+`;

--- a/tests/graphql_arguments/hello.graphql
+++ b/tests/graphql_arguments/hello.graphql
@@ -1,0 +1,4 @@
+{
+  short(var: $var, int: 5, float: 5.6, bool: true, string: "hello world!")
+  long(var: $thisIsAReallyLongVariableNameRight, int: 52342342342, float: 5.6, bool: true, string: "hello world this is a very long string!")
+}

--- a/tests/graphql_arguments/jsfmt.spec.js
+++ b/tests/graphql_arguments/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "graphql" });


### PR DESCRIPTION
This kind of depends on #1991 to actually be sane - the snapshot will change after that. But the arguments support definitely works.