### PR TITLE
Add parens around all string literals at top level

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -405,8 +405,23 @@ FastPath.prototype.needsParens = function() {
         parent.type === "IntersectionTypeAnnotation"
       );
 
+    case "StringLiteral":
     case "NumericLiteral":
     case "Literal":
+      if (
+        typeof node.value === "string" &&
+        parent.type === "ExpressionStatement" &&
+        !parent.directive
+      ) {
+        // To avoid becoming a directive
+        const grandParent = this.getParentNode(1);
+
+        return (
+          grandParent.type === "Program" ||
+          grandParent.type === "BlockStatement"
+        );
+      }
+
       return (
         parent.type === "MemberExpression" &&
         typeof node.value === "number" &&
@@ -523,9 +538,6 @@ FastPath.prototype.needsParens = function() {
 
     case "ClassExpression":
       return parent.type === "ExportDefaultDeclaration";
-
-    case "StringLiteral":
-      return parent.type === "ExpressionStatement"; // To avoid becoming a directive
   }
 
   return false;

--- a/tests/do/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/do/__snapshots__/jsfmt.spec.js.snap
@@ -11,8 +11,8 @@ const envSpecific = {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const envSpecific = {
   domain: do {
-    if (env === "production") ("https://abc.mno.com/");
-    else if (env === "development") ("http://localhost:4000");
+    if (env === "production") "https://abc.mno.com/";
+    else if (env === "development") "http://localhost:4000";
   }
 };
 

--- a/tests/expression_statement/jsfmt.spec.js
+++ b/tests/expression_statement/jsfmt.spec.js
@@ -1,2 +1,1 @@
-// TODO: Re-enable Flow when the following fix is merged facebook/flow#3234.
-run_spec(__dirname, { parser: "babylon" } /*, ["typescript"] */);
+run_spec(__dirname, { parser: "babylon" }, ["flow"]);

--- a/tests/quotes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/quotes/__snapshots__/jsfmt.spec.js.snap
@@ -145,79 +145,79 @@ exports[`strings.js 1`] = `
 // for consistency.
 
 // Simple strings.
-"abc";
-"abc";
+("abc");
+("abc");
 
 // Escape.
-"\\0";
+("\\0");
 
 // Emoji.
-"🐶";
+("🐶");
 // Empty string.
-"";
-"";
+("");
+("");
 // Single double quote.
-'"';
-'"';
+('"');
+('"');
 // Single single quote.
-"'";
-"'";
+("'");
+("'");
 // Unnecessary escapes.
-"'";
-'"';
-"a";
-"a";
-"hola";
-"hola";
-"hol\\\\a (the a is not escaped)";
-"hol\\\\a (the a is not escaped)";
-"multiple a unnecessary a escapes";
-"multiple a unnecessary a escapes";
-"unnecessarily escaped character preceded by escaped backslash \\\\a";
-"unnecessarily escaped character preceded by escaped backslash \\\\a";
-"unescaped character preceded by two escaped backslashes       \\\\\\\\a";
-"unescaped character preceded by two escaped backslashes       \\\\\\\\a";
-"aa"; // consecutive unnecessarily escaped characters
-"aa"; // consecutive unnecessarily escaped characters
-"escaped \\u2030 ‰ (should not stay escaped)";
+("'");
+('"');
+("a");
+("a");
+("hola");
+("hola");
+("hol\\\\a (the a is not escaped)");
+("hol\\\\a (the a is not escaped)");
+("multiple a unnecessary a escapes");
+("multiple a unnecessary a escapes");
+("unnecessarily escaped character preceded by escaped backslash \\\\a");
+("unnecessarily escaped character preceded by escaped backslash \\\\a");
+("unescaped character preceded by two escaped backslashes       \\\\\\\\a");
+("unescaped character preceded by two escaped backslashes       \\\\\\\\a");
+("aa"); // consecutive unnecessarily escaped characters
+("aa"); // consecutive unnecessarily escaped characters
+("escaped \\u2030 ‰ (should not stay escaped)");
 // Meaningful escapes
-"octal escapes \\0 \\1 \\2 \\3 \\4 \\5 \\6 \\7";
-"octal escapes \\0 \\1 \\2 \\3 \\4 \\5 \\6 \\7";
-"meaningfully escaped alphabetical characters \\n \\r \\v \\t \\b \\f \\u2713 \\x61";
-"meaningfully escaped alphabetical characters \\n \\r \\v \\t \\b \\f \\u2713 \\x61";
-"escaped newline \\
-";
-"escaped carriage return \\
-";
-"escaped \\u2028 \\ ";
-"escaped \\u2029 \\ ";
+("octal escapes \\0 \\1 \\2 \\3 \\4 \\5 \\6 \\7");
+("octal escapes \\0 \\1 \\2 \\3 \\4 \\5 \\6 \\7");
+("meaningfully escaped alphabetical characters \\n \\r \\v \\t \\b \\f \\u2713 \\x61");
+("meaningfully escaped alphabetical characters \\n \\r \\v \\t \\b \\f \\u2713 \\x61");
+("escaped newline \\
+");
+("escaped carriage return \\
+");
+("escaped \\u2028 \\ ");
+("escaped \\u2029 \\ ");
 // One of each.
-"\\"'";
-"\\"'";
+("\\"'");
+("\\"'");
 // One of each with unnecessary escapes.
-"\\"'";
-"\\"'";
+("\\"'");
+("\\"'");
 // More double quotes than single quotes.
-'"\\'"';
-'"\\'"';
+('"\\'"');
+('"\\'"');
 // More single quotes than double quotes.
-"\\"''";
-"\\"''";
+("\\"''");
+("\\"''");
 // Two of each.
-"\\"\\"''";
-"\\"\\"''";
+("\\"\\"''");
+("\\"\\"''");
 // Single backslash.
-"\\\\";
-"\\\\";
+("\\\\");
+("\\\\");
 // Backslases.
-"\\"\\\\\\"\\\\\\\\\\" ''\\\\'\\\\'\\\\\\\\'";
-'\\'\\\\\\'\\\\\\\\\\' ""\\\\"\\\\"\\\\\\\\"';
+("\\"\\\\\\"\\\\\\\\\\" ''\\\\'\\\\'\\\\\\\\'");
+('\\'\\\\\\'\\\\\\\\\\' ""\\\\"\\\\"\\\\\\\\"');
 // Somewhat more real-word example.
-"He's sayin': \\"How's it goin'?\\" Don't ask me why.";
-"He's sayin': \\"How's it goin'?\\" Don't ask me why.";
+("He's sayin': \\"How's it goin'?\\" Don't ask me why.");
+("He's sayin': \\"How's it goin'?\\" Don't ask me why.");
 // Somewhat more real-word example 2.
-'var backslash = "\\\\", doubleQuote = \\'"\\';';
-'var backslash = "\\\\", doubleQuote = \\'"\\';';
+('var backslash = "\\\\", doubleQuote = \\'"\\';');
+('var backslash = "\\\\", doubleQuote = \\'"\\';');
 
 `;
 
@@ -336,78 +336,78 @@ exports[`strings.js 2`] = `
 // for consistency.
 
 // Simple strings.
-'abc';
-'abc';
+('abc');
+('abc');
 
 // Escape.
-'\\0';
+('\\0');
 
 // Emoji.
-'🐶';
+('🐶');
 // Empty string.
-'';
-'';
+('');
+('');
 // Single double quote.
-'"';
-'"';
+('"');
+('"');
 // Single single quote.
-"'";
-"'";
+("'");
+("'");
 // Unnecessary escapes.
-"'";
-'"';
-'a';
-'a';
-'hola';
-'hola';
-'hol\\\\a (the a is not escaped)';
-'hol\\\\a (the a is not escaped)';
-'multiple a unnecessary a escapes';
-'multiple a unnecessary a escapes';
-'unnecessarily escaped character preceded by escaped backslash \\\\a';
-'unnecessarily escaped character preceded by escaped backslash \\\\a';
-'unescaped character preceded by two escaped backslashes       \\\\\\\\a';
-'unescaped character preceded by two escaped backslashes       \\\\\\\\a';
-'aa'; // consecutive unnecessarily escaped characters
-'aa'; // consecutive unnecessarily escaped characters
-'escaped \\u2030 ‰ (should not stay escaped)';
+("'");
+('"');
+('a');
+('a');
+('hola');
+('hola');
+('hol\\\\a (the a is not escaped)');
+('hol\\\\a (the a is not escaped)');
+('multiple a unnecessary a escapes');
+('multiple a unnecessary a escapes');
+('unnecessarily escaped character preceded by escaped backslash \\\\a');
+('unnecessarily escaped character preceded by escaped backslash \\\\a');
+('unescaped character preceded by two escaped backslashes       \\\\\\\\a');
+('unescaped character preceded by two escaped backslashes       \\\\\\\\a');
+('aa'); // consecutive unnecessarily escaped characters
+('aa'); // consecutive unnecessarily escaped characters
+('escaped \\u2030 ‰ (should not stay escaped)');
 // Meaningful escapes
-'octal escapes \\0 \\1 \\2 \\3 \\4 \\5 \\6 \\7';
-'octal escapes \\0 \\1 \\2 \\3 \\4 \\5 \\6 \\7';
-'meaningfully escaped alphabetical characters \\n \\r \\v \\t \\b \\f \\u2713 \\x61';
-'meaningfully escaped alphabetical characters \\n \\r \\v \\t \\b \\f \\u2713 \\x61';
-'escaped newline \\
-';
-'escaped carriage return \\
-';
-'escaped \\u2028 \\ ';
-'escaped \\u2029 \\ ';
+('octal escapes \\0 \\1 \\2 \\3 \\4 \\5 \\6 \\7');
+('octal escapes \\0 \\1 \\2 \\3 \\4 \\5 \\6 \\7');
+('meaningfully escaped alphabetical characters \\n \\r \\v \\t \\b \\f \\u2713 \\x61');
+('meaningfully escaped alphabetical characters \\n \\r \\v \\t \\b \\f \\u2713 \\x61');
+('escaped newline \\
+');
+('escaped carriage return \\
+');
+('escaped \\u2028 \\ ');
+('escaped \\u2029 \\ ');
 // One of each.
-'"\\'';
-'"\\'';
+('"\\'');
+('"\\'');
 // One of each with unnecessary escapes.
-'"\\'';
-'"\\'';
+('"\\'');
+('"\\'');
 // More double quotes than single quotes.
-'"\\'"';
-'"\\'"';
+('"\\'"');
+('"\\'"');
 // More single quotes than double quotes.
-"\\"''";
-"\\"''";
+("\\"''");
+("\\"''");
 // Two of each.
-'""\\'\\'';
-'""\\'\\'';
+('""\\'\\'');
+('""\\'\\'');
 // Single backslash.
-'\\\\';
-'\\\\';
+('\\\\');
+('\\\\');
 // Backslases.
-"\\"\\\\\\"\\\\\\\\\\" ''\\\\'\\\\'\\\\\\\\'";
-'\\'\\\\\\'\\\\\\\\\\' ""\\\\"\\\\"\\\\\\\\"';
+("\\"\\\\\\"\\\\\\\\\\" ''\\\\'\\\\'\\\\\\\\'");
+('\\'\\\\\\'\\\\\\\\\\' ""\\\\"\\\\"\\\\\\\\"');
 // Somewhat more real-word example.
-"He's sayin': \\"How's it goin'?\\" Don't ask me why.";
-"He's sayin': \\"How's it goin'?\\" Don't ask me why.";
+("He's sayin': \\"How's it goin'?\\" Don't ask me why.");
+("He's sayin': \\"How's it goin'?\\" Don't ask me why.");
 // Somewhat more real-word example 2.
-'var backslash = "\\\\", doubleQuote = \\'"\\';';
-'var backslash = "\\\\", doubleQuote = \\'"\\';';
+('var backslash = "\\\\", doubleQuote = \\'"\\';');
+('var backslash = "\\\\", doubleQuote = \\'"\\';');
 
 `;


### PR DESCRIPTION
This is the backed out change from #1940.

It fixes the problem that in all parses besides babylon this:

```js
("use strict");
```

will be turned into 
```js
"use strict";
```

The fix is to add parens around all string literals which are on top level (`Program, BlockStatement`) and could be treated as Directives by mistake.

In the other PR I had a more precise check for this which checked if the string literal at the current position could be interpreted as directive. Not sure what you think, but I thought it is really rare to write code like
```js
if (x) { ... }
"something";
```
So i decided to go for a probably more performant way and wrap every top level ExpressionStatement with a string literal (which is not marked as directive) in parens.

I could also restore the other method if you prefer it to be more correct. (https://github.com/prettier/prettier/pull/1940/files#diff-db385a780be1944fa983e81c7e7b720aR408)