### PR TITLE
Allow --debug-check to work with stdin

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -202,7 +202,7 @@ function format(input, opt) {
           diff(input, pp);
       }
     }
-    return {};
+    return { formatted: opt.filepath || "(stdin)\n" };
   }
 
   return prettier.formatWithCursor(input, opt);
@@ -280,7 +280,7 @@ if (stdin) {
   });
 } else {
   eachFilename(filepatterns, filename => {
-    if (write || argv["debug-check"]) {
+    if (write) {
       // Don't use `console.log` here since we need to replace this line.
       process.stdout.write(filename);
     }
@@ -358,7 +358,6 @@ if (stdin) {
         }
       }
     } else if (argv["debug-check"]) {
-      process.stdout.write("\n");
       if (output) {
         console.log(output);
       } else {

--- a/tests_integration/__tests__/debug-check.js
+++ b/tests_integration/__tests__/debug-check.js
@@ -10,3 +10,12 @@ test("doesn't crash when --debug-check is passed", () => {
 
   expect(result.stderr).toEqual("");
 });
+
+test("checks stdin with --debug-check", () => {
+  const result = runPrettier("cli/with-shebang", ["--debug-check"], {
+    input: "0"
+  });
+
+  expect(result.stdout).toEqual("(stdin)\n");
+  expect(result.stderr).toEqual("");
+});

--- a/tests_integration/__tests__/debug-check.js
+++ b/tests_integration/__tests__/debug-check.js
@@ -8,6 +8,7 @@ test("doesn't crash when --debug-check is passed", () => {
     "--debug-check"
   ]);
 
+  expect(result.stdout).toEqual("issue1890.js\n");
   expect(result.stderr).toEqual("");
 });
 

--- a/tests_integration/runPrettier.js
+++ b/tests_integration/runPrettier.js
@@ -12,14 +12,18 @@ const PRETTIER_PATH = path.resolve(__dirname, "../bin/prettier.js");
 // return the result of the spawned process:
 //  [ 'status', 'signal', 'output', 'pid', 'stdout', 'stderr',
 //    'envPairs', 'options', 'args', 'file' ]
-function runPrettier(dir, args) {
+function runPrettier(dir, args, options) {
   const isRelative = dir[0] !== "/";
 
   if (isRelative) {
     dir = path.resolve(__dirname, dir);
   }
 
-  const result = spawnSync(PRETTIER_PATH, args || [], { cwd: dir });
+  const result = spawnSync(
+    PRETTIER_PATH,
+    args || [],
+    Object.assign({}, options, { cwd: dir })
+  );
 
   result.stdout = result.stdout && result.stdout.toString();
   result.stderr = result.stderr && result.stderr.toString();


### PR DESCRIPTION
This makes it easier to quickly test formatting code snippets with e.g.

    pbpaste | prettier --debug-check

Before, the following would happen:

    $ pbpaste | prettier --debug-check
    stdin: TypeError: Invalid data, chunk must be a string or buffer, not undefined
        at WriteStream.Socket.write (net.js:693:11)
        at writeOutput (/Users/josephfrazier/workspace/prettier/bin/prettier.js:375:18)
        at getStdin.then.input (/Users/josephfrazier/workspace/prettier/bin/prettier.js:275:7)
        at <anonymous>
        at process._tickCallback (internal/process/next_tick.js:169:7)
    $

Now, it looks like this:

    $ pbpaste | prettier --debug-check
    (stdin)
    $