### PR TITLE
Add .yarnrc to use exact versions

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+save-prefix ""


### PR DESCRIPTION
Now, `yarn add` and `yarn upgrade` will write exact versions to
package.json and yarn.lock.

See commit fadbbeb (https://github.com/prettier/prettier/pull/291)