### PR TITLE
Upgrade prettier to v1.4.2, fix lint issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "postcss-scss": "1.0.0",
     "postcss-selector-parser": "2.2.3",
     "postcss-values-parser": "git://github.com/shellscape/postcss-values-parser.git#5e351360479116f3fe309602cdd15b0a233bc29f",
-    "prettier": "1.4.0",
+    "prettier": "1.4.2",
     "rimraf": "2.6.1",
     "rollup": "0.41.1",
     "rollup-plugin-commonjs": "7.0.0",

--- a/src/comments.js
+++ b/src/comments.js
@@ -68,12 +68,7 @@ function getSortedChildNodes(node, text, resultArray) {
     });
   }
 
-  for (
-    let i = 0,
-      nameCount = names.length;
-    i < nameCount;
-    ++i
-  ) {
+  for (let i = 0, nameCount = names.length; i < nameCount; ++i) {
     getSortedChildNodes(node[names[i]], text, resultArray);
   }
 

--- a/src/parser-babylon.js
+++ b/src/parser-babylon.js
@@ -38,8 +38,7 @@ function parse(text) {
       throw createError(
         // babel error prints (l:c) with cols that are zero indexed
         // so we need our custom error
-        originalError.message
-          .replace(/ \(.*\)/, ""),
+        originalError.message.replace(/ \(.*\)/, ""),
         {
           start: {
             line: originalError.loc.line,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2544,9 +2544,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@1.4.0:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.4.0.tgz#e648862b3737c85e3592cf85571dc42939bb5216"
+prettier@1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.4.2.tgz#bcdd95ed1eca434ac7f98ca26ea4d25a2af6a2ac"
 
 pretty-format@^20.0.3:
   version "20.0.3"


### PR DESCRIPTION
This corrects the regressions seen in commit
26e829b (https://github.com/prettier/prettier/pull/1888)