### PR TITLE
Add semi for functions without body

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -395,7 +395,7 @@ function genericPrintNoParens(path, options, print, args) {
         parts.push("declare ");
       }
       parts.push(printFunctionDeclaration(path, print, options));
-      if (n.type === "TSNamespaceFunctionDeclaration" && !n.body) {
+      if (!n.body) {
         parts.push(semi);
       }
       return concat(parts);

--- a/tests/typescript/conformance/types/functions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/functions/__snapshots__/jsfmt.spec.js.snap
@@ -507,7 +507,7 @@ function f(x: string): void {
     return;
 } 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-function f(x: string): number
+function f(x: string): number;
 function f(x: string): void {
   return;
 }
@@ -520,7 +520,7 @@ function f(x: string): number {
     return 0;
 } 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-function f(x: string): void
+function f(x: string): void;
 function f(x: string): number {
   return 0;
 }
@@ -533,7 +533,7 @@ function f(x: string): void {
     return;
 } 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-function f(x: string): void
+function f(x: string): void;
 function f(x: string): void {
   return;
 }
@@ -553,14 +553,14 @@ function fn5(x: string, ...y: any[], z: string);
 function fn5() { }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 //Function overload signature with optional parameter followed by non-optional parameter
-function fn4a(x?: number, y: string)
+function fn4a(x?: number, y: string);
 function fn4a() {}
 
-function fn4b(n: string, x?: number, y: string)
+function fn4b(n: string, x?: number, y: string);
 function fn4b() {}
 
 //Function overload signature with rest param followed by non-optional parameter
-function fn5(x: string, ...y: any[], z: string)
+function fn5(x: string, ...y: any[], z: string);
 function fn5() {}
 
 `;

--- a/tests/typescript_export/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_export/__snapshots__/jsfmt.spec.js.snap
@@ -4,7 +4,7 @@ exports[`comment.js 1`] = `
 export function match(): string /* the matching pattern */
 a
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-export function match(): string /* the matching pattern */
+export function match(): string; /* the matching pattern */
 a;
 
 `;

--- a/tests/typescript_method/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_method/__snapshots__/jsfmt.spec.js.snap
@@ -5,11 +5,17 @@ declare module 'foo' {
   function foo(namespace: string): void;
   function bar(namespace: string): void;
 }
+
+function pickCard(x: {suit: string; card: number; }[]): number;
+function pickCard(x: number): {suit: string; card: number; };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare module "foo" {
   function foo(namespace: string): void;
   function bar(namespace: string): void;
 }
+
+function pickCard(x: { suit: string; card: number }[]): number;
+function pickCard(x: number): { suit: string; card: number };
 
 `;
 

--- a/tests/typescript_method/semi.js
+++ b/tests/typescript_method/semi.js
@@ -2,3 +2,6 @@ declare module 'foo' {
   function foo(namespace: string): void;
   function bar(namespace: string): void;
 }
+
+function pickCard(x: {suit: string; card: number; }[]): number;
+function pickCard(x: number): {suit: string; card: number; };


### PR DESCRIPTION
We don't need to be overly restrictive and should add the semi if there's no body

Fixes #2003