### PR TITLE
Only prevent lone `set` if there's no type annotations

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -4292,7 +4292,10 @@ function classPropMayCauseASIProblems(path) {
 
   // this isn't actually possible yet with most parsers available today
   // so isn't properly tested yet.
-  if (name === "static" || name === "get" || name === "set") {
+  if (
+    (name === "static" || name === "get" || name === "set") &&
+    !node.typeAnnotation
+  ) {
     return true;
   }
 }

--- a/tests/typescript_semi/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_semi/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`no-semi.ts 1`] = `
+export class Mutation {
+  private set: NQuad[];
+  private delete: NQuad[];
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export class Mutation {
+  private set: NQuad[]
+  private delete: NQuad[]
+}
+
+`;

--- a/tests/typescript_semi/jsfmt.spec.js
+++ b/tests/typescript_semi/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript", semi: false });

--- a/tests/typescript_semi/no-semi.ts
+++ b/tests/typescript_semi/no-semi.ts
@@ -1,0 +1,4 @@
+export class Mutation {
+  private set: NQuad[];
+  private delete: NQuad[];
+}


### PR DESCRIPTION
If there are, it's not ambiguous.

Fixes #2023