### PR TITLE
Add group around TSMethodSignature

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2450,7 +2450,7 @@ function genericPrintNoParens(path, options, print, args) {
       if (n.typeAnnotation) {
         parts.push(": ", path.call(print, "typeAnnotation"));
       }
-      return concat(parts);
+      return group(concat(parts));
     case "TSNamespaceExportDeclaration":
       if (n.declaration) {
         // Temporary fix until https://github.com/eslint/typescript-eslint-parser/issues/263

--- a/tests/typescript_interface/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_interface/__snapshots__/jsfmt.spec.js.snap
@@ -9,6 +9,19 @@ abstract interface I {}
 
 `;
 
+exports[`comments.js 1`] = `
+interface ScreenObject {
+	// I make things weird.
+	at(point: Point): Screen | undefined;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+interface ScreenObject {
+  // I make things weird.
+  at(point: Point): Screen | undefined;
+}
+
+`;
+
 exports[`separator.ts 1`] = `
 declare module 'selenium-webdriver' {
   export const until: {

--- a/tests/typescript_interface/comments.js
+++ b/tests/typescript_interface/comments.js
@@ -1,0 +1,4 @@
+interface ScreenObject {
+	// I make things weird.
+	at(point: Point): Screen | undefined;
+}


### PR DESCRIPTION
This ensures that the comment size is not taken into account during measurement

Fixes #1976