### PR TITLE
Add an option to indent JSX atts with single space

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -21,6 +21,7 @@ const argv = minimist(process.argv.slice(2), {
     "single-quote",
     "bracket-spacing",
     "jsx-bracket-same-line",
+    "jsx-attributes-indent",
     // The supports-color package (a sub sub dependency) looks directly at
     // `process.argv` for `--no-color` and such-like options. The reason it is
     // listed here is to avoid "Ignored unknown option: --no-color" warnings.
@@ -165,6 +166,7 @@ const options = {
   bracketSpacing: argv["bracket-spacing"],
   singleQuote: argv["single-quote"],
   jsxBracketSameLine: argv["jsx-bracket-same-line"],
+  jsxAttributesIndent: argv["jsx-attributes-indent"],
   filepath: argv["stdin-filepath"],
   trailingComma: getTrailingComma(),
   parser: getParserOption()
@@ -247,6 +249,7 @@ if (argv["help"] || (!filepatterns.length && !stdin)) {
       "  --single-quote           Use single quotes instead of double quotes.\n" +
       "  --no-bracket-spacing     Do not print spaces between brackets.\n" +
       "  --jsx-bracket-same-line  Put > on the last line instead of at a new line.\n" +
+      "  --jsx-attributes-indent  Indent multiline attributes only with a single space.\n" +
       "  --trailing-comma <none|es5|all>\n" +
       "                           Print trailing commas wherever possible. Defaults to none.\n" +
       "  --parser <flow|babylon|typescript|postcss>\n" +

--- a/docs/index.html
+++ b/docs/index.html
@@ -102,6 +102,7 @@ function require(path) { return window[path.replace(/.+-/, '')]; }
     <label><input type="checkbox" id="singleQuote"></input> singleQuote</label>
     <label><input type="checkbox" id="bracketSpacing" checked></input> bracketSpacing</label>
     <label><input type="checkbox" id="jsxBracketSameLine"></input> jsxBracketSameLine</label>
+    <label><input type="checkbox" id="jsxAttributesIndent"></input> jsxAttributesIndent</label>
     <label>trailingComma <select id="trailingComma"><option value="none">none</option><option value="es5">es5</option><option value="all">all</option></select></label>
     <label>parser <select id="parser"><option value="babylon">babylon</option><option value="flow">flow</option><option value="typescript">typescript</option><option value="postcss">postcss</option></select></label>
     <span style="flex: 1"></span>
@@ -123,7 +124,7 @@ function require(path) { return window[path.replace(/.+-/, '')]; }
 
 <script id="code">
 (function () {
-var OPTIONS = ['printWidth', 'tabWidth', 'singleQuote', 'trailingComma', 'bracketSpacing', 'jsxBracketSameLine', 'parser', 'semi', 'useTabs', 'doc'];
+var OPTIONS = ['printWidth', 'tabWidth', 'singleQuote', 'trailingComma', 'bracketSpacing', 'jsxBracketSameLine', 'jsxAttributesIndent', 'parser', 'semi', 'useTabs', 'doc'];
 function setOptions(options) {
   OPTIONS.forEach(function(option) {
     var elem = document.getElementById(option);

--- a/docs/index.js
+++ b/docs/index.js
@@ -3894,9 +3894,11 @@ function genericPrintNoParens(path, options, print, args) {
           return group$1(concat$2(["<", path.call(print, "name"), " ", concat$2(path.map(print, "attributes")), _n2.selfClosing ? " />" : ">"]));
         }
 
-        return group$1(concat$2(["<", path.call(print, "name"), concat$2([indent$2(concat$2(path.map(function (attr) {
+        var attributes = concat$2(path.map(function (attr) {
           return concat$2([line$1, print(attr)]);
-        }, "attributes"))), _n2.selfClosing ? line$1 : options.jsxBracketSameLine ? ">" : softline$1]), _n2.selfClosing ? "/>" : options.jsxBracketSameLine ? "" : ">"]));
+        }, "attributes"));
+
+        return group$1(concat$2(["<", path.call(print, "name"), concat$2([options.jsxAttributesIndent ? align$1(1, attributes) : indent$2(attributes), _n2.selfClosing ? line$1 : options.jsxBracketSameLine ? ">" : softline$1]), _n2.selfClosing ? "/>" : options.jsxBracketSameLine ? "" : ">"]));
       }
     case "JSXClosingElement":
       return concat$2(["</", path.call(print, "name"), ">"]);
@@ -9560,6 +9562,7 @@ var defaults = {
   trailingComma: "none",
   bracketSpacing: true,
   jsxBracketSameLine: false,
+  jsxAttributesIndent: false,
   parser: "babylon",
   semi: true
 };

--- a/src/options.js
+++ b/src/options.js
@@ -14,6 +14,7 @@ const defaults = {
   trailingComma: "none",
   bracketSpacing: true,
   jsxBracketSameLine: false,
+  jsxAttributesIndent: false,
   parser: "babylon",
   semi: true
 };

--- a/src/printer.js
+++ b/src/printer.js
@@ -1597,16 +1597,18 @@ function genericPrintNoParens(path, options, print, args) {
         );
       }
 
+      const attributes = concat(
+        path.map(attr => concat([line, print(attr)]), "attributes")
+      );
+
       return group(
         concat([
           "<",
           path.call(print, "name"),
           concat([
-            indent(
-              concat(
-                path.map(attr => concat([line, print(attr)]), "attributes")
-              )
-            ),
+            options.jsxAttributesIndent
+              ? align(1, attributes)
+              : indent(attributes),
             n.selfClosing ? line : options.jsxBracketSameLine ? ">" : softline
           ]),
           n.selfClosing ? "/>" : options.jsxBracketSameLine ? "" : ">"

--- a/tests/jsx-attributes-indent/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-attributes-indent/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`attributes-indent.js 1`] = `
+<SomeHighlyConfiguredComponent
+  onEnter={this.onEnter}
+  onLeave={this.onLeave}
+  onChange={this.onChange}
+  initialValue={this.state.initialValue}
+  ignoreStuff={true}
+>
+  <div>and the children go here</div>
+  <div>and here too</div>
+</SomeHighlyConfiguredComponent>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<SomeHighlyConfiguredComponent
+ onEnter={this.onEnter}
+ onLeave={this.onLeave}
+ onChange={this.onChange}
+ initialValue={this.state.initialValue}
+ ignoreStuff={true}
+>
+  <div>and the children go here</div>
+  <div>and here too</div>
+</SomeHighlyConfiguredComponent>;
+
+`;
+
+exports[`attributes-indent.js 2`] = `
+<SomeHighlyConfiguredComponent
+  onEnter={this.onEnter}
+  onLeave={this.onLeave}
+  onChange={this.onChange}
+  initialValue={this.state.initialValue}
+  ignoreStuff={true}
+>
+  <div>and the children go here</div>
+  <div>and here too</div>
+</SomeHighlyConfiguredComponent>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<SomeHighlyConfiguredComponent
+  onEnter={this.onEnter}
+  onLeave={this.onLeave}
+  onChange={this.onChange}
+  initialValue={this.state.initialValue}
+  ignoreStuff={true}
+>
+  <div>and the children go here</div>
+  <div>and here too</div>
+</SomeHighlyConfiguredComponent>;
+
+`;

--- a/tests/jsx-attributes-indent/attributes-indent.js
+++ b/tests/jsx-attributes-indent/attributes-indent.js
@@ -1,0 +1,10 @@
+<SomeHighlyConfiguredComponent
+  onEnter={this.onEnter}
+  onLeave={this.onLeave}
+  onChange={this.onChange}
+  initialValue={this.state.initialValue}
+  ignoreStuff={true}
+>
+  <div>and the children go here</div>
+  <div>and here too</div>
+</SomeHighlyConfiguredComponent>

--- a/tests/jsx-attributes-indent/jsfmt.spec.js
+++ b/tests/jsx-attributes-indent/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname, { jsxAttributesIndent: true }, ["typescript"]);
+run_spec(__dirname, { jsxAttributesIndent: false }, ["typescript"]);


### PR DESCRIPTION
This will add the `jsxAttributesIndent` option.

Indenting attributes with a single space provides much more readable code, as the boundaries between attributes, child nodes and closing tags are apparent, and it scales well for large amount of tags:

```html
<div
 attr1="my attr"
 attr2="my other attr">
    <child />
    <child
     nestedAttr2="test"
     nestedAttr3="test" />
</div>
```

The name of the option is not the best though, we can certainly update that.