### PR TITLE
Break method chains on non-literal computed member expressions

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3487,7 +3487,10 @@ function printMemberChain(path, options, print) {
     ) {
       // [0] should be appended at the end of the group instead of the
       // beginning of the next one
-      if (printedNodes[i].node.computed) {
+      if (
+        printedNodes[i].node.computed &&
+        isLiteral(printedNodes[i].node.property)
+      ) {
         currentGroup.push(printedNodes[i]);
         continue;
       }

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -350,6 +350,23 @@ angular
 
 `;
 
+exports[`computed.js 1`] = `
+nock(/test/)
+  .matchHeader('Accept', 'application/json')
+  [httpMethodNock(method)]('/foo')
+  .reply(200, {
+    foo: 'bar',
+  });
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+nock(/test/)
+  .matchHeader("Accept", "application/json")
+  [httpMethodNock(method)]("/foo")
+  .reply(200, {
+    foo: "bar"
+  });
+
+`;
+
 exports[`first_long.js 1`] = `
 export default function theFunction(action$, store) {
   return action$.ofType(THE_ACTION).switchMap(action => Observable

--- a/tests/method-chain/computed.js
+++ b/tests/method-chain/computed.js
@@ -1,0 +1,6 @@
+nock(/test/)
+  .matchHeader('Accept', 'application/json')
+  [httpMethodNock(method)]('/foo')
+  .reply(200, {
+    foo: 'bar',
+  });


### PR DESCRIPTION
**Before:**
```js
nock(/test/)
  .matchHeader("Accept", "application/json")[httpMethodNock(method)]("/foo")
  .reply(200, {
    foo: "bar",
  });
```

**After:**

```js
nock(/test/)
  .matchHeader('Accept', 'application/json')
  [httpMethodNock(method)]('/foo')
  .reply(200, {
    foo: 'bar',
  });
```

Fixes #2075