### PR TITLE
Allow break with both default and named import

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -659,6 +659,7 @@ function genericPrintNoParens(path, options, print, args) {
 
         if (
           grouped.length === 1 &&
+          standalones.length === 0 &&
           n.specifiers &&
           !n.specifiers.some(node => node.comments)
         ) {

--- a/tests/flow_import_type_specifier/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_import_type_specifier/__snapshots__/jsfmt.spec.js.snap
@@ -10,6 +10,8 @@ import type {} from 'foo';
 
 import type {somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
 import type {a, somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+
+import transformRouterContext, { type TransformedContextRouter } from '../../helpers/transformRouterContext';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /**
  * @flow
@@ -23,5 +25,9 @@ import type {
   a,
   somethingSuperLongsomethingSuperLong
 } from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
+
+import transformRouterContext, {
+  type TransformedContextRouter
+} from "../../helpers/transformRouterContext";
 
 `;

--- a/tests/flow_import_type_specifier/test.js
+++ b/tests/flow_import_type_specifier/test.js
@@ -7,3 +7,5 @@ import type {} from 'foo';
 
 import type {somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
 import type {a, somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+
+import transformRouterContext, { type TransformedContextRouter } from '../../helpers/transformRouterContext';

--- a/tests/import/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/import/__snapshots__/jsfmt.spec.js.snap
@@ -236,7 +236,9 @@ import {a, somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethi
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import somethingSuperLongsomethingSuperLong from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
 import { somethingSuperLongsomethingSuperLong } from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
-import a, { somethingSuperLongsomethingSuperLong } from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
+import a, {
+  somethingSuperLongsomethingSuperLong
+} from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
 import {
   a,
   somethingSuperLongsomethingSuperLong
@@ -252,7 +254,9 @@ import {a, somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethi
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import somethingSuperLongsomethingSuperLong from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
 import {somethingSuperLongsomethingSuperLong} from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
-import a, {somethingSuperLongsomethingSuperLong} from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
+import a, {
+  somethingSuperLongsomethingSuperLong
+} from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
 import {
   a,
   somethingSuperLongsomethingSuperLong


### PR DESCRIPTION
Not specific to flow `import type`.
Fixes #2050