### PR TITLE
TypeScript: Remove parens from type annotations where possible

### DIFF
--- a/src/clean-ast.js
+++ b/src/clean-ast.js
@@ -98,12 +98,10 @@ function massageAST(ast) {
       delete newObj.specifiers;
     }
 
-    // (TypeScript) allow parenthesization of TSFunctionType/TSUnionType
+    // (TypeScript) bypass TSParenthesizedType
     if (
       ast.type === "TSParenthesizedType" &&
-      ast.typeAnnotation.type === "TypeAnnotation" &&
-      (ast.typeAnnotation.typeAnnotation.type === "TSFunctionType" ||
-        ast.typeAnnotation.typeAnnotation.type === "TSUnionType")
+      ast.typeAnnotation.type === "TypeAnnotation"
     ) {
       return newObj.typeAnnotation.typeAnnotation;
     }

--- a/src/clean-ast.js
+++ b/src/clean-ast.js
@@ -98,11 +98,12 @@ function massageAST(ast) {
       delete newObj.specifiers;
     }
 
-    // (TypeScript) allow parenthesization of TSFunctionType
+    // (TypeScript) allow parenthesization of TSFunctionType/TSUnionType
     if (
       ast.type === "TSParenthesizedType" &&
       ast.typeAnnotation.type === "TypeAnnotation" &&
-      ast.typeAnnotation.typeAnnotation.type === "TSFunctionType"
+      (ast.typeAnnotation.typeAnnotation.type === "TSFunctionType" ||
+        ast.typeAnnotation.typeAnnotation.type === "TSUnionType")
     ) {
       return newObj.typeAnnotation.typeAnnotation;
     }

--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -343,6 +343,20 @@ FastPath.prototype.needsParens = function() {
           return false;
       }
 
+    case "TSParenthesizedType": {
+      // Union types don't need to be wrapped in parens in some cases
+      if (
+        (parent.type === "VariableDeclarator" ||
+          parent.type === "TypeAnnotation" ||
+          parent.type === "GenericTypeAnnotation") &&
+        node.typeAnnotation.type === "TypeAnnotation" &&
+        node.typeAnnotation.typeAnnotation.type === "TSUnionType"
+      ) {
+        return false;
+      }
+      return true;
+    }
+
     case "SequenceExpression":
       switch (parent.type) {
         case "ReturnStatement":

--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -344,14 +344,15 @@ FastPath.prototype.needsParens = function() {
       }
 
     case "TSParenthesizedType": {
-      // Union types don't need to be wrapped in parens in some cases
       if (
-        (parent.type === "VariableDeclarator" ||
-          parent.type === "TypeAnnotation" ||
-          parent.type === "GenericTypeAnnotation") &&
-        node.typeAnnotation.type === "TypeAnnotation" &&
-        node.typeAnnotation.typeAnnotation.type === "TSUnionType"
+        parent.type === "VariableDeclarator" ||
+        parent.type === "TypeAnnotation" ||
+        parent.type === "GenericTypeAnnotation"
       ) {
+        return false;
+      }
+      // Delegate to inner TSParenthesizedType
+      if (node.typeAnnotation.type === "TSParenthesizedType") {
         return false;
       }
       return true;

--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -345,9 +345,11 @@ FastPath.prototype.needsParens = function() {
 
     case "TSParenthesizedType": {
       if (
-        parent.type === "VariableDeclarator" ||
-        parent.type === "TypeAnnotation" ||
-        parent.type === "GenericTypeAnnotation"
+        (parent.type === "VariableDeclarator" ||
+          parent.type === "TypeAnnotation" ||
+          parent.type === "GenericTypeAnnotation") &&
+        (node.typeAnnotation.type === "TypeAnnotation" &&
+          node.typeAnnotation.typeAnnotation.type !== "TSFunctionType")
       ) {
         return false;
       }

--- a/src/printer.js
+++ b/src/printer.js
@@ -2348,8 +2348,9 @@ function genericPrintNoParens(path, options, print, args) {
       ]);
     case "TSTypeQuery":
       return concat(["typeof ", path.call(print, "exprName")]);
-    case "TSParenthesizedType":
-      return concat(["(", path.call(print, "typeAnnotation"), ")"]);
+    case "TSParenthesizedType": {
+      return path.call(print, "typeAnnotation");
+    }
     case "TSIndexSignature": {
       const parent = path.getParentNode();
       let printedParams = [];

--- a/tests/typescript/custom/typeParameters/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/custom/typeParameters/__snapshots__/jsfmt.spec.js.snap
@@ -50,7 +50,7 @@ type AwkwardlyLongFunctionTypeDefinition = <
   arg1: GenericTypeNumberOne,
   arg2: GenericTypeNumberTwo,
   arg3: GenericTypeNumberThree
-) => (GenericTypeNumberOne | GenericTypeNumberTwo | GenericTypeNumberThree);
+) => GenericTypeNumberOne | GenericTypeNumberTwo | GenericTypeNumberThree;
 
 `;
 

--- a/tests/typescript_union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_union/__snapshots__/jsfmt.spec.js.snap
@@ -94,6 +94,7 @@ export type Multi = (string | number)[];
 function f(): (string | number) {}
 
 var x: (string | number);
+var y: ((string | number));
 
 class Foo<T extends (string | number)> {}
 
@@ -123,6 +124,7 @@ export type Multi = (string | number)[];
 function f(): string | number {}
 
 var x: string | number;
+var y: string | number;
 
 class Foo<T extends string | number> {}
 

--- a/tests/typescript_union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_union/__snapshots__/jsfmt.spec.js.snap
@@ -68,3 +68,67 @@ type window = Window & {
 };
 
 `;
+
+exports[`union-parens.ts 1`] = `
+
+export type A = (
+  | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+);
+
+export type B = (
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa |
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+);
+
+export type C =
+  | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type D =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa |
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type Multi = (string | number)[];
+
+function f(): (string | number) {}
+
+var x: (string | number);
+
+class Foo<T extends (string | number)> {}
+
+interface Interface {
+    i: (X | Y) & Z;
+    j: Partial<(X | Y)>;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export type A =
+  | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type B =
+  | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type C =
+  | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type D =
+  | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type Multi = (string | number)[];
+
+function f(): string | number {}
+
+var x: string | number;
+
+class Foo<T extends string | number> {}
+
+interface Interface {
+  i: (X | Y) & Z;
+  j: Partial<X | Y>;
+}
+
+`;

--- a/tests/typescript_union/union-parens.ts
+++ b/tests/typescript_union/union-parens.ts
@@ -22,6 +22,7 @@ export type Multi = (string | number)[];
 function f(): (string | number) {}
 
 var x: (string | number);
+var y: ((string | number));
 
 class Foo<T extends (string | number)> {}
 

--- a/tests/typescript_union/union-parens.ts
+++ b/tests/typescript_union/union-parens.ts
@@ -1,0 +1,31 @@
+
+export type A = (
+  | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+);
+
+export type B = (
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa |
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+);
+
+export type C =
+  | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  | bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type D =
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa |
+  bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb;
+
+export type Multi = (string | number)[];
+
+function f(): (string | number) {}
+
+var x: (string | number);
+
+class Foo<T extends (string | number)> {}
+
+interface Interface {
+    i: (X | Y) & Z;
+    j: Partial<(X | Y)>;
+}


### PR DESCRIPTION
Maybe this is taking on too much responsibility, but it does bring it more in line with how prettier handles parenthesization in regular JavaScript.

Fixes #1885