### PR TITLE
TypeScript: print arrow function type params on same line as params

### DIFF
--- a/tests/typescript_typeparams/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_typeparams/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`long-function-arg.ts 1`] = `
+export const forwardS = R.curry(
+  <V,T>(prop: string, reducer: ReducerFunction<V, T>, value: V, state: {[name: string]: T}) =>
+  R.assoc(prop, reducer(value, state[prop]), state)
+)
+
+export const forwardS = R.curry(
+  <VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV, TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT>(prop: string, reducer: ReducerFunction<V, T>, value: V, state: {[name: string]: T}) =>
+  R.assoc(prop, reducer(value, state[prop]), state)
+)
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export const forwardS = R.curry(
+  <V, T>(
+    prop: string,
+    reducer: ReducerFunction<V, T>,
+    value: V,
+    state: { [name: string]: T }
+  ) => R.assoc(prop, reducer(value, state[prop]), state)
+);
+
+export const forwardS = R.curry(
+  <
+    VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV,
+    TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT
+  >(
+    prop: string,
+    reducer: ReducerFunction<V, T>,
+    value: V,
+    state: { [name: string]: T }
+  ) => R.assoc(prop, reducer(value, state[prop]), state)
+);
+
+`;

--- a/tests/typescript_typeparams/jsfmt.spec.js
+++ b/tests/typescript_typeparams/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });

--- a/tests/typescript_typeparams/long-function-arg.ts
+++ b/tests/typescript_typeparams/long-function-arg.ts
@@ -1,0 +1,10 @@
+export const forwardS = R.curry(
+  <V,T>(prop: string, reducer: ReducerFunction<V, T>, value: V, state: {[name: string]: T}) =>
+  R.assoc(prop, reducer(value, state[prop]), state)
+)
+
+export const forwardS = R.curry(
+  <VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV, TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT>(prop: string, reducer: ReducerFunction<V, T>, value: V, state: {[name: string]: T}) =>
+  R.assoc(prop, reducer(value, state[prop]), state)
+)
+


### PR DESCRIPTION
**Before:**
```ts
export const forwardS = R.curry(<
  V,
  T
>(prop: string, reducer: ReducerFunction<V, T>, value: V, state: { [name: string]: T }) =>
  R.assoc(prop, reducer(value, state[prop]), state)
);
```

**After:**
```ts
export const forwardS = R.curry(
  <V, T>(
    prop: string,
    reducer: ReducerFunction<V, T>,
    value: V,
    state: { [name: string]: T }
  ) => R.assoc(prop, reducer(value, state[prop]), state)
);
```

Fixes #2099