### PR TITLE
Format CSS in template literals with expressions

### DIFF
--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -64,6 +64,7 @@ function fromBabylonFlowOrTypeScript(path) {
           text: text
         };
       }
+      break;
     }
     case "TemplateElement": {
       const parent = path.getParentNode();

--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const util = require("./util");
-const { traverseDoc } = require("./doc-utils");
+const traverseDoc = require("./doc-utils").traverseDoc;
 const docBuilders = require("./doc-builders");
 const indent = docBuilders.indent;
 const hardline = docBuilders.hardline;

--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -44,7 +44,7 @@ function fromBabylonFlowOrTypeScript(path) {
        * <style jsx>{`div{color:red}`}</style>
        * ```
        */
-      if (
+      const isStyledJsx =
         parentParent &&
         node.quasis &&
         parent.type === "JSXExpressionContainer" &&
@@ -52,8 +52,22 @@ function fromBabylonFlowOrTypeScript(path) {
         parentParent.openingElement.name.name === "style" &&
         parentParent.openingElement.attributes.some(
           attribute => attribute.name.name === "jsx"
-        )
-      ) {
+        );
+
+      /*
+       * styled-components:
+       * styled.button`color: red`
+       * Foo.extend`color: red`
+       */
+      const isStyledComponents =
+        parent &&
+        parent.type === "TaggedTemplateExpression" &&
+        parent.tag.type === "MemberExpression" &&
+        (parent.tag.object.name === "styled" ||
+          (/^[A-Z]/.test(parent.tag.object.name) &&
+            parent.tag.property.name === "extend"));
+
+      if (isStyledJsx || isStyledComponents) {
         // Get full template literal with expressions replaced by placeholders
         const rawQuasis = node.quasis.map(q => q.value.raw);
         const text = rawQuasis.join("@prettier-placeholder");
@@ -64,6 +78,7 @@ function fromBabylonFlowOrTypeScript(path) {
           text: text
         };
       }
+
       break;
     }
     case "TemplateElement": {
@@ -71,6 +86,7 @@ function fromBabylonFlowOrTypeScript(path) {
       const parentParent = path.getParentNode(1);
 
       /*
+<<<<<<< HEAD
        * styled-components:
        * styled.button`color: red`
        * Foo.extend`color: red`
@@ -96,6 +112,8 @@ function fromBabylonFlowOrTypeScript(path) {
       }
 
       /*
+=======
+>>>>>>> Add support for styled-components with expressions
        * react-relay and graphql-tag
        * graphql`...`
        * graphql.experimental`...`

--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -71,7 +71,6 @@ function fromBabylonFlowOrTypeScript(path) {
         // Get full template literal with expressions replaced by placeholders
         const rawQuasis = node.quasis.map(q => q.value.raw);
         const text = rawQuasis.join("@prettier-placeholder");
-
         return {
           options: { parser: "postcss" },
           transformDoc: transformCssDoc,
@@ -86,34 +85,6 @@ function fromBabylonFlowOrTypeScript(path) {
       const parentParent = path.getParentNode(1);
 
       /*
-<<<<<<< HEAD
-       * styled-components:
-       * styled.button`color: red`
-       * Foo.extend`color: red`
-       */
-      if (
-        parentParent &&
-        parentParent.type === "TaggedTemplateExpression" &&
-        parent.quasis.length === 1 &&
-        parentParent.tag.type === "MemberExpression" &&
-        (parentParent.tag.object.name === "styled" ||
-          (/^[A-Z]/.test(parentParent.tag.object.name) &&
-            parentParent.tag.property.name === "extend"))
-      ) {
-        return {
-          options: { parser: "postcss" },
-          transformDoc: doc =>
-            concat([
-              indent(concat([softline, stripTrailingHardline(doc)])),
-              softline
-            ]),
-          text: parent.quasis[0].value.raw
-        };
-      }
-
-      /*
-=======
->>>>>>> Add support for styled-components with expressions
        * react-relay and graphql-tag
        * graphql`...`
        * graphql.experimental`...`

--- a/src/printer.js
+++ b/src/printer.js
@@ -82,7 +82,10 @@ function genericPrint(path, options, printPath, args) {
     const next = multiparser.getSubtreeParser(path, options);
     if (next) {
       try {
-        return multiparser.printSubtree(next, options);
+        const expressionDocs = node.expressions
+          ? path.map(printPath, "expressions")
+          : [];
+        return multiparser.printSubtree(node, next, options);
       } catch (error) {
         if (process.env.PRETTIER_DEBUG) {
           console.error(error);

--- a/src/printer.js
+++ b/src/printer.js
@@ -85,7 +85,7 @@ function genericPrint(path, options, printPath, args) {
         const expressionDocs = node.expressions
           ? path.map(printPath, "expressions")
           : [];
-        return multiparser.printSubtree(node, next, options);
+        return multiparser.printSubtree(next, options, expressionDocs);
       } catch (error) {
         if (process.env.PRETTIER_DEBUG) {
           console.error(error);

--- a/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
@@ -59,3 +59,97 @@ color: red; display: none
 </div>;
 
 `;
+
+exports[`styled-jsx-with-expressions.js 1`] = `
+<style jsx>{\`
+  div {
+  display: \${expr};
+    color: \${expr};
+    \${expr};
+    \${expr};
+    background: red;
+  animation: \${expr} 10s ease-out;
+  }
+  @media (\${expr}) {
+   div.\${expr} {
+    color: red;
+   }
+  \${expr} {
+    color: red;
+  }
+  }
+  @media (min-width: \${expr}) {
+   div.\${expr} {
+    color: red;
+   }
+  all\${expr} {
+    color: red;
+  }
+  }
+  @font-face {
+    \${expr}
+  }
+\`}</style>;
+
+<style jsx>{\`
+  div {
+  animation: linear \${seconds}s ease-out;
+  }
+\`}</style>;
+
+<style jsx>{\`
+  div {
+  animation: 3s ease-in 1s \${foo => foo.getIterations()} reverse both paused slidein;
+  }
+\`}</style>;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<style jsx>{\`
+  div {
+    display: \${expr};
+    color: \${expr};
+    \${expr};
+    \${expr};
+    background: red;
+    animation: \${expr} 10s ease-out;
+  }
+  @media (\${expr}) {
+    div.\${expr} {
+      color: red;
+    }
+    \${expr} {
+      color: red;
+    }
+  }
+  @media (min-width: \${expr}) {
+    div.\${expr} {
+      color: red;
+    }
+    all\${expr} {
+      color: red;
+    }
+  }
+  @font-face {
+    \${expr};
+  }
+\`}</style>;
+
+<style jsx>{\`
+  div {
+    animation: linear \${seconds}s ease-out;
+  }
+\`}</style>;
+
+<style jsx>{\`
+  div {
+    animation: 3s
+      ease-in
+      1s
+      \${foo => foo.getIterations()}
+      reverse
+      both
+      paused
+      slidein;
+  }
+\`}</style>;
+
+`;

--- a/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`styled-components-with-expressions.js 1`] = `
+const Button = styled.a\`
+/* Comment */
+	display: \${props=>props.display};
+\`;
+
+styled.div\`
+	display: \${props=>props.display};
+	border: \${props=>props.border}px;
+	margin: 10px \${props=>props.border}px ;
+\`;
+
+const EqualDivider = styled.div\`
+margin: 0.5rem;
+		padding: 1rem;
+	background: papayawhip    ;
+
+	> * {
+	flex: 1;
+
+	&:not(:first-child) {
+			\${props => props.vertical ? 'margin-top' : 'margin-left'}: 1rem;
+		}
+	}
+\`;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const Button = styled.a\`
+  /* Comment */
+  display: \${props => props.display};
+\`;
+
+styled.div\`
+  display: \${props => props.display};
+  border: \${props => props.border}px;
+  margin: 10px \${props => props.border}px;
+\`;
+
+const EqualDivider = styled.div\`
+  margin: 0.5rem;
+  padding: 1rem;
+  background: papayawhip;
+  > * {
+    flex: 1;
+    &:not(:first-child) {
+      \${props => (props.vertical ? "margin-top" : "margin-left")}: 1rem;
+    }
+  }
+\`;
+
+`;
+
 exports[`styled-jsx.js 1`] = `
 <style jsx>{\`
 	/* a comment */

--- a/tests/template_literals/styled-components-with-expressions.js
+++ b/tests/template_literals/styled-components-with-expressions.js
@@ -1,0 +1,24 @@
+const Button = styled.a`
+/* Comment */
+	display: ${props=>props.display};
+`;
+
+styled.div`
+	display: ${props=>props.display};
+	border: ${props=>props.border}px;
+	margin: 10px ${props=>props.border}px ;
+`;
+
+const EqualDivider = styled.div`
+margin: 0.5rem;
+		padding: 1rem;
+	background: papayawhip    ;
+
+	> * {
+	flex: 1;
+
+	&:not(:first-child) {
+			${props => props.vertical ? 'margin-top' : 'margin-left'}: 1rem;
+		}
+	}
+`;

--- a/tests/template_literals/styled-jsx-with-expressions.js
+++ b/tests/template_literals/styled-jsx-with-expressions.js
@@ -1,0 +1,41 @@
+<style jsx>{`
+  div {
+  display: ${expr};
+    color: ${expr};
+    ${expr};
+    ${expr};
+    background: red;
+  animation: ${expr} 10s ease-out;
+  }
+  @media (${expr}) {
+   div.${expr} {
+    color: red;
+   }
+  ${expr} {
+    color: red;
+  }
+  }
+  @media (min-width: ${expr}) {
+   div.${expr} {
+    color: red;
+   }
+  all${expr} {
+    color: red;
+  }
+  }
+  @font-face {
+    ${expr}
+  }
+`}</style>;
+
+<style jsx>{`
+  div {
+  animation: linear ${seconds}s ease-out;
+  }
+`}</style>;
+
+<style jsx>{`
+  div {
+  animation: 3s ease-in 1s ${foo => foo.getIterations()} reverse both paused slidein;
+  }
+`}</style>;


### PR DESCRIPTION
This adds support for formatting CSS inside template literals with expressions (#1948). For example:  
```jsx
<style jsx>{`
  div {
    animation: linear ${seconds}s ease-out;
  }
`}</style>;
```

Currently is only working for styled-jsx, but if you like the approach, I can add styled-components too, it should be easy.

It works like this: 
1. It replace all the expressions from the template literal with `@prettier-placeholder` 
2. Parse and print the template literal (css) doc
3. Print the doc for each expression
4. Traverse the css doc replacing all the placeholders with the expression docs  

If it fails to find or replace any of the placeholders it throws an error and abort the formatting of the template literal.



