### PR TITLE
TypeScript: workaround - don't wrap directives in parens

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -130,7 +130,7 @@ FastPath.prototype.map = function map(callback /*, name1, name2, ... */) {
   return result;
 };
 
-FastPath.prototype.needsParens = function() {
+FastPath.prototype.needsParens = function(options) {
   const parent = this.getParentNode();
   if (!parent) {
     return false;
@@ -424,7 +424,11 @@ FastPath.prototype.needsParens = function() {
       if (
         typeof node.value === "string" &&
         parent.type === "ExpressionStatement" &&
-        !parent.directive
+        // TypeScript workaround for eslint/typescript-eslint-parser#267
+        // See corresponding workaround in printer.js case: "Literal"
+        ((options.parser !== "typescript" && !parent.directive) ||
+          (options.parser === "typescript" &&
+            options.originalText.substr(util.locStart(node) - 1, 1) === "("))
       ) {
         // To avoid becoming a directive
         const grandParent = this.getParentNode(1);

--- a/src/printer.js
+++ b/src/printer.js
@@ -166,7 +166,7 @@ function genericPrint(path, options, printPath, args) {
   } else {
     // Nodes with decorators can't have parentheses, so we can avoid
     // computing path.needsParens() except in this case.
-    needsParens = path.needsParens();
+    needsParens = path.needsParens(options);
   }
 
   if (node.type) {
@@ -1137,7 +1137,7 @@ function genericPrintNoParens(path, options, print, args) {
       return printNumber(n.extra.raw);
     case "BooleanLiteral": // Babel 6 Literal split
     case "StringLiteral": // Babel 6 Literal split
-    case "Literal":
+    case "Literal": {
       if (n.regex) {
         return printRegex(n.regex);
       }
@@ -1147,7 +1147,18 @@ function genericPrintNoParens(path, options, print, args) {
       if (typeof n.value !== "string") {
         return "" + n.value;
       }
-      return nodeStr(n, options); // Babel 6
+      // TypeScript workaround for eslint/typescript-eslint-parser#267
+      // See corresponding workaround in fast-path.js needsParens()
+      const grandParent = path.getParentNode(1);
+      const isTypeScriptDirective =
+        options.parser === "typescript" &&
+        typeof n.value === "string" &&
+        grandParent &&
+        (grandParent.type === "Program" ||
+          grandParent.type === "BlockStatement");
+
+      return nodeStr(n, options, isTypeScriptDirective);
+    }
     case "Directive":
       return path.call(print, "value"); // Babel 6
     case "DirectiveLiteral":
@@ -4100,7 +4111,7 @@ function adjustClause(node, clause, forceSpace) {
   return indent(concat([line, clause]));
 }
 
-function nodeStr(node, options, isFlowDirectiveLiteral) {
+function nodeStr(node, options, isFlowOrTypeScriptDirectiveLiteral) {
   const raw = node.extra ? node.extra.raw : node.raw;
   // `rawContent` is the string exactly like it appeared in the input source
   // code, with its enclosing quote.
@@ -4114,7 +4125,8 @@ function nodeStr(node, options, isFlowDirectiveLiteral) {
 
   let shouldUseAlternateQuote = false;
   const isDirectiveLiteral =
-    isFlowDirectiveLiteral || node.type === "DirectiveLiteral";
+    isFlowOrTypeScriptDirectiveLiteral || node.type === "DirectiveLiteral";
+
   let canChangeDirectiveQuotes = false;
 
   // If `rawContent` contains at least one of the quote preferred for enclosing

--- a/tests/directives/jsfmt.spec.js
+++ b/tests/directives/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, null, ["babylon" /*, "typescript"*/]);
+run_spec(__dirname, null, ["babylon", "typescript"]);

--- a/tests/expression_statement/jsfmt.spec.js
+++ b/tests/expression_statement/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, { parser: "babylon" }, ["flow"]);
+run_spec(__dirname, { parser: "babylon" }, ["flow", "typescript"]);


### PR DESCRIPTION
This was introduced by #1999.

typescript-eslint-parser doesn't mark directives as such (see https://github.com/eslint/typescript-eslint-parser/issues/267)

This works around the problem by detecting a leading `(` in the source, which means we can enable these tests, and should suffice for all but extreme circumstances.

Fixes #2074