### PR TITLE
Doc: Uncheck Immediate file synchronization

### DIFF
--- a/editors/webstorm/README.md
+++ b/editors/webstorm/README.md
@@ -38,3 +38,4 @@ Go to *File | Settings | Tools | File Watchers* for Windows and Linux or *WebSto
 * **Program** set the full path to a `prettier` executable, such as `/Users/developer/repo/jest/node_modules/.bin/prettier` (on OS X and Linux) or `C:/\Users\developer\repo\jest\node_modules\.bin\prettier.cmd` (on Windows).
 * **Parameters** set `--write [other opts] $FilePath$`
 * **Working directory** set `$ProjectFileDir$`
+* **Immediate file synchronization**: Uncheck to reformat on Save only (otherwise code will jump around while you type)


### PR DESCRIPTION
In WebStorm file watcher, it doesn't make sense to reformat with Immediate file synchronization since the code jumps around while you type and if you sneak in a character while reformatting WebStorm pops a conflict alert.

So it's much saner to reformat on Save only.