### PR TITLE
Fix comments in non strict mode

### DIFF
--- a/src/parser-babylon.js
+++ b/src/parser-babylon.js
@@ -30,7 +30,7 @@ function parse(text) {
     ast = babylon.parse(text, babylonOptions);
   } catch (originalError) {
     try {
-      return babylon.parse(
+      ast = babylon.parse(
         text,
         Object.assign({}, babylonOptions, { strictMode: false })
       );

--- a/tests/non-strict/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/non-strict/__snapshots__/jsfmt.spec.js.snap
@@ -9,6 +9,27 @@ function f(a, a) {
 
 `;
 
+exports[`keywords.js 1`] = `
+var package = require('../package');
+
+/**
+ * My amazing comment
+ */
+function myFunction() {
+	return 'StringGainz';
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+var package = require("../package");
+
+/**
+ * My amazing comment
+ */
+function myFunction() {
+  return "StringGainz";
+}
+
+`;
+
 exports[`octal-number.js 1`] = `
 0777
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/non-strict/keywords.js
+++ b/tests/non-strict/keywords.js
@@ -1,0 +1,8 @@
+var package = require('../package');
+
+/**
+ * My amazing comment
+ */
+function myFunction() {
+	return 'StringGainz';
+}


### PR DESCRIPTION
It turns out that by returning there, we didn't go through the line `delete ast.tokens` and the comments attachment logic would attach it to a random token. It's great that this fail-safe caught this bug!

Fixes #2111