### PR TITLE
Add `graphql.experimental` parsing for react-relay

### DIFF
--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -94,6 +94,7 @@ function fromBabylonFlowOrTypeScript(path) {
       /*
        * react-relay and graphql-tag
        * graphql`...`
+       * graphql.experimental`...`
        * gql`...`
        */
       if (
@@ -103,9 +104,12 @@ function fromBabylonFlowOrTypeScript(path) {
         // ((parentParent.tag.type === "MemberExpression" &&
         //   parentParent.tag.object.name === "Relay" &&
         //   parentParent.tag.property.name === "QL") ||
-        (parentParent.tag.type === "Identifier" &&
-          (parentParent.tag.name === "gql" ||
-            parentParent.tag.name === "graphql"))
+        ((parentParent.tag.type === "MemberExpression" &&
+          parentParent.tag.object.name === "graphql" &&
+          parentParent.tag.property.name === "experimental") ||
+          (parentParent.tag.type === "Identifier" &&
+            (parentParent.tag.name === "gql" ||
+              parentParent.tag.name === "graphql")))
       ) {
         return {
           options: { parser: "graphql" },

--- a/tests/multiparser_js_graphql/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_graphql/__snapshots__/jsfmt.spec.js.snap
@@ -36,10 +36,28 @@ graphql\`
   )
 { markReadNotification(data: $input ) { notification {seenState} } }
 \`;
+
+graphql.experimental\`
+ mutation     MarkReadNotificationMutation(
+    $input
+    : MarkReadNotificationData!
+  )
+{ markReadNotification(data: $input ) { notification {seenState} } }
+\`;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const { graphql } = require("react-relay");
 
 graphql\`
+  mutation MarkReadNotificationMutation($input: MarkReadNotificationData!) {
+    markReadNotification(data: $input) {
+      notification {
+        seenState
+      }
+    }
+  }
+\`;
+
+graphql.experimental\`
   mutation MarkReadNotificationMutation($input: MarkReadNotificationData!) {
     markReadNotification(data: $input) {
       notification {

--- a/tests/multiparser_js_graphql/react-relay.js
+++ b/tests/multiparser_js_graphql/react-relay.js
@@ -7,3 +7,11 @@ graphql`
   )
 { markReadNotification(data: $input ) { notification {seenState} } }
 `;
+
+graphql.experimental`
+ mutation     MarkReadNotificationMutation(
+    $input
+    : MarkReadNotificationData!
+  )
+{ markReadNotification(data: $input ) { notification {seenState} } }
+`;


### PR DESCRIPTION
Followed in the footsteps of #2092 to add support for the `graphql.experimental` tag present in Relay modern.