### PR TITLE
Add test for comment in TypeScript type parameters

### DIFF
--- a/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
@@ -124,6 +124,13 @@ export type WrappedFormUtils = {
 
 `;
 
+exports[`type-parameters.ts 1`] = `
+functionName<A /* A comment */>();
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+functionName<A /* A comment */>();
+
+`;
+
 exports[`types.ts 1`] = `
 (() => {
   // swallow error and fallback to using directory as path

--- a/tests/typescript_comments/type-parameters.ts
+++ b/tests/typescript_comments/type-parameters.ts
@@ -1,0 +1,1 @@
+functionName<A /* A comment */>();


### PR DESCRIPTION
The PR that upgraded TS to 2.4 (https://github.com/prettier/prettier/pull/2120) also fixed https://github.com/prettier/prettier/issues/2054 because it also included the fix commit in `typescript-eslint-parser`.

This PR just adds an explicit test case for https://github.com/prettier/prettier/issues/2054 to prevent regressions.