### PR TITLE
Override tsep loggerFn with noop

### DIFF
--- a/src/parser-typescript.js
+++ b/src/parser-typescript.js
@@ -38,7 +38,7 @@ function tryParseTypeScript(text, jsx) {
     ecmaFeatures: { jsx },
     // Override logger function with noop,
     // to avoid unsupported version errors being logged
-    loggerFn: Function.prototype
+    loggerFn: () => {}
   });
 }
 

--- a/src/parser-typescript.js
+++ b/src/parser-typescript.js
@@ -35,7 +35,10 @@ function tryParseTypeScript(text, jsx) {
     tokens: true,
     comment: true,
     useJSXTextNode: true,
-    ecmaFeatures: { jsx }
+    ecmaFeatures: { jsx },
+    // Override logger function with noop,
+    // to avoid unsupported version errors being logged
+    loggerFn: Function.prototype
   });
 }
 


### PR DESCRIPTION
This takes advantage of the new option in `typescript-eslint-parser` for providing your own logger function.

See https://github.com/eslint/typescript-eslint-parser/issues/321 for further details