### PR TITLE
Let `prettier --stdin` work with keyboard input

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -4,7 +4,7 @@
 
 const fs = require("fs");
 const path = require("path");
-const getStdin = require("get-stdin");
+const getStream = require("get-stream");
 const glob = require("glob");
 const chalk = require("chalk");
 const minimist = require("minimist");
@@ -252,7 +252,7 @@ if (argv["help"] || (!filepatterns.length && !stdin)) {
 }
 
 if (stdin) {
-  getStdin().then(input => {
+  getStream(process.stdin).then(input => {
     try {
       writeOutput(format(input, options));
     } catch (e) {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "eslint-plugin-prettier": "2.1.1",
     "esutils": "2.0.2",
     "flow-parser": "0.47.0",
-    "get-stdin": "5.0.1",
+    "get-stream": "3.0.0",
     "glob": "7.1.2",
     "graphql": "0.10.1",
     "jest": "20.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1583,9 +1583,9 @@ get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
 
-get-stdin@5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-5.0.1.tgz#122e161591e21ff4c52530305693f20e6393a398"
+get-stream@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
 
 getpass@^0.1.1:
   version "0.1.7"


### PR DESCRIPTION
This uses [get-stream] instead of [get-stdin], since the latter just
gives an empty string if process.stdin is a TTY
(see https://github.com/sindresorhus/get-stdin/issues/21)

[get-stream]: https://github.com/sindresorhus/get-stream
[get-stdin]: https://github.com/sindresorhus/get-stdin