### PR TITLE
Lock tsep to specific commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "rollup-plugin-node-resolve": "2.0.0",
     "rollup-plugin-replace": "1.1.1",
     "typescript": "2.4.0",
-    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#ts-2.4",
+    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#6da23fd004ea60b84a5cfff469c89e93c0770b6f",
     "uglify-es": "3.0.15",
     "webpack": "2.6.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3589,7 +3589,7 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#ts-2.4":
+"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#6da23fd004ea60b84a5cfff469c89e93c0770b6f":
   version "3.0.0"
   resolved "git://github.com/eslint/typescript-eslint-parser.git#6da23fd004ea60b84a5cfff469c89e93c0770b6f"
   dependencies:


### PR DESCRIPTION
There will be plenty of breaking changes in tsep over the next few weeks to align with TS Team on preferred AST structure.

One such change has been merged into master and I will be including it in the ts-2.4 branch accordingly.

I ran things locally and this will cause a test in prettier to fail, which will need to be addressed in a separate PR.

To protect users from these scenarios, we should definitely always lock to a specific commit, even though the branch name is obviously more readable.

This commit is the current latest on the ts-2.4 branch (before pulling in the breaking change from master)