### PR TITLE
Update tsep

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "rollup-plugin-node-resolve": "2.0.0",
     "rollup-plugin-replace": "1.1.1",
     "typescript": "2.4.0",
-    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#6da23fd004ea60b84a5cfff469c89e93c0770b6f",
+    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#479b592c0ad84a6ec5170fbe1821ed5ca90c4ee1",
     "uglify-es": "3.0.15",
     "webpack": "2.6.1"
   },

--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -345,7 +345,8 @@ FastPath.prototype.needsParens = function(options) {
 
     case "TSParenthesizedType": {
       if (
-        (parent.type === "VariableDeclarator" ||
+        (parent.type === "TypeParameter" ||
+          parent.type === "VariableDeclarator" ||
           parent.type === "TypeAnnotation" ||
           parent.type === "GenericTypeAnnotation") &&
         (node.typeAnnotation.type === "TypeAnnotation" &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -3589,9 +3589,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#6da23fd004ea60b84a5cfff469c89e93c0770b6f":
+"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#479b592c0ad84a6ec5170fbe1821ed5ca90c4ee1":
   version "3.0.0"
-  resolved "git://github.com/eslint/typescript-eslint-parser.git#6da23fd004ea60b84a5cfff469c89e93c0770b6f"
+  resolved "git://github.com/eslint/typescript-eslint-parser.git#479b592c0ad84a6ec5170fbe1821ed5ca90c4ee1"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.3.0"


### PR DESCRIPTION
This PR fixes #2154.

This update in tsep contains a breaking AST change:

E.g. for source `function f<T extends object = object>() {}`:

Before:

```ts
"type": "TypeParameterDeclaration",
"params": [
  {
    "type": "TypeParameter",
    "name": "T",
    "constraint": {
      "type": "TypeAnnotation",
      "typeAnnotation": {
        "type": "TSObjectKeyword"
      }
    },
    "default": {
      "type": "TSObjectKeyword"
    }
  }
]
```

After:

```ts
"type": "TypeParameterDeclaration",
"params": [
  {
    "type": "TypeParameter",
    "name": "T",
    "constraint": {
      "type": "TSObjectKeyword"
    },
    "default": {
      "type": "TSObjectKeyword"
    }
  }
]
```

This breaks 1 test in `typescript_union`:

```ts
class Foo<T extends (string | number)> {}
```

But this PR fixes that.