### PR TITLE
[RFC] Expose CLI programmatically

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -12,379 +12,395 @@ const readline = require("readline");
 const prettier = eval("require")("../index");
 const cleanAST = require("../src/clean-ast.js").cleanAST;
 
-const argv = minimist(process.argv.slice(2), {
-  boolean: [
-    "write",
-    "stdin",
-    "use-tabs",
-    "semi",
-    "single-quote",
-    "bracket-spacing",
-    "jsx-bracket-same-line",
-    // The supports-color package (a sub sub dependency) looks directly at
-    // `process.argv` for `--no-color` and such-like options. The reason it is
-    // listed here is to avoid "Ignored unknown option: --no-color" warnings.
-    // See https://github.com/chalk/supports-color/#info for more information.
-    "color",
-    "list-different",
-    "help",
-    "version",
-    "debug-print-doc",
-    "debug-check",
-    "with-node-modules",
-    // Deprecated in 0.0.10
-    "flow-parser"
-  ],
-  string: [
-    "print-width",
-    "tab-width",
-    "parser",
-    "trailing-comma",
-    "cursor-offset",
-    "range-start",
-    "range-end",
-    "stdin-filepath"
-  ],
-  default: {
-    semi: true,
-    color: true,
-    "bracket-spacing": true,
-    parser: "babylon"
-  },
-  alias: { help: "h", version: "v", "list-different": "l" },
-  unknown: param => {
-    if (param.startsWith("-")) {
-      console.warn("Ignored unknown option: " + param + "\n");
-      return false;
-    }
-  }
-});
-
-if (argv["version"]) {
-  console.log(prettier.version);
-  process.exit(0);
+if (require.main === module) {
+  cli(process.argv.slice(2));
 }
 
-const filepatterns = argv["_"];
-const write = argv["write"];
-const stdin = argv["stdin"] || (!filepatterns.length && !process.stdin.isTTY);
-const ignoreNodeModules = argv["with-node-modules"] === false;
-const globOptions = {
-  ignore: ignoreNodeModules && "**/node_modules/**",
-  dot: true
-};
+module.exports = cli;
 
-if (write && argv["debug-check"]) {
-  console.error("Cannot use --write and --debug-check together.");
-  process.exit(1);
-}
-
-function getParserOption() {
-  const optionName = "parser";
-  const value = argv[optionName];
-
-  if (value === undefined) {
-    return value;
-  }
-
-  // For backward compatibility. Deprecated in 0.0.10
-  if (argv["flow-parser"]) {
-    console.warn("`--flow-parser` is deprecated. Use `--parser flow` instead.");
-    return "flow";
-  }
-
-  return value;
-}
-
-function getIntOption(optionName) {
-  const value = argv[optionName];
-
-  if (value === undefined) {
-    return value;
-  }
-
-  if (/^\d+$/.test(value)) {
-    return Number(value);
-  }
-
-  console.error(
-    "Invalid --" +
-      optionName +
-      " value. Expected an integer, but received: " +
-      JSON.stringify(value)
-  );
-  process.exit(1);
-}
-
-function getTrailingComma() {
-  switch (argv["trailing-comma"]) {
-    case undefined:
-    case "none":
-      return "none";
-    case "":
-      console.warn(
-        "Warning: `--trailing-comma` was used without an argument. This is deprecated. " +
-          'Specify "none", "es5", or "all".'
-      );
-      return "es5";
-    case "es5":
-      return "es5";
-    case "all":
-      return "all";
-    default:
-      throw new Error("Invalid option for --trailing-comma");
-  }
-}
-
-const options = {
-  cursorOffset: getIntOption("cursor-offset"),
-  rangeStart: getIntOption("range-start"),
-  rangeEnd: getIntOption("range-end"),
-  useTabs: argv["use-tabs"],
-  semi: argv["semi"],
-  printWidth: getIntOption("print-width"),
-  tabWidth: getIntOption("tab-width"),
-  bracketSpacing: argv["bracket-spacing"],
-  singleQuote: argv["single-quote"],
-  jsxBracketSameLine: argv["jsx-bracket-same-line"],
-  filepath: argv["stdin-filepath"],
-  trailingComma: getTrailingComma(),
-  parser: getParserOption()
-};
-
-function format(input, opt) {
-  if (argv["debug-print-doc"]) {
-    const doc = prettier.__debug.printToDoc(input, opt);
-    return prettier.__debug.formatDoc(doc);
-  }
-
-  if (argv["debug-check"]) {
-    function diff(a, b) {
-      return require("diff").createTwoFilesPatch("", "", a, b, "", "", {
-        context: 2
-      });
-    }
-
-    const pp = prettier.format(input, opt);
-    const pppp = prettier.format(pp, opt);
-    if (pp !== pppp) {
-      throw "prettier(input) !== prettier(prettier(input))\n" + diff(pp, pppp);
-    } else {
-      const ast = cleanAST(prettier.__debug.parse(input, opt));
-      const past = cleanAST(prettier.__debug.parse(pp, opt));
-
-      if (ast !== past) {
-        const MAX_AST_SIZE = 2097152; // 2MB
-        const astDiff = ast.length > MAX_AST_SIZE || past.length > MAX_AST_SIZE
-          ? "AST diff too large to render"
-          : diff(ast, past);
-        throw "ast(input) !== ast(prettier(input))\n" +
-          astDiff +
-          "\n" +
-          diff(input, pp);
+function cli(processArgvSlice2) {
+  const argv = minimist(processArgvSlice2, {
+    boolean: [
+      "write",
+      "stdin",
+      "use-tabs",
+      "semi",
+      "single-quote",
+      "bracket-spacing",
+      "jsx-bracket-same-line",
+      // The supports-color package (a sub sub dependency) looks directly at
+      // `process.argv` for `--no-color` and such-like options. The reason it is
+      // listed here is to avoid "Ignored unknown option: --no-color" warnings.
+      // See https://github.com/chalk/supports-color/#info for more information.
+      "color",
+      "list-different",
+      "help",
+      "version",
+      "debug-print-doc",
+      "debug-check",
+      "with-node-modules",
+      // Deprecated in 0.0.10
+      "flow-parser"
+    ],
+    string: [
+      "print-width",
+      "tab-width",
+      "parser",
+      "trailing-comma",
+      "cursor-offset",
+      "range-start",
+      "range-end",
+      "stdin-filepath"
+    ],
+    default: {
+      semi: true,
+      color: true,
+      "bracket-spacing": true,
+      parser: "babylon"
+    },
+    alias: { help: "h", version: "v", "list-different": "l" },
+    unknown: param => {
+      if (param.startsWith("-")) {
+        console.warn("Ignored unknown option: " + param + "\n");
+        return false;
       }
     }
-    return { formatted: opt.filepath || "(stdin)\n" };
-  }
-
-  return prettier.formatWithCursor(input, opt);
-}
-
-function handleError(filename, e) {
-  const isParseError = Boolean(e && e.loc);
-  const isValidationError = /Validation Error/.test(e && e.message);
-
-  // For parse errors and validation errors, we only want to show the error
-  // message formatted in a nice way. `String(e)` takes care of that. Other
-  // (unexpected) errors are passed as-is as a separate argument to
-  // `console.error`. That includes the stack trace (if any), and shows a nice
-  // `util.inspect` of throws things that aren't `Error` objects. (The Flow
-  // parser has mistakenly thrown arrays sometimes.)
-  if (isParseError) {
-    console.error(filename + ": " + String(e));
-  } else if (isValidationError) {
-    console.error(String(e));
-    // If validation fails for one file, it will fail for all of them.
-    process.exit(1);
-  } else {
-    console.error(filename + ":", e.stack || e);
-  }
-
-  // Don't exit the process if one file failed
-  process.exitCode = 2;
-}
-
-if (argv["help"] || (!filepatterns.length && !stdin)) {
-  console.log(
-    "Usage: prettier [opts] [filename ...]\n\n" +
-      "Available options:\n" +
-      "  --write                  Edit the file in-place. (Beware!)\n" +
-      "  --list-different or -l   Print filenames of files that are different from Prettier formatting.\n" +
-      "  --stdin                  Read input from stdin.\n" +
-      "  --stdin-filepath         Path to the file used to read from stdin.\n" +
-      "  --print-width <int>      Specify the length of line that the printer will wrap on. Defaults to 80.\n" +
-      "  --tab-width <int>        Specify the number of spaces per indentation-level. Defaults to 2.\n" +
-      "  --use-tabs               Indent lines with tabs instead of spaces.\n" +
-      "  --no-semi                Do not print semicolons, except at the beginning of lines which may need them.\n" +
-      "  --single-quote           Use single quotes instead of double quotes.\n" +
-      "  --no-bracket-spacing     Do not print spaces between brackets.\n" +
-      "  --jsx-bracket-same-line  Put > on the last line instead of at a new line.\n" +
-      "  --trailing-comma <none|es5|all>\n" +
-      "                           Print trailing commas wherever possible. Defaults to none.\n" +
-      "  --parser <flow|babylon|typescript|postcss>\n" +
-      "                           Specify which parse to use. Defaults to babylon.\n" +
-      "  --cursor-offset <int>    Print (to stderr) where a cursor at the given position would move to after formatting.\n" +
-      "                           This option cannot be used with --range-start and --range-end\n" +
-      "  --range-start <int>      Format code starting at a given character offset.\n" +
-      "                           The range will extend backwards to the start of the first line containing the selected statement.\n" +
-      "                           This option cannot be used with --cursor-offset.\n" +
-      "                           Defaults to 0.\n" +
-      "  --range-end <int>        Format code ending at a given character offset (exclusive).\n" +
-      "                           The range will extend forwards to the end of the selected statement.\n" +
-      "                           This option cannot be used with --cursor-offset.\n" +
-      "                           Defaults to Infinity.\n" +
-      "  --no-color               Do not colorize error messages.\n" +
-      "  --with-node-modules      Process files inside `node_modules` directory.\n" +
-      "  --version or -v          Print Prettier version.\n" +
-      "\n"
-  );
-  process.exit(argv["help"] ? 0 : 1);
-}
-
-if (stdin) {
-  getStream(process.stdin).then(input => {
-    try {
-      writeOutput(format(input, options));
-    } catch (e) {
-      handleError("stdin", e);
-      return;
-    }
   });
-} else {
-  eachFilename(filepatterns, filename => {
-    if (write) {
-      // Don't use `console.log` here since we need to replace this line.
-      process.stdout.write(filename);
+
+  if (argv["version"]) {
+    console.log(prettier.version);
+    process.exit(0);
+  }
+
+  const filepatterns = argv["_"];
+  const write = argv["write"];
+  const stdin = argv["stdin"] || (!filepatterns.length && !process.stdin.isTTY);
+  const ignoreNodeModules = argv["with-node-modules"] === false;
+  const globOptions = {
+    ignore: ignoreNodeModules && "**/node_modules/**",
+    dot: true
+  };
+
+  if (write && argv["debug-check"]) {
+    console.error("Cannot use --write and --debug-check together.");
+    process.exit(1);
+  }
+
+  function getParserOption() {
+    const optionName = "parser";
+    const value = argv[optionName];
+
+    if (value === undefined) {
+      return value;
     }
 
-    let input;
-    try {
-      input = fs.readFileSync(filename, "utf8");
-    } catch (e) {
-      // Add newline to split errors from filename line.
-      process.stdout.write("\n");
-
-      console.error("Unable to read file: " + filename + "\n" + e);
-      // Don't exit the process if one file failed
-      process.exitCode = 2;
-      return;
+    // For backward compatibility. Deprecated in 0.0.10
+    if (argv["flow-parser"]) {
+      console.warn(
+        "`--flow-parser` is deprecated. Use `--parser flow` instead."
+      );
+      return "flow";
     }
 
-    if (argv["list-different"]) {
-      if (
-        !prettier.check(
+    return value;
+  }
+
+  function getIntOption(optionName) {
+    const value = argv[optionName];
+
+    if (value === undefined) {
+      return value;
+    }
+
+    if (/^\d+$/.test(value)) {
+      return Number(value);
+    }
+
+    console.error(
+      "Invalid --" +
+        optionName +
+        " value. Expected an integer, but received: " +
+        JSON.stringify(value)
+    );
+    process.exit(1);
+  }
+
+  function getTrailingComma() {
+    switch (argv["trailing-comma"]) {
+      case undefined:
+      case "none":
+        return "none";
+      case "":
+        console.warn(
+          "Warning: `--trailing-comma` was used without an argument. This is deprecated. " +
+            'Specify "none", "es5", or "all".'
+        );
+        return "es5";
+      case "es5":
+        return "es5";
+      case "all":
+        return "all";
+      default:
+        throw new Error("Invalid option for --trailing-comma");
+    }
+  }
+
+  const options = {
+    cursorOffset: getIntOption("cursor-offset"),
+    rangeStart: getIntOption("range-start"),
+    rangeEnd: getIntOption("range-end"),
+    useTabs: argv["use-tabs"],
+    semi: argv["semi"],
+    printWidth: getIntOption("print-width"),
+    tabWidth: getIntOption("tab-width"),
+    bracketSpacing: argv["bracket-spacing"],
+    singleQuote: argv["single-quote"],
+    jsxBracketSameLine: argv["jsx-bracket-same-line"],
+    filepath: argv["stdin-filepath"],
+    trailingComma: getTrailingComma(),
+    parser: getParserOption()
+  };
+
+  function format(input, opt) {
+    if (argv["debug-print-doc"]) {
+      const doc = prettier.__debug.printToDoc(input, opt);
+      return prettier.__debug.formatDoc(doc);
+    }
+
+    if (argv["debug-check"]) {
+      function diff(a, b) {
+        return require("diff").createTwoFilesPatch("", "", a, b, "", "", {
+          context: 2
+        });
+      }
+
+      const pp = prettier.format(input, opt);
+      const pppp = prettier.format(pp, opt);
+      if (pp !== pppp) {
+        throw "prettier(input) !== prettier(prettier(input))\n" +
+          diff(pp, pppp);
+      } else {
+        const ast = cleanAST(prettier.__debug.parse(input, opt));
+        const past = cleanAST(prettier.__debug.parse(pp, opt));
+
+        if (ast !== past) {
+          const MAX_AST_SIZE = 2097152; // 2MB
+          const astDiff = ast.length > MAX_AST_SIZE ||
+            past.length > MAX_AST_SIZE
+            ? "AST diff too large to render"
+            : diff(ast, past);
+          throw "ast(input) !== ast(prettier(input))\n" +
+            astDiff +
+            "\n" +
+            diff(input, pp);
+        }
+      }
+      return { formatted: opt.filepath || "(stdin)\n" };
+    }
+
+    return prettier.formatWithCursor(input, opt);
+  }
+
+  function handleError(filename, e) {
+    const isParseError = Boolean(e && e.loc);
+    const isValidationError = /Validation Error/.test(e && e.message);
+
+    // For parse errors and validation errors, we only want to show the error
+    // message formatted in a nice way. `String(e)` takes care of that. Other
+    // (unexpected) errors are passed as-is as a separate argument to
+    // `console.error`. That includes the stack trace (if any), and shows a nice
+    // `util.inspect` of throws things that aren't `Error` objects. (The Flow
+    // parser has mistakenly thrown arrays sometimes.)
+    if (isParseError) {
+      console.error(filename + ": " + String(e));
+    } else if (isValidationError) {
+      console.error(String(e));
+      // If validation fails for one file, it will fail for all of them.
+      process.exit(1);
+    } else {
+      console.error(filename + ":", e.stack || e);
+    }
+
+    // Don't exit the process if one file failed
+    process.exitCode = 2;
+  }
+
+  if (argv["help"] || (!filepatterns.length && !stdin)) {
+    console.log(
+      "Usage: prettier [opts] [filename ...]\n\n" +
+        "Available options:\n" +
+        "  --write                  Edit the file in-place. (Beware!)\n" +
+        "  --list-different or -l   Print filenames of files that are different from Prettier formatting.\n" +
+        "  --stdin                  Read input from stdin.\n" +
+        "  --stdin-filepath         Path to the file used to read from stdin.\n" +
+        "  --print-width <int>      Specify the length of line that the printer will wrap on. Defaults to 80.\n" +
+        "  --tab-width <int>        Specify the number of spaces per indentation-level. Defaults to 2.\n" +
+        "  --use-tabs               Indent lines with tabs instead of spaces.\n" +
+        "  --no-semi                Do not print semicolons, except at the beginning of lines which may need them.\n" +
+        "  --single-quote           Use single quotes instead of double quotes.\n" +
+        "  --no-bracket-spacing     Do not print spaces between brackets.\n" +
+        "  --jsx-bracket-same-line  Put > on the last line instead of at a new line.\n" +
+        "  --trailing-comma <none|es5|all>\n" +
+        "                           Print trailing commas wherever possible. Defaults to none.\n" +
+        "  --parser <flow|babylon|typescript|postcss>\n" +
+        "                           Specify which parse to use. Defaults to babylon.\n" +
+        "  --cursor-offset <int>    Print (to stderr) where a cursor at the given position would move to after formatting.\n" +
+        "                           This option cannot be used with --range-start and --range-end\n" +
+        "  --range-start <int>      Format code starting at a given character offset.\n" +
+        "                           The range will extend backwards to the start of the first line containing the selected statement.\n" +
+        "                           This option cannot be used with --cursor-offset.\n" +
+        "                           Defaults to 0.\n" +
+        "  --range-end <int>        Format code ending at a given character offset (exclusive).\n" +
+        "                           The range will extend forwards to the end of the selected statement.\n" +
+        "                           This option cannot be used with --cursor-offset.\n" +
+        "                           Defaults to Infinity.\n" +
+        "  --no-color               Do not colorize error messages.\n" +
+        "  --with-node-modules      Process files inside `node_modules` directory.\n" +
+        "  --version or -v          Print Prettier version.\n" +
+        "\n"
+    );
+    process.exit(argv["help"] ? 0 : 1);
+  }
+
+  if (stdin) {
+    getStream(process.stdin).then(input => {
+      try {
+        writeOutput(format(input, options));
+      } catch (e) {
+        handleError("stdin", e);
+        return;
+      }
+    });
+  } else {
+    eachFilename(filepatterns, filename => {
+      if (write) {
+        // Don't use `console.log` here since we need to replace this line.
+        process.stdout.write(filename);
+      }
+
+      let input;
+      try {
+        input = fs.readFileSync(filename, "utf8");
+      } catch (e) {
+        // Add newline to split errors from filename line.
+        process.stdout.write("\n");
+
+        console.error("Unable to read file: " + filename + "\n" + e);
+        // Don't exit the process if one file failed
+        process.exitCode = 2;
+        return;
+      }
+
+      if (argv["list-different"]) {
+        if (
+          !prettier.check(
+            input,
+            Object.assign({}, options, { filepath: filename })
+          )
+        ) {
+          if (!write) {
+            console.log(filename);
+          }
+          process.exitCode = 1;
+        }
+      }
+
+      const start = Date.now();
+
+      let result;
+      let output;
+
+      try {
+        result = format(
           input,
           Object.assign({}, options, { filepath: filename })
-        )
-      ) {
-        if (!write) {
-          console.log(filename);
-        }
-        process.exitCode = 1;
+        );
+        output = result.formatted;
+      } catch (e) {
+        // Add newline to split errors from filename line.
+        process.stdout.write("\n");
+
+        handleError(filename, e);
+        return;
       }
-    }
 
-    const start = Date.now();
+      if (write) {
+        // Remove previously printed filename to log it with duration.
+        readline.clearLine(process.stdout, 0);
+        readline.cursorTo(process.stdout, 0, null);
 
-    let result;
-    let output;
-
-    try {
-      result = format(
-        input,
-        Object.assign({}, options, { filepath: filename })
-      );
-      output = result.formatted;
-    } catch (e) {
-      // Add newline to split errors from filename line.
-      process.stdout.write("\n");
-
-      handleError(filename, e);
-      return;
-    }
-
-    if (write) {
-      // Remove previously printed filename to log it with duration.
-      readline.clearLine(process.stdout, 0);
-      readline.cursorTo(process.stdout, 0, null);
-
-      // Don't write the file if it won't change in order not to invalidate
-      // mtime based caches.
-      if (output === input) {
-        if (!argv["list-different"]) {
-          console.log(chalk.grey("%s %dms"), filename, Date.now() - start);
-        }
-      } else {
-        if (argv["list-different"]) {
-          console.log(filename);
+        // Don't write the file if it won't change in order not to invalidate
+        // mtime based caches.
+        if (output === input) {
+          if (!argv["list-different"]) {
+            console.log(chalk.grey("%s %dms"), filename, Date.now() - start);
+          }
         } else {
-          console.log("%s %dms", filename, Date.now() - start);
-        }
+          if (argv["list-different"]) {
+            console.log(filename);
+          } else {
+            console.log("%s %dms", filename, Date.now() - start);
+          }
 
-        try {
-          fs.writeFileSync(filename, output, "utf8");
-        } catch (err) {
-          console.error("Unable to write file: " + filename + "\n" + err);
-          // Don't exit the process if one file failed
+          try {
+            fs.writeFileSync(filename, output, "utf8");
+          } catch (err) {
+            console.error("Unable to write file: " + filename + "\n" + err);
+            // Don't exit the process if one file failed
+            process.exitCode = 2;
+          }
+        }
+      } else if (argv["debug-check"]) {
+        if (output) {
+          console.log(output);
+        } else {
           process.exitCode = 2;
         }
+      } else if (!argv["list-different"]) {
+        writeOutput(result);
       }
-    } else if (argv["debug-check"]) {
-      if (output) {
-        console.log(output);
-      } else {
-        process.exitCode = 2;
-      }
-    } else if (!argv["list-different"]) {
-      writeOutput(result);
-    }
-  });
-}
-
-function writeOutput(result) {
-  // Don't use `console.log` here since it adds an extra newline at the end.
-  process.stdout.write(result.formatted);
-
-  if (options.cursorOffset) {
-    process.stderr.write(result.cursorOffset + "\n");
+    });
   }
-}
 
-function eachFilename(patterns, callback) {
-  patterns.forEach(pattern => {
-    if (!glob.hasMagic(pattern)) {
-      if (shouldIgnorePattern(pattern)) {
-        return;
-      }
-      callback(pattern);
-      return;
+  function writeOutput(result) {
+    // Don't use `console.log` here since it adds an extra newline at the end.
+    process.stdout.write(result.formatted);
+
+    if (options.cursorOffset) {
+      process.stderr.write(result.cursorOffset + "\n");
     }
+  }
 
-    glob(pattern, globOptions, (err, filenames) => {
-      if (err) {
-        console.error("Unable to expand glob pattern: " + pattern + "\n" + err);
-        // Don't exit the process if one pattern failed
-        process.exitCode = 2;
+  function eachFilename(patterns, callback) {
+    patterns.forEach(pattern => {
+      if (!glob.hasMagic(pattern)) {
+        if (shouldIgnorePattern(pattern)) {
+          return;
+        }
+        callback(pattern);
         return;
       }
 
-      filenames.forEach(filename => {
-        callback(filename);
+      glob(pattern, globOptions, (err, filenames) => {
+        if (err) {
+          console.error(
+            "Unable to expand glob pattern: " + pattern + "\n" + err
+          );
+          // Don't exit the process if one pattern failed
+          process.exitCode = 2;
+          return;
+        }
+
+        filenames.forEach(filename => {
+          callback(filename);
+        });
       });
     });
-  });
-}
+  }
 
-function shouldIgnorePattern(pattern) {
-  return ignoreNodeModules && path.resolve(pattern).includes("/node_modules/");
+  function shouldIgnorePattern(pattern) {
+    return (
+      ignoreNodeModules && path.resolve(pattern).includes("/node_modules/")
+    );
+  }
 }

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -21,7 +21,7 @@ if (require.main === module) {
   ).exitCode;
 }
 
-module.exports = cli;
+module.exports = { cli: cli };
 
 function cli(args, stdin, stdout, stderr) {
   let exitCode = 0;

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -33,12 +33,18 @@ if (require.main === module) {
 module.exports = { cli: cliWrapper };
 
 function cliWrapper(args, stdin, stdout, stderr) {
-  return cli(args, stdin, stdout, stderr).catch(err => {
+  try {
+    return cli(args, stdin, stdout, stderr).catch(errHandler);
+  } catch (err) {
+    return errHandler(err);
+  }
+
+  function errHandler(err) {
     if (!("exitCode" in err)) {
       err.exitCode = 1;
     }
-    throw err;
-  });
+    return Promise.reject(err);
+  }
 }
 
 function cli(args, stdin, stdout, stderr) {
@@ -94,7 +100,7 @@ function cli(args, stdin, stdout, stderr) {
 
   if (argv["version"]) {
     stdout.write(prettier.version + "\n");
-    return { exitCode: 0 };
+    return Promise.resolve({ exitCode: 0 });
   }
 
   const filepatterns = argv["_"];
@@ -284,7 +290,7 @@ function cli(args, stdin, stdout, stderr) {
         "  --version or -v          Print Prettier version.\n" +
         "\n\n"
     );
-    return { exitCode: argv["help"] ? 0 : 1 };
+    return Promise.resolve({ exitCode: argv["help"] ? 0 : 1 });
   }
 
   if (readStdin) {

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -20,7 +20,12 @@ if (require.main === module) {
       process.exitCode = result.exitCode;
     })
     .catch(err => {
-      process.exitCode = err.exitCode;
+      if (typeof err === "string" || err instanceof Error) {
+        console.error(err);
+        process.exitCode = 1;
+      } else {
+        process.exitCode = err.exitCode;
+      }
     });
 }
 

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -12,6 +12,7 @@ const readline = require("readline");
 const prettier = eval("require")("../index");
 const cleanAST = require("../src/clean-ast.js").cleanAST;
 
+// If invoked directly, pass-through CLI arguments and streams
 if (require.main === module) {
   process.exitCode = cli(
     process.argv.slice(2),

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -15,21 +15,33 @@ const cleanAST = require("../src/clean-ast.js").cleanAST;
 
 // If invoked directly, pass-through CLI arguments and streams
 if (require.main === module) {
-  cli(process.argv.slice(2), process.stdin, process.stdout, process.stderr)
+  cliWrapper(
+    process.argv.slice(2),
+    process.stdin,
+    process.stdout,
+    process.stderr
+  )
     .then(result => {
       process.exitCode = result.exitCode;
     })
     .catch(err => {
       if (typeof err === "string" || err instanceof Error) {
         console.error(err);
-        process.exitCode = 1;
-      } else {
-        process.exitCode = err.exitCode;
       }
+      process.exitCode = err.exitCode || 1;
     });
 }
 
-module.exports = { cli: cli };
+module.exports = { cli: cliWrapper };
+
+function cliWrapper(args, stdin, stdout, stderr) {
+  return cli(args, stdin, stdout, stderr).catch(err => {
+    if (!("exitCode" in err)) {
+      err.exitCode = 1;
+    }
+    throw err;
+  });
+}
 
 function cli(args, stdin, stdout, stderr) {
   let exitCode = 0;

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -23,10 +23,10 @@ if (require.main === module) {
 
 module.exports = cli;
 
-function cli(processArgvSlice2, stdin, stdout, stderr) {
+function cli(args, stdin, stdout, stderr) {
   let exitCode = 0;
 
-  const argv = minimist(processArgvSlice2, {
+  const argv = minimist(args, {
     boolean: [
       "write",
       "stdin",

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -30,6 +30,8 @@ if (require.main === module) {
 
 module.exports = { cli: cliWrapper };
 
+// The cli() function throws Errors in order to exit early,
+// so we need to convert those into resolved Promises.
 function cliWrapper(args, stdin, stdout, stderr) {
   try {
     return cli(args, stdin, stdout, stderr);

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -397,20 +397,14 @@ function cli(args, stdin, stdout, stderr) {
         return;
       }
 
-      glob(pattern, globOptions, (err, filenames) => {
-        if (err) {
-          console.error(
-            "Unable to expand glob pattern: " + pattern + "\n" + err
-          );
-          // Don't exit the process if one pattern failed
-          exitCode = 2;
-          return;
-        }
-
-        filenames.forEach(filename => {
-          callback(filename);
-        });
-      });
+      try {
+        glob.sync(pattern, globOptions).forEach(callback);
+      } catch (err) {
+        console.error("Unable to expand glob pattern: " + pattern + "\n" + err);
+        // Don't exit the process if one pattern failed
+        exitCode = 2;
+        return;
+      }
     });
   }
 

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -21,12 +21,12 @@ if (require.main === module) {
     process.stdout,
     process.stderr
   )
-    .then(result => {
-      process.exitCode = result.exitCode;
-    })
     .catch(err => {
       console.error(err.message);
-      process.exitCode = err.exitCode;
+      return err;
+    })
+    .then(result => {
+      process.exitCode = result.exitCode;
     });
 }
 

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -32,12 +32,8 @@ module.exports = { cli: cliWrapper };
 
 function cliWrapper(args, stdin, stdout, stderr) {
   try {
-    return cli(args, stdin, stdout, stderr).catch(errHandler);
+    return cli(args, stdin, stdout, stderr);
   } catch (err) {
-    return errHandler(err);
-  }
-
-  function errHandler(err) {
     if (!("exitCode" in err)) {
       err.exitCode = 1;
     }

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -20,14 +20,12 @@ if (require.main === module) {
     process.stdin,
     process.stdout,
     process.stderr
-  )
-    .catch(err => {
-      console.error(err.message);
-      return err;
-    })
-    .then(result => {
-      process.exitCode = result.exitCode;
-    });
+  ).then(result => {
+    process.exitCode = result.exitCode;
+    if (result.message) {
+      console.error(result.message);
+    }
+  });
 }
 
 module.exports = { cli: cliWrapper };
@@ -43,7 +41,7 @@ function cliWrapper(args, stdin, stdout, stderr) {
     if (!("exitCode" in err)) {
       err.exitCode = 1;
     }
-    return Promise.reject(err);
+    return Promise.resolve(err);
   }
 }
 

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -18,7 +18,7 @@ if (require.main === module) {
     process.stdin,
     process.stdout,
     process.stderr
-  );
+  ).exitCode;
 }
 
 module.exports = cli;
@@ -76,7 +76,7 @@ function cli(args, stdin, stdout, stderr) {
 
   if (argv["version"]) {
     console.log(prettier.version);
-    return 0;
+    return { exitCode: 0 };
   }
 
   const filepatterns = argv["_"];
@@ -90,7 +90,7 @@ function cli(args, stdin, stdout, stderr) {
 
   if (write && argv["debug-check"]) {
     console.error("Cannot use --write and --debug-check together.");
-    return 1;
+    return { exitCode: 1 };
   }
 
   function getParserOption() {
@@ -129,7 +129,7 @@ function cli(args, stdin, stdout, stderr) {
         " value. Expected an integer, but received: " +
         JSON.stringify(value)
     );
-    return 1;
+    return { exitCode: 1 };
   }
 
   function getTrailingComma() {
@@ -223,7 +223,7 @@ function cli(args, stdin, stdout, stderr) {
     } else if (isValidationError) {
       console.error(String(e));
       // If validation fails for one file, it will fail for all of them.
-      return 1;
+      return { exitCode: 1 };
     } else {
       console.error(filename + ":", e.stack || e);
     }
@@ -266,7 +266,7 @@ function cli(args, stdin, stdout, stderr) {
         "  --version or -v          Print Prettier version.\n" +
         "\n"
     );
-    return argv["help"] ? 0 : 1;
+    return { exitCode: argv["help"] ? 0 : 1 };
   }
 
   if (readStdin) {
@@ -411,5 +411,5 @@ function cli(args, stdin, stdout, stderr) {
     );
   }
 
-  return exitCode;
+  return { exitCode: exitCode };
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "rollup-plugin-node-globals": "1.1.0",
     "rollup-plugin-node-resolve": "2.0.0",
     "rollup-plugin-replace": "1.1.1",
+    "string-to-stream": "1.1.0",
     "typescript": "2.4.0",
     "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#479b592c0ad84a6ec5170fbe1821ed5ca90c4ee1",
     "uglify-es": "3.0.15",

--- a/tests/cli/jsfmt.spec.js
+++ b/tests/cli/jsfmt.spec.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const stream = require("stream");
 const stringToStream = require("string-to-stream");
 const prettierCli = require("../../bin/prettier");

--- a/tests/cli/jsfmt.spec.js
+++ b/tests/cli/jsfmt.spec.js
@@ -1,0 +1,28 @@
+const stream = require("stream");
+const stringToStream = require("string-to-stream");
+const prettierCli = require("../../bin/prettier");
+
+test("can pass arguments, stdin/stdout/stderr to CLI programmatically", done => {
+  const stdin = stringToStream("0");
+
+  let output = "";
+  const stdout = new stream.Writable({
+    write: function(chunk, encoding, next) {
+      output += chunk.toString();
+      next();
+      if (output === "0;\n") {
+        done();
+      }
+    }
+  });
+
+  const stderr = new stream.Writable({
+    write: function(chunk, encoding, next) {
+      next();
+    }
+  });
+
+  const result = prettierCli.cli(["--stdin"], stdin, stdout, stderr);
+  expect(result.exitCode).toEqual(0);
+  // the formatted code is checked by the stdout stream's write method
+});

--- a/tests/cli/jsfmt.spec.js
+++ b/tests/cli/jsfmt.spec.js
@@ -12,9 +12,6 @@ test("can pass arguments, stdin/stdout/stderr to CLI programmatically", done => 
     write: function(chunk, encoding, next) {
       output += chunk.toString();
       next();
-      if (output === "0;\n") {
-        done();
-      }
     }
   });
 
@@ -24,7 +21,9 @@ test("can pass arguments, stdin/stdout/stderr to CLI programmatically", done => 
     }
   });
 
-  const result = prettierCli.cli(["--stdin"], stdin, stdout, stderr);
-  expect(result.exitCode).toEqual(0);
-  // the formatted code is checked by the stdout stream's write method
+  prettierCli.cli(["--stdin"], stdin, stdout, stderr).then(result => {
+    expect(result.exitCode).toEqual(0);
+    expect(output).toEqual("0;\n");
+    done();
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2991,7 +2991,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.4, readable-stream@^2.2.2, readable-stream@^2.2.6:
+readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.0, readable-stream@^2.1.4, readable-stream@^2.2.2, readable-stream@^2.2.6:
   version "2.2.11"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.2.11.tgz#0796b31f8d7688007ff0b93a8088d34aa17c0f72"
   dependencies:
@@ -3407,6 +3407,13 @@ string-length@^1.0.1:
   resolved "https://registry.yarnpkg.com/string-length/-/string-length-1.0.1.tgz#56970fb1c38558e9e70b728bf3de269ac45adfac"
   dependencies:
     strip-ansi "^3.0.0"
+
+string-to-stream@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/string-to-stream/-/string-to-stream-1.1.0.tgz#acf2c9ead1c418e148509a12d2cbb469f333a218"
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "^2.1.0"
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
(This diff is best viewed ignoring whitespace changes: https://github.com/prettier/prettier/pull/2168/files?w=true)

These changes make `./bin/prettier.js` export an object with a `cli`
method that takes the following parameters:

* an array of CLI arguments
* stdin stream
* stdout stream
* stderr stream

and returns a Promise resolving to an object with an `exitCode`
property. The object may be an Error.

This allows `prettier` wrappers like [`prettier_d`](https://github.com/josephfrazier/prettier_d)
to simply pass the arguments/streams to a preloaded prettier instance,
which handles all the CLI parsing and subsequent processing.

There is an example of using the new API in
[tests/cli/jsfmt.spec.js](https://github.com/prettier/prettier/pull/2168/files#diff-5634bffbb4a3818324c97e0341005e36).