### PR TITLE
Fix dist/ build by upgrading typescript to nightly

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "postcss-scss": "1.0.0",
     "postcss-selector-parser": "2.2.3",
     "postcss-values-parser": "git://github.com/shellscape/postcss-values-parser.git#5e351360479116f3fe309602cdd15b0a233bc29f",
-    "typescript": "2.4.0",
+    "typescript": "2.5.0-dev.20170617",
     "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#479b592c0ad84a6ec5170fbe1821ed5ca90c4ee1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3596,9 +3596,9 @@ typedarray@^0.0.6:
     lodash.unescape "4.0.1"
     semver "5.3.0"
 
-typescript@2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.0.tgz#aef5a8d404beba36ad339abf079ddddfffba86dd"
+typescript@2.5.0-dev.20170617:
+  version "2.5.0-dev.20170617"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.0-dev.20170617.tgz#5c72d3d4ea278f8db662f513c6911cd31378f024"
 
 uglify-es@3.0.15:
   version "3.0.15"


### PR DESCRIPTION
Before, this error happened upon `yarn build`:

    🚨   (commonjs plugin) Binding arguments in strict mode (49161:16) in /Users/josephfrazier/workspace/prettier/node_modules/typescript/lib/typescript.js