### PR TITLE
Fix dist/ build on machines that don't support `sed -i ''`

### DIFF
--- a/scripts/build/build.sh
+++ b/scripts/build/build.sh
@@ -70,7 +70,7 @@ echo;
 ## --- Misc ---
 
 echo 'Remove eval'
-sed -i '' -e 's/eval("require")/require/g' dist/index.js dist/bin/prettier.js
+sed --in-place='' -e 's/eval("require")/require/g' dist/index.js dist/bin/prettier.js
 
 echo 'Create prettier-version.js'
 node -p '`prettierVersion = "${require(".").version}";`' > docs/lib/prettier-version.js


### PR DESCRIPTION
Here's an example of the error that happens upon `yarn build`:

    sed: can't read : No such file or directory