### PR TITLE
Build/test dist/ on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,17 @@ cache:
   yarn: true
   directories:
   - node_modules
+env:
+  - NODE_ENV=development
+  - NODE_ENV=production
+matrix:
+  allow_failures:
+    - env: NODE_ENV=production
+  fast_finish: true
+install:
+  - yarn install --production=false
+before_script:
+  - if [ "${NODE_ENV}" = "production" ]; then yarn build; fi
 script:
   - yarn lint
   - AST_COMPARE=1 yarn test -- --runInBand


### PR DESCRIPTION
This helps us keep track of whether or not the dist/ build actually
works (see https://github.com/prettier/prettier/pull/2174). Note that
the dist/ jobs are allowed to fail, and do not affect overall build
time, so they shouldn't slow anything down (see
https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/).