### PR TITLE
Add json parser to dist/ build

### DIFF
--- a/scripts/build/build.sh
+++ b/scripts/build/build.sh
@@ -30,6 +30,9 @@ node_modules/.bin/rollup -c scripts/build/rollup.parser.config.js --environment 
 echo 'Bundling lib parse5...';
 node_modules/.bin/rollup -c scripts/build/rollup.parser.config.js --environment parser:parse5
 
+echo 'Bundling lib json...';
+node_modules/.bin/rollup -c scripts/build/rollup.parser.config.js --environment parser:json
+
 echo 'Bundling lib postcss...';
 # PostCSS has dependency cycles and won't work correctly with rollup :(
 ./node_modules/.bin/webpack --hide-modules src/parser-postcss.js dist/parser-postcss.js
@@ -64,6 +67,9 @@ node_modules/.bin/rollup -c scripts/build/rollup.docs.config.js --environment fi
 
 echo 'Bundling docs parse5...';
 node_modules/.bin/rollup -c scripts/build/rollup.docs.config.js --environment filepath:parser-parse5.js
+
+echo 'Bundling docs json...';
+node_modules/.bin/rollup -c scripts/build/rollup.docs.config.js --environment filepath:parser-json.js
 
 echo;
 


### PR DESCRIPTION
Following up on https://github.com/prettier/prettier/pull/2173, this fixes the build, as shown by:

    yarn build
    yarn test --prod -- tests/json/