### PR TITLE
Fix css-modules composes breaking with long line width

### DIFF
--- a/src/printer-postcss.js
+++ b/src/printer-postcss.js
@@ -10,6 +10,9 @@ const softline = docBuilders.softline;
 const group = docBuilders.group;
 const indent = docBuilders.indent;
 
+const docUtils = require("./doc-utils");
+const removeLines = docUtils.removeLines;
+
 function genericPrint(path, options, print) {
   const n = path.getValue();
 
@@ -80,7 +83,7 @@ function genericPrint(path, options, print) {
         ":",
         isValueExtend ? "" : " ",
         isComposed
-          ? n.value.group.group.groups.join("")
+          ? removeLines(path.call(print, "value"))
           : path.call(print, "value"),
         n.important ? " !important" : "",
         n.nodes

--- a/src/printer-postcss.js
+++ b/src/printer-postcss.js
@@ -69,13 +69,19 @@ function genericPrint(path, options, print) {
         n.value.group.type === "value-value" &&
         n.value.group.group.type === "value-func" &&
         n.value.group.group.value === "extend";
+      const isComposed =
+        n.value.type === "value-root" &&
+        n.value.group.type === "value-value" &&
+        n.prop === "composes";
 
       return concat([
         n.raws.before.replace(/[\s;]/g, ""),
         n.prop,
         ":",
         isValueExtend ? "" : " ",
-        path.call(print, "value"),
+        isComposed
+          ? n.value.group.group.groups.join("")
+          : path.call(print, "value"),
         n.important ? " !important" : "",
         n.nodes
           ? concat([

--- a/tests/css_composes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_composes/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`composes.css 1`] = `
+.reference {
+  composes: selector from "a/long/file/path/exceeding/the/maximum/length/forcing/a/line-wrap/file.css";
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.reference {
+  composes: selector from "a/long/file/path/exceeding/the/maximum/length/forcing/a/line-wrap/file.css";
+}
+
+`;

--- a/tests/css_composes/composes.css
+++ b/tests/css_composes/composes.css
@@ -1,0 +1,3 @@
+.reference {
+  composes: selector from "a/long/file/path/exceeding/the/maximum/length/forcing/a/line-wrap/file.css";
+}

--- a/tests/css_composes/jsfmt.spec.js
+++ b/tests/css_composes/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "postcss" });


### PR DESCRIPTION
# Background & Context

When using `css-modules` with `composes` formatting the source code using prettier's defaults seem to cause an error in the `css-loader`. 

## Example

```css
.reference {
  composes: selector from "a/long/file/path/exceeding/the/maximum/length/forcing/a/line-wrap/file.css";
}
```

will be formatted to

```css
.reference {
  composes: 
      selector 
      from "a/long/file/path/exceeding/the/maximum/length/forcing/a/line-wrap/file.css";
}
```

This pull request attempts to fix that by detecting the use of composition and by passing the normal formatting flow.

Closes #2189 