### PR TITLE
Use eslint-friendly-formatter to make errors clickable

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-preset-es2015": "6.24.1",
     "cross-spawn": "5.1.0",
     "eslint": "3.19.0",
+    "eslint-friendly-formatter": "3.0.0",
     "eslint-plugin-prettier": "2.1.1",
     "jest": "20.0.0",
     "mkdirp": "^0.5.1",
@@ -56,7 +57,7 @@
   "scripts": {
     "test": "jest",
     "test-integration": "jest tests_integration",
-    "lint": "eslint .",
+    "lint": "EFF_NO_LINK_RULES=true eslint . --format 'node_modules/eslint-friendly-formatter'",
     "build": "./scripts/build/build.sh"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -916,6 +916,10 @@ co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
+coalescy@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/coalescy/-/coalescy-1.0.0.tgz#4b065846b836361ada6c4b4a4abf4bc1cac31bf1"
+
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
@@ -1265,6 +1269,16 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-friendly-formatter@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-friendly-formatter/-/eslint-friendly-formatter-3.0.0.tgz#278874435a6c46ec1d94fa0b1ff494e30ef04290"
+  dependencies:
+    chalk "^1.0.0"
+    coalescy "1.0.0"
+    extend "^3.0.0"
+    minimist "^1.2.0"
+    text-table "^0.2.0"
+
 eslint-plugin-prettier@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.1.1.tgz#2fb7e2ab961f2b61d2c8cf91bc17716ca8c53868"
@@ -1403,7 +1417,7 @@ expand-range@^1.8.1:
   dependencies:
     fill-range "^2.1.0"
 
-extend@~3.0.0:
+extend@^3.0.0, extend@~3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
 
@@ -3542,7 +3556,7 @@ test-exclude@^4.1.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
-text-table@~0.2.0:
+text-table@^0.2.0, text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
 


### PR DESCRIPTION
This changes the eslint error formatting from:

    /Users/josephfrazier/workspace/prettier/src/printer-postcss.js
      3:31  error  Insert `;`  prettier/prettier

to:

    ✘  prettier/prettier  Insert `;`
    src/printer-postcss.js:3:31
    const util = require("./util")
                                   ^

which makes them clickable in terminals like iTerm2 and Guake. See
[eslint-friendly-formatter] for details.

[eslint-friendly-formatter]: https://github.com/royriojas/eslint-friendly-formatter