### PR TITLE
Turn allowImportExportEverywhere on

### DIFF
--- a/src/parser-babylon.js
+++ b/src/parser-babylon.js
@@ -8,7 +8,7 @@ function parse(text) {
 
   const babylonOptions = {
     sourceType: "module",
-    allowImportExportEverywhere: false,
+    allowImportExportEverywhere: true,
     allowReturnOutsideFunction: true,
     plugins: [
       "jsx",


### PR DESCRIPTION
This allows prettier to be used in environments which supports nested import statments, Meteor for example.