### PR TITLE
MultiParser: move css expression doc printing to transformCssDoc

### DIFF
--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -8,12 +8,12 @@ const hardline = docBuilders.hardline;
 const softline = docBuilders.softline;
 const concat = docBuilders.concat;
 
-function printSubtree(subtreeParser, options, expressionDocs) {
+function printSubtree(subtreeParser, path, print, options) {
   const next = Object.assign({}, { transformDoc: doc => doc }, subtreeParser);
   next.options = Object.assign({}, options, next.options);
   const ast = require("./parser").parse(next.text, next.options);
   const nextDoc = require("./printer").printAstToDoc(ast, next.options);
-  return next.transformDoc(nextDoc, expressionDocs);
+  return next.transformDoc(nextDoc, { path, print });
 }
 
 /**
@@ -163,7 +163,11 @@ function fromHtmlParser2(path, options) {
   }
 }
 
-function transformCssDoc(quasisDoc, expressionDocs) {
+function transformCssDoc(quasisDoc, parent) {
+  const parentNode = parent.path.getValue();
+  const expressionDocs = parentNode.expressions
+    ? parent.path.map(parent.print, "expressions")
+    : [];
   const newDoc = replacePlaceholders(quasisDoc, expressionDocs);
   if (!newDoc) {
     throw new Error("Couldn't insert all the expressions");

--- a/src/printer.js
+++ b/src/printer.js
@@ -82,10 +82,7 @@ function genericPrint(path, options, printPath, args) {
     const next = multiparser.getSubtreeParser(path, options);
     if (next) {
       try {
-        const expressionDocs = node.expressions
-          ? path.map(printPath, "expressions")
-          : [];
-        return multiparser.printSubtree(next, options, expressionDocs);
+        return multiparser.printSubtree(next, path, printPath, options);
       } catch (error) {
         if (process.env.PRETTIER_DEBUG) {
           console.error(error);


### PR DESCRIPTION
I think we should move this logic out of `genericPrint` and into `transformCssDoc`, but I'm not sure of the best way to accomplish this.

This PR adds a second argument to `transformDoc` called `parent` which contains both the `path` and `print` functions of the parent context.