### PR TITLE
Turn off trailing comma for json

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -37,6 +37,7 @@ function normalize(options) {
     normalized.parser = "typescript";
   } else if (/\.json$/.test(filepath)) {
     normalized.parser = "json";
+    normalized.trailingComma = "none";
   }
 
   if (typeof normalized.trailingComma === "boolean") {


### PR DESCRIPTION
When using `--trailing-comma all` trailing commas are added to json files. This will force it off if it's running on a json file.