### PR TITLE
Fix up empty JSX element detection

### DIFF
--- a/src/doc-utils.js
+++ b/src/doc-utils.js
@@ -167,6 +167,10 @@ function removeLines(doc) {
   });
 }
 
+function rawText(node) {
+  return node.extra ? node.extra.raw : node.raw;
+}
+
 module.exports = {
   isEmpty,
   willBreak,
@@ -174,5 +178,6 @@ module.exports = {
   traverseDoc,
   mapDoc,
   propagateBreaks,
-  removeLines
+  removeLines,
+  rawText
 };

--- a/src/printer.js
+++ b/src/printer.js
@@ -28,6 +28,7 @@ const docUtils = require("./doc-utils");
 const willBreak = docUtils.willBreak;
 const isLineNext = docUtils.isLineNext;
 const isEmpty = docUtils.isEmpty;
+const rawText = docUtils.rawText;
 
 function shouldPrintComma(options, level) {
   level = level || "es5";
@@ -3642,12 +3643,27 @@ function isEmptyJSXElement(node) {
     return false;
   }
 
-  // if there is one child but it's just a newline, treat as empty
-  const value = node.children[0].value;
-  if (!/\S/.test(value) && /\n/.test(value)) {
-    return true;
-  }
-  return false;
+  // if there is one text child and does not contain any meaningful text
+  // we can treat the element as empty.
+  const child = node.children[0];
+  return isLiteral(child) && !isMeaningfulJSXText(child);
+}
+
+// Only space, newline, carriage return, and tab are treated as whitespace
+// inside JSX.
+const jsxWhitespaceChars = " \n\r\t";
+const containsNonJsxWhitespaceRegex = new RegExp(
+  "[^" + jsxWhitespaceChars + "]"
+);
+
+// Meaningful if it contains non-whitespace characters,
+// or it contains whitespace without a new line.
+function isMeaningfulJSXText(node) {
+  return (
+    isLiteral(node) &&
+    (containsNonJsxWhitespaceRegex.test(rawText(node)) ||
+      !/\n/.test(rawText(node)))
+  );
 }
 
 // JSX Children are strange, mostly for two reasons:

--- a/tests/jsx_escape/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx_escape/__snapshots__/jsfmt.spec.js.snap
@@ -17,6 +17,11 @@ exports[`escape.js 2`] = `
 exports[`nbsp.js 1`] = `
 many_nbsp = <div>&nbsp; &nbsp; </div>
 single_nbsp = <div>&nbsp;</div>
+nbsp_with_newline =
+  <div>
+    &nbsp;
+  </div>
+
 many_raw_nbsp = <div>   </div>
 many_raw_spaces = <div>   </div>
 
@@ -26,6 +31,12 @@ raw_amp = <span>foo & bar</span>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 many_nbsp = <div>&nbsp; &nbsp; </div>;
 single_nbsp = <div>&nbsp;</div>;
+nbsp_with_newline = (
+  <div>
+    &nbsp;
+  </div>
+);
+
 many_raw_nbsp = <div>   </div>;
 many_raw_spaces = <div>   </div>;
 
@@ -37,6 +48,11 @@ raw_amp = <span>foo & bar</span>;
 exports[`nbsp.js 2`] = `
 many_nbsp = <div>&nbsp; &nbsp; </div>
 single_nbsp = <div>&nbsp;</div>
+nbsp_with_newline =
+  <div>
+    &nbsp;
+  </div>
+
 many_raw_nbsp = <div>   </div>
 many_raw_spaces = <div>   </div>
 
@@ -46,6 +62,12 @@ raw_amp = <span>foo & bar</span>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 many_nbsp = <div>&nbsp; &nbsp; </div>;
 single_nbsp = <div>&nbsp;</div>;
+nbsp_with_newline = (
+  <div>
+    &nbsp;
+  </div>
+);
+
 many_raw_nbsp = <div>   </div>;
 many_raw_spaces = <div>   </div>;
 

--- a/tests/jsx_escape/nbsp.js
+++ b/tests/jsx_escape/nbsp.js
@@ -1,5 +1,10 @@
 many_nbsp = <div>&nbsp; &nbsp; </div>
 single_nbsp = <div>&nbsp;</div>
+nbsp_with_newline =
+  <div>
+    &nbsp;
+  </div>
+
 many_raw_nbsp = <div>   </div>
 many_raw_spaces = <div>   </div>
 


### PR DESCRIPTION
As raised in https://github.com/prettier/prettier/issues/2217 Prettier can currently cause `&nbsp;` to disappear when the JSX tag contains a new line.

This was caused by an incorrect algorithm to determine whether a JSX element is empty. We weren't checking the raw value of the text, so incorrectly thought that `&nbsp;` was whitespace (rather than text).

This PR fixes this by pulling in some code from https://github.com/prettier/prettier/pull/1831 that lets us determine whether a JSX element contains "meaningful" text.
