### PR TITLE
Don't indent + in object value

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -304,7 +304,9 @@ function genericPrintNoParens(path, options, print, args) {
         (parent.type === "JSXExpressionContainer" &&
           parentParent.type === "JSXAttribute") ||
         (n === parent.body && parent.type === "ArrowFunctionExpression") ||
-        (n !== parent.body && parent.type === "ForStatement")
+        (n !== parent.body && parent.type === "ForStatement") ||
+        parent.type === "ObjectProperty" ||
+        parent.type === "Property"
       ) {
         return group(concat(parts));
       }

--- a/tests/objects/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/objects/__snapshots__/jsfmt.spec.js.snap
@@ -106,8 +106,8 @@ const blablah =
 const k = {
   blablah:
     "aldkfkladfskladklsfkladklfkaldfadfkdaf" +
-      "adlfasdklfkldsklfakldsfkladsfkadsfladsfa" +
-      "dflkadfkladsfklkadlfkladlfkadklfjadlfdfdaf"
+    "adlfasdklfkldsklfakldsfkladsfkadsfladsfa" +
+    "dflkadfkladsfklkadlfkladlfkadklfjadlfdfdaf"
 };
 
 somethingThatsAReallyLongPropName =


### PR DESCRIPTION
This is a "regression" from when we started using the same heuristic for `=` and `:`

Fixes #2129