### PR TITLE
Range Formatter: Remove Program/File from valid Ancestor

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,11 @@ function findSiblingAncestors(startNodeAndParents, endNodeAndParents) {
   let resultEndNode = endNodeAndParents.node;
 
   for (const endParent of endNodeAndParents.parentNodes) {
-    if (util.locStart(endParent) >= util.locStart(startNodeAndParents.node)) {
+    if (
+      endParent.type !== "Program" &&
+      endParent.type !== "File" &&
+      util.locStart(endParent) >= util.locStart(startNodeAndParents.node)
+    ) {
       resultEndNode = endParent;
     } else {
       break;
@@ -112,7 +116,10 @@ function findSiblingAncestors(startNodeAndParents, endNodeAndParents) {
   }
 
   for (const startParent of startNodeAndParents.parentNodes) {
-    if (util.locEnd(startParent) <= util.locEnd(endNodeAndParents.node)) {
+    if (
+      startParent.type !== "Program" &&
+      startParent.type !== "File" &&
+      util.locEnd(startParent) <= util.locEnd(endNodeAndParents.node)) {
       resultStartNode = startParent;
     } else {
       break;

--- a/index.js
+++ b/index.js
@@ -119,7 +119,8 @@ function findSiblingAncestors(startNodeAndParents, endNodeAndParents) {
     if (
       startParent.type !== "Program" &&
       startParent.type !== "File" &&
-      util.locEnd(startParent) <= util.locEnd(endNodeAndParents.node)) {
+      util.locEnd(startParent) <= util.locEnd(endNodeAndParents.node)
+    ) {
       resultStartNode = startParent;
     } else {
       break;

--- a/tests/range/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/range/__snapshots__/jsfmt.spec.js.snap
@@ -176,6 +176,46 @@ function ugly ( {a=1,     b     =   2     }      ) {
 
 `;
 
+exports[`range-end.js 1`] = `
+// Unchanged
+call(
+  1, 2,3
+);
+
+
+call(
+  1, 2,3
+);~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Unchanged
+call(
+  1, 2,3
+);
+
+
+call(1, 2, 3);
+`;
+
+exports[`range-start.js 1`] = `
+call(
+  1, 2,3
+);
+
+
+// Unchanged
+call(
+  1, 2,3
+);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+call(1, 2, 3);
+
+
+// Unchanged
+call(
+  1, 2,3
+);
+
+`;
+
 exports[`try-catch.js 1`] = `
 try {}
 catch (err) {}

--- a/tests/range/range-end.js
+++ b/tests/range/range-end.js
@@ -1,0 +1,9 @@
+// Unchanged
+call(
+  1, 2,3
+);
+
+<<<PRETTIER_RANGE_START>>>
+call(
+  1, 2,3
+);<<<PRETTIER_RANGE_END>>>

--- a/tests/range/range-start.js
+++ b/tests/range/range-start.js
@@ -1,0 +1,9 @@
+<<<PRETTIER_RANGE_START>>>call(
+  1, 2,3
+);
+<<<PRETTIER_RANGE_END>>>
+
+// Unchanged
+call(
+  1, 2,3
+);


### PR DESCRIPTION
Fix edge range formatting the entire file.
Fixes #2245 

This PR removes Program and File node type from valid ancestors as those 2 nodes cover the entire file.

This is my try to fix the issue with formatting the entire file on selecting an edge node.
Also added 2 tests to cover both start node and end node selection