### PR TITLE
Add caching for printing

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -4657,7 +4657,7 @@ function isObjectType(n) {
 function printAstToDoc(ast, options, addAlignmentSize) {
   addAlignmentSize = addAlignmentSize || 0;
 
-  var cache = new Map();
+  const cache = new Map();
 
   function printGenerically(path, args) {
     const node = path.getValue();

--- a/tests/performance/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/performance/__snapshots__/jsfmt.spec.js.snap
@@ -10,7 +10,17 @@ someObject.someFunction().then(function() {
             return someObject.someFunction().then(function() {
               return someObject.someFunction().then(function() {
                 return someObject.someFunction().then(function() {
-                  anotherFunction();
+                  return someObject.someFunction().then(function() {
+                    return someObject.someFunction().then(function() {
+                      return someObject.someFunction().then(function() {
+                        return someObject.someFunction().then(function() {
+                          return someObject.someFunction().then(function() {
+                            anotherFunction();
+                          });
+                        });
+                      });
+                    });
+                  });
                 });
               });
             });
@@ -30,7 +40,17 @@ someObject.someFunction().then(function() {
             return someObject.someFunction().then(function() {
               return someObject.someFunction().then(function() {
                 return someObject.someFunction().then(function() {
-                  anotherFunction();
+                  return someObject.someFunction().then(function() {
+                    return someObject.someFunction().then(function() {
+                      return someObject.someFunction().then(function() {
+                        return someObject.someFunction().then(function() {
+                          return someObject.someFunction().then(function() {
+                            anotherFunction();
+                          });
+                        });
+                      });
+                    });
+                  });
                 });
               });
             });

--- a/tests/performance/nested.js
+++ b/tests/performance/nested.js
@@ -7,7 +7,17 @@ someObject.someFunction().then(function() {
             return someObject.someFunction().then(function() {
               return someObject.someFunction().then(function() {
                 return someObject.someFunction().then(function() {
-                  anotherFunction();
+                  return someObject.someFunction().then(function() {
+                    return someObject.someFunction().then(function() {
+                      return someObject.someFunction().then(function() {
+                        return someObject.someFunction().then(function() {
+                          return someObject.someFunction().then(function() {
+                            anotherFunction();
+                          });
+                        });
+                      });
+                    });
+                  });
                 });
               });
             });


### PR DESCRIPTION
For printing the last argument expansion, we need to print the same node a bit differently with a flag. It's not easy to re-print just the node that is different so we end up printing all the sub-tree twice. Since it is often nested, it means that we run into an exponential complexity.

I finally found a simple solution: we can use a Map to store the nodes and their printed values. It is really cheap to do so (I can't notice a time difference with or without on normal code) and allows us to stop going through the two sub-trees in the bad case.

Fixes #1250