### PR TITLE
Forward originalText in multiparser

### DIFF
--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -11,7 +11,9 @@ const concat = docBuilders.concat;
 
 function printSubtree(subtreeParser, path, print, options) {
   const next = Object.assign({}, { transformDoc: doc => doc }, subtreeParser);
-  next.options = Object.assign({}, options, next.options);
+  next.options = Object.assign({}, options, next.options, {
+    originalText: next.text
+  });
   const ast = require("./parser").parse(next.text, next.options);
   const astComments = ast.comments;
   delete ast.comments;

--- a/tests/multiparser_html_ts/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_html_ts/__snapshots__/jsfmt.spec.js.snap
@@ -33,6 +33,7 @@ exports[`html-with-ts-script.html 1`] = `
 
   <script lang="ts">
     type X = { [K in keyof Y]: Partial<K> };
+
     class Foo<T> {
       constructor(private foo: keyof Apple) {}
     }

--- a/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
@@ -17,11 +17,13 @@ border-color : tomato
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const Button = styled.button\`
   color: palevioletred;
+
   font-size: 1em;
 \`;
 
 const TomatoButton = Button.extend\`
   color: tomato;
+
   border-color: tomato;
 \`;
 

--- a/tests/multiparser_text/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_text/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`text.js 1`] = `
+a = {
+  viewer: graphql\`
+    fragment x on Viewer {
+      y(named: [
+        "projects_feedback_ids" # PROJECTS_FEEDBACK_IDS
+      ]) {
+        name
+      }
+    }
+  \`,
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+a = {
+  viewer: graphql\`
+    fragment x on Viewer {
+      y(
+        named: [
+          "projects_feedback_ids" # PROJECTS_FEEDBACK_IDS
+        ]
+      ) {
+        name
+      }
+    }
+  \`
+};
+
+`;

--- a/tests/multiparser_text/jsfmt.spec.js
+++ b/tests/multiparser_text/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname);

--- a/tests/multiparser_text/text.js
+++ b/tests/multiparser_text/text.js
@@ -1,0 +1,11 @@
+a = {
+  viewer: graphql`
+    fragment x on Viewer {
+      y(named: [
+        "projects_feedback_ids" # PROJECTS_FEEDBACK_IDS
+      ]) {
+        name
+      }
+    }
+  `,
+}

--- a/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
@@ -41,8 +41,10 @@ const EqualDivider = styled.div\`
   margin: 0.5rem;
   padding: 1rem;
   background: papayawhip;
+
   > * {
     flex: 1;
+
     &:not(:first-child) {
       \${props => (props.vertical ? "margin-top" : "margin-left")}: 1rem;
     }


### PR DESCRIPTION
If we don't, all the places where we read from the original text (mostly comments) are reading into random places.

Fixes #2258