### PR TITLE
Fix variance location

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1725,10 +1725,6 @@ function genericPrintNoParens(path, options, print, args) {
       return concat(parts);
     case "ClassProperty":
     case "TSAbstractClassProperty": {
-      const variance = getFlowVariance(n);
-      if (variance) {
-        parts.push(variance);
-      }
       if (n.accessibility) {
         parts.push(n.accessibility + " ");
       }
@@ -1740,6 +1736,10 @@ function genericPrintNoParens(path, options, print, args) {
       }
       if (n.readonly) {
         parts.push("readonly ");
+      }
+      const variance = getFlowVariance(n);
+      if (variance) {
+        parts.push(variance);
       }
       if (n.computed) {
         parts.push("[", path.call(print, "key"), "]");

--- a/tests/flow_variance/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_variance/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`variance.js 1`] = `
+class Route {
+  static +param: T;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class Route {
+  static +param: T;
+}
+
+`;

--- a/tests/flow_variance/jsfmt.spec.js
+++ b/tests/flow_variance/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, null, ["babylon"]);

--- a/tests/flow_variance/variance.js
+++ b/tests/flow_variance/variance.js
@@ -1,0 +1,3 @@
+class Route {
+  static +param: T;
+}


### PR DESCRIPTION
Turns out when we refactored for TS, we moved it before "static" and it no longer parses. Oops.