### PR TITLE
Fix unstable arrow comments

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2963,7 +2963,10 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
   //     }                     b,
   //   })                    ) => {
   //                         })
-  if (expandArg) {
+  if (
+    expandArg &&
+    !(fun[paramsField] && fun[paramsField].some(n => n.comments))
+  ) {
     return group(
       concat([
         docUtils.removeLines(typeParams),
@@ -3047,7 +3050,7 @@ function canPrintParamsWithoutParens(node) {
     !node.rest &&
     node.params[0].type === "Identifier" &&
     !node.params[0].typeAnnotation &&
-    !util.hasBlockComments(node.params[0]) &&
+    !node.params[0].comments &&
     !node.params[0].optional &&
     !node.predicate &&
     !node.returnType

--- a/tests/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -269,6 +269,13 @@ export const bem = block =>
         element ? \`__\${css(element)}\` : "",
         modifier ? \`--\${css(modifier)}\` : ""
       ].join("");
+
+<FlatList
+  renderItem={(
+    info, // $FlowExpectedError - bad widgetCount type 6, should be Object
+  ) => <span>{info.item.widget.missingProp}</span>}
+  data={data}
+/>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /**
  * Curried function that ends with a BEM CSS Selector
@@ -293,6 +300,13 @@ export const bem = block =>
         element ? \`__\${css(element)}\` : "",
         modifier ? \`--\${css(modifier)}\` : ""
       ].join("");
+
+<FlatList
+  renderItem={(
+    info // $FlowExpectedError - bad widgetCount type 6, should be Object
+  ) => <span>{info.item.widget.missingProp}</span>}
+  data={data}
+/>;
 
 `;
 

--- a/tests/arrows/comment.js
+++ b/tests/arrows/comment.js
@@ -21,3 +21,10 @@ export const bem = block =>
         element ? `__${css(element)}` : "",
         modifier ? `--${css(modifier)}` : ""
       ].join("");
+
+<FlatList
+  renderItem={(
+    info, // $FlowExpectedError - bad widgetCount type 6, should be Object
+  ) => <span>{info.item.widget.missingProp}</span>}
+  data={data}
+/>

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -243,7 +243,9 @@ function a(/* comment */) {} // comment
 function b() {} // comment
 function c(/* comment */ argA, argB, argC) {} // comment
 call((/*object*/ row) => {});
-KEYPAD_NUMBERS.map(num => <div />); // Buttons 0-9
+KEYPAD_NUMBERS.map((
+  num // Buttons 0-9
+) => <div />);
 
 `;
 


### PR DESCRIPTION
It outputted which is completely wrong

```js
<FlatList
  renderItem={info => <span>{info.item.widget.missingProp // $FlowExpectedError - bad widgetCount type 6, should be Object
    }</span>}
/>;
```