### PR TITLE
Add module, class and typed nodes to sourceElements (Range formater)

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,6 +185,16 @@ function isSourceElement(node) {
     case "VariableDeclaration":
     case "WhileStatement":
     case "WithStatement":
+    case "ClassDeclaration": // ES 2015
+    case "ImportDeclaration": // Module
+    case "ExportDefaultDeclaration": // Module
+    case "ExportNamedDeclaration": // Module
+    case "ExportAllDeclaration": // Module
+    case "TypeAlias": // Flow
+    case "InterfaceDeclaration": // Flow, Typescript
+    case "TypeAliasDeclaration": // Typescript
+    case "ExportAssignment": // Typescript
+    case "ExportDeclaration": // Typescript
       return true;
   }
   return false;

--- a/tests/range/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/range/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`class-declaration.js 1`] = `
+
+
+class    a {
+  b(   ) {}
+}
+
+let    x~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+class a {
+  b() {}
+}
+
+let    x
+`;
+
 exports[`different-levels.js 1`] = `
 call(1,2,3)
 call(1,2,3)
@@ -40,6 +57,97 @@ function ugly ( {a=1,     b     =   2     }      ) {
     }
   }
 }
+
+`;
+
+exports[`module-export1.js 1`] = `
+import  def , {named}  from    'x'
+
+export *  from   'd'
+
+export    const  x
+  =  42
+
+export   default    42
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import  def , {named}  from    'x'
+
+export * from "d";
+
+export    const  x
+  =  42
+
+export   default    42
+
+
+`;
+
+exports[`module-export2.js 1`] = `
+import  def , {named}  from    'x'
+
+export *  from   'd'
+
+export    const  x
+  =  42
+
+export   default    42
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import  def , {named}  from    'x'
+
+export *  from   'd'
+
+export const x = 42;
+
+export   default    42
+
+
+`;
+
+exports[`module-export3.js 1`] = `
+import  def , {named}  from    'x'
+
+export *  from   'd'
+
+export    const  x
+  =  42
+
+export   default    42
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import  def , {named}  from    'x'
+
+export *  from   'd'
+
+export    const  x
+  =  42
+
+export default 42;
+
+
+`;
+
+exports[`module-import.js 1`] = `
+import  def , {named}  from    'x'
+
+export *  from   'd'
+
+export    const  x
+  =  42
+
+export   default    42
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import def, { named } from "x";
+
+export *  from   'd'
+
+export    const  x
+  =  42
+
+export   default    42
+
 
 `;
 

--- a/tests/range/class-declaration.js
+++ b/tests/range/class-declaration.js
@@ -1,0 +1,7 @@
+
+
+class   <<<PRETTIER_RANGE_START>>> a {
+  b(   ) {}<<<PRETTIER_RANGE_END>>>
+}
+
+let    x

--- a/tests/range/module-export1.js
+++ b/tests/range/module-export1.js
@@ -1,0 +1,9 @@
+import  def , {named}  from    'x'
+
+export * <<<PRETTIER_RANGE_START>>> from   'd'<<<PRETTIER_RANGE_END>>>
+
+export    const  x
+  =  42
+
+export   default    42
+

--- a/tests/range/module-export2.js
+++ b/tests/range/module-export2.js
@@ -1,0 +1,9 @@
+import  def , {named}  from    'x'
+
+export *  from   'd'
+<<<PRETTIER_RANGE_START>>>
+export    const  x
+  <<<PRETTIER_RANGE_END>>>=  42
+
+export   default    42
+

--- a/tests/range/module-export3.js
+++ b/tests/range/module-export3.js
@@ -1,0 +1,9 @@
+import  def , {named}  from    'x'
+
+export *  from   'd'
+
+export    const  x
+  =  42
+
+export   default  <<<PRETTIER_RANGE_START>>>  42<<<PRETTIER_RANGE_END>>>
+

--- a/tests/range/module-import.js
+++ b/tests/range/module-import.js
@@ -1,0 +1,9 @@
+import <<<PRETTIER_RANGE_START>>> def , {named} <<<PRETTIER_RANGE_END>>> from    'x'
+
+export *  from   'd'
+
+export    const  x
+  =  42
+
+export   default    42
+


### PR DESCRIPTION
Added various missing types for babylon, flow and typescript parsers.
It now allows to *range format* those node types.

Added tests to cover module and class.

Fixes #2246

I'm not sure if it's good to mix all those node types for every parser. We may end with a long list. They would certainly fit better in their respective parser list but duplicating nodes between javascript parsers.
Neither postcss parser nor *future parser* are included

@josephfrazier as asked, but it may still miss some nodes.