### PR TITLE
Tweak to support FB translation pipeline

### DIFF
--- a/tests/flow/more_react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/more_react/__snapshots__/jsfmt.spec.js.snap
@@ -99,7 +99,8 @@ var App = React.createClass({
 
     return (
       <div>
-        {foo(x, y)}{foo(z, x)} // error, since z: number
+        {foo(x, y)}
+        {foo(z, x)} // error, since z: number
       </div>
     );
   }

--- a/tests/jsx-newlines/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-newlines/__snapshots__/jsfmt.spec.js.snap
@@ -117,7 +117,10 @@ newlines_elems_spaced = (
 
 newlines_mixed = (
   <div>
-    hi<span>there</span>how are <strong>you</strong>are you fine today?
+    hi
+    <span>there</span>
+    how are <strong>you</strong>
+    are you fine today?
   </div>
 );
 
@@ -126,7 +129,10 @@ newlines_elems = (
     <div>
       <div />
     </div>
-    hi<div /><span /><Big />
+    hi
+    <div />
+    <span />
+    <Big />
   </div>
 );
 

--- a/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
@@ -189,8 +189,7 @@ not_broken_end = (
 
 not_broken_begin = (
   <div>
-    <br />
-    {" "}long text long text long text long text long text long text long text
+    <br /> long text long text long text long text long text long text long text
     long text<link>url</link> long text long text
   </div>
 );

--- a/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
@@ -135,8 +135,9 @@ const render6 = ({ styles }) =>
 
 const render7 = () =>
   <div>
-    <span /><span>Dont break each elem onto its own line.</span> <span /><div />{" "}
-    <div />
+    <span />
+    <span>Dont break each elem onto its own line.</span> <span />
+    <div /> <div />
   </div>;
 
 const render7A = () =>

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -253,7 +253,8 @@ expression_does_not_break =
 
 // FIXME
 br_triggers_expression_break =
-  <div><br />text text text text text text text text text text text {this.props.type} </div>
+  <div><br />
+  text text text text text text text text text text text {this.props.type} </div>
 
 jsx_whitespace_after_tag =
   <div>
@@ -271,6 +272,33 @@ x =
     </div>{" "}
     HRS
   </div>
+
+x =
+  <div>
+    <h2>Message</h2>
+    Hello, I'm a simple message.
+  </div>
+
+x =
+  <div>
+    Hello, I'm a simple message.
+    <h2>Message</h2>
+  </div>
+
+x =
+  <div>
+    <div>
+      <div>
+        <div>
+          <div>
+            Line {startRange.row + 1}:{startRange.column + 1} - {endRange.row + 1}:{endRange.column + 1}{caller}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Wrapping text
 x = (
@@ -303,7 +331,9 @@ x = (
 // Wrapping tags
 x = (
   <div>
-    <a /><b /><c />
+    <a />
+    <b />
+    <c />
     <first>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</first>{" "}
     <first>f</first>
   </div>
@@ -329,7 +359,8 @@ x = (
 x = (
   <div>
     before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}
-    {stuff}{stuff}after{stuff}after
+    {stuff}
+    {stuff}after{stuff}after
   </div>
 );
 
@@ -387,7 +418,9 @@ x = (
 
 x = (
   <div>
-    <div>First</div>Second<div>Third</div>
+    <div>First</div>
+    Second
+    <div>Third</div>
   </div>
 );
 
@@ -532,7 +565,8 @@ no_text_one_tag_per_line = (
 
 with_text_fill_line = (
   <div>
-    Text <first /><second />
+    Text <first />
+    <second />
   </div>
 );
 
@@ -546,22 +580,21 @@ line_after_br = (
 
 line_after_br_2 = (
   <div>
-    A<br />
-    B<br />
-    C
+    A<br />B<br />C
   </div>
 );
 
 br_followed_by_whitespace = (
   <div>
-    <br />
-    {" "}text
+    <br /> text
   </div>
 );
 
 dont_preserve_blank_lines_when_jsx_contains_text = (
   <div>
-    <div>Zeroth</div><div>First</div>Second
+    <div>Zeroth</div>
+    <div>First</div>
+    Second
   </div>
 );
 
@@ -612,6 +645,36 @@ x = (
       text text text text text text text text text text text
     </div>{" "}
     HRS
+  </div>
+);
+
+x = (
+  <div>
+    <h2>Message</h2>
+    Hello, I'm a simple message.
+  </div>
+);
+
+x = (
+  <div>
+    Hello, I'm a simple message.
+    <h2>Message</h2>
+  </div>
+);
+
+x = (
+  <div>
+    <div>
+      <div>
+        <div>
+          <div>
+            Line {startRange.row + 1}:{startRange.column + 1} -{" "}
+            {endRange.row + 1}:{endRange.column + 1}
+            {caller}
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 );
 

--- a/tests/jsx-text-wrap/test.js
+++ b/tests/jsx-text-wrap/test.js
@@ -250,7 +250,8 @@ expression_does_not_break =
 
 // FIXME
 br_triggers_expression_break =
-  <div><br />text text text text text text text text text text text {this.props.type} </div>
+  <div><br />
+  text text text text text text text text text text text {this.props.type} </div>
 
 jsx_whitespace_after_tag =
   <div>
@@ -268,3 +269,30 @@ x =
     </div>{" "}
     HRS
   </div>
+
+x =
+  <div>
+    <h2>Message</h2>
+    Hello, I'm a simple message.
+  </div>
+
+x =
+  <div>
+    Hello, I'm a simple message.
+    <h2>Message</h2>
+  </div>
+
+x =
+  <div>
+    <div>
+      <div>
+        <div>
+          <div>
+            Line {startRange.row + 1}:{startRange.column + 1} - {endRange.row + 1}:{endRange.column + 1}{caller}
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+


### PR DESCRIPTION
As mentioned in https://github.com/prettier/prettier/issues/2233#issuecomment-310850386 the current master won't work for Facebook as it breaks the formatting of their translation pipeline.

This PR aims to be a short term fix to add that support back in, so that the Prettier release is no longer blocked.

This PR also affects https://github.com/prettier/prettier/issues/2231, as it tweaks/improves formatting when there are consecutive tag/expression elements with no white space between them  (as this was the quickest way to fix the FB issue).