### PR TITLE
Improve JSX output when there is a single expression

### DIFF
--- a/tests/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -304,7 +304,10 @@ export const bem = block =>
 <FlatList
   renderItem={(
     info // $FlowExpectedError - bad widgetCount type 6, should be Object
-  ) => <span>{info.item.widget.missingProp}</span>}
+  ) =>
+    <span>
+      {info.item.widget.missingProp}
+    </span>}
   data={data}
 />;
 

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -497,7 +497,9 @@ Observable.of(process)
   .takeUntil(exit);
 
 // Comments disappear inside of JSX
-<div>{/* Some comment */}</div>;
+<div>
+  {/* Some comment */}
+</div>;
 
 // Comments in JSX tag are placed in a non optimal way
 <div
@@ -596,15 +598,23 @@ exports[`jsx.js 1`] = `
 
 <div>{/*<div>  Some very v  ery very very long line to break line width limit </div>*/}</div>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-<div>{/* comment */}</div>;
+<div>
+  {/* comment */}
+</div>;
 
-<div>{/* comment */}</div>;
+<div>
+  {/* comment */}
+</div>;
 
-<div>{/* comment
-*/}</div>;
+<div>
+  {/* comment
+*/}
+</div>;
 
-<div>{a /* comment
-*/}</div>;
+<div>
+  {a /* comment
+*/}
+</div>;
 
 <div>
   {
@@ -614,9 +624,13 @@ exports[`jsx.js 1`] = `
   }
 </div>;
 
-<div>{/* comment */}</div>;
+<div>
+  {/* comment */}
+</div>;
 
-<div>{/* comment */}</div>;
+<div>
+  {/* comment */}
+</div>;
 
 <div>
   {

--- a/tests/flow/multiflow/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/multiflow/__snapshots__/jsfmt.spec.js.snap
@@ -222,8 +222,12 @@ declare function ExpectsProps(props: { name: string }, children: any): string;
 declare function ExpectsChildrenTuple(props: any, children: [string]): string;
 <ExpectsChildrenTuple />; // Error - mising child
 <ExpectsChildrenTuple>Hi</ExpectsChildrenTuple>; // No error
-<ExpectsChildrenTuple>{123}</ExpectsChildrenTuple>; // Error: number ~> string
-<ExpectsChildrenTuple>Hi {"there"}</ExpectsChildrenTuple>; // Error: too many children
+<ExpectsChildrenTuple>
+  {123}
+</ExpectsChildrenTuple>; // Error: number ~> string
+<ExpectsChildrenTuple>
+  Hi {"there"}
+</ExpectsChildrenTuple>; // Error: too many children
 
 declare function ExpectsChildrenArray(
   props: any,
@@ -231,8 +235,12 @@ declare function ExpectsChildrenArray(
 ): string;
 <ExpectsChildrenArray />; // No error - 0 children is fine
 <ExpectsChildrenArray>Hi</ExpectsChildrenArray>; // No error - 1 child is fine
-<ExpectsChildrenArray>{123}</ExpectsChildrenArray>; // Error: number ~> string
-<ExpectsChildrenArray>Hi {"there"}</ExpectsChildrenArray>; // No error - 2 children is fine
+<ExpectsChildrenArray>
+  {123}
+</ExpectsChildrenArray>; // Error: number ~> string
+<ExpectsChildrenArray>
+  Hi {"there"}
+</ExpectsChildrenArray>; // No error - 2 children is fine
 
 `;
 

--- a/tests/flow/new_react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/new_react/__snapshots__/jsfmt.spec.js.snap
@@ -793,7 +793,11 @@ class Example extends React.Component {
   props: { bar: string };
 
   render() {
-    return <div>{this.props.bar}</div>;
+    return (
+      <div>
+        {this.props.bar}
+      </div>
+    );
   }
 }
 
@@ -865,7 +869,11 @@ var ReactClass = React.createClass({
   render: function(): any {
     // Any state access here seems to make state any
     this.state;
-    return <div>{this.state.bar.qux}</div>;
+    return (
+      <div>
+        {this.state.bar.qux}
+      </div>
+    );
   }
 });
 
@@ -973,7 +981,11 @@ var C = React.createClass({
 
   render() {
     this.setState({ y: 0 });
-    return <div>{this.state.z}</div>;
+    return (
+      <div>
+        {this.state.z}
+      </div>
+    );
   }
 });
 

--- a/tests/flow/react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/react/__snapshots__/jsfmt.spec.js.snap
@@ -741,7 +741,11 @@ class Bar extends React.Component {
     test: number
   };
   render() {
-    return <div>{this.props.test}</div>;
+    return (
+      <div>
+        {this.props.test}
+      </div>
+    );
   }
 }
 
@@ -1619,9 +1623,17 @@ var Example = React.createClass({
   },
   render() {
     if (typeof this.props.prop === "string") {
-      return <div>{this.props.prop}</div>;
+      return (
+        <div>
+          {this.props.prop}
+        </div>
+      );
     } else {
-      return <div>{this.props.prop.toFixed(2)}</div>;
+      return (
+        <div>
+          {this.props.prop.toFixed(2)}
+        </div>
+      );
     }
   }
 });

--- a/tests/flow/react_modules/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/react_modules/__snapshots__/jsfmt.spec.js.snap
@@ -38,7 +38,11 @@ var HelloLocal = React.createClass({
   },
 
   render: function(): React.Element<*> {
-    return <div>{this.props.name}</div>;
+    return (
+      <div>
+        {this.props.name}
+      </div>
+    );
   }
 });
 
@@ -82,7 +86,11 @@ var Hello = React.createClass({
   },
 
   render: function(): React.Element<*> {
-    return <div>{this.props.name}</div>;
+    return (
+      <div>
+        {this.props.name}
+      </div>
+    );
   }
 });
 
@@ -128,7 +136,11 @@ class HelloLocal extends React.Component<void, { name: string }, void> {
     name: React.PropTypes.string.isRequired
   };
   render(): React.Element<*> {
-    return <div>{this.props.name}</div>;
+    return (
+      <div>
+        {this.props.name}
+      </div>
+    );
   }
 }
 
@@ -174,7 +186,11 @@ class Hello extends React.Component<void, { name: string }, void> {
   };
 
   render(): React.Element<*> {
-    return <div>{this.props.name}</div>;
+    return (
+      <div>
+        {this.props.name}
+      </div>
+    );
   }
 }
 
@@ -220,7 +236,11 @@ class HelloLocal extends React.Component<void, Props, void> {
   props: Props;
 
   render(): React.Element<*> {
-    return <div>{this.props.name}</div>;
+    return (
+      <div>
+        {this.props.name}
+      </div>
+    );
   }
 }
 
@@ -266,7 +286,11 @@ class Hello extends React.Component<{}, Props, void> {
   static defaultProps: {};
 
   render(): React.Element<*> {
-    return <div>{this.props.name}</div>;
+    return (
+      <div>
+        {this.props.name}
+      </div>
+    );
   }
 }
 

--- a/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
@@ -160,9 +160,14 @@ const render7B = () =>
     </span>
   </div>;
 
-const render8 = props => <div>{props.text}</div>;
+const render8 = props =>
+  <div>
+    {props.text}
+  </div>;
 const render9 = props =>
-  <div>{props.looooooooooooooooooooooooooooooong_text}</div>;
+  <div>
+    {props.looooooooooooooooooooooooooooooong_text}
+  </div>;
 const render10 = props =>
   <div>
     {props.even_looooooooooooooooooooooooooooooooooooooooooonger_contents}

--- a/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
@@ -284,7 +284,9 @@ const els = items.map(item => (
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const els = items.map(item =>
   <div className="whatever">
-    <span>{children}</span>
+    <span>
+      {children}
+    </span>
   </div>
 );
 

--- a/tests/typescript_tsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_tsx/__snapshots__/jsfmt.spec.js.snap
@@ -38,9 +38,15 @@ const MyCoolList = ({ things }) =>
 
 const MyCoolThing = ({ thingo }) => <li>{thingo}</li>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-const MyCoolList = ({ things }) => <ul>{things.map(MyCoolThing)}</ul>;
+const MyCoolList = ({ things }) =>
+  <ul>
+    {things.map(MyCoolThing)}
+  </ul>;
 
-const MyCoolThing = ({ thingo }) => <li>{thingo}</li>;
+const MyCoolThing = ({ thingo }) =>
+  <li>
+    {thingo}
+  </li>;
 
 `;
 


### PR DESCRIPTION
This adds the improvement discussed in https://github.com/prettier/prettier/issues/2232

When outputting a JSX element that contains a single expression (code wrapped in `{` `}`) we ensure the output is multiline when there is no parent element, or the parent element does not contain text:

```jsx 
<div>
  {variable}
</div>
```

But when the parent element contains text we allow the JSX element to be inlined.

```jsx
// The expression can stay inlined here
<div>
  First <span>{variable}</span>
</div>
```

Fixes #2264 
Fixes #2232