### PR TITLE
Add Prettier + ESLint integration comparison table

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,17 @@ passes `prettier` output to `standard --fix`
 - [`Prettier Bookmarklet`](https://prettier.glitch.me/) provides a bookmarklet and exposes a REST API for Prettier that allows to format CodeMirror editor in your browser
 - [`prettier-github`](https://github.com/jgierer12/prettier-github) formats code in GitHub comments
 
+## Using Prettier with ESLint
+
+| | [`prettier-eslint`](https://github.com/prettier/prettier-eslint) | [`eslint-plugin-prettier`](https://github.com/prettier/eslint-plugin-prettier) | [`eslint-config-prettier`](https://github.com/prettier/eslint-config-prettier) |
+|--|:--:|:--:|:--:|
+| What it is | A JavaScript module exporting a single function. | An ESLint plugin. | An ESLint configuration. |
+| What it does | Runs the code (string) through `prettier` then `eslint --fix`. The output is also a string. | Plugins usually contain implementations for additional rules that ESLint will check for. This plugin uses Prettier under the hood and will raise ESLint errors when your code differs from Prettier's expected output. | This config turns off formatting-related rules that might conflict with Prettier, allowing you to use Prettier with other ESLint configs like [`eslint-config-airbnb`](https://www.npmjs.com/package/eslint-config-airbnb). | 
+| How to use it | Either calling the function in your code or via [`prettier-eslint-cli`](https://github.com/prettier/prettier-eslint-cli) if you prefer the command line. | Add it to your `.eslintrc`. | Add it to your `.eslintrc`. |
+| Is the final output Prettier compliant? | Depends on your ESLint config | Yes | Yes |
+| Do you need to run `prettier` command separately? | No | No | Yes |
+| Do you need to use anything else? | No | You may want to turn off conflicting rules using `eslint-config-prettier`. | No |
+
 ## Technical Details
 
 This printer is a fork of


### PR DESCRIPTION
Was trying to use ESLint with Prettier but was confused between the various approaches meant for this case. Hence I did some research and came up with this table. Would this be suitable to be added to the README?