### PR TITLE
Print comments attached to {' '}

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3670,7 +3670,8 @@ function isJSXWhitespaceExpression(node) {
   return (
     node.type === "JSXExpressionContainer" &&
     isLiteral(node.expression) &&
-    node.expression.value === " "
+    node.expression.value === " " &&
+    !node.expression.comments
   );
 }
 

--- a/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`comments.js 1`] = `
+<div>
+  {
+    // TODO: don't harcode this space! not all locales use whitespace
+    // in the same way
+    ' '
+  }
+</div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<div>
+  {
+    // TODO: don't harcode this space! not all locales use whitespace
+    // in the same way
+    " "
+  }
+</div>;
+
+`;
+
 exports[`test.js 1`] = `
 after =
   <span>

--- a/tests/jsx-significant-space/comments.js
+++ b/tests/jsx-significant-space/comments.js
@@ -1,0 +1,7 @@
+<div>
+  {
+    // TODO: don't harcode this space! not all locales use whitespace
+    // in the same way
+    ' '
+  }
+</div>


### PR DESCRIPTION
We had two occurrences on fb codebase where people attached comments on `{' '}` which would be swallowed. Instead of dropping the comments, let's make the algorithm a bit less naive.