### PR TITLE
Fix quotes and trailing commas in JSON

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "graphql": "0.10.1",
     "jest-validate": "20.0.3",
     "json-to-ast": "2.0.0-alpha1.2",
+    "json5": "0.5.1",
     "minimist": "1.2.0",
     "parse5": "3.0.2",
     "postcss": "^6.0.1",

--- a/src/parser-json.js
+++ b/src/parser-json.js
@@ -2,11 +2,24 @@
 
 const createError = require("./parser-create-error");
 
-function parse(text) {
+function parseLoose(text) {
   const jsonToAst = require("json-to-ast");
+
+  let ast;
+
   try {
-    const ast = jsonToAst(text);
-    return toBabylon(ast);
+    ast = jsonToAst(text);
+  } catch (err) {
+    const json5 = require("json5");
+    ast = jsonToAst(JSON.stringify(json5.parse(text), null, 2));
+  }
+
+  return toBabylon(ast);
+}
+
+function parse(text) {
+  try {
+    return parseLoose(text);
   } catch (err) {
     const firstNewlineIndex = err.message.indexOf("\n");
     const firstLine = err.message.slice(0, firstNewlineIndex);

--- a/tests/json/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/json/__snapshots__/jsfmt.spec.js.snap
@@ -7,6 +7,50 @@ true
 
 `;
 
+exports[`json5.json 1`] = `
+{
+    foo: 'bar',
+    while: true,
+ 
+    this: 'is a \\
+multi-line string',
+ 
+    // this is an inline comment 
+    here: 'is another', // inline comment 
+ 
+    /* this is a block comment
+       that continues on another line */
+ 
+    hex: 0xDEADbeef,
+    half: .5,
+    delta: +10,
+    to: Infinity,   // and beyond! 
+ 
+    finally: 'a trailing comma',
+    oh: [
+        "we shouldn't forget",
+        'arrays can have',
+        'trailing commas too',
+    ],
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{
+  "foo": "bar",
+  "while": true,
+
+  "this": "is a multi-line string",
+  "here": "is another",
+  "hex": 3735928559,
+  "half": 0.5,
+  "delta": 10,
+  "to": null,
+
+  "finally": "a trailing comma",
+  "oh": ["we shouldn't forget", "arrays can have", "trailing commas too"]
+}
+
+`;
+
 exports[`multi-line.json 1`] = `
 {"key1":[true,false,null],"key2":{"key3":[1,2,"3",
 1e10,1e-3]}}

--- a/tests/json/json5.json
+++ b/tests/json/json5.json
@@ -1,0 +1,25 @@
+{
+    foo: 'bar',
+    while: true,
+ 
+    this: 'is a \
+multi-line string',
+ 
+    // this is an inline comment 
+    here: 'is another', // inline comment 
+ 
+    /* this is a block comment
+       that continues on another line */
+ 
+    hex: 0xDEADbeef,
+    half: .5,
+    delta: +10,
+    to: Infinity,   // and beyond! 
+ 
+    finally: 'a trailing comma',
+    oh: [
+        "we shouldn't forget",
+        'arrays can have',
+        'trailing commas too',
+    ],
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2338,7 +2338,7 @@ json-to-ast@2.0.0-alpha1.2:
   version "2.0.0-alpha1.2"
   resolved "https://registry.yarnpkg.com/json-to-ast/-/json-to-ast-2.0.0-alpha1.2.tgz#fe27fd89eb639eca1e01f578e79d46ee36e238e8"
 
-json5@^0.5.0, json5@^0.5.1:
+json5@0.5.1, json5@^0.5.0, json5@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/json5/-/json5-0.5.1.tgz#1eade7acc012034ad84e2396767ead9fa5495821"
 


### PR DESCRIPTION
As @zimme suggested, this fixes https://github.com/prettier/prettier/issues/2290 by using [json5] to
parse JSON loosely. Comments, blank lines, and non-JSON values like Infinity
will not be preserved.

This also won't play well with range-formatting or cursor translation, but
those should continue to work with valid JSON as they used to.

[json5]: https://github.com/json5/json5