### PR TITLE
GraphQL: Use spaces instead of commas

### DIFF
--- a/src/printer-graphql.js
+++ b/src/printer-graphql.js
@@ -39,12 +39,11 @@ function genericPrint(path, options, print) {
                   concat([
                     softline,
                     join(
-                      concat([",", ifBreak("", " "), softline]),
+                      concat([ifBreak("", ", "), softline]),
                       path.map(print, "variableDefinitions")
                     )
                   ])
                 ),
-                options.trailingComma === "none" ? "" : ifBreak(","),
                 softline,
                 ")"
               ])
@@ -89,12 +88,11 @@ function genericPrint(path, options, print) {
                     concat([
                       softline,
                       join(
-                        concat([",", ifBreak("", " "), softline]),
+                        concat([ifBreak("", ", "), softline]),
                         path.map(print, "arguments")
                       )
                     ])
                   ),
-                  options.trailingComma === "none" ? "" : ifBreak(","),
                   softline,
                   ")"
                 ])
@@ -134,12 +132,11 @@ function genericPrint(path, options, print) {
             concat([
               softline,
               join(
-                concat([",", ifBreak("", " "), softline]),
+                concat([ifBreak("", ", "), softline]),
                 path.map(print, "values")
               )
             ])
           ),
-          options.trailingComma === "none" ? "" : ifBreak(","),
           softline,
           "]"
         ])
@@ -154,12 +151,11 @@ function genericPrint(path, options, print) {
             concat([
               softline,
               join(
-                concat([",", ifBreak("", " "), softline]),
+                concat([ifBreak("", ", "), softline]),
                 path.map(print, "fields")
               )
             ])
           ),
-          options.trailingComma === "none" ? "" : ifBreak(","),
           softline,
           ifBreak("", options.bracketSpacing && n.fields.length > 0 ? " " : ""),
           "}"
@@ -187,12 +183,11 @@ function genericPrint(path, options, print) {
                   concat([
                     softline,
                     join(
-                      concat([",", ifBreak("", " "), softline]),
+                      concat([ifBreak("", ", "), softline]),
                       path.map(print, "arguments")
                     )
                   ])
                 ),
-                options.trailingComma === "none" ? "" : ifBreak(","),
                 softline,
                 ")"
               ])

--- a/tests/graphql_arguments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_arguments/__snapshots__/jsfmt.spec.js.snap
@@ -9,10 +9,10 @@ exports[`hello.graphql 1`] = `
 {
   short(var: $var, int: 5, float: 5.6, bool: true, string: "hello world!")
   long(
-    var: $thisIsAReallyLongVariableNameRight,
-    int: 52342342342,
-    float: 5.6,
-    bool: true,
+    var: $thisIsAReallyLongVariableNameRight
+    int: 52342342342
+    float: 5.6
+    bool: true
     string: "hello world this is a very long string!"
   )
 }

--- a/tests/graphql_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_comments/__snapshots__/jsfmt.spec.js.snap
@@ -10,7 +10,7 @@ query (
  }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 query(
-  $string: String, # Some variable comment
+  $string: String # Some variable comment
   $bool: Boolean # Some comment
 ) {
   someField

--- a/tests/graphql_lists/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_lists/__snapshots__/jsfmt.spec.js.snap
@@ -10,8 +10,8 @@ exports[`lists.graphql 1`] = `
   shortWithList(list: [1, 2, 3])
   longWithList(
     list: [
-      "hello world this is a very long string!",
-      "hello world this is a very long string!",
+      "hello world this is a very long string!"
+      "hello world this is a very long string!"
       "hello world this is a very long string!"
     ]
   )

--- a/tests/graphql_objects/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_objects/__snapshots__/jsfmt.spec.js.snap
@@ -16,7 +16,7 @@ exports[`objects.graphql 1`] = `
   multilineObj(obj: { hello: "world", x: 5 })
   longWithObj(
     obj: {
-      longString: "hello world this is a very long string!",
+      longString: "hello world this is a very long string!"
       list: [1, 2, 3, 4, 5, 6, 7]
     }
   )

--- a/tests/graphql_trailing_comma/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_trailing_comma/__snapshots__/jsfmt.spec.js.snap
@@ -23,26 +23,26 @@ query Query(
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 query Query(
-  $pageID: ID!,
-  $scale: Float,
-  $PROJECT_UNIT_PROFILE_PICTURE_SIZE: Int,
+  $pageID: ID!
+  $scale: Float
+  $PROJECT_UNIT_PROFILE_PICTURE_SIZE: Int
   $PROJECT_UNIT_CARD_SIZE: Int
 )
   @argumentDefinitions(
     count: {
-      type: "Int",
-      defaultValue: 20,
+      type: "Int"
+      defaultValue: 20
       someSuperSuperSuperSuperLongType: 301
-    },
+    }
     test: [
       { type: "Int", defaultValue: 20, someSuperSuperSuperSuperLongType: 301 }
     ]
   ) {
   cover_photo {
     image(
-      width: $PROJECT_UNIT_CARD_SIZE,
-      height: $PROJECT_UNIT_CARD_SIZE,
-      sizing: "cover-fill",
+      width: $PROJECT_UNIT_CARD_SIZE
+      height: $PROJECT_UNIT_CARD_SIZE
+      sizing: "cover-fill"
       scale: $scale
     ) {
       uri
@@ -75,27 +75,27 @@ query Query(
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 query Query(
-  $pageID: ID!,
-  $scale: Float,
-  $PROJECT_UNIT_PROFILE_PICTURE_SIZE: Int,
-  $PROJECT_UNIT_CARD_SIZE: Int,
+  $pageID: ID!
+  $scale: Float
+  $PROJECT_UNIT_PROFILE_PICTURE_SIZE: Int
+  $PROJECT_UNIT_CARD_SIZE: Int
 )
   @argumentDefinitions(
     count: {
-      type: "Int",
-      defaultValue: 20,
-      someSuperSuperSuperSuperLongType: 301,
-    },
+      type: "Int"
+      defaultValue: 20
+      someSuperSuperSuperSuperLongType: 301
+    }
     test: [
-      { type: "Int", defaultValue: 20, someSuperSuperSuperSuperLongType: 301 },
-    ],
+      { type: "Int", defaultValue: 20, someSuperSuperSuperSuperLongType: 301 }
+    ]
   ) {
   cover_photo {
     image(
-      width: $PROJECT_UNIT_CARD_SIZE,
-      height: $PROJECT_UNIT_CARD_SIZE,
-      sizing: "cover-fill",
-      scale: $scale,
+      width: $PROJECT_UNIT_CARD_SIZE
+      height: $PROJECT_UNIT_CARD_SIZE
+      sizing: "cover-fill"
+      scale: $scale
     ) {
       uri
     }
@@ -127,27 +127,27 @@ query Query(
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 query Query(
-  $pageID: ID!,
-  $scale: Float,
-  $PROJECT_UNIT_PROFILE_PICTURE_SIZE: Int,
-  $PROJECT_UNIT_CARD_SIZE: Int,
+  $pageID: ID!
+  $scale: Float
+  $PROJECT_UNIT_PROFILE_PICTURE_SIZE: Int
+  $PROJECT_UNIT_CARD_SIZE: Int
 )
   @argumentDefinitions(
     count: {
-      type: "Int",
-      defaultValue: 20,
-      someSuperSuperSuperSuperLongType: 301,
-    },
+      type: "Int"
+      defaultValue: 20
+      someSuperSuperSuperSuperLongType: 301
+    }
     test: [
-      { type: "Int", defaultValue: 20, someSuperSuperSuperSuperLongType: 301 },
-    ],
+      { type: "Int", defaultValue: 20, someSuperSuperSuperSuperLongType: 301 }
+    ]
   ) {
   cover_photo {
     image(
-      width: $PROJECT_UNIT_CARD_SIZE,
-      height: $PROJECT_UNIT_CARD_SIZE,
-      sizing: "cover-fill",
-      scale: $scale,
+      width: $PROJECT_UNIT_CARD_SIZE
+      height: $PROJECT_UNIT_CARD_SIZE
+      sizing: "cover-fill"
+      scale: $scale
     ) {
       uri
     }

--- a/tests/graphql_variable_definitions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_variable_definitions/__snapshots__/jsfmt.spec.js.snap
@@ -24,10 +24,10 @@ query short($foo: ComplexType, $site: Site = MOBILE, $nonNull: Int!) {
 }
 
 query long(
-  $foo: ComplexType,
-  $site: Float = 124241.12312,
-  $bar: String = "Long string here",
-  $arg: String = "Hello world!",
+  $foo: ComplexType
+  $site: Float = 124241.12312
+  $bar: String = "Long string here"
+  $arg: String = "Hello world!"
   $nonNull: String!
 ) {
   hello
@@ -38,9 +38,9 @@ query lists($foo: [Int], $bar: [Int!], $arg: [Int!]!) {
 }
 
 query listslong(
-  $foo: [String],
-  $bar: [String!],
-  $arg: [Int!]!,
+  $foo: [String]
+  $bar: [String!]
+  $arg: [Int!]!
   $veryLongName: [Int!]
 ) {
   ok


### PR DESCRIPTION
"Daniel Schafer: Yeah, that's definitely what I'd describe as the canonical style; anytime you have two "things" on a line, use commas, but if you have a newline it's not needed."