### PR TITLE
GraphQL: Remove circular dependency in ast

### DIFF
--- a/src/parser-graphql.js
+++ b/src/parser-graphql.js
@@ -21,12 +21,26 @@ function parseComments(ast) {
   return comments;
 }
 
+function removeTokens(node) {
+  if (node && typeof node === "object") {
+    delete node.startToken;
+    delete node.endToken;
+    delete node.prev;
+    delete node.next;
+    for (const key in node) {
+      removeTokens(node[key]);
+    }
+  }
+  return node;
+}
+
 function parse(text) {
   // Inline the require to avoid loading all the JS if we don't use it
   const parser = require("graphql/language");
   try {
     const ast = parser.parse(text);
     ast.comments = parseComments(ast);
+    removeTokens(ast);
     return ast;
   } catch (error) {
     const GraphQLError = require("graphql/error").GraphQLError;

--- a/tests/graphql_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_comments/__snapshots__/jsfmt.spec.js.snap
@@ -30,3 +30,28 @@ query {
 }
 
 `;
+
+exports[`tokens.graphql 1`] = `
+# import "./claimsFragment.gql"
+
+query claimsByBookingReferenceAndLastName($bookingReference: String!, $lastName: String!) {
+  claimsByBookingReferenceAndLastName(bookingReference: $bookingReference, lastName: $lastName) {
+    ... claim
+  }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# import "./claimsFragment.gql"
+
+query claimsByBookingReferenceAndLastName(
+  $bookingReference: String!,
+  $lastName: String!
+) {
+  claimsByBookingReferenceAndLastName(
+    bookingReference: $bookingReference,
+    lastName: $lastName
+  ) {
+    ...claim
+  }
+}
+
+`;

--- a/tests/graphql_comments/tokens.graphql
+++ b/tests/graphql_comments/tokens.graphql
@@ -1,0 +1,7 @@
+# import "./claimsFragment.gql"
+
+query claimsByBookingReferenceAndLastName($bookingReference: String!, $lastName: String!) {
+  claimsByBookingReferenceAndLastName(bookingReference: $bookingReference, lastName: $lastName) {
+    ... claim
+  }
+}


### PR DESCRIPTION
The tokens are attached to the location via the prototype (so they are not visible when you JSON.stringify) but the various places where we traverse the ast see them. It causes stack overflows and comments that are not printed because they are attached to tokens instead of real nodes.

Fixes #2302 
Fixes #2299