### PR TITLE
GraphQL: Fix directives separator

### DIFF
--- a/src/printer-graphql.js
+++ b/src/printer-graphql.js
@@ -281,7 +281,7 @@ function genericPrint(path, options, print) {
               ])
             )
           : "",
-        concat([" on ", join(", ", path.map(print, "locations"))])
+        concat([" on ", join(" | ", path.map(print, "locations"))])
       ]);
     }
 

--- a/tests/graphql_directive_decl/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_directive_decl/__snapshots__/jsfmt.spec.js.snap
@@ -6,6 +6,7 @@ directive @a(as: String) on FIELD1
 directive @a(as: String = 1) on FIELD1
 directive @a(as: String, b: Int!) on FIELD1
 directive @a(as: String! = 1 @deprecated) on FIELD1
+directive @a(as: String! = 1 @deprecated) on FIELD1 | FIELD2
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 directive @a on FIELD1
 
@@ -16,5 +17,7 @@ directive @a(as: String = 1) on FIELD1
 directive @a(as: String, b: Int!) on FIELD1
 
 directive @a(as: String! = 1 @deprecated) on FIELD1
+
+directive @a(as: String! = 1 @deprecated) on FIELD1 | FIELD2
 
 `;

--- a/tests/graphql_directive_decl/directive_decl.graphql
+++ b/tests/graphql_directive_decl/directive_decl.graphql
@@ -3,3 +3,4 @@ directive @a(as: String) on FIELD1
 directive @a(as: String = 1) on FIELD1
 directive @a(as: String, b: Int!) on FIELD1
 directive @a(as: String! = 1 @deprecated) on FIELD1
+directive @a(as: String! = 1 @deprecated) on FIELD1 | FIELD2


### PR DESCRIPTION
I couldn't figure out what the separator was, I tried `,`, `on` but none of them worked. Turns out it is `|`!