### PR TITLE
Add support for range-formatting GraphQL

### DIFF
--- a/index.js
+++ b/index.js
@@ -212,6 +212,20 @@ function isSourceElement(opts, node) {
     case "ExportDeclaration": // Typescript
     case "OperationDefinition": // GraphQL
     case "FragmentDefinition": // GraphQL
+    case "VariableDefinition": // GraphQL
+    case "TypeExtensionDefinition": // GraphQL
+    case "ObjectTypeDefinition": // GraphQL
+    case "FieldDefinition": // GraphQL
+    case "DirectiveDefinition": // GraphQL
+    case "EnumTypeDefinition": // GraphQL
+    case "EnumValueDefinition": // GraphQL
+    case "InputValueDefinition": // GraphQL
+    case "InputObjectTypeDefinition": // GraphQL
+    case "SchemaDefinition": // GraphQL
+    case "OperationTypeDefinition": // GraphQL
+    case "InterfaceTypeDefinition": // GraphQL
+    case "UnionTypeDefinition": // GraphQL
+    case "ScalarTypeDefinition": // GraphQL
       return true;
   }
   return false;

--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ function isSourceElement(opts, node) {
   if (node == null) {
     return false;
   }
-  switch (node.type) {
+  switch (node.type || node.kind) {
     case "ObjectExpression": // JSON
     case "ArrayExpression": // JSON
     case "StringLiteral": // JSON
@@ -210,6 +210,8 @@ function isSourceElement(opts, node) {
     case "TypeAliasDeclaration": // Typescript
     case "ExportAssignment": // Typescript
     case "ExportDeclaration": // Typescript
+    case "OperationDefinition": // GraphQL
+    case "FragmentDefinition": // GraphQL
       return true;
   }
   return false;

--- a/tests/range_graphql/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/range_graphql/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`issue2296.graphql 1`] = `
+{NPC{life}}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{
+  NPC {
+    life
+  }
+}
+
+`;

--- a/tests/range_graphql/issue2296.graphql
+++ b/tests/range_graphql/issue2296.graphql
@@ -1,0 +1,1 @@
+{NP<<<PRETTIER_RANGE_END>>>C{life}}

--- a/tests/range_graphql/jsfmt.spec.js
+++ b/tests/range_graphql/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "graphql" });


### PR DESCRIPTION
As mentioned in https://github.com/prettier/prettier/issues/2296#issuecomment-311527787, `isSourceElement()` did not account for GraphQL. This fixes https://github.com/prettier/prettier/issues/2296