### PR TITLE
TypeScript: don't add namespace keyword to global declaration

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2588,12 +2588,13 @@ function genericPrintNoParens(path, options, print, args) {
         parts.push(printTypeScriptModifiers(path, options, print));
 
         // Global declaration looks like this:
-        // declare global { ... }
+        // (declare)? global { ... }
         const isGlobalDeclaration =
           n.name.type === "Identifier" &&
           n.name.name === "global" &&
-          n.modifiers &&
-          n.modifiers.some(modifier => modifier.type === "TSDeclareKeyword");
+          !/namespace|module/.test(
+            options.originalText.slice(util.locStart(n), util.locStart(n.name))
+          );
 
         if (!isGlobalDeclaration) {
           parts.push(isExternalModule ? "module " : "namespace ");

--- a/tests/typescript_module/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_module/__snapshots__/jsfmt.spec.js.snap
@@ -6,3 +6,24 @@ declare module 'autoprefixer';
 declare module "autoprefixer";
 
 `;
+
+exports[`global.js 1`] = `
+namespace global {}
+module global {}
+global {}
+declare global {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+namespace global {
+
+}
+namespace global {
+
+}
+global {
+
+}
+declare global {
+
+}
+
+`;

--- a/tests/typescript_module/global.js
+++ b/tests/typescript_module/global.js
@@ -1,0 +1,4 @@
+namespace global {}
+module global {}
+global {}
+declare global {}


### PR DESCRIPTION
TIL this is valid in ambient contexts.

Fixes #2327