### PR TITLE
Add support for css, keyframes and injectGlobal keywords

### DIFF
--- a/src/clean-ast.js
+++ b/src/clean-ast.js
@@ -157,7 +157,10 @@ function massageAST(ast) {
       ast.type === "TaggedTemplateExpression" &&
       (ast.tag.type === "MemberExpression" ||
         (ast.tag.type === "Identifier" &&
-          (ast.tag.name === "gql" || ast.tag.name === "graphql")))
+          (ast.tag.name === "gql" ||
+            ast.tag.name === "graphql" ||
+            ast.tag.name === "css" ||
+            ast.tag.name === "keyframes")))
     ) {
       newObj.quasi.quasis.forEach(quasi => delete quasi.value);
     }

--- a/src/clean-ast.js
+++ b/src/clean-ast.js
@@ -160,7 +160,8 @@ function massageAST(ast) {
           (ast.tag.name === "gql" ||
             ast.tag.name === "graphql" ||
             ast.tag.name === "css" ||
-            ast.tag.name === "keyframes")))
+            ast.tag.name === "keyframes" ||
+            ast.tag.name === "injectGlobal")))
     ) {
       newObj.quasi.quasis.forEach(quasi => delete quasi.value);
     }

--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -295,6 +295,7 @@ function isStyledJsx(path) {
  * Foo.extend`color: red`
  * css`color: red`
  * keyframes`0% { opacity: 0; }`
+ * injectGlobal`body{ margin:0: }`
  */
 function isStyledComponents(path) {
   const parent = path.getParentNode();
@@ -306,7 +307,9 @@ function isStyledComponents(path) {
         (/^[A-Z]/.test(parent.tag.object.name) &&
           parent.tag.property.name === "extend"))) ||
       (parent.tag.type === "Identifier" &&
-        (parent.tag.name === "css" || parent.tag.name === "keyframes")))
+        (parent.tag.name === "css" ||
+          parent.tag.name === "keyframes" ||
+          parent.tag.name === "injectGlobal")))
   );
 }
 

--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -304,7 +304,8 @@ function isStyledComponents(path) {
       (parent.tag.object.name === "styled" ||
         (/^[A-Z]/.test(parent.tag.object.name) &&
           parent.tag.property.name === "extend"))) ||
-      (parent.tag.type === "Identifier" && parent.tag.name === "css"))
+      (parent.tag.type === "Identifier" &&
+        (parent.tag.name === "css" || parent.tag.name === "keyframes")))
   );
 }
 

--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -290,13 +290,10 @@ function isStyledJsx(path) {
 }
 
 /**
- * Template literal in this context:
+ * Template literal in these contexts:
  * styled.button`color: red`
- * or
  * Foo.extend`color: red`
- * or
  * css`color: red`
- * or
  * keyframes`0% { opacity: 0; }`
  */
 function isStyledComponents(path) {

--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -294,6 +294,10 @@ function isStyledJsx(path) {
  * styled.button`color: red`
  * or
  * Foo.extend`color: red`
+ * or
+ * css`color: red`
+ * or
+ * keyframes`0% { opacity: 0; }`
  */
 function isStyledComponents(path) {
   const parent = path.getParentNode();

--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -300,10 +300,11 @@ function isStyledComponents(path) {
   return (
     parent &&
     parent.type === "TaggedTemplateExpression" &&
-    parent.tag.type === "MemberExpression" &&
-    (parent.tag.object.name === "styled" ||
-      (/^[A-Z]/.test(parent.tag.object.name) &&
-        parent.tag.property.name === "extend"))
+    ((parent.tag.type === "MemberExpression" &&
+      (parent.tag.object.name === "styled" ||
+        (/^[A-Z]/.test(parent.tag.object.name) &&
+          parent.tag.property.name === "extend"))) ||
+      (parent.tag.type === "Identifier" && parent.tag.name === "css"))
   );
 }
 

--- a/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
@@ -25,6 +25,25 @@ margin: 0.5rem;
 		}
 	}
 \`;
+
+const header = css\`
+.top-bar {background:black;
+margin: 0;
+    position: fixed;
+	top: 0;left:0;
+	width: 100%;
+    text-align: center     ;
+	padding: 15px  0  0  1em;
+		z-index: 9999;
+}
+
+.top-bar .logo {
+  height: 30px;
+  margin: auto; 
+    position: absolute;
+	left: 0;right: 0;
+}
+\`;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const Button = styled.a\`
   /* Comment */
@@ -48,6 +67,28 @@ const EqualDivider = styled.div\`
     &:not(:first-child) {
       \${props => (props.vertical ? "margin-top" : "margin-left")}: 1rem;
     }
+  }
+\`;
+
+const header = css\`
+  .top-bar {
+    background: black;
+    margin: 0;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    text-align: center;
+    padding: 15px 0 0 1em;
+    z-index: 9999;
+  }
+
+  .top-bar .logo {
+    height: 30px;
+    margin: auto;
+    position: absolute;
+    left: 0;
+    right: 0;
   }
 \`;
 

--- a/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
@@ -53,6 +53,17 @@ opacity: 0;
        opacity: 1;
   }
 \`;
+
+injectGlobal\`
+  @font-face {
+font-family: 'Operator Mono'  ;
+     src: url('../fonts/Operator-Mono.ttf');
+  }
+
+  body {
+    margin: 0;padding:0;
+  }
+\`;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const Button = styled.a\`
   /* Comment */
@@ -107,6 +118,18 @@ const fadeIn = keyframes\`
   }
   100% {
     opacity: 1;
+  }
+\`;
+
+injectGlobal\`
+  @font-face {
+    font-family: 'Operator Mono';
+    src: url('../fonts/Operator-Mono.ttf');
+  }
+
+  body {
+    margin: 0;
+    padding: 0;
   }
 \`;
 

--- a/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
@@ -44,6 +44,15 @@ margin: 0;
 	left: 0;right: 0;
 }
 \`;
+
+const fadeIn = keyframes\`
+  0% {
+opacity: 0;
+  }
+  100%    {
+       opacity: 1;
+  }
+\`;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const Button = styled.a\`
   /* Comment */
@@ -89,6 +98,15 @@ const header = css\`
     position: absolute;
     left: 0;
     right: 0;
+  }
+\`;
+
+const fadeIn = keyframes\`
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
   }
 \`;
 

--- a/tests/template_literals/styled-components-with-expressions.js
+++ b/tests/template_literals/styled-components-with-expressions.js
@@ -22,3 +22,22 @@ margin: 0.5rem;
 		}
 	}
 `;
+
+const header = css`
+.top-bar {background:black;
+margin: 0;
+    position: fixed;
+	top: 0;left:0;
+	width: 100%;
+    text-align: center     ;
+	padding: 15px  0  0  1em;
+		z-index: 9999;
+}
+
+.top-bar .logo {
+  height: 30px;
+  margin: auto; 
+    position: absolute;
+	left: 0;right: 0;
+}
+`;

--- a/tests/template_literals/styled-components-with-expressions.js
+++ b/tests/template_literals/styled-components-with-expressions.js
@@ -41,3 +41,12 @@ margin: 0;
 	left: 0;right: 0;
 }
 `;
+
+const fadeIn = keyframes`
+  0% {
+opacity: 0;
+  }
+  100%    {
+       opacity: 1;
+  }
+`;

--- a/tests/template_literals/styled-components-with-expressions.js
+++ b/tests/template_literals/styled-components-with-expressions.js
@@ -50,3 +50,14 @@ opacity: 0;
        opacity: 1;
   }
 `;
+
+injectGlobal`
+  @font-face {
+font-family: 'Operator Mono'  ;
+     src: url('../fonts/Operator-Mono.ttf');
+  }
+
+  body {
+    margin: 0;padding:0;
+  }
+`;


### PR DESCRIPTION
This is my fix for #2330 

I also added the keyword `keyframes` that is used in the [same way](https://www.styled-components.com/docs/api#helpers) as `css`

The AST for them is slightly different since they are not `MemberExpression` but simple `Identifier`

