### PR TITLE
Add `.gql` file extension to be parsed as GraphQL

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -35,7 +35,7 @@ function normalize(options) {
     normalized.parser = "parse5";
   } else if (/\.(ts|tsx)$/.test(filepath)) {
     normalized.parser = "typescript";
-  } else if (/\.graphql$/.test(filepath)) {
+  } else if (/\.(graphql|gql)$/.test(filepath)) {
     normalized.parser = "graphql";
   } else if (/\.json$/.test(filepath)) {
     normalized.parser = "json";


### PR DESCRIPTION
GraphQL files are also commonly used with the `.gql` file extension. This makes files using that extension parsed as GraphQL.

Here's a search on GitHub showing the usage of the `.gql` extension: https://github.com/search?utf8=%E2%9C%93&q=extension%3A.gql+query&type=Code