### PR TITLE
Fix indentation of a do-while condition

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -265,7 +265,7 @@ function genericPrintNoParens(path, options, print, args) {
         n !== parent.body &&
         (parent.type === "IfStatement" ||
           parent.type === "WhileStatement" ||
-          parent.type === "DoStatement");
+          parent.type === "DoWhileStatement");
 
       const parts = printBinaryishExpressions(
         path,
@@ -1435,7 +1435,12 @@ function genericPrintNoParens(path, options, print, args) {
       parts.push("while (");
 
       parts.push(
-        group(concat([indent(softline), path.call(print, "test"), softline])),
+        group(
+          concat([
+            indent(concat([softline, path.call(print, "test")])),
+            softline
+          ])
+        ),
         ")",
         semi
       );

--- a/tests/while/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/while/__snapshots__/jsfmt.spec.js.snap
@@ -6,6 +6,11 @@ while (someVeryLongStringA && someVeryLongStringB && someVeryLongStringC && some
 do {}
 while (someVeryLongStringA && someVeryLongStringB && someVeryLongStringC && someVeryLongStringD);
 
+if (someVeryLongFunc(someVeryLongArgA, someVeryLongArgB, someVeryLongArgC, someVeryLongArgD)) {}
+while (someVeryLongFunc(someVeryLongArgA, someVeryLongArgB, someVeryLongArgC, someVeryLongArgD)) {}
+do {}
+while (someVeryLongFunc(someVeryLongArgA, someVeryLongArgB, someVeryLongArgC, someVeryLongArgD));
+
 while (0) 1;
 
 do 1;
@@ -29,6 +34,32 @@ do {} while (
   someVeryLongStringB &&
   someVeryLongStringC &&
   someVeryLongStringD
+);
+
+if (
+  someVeryLongFunc(
+    someVeryLongArgA,
+    someVeryLongArgB,
+    someVeryLongArgC,
+    someVeryLongArgD
+  )
+) {
+}
+while (
+  someVeryLongFunc(
+    someVeryLongArgA,
+    someVeryLongArgB,
+    someVeryLongArgC,
+    someVeryLongArgD
+  )
+) {}
+do {} while (
+  someVeryLongFunc(
+    someVeryLongArgA,
+    someVeryLongArgB,
+    someVeryLongArgC,
+    someVeryLongArgD
+  )
 );
 
 while (0) 1;

--- a/tests/while/indent.js
+++ b/tests/while/indent.js
@@ -3,6 +3,11 @@ while (someVeryLongStringA && someVeryLongStringB && someVeryLongStringC && some
 do {}
 while (someVeryLongStringA && someVeryLongStringB && someVeryLongStringC && someVeryLongStringD);
 
+if (someVeryLongFunc(someVeryLongArgA, someVeryLongArgB, someVeryLongArgC, someVeryLongArgD)) {}
+while (someVeryLongFunc(someVeryLongArgA, someVeryLongArgB, someVeryLongArgC, someVeryLongArgD)) {}
+do {}
+while (someVeryLongFunc(someVeryLongArgA, someVeryLongArgB, someVeryLongArgC, someVeryLongArgD));
+
 while (0) 1;
 
 do 1;


### PR DESCRIPTION
Fixes #2353. Use the same printing code for both `WhileStatement` and `DoWhileStatement`. Fix calculation of `isInsideParenthesis` when printing a `LogicalExpression`. There is no such thing as `DoStatement` -- it should be `DoWhileStatement`.