### PR TITLE
Add a `--paren-spacing` option to add whitespace according to WordPress style rules

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -20,6 +20,7 @@ const argv = minimist(process.argv.slice(2), {
     "semi",
     "single-quote",
     "bracket-spacing",
+    "paren-spacing",
     "jsx-bracket-same-line",
     // The supports-color package (a sub sub dependency) looks directly at
     // `process.argv` for `--no-color` and such-like options. The reason it is
@@ -145,6 +146,7 @@ const options = {
   printWidth: getIntOption("print-width"),
   tabWidth: getIntOption("tab-width"),
   bracketSpacing: argv["bracket-spacing"],
+  parenSpacing: argv["paren-spacing"],
   singleQuote: argv["single-quote"],
   jsxBracketSameLine: argv["jsx-bracket-same-line"],
   filepath: argv["stdin-filepath"],
@@ -228,6 +230,7 @@ if (argv["help"] || (!filepatterns.length && !stdin)) {
       "  --no-semi                Do not print semicolons, except at the beginning of lines which may need them.\n" +
       "  --single-quote           Use single quotes instead of double quotes.\n" +
       "  --no-bracket-spacing     Do not print spaces between brackets.\n" +
+      "  --paren-spacing          Put spaces between parens, WordPress style.\n" +
       "  --jsx-bracket-same-line  Put > on the last line instead of at a new line.\n" +
       "  --trailing-comma <none|es5|all>\n" +
       "                           Print trailing commas wherever possible. Defaults to none.\n" +

--- a/docs/index.html
+++ b/docs/index.html
@@ -247,6 +247,7 @@
           <label><input type="checkbox" data-inverted id="semi"></input> --no-semi</label>
           <label><input type="checkbox" id="singleQuote"></input> --single-quote</label>
           <label><input type="checkbox" data-inverted id="bracketSpacing"></input> --no-bracket-spacing</label>
+          <label><input type="checkbox" id="parenSpacing"></input> --paren-spacing</label>
           <label><input type="checkbox" id="jsxBracketSameLine"></input> --jsx-bracket-same-line</label>
         </div>
         <div class="options last">

--- a/docs/playground.js
+++ b/docs/playground.js
@@ -30,6 +30,7 @@ window.onload = function() {
     "singleQuote",
     "trailingComma",
     "bracketSpacing",
+    "parenSpacing",
     "jsxBracketSameLine",
     "parser",
     "semi",

--- a/src/doc-builders.js
+++ b/src/doc-builders.js
@@ -43,6 +43,7 @@ function group(contents, opts) {
     type: "group",
     contents: contents,
     break: !!opts.shouldBreak,
+    addedLine: !!opts.addedLine,
     expandedStates: opts.expandedStates
   };
 }

--- a/src/doc-debug.js
+++ b/src/doc-debug.js
@@ -94,6 +94,7 @@ function printDoc(doc) {
 
     return (
       (doc.break ? "wrappedGroup" : "group") +
+      (doc.addedLine ? "WithTrailingLine" : "") +
       "(" +
       printDoc(doc.contents) +
       ")"

--- a/src/options.js
+++ b/src/options.js
@@ -13,6 +13,7 @@ const defaults = {
   singleQuote: false,
   trailingComma: "none",
   bracketSpacing: true,
+  parenSpacing: false,
   jsxBracketSameLine: false,
   parser: "babylon",
   semi: true

--- a/src/printer.js
+++ b/src/printer.js
@@ -64,6 +64,8 @@ function getPrintFunction(options) {
 }
 
 function genericPrint(path, options, printPath, args) {
+  const parenSpace = options.parenSpacing ? " " : "";
+
   assert.ok(path instanceof FastPath);
 
   const node = path.getValue();
@@ -176,13 +178,13 @@ function genericPrint(path, options, printPath, args) {
 
   const parts = [];
   if (needsParens) {
-    parts.unshift("(");
+    parts.unshift("(", parenSpace);
   }
 
   parts.push(linesWithoutParens);
 
   if (needsParens) {
-    parts.push(")");
+    parts.push(parenSpace, ")");
   }
 
   if (decorators.length > 0) {
@@ -194,6 +196,8 @@ function genericPrint(path, options, printPath, args) {
 function genericPrintNoParens(path, options, print, args) {
   const n = path.getValue();
   const semi = options.semi ? ";" : "";
+  const parenSpace = options.parenSpacing ? " " : "";
+  const parenLine = options.parenSpacing ? line : softline;
 
   if (!n) {
     return "";
@@ -247,7 +251,13 @@ function genericPrintNoParens(path, options, print, args) {
       }
       return concat([path.call(print, "expression"), semi]); // Babel extension.
     case "ParenthesizedExpression":
-      return concat(["(", path.call(print, "expression"), ")"]);
+      return concat([
+        "(",
+        parenSpace,
+        path.call(print, "expression"),
+        parenSpace,
+        ")"
+      ]);
     case "AssignmentExpression":
       return printAssignment(
         n.left,
@@ -469,9 +479,12 @@ function genericPrintNoParens(path, options, print, args) {
       }
 
       // if the arrow function is expanded as last argument, we are adding a
-      // level of indentation and need to add a softline to align the closing )
+      // level of indentation and need to add a (soft) line to align the closing )
       // with the opening (.
-      const shouldAddSoftLine = args && args.expandLastArg;
+      // This means that the (soft) line is sometimes added, sometimes not. Add this fact as
+      // an `addedLine` opt to the returned `group`. It will be used by code that takes care
+      // of adding a space before the closing paren when the `paren-spacing` option is on.
+      const shouldAddLine = args && args.expandLastArg;
 
       // In order to avoid confusion between
       // a => a ? a : a
@@ -491,20 +504,21 @@ function genericPrintNoParens(path, options, print, args) {
               indent(
                 concat([
                   line,
-                  shouldAddParens ? ifBreak("", "(") : "",
+                  shouldAddParens ? ifBreak("", concat(["(", parenSpace])) : "",
                   body,
-                  shouldAddParens ? ifBreak("", ")") : ""
+                  shouldAddParens ? ifBreak("", concat([parenSpace, ")"])) : ""
                 ])
               ),
-              shouldAddSoftLine
+              shouldAddLine
                 ? concat([
                     ifBreak(shouldPrintComma(options, "all") ? "," : ""),
-                    softline
+                    parenLine
                   ])
                 : ""
             ])
           )
-        ])
+        ]),
+        { addedLine: shouldAddLine }
       );
     }
     case "MethodDefinition":
@@ -836,7 +850,13 @@ function genericPrintNoParens(path, options, print, args) {
           isNew ? "new " : "",
           path.call(print, "callee"),
           path.call(print, "typeParameters"),
-          concat(["(", join(", ", path.map(print, "arguments")), ")"])
+          concat([
+            "(",
+            parenSpace,
+            join(", ", path.map(print, "arguments")),
+            parenSpace,
+            ")"
+          ])
         ]);
       }
 
@@ -1020,7 +1040,13 @@ function genericPrintNoParens(path, options, print, args) {
       } else {
         let printedLeft;
         if (n.computed) {
-          printedLeft = concat(["[", path.call(print, "key"), "]"]);
+          printedLeft = concat([
+            "[",
+            parenSpace,
+            path.call(print, "key"),
+            parenSpace,
+            "]"
+          ]);
         } else {
           printedLeft = printPropertyKey(path, options, print);
         }
@@ -1092,7 +1118,7 @@ function genericPrintNoParens(path, options, print, args) {
               "[",
               indent(
                 concat([
-                  softline,
+                  parenLine,
                   printArrayItems(path, options, "elements", print)
                 ])
               ),
@@ -1109,7 +1135,7 @@ function genericPrintNoParens(path, options, print, args) {
                 options,
                 /* sameIndent */ true
               ),
-              softline,
+              parenLine,
               "]"
             ])
           )
@@ -1192,7 +1218,16 @@ function genericPrintNoParens(path, options, print, args) {
     case "UnaryExpression":
       parts.push(n.operator);
 
-      if (/[a-z]$/.test(n.operator)) {
+      if (
+        /[a-z]$/.test(n.operator) ||
+        (options.parenSpacing &&
+          n.operator === "!" &&
+          !(
+            n.argument &&
+            n.argument.type === "UnaryExpression" &&
+            n.argument.operator === "!"
+          ))
+      ) {
         parts.push(" ");
       }
 
@@ -1212,9 +1247,13 @@ function genericPrintNoParens(path, options, print, args) {
       const printed = concat([
         line,
         "? ",
-        n.consequent.type === "ConditionalExpression" ? ifBreak("", "(") : "",
+        n.consequent.type === "ConditionalExpression"
+          ? ifBreak("", concat(["(", parenSpace]))
+          : "",
         align(2, path.call(print, "consequent")),
-        n.consequent.type === "ConditionalExpression" ? ifBreak("", ")") : "",
+        n.consequent.type === "ConditionalExpression"
+          ? ifBreak("", concat([parenSpace, ")"]))
+          : "",
         line,
         ": ",
         align(2, path.call(print, "alternate"))
@@ -1286,7 +1325,9 @@ function genericPrintNoParens(path, options, print, args) {
       return group(
         concat([
           "with (",
+          parenSpace,
           path.call(print, "object"),
+          parenSpace,
           ")",
           adjustClause(n.body, path.call(print, "body"))
         ])
@@ -1298,8 +1339,8 @@ function genericPrintNoParens(path, options, print, args) {
           "if (",
           group(
             concat([
-              indent(concat([softline, path.call(print, "test")])),
-              softline
+              indent(concat([parenLine, path.call(print, "test")])),
+              parenLine
             ])
           ),
           ")",
@@ -1355,7 +1396,7 @@ function genericPrintNoParens(path, options, print, args) {
               concat([
                 indent(
                   concat([
-                    softline,
+                    parenLine,
                     path.call(print, "init"),
                     ";",
                     line,
@@ -1365,7 +1406,7 @@ function genericPrintNoParens(path, options, print, args) {
                     path.call(print, "update")
                   ])
                 ),
-                softline
+                parenLine
               ])
             ),
             ")",
@@ -1380,8 +1421,8 @@ function genericPrintNoParens(path, options, print, args) {
           "while (",
           group(
             concat([
-              indent(concat([softline, path.call(print, "test")])),
-              softline
+              indent(concat([parenLine, path.call(print, "test")])),
+              parenLine
             ])
           ),
           ")",
@@ -1393,9 +1434,11 @@ function genericPrintNoParens(path, options, print, args) {
       return group(
         concat([
           n.each ? "for each (" : "for (",
+          parenSpace,
           path.call(print, "left"),
           " in ",
           path.call(print, "right"),
+          parenSpace,
           ")",
           adjustClause(n.body, path.call(print, "body"))
         ])
@@ -1413,9 +1456,11 @@ function genericPrintNoParens(path, options, print, args) {
           "for",
           isAwait ? " await" : "",
           " (",
+          parenSpace,
           path.call(print, "left"),
           " of ",
           path.call(print, "right"),
+          parenSpace,
           ")",
           adjustClause(n.body, path.call(print, "body"))
         ])
@@ -1437,8 +1482,8 @@ function genericPrintNoParens(path, options, print, args) {
       parts.push(
         group(
           concat([
-            indent(concat([softline, path.call(print, "test")])),
-            softline
+            indent(concat([parenLine, path.call(print, "test")])),
+            parenLine
           ])
         ),
         ")",
@@ -1496,14 +1541,14 @@ function genericPrintNoParens(path, options, print, args) {
 
       return concat(parts);
     case "CatchClause":
-      parts.push("catch (", path.call(print, "param"));
+      parts.push("catch (", parenSpace, path.call(print, "param"));
 
       if (n.guard) {
         // Note: esprima does not recognize conditional catch clauses.
         parts.push(" if ", path.call(print, "guard"));
       }
 
-      parts.push(") ", path.call(print, "body"));
+      parts.push(parenSpace, ") ", path.call(print, "body"));
 
       return concat(parts);
     case "ThrowStatement":
@@ -1512,7 +1557,9 @@ function genericPrintNoParens(path, options, print, args) {
     case "SwitchStatement":
       return concat([
         "switch (",
+        parenSpace,
         path.call(print, "discriminant"),
+        parenSpace,
         ") {",
         n.cases.length > 0
           ? indent(
@@ -1595,7 +1642,14 @@ function genericPrintNoParens(path, options, print, args) {
     case "TSQualifiedName":
       return join(".", [path.call(print, "left"), path.call(print, "right")]);
     case "JSXSpreadAttribute":
-      return concat(["{...", path.call(print, "argument"), "}"]);
+      return concat([
+        "{",
+        parenSpace,
+        "...",
+        path.call(print, "argument"),
+        parenSpace,
+        "}"
+      ]);
     case "JSXExpressionContainer": {
       const parent = path.getParentNode(0);
 
@@ -1614,15 +1668,22 @@ function genericPrintNoParens(path, options, print, args) {
 
       if (shouldInline) {
         return group(
-          concat(["{", path.call(print, "expression"), lineSuffixBoundary, "}"])
+          concat([
+            "{",
+            parenSpace,
+            path.call(print, "expression"),
+            lineSuffixBoundary,
+            parenSpace,
+            "}"
+          ])
         );
       }
 
       return group(
         concat([
           "{",
-          indent(concat([softline, path.call(print, "expression")])),
-          softline,
+          indent(concat([parenLine, path.call(print, "expression")])),
+          parenLine,
           lineSuffixBoundary,
           "}"
         ])
@@ -1832,7 +1893,14 @@ function genericPrintNoParens(path, options, print, args) {
 
           const aligned = addAlignmentToDoc(expressions[i], size, tabWidth);
 
-          parts.push("${", aligned, lineSuffixBoundary, "}");
+          parts.push(
+            "${",
+            parenSpace,
+            aligned,
+            lineSuffixBoundary,
+            parenSpace,
+            "}"
+          );
         }
       }, "quasis");
 
@@ -2818,7 +2886,23 @@ function shouldGroupFirstArg(args) {
   );
 }
 
+function hasAddedLine(arg) {
+  switch (arg.type) {
+    case "concat":
+      if (arg.parts.length > 0) {
+        return hasAddedLine(arg.parts[arg.parts.length - 1]);
+      }
+      return false;
+    case "group":
+      return arg.addedLine;
+    default:
+      return false;
+  }
+}
+
 function printArgumentsList(path, options, print) {
+  const parenSpace = options.parenSpacing ? " " : "";
+  const parenLine = options.parenSpacing ? line : softline;
   const printed = path.map(print, "arguments");
   if (printed.length === 0) {
     return concat([
@@ -2841,6 +2925,7 @@ function printArgumentsList(path, options, print) {
 
     // We want to print the last argument with a special flag
     let printedExpanded;
+    let lastArgAddedLine = false;
     let i = 0;
     path.each(argPath => {
       if (shouldGroupFirst && i === 0) {
@@ -2849,9 +2934,11 @@ function printArgumentsList(path, options, print) {
         ].concat(printed.slice(1));
       }
       if (shouldGroupLast && i === args.length - 1) {
-        printedExpanded = printed
-          .slice(0, -1)
-          .concat(argPath.call(p => print(p, { expandLastArg: true })));
+        const printedLastArg = argPath.call(p =>
+          print(p, { expandLastArg: true })
+        );
+        lastArgAddedLine = hasAddedLine(printedLastArg);
+        printedExpanded = printed.slice(0, -1).concat(printedLastArg);
       }
       i++;
     }, "arguments");
@@ -2860,22 +2947,32 @@ function printArgumentsList(path, options, print) {
       printed.some(willBreak) ? breakParent : "",
       conditionalGroup(
         [
-          concat(["(", join(concat([", "]), printedExpanded), ")"]),
+          concat([
+            "(",
+            parenSpace,
+            join(concat([", "]), printedExpanded),
+            lastArgAddedLine ? "" : parenSpace,
+            ")"
+          ]),
           shouldGroupFirst
             ? concat([
                 "(",
+                parenSpace,
                 group(printedExpanded[0], { shouldBreak: true }),
                 printed.length > 1 ? ", " : "",
                 join(concat([",", line]), printed.slice(1)),
+                parenSpace,
                 ")"
               ])
             : concat([
                 "(",
+                parenSpace,
                 join(concat([",", line]), printed.slice(0, -1)),
                 printed.length > 1 ? ", " : "",
                 group(util.getLast(printedExpanded), {
                   shouldBreak: true
                 }),
+                lastArgAddedLine ? "" : parenSpace,
                 ")"
               ]),
           group(
@@ -2897,9 +2994,9 @@ function printArgumentsList(path, options, print) {
   return group(
     concat([
       "(",
-      indent(concat([softline, join(concat([",", line]), printed)])),
+      indent(concat([parenLine, join(concat([",", line]), printed)])),
       ifBreak(shouldPrintComma(options, "all") ? "," : ""),
-      softline,
+      parenLine,
       ")"
     ]),
     { shouldBreak: printed.some(willBreak) }
@@ -2924,6 +3021,8 @@ function printFunctionTypeParameters(path, options, print) {
 function printFunctionParams(path, print, options, expandArg, printTypeParams) {
   const fun = path.getValue();
   const paramsField = fun.parameters ? "parameters" : "params";
+  const parenSpace = options.parenSpacing ? " " : "";
+  const parenLine = options.parenSpacing ? line : softline;
 
   const typeParams = printTypeParams
     ? printFunctionTypeParameters(path, options, print)
@@ -2978,7 +3077,9 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
       concat([
         docUtils.removeLines(typeParams),
         "(",
+        parenSpace,
         join(", ", printed.map(docUtils.removeLines)),
+        parenSpace,
         ")"
       ])
     );
@@ -2992,7 +3093,14 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
   //   c
   // }) {}
   if (shouldHugArguments(fun)) {
-    return concat([typeParams, "(", join(", ", printed), ")"]);
+    return concat([
+      typeParams,
+      "(",
+      parenSpace,
+      join(", ", printed),
+      parenSpace,
+      ")"
+    ]);
   }
 
   const parent = path.getParentNode();
@@ -3042,11 +3150,11 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
   return concat([
     typeParams,
     "(",
-    indent(concat([softline, join(concat([",", line]), printed)])),
+    indent(concat([parenLine, join(concat([",", line]), printed)])),
     ifBreak(
       canHaveTrailingComma && shouldPrintComma(options, "all") ? "," : ""
     ),
-    softline,
+    parenLine,
     ")"
   ]);
 }
@@ -3383,6 +3491,8 @@ function printClass(path, options, print) {
 }
 
 function printMemberLookup(path, options, print) {
+  const parenSpace = options.parenSpacing ? " " : "";
+  const parenLine = options.parenSpacing ? line : softline;
   const property = path.call(print, "property");
   const n = path.getValue();
 
@@ -3395,11 +3505,11 @@ function printMemberLookup(path, options, print) {
     (n.property.type === "Literal" && typeof n.property.value === "number") ||
     n.property.type === "NumericLiteral"
   ) {
-    return concat(["[", property, "]"]);
+    return concat(["[", parenSpace, property, parenSpace, "]"]);
   }
 
   return group(
-    concat(["[", indent(concat([softline, property])), softline, "]"])
+    concat(["[", indent(concat([parenLine, property])), parenLine, "]"])
   );
 }
 


### PR DESCRIPTION
This PR adds a `--paren-spacing` option to Prettier that adds whitespace inside `()` and `[]` parens and inside `{}` in JSX attributes and string template arguments. For example:
```js
function Comp( props ) {
  while ( ! a( 1, 2, [ 3, 4 ] ) ) {
    perform( p, e, { r, f } );
  }

  const label = `label: ${ props.name }`;
  return (
    <Button onClick={ this.handleClick }>
      { label }
    </Button>
  );
}
```
This style is widely used in the WordPress community, e.g., in projects like [Calypso](https://github.com/automattic/wp-calypso), [Gutenberg](https://github.com/WordPress/gutenberg) or in Javascript code in WordPress core.

I don't really expect that this PR will ever be merged, as it's directly opposed to the Prettier design principle of adding as few options as possible. It's more likely that we'll be maintaining and updating this patch in a fork.

Its purpose is rather to provide the maintainers with info on how people use and abuse Prettier, and to ask for feedback:
- is this the right way to implement the paren spacing option? Are there any potential improvements?
- can anything be done in the official Prettier codebase to make this patch simpler and more maintainable? Like adding some abstractions etc.

**How it works?**
Very similar to the existing `bracket-spacing` option: when enabled, add a space (`" "`) at the right places, or turn a `softline` into `line`.

The patch doesn't support paren spacing in Flow and Typescript constructs, as it's not (yet) used in any our code and I'm not very familiar with their syntax. It should be easy to add at any time though.

There's only one part that's tricky, and that's expanding last function argument:
```js
map( as, a =>
  b(a) // there's a `softline/line` at the end of last arg
); // no space before `)`

map( as, a => [
  a
] ); // no `line` at the end of last arg, space before `)`
```
The last arg's doc sometimes has a `softline/line` at the end, sometimes not. There's a space before the closing `)`, sometimes not. To handle all cases correctly, I had to add an `addedLine` option to the `group` with the formatted last arg, and then check for that option in `printArgumentsList`.