### PR TITLE
Strip BOM before parsing

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const stripBom = require("strip-bom");
 const comments = require("./src/comments");
 const version = require("./package.json").version;
 const printAstToDoc = require("./src/printer").printAstToDoc;
@@ -54,6 +55,7 @@ function ensureAllCommentsPrinted(astComments) {
 }
 
 function formatWithCursor(text, opts, addAlignmentSize) {
+  text = stripBom(text);
   addAlignmentSize = addAlignmentSize || 0;
 
   const ast = parser.parse(text, opts);

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "rollup-plugin-node-resolve": "2.0.0",
     "rollup-plugin-replace": "1.1.1",
     "shelljs": "0.7.8",
+    "strip-bom": "3.0.0",
     "sw-toolbox": "3.6.0",
     "uglify-es": "3.0.15",
     "webpack": "2.6.1"

--- a/tests/css_bom/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_bom/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`bom.css 1`] = `
+﻿
+
+/* Block comment */
+
+html {
+  content: "#{1}";
+
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/* Block comment */
+
+html {
+  content: "#{1}";
+}
+
+`;

--- a/tests/css_bom/bom.css
+++ b/tests/css_bom/bom.css
@@ -1,0 +1,8 @@
+﻿
+
+/* Block comment */
+
+html {
+  content: "#{1}";
+
+}

--- a/tests/css_bom/jsfmt.spec.js
+++ b/tests/css_bom/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "postcss" });


### PR DESCRIPTION
We don't reprint the BOM anyway so we may as well remove it as early as possible.

Fixes #2362