### PR TITLE
Make "print width" documentation clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,9 +453,9 @@ Default | CLI Override | API Override
 
 > **We strongly recommend against using more than 80 columns:**
  
-> Normally when specifying a line length of 120 in a styleguide this means the maximum amount of characters on a line. On average the length of line will be around 80 characters for readibility and doesn't often meet this maximum.
+> Normally when specifying a line length of 120 in a styleguide this means the maximum amount of characters on a line. On average the line length will be around 80 characters for readibility and doesn't meet this maximum.
 
-> Prettier will put as much code as it can in one line, so every line will be at around 110 - 120 characters. This is harder to read than around 80 characters.
+> Prettier will put as much code as it can in one line, so every line will have around 110 - 120 characters. This is harder to read than around 80 characters.
 
 ### Tab Width
 Specify the number of spaces per indentation-level.

--- a/README.md
+++ b/README.md
@@ -445,15 +445,17 @@ matrix(
 Prettier ships with a handful of customizable format options, usable in both the CLI and API.
 
 ### Print Width
-Specify the length of line that the printer will wrap on.
-
-**We strongly recommend against using more than 80 columns.**
-
-Prettier works by cramming as much content as possible until it reaches the limit, which happens to work well for 80 columns but makes lines that are very crowded. When a bigger column count is used in styleguides, it usually means that code is allowed to go beyond 80 columns, but not to make every single line go there, like Prettier would do.
+Specify the line length that the printer will wrap on.
 
 Default | CLI Override | API Override
 --------|--------------|-------------
 `80` | `--print-width <int>` | `printWidth: <int>`
+
+> **We strongly recommend against using more than 80 columns:**
+ 
+> Normally when specifying a line length of 120 in a styleguide this means the maximum amount of characters on a line. On average the length of line will be around 80 characters for readibility and doesn't often meet this maximum.
+
+> Prettier will put as much code as it can in one line, so every line will be at around 110 - 120 characters. This is harder to read than around 80 characters.
 
 ### Tab Width
 Specify the number of spaces per indentation-level.

--- a/README.md
+++ b/README.md
@@ -447,15 +447,15 @@ Prettier ships with a handful of customizable format options, usable in both the
 ### Print Width
 Specify the line length that the printer will wrap on.
 
+> **We strongly recommend against using more than 80 columns:**
+ 
+> In a code styleguide the maximum amount of characters on a line can specified with a 'line length', this is typically 120 characters. This is not neccessarily the amount of characters that _will_ be on a line. For readibility, the average amount of characters will be 80 characters on a line.
+
+> Prettier will put as many characters on a line, so with a line length of 120 every line would have around 110 - 120 characters. This is harder to read than around 80 characters.
+
 Default | CLI Override | API Override
 --------|--------------|-------------
 `80` | `--print-width <int>` | `printWidth: <int>`
-
-> **We strongly recommend against using more than 80 columns:**
- 
-> Normally when specifying a line length of 120 in a styleguide this means the maximum amount of characters on a line. On average the line length will be around 80 characters for readibility and doesn't meet this maximum.
-
-> Prettier will put as much code as it can in one line, so every line will have around 110 - 120 characters. This is harder to read than around 80 characters.
 
 ### Tab Width
 Specify the number of spaces per indentation-level.

--- a/README.md
+++ b/README.md
@@ -447,11 +447,13 @@ Prettier ships with a handful of customizable format options, usable in both the
 ### Print Width
 Specify the line length that the printer will wrap on.
 
-> **We strongly recommend against using more than 80 columns:**
- 
-> In a code styleguide the maximum amount of characters on a line can specified with a 'line length', this is typically 120 characters. This is not neccessarily the amount of characters that _will_ be on a line. For readibility, the average amount of characters will be 80 characters on a line.
-
-> Prettier will put as many characters on a line, so with a line length of 120 every line would have around 110 - 120 characters. This is harder to read than around 80 characters.
+> **For readability we recommend against using more than 80 characters:**
+>
+>In code styleguides the maximum amount of characters on a line can specified with a 'line length'. Line lengths are typically set to 120 characters.
+>
+>This is not the amount of characters that will be on a line. For readability, the average amount of characters will be 80 characters on a line.
+>
+>Prettier will put the maximum amount of characters on a line. With the print width set to 120 every line would have around 110 - 120 characters. This is harder to read than the recommended 80 characters.
 
 Default | CLI Override | API Override
 --------|--------------|-------------

--- a/README.md
+++ b/README.md
@@ -449,9 +449,9 @@ Specify the line length that the printer will wrap on.
 
 > **For readability we recommend against using more than 80 characters:**
 >
->In code styleguides the maximum amount of characters on a line can specified with a 'line length'. Line lengths are typically set to 120 characters.
+>In code styleguides, maximum line length rules are often set to 100 or 120.
 >
->This is not the amount of characters that will be on a line. For readability, the average amount of characters will be 80 characters on a line.
+>This is not the amount of characters that will always be on a line. For readability a developer will use whitespace to break up long lines so the average amount of characters will be 80 characters on a line.
 >
 >Prettier will put the maximum amount of characters on a line. With the print width set to 120 every line would have around 110 - 120 characters. This is harder to read than the recommended 80 characters.
 

--- a/README.md
+++ b/README.md
@@ -449,11 +449,9 @@ Specify the line length that the printer will wrap on.
 
 > **For readability we recommend against using more than 80 characters:**
 >
->In code styleguides, maximum line length rules are often set to 100 or 120.
->
->This is not the amount of characters that will always be on a line. For readability a developer will use whitespace to break up long lines so the average amount of characters will be 80 characters on a line.
->
->Prettier will put the maximum amount of characters on a line. With the print width set to 120 every line would have around 110 - 120 characters. This is harder to read than the recommended 80 characters.
+>In code styleguides, maximum line length rules are often set to 100 or 120. However, when humans write code, they don't strive to reach the maximum number of columns on every line. Developers often use whitespace to break up long lines for readability. In practice, the average line length often ends up well below the maximum.
+> 
+> Prettier, on the other hand, strives to fit the most code into every line. With the print width set to 120, prettier may produce overly compact, or otherwise undesirable code.
 
 Default | CLI Override | API Override
 --------|--------------|-------------


### PR DESCRIPTION
https://github.com/prettier/prettier/issues/2375

Have used @k15a's explanation as a base.

Can you please give me feedback as to whether the new one is any clearer.