### PR TITLE
Update bash script in README to mimic lint-staged behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,14 +341,13 @@ Alternately you can save this script as `.git/hooks/pre-commit` and give it exec
 jsfiles=$(git diff --cached --name-only --diff-filter=ACM | grep '\.jsx\?$' | tr '\n' ' ')
 [ -z "$jsfiles" ] && exit 0
 
-diffs=$(node_modules/.bin/prettier -l $jsfiles)
-[ -z "$diffs" ] && exit 0
+# Prettify all staged .js files
+echo "jsfiles" | xargs ./node_modules/.bin/prettier --write
 
-echo "here"
-echo >&2 "Javascript files must be formatted with Prettier. Please run:"
-echo >&2 "node_modules/.bin/prettier --write "$diffs""
+# Add back the modified/prettified files to staging
+echo "jsfiles" | xargs git add
 
-exit 1
+exit 0
 ```
 
 ### API


### PR DESCRIPTION
### Issue

README's "Pre-commit Hook" section describes 3 ways to put Prettier as pre-commit hook. One one hand where the lint-staged example demonstrates auto formatting and adding to git staging, the bash script example show a different workflow of showing errors and failing the hook if unformatted code find.

1. All the examples should result in same thing to be considered alternatives of each other and create less confusion for developers to try each method
2. IMO failing a pre-commit hook goes against the philosophy of prettier. Why should the workflow break, when Prettier can automatically format things just before committing!

### Fix

I have updated the bash script to work exactly same as lint-staged example i.e. auto-fix the formatting of staged files and add them back to git staging.