### PR TITLE
travis: Test prettier without its devDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ before_script:
 script:
   - yarn lint
   - AST_COMPARE=1 yarn test -- --runInBand
+  # A basic test to ensure prettier runs without devDependencies
+  - rm -rf node_modules
+  - yarn install --production=true
+  - ./bin/prettier.js ./bin/prettier.js >/dev/null
 #deploy:
 #  provider: script
 #  script: website/deploy.sh


### PR DESCRIPTION
This helps ensure it can be installed/run from a commit on github. For example, https://github.com/prettier/prettier/commit/6f9824778dc7600e81c6237f9f23a7de82baf04b broke that functionality by adding `strip-bom` to `devDependencies` instead of `dependencies`. I fixed this in https://github.com/prettier/prettier/commit/782835de752c314a55e66e52531166c2b5ee64b3, but it'd be nice to catch this sort of thing pro-actively.