### PR TITLE
Switch a use of .map to .each

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3194,7 +3194,7 @@ function printExportDeclaration(path, options, print) {
         const defaultSpecifiers = [];
         const namespaceSpecifiers = [];
 
-        path.map(specifierPath => {
+        path.each(specifierPath => {
           const specifierType = path.getValue().type;
           if (specifierType === "ExportSpecifier") {
             specifiers.push(print(specifierPath));


### PR DESCRIPTION
Which avoids building an array for the result, and is also slightly clearer.