### PR TITLE
Add some standardjs-esque eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     "no-console": "off",
     "no-else-return": "error",
     "no-inner-declarations": "off",
+    "no-unneeded-ternary": "error",
     "no-useless-return": "error",
     "no-var": "error",
     "one-var": ["error", "never"],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -24,7 +24,8 @@ module.exports = {
     "prefer-const": "error",
     "prettier/prettier": "error",
     "react/no-deprecated": "off",
-    strict: "error"
+    strict: "error",
+    "symbol-description": "error"
   },
   parserOptions: {
     ecmaFeatures: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,6 +18,7 @@ module.exports = {
     "no-inner-declarations": "off",
     "no-useless-return": "error",
     "no-var": "error",
+    "one-var": ["error", "never"],
     "prefer-arrow-callback": "error",
     "prefer-const": "error",
     "prettier/prettier": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,8 +25,7 @@ module.exports = {
     "prettier/prettier": "error",
     "react/no-deprecated": "off",
     strict: "error",
-    "symbol-description": "error",
-    yoda: "error"
+    "symbol-description": "error"
   },
   parserOptions: {
     ecmaFeatures: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -25,7 +25,8 @@ module.exports = {
     "prettier/prettier": "error",
     "react/no-deprecated": "off",
     strict: "error",
-    "symbol-description": "error"
+    "symbol-description": "error",
+    yoda: "error"
   },
   parserOptions: {
     ecmaFeatures: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     "no-console": "off",
     "no-else-return": "error",
     "no-inner-declarations": "off",
+    "no-useless-return": "error",
     "no-var": "error",
     "prefer-arrow-callback": "error",
     "prefer-const": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
     ],
     "no-console": "off",
     "no-else-return": "error",
-    "no-inner-declarations": "off",
+    "no-inner-declarations": "error",
     "no-unneeded-ternary": "error",
     "no-useless-return": "error",
     "no-var": "error",

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -260,7 +260,6 @@ if (stdin) {
       writeOutput(format(input, options));
     } catch (e) {
       handleError("stdin", e);
-      return;
     }
   });
 } else {
@@ -393,6 +392,5 @@ function eachFilename(patterns, callback) {
       );
       // Don't exit the process if one pattern failed
       process.exitCode = 2;
-      return;
     });
 }

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -151,6 +151,12 @@ const options = {
   parser: getParserOption()
 };
 
+function diff(a, b) {
+  return require("diff").createTwoFilesPatch("", "", a, b, "", "", {
+    context: 2
+  });
+}
+
 function format(input, opt) {
   if (argv["debug-print-doc"]) {
     const doc = prettier.__debug.printToDoc(input, opt);
@@ -158,12 +164,6 @@ function format(input, opt) {
   }
 
   if (argv["debug-check"]) {
-    function diff(a, b) {
-      return require("diff").createTwoFilesPatch("", "", a, b, "", "", {
-        context: 2
-      });
-    }
-
     const pp = prettier.format(input, opt);
     const pppp = prettier.format(pp, opt);
     if (pp !== pppp) {

--- a/index.js
+++ b/index.js
@@ -282,7 +282,7 @@ function calculateRange(text, opts, ast) {
 }
 
 function formatRange(text, opts, ast) {
-  if (0 < opts.rangeStart || opts.rangeEnd < text.length) {
+  if (opts.rangeStart > 0 || opts.rangeEnd < text.length) {
     const range = calculateRange(text, opts, ast);
     const rangeStart = range.rangeStart;
     const rangeEnd = range.rangeEnd;

--- a/index.js
+++ b/index.js
@@ -282,7 +282,7 @@ function calculateRange(text, opts, ast) {
 }
 
 function formatRange(text, opts, ast) {
-  if (opts.rangeStart > 0 || opts.rangeEnd < text.length) {
+  if (0 < opts.rangeStart || opts.rangeEnd < text.length) {
     const range = calculateRange(text, opts, ast);
     const rangeStart = range.rangeStart;
     const rangeEnd = range.rangeEnd;

--- a/scripts/build/rollup.parser.config.js
+++ b/scripts/build/rollup.parser.config.js
@@ -41,5 +41,5 @@ export default Object.assign(baseConfig, {
     "os",
     "crypto"
   ],
-  useStrict: parser === "flow" ? false : true
+  useStrict: parser !== "flow"
 });

--- a/src/comments.js
+++ b/src/comments.js
@@ -81,10 +81,11 @@ function getSortedChildNodes(node, text, resultArray) {
 // least one of which is guaranteed to be defined.
 function decorateComment(node, comment, text) {
   const childNodes = getSortedChildNodes(node, text);
-  let precedingNode, followingNode;
+  let precedingNode;
+  let followingNode;
   // Time to dust off the old binary search robes and wizard hat.
-  let left = 0,
-    right = childNodes.length;
+  let left = 0;
+  let right = childNodes.length;
   while (left < right) {
     const middle = (left + right) >> 1;
     const child = childNodes[middle];

--- a/src/doc-builders.js
+++ b/src/doc-builders.js
@@ -85,7 +85,7 @@ const literalline = concat([
   { type: "line", hard: true, literal: true },
   breakParent
 ]);
-const cursor = { type: "cursor", placeholder: Symbol() };
+const cursor = { type: "cursor", placeholder: Symbol("cursor") };
 
 function join(sep, arr) {
   const res = [];

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -30,7 +30,8 @@ self.onmessage = function(message) {
   delete options.doc;
 
   var formatted = formatCode(message.data.text, options);
-  var doc, ast;
+  var doc;
+  var ast;
 
   if (message.data.ast) {
     try {


### PR DESCRIPTION
I experimented with simplifying the eslint config to just use [eslint-config-standard](https://github.com/standard/eslint-config-standard) and [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier). There were too many errors to make it a quick change, but I did find a few useful rules we could adopt instead.