### PR TITLE
(#2404) Print TypeParameter even when unary function type

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3039,6 +3039,7 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
     fun[paramsField].length === 1 &&
     fun[paramsField][0].name === null &&
     fun[paramsField][0].typeAnnotation &&
+    fun.typeParameters === null &&
     flowTypeAnnotations.indexOf(fun[paramsField][0].typeAnnotation.type) !==
       -1 &&
     !(

--- a/tests/flow_generic/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_generic/__snapshots__/jsfmt.spec.js.snap
@@ -156,6 +156,24 @@ type State = {
 
 `;
 
+exports[`type.js 1`] = `
+type F = <T>(T) => T;
+type G = (<A, B>(A) => B);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+type F = <T>(T) => T;
+type G = <A, B>(A) => B;
+
+`;
+
+exports[`type.js 2`] = `
+type F = <T>(T) => T;
+type G = (<A, B>(A) => B);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+type F = <T>(T) => T;
+type G = <A, B>(A) => B;
+
+`;
+
 exports[`union.js 1`] = `
 type Foo = Promise<
   { ok: true, bar: string, baz: SomeOtherLongType } | 

--- a/tests/flow_generic/type.js
+++ b/tests/flow_generic/type.js
@@ -1,0 +1,2 @@
+type F = <T>(T) => T;
+type G = (<A, B>(A) => B);


### PR DESCRIPTION
There was a path in the code when `isFlowShorthandWithOneArg` is true that prints the function parameters without parens or type parameters.

I fixed it by adding a condition that the node must have empty `typeParameters` to enter the branch.

Fixes #2404.