### PR TITLE
Trim whitespace in descendant combinator, fixes #2410

### DIFF
--- a/src/clean-ast.js
+++ b/src/clean-ast.js
@@ -70,6 +70,10 @@ function massageAST(ast) {
       delete newObj.params;
     }
 
+    if (ast.type === "selector-combinator") {
+      newObj.value = newObj.value.replace(/\s+/g, " ");
+    }
+
     if (ast.type === "media-feature") {
       newObj.value = newObj.value.replace(/ /g, "");
     }

--- a/src/printer-postcss.js
+++ b/src/printer-postcss.js
@@ -212,7 +212,7 @@ function genericPrint(path, options, print) {
           : line;
         return concat([leading, n.value, " "]);
       }
-      return n.value;
+      return n.value.trim() || line;
     }
     case "selector-universal": {
       return n.value;

--- a/tests/css_combinator/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_combinator/__snapshots__/jsfmt.spec.js.snap
@@ -3,8 +3,32 @@
 exports[`combinator.css 1`] = `
 -Option/root .public/section ~ .public/section:before {
 }
+
+.x .y {}
+.x > .y {}
+.x ~ .y {}
+.x + .y {}
+.x.y {}
+.x     .y {}
+.x
+    .y {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 -Option/root .public/section ~ .public/section:before {
+}
+
+.x .y {
+}
+.x > .y {
+}
+.x ~ .y {
+}
+.x + .y {
+}
+.x.y {
+}
+.x .y {
+}
+.x .y {
 }
 
 `;

--- a/tests/css_combinator/combinator.css
+++ b/tests/css_combinator/combinator.css
@@ -1,2 +1,11 @@
 -Option/root .public/section ~ .public/section:before {
 }
+
+.x .y {}
+.x > .y {}
+.x ~ .y {}
+.x + .y {}
+.x.y {}
+.x     .y {}
+.x
+    .y {}

--- a/tests/css_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_comments/__snapshots__/jsfmt.spec.js.snap
@@ -96,12 +96,24 @@ exports[`selector.css 1`] = `
 .powerPathNavigator table.powerPathInfo th:active,
 .powerPathNavigator table.powerPathInfo th:active + th:last-child {
 }
+
+/* pressed buttons */
+.powerPathNavigator .helm button.pressedButton,
+.powerPathNavigator .helm button:active:not(.disabledButton) {
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .powerPathNavigator .helm button.pressedButton,
 /* pressed buttons */
-.powerPathNavigator .helm button:active:not(.disabledButton),
+  .powerPathNavigator
+  .helm
+  button:active:not(.disabledButton),
 .powerPathNavigator table.powerPathInfo th:active,
 .powerPathNavigator table.powerPathInfo th:active + th:last-child {
+}
+
+/* pressed buttons */
+.powerPathNavigator .helm button.pressedButton,
+.powerPathNavigator .helm button:active:not(.disabledButton) {
 }
 
 `;

--- a/tests/css_comments/selector.css
+++ b/tests/css_comments/selector.css
@@ -3,3 +3,8 @@
 .powerPathNavigator table.powerPathInfo th:active,
 .powerPathNavigator table.powerPathInfo th:active + th:last-child {
 }
+
+/* pressed buttons */
+.powerPathNavigator .helm button.pressedButton,
+.powerPathNavigator .helm button:active:not(.disabledButton) {
+}

--- a/tests/css_selector_list/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_selector_list/__snapshots__/jsfmt.spec.js.snap
@@ -28,8 +28,10 @@ exports[`selectors.css 1`] = `
   }
 }
 
-.asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas .asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas,
-.asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas .asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas {
+.asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas
+  .asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas,
+.asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas
+  .asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas {
 }
 
 `;


### PR DESCRIPTION
Fix is trivial, use `line` instead of arbitrary whitespace.

However due to comments being AST nodes this breaks a test.

Fixes #2410