### PR TITLE
Add pre-commit metadata directly to prettier

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,5 @@
+-   id: prettier
+    name: prettier
+    entry: prettier --write
+    language: node
+    types: [javascript]

--- a/README.md
+++ b/README.md
@@ -318,19 +318,18 @@ See https://github.com/okonet/lint-staged#configuration for more details about h
 
 ##### Option 2. [pre-commit](https://github.com/pre-commit/pre-commit)
 
-Copy the following config in your pre-commit config yaml file:
+Copy the following config into your `.pre-commit-config.yaml` file:
 
 ```yaml
 
-    -   repo: https://github.com/awebdeveloper/pre-commit-prettier
+    -   repo: https://github.com/prettier/prettier
         sha: ''  # Use the sha or tag you want to point at
         hooks:
         -   id: prettier
-            additional_dependencies: ['prettier@1.4.2']
 
- ```
+```
 
-Find more info from [here](https://github.com/awebdeveloper/pre-commit-prettier).
+Find more info from [here](http://pre-commit.com).
 
 ##### Option 3. bash script
 


### PR DESCRIPTION
Hi! [pre-commit](https://github.com/pre-commit/pre-commit) maintainer here :D

Figured you guys could simplify the pre-commit install instructions (and release burden with having to bump the version in the README over-and-over) by adding the metadata directly to this repository.