### PR TITLE
Fixed command line arg of `bracketSpacing`

### DIFF
--- a/docs/en/options.md
+++ b/docs/en/options.md
@@ -81,7 +81,7 @@ Valid options:
 
 Default | CLI Override | API Override
 --------|--------------|-------------
-`true` | `--no-bracket-spacing` | `bracketSpacing: <bool>`
+`true` | `--bracket-spacing` | `bracketSpacing: <bool>`
 
 ## JSX Brackets
 Put the `>` of a multi-line JSX element at the end of the last line instead of being alone on the next line.


### PR DESCRIPTION
The command line argument for the `bracketSpacing` option is called `--bracket-spacing` (and not `--no-bracket-spacing`)