### PR TITLE
[RFC] Arrow Functions params have parens unless they implicitly return

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -431,7 +431,7 @@ function genericPrintNoParens(path, options, print, args) {
         parts.push("async ");
       }
 
-      if (canPrintParamsWithoutParens(n)) {
+      if (n.expression === true && canPrintParamsWithoutParens(n)) {
         parts.push(path.call(print, "params", 0));
       } else {
         parts.push(

--- a/tests/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -33,7 +33,7 @@ x => (y += z);
 f(a => ({})) + 1;
 (a => ({})) || 0;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-(a => {}).length;
+((a) => {}).length;
 typeof (() => {});
 export default (() => {})();
 (() => {})()\`\`;
@@ -326,11 +326,11 @@ const middleware = options => (req, res, next) => {
   // ...
 };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-const fn = b => c => d => {
+const fn = b => c => (d) => {
   return 3;
 };
 
-const mw = store => next => action => {
+const mw = store => next => (action) => {
   return next(action);
 };
 

--- a/tests/binary-expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/binary-expressions/__snapshots__/jsfmt.spec.js.snap
@@ -231,7 +231,7 @@ foooooooooooooooooooooooooooooooooooooooooooooooooooooooooo(
 const isPartOfPackageJSON =
   dependenciesArray.indexOf(dependencyWithOutRelativePath.split("/")[0]) !== -1;
 
-defaultContent.filter(defaultLocale => {
+defaultContent.filter((defaultLocale) => {
   // ...
 })[0] || null;
 

--- a/tests/cursor/jsfmt.spec.js
+++ b/tests/cursor/jsfmt.spec.js
@@ -25,11 +25,11 @@ test("keeps cursor inside formatted node", () => {
 
 test("doesn't insert second placeholder for nonexistent TypeAnnotation", () => {
   const code = `
-foo('bar', cb => {
+foo('bar', (cb) => {
   console.log('stuff')
 })`;
   expect(prettier.formatWithCursor(code, { cursorOffset: 24 })).toEqual({
-    formatted: `foo("bar", cb => {
+    formatted: `foo("bar", (cb) => {
   console.log("stuff");
 });
 `,

--- a/tests/first_argument_expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/first_argument_expansion/__snapshots__/jsfmt.spec.js.snap
@@ -105,7 +105,7 @@ func(function() {
   thing();
 }, this.props.timeout * 1000);
 
-func(that => {
+func((that) => {
   thing();
 }, this.props.getTimeout());
 
@@ -125,7 +125,7 @@ func(() => {
   thing();
 }, /regex.*?/);
 
-compose(a => {
+compose((a) => {
   return a.thing;
 }, b => b * b);
 
@@ -162,16 +162,16 @@ func(
 );
 
 compose(
-  a => {
+  (a) => {
     return a.thing;
   },
-  b => {
+  (b) => {
     return b + "";
   }
 );
 
 compose(
-  a => {
+  (a) => {
     return a.thing;
   },
   b => [1, 2, 3, 4, 5]

--- a/tests/flow/annot/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/annot/__snapshots__/jsfmt.spec.js.snap
@@ -111,7 +111,7 @@ function param_anno2(
   // just assign result to new var instead of reassigning to param.
 
   // Transform the requests to the format the Graph API expects.
-  batchRequests = batchRequests.map(request => {
+  batchRequests = batchRequests.map((request) => {
     return {
       method: request.method,
       params: request.params,

--- a/tests/flow/array-filter/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/array-filter/__snapshots__/jsfmt.spec.js.snap
@@ -44,7 +44,7 @@ console.log(filteredItems);
 
 function filterItems(items: Array<string | number>): Array<string | number> {
   return items
-    .map(item => {
+    .map((item) => {
       if (typeof item === "string") {
         return item.length > 2 ? item : null;
       } else {

--- a/tests/flow/async_iteration/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/async_iteration/__snapshots__/jsfmt.spec.js.snap
@@ -140,7 +140,7 @@ declare var gen: AsyncGenerator<void, string, void>;
 
 // You can pass whatever you like to return, it doesn't need to be related to
 // the AsyncGenerator's return type
-gen.return(0).then(result => {
+gen.return(0).then((result) => {
   (result.value: void); // error: string | number ~> void
 });
 
@@ -153,7 +153,7 @@ async function* refuse_return() {
     return 0;
   }
 }
-refuse_return().return("string").then(result => {
+refuse_return().return("string").then((result) => {
   if (result.done) {
     (result.value: string); // error: number | void ~> string
   }

--- a/tests/flow/call_properties/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/call_properties/__snapshots__/jsfmt.spec.js.snap
@@ -312,7 +312,7 @@ var d: { (): string } = x => "hi";
 // ...but subtyping rules still apply
 var e: { (x: any): void } = () => {}; // arity
 var f: { (): mixed } = () => "hi"; // return type
-var g: { (x: Date): void } = x => {
+var g: { (x: Date): void } = (x) => {
   x * 2;
 }; // param type (date < number)
 

--- a/tests/flow/geolocation/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/geolocation/__snapshots__/jsfmt.spec.js.snap
@@ -26,11 +26,11 @@ geolocation.clearWatch(id);
 
 var geolocation = new Geolocation();
 var id = geolocation.watchPosition(
-  position => {
+  (position) => {
     var coords: Coordinates = position.coords;
     var accuracy: number = coords.accuracy;
   },
-  e => {
+  (e) => {
     var message: string = e.message;
     switch (e.code) {
       case e.PERMISSION_DENIED:

--- a/tests/flow/object_api/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/object_api/__snapshots__/jsfmt.spec.js.snap
@@ -184,12 +184,12 @@ var sealed = { one: "one", two: "two" };
 (Object.keys(sealed): void); // error, Array<string>
 
 var unsealed = {};
-Object.keys(unsealed).forEach(k => {
+Object.keys(unsealed).forEach((k) => {
   (k: number); // error: string ~> number
 });
 
 var dict: { [k: number]: string } = {};
-Object.keys(dict).forEach(k => {
+Object.keys(dict).forEach((k) => {
   (k: number); // error: string ~> number
 });
 

--- a/tests/flow/objmap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/objmap/__snapshots__/jsfmt.spec.js.snap
@@ -34,7 +34,7 @@ var o = keyMirror({
 promiseAllByKey({
   foo: Promise.resolve(0),
   bar: "bar"
-}).then(o => {
+}).then((o) => {
   (o.foo: string); // error, number ~> string
   (o.bar: "bar"); // ok
 });

--- a/tests/flow/promises/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/promises/__snapshots__/jsfmt.spec.js.snap
@@ -50,7 +50,7 @@ Promise.all([
   pstr,
   pnum,
   true // non-Promise values passed through
-]).then(xs => {
+]).then((xs) => {
   // tuple information is preserved
   let [a, b, c] = xs;
   (a: number); // Error: string ~> number
@@ -58,7 +58,7 @@ Promise.all([
   (c: string); // Error: boolean ~> string
 
   // array element type is (string | number | boolean)
-  xs.forEach(x => {
+  xs.forEach((x) => {
     (x: void); // Errors: string ~> void, number ~> void, boolean ~> void
   });
 });

--- a/tests/flow/react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/react/__snapshots__/jsfmt.spec.js.snap
@@ -1009,7 +1009,7 @@ var Example = React.createClass({
 });
 
 var ok_void = <Example func={() => {}} />;
-var ok_args = <Example func={x => {}} />;
+var ok_args = <Example func={(x) => {}} />;
 var ok_retval = <Example func={() => 1} />;
 
 var fail_mistyped = <Example func={2} />;

--- a/tests/flow/spread/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/spread/__snapshots__/jsfmt.spec.js.snap
@@ -186,7 +186,7 @@ function test(
   x: { kind: ?string },
   kinds: { [key: string]: string }
 ): Array<{ kind: ?string }> {
-  return map(kinds, value => {
+  return map(kinds, (value) => {
     (value: string); // OK
     return {
       ...x,

--- a/tests/flow/union_new/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/union_new/__snapshots__/jsfmt.spec.js.snap
@@ -744,7 +744,7 @@ type B2 = string;
 
 function fun(a: ((x: number) => void) | ((x: string) => void)) {}
 
-fun((x => {}: A1));
+fun(((x) => {}: A1));
 
 type A1 = (x: B1) => void;
 
@@ -814,7 +814,7 @@ type B2 = string;
 
 function fun(a: ((x: number) => void) | ((x: string) => void)) {}
 
-const a1 = (x => {}: A1);
+const a1 = ((x) => {}: A1);
 fun(a1);
 
 function fun_call(x: string) {
@@ -1427,7 +1427,7 @@ bar(() => { });
 // functions as objects
 
 function foo<X>(target: EventTarget) {
-  target.addEventListener("click", e => {});
+  target.addEventListener("click", (e) => {});
 }
 
 declare class EventTarget {

--- a/tests/import_then/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/import_then/__snapshots__/jsfmt.spec.js.snap
@@ -13,7 +13,7 @@ import(
 import("myreallylongdynamicallyloadedmodulenamemyreallylongdynamicallyloadedmodulename");
 
 import("myreallylongdynamicallyloadedmodulenamemyreallylongdynamicallyloadedmodulename").then(
-  exports => {}
+  (exports) => {}
 );
 
 `;
@@ -23,7 +23,7 @@ const x = import('some-module').then(x => {
   // ...
 });
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-const x = import("some-module").then(x => {
+const x = import("some-module").then((x) => {
   // ...
 });
 

--- a/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
@@ -329,7 +329,7 @@ export const setProp = y => ({
   a: "very, very, very long very, very long text"
 });
 
-export const log = y => {
+export const log = (y) => {
   console.log("very, very, very long very, very long text");
 };
 

--- a/tests/member/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/member/__snapshots__/jsfmt.spec.js.snap
@@ -27,7 +27,7 @@ const veryVeryVeryVeryVeryVeryVeryLong =
 const small = doc.expandedStates[doc.expandedStates.length - 1];
 
 const promises = [
-  promise.resolve().then(console.log).catch(err => {
+  promise.resolve().then(console.log).catch((err) => {
     console.log(err);
     return null;
   }),
@@ -41,7 +41,7 @@ const promises = [
     .veryLongFunctionCall()
     .veryLongFunctionCall()
     .then(console.log)
-    .catch(err => {
+    .catch((err) => {
       console.log(err);
       return null;
     }),

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -61,7 +61,7 @@ it('should group messages with same created time', () => {
   });
 });
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-export default store => {
+export default (store) => {
   return callApi(endpoint, schema).then(
     response =>
       next(
@@ -315,7 +315,7 @@ const configModel = this.baseConfigurationService
 this.doWriteConfiguration(target, value, options) // queue up writes to prevent race conditions
   .then(
     () => null,
-    error => {
+    (error) => {
       return options.donotNotifyError
         ? TPromise.wrapError(error)
         : this.onError(error, target, value);
@@ -424,7 +424,7 @@ function f() {
   return this._getWorker(workerOptions)({
     filePath,
     hasteImplModulePath: this._options.hasteImplModulePath
-  }).then(metadata => {
+  }).then((metadata) => {
     // \`1\` for truthy values instead of \`true\` to save cache space.
     fileMetadata[H.VISITED] = 1;
     const metadataId = metadata.id;
@@ -453,7 +453,7 @@ Object.keys(
   availableLocales({
     test: true
   })
-).forEach(locale => {
+).forEach((locale) => {
   // ...
 });
 

--- a/tests/performance/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/performance/__snapshots__/jsfmt.spec.js.snap
@@ -148,7 +148,7 @@ tap.test("RecordImport.advance", (t) => {
     });
 });
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-tap.test("RecordImport.advance", t => {
+tap.test("RecordImport.advance", (t) => {
   const checkStates = (batches, states) => {
     t.equal(batches.length, states.length);
     for (const batch of batches) {
@@ -160,7 +160,7 @@ tap.test("RecordImport.advance", t => {
   const batch = init.getRecordBatch();
   const dataFile = path.resolve(process.cwd(), "testData", "default.json");
 
-  const getBatches = callback => {
+  const getBatches = (callback) => {
     RecordImport.find({}, "", {}, (err, batches) => {
       callback(
         null,
@@ -171,8 +171,8 @@ tap.test("RecordImport.advance", t => {
     });
   };
 
-  mockFS(callback => {
-    batch.setResults([fs.createReadStream(dataFile)], err => {
+  mockFS((callback) => {
+    batch.setResults([fs.createReadStream(dataFile)], (err) => {
       t.error(err, "Error should be empty.");
       t.equal(batch.results.length, 6, "Check number of results");
       for (const result of batch.results) {
@@ -184,26 +184,26 @@ tap.test("RecordImport.advance", t => {
       getBatches((err, batches) => {
         checkStates(batches, ["started"]);
 
-        RecordImport.advance(err => {
+        RecordImport.advance((err) => {
           t.error(err, "Error should be empty.");
 
           getBatches((err, batches) => {
             checkStates(batches, ["process.completed"]);
 
             // Need to manually move to the next step
-            batch.importRecords(err => {
+            batch.importRecords((err) => {
               t.error(err, "Error should be empty.");
 
               getBatches((err, batches) => {
                 checkStates(batches, ["import.completed"]);
 
-                RecordImport.advance(err => {
+                RecordImport.advance((err) => {
                   t.error(err, "Error should be empty.");
 
                   getBatches((err, batches) => {
                     checkStates(batches, ["similarity.sync.completed"]);
 
-                    RecordImport.advance(err => {
+                    RecordImport.advance((err) => {
                       t.error(err, "Error should be empty.");
 
                       t.ok(batch.getCurState().name(i18n));

--- a/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
@@ -93,22 +93,26 @@ it(\`handles
   console.log("hello!");
 });
 
-test("does something really long and complicated so I have to write a very long name for the test", done => {
+test("does something really long and complicated so I have to write a very long name for the test", (
+  done
+) => {
   console.log("hello!");
 });
 
-test(\`does something really long and complicated so I have to write a very long name for the test\`, done => {
+test(\`does something really long and complicated so I have to write a very long name for the test\`, (
+  done
+) => {
   console.log("hello!");
 });
 
 describe("does something really long and complicated so I have to write a very long name for the describe block", () => {
-  it("an example test", done => {
+  it("an example test", (done) => {
     console.log("hello!");
   });
 });
 
 describe(\`does something really long and complicated so I have to write a very long name for the describe block\`, () => {
-  it(\`an example test\`, done => {
+  it(\`an example test\`, (done) => {
     console.log("hello!");
   });
 });

--- a/tests/typescript/conformance/types/functions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/functions/__snapshots__/jsfmt.spec.js.snap
@@ -464,35 +464,35 @@ class AnotherClass {
 // if f is a contextually typed function expression, the inferred return type is the union type
 // of the types of the return statement expressions in the function body,
 // ignoring return statements with no expressions.
-var f7: (x: number) => string | number = x => {
+var f7: (x: number) => string | number = (x) => {
   // should be (x: number) => number | string
   if (x < 0) {
     return x;
   }
   return x.toString();
 };
-var f8: (x: number) => any = x => {
+var f8: (x: number) => any = (x) => {
   // should be (x: number) => Base
   return new Base();
   return new Derived2();
 };
-var f9: (x: number) => any = x => {
+var f9: (x: number) => any = (x) => {
   // should be (x: number) => Base
   return new Base();
   return new Derived();
   return new Derived2();
 };
-var f10: (x: number) => any = x => {
+var f10: (x: number) => any = (x) => {
   // should be (x: number) => Derived | Derived1
   return new Derived();
   return new Derived2();
 };
-var f11: (x: number) => any = x => {
+var f11: (x: number) => any = (x) => {
   // should be (x: number) => Base | AnotherClass
   return new Base();
   return new AnotherClass();
 };
-var f12: (x: number) => any = x => {
+var f12: (x: number) => any = (x) => {
   // should be (x: number) => Base | AnotherClass
   return new Base();
   return; // should be ignored


### PR DESCRIPTION
As discussed in https://github.com/prettier/prettier/issues/812#issuecomment-313829292

I'm not sure this is the right move, and I think several of the changes may be regressions. 