### PR TITLE
Allow single expressions in JSX to be inline

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3872,16 +3872,11 @@ function printJSXElement(path, options, print) {
     return child;
   });
 
-  const parent = path.getParentNode();
-  const parentContainsText =
-    parent.type === "JSXElement" &&
-    parent.children.filter(child => isMeaningfulJSXText(child)).length > 0;
-
   const containsTag =
     n.children.filter(child => child.type === "JSXElement").length > 0;
-  const numExpressions = n.children.filter(
-    child => child.type === "JSXExpressionContainer"
-  ).length;
+  const containsMultipleExpressions =
+    n.children.filter(child => child.type === "JSXExpressionContainer").length >
+    1;
   const containsMultipleAttributes = n.openingElement.attributes.length > 1;
 
   // Record any breaks. Should never go from true to false, only false to true.
@@ -3889,7 +3884,7 @@ function printJSXElement(path, options, print) {
     willBreak(openingLines) ||
     containsTag ||
     containsMultipleAttributes ||
-    (parentContainsText ? numExpressions > 1 : numExpressions > 0);
+    containsMultipleExpressions;
 
   const rawJsxWhitespace = options.singleQuote ? "{' '}" : '{" "}';
   const jsxWhitespace = ifBreak(concat([rawJsxWhitespace, softline]), " ");

--- a/tests/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -304,10 +304,7 @@ export const bem = block =>
 <FlatList
   renderItem={(
     info // $FlowExpectedError - bad widgetCount type 6, should be Object
-  ) =>
-    <span>
-      {info.item.widget.missingProp}
-    </span>}
+  ) => <span>{info.item.widget.missingProp}</span>}
   data={data}
 />;
 

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -497,9 +497,7 @@ Observable.of(process)
   .takeUntil(exit);
 
 // Comments disappear inside of JSX
-<div>
-  {/* Some comment */}
-</div>;
+<div>{/* Some comment */}</div>;
 
 // Comments in JSX tag are placed in a non optimal way
 <div
@@ -598,23 +596,15 @@ exports[`jsx.js 1`] = `
 
 <div>{/*<div>  Some very v  ery very very long line to break line width limit </div>*/}</div>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-<div>
-  {/* comment */}
-</div>;
+<div>{/* comment */}</div>;
 
-<div>
-  {/* comment */}
-</div>;
+<div>{/* comment */}</div>;
 
-<div>
-  {/* comment
-*/}
-</div>;
+<div>{/* comment
+*/}</div>;
 
-<div>
-  {a /* comment
-*/}
-</div>;
+<div>{a /* comment
+*/}</div>;
 
 <div>
   {
@@ -624,13 +614,9 @@ exports[`jsx.js 1`] = `
   }
 </div>;
 
-<div>
-  {/* comment */}
-</div>;
+<div>{/* comment */}</div>;
 
-<div>
-  {/* comment */}
-</div>;
+<div>{/* comment */}</div>;
 
 <div>
   {

--- a/tests/flow/multiflow/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/multiflow/__snapshots__/jsfmt.spec.js.snap
@@ -222,12 +222,8 @@ declare function ExpectsProps(props: { name: string }, children: any): string;
 declare function ExpectsChildrenTuple(props: any, children: [string]): string;
 <ExpectsChildrenTuple />; // Error - mising child
 <ExpectsChildrenTuple>Hi</ExpectsChildrenTuple>; // No error
-<ExpectsChildrenTuple>
-  {123}
-</ExpectsChildrenTuple>; // Error: number ~> string
-<ExpectsChildrenTuple>
-  Hi {"there"}
-</ExpectsChildrenTuple>; // Error: too many children
+<ExpectsChildrenTuple>{123}</ExpectsChildrenTuple>; // Error: number ~> string
+<ExpectsChildrenTuple>Hi {"there"}</ExpectsChildrenTuple>; // Error: too many children
 
 declare function ExpectsChildrenArray(
   props: any,
@@ -235,12 +231,8 @@ declare function ExpectsChildrenArray(
 ): string;
 <ExpectsChildrenArray />; // No error - 0 children is fine
 <ExpectsChildrenArray>Hi</ExpectsChildrenArray>; // No error - 1 child is fine
-<ExpectsChildrenArray>
-  {123}
-</ExpectsChildrenArray>; // Error: number ~> string
-<ExpectsChildrenArray>
-  Hi {"there"}
-</ExpectsChildrenArray>; // No error - 2 children is fine
+<ExpectsChildrenArray>{123}</ExpectsChildrenArray>; // Error: number ~> string
+<ExpectsChildrenArray>Hi {"there"}</ExpectsChildrenArray>; // No error - 2 children is fine
 
 `;
 

--- a/tests/flow/new_react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/new_react/__snapshots__/jsfmt.spec.js.snap
@@ -793,11 +793,7 @@ class Example extends React.Component {
   props: { bar: string };
 
   render() {
-    return (
-      <div>
-        {this.props.bar}
-      </div>
-    );
+    return <div>{this.props.bar}</div>;
   }
 }
 
@@ -869,11 +865,7 @@ var ReactClass = React.createClass({
   render: function(): any {
     // Any state access here seems to make state any
     this.state;
-    return (
-      <div>
-        {this.state.bar.qux}
-      </div>
-    );
+    return <div>{this.state.bar.qux}</div>;
   }
 });
 
@@ -981,11 +973,7 @@ var C = React.createClass({
 
   render() {
     this.setState({ y: 0 });
-    return (
-      <div>
-        {this.state.z}
-      </div>
-    );
+    return <div>{this.state.z}</div>;
   }
 });
 

--- a/tests/flow/react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/react/__snapshots__/jsfmt.spec.js.snap
@@ -741,11 +741,7 @@ class Bar extends React.Component {
     test: number
   };
   render() {
-    return (
-      <div>
-        {this.props.test}
-      </div>
-    );
+    return <div>{this.props.test}</div>;
   }
 }
 
@@ -1623,17 +1619,9 @@ var Example = React.createClass({
   },
   render() {
     if (typeof this.props.prop === "string") {
-      return (
-        <div>
-          {this.props.prop}
-        </div>
-      );
+      return <div>{this.props.prop}</div>;
     } else {
-      return (
-        <div>
-          {this.props.prop.toFixed(2)}
-        </div>
-      );
+      return <div>{this.props.prop.toFixed(2)}</div>;
     }
   }
 });

--- a/tests/flow/react_modules/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/react_modules/__snapshots__/jsfmt.spec.js.snap
@@ -38,11 +38,7 @@ var HelloLocal = React.createClass({
   },
 
   render: function(): React.Element<*> {
-    return (
-      <div>
-        {this.props.name}
-      </div>
-    );
+    return <div>{this.props.name}</div>;
   }
 });
 
@@ -86,11 +82,7 @@ var Hello = React.createClass({
   },
 
   render: function(): React.Element<*> {
-    return (
-      <div>
-        {this.props.name}
-      </div>
-    );
+    return <div>{this.props.name}</div>;
   }
 });
 
@@ -136,11 +128,7 @@ class HelloLocal extends React.Component<void, { name: string }, void> {
     name: React.PropTypes.string.isRequired
   };
   render(): React.Element<*> {
-    return (
-      <div>
-        {this.props.name}
-      </div>
-    );
+    return <div>{this.props.name}</div>;
   }
 }
 
@@ -186,11 +174,7 @@ class Hello extends React.Component<void, { name: string }, void> {
   };
 
   render(): React.Element<*> {
-    return (
-      <div>
-        {this.props.name}
-      </div>
-    );
+    return <div>{this.props.name}</div>;
   }
 }
 
@@ -236,11 +220,7 @@ class HelloLocal extends React.Component<void, Props, void> {
   props: Props;
 
   render(): React.Element<*> {
-    return (
-      <div>
-        {this.props.name}
-      </div>
-    );
+    return <div>{this.props.name}</div>;
   }
 }
 
@@ -286,11 +266,7 @@ class Hello extends React.Component<{}, Props, void> {
   static defaultProps: {};
 
   render(): React.Element<*> {
-    return (
-      <div>
-        {this.props.name}
-      </div>
-    );
+    return <div>{this.props.name}</div>;
   }
 }
 

--- a/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
@@ -161,14 +161,9 @@ const render7B = () =>
     </span>
   </div>;
 
-const render8 = props =>
-  <div>
-    {props.text}
-  </div>;
+const render8 = props => <div>{props.text}</div>;
 const render9 = props =>
-  <div>
-    {props.looooooooooooooooooooooooooooooong_text}
-  </div>;
+  <div>{props.looooooooooooooooooooooooooooooong_text}</div>;
 const render10 = props =>
   <div>
     {props.even_looooooooooooooooooooooooooooooooooooooooooonger_contents}

--- a/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
@@ -284,9 +284,7 @@ const els = items.map(item => (
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const els = items.map(item =>
   <div className="whatever">
-    <span>
-      {children}
-    </span>
+    <span>{children}</span>
   </div>
 );
 

--- a/tests/typescript_tsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_tsx/__snapshots__/jsfmt.spec.js.snap
@@ -38,15 +38,9 @@ const MyCoolList = ({ things }) =>
 
 const MyCoolThing = ({ thingo }) => <li>{thingo}</li>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-const MyCoolList = ({ things }) =>
-  <ul>
-    {things.map(MyCoolThing)}
-  </ul>;
+const MyCoolList = ({ things }) => <ul>{things.map(MyCoolThing)}</ul>;
 
-const MyCoolThing = ({ thingo }) =>
-  <li>
-    {thingo}
-  </li>;
+const MyCoolThing = ({ thingo }) => <li>{thingo}</li>;
 
 `;
 


### PR DESCRIPTION
This PR changes the behaviour of JSX printing to allow single expressions to be output inline. It follows a discussion in: https://github.com/prettier/prettier/issues/2324

The following:

```jsx
<h3>
  {stage.title}
</h3>
```

Will now be formatted as:

```jsx
<h3>{stage.title}</h3>
```

However as multiple expressions are still output multiline.

```jsx
<h3>{stage.title}{stage.body}</h3>
```

Will still be formatted as:

```jsx
<h3>
  {stage.title}
  {stage.body}
</h3>
```