### PR TITLE
Rename --resolve-config to --find-config-path

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,14 +244,14 @@ Another useful flag is `--list-different` (or `-l`) which prints the filenames o
 prettier --single-quote --list-different "src/**/*.js"
 ```
 
-#### `--resolve-config` and `--config`
+#### `--find-config-path` and `--config`
 
 If you are repeatedly formatting individual files with `prettier`, you will incur a small performance cost
 when prettier attempts to look up a [configuration file](#configuration-file). In order to skip this, you may
 ask prettier to find the config file once, and re-use it later on.
 
 ```bash
-prettier --resolve-config ./my/file.js
+prettier --find-config-path ./my/file.js
 ./my/.prettierrc
 ```
 

--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -55,7 +55,7 @@ const argv = minimist(args, {
     "range-end",
     "stdin-filepath",
     "config",
-    "resolve-config"
+    "find-config-path"
   ],
   default: {
     color: true
@@ -98,8 +98,8 @@ if (write && argv["debug-check"]) {
   process.exit(1);
 }
 
-if (argv["resolve-config"] && filepatterns.length) {
-  console.error("Cannot use --resolve-config with multiple files");
+if (argv["find-config-path"] && filepatterns.length) {
+  console.error("Cannot use --find-config-path with multiple files");
   process.exit(1);
 }
 
@@ -274,7 +274,7 @@ function handleError(filename, e) {
 
 if (
   argv["help"] ||
-  (!filepatterns.length && !stdin && !argv["resolve-config"])
+  (!filepatterns.length && !stdin && !argv["find-config-path"])
 ) {
   console.log(
     "Usage: prettier [opts] [filename ...]\n\n" +
@@ -282,7 +282,8 @@ if (
       "  --write                  Edit the file in-place. (Beware!)\n" +
       "  --list-different or -l   Print filenames of files that are different from Prettier formatting.\n" +
       "  --config                 Path to a prettier configuration file (.prettierrc, package.json, prettier.config.js).\n" +
-      "  --resolve-config <path>  Resolve the path to a configuration file for a given input file.\n" +
+      "  --find-config-path <path> \n" +
+      "                           Finds and prints the path to a configuration file for a given input file.\n" +
       "  --stdin                  Read input from stdin.\n" +
       "  --stdin-filepath         Path to the file used to read from stdin.\n" +
       "  --print-width <int>      Specify the length of line that the printer will wrap on. Defaults to 80.\n" +
@@ -314,8 +315,8 @@ if (
   process.exit(argv["help"] ? 0 : 1);
 }
 
-if (argv["resolve-config"]) {
-  resolveConfig(argv["resolve-config"]);
+if (argv["find-config-path"]) {
+  resolveConfig(argv["find-config-path"]);
 } else if (stdin) {
   getStream(process.stdin).then(input => {
     getOptionsForFile(process.cwd()).then(options => {

--- a/tests_integration/__tests__/__snapshots__/config-resolution.js.snap
+++ b/tests_integration/__tests__/__snapshots__/config-resolution.js.snap
@@ -63,7 +63,7 @@ function f() {
 "
 `;
 
-exports[`resolves configuration file with --resolve-config file 1`] = `
+exports[`resolves configuration file with --find-config-path file 1`] = `
 ".prettierrc
 "
 `;

--- a/tests_integration/__tests__/config-resolution.js
+++ b/tests_integration/__tests__/config-resolution.js
@@ -27,17 +27,17 @@ test("accepts configuration from --config", () => {
   expect(output.status).toEqual(0);
 });
 
-test("resolves configuration file with --resolve-config file", () => {
+test("resolves configuration file with --find-config-path file", () => {
   const output = runPrettier("cli/config/", [
-    "--resolve-config",
+    "--find-config-path",
     "no-config/file.js"
   ]);
   expect(output.stdout).toMatchSnapshot();
   expect(output.status).toEqual(0);
 });
 
-test("prints nothing when no file found with --resolve-config", () => {
-  const output = runPrettier("cli/config/", ["--resolve-config", ".."]);
+test("prints nothing when no file found with --find-config-path", () => {
+  const output = runPrettier("cli/config/", ["--find-config-path", ".."]);
   expect(output.stdout).toEqual("");
   expect(output.status).toEqual(1);
 });


### PR DESCRIPTION
`--resolve-config` is different to `prettier.resolveConfig` in return value, so I'm changing it to `--find-config-path`.