### PR TITLE
Do not allow first arg to hug if the second is binary-ish

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2907,7 +2907,7 @@ function shouldGroupFirstArg(args) {
     (firstArg.type === "FunctionExpression" ||
       (firstArg.type === "ArrowFunctionExpression" &&
         firstArg.body.type === "BlockStatement")) &&
-    !couldGroupArg(secondArg)
+    (!couldGroupArg(secondArg) && !isBinaryish(secondArg))
   );
 }
 

--- a/tests/first_argument_expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/first_argument_expansion/__snapshots__/jsfmt.spec.js.snap
@@ -101,9 +101,12 @@ func(() => {
   thing();
 }, identifier);
 
-func(function() {
-  thing();
-}, this.props.timeout * 1000);
+func(
+  function() {
+    thing();
+  },
+  this.props.timeout * 1000
+);
 
 func(that => {
   thing();

--- a/tests/function_hug/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/function_hug/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,161 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`function_block_logical.js 1`] = `
+// A
+f(x => { y }, err.message.includes("asd") && err.message.includes("id") &&
+     err.message.includes('"1"') && err.message.includes("Model") &&
+     err.message.includes("/id") && err.message.includes("identifier(number)")
+)
+
+// B
+var a = err.message.includes("asd") && err.message.includes("id") &&
+     err.message.includes('"1"') && err.message.includes("Model") &&
+     err.message.includes("/id") && err.message.includes("identifier(number)")
+
+// C
+f(err.message.includes("asd") && err.message.includes("id") &&
+     err.message.includes('"1"') && err.message.includes("Model") &&
+     err.message.includes("/id") && err.message.includes("identifier(number)") )
+
+// D
+f(x, y, err.message.includes("asd") && err.message.includes("id") &&
+     err.message.includes('"1"') && err.message.includes("Model") &&
+     err.message.includes("/id") && err.message.includes("identifier(number)"),z,zz)
+
+// E
+f(x => y, err.message.includes("asd") && err.message.includes("id") &&
+     err.message.includes('"1"') && err.message.includes("Model") &&
+     err.message.includes("/id") && err.message.includes("identifier(number)"))
+
+// F
+f(function x() { y }, err.message.includes("asd") && err.message.includes("id") &&
+     err.message.includes('"1"') && err.message.includes("Model") &&
+     err.message.includes("/id") && err.message.includes("identifier(number)"))
+
+// G
+f(x => {}, err.message.includes("asd") && err.message.includes("id") &&
+     err.message.includes('"1"') && err.message.includes("Model") &&
+     err.message.includes("/id") && err.message.includes("identifier(number)"))
+
+// H
+f(x => { y }, err.message.includes("asd") && err.message.includes("id") &&
+     err.message.includes('"1"') && err.message.includes("Model") &&
+     err.message.includes("/id") && err.message.includes("identifier(number)"))
+
+// I
+f(
+  // a comment
+  x => { y },
+  err.message.includes("asd") && err.message.includes("id") &&
+     err.message.includes('"1"') && err.message.includes("Model") &&
+     err.message.includes("/id") && err.message.includes("identifier(number)"))
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// A
+f(
+  x => {
+    y;
+  },
+  err.message.includes("asd") &&
+    err.message.includes("id") &&
+    err.message.includes('"1"') &&
+    err.message.includes("Model") &&
+    err.message.includes("/id") &&
+    err.message.includes("identifier(number)")
+);
+
+// B
+var a =
+  err.message.includes("asd") &&
+  err.message.includes("id") &&
+  err.message.includes('"1"') &&
+  err.message.includes("Model") &&
+  err.message.includes("/id") &&
+  err.message.includes("identifier(number)");
+
+// C
+f(
+  err.message.includes("asd") &&
+    err.message.includes("id") &&
+    err.message.includes('"1"') &&
+    err.message.includes("Model") &&
+    err.message.includes("/id") &&
+    err.message.includes("identifier(number)")
+);
+
+// D
+f(
+  x,
+  y,
+  err.message.includes("asd") &&
+    err.message.includes("id") &&
+    err.message.includes('"1"') &&
+    err.message.includes("Model") &&
+    err.message.includes("/id") &&
+    err.message.includes("identifier(number)"),
+  z,
+  zz
+);
+
+// E
+f(
+  x => y,
+  err.message.includes("asd") &&
+    err.message.includes("id") &&
+    err.message.includes('"1"') &&
+    err.message.includes("Model") &&
+    err.message.includes("/id") &&
+    err.message.includes("identifier(number)")
+);
+
+// F
+f(
+  function x() {
+    y;
+  },
+  err.message.includes("asd") &&
+    err.message.includes("id") &&
+    err.message.includes('"1"') &&
+    err.message.includes("Model") &&
+    err.message.includes("/id") &&
+    err.message.includes("identifier(number)")
+);
+
+// G
+f(
+  x => {},
+  err.message.includes("asd") &&
+    err.message.includes("id") &&
+    err.message.includes('"1"') &&
+    err.message.includes("Model") &&
+    err.message.includes("/id") &&
+    err.message.includes("identifier(number)")
+);
+
+// H
+f(
+  x => {
+    y;
+  },
+  err.message.includes("asd") &&
+    err.message.includes("id") &&
+    err.message.includes('"1"') &&
+    err.message.includes("Model") &&
+    err.message.includes("/id") &&
+    err.message.includes("identifier(number)")
+);
+
+// I
+f(
+  // a comment
+  x => {
+    y;
+  },
+  err.message.includes("asd") &&
+    err.message.includes("id") &&
+    err.message.includes('"1"') &&
+    err.message.includes("Model") &&
+    err.message.includes("/id") &&
+    err.message.includes("identifier(number)")
+);
+
+`;

--- a/tests/function_hug/function_block_logical.js
+++ b/tests/function_hug/function_block_logical.js
@@ -1,0 +1,48 @@
+// A
+f(x => { y }, err.message.includes("asd") && err.message.includes("id") &&
+     err.message.includes('"1"') && err.message.includes("Model") &&
+     err.message.includes("/id") && err.message.includes("identifier(number)")
+)
+
+// B
+var a = err.message.includes("asd") && err.message.includes("id") &&
+     err.message.includes('"1"') && err.message.includes("Model") &&
+     err.message.includes("/id") && err.message.includes("identifier(number)")
+
+// C
+f(err.message.includes("asd") && err.message.includes("id") &&
+     err.message.includes('"1"') && err.message.includes("Model") &&
+     err.message.includes("/id") && err.message.includes("identifier(number)") )
+
+// D
+f(x, y, err.message.includes("asd") && err.message.includes("id") &&
+     err.message.includes('"1"') && err.message.includes("Model") &&
+     err.message.includes("/id") && err.message.includes("identifier(number)"),z,zz)
+
+// E
+f(x => y, err.message.includes("asd") && err.message.includes("id") &&
+     err.message.includes('"1"') && err.message.includes("Model") &&
+     err.message.includes("/id") && err.message.includes("identifier(number)"))
+
+// F
+f(function x() { y }, err.message.includes("asd") && err.message.includes("id") &&
+     err.message.includes('"1"') && err.message.includes("Model") &&
+     err.message.includes("/id") && err.message.includes("identifier(number)"))
+
+// G
+f(x => {}, err.message.includes("asd") && err.message.includes("id") &&
+     err.message.includes('"1"') && err.message.includes("Model") &&
+     err.message.includes("/id") && err.message.includes("identifier(number)"))
+
+// H
+f(x => { y }, err.message.includes("asd") && err.message.includes("id") &&
+     err.message.includes('"1"') && err.message.includes("Model") &&
+     err.message.includes("/id") && err.message.includes("identifier(number)"))
+
+// I
+f(
+  // a comment
+  x => { y },
+  err.message.includes("asd") && err.message.includes("id") &&
+     err.message.includes('"1"') && err.message.includes("Model") &&
+     err.message.includes("/id") && err.message.includes("identifier(number)"))

--- a/tests/function_hug/jsfmt.spec.js
+++ b/tests/function_hug/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, null, ["babylon", "typescript"]);


### PR DESCRIPTION
This issue was introduced back in #947.

The bug is that a complex second argument that is not allowed to "be grouped" does not prevent prettier from hugging the first argument, leading to outputs like this:

```js
f(x => {
  y;
}, err.message.includes("asd") && err.message.includes("id") && err.message.includes('"1"') && err.message.includes("Model") && err.message.includes("/id") && err.message.includes("identifier(number)"));
```

The fix is to let second args that are "binary-ish" (logical and binary expressions) prevent the first one from hugging.

This change caused one snapshot test to fail, but I prefer the new output:

Before:
```js
func(function() {
  thing();
}, this.props.timeout * 1000);
```

After:
```js
func(
  function() {
    thing();
  },
  this.props.timeout * 1000
);
```

We could add further restrictions (such as function calls, member expressions, etc), or invert the criteria by only allowing literals and identifiers. This was previously discussed. https://github.com/prettier/prettier/pull/947#issuecomment-287430778

Thoughts on this one, @vjeux & @jlongster?

Fixes #2456