### PR TITLE
Don't call shouldHugType for function arguments

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -4770,7 +4770,7 @@ function isNodeStartingWithDeclare(node, options) {
 }
 
 function shouldHugType(node) {
-  if (node.type === "ObjectTypeAnnotation" || node.type === "TSTypeLiteral") {
+  if (isObjectType(node)) {
     return true;
   }
 
@@ -4796,6 +4796,7 @@ function shouldHugType(node) {
       return true;
     }
   }
+
   return false;
 }
 
@@ -4809,9 +4810,9 @@ function shouldHugArguments(fun) {
       (fun.params[0].type === "Identifier" &&
         fun.params[0].typeAnnotation &&
         fun.params[0].typeAnnotation.type === "TypeAnnotation" &&
-        shouldHugType(fun.params[0].typeAnnotation.typeAnnotation)) ||
+        isObjectType(fun.params[0].typeAnnotation.typeAnnotation)) ||
       (fun.params[0].type === "FunctionTypeParam" &&
-        shouldHugType(fun.params[0].typeAnnotation))) &&
+        isObjectType(fun.params[0].typeAnnotation))) &&
     !fun.rest
   );
 }

--- a/tests/flow_union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_union/__snapshots__/jsfmt.spec.js.snap
@@ -14,6 +14,19 @@ interface RelayProps {
 }
 
 export function aPrettyLongFunction(aRatherLongParamName: string | null): string {}
+
+export function aPrettyLongFunctionA(aRatherLongParameterName: {} | null): string[] {}
+export function aPrettyLongFunctionB(aRatherLongParameterName: Function | null): string[] {}
+export interface MyInterface {}
+export function aPrettyLongFunctionC(aRatherLongParameterName: MyInterface | null): string[] {}
+export type MyType = MyInterface
+export function aPrettyLongFunctionD(aRatherLongParameterName: MyType | null): string[] {}
+
+export function aShortFn(aShortParmName: MyType | null): string[] {}
+
+export function aPrettyLongFunctionE(aRatherLongParameterName: Array<{
+  __id: string,
+} | null> | null | void): string[] {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 interface RelayProps {
   articles:
@@ -34,5 +47,28 @@ interface RelayProps {
 export function aPrettyLongFunction(
   aRatherLongParamName: string | null
 ): string {}
+
+export function aPrettyLongFunctionA(
+  aRatherLongParameterName: {} | null
+): string[] {}
+export function aPrettyLongFunctionB(
+  aRatherLongParameterName: Function | null
+): string[] {}
+export interface MyInterface {}
+export function aPrettyLongFunctionC(
+  aRatherLongParameterName: MyInterface | null
+): string[] {}
+export type MyType = MyInterface;
+export function aPrettyLongFunctionD(
+  aRatherLongParameterName: MyType | null
+): string[] {}
+
+export function aShortFn(aShortParmName: MyType | null): string[] {}
+
+export function aPrettyLongFunctionE(
+  aRatherLongParameterName: Array<{
+    __id: string
+  } | null> | null | void
+): string[] {}
 
 `;

--- a/tests/flow_union/union.js
+++ b/tests/flow_union/union.js
@@ -11,3 +11,16 @@ interface RelayProps {
 }
 
 export function aPrettyLongFunction(aRatherLongParamName: string | null): string {}
+
+export function aPrettyLongFunctionA(aRatherLongParameterName: {} | null): string[] {}
+export function aPrettyLongFunctionB(aRatherLongParameterName: Function | null): string[] {}
+export interface MyInterface {}
+export function aPrettyLongFunctionC(aRatherLongParameterName: MyInterface | null): string[] {}
+export type MyType = MyInterface
+export function aPrettyLongFunctionD(aRatherLongParameterName: MyType | null): string[] {}
+
+export function aShortFn(aShortParmName: MyType | null): string[] {}
+
+export function aPrettyLongFunctionE(aRatherLongParameterName: Array<{
+  __id: string,
+} | null> | null | void): string[] {}

--- a/tests/function_single_destructuring/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/function_single_destructuring/__snapshots__/jsfmt.spec.js.snap
@@ -14,6 +14,19 @@ function StatelessFunctionalComponent({
   return <div />
 }
 
+function StatelessFunctionalComponent({
+  isActive,
+  onFiltersUpdated,
+  onSelect,
+  onSubmitAndDeselect,
+  onCancel,
+  searchFilters,
+  title,
+  items,
+}: MyType | null | void) {
+  return <div />
+}
+
 const StatelessFunctionalComponent = ({
   isActive,
   onFiltersUpdated,
@@ -77,6 +90,19 @@ function StatelessFunctionalComponent({
   title,
   items
 }) {
+  return <div />;
+}
+
+function StatelessFunctionalComponent({
+  isActive,
+  onFiltersUpdated,
+  onSelect,
+  onSubmitAndDeselect,
+  onCancel,
+  searchFilters,
+  title,
+  items
+}: MyType | null | void) {
   return <div />;
 }
 

--- a/tests/function_single_destructuring/test.js
+++ b/tests/function_single_destructuring/test.js
@@ -11,6 +11,19 @@ function StatelessFunctionalComponent({
   return <div />
 }
 
+function StatelessFunctionalComponent({
+  isActive,
+  onFiltersUpdated,
+  onSelect,
+  onSubmitAndDeselect,
+  onCancel,
+  searchFilters,
+  title,
+  items,
+}: MyType | null | void) {
+  return <div />
+}
+
 const StatelessFunctionalComponent = ({
   isActive,
   onFiltersUpdated,


### PR DESCRIPTION
We only want to hug arguments if it is a single object as an argument. #1734 was too aggressive.

Fixes #2458