### PR TITLE
Cleanup

### DIFF
--- a/scripts/run-external-typescript-tests.js
+++ b/scripts/run-external-typescript-tests.js
@@ -10,8 +10,7 @@
  * If you have any ideas on how to fix this, please send a PR!
  */
 if (process.platform !== "win32") {
-  console.error("Error: this script currently only works on windows.");
-  process.exit(1);
+  console.log("Warning: this script may not work on macOS.");
 }
 
 const fs = require("fs");

--- a/src/parser-babylon.js
+++ b/src/parser-babylon.js
@@ -22,7 +22,8 @@ function parse(text) {
       "functionBind",
       "functionSent",
       "dynamicImport",
-      "numericSeparator"
+      "numericSeparator",
+      "importMeta"
     ]
   };
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -187,7 +187,7 @@ function genericPrint(path, options, printPath, args) {
       decoratorPath => {
         const decorator = decoratorPath.getValue();
         const prefix =
-          decorator.type === "Decorator" || decorator.type === "TSDecorator"
+          decorator.type === "Decorator"
             ? ""
             : "@";
         decorators.push(prefix, printPath(decoratorPath), hardline);
@@ -272,7 +272,6 @@ function genericPrintNoParens(path, options, print, args) {
 
       return concat(parts);
     // Babel extension.
-    case "Noop":
     case "EmptyStatement":
       return "";
     case "ExpressionStatement":
@@ -419,8 +418,6 @@ function genericPrintNoParens(path, options, print, args) {
       parts.push(printBindExpressionCallee(path, options, print));
 
       return concat(parts);
-    case "Path":
-      return join(".", n.body);
     case "Identifier": {
       const parentNode = path.getParentNode();
       const isFunctionDeclarationIdentifier =
@@ -591,18 +588,6 @@ function genericPrintNoParens(path, options, print, args) {
       }
 
       return concat(parts);
-    case "ModuleDeclaration":
-      parts.push("module", path.call(print, "id"));
-
-      if (n.source) {
-        assert.ok(!n.body);
-
-        parts.push("from", path.call(print, "source"));
-      } else {
-        parts.push(path.call(print, "body"));
-      }
-
-      return join(" ", parts);
     case "ImportSpecifier":
       if (n.imported) {
         if (n.importKind) {
@@ -639,8 +624,6 @@ function genericPrintNoParens(path, options, print, args) {
       }
 
       return concat(parts);
-    case "ExportBatchSpecifier":
-      return "*";
     case "ImportNamespaceSpecifier":
       parts.push("* as ");
 
@@ -660,7 +643,6 @@ function genericPrintNoParens(path, options, print, args) {
     case "TSExportAssigment": {
       return concat(["export = ", path.call(print, "expression"), semi]);
     }
-    case "ExportDeclaration":
     case "ExportDefaultDeclaration":
     case "ExportNamedDeclaration":
       return printExportDeclaration(path, options, print);
@@ -1050,12 +1032,6 @@ function genericPrintNoParens(path, options, print, args) {
 
       return group(content, { shouldBreak });
     }
-    case "PropertyPattern":
-      return concat([
-        path.call(print, "key"),
-        ": ",
-        path.call(print, "pattern")
-      ]);
     // Babel 6
     case "ObjectProperty": // Non-standard AST node type.
     case "Property":
@@ -1095,7 +1071,6 @@ function genericPrintNoParens(path, options, print, args) {
       return concat(parts); // Babel 6
     case "ObjectMethod":
       return printObjectMethod(path, options, print);
-    case "TSDecorator":
     case "Decorator":
       return concat(["@", path.call(print, "expression")]);
     case "ArrayExpression":
@@ -1229,15 +1204,6 @@ function genericPrintNoParens(path, options, print, args) {
     case "Directive":
       return path.call(print, "value"); // Babel 6
     case "DirectiveLiteral":
-      return nodeStr(n, options);
-    case "ModuleSpecifier":
-      /* istanbul ignore if */
-      if (n.local) {
-        throw new Error("The ESTree ModuleSpecifier type should be abstract");
-      }
-
-      // The Esprima ModuleSpecifier type is just a string-valued
-      // Literal identifying the imported-from module.
       return nodeStr(n, options);
     case "UnaryExpression":
       parts.push(n.operator);
@@ -1815,15 +1781,6 @@ function genericPrintNoParens(path, options, print, args) {
         requiresHardline ? hardline : ""
       ]);
     }
-    case "Keyword": {
-      return n.name;
-    }
-    case "TypeAnnotatedIdentifier":
-      return concat([
-        path.call(print, "annotation"),
-        " ",
-        path.call(print, "identifier")
-      ]);
     case "ClassBody":
       if (!n.comments && n.body.length === 0) {
         return "{}";
@@ -1844,17 +1801,6 @@ function genericPrintNoParens(path, options, print, args) {
         hardline,
         "}"
       ]);
-    case "ClassPropertyDefinition":
-      parts.push("static ", path.call(print, "definition"));
-
-      if (
-        n.definition.type !== "MethodDefinition" &&
-        n.definition.type !== "TSAbstractMethodDefinition"
-      ) {
-        parts.push(semi);
-      }
-
-      return concat(parts);
     case "ClassProperty":
     case "TSAbstractClassProperty": {
       if (n.accessibility) {
@@ -1913,13 +1859,6 @@ function genericPrintNoParens(path, options, print, args) {
       }
 
       return concat(parts);
-    case "TSHeritageClause":
-      return join(", ", path.map(print, "types"));
-    case "TSExpressionWithTypeArguments":
-      return concat([
-        path.call(print, "expression"),
-        printTypeParameters(path, options, print, "typeArguments")
-      ]);
     case "TemplateElement":
       return join(literalline, n.value.raw.split(/\r?\n/g));
     case "TemplateLiteral": {
@@ -2378,8 +2317,6 @@ function genericPrintNoParens(path, options, print, args) {
       return concat(["typeof ", path.call(print, "argument")]);
     case "VoidTypeAnnotation":
       return "void";
-    case "NullTypeAnnotation":
-      return "null";
     case "InferredPredicate":
       return "%checks";
     // Unhandled types below. If encountered, nodes of these types should
@@ -2387,12 +2324,8 @@ function genericPrintNoParens(path, options, print, args) {
     // supported by the pretty-printer.
     case "DeclaredPredicate":
       return concat(["%checks(", path.call(print, "value"), ")"]);
-    case "TSAbstractKeyword":
-      return "abstract";
     case "TSAnyKeyword":
       return "any";
-    case "TSAsyncKeyword":
-      return "async";
     case "TSBooleanKeyword":
       return "boolean";
     case "TSConstKeyword":
@@ -2407,18 +2340,10 @@ function genericPrintNoParens(path, options, print, args) {
       return "number";
     case "TSObjectKeyword":
       return "object";
-    case "TSProtectedKeyword":
-      return "protected";
-    case "TSPrivateKeyword":
-      return "private";
-    case "TSPublicKeyword":
-      return "public";
     case "TSReadonlyKeyword":
       return "readonly";
     case "TSSymbolKeyword":
       return "symbol";
-    case "TSStaticKeyword":
-      return "static";
     case "TSStringKeyword":
       return "string";
     case "TSUndefinedKeyword":
@@ -3135,7 +3060,6 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
     "ThisTypeAnnotation",
     "NumberTypeAnnotation",
     "VoidTypeAnnotation",
-    "NullTypeAnnotation",
     "EmptyTypeAnnotation",
     "MixedTypeAnnotation",
     "BooleanTypeAnnotation",
@@ -3314,57 +3238,49 @@ function printExportDeclaration(path, options, print) {
     }
   } else {
     if (decl.specifiers && decl.specifiers.length > 0) {
-      if (
-        decl.specifiers.length === 1 &&
-        decl.specifiers[0].type === "ExportBatchSpecifier"
-      ) {
-        parts.push("*");
-      } else {
-        const specifiers = [];
-        const defaultSpecifiers = [];
-        const namespaceSpecifiers = [];
+      const specifiers = [];
+      const defaultSpecifiers = [];
+      const namespaceSpecifiers = [];
+      path.each(specifierPath => {
+        const specifierType = path.getValue().type;
+        if (specifierType === "ExportSpecifier") {
+          specifiers.push(print(specifierPath));
+        } else if (specifierType === "ExportDefaultSpecifier") {
+          defaultSpecifiers.push(print(specifierPath));
+        } else if (specifierType === "ExportNamespaceSpecifier") {
+          namespaceSpecifiers.push(concat(["* as ", print(specifierPath)]));
+        }
+      }, "specifiers");
 
-        path.each(specifierPath => {
-          const specifierType = path.getValue().type;
-          if (specifierType === "ExportSpecifier") {
-            specifiers.push(print(specifierPath));
-          } else if (specifierType === "ExportDefaultSpecifier") {
-            defaultSpecifiers.push(print(specifierPath));
-          } else if (specifierType === "ExportNamespaceSpecifier") {
-            namespaceSpecifiers.push(concat(["* as ", print(specifierPath)]));
-          }
-        }, "specifiers");
+      const isNamespaceFollowed =
+        namespaceSpecifiers.length !== 0 &&
+        (specifiers.length !== 0 || defaultSpecifiers.length !== 0);
+      const isDefaultFollowed =
+        defaultSpecifiers.length !== 0 && specifiers.length !== 0;
 
-        const isNamespaceFollowed =
-          namespaceSpecifiers.length !== 0 &&
-          (specifiers.length !== 0 || defaultSpecifiers.length !== 0);
-        const isDefaultFollowed =
-          defaultSpecifiers.length !== 0 && specifiers.length !== 0;
-
-        parts.push(
-          decl.exportKind === "type" ? "type " : "",
-          concat(namespaceSpecifiers),
-          concat([isNamespaceFollowed ? ", " : ""]),
-          concat(defaultSpecifiers),
-          concat([isDefaultFollowed ? ", " : ""]),
-          specifiers.length !== 0
-            ? group(
-                concat([
-                  "{",
-                  indent(
-                    concat([
-                      options.bracketSpacing ? line : softline,
-                      join(concat([",", line]), specifiers)
-                    ])
-                  ),
-                  ifBreak(shouldPrintComma(options) ? "," : ""),
-                  options.bracketSpacing ? line : softline,
-                  "}"
-                ])
-              )
-            : ""
-        );
-      }
+      parts.push(
+        decl.exportKind === "type" ? "type " : "",
+        concat(namespaceSpecifiers),
+        concat([isNamespaceFollowed ? ", " : ""]),
+        concat(defaultSpecifiers),
+        concat([isDefaultFollowed ? ", " : ""]),
+        specifiers.length !== 0
+          ? group(
+              concat([
+                "{",
+                indent(
+                  concat([
+                    options.bracketSpacing ? line : softline,
+                    join(concat([",", line]), specifiers)
+                  ])
+                ),
+                ifBreak(shouldPrintComma(options) ? "," : ""),
+                options.bracketSpacing ? line : softline,
+                "}"
+              ])
+            )
+          : ""
+      );
     } else {
       parts.push("{}");
     }

--- a/src/printer.js
+++ b/src/printer.js
@@ -186,10 +186,7 @@ function genericPrint(path, options, printPath, args) {
     path.each(
       decoratorPath => {
         const decorator = decoratorPath.getValue();
-        const prefix =
-          decorator.type === "Decorator"
-            ? ""
-            : "@";
+        const prefix = decorator.type === "Decorator" ? "" : "@";
         decorators.push(prefix, printPath(decoratorPath), hardline);
       },
       "declaration",

--- a/src/printer.js
+++ b/src/printer.js
@@ -989,7 +989,8 @@ function genericPrintNoParens(path, options, print, args) {
             leftBrace,
             comments.printDanglingComments(path, options),
             softline,
-            rightBrace
+            rightBrace,
+            n.optional ? "?" : ""
           ])
         );
       } else {
@@ -1005,6 +1006,7 @@ function genericPrintNoParens(path, options, print, args) {
               : ""
           ),
           concat([options.bracketSpacing ? line : softline, rightBrace]),
+          n.optional ? "?" : "",
           n.typeAnnotation ? ": " : "",
           path.call(print, "typeAnnotation")
         ]);
@@ -1134,6 +1136,10 @@ function genericPrintNoParens(path, options, print, args) {
             ])
           )
         );
+      }
+
+      if (n.optional) {
+        parts.push("?");
       }
 
       if (n.typeAnnotation) {
@@ -2321,8 +2327,12 @@ function genericPrintNoParens(path, options, print, args) {
     // supported by the pretty-printer.
     case "DeclaredPredicate":
       return concat(["%checks(", path.call(print, "value"), ")"]);
+    case "TSAbstractKeyword":
+      return "abstract";
     case "TSAnyKeyword":
       return "any";
+    case "TSAsyncKeyword":
+      return "async";
     case "TSBooleanKeyword":
       return "boolean";
     case "TSConstKeyword":
@@ -2337,10 +2347,18 @@ function genericPrintNoParens(path, options, print, args) {
       return "number";
     case "TSObjectKeyword":
       return "object";
+    case "TSProtectedKeyword":
+      return "protected";
+    case "TSPrivateKeyword":
+      return "private";
+    case "TSPublicKeyword":
+      return "public";
     case "TSReadonlyKeyword":
       return "readonly";
     case "TSSymbolKeyword":
       return "symbol";
+    case "TSStaticKeyword":
+      return "static";
     case "TSStringKeyword":
       return "string";
     case "TSUndefinedKeyword":

--- a/src/util.js
+++ b/src/util.js
@@ -3,7 +3,6 @@
 function isExportDeclaration(node) {
   if (node) {
     switch (node.type) {
-      case "ExportDeclaration":
       case "ExportDefaultDeclaration":
       case "ExportDefaultSpecifier":
       case "DeclareExportDeclaration":

--- a/tests/flow_type_declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_type_declarations/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`declare_type.js 1`] = `
+declare type A = string;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+declare type A = string;
+
+`;
+
 exports[`long.js 1`] = `
 export type AdamPlacementValidationSingleErrorKey =
   'SOME_FANCY_TARGETS.GLOBAL_TARGET';

--- a/tests/flow_type_declarations/declare_type.js
+++ b/tests/flow_type_declarations/declare_type.js
@@ -1,0 +1,1 @@
+declare type A = string;

--- a/tests/import_meta/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/import_meta/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`import_meta.js 1`] = `
+const x = import.meta;
+const url = import.meta.url;
+import.meta;
+import.meta.url;
+import.meta.couldBeMutable = true;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const x = import.meta;
+const url = import.meta.url;
+import.meta;
+import.meta.url;
+import.meta.couldBeMutable = true;
+
+`;

--- a/tests/import_meta/import_meta.js
+++ b/tests/import_meta/import_meta.js
@@ -1,0 +1,5 @@
+const x = import.meta;
+const url = import.meta.url;
+import.meta;
+import.meta.url;
+import.meta.couldBeMutable = true;

--- a/tests/import_meta/jsfmt.spec.js
+++ b/tests/import_meta/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "babylon" });

--- a/tests/jsx_namespace/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx_namespace/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`jsx_namespaced_name.js 1`] = `
+<jsx:namespacedname />;
+
+<jsx:namespacedname>1</jsx:namespacedname>;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<jsx:namespacedname />;
+
+<jsx:namespacedname>1</jsx:namespacedname>;
+
+`;

--- a/tests/jsx_namespace/jsfmt.spec.js
+++ b/tests/jsx_namespace/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, null, ["babylon"]);

--- a/tests/jsx_namespace/jsx_namespaced_name.js
+++ b/tests/jsx_namespace/jsx_namespaced_name.js
@@ -1,0 +1,3 @@
+<jsx:namespacedname />;
+
+<jsx:namespacedname>1</jsx:namespacedname>;

--- a/tests/typescript_destructuring/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_destructuring/__snapshots__/jsfmt.spec.js.snap
@@ -2,7 +2,13 @@
 
 exports[`destructuring.ts 1`] = `
 ({ foo = [] } = bar);
+
+function f({ x }?) {}
+function g([ x ]?) {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ({ foo = [] } = bar);
+
+function f({ x }?) {}
+function g([x]?) {}
 
 `;

--- a/tests/typescript_destructuring/destructuring.ts
+++ b/tests/typescript_destructuring/destructuring.ts
@@ -1,1 +1,4 @@
 ({ foo = [] } = bar);
+
+function f({ x }?) {}
+function g([ x ]?) {}

--- a/tests/typescript_keywords/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_keywords/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,89 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`keywords.js 1`] = `
+// All of these should be an error
+
+module Y3 {
+    public module Module {
+        class A { s: string }
+    }
+
+    // Apparently this parses :P
+    export private public protected static readonly async enum X { }
+}
+
+module Y4 {
+    public enum Color { Blue, Red }
+}
+
+module YY3 {
+    private module Module {
+        class A { s: string }
+    }
+}
+
+module YY4 {
+    private enum Color { Blue, Red }
+}
+
+module YYY3 {
+    static module Module {
+        class A { s: string }
+    }
+}
+
+module YYY4 {
+    static enum Color { Blue, Red }
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// All of these should be an error
+
+namespace Y3 {
+  public namespace Module {
+    class A {
+      s: string;
+    }
+  }
+
+  // Apparently this parses :P
+  export private public protected static readonly async enum X {}
+}
+
+namespace Y4 {
+  public enum Color {
+    Blue,
+    Red
+  }
+}
+
+namespace YY3 {
+  private namespace Module {
+    class A {
+      s: string;
+    }
+  }
+}
+
+namespace YY4 {
+  private enum Color {
+    Blue,
+    Red
+  }
+}
+
+namespace YYY3 {
+  static namespace Module {
+    class A {
+      s: string;
+    }
+  }
+}
+
+namespace YYY4 {
+  static enum Color {
+    Blue,
+    Red
+  }
+}
+
+`;

--- a/tests/typescript_keywords/jsfmt.spec.js
+++ b/tests/typescript_keywords/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "typescript" });

--- a/tests/typescript_keywords/keywords.js
+++ b/tests/typescript_keywords/keywords.js
@@ -1,0 +1,34 @@
+// All of these should be an error
+
+module Y3 {
+    public module Module {
+        class A { s: string }
+    }
+
+    // Apparently this parses :P
+    export private public protected static readonly async enum X { }
+}
+
+module Y4 {
+    public enum Color { Blue, Red }
+}
+
+module YY3 {
+    private module Module {
+        class A { s: string }
+    }
+}
+
+module YY4 {
+    private enum Color { Blue, Red }
+}
+
+module YYY3 {
+    static module Module {
+        class A { s: string }
+    }
+}
+
+module YYY4 {
+    static enum Color { Blue, Red }
+}


### PR DESCRIPTION
* Cleanup unused AST nodes
* Add tests for JSXNamespacedName
* **Turn on importMeta babylon plugin**
* Add tests for DeclareTypeAlias

This actually caught a minor issue, we didn't have the `importMeta` babylon plugin turned on. [repro](https://prettier.io/playground/#%7B%22content%22%3A%22const%20x%20%3D%20import.meta%3B%5Cnconst%20url%20%3D%20import.meta.url%3B%5Cnimport.meta%3B%5Cnimport.meta.url%3B%5Cnimport.meta.couldBeMutable%20%3D%20true%3B%5Cn%22%2C%22options%22%3A%7B%22printWidth%22%3A80%2C%22tabWidth%22%3A2%2C%22singleQuote%22%3Afalse%2C%22trailingComma%22%3A%22none%22%2C%22bracketSpacing%22%3Atrue%2C%22jsxBracketSameLine%22%3Afalse%2C%22parser%22%3A%22babylon%22%2C%22semi%22%3Atrue%2C%22useTabs%22%3Afalse%2C%22doc%22%3Afalse%2C%22ast%22%3Atrue%7D%7D)

There's still a lot of `TS*Keyword` nodes that _are_ used, though, so I'm not sure if its 100% safe to remove all the TS nodes that I did.