### PR TITLE
CSS Modules: respect print width when composing local and global classes

### DIFF
--- a/src/printer-postcss.js
+++ b/src/printer-postcss.js
@@ -73,17 +73,22 @@ function genericPrint(path, options, print) {
         n.value.group.type === "value-value" &&
         n.value.group.group.type === "value-func" &&
         n.value.group.group.value === "extend";
-      const isComposed =
+
+      const isComposedAndExternal =
         n.value.type === "value-root" &&
         n.value.group.type === "value-value" &&
-        n.prop === "composes";
+        n.prop === "composes" &&
+        n.value.group.group.groups &&
+        n.value.group.group.groups.some(
+          node => node.type === "value-word" && node.value === "from"
+        );
 
       return concat([
         n.raws.before.replace(/[\s;]/g, ""),
         n.prop,
         ":",
         isValueExtend ? "" : " ",
-        isComposed
+        isComposedAndExternal
           ? removeLines(path.call(print, "value"))
           : path.call(print, "value"),
         n.important ? " !important" : "",

--- a/tests/css_composes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_composes/__snapshots__/jsfmt.spec.js.snap
@@ -10,3 +10,43 @@ exports[`composes.css 1`] = `
 }
 
 `;
+
+exports[`composes_global_classes.css 1`] = `
+.reference0 {
+  composes: global(class1) global(class2) global(class3) global(class4) global(longClassNameLongClassNameLongClassNameLongClassName) global(class5);
+}
+
+.reference1 {
+  composes: global(class);
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.reference0 {
+  composes: global(class1) global(class2) global(class3) global(class4)
+    global(longClassNameLongClassNameLongClassNameLongClassName) global(class5);
+}
+
+.reference1 {
+  composes: global(class);
+}
+
+`;
+
+exports[`composes_local_classes.css 1`] = `
+.reference0 {
+  composes: class1 class2 class3 class4 longClassNameLongClassNameLongClassNameLongClassName class5;
+}
+
+.reference1 {
+  composes: class;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.reference0 {
+  composes: class1 class2 class3 class4
+    longClassNameLongClassNameLongClassNameLongClassName class5;
+}
+
+.reference1 {
+  composes: class;
+}
+
+`;

--- a/tests/css_composes/composes_global_classes.css
+++ b/tests/css_composes/composes_global_classes.css
@@ -1,0 +1,7 @@
+.reference0 {
+  composes: global(class1) global(class2) global(class3) global(class4) global(longClassNameLongClassNameLongClassNameLongClassName) global(class5);
+}
+
+.reference1 {
+  composes: global(class);
+}

--- a/tests/css_composes/composes_local_classes.css
+++ b/tests/css_composes/composes_local_classes.css
@@ -1,0 +1,7 @@
+.reference0 {
+  composes: class1 class2 class3 class4 longClassNameLongClassNameLongClassNameLongClassName class5;
+}
+
+.reference1 {
+  composes: class;
+}


### PR DESCRIPTION
Context: https://github.com/prettier/prettier/issues/2391
Previous work: https://github.com/prettier/prettier/pull/2190

This PR breaks `composes` into multiple lines when it doesn't contain external classes.

For example, the following selector:
```.css
.reference {
  composes: global(class1) global(class2) global(class3) global(class4) global(longClassNameLongClassNameLongClassNameLongClassName) global(class5);
}
```
is formatted to:
```.css
.reference {
  composes: global(class1) global(class2) global(class3) global(class4)
    global(longClassNameLongClassNameLongClassNameLongClassName) global(class5);
}
```
like in prettier 1.4.x

---

I kept the original behaviour introduced in https://github.com/prettier/prettier/pull/2190, so that for example:

```.css
.reference {
  composes: selector from "a/long/file/path/exceeding/the/maximum/length/forcing/a/line-wrap/file.css";
}
```
stays in a single line, but I'm not entirely sure if it's needed, as the latest version of [`css-loader`](https://github.com/moretti/css-modules-test/blob/master/src/index.css#L2) doesn't seem to have any issue with multi-line `composes`.
