### PR TITLE
Update tsep and account for TSTypeReference change

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "postcss-values-parser": "git://github.com/shellscape/postcss-values-parser.git#5e351360479116f3fe309602cdd15b0a233bc29f",
     "strip-bom": "3.0.0",
     "typescript": "2.5.0-dev.20170617",
-    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#7c38401aa1452e6cc493151b8ab3a591e4d5e74a"
+    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#e1db075b938bf74acfe16c6f3e63dc4dc12c0e58"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",

--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -351,7 +351,8 @@ FastPath.prototype.needsParens = function(options) {
         (parent.type === "TypeParameter" ||
           parent.type === "VariableDeclarator" ||
           parent.type === "TypeAnnotation" ||
-          parent.type === "GenericTypeAnnotation") &&
+          parent.type === "GenericTypeAnnotation" ||
+          parent.type === "TSTypeReference") &&
         (node.typeAnnotation.type === "TypeAnnotation" &&
           node.typeAnnotation.typeAnnotation.type !== "TSFunctionType" &&
           grandParent.type !== "TSTypeOperator")

--- a/src/printer.js
+++ b/src/printer.js
@@ -3287,6 +3287,8 @@ function printTypeParameters(path, options, print, paramsKey) {
     (shouldHugType(n[paramsKey][0]) ||
       (n[paramsKey][0].type === "GenericTypeAnnotation" &&
         shouldHugType(n[paramsKey][0].id)) ||
+      (n[paramsKey][0].type === "TSTypeReference" &&
+        shouldHugType(n[paramsKey][0].typeName)) ||
       n[paramsKey][0].type === "NullableTypeAnnotation");
 
   if (shouldInline) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3812,9 +3812,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#7c38401aa1452e6cc493151b8ab3a591e4d5e74a":
+"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#e1db075b938bf74acfe16c6f3e63dc4dc12c0e58":
   version "4.0.0"
-  resolved "git://github.com/eslint/typescript-eslint-parser.git#7c38401aa1452e6cc493151b8ab3a591e4d5e74a"
+  resolved "git://github.com/eslint/typescript-eslint-parser.git#e1db075b938bf74acfe16c6f3e63dc4dc12c0e58"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.3.0"


### PR DESCRIPTION
In order to resolve https://github.com/JamesHenry/tsep-babylon-test/issues/5, tsep has been updated.

We are now explicitly using `TSTypeReference` in places where we previously used `GenericTypeAnnotation` (please see that issue for more context).

I have updated the dependency and made one minor code change to account for parens, but there is one broken test remaining and its failure is subjective so I just wanted to leave it open for now.

The case for printing `GenericTypeAnnotation` (and therefore the current behaviour on master is:

```js
case "GenericTypeAnnotation":
      return concat([
        path.call(print, "id"),
        path.call(print, "typeParameters")
      ]);
``` 

The case for printing `TSTypeReference` (and therefore breaking the 1 remaining test):

```js
case "TSTypeReference":
      return concat([
        path.call(print, "typeName"),
        printTypeParameters(path, options, print, "typeParameters")
      ]);
```

It seems strange that the handling of `typeParameters` in the above two cases is inconsistent - is this just an oversight?

The failing test diff looks like this:

<img width="663" alt="screen shot 2017-07-19 at 18 21 32" src="https://user-images.githubusercontent.com/900523/28380687-2212d0ae-6cb0-11e7-9dd8-5b22638ad959.png">

As I say, this is subjective and we could arguably opt for either one in this case. Just let me know what you think @azz @vjeux 