### PR TITLE
Fix variable name in git precommit example

### DIFF
--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -154,10 +154,10 @@ jsfiles=$(git diff --cached --name-only --diff-filter=ACM | grep '\.jsx\?$' | tr
 [ -z "$jsfiles" ] && exit 0
 
 # Prettify all staged .js files
-echo "jsfiles" | xargs ./node_modules/.bin/prettier --write
+echo "$jsfiles" | xargs ./node_modules/.bin/prettier --write
 
 # Add back the modified/prettified files to staging
-echo "jsfiles" | xargs git add
+echo "$jsfiles" | xargs git add
 
 exit 0
 ```


### PR DESCRIPTION
echo "jsfiles" will not work. The example references a variable, not a static string. This commit makes the example functionally correct.