### PR TITLE
Add support for flow opaque types

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dashify": "0.2.2",
     "diff": "3.2.0",
     "esutils": "2.0.2",
-    "flow-parser": "0.47.0",
+    "flow-parser": "0.51.0",
     "get-stream": "3.0.0",
     "globby": "^6.1.0",
     "graphql": "0.10.1",

--- a/src/printer.js
+++ b/src/printer.js
@@ -1966,6 +1966,31 @@ function genericPrintNoParens(path, options, print, args) {
       return concat(["declare export * from ", path.call(print, "source")]);
     case "DeclareExportDeclaration":
       return concat(["declare ", printExportDeclaration(path, options, print)]);
+    case "DeclareOpaqueType":
+    case "OpaqueType": {
+      parts.push(
+        "opaque type ",
+        path.call(print, "id"),
+        path.call(print, "typeParameters")
+      );
+
+      if (n.supertype) {
+        parts.push(": ", path.call(print, "supertype"));
+      }
+
+      if (n.impltype) {
+        parts.push(" = ", path.call(print, "impltype"));
+      }
+
+      parts.push(semi);
+
+      if (n.type === "DeclareOpaqueType") {
+        return printFlowDeclaration(path, parts);
+      }
+
+      return concat(parts);
+    }
+
     case "FunctionTypeAnnotation":
     case "TSFunctionType": {
       // FunctionTypeAnnotation is ambiguous:

--- a/tests/flow_type_declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_type_declarations/__snapshots__/jsfmt.spec.js.snap
@@ -27,3 +27,36 @@ export type SomeOtherLongLongLongLongLongLongLongLongLongLongLongLongLongLongKey
 type SomeOtherLongLongLongLongLongLongLongLongLongLongLongLongLongLongKey = SomeReallyLongLongLongLongLongLongIdentifier;
 
 `;
+
+exports[`opaque.js 1`] = `
+declare export opaque type Foo;
+declare export opaque type Bar<T>;
+declare export opaque type Baz: Foo;
+declare export opaque type Foo<T>: Bar<T>;
+declare export opaque type Foo<T>: Bar;
+declare export opaque type Foo: Bar<T>;
+opaque type ID = string;
+opaque type Foo<T> = Bar<T>;
+opaque type Maybe<T> = _Maybe<T, *>;
+export opaque type Foo = number;
+opaque type union =
+ | {type: "A"}
+ | {type: "B"};
+opaque type overloads =
+  & ((x: string) => number)
+  & ((x: number) => string);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+declare export opaque type Foo;
+declare export opaque type Bar<T>;
+declare export opaque type Baz: Foo;
+declare export opaque type Foo<T>: Bar<T>;
+declare export opaque type Foo<T>: Bar;
+declare export opaque type Foo: Bar<T>;
+opaque type ID = string;
+opaque type Foo<T> = Bar<T>;
+opaque type Maybe<T> = _Maybe<T, *>;
+export opaque type Foo = number;
+opaque type union = { type: "A" } | { type: "B" };
+opaque type overloads = ((x: string) => number) & ((x: number) => string);
+
+`;

--- a/tests/flow_type_declarations/opaque.js
+++ b/tests/flow_type_declarations/opaque.js
@@ -1,0 +1,16 @@
+declare export opaque type Foo;
+declare export opaque type Bar<T>;
+declare export opaque type Baz: Foo;
+declare export opaque type Foo<T>: Bar<T>;
+declare export opaque type Foo<T>: Bar;
+declare export opaque type Foo: Bar<T>;
+opaque type ID = string;
+opaque type Foo<T> = Bar<T>;
+opaque type Maybe<T> = _Maybe<T, *>;
+export opaque type Foo = number;
+opaque type union =
+ | {type: "A"}
+ | {type: "B"};
+opaque type overloads =
+  & ((x: string) => number)
+  & ((x: number) => string);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1545,9 +1545,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-parser@0.47.0:
-  version "0.47.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.47.0.tgz#c57d35ff19bb40fb0f07222298e58cd4afa8a59a"
+flow-parser@0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.51.0.tgz#e1c0ceb6f802ba21d16c2fda8e42c824f40f4684"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Support added in Babylon 7.0.0-beta.17 and Flow 0.51