### PR TITLE
Don't pass config path through to cosmiconfig

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -108,8 +108,12 @@ if (argv["find-config-path"] && filepatterns.length) {
 }
 
 function getOptionsForFile(filePath) {
-  return resolver
-    .resolveConfig(filePath, { configFile: argv["config"] })
+  const optionsPromise =
+    argv["config"] === false
+      ? Promise.resolve(null)
+      : resolver.resolveConfig(filePath);
+
+  return optionsPromise
     .then(options => {
       const parsedArgs = minimist(args, {
         boolean: booleanOptionNames,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "babel-code-frame": "7.0.0-alpha.12",
     "babylon": "7.0.0-beta.17",
     "chalk": "2.0.1",
-    "cosmiconfig": "2.1.3",
+    "cosmiconfig": "2.2.2",
     "dashify": "0.2.2",
     "diff": "3.2.0",
     "esutils": "2.0.2",

--- a/src/resolve-config.js
+++ b/src/resolve-config.js
@@ -8,26 +8,16 @@ const withCache = cosmiconfig("prettier");
 const noCache = cosmiconfig("prettier", { cache: false });
 
 function resolveConfig(filePath, opts) {
-  if (opts && opts.configFile === false) {
-    // do not look for a config file
-    return Promise.resolve(null);
-  }
-
   const useCache = !(opts && opts.useCache === false);
   const fileDir = filePath ? path.dirname(filePath) : undefined;
 
-  return (
-    (useCache ? withCache : noCache)
-      // https://github.com/davidtheclark/cosmiconfig/pull/68
-      .load(fileDir, opts && opts.configFile)
-      .then(result => {
-        if (!result) {
-          return null;
-        }
+  return (useCache ? withCache : noCache).load(fileDir).then(result => {
+    if (!result) {
+      return null;
+    }
 
-        return mergeOverrides(result.config, filePath);
-      })
-  );
+    return mergeOverrides(result.config, filePath);
+  });
 }
 
 function clearCache() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1020,9 +1020,9 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cosmiconfig@2.1.3:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-2.1.3.tgz#952771eb0dddc1cb3fa2f6fbe51a522e93b3ee0a"
+cosmiconfig@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-2.2.2.tgz#6173cebd56fac042c1f4390edf7af6c07c7cb892"
   dependencies:
     is-directory "^0.3.1"
     js-yaml "^3.4.3"


### PR DESCRIPTION
Due to a small bug in cosmiconfig (which I fixed in https://github.com/davidtheclark/cosmiconfig/pull/68), I had to pass the config path from our `argv` all the way to `cosmiconfig`, despite it already parsing the `process.argv` itself.

As this is fixed we no longer need to do this.