### PR TITLE
Remove .npmignore and update .ignore

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,6 +1,3 @@
-docs/index.js
-docs/parser-babylon.js
-docs/parser-flow.js
-docs/parser-postcss.js
-docs/parser-typescript.js
+website/static/lib
 dist
+

--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-yarn.lock
-tests
-tests_config


### PR DESCRIPTION
`.ignore` file was out of date since the new website was built.

`.npmignore` is no longer needed as we publish from the `dist/` directory.