### PR TITLE
Keep parens around FunctionTypeAnnotation inside ArrayTypeAnnotation

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -445,7 +445,8 @@ FastPath.prototype.needsParens = function(options) {
     case "FunctionTypeAnnotation":
       return (
         parent.type === "UnionTypeAnnotation" ||
-        parent.type === "IntersectionTypeAnnotation"
+        parent.type === "IntersectionTypeAnnotation" ||
+        parent.type === "ArrayTypeAnnotation"
       );
 
     case "StringLiteral":

--- a/tests/flow_annotation/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_annotation/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`array_of_functions.js 1`] = `
+const actionArray: (() => void)[] = [];
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const actionArray: (() => void)[] = [];
+
+`;

--- a/tests/flow_annotation/array_of_functions.js
+++ b/tests/flow_annotation/array_of_functions.js
@@ -1,0 +1,1 @@
+const actionArray: (() => void)[] = [];

--- a/tests/flow_annotation/jsfmt.spec.js
+++ b/tests/flow_annotation/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, null, ["babylon"]);


### PR DESCRIPTION
Without this, this:

    const actionArray: (() => void)[] = [];

is formatted as:

    const actionArray: () => void[] = [];

Fixes #2559