### PR TITLE
Update README.md to add a notice about using lint-staged

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ and add this config to your `package.json`:
   }
 }
 ```
-There is a limitation where if you use the [Github Desktop](https://desktop.github.com/) app to commit specific lines, this approach will stage the whole file after regardless. See this [issue](https://github.com/okonet/lint-staged/issues/62) for more info.
+There is a limitation where if you stage specific lines this approach will stage the whole file after regardless. See this [issue](https://github.com/okonet/lint-staged/issues/62) for more info.
 
 See https://github.com/okonet/lint-staged#configuration for more details about how you can configure lint-staged.
 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ There is a limitation where if you use the [Github Desktop](https://desktop.gith
 
 See https://github.com/okonet/lint-staged#configuration for more details about how you can configure lint-staged.
 
+
 ##### Option 2. [pre-commit](https://github.com/pre-commit/pre-commit)
 
 Copy the following config into your `.pre-commit-config.yaml` file:

--- a/README.md
+++ b/README.md
@@ -342,9 +342,9 @@ and add this config to your `package.json`:
   }
 }
 ```
+There is a limitation where if you use the [Github Desktop](https://desktop.github.com/) app to commit specific lines, this approach will stage the whole file after regardless. See this [issue](https://github.com/okonet/lint-staged/issues/62) for more info.
 
 See https://github.com/okonet/lint-staged#configuration for more details about how you can configure lint-staged.
-
 
 ##### Option 2. [pre-commit](https://github.com/pre-commit/pre-commit)
 


### PR DESCRIPTION
The lint-staged example under pre-commit hooks has a limitation where if you use the [Github Desktop](https://desktop.github.com/) app to commit specific lines, this approach will stage the whole file after regardless. See this [issue](https://github.com/okonet/lint-staged/issues/62) for more info.