### PR TITLE
Purge usage of `.eslintrc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Just add Prettier as an ESLint rule using [eslint-plugin-prettier](https://githu
 ```js
 yarn add --dev prettier eslint-plugin-prettier
 
-// .eslintrc
+// .eslintrc.json
 {
   "plugins": [
     "prettier"

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -71,7 +71,7 @@ Just add Prettier as an ESLint rule using [eslint-plugin-prettier](https://githu
 ```js
 yarn add --dev prettier eslint-plugin-prettier
 
-// .eslintrc
+// .eslintrc.json
 {
   "plugins": [
     "prettier"


### PR DESCRIPTION
Because `.eslintrc` is deprecated and should not be used anymore.