### PR TITLE
Update website setup to use latest version of Docusaurus

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-prettier.io

--- a/docs/editors.md
+++ b/docs/editors.md
@@ -1,10 +1,6 @@
 ---
 id: editors
 title: Editor Integration
-layout: docs
-category: Prettier
-permalink: docs/en/editors.html
-previous: options
 ---
 
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -1,11 +1,6 @@
 ---
 id: options
 title: Options
-layout: docs
-category: Prettier
-permalink: docs/en/options.html
-previous: usage
-next: editors
 ---
 
 Prettier ships with a handful of customizable format options, usable in both the CLI and API.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,11 +1,6 @@
 ---
 id: usage
 title: Usage
-layout: docs
-category: Prettier
-permalink: docs/en/usage.html
-previous: why-prettier
-next: options
 ---
 
 

--- a/docs/why-prettier.md
+++ b/docs/why-prettier.md
@@ -1,10 +1,6 @@
 ---
 id: why-prettier
 title: Why Prettier?
-layout: docs
-category: Prettier
-permalink: docs/en/why-prettier.html
-next: usage
 ---
 
 ## Building and enforcing a style guide

--- a/website/package.json
+++ b/website/package.json
@@ -5,6 +5,6 @@
     "publish-gh-pages": "docusaurus-publish"
   },
   "devDependencies": {
-    "docusaurus": "^1.0.0-alpha.9"
+    "docusaurus": "^1.0.0-alpha.35"
   }
 }

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -1,0 +1,5 @@
+{
+  "docs": {
+    "Prettier": ["why-prettier", "usage", "options", "editors"]
+  }
+}

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -16,7 +16,7 @@ const siteConfig = {
   baseUrl: "/",
   projectName: PACKAGE.name,
   repo: PACKAGE.repository,
-  cname: "prettier.io"
+  cname: "prettier.io",
   users,
   editors,
   supportedLanguages,

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -16,45 +16,21 @@ const siteConfig = {
   baseUrl: "/",
   projectName: PACKAGE.name,
   repo: PACKAGE.repository,
+  cname: "prettier.io"
   users,
   editors,
   supportedLanguages,
   /* base url for editing docs, usage example: editUrl + 'en/doc1.md' */
   editUrl: `${GITHUB_URL}/edit/master/docs/`,
-  /* header links for links on this site, 'LANGUAGE' will be replaced by whatever
-     language the page is for, ex: 'en' */
-  headerLinksInternal: [
-    {
-      section: "docs",
-      href: "/docs/LANGUAGE/why-prettier.html",
-      text: "Docs"
-    },
-    // { section: "help", href: "/LANGUAGE/help/", text: "Help" },
-    // {section: 'blog', href: '/test-site/blog', text: 'Blog'},
-    {
-      section: "playground",
-      href: "/playground/",
-      text: "Playground"
-    }
-  ],
-  /* header links for links outside the site */
-  headerLinksExternal: [
-    {
-      section: "github",
-      href: GITHUB_URL,
-      text: "GitHub"
-    }
+  headerLinks: [
+    { doc: "why-prettier", label: "Docs" },
+    { href: "/playground/", label: "Playground" },
+    { href: GITHUB_URL, label: "GitHub" }
   ],
   /* path to images for header/footer */
   headerIcon: "icon.png",
   footerIcon: "icon.png",
   favicon: "icon.png",
-  /* default link for docsSidebar */
-  docsSidebarDefaults: {
-    layout: "docs",
-    root: "/docs/en/why-prettier.html",
-    title: "Docs"
-  },
   /* colors for website */
   colors: {
     primaryColor: "#1A2B34",
@@ -62,28 +38,8 @@ const siteConfig = {
     prismColor:
       "rgba(26, 43, 52, 0.03)" /* primaryColor in rgba form, with 0.03 alpha */
   },
-  tagline: "Opinionated Code Formatter"
+  tagline: "Opinionated Code Formatter",
+  useEnglishUrl: true
 };
-
-let languages;
-if (fs.existsSync("./languages.js")) {
-  languages = require("./languages.js");
-  siteConfig["en"] = require("./i18n/en.js");
-} else {
-  languages = [
-    {
-      enabled: true,
-      name: "English",
-      tag: "en"
-    }
-  ];
-}
-
-const enabledLanguages = languages.filter(lang => lang.enabled);
-
-siteConfig.languages = enabledLanguages;
-
-/* INJECT LOCALIZED FILES BEGIN */
-/* INJECT LOCALIZED FILES END */
 
 module.exports = siteConfig;

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const fs = require("fs");
-
 const PACKAGE = require("../package");
 const GITHUB_URL = `https://github.com/${PACKAGE.repository}`;
 

--- a/website/static/CNAME
+++ b/website/static/CNAME
@@ -1,1 +1,0 @@
-prettier.io

--- a/website/users.json
+++ b/website/users.json
@@ -20,7 +20,7 @@
   {
     "caption": "Babel",
     "image": "/images/babel-200x100.png",
-    "infoLink": "https://babeljs.jo",
+    "infoLink": "https://babeljs.io",
     "pinned": true
   },
   {


### PR DESCRIPTION
Docusaurus, which is used to generate Prettier's website, will go through some API changes. The actual site will not change, but there are a few changes to how things are set-up. These are the changes I've made to the repo: 

- Move document markdown files from `docs/en` to `docs/`. Site urls will not be changed due to new `siteConfig` field, `useEnglishUrl: true`. If that field is removed, site urls will use, for example, `docs/why-prettier.html` instead of `docs/en/why-prettier.html`.
- Change document markdown headers to only use `id` and `title` fields. Sidebar information is now inside the `website/sidebars.json` file.
- Update `siteConfig.js` to remove unnecessary fields and update how header navbar links are made using `headerLinks`.
- Add new `cname` field to `siteConfig.js` so that the `CNAME` file will be automatically generated. Remove `CNAME` file from other places.
- Fix typo in `website/users.json`.

I will coordinate with @vjeux to merge this immediately after I publish the latest version of Docusaurus to npm.