### PR TITLE
Do not accept declare on previous line

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -4676,7 +4676,9 @@ function isNodeStartingWithDeclare(node, options) {
     return false;
   }
   return (
-    options.originalText.slice(0, util.locStart(node)).match(/declare\s*$/) ||
+    options.originalText
+      .slice(0, util.locStart(node))
+      .match(/declare[ \t]*$/) ||
     options.originalText
       .slice(node.range[0], node.range[1])
       .startsWith("declare ")

--- a/tests/typescript_declare/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_declare/__snapshots__/jsfmt.spec.js.snap
@@ -29,3 +29,18 @@ declare interface Dictionary<T> {
 }
 
 `;
+
+exports[`declare_var.ts 1`] = `
+// tslint:disable-next-line:no-use-before-declare
+const hello = 5;
+
+// tslint:disable-next-line:no-use-before-declare
+declare const hello = 5;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// tslint:disable-next-line:no-use-before-declare
+const hello = 5;
+
+// tslint:disable-next-line:no-use-before-declare
+declare const hello = 5;
+
+`;

--- a/tests/typescript_declare/declare_var.ts
+++ b/tests/typescript_declare/declare_var.ts
@@ -1,0 +1,5 @@
+// tslint:disable-next-line:no-use-before-declare
+const hello = 5;
+
+// tslint:disable-next-line:no-use-before-declare
+declare const hello = 5;


### PR DESCRIPTION
This will fix #2604, but not the general case, which is tracked in https://github.com/eslint/typescript-eslint-parser/issues/185. 