### PR TITLE
Update: tsep version upgrade and changes to TS enum structure

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "postcss-values-parser": "git://github.com/shellscape/postcss-values-parser.git#5e351360479116f3fe309602cdd15b0a233bc29f",
     "strip-bom": "3.0.0",
     "typescript": "2.5.0-dev.20170617",
-    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#e1db075b938bf74acfe16c6f3e63dc4dc12c0e58"
+    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#65b019ba9a10475af30e664ce38e550c21acdedd"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",

--- a/src/printer.js
+++ b/src/printer.js
@@ -2558,8 +2558,11 @@ function genericPrintNoParens(path, options, print, args) {
       if (n.modifiers) {
         parts.push(printTypeScriptModifiers(path, options, print));
       }
+      if (n.const) {
+        parts.push("const ");
+      }
 
-      parts.push("enum ", path.call(print, "name"), " ");
+      parts.push("enum ", path.call(print, "id"), " ");
 
       if (n.members.length === 0) {
         parts.push(
@@ -2598,7 +2601,7 @@ function genericPrintNoParens(path, options, print, args) {
 
       return concat(parts);
     case "TSEnumMember":
-      parts.push(path.call(print, "name"));
+      parts.push(path.call(print, "id"));
       if (n.initializer) {
         parts.push(" = ", path.call(print, "initializer"));
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3808,9 +3808,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#e1db075b938bf74acfe16c6f3e63dc4dc12c0e58":
-  version "4.0.0"
-  resolved "git://github.com/eslint/typescript-eslint-parser.git#e1db075b938bf74acfe16c6f3e63dc4dc12c0e58"
+"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#65b019ba9a10475af30e664ce38e550c21acdedd":
+  version "6.0.1"
+  resolved "git://github.com/eslint/typescript-eslint-parser.git#65b019ba9a10475af30e664ce38e550c21acdedd"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.3.0"


### PR DESCRIPTION
No changes for users, this is the latest version of `typescript-eslint-parser` and includes a structural change to TS enums