### PR TITLE
Work around issue #2584

### DIFF
--- a/src/parser-postcss.js
+++ b/src/parser-postcss.js
@@ -205,6 +205,17 @@ function requireParser(isSCSS) {
   if (isSCSS) {
     return require("postcss-scss");
   }
+
+  // TODO: Remove this hack when this issue is fixed:
+  // https://github.com/shellscape/postcss-less/issues/88
+  const LessParser = require("postcss-less/dist/less-parser");
+  LessParser.prototype.atrule = function() {
+    return Object.getPrototypeOf(LessParser.prototype).atrule.apply(
+      this,
+      arguments
+    );
+  };
+
   return require("postcss-less");
 }
 

--- a/tests/css_import/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_import/__snapshots__/jsfmt.spec.js.snap
@@ -7,6 +7,17 @@ exports[`directives.css 1`] = `
 
 `;
 
+exports[`multiple.css 1`] = `
+/* This isn't valid CSS, SCSS or Less, but we should be lenient and make sure
+/* that nothing is lost when printing. */
+@import "one" two "three";
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/* This isn't valid CSS, SCSS or Less, but we should be lenient and make sure
+/* that nothing is lost when printing. */
+@import "one" two "three";
+
+`;
+
 exports[`nodes.css 1`] = `
 @import "test.less" {}
 
@@ -15,7 +26,8 @@ exports[`nodes.css 1`] = `
   c: d;
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-@import "test.less";
+@import "test.less" {
+}
 
 @import "test.less" {
   a: b;

--- a/tests/css_import/multiple.css
+++ b/tests/css_import/multiple.css
@@ -1,0 +1,3 @@
+/* This isn't valid CSS, SCSS or Less, but we should be lenient and make sure
+/* that nothing is lost when printing. */
+@import "one" two "three";


### PR DESCRIPTION
parser-postcss parses `@import` at-rules specially, and unfortunately
buggily. This monkey-patches parser-postcss to parse all at-rules the
same way.

Fixes #2584.

postcss-less bug: https://github.com/shellscape/postcss-less/issues/88