### PR TITLE
Clarifying JSX Brackets option

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ Default | CLI Override | API Override
 `true` | `--no-bracket-spacing` | `bracketSpacing: <bool>`
 
 ### JSX Brackets
-Put the `>` of a multi-line JSX element at the end of the last line instead of being alone on the next line.
+Put the `>` of a multi-line JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
 
 Default | CLI Override | API Override
 --------|--------------|-------------


### PR DESCRIPTION
Thought the setting wasn't working properly when it didn't apply to self closing elements, and was about to open an issue until I found out it's working as intended.