### PR TITLE
Better fix for class comments

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -192,7 +192,6 @@ function attach(comments, ast, text) {
           comment
         ) ||
         handleTryStatementComments(enclosingNode, followingNode, comment) ||
-        handleClassComments(enclosingNode, comment) ||
         handleImportSpecifierComments(enclosingNode, comment) ||
         handleObjectPropertyComments(enclosingNode, comment) ||
         handleForComments(enclosingNode, precedingNode, comment) ||
@@ -247,7 +246,6 @@ function attach(comments, ast, text) {
           followingNode,
           comment
         ) ||
-        handleClassComments(enclosingNode, comment) ||
         handleLabeledStatementComments(enclosingNode, comment) ||
         handleCallExpressionComments(precedingNode, enclosingNode, comment) ||
         handlePropertyComments(enclosingNode, comment) ||
@@ -640,18 +638,6 @@ function handleLastFunctionArgComments(
     getNextNonSpaceNonCommentCharacter(text, comment) === ")"
   ) {
     addTrailingComment(precedingNode, comment);
-    return true;
-  }
-  return false;
-}
-
-function handleClassComments(enclosingNode, comment) {
-  if (
-    enclosingNode &&
-    (enclosingNode.type === "ClassDeclaration" ||
-      enclosingNode.type === "ClassExpression")
-  ) {
-    addLeadingComment(enclosingNode, comment);
     return true;
   }
   return false;

--- a/src/printer.js
+++ b/src/printer.js
@@ -3381,10 +3381,23 @@ function printClass(path, options, print) {
 
   const partsGroup = [];
   if (n.superClass) {
-    parts.push(
-      " extends ",
+    if (hasLeadingOwnLineComment(options.originalText, n.superClass)) {
+      parts.push(hardline);
+    } else {
+      parts.push(" ");
+    }
+
+    const printed = concat([
+      "extends ",
       path.call(print, "superClass"),
       path.call(print, "superTypeParameters")
+    ]);
+    parts.push(
+      path.call(
+        superClass =>
+          comments.printComments(superClass, () => printed, options),
+        "superClass"
+      )
     );
   } else if (n.extends && n.extends.length > 0) {
     parts.push(" extends ", join(", ", path.map(print, "extends")));
@@ -3402,7 +3415,16 @@ function printClass(path, options, print) {
     parts.push(group(indent(concat(partsGroup))));
   }
 
-  parts.push(" ", path.call(print, "body"));
+  if (
+    n.body &&
+    n.body.comments &&
+    hasLeadingOwnLineComment(options.originalText, n.body)
+  ) {
+    parts.push(hardline);
+  } else {
+    parts.push(" ");
+  }
+  parts.push(path.call(print, "body"));
 
   return parts;
 }
@@ -4721,7 +4743,10 @@ function printAstToDoc(ast, options, addAlignmentSize) {
       (node && node.type === "JSXElement") ||
       (parent &&
         (parent.type === "UnionTypeAnnotation" ||
-          parent.type === "TSUnionType"))
+          parent.type === "TSUnionType" ||
+          ((parent.type === "ClassDeclaration" ||
+            parent.type === "ClassExpression") &&
+            parent.superClass === node)))
     ) {
       res = genericPrint(path, options, printGenerically, args);
     } else {

--- a/tests/class_comment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/class_comment/__snapshots__/jsfmt.spec.js.snap
@@ -42,33 +42,35 @@ class X {
     '</div>';
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// comment 1
+class A // comment 1
 // comment 2
-class A extends B {}
+extends B {}
 
-// comment1
+class A extends B // comment1
 // comment2
 // comment3
-class A extends B {}
+{
+}
 
 class A /* a */ extends B {}
 class A extends B /* a */ {
 }
-class A extends /* a */ B {}
+class A /* a */ extends B {}
 
-// comment 1
+(class A // comment 1
 // comment 2
-(class A extends B {});
+extends B {});
 
-// comment1
+(class A extends B // comment1
 // comment2
 // comment3
-(class A extends B {});
+{
+});
 
 (class A /* a */ extends B {});
 (class A extends B /* a */ {
 });
-(class A extends /* a */ B {});
+(class A /* a */ extends B {});
 
 class x {
   focus() // do nothing


### PR DESCRIPTION
We used to be very naive and just push all the comments at the top of the class, but it's very brute force (and breaks some flow annotations inside of fb) so we can do better :)