### PR TITLE
Fix interleaved comments in class decorators

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -192,6 +192,12 @@ function attach(comments, ast, text) {
           comment
         ) ||
         handleTryStatementComments(enclosingNode, followingNode, comment) ||
+        handleClassComments(
+          enclosingNode,
+          precedingNode,
+          followingNode,
+          comment
+        ) ||
         handleImportSpecifierComments(enclosingNode, comment) ||
         handleObjectPropertyComments(enclosingNode, comment) ||
         handleForComments(enclosingNode, precedingNode, comment) ||
@@ -243,6 +249,12 @@ function attach(comments, ast, text) {
           text,
           precedingNode,
           enclosingNode,
+          followingNode,
+          comment
+        ) ||
+        handleClassComments(
+          enclosingNode,
+          precedingNode,
           followingNode,
           comment
         ) ||
@@ -546,6 +558,32 @@ function handleObjectPropertyAssignment(enclosingNode, precedingNode, comment) {
     enclosingNode.value.type === "AssignmentPattern"
   ) {
     addTrailingComment(enclosingNode.value.left, comment);
+    return true;
+  }
+  return false;
+}
+
+function handleClassComments(
+  enclosingNode,
+  precedingNode,
+  followingNode,
+  comment
+) {
+  if (
+    enclosingNode &&
+    (enclosingNode.type === "ClassDeclaration" ||
+      enclosingNode.type === "ClassExpression") &&
+    (enclosingNode.decorators && enclosingNode.decorators.length > 0) &&
+    !(followingNode && followingNode.type === "Decorator")
+  ) {
+    if (!enclosingNode.decorators || enclosingNode.decorators.length === 0) {
+      addLeadingComment(enclosingNode, comment);
+    } else {
+      addTrailingComment(
+        enclosingNode.decorators[enclosingNode.decorators.length - 1],
+        comment
+      );
+    }
     return true;
   }
   return false;

--- a/tests/decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators/__snapshots__/jsfmt.spec.js.snap
@@ -25,6 +25,13 @@ class X {
   ],
 })
 export class AppModule {}
+
+// A
+@Foo()
+// B
+@Bar()
+// C
+export class Bar{}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var x = 100;
 
@@ -47,6 +54,13 @@ class X {}
   ]
 })
 export class AppModule {}
+
+// A
+@Foo()
+// B
+@Bar()
+// C
+export class Bar {}
 
 `;
 

--- a/tests/decorators/comments.js
+++ b/tests/decorators/comments.js
@@ -22,3 +22,10 @@ class X {
   ],
 })
 export class AppModule {}
+
+// A
+@Foo()
+// B
+@Bar()
+// C
+export class Bar{}


### PR DESCRIPTION
I wrote this fix a while ago but it conflicted with the class heuristic, now that #2660 fixes it, we can ship this one as well!

Fixes #1460
Fixes #2507