### PR TITLE
Support TypeScript 2.5 RC

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "postcss-selector-parser": "2.2.3",
     "postcss-values-parser": "git://github.com/lydell/postcss-values-parser.git#af2c80b2bb558a6e7d61540d97f068f9fa162b38",
     "strip-bom": "3.0.0",
-    "typescript": "2.5.0-dev.20170617",
-    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#01c34f44e7bb3b8a1ec3d28433a6e0c9b2901d3c"
+    "typescript": "2.5.1",
+    "typescript-eslint-parser": "git://github.com/eslint/typescript-eslint-parser.git#801d65585af6995a223136862944095b48f5c567"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",

--- a/tests/optional_catch_binding/jsfmt.spec.js
+++ b/tests/optional_catch_binding/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, { parser: "babylon" });
+run_spec(__dirname, { parser: "babylon" }, ["typescript"]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3808,16 +3808,16 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#01c34f44e7bb3b8a1ec3d28433a6e0c9b2901d3c":
+"typescript-eslint-parser@git://github.com/eslint/typescript-eslint-parser.git#801d65585af6995a223136862944095b48f5c567":
   version "6.0.1"
-  resolved "git://github.com/eslint/typescript-eslint-parser.git#01c34f44e7bb3b8a1ec3d28433a6e0c9b2901d3c"
+  resolved "git://github.com/eslint/typescript-eslint-parser.git#801d65585af6995a223136862944095b48f5c567"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.3.0"
 
-typescript@2.5.0-dev.20170617:
-  version "2.5.0-dev.20170617"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.0-dev.20170617.tgz#5c72d3d4ea278f8db662f513c6911cd31378f024"
+typescript@2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.1.tgz#ce7cc93ada3de19475cc9d17e3adea7aee1832aa"
 
 uglify-es@3.0.15:
   version "3.0.15"


### PR DESCRIPTION
This points typescript-eslint-parser to the latest commit on the `ts-2.5` branch (PR: https://github.com/eslint/typescript-eslint-parser/pull/370).

Only change is the support for optional catch binding in TypeScript, too :tada:.

Bumping the bundled TypeScript version to 2.5.1 (RC, [Release notes](https://blogs.msdn.microsoft.com/typescript/2017/08/17/announcing-typescript-2-5-rc/))

@vjeux Do you want to sneak this in to 1.6 release?