### PR TITLE
Ensure parens around LogicalExpression inside ExperimentalSpreadProperty

### DIFF
--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -309,6 +309,7 @@ FastPath.prototype.needsParens = function(options) {
         case "UnaryExpression":
         case "SpreadElement":
         case "SpreadProperty":
+        case "ExperimentalSpreadProperty":
         case "BindExpression":
         case "AwaitExpression":
         case "TSAsExpression":

--- a/tests/spread/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/spread/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`spread.js 1`] = `
+const foo = { ...(a || b) };
+const foo2 = { ...a || b };
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const foo = { ...(a || b) };
+const foo2 = { ...(a || b) };
+
+`;

--- a/tests/spread/jsfmt.spec.js
+++ b/tests/spread/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, null, ["babylon", "typescript"]);

--- a/tests/spread/spread.js
+++ b/tests/spread/spread.js
@@ -1,0 +1,2 @@
+const foo = { ...(a || b) };
+const foo2 = { ...a || b };


### PR DESCRIPTION
Also, noticed we didn't have any tests covering this case for any of the parsers.

Fixes #2708 