### PR TITLE
feat(resolve-config): add `.sync()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ A promise is returned which will resolve to:
 The promise will be rejected if there was an error parsing the configuration file.
 
 If `options.useCache` is `false`, all caching will be bypassed.
+If `options.sync` is `true`, result will be returned directly.
 
 ```js
 const text = fs.readFileSync(filePath, "utf8");
@@ -447,11 +448,13 @@ prettier.resolveConfig(filePath).then(options => {
 })
 ```
 
-#### `prettier.clearConfigCache()`
+#### `prettier.clearConfigCache([opts])`
 
 As you repeatedly call `resolveConfig`, the file system structure will be cached for performance.
 This function will clear the cache. Generally this is only needed for editor integrations that
 know that the file system has changed since the last format took place.
+
+If `options.sync` is `true`, caches from sync resolution will be cleared, otherwise clear async's.
 
 #### Custom Parser API
 

--- a/README.md
+++ b/README.md
@@ -439,7 +439,6 @@ A promise is returned which will resolve to:
 The promise will be rejected if there was an error parsing the configuration file.
 
 If `options.useCache` is `false`, all caching will be bypassed.
-If `options.sync` is `true`, result will be returned directly.
 
 ```js
 const text = fs.readFileSync(filePath, "utf8");
@@ -447,6 +446,8 @@ prettier.resolveConfig(filePath).then(options => {
   const formatted = prettier.format(text, options);
 })
 ```
+
+Use `prettier.resolveConfig.sync([filePath [, options]])` if you'd like to use sync version.
 
 #### `prettier.clearConfigCache()`
 

--- a/README.md
+++ b/README.md
@@ -448,13 +448,11 @@ prettier.resolveConfig(filePath).then(options => {
 })
 ```
 
-#### `prettier.clearConfigCache([opts])`
+#### `prettier.clearConfigCache()`
 
 As you repeatedly call `resolveConfig`, the file system structure will be cached for performance.
 This function will clear the cache. Generally this is only needed for editor integrations that
 know that the file system has changed since the last format took place.
-
-If `options.sync` is `true`, caches from sync resolution will be cleared, otherwise clear async's.
 
 #### Custom Parser API
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "babel-code-frame": "7.0.0-alpha.12",
     "babylon": "7.0.0-beta.22",
     "chalk": "2.0.1",
-    "cosmiconfig": "git://github.com/davidtheclark/cosmiconfig.git#da48c813df616d8c8eb7f4bc3c2e4cb2f37d05a3",
+    "cosmiconfig": "davidtheclark/cosmiconfig#3.0",
     "dashify": "0.2.2",
     "diff": "3.2.0",
     "esutils": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "babel-code-frame": "7.0.0-alpha.12",
     "babylon": "7.0.0-beta.22",
     "chalk": "2.0.1",
-    "cosmiconfig": "2.2.2",
+    "cosmiconfig": "git://github.com/davidtheclark/cosmiconfig.git#da48c813df616d8c8eb7f4bc3c2e4cb2f37d05a3",
     "dashify": "0.2.2",
     "diff": "3.2.0",
     "esutils": "2.0.2",

--- a/src/resolve-config.js
+++ b/src/resolve-config.js
@@ -23,13 +23,9 @@ function resolveConfig(filePath, opts) {
     });
 }
 
-function clearCache(opts) {
-  const sync = opts && opts.sync === true;
-  if (sync) {
-    syncWithCache.clearCaches();
-  } else {
-    asyncWithCache.clearCaches();
-  }
+function clearCache() {
+  syncWithCache.clearCaches();
+  asyncWithCache.clearCaches();
 }
 
 function resolveConfigFile(filePath, opts) {

--- a/src/resolve-config.js
+++ b/src/resolve-config.js
@@ -3,31 +3,43 @@
 const cosmiconfig = require("cosmiconfig");
 const minimatch = require("minimatch");
 
-const withCache = cosmiconfig("prettier");
-const noCache = cosmiconfig("prettier", { cache: false });
+const asyncWithCache = cosmiconfig("prettier");
+const asyncNoCache = cosmiconfig("prettier", { cache: false });
+const syncWithCache = cosmiconfig("prettier", { sync: true });
+const syncNoCache = cosmiconfig("prettier", { cache: false, sync: true });
 
 function resolveConfig(filePath, opts) {
+  const sync = opts && opts.sync === true;
   const useCache = !(opts && opts.useCache === false);
 
-  return (useCache ? withCache : noCache).load(filePath).then(result => {
-    if (!result) {
-      return null;
-    }
-
-    return mergeOverrides(result.config, filePath);
-  });
+  if (sync) {
+    const result = (useCache ? syncWithCache : syncNoCache).load(filePath);
+    return !result ? null : mergeOverrides(result.config, filePath);
+  }
+  return (useCache ? asyncWithCache : asyncNoCache)
+    .load(filePath)
+    .then(result => {
+      return !result ? null : mergeOverrides(result.config, filePath);
+    });
 }
 
-function clearCache() {
-  withCache.clearCaches();
+function clearCache(opts) {
+  const sync = opts && opts.sync === true;
+  if (sync) {
+    syncWithCache.clearCaches();
+  } else {
+    asyncWithCache.clearCaches();
+  }
 }
 
-function resolveConfigFile(filePath) {
-  return noCache.load(filePath).then(result => {
-    if (result) {
-      return result.filepath;
-    }
-    return null;
+function resolveConfigFile(filePath, opts) {
+  const sync = opts && opts.sync === true;
+  if (sync) {
+    const result = syncNoCache.load(filePath);
+    return result ? result.filepath : null;
+  }
+  return asyncNoCache.load(filePath).then(result => {
+    return result ? result.filepath : null;
   });
 }
 

--- a/tests_integration/__tests__/config-resolution.js
+++ b/tests_integration/__tests__/config-resolution.js
@@ -54,8 +54,8 @@ test("API resolveConfig with no args", () => {
   });
 });
 
-test("API resolveConfig sync with no args", () => {
-  expect(prettier.resolveConfig(undefined, { sync: true })).toBeNull();
+test("API resolveConfig.sync with no args", () => {
+  expect(prettier.resolveConfig.sync()).toBeNull();
 });
 
 test("API resolveConfig with file arg", () => {
@@ -67,9 +67,9 @@ test("API resolveConfig with file arg", () => {
   });
 });
 
-test("API resolveConfig sync with file arg", () => {
+test("API resolveConfig.sync with file arg", () => {
   const file = path.resolve(path.join(__dirname, "../cli/config/js/file.js"));
-  expect(prettier.resolveConfig(file, { sync: true })).toMatchObject({
+  expect(prettier.resolveConfig.sync(file)).toMatchObject({
     tabWidth: 8
   });
 });
@@ -85,11 +85,11 @@ test("API resolveConfig with file arg and extension override", () => {
   });
 });
 
-test("API resolveConfig sync with file arg and extension override", () => {
+test("API resolveConfig.sync with file arg and extension override", () => {
   const file = path.resolve(
     path.join(__dirname, "../cli/config/no-config/file.ts")
   );
-  expect(prettier.resolveConfig(file, { sync: true })).toMatchObject({
+  expect(prettier.resolveConfig.sync(file)).toMatchObject({
     semi: true
   });
 });

--- a/tests_integration/__tests__/config-resolution.js
+++ b/tests_integration/__tests__/config-resolution.js
@@ -54,12 +54,23 @@ test("API resolveConfig with no args", () => {
   });
 });
 
+test("API resolveConfig sync with no args", () => {
+  expect(prettier.resolveConfig(undefined, { sync: true })).toBeNull();
+});
+
 test("API resolveConfig with file arg", () => {
   const file = path.resolve(path.join(__dirname, "../cli/config/js/file.js"));
   return prettier.resolveConfig(file).then(result => {
     expect(result).toMatchObject({
       tabWidth: 8
     });
+  });
+});
+
+test("API resolveConfig sync with file arg", () => {
+  const file = path.resolve(path.join(__dirname, "../cli/config/js/file.js"));
+  expect(prettier.resolveConfig(file, { sync: true })).toMatchObject({
+    tabWidth: 8
   });
 });
 
@@ -71,5 +82,14 @@ test("API resolveConfig with file arg and extension override", () => {
     expect(result).toMatchObject({
       semi: true
     });
+  });
+});
+
+test("API resolveConfig sync with file arg and extension override", () => {
+  const file = path.resolve(
+    path.join(__dirname, "../cli/config/no-config/file.ts")
+  );
+  expect(prettier.resolveConfig(file, { sync: true })).toMatchObject({
+    semi: true
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1045,9 +1045,9 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-"cosmiconfig@git://github.com/davidtheclark/cosmiconfig.git#da48c813df616d8c8eb7f4bc3c2e4cb2f37d05a3":
+cosmiconfig@davidtheclark/cosmiconfig#3.0:
   version "2.2.2"
-  resolved "git://github.com/davidtheclark/cosmiconfig.git#da48c813df616d8c8eb7f4bc3c2e4cb2f37d05a3"
+  resolved "https://codeload.github.com/davidtheclark/cosmiconfig/tar.gz/12239b263684a7268883eccb30714446e105ff95"
   dependencies:
     is-directory "^0.3.1"
     is-promise "^2.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1045,16 +1045,17 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cosmiconfig@2.2.2:
+"cosmiconfig@git://github.com/davidtheclark/cosmiconfig.git#da48c813df616d8c8eb7f4bc3c2e4cb2f37d05a3":
   version "2.2.2"
-  resolved "https://registry.yarnpkg.com/cosmiconfig/-/cosmiconfig-2.2.2.tgz#6173cebd56fac042c1f4390edf7af6c07c7cb892"
+  resolved "git://github.com/davidtheclark/cosmiconfig.git#da48c813df616d8c8eb7f4bc3c2e4cb2f37d05a3"
   dependencies:
     is-directory "^0.3.1"
-    js-yaml "^3.4.3"
+    is-promise "^2.1.0"
+    js-yaml "^3.9.0"
     minimist "^1.2.0"
-    object-assign "^4.1.0"
     os-homedir "^1.0.1"
     parse-json "^2.2.0"
+    please-upgrade-node "^3.0.1"
     require-from-string "^1.1.0"
 
 create-ecdh@^4.0.0:
@@ -2409,14 +2410,14 @@ js-tokens@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.1.tgz#08e9f132484a2c45a30907e9dc4d5567b7f114d7"
 
-js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.8.4:
+js-yaml@^3.7.0, js-yaml@^3.8.4:
   version "3.8.4"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.4.tgz#520b4564f86573ba96662af85a8cafa7b4b5a6f6"
   dependencies:
     argparse "^1.0.7"
     esprima "^3.1.1"
 
-js-yaml@^3.8.1:
+js-yaml@^3.8.1, js-yaml@^3.9.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
   dependencies:
@@ -3078,6 +3079,10 @@ pkg-dir@^1.0.0:
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-1.0.0.tgz#7a4b508a8d5bb2d629d447056ff4e9c9314cf3d4"
   dependencies:
     find-up "^1.0.0"
+
+please-upgrade-node@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.0.1.tgz#0a681f2c18915e5433a5ca2cd94e0b8206a782db"
 
 pluralize@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
I'd like to use `resolveConfig` in [tslint-plugin-prettier](https://github.com/ikatyang/tslint-plugin-prettier) to support config file, but unfortunately tslint did not provide async way to load rules. (There is also a feature request for https://github.com/prettier/eslint-plugin-prettier/issues/46, but I'm not sure if eslint supported async or not.)

Then I found cosmiconfig itself supports `sync` option so I started to write this PR, but after I wrote this PR, I realized that it just supports `sync` at 3.0 branch (https://github.com/davidtheclark/cosmiconfig/pull/78). 😅