### PR TITLE
Fix cosmiconfig dependency branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "babel-code-frame": "7.0.0-alpha.12",
     "babylon": "7.0.0-beta.22",
     "chalk": "2.0.1",
-    "cosmiconfig": "davidtheclark/cosmiconfig#3.0",
+    "cosmiconfig": "davidtheclark/cosmiconfig",
     "dashify": "0.2.2",
     "diff": "3.2.0",
     "esutils": "2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1045,9 +1045,9 @@ core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cosmiconfig@davidtheclark/cosmiconfig#3.0:
+cosmiconfig@davidtheclark/cosmiconfig:
   version "2.2.2"
-  resolved "https://codeload.github.com/davidtheclark/cosmiconfig/tar.gz/12239b263684a7268883eccb30714446e105ff95"
+  resolved "https://codeload.github.com/davidtheclark/cosmiconfig/tar.gz/6eb3cc85d3a435e6b9e252b341e601960312f410"
   dependencies:
     is-directory "^0.3.1"
     is-promise "^2.1.0"


### PR DESCRIPTION
The `3.0` branch was [merged] and [deleted],
so we should use the default branch now.

[merged]: https://github.com/davidtheclark/cosmiconfig/pull/78#event-1232367869
[deleted]: https://github.com/davidtheclark/cosmiconfig/pull/78#event-1232367884