### PR TITLE
Upgrade chalk to v2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "babel-code-frame": "7.0.0-alpha.12",
     "babylon": "7.0.0-beta.22",
-    "chalk": "2.0.1",
+    "chalk": "2.1.0",
     "cosmiconfig": "davidtheclark/cosmiconfig#3.0",
     "dashify": "0.2.2",
     "diff": "3.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -880,9 +880,9 @@ center-align@^0.1.1:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
 
-chalk@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
+chalk@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"


### PR DESCRIPTION
This fixes a warning when installing prettier from github:

    warning prettier > chalk@2.0.1: Please upgrade to Chalk 2.1.0 - template literals in this version (2.0.1) are quite buggy.