### PR TITLE
Make run-external-typescript-tests.js cross-platform

### DIFF
--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -359,6 +359,7 @@ function formatFiles(argv, filepatterns) {
 
 module.exports = {
   resolveConfig,
+  format,
   formatStdin,
   formatFiles
 };


### PR DESCRIPTION
The old version had quite a bit of code related to grouping errors,
showing the number of errors per group and saving the groups of errors
to different files. However, now there are only 12 bad tests so I didn't
bother porting that logic to the new version. Instead, the errors a
simply printed to stdout.