### PR TITLE
chore(deps): remove devDependency `cross-spawn`

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "babel-preset-es2015": "6.24.1",
     "codecov": "2.2.0",
     "cross-env": "5.0.1",
-    "cross-spawn": "5.1.0",
     "eslint": "4.1.1",
     "eslint-friendly-formatter": "3.0.0",
     "eslint-plugin-import": "2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1092,7 +1092,7 @@ cross-env@5.0.1:
     cross-spawn "^5.1.0"
     is-windows "^1.0.0"
 
-cross-spawn@5.1.0, cross-spawn@^5.1.0:
+cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:


### PR DESCRIPTION
It seems the only usage of `cross-spawn` was in `runPrettier.js`, but it was removed in #2730.