### PR TITLE
Improve lint-staged setup example by adding more filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ and add this config to your `package.json`:
     "precommit": "lint-staged"
   },
   "lint-staged": {
-    "*.js": [
+    "*.{js,json,css}": [
       "prettier --write",
       "git add"
     ]


### PR DESCRIPTION
lint-staged use [minimatch](https://github.com/isaacs/minimatch). It's a good idea to add more than one filetype since prettier handle several kind of languages :)