### PR TITLE
Refactor error handling

### DIFF
--- a/src/cli-constant.js
+++ b/src/cli-constant.js
@@ -17,6 +17,12 @@ const stringOptionNames = [
   "trailing-comma"
 ];
 
+const defaultOptions = {
+  "bracket-spacing": true,
+  semi: true,
+  parser: "babylon"
+};
+
 const options = {
   boolean: [
     "write",
@@ -45,7 +51,8 @@ const options = {
   ].concat(stringOptionNames),
   default: {
     color: true,
-    "ignore-path": ".prettierignore"
+    "ignore-path": ".prettierignore",
+    "config-precedence": "cli-override"
   },
   alias: {
     help: "h",
@@ -111,6 +118,7 @@ Available options:
 module.exports = {
   booleanOptionNames,
   stringOptionNames,
+  defaultOptions,
   options,
   usage
 };

--- a/tests_integration/__tests__/__snapshots__/config-invalid.js.snap
+++ b/tests_integration/__tests__/__snapshots__/config-invalid.js.snap
@@ -1,20 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`throw error with invalid config format 1`] = `"Failed to parse \\"<cwd>/tests_integration/cli/config/invalid/file/.prettierrc\\" as JSON, JS, or YAML."`;
+exports[`throw error with invalid config format 1`] = `
+"Error: Invalid configuration file.
+Failed to parse \\"<cwd>/tests_integration/cli/config/invalid/file/.prettierrc\\" as JSON, JS, or YAML.
+"
+`;
 
 exports[`throw error with invalid config option (int) 1`] = `
-"Invalid --tab-width value. Expected an integer, but received: 0.5
+"Error: Invalid --tab-width value.
+Expected an integer, but received: 0.5
 "
 `;
 
 exports[`throw error with invalid config option (trailingComma) 1`] = `
-"Invalid configuration:
+"Error: Invalid option for --trailing-comma.
+Expected \\"none\\", \\"es5\\" or \\"all\\", but received: \\"wow\\"
 "
 `;
 
 exports[`throw error with invalid config precedence option (configPrecedence) 1`] = `
-"Invalid configuration:
+"Error: Invalid option for --config-precedence.
+Expected \\"cli-override\\", \\"file-override\\" or \\"prefer-file\\", but received: \\"option/configPrecedence\\"
 "
 `;
 
-exports[`throw error with invalid config target (directory) 1`] = `"EISDIR: illegal operation on a directory, read"`;
+exports[`throw error with invalid config target (directory) 1`] = `
+"Error: Invalid configuration file.
+EISDIR: illegal operation on a directory, read
+"
+`;


### PR DESCRIPTION
Still a lot of room for improvement, but at least we get correct error messages.

@mitermayer I made some changes to the `config-precedence` option too, trying to avoid extra  calls to `minimist` and additional Object.assigns where possible. Not sure if I made it better or worse...