### PR TITLE
chore(github): add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,15 @@
+<!-- BUGS: Please use this template. -->
+
+**Prettier Version:** 1.6.1 / master
+
+**Code**
+
+([playground](https://prettier.io/playground/#.....))
+
+```js
+// code snippet
+```
+
+**Expected behavior:**
+
+**Actual behavior:**


### PR DESCRIPTION
Sometimes people report bugs with only screenshot and no version provided, it'd be better to tell them to provide appropriate information so as to better describe what the problem is. (And maybe they'll find out that the bug was already fixed on master while they're trying to reproduce on the playground.)