### PR TITLE
Group last argument if it's an empty object with a comment

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2844,8 +2844,10 @@ function printMethod(path, options, print) {
 
 function couldGroupArg(arg) {
   return (
-    (arg.type === "ObjectExpression" && arg.properties.length > 0) ||
-    (arg.type === "ArrayExpression" && arg.elements.length > 0) ||
+    (arg.type === "ObjectExpression" &&
+      (arg.properties.length > 0 || arg.comments)) ||
+    (arg.type === "ArrayExpression" &&
+      (arg.elements.length > 0 || arg.comments)) ||
     arg.type === "TSTypeAssertionExpression" ||
     arg.type === "TSAsExpression" ||
     arg.type === "FunctionExpression" ||
@@ -2863,7 +2865,8 @@ function shouldGroupLastArg(args) {
   const lastArg = util.getLast(args);
   const penultimateArg = util.getPenultimate(args);
   return (
-    (!lastArg.comments || !lastArg.comments.length) &&
+    !hasLeadingComment(lastArg) &&
+    !hasTrailingComment(lastArg) &&
     couldGroupArg(lastArg) &&
     // If the last two arguments are of the same type,
     // disable last element expansion.

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -184,11 +184,9 @@ expect(() => {}).toTriggerReadyStateChanges([
 
 [1 /* first comment */, 2 /* second comment */, 3];
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-expect(() => {}).toTriggerReadyStateChanges(
-  [
-    // Nothing.
-  ]
-);
+expect(() => {}).toTriggerReadyStateChanges([
+  // Nothing.
+]);
 
 [1 /* first comment */, 2 /* second comment */, 3];
 

--- a/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/last_argument_expansion/__snapshots__/jsfmt.spec.js.snap
@@ -277,6 +277,61 @@ someReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReal
 
 `;
 
+exports[`empty-object.js 1`] = `
+func(first, second, third, fourth, fifth, aReallyLongArgumentsListToForceItToBreak, {
+  // comment
+})
+
+func({
+  // comment
+})
+
+func(
+  {} // comment
+)
+
+func(
+  {}
+  // comment
+)
+
+func(
+  // comment
+  {}
+)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+func(
+  first,
+  second,
+  third,
+  fourth,
+  fifth,
+  aReallyLongArgumentsListToForceItToBreak,
+  {
+    // comment
+  }
+);
+
+func({
+  // comment
+});
+
+func(
+  {} // comment
+);
+
+func(
+  {}
+  // comment
+);
+
+func(
+  // comment
+  {}
+);
+
+`;
+
 exports[`jsx.js 1`] = `
 const els = items.map(item => (
   <div className="whatever">
@@ -411,38 +466,12 @@ func(
   yes,
   []
 );
-func(
-  one,
-  two,
-  three,
-  four,
-  five,
-  six,
-  seven,
-  eig,
-  is,
-  this,
-  too,
-  long,
-  yes,
-  [
-    // Comments
-  ]
-);
-func(
-  five,
-  six,
-  seven,
-  eig,
-  is,
-  this,
-  too,
-  long,
-  yes,
-  [
-    // Comments
-  ]
-);
+func(one, two, three, four, five, six, seven, eig, is, this, too, long, yes, [
+  // Comments
+]);
+func(five, six, seven, eig, is, this, too, long, yes, [
+  // Comments
+]);
 
 func(one, two, three, four, five, six, seven, eig, is, this, too, long, no, {});
 func(
@@ -461,24 +490,9 @@ func(
   yes,
   {}
 );
-func(
-  one,
-  two,
-  three,
-  four,
-  five,
-  six,
-  seven,
-  eig,
-  is,
-  this,
-  too,
-  long,
-  yes,
-  {
-    // Comments
-  }
-);
+func(one, two, three, four, five, six, seven, eig, is, this, too, long, yes, {
+  // Comments
+});
 
 foo(
   (

--- a/tests/last_argument_expansion/empty-object.js
+++ b/tests/last_argument_expansion/empty-object.js
@@ -1,0 +1,21 @@
+func(first, second, third, fourth, fifth, aReallyLongArgumentsListToForceItToBreak, {
+  // comment
+})
+
+func({
+  // comment
+})
+
+func(
+  {} // comment
+)
+
+func(
+  {}
+  // comment
+)
+
+func(
+  // comment
+  {}
+)


### PR DESCRIPTION
```
func({
  // comment
})
```

was changing to

```
func(
  {
    // comment
  }
);
```

[playground link](https://prettier.io/playground/#%7B%22content%22%3A%22func(%7B%5Cn%20%20%2F%2Fcomment%5Cn%7D)%22%2C%22options%22%3A%7B%22printWidth%22%3A80%2C%22tabWidth%22%3A2%2C%22singleQuote%22%3Afalse%2C%22trailingComma%22%3A%22none%22%2C%22bracketSpacing%22%3Atrue%2C%22jsxBracketSameLine%22%3Afalse%2C%22parser%22%3A%22babylon%22%2C%22semi%22%3Atrue%2C%22useTabs%22%3Afalse%2C%22doc%22%3Afalse%2C%22ast%22%3Afalse%7D%7D)

I'm not sure this was intended but this fixes #2617. Let me know if this should target only the case in that issue or not.