### PR TITLE
Use `files:` over `types:` in pre-commit configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,4 +2,5 @@
     name: prettier
     entry: prettier --write
     language: node
-    types: [javascript]
+    # From https://github.com/prettier/prettier/blob/133303f47a30f6b3e46ffdf9d5c2d6609d65c416/src/options.js#L32-L42
+    files: \.(css|less|scss|html|ts|tsx|graphql|gql|json|js|jsx)$


### PR DESCRIPTION
See https://github.com/prettier/prettier/issues/2745