### PR TITLE
Keep original empty lines in argument list

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -2901,27 +2901,27 @@ function printArgumentsList(path, options, print) {
     ]);
   }
 
-  const lastArgIndex = args.length - 1;
   let anyArgEmptyLine = false;
   let hasEmptyLineFollowingFirstArg = false;
+  const lastArgIndex = args.length - 1;
   const printedArguments = path.map((argPath, index) => {
     const arg = argPath.getNode();
-    const printedArg = print(argPath);
+    const parts = [print(argPath)];
 
     if (index === lastArgIndex) {
-      return concat([printedArg]);
-    }
-
-    if (util.isNextLineEmpty(options.originalText, arg)) {
+      // do nothing
+    } else if (util.isNextLineEmpty(options.originalText, arg)) {
       if (index === 0) {
         hasEmptyLineFollowingFirstArg = true;
       }
 
       anyArgEmptyLine = true;
-      return concat([printedArg, ",", hardline, hardline]);
+      parts.push(",", hardline, hardline);
+    } else {
+      parts.push(",", line);
     }
 
-    return concat([printedArg, ",", line]);
+    return concat(parts);
   }, "arguments");
 
   // This is just an optimization; I think we could return the

--- a/src/printer.js
+++ b/src/printer.js
@@ -2896,7 +2896,7 @@ function printArgumentsList(path, options, print) {
   const lastArgIndex = args.length - 1;
 
   const firstArgComments = args.length === 0 ? [] : args[0].comments;
-  const hasEmptyLineAfterOpeningParen =
+  const shouldHaveEmptyLineAfterOpeningParen =
     args.length === 0
       ? false
       : util.isPreviousLineEmpty(
@@ -2907,7 +2907,7 @@ function printArgumentsList(path, options, print) {
         );
 
   const lastArgComments = args.length === 0 ? [] : args[lastArgIndex].comments;
-  const hasEmptyLineBeforeClosingParen =
+  const shouldHaveEmptyLineBeforeClosingParen =
     args.length === 0
       ? false
       : util.isNextLineEmpty(
@@ -2920,10 +2920,10 @@ function printArgumentsList(path, options, print) {
 
   const emptyLineCommands = [line, breakParent];
   const afterOpeningParenParts = concat(
-    hasEmptyLineAfterOpeningParen ? emptyLineCommands : []
+    shouldHaveEmptyLineAfterOpeningParen ? emptyLineCommands : []
   );
   const beforeClosingParenParts = concat(
-    hasEmptyLineBeforeClosingParen ? emptyLineCommands : []
+    shouldHaveEmptyLineBeforeClosingParen ? emptyLineCommands : []
   );
   const hasEmptyLineAfterArgs = args.map(arg =>
     util.isNextLineEmpty(options.originalText, arg)
@@ -2943,8 +2943,8 @@ function printArgumentsList(path, options, print) {
   const shouldGroupFirst = shouldGroupFirstArg(args);
   const shouldGroupLast = shouldGroupLastArg(args);
   if (
-    !hasEmptyLineAfterOpeningParen &&
-    !hasEmptyLineBeforeClosingParen &&
+    !shouldHaveEmptyLineAfterOpeningParen &&
+    !shouldHaveEmptyLineBeforeClosingParen &&
     hasEmptyLineAfterArgs.every(
       hasEmptyLineAfterArg => !hasEmptyLineAfterArg
     ) &&

--- a/src/printer.js
+++ b/src/printer.js
@@ -3018,14 +3018,11 @@ function printArgumentsList(path, options, print) {
         return result.concat(printedArg);
       }
 
-      const emptyLineCommands = hasEmptyLineAfterArgs[index]
-        ? [breakParent, line]
-        : [];
-
-      return result.concat(
-        printedArg,
-        concat([",", line, ...emptyLineCommands])
+      const emptyLineParts = concat(
+        hasEmptyLineAfterArgs[index] ? [breakParent, line] : []
       );
+
+      return result.concat(printedArg, concat([",", line, emptyLineParts]));
     }, [])
   );
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -2925,20 +2925,17 @@ function printArgumentsList(path, options, print) {
   const beforeClosingParenParts = concat(
     hasEmptyLineBeforeClosingParen ? emptyLineCommands : []
   );
+  const hasEmptyLineAfterArgs = args.map(arg =>
+    util.isNextLineEmpty(options.originalText, arg)
+  );
 
   if (printed.length === 0) {
     return concat([
       "(",
-      afterOpeningParenParts,
       comments.printDanglingComments(path, options, /* sameIndent */ true),
-      beforeClosingParenParts,
       ")"
     ]);
   }
-
-  const hasEmptyLineAfterArgs = args.map(arg =>
-    util.isNextLineEmpty(options.originalText, arg)
-  );
 
   // This is just an optimization; I think we could return the
   // conditional group for all function calls, but it's more expensive

--- a/src/printer.js
+++ b/src/printer.js
@@ -2917,7 +2917,7 @@ function printArgumentsList(path, options, print) {
         hasFirstArgEmptyLine = true;
       }
 
-      anyArgEmptyLine = true
+      anyArgEmptyLine = true;
       return concat([printedArg, ",", hardline, hardline]);
     }
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -2919,19 +2919,19 @@ function printArgumentsList(path, options, print) {
         );
 
   const emptyLineCommands = [line, breakParent];
-  const afterOpeningParenCommands = hasEmptyLineAfterOpeningParen
-    ? emptyLineCommands
-    : [];
-  const beforeClosingParenCommands = hasEmptyLineBeforeClosingParen
-    ? emptyLineCommands
-    : [];
+  const afterOpeningParenParts = concat(
+    hasEmptyLineAfterOpeningParen ? emptyLineCommands : []
+  );
+  const beforeClosingParenParts = concat(
+    hasEmptyLineBeforeClosingParen ? emptyLineCommands : []
+  );
 
   if (printed.length === 0) {
     return concat([
       "(",
-      ...afterOpeningParenCommands,
+      afterOpeningParenParts,
       comments.printDanglingComments(path, options, /* sameIndent */ true),
-      ...beforeClosingParenCommands,
+      beforeClosingParenParts,
       ")"
     ]);
   }
@@ -3032,11 +3032,11 @@ function printArgumentsList(path, options, print) {
   return group(
     concat([
       "(",
-      ...afterOpeningParenCommands,
+      afterOpeningParenParts,
       indent(concat([softline, printedArgumentList])),
       ifBreak(shouldPrintComma(options, "all") ? "," : ""),
       softline,
-      ...beforeClosingParenCommands,
+      beforeClosingParenParts,
       ")"
     ]),
     { shouldBreak: printed.some(willBreak) }

--- a/src/printer.js
+++ b/src/printer.js
@@ -2903,7 +2903,7 @@ function printArgumentsList(path, options, print) {
 
   const lastArgIndex = args.length - 1;
   let anyArgEmptyLine = false;
-  let hasFirstArgEmptyLine = false;
+  let hasEmptyLineFollowingFirstArg = false;
   const printedArguments = path.map((argPath, index) => {
     const arg = argPath.getNode();
     const printedArg = print(argPath);
@@ -2914,7 +2914,7 @@ function printArgumentsList(path, options, print) {
 
     if (util.isNextLineEmpty(options.originalText, arg)) {
       if (index === 0) {
-        hasFirstArgEmptyLine = true;
+        hasEmptyLineFollowingFirstArg = true;
       }
 
       anyArgEmptyLine = true;
@@ -2944,8 +2944,8 @@ function printArgumentsList(path, options, print) {
           concat([
             argPath.call(p => print(p, { expandFirstArg: true })),
             printedArguments.length > 1 ? "," : "",
-            hasFirstArgEmptyLine ? hardline : line,
-            hasFirstArgEmptyLine ? hardline : ""
+            hasEmptyLineFollowingFirstArg ? hardline : line,
+            hasEmptyLineFollowingFirstArg ? hardline : ""
           ])
         ].concat(printedArguments.slice(1));
       }
@@ -3001,7 +3001,7 @@ function printArgumentsList(path, options, print) {
       softline,
       ")"
     ]),
-    { shouldBreak: printedArguments.some(willBreak) || anyArgEmptyLine }
+    { shouldBreak: printedArguments.some(willBreak) }
   );
 }
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -2892,17 +2892,6 @@ function shouldGroupFirstArg(args) {
 
 function printArgumentsList(path, options, print) {
   const args = path.getValue().arguments;
-  const lastArgIndex = args.length - 1;
-  const hasEmptyLineAfterArgs = args.map((arg, index) => {
-    if (index === lastArgIndex) {
-      return false;
-    }
-
-    return util.isNextLineEmpty(options.originalText, arg);
-  });
-  const anyArgEmptyLine = hasEmptyLineAfterArgs.some(
-    hasEmptyLineAfterArg => hasEmptyLineAfterArg
-  );
 
   if (args.length === 0) {
     return concat([
@@ -2912,14 +2901,23 @@ function printArgumentsList(path, options, print) {
     ]);
   }
 
+  const lastArgIndex = args.length - 1;
+  let anyArgEmptyLine = false;
+  let hasFirstArgEmptyLine = false;
   const printedArguments = path.map((argPath, index) => {
+    const arg = argPath.getNode();
     const printedArg = print(argPath);
 
     if (index === lastArgIndex) {
       return concat([printedArg]);
     }
 
-    if (hasEmptyLineAfterArgs[index]) {
+    if (util.isNextLineEmpty(options.originalText, arg)) {
+      if (index === 0) {
+        hasFirstArgEmptyLine = true;
+      }
+
+      anyArgEmptyLine = true
       return concat([printedArg, ",", hardline, hardline]);
     }
 
@@ -2946,8 +2944,8 @@ function printArgumentsList(path, options, print) {
           concat([
             argPath.call(p => print(p, { expandFirstArg: true })),
             printedArguments.length > 1 ? "," : "",
-            hasEmptyLineAfterArgs[0] ? hardline : line,
-            hasEmptyLineAfterArgs[0] ? hardline : ""
+            hasFirstArgEmptyLine ? hardline : line,
+            hasFirstArgEmptyLine ? hardline : ""
           ])
         ].concat(printedArguments.slice(1));
       }

--- a/src/printer.js
+++ b/src/printer.js
@@ -2914,12 +2914,13 @@ function printArgumentsList(path, options, print) {
 
   const printedArguments = path.map((argPath, index) => {
     const printedArg = print(argPath);
-    if (hasEmptyLineAfterArgs[index]) {
-      return concat([printedArg, ",", hardline, hardline]);
+
+    if (index === lastArgIndex) {
+      return concat([printedArg]);
     }
 
-    if (lastArgIndex === index) {
-      return concat([printedArg]);
+    if (hasEmptyLineAfterArgs[index]) {
+      return concat([printedArg, ",", hardline, hardline]);
     }
 
     return concat([printedArg, ",", line]);
@@ -2928,7 +2929,7 @@ function printArgumentsList(path, options, print) {
   // This is just an optimization; I think we could return the
   // conditional group for all function calls, but it's more expensive
   // so only do it for specific forms.
-  const shouldGroupFirst = shouldGroupFirstArg(args); // 2 args only
+  const shouldGroupFirst = shouldGroupFirstArg(args);
   const shouldGroupLast = shouldGroupLastArg(args);
   if (shouldGroupFirst || shouldGroupLast) {
     const shouldBreak =

--- a/src/printer.js
+++ b/src/printer.js
@@ -3001,7 +3001,7 @@ function printArgumentsList(path, options, print) {
       softline,
       ")"
     ]),
-    { shouldBreak: printedArguments.some(willBreak) }
+    { shouldBreak: printedArguments.some(willBreak) || anyArgEmptyLine }
   );
 }
 

--- a/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
@@ -174,12 +174,15 @@ func(
 );
 
 doSomething(
+
    { tomorrow: maybe, today: never[always] },
 
    1337,
 
    // This is important
    { helloWorld, someImportantStuff }
+
+
 );
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 longArgNamesWithComments(

--- a/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,217 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`argument-list.js 1`] = `
+longArgNamesWithComments(
+
+  // Hello World
+
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong1,
+
+  // Hello World
+
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong2,
+
+  /* Hello World */
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong3,
+
+
+);
+
+shortArgNames(
+
+
+  short,
+
+  short2,
+  short3,
+);
+
+comments(
+
+  // Comment
+
+  /* Some comments */
+  short,
+  /* Another comment */
+
+
+  short2, // Even more comments
+
+
+  /* Another comment */
+
+
+  // Long Long Long Long Long Comment
+
+
+
+  /* Long Long Long Long Long Comment */
+  // Long Long Long Long Long Comment
+
+  short3,
+  // More comments
+
+
+);
+
+differentArgTypes(
+
+  () => {
+    return true
+  },
+
+  isTrue ?
+    doSomething() : 12,
+
+);
+
+moreArgTypes(
+
+  [1, 2,
+    3],
+
+  {
+    name: 'Hello World',
+    age: 29
+  },
+
+  doSomething(
+
+    // Hello world
+
+
+    // Hello world again
+    { name: 'Hello World', age: 34 },
+
+
+    oneThing
+      + anotherThing,
+
+    // Comment
+
+  ),
+
+);
+
+evenMoreArgTypes(
+  doSomething(
+    { name: 'Hello World', age: 34 },
+
+
+    true
+
+  ),
+
+  14,
+
+  1 + 2
+    - 90/80,
+
+  !98 *
+    60 -
+    90,
+
+
+
+)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+longArgNamesWithComments(
+
+  // Hello World
+
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong1,
+
+  // Hello World
+
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong2,
+
+  /* Hello World */
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong3
+
+);
+
+shortArgNames(
+
+  short,
+
+  short2,
+  short3
+);
+
+comments(
+
+  // Comment
+
+  /* Some comments */
+  short,
+  /* Another comment */
+
+  short2, // Even more comments
+
+  /* Another comment */
+
+  // Long Long Long Long Long Comment
+
+  /* Long Long Long Long Long Comment */
+  // Long Long Long Long Long Comment
+
+  short3
+  // More comments
+
+);
+
+differentArgTypes(
+
+  () => {
+    return true;
+  },
+
+  isTrue ? doSomething() : 12
+
+);
+
+moreArgTypes(
+
+  [1, 2, 3],
+
+  {
+    name: "Hello World",
+    age: 29
+  },
+
+  doSomething(
+
+    // Hello world
+
+    // Hello world again
+    { name: "Hello World", age: 34 },
+
+    oneThing + anotherThing
+
+    // Comment
+
+  )
+
+);
+
+evenMoreArgTypes(
+  doSomething(
+    { name: "Hello World", age: 34 },
+
+    true
+
+  ),
+
+  14,
+
+  1 + 2 - 90 / 80,
+
+  !98 * 60 - 90
+
+);
+
+`;
+
 exports[`comments.js 1`] = `
 function a() {
   const a = 5; // comment

--- a/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
@@ -114,6 +114,73 @@ evenMoreArgTypes(
 
 
 )
+
+foo.apply(null,
+
+// Array here
+[1, 2]);
+
+
+bar.on("readable",
+
+() => {
+  doStuff()
+});
+
+foo(['A, B'],
+
+/* function here */
+function doSomething() { return true; });
+
+doSomething.apply(null,
+
+[
+  'Hello world 1',
+  'Hello world 2',
+  'Hello world 3',
+]);
+
+
+doAnotherThing("node",
+
+{
+  solution_type,
+  time_frame
+});
+
+stuff.doThing(someStuff,
+
+  -1, {
+  accept: node => doSomething(node)
+});
+
+doThing(
+
+  someOtherStuff,
+
+  // This is important
+  true, {
+  decline: creditCard => takeMoney(creditCard)
+}
+
+);
+
+func(
+  () => {
+   thing();
+  },
+
+  { yes: true, no: 5 }
+);
+
+doSomething(
+   { tomorrow: maybe, today: never[always] },
+
+   1337,
+
+   // This is important
+   { helloWorld, someImportantStuff }
+);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 longArgNamesWithComments(
   // Hello World
@@ -195,6 +262,81 @@ evenMoreArgTypes(
   1 + 2 - 90 / 80,
 
   !98 * 60 - 90
+);
+
+foo.apply(
+  null,
+
+  // Array here
+  [1, 2]
+);
+
+bar.on(
+  "readable",
+
+  () => {
+    doStuff();
+  }
+);
+
+foo(
+  ["A, B"],
+
+  /* function here */
+  function doSomething() {
+    return true;
+  }
+);
+
+doSomething.apply(
+  null,
+
+  ["Hello world 1", "Hello world 2", "Hello world 3"]
+);
+
+doAnotherThing(
+  "node",
+
+  {
+    solution_type,
+    time_frame
+  }
+);
+
+stuff.doThing(
+  someStuff,
+
+  -1,
+  {
+    accept: node => doSomething(node)
+  }
+);
+
+doThing(
+  someOtherStuff,
+
+  // This is important
+  true,
+  {
+    decline: creditCard => takeMoney(creditCard)
+  }
+);
+
+func(
+  () => {
+    thing();
+  },
+
+  { yes: true, no: 5 }
+);
+
+doSomething(
+  { tomorrow: maybe, today: never[always] },
+
+  1337,
+
+  // This is important
+  { helloWorld, someImportantStuff }
 );
 
 `;

--- a/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
@@ -155,9 +155,13 @@ comments(
   // More comments
 );
 
-differentArgTypes(() => {
-  return true;
-}, isTrue ? doSomething() : 12);
+differentArgTypes(
+  () => {
+    return true;
+  },
+
+  isTrue ? doSomething() : 12
+);
 
 moreArgTypes(
   [1, 2, 3],

--- a/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
@@ -134,6 +134,8 @@ function doSomething() { return true; });
 
 doSomething.apply(null,
 
+// Comment
+
 [
   'Hello world 1',
   'Hello world 2',
@@ -178,6 +180,8 @@ doSomething(
    { tomorrow: maybe, today: never[always] },
 
    1337,
+
+   /* Comment */
 
    // This is important
    { helloWorld, someImportantStuff }
@@ -294,6 +298,8 @@ foo(
 doSomething.apply(
   null,
 
+  // Comment
+
   ["Hello world 1", "Hello world 2", "Hello world 3"]
 );
 
@@ -337,6 +343,8 @@ doSomething(
   { tomorrow: maybe, today: never[always] },
 
   1337,
+
+  /* Comment */
 
   // This is important
   { helloWorld, someImportantStuff }

--- a/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
@@ -116,7 +116,6 @@ evenMoreArgTypes(
 )
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 longArgNamesWithComments(
-
   // Hello World
 
   longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong1,
@@ -127,11 +126,9 @@ longArgNamesWithComments(
 
   /* Hello World */
   longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong3
-
 );
 
 shortArgNames(
-
   short,
 
   short2,
@@ -139,7 +136,6 @@ shortArgNames(
 );
 
 comments(
-
   // Comment
 
   /* Some comments */
@@ -157,21 +153,13 @@ comments(
 
   short3
   // More comments
-
 );
 
-differentArgTypes(
-
-  () => {
-    return true;
-  },
-
-  isTrue ? doSomething() : 12
-
-);
+differentArgTypes(() => {
+  return true;
+}, isTrue ? doSomething() : 12);
 
 moreArgTypes(
-
   [1, 2, 3],
 
   {
@@ -180,7 +168,6 @@ moreArgTypes(
   },
 
   doSomething(
-
     // Hello world
 
     // Hello world again
@@ -189,9 +176,7 @@ moreArgTypes(
     oneThing + anotherThing
 
     // Comment
-
   )
-
 );
 
 evenMoreArgTypes(
@@ -199,7 +184,6 @@ evenMoreArgTypes(
     { name: "Hello World", age: 34 },
 
     true
-
   ),
 
   14,
@@ -207,7 +191,6 @@ evenMoreArgTypes(
   1 + 2 - 90 / 80,
 
   !98 * 60 - 90
-
 );
 
 `;

--- a/tests/preserve_line/argument-list.js
+++ b/tests/preserve_line/argument-list.js
@@ -131,6 +131,8 @@ function doSomething() { return true; });
 
 doSomething.apply(null,
 
+// Comment
+
 [
   'Hello world 1',
   'Hello world 2',
@@ -175,6 +177,8 @@ doSomething(
    { tomorrow: maybe, today: never[always] },
 
    1337,
+
+   /* Comment */
 
    // This is important
    { helloWorld, someImportantStuff }

--- a/tests/preserve_line/argument-list.js
+++ b/tests/preserve_line/argument-list.js
@@ -1,0 +1,113 @@
+longArgNamesWithComments(
+
+  // Hello World
+
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong1,
+
+  // Hello World
+
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong2,
+
+  /* Hello World */
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong3,
+
+
+);
+
+shortArgNames(
+
+
+  short,
+
+  short2,
+  short3,
+);
+
+comments(
+
+  // Comment
+
+  /* Some comments */
+  short,
+  /* Another comment */
+
+
+  short2, // Even more comments
+
+
+  /* Another comment */
+
+
+  // Long Long Long Long Long Comment
+
+
+
+  /* Long Long Long Long Long Comment */
+  // Long Long Long Long Long Comment
+
+  short3,
+  // More comments
+
+
+);
+
+differentArgTypes(
+
+  () => {
+    return true
+  },
+
+  isTrue ?
+    doSomething() : 12,
+
+);
+
+moreArgTypes(
+
+  [1, 2,
+    3],
+
+  {
+    name: 'Hello World',
+    age: 29
+  },
+
+  doSomething(
+
+    // Hello world
+
+
+    // Hello world again
+    { name: 'Hello World', age: 34 },
+
+
+    oneThing
+      + anotherThing,
+
+    // Comment
+
+  ),
+
+);
+
+evenMoreArgTypes(
+  doSomething(
+    { name: 'Hello World', age: 34 },
+
+
+    true
+
+  ),
+
+  14,
+
+  1 + 2
+    - 90/80,
+
+  !98 *
+    60 -
+    90,
+
+
+
+)

--- a/tests/preserve_line/argument-list.js
+++ b/tests/preserve_line/argument-list.js
@@ -111,3 +111,70 @@ evenMoreArgTypes(
 
 
 )
+
+foo.apply(null,
+
+// Array here
+[1, 2]);
+
+
+bar.on("readable",
+
+() => {
+  doStuff()
+});
+
+foo(['A, B'],
+
+/* function here */
+function doSomething() { return true; });
+
+doSomething.apply(null,
+
+[
+  'Hello world 1',
+  'Hello world 2',
+  'Hello world 3',
+]);
+
+
+doAnotherThing("node",
+
+{
+  solution_type,
+  time_frame
+});
+
+stuff.doThing(someStuff,
+
+  -1, {
+  accept: node => doSomething(node)
+});
+
+doThing(
+
+  someOtherStuff,
+
+  // This is important
+  true, {
+  decline: creditCard => takeMoney(creditCard)
+}
+
+);
+
+func(
+  () => {
+   thing();
+  },
+
+  { yes: true, no: 5 }
+);
+
+doSomething(
+   { tomorrow: maybe, today: never[always] },
+
+   1337,
+
+   // This is important
+   { helloWorld, someImportantStuff }
+);

--- a/tests/preserve_line/argument-list.js
+++ b/tests/preserve_line/argument-list.js
@@ -171,10 +171,13 @@ func(
 );
 
 doSomething(
+
    { tomorrow: maybe, today: never[always] },
 
    1337,
 
    // This is important
    { helloWorld, someImportantStuff }
+
+
 );


### PR DESCRIPTION
For https://github.com/prettier/prettier/issues/2367, so that empty lines in an argument list will be kept and printed. For example,

```
f(
  // hi
  adbldsaklfkljadskljasdklfklasdfkladsklfkladsfkladsklfkadlsflkadskfladsklfdsaf,
  
  // hey
  adbldsaklfkljadskljasdklfklasdfkladsklfkladsfkladsklfkadlsflkadskfladsklfdsaf,
);
```

will be printed without any change and hence the empty line in the middle will be kept.

Let me know if my approach is appropriate or/and you have any improvement in mind for this PR. Any feedback is greatly appreciated! 😄 