### PR TITLE
Change when to print ternaries in JSX mode

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1244,8 +1244,6 @@ function genericPrintNoParens(path, options, print, args) {
         n.test.type === "JSXElement" ||
         n.consequent.type === "JSXElement" ||
         n.alternate.type === "JSXElement" ||
-        parent.type === "JSXExpressionContainer" ||
-        firstNonConditionalParent.type === "JSXExpressionContainer" ||
         conditionalExpressionChainContainsJSX(lastConditionalParent)
       ) {
         jsxMode = true;
@@ -1263,20 +1261,19 @@ function genericPrintNoParens(path, options, print, args) {
           ]);
 
         // The only things we don't wrap are:
-        // * Nested conditional expressions
+        // * Nested conditional expressions in alternates
         // * null
-        const shouldNotWrap = node =>
-          node.type === "ConditionalExpression" ||
+        const isNull = node =>
           node.type === "NullLiteral" ||
           (node.type === "Literal" && node.value === null);
 
         parts.push(
           " ? ",
-          shouldNotWrap(n.consequent)
+          isNull(n.consequent)
             ? path.call(print, "consequent")
             : wrap(path.call(print, "consequent")),
           " : ",
-          shouldNotWrap(n.alternate)
+          n.alternate.type === "ConditionalExpression" || isNull(n.alternate)
             ? path.call(print, "alternate")
             : wrap(path.call(print, "alternate"))
         );

--- a/tests/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -20,84 +20,70 @@ exports[`conditional-expression.js 1`] = `
 //
 //  test ? consequent : alternate;
 //
-// We print a conditional expression in JSX mode if any of the following are
-// true:
-// * Its parent is a JSXExpressionContainer
-// * Its test, consequent, or alternate are JSXElements
-// * It is in a chain with other ConditionalExpressions, and the outermost
-//   one's parent is a JSXExpressionContainer
-// * It is in a chain with other ConditionalExpressions, and any of the
-//   tests, consequents, or alternates of any of the ConditionalExpressions in
-//   the chain are JSXElements.
+// We only print a conditional expression in JSX mode if its test,
+// consequent, or alternate are JSXElements.
 // Otherwise, we print in normal mode.
 
-// This ConditionalExpression does not meet any of the other criteria for
-// printing in JSX mode, so it prints in normal mode. The line does not break.
+// This ConditionalExpression has no JSXElements so it prints in normal mode.
+// The line does not break.
 normalModeNonBreaking ? "a" : "b";
 
-// This ConditionalExpression does not meet any of the criteria to print in JSX
-// mode, so it prints in normal mode. Its consequent is very long, so it breaks
-// out to multiple lines.
+// This ConditionalExpression has no JSXElements so it prints in normal mode.
+// Its consequent is very long, so it breaks out to multiple lines.
 normalModeBreaking
   ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
   : "c";
 
-// This ConditionalExpression prints in JSX mode because its parent is a
+// This ConditionalExpression prints in normal mode even though its parent is a
 // JSXExpressionContainer. The line does not break, so it does not contain
 // parens.
 <div>
   {a ? "b" : "c"}
 </div>;
 
-// This ConditionalExpression prints in JSX mode because its parent is a
-// JSXExpressionContainer. Because the consequent is long enough to break the
-// line, both its consequent and alternate break out and are wrapped in parens.
+// This ConditionalExpression prints in normal mode even though its parent is a
+// JSXExpressionContainer. Because the consequent is very long, they are broken in
+// multiple lines but no parens are added.
 <div>
-  {a ? (
-    johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-  ) : (
-    "c"
-  )}
+  {a
+    ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
+    : "c"}
 </div>;
 
-// This ConditionalExpression prints in JSX mode because its parent is a
-// JSXExpressionContainer. The consequent is long enough to break the line, but
-// because the alternate is null, only the consequent is wrapped in parens.
+// This ConditionalExpression prints in normal mode even though its parent is a
+// JSXExpressionContainer. Because the consequent is very long, they are broken in
+// multiple lines but no parens are added.
 <div>
-  {a ? (
-    johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-  ) : null}
+  {a
+    ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
+    : null}
 </div>;
 
-// This ConditionalExpression prints in JSX mode because its parent is a
-// JSXExpressionContainer. Because the alternate is long enough to break the
-// line, both its consequent and alternate break out and are wrapped in parens.
+// This ConditionalExpression prints in normal mode even though its parent is a
+// JSXExpressionContainer. Because the alternate is very long, they are broken in
+// multiple lines but no parens are added.
 <div>
-  {a ? (
-    "b"
-  ) : (
-    johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-  )}
+  {a
+    ? "b"
+    : johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa}
 </div>;
 
-// This ConditionalExpression prints in JSX mode because its parent is a
-// JSXExpressionContainer. The alternate is long enough to break the line, but
-// because the consequent is null, only the alternate is wrapped in parens.
+// This ConditionalExpression prints in normal mode even though its parent is a
+// JSXExpressionContainer. Because the alternate is very long, they are broken in
+// multiple lines but no parens are added.
 <div>
-  {a ? null : (
-    johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-  )}
+  {a
+    ? null
+    : johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa}
 </div>;
 
-// This ConditionalExpression prints in JSX mode because its parent is a
-// JSXExpressionContainer. Because the test is long enough to break the
-// line, both its consequent and alternate break out and are wrapped in parens.
+// This ConditionalExpression prints in normal mode even though its parent is a
+// JSXExpressionContainer. Because the test is very long, they are broken in
+// multiple lines but no parens are added.
 <div>
-  {johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa ? (
-    "b"
-  ) : (
-    "c"
-  )}
+  {johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
+    ? "b"
+    : "c"}
 </div>;
 
 // This ConditionalExpression prints in JSX mode because its test is a
@@ -153,17 +139,14 @@ jsxModeFromElementBreaking ? (
   {a ? "a" : b ? "b" : "c"}
 </div>;
 
-// This chain of ConditionalExpressions prints in JSX mode because the parent of
-// the outermost ConditionalExpression is a JSXExpressionContainer. It is
-// breaking.
+// This chain of ConditionalExpressions prints in normal mode even though its parent is a
+// JSXExpressionContainer. It is breaking.
 <div>
-  {a ? (
-    "a"
-  ) : b ? (
-    "b"
-  ) : (
-    thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo
-  )}
+  {a
+    ? "a"
+    : b
+      ? "b"
+      : thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo}
 </div>;
 
 // This chain of ConditionalExpressions prints in JSX mode because there is a
@@ -197,6 +180,20 @@ cable ? (
 ) : affairs ? (
   "network"
 ) : "dunno";
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain. It is breaking; notice the consequents
+// and alternates in the entire chain get wrapped in parens.
+<div>
+  {properties.length > 1 ||
+  (properties.length === 1 && properties[0].apps.size > 1) ? (
+    draggingApp == null || newPropertyName == null ? (
+      <MigrationPropertyListItem />
+    ) : (
+      <MigrationPropertyListItem apps={Immutable.List()} />
+    )
+  ) : null}
+</div>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // There are two ways to print ConditionalExpressions: "normal mode" and
 // "JSX mode". This is normal mode (when breaking):
@@ -217,82 +214,68 @@ cable ? (
 //
 //  test ? consequent : alternate;
 //
-// We print a conditional expression in JSX mode if any of the following are
-// true:
-// * Its parent is a JSXExpressionContainer
-// * Its test, consequent, or alternate are JSXElements
-// * It is in a chain with other ConditionalExpressions, and the outermost
-//   one's parent is a JSXExpressionContainer
-// * It is in a chain with other ConditionalExpressions, and any of the
-//   tests, consequents, or alternates of any of the ConditionalExpressions in
-//   the chain are JSXElements.
+// We only print a conditional expression in JSX mode if its test,
+// consequent, or alternate are JSXElements.
 // Otherwise, we print in normal mode.
 
-// This ConditionalExpression does not meet any of the other criteria for
-// printing in JSX mode, so it prints in normal mode. The line does not break.
+// This ConditionalExpression has no JSXElements so it prints in normal mode.
+// The line does not break.
 normalModeNonBreaking ? "a" : "b";
 
-// This ConditionalExpression does not meet any of the criteria to print in JSX
-// mode, so it prints in normal mode. Its consequent is very long, so it breaks
-// out to multiple lines.
+// This ConditionalExpression has no JSXElements so it prints in normal mode.
+// Its consequent is very long, so it breaks out to multiple lines.
 normalModeBreaking
   ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
   : "c";
 
-// This ConditionalExpression prints in JSX mode because its parent is a
+// This ConditionalExpression prints in normal mode even though its parent is a
 // JSXExpressionContainer. The line does not break, so it does not contain
 // parens.
 <div>{a ? "b" : "c"}</div>;
 
-// This ConditionalExpression prints in JSX mode because its parent is a
-// JSXExpressionContainer. Because the consequent is long enough to break the
-// line, both its consequent and alternate break out and are wrapped in parens.
+// This ConditionalExpression prints in normal mode even though its parent is a
+// JSXExpressionContainer. Because the consequent is very long, they are broken in
+// multiple lines but no parens are added.
 <div>
-  {a ? (
-    johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-  ) : (
-    "c"
-  )}
+  {a
+    ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
+    : "c"}
 </div>;
 
-// This ConditionalExpression prints in JSX mode because its parent is a
-// JSXExpressionContainer. The consequent is long enough to break the line, but
-// because the alternate is null, only the consequent is wrapped in parens.
+// This ConditionalExpression prints in normal mode even though its parent is a
+// JSXExpressionContainer. Because the consequent is very long, they are broken in
+// multiple lines but no parens are added.
 <div>
-  {a ? (
-    johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-  ) : null}
+  {a
+    ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
+    : null}
 </div>;
 
-// This ConditionalExpression prints in JSX mode because its parent is a
-// JSXExpressionContainer. Because the alternate is long enough to break the
-// line, both its consequent and alternate break out and are wrapped in parens.
+// This ConditionalExpression prints in normal mode even though its parent is a
+// JSXExpressionContainer. Because the alternate is very long, they are broken in
+// multiple lines but no parens are added.
 <div>
-  {a ? (
-    "b"
-  ) : (
-    johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-  )}
+  {a
+    ? "b"
+    : johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa}
 </div>;
 
-// This ConditionalExpression prints in JSX mode because its parent is a
-// JSXExpressionContainer. The alternate is long enough to break the line, but
-// because the consequent is null, only the alternate is wrapped in parens.
+// This ConditionalExpression prints in normal mode even though its parent is a
+// JSXExpressionContainer. Because the alternate is very long, they are broken in
+// multiple lines but no parens are added.
 <div>
-  {a ? null : (
-    johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-  )}
+  {a
+    ? null
+    : johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa}
 </div>;
 
-// This ConditionalExpression prints in JSX mode because its parent is a
-// JSXExpressionContainer. Because the test is long enough to break the
-// line, both its consequent and alternate break out and are wrapped in parens.
+// This ConditionalExpression prints in normal mode even though its parent is a
+// JSXExpressionContainer. Because the test is very long, they are broken in
+// multiple lines but no parens are added.
 <div>
-  {johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa ? (
-    "b"
-  ) : (
-    "c"
-  )}
+  {johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
+    ? "b"
+    : "c"}
 </div>;
 
 // This ConditionalExpression prints in JSX mode because its test is a
@@ -352,17 +335,14 @@ jsxModeFromElementBreaking ? (
 // non-breaking.
 <div>{a ? "a" : b ? "b" : "c"}</div>;
 
-// This chain of ConditionalExpressions prints in JSX mode because the parent of
-// the outermost ConditionalExpression is a JSXExpressionContainer. It is
-// breaking.
+// This chain of ConditionalExpressions prints in normal mode even though its parent is a
+// JSXExpressionContainer. It is breaking.
 <div>
-  {a ? (
-    "a"
-  ) : b ? (
-    "b"
-  ) : (
-    thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo
-  )}
+  {a
+    ? "a"
+    : b
+      ? "b"
+      : thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo}
 </div>;
 
 // This chain of ConditionalExpressions prints in JSX mode because there is a
@@ -404,6 +384,20 @@ cable ? (
 ) : (
   "dunno"
 );
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain. It is breaking; notice the consequents
+// and alternates in the entire chain get wrapped in parens.
+<div>
+  {properties.length > 1 ||
+  (properties.length === 1 && properties[0].apps.size > 1) ? (
+    draggingApp == null || newPropertyName == null ? (
+      <MigrationPropertyListItem />
+    ) : (
+      <MigrationPropertyListItem apps={Immutable.List()} />
+    )
+  ) : null}
+</div>;
 
 `;
 

--- a/tests/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -34,58 +34,6 @@ normalModeBreaking
   ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
   : "c";
 
-// This ConditionalExpression prints in normal mode even though its parent is a
-// JSXExpressionContainer. The line does not break, so it does not contain
-// parens.
-<div>
-  {a ? "b" : "c"}
-</div>;
-
-// This ConditionalExpression prints in normal mode even though its parent is a
-// JSXExpressionContainer. Because the consequent is very long, they are broken in
-// multiple lines but no parens are added.
-<div>
-  {a
-    ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-    : "c"}
-</div>;
-
-// This ConditionalExpression prints in normal mode even though its parent is a
-// JSXExpressionContainer. Because the consequent is very long, they are broken in
-// multiple lines but no parens are added.
-<div>
-  {a
-    ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-    : null}
-</div>;
-
-// This ConditionalExpression prints in normal mode even though its parent is a
-// JSXExpressionContainer. Because the alternate is very long, they are broken in
-// multiple lines but no parens are added.
-<div>
-  {a
-    ? "b"
-    : johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa}
-</div>;
-
-// This ConditionalExpression prints in normal mode even though its parent is a
-// JSXExpressionContainer. Because the alternate is very long, they are broken in
-// multiple lines but no parens are added.
-<div>
-  {a
-    ? null
-    : johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa}
-</div>;
-
-// This ConditionalExpression prints in normal mode even though its parent is a
-// JSXExpressionContainer. Because the test is very long, they are broken in
-// multiple lines but no parens are added.
-<div>
-  {johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-    ? "b"
-    : "c"}
-</div>;
-
 // This ConditionalExpression prints in JSX mode because its test is a
 // JSXElement. It is non-breaking.
 // Note: I have never, ever seen someone use a JSXElement as the test in a
@@ -137,16 +85,6 @@ jsxModeFromElementBreaking ? (
 // non-breaking.
 <div>
   {a ? "a" : b ? "b" : "c"}
-</div>;
-
-// This chain of ConditionalExpressions prints in normal mode even though its parent is a
-// JSXExpressionContainer. It is breaking.
-<div>
-  {a
-    ? "a"
-    : b
-      ? "b"
-      : thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo}
 </div>;
 
 // This chain of ConditionalExpressions prints in JSX mode because there is a
@@ -228,56 +166,6 @@ normalModeBreaking
   ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
   : "c";
 
-// This ConditionalExpression prints in normal mode even though its parent is a
-// JSXExpressionContainer. The line does not break, so it does not contain
-// parens.
-<div>{a ? "b" : "c"}</div>;
-
-// This ConditionalExpression prints in normal mode even though its parent is a
-// JSXExpressionContainer. Because the consequent is very long, they are broken in
-// multiple lines but no parens are added.
-<div>
-  {a
-    ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-    : "c"}
-</div>;
-
-// This ConditionalExpression prints in normal mode even though its parent is a
-// JSXExpressionContainer. Because the consequent is very long, they are broken in
-// multiple lines but no parens are added.
-<div>
-  {a
-    ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-    : null}
-</div>;
-
-// This ConditionalExpression prints in normal mode even though its parent is a
-// JSXExpressionContainer. Because the alternate is very long, they are broken in
-// multiple lines but no parens are added.
-<div>
-  {a
-    ? "b"
-    : johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa}
-</div>;
-
-// This ConditionalExpression prints in normal mode even though its parent is a
-// JSXExpressionContainer. Because the alternate is very long, they are broken in
-// multiple lines but no parens are added.
-<div>
-  {a
-    ? null
-    : johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa}
-</div>;
-
-// This ConditionalExpression prints in normal mode even though its parent is a
-// JSXExpressionContainer. Because the test is very long, they are broken in
-// multiple lines but no parens are added.
-<div>
-  {johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-    ? "b"
-    : "c"}
-</div>;
-
 // This ConditionalExpression prints in JSX mode because its test is a
 // JSXElement. It is non-breaking.
 // Note: I have never, ever seen someone use a JSXElement as the test in a
@@ -334,16 +222,6 @@ jsxModeFromElementBreaking ? (
 // the outermost ConditionalExpression is a JSXExpressionContainer. It is
 // non-breaking.
 <div>{a ? "a" : b ? "b" : "c"}</div>;
-
-// This chain of ConditionalExpressions prints in normal mode even though its parent is a
-// JSXExpressionContainer. It is breaking.
-<div>
-  {a
-    ? "a"
-    : b
-      ? "b"
-      : thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo}
-</div>;
 
 // This chain of ConditionalExpressions prints in JSX mode because there is a
 // JSX element somewhere in the chain. It is non-breaking.

--- a/tests/jsx/conditional-expression.js
+++ b/tests/jsx/conditional-expression.js
@@ -17,84 +17,70 @@
 //
 //  test ? consequent : alternate;
 //
-// We print a conditional expression in JSX mode if any of the following are
-// true:
-// * Its parent is a JSXExpressionContainer
-// * Its test, consequent, or alternate are JSXElements
-// * It is in a chain with other ConditionalExpressions, and the outermost
-//   one's parent is a JSXExpressionContainer
-// * It is in a chain with other ConditionalExpressions, and any of the
-//   tests, consequents, or alternates of any of the ConditionalExpressions in
-//   the chain are JSXElements.
+// We only print a conditional expression in JSX mode if its test,
+// consequent, or alternate are JSXElements.
 // Otherwise, we print in normal mode.
 
-// This ConditionalExpression does not meet any of the other criteria for
-// printing in JSX mode, so it prints in normal mode. The line does not break.
+// This ConditionalExpression has no JSXElements so it prints in normal mode.
+// The line does not break.
 normalModeNonBreaking ? "a" : "b";
 
-// This ConditionalExpression does not meet any of the criteria to print in JSX
-// mode, so it prints in normal mode. Its consequent is very long, so it breaks
-// out to multiple lines.
+// This ConditionalExpression has no JSXElements so it prints in normal mode.
+// Its consequent is very long, so it breaks out to multiple lines.
 normalModeBreaking
   ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
   : "c";
 
-// This ConditionalExpression prints in JSX mode because its parent is a
+// This ConditionalExpression prints in normal mode even though its parent is a
 // JSXExpressionContainer. The line does not break, so it does not contain
 // parens.
 <div>
   {a ? "b" : "c"}
 </div>;
 
-// This ConditionalExpression prints in JSX mode because its parent is a
-// JSXExpressionContainer. Because the consequent is long enough to break the
-// line, both its consequent and alternate break out and are wrapped in parens.
+// This ConditionalExpression prints in normal mode even though its parent is a
+// JSXExpressionContainer. Because the consequent is very long, they are broken in
+// multiple lines but no parens are added.
 <div>
-  {a ? (
-    johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-  ) : (
-    "c"
-  )}
+  {a
+    ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
+    : "c"}
 </div>;
 
-// This ConditionalExpression prints in JSX mode because its parent is a
-// JSXExpressionContainer. The consequent is long enough to break the line, but
-// because the alternate is null, only the consequent is wrapped in parens.
+// This ConditionalExpression prints in normal mode even though its parent is a
+// JSXExpressionContainer. Because the consequent is very long, they are broken in
+// multiple lines but no parens are added.
 <div>
-  {a ? (
-    johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-  ) : null}
+  {a
+    ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
+    : null}
 </div>;
 
-// This ConditionalExpression prints in JSX mode because its parent is a
-// JSXExpressionContainer. Because the alternate is long enough to break the
-// line, both its consequent and alternate break out and are wrapped in parens.
+// This ConditionalExpression prints in normal mode even though its parent is a
+// JSXExpressionContainer. Because the alternate is very long, they are broken in
+// multiple lines but no parens are added.
 <div>
-  {a ? (
-    "b"
-  ) : (
-    johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-  )}
+  {a
+    ? "b"
+    : johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa}
 </div>;
 
-// This ConditionalExpression prints in JSX mode because its parent is a
-// JSXExpressionContainer. The alternate is long enough to break the line, but
-// because the consequent is null, only the alternate is wrapped in parens.
+// This ConditionalExpression prints in normal mode even though its parent is a
+// JSXExpressionContainer. Because the alternate is very long, they are broken in
+// multiple lines but no parens are added.
 <div>
-  {a ? null : (
-    johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-  )}
+  {a
+    ? null
+    : johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa}
 </div>;
 
-// This ConditionalExpression prints in JSX mode because its parent is a
-// JSXExpressionContainer. Because the test is long enough to break the
-// line, both its consequent and alternate break out and are wrapped in parens.
+// This ConditionalExpression prints in normal mode even though its parent is a
+// JSXExpressionContainer. Because the test is very long, they are broken in
+// multiple lines but no parens are added.
 <div>
-  {johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa ? (
-    "b"
-  ) : (
-    "c"
-  )}
+  {johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
+    ? "b"
+    : "c"}
 </div>;
 
 // This ConditionalExpression prints in JSX mode because its test is a
@@ -150,17 +136,14 @@ jsxModeFromElementBreaking ? (
   {a ? "a" : b ? "b" : "c"}
 </div>;
 
-// This chain of ConditionalExpressions prints in JSX mode because the parent of
-// the outermost ConditionalExpression is a JSXExpressionContainer. It is
-// breaking.
+// This chain of ConditionalExpressions prints in normal mode even though its parent is a
+// JSXExpressionContainer. It is breaking.
 <div>
-  {a ? (
-    "a"
-  ) : b ? (
-    "b"
-  ) : (
-    thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo
-  )}
+  {a
+    ? "a"
+    : b
+      ? "b"
+      : thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo}
 </div>;
 
 // This chain of ConditionalExpressions prints in JSX mode because there is a
@@ -194,3 +177,17 @@ cable ? (
 ) : affairs ? (
   "network"
 ) : "dunno";
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain. It is breaking; notice the consequents
+// and alternates in the entire chain get wrapped in parens.
+<div>
+  {properties.length > 1 ||
+  (properties.length === 1 && properties[0].apps.size > 1) ? (
+    draggingApp == null || newPropertyName == null ? (
+      <MigrationPropertyListItem />
+    ) : (
+      <MigrationPropertyListItem apps={Immutable.List()} />
+    )
+  ) : null}
+</div>;

--- a/tests/jsx/conditional-expression.js
+++ b/tests/jsx/conditional-expression.js
@@ -31,58 +31,6 @@ normalModeBreaking
   ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
   : "c";
 
-// This ConditionalExpression prints in normal mode even though its parent is a
-// JSXExpressionContainer. The line does not break, so it does not contain
-// parens.
-<div>
-  {a ? "b" : "c"}
-</div>;
-
-// This ConditionalExpression prints in normal mode even though its parent is a
-// JSXExpressionContainer. Because the consequent is very long, they are broken in
-// multiple lines but no parens are added.
-<div>
-  {a
-    ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-    : "c"}
-</div>;
-
-// This ConditionalExpression prints in normal mode even though its parent is a
-// JSXExpressionContainer. Because the consequent is very long, they are broken in
-// multiple lines but no parens are added.
-<div>
-  {a
-    ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-    : null}
-</div>;
-
-// This ConditionalExpression prints in normal mode even though its parent is a
-// JSXExpressionContainer. Because the alternate is very long, they are broken in
-// multiple lines but no parens are added.
-<div>
-  {a
-    ? "b"
-    : johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa}
-</div>;
-
-// This ConditionalExpression prints in normal mode even though its parent is a
-// JSXExpressionContainer. Because the alternate is very long, they are broken in
-// multiple lines but no parens are added.
-<div>
-  {a
-    ? null
-    : johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa}
-</div>;
-
-// This ConditionalExpression prints in normal mode even though its parent is a
-// JSXExpressionContainer. Because the test is very long, they are broken in
-// multiple lines but no parens are added.
-<div>
-  {johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-    ? "b"
-    : "c"}
-</div>;
-
 // This ConditionalExpression prints in JSX mode because its test is a
 // JSXElement. It is non-breaking.
 // Note: I have never, ever seen someone use a JSXElement as the test in a
@@ -134,16 +82,6 @@ jsxModeFromElementBreaking ? (
 // non-breaking.
 <div>
   {a ? "a" : b ? "b" : "c"}
-</div>;
-
-// This chain of ConditionalExpressions prints in normal mode even though its parent is a
-// JSXExpressionContainer. It is breaking.
-<div>
-  {a
-    ? "a"
-    : b
-      ? "b"
-      : thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo}
 </div>;
 
 // This chain of ConditionalExpressions prints in JSX mode because there is a


### PR DESCRIPTION
As it was decided in #2729, prettier should print ternaries in normal mode, even in JSX, when it does n't contain JSXElements. This commit changes this check and updates the test.

Also, this commit changes how to print nested conditionals in the consequents (shown on https://github.com/prettier/prettier/issues/2729#issuecomment-327232494), so prettier now won't wrap only `null` and a conditional expression if it's the consequent.

Fixes #2729

