### PR TITLE
Keep conditional expressions in one line on method chains

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3705,7 +3705,9 @@ function printMemberChain(path, options, print) {
     groups.length <= cutoff &&
     !hasComment &&
     // (a || b).map() should be break before .map() instead of ||
-    groups[0][0].node.type !== "LogicalExpression"
+    groups[0][0].node.type !== "LogicalExpression" &&
+    // (a ? b : c).map() should be break before .map() instead of ?
+    groups[0][0].node.type !== "ConditionalExpression"
   ) {
     return group(oneLine);
   }

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -416,6 +416,27 @@ exports[`computed-merge.js 1`] = `
 
 `;
 
+exports[`conditional.js 1`] = `
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.response(401))
+.map(res => res.json());
+
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(defaultUser))
+.map(res => res.json());
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+(valid ? helper.responseBody(this.currentUser) : helper.response(401))
+  .map(res => res.json());
+
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(defaultUser))
+  .map(res => res.json());
+
+`;
+
 exports[`first_long.js 1`] = `
 export default function theFunction(action$, store) {
   return action$.ofType(THE_ACTION).switchMap(action => Observable

--- a/tests/method-chain/conditional.js
+++ b/tests/method-chain/conditional.js
@@ -1,0 +1,9 @@
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.response(401))
+.map(res => res.json());
+
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(defaultUser))
+.map(res => res.json());


### PR DESCRIPTION
Fixes #2775.

This commit will make conditional expressions to match the behavior of
logical expression in method chains:

```js
(a ? b : c).map()

// if the conditional fits in oneline
(a ? b : c)
  .map()

// if the conditional doesn't fit
(a
  ? b
  : c)
  .map()