### PR TITLE
Break closing paren of ConditionalExpression in member chains

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3719,10 +3719,7 @@ function printMemberChain(path, options, print) {
 
   // If we only have a single `.`, we shouldn't do anything fancy and just
   // render everything concatenated together.
-  if (
-    groups.length <= cutoff &&
-    !hasComment
-  ) {
+  if (groups.length <= cutoff && !hasComment) {
     return group(oneLine);
   }
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -1309,10 +1309,19 @@ function genericPrintNoParens(path, options, print, args) {
           ? parent === firstNonConditionalParent ? group(doc) : doc
           : group(doc); // Always group in normal mode.
 
+      // Break the closing paren to keep the chain right after it:
+      // (a
+      //   ? b
+      //   : c
+      // ).call()
+      const breakClosingParen =
+        !jsxMode && parent.type === "MemberExpression" && !parent.computed;
+
       return maybeGroup(
         concat([
           path.call(print, "test"),
-          forceNoIndent ? concat(parts) : indent(concat(parts))
+          forceNoIndent ? concat(parts) : indent(concat(parts)),
+          breakClosingParen ? ifBreak(softline, "") : ""
         ])
       );
     }
@@ -3705,9 +3714,7 @@ function printMemberChain(path, options, print) {
     groups.length <= cutoff &&
     !hasComment &&
     // (a || b).map() should be break before .map() instead of ||
-    groups[0][0].node.type !== "LogicalExpression" &&
-    // (a ? b : c).map() should be break before .map() instead of ?
-    groups[0][0].node.type !== "ConditionalExpression"
+    groups[0][0].node.type !== "LogicalExpression"
   ) {
     return group(oneLine);
   }

--- a/tests/member/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/member/__snapshots__/jsfmt.spec.js.snap
@@ -8,7 +8,8 @@ exports[`conditional.js 1`] = `
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 (valid
   ? helper.responseBody(this.currentUser)
-  : helper.responseBody(this.defaultUser)).prop;
+  : helper.responseBody(this.defaultUser)
+).prop;
 
 `;
 

--- a/tests/member/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/member/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`conditional.js 1`] = `
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(this.defaultUser))
+.prop;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(this.defaultUser)).prop;
+
+`;
+
 exports[`expand.js 1`] = `
 const veryVeryVeryVeryVeryVeryVeryLong = doc.expandedStates[doc.expandedStates.length - 1];
 const small = doc.expandedStates[doc.expandedStates.length - 1];

--- a/tests/member/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/member/__snapshots__/jsfmt.spec.js.snap
@@ -66,3 +66,17 @@ const promises = [
 ];
 
 `;
+
+exports[`logical.js 1`] = `
+(veryLongVeryLongVeryLong || e).prop;
+
+(veryLongVeryLongVeryLong || anotherVeryLongVeryLongVeryLong || veryVeryVeryLongError).prop;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+(veryLongVeryLongVeryLong || e).prop;
+
+(veryLongVeryLongVeryLong ||
+  anotherVeryLongVeryLongVeryLong ||
+  veryVeryVeryLongError
+).prop;
+
+`;

--- a/tests/member/conditional.js
+++ b/tests/member/conditional.js
@@ -1,0 +1,4 @@
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(this.defaultUser))
+.prop;

--- a/tests/member/logical.js
+++ b/tests/member/logical.js
@@ -1,0 +1,3 @@
+(veryLongVeryLongVeryLong || e).prop;
+
+(veryLongVeryLongVeryLong || anotherVeryLongVeryLongVeryLong || veryVeryVeryLongError).prop;

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -417,23 +417,63 @@ exports[`computed-merge.js 1`] = `
 `;
 
 exports[`conditional.js 1`] = `
+(a ? b : c).d();
+
+(a ? b : c).d().e();
+
+(a ? b : c).d().e().f();
+
 (valid
   ? helper.responseBody(this.currentUser)
-  : helper.response(401))
-.map(res => res.json());
+  : helper.responseBody(this.defaultUser))
+.map();
+
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(this.defaultUser))
+.map().filter();
 
 (valid
   ? helper.responseBody(this.currentUser)
   : helper.responseBody(defaultUser))
-.map(res => res.json());
+.map();
+
+object[valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(defaultUser)]
+.map();
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-(valid ? helper.responseBody(this.currentUser) : helper.response(401))
-  .map(res => res.json());
+(a ? b : c).d();
+
+(a ? b : c).d().e();
+
+(a ? b : c)
+  .d()
+  .e()
+  .f();
 
 (valid
   ? helper.responseBody(this.currentUser)
-  : helper.responseBody(defaultUser))
-  .map(res => res.json());
+  : helper.responseBody(this.defaultUser)
+).map();
+
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(this.defaultUser)
+)
+  .map()
+  .filter();
+
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(defaultUser)
+).map();
+
+object[
+  valid
+    ? helper.responseBody(this.currentUser)
+    : helper.responseBody(defaultUser)
+].map();
 
 `;
 

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -572,9 +572,35 @@ Object.keys(
 exports[`logical.js 1`] = `
 (veryLongVeryLongVeryLong || e).map(tickets =>
   TicketRecord.createFromSomeLongString());
+
+(veryLongVeryLongVeryLong || e).map(tickets =>
+  TicketRecord.createFromSomeLongString()).filter(obj => !!obj);
+
+(veryLongVeryLongVeryLong || anotherVeryLongVeryLongVeryLong || veryVeryVeryLongError).map(tickets =>
+  TicketRecord.createFromSomeLongString());
+
+(veryLongVeryLongVeryLong || anotherVeryLongVeryLongVeryLong || veryVeryVeryLongError).map(tickets =>
+  TicketRecord.createFromSomeLongString()).filter(obj => !!obj);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+(veryLongVeryLongVeryLong || e).map(tickets =>
+  TicketRecord.createFromSomeLongString()
+);
+
 (veryLongVeryLongVeryLong || e)
-  .map(tickets => TicketRecord.createFromSomeLongString());
+  .map(tickets => TicketRecord.createFromSomeLongString())
+  .filter(obj => !!obj);
+
+(veryLongVeryLongVeryLong ||
+  anotherVeryLongVeryLongVeryLong ||
+  veryVeryVeryLongError
+).map(tickets => TicketRecord.createFromSomeLongString());
+
+(veryLongVeryLongVeryLong ||
+  anotherVeryLongVeryLongVeryLong ||
+  veryVeryVeryLongError
+)
+  .map(tickets => TicketRecord.createFromSomeLongString())
+  .filter(obj => !!obj);
 
 `;
 

--- a/tests/method-chain/conditional.js
+++ b/tests/method-chain/conditional.js
@@ -1,9 +1,25 @@
+(a ? b : c).d();
+
+(a ? b : c).d().e();
+
+(a ? b : c).d().e().f();
+
 (valid
   ? helper.responseBody(this.currentUser)
-  : helper.response(401))
-.map(res => res.json());
+  : helper.responseBody(this.defaultUser))
+.map();
+
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(this.defaultUser))
+.map().filter();
 
 (valid
   ? helper.responseBody(this.currentUser)
   : helper.responseBody(defaultUser))
-.map(res => res.json());
+.map();
+
+object[valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(defaultUser)]
+.map();

--- a/tests/method-chain/logical.js
+++ b/tests/method-chain/logical.js
@@ -1,2 +1,11 @@
 (veryLongVeryLongVeryLong || e).map(tickets =>
   TicketRecord.createFromSomeLongString());
+
+(veryLongVeryLongVeryLong || e).map(tickets =>
+  TicketRecord.createFromSomeLongString()).filter(obj => !!obj);
+
+(veryLongVeryLongVeryLong || anotherVeryLongVeryLongVeryLong || veryVeryVeryLongError).map(tickets =>
+  TicketRecord.createFromSomeLongString());
+
+(veryLongVeryLongVeryLong || anotherVeryLongVeryLongVeryLong || veryVeryVeryLongError).map(tickets =>
+  TicketRecord.createFromSomeLongString()).filter(obj => !!obj);


### PR DESCRIPTION
Still related to #2775, maybe a better way to print this case.

```js
(a
  ? b
  : c
).prop;

(a
  ? b
  : c
).call();

(a
  ? b
  : c
)
  .call1()
  .call2();
```

If you guys think this is cool, let me know if I should do the same for LogicalExpression (I believe so) and we can do it in a single commit

Thanks!