### PR TITLE
Improve the playground

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,15 +1,24 @@
-<!-- BUGS: Please use this template. -->
+<!-- BUGGY OR UGLY? Please use this template.
+
+Tip! Don't write this stuff manually.
+
+1. Go to https://prettier.io/playground/
+2. Paste your code and set options
+3. Press the "Copy as markdown" button in the upper right
+
+-->
 
 **Prettier Version:** 1.6.1 / master
+([Playground link](https://prettier.io/playground/#.....))
 
-**Code**
+**Input:**
+```js
+// code snippet
+```
 
-([playground](https://prettier.io/playground/#.....))
-
+**Output:**
 ```js
 // code snippet
 ```
 
 **Expected behavior:**
-
-**Actual behavior:**

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,7 +10,7 @@ Tip! Don't write this stuff manually.
 
 **Prettier 1.6.1**
 [Playground link](https://prettier.io/playground/#.....)
-```
+```sh
 # Options (if any):
 --single-quote
 ```

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,7 +8,7 @@ Tip! Don't write this stuff manually.
 
 -->
 
-**Prettier Version:** 1.6.1 / master
+**Prettier Version:** 1.6.1
 ([Playground link](https://prettier.io/playground/#.....))
 
 **Input:**

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,22 +2,26 @@
 
 Tip! Don't write this stuff manually.
 
-1. Go to https://prettier.io/playground/
+1. Go to https://prettier.io/playground
 2. Paste your code and set options
-3. Press the "Copy as markdown" button in the upper right
+3. Press the "Report issue" button in the lower right
 
 -->
 
-**Prettier Version:** 1.6.1
-([Playground link](https://prettier.io/playground/#.....))
+**Prettier 1.6.1**
+[Playground link](https://prettier.io/playground/#.....)
+```
+# Options (if any):
+--single-quote
+```
 
 **Input:**
-```js
+```jsx
 // code snippet
 ```
 
 **Output:**
-```js
+```jsx
 // code snippet
 ```
 

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -106,9 +106,6 @@ shell.sed(
   ".github/ISSUE_TEMPLATE.md"
 );
 
-shell.echo("Create prettier-version.js");
-pipe(`prettierVersion = "${pkg.version}";\n`).to(`${docs}/prettier-version.js`);
-
 shell.echo("Copy sw-toolbox.js to docs");
 shell.cp("node_modules/sw-toolbox/sw-toolbox.js", `${docs}/sw-toolbox.js`);
 

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -4,6 +4,7 @@
 
 const path = require("path");
 const pkg = require("../../package.json");
+const formatMarkdown = require("../../website/static/markdown");
 const shell = require("shelljs");
 
 const rootDir = path.join(__dirname, "..", "..");
@@ -99,12 +100,22 @@ shell.sed(
 );
 
 shell.echo("Update ISSUE_TEMPLATE.md");
-shell.sed(
-  "-i",
-  /(?!Prettier Version.*?)\d+\.\d+\.\d+/,
-  pkg.version,
-  ".github/ISSUE_TEMPLATE.md"
+const issueTemplate = shell.cat(".github/ISSUE_TEMPLATE.md").stdout;
+const newIssueTemplate = issueTemplate.replace(
+  /-->[^]*$/,
+  "-->\n\n" +
+    formatMarkdown(
+      "// code snippet",
+      "// code snippet",
+      "",
+      pkg.version,
+      "https://prettier.io/playground/#.....",
+      { parser: "babylon" },
+      [["# Options (if any):", true], ["--single-quote", true]],
+      true
+    )
 );
+pipe(newIssueTemplate).to(".github/ISSUE_TEMPLATE.md");
 
 shell.echo("Copy sw-toolbox.js to docs");
 shell.cp("node_modules/sw-toolbox/sw-toolbox.js", `${docs}/sw-toolbox.js`);

--- a/website/pages/playground/index.html
+++ b/website/pages/playground/index.html
@@ -61,6 +61,8 @@
       padding: 10px 27px;
       background-color: #1a2b34;
       color: #e0e0e0;
+      position: relative;
+      z-index: 20;
     }
 
     @media (max-width: 400px) {
@@ -102,10 +104,6 @@
       margin-left: 15px;
     }
 
-    textarea.loading {
-      opacity: 0;
-    }
-
     .editors-container {
       display: flex;
       flex: 1;
@@ -141,6 +139,10 @@
       }
     }
 
+    .editor.loading {
+      opacity: 0;
+    }
+
     .CodeMirror {
       height: auto;
       position: absolute;
@@ -149,6 +151,40 @@
       right: 0;
       bottom: 0;
       line-height: 1.6;
+    }
+
+    .bottom-bar {
+      position: relative;
+    }
+
+    .bottom-bar-buttons {
+      position: absolute;
+      z-index: 10;
+      top: 0;
+      left: 0;
+      padding: 9px;
+      display: flex;
+    }
+
+    .bottom-bar-buttons-right {
+      left: auto;
+      right: 0;
+    }
+
+    .bottom-bar-buttons > * + * {
+      margin-left: 9px;
+    }
+
+    @media (max-width: 799px) {
+      .bottom-bar-buttons {
+        top: auto;
+        bottom: 100%;
+        padding: 2px;
+      }
+
+      .bottom-bar-buttons > * + * {
+        margin-left: 2px;
+      }
     }
 
     .options-details {
@@ -204,7 +240,6 @@
       display: inline-block;
       height: 18px;
       padding: 0 5px;
-      margin: 0;
       border: 1px solid #d1d2d3;
       border-radius: 0.25em;
       background-image: linear-gradient(to bottom, #fafbfc, #e4ebf0);
@@ -212,6 +247,8 @@
       line-height: 18px;
       font-weight: 600;
       font-family: inherit;
+      color: inherit;
+      text-decoration: none;
       cursor: pointer;
       outline: none;
       position: relative;
@@ -234,7 +271,7 @@
     .tooltip {
       position: absolute;
       z-index: 1;
-      top: 100%;
+      bottom: 100%;
       left: 50%;
       transform: translateX(-50%);
       margin-top: 4px;
@@ -247,12 +284,12 @@
     .tooltip::before {
       content: "";
       position: absolute;
-      bottom: 100%;
+      top: 100%;
       left: 50%;
       transform: translateX(-50%);
       border: 6px solid transparent;
-      border-top: none;
-      border-bottom-color: black;
+      border-bottom: none;
+      border-top-color: black;
     }
   </style>
 </head>
@@ -261,13 +298,10 @@
   <header>
     <a href="/" class="logo-wrapper">
       <img class="logo" src="/icon.png" alt="">
-      <h1>Prettier <span class="version"></span></h1>
+      <h1>Prettier <span id="version"></span></h1>
     </a>
 
     <span class="links">
-      <button type="button" class="btn copy-markdown">
-        Copy as markdown
-      </button>
       <a
         class="github-button"
         href="https://github.com/prettier/prettier"
@@ -280,22 +314,28 @@
 
   <div class="editors-container">
     <div class="editors">
-      <div class="editor input">
-        <textarea class="loading" id="input-editor"></textarea>
+      <div class="editor loading input">
+        <textarea id="input-editor"></textarea>
       </div>
-      <div class="editor ast" style="display: none;">
-        <textarea class="loading" id="ast-editor"></textarea>
+      <div class="editor loading ast">
+        <textarea id="ast-editor"></textarea>
       </div>
-      <div class="editor doc" style="display: none;">
-        <textarea class="loading" id="doc-editor"></textarea>
+      <div class="editor loading doc">
+        <textarea id="doc-editor"></textarea>
       </div>
-      <div class="editor output">
-        <textarea class="loading" id="output-editor"></textarea>
+      <div class="editor loading output">
+        <textarea id="output-editor"></textarea>
       </div>
     </div>
   </div>
 
-  <div>
+  <div class="bottom-bar">
+    <div class="bottom-bar-buttons">
+      <button type="button" class="btn" id="button-clear">
+        Clear
+      </button>
+    </div>
+
     <details class="options-details">
       <summary class="options-summary">Options</summary>
 
@@ -320,6 +360,20 @@
         </div>
       </div>
     </details>
+
+    <div class="bottom-bar-buttons bottom-bar-buttons-right">
+      <button type="button" class="btn" id="button-copy-link">
+        Copy link
+      </button>
+      <button type="button" class="btn" id="button-copy-markdown">
+        Copy markdown
+      </button>
+      <a href="https://github.com/prettier/prettier/issues/new"
+        target="_blank" rel="noopener"
+        class="btn" id="button-report-issue">
+        Report issue
+      </a>
+    </div>
   </div>
 
   <script src="/install-service-worker.js"></script>

--- a/website/pages/playground/index.html
+++ b/website/pages/playground/index.html
@@ -136,17 +136,20 @@
     }
 
     .editor {
+      box-sizing: border-box;
       display: flex;
       flex: 1;
       flex-basis: 100%;
       position: relative;
-      border-top: 1px solid #1A2B34;
+      border-bottom: 1px solid #ddd;
     }
 
     /* display as 2x2 grid */
     @media (min-width: 800px) {
       .editor {
         flex-basis: 50%;
+        border-left: 1px solid #ddd;
+        margin-left: -1px;
       }
     }
 

--- a/website/pages/playground/index.html
+++ b/website/pages/playground/index.html
@@ -27,7 +27,7 @@
   <script src="/playground.js"></script>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/codemirror.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/mode/javascript/javascript.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/mode/loadmode.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/display/rulers.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/search/searchcursor.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/edit/matchbrackets.js"></script>

--- a/website/pages/playground/index.html
+++ b/website/pages/playground/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
@@ -11,8 +11,8 @@
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="application-name" content="Prettier">
   <meta name="apple-mobile-web-app-title" content="Prettier">
-  <meta name="theme-color" content="#1A2B34">
-  <meta name="msapplication-navbutton-color" content="#1A2B34">
+  <meta name="theme-color" content="#1a2b34">
+  <meta name="msapplication-navbutton-color" content="#1a2b34">
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
   <meta name="msapplication-starturl" content="/">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
@@ -37,83 +37,66 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js"></script>
 
   <style type="text/css">
-    html,
-    body {
-      font-family: "Helvetica Neue", "Open Sans", sans-serif;
-      font-size: 11.7px;
-      margin: 0;
-      padding: 0;
-      background-color: #FAFAFA;
-      color: #6A6A6A;
+    html {
+      background-color: #fafafa;
+      color: #6a6a6a;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      font-size: 12px;
+      line-height: 1.25;
     }
 
     body {
       display: flex;
       flex-direction: column;
       height: 100vh;
-    }
-
-    .options-summary {
-      font-size: 1.4em;
-      margin-top: 8px;
-      text-align: center;
+      margin: 0;
     }
 
     header {
-      height: 30px;
-      padding: 10px 10px;
       display: flex;
-      flex-flow: row nowrap;
-      position: relative;
-      text-align: left;
+      flex-wrap: nowrap;
       justify-content: space-between;
       align-items: center;
-      background-color: #1A2B34;
+      height: 30px;
+      padding: 10px 27px;
+      background-color: #1a2b34;
       color: #e0e0e0;
     }
 
-    @media (max-width: 500px) {
-      .tagline {
-        display: none;
+    @media (max-width: 400px) {
+      header {
+        padding: 10px;
       }
     }
 
-    header a {
-      height: 34px;
-      display: flex;
-      text-decoration: none;
-    }
-
     header a,
-    header a:visited {
-      color: #fff;
-    }
-
+    header a:visited,
     header a:focus,
     header a:active,
     header a:hover {
-      color: #fff;
+      color: white;
+      text-decoration: none;
+    }
+
+    .logo-wrapper {
+      display: flex;
+      align-items: center;
     }
 
     .logo {
-      height: 100%;
-      margin-left: 10px;
+      height: 34px;
       margin-right: 10px;
     }
 
-    header h2 {
-      display: block;
-      font-family: "Helvetica Neue", Arial, sans-serif;
-      font-weight: 400;
-      line-height: 8px;
-      position: relative;
-      z-index: 9999;
+    header h1 {
+      margin: 0;
+      font-size: 18px;
+      font-weight: normal;
     }
 
     .links {
       display: flex;
-      font-size: 1.3em;
-      margin-right: 30px;
+      font-size: 16px;
     }
     .links > * + * {
       margin-left: 15px;
@@ -125,7 +108,7 @@
 
     .editors-container {
       display: flex;
-      flex-grow: 1;
+      flex: 1;
     }
 
     .editors {
@@ -137,8 +120,7 @@
     .editor {
       box-sizing: border-box;
       display: flex;
-      flex: 1;
-      flex-basis: 100%;
+      flex: 1 1 100%;
       position: relative;
       border-bottom: 1px solid #ddd;
     }
@@ -159,11 +141,6 @@
       }
     }
 
-    .arrow {
-      align-self: center;
-      font-size: 1.2em;
-    }
-
     .CodeMirror {
       height: auto;
       position: absolute;
@@ -171,9 +148,16 @@
       left: 0;
       right: 0;
       bottom: 0;
-      font-family: Menlo, monospace;
-      font-size: 11.05px;
-      line-height: 17.68px;
+      line-height: 1.6;
+    }
+
+    .options-details {
+      padding: 8px 0;
+    }
+
+    .options-summary {
+      font-size: 1.4em;
+      text-align: center;
     }
 
     .options-container {
@@ -183,11 +167,11 @@
     }
 
     .options {
-      padding: 0 10px;
-      display: flex;
       flex-flow: column wrap;
-      flex-grow: 1;
+      flex: 1;
+      display: flex;
       justify-content: space-around;
+      padding: 0 10px;
       margin: 5px;
       margin-bottom: 0;
       min-width: 150px;
@@ -214,10 +198,6 @@
       max-width: 40px;
     }
 
-    footer {
-      text-align: center;
-    }
-
     /* Copied from the GitHub button styling. */
     .btn {
       box-sizing: content-box;
@@ -231,7 +211,7 @@
       font-size: 11px;
       line-height: 18px;
       font-weight: 600;
-      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      font-family: inherit;
       cursor: pointer;
       outline: none;
       position: relative;
@@ -248,7 +228,7 @@
       background-color: #e9ecef;
       background-image: none;
       border-color: #afb1b2;
-      box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);
+      box-shadow: inset 0 0.15em 0.3em rgba(27, 31, 35, 0.15);
     }
 
     .tooltip {
@@ -279,9 +259,9 @@
 
 <body>
   <header>
-    <a href="/">
+    <a href="/" class="logo-wrapper">
       <img class="logo" src="/icon.png" alt="">
-      <h2>Prettier</h2>
+      <h1>Prettier <span class="version"></span></h1>
     </a>
 
     <span class="links">
@@ -316,7 +296,7 @@
   </div>
 
   <div>
-    <details>
+    <details class="options-details">
       <summary class="options-summary">Options</summary>
 
       <div class="options-container">
@@ -341,15 +321,6 @@
       </div>
     </details>
   </div>
-
-  <footer>
-    <p class="version-link">
-      <a href="https://github.com/prettier/prettier">
-        Prettier
-        <span class="version"></span>
-      </a>
-    </p>
-  </footer>
 
   <script src="/install-service-worker.js"></script>
 

--- a/website/pages/playground/index.html
+++ b/website/pages/playground/index.html
@@ -163,7 +163,7 @@
       z-index: 10;
       top: 0;
       left: 0;
-      padding: 9px;
+      padding: 8px;
       display: flex;
     }
 

--- a/website/pages/playground/index.html
+++ b/website/pages/playground/index.html
@@ -278,7 +278,7 @@
 <body>
   <header>
     <a href="/">
-      <img class="logo" src="/icon.png">
+      <img class="logo" src="/icon.png" alt="">
       <h2>Prettier</h2>
     </a>
 
@@ -296,7 +296,7 @@
     </span>
   </header>
 
-  <section class="editors-container">
+  <div class="editors-container">
     <div class="editors">
       <div class="editor input">
         <textarea class="loading" id="input-editor"></textarea>
@@ -311,34 +311,34 @@
         <textarea class="loading" id="output-editor"></textarea>
       </div>
     </div>
-  </section>
+  </div>
 
-  <section>
+  <div>
     <details>
       <summary class="options-summary">Options</summary>
 
       <div class="options-container">
         <div class="options">
-          <label>--print-width <input type="number" value="80" min="0" id="printWidth"></input> </label>
-          <label>--tab-width <input type="number" min="0" value="2" id="tabWidth"></input> </label>
+          <label>--print-width <input type="number" value="80" min="0" id="printWidth"></label>
+          <label>--tab-width <input type="number" min="0" value="2" id="tabWidth"></label>
         </div>
         <div class="options">
-          <label><input type="checkbox" id="useTabs"></input> --use-tabs</label>
-          <label><input type="checkbox" data-inverted id="semi"></input> --no-semi</label>
-          <label><input type="checkbox" id="singleQuote"></input> --single-quote</label>
-          <label><input type="checkbox" data-inverted id="bracketSpacing"></input> --no-bracket-spacing</label>
-          <label><input type="checkbox" id="jsxBracketSameLine"></input> --jsx-bracket-same-line</label>
+          <label><input type="checkbox" id="useTabs"> --use-tabs</label>
+          <label><input type="checkbox" data-inverted id="semi"> --no-semi</label>
+          <label><input type="checkbox" id="singleQuote"> --single-quote</label>
+          <label><input type="checkbox" data-inverted id="bracketSpacing"> --no-bracket-spacing</label>
+          <label><input type="checkbox" id="jsxBracketSameLine"> --jsx-bracket-same-line</label>
         </div>
         <div class="options last">
           <label>--trailing-comma <select id="trailingComma"><option value="none">none</option><option value="es5">es5</option><option value="all">all</option></select></label>
           <label>--parser <select id="parser"><option value="babylon">babylon</option><option value="flow">flow</option><option value="typescript">typescript</option><option value="postcss">postcss</option><option value="json">json</option><option value="graphql">graphql</option></select></label>
           <span style="flex: 0.3"></span>
-          <label><input type="checkbox" id="ast"></input> show AST (debug)</label>
-          <label><input type="checkbox" id="doc"></input> show doc (debug)</label>
+          <label><input type="checkbox" id="ast"> show AST (debug)</label>
+          <label><input type="checkbox" id="doc"> show doc (debug)</label>
         </div>
       </div>
     </details>
-  </section>
+  </div>
 
   <footer>
     <p class="version-link">

--- a/website/pages/playground/index.html
+++ b/website/pages/playground/index.html
@@ -35,6 +35,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/comment/comment.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/wrap/hardwrap.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/keymap/sublime.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js"></script>
 
   <style type="text/css">
     html,
@@ -111,8 +112,12 @@
     }
 
     .links {
+      display: flex;
       font-size: 1.3em;
       margin-right: 30px;
+    }
+    .links > * + * {
+      margin-left: 15px;
     }
 
     textarea.loading {
@@ -210,6 +215,63 @@
     footer {
       text-align: center;
     }
+
+    /* Copied from the GitHub button styling. */
+    .btn {
+      box-sizing: content-box;
+      display: inline-block;
+      height: 18px;
+      padding: 0 5px;
+      margin: 0;
+      border: 1px solid #d1d2d3;
+      border-radius: 0.25em;
+      background-image: linear-gradient(to bottom, #fafbfc, #e4ebf0);
+      font-size: 11px;
+      line-height: 18px;
+      font-weight: 600;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      cursor: pointer;
+      outline: none;
+      position: relative;
+    }
+    .btn:focus {
+      border-color: #c8e1ff;
+    }
+    .btn:hover {
+      background-color:#e6ebf1;
+      background-image: linear-gradient(to bottom, #f0f3f6, #dce3ec);
+      border-color:#afb1b2;
+    }
+    .btn:active {
+      background-color: #e9ecef;
+      background-image: none;
+      border-color: #afb1b2;
+      box-shadow: inset 0 0.15em 0.3em rgba(27,31,35,0.15);
+    }
+
+    .tooltip {
+      position: absolute;
+      z-index: 1;
+      top: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      margin-top: 4px;
+      padding: 0.4em 0.8em;
+      background-color: black;
+      color: white;
+      border-radius: 0.4em;
+      pointer-events: none;
+    }
+    .tooltip::before {
+      content: "";
+      position: absolute;
+      bottom: 100%;
+      left: 50%;
+      transform: translateX(-50%);
+      border: 6px solid transparent;
+      border-top: none;
+      border-bottom-color: black;
+    }
   </style>
 </head>
 
@@ -221,6 +283,9 @@
     </a>
 
     <span class="links">
+      <button type="button" class="btn copy-markdown">
+        Copy as markdown
+      </button>
       <a
         class="github-button"
         href="https://github.com/prettier/prettier"
@@ -280,7 +345,7 @@
       <a href="https://github.com/prettier/prettier">
         prettier version
         <span class="version"></span>
-        (master)
+        / master
       </a>
     </p>
   </footer>

--- a/website/pages/playground/index.html
+++ b/website/pages/playground/index.html
@@ -326,6 +326,9 @@
       <div class="editor loading output">
         <textarea id="output-editor"></textarea>
       </div>
+      <div class="editor loading output2">
+        <textarea id="output2-editor"></textarea>
+      </div>
     </div>
   </div>
 
@@ -357,6 +360,7 @@
           <span style="flex: 0.3"></span>
           <label><input type="checkbox" id="ast"> show AST (debug)</label>
           <label><input type="checkbox" id="doc"> show doc (debug)</label>
+          <label><input type="checkbox" id="output2"> show second format (debug)</label>
         </div>
       </div>
     </details>

--- a/website/pages/playground/index.html
+++ b/website/pages/playground/index.html
@@ -23,7 +23,6 @@
   <link rel="stylesheet" crossorigin  href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/codemirror.css">
   <link rel="stylesheet" crossorigin  href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/theme/neat.css">
 
-  <script src="/lib/prettier-version.js"></script>
   <script src="/playground.js"></script>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/codemirror.js"></script>
@@ -346,9 +345,8 @@
   <footer>
     <p class="version-link">
       <a href="https://github.com/prettier/prettier">
-        prettier version
+        Prettier
         <span class="version"></span>
-        / master
       </a>
     </p>
   </footer>

--- a/website/pages/playground/index.html
+++ b/website/pages/playground/index.html
@@ -21,13 +21,15 @@
   <link rel="apple-touch-icon" href="/icon.png">
 
   <link rel="stylesheet" crossorigin  href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/codemirror.css">
-  <link rel="stylesheet" crossorigin  href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/theme/neat.css">
 
   <script src="/markdown.js"></script>
   <script src="/playground.js"></script>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/codemirror.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/mode/loadmode.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/mode/javascript/javascript.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/mode/xml/xml.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/mode/jsx/jsx.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/mode/css/css.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/display/rulers.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/search/searchcursor.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/edit/matchbrackets.js"></script>

--- a/website/pages/playground/index.html
+++ b/website/pages/playground/index.html
@@ -303,10 +303,10 @@
       <div class="editor input">
         <textarea class="loading" id="input-editor"></textarea>
       </div>
-      <div class="editor ast">
+      <div class="editor ast" style="display: none;">
         <textarea class="loading" id="ast-editor"></textarea>
       </div>
-      <div class="editor doc">
+      <div class="editor doc" style="display: none;">
         <textarea class="loading" id="doc-editor"></textarea>
       </div>
       <div class="editor output">

--- a/website/pages/playground/index.html
+++ b/website/pages/playground/index.html
@@ -23,6 +23,7 @@
   <link rel="stylesheet" crossorigin  href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/codemirror.css">
   <link rel="stylesheet" crossorigin  href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/theme/neat.css">
 
+  <script src="/markdown.js"></script>
   <script src="/playground.js"></script>
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/codemirror.js"></script>

--- a/website/static/lib/prettier-version.js
+++ b/website/static/lib/prettier-version.js
@@ -1,1 +1,0 @@
-prettierVersion = "1.6.1";

--- a/website/static/markdown.js
+++ b/website/static/markdown.js
@@ -1,0 +1,87 @@
+/* eslint-env browser */
+/* eslint no-var: off, strict: off, prefer-arrow-callback: off */
+
+// NOTE: This file must work both in the playground, and in the build scripts to
+// generate the issue template.
+
+(function() {
+  function formatMarkdown(
+    input,
+    output,
+    output2,
+    version,
+    url,
+    options,
+    cliOptions,
+    full
+  ) {
+    var syntax = getMarkdownSyntax(options);
+    var optionsString = formatCLIOptions(cliOptions);
+    var isIdempotent = output2 === "" || output === output2;
+
+    return [
+      "**Prettier " + version + "**",
+      "[Playground link](" + url + ")",
+      optionsString === "" ? null : codeBlock(optionsString),
+      "",
+      "**Input:**",
+      codeBlock(input, syntax),
+      "",
+      "**Output:**",
+      codeBlock(output, syntax)
+    ]
+      .concat(
+        isIdempotent
+          ? []
+          : ["", "**Second Output:**", codeBlock(output2, syntax)]
+      )
+      .concat(full ? ["", "**Expected behavior:**", ""] : [])
+      .filter(function(part) {
+        return part != null;
+      })
+      .join("\n");
+  }
+
+  function getMarkdownSyntax(options) {
+    switch (options.parser) {
+      case "babylon":
+      case "flow":
+        return "jsx";
+      case "typescript":
+        return "tsx";
+      case "postcss":
+        return "scss";
+      default:
+        return options.parser;
+    }
+  }
+
+  function formatCLIOptions(cliOptions) {
+    return cliOptions
+      .map(function(option) {
+        var name = option[0];
+        var value = option[1];
+        return value === true ? name : name + " " + value;
+      })
+      .join("\n");
+  }
+
+  function codeBlock(content, syntax) {
+    var backtickSequences = content.match(/`+/g) || [];
+    var longestBacktickSequenceLength = Math.max.apply(
+      null,
+      backtickSequences.map(function(backticks) {
+        return backticks.length;
+      })
+    );
+    var fenceLength = Math.max(3, longestBacktickSequenceLength + 1);
+    var fence = Array(fenceLength + 1).join("`");
+    return [fence + (syntax || ""), content, fence].join("\n");
+  }
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = formatMarkdown;
+  } else {
+    window.formatMarkdown = formatMarkdown;
+  }
+})();

--- a/website/static/markdown.js
+++ b/website/static/markdown.js
@@ -22,7 +22,7 @@
     return [
       "**Prettier " + version + "**",
       "[Playground link](" + url + ")",
-      optionsString === "" ? null : codeBlock(optionsString),
+      optionsString === "" ? null : codeBlock(optionsString, "sh"),
       "",
       "**Input:**",
       codeBlock(input, syntax),

--- a/website/static/playground.js
+++ b/website/static/playground.js
@@ -8,6 +8,20 @@ var docEditor;
 var astEditor;
 var outputEditor;
 
+var OPTIONS = [
+  "printWidth",
+  "tabWidth",
+  "singleQuote",
+  "trailingComma",
+  "bracketSpacing",
+  "jsxBracketSameLine",
+  "parser",
+  "semi",
+  "useTabs",
+  "doc",
+  "ast"
+];
+
 var state = (function loadState(hash) {
   try {
     return JSON.parse(hash);
@@ -30,12 +44,14 @@ var worker = new Worker("/worker.js");
 worker.onmessage = function(message) {
   if (prettierVersion === "?") {
     prettierVersion = message.data.version;
-    document.querySelector(".version").textContent = prettierVersion;
+    document.getElementById("version").textContent = prettierVersion;
   }
   if (outputEditor && docEditor && astEditor) {
     outputEditor.setValue(message.data.formatted);
     docEditor.setValue(message.data.doc || "");
     astEditor.setValue(message.data.ast || "");
+    document.getElementById("button-report-issue").search =
+      "body=" + encodeURIComponent(createIssueTemplate());
   }
 };
 
@@ -43,152 +59,7 @@ worker.onmessage = function(message) {
 worker.postMessage({ text: "", options: state.options });
 
 window.onload = function() {
-  var OPTIONS = [
-    "printWidth",
-    "tabWidth",
-    "singleQuote",
-    "trailingComma",
-    "bracketSpacing",
-    "jsxBracketSameLine",
-    "parser",
-    "semi",
-    "useTabs",
-    "doc",
-    "ast"
-  ];
   state.options && setOptions(state.options);
-
-  function setOptions(options) {
-    OPTIONS.forEach(function(option) {
-      var elem = document.getElementById(option);
-      if (elem.tagName === "SELECT") {
-        elem.value = options[option];
-      } else if (elem.type === "number") {
-        elem.value = options[option];
-      } else {
-        var isInverted = elem.hasAttribute("data-inverted");
-        elem.checked = isInverted ? !options[option] : options[option];
-      }
-    });
-  }
-
-  function getOptions() {
-    var options = {};
-    OPTIONS.forEach(function(option) {
-      var elem = document.getElementById(option);
-      if (elem.tagName === "SELECT") {
-        options[option] = elem.value;
-      } else if (elem.type === "number") {
-        options[option] = Number(elem.value);
-      } else {
-        var isInverted = elem.hasAttribute("data-inverted");
-        options[option] = isInverted ? !elem.checked : elem.checked;
-      }
-    });
-    return options;
-  }
-
-  function getCLIOptions() {
-    return OPTIONS.sort()
-      .map(function(option) {
-        var elem = document.getElementById(option);
-        var match = elem.parentNode.textContent.match(/--\S+/);
-        if (!match) {
-          return null;
-        }
-        var name = match[0];
-        if (elem.tagName === "SELECT") {
-          if (elem.value === elem.options[0].value) {
-            return null;
-          }
-          return [name, elem.value];
-        } else if (elem.type === "number") {
-          if (elem.value === elem.getAttribute("value")) {
-            return null;
-          }
-          return [name, elem.value];
-        } else if (elem.type === "checkbox") {
-          if (!elem.checked) {
-            return null;
-          }
-          return [name, true];
-        }
-        return null;
-      })
-      .filter(Boolean);
-  }
-
-  function replaceHash(hash) {
-    if (
-      typeof URL === "function" &&
-      typeof history === "object" &&
-      typeof history.replaceState === "function"
-    ) {
-      var url = new URL(location);
-      url.hash = hash;
-      history.replaceState(null, null, url);
-    } else {
-      location.hash = hash;
-    }
-  }
-
-  function setCodemirrorMode(editor, mode) {
-    editor.setOption("mode", mode);
-    CodeMirror.autoLoadMode(editor, mode);
-  }
-
-  function formatAsync() {
-    var options = getOptions();
-
-    var mode = util.getCodemirrorMode(options);
-    setCodemirrorMode(inputEditor, mode);
-    setCodemirrorMode(outputEditor, mode);
-
-    outputEditor.setOption("rulers", [
-      { column: options.printWidth, color: "#444444" }
-    ]);
-    document.querySelector(".ast").style.display = options.ast ? "" : "none";
-    document.querySelector(".doc").style.display = options.doc ? "" : "none";
-
-    var value = encodeURIComponent(
-      JSON.stringify(
-        Object.assign({ content: inputEditor.getValue(), options: options })
-      )
-    );
-    replaceHash(value);
-    worker.postMessage({
-      text: inputEditor.getValue(),
-      options: options,
-      ast: options.ast,
-      doc: options.doc
-    });
-  }
-
-  function createMarkdown() {
-    var input = inputEditor.getValue();
-    var output = outputEditor.getValue();
-    var options = getOptions();
-    var cliOptions = getCLIOptions();
-    var markdown = util.formatMarkdown(
-      input,
-      output,
-      prettierVersion,
-      window.location.href,
-      options,
-      cliOptions
-    );
-    return markdown;
-  }
-
-  function showTooltip(elem, text) {
-    var tooltip = document.createElement("span");
-    tooltip.className = "tooltip";
-    tooltip.textContent = text;
-    elem.appendChild(tooltip);
-    window.setTimeout(function() {
-      elem.removeChild(tooltip);
-    }, 2000);
-  }
 
   CodeMirror.modeURL =
     "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/mode/%N/%N.js";
@@ -227,16 +98,28 @@ window.onload = function() {
   setCodemirrorMode(docEditor, "javascript");
   setCodemirrorMode(astEditor, "javascript");
 
-  Array.from(document.querySelectorAll("textarea")).forEach(function(element) {
-    element.classList.remove("loading");
-  });
+  var editors = document.querySelectorAll(".editor");
+  for (var i = 0; i < editors.length; i++) {
+    editors[i].classList.remove("loading");
+  }
 
   inputEditor.setValue(state.content);
   document.querySelector(".options-container").onchange = formatAsync;
 
-  var clipboard = new Clipboard(".copy-markdown", {
-    text: function() {
-      return createMarkdown();
+  document.getElementById("button-clear").onclick = function() {
+    inputEditor.setValue("");
+  };
+
+  var clipboard = new Clipboard("#button-copy-link, #button-copy-markdown", {
+    text: function(trigger) {
+      switch (trigger.id) {
+        case "button-copy-link":
+          return window.location.href;
+        case "button-copy-markdown":
+          return createMarkdown();
+        default:
+          return "";
+      }
     }
   });
   clipboard.on("success", function(e) {
@@ -247,13 +130,149 @@ window.onload = function() {
   });
 };
 
+function setOptions(options) {
+  OPTIONS.forEach(function(option) {
+    var elem = document.getElementById(option);
+    if (elem.tagName === "SELECT") {
+      elem.value = options[option];
+    } else if (elem.type === "number") {
+      elem.value = options[option];
+    } else {
+      var isInverted = elem.hasAttribute("data-inverted");
+      elem.checked = isInverted ? !options[option] : options[option];
+    }
+  });
+}
+
+function getOptions() {
+  var options = {};
+  OPTIONS.forEach(function(option) {
+    var elem = document.getElementById(option);
+    if (elem.tagName === "SELECT") {
+      options[option] = elem.value;
+    } else if (elem.type === "number") {
+      options[option] = Number(elem.value);
+    } else {
+      var isInverted = elem.hasAttribute("data-inverted");
+      options[option] = isInverted ? !elem.checked : elem.checked;
+    }
+  });
+  return options;
+}
+
+function getCLIOptions() {
+  return OPTIONS.sort()
+    .map(function(option) {
+      var elem = document.getElementById(option);
+      var match = elem.parentNode.textContent.match(/--\S+/);
+      if (!match) {
+        return null;
+      }
+      var name = match[0];
+      if (elem.tagName === "SELECT") {
+        if (elem.value === elem.options[0].value) {
+          return null;
+        }
+        return [name, elem.value];
+      } else if (elem.type === "number") {
+        if (elem.value === elem.getAttribute("value")) {
+          return null;
+        }
+        return [name, elem.value];
+      } else if (elem.type === "checkbox") {
+        if (!elem.checked) {
+          return null;
+        }
+        return [name, true];
+      }
+      return null;
+    })
+    .filter(Boolean);
+}
+
+function replaceHash(hash) {
+  if (
+    typeof URL === "function" &&
+    typeof history === "object" &&
+    typeof history.replaceState === "function"
+  ) {
+    var url = new URL(location);
+    url.hash = hash;
+    history.replaceState(null, null, url);
+  } else {
+    location.hash = hash;
+  }
+}
+
+function setCodemirrorMode(editor, mode) {
+  editor.setOption("mode", mode);
+  CodeMirror.autoLoadMode(editor, mode);
+}
+
+function formatAsync() {
+  var options = getOptions();
+
+  var mode = util.getCodemirrorMode(options);
+  setCodemirrorMode(inputEditor, mode);
+  setCodemirrorMode(outputEditor, mode);
+
+  outputEditor.setOption("rulers", [
+    { column: options.printWidth, color: "#444444" }
+  ]);
+  document.querySelector(".ast").style.display = options.ast ? "" : "none";
+  document.querySelector(".doc").style.display = options.doc ? "" : "none";
+
+  var value = encodeURIComponent(
+    JSON.stringify(
+      Object.assign({ content: inputEditor.getValue(), options: options })
+    )
+  );
+  replaceHash(value);
+  worker.postMessage({
+    text: inputEditor.getValue(),
+    options: options,
+    ast: options.ast,
+    doc: options.doc
+  });
+}
+
+function createMarkdown() {
+  var input = inputEditor.getValue();
+  var output = outputEditor.getValue();
+  var options = getOptions();
+  var cliOptions = getCLIOptions();
+  var markdown = util.formatMarkdown(
+    input,
+    output,
+    prettierVersion,
+    window.location.href,
+    options,
+    cliOptions
+  );
+  return markdown;
+}
+
+function createIssueTemplate() {
+  return [createMarkdown(), "", "**Expected behavior:**", ""].join("\n");
+}
+
+function showTooltip(elem, text) {
+  var tooltip = document.createElement("span");
+  tooltip.className = "tooltip";
+  tooltip.textContent = text;
+  elem.appendChild(tooltip);
+  window.setTimeout(function() {
+    elem.removeChild(tooltip);
+  }, 2000);
+}
+
 var util = (function() {
   function formatMarkdown(input, output, version, url, options, cliOptions) {
     var syntax = getMarkdownSyntax(options);
     var optionsString = formatCLIOptions(cliOptions);
 
     return [
-      "**Prettier " + version,
+      "**Prettier " + version + "**",
       "[Playground link](" + url + ")",
       optionsString === "" ? null : codeBlock(optionsString),
       "",

--- a/website/static/playground.js
+++ b/website/static/playground.js
@@ -116,6 +116,12 @@ window.onload = function() {
   function formatAsync() {
     var options = getOptions();
 
+    var mode = util.getCodemirrorMode(options);
+    inputEditor.setOption("mode", mode);
+    outputEditor.setOption("mode", mode);
+    CodeMirror.autoLoadMode(inputEditor, mode);
+    CodeMirror.autoLoadMode(outputEditor, mode);
+
     outputEditor.setOption("rulers", [
       { column: options.printWidth, color: "#444444" }
     ]);
@@ -165,6 +171,9 @@ window.onload = function() {
       elem.removeChild(tooltip);
     }, 2000);
   }
+
+  CodeMirror.modeURL =
+    "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/mode/%N/%N.js";
 
   var editorOptions = {
     lineNumbers: true,
@@ -257,6 +266,15 @@ var util = (function() {
     }
   }
 
+  function getCodemirrorMode(options) {
+    switch (options.parser) {
+      case "postcss":
+        return "css";
+      default:
+        return "javascript";
+    }
+  }
+
   function formatCLIOptions(cliOptions) {
     return cliOptions
       .map(function(option) {
@@ -282,6 +300,7 @@ var util = (function() {
 
   return {
     formatMarkdown: formatMarkdown,
-    getMarkdownSyntax: getMarkdownSyntax
+    getMarkdownSyntax: getMarkdownSyntax,
+    getCodemirrorMode: getCodemirrorMode
   };
 })();

--- a/website/static/playground.js
+++ b/website/static/playground.js
@@ -113,24 +113,23 @@ window.onload = function() {
     }
   }
 
+  function setCodemirrorMode(editor, mode) {
+    editor.setOption("mode", mode);
+    CodeMirror.autoLoadMode(editor, mode);
+  }
+
   function formatAsync() {
     var options = getOptions();
 
     var mode = util.getCodemirrorMode(options);
-    inputEditor.setOption("mode", mode);
-    outputEditor.setOption("mode", mode);
-    CodeMirror.autoLoadMode(inputEditor, mode);
-    CodeMirror.autoLoadMode(outputEditor, mode);
+    setCodemirrorMode(inputEditor, mode);
+    setCodemirrorMode(outputEditor, mode);
 
     outputEditor.setOption("rulers", [
       { column: options.printWidth, color: "#444444" }
     ]);
-    document.querySelector(".ast").style.display = options.ast
-      ? "flex"
-      : "none";
-    document.querySelector(".doc").style.display = options.doc
-      ? "flex"
-      : "none";
+    document.querySelector(".ast").style.display = options.ast ? "" : "none";
+    document.querySelector(".doc").style.display = options.doc ? "" : "none";
 
     var value = encodeURIComponent(
       JSON.stringify(
@@ -175,13 +174,14 @@ window.onload = function() {
   CodeMirror.modeURL =
     "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/mode/%N/%N.js";
 
+  var theme = "neat";
   var editorOptions = {
     lineNumbers: true,
     keyMap: "sublime",
     autoCloseBrackets: true,
     matchBrackets: true,
     showCursorWhenSelecting: true,
-    theme: "neat",
+    theme: theme,
     tabWidth: 2
   };
   var inputEditor = CodeMirror.fromTextArea(
@@ -192,16 +192,19 @@ window.onload = function() {
 
   var docEditor = CodeMirror.fromTextArea(
     document.getElementById("doc-editor"),
-    { readOnly: true, lineNumbers: false, theme: "neat" }
+    { readOnly: true, lineNumbers: false, theme: theme }
   );
   var astEditor = CodeMirror.fromTextArea(
     document.getElementById("ast-editor"),
-    { readOnly: true, lineNumbers: false, theme: "neat" }
+    { readOnly: true, lineNumbers: false, theme: theme }
   );
   var outputEditor = CodeMirror.fromTextArea(
     document.getElementById("output-editor"),
-    { readOnly: true, lineNumbers: true, theme: "neat" }
+    { readOnly: true, lineNumbers: true, theme: theme }
   );
+
+  setCodemirrorMode(docEditor, "javascript");
+  setCodemirrorMode(astEditor, "javascript");
 
   Array.from(document.querySelectorAll("textarea")).forEach(function(element) {
     element.classList.remove("loading");

--- a/website/static/playground.js
+++ b/website/static/playground.js
@@ -32,13 +32,29 @@ var state = (function loadState(hash) {
   } catch (error) {
     return {
       options: undefined,
-      content:
-        'hello ( "world"\n);\n\n' +
-        '[ "lorem", "ipsum", \'dolor\', sit("amet"), consectetur[ \'adipiscing\' ] + "elit" ].reduce(\n  (first, second) => first + second,\n  "")\n\n' +
-        "const Foo = ({ bar, baz, things }) => {\n" +
-        '  return <div style={{\ncolor: "papayawhip"}}>\n' +
-        "    <br/>{things.map(thing => reallyLongPleaseDontPutOnOneLine(thing) ? <p>{ok}</p> : <Quax bar={bar} baz={ baz } {...thing}></Quax>)\n" +
-        "  }</div>}"
+      content: [
+        'function HelloWorld({greeting = "hello", greeted = \'"World"\', silent = false, onMouseOver,}) {',
+        "",
+        "  if(!greeting){return null};",
+        "",
+        "     // TODO: Don't use random in render",
+        '  let num = Math.floor (Math.random() * 1E+7).toString().replace(/\\.\\d+/ig, "")',
+        "",
+        "  return <div className='HelloWorld' title={`You are visitor number ${ num }`} onMouseOver={onMouseOver}>",
+        "",
+        "    <strong>{ greeting.slice( 0, 1 ).toUpperCase() + greeting.slice(1).toLowerCase() }</strong>",
+        '    {greeting.endsWith(",") ? " " : <span style={{color: \'\\grey\'}}>", "</span> }',
+        "    <em>",
+        "\t{ greeted }",
+        "\t</em>",
+        "    { (silent)",
+        '      ? "."',
+        '      : "!"}',
+        "",
+        "    </div>;",
+        "",
+        "}"
+      ].join("\n")
     };
   }
 })(decodeURIComponent(location.hash.slice(1)));

--- a/website/static/playground.js
+++ b/website/static/playground.js
@@ -88,18 +88,14 @@ worker.postMessage({ text: "", options: state.options });
 window.onload = function() {
   state.options && setOptions(state.options);
 
-  CodeMirror.modeURL =
-    "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/mode/%N/%N.js";
-
-  var theme = "neat";
   var editorOptions = {
     lineNumbers: true,
     keyMap: "sublime",
     autoCloseBrackets: true,
     matchBrackets: true,
     showCursorWhenSelecting: true,
-    theme: theme,
-    tabWidth: 2
+    tabWidth: 2,
+    mode: "jsx"
   };
   inputEditor = CodeMirror.fromTextArea(
     document.getElementById("input-editor"),
@@ -110,24 +106,29 @@ window.onload = function() {
   docEditor = CodeMirror.fromTextArea(document.getElementById("doc-editor"), {
     readOnly: true,
     lineNumbers: false,
-    theme: theme
+    mode: "jsx"
   });
   astEditor = CodeMirror.fromTextArea(document.getElementById("ast-editor"), {
     readOnly: true,
     lineNumbers: false,
-    theme: theme
+    mode: "jsx"
   });
   outputEditor = CodeMirror.fromTextArea(
     document.getElementById("output-editor"),
-    { readOnly: true, lineNumbers: true, theme: theme }
+    {
+      readOnly: true,
+      lineNumbers: true,
+      mode: "jsx"
+    }
   );
   output2Editor = CodeMirror.fromTextArea(
     document.getElementById("output2-editor"),
-    { readOnly: true, lineNumbers: true, theme: theme }
+    {
+      readOnly: true,
+      lineNumbers: true,
+      mode: "jsx"
+    }
   );
-
-  setCodemirrorMode(docEditor, "javascript");
-  setCodemirrorMode(astEditor, "javascript");
 
   var editors = document.querySelectorAll(".editor");
   for (var i = 0; i < editors.length; i++) {
@@ -235,17 +236,12 @@ function replaceHash(hash) {
   }
 }
 
-function setCodemirrorMode(editor, mode) {
-  editor.setOption("mode", mode);
-  CodeMirror.autoLoadMode(editor, mode);
-}
-
 function getCodemirrorMode(options) {
   switch (options.parser) {
     case "postcss":
       return "css";
     default:
-      return "javascript";
+      return "jsx";
   }
 }
 
@@ -253,9 +249,9 @@ function formatAsync() {
   var options = getOptions();
 
   var mode = getCodemirrorMode(options);
-  setCodemirrorMode(inputEditor, mode);
-  setCodemirrorMode(outputEditor, mode);
-  setCodemirrorMode(output2Editor, mode);
+  inputEditor.setOption("mode", mode);
+  outputEditor.setOption("mode", mode);
+  output2Editor.setOption("mode", mode);
 
   [outputEditor, output2Editor].forEach(function(editor) {
     editor.setOption("rulers", [

--- a/website/static/service-worker.js
+++ b/website/static/service-worker.js
@@ -22,7 +22,9 @@ toolbox.precache([
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/codemirror.css",
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/theme/neat.css",
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/codemirror.js",
+  "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/mode/loadmode.js",
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/mode/javascript/javascript.js",
+  "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/mode/css/css.js",
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/display/rulers.js",
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/search/searchcursor.js",
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/edit/matchbrackets.js",
@@ -30,6 +32,7 @@ toolbox.precache([
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/comment/comment.js",
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/wrap/hardwrap.js",
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/keymap/sublime.js",
+  "https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js",
 
   // Images
   "/prettier.png"

--- a/website/static/service-worker.js
+++ b/website/static/service-worker.js
@@ -20,10 +20,10 @@ toolbox.precache([
 
   // CodeMirror
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/codemirror.css",
-  "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/theme/neat.css",
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/codemirror.js",
-  "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/mode/loadmode.js",
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/mode/javascript/javascript.js",
+  "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/mode/xml/xml.js",
+  "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/mode/jsx/jsx.js",
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/mode/css/css.js",
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/display/rulers.js",
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/search/searchcursor.js",

--- a/website/static/service-worker.js
+++ b/website/static/service-worker.js
@@ -13,6 +13,7 @@ toolbox.precache([
   "lib/parser-postcss.js",
   "lib/parser-flow.js",
   "lib/parser-graphql.js",
+  "markdown.js",
   "playground.js",
   "lib/sw-toolbox.js",
   "lib/sw-toolbox-companion.js",

--- a/website/static/service-worker.js
+++ b/website/static/service-worker.js
@@ -7,7 +7,6 @@ importScripts("lib/sw-toolbox.js");
 
 toolbox.precache([
   // Scripts
-  "lib/prettier-version.js",
   "lib/index.js",
   "lib/parser-babylon.js",
   "lib/parser-typescript.js",

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -27,10 +27,12 @@ self.onmessage = function(message) {
 
   delete options.ast;
   delete options.doc;
+  delete options.output2;
 
   var formatted = formatCode(message.data.text, options);
   var doc;
   var ast;
+  var formatted2;
 
   if (message.data.ast) {
     var actualAst;
@@ -63,10 +65,15 @@ self.onmessage = function(message) {
     }
   }
 
+  if (message.data.formatted2) {
+    formatted2 = formatCode(formatted, options);
+  }
+
   self.postMessage({
     formatted: formatted,
     doc: doc,
     ast: ast,
+    formatted2: formatted2,
     version: prettier.version
   });
 };

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -63,7 +63,12 @@ self.onmessage = function(message) {
     }
   }
 
-  self.postMessage({ formatted: formatted, doc: doc, ast: ast });
+  self.postMessage({
+    formatted: formatted,
+    doc: doc,
+    ast: ast,
+    version: prettier.version
+  });
 };
 
 function formatCode(text, options) {

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -33,14 +33,21 @@ self.onmessage = function(message) {
   var ast;
 
   if (message.data.ast) {
+    var actualAst;
+    var errored = false;
     try {
-      ast = JSON.stringify(
-        prettier.__debug.parse(message.data.text, options),
-        null,
-        2
-      );
+      actualAst = prettier.__debug.parse(message.data.text, options);
+      ast = JSON.stringify(actualAst);
     } catch (e) {
-      ast = e.toString();
+      errored = true;
+      ast = String(e);
+    }
+    if (!errored) {
+      try {
+        ast = formatCode(ast, { parser: "json" });
+      } catch (e) {
+        ast = JSON.stringify(actualAst, null, 2);
+      }
     }
   }
 
@@ -52,7 +59,7 @@ self.onmessage = function(message) {
         { parser: "babylon" }
       );
     } catch (e) {
-      doc = e.toString();
+      doc = String(e);
     }
   }
 
@@ -70,7 +77,7 @@ function formatCode(text, options) {
       lazyLoadParser(e.parser);
       return formatCode(text, options);
     }
-    return e.toString();
+    return String(e);
   }
 }
 


### PR DESCRIPTION
- Add helpful buttons:
  - "Clear" to empty the code input.
  - "Copy link" for those who don't see that the URL changes.
  - "Copy markdown" to copy a markdown link and inline code snippets.
  - "Report issue" to open a new issue with the playground prefilled.
- Add "show second format (debug)" checkbox for debugging idempotency issues. 
- Update the issue template on build to be in sync with the "Report issue" button.
- Extra things I did while at it:
  - Change CodeMirror mode based on parser.
  - Fix some HTML errors and warnings.
  - Clean up CSS.
  - Minor design tweaks.
  - Updated the default example code.
  - And more...

Example "Copy as markdown" output:

**Prettier 1.6.1**
[Playground link](http://localhost:3000/playground/#%7B%22content%22%3A%22const%20Hello%20%3D%20(%7Bname%7D)%20%3D%3E%20%3Cdiv%20class%3D%5C%22HelloWorld%5C%22%20onClick%3D%7B()%20%3D%3E%20%7Balert(%5C%22Click!%5C%22)%7D%7D%3EHello%2C%20%3Cstrong%3E%7Bname%7D!%3C%2Fstrong%3E%3C%2Fdiv%3E%22%2C%22options%22%3A%7B%22printWidth%22%3A80%2C%22tabWidth%22%3A4%2C%22singleQuote%22%3Atrue%2C%22trailingComma%22%3A%22none%22%2C%22bracketSpacing%22%3Atrue%2C%22jsxBracketSameLine%22%3Atrue%2C%22parser%22%3A%22typescript%22%2C%22semi%22%3Atrue%2C%22useTabs%22%3Afalse%2C%22doc%22%3Afalse%2C%22ast%22%3Afalse%7D%7D)
```
--jsx-bracket-same-line
--parser typescript
--single-quote
--tab-width 4
```

**Input:**
```tsx
const Hello = ({name}) => <div class="HelloWorld" onClick={() => {alert("Click!")}}>Hello, <strong>{name}!</strong></div>
```

**Output:**
```tsx
const Hello = ({ name }) => (
    <div
        class="HelloWorld"
        onClick={() => {
            alert('Click!');
        }}>
        Hello, <strong>{name}!</strong>
    </div>
);

```