### PR TITLE
fix webstorm integration guide

### DIFF
--- a/editors/webstorm/README.md
+++ b/editors/webstorm/README.md
@@ -6,7 +6,7 @@ Go to *File | Settings | Tools | External Tools* for Windows and Linux or *WebSt
 
 * **Program** set `prettier`
 
-> If on the other hand you have `prettier` installed locally, replace the **Program** with `./node_modules/.bin/prettier` (on OS X and Linux) or `.\node_modules\.bin\prettier.cmd` (on Windows).
+> If on the other hand you have `prettier` installed locally, replace the **Program** with `$ProjectFileDir$/node_modules/.bin/prettier` (on OS X and Linux) or `$ProjectFileDir$\node_modules\.bin\prettier.cmd` (on Windows).
 
 * **Parameters** set `--write [other opts] $FilePathRelativeToProjectRoot$`
 * **Working directory** set `$ProjectFileDir$`
@@ -16,7 +16,7 @@ Go to *File | Settings | Tools | External Tools* for Windows and Linux or *WebSt
 ### Process directories
 
 * Clone the External tool created above and name it `Prettier Directories`
-* **Parameters** set `--write [other opts] $FileDirRelativeToProjectRoot$/**/(*.js|*.jsx)`
+* **Parameters** set `--write [other opts] $FileDirRelativeToProjectRoot$/**/{*.js,*.jsx}`
 
 ## Usage
 


### PR DESCRIPTION
The request fixes two issues in the docs:
1. When `prettier` is installed locally, we have to provide the absolute path to the executable. Otherwise, Webstorm will throw `Cannot run program ".\node_modules\.bin\prettier.cmd"` error. Checked in v2017.2.2 on Win10 but may vary depending on the version or platform.
2. The glob pattern in the `Process directories` section is incorrect.