### PR TITLE
Make cosmiconfig initialization lazy. Add typescript definitions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Do not look for a configuration file.  The default settings will be used.
 
 #### `--config-precedence`
 
-Defines how config file should be evaluated in combination of CLI options. 
+Defines how config file should be evaluated in combination of CLI options.
 
 **cli-override (default)**
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,40 @@
+export = prettier;
+
+declare interface Options {
+  cursorOffset?: number;
+  printWidth?: number;
+  tabWidth?: number;
+  useTabs?: boolean;
+  semi?: boolean;
+  singleQuote?: boolean;
+  trailingComma?: 'none' | 'es5' | 'all';
+  bracketSpacing?: boolean;
+  jsxBracketSameLine?: boolean;
+  rangeStart?: number;
+  rangeEnd?: number;
+  parser?: 'babylon' | 'flow' | 'typescript' | 'postcss' | 'json' | 'graphql';
+  filepath?: string;
+}
+
+declare interface ConfigOpts {
+  useCache?: boolean;
+}
+
+declare interface ResponseWithCursor {
+  formatted: string;
+  cursorOffset: number;
+}
+
+declare interface ResolveConfig {
+  (filePath: string, options: ConfigOpts): Promise<Options | null>;
+  sync(filePath: string, options: ConfigOpts): Options | null;
+}
+
+declare namespace prettier {
+  let version: string;
+  let resolveConfig: ResolveConfig;
+  function format(source: string, options: Options): string;
+  function check(source: string, options: Options): boolean;
+  function formatWithCursor(source: string, options: Options): ResponseWithCursor;
+  function clearConfigCache(): void;
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "author": "James Long",
   "license": "MIT",
   "main": "./index.js",
+  "typings": "./index.d.ts",
   "dependencies": {
     "babel-code-frame": "7.0.0-alpha.12",
     "babylon": "7.0.0-beta.22",


### PR DESCRIPTION
Fixes: https://github.com/prettier/prettier/issues/2797

This is currently blocking my company's integration. Can we get an canary release of some sort in with this fix?
