### PR TITLE
docs(readme): port requirePragma docs to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -670,6 +670,30 @@ Default | CLI Override | API Override
 --------|--------------|-------------
 None | `--stdin-filepath <string>` | `filepath: "<string>"`
 
+### Require pragma
+Prettier can restrict itself to only format files that contain a special comment, called a pragma, at the top of the file. This is very useful
+when gradually transitioning large, unformatted codebases to prettier.
+
+For example, a file with the following as its first comment will be formatted when `--require-pragma` is supplied:
+
+```js
+/**
+ * @prettier
+ */
+```
+
+or
+
+```js
+/**
+ * @format
+ */
+```
+
+Default | CLI Override | API Override
+--------|--------------|-------------
+`false` | `--require-pragma` | `requirePragma`
+
 ## Configuration File
 
 Prettier uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) for configuration file support.

--- a/docs/options.md
+++ b/docs/options.md
@@ -155,4 +155,4 @@ or
 
 Default | CLI Override | API Override
 --------|--------------|-------------
-None | `--require-pragma` | `requirePragma`
+`false` | `--require-pragma` | `requirePragma`


### PR DESCRIPTION
Currently, the docs are not synchronized between `options.md` and `README.md`. 

We should do this in the future: https://github.com/prettier/prettier/pull/2767#issuecomment-327744705.