### PR TITLE
Don't lowercase CSS custom media names

### DIFF
--- a/src/printer-postcss.js
+++ b/src/printer-postcss.js
@@ -81,7 +81,7 @@ function genericPrint(path, options, print) {
 
       return concat([
         n.raws.before.replace(/[\s;]/g, ""),
-        n.prop.startsWith("--") ? n.prop : maybeToLowerCase(n.prop),
+        maybeToLowerCase(n.prop),
         ":",
         isValueExtend ? "" : " ",
         isComposed
@@ -482,7 +482,10 @@ function printNumber(rawNumber) {
 }
 
 function maybeToLowerCase(value) {
-  return value.includes("$") || value.includes("@") || value.includes("#")
+  return value.includes("$") ||
+  value.includes("@") ||
+  value.includes("#") ||
+  value.startsWith("--")
     ? value
     : value.toLowerCase();
 }

--- a/tests/css_case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_case/__snapshots__/jsfmt.spec.js.snap
@@ -35,6 +35,9 @@ a[HREF=KeepAttrValue]:HOVER::FIRST-letter,
   }
 }
 
+@custom-media --KeepCustomMedia screen and (width >= 768px);
+@media (--KeepCustomMedia) {}
+
 @KeepDetachedRuleset: /*:*/ {
   BACKGROUND: RED;
 }
@@ -102,6 +105,10 @@ a[href="KeepAttrValue"]:hover::first-letter,
   to {
     prop: val;
   }
+}
+
+@custom-media --KeepCustomMedia screen and (width >= 768px);
+@media (--KeepCustomMedia) {
 }
 
 @KeepDetachedRuleset: {
@@ -184,6 +191,9 @@ a[HREF=KeepAttrValue]:HOVER::FIRST-letter,
   }
 }
 
+@custom-media --KeepCustomMedia screen and (width >= 768px);
+@media (--KeepCustomMedia) {}
+
 @FUNCTION KeepFuncName() {
     @RETURN 12;
 }
@@ -254,6 +264,10 @@ a[href="KeepAttrValue"]:hover::first-letter,
   to {
     prop: val;
   }
+}
+
+@custom-media --KeepCustomMedia screen and (width >= 768px);
+@media (--KeepCustomMedia) {
 }
 
 @function KeepFuncName() {

--- a/tests/css_case/case.less
+++ b/tests/css_case/case.less
@@ -32,6 +32,9 @@ a[HREF=KeepAttrValue]:HOVER::FIRST-letter,
   }
 }
 
+@custom-media --KeepCustomMedia screen and (width >= 768px);
+@media (--KeepCustomMedia) {}
+
 @KeepDetachedRuleset: /*:*/ {
   BACKGROUND: RED;
 }

--- a/tests/css_case/case.scss
+++ b/tests/css_case/case.scss
@@ -33,6 +33,9 @@ a[HREF=KeepAttrValue]:HOVER::FIRST-letter,
   }
 }
 
+@custom-media --KeepCustomMedia screen and (width >= 768px);
+@media (--KeepCustomMedia) {}
+
 @FUNCTION KeepFuncName() {
     @RETURN 12;
 }


### PR DESCRIPTION
Fixes #2820. While that issue is about `@media (--fooBar)` in
particular, this commit changes to never lowercase stuff starting with
`--` in general, as it seems like those `--customStuff` things can pop
up kind of anywhere.