### PR TITLE
feat: support detailed `--help`

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "ignore": "^3.3.3",
     "jest-docblock": "21.1.0",
     "jest-validate": "21.1.0",
+    "leven": "2.1.0",
     "mem": "1.1.0",
     "minimatch": "3.0.4",
     "minimist": "1.2.0",

--- a/src/cli-constant.js
+++ b/src/cli-constant.js
@@ -49,7 +49,7 @@ const categoryOrder = [
  *     // in --help as <a|b|c>.
  *     // Use an object instead of a string if a choice is deprecated and should
  *     // be treated as `redirect` instead.
- *     choices?: Array<string | { value: string, deprecated: boolean, redirect: string, description }>;
+ *     choices?: Array<string | { value: string, deprecated: boolean, redirect: string, description: string }>;
  *
  *     // If the option has a value that is an exception to the regular value
  *     // constraints, indicate that value here (or use a function for more

--- a/src/cli-constant.js
+++ b/src/cli-constant.js
@@ -152,7 +152,10 @@ const detailedOptions = normalizeDetailedOptions({
   help: {
     type: "flag",
     alias: "h",
-    description: "Show CLI usage, or details about the given flag."
+    description: dedent(`
+      Show CLI usage, or details about the given flag.
+      Example: --help write
+    `)
   },
   "ignore-path": {
     type: "path",

--- a/src/cli-constant.js
+++ b/src/cli-constant.js
@@ -154,8 +154,7 @@ const detailedOptions = normalizeDetailedOptions({
   help: {
     type: "flag",
     alias: "h",
-    description:
-      "Show CLI usages, or detailed option usage if flag name present."
+    description: "Show CLI usage, or details about the given flag."
   },
   "ignore-path": {
     type: "path",

--- a/src/cli-constant.js
+++ b/src/cli-constant.js
@@ -118,10 +118,8 @@ const detailedOptions = normalizeDetailedOptions({
         `)
       }
     ],
-    description: dedent(`
-      Define in which order config files and CLI options should be evaluated.
-      Defaults to cli-override.
-    `)
+    description:
+      "Define in which order config files and CLI options should be evaluated."
   },
   "cursor-offset": {
     type: "int",
@@ -160,10 +158,7 @@ const detailedOptions = normalizeDetailedOptions({
     type: "path",
     category: CATEGORY_CONFIG,
     default: ".prettierignore",
-    description: dedent(`
-      Path to a file with patterns describing files to ignore.
-      Defaults to ./.prettierignore.
-    `)
+    description: "Path to a file with patterns describing files to ignore."
   },
   "jsx-bracket-same-line": {
     type: "boolean",
@@ -184,14 +179,14 @@ const detailedOptions = normalizeDetailedOptions({
     forwardToApi: true,
     exception: value => typeof value === "string", // Allow path to a parser module.
     choices: ["flow", "babylon", "typescript", "postcss", "json", "graphql"],
-    description: "Which parser to use. Defaults to babylon.",
+    description: "Which parser to use.",
     getter: (value, argv) => (argv["flow-parser"] ? "flow" : value)
   },
   "print-width": {
     type: "int",
     category: CATEGORY_FORMAT,
     forwardToApi: true,
-    description: "The line length where Prettier will try wrap. Defaults to 80."
+    description: "The line length where Prettier will try wrap."
   },
   "range-end": {
     type: "int",
@@ -202,7 +197,6 @@ const detailedOptions = normalizeDetailedOptions({
       Format code ending at a given character offset (exclusive).
       The range will extend forwards to the end of the selected statement.
       This option cannot be used with --cursor-offset.
-      Defaults to Infinity.
     `)
   },
   "range-start": {
@@ -213,7 +207,6 @@ const detailedOptions = normalizeDetailedOptions({
       Format code starting at a given character offset.
       The range will extend backwards to the start of the first line containing the selected statement.
       This option cannot be used with --cursor-offset.
-      Defaults to 0.
     `)
   },
   "require-pragma": {
@@ -250,7 +243,7 @@ const detailedOptions = normalizeDetailedOptions({
     type: "int",
     category: CATEGORY_FORMAT,
     forwardToApi: true,
-    description: "Number of spaces per indentation level. Defaults to 2."
+    description: "Number of spaces per indentation level."
   },
   "trailing-comma": {
     type: "choice",
@@ -270,8 +263,7 @@ const detailedOptions = normalizeDetailedOptions({
       },
       { value: "", deprecated: true, redirect: "es5" }
     ],
-    description:
-      "Print trailing commas wherever possible when multi-line. Defaults to none."
+    description: "Print trailing commas wherever possible when multi-line."
   },
   "use-tabs": {
     type: "boolean",

--- a/src/cli-constant.js
+++ b/src/cli-constant.js
@@ -358,7 +358,7 @@ function normalizeDetailedOptions(rawDetailedOptions) {
         option.choices &&
         option.choices.map(choice =>
           Object.assign(
-            { description: "undocumented", deprecated: false },
+            { description: "", deprecated: false },
             typeof choice === "object" ? choice : { value: choice }
           )
         ),

--- a/src/cli-constant.js
+++ b/src/cli-constant.js
@@ -266,10 +266,8 @@ const detailedOptions = normalizeDetailedOptions({
       },
       {
         value: "all",
-        description: dedent(`
-          Trailing commas wherever possible (including function arguments).
-          This requires node 8 or a transform.
-        `)
+        description:
+          "Trailing commas wherever possible (including function arguments)."
       },
       { value: "", deprecated: true, redirect: "es5" }
     ],

--- a/src/cli-constant.js
+++ b/src/cli-constant.js
@@ -48,8 +48,12 @@ const categoryOrder = [
  *     // Specify available choices for validation. They will also be displayed
  *     // in --help as <a|b|c>.
  *     // Use an object instead of a string if a choice is deprecated and should
- *     // be treated as `redirect` instead.
- *     choices?: Array<string | { value: string, deprecated: boolean, redirect: string, description: string }>;
+ *     // be treated as `redirect` instead, or if you'd like to add description for
+ *     // the choice.
+ *     choices?: Array<
+ *       | string
+ *       | { value: string, description?: string, deprecated?: boolean, redirect?: string }
+ *     >;
  *
  *     // If the option has a value that is an exception to the regular value
  *     // constraints, indicate that value here (or use a function for more

--- a/src/cli-constant.js
+++ b/src/cli-constant.js
@@ -79,6 +79,7 @@ const detailedOptions = normalizeDetailedOptions({
     type: "boolean",
     category: CATEGORY_FORMAT,
     forwardToApi: true,
+    description: "Print spaces between brackets.",
     oppositeDescription: "Do not print spaces between brackets."
   },
   color: {
@@ -88,6 +89,7 @@ const detailedOptions = normalizeDetailedOptions({
     // See https://github.com/chalk/supports-color/#info for more information.
     type: "boolean",
     default: true,
+    description: "Colorize error messages.",
     oppositeDescription: "Do not colorize error messages."
   },
   config: {
@@ -224,6 +226,7 @@ const detailedOptions = normalizeDetailedOptions({
     type: "boolean",
     category: CATEGORY_FORMAT,
     forwardToApi: true,
+    description: "Print semicolons.",
     oppositeDescription:
       "Do not print semicolons, except at the beginning of lines which may need them."
   },

--- a/src/cli-constant.js
+++ b/src/cli-constant.js
@@ -115,11 +115,7 @@ const detailedOptions = normalizeDetailedOptions({
       }
     ],
     description: dedent(`
-      Define in which order config files and CLI options should be evaluated
-      cli-override  | default config => config file => CLI options
-      file-override | default config => CLI options => config file
-      prefer-file   | default config => config file (if config file is found) or
-                      default config => CLI options (if no config file is found)
+      Define in which order config files and CLI options should be evaluated.
       Defaults to cli-override.
     `)
   },

--- a/src/cli-constant.js
+++ b/src/cli-constant.js
@@ -148,10 +148,10 @@ const detailedOptions = normalizeDetailedOptions({
     deprecated: "Use `--parser flow` instead."
   },
   help: {
-    type: "option-name",
+    type: "flag",
     alias: "h",
     description:
-      "Show CLI usages, or detailed option usage if option name present."
+      "Show CLI usages, or detailed option usage if flag name present."
   },
   "ignore-path": {
     type: "path",

--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -374,9 +374,9 @@ function createUsage() {
 
 function createOptionUsage(option, threshold) {
   const name = `--${option.name}`;
-  const alias = option.alias ? `or -${option.alias}` : null;
+  const alias = option.alias ? `-${option.alias},` : null;
   const type = createOptionUsageType(option);
-  const header = [name, alias, type].filter(Boolean).join(" ");
+  const header = [alias, name, type].filter(Boolean).join(" ");
   return createOptionUsageRow(header, option.description, threshold);
 }
 

--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -375,7 +375,14 @@ function createUsage() {
 
 function createOptionUsage(option, threshold) {
   const header = createOptionUsageHeader(option);
-  return createOptionUsageRow(header, option.description, threshold);
+  const optionDefaultValue = getOptionDefaultValue(option.name);
+  return createOptionUsageRow(
+    header,
+    `${option.description}${optionDefaultValue === undefined
+      ? ""
+      : `\nDefaults to ${optionDefaultValue}.`}`,
+    threshold
+  );
 }
 
 function createOptionUsageHeader(option) {

--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -417,32 +417,37 @@ function createOptionUsageType(option) {
   }
 }
 
-function createDetailedUsage(optionName) {
-  const options = getOptionsWithOpposites(constant.detailedOptions);
+function getOptionWithLevenSuggestion(options, optionName) {
   const optionNames = options.map(option => option.name);
+  const optionIndex = optionNames.indexOf(optionName);
 
-  let optionIndex = optionNames.indexOf(optionName);
-
-  if (optionIndex === -1) {
-    const suggestionOptionIndex = optionNames.findIndex(
-      currentOptionName => leven(currentOptionName, optionName) < 3
-    );
-
-    if (suggestionOptionIndex !== -1) {
-      const suggestionOptionName = options[suggestionOptionIndex].name;
-      console.warn(
-        `Unknown option name "${optionName}", did you mean "${suggestionOptionName}"?\n`
-      );
-      optionName = suggestionOptionName;
-      optionIndex = suggestionOptionIndex;
-    } else {
-      throw new Error(`Unknown option name "${optionName}"`);
-    }
+  if (optionIndex !== -1) {
+    return options[optionIndex];
   }
 
-  const option = options[optionIndex];
+  const suggestionOptionIndex = optionNames.findIndex(
+    currentOptionName => leven(currentOptionName, optionName) < 3
+  );
 
-  const optionTitleName = kebabToTitle(optionName);
+  if (suggestionOptionIndex !== -1) {
+    const suggestionOptionName = options[suggestionOptionIndex].name;
+    console.warn(
+      `Unknown option name "${optionName}", did you mean "${suggestionOptionName}"?\n`
+    );
+
+    return options[suggestionOptionIndex];
+  }
+
+  throw new Error(`Unknown option name "${optionName}"`);
+}
+
+function createDetailedUsage(optionName) {
+  const option = getOptionWithLevenSuggestion(
+    getOptionsWithOpposites(constant.detailedOptions),
+    optionName
+  );
+
+  const optionTitleName = kebabToTitle(option.name);
 
   const header = `${optionTitleName} (${createOptionUsageHeader(option)})`;
 
@@ -466,7 +471,7 @@ function createDetailedUsage(optionName) {
           return `\n\nValid options:\n\n${choiceUsages.join("\n")}`;
         })();
 
-  const optionDefaultValue = getOptionDefaultValue(optionName);
+  const optionDefaultValue = getOptionDefaultValue(option.name);
   const defaults =
     optionDefaultValue !== undefined
       ? `\n\nDefault: ${optionDefaultValue}`

--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -453,7 +453,8 @@ function getOptionWithLevenSuggestion(options, optionName) {
     return options[suggestedOptionNameContainer.index];
   }
 
-  throw new Error(`Unknown option name "${optionName}"`);
+  console.warn(`Unknown option name "${optionName}"\n`);
+  return options.find(option => option.name === "help");
 }
 
 function createChoiceUsages(choices, margin, indentation) {

--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -424,12 +424,12 @@ function createDetailedUsage(optionName) {
     if (suggestionOptionIndex !== -1) {
       const suggestionOptionName = options[suggestionOptionIndex].name;
       console.warn(
-        `Unexpected option name "${optionName}", did you mean "${suggestionOptionName}"?\n`
+        `Unknown option name "${optionName}", did you mean "${suggestionOptionName}"?\n`
       );
       optionName = suggestionOptionName;
       optionIndex = suggestionOptionIndex;
     } else {
-      throw new Error(`Unexpected option name "${optionName}"`);
+      throw new Error(`Unknown option name "${optionName}"`);
     }
   }
 

--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -352,7 +352,15 @@ function getOptionsWithOpposites(options) {
 }
 
 function createUsage() {
-  const options = getOptionsWithOpposites(constant.detailedOptions);
+  const options = getOptionsWithOpposites(constant.detailedOptions).filter(
+    // remove unnecessary option (e.g. `semi`, `color`, etc.), which is only used for --help <flag>
+    option =>
+      !(
+        option.type === "boolean" &&
+        option.oppositeDescription &&
+        !option.name.startsWith("no-")
+      )
+  );
 
   const groupedOptions = groupBy(options, option => option.category);
 

--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -463,10 +463,7 @@ function createDetailedUsage(optionName) {
     optionName
   );
 
-  const optionTitleName = kebabToTitle(option.name);
-
-  const header = `${optionTitleName} (${createOptionUsageHeader(option)})`;
-
+  const header = createOptionUsageHeader(option);
   const description = `\n\n${indent(option.description, 2)}`;
 
   const choices =
@@ -509,13 +506,6 @@ function getOptionDefaultValue(optionName) {
 
 function kebabToCamel(str) {
   return str.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
-}
-
-function kebabToTitle(str) {
-  return str.replace(
-    /(^|-)([a-z])/g,
-    (_, prefix, char) => " ".repeat(prefix.length) + char.toUpperCase()
-  );
 }
 
 function indent(str, spaces) {

--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -436,7 +436,6 @@ function createDetailedUsage(optionName) {
   const option = options[optionIndex];
 
   const optionTitleName = kebabToTitle(optionName);
-  const optionCamelName = kebabToCamel(optionName);
 
   const header = `${optionTitleName} (${createOptionUsageHeader(option)})`;
 
@@ -460,14 +459,33 @@ function createDetailedUsage(optionName) {
           return `\n\nValid options:\n\n${choiceUsages.join("\n")}`;
         })();
 
+  const optionDefaultValue = getOptionDefaultValue(optionName);
   const defaults =
-    option.default !== undefined
-      ? `\n\nDefault: ${option.default}`
-      : optionCamelName in apiDefaultOptions
-        ? `\n\nDefault: ${apiDefaultOptions[optionCamelName]}`
-        : "";
+    optionDefaultValue !== undefined
+      ? `\n\nDefault: ${optionDefaultValue}`
+      : "";
 
   return `${header}${description}${choices}${defaults}`;
+}
+
+function getOptionDefaultValue(optionName) {
+  // --no-option
+  if (!(optionName in constant.detailedOptionMap)) {
+    return undefined;
+  }
+
+  const option = constant.detailedOptionMap[optionName];
+
+  if (option.default !== undefined) {
+    return option.default;
+  }
+
+  const optionCamelName = kebabToCamel(optionName);
+  if (optionCamelName in apiDefaultOptions) {
+    return apiDefaultOptions[optionCamelName];
+  }
+
+  return undefined;
 }
 
 function kebabToCamel(str) {

--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -348,7 +348,7 @@ function getOptionsWithOpposites(options) {
         })
       : null
   ]);
-  return [].concat.apply([], optionsWithOpposites).filter(Boolean);
+  return flattenArray(optionsWithOpposites).filter(Boolean);
 }
 
 function createUsage() {

--- a/src/cli.js
+++ b/src/cli.js
@@ -22,11 +22,9 @@ function run(args) {
 
   if (argv["help"] !== undefined) {
     console.log(
-      argv["help"] === ""
-        ? util.createUsage()
-        : Array.isArray(argv["help"]) // ["--help", "--help"] -> argv: { help: ["", ""] }
-          ? util.createDetailedUsage("--help")
-          : util.createDetailedUsage(argv["help"])
+      typeof argv["help"] === "string" && argv["help"] !== ""
+        ? util.createDetailedUsage(argv["help"])
+        : util.createUsage()
     );
     process.exit(0);
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -24,7 +24,9 @@ function run(args) {
     console.log(
       argv["help"] === ""
         ? util.createUsage()
-        : util.createDetailedUsage(argv["help"])
+        : Array.isArray(argv["help"]) // ["--help", "--help"] -> argv: { help: ["", ""] }
+          ? util.createDetailedUsage("--help")
+          : util.createDetailedUsage(argv["help"])
     );
     process.exit(0);
   }

--- a/src/cli.js
+++ b/src/cli.js
@@ -20,8 +20,12 @@ function run(args) {
     process.exit(0);
   }
 
-  if (argv["help"]) {
-    console.log(util.createUsage());
+  if (argv["help"] !== undefined) {
+    console.log(
+      argv["help"] === ""
+        ? util.createUsage()
+        : util.createDetailedUsage(argv["help"])
+    );
     process.exit(0);
   }
 

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -65,6 +65,13 @@ Default: false
 "
 `;
 
+exports[`show detailed usage with --help l (alias) 1`] = `
+"-l, --list-different
+
+  Print the names of files that are different from Prettier's formatting.
+"
+`;
+
 exports[`show detailed usage with --help list-different 1`] = `
 "-l, --list-different
 

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -4,7 +4,6 @@ exports[`show detailed usage with --help config-precedence 1`] = `
 "Config Precedence (--config-precedence <cli-override|file-override|prefer-file>)
 
   Define in which order config files and CLI options should be evaluated.
-  Defaults to cli-override.
 
 Valid options:
 
@@ -37,7 +36,7 @@ exports[`show detailed usage with --help no-option 1`] = `
 exports[`show detailed usage with --help parser 1`] = `
 "Parser (--parser <flow|babylon|typescript|postcss|json|graphql>)
 
-  Which parser to use. Defaults to babylon.
+  Which parser to use.
 
 Valid options:
 
@@ -55,7 +54,7 @@ Default: babylon
 exports[`show detailed usage with --help trailing-comma 1`] = `
 "Trailing Comma (--trailing-comma <none|es5|all>)
 
-  Print trailing commas wherever possible when multi-line. Defaults to none.
+  Print trailing commas wherever possible when multi-line.
 
 Valid options:
 
@@ -82,15 +81,22 @@ Format options:
 
   --no-bracket-spacing     Do not print spaces between brackets.
   --jsx-bracket-same-line  Put > on the last line instead of at a new line.
+                           Defaults to false.
   --parser <flow|babylon|typescript|postcss|json|graphql>
-                           Which parser to use. Defaults to babylon.
-  --print-width <int>      The line length where Prettier will try wrap. Defaults to 80.
+                           Which parser to use.
+                           Defaults to babylon.
+  --print-width <int>      The line length where Prettier will try wrap.
+                           Defaults to 80.
   --no-semi                Do not print semicolons, except at the beginning of lines which may need them.
   --single-quote           Use single quotes instead of double quotes.
-  --tab-width <int>        Number of spaces per indentation level. Defaults to 2.
+                           Defaults to false.
+  --tab-width <int>        Number of spaces per indentation level.
+                           Defaults to 2.
   --trailing-comma <none|es5|all>
-                           Print trailing commas wherever possible when multi-line. Defaults to none.
+                           Print trailing commas wherever possible when multi-line.
+                           Defaults to none.
   --use-tabs               Indent with tabs instead of spaces.
+                           Defaults to false.
 
 Config options:
 
@@ -102,13 +108,14 @@ Config options:
   --find-config-path <path>
                            Find and print the path to a configuration file for the given input file.
   --ignore-path <path>     Path to a file with patterns describing files to ignore.
-                           Defaults to ./.prettierignore.
+                           Defaults to .prettierignore.
   --with-node-modules      Process files inside 'node_modules' directory.
 
 Editor options:
 
   --cursor-offset <int>    Print (to stderr) where a cursor at the given position would move to after formatting.
                            This option cannot be used with --range-start and --range-end.
+                           Defaults to -1.
   --range-end <int>        Format code ending at a given character offset (exclusive).
                            The range will extend forwards to the end of the selected statement.
                            This option cannot be used with --cursor-offset.
@@ -124,6 +131,7 @@ Other options:
   -h, --help <flag>        Show CLI usage, or details about the given flag.
   --require-pragma         Require either '@prettier' or '@format' to be present in the file's first docblock comment
                            in order for it to be formatted.
+                           Defaults to false.
   --stdin                  Force reading input from stdin.
   --stdin-filepath <path>  Path to the file to pretend that stdin comes from.
   -v, --version            Print Prettier version.
@@ -135,7 +143,7 @@ Other options:
 exports[`show warning with --help not-found (typo) 1`] = `
 "Parser (--parser <flow|babylon|typescript|postcss|json|graphql>)
 
-  Which parser to use. Defaults to babylon.
+  Which parser to use.
 
 Valid options:
 
@@ -171,15 +179,22 @@ Format options:
 
   --no-bracket-spacing     Do not print spaces between brackets.
   --jsx-bracket-same-line  Put > on the last line instead of at a new line.
+                           Defaults to false.
   --parser <flow|babylon|typescript|postcss|json|graphql>
-                           Which parser to use. Defaults to babylon.
-  --print-width <int>      The line length where Prettier will try wrap. Defaults to 80.
+                           Which parser to use.
+                           Defaults to babylon.
+  --print-width <int>      The line length where Prettier will try wrap.
+                           Defaults to 80.
   --no-semi                Do not print semicolons, except at the beginning of lines which may need them.
   --single-quote           Use single quotes instead of double quotes.
-  --tab-width <int>        Number of spaces per indentation level. Defaults to 2.
+                           Defaults to false.
+  --tab-width <int>        Number of spaces per indentation level.
+                           Defaults to 2.
   --trailing-comma <none|es5|all>
-                           Print trailing commas wherever possible when multi-line. Defaults to none.
+                           Print trailing commas wherever possible when multi-line.
+                           Defaults to none.
   --use-tabs               Indent with tabs instead of spaces.
+                           Defaults to false.
 
 Config options:
 
@@ -191,13 +206,14 @@ Config options:
   --find-config-path <path>
                            Find and print the path to a configuration file for the given input file.
   --ignore-path <path>     Path to a file with patterns describing files to ignore.
-                           Defaults to ./.prettierignore.
+                           Defaults to .prettierignore.
   --with-node-modules      Process files inside 'node_modules' directory.
 
 Editor options:
 
   --cursor-offset <int>    Print (to stderr) where a cursor at the given position would move to after formatting.
                            This option cannot be used with --range-start and --range-end.
+                           Defaults to -1.
   --range-end <int>        Format code ending at a given character offset (exclusive).
                            The range will extend forwards to the end of the selected statement.
                            This option cannot be used with --cursor-offset.
@@ -213,6 +229,7 @@ Other options:
   -h, --help <flag>        Show CLI usage, or details about the given flag.
   --require-pragma         Require either '@prettier' or '@format' to be present in the file's first docblock comment
                            in order for it to be formatted.
+                           Defaults to false.
   --stdin                  Force reading input from stdin.
   --stdin-filepath <path>  Path to the file to pretend that stdin comes from.
   -v, --version            Print Prettier version.

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -310,6 +310,19 @@ Other options:
 "
 `;
 
+exports[`show warning with --help --help 1`] = `
+"-h, --help <flag>
+
+  Show CLI usage, or details about the given flag.
+"
+`;
+
+exports[`show warning with --help --help 2`] = `
+"Unknown option name \\"--help\\", did you mean \\"help\\"?
+
+"
+`;
+
 exports[`show warning with --help not-found (typo) 1`] = `
 "--parser <flow|babylon|typescript|postcss|json|graphql>
 

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -121,7 +121,7 @@ Editor options:
 Other options:
 
   --no-color               Do not colorize error messages.
-  -h, --help <flag>        Show CLI usages, or detailed option usage if flag name present.
+  -h, --help <flag>        Show CLI usage, or details about the given flag.
   --require-pragma         Require either '@prettier' or '@format' to be present in the file's first docblock comment
                            in order for it to be formatted.
   --stdin                  Force reading input from stdin.
@@ -210,7 +210,7 @@ Editor options:
 Other options:
 
   --no-color               Do not colorize error messages.
-  -h, --help <flag>        Show CLI usages, or detailed option usage if flag name present.
+  -h, --help <flag>        Show CLI usage, or details about the given flag.
   --require-pragma         Require either '@prettier' or '@format' to be present in the file's first docblock comment
                            in order for it to be formatted.
   --stdin                  Force reading input from stdin.

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -44,6 +44,7 @@ exports[`show detailed usage with --help help 1`] = `
 "-h, --help <flag>
 
   Show CLI usage, or details about the given flag.
+  Example: --help write
 "
 `;
 
@@ -306,6 +307,7 @@ Other options:
 
   --no-color               Do not colorize error messages.
   -h, --help <flag>        Show CLI usage, or details about the given flag.
+                           Example: --help write
   --require-pragma         Require either '@prettier' or '@format' to be present in the file's first docblock comment
                            in order for it to be formatted.
                            Defaults to false.
@@ -313,19 +315,6 @@ Other options:
   --stdin-filepath <path>  Path to the file to pretend that stdin comes from.
   -v, --version            Print Prettier version.
 
-
-"
-`;
-
-exports[`show warning with --help --help 1`] = `
-"-h, --help <flag>
-
-  Show CLI usage, or details about the given flag.
-"
-`;
-
-exports[`show warning with --help --help 2`] = `
-"Unknown option name \\"--help\\", did you mean \\"help\\"?
 
 "
 `;
@@ -350,6 +339,20 @@ Default: babylon
 
 exports[`show warning with --help not-found (typo) 2`] = `
 "Unknown option name \\"parserr\\", did you mean \\"parser\\"?
+
+"
+`;
+
+exports[`show warning with --help not-found 1`] = `
+"-h, --help <flag>
+
+  Show CLI usage, or details about the given flag.
+  Example: --help write
+"
+`;
+
+exports[`show warning with --help not-found 2`] = `
+"Unknown option name \\"not-found\\"
 
 "
 `;
@@ -417,6 +420,7 @@ Other options:
 
   --no-color               Do not colorize error messages.
   -h, --help <flag>        Show CLI usage, or details about the given flag.
+                           Example: --help write
   --require-pragma         Require either '@prettier' or '@format' to be present in the file's first docblock comment
                            in order for it to be formatted.
                            Defaults to false.
@@ -434,10 +438,6 @@ exports[`throw error with --find-config-path + multiple files 1`] = `
 "Cannot use --find-config-path with multiple files
 "
 `;
-
-exports[`throw error with --help not-found 1`] = `""`;
-
-exports[`throw error with --help not-found 2`] = `"Unknown option name \\"not-found\\""`;
 
 exports[`throw error with --write + --debug-check 1`] = `
 "Cannot use --write and --debug-check together.

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -66,7 +66,6 @@ Valid options:
   none   No trailing commas.
   es5    Trailing commas where valid in ES5 (objects, arrays, etc.)
   all    Trailing commas wherever possible (including function arguments).
-         This requires node 8 or a transform.
 
 Default: none
 "

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -41,12 +41,12 @@ exports[`show detailed usage with --help parser 1`] = `
 
 Valid options:
 
-  flow         undocumented
-  babylon      undocumented
-  typescript   undocumented
-  postcss      undocumented
-  json         undocumented
-  graphql      undocumented
+  flow         
+  babylon      
+  typescript   
+  postcss      
+  json         
+  graphql      
 
 Default: babylon
 "
@@ -139,12 +139,12 @@ exports[`show warning with --help not-found (typo) 1`] = `
 
 Valid options:
 
-  flow         undocumented
-  babylon      undocumented
-  typescript   undocumented
-  postcss      undocumented
-  json         undocumented
-  graphql      undocumented
+  flow         
+  babylon      
+  typescript   
+  postcss      
+  json         
+  graphql      
 
 Default: babylon
 "

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -73,7 +73,7 @@ Stdin is read if it is piped to Prettier and no files are given.
 
 Output options:
 
-  --list-different or -l   Print the names of files that are different from Prettier's formatting.
+  -l, --list-different     Print the names of files that are different from Prettier's formatting.
   --write                  Edit files in-place. (Beware!)
 
 Format options:
@@ -123,13 +123,12 @@ Editor options:
 Other options:
 
   --no-color               Do not colorize error messages.
-  --help or -h <option-name>
-                           Show CLI usages, or detailed option usage if option name present.
+  -h, --help <option-name> Show CLI usages, or detailed option usage if option name present.
   --require-pragma         Require either '@prettier' or '@format' to be present in the file's first docblock comment
                            in order for it to be formatted.
   --stdin                  Force reading input from stdin.
   --stdin-filepath <path>  Path to the file to pretend that stdin comes from.
-  --version or -v          Print Prettier version.
+  -v, --version            Print Prettier version.
 
 
 "
@@ -167,7 +166,7 @@ Stdin is read if it is piped to Prettier and no files are given.
 
 Output options:
 
-  --list-different or -l   Print the names of files that are different from Prettier's formatting.
+  -l, --list-different     Print the names of files that are different from Prettier's formatting.
   --write                  Edit files in-place. (Beware!)
 
 Format options:
@@ -217,13 +216,12 @@ Editor options:
 Other options:
 
   --no-color               Do not colorize error messages.
-  --help or -h <option-name>
-                           Show CLI usages, or detailed option usage if option name present.
+  -h, --help <option-name> Show CLI usages, or detailed option usage if option name present.
   --require-pragma         Require either '@prettier' or '@format' to be present in the file's first docblock comment
                            in order for it to be formatted.
   --stdin                  Force reading input from stdin.
   --stdin-filepath <path>  Path to the file to pretend that stdin comes from.
-  --version or -v          Print Prettier version.
+  -v, --version            Print Prettier version.
 
 
 "

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -31,6 +31,13 @@ Default: -1
 "
 `;
 
+exports[`show detailed usage with --help no-option 1`] = `
+"No Semi (--no-semi)
+
+  Do not print semicolons, except at the beginning of lines which may need them.
+"
+`;
+
 exports[`show detailed usage with --help parser 1`] = `
 "Parser (--parser <flow|babylon|typescript|postcss|json|graphql>)
 

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -284,8 +284,6 @@ Output options:
 
 Format options:
 
-  --bracket-spacing        Print spaces between brackets.
-                           Defaults to true.
   --no-bracket-spacing     Do not print spaces between brackets.
   --jsx-bracket-same-line  Put > on the last line instead of at a new line.
                            Defaults to false.
@@ -294,8 +292,6 @@ Format options:
                            Defaults to babylon.
   --print-width <int>      The line length where Prettier will try wrap.
                            Defaults to 80.
-  --semi                   Print semicolons.
-                           Defaults to true.
   --no-semi                Do not print semicolons, except at the beginning of lines which may need them.
   --single-quote           Use single quotes instead of double quotes.
                            Defaults to false.
@@ -336,8 +332,6 @@ Editor options:
 
 Other options:
 
-  --color                  Colorize error messages.
-                           Defaults to true.
   --no-color               Do not colorize error messages.
   -h, --help <flag>        Show CLI usage, or details about the given flag.
                            Example: --help write
@@ -403,8 +397,6 @@ Output options:
 
 Format options:
 
-  --bracket-spacing        Print spaces between brackets.
-                           Defaults to true.
   --no-bracket-spacing     Do not print spaces between brackets.
   --jsx-bracket-same-line  Put > on the last line instead of at a new line.
                            Defaults to false.
@@ -413,8 +405,6 @@ Format options:
                            Defaults to babylon.
   --print-width <int>      The line length where Prettier will try wrap.
                            Defaults to 80.
-  --semi                   Print semicolons.
-                           Defaults to true.
   --no-semi                Do not print semicolons, except at the beginning of lines which may need them.
   --single-quote           Use single quotes instead of double quotes.
                            Defaults to false.
@@ -455,8 +445,6 @@ Editor options:
 
 Other options:
 
-  --color                  Colorize error messages.
-                           Defaults to true.
   --no-color               Do not colorize error messages.
   -h, --help <flag>        Show CLI usage, or details about the given flag.
                            Example: --help write

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`show detailed usage with --help bracket-spacing 1`] = `
+"--bracket-spacing
+
+  Print spaces between brackets.
+
+Default: true
+"
+`;
+
+exports[`show detailed usage with --help color 1`] = `
+"--color
+
+  Colorize error messages.
+
+Default: true
+"
+`;
+
 exports[`show detailed usage with --help config 1`] = `
 "--config <path>
 
@@ -167,6 +185,15 @@ Default: false
 "
 `;
 
+exports[`show detailed usage with --help semi 1`] = `
+"--semi
+
+  Print semicolons.
+
+Default: true
+"
+`;
+
 exports[`show detailed usage with --help single-quote 1`] = `
 "--single-quote
 
@@ -257,6 +284,8 @@ Output options:
 
 Format options:
 
+  --bracket-spacing        Print spaces between brackets.
+                           Defaults to true.
   --no-bracket-spacing     Do not print spaces between brackets.
   --jsx-bracket-same-line  Put > on the last line instead of at a new line.
                            Defaults to false.
@@ -265,6 +294,8 @@ Format options:
                            Defaults to babylon.
   --print-width <int>      The line length where Prettier will try wrap.
                            Defaults to 80.
+  --semi                   Print semicolons.
+                           Defaults to true.
   --no-semi                Do not print semicolons, except at the beginning of lines which may need them.
   --single-quote           Use single quotes instead of double quotes.
                            Defaults to false.
@@ -305,6 +336,8 @@ Editor options:
 
 Other options:
 
+  --color                  Colorize error messages.
+                           Defaults to true.
   --no-color               Do not colorize error messages.
   -h, --help <flag>        Show CLI usage, or details about the given flag.
                            Example: --help write
@@ -370,6 +403,8 @@ Output options:
 
 Format options:
 
+  --bracket-spacing        Print spaces between brackets.
+                           Defaults to true.
   --no-bracket-spacing     Do not print spaces between brackets.
   --jsx-bracket-same-line  Put > on the last line instead of at a new line.
                            Defaults to false.
@@ -378,6 +413,8 @@ Format options:
                            Defaults to babylon.
   --print-width <int>      The line length where Prettier will try wrap.
                            Defaults to 80.
+  --semi                   Print semicolons.
+                           Defaults to true.
   --no-semi                Do not print semicolons, except at the beginning of lines which may need them.
   --single-quote           Use single quotes instead of double quotes.
                            Defaults to false.
@@ -418,6 +455,8 @@ Editor options:
 
 Other options:
 
+  --color                  Colorize error messages.
+                           Defaults to true.
   --no-color               Do not colorize error messages.
   -h, --help <flag>        Show CLI usage, or details about the given flag.
                            Example: --help write

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -1,5 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`show detailed usage with --help config-precedence 1`] = `
+"Config Precedence (--config-precedence <cli-override|file-override|prefer-file>)
+
+  Define in which order config files and CLI options should be evaluated
+  cli-override  | default config => config file => CLI options
+  file-override | default config => CLI options => config file
+  prefer-file   | default config => config file (if config file is found) or
+                  default config => CLI options (if no config file is found)
+  Defaults to cli-override.
+
+Valid options:
+
+  cli-override    CLI options take precedence over config file
+  file-override   Config file take precedence over CLI options
+  prefer-file     If a config file is found will evaluate it and ignore other CLI options.
+                  If no config file is found CLI options will evaluate as normal.
+
+Default: cli-override
+"
+`;
+
+exports[`show detailed usage with --help cursor-offset 1`] = `
+"Cursor Offset (--cursor-offset <int>)
+
+  Print (to stderr) where a cursor at the given position would move to after formatting.
+  This option cannot be used with --range-start and --range-end.
+
+Default: -1
+"
+`;
+
+exports[`show detailed usage with --help parser 1`] = `
+"Parser (--parser <flow|babylon|typescript|postcss|json|graphql>)
+
+  Which parser to use. Defaults to babylon.
+
+Valid options:
+
+  flow         undocumented
+  babylon      undocumented
+  typescript   undocumented
+  postcss      undocumented
+  json         undocumented
+  graphql      undocumented
+
+Default: babylon
+"
+`;
+
+exports[`show detailed usage with --help trailing-comma 1`] = `
+"Trailing Comma (--trailing-comma <none|es5|all>)
+
+  Print trailing commas wherever possible when multi-line. Defaults to none.
+
+Valid options:
+
+  none   No trailing commas.
+  es5    Trailing commas where valid in ES5 (objects, arrays, etc.)
+  all    Trailing commas wherever possible (including function arguments).
+         This requires node 8 or a transform.
+
+Default: none
+"
+`;
+
 exports[`show usage with --help 1`] = `
 "Usage: prettier [options] [file/glob ...]
 
@@ -58,13 +123,38 @@ Editor options:
 Other options:
 
   --no-color               Do not colorize error messages.
-  --help or -h             Show help.
+  --help or -h <option-name>
+                           Show CLI usages, or detailed option usage if option name present.
   --require-pragma         Require either '@prettier' or '@format' to be present in the file's first docblock comment
                            in order for it to be formatted.
   --stdin                  Force reading input from stdin.
   --stdin-filepath <path>  Path to the file to pretend that stdin comes from.
   --version or -v          Print Prettier version.
 
+
+"
+`;
+
+exports[`show warning with --help not-found (typo) 1`] = `
+"Parser (--parser <flow|babylon|typescript|postcss|json|graphql>)
+
+  Which parser to use. Defaults to babylon.
+
+Valid options:
+
+  flow         undocumented
+  babylon      undocumented
+  typescript   undocumented
+  postcss      undocumented
+  json         undocumented
+  graphql      undocumented
+
+Default: babylon
+"
+`;
+
+exports[`show warning with --help not-found (typo) 2`] = `
+"Unexpected option name \\"parserr\\", did you mean \\"parser\\"?
 
 "
 `;
@@ -127,7 +217,8 @@ Editor options:
 Other options:
 
   --no-color               Do not colorize error messages.
-  --help or -h             Show help.
+  --help or -h <option-name>
+                           Show CLI usages, or detailed option usage if option name present.
   --require-pragma         Require either '@prettier' or '@format' to be present in the file's first docblock comment
                            in order for it to be formatted.
   --stdin                  Force reading input from stdin.
@@ -144,6 +235,10 @@ exports[`throw error with --find-config-path + multiple files 1`] = `
 "Cannot use --find-config-path with multiple files
 "
 `;
+
+exports[`throw error with --help not-found 1`] = `""`;
+
+exports[`throw error with --help not-found 2`] = `"Unexpected option name \\"not-found\\""`;
 
 exports[`throw error with --write + --debug-check 1`] = `
 "Cannot use --write and --debug-check together.

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -151,7 +151,7 @@ Default: babylon
 `;
 
 exports[`show warning with --help not-found (typo) 2`] = `
-"Unexpected option name \\"parserr\\", did you mean \\"parser\\"?
+"Unknown option name \\"parserr\\", did you mean \\"parser\\"?
 
 "
 `;
@@ -230,7 +230,7 @@ exports[`throw error with --find-config-path + multiple files 1`] = `
 
 exports[`throw error with --help not-found 1`] = `""`;
 
-exports[`throw error with --help not-found 2`] = `"Unexpected option name \\"not-found\\""`;
+exports[`throw error with --help not-found 2`] = `"Unknown option name \\"not-found\\""`;
 
 exports[`throw error with --write + --debug-check 1`] = `
 "Cannot use --write and --debug-check together.

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -121,7 +121,7 @@ Editor options:
 Other options:
 
   --no-color               Do not colorize error messages.
-  -h, --help <option-name> Show CLI usages, or detailed option usage if option name present.
+  -h, --help <flag>        Show CLI usages, or detailed option usage if flag name present.
   --require-pragma         Require either '@prettier' or '@format' to be present in the file's first docblock comment
                            in order for it to be formatted.
   --stdin                  Force reading input from stdin.
@@ -210,7 +210,7 @@ Editor options:
 Other options:
 
   --no-color               Do not colorize error messages.
-  -h, --help <option-name> Show CLI usages, or detailed option usage if option name present.
+  -h, --help <flag>        Show CLI usages, or detailed option usage if flag name present.
   --require-pragma         Require either '@prettier' or '@format' to be present in the file's first docblock comment
                            in order for it to be formatted.
   --stdin                  Force reading input from stdin.

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`show detailed usage with --help config-precedence 1`] = `
-"Config Precedence (--config-precedence <cli-override|file-override|prefer-file>)
+"--config-precedence <cli-override|file-override|prefer-file>
 
   Define in which order config files and CLI options should be evaluated.
 
@@ -17,7 +17,7 @@ Default: cli-override
 `;
 
 exports[`show detailed usage with --help cursor-offset 1`] = `
-"Cursor Offset (--cursor-offset <int>)
+"--cursor-offset <int>
 
   Print (to stderr) where a cursor at the given position would move to after formatting.
   This option cannot be used with --range-start and --range-end.
@@ -27,14 +27,14 @@ Default: -1
 `;
 
 exports[`show detailed usage with --help no-option 1`] = `
-"No Semi (--no-semi)
+"--no-semi
 
   Do not print semicolons, except at the beginning of lines which may need them.
 "
 `;
 
 exports[`show detailed usage with --help parser 1`] = `
-"Parser (--parser <flow|babylon|typescript|postcss|json|graphql>)
+"--parser <flow|babylon|typescript|postcss|json|graphql>
 
   Which parser to use.
 
@@ -52,7 +52,7 @@ Default: babylon
 `;
 
 exports[`show detailed usage with --help trailing-comma 1`] = `
-"Trailing Comma (--trailing-comma <none|es5|all>)
+"--trailing-comma <none|es5|all>
 
   Print trailing commas wherever possible when multi-line.
 
@@ -141,7 +141,7 @@ Other options:
 `;
 
 exports[`show warning with --help not-found (typo) 1`] = `
-"Parser (--parser <flow|babylon|typescript|postcss|json|graphql>)
+"--parser <flow|babylon|typescript|postcss|json|graphql>
 
   Which parser to use.
 

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -3,11 +3,7 @@
 exports[`show detailed usage with --help config-precedence 1`] = `
 "Config Precedence (--config-precedence <cli-override|file-override|prefer-file>)
 
-  Define in which order config files and CLI options should be evaluated
-  cli-override  | default config => config file => CLI options
-  file-override | default config => CLI options => config file
-  prefer-file   | default config => config file (if config file is found) or
-                  default config => CLI options (if no config file is found)
+  Define in which order config files and CLI options should be evaluated.
   Defaults to cli-override.
 
 Valid options:
@@ -101,11 +97,7 @@ Config options:
   --config <path>          Path to a Prettier configuration file (.prettierrc, package.json, prettier.config.js).
   --no-config              Do not look for a configuration file.
   --config-precedence <cli-override|file-override|prefer-file>
-                           Define in which order config files and CLI options should be evaluated
-                           cli-override  | default config => config file => CLI options
-                           file-override | default config => CLI options => config file
-                           prefer-file   | default config => config file (if config file is found) or
-                                           default config => CLI options (if no config file is found)
+                           Define in which order config files and CLI options should be evaluated.
                            Defaults to cli-override.
   --find-config-path <path>
                            Find and print the path to a configuration file for the given input file.
@@ -194,11 +186,7 @@ Config options:
   --config <path>          Path to a Prettier configuration file (.prettierrc, package.json, prettier.config.js).
   --no-config              Do not look for a configuration file.
   --config-precedence <cli-override|file-override|prefer-file>
-                           Define in which order config files and CLI options should be evaluated
-                           cli-override  | default config => config file => CLI options
-                           file-override | default config => CLI options => config file
-                           prefer-file   | default config => config file (if config file is found) or
-                                           default config => CLI options (if no config file is found)
+                           Define in which order config files and CLI options should be evaluated.
                            Defaults to cli-override.
   --find-config-path <path>
                            Find and print the path to a configuration file for the given input file.

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`show detailed usage with --help config 1`] = `
+"--config <path>
+
+  Path to a Prettier configuration file (.prettierrc, package.json, prettier.config.js).
+"
+`;
+
 exports[`show detailed usage with --help config-precedence 1`] = `
 "--config-precedence <cli-override|file-override|prefer-file>
 
@@ -26,7 +33,67 @@ Default: -1
 "
 `;
 
-exports[`show detailed usage with --help no-option 1`] = `
+exports[`show detailed usage with --help find-config-path 1`] = `
+"--find-config-path <path>
+
+  Find and print the path to a configuration file for the given input file.
+"
+`;
+
+exports[`show detailed usage with --help help 1`] = `
+"-h, --help <flag>
+
+  Show CLI usage, or details about the given flag.
+"
+`;
+
+exports[`show detailed usage with --help ignore-path 1`] = `
+"--ignore-path <path>
+
+  Path to a file with patterns describing files to ignore.
+
+Default: .prettierignore
+"
+`;
+
+exports[`show detailed usage with --help jsx-bracket-same-line 1`] = `
+"--jsx-bracket-same-line
+
+  Put > on the last line instead of at a new line.
+
+Default: false
+"
+`;
+
+exports[`show detailed usage with --help list-different 1`] = `
+"-l, --list-different
+
+  Print the names of files that are different from Prettier's formatting.
+"
+`;
+
+exports[`show detailed usage with --help no-bracket-spacing 1`] = `
+"--no-bracket-spacing
+
+  Do not print spaces between brackets.
+"
+`;
+
+exports[`show detailed usage with --help no-color 1`] = `
+"--no-color
+
+  Do not colorize error messages.
+"
+`;
+
+exports[`show detailed usage with --help no-config 1`] = `
+"--no-config
+
+  Do not look for a configuration file.
+"
+`;
+
+exports[`show detailed usage with --help no-semi 1`] = `
 "--no-semi
 
   Do not print semicolons, except at the beginning of lines which may need them.
@@ -51,6 +118,79 @@ Default: babylon
 "
 `;
 
+exports[`show detailed usage with --help print-width 1`] = `
+"--print-width <int>
+
+  The line length where Prettier will try wrap.
+
+Default: 80
+"
+`;
+
+exports[`show detailed usage with --help range-end 1`] = `
+"--range-end <int>
+
+  Format code ending at a given character offset (exclusive).
+  The range will extend forwards to the end of the selected statement.
+  This option cannot be used with --cursor-offset.
+
+Default: Infinity
+"
+`;
+
+exports[`show detailed usage with --help range-start 1`] = `
+"--range-start <int>
+
+  Format code starting at a given character offset.
+  The range will extend backwards to the start of the first line containing the selected statement.
+  This option cannot be used with --cursor-offset.
+
+Default: 0
+"
+`;
+
+exports[`show detailed usage with --help require-pragma 1`] = `
+"--require-pragma
+
+  Require either '@prettier' or '@format' to be present in the file's first docblock comment
+  in order for it to be formatted.
+
+Default: false
+"
+`;
+
+exports[`show detailed usage with --help single-quote 1`] = `
+"--single-quote
+
+  Use single quotes instead of double quotes.
+
+Default: false
+"
+`;
+
+exports[`show detailed usage with --help stdin 1`] = `
+"--stdin
+
+  Force reading input from stdin.
+"
+`;
+
+exports[`show detailed usage with --help stdin-filepath 1`] = `
+"--stdin-filepath <path>
+
+  Path to the file to pretend that stdin comes from.
+"
+`;
+
+exports[`show detailed usage with --help tab-width 1`] = `
+"--tab-width <int>
+
+  Number of spaces per indentation level.
+
+Default: 2
+"
+`;
+
 exports[`show detailed usage with --help trailing-comma 1`] = `
 "--trailing-comma <none|es5|all>
 
@@ -63,6 +203,36 @@ Valid options:
   all    Trailing commas wherever possible (including function arguments).
 
 Default: none
+"
+`;
+
+exports[`show detailed usage with --help use-tabs 1`] = `
+"--use-tabs
+
+  Indent with tabs instead of spaces.
+
+Default: false
+"
+`;
+
+exports[`show detailed usage with --help version 1`] = `
+"-v, --version
+
+  Print Prettier version.
+"
+`;
+
+exports[`show detailed usage with --help with-node-modules 1`] = `
+"--with-node-modules
+
+  Process files inside 'node_modules' directory.
+"
+`;
+
+exports[`show detailed usage with --help write 1`] = `
+"--write
+
+  Edit files in-place. (Beware!)
 "
 `;
 

--- a/tests_integration/__tests__/early-exit.js
+++ b/tests_integration/__tests__/early-exit.js
@@ -18,6 +18,14 @@ test("show usage with --help", () => {
   expect(result.status).toEqual(0);
 });
 
+test("show warning with --help --help", () => {
+  const result = runPrettier("cli", ["--help", "--help"]);
+
+  expect(result.stdout).toMatchSnapshot();
+  expect(result.stderr).toMatchSnapshot();
+  expect(result.status).toEqual(0);
+});
+
 constant.detailedOptions.forEach(option => {
   const optionNames = [
     option.description ? option.name : null,

--- a/tests_integration/__tests__/early-exit.js
+++ b/tests_integration/__tests__/early-exit.js
@@ -26,6 +26,12 @@ test("show warning with --help --help", () => {
   expect(result.status).toEqual(0);
 });
 
+test(`show detailed usage with --help l (alias)`, () => {
+  const result = runPrettier("cli", ["--help", "l"]);
+  expect(result.stdout).toMatchSnapshot();
+  expect(result.status).toEqual(0);
+});
+
 constant.detailedOptions.forEach(option => {
   const optionNames = [
     option.description ? option.name : null,

--- a/tests_integration/__tests__/early-exit.js
+++ b/tests_integration/__tests__/early-exit.js
@@ -17,6 +17,50 @@ test("show usage with --help", () => {
   expect(result.status).toEqual(0);
 });
 
+test("show detailed usage with --help trailing-comma", () => {
+  const result = runPrettier("cli", ["--help", "trailing-comma"]);
+
+  expect(result.stdout).toMatchSnapshot();
+  expect(result.status).toEqual(0);
+});
+
+test("show detailed usage with --help config-precedence", () => {
+  const result = runPrettier("cli", ["--help", "config-precedence"]);
+
+  expect(result.stdout).toMatchSnapshot();
+  expect(result.status).toEqual(0);
+});
+
+test("show detailed usage with --help cursor-offset", () => {
+  const result = runPrettier("cli", ["--help", "cursor-offset"]);
+
+  expect(result.stdout).toMatchSnapshot();
+  expect(result.status).toEqual(0);
+});
+
+test("show detailed usage with --help parser", () => {
+  const result = runPrettier("cli", ["--help", "parser"]);
+
+  expect(result.stdout).toMatchSnapshot();
+  expect(result.status).toEqual(0);
+});
+
+test("throw error with --help not-found", () => {
+  const result = runPrettier("cli", ["--help", "not-found"]);
+
+  expect(result.stdout).toMatchSnapshot();
+  expect(result.stderr).toMatchSnapshot();
+  expect(result.status).not.toEqual(0);
+});
+
+test("show warning with --help not-found (typo)", () => {
+  const result = runPrettier("cli", ["--help", "parserr"]);
+
+  expect(result.stdout).toMatchSnapshot();
+  expect(result.stderr).toMatchSnapshot();
+  expect(result.status).toEqual(0);
+});
+
 test("throw error with --write + --debug-check", () => {
   const result = runPrettier("cli", ["--write", "--debug-check"]);
 

--- a/tests_integration/__tests__/early-exit.js
+++ b/tests_integration/__tests__/early-exit.js
@@ -45,6 +45,13 @@ test("show detailed usage with --help parser", () => {
   expect(result.status).toEqual(0);
 });
 
+test("show detailed usage with --help no-option", () => {
+  const result = runPrettier("cli", ["--help", "no-semi"]);
+
+  expect(result.stdout).toMatchSnapshot();
+  expect(result.status).toEqual(0);
+});
+
 test("throw error with --help not-found", () => {
   const result = runPrettier("cli", ["--help", "not-found"]);
 

--- a/tests_integration/__tests__/early-exit.js
+++ b/tests_integration/__tests__/early-exit.js
@@ -18,14 +18,6 @@ test("show usage with --help", () => {
   expect(result.status).toEqual(0);
 });
 
-test("show warning with --help --help", () => {
-  const result = runPrettier("cli", ["--help", "--help"]);
-
-  expect(result.stdout).toMatchSnapshot();
-  expect(result.stderr).toMatchSnapshot();
-  expect(result.status).toEqual(0);
-});
-
 test(`show detailed usage with --help l (alias)`, () => {
   const result = runPrettier("cli", ["--help", "l"]);
   expect(result.stdout).toMatchSnapshot();
@@ -47,12 +39,12 @@ constant.detailedOptions.forEach(option => {
   });
 });
 
-test("throw error with --help not-found", () => {
+test("show warning with --help not-found", () => {
   const result = runPrettier("cli", ["--help", "not-found"]);
 
   expect(result.stdout).toMatchSnapshot();
   expect(result.stderr).toMatchSnapshot();
-  expect(result.status).not.toEqual(0);
+  expect(result.status).toEqual(0);
 });
 
 test("show warning with --help not-found (typo)", () => {

--- a/tests_integration/__tests__/early-exit.js
+++ b/tests_integration/__tests__/early-exit.js
@@ -2,6 +2,7 @@
 
 const prettier = require("../..");
 const runPrettier = require("../runPrettier");
+const constant = require("../../src/cli-constant");
 
 test("show version with --version", () => {
   const result = runPrettier("cli/with-shebang", ["--version"]);
@@ -17,39 +18,19 @@ test("show usage with --help", () => {
   expect(result.status).toEqual(0);
 });
 
-test("show detailed usage with --help trailing-comma", () => {
-  const result = runPrettier("cli", ["--help", "trailing-comma"]);
+constant.detailedOptions.forEach(option => {
+  const optionNames = [
+    option.description ? option.name : null,
+    option.oppositeDescription ? `no-${option.name}` : null
+  ].filter(Boolean);
 
-  expect(result.stdout).toMatchSnapshot();
-  expect(result.status).toEqual(0);
-});
-
-test("show detailed usage with --help config-precedence", () => {
-  const result = runPrettier("cli", ["--help", "config-precedence"]);
-
-  expect(result.stdout).toMatchSnapshot();
-  expect(result.status).toEqual(0);
-});
-
-test("show detailed usage with --help cursor-offset", () => {
-  const result = runPrettier("cli", ["--help", "cursor-offset"]);
-
-  expect(result.stdout).toMatchSnapshot();
-  expect(result.status).toEqual(0);
-});
-
-test("show detailed usage with --help parser", () => {
-  const result = runPrettier("cli", ["--help", "parser"]);
-
-  expect(result.stdout).toMatchSnapshot();
-  expect(result.status).toEqual(0);
-});
-
-test("show detailed usage with --help no-option", () => {
-  const result = runPrettier("cli", ["--help", "no-semi"]);
-
-  expect(result.stdout).toMatchSnapshot();
-  expect(result.status).toEqual(0);
+  optionNames.forEach(optionName => {
+    test(`show detailed usage with --help ${optionName}`, () => {
+      const result = runPrettier("cli", ["--help", optionName]);
+      expect(result.stdout).toMatchSnapshot();
+      expect(result.status).toEqual(0);
+    });
+  });
 });
 
 test("throw error with --help not-found", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2581,7 +2581,7 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-leven@^2.1.0:
+leven@2.1.0, leven@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
 


### PR DESCRIPTION
main:

- Fixes #2826

side:

- replace `or` with `,`, e.g. `--help or -h` -> `-h, --help`
- add DidYouMean redirection for `--help <typo>` using leven