### PR TITLE
Do not print trailing comma after broken arrows

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -569,12 +569,7 @@ function genericPrintNoParens(path, options, print, args) {
                   shouldAddParens ? ifBreak("", ")") : ""
                 ])
               ),
-              shouldAddSoftLine
-                ? concat([
-                    ifBreak(shouldPrintComma(options, "all") ? "," : ""),
-                    softline
-                  ])
-                : ""
+              shouldAddSoftLine ? softline : ""
             ])
           )
         ])

--- a/tests/arrow-call/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/arrow-call/__snapshots__/jsfmt.spec.js.snap
@@ -140,12 +140,12 @@ const composition = (ViewComponent, ContainerComponent) =>
   };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const testResults = results.testResults.map(testResult =>
-  formatResult(testResult, formatter, reporter),
+  formatResult(testResult, formatter, reporter)
 );
 
 it("mocks regexp instances", () => {
   expect(() =>
-    moduleMocker.generateFromMetadata(moduleMocker.getMetadata(/a/)),
+    moduleMocker.generateFromMetadata(moduleMocker.getMetadata(/a/))
   ).not.toThrow();
 });
 
@@ -154,19 +154,19 @@ expect(() => asyncRequest({ url: "/test-endpoint" })).toThrowError(
 );
 
 expect(() =>
-  asyncRequest({ url: "/test-endpoint-but-with-a-long-url" }),
+  asyncRequest({ url: "/test-endpoint-but-with-a-long-url" })
 ).toThrowError(/Required parameter/);
 
 expect(() =>
-  asyncRequest({ url: "/test-endpoint-but-with-a-suuuuuuuuper-long-url" }),
+  asyncRequest({ url: "/test-endpoint-but-with-a-suuuuuuuuper-long-url" })
 ).toThrowError(/Required parameter/);
 
 expect(() =>
-  asyncRequest({ type: "foo", url: "/test-endpoint" }),
+  asyncRequest({ type: "foo", url: "/test-endpoint" })
 ).not.toThrowError();
 
 expect(() =>
-  asyncRequest({ type: "foo", url: "/test-endpoint-but-with-a-long-url" }),
+  asyncRequest({ type: "foo", url: "/test-endpoint-but-with-a-long-url" })
 ).not.toThrowError();
 
 const a = Observable.fromPromise(axiosInstance.post("/carts/mine")).map(


### PR DESCRIPTION
Fixes #2856.

That issue is still marked needs-discussion, but I figured it would be helpful to see what the change would be.