### PR TITLE
Fix line break in test declarations with 2nd argument as a function

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -845,6 +845,23 @@ function genericPrintNoParens(path, options, print, args) {
     case "CallExpression": {
       const isNew = n.type === "NewExpression";
       const unitTestRe = /^(f|x)?(it|describe|test)$/;
+      const isTestDeclaration =
+        !isNew &&
+        ((n.callee.type === "Identifier" && unitTestRe.test(n.callee.name)) ||
+          (n.callee.type === "MemberExpression" &&
+            n.callee.object.type === "Identifier" &&
+            n.callee.property.type === "Identifier" &&
+            unitTestRe.test(n.callee.object.name) &&
+            (n.callee.property.name === "only" ||
+              n.callee.property.name === "skip"))) &&
+        n.arguments.length === 2 &&
+        (n.arguments[0].type === "StringLiteral" ||
+          n.arguments[0].type === "TemplateLiteral" ||
+          (n.arguments[0].type === "Literal" &&
+            typeof n.arguments[0].value === "string")) &&
+        (n.arguments[1].type === "FunctionExpression" ||
+          n.arguments[1].type === "ArrowFunctionExpression") &&
+        n.arguments[1].params.length <= 1;
 
       const optional = printOptionalToken(path);
       if (
@@ -858,29 +875,18 @@ function genericPrintNoParens(path, options, print, args) {
           isTemplateOnItsOwnLine(n.arguments[0], options.originalText)) ||
         // Keep test declarations on a single line
         // e.g. `it('long name', () => {`
-        (!isNew &&
-          ((n.callee.type === "Identifier" && unitTestRe.test(n.callee.name)) ||
-            (n.callee.type === "MemberExpression" &&
-              n.callee.object.type === "Identifier" &&
-              n.callee.property.type === "Identifier" &&
-              unitTestRe.test(n.callee.object.name) &&
-              (n.callee.property.name === "only" ||
-                n.callee.property.name === "skip"))) &&
-          n.arguments.length === 2 &&
-          (n.arguments[0].type === "StringLiteral" ||
-            n.arguments[0].type === "TemplateLiteral" ||
-            (n.arguments[0].type === "Literal" &&
-              typeof n.arguments[0].value === "string")) &&
-          (n.arguments[1].type === "FunctionExpression" ||
-            n.arguments[1].type === "ArrowFunctionExpression") &&
-          n.arguments[1].params.length <= 1)
+        isTestDeclaration
       ) {
+        let printedArgs = path.map(print, "arguments");
+        if (isTestDeclaration) {
+          printedArgs = printedArgs.map(docUtils.removeLines);
+        }
         return concat([
           isNew ? "new " : "",
           path.call(print, "callee"),
           optional,
           path.call(print, "typeParameters"),
-          concat(["(", join(", ", path.map(print, "arguments")), ")"])
+          concat(["(", join(", ", printedArgs), ")"])
         ]);
       }
 

--- a/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
@@ -11,6 +11,17 @@ it("does something really long and complicated so I have to write a very long na
   console.log("hello!");
 });
 
+it("does something really long and complicated so I have to write a very long name for the test", function(done) {
+  console.log("hello!");
+});
+
+it(\`handles
+  some
+    newlines
+  does something really long and complicated so I have to write a very long name for the test\`, function(done) {
+  console.log("hello!");
+});
+
 it(\`does something really long and complicated so I have to write a very long name for the test\`, function() {
   console.log("hello!");
 });
@@ -97,6 +108,17 @@ it("does something really long and complicated so I have to write a very long na
 });
 
 it("does something really long and complicated so I have to write a very long name for the test", function() {
+  console.log("hello!");
+});
+
+it("does something really long and complicated so I have to write a very long name for the test", function(done) {
+  console.log("hello!");
+});
+
+it(\`handles
+  some
+    newlines
+  does something really long and complicated so I have to write a very long name for the test\`, function(done) {
   console.log("hello!");
 });
 

--- a/tests/test_declarations/test_declarations.js
+++ b/tests/test_declarations/test_declarations.js
@@ -8,6 +8,17 @@ it("does something really long and complicated so I have to write a very long na
   console.log("hello!");
 });
 
+it("does something really long and complicated so I have to write a very long name for the test", function(done) {
+  console.log("hello!");
+});
+
+it(`handles
+  some
+    newlines
+  does something really long and complicated so I have to write a very long name for the test`, function(done) {
+  console.log("hello!");
+});
+
 it(`does something really long and complicated so I have to write a very long name for the test`, function() {
   console.log("hello!");
 });


### PR DESCRIPTION
Fixes #1473

Basically this prevents breaking a test declaration when the 2nd argument is a function declaration:

```js
// current output
test("long string", function(
  done
) {
  // body
});

// with this PR
test("long string", function(done) {
  // body
});
```

I wasn't sure how recommended it is to use `removeLines` but since this case was quite specific, I didn't think it would be much trouble. Let me know if I should solve this some other way!