### PR TITLE
Use semicolons in Flow interface-like bodies (#2593)

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -937,14 +937,22 @@ function genericPrintNoParens(path, options, print, args) {
             util.locStart(n),
             util.locEnd(n)
           ));
-      const separator =
-        n.type === "TSInterfaceBody" || n.type === "TSTypeLiteral"
+      const parent = path.getParentNode(0);
+      const isFlowInterfaceLikeBody =
+        isTypeAnnotation &&
+        parent &&
+        (parent.type === "InterfaceDeclaration" ||
+          parent.type === "DeclareInterface" ||
+          parent.type === "DeclareClass") &&
+        path.getName() === "body";
+      const separator = isFlowInterfaceLikeBody
+        ? ";"
+        : n.type === "TSInterfaceBody" || n.type === "TSTypeLiteral"
           ? ifBreak(semi, ";")
           : ",";
       const fields = [];
       const leftBrace = n.exact ? "{|" : "{";
       const rightBrace = n.exact ? "|}" : "}";
-      const parent = path.getParentNode(0);
 
       let propertiesField;
 

--- a/tests/flow/annot/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/annot/__snapshots__/jsfmt.spec.js.snap
@@ -268,8 +268,8 @@ type Merge<T> = (a: T, b: T) => T;
 
 // hypothetical immutable map
 declare class Map<K, V> {
-  (): Map<K, V>,
-  insertWith(fn: Merge<V>, k: K, v: V): Map<K, V>
+  (): Map<K, V>;
+  insertWith(fn: Merge<V>, k: K, v: V): Map<K, V>;
 }
 
 declare function foldr<A, B>(fn: (a: A, b: B) => B, b: B, as: A[]): B;

--- a/tests/flow/any/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/any/__snapshots__/jsfmt.spec.js.snap
@@ -183,8 +183,8 @@ function bar2(x: mixed) {
 // @flow
 
 declare class C {
-  bar(n1: number, n2: number): number,
-  bar(s1: string, s2: string): string
+  bar(n1: number, n2: number): number;
+  bar(s1: string, s2: string): string;
 }
 
 function foo(c: C, x: any): string {

--- a/tests/flow/async_iteration/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/async_iteration/__snapshots__/jsfmt.spec.js.snap
@@ -85,9 +85,9 @@ async function f() {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare interface File {
-  readLine(): Promise<string>,
-  close(): void,
-  EOF: boolean
+  readLine(): Promise<string>;
+  close(): void;
+  EOF: boolean;
 }
 
 declare function fileOpen(path: string): Promise<File>;

--- a/tests/flow/call_caching1/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/call_caching1/__snapshots__/jsfmt.spec.js.snap
@@ -48,7 +48,7 @@ foo(
 /* @flow */
 
 declare class Bar<K> {
-  update<K_>(updater: (value: this) => Bar<K_>): Bar<K_>
+  update<K_>(updater: (value: this) => Bar<K_>): Bar<K_>;
 }
 
 declare function foo<U>(
@@ -84,14 +84,14 @@ outer.set(ImmBox(inner));
 // @flow
 
 declare class ImmBox<T> {
-  static <U>(x: any): ImmBox<U>,
-  static (x: any): any
+  static <U>(x: any): ImmBox<U>;
+  static (x: any): any;
 }
 
 declare class Box<T> {
-  constructor(x: T): void,
-  set(value: T): void,
-  get(): T
+  constructor(x: T): void;
+  set(value: T): void;
+  get(): T;
 }
 
 const outer = new Box();

--- a/tests/flow/call_caching1/lib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/call_caching1/lib/__snapshots__/jsfmt.spec.js.snap
@@ -28,11 +28,11 @@ declare class Map<K, V> {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class Array<T> {
-  @@iterator(): Iterator<T>,
+  @@iterator(): Iterator<T>;
   map<U>(
     callbackfn: (value: T, index: number, array: Array<T>) => U,
     thisArg?: any
-  ): Array<U>
+  ): Array<U>;
 }
 
 type IteratorResult<Yield, Return> =
@@ -40,20 +40,20 @@ type IteratorResult<Yield, Return> =
   | { done: false, value: Yield };
 
 interface $Iterator<+Yield, +Return, -Next> {
-  @@iterator(): $Iterator<Yield, Return, Next>,
-  next(value?: Next): IteratorResult<Yield, Return>
+  @@iterator(): $Iterator<Yield, Return, Next>;
+  next(value?: Next): IteratorResult<Yield, Return>;
 }
 type Iterator<+T> = $Iterator<T, void, void>;
 
 interface $Iterable<+Yield, +Return, -Next> {
-  @@iterator(): $Iterator<Yield, Return, Next>
+  @@iterator(): $Iterator<Yield, Return, Next>;
 }
 type Iterable<+T> = $Iterable<T, void, void>;
 
 declare class Map<K, V> {
-  @@iterator(): Iterator<[K, V]>,
-  constructor(iterable: ?Iterable<[K, V]>): void,
-  set(key: K, value: V): Map<K, V>
+  @@iterator(): Iterator<[K, V]>;
+  constructor(iterable: ?Iterable<[K, V]>): void;
+  set(key: K, value: V): Map<K, V>;
 }
 
 `;
@@ -70,10 +70,10 @@ declare module "immutable" {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare module "immutable" {
   declare class Map<K, V> {
-    static <K, V>(iter: Iterator<[K, V]>): Map<K, V>,
-    static <K: string, V>(object: { +[k: K]: V }): Map<K, V>,
+    static <K, V>(iter: Iterator<[K, V]>): Map<K, V>;
+    static <K: string, V>(object: { +[k: K]: V }): Map<K, V>;
 
-    set(key: K, value: V): this
+    set(key: K, value: V): this;
   }
 }
 

--- a/tests/flow/call_caching2/lib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/call_caching2/lib/__snapshots__/jsfmt.spec.js.snap
@@ -16,9 +16,9 @@ declare class Iterable<S> {
 declare class Array<T> {}
 
 declare class Iterable<S> {
-  static <V, Iter: Iterable<V>>(iter: Iter): Iter,
-  static <T>(iter: Array<T>): Iterable<T>,
-  size: number
+  static <V, Iter: Iterable<V>>(iter: Iter): Iter;
+  static <T>(iter: Array<T>): Iterable<T>;
+  size: number;
 }
 
 `;

--- a/tests/flow/callable/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/callable/__snapshots__/jsfmt.spec.js.snap
@@ -56,7 +56,7 @@ var dict: { [k: string]: any } = {};
 dict(); // error, callable signature not found
 
 interface ICall {
-  (x: string): void
+  (x: string): void;
 }
 declare var icall: ICall;
 icall(0); // error, number ~> string

--- a/tests/flow/constructor/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/constructor/__snapshots__/jsfmt.spec.js.snap
@@ -35,14 +35,14 @@ class D {
 // the return type of a constructor overrides the type of the class
 declare class Bar<T> {}
 declare class Foo<T> {
-  constructor<U>(iterable: U): Bar<U>
+  constructor<U>(iterable: U): Bar<U>;
 }
 (new Foo("x"): Bar<string>); // ok
 (new Foo(123): Bar<string>); // error, number !~> string
 
 // also overrides when it returns a different specialization of the same class
 declare class Baz<T> {
-  constructor<U>(iterable: U): Baz<U>
+  constructor<U>(iterable: U): Baz<U>;
 }
 (new Baz("x"): Baz<string>); // ok
 (new Baz(123): Baz<string>); // error, number !~> string

--- a/tests/flow/constructor_annots/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/constructor_annots/__snapshots__/jsfmt.spec.js.snap
@@ -41,13 +41,13 @@ exports.Foo = Foo;
 
 // so you want to type Foo, by declaring it as a class
 interface IFooPrototype {
-  m: () => number
+  m: () => number;
 }
 interface IFoo extends IFooPrototype {
-  x: boolean, // error, should have declared x: number instead
-  static (): void,
-  static y: boolean, // error, should have declared static y: number instead
-  constructor(): void
+  x: boolean; // error, should have declared x: number instead
+  static (): void;
+  static y: boolean; // error, should have declared static y: number instead
+  constructor(): void;
 }
 exports.Foo2 = (Foo: Class<IFoo>);
 

--- a/tests/flow/declare_class/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declare_class/__snapshots__/jsfmt.spec.js.snap
@@ -18,10 +18,10 @@ declare class D extends C { }
 new D(123); // error, number ~> string
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class C {
-  static x: number,
-  static foo(x: number): void,
+  static x: number;
+  static foo(x: number): void;
 
-  constructor(x: string): void
+  constructor(x: string): void;
 }
 
 C.x = "";

--- a/tests/flow/declare_class/lib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declare_class/lib/__snapshots__/jsfmt.spec.js.snap
@@ -12,13 +12,13 @@ declare class D extends _module.C {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class _C {
-  foo(): number
+  foo(): number;
 }
 declare var _module: {
   C: Class<_C>
 };
 declare class D extends _module.C {
-  foo(): string
+  foo(): string;
 }
 
 `;

--- a/tests/flow/declare_type/lib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/declare_type/lib/__snapshots__/jsfmt.spec.js.snap
@@ -46,7 +46,7 @@ declare module 'foo' {
 
 declare module "foo" {
   declare class A {
-    toz: number
+    toz: number;
   }
 
   declare var n: string;

--- a/tests/flow/getters_and_setters_disabled/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/getters_and_setters_disabled/__snapshots__/jsfmt.spec.js.snap
@@ -58,9 +58,9 @@ type T = {
 };
 
 declare class Foo {
-  get a(): number,
-  set b(x: number): void,
-  c: 10
+  get a(): number;
+  set b(x: number): void;
+  c: 10;
 }
 
 class Bar {

--- a/tests/flow/getters_and_setters_enabled/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/getters_and_setters_enabled/__snapshots__/jsfmt.spec.js.snap
@@ -197,28 +197,28 @@ foo.propOverriddenWithSetter = 123; // Error number ~> string
 var z: number = 123;
 
 declare class Foo {
-  get goodGetterWithAnnotation(): number,
-  set goodSetterWithAnnotation(x: number): void,
+  get goodGetterWithAnnotation(): number;
+  set goodSetterWithAnnotation(x: number): void;
 
-  get propWithMatchingGetterAndSetter(): number,
-  set propWithMatchingGetterAndSetter(x: number): void,
-
-  // The getter and setter need not have the same type - no error
-  get propWithSubtypingGetterAndSetter(): ?number,
-  set propWithSubtypingGetterAndSetter(x: number): void,
+  get propWithMatchingGetterAndSetter(): number;
+  set propWithMatchingGetterAndSetter(x: number): void;
 
   // The getter and setter need not have the same type - no error
-  set propWithSubtypingGetterAndSetterReordered(x: number): void,
-  get propWithSubtypingGetterAndSetterReordered(): ?number,
+  get propWithSubtypingGetterAndSetter(): ?number;
+  set propWithSubtypingGetterAndSetter(x: number): void;
 
-  get propWithMismatchingGetterAndSetter(): number,
-  set propWithMismatchingGetterAndSetter(x: string): void, // doesn't match getter (OK)
+  // The getter and setter need not have the same type - no error
+  set propWithSubtypingGetterAndSetterReordered(x: number): void;
+  get propWithSubtypingGetterAndSetterReordered(): ?number;
 
-  propOverriddenWithGetter: number,
-  get propOverriddenWithGetter(): string,
+  get propWithMismatchingGetterAndSetter(): number;
+  set propWithMismatchingGetterAndSetter(x: string): void; // doesn't match getter (OK)
 
-  propOverriddenWithSetter: number,
-  set propOverriddenWithSetter(x: string): void
+  propOverriddenWithGetter: number;
+  get propOverriddenWithGetter(): string;
+
+  propOverriddenWithSetter: number;
+  set propOverriddenWithSetter(x: string): void;
 }
 
 var foo = new Foo();

--- a/tests/flow/interface/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/interface/__snapshots__/jsfmt.spec.js.snap
@@ -24,12 +24,12 @@ interface Bad {
 // @flow
 
 interface Ok {
-  [key: string]: string
+  [key: string]: string;
 }
 
 interface Bad {
-  [k1: string]: string,
-  [k2: number]: number // error: not supported (yet)
+  [k1: string]: string;
+  [k2: number]: number; // error: not supported (yet)
 }
 
 `;
@@ -154,7 +154,7 @@ function foo(k: K) {
   (k.y: number); // error: y is string in I
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-interface I { x: number, y: string }
+interface I { x: number; y: string }
 interface J { y: number }
 interface K extends I, J { x: string } // error: x is number in I
 function foo(k: K) {
@@ -179,8 +179,8 @@ interface I { foo(x: number): void }
 (function foo(x: number) {}: I); // error, property \`foo\` not found function
 
 declare class C {
-  bar(i: I): void,
-  bar(f: (x: number) => void): void
+  bar(i: I): void;
+  bar(f: (x: number) => void): void;
 }
 
 new C().bar((x: string) => {}); // error, number ~/~> string

--- a/tests/flow/lib_interfaces/declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/lib_interfaces/declarations/__snapshots__/jsfmt.spec.js.snap
@@ -10,11 +10,11 @@ interface CArrays<T> extends C<Array<T>> {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 interface C<T> {
-  foo(): CArrays<T>,
-  bar(): C<any>
+  foo(): CArrays<T>;
+  bar(): C<any>;
 }
 interface CArrays<T> extends C<Array<T>> {
-  bar(): C<any>
+  bar(): C<any>;
 }
 
 `;

--- a/tests/flow/method_properties/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/method_properties/__snapshots__/jsfmt.spec.js.snap
@@ -12,7 +12,7 @@ export {Foo};
 // @flow
 
 declare class Foo {
-  bar?: () => string
+  bar?: () => string;
 }
 
 export { Foo };

--- a/tests/flow/object-method/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/object-method/__snapshots__/jsfmt.spec.js.snap
@@ -20,7 +20,7 @@ import type { ObjectType } from './test';
 function subtypeCheck(x: Interface): ObjectType { return x; }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 interface Interface {
-  m(): void
+  m(): void;
 }
 import type { ObjectType } from "./test";
 

--- a/tests/flow/optional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/optional/__snapshots__/jsfmt.spec.js.snap
@@ -301,7 +301,7 @@ var i:I<number> = new I();
 var j:I<number> = i.map(id => id);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class I<V> {
-  map<M>(mapper: (value?: V) => M): I<M>
+  map<M>(mapper: (value?: V) => M): I<M>;
 }
 var i: I<number> = new I();
 var j: I<number> = i.map(id => id);

--- a/tests/flow/overload/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/overload/__snapshots__/jsfmt.spec.js.snap
@@ -65,11 +65,11 @@ var x3: string = "".replace(/pattern/, "...");
 var x4: number = "".split(/pattern/)[0];
 
 declare class C {
-  foo(x: number): number,
-  foo(x: string): string,
+  foo(x: number): number;
+  foo(x: string): string;
 
-  bar(x: { a: number }): number,
-  bar(x: { a: string }): string
+  bar(x: { a: number }): number;
+  bar(x: { a: string }): string;
 }
 
 var a = new C();
@@ -130,8 +130,8 @@ var foo = new Foo;
 (foo.bar('hmmm'): number); // error
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class Foo {
-  bar(x: "hmm"): number,
-  bar(x: string): string
+  bar(x: "hmm"): number;
+  bar(x: string): string;
 }
 var foo = new Foo();
 (foo.bar("hmm"): number); // OK

--- a/tests/flow/overload/lib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/overload/lib/__snapshots__/jsfmt.spec.js.snap
@@ -7,8 +7,8 @@ declare class FakeUint8Array {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class FakeUint8Array {
-  set(index: number, value: number): void,
-  set(array: FakeUint8Array | Array<number>, offset?: number): void
+  set(index: number, value: number): void;
+  set(array: FakeUint8Array | Array<number>, offset?: number): void;
 }
 
 `;

--- a/tests/flow/poly_overload/decls/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/poly_overload/decls/__snapshots__/jsfmt.spec.js.snap
@@ -23,16 +23,16 @@ interface Other<X> { x: X }
 interface None<Y> {}
 interface Nada<Y> { y: Y }
 interface A<X> {
-  foo<Y>(s: Some<X>, e: None<Y>): A<Y>,
-  foo<Y>(s: Some<X>, e: Nada<Y>): A<Y>,
-  foo<Y>(s: Other<X>, e: None<Y>): A<Y>,
-  foo<Y>(s: Other<X>, e: Nada<Y>): A<Y>
+  foo<Y>(s: Some<X>, e: None<Y>): A<Y>;
+  foo<Y>(s: Some<X>, e: Nada<Y>): A<Y>;
+  foo<Y>(s: Other<X>, e: None<Y>): A<Y>;
+  foo<Y>(s: Other<X>, e: Nada<Y>): A<Y>;
 }
 interface B<X> extends A<X> {
-  foo<Y>(s: Some<X>, e: None<Y>): B<Y>,
-  foo<Y>(s: Some<X>, e: Nada<Y>): B<Y>,
-  foo<Y>(s: Other<X>, e: None<Y>): B<Y>,
-  foo<Y>(s: Other<X>, e: Nada<Y>): B<Y>
+  foo<Y>(s: Some<X>, e: None<Y>): B<Y>;
+  foo<Y>(s: Some<X>, e: Nada<Y>): B<Y>;
+  foo<Y>(s: Other<X>, e: None<Y>): B<Y>;
+  foo<Y>(s: Other<X>, e: Nada<Y>): B<Y>;
 }
 
 `;

--- a/tests/flow/refinements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/refinements/__snapshots__/jsfmt.spec.js.snap
@@ -432,7 +432,7 @@ function foo2(x: ?Class<Foo>): string {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class Foo {
-  foo: string
+  foo: string;
 }
 
 function foo0(x: ?string): string {

--- a/tests/flow/return_new/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/return_new/__snapshots__/jsfmt.spec.js.snap
@@ -73,8 +73,8 @@ d.x = ""; // error, string ~/~ number (but property x is found)
 module.exports = D;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class D {
-  constructor(): { x: number }, // OK
-  y: any
+  constructor(): { x: number }; // OK
+  y: any;
 }
 
 var d = new D();

--- a/tests/flow/static_overload/lib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/static_overload/lib/__snapshots__/jsfmt.spec.js.snap
@@ -7,8 +7,8 @@ declare class StaticOverload {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class StaticOverload {
-  static foo(x: number): number,
-  static foo(x: string): string
+  static foo(x: number): number;
+  static foo(x: string): string;
 }
 
 `;

--- a/tests/flow/structural_subtyping/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/structural_subtyping/__snapshots__/jsfmt.spec.js.snap
@@ -19,7 +19,7 @@ var lengthTest4: IHasLength = true; // bool doesn't have length
  */
 
 interface IHasLength {
-  length: number
+  length: number;
 }
 
 var lengthTest1: IHasLength = [];
@@ -63,15 +63,15 @@ class ClassWithXString {
 }
 
 interface IHasXString {
-  x: string
+  x: string;
 }
 
 interface IHasXNumber {
-  x: number
+  x: number;
 }
 
 interface IHasYString {
-  y: string
+  y: string;
 }
 
 var testInstance1: IHasXString = new ClassWithXString();
@@ -107,7 +107,7 @@ function propTest6(y: {[key: string]: number}) {
  */
 
 interface IHasXString {
-  x: string
+  x: string;
 }
 
 var propTest1: IHasXString = { x: "hello" };
@@ -142,8 +142,8 @@ var test3: HasOptional = { a: "hello", b: true }; // Error: boolean ~> number
 /* @flow */
 
 interface HasOptional {
-  a: string,
-  b?: number
+  a: string;
+  b?: number;
 }
 
 var test1: HasOptional = { a: "hello" };

--- a/tests/flow/tagged-unions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/tagged-unions/__snapshots__/jsfmt.spec.js.snap
@@ -98,16 +98,16 @@ if (data.kind === "user") {
 /* @flow */
 
 declare interface IDataBase {
-  id: string,
-  name: string
+  id: string;
+  name: string;
 }
 
 declare interface IUserData extends IDataBase {
-  kind: "user"
+  kind: "user";
 }
 
 declare interface ISystemData extends IDataBase {
-  kind: "system"
+  kind: "system";
 }
 
 declare type IData = IUserData | ISystemData;
@@ -155,16 +155,16 @@ if (data.kind === "system") {
 /* @flow */
 
 declare interface IDataBase {
-  id: string,
-  name: string
+  id: string;
+  name: string;
 }
 
 declare interface IUserData extends IDataBase {
-  kind: "user"
+  kind: "user";
 }
 
 declare interface ISystemData extends IDataBase {
-  kind: "system"
+  kind: "system";
 }
 
 declare type IData = IUserData | ISystemData;

--- a/tests/flow/taint/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/taint/__snapshots__/jsfmt.spec.js.snap
@@ -295,11 +295,11 @@ declare var fakeDocument: FakeDocument;
 declare var fakeLocation: FakeLocation;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class FakeLocation {
-  assign(url: string): void
+  assign(url: string): void;
 }
 
 declare class FakeDocument {
-  location: FakeLocation
+  location: FakeLocation;
 }
 
 declare function doStuff(x: $Tainted<any>): void;

--- a/tests/flow/this_type/lib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/this_type/lib/__snapshots__/jsfmt.spec.js.snap
@@ -26,15 +26,15 @@ declare module "mini-immutable" {
 // is disabled for perf reasons, these will produce warnings.
 
 declare class LinkedList {
-  next(): this
+  next(): this;
 }
 declare class DoublyLinkedList extends LinkedList {
-  prev(): this
+  prev(): this;
 }
 
 declare module "mini-immutable" {
   declare class Map<K, V> {
-    set(key: K, value: V): this // more precise than Map<K,V> (see below)
+    set(key: K, value: V): this; // more precise than Map<K,V> (see below)
   }
   declare class OrderedMap<K, V> extends Map<K, V> {
     // inherits set method returning OrderedMap<K,V> instead of Map<K,V>

--- a/tests/flow/traits/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/traits/__snapshots__/jsfmt.spec.js.snap
@@ -28,16 +28,16 @@ declare class Foo extends Qux<string> {
 }
 declare class Bar<T> extends Baz<T> {
   // KeyedIterable <: Iterable
-  y: T
+  y: T;
 }
 declare class Qux<T> extends Baz<T> {
   // Collection <: Iterable
-  y: T,
-  z: T
+  y: T;
+  z: T;
 }
 declare class Baz<T> {
   // Iterable
-  x: T
+  x: T;
 }
 
 (new Foo().x: number); // error: Qux wins

--- a/tests/flow/type_args_nonstrict/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type_args_nonstrict/__snapshots__/jsfmt.spec.js.snap
@@ -125,12 +125,12 @@ type MySubobject = { y: number } & MyObject; // no error
 // arity error in interface extends
 
 interface MyInterface<T> {
-  x: T
+  x: T;
 }
 
 interface MySubinterface extends MyInterface {
   // no error
-  y: number
+  y: number;
 }
 
 // no arity error in extends of polymorphic class

--- a/tests/flow/type_args_strict/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type_args_strict/__snapshots__/jsfmt.spec.js.snap
@@ -123,12 +123,12 @@ type MySubobject = { y: number } & MyObject; // error, missing argument list
 // arity error in interface extends
 
 interface MyInterface<T> {
-  x: T
+  x: T;
 }
 
 interface MySubinterface extends MyInterface {
   // error, missing argument list
-  y: number
+  y: number;
 }
 
 // *no* arity error in extends of polymorphic class

--- a/tests/flow/type_param_scope/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type_param_scope/__snapshots__/jsfmt.spec.js.snap
@@ -126,19 +126,19 @@ class B<T> extends A<T> {
 }
 
 interface C<T> {
-  m<T>(x: T): C<T>
+  m<T>(x: T): C<T>;
 }
 
 interface D<T> extends C<T> {
-  m<T>(x: T): D<T>
+  m<T>(x: T): D<T>;
 }
 
 declare class E<T> {
-  m<T>(x: T): E<T>
+  m<T>(x: T): E<T>;
 }
 
 declare class F<T> extends E<T> {
-  m<T>(x: T): F<T>
+  m<T>(x: T): F<T>;
 }
 
 // Bounds can refer to parent type params (until they are shadowed).

--- a/tests/flow/type_param_variance2/libs/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/type_param_variance2/libs/__snapshots__/jsfmt.spec.js.snap
@@ -64,33 +64,33 @@ declare class Promise<R> {
       resolve: (result?: Promise<R> | R) => void,
       reject: (error?: any) => void
     ) => void
-  ): void,
+  ): void;
 
   then<U>(
     onFulfill?: ?(value: R) => Promise<U> | ?U,
     onReject?: ?(error: any) => Promise<U> | ?U
-  ): Promise<U>,
+  ): Promise<U>;
 
   done<U>(
     onFulfill?: ?(value: R) => void,
     onReject?: ?(error: any) => void
-  ): void,
+  ): void;
 
-  catch<U>(onReject?: (error: any) => ?Promise<U> | U): Promise<U>,
+  catch<U>(onReject?: (error: any) => ?Promise<U> | U): Promise<U>;
 
-  static resolve<T>(object?: Promise<T> | T): Promise<T>,
-  static reject<T>(error?: any): Promise<T>,
+  static resolve<T>(object?: Promise<T> | T): Promise<T>;
+  static reject<T>(error?: any): Promise<T>;
 
   // Non-standard APIs
-  finally<U>(onSettled?: ?(value: any) => Promise<U> | U): Promise<U>,
+  finally<U>(onSettled?: ?(value: any) => Promise<U> | U): Promise<U>;
 
-  static cast<T>(object?: T): Promise<T>,
-  static all<T>(promises: Array<?Promise<T> | T>): Promise<Array<T>>,
-  static race<T>(promises: Array<Promise<T>>): Promise<T>,
+  static cast<T>(object?: T): Promise<T>;
+  static all<T>(promises: Array<?Promise<T> | T>): Promise<Array<T>>;
+  static race<T>(promises: Array<Promise<T>>): Promise<T>;
 
   static allObject<T: Object>(
     promisesByKey: T
-  ): Promise<{ [key: $Keys<T>]: any }>
+  ): Promise<{ [key: $Keys<T>]: any }>;
 }
 
 `;

--- a/tests/flow/union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/union/__snapshots__/jsfmt.spec.js.snap
@@ -208,7 +208,7 @@ myclass.myfun(["1", "2", "3", "4", "5", "6", function (ar) {}])
 myclass.myfun(["1", "2", "3", "4", "5", "6", "7", function (ar) {}])
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class Myclass {
-  myfun(myarray: Array<Function | string>): any
+  myfun(myarray: Array<Function | string>): any;
 }
 declare var myclass: Myclass;
 
@@ -538,8 +538,8 @@ function CD(b) {
 }
 
 declare class F {
-  foo(x: number): void,
-  foo(x: string): void
+  foo(x: number): void;
+  foo(x: string): void;
 }
 function corge(b) {
   var x = b ? "" : 0;

--- a/tests/flow/union_new/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/union_new/__snapshots__/jsfmt.spec.js.snap
@@ -1385,7 +1385,7 @@ function foo(c: C<number>) {
 // annotations
 
 declare class C<X> {
-  get(): X
+  get(): X;
 }
 
 function union(o: { x: string } | { x: number }) {}
@@ -1431,8 +1431,8 @@ function foo<X>(target: EventTarget) {
 }
 
 declare class EventTarget {
-  addEventListener(type: "foo", listener: KeyboardEventHandler): void,
-  addEventListener(type: string, listener: EventHandler): void
+  addEventListener(type: "foo", listener: KeyboardEventHandler): void;
+  addEventListener(type: string, listener: EventHandler): void;
 }
 
 declare class Event {}
@@ -1530,8 +1530,8 @@ new C().m(f());
 // method overloads
 
 declare class C {
-  m(x: number): void,
-  m(x: string): void
+  m(x: number): void;
+  m(x: string): void;
 }
 
 function f() {
@@ -1565,8 +1565,8 @@ function m<X>() {
 }
 
 declare class D {
-  constructor(_: void): void,
-  constructor(_: null): void
+  constructor(_: void): void;
+  constructor(_: null): void;
 }
 
 `;
@@ -1759,15 +1759,15 @@ declare class D extends C {
 // scaling test for full type resolution
 
 declare class C {
-  addListener(event: string, listener: Function): C,
-  emit(event: string, ...args: Array<any>): boolean,
-  listeners(event: string): Array<Function>,
-  listenerCount(event: string): number,
-  on(event: string, listener: Function): C,
-  once(event: string, listener: Function): C,
-  removeAllListeners(event?: string): C,
-  removeListener(event: string, listener: Function): C,
-  setMaxListeners(n: number): void
+  addListener(event: string, listener: Function): C;
+  emit(event: string, ...args: Array<any>): boolean;
+  listeners(event: string): Array<Function>;
+  listenerCount(event: string): number;
+  on(event: string, listener: Function): C;
+  once(event: string, listener: Function): C;
+  removeAllListeners(event?: string): C;
+  removeListener(event: string, listener: Function): C;
+  setMaxListeners(n: number): void;
 }
 
 declare class D extends C {
@@ -1776,16 +1776,16 @@ declare class D extends C {
     hostname?: string,
     backlog?: number,
     callback?: Function
-  ): D,
-  listen(path: string, callback?: Function): D,
-  listen(handle: Object, callback?: Function): D,
-  close(callback?: Function): D,
-  address(): number,
-  connections: number,
-  maxConnections: number,
-  getConnections(callback: Function): void,
-  ref(): D,
-  unref(): D
+  ): D;
+  listen(path: string, callback?: Function): D;
+  listen(handle: Object, callback?: Function): D;
+  close(callback?: Function): D;
+  address(): number;
+  connections: number;
+  maxConnections: number;
+  getConnections(callback: Function): void;
+  ref(): D;
+  unref(): D;
 }
 
 (0: D | number);
@@ -1857,8 +1857,8 @@ declare var y: T;
 (foo(y): T);
 
 declare class Record {
-  set(x: "foo", y: number): void,
-  set(x: "bar", y: string): void
+  set(x: "foo", y: number): void;
+  set(x: "bar", y: string): void;
 }
 
 new Record().set("foo", "42");
@@ -1966,11 +1966,11 @@ declare class D<T> {
   reduce(
     callbackfn: (previousValue: T, currentValue: T) => T,
     initialValue: void
-  ): T,
+  ): T;
   reduce<U>(
     callbackfn: (previousValue: U, currentValue: T) => U,
     initialValue: U
-  ): U
+  ): U;
 }
 
 class C {
@@ -2054,12 +2054,12 @@ function foo(): ImmutableMap<string, boolean> {
 interface SomeIterator<T> {}
 
 interface SomeIterable<T> {
-  it(): SomeIterator<T>
+  it(): SomeIterator<T>;
 }
 
 declare class SomeMap<K, V> {
-  it(): SomeIterator<[K, V]>,
-  set(k: K, v: V): void
+  it(): SomeIterator<[K, V]>;
+  set(k: K, v: V): void;
 }
 
 declare class ImmutableMap<K, V> {}

--- a/tests/flow/union_new/lib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/union_new/lib/__snapshots__/jsfmt.spec.js.snap
@@ -31,25 +31,25 @@ declare class Rows {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare class Set<T> {
-  add(x: any): Set<T>
+  add(x: any): Set<T>;
 }
 
 declare class Row {
   reduce_row(
     callbackfn: (previousValue: number, currentValue: number) => number,
     initialValue: void
-  ): number,
+  ): number;
   reduce_row<U>(
     callbackfn: (previousValue: U, currentValue: number) => U,
     initialValue: U
-  ): U
+  ): U;
 }
 
 declare class Rows {
   reduce_rows<X>(
     callbackfn: (previousValue: X, currentValue: Row) => X,
     initialValue: X
-  ): X
+  ): X;
 }
 
 `;

--- a/tests/flow_function_parentheses/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_function_parentheses/__snapshots__/jsfmt.spec.js.snap
@@ -120,7 +120,7 @@ class X {
 }
 
 interface F {
-  ideConnectionFactoryLongLongLong: child_process$ChildProcess => FlowIDEConnection
+  ideConnectionFactoryLongLongLong: child_process$ChildProcess => FlowIDEConnection;
 }
 
 type ExtractType = <A>(B<C>) => D;
@@ -213,7 +213,7 @@ class X {
 }
 
 interface F {
-  ideConnectionFactoryLongLongLong: child_process$ChildProcess => FlowIDEConnection,
+  ideConnectionFactoryLongLongLong: child_process$ChildProcess => FlowIDEConnection;
 }
 
 type ExtractType = <A>(B<C>) => D;

--- a/tests/flow_method/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_method/__snapshots__/jsfmt.spec.js.snap
@@ -36,8 +36,8 @@ declare function f(): void;
 var f: () => void;
 
 declare class X {
-  static deserialize(): mixed,
-  static deserialize: () => mixed
+  static deserialize(): mixed;
+  static deserialize: () => mixed;
 }
 
 `;

--- a/tests/flow_union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_union/__snapshots__/jsfmt.spec.js.snap
@@ -35,13 +35,13 @@ interface RelayProps {
       } | null>
     | null
     | void
-    | 1
+    | 1;
 }
 
 interface RelayProps {
   articles: Array<{
     __id: string
-  } | null> | null | void
+  } | null> | null | void;
 }
 
 export function aPrettyLongFunction(

--- a/tests/interface/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/interface/__snapshots__/jsfmt.spec.js.snap
@@ -18,7 +18,7 @@ export class Environment2 extends GenericEnvironment<
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 export interface Environment1
   extends GenericEnvironment<SomeType, AnotherType, YetAnotherType> {
-  m(): void
+  m(): void;
 }
 export class Environment2 extends GenericEnvironment<
   SomeType,

--- a/tests/no-semi/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/no-semi/__snapshots__/jsfmt.spec.js.snap
@@ -81,6 +81,240 @@ x
 
 `;
 
+exports[`flow-interfaces.js 1`] = `
+declare class A {
+    one: boolean;
+    two: { three: string }
+    | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// declare class B {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+
+declare interface C {
+    one: boolean;
+    two: { three: string }
+    | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// declare interface D {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+
+interface E {
+    one: boolean;
+    two: { three: string }
+    | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// interface F {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+declare class A {
+  one: boolean;
+  two: { three: string } | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// declare class B {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+
+declare interface C {
+  one: boolean;
+  two: { three: string } | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// declare interface D {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+
+interface E {
+  one: boolean;
+  two: { three: string } | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// interface F {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+
+`;
+
+exports[`flow-interfaces.js 2`] = `
+declare class A {
+    one: boolean;
+    two: { three: string }
+    | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// declare class B {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+
+declare interface C {
+    one: boolean;
+    two: { three: string }
+    | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// declare interface D {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+
+interface E {
+    one: boolean;
+    two: { three: string }
+    | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// interface F {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+declare class A {
+  one: boolean;
+  two: { three: string } | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// declare class B {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+
+declare interface C {
+  one: boolean;
+  two: { three: string } | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// declare interface D {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+
+interface E {
+  one: boolean;
+  two: { three: string } | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// interface F {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+
+`;
+
+exports[`flow-interfaces.js 3`] = `
+declare class A {
+    one: boolean;
+    two: { three: string }
+    | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// declare class B {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+
+declare interface C {
+    one: boolean;
+    two: { three: string }
+    | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// declare interface D {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+
+interface E {
+    one: boolean;
+    two: { three: string }
+    | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// interface F {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+declare class A {
+  one: boolean;
+  two: { three: string } | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// declare class B {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+
+declare interface C {
+  one: boolean;
+  two: { three: string } | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// declare interface D {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+
+interface E {
+  one: boolean;
+  two: { three: string } | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// interface F {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+
+`;
+
 exports[`issue2006.js 1`] = `
 switch (n) {
   case 11:

--- a/tests/no-semi/flow-interfaces.js
+++ b/tests/no-semi/flow-interfaces.js
@@ -1,0 +1,38 @@
+declare class A {
+    one: boolean;
+    two: { three: string }
+    | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// declare class B {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+
+declare interface C {
+    one: boolean;
+    two: { three: string }
+    | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// declare interface D {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }
+
+interface E {
+    one: boolean;
+    two: { three: string }
+    | number;
+}
+
+// NOTE: Flow and Babylon both fail to apply ASI here
+// interface F {
+//     one: boolean
+//     two: { three: string }
+//     | number
+// }

--- a/tests/rest/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/rest/__snapshots__/jsfmt.spec.js.snap
@@ -25,7 +25,7 @@ declare class C {
   f(
     superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong,
     ...args
-  ): void,
+  ): void;
 }
 
 function f(
@@ -36,7 +36,7 @@ function f(
 declare class C {
   f(
     ...superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong
-  ): void,
+  ): void;
 }
 
 [


### PR DESCRIPTION
Closes #2593, specifically per @vjeux's [comment](https://github.com/prettier/prettier/issues/2593#issuecomment-331517378) there.

The bit of nuance in this solution (as detailed in https://github.com/prettier/prettier/issues/2593#issuecomment-331855475) is that this emits semicolons in all affected cases, even with `semi: false`, because neither Flow nor Babylon performs ASI in `InterfaceDeclaration`, `DeclareInterface`, and `DeclareClass` bodies (which they probably _should_ at some point, by direct analogy with e.g `ClassDeclaration`)

I feel this is the simplest solution if we want to move forward with this fix in Prettier, given the current parser landscape. The alternatives would be:

1. Skip the last semicolon in `semi: false` mode.
2. Use semicolons in `semi: true` mode, and commas in `semi: false` mode.
3. Always use commas ( = keep current behaviour and don't fix #2593 at this time).