### PR TITLE
We do not need to have a reference to the toolbox-companion since we

### DIFF
--- a/website/static/service-worker.js
+++ b/website/static/service-worker.js
@@ -16,7 +16,6 @@ toolbox.precache([
   "markdown.js",
   "playground.js",
   "lib/sw-toolbox.js",
-  "lib/sw-toolbox-companion.js",
 
   // CodeMirror
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/codemirror.css",


### PR DESCRIPTION
have our own implementation of it under install-service-worker.js

The file `sw-toolbox-companion.js` (https://raw.githubusercontent.com/GoogleChromeLabs/sw-toolbox/master/companion.js) is

```javascript
/*
	Copyright 2016 Google Inc. All Rights Reserved.

	Licensed under the Apache License, Version 2.0 (the "License");
	you may not use this file except in compliance with the License.
	You may obtain a copy of the License at

	    http://www.apache.org/licenses/LICENSE-2.0

	Unless required by applicable law or agreed to in writing, software
	distributed under the License is distributed on an "AS IS" BASIS,
	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
	See the License for the specific language governing permissions and
	limitations under the License.
*/
(function() {
  'use strict';
  var workerScript = document.currentScript && document.currentScript.dataset.serviceWorker;

  if (workerScript && 'serviceWorker' in navigator) {
    navigator.serviceWorker.register(workerScript);
  }
})();
```

Is equivalent to our file `website/static/install-service-worker.js`

```javascript
if ("serviceWorker" in navigator) {
  navigator.serviceWorker.register("/service-worker.js", {
    scope: "/playground/"
  });
}
```

We in-fact we have not been using the companion script at all and we been getting 400 errors since that file does not current exist in our static resources folder

![resource-error-](https://user-images.githubusercontent.com/1042131/30820949-69f8c678-a1d8-11e7-8d29-b28534c76092.png)

fixes: https://github.com/prettier/prettier/issues/2893