### PR TITLE
fix(cli): validate options for every `config-precedence`

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "babel-code-frame": "7.0.0-alpha.12",
     "babylon": "7.0.0-beta.23",
+    "camelcase": "4.1.0",
     "chalk": "2.1.0",
     "cosmiconfig": "3.0.1",
     "dashify": "0.2.2",

--- a/src/cli-constant.js
+++ b/src/cli-constant.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const camelCase = require("camelcase");
+
 const CATEGORY_CONFIG = "Config";
 const CATEGORY_EDITOR = "Editor";
 const CATEGORY_FORMAT = "Format";
@@ -335,10 +337,6 @@ function dedent(str) {
   return str.replace(new RegExp(`^ {${spaces}}`, "gm"), "").trim();
 }
 
-function kebabToCamel(str) {
-  return str.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
-}
-
 function normalizeDetailedOptions(rawDetailedOptions) {
   const names = Object.keys(rawDetailedOptions).sort();
 
@@ -351,7 +349,7 @@ function normalizeDetailedOptions(rawDetailedOptions) {
         option.forwardToApi &&
         (typeof option.forwardToApi === "string"
           ? option.forwardToApi
-          : kebabToCamel(name)),
+          : camelCase(name)),
       choices:
         option.choices &&
         option.choices.map(choice =>

--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -152,7 +152,10 @@ function getOptionsOrDie(argv, filePath) {
 
 function getOptionsForFile(argv, filePath) {
   const options = getOptionsOrDie(argv, filePath);
-  return applyConfigPrecedence(argv, options);
+  return applyConfigPrecedence(
+    argv,
+    options && normalizeConfigs("api", options, constant.detailedOptionMap)
+  );
 }
 
 function parseArgsToOptions(argv, overrideDefaults) {
@@ -180,21 +183,11 @@ function applyConfigPrecedence(argv, options) {
   try {
     switch (argv["config-precedence"]) {
       case "cli-override":
-        return parseArgsToOptions(
-          argv,
-          normalizeConfigs("api", options, constant.detailedOptionMap)
-        );
+        return parseArgsToOptions(argv, options);
       case "file-override":
-        return Object.assign(
-          {},
-          parseArgsToOptions(argv),
-          normalizeConfigs("api", options, constant.detailedOptionMap)
-        );
+        return Object.assign({}, parseArgsToOptions(argv), options);
       case "prefer-file":
-        return (
-          normalizeConfigs("api", options, constant.detailedOptionMap) ||
-          parseArgsToOptions(argv)
-        );
+        return options || parseArgsToOptions(argv);
     }
   } catch (error) {
     console.error(error.toString());

--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const path = require("path");
+const camelCase = require("camelcase");
 const dashify = require("dashify");
 const minimist = require("minimist");
 const getStream = require("get-stream");
@@ -529,16 +530,12 @@ function getOptionDefaultValue(optionName) {
     return option.default;
   }
 
-  const optionCamelName = kebabToCamel(optionName);
+  const optionCamelName = camelCase(optionName);
   if (optionCamelName in apiDefaultOptions) {
     return apiDefaultOptions[optionCamelName];
   }
 
   return undefined;
-}
-
-function kebabToCamel(str) {
-  return str.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
 }
 
 function indent(str, spaces) {
@@ -621,13 +618,13 @@ function normalizeConfigs(type, rawConfigs, options) {
   return normalized;
 
   function getOptionName(option) {
-    return type === "cli" ? `--${option.name}` : kebabToCamel(option.name);
+    return type === "cli" ? `--${option.name}` : camelCase(option.name);
   }
 
   function getRedirectName(option, choice) {
     return type === "cli"
       ? `--${option.name}=${choice.redirect}`
-      : `{ ${kebabToCamel(option.name)}: ${JSON.stringify(choice.redirect)} }`;
+      : `{ ${camelCase(option.name)}: ${JSON.stringify(choice.redirect)} }`;
   }
 
   function getValue(rawValue, option) {

--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -544,8 +544,8 @@ function groupBy(array, getKey) {
 }
 
 /** @param {'api' | 'cli'} type */
-function normalizeConfig(type, rawConfigs, options) {
-  if (type === "api" && rawConfigs === null) {
+function normalizeConfig(type, rawConfig, options) {
+  if (type === "api" && rawConfig === null) {
     return null;
   }
 
@@ -555,8 +555,8 @@ function normalizeConfig(type, rawConfigs, options) {
 
   const normalized = {};
 
-  Object.keys(rawConfigs).forEach(rawKey => {
-    const rawValue = rawConfigs[rawKey];
+  Object.keys(rawConfig).forEach(rawKey => {
+    const rawValue = rawConfig[rawKey];
 
     const key = type === "cli" ? rawKey : dashify(rawKey);
 
@@ -630,7 +630,7 @@ function normalizeConfig(type, rawConfigs, options) {
       consoleWarn(warning);
     }
 
-    const value = option.getter(rawValue, rawConfigs);
+    const value = option.getter(rawValue, rawConfig);
 
     if (option.type === "choice") {
       const choice = option.choices.find(choice => choice.value === rawValue);

--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -154,13 +154,13 @@ function getOptionsForFile(argv, filePath) {
   const options = getOptionsOrDie(argv, filePath);
   return applyConfigPrecedence(
     argv,
-    options && normalizeConfigs("api", options, constant.detailedOptionMap)
+    options && normalizeConfig("api", options, constant.detailedOptionMap)
   );
 }
 
 function parseArgsToOptions(argv, overrideDefaults) {
   return getOptions(
-    normalizeConfigs(
+    normalizeConfig(
       "cli",
       minimist(
         argv.__args,
@@ -544,7 +544,7 @@ function groupBy(array, getKey) {
 }
 
 /** @param {'api' | 'cli'} type */
-function normalizeConfigs(type, rawConfigs, options) {
+function normalizeConfig(type, rawConfigs, options) {
   if (type === "api" && rawConfigs === null) {
     return null;
   }
@@ -658,5 +658,5 @@ module.exports = {
   formatFiles,
   createUsage,
   createDetailedUsage,
-  normalizeConfigs
+  normalizeConfig
 };

--- a/src/cli-validator.js
+++ b/src/cli-validator.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const camelCase = require("camelcase");
+
 function validateArgv(argv) {
   if (argv["write"] && argv["debug-check"]) {
     console.error("Cannot use --write and --debug-check together.");
@@ -13,11 +15,7 @@ function validateArgv(argv) {
 }
 
 function getOptionName(type, option) {
-  return type === "cli" ? `--${option.name}` : kebabToCamel(option.name);
-}
-
-function kebabToCamel(str) {
-  return str.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+  return type === "cli" ? `--${option.name}` : camelCase(option.name);
 }
 
 function validateIntOption(type, value, option) {

--- a/src/cli-validator.js
+++ b/src/cli-validator.js
@@ -12,18 +12,30 @@ function validateArgv(argv) {
   }
 }
 
-function validateIntOption(value, option) {
-  if (!/^\d+$/.test(value)) {
+function getOptionName(type, option) {
+  return type === "cli" ? `--${option.name}` : kebabToCamel(option.name);
+}
+
+function kebabToCamel(str) {
+  return str.replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+}
+
+function validateIntOption(type, value, option) {
+  if (!/^\d+$/.test(value) || (type === "api" && typeof value !== "number")) {
+    const optionName = getOptionName(type, option);
     throw new Error(
-      `Invalid --${option.name} value.\nExpected an integer, but received: ${value}`
+      `Invalid ${optionName} value.\n` +
+        `Expected an integer, but received: ${JSON.stringify(value)}`
     );
   }
 }
 
-function validateChoiceOption(value, option) {
+function validateChoiceOption(type, value, option) {
   if (!option.choices.some(choice => choice.value === value)) {
+    const optionName = getOptionName(type, option);
     throw new Error(
-      `Invalid option for --${option.name}.\nExpected ${getJoinedChoices()}, but received: "${value}"`
+      `Invalid option for ${optionName}.\n` +
+        `Expected ${getJoinedChoices()}, but received: ${JSON.stringify(value)}`
     );
   }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -8,7 +8,10 @@ const util = require("./cli-util");
 const validator = require("./cli-validator");
 
 function run(args) {
-  const argv = util.normalizeArgv(minimist(args, constant.minimistOptions));
+  const argv = util.normalizeConfigs(
+    "cli",
+    minimist(args, constant.minimistOptions)
+  );
 
   argv.__args = args;
   argv.__filePatterns = argv["_"];

--- a/src/cli.js
+++ b/src/cli.js
@@ -8,7 +8,7 @@ const util = require("./cli-util");
 const validator = require("./cli-validator");
 
 function run(args) {
-  const argv = util.normalizeConfigs(
+  const argv = util.normalizeConfig(
     "cli",
     minimist(args, constant.minimistOptions)
   );

--- a/tests_integration/__tests__/__snapshots__/config-invalid.js.snap
+++ b/tests_integration/__tests__/__snapshots__/config-invalid.js.snap
@@ -7,13 +7,13 @@ Failed to parse \\"<cwd>/tests_integration/cli/config/invalid/file/.prettierrc\\
 `;
 
 exports[`throw error with invalid config option (int) 1`] = `
-"Error: Invalid --tab-width value.
+"Error: Invalid tabWidth value.
 Expected an integer, but received: 0.5
 "
 `;
 
 exports[`throw error with invalid config option (trailingComma) 1`] = `
-"Error: Invalid option for --trailing-comma.
+"Error: Invalid option for trailingComma.
 Expected \\"none\\", \\"es5\\" or \\"all\\", but received: \\"wow\\"
 "
 `;

--- a/tests_integration/__tests__/__snapshots__/config-invalid.js.snap
+++ b/tests_integration/__tests__/__snapshots__/config-invalid.js.snap
@@ -7,15 +7,13 @@ Failed to parse \\"<cwd>/tests_integration/cli/config/invalid/file/.prettierrc\\
 `;
 
 exports[`throw error with invalid config option (int) 1`] = `
-"Error: Invalid tabWidth value.
-Expected an integer, but received: 0.5
-"
+"Invalid tabWidth value.
+Expected an integer, but received: 0.5"
 `;
 
 exports[`throw error with invalid config option (trailingComma) 1`] = `
-"Error: Invalid option for trailingComma.
-Expected \\"none\\", \\"es5\\" or \\"all\\", but received: \\"wow\\"
-"
+"Invalid option for trailingComma.
+Expected \\"none\\", \\"es5\\" or \\"all\\", but received: \\"wow\\""
 `;
 
 exports[`throw error with invalid config precedence option (configPrecedence) 1`] = `

--- a/tests_integration/__tests__/__snapshots__/with-config-precedence.js.snap
+++ b/tests_integration/__tests__/__snapshots__/with-config-precedence.js.snap
@@ -145,3 +145,21 @@ function rcYaml() {
 }
 "
 `;
+
+exports[`CLI validate options with --config-precedence cli-override 1`] = `
+"Error: Invalid printWidth value.
+Expected an integer, but received: 0.5
+"
+`;
+
+exports[`CLI validate options with --config-precedence file-override 1`] = `
+"Error: Invalid printWidth value.
+Expected an integer, but received: 0.5
+"
+`;
+
+exports[`CLI validate options with --config-precedence prefer-file 1`] = `
+"Error: Invalid printWidth value.
+Expected an integer, but received: 0.5
+"
+`;

--- a/tests_integration/__tests__/__snapshots__/with-config-precedence.js.snap
+++ b/tests_integration/__tests__/__snapshots__/with-config-precedence.js.snap
@@ -147,19 +147,16 @@ function rcYaml() {
 `;
 
 exports[`CLI validate options with --config-precedence cli-override 1`] = `
-"Error: Invalid printWidth value.
-Expected an integer, but received: 0.5
-"
+"Invalid printWidth value.
+Expected an integer, but received: 0.5"
 `;
 
 exports[`CLI validate options with --config-precedence file-override 1`] = `
-"Error: Invalid printWidth value.
-Expected an integer, but received: 0.5
-"
+"Invalid printWidth value.
+Expected an integer, but received: 0.5"
 `;
 
 exports[`CLI validate options with --config-precedence prefer-file 1`] = `
-"Error: Invalid printWidth value.
-Expected an integer, but received: 0.5
-"
+"Invalid printWidth value.
+Expected an integer, but received: 0.5"
 `;

--- a/tests_integration/__tests__/with-config-precedence.js
+++ b/tests_integration/__tests__/with-config-precedence.js
@@ -72,3 +72,30 @@ test("CLI overrides gets applied when no config exists with --config-precedence 
   expect(output.stdout).toMatchSnapshot();
   expect(output.status).toEqual(0);
 });
+
+test("CLI validate options with --config-precedence cli-override", () => {
+  const output = runPrettier("cli/config-precedence", [
+    "--config-precedence",
+    "cli-override"
+  ]);
+  expect(output.stderr).toMatchSnapshot();
+  expect(output.status).not.toEqual(0);
+});
+
+test("CLI validate options with --config-precedence file-override", () => {
+  const output = runPrettier("cli/config-precedence", [
+    "--config-precedence",
+    "file-override"
+  ]);
+  expect(output.stderr).toMatchSnapshot();
+  expect(output.status).not.toEqual(0);
+});
+
+test("CLI validate options with --config-precedence prefer-file", () => {
+  const output = runPrettier("cli/config-precedence", [
+    "--config-precedence",
+    "prefer-file"
+  ]);
+  expect(output.stderr).toMatchSnapshot();
+  expect(output.status).not.toEqual(0);
+});

--- a/tests_integration/cli/config-precedence/.prettierrc
+++ b/tests_integration/cli/config-precedence/.prettierrc
@@ -1,0 +1,1 @@
+{"printWidth": 0.5}

--- a/yarn.lock
+++ b/yarn.lock
@@ -864,6 +864,10 @@ callsites@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
 
+camelcase@4.1.0, camelcase@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
+
 camelcase@^1.0.2:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-1.2.1.tgz#9bb5304d2e0b56698b2c758b08a3eaa9daa58a39"
@@ -871,10 +875,6 @@ camelcase@^1.0.2:
 camelcase@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-3.0.0.tgz#32fc4b9fcdaf845fcdf7e73bb97cac2261f0ab0a"
-
-camelcase@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-4.1.0.tgz#d545635be1e33c542649c69173e5de6acfae34dd"
 
 caseless@~0.11.0:
   version "0.11.0"


### PR DESCRIPTION
Main:

- Fixes #2890

Side:

- before
  - validation errors -> "--trailing-comma ..."
- after
  - validation errors from cli -> "--trailing-comma ..."
  - validation errors from config files -> "trailingComma ..."