### PR TITLE
Support fit(), xit(), it.only(), etc

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -844,6 +844,8 @@ function genericPrintNoParens(path, options, print, args) {
     case "NewExpression":
     case "CallExpression": {
       const isNew = n.type === "NewExpression";
+      const unitTestRe = /^(f|x)?(it|describe|test)$/;
+
       const optional = printOptionalToken(path);
       if (
         // We want to keep require calls as a unit
@@ -857,10 +859,13 @@ function genericPrintNoParens(path, options, print, args) {
         // Keep test declarations on a single line
         // e.g. `it('long name', () => {`
         (!isNew &&
-          n.callee.type === "Identifier" &&
-          (n.callee.name === "it" ||
-            n.callee.name === "test" ||
-            n.callee.name === "describe") &&
+          ((n.callee.type === "Identifier" && unitTestRe.test(n.callee.name)) ||
+            (n.callee.type === "MemberExpression" &&
+              n.callee.object.type === "Identifier" &&
+              n.callee.property.type === "Identifier" &&
+              unitTestRe.test(n.callee.object.name) &&
+              (n.callee.property.name === "only" ||
+                n.callee.property.name === "skip"))) &&
           n.arguments.length === 2 &&
           (n.arguments[0].type === "StringLiteral" ||
             n.arguments[0].type === "TemplateLiteral" ||

--- a/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
@@ -46,7 +46,17 @@ describe(\`does something really long and complicated so I have to write a very 
   });
 });
 
-// Should break
+xdescribe("does something really long and complicated so I have to write a very long name for the describe block", () => {});
+
+fdescribe("does something really long and complicated so I have to write a very long name for the describe block", () => {});
+
+describe.only(\`does something really long and complicated so I have to write a very long name for the test\`, () => {});
+
+describe.skip(\`does something really long and complicated so I have to write a very long name for the test\`, () => {});
+
+fit("does something really long and complicated so I have to write a very long name for the describe block", () => {});
+
+xit("does something really long and complicated so I have to write a very long name for the describe block", () => {});
 
 it.only("does something really long and complicated so I have to write a very long name for the test", () => {
   console.log("hello!");
@@ -55,6 +65,18 @@ it.only("does something really long and complicated so I have to write a very lo
 it.only(\`does something really long and complicated so I have to write a very long name for the test\`, () => {
   console.log("hello!");
 });
+
+it.skip(\`does something really long and complicated so I have to write a very long name for the test\`, () => {});
+
+test.only(\`does something really long and complicated so I have to write a very long name for the test\`, () => {});
+
+test.skip(\`does something really long and complicated so I have to write a very long name for the test\`, () => {});
+
+ftest("does something really long and complicated so I have to write a very long name for the describe block", () => {});
+
+xtest("does something really long and complicated so I have to write a very long name for the describe block", () => {});
+
+// Should break
 
 it.only("does something really long and complicated so I have to write a very long name for the test", 10, () => {
   console.log("hello!");
@@ -113,21 +135,37 @@ describe(\`does something really long and complicated so I have to write a very 
   });
 });
 
+xdescribe("does something really long and complicated so I have to write a very long name for the describe block", () => {});
+
+fdescribe("does something really long and complicated so I have to write a very long name for the describe block", () => {});
+
+describe.only(\`does something really long and complicated so I have to write a very long name for the test\`, () => {});
+
+describe.skip(\`does something really long and complicated so I have to write a very long name for the test\`, () => {});
+
+fit("does something really long and complicated so I have to write a very long name for the describe block", () => {});
+
+xit("does something really long and complicated so I have to write a very long name for the describe block", () => {});
+
+it.only("does something really long and complicated so I have to write a very long name for the test", () => {
+  console.log("hello!");
+});
+
+it.only(\`does something really long and complicated so I have to write a very long name for the test\`, () => {
+  console.log("hello!");
+});
+
+it.skip(\`does something really long and complicated so I have to write a very long name for the test\`, () => {});
+
+test.only(\`does something really long and complicated so I have to write a very long name for the test\`, () => {});
+
+test.skip(\`does something really long and complicated so I have to write a very long name for the test\`, () => {});
+
+ftest("does something really long and complicated so I have to write a very long name for the describe block", () => {});
+
+xtest("does something really long and complicated so I have to write a very long name for the describe block", () => {});
+
 // Should break
-
-it.only(
-  "does something really long and complicated so I have to write a very long name for the test",
-  () => {
-    console.log("hello!");
-  }
-);
-
-it.only(
-  \`does something really long and complicated so I have to write a very long name for the test\`,
-  () => {
-    console.log("hello!");
-  }
-);
 
 it.only(
   "does something really long and complicated so I have to write a very long name for the test",

--- a/tests/test_declarations/test_declarations.js
+++ b/tests/test_declarations/test_declarations.js
@@ -43,7 +43,17 @@ describe(`does something really long and complicated so I have to write a very l
   });
 });
 
-// Should break
+xdescribe("does something really long and complicated so I have to write a very long name for the describe block", () => {});
+
+fdescribe("does something really long and complicated so I have to write a very long name for the describe block", () => {});
+
+describe.only(`does something really long and complicated so I have to write a very long name for the test`, () => {});
+
+describe.skip(`does something really long and complicated so I have to write a very long name for the test`, () => {});
+
+fit("does something really long and complicated so I have to write a very long name for the describe block", () => {});
+
+xit("does something really long and complicated so I have to write a very long name for the describe block", () => {});
 
 it.only("does something really long and complicated so I have to write a very long name for the test", () => {
   console.log("hello!");
@@ -52,6 +62,18 @@ it.only("does something really long and complicated so I have to write a very lo
 it.only(`does something really long and complicated so I have to write a very long name for the test`, () => {
   console.log("hello!");
 });
+
+it.skip(`does something really long and complicated so I have to write a very long name for the test`, () => {});
+
+test.only(`does something really long and complicated so I have to write a very long name for the test`, () => {});
+
+test.skip(`does something really long and complicated so I have to write a very long name for the test`, () => {});
+
+ftest("does something really long and complicated so I have to write a very long name for the describe block", () => {});
+
+xtest("does something really long and complicated so I have to write a very long name for the describe block", () => {});
+
+// Should break
 
 it.only("does something really long and complicated so I have to write a very long name for the test", 10, () => {
   console.log("hello!");


### PR DESCRIPTION
Inlines the following forms:

```js
it.only(...)
it.skip(...)
xit(...)
fit(...)

describe.only(...)
describe.skip(...)
xdescribe(...)
fdescribe(...)

test.only(...)
test.skip(...)
xtest(...)
ftest(...)
```

Closes #2855