### PR TITLE
Don't use ANSI codes if stdout isn't a TTY

### DIFF
--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -272,7 +272,7 @@ function eachFilename(argv, patterns, callback) {
 
 function formatFiles(argv) {
   eachFilename(argv, argv.__filePatterns, (filename, options) => {
-    if (argv["write"]) {
+    if (argv["write"] && process.stdout.isTTY) {
       // Don't use `console.log` here since we need to replace this line.
       process.stdout.write(filename);
     }
@@ -313,9 +313,11 @@ function formatFiles(argv) {
     }
 
     if (argv["write"]) {
-      // Remove previously printed filename to log it with duration.
-      readline.clearLine(process.stdout, 0);
-      readline.cursorTo(process.stdout, 0, null);
+      if (process.stdout.isTTY) {
+        // Remove previously printed filename to log it with duration.
+        readline.clearLine(process.stdout, 0);
+        readline.cursorTo(process.stdout, 0, null);
+      }
 
       // Don't write the file if it won't change in order not to invalidate
       // mtime based caches.

--- a/tests_integration/__tests__/__snapshots__/piped-output.js.snap
+++ b/tests_integration/__tests__/__snapshots__/piped-output.js.snap
@@ -1,15 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`no file diffs with --list-different + formated file 1`] = `Array []`;
+exports[`no file diffs with --list-different + formatted file 1`] = `Array []`;
 
-exports[`no file diffs with --list-different + formated file 2`] = `Array []`;
+exports[`no file diffs with --list-different + formatted file 2`] = `Array []`;
 
-exports[`output with --list-different + unformated differs when piped 1`] = `
+exports[`output with --list-different + unformatted differs when piped 1`] = `
 "unformated.js[2K[1Gunformated.js
 "
 `;
 
-exports[`output with --list-different + unformated differs when piped 2`] = `
+exports[`output with --list-different + unformatted differs when piped 2`] = `
 "unformated.js
 "
 `;

--- a/tests_integration/__tests__/__snapshots__/piped-output.js.snap
+++ b/tests_integration/__tests__/__snapshots__/piped-output.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`no file diffs with --list-different + formated file 1`] = `Array []`;
+
+exports[`no file diffs with --list-different + formated file 2`] = `Array []`;
+
+exports[`output with --list-different + unformated differs when piped 1`] = `
+"unformated.js[2K[1Gunformated.js
+"
+`;
+
+exports[`output with --list-different + unformated differs when piped 2`] = `
+"unformated.js
+"
+`;

--- a/tests_integration/__tests__/piped-output.js
+++ b/tests_integration/__tests__/piped-output.js
@@ -1,0 +1,50 @@
+"use strict";
+
+const runPrettier = require("../runPrettier");
+
+test("output with --list-different + unformated differs when piped", () => {
+  const result0 = runPrettier(
+    "cli/write",
+    ["--write", "--list-different", "unformated.js"],
+    { stdoutIsTTY: true }
+  );
+
+  const result1 = runPrettier(
+    "cli/write",
+    ["--write", "--list-different", "unformated.js"],
+    { stdoutIsTTY: false }
+  );
+
+  expect(result0.stdout).toMatchSnapshot();
+  expect(result0.status).toEqual(1);
+
+  expect(result1.stdout).toMatchSnapshot();
+  expect(result1.status).toEqual(1);
+
+  expect(result0.stdout).not.toEqual(result1.stdout);
+  expect(result0.stdout.length).toBeGreaterThan(result1.stdout.length);
+  expect(result0.write).toEqual(result1.write);
+});
+
+test("no file diffs with --list-different + formated file", () => {
+  const result0 = runPrettier(
+    "cli/write",
+    ["--write", "--list-different", "formated.js"],
+    { stdoutIsTTY: true }
+  );
+  const result1 = runPrettier(
+    "cli/write",
+    ["--write", "--list-different", "formated.js"],
+    { stdoutIsTTY: false }
+  );
+
+  expect(result0.write).toMatchSnapshot();
+  expect(result0.status).toEqual(0);
+
+  expect(result1.write).toMatchSnapshot();
+  expect(result1.status).toEqual(0);
+
+  expect(result0.stdout).not.toEqual(result1.stdout);
+  expect(result0.stdout.length).toBeGreaterThan(result1.stdout.length);
+  expect(result0.write).toEqual(result1.write);
+});

--- a/tests_integration/__tests__/piped-output.js
+++ b/tests_integration/__tests__/piped-output.js
@@ -2,16 +2,16 @@
 
 const runPrettier = require("../runPrettier");
 
-test("output with --list-different + unformated differs when piped", () => {
+test("output with --list-different + unformatted differs when piped", () => {
   const result0 = runPrettier(
     "cli/write",
-    ["--write", "--list-different", "unformated.js"],
+    ["--write", "--list-different", "--no-color", "unformated.js"],
     { stdoutIsTTY: true }
   );
 
   const result1 = runPrettier(
     "cli/write",
-    ["--write", "--list-different", "unformated.js"],
+    ["--write", "--list-different", "--no-color", "unformated.js"],
     { stdoutIsTTY: false }
   );
 
@@ -26,15 +26,15 @@ test("output with --list-different + unformated differs when piped", () => {
   expect(result0.write).toEqual(result1.write);
 });
 
-test("no file diffs with --list-different + formated file", () => {
+test("no file diffs with --list-different + formatted file", () => {
   const result0 = runPrettier(
     "cli/write",
-    ["--write", "--list-different", "formated.js"],
+    ["--write", "--list-different", "--no-color", "formated.js"],
     { stdoutIsTTY: true }
   );
   const result1 = runPrettier(
     "cli/write",
-    ["--write", "--list-different", "formated.js"],
+    ["--write", "--list-different", "--no-color", "formated.js"],
     { stdoutIsTTY: false }
   );
 

--- a/tests_integration/runPrettier.js
+++ b/tests_integration/runPrettier.js
@@ -44,9 +44,11 @@ function runPrettier(dir, args, options) {
   const originalArgv = process.argv;
   const originalExitCode = process.exitCode;
   const originalStdinIsTTY = process.stdin.isTTY;
+  const originalStdoutIsTTY = process.stdout.isTTY;
 
   process.chdir(normalizeDir(dir));
   process.stdin.isTTY = !!options.isTTY;
+  process.stdout.isTTY = !!options.stdoutIsTTY;
   process.argv = ["path/to/node", "path/to/prettier/bin"].concat(args);
 
   jest.resetModules();
@@ -65,6 +67,7 @@ function runPrettier(dir, args, options) {
     process.argv = originalArgv;
     process.exitCode = originalExitCode;
     process.stdin.isTTY = originalStdinIsTTY;
+    process.stdout.isTTY = originalStdoutIsTTY;
     jest.restoreAllMocks();
   }
 


### PR DESCRIPTION
I've tried to pipe the output of `--list-differences` into `xargs git add`, but due to the progress information, the stdout is not really usable.

This commit could fix that by suppressing output information. I think it might make sense to change `process.stdout`/`console.log` to `process.stderr`/`console.error` in case of errors, but I did not want to put multiple things into one PR.

Doing `yarn` did not work for me as it currently cannot find the Git commit of `postcss-values-parser` referenced in the `package.json`. I've installed the `latest` version of it to get it to run, but this is probably the cause why the `css_numbers/jsfmt.spec.js` test fails for me locally.

**Edit:** Forgot `yarn lint` initially, which is now fixed :)