### PR TITLE
Fix editor styling on empty editors

### DIFF
--- a/website/static/playground.js
+++ b/website/static/playground.js
@@ -135,6 +135,7 @@ window.onload = function() {
     editors[i].classList.remove("loading");
   }
 
+  setEditorStyles();
   inputEditor.setValue(state.content);
   document.querySelector(".options-container").onchange = formatAsync;
 
@@ -251,6 +252,25 @@ function getCodemirrorMode(options) {
 
 function formatAsync() {
   var options = getOptions();
+  setEditorStyles();
+
+  var value = encodeURIComponent(
+    JSON.stringify(
+      Object.assign({ content: inputEditor.getValue(), options: options })
+    )
+  );
+  replaceHash(value);
+  worker.postMessage({
+    text: inputEditor.getValue(),
+    options: options,
+    ast: options.ast,
+    doc: options.doc,
+    formatted2: options.output2
+  });
+}
+
+function setEditorStyles() {
+  var options = getOptions();
 
   var mode = getCodemirrorMode(options);
   inputEditor.setOption("mode", mode);
@@ -267,20 +287,6 @@ function formatAsync() {
   document.querySelector(".output2").style.display = options.output2
     ? ""
     : "none";
-
-  var value = encodeURIComponent(
-    JSON.stringify(
-      Object.assign({ content: inputEditor.getValue(), options: options })
-    )
-  );
-  replaceHash(value);
-  worker.postMessage({
-    text: inputEditor.getValue(),
-    options: options,
-    ast: options.ast,
-    doc: options.doc,
-    formatted2: options.output2
-  });
 }
 
 function createMarkdown(full) {


### PR DESCRIPTION
Fixes https://github.com/prettier/prettier/issues/2881

Currently when an empty playground loads, [`setValue`](https://github.com/prettier/prettier/blob/master/website/static/playground.js#L138) is called with an empty string which means the change doesn't fire. Since editor styling happens as part of `formatAsync`, the editor can show the wrong debug panes and rulers on the initial load.

This PR fixes that by extracting the editor styling into its own function, `setEditorStyles`, and calls it as part of `window.onload` so that the editor always gets styled, even if the change event doesn't happen.

I also moved the `editor.setOption("mode", mode)` calls into the new function, just to keep editor styling logic happening in one place. If you'd like those to remain in `formatAsync`, I'm happy to make that change. 

Let me know what you think. Thanks!