### PR TITLE
Fix unit tests on Windows

### DIFF
--- a/tests_integration/__tests__/config-invalid.js
+++ b/tests_integration/__tests__/config-invalid.js
@@ -2,7 +2,7 @@
 
 const runPrettier = require("../runPrettier");
 
-expect.addSnapshotSerializer(require("../cwd-serializer"));
+expect.addSnapshotSerializer(require("../path-serializer"));
 
 test("throw error with invalid config format", () => {
   const output = runPrettier("cli/config/invalid", [

--- a/tests_integration/__tests__/config-resolution.js
+++ b/tests_integration/__tests__/config-resolution.js
@@ -5,6 +5,8 @@ const path = require("path");
 const runPrettier = require("../runPrettier");
 const prettier = require("../../");
 
+expect.addSnapshotSerializer(require("../path-serializer"));
+
 test("resolves configuration from external files", () => {
   const output = runPrettier("cli/config/", ["**/*.js"]);
   expect(output.stdout).toMatchSnapshot();

--- a/tests_integration/__tests__/invalid-ignore.js
+++ b/tests_integration/__tests__/invalid-ignore.js
@@ -2,7 +2,7 @@
 
 const runPrettier = require("../runPrettier");
 
-expect.addSnapshotSerializer(require("../cwd-serializer"));
+expect.addSnapshotSerializer(require("../path-serializer"));
 
 test("throw error with invalid ignore", () => {
   const result = runPrettier("cli/invalid-ignore", ["something.js"]);

--- a/tests_integration/path-serializer.js
+++ b/tests_integration/path-serializer.js
@@ -2,7 +2,8 @@
 
 module.exports = {
   test: value =>
-    typeof value === "string" && value.indexOf(process.cwd()) !== -1,
+    typeof value === "string" &&
+    (value.indexOf("\\") > -1 || value.indexOf(process.cwd()) > -1),
   print: (value, serializer) =>
     serializer(value.replace(process.cwd(), "<cwd>").replace(/\\/g, "/"))
 };


### PR DESCRIPTION
Some unit tests were failing on Windows due to path separators.

<details>

```
  ● resolves json configuration file with --find-config-path file

    expect(value).toMatchSnapshot()

    Received value does not match stored snapshot 1.

    - Snapshot
    + Received

    - "rc-json/.prettierrc.json
    + "rc-json\\.prettierrc.json
      "

      at Object.<anonymous> (tests_integration/__tests__/config-resolution.js:47:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:169:7)

  ● resolves yaml configuration file with --find-config-path file

    expect(value).toMatchSnapshot()

    Received value does not match stored snapshot 1.

    - Snapshot
    + Received

    - "rc-yaml/.prettierrc.yaml
    + "rc-yaml\\.prettierrc.yaml
      "

      at Object.<anonymous> (tests_integration/__tests__/config-resolution.js:56:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:169:7)
```
</details>