### PR TITLE
Force template literals to break after ` for styled-components

### DIFF
--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -42,10 +42,8 @@ function fromBabylonFlowOrTypeScript(path) {
   switch (node.type) {
     case "TemplateLiteral": {
       const isCss = [isStyledJsx, isStyledComponents].some(isIt => isIt(path));
-      const isEmpty =
-        node.quasis.length === 1 && !node.quasis[0].value.raw.trim();
 
-      if (isCss && !isEmpty) {
+      if (isCss) {
         // Get full template literal with expressions replaced by placeholders
         const rawQuasis = node.quasis.map(q => q.value.raw);
         const text = rawQuasis.join("@prettier-placeholder");
@@ -179,6 +177,13 @@ function fromHtmlParser2(path, options) {
 
 function transformCssDoc(quasisDoc, parent) {
   const parentNode = parent.path.getValue();
+
+  const isEmpty =
+    parentNode.quasis.length === 1 && !parentNode.quasis[0].value.raw.trim();
+  if (isEmpty) {
+    return "``";
+  }
+
   const expressionDocs = parentNode.expressions
     ? parent.path.map(parent.print, "expressions")
     : [];

--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -42,8 +42,10 @@ function fromBabylonFlowOrTypeScript(path) {
   switch (node.type) {
     case "TemplateLiteral": {
       const isCss = [isStyledJsx, isStyledComponents].some(isIt => isIt(path));
+      const isEmpty =
+        node.quasis.length === 1 && !node.quasis[0].value.raw.trim();
 
-      if (isCss) {
+      if (isCss && !isEmpty) {
         // Get full template literal with expressions replaced by placeholders
         const rawQuasis = node.quasis.map(q => q.value.raw);
         const text = rawQuasis.join("@prettier-placeholder");
@@ -187,7 +189,7 @@ function transformCssDoc(quasisDoc, parent) {
   }
   return concat([
     "`",
-    indent(concat([softline, stripTrailingHardline(newDoc)])),
+    indent(concat([hardline, stripTrailingHardline(newDoc)])),
     softline,
     "`"
   ]);

--- a/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
@@ -30,7 +30,7 @@ border : rebeccapurple\`;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const ListItem = styled.li\`\`;
 
-const ListItem = styled.li\` \`;
+const ListItem = styled.li\`\`;
 
 const Dropdown = styled.div\`
   position: relative;

--- a/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
@@ -1,6 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`styled-components.js 1`] = `
+const ListItem = styled.li\`\`;
+
+const ListItem = styled.li\` \`;
+
+const Dropdown = styled.div\`position: relative;\`
+
 const Button = styled.button\`
 	  color:   palevioletred ;
 
@@ -22,6 +28,14 @@ styled(ExistingComponent)\`
 styled.button.attr({})\`
 border : rebeccapurple\`;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const ListItem = styled.li\`\`;
+
+const ListItem = styled.li\` \`;
+
+const Dropdown = styled.div\`
+  position: relative;
+\`;
+
 const Button = styled.button\`
   color: palevioletred;
 

--- a/tests/multiparser_js_css/styled-components.js
+++ b/tests/multiparser_js_css/styled-components.js
@@ -1,3 +1,9 @@
+const ListItem = styled.li``;
+
+const ListItem = styled.li` `;
+
+const Dropdown = styled.div`position: relative;`
+
 const Button = styled.button`
 	  color:   palevioletred ;
 


### PR DESCRIPTION
There isn't a specific issue for this, but it was mentioned in https://github.com/prettier/prettier/issues/2291#issuecomment-311489067 and https://github.com/prettier/prettier/issues/2350#issuecomment-328346243.

```js
// input
const Dropdown = styled.div`position: relative`;

// output
const Dropdown = styled.div`
  position: relative;
`;
```