### PR TITLE
fix: ignore and show warning for unknown option from config file

### DIFF
--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -581,8 +581,13 @@ function normalizeConfig(type, rawConfig, options) {
 
     const option = constant.detailedOptionMap[key];
 
-    if (type === "cli" && option === undefined) {
-      // unknown option
+    // unknown option
+    if (option === undefined) {
+      // no need to warn for CLI since it's already warned in minimist
+      if (type === "api") {
+        console.warn(`Ignored unknown option: ${rawKey}`);
+      }
+
       return;
     }
 

--- a/tests_integration/__tests__/__snapshots__/config-invalid.js.snap
+++ b/tests_integration/__tests__/__snapshots__/config-invalid.js.snap
@@ -1,5 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`show warning with unknown option 1`] = `
+"Ignored unknown option: hello
+"
+`;
+
 exports[`throw error with invalid config format 1`] = `
 "Error: Invalid configuration file.
 Failed to parse \\"<cwd>/tests_integration/cli/config/invalid/file/.prettierrc\\" as JSON, JS, or YAML.

--- a/tests_integration/__tests__/config-invalid.js
+++ b/tests_integration/__tests__/config-invalid.js
@@ -45,3 +45,12 @@ test("throw error with invalid config precedence option (configPrecedence)", () 
   expect(output.stderr).toMatchSnapshot();
   expect(output.status).not.toBe(0);
 });
+
+test("show warning with unknown option", () => {
+  const output = runPrettier("cli/config/invalid", [
+    "--config",
+    "option/unknown"
+  ]);
+  expect(output.stderr).toMatchSnapshot();
+  expect(output.status).toBe(0);
+});

--- a/tests_integration/cli/config/invalid/option/unknown
+++ b/tests_integration/cli/config/invalid/option/unknown
@@ -1,0 +1,3 @@
+{
+    "hello": "world"
+}


### PR DESCRIPTION
Context: https://github.com/prettier/prettier/issues/2908#issuecomment-332839291

- before: throw `TypeError: Cannot read property 'name' of undefined`
- after: warn `Ignored unknown option: unknown-key`