### PR TITLE
WIP: Make production tests always run against dist/

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -2,4 +2,17 @@
 
 "use strict";
 
-require("../src/cli").run(process.argv.slice(2));
+const cli = require("../src/cli");
+
+function run() {
+  cli.run(process.argv.slice(2));
+}
+
+module.exports = {
+  run,
+  mockable: cli.mockable
+};
+
+if (require.main === module) {
+  run();
+}

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "rollup-plugin-node-resolve": "2.0.0",
     "rollup-plugin-replace": "1.1.1",
     "shelljs": "0.7.8",
+    "strip-ansi": "4.0.0",
     "sw-toolbox": "3.6.0",
     "uglify-es": "3.0.15",
     "webpack": "2.6.1"

--- a/scripts/build/rollup.bin.config.js
+++ b/scripts/build/rollup.bin.config.js
@@ -8,6 +8,7 @@ export default Object.assign(baseConfig, {
   entry: "bin/prettier.js",
   dest: "dist/bin/prettier.js",
   format: "cjs",
+  exports: "named",
   banner: "#!/usr/bin/env node",
   plugins: [
     replace({

--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -24,6 +24,10 @@ const OPTION_USAGE_THRESHOLD = 25;
 const CHOICE_USAGE_MARGIN = 3;
 const CHOICE_USAGE_INDENTATION = 2;
 
+const mockable = {
+  getStream
+};
+
 function getOptions(argv) {
   return constant.detailedOptions
     .filter(option => option.forwardToApi)
@@ -205,7 +209,7 @@ function applyConfigPrecedence(argv, options) {
 }
 
 function formatStdin(argv) {
-  getStream(process.stdin).then(input => {
+  mockable.getStream(process.stdin).then(input => {
     const options = getOptionsForFile(argv, process.cwd());
 
     if (listDifferent(argv, input, options, "(stdin)")) {
@@ -672,5 +676,6 @@ module.exports = {
   formatFiles,
   createUsage,
   createDetailedUsage,
-  normalizeConfig
+  normalizeConfig,
+  mockable
 };

--- a/src/cli.js
+++ b/src/cli.js
@@ -48,5 +48,6 @@ function run(args) {
 }
 
 module.exports = {
-  run
+  run,
+  mockable: util.mockable
 };

--- a/tests/cursor/jsfmt.spec.js
+++ b/tests/cursor/jsfmt.spec.js
@@ -1,4 +1,4 @@
-const prettier = require("../..");
+const prettier = require("../../tests_config/require_prettier");
 
 test("translates cursor correctly in basic case", () => {
   expect(prettier.formatWithCursor(" 1", { cursorOffset: 2 })).toEqual({

--- a/tests_config/require_prettier.js
+++ b/tests_config/require_prettier.js
@@ -1,0 +1,6 @@
+"use strict";
+
+const isProduction = process.env.NODE_ENV === "production";
+const prettier = require(isProduction ? "../dist/" : "../");
+
+module.exports = prettier;

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -1,9 +1,8 @@
 "use strict";
 
-const isProduction = process.env.NODE_ENV === "production";
 const fs = require("fs");
 const extname = require("path").extname;
-const prettier = require(isProduction ? "../dist/" : "../");
+const prettier = require("./require_prettier");
 const parser = require("../src/parser");
 const massageAST = require("../src/clean-ast.js").massageAST;
 

--- a/tests_integration/__tests__/config-resolution.js
+++ b/tests_integration/__tests__/config-resolution.js
@@ -3,7 +3,7 @@
 const path = require("path");
 
 const runPrettier = require("../runPrettier");
-const prettier = require("../../");
+const prettier = require("../../tests_config/require_prettier");
 
 expect.addSnapshotSerializer(require("../path-serializer"));
 

--- a/tests_integration/__tests__/early-exit.js
+++ b/tests_integration/__tests__/early-exit.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const prettier = require("../..");
+const prettier = require("../../tests_config/require_prettier");
 const runPrettier = require("../runPrettier");
 const constant = require("../../src/cli-constant");
 

--- a/tests_integration/__tests__/parser-api.js
+++ b/tests_integration/__tests__/parser-api.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const prettier = require("../..");
+const prettier = require("../../tests_config/require_prettier");
 const runPrettier = require("../runPrettier");
 
 test("allows custom parser provided as object", () => {

--- a/tests_integration/__tests__/stdin-filepath.js
+++ b/tests_integration/__tests__/stdin-filepath.js
@@ -5,7 +5,7 @@ const runPrettier = require("../runPrettier");
 test("format correctly if stdin content compatible with stdin-filepath", () => {
   const result = runPrettier(
     "cli",
-    ["--no-color", "--stdin-filepath", "abc.css"],
+    ["--stdin-filepath", "abc.css"],
     { input: ".name { display: none; }" } // css
   );
 
@@ -17,7 +17,7 @@ test("format correctly if stdin content compatible with stdin-filepath", () => {
 test("throw error if stdin content incompatible with stdin-filepath", () => {
   const result = runPrettier(
     "cli",
-    ["--no-color", "--stdin-filepath", "abc.js"],
+    ["--stdin-filepath", "abc.js"],
     { input: ".name { display: none; }" } // css
   );
 

--- a/tests_integration/__tests__/write.js
+++ b/tests_integration/__tests__/write.js
@@ -17,11 +17,7 @@ test("do not write file with --write + formated file", () => {
 });
 
 test("do not write file with --write + invalid file", () => {
-  const result = runPrettier("cli/write", [
-    "--write",
-    "invalid.js",
-    "--no-color"
-  ]);
+  const result = runPrettier("cli/write", ["--write", "invalid.js"]);
 
   expect(result.stderr).toMatchSnapshot();
   expect(result.write).toHaveLength(0);

--- a/tests_integration/runPrettier.js
+++ b/tests_integration/runPrettier.js
@@ -3,6 +3,8 @@
 const fs = require("fs");
 const path = require("path");
 
+const isProduction = process.env.NODE_ENV === "production";
+
 function runPrettier(dir, args, options) {
   args = args || [];
   options = options || {};
@@ -55,7 +57,7 @@ function runPrettier(dir, args, options) {
   }));
 
   try {
-    require("../bin/prettier");
+    require(isProduction ? "../dist/bin/prettier" : "../bin/prettier");
     status = (status === undefined ? process.exitCode : status) || 0;
   } catch (error) {
     status = 1;

--- a/tests_integration/runPrettier.js
+++ b/tests_integration/runPrettier.js
@@ -3,6 +3,7 @@
 const isProduction = process.env.NODE_ENV === "production";
 const fs = require("fs");
 const path = require("path");
+const stripAnsi = require("strip-ansi");
 const bin = require(isProduction ? "../dist/bin/prettier" : "../bin/prettier");
 
 function runPrettier(dir, args, options) {
@@ -72,7 +73,16 @@ function runPrettier(dir, args, options) {
     jest.restoreAllMocks();
   }
 
-  return { status, stdout, stderr, write };
+  // Colors are removed from the output here (using `stripAnsi`) because:
+  // - It makes snapshots difficult to read.
+  // - Manually passing `--no-color` in tests is tedious, and doesn't work in
+  //   the production build for some reason (only in the tests).
+  return {
+    status,
+    stdout: stripAnsi(stdout),
+    stderr: stripAnsi(stderr),
+    write
+  };
 
   function appendStdout(text) {
     if (status === undefined) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3832,17 +3832,17 @@ stringstream@~0.0.4:
   version "0.0.5"
   resolved "https://registry.yarnpkg.com/stringstream/-/stringstream-0.0.5.tgz#4e484cd4de5a0bbbee18e46307710a8a81621878"
 
+strip-ansi@4.0.0, strip-ansi@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
+  dependencies:
+    ansi-regex "^3.0.0"
+
 strip-ansi@^3.0.0, strip-ansi@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-3.0.1.tgz#6a385fb8853d952d5ff05d0e8aaf94278dc63dcf"
   dependencies:
     ansi-regex "^2.0.0"
-
-strip-ansi@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-4.0.0.tgz#a8479022eb1ac368a871389b635262c505ee368f"
-  dependencies:
-    ansi-regex "^3.0.0"
 
 strip-bom@3.0.0, strip-bom@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
The good: This catches the errors that #2930 fixes!
The bad: Other tests fail :(

Production test summary:

```
Test Suites: 9 failed, 735 passed, 744 total
Tests:       23 failed, 2507 passed, 2530 total
Snapshots:   18 failed, 2025 passed, 2043 total
```

<details>
<summary>Details</summary>
<pre>Summary of all failing tests
 FAIL  tests_integration/__tests__/with-config-precedence.js
  ● CLI overrides take precedence without --config-precedence

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - Snapshot
    + Received
    
    @@ -5,46 +5,6 @@
        "jest/Component.js should not have semi"
      )
      console.log(
        "jest/Component.test.js should have semi"
      );
    - function js() {
    -         console.log(
    -                 "js/file.js should have tab width 8"
    -         );
    - }
    - "use strict";
    - 
    - module.exports = {
    -         tabWidth: 8
    - };
    - function noConfigJs() {
    -   console.log(
    -     "no-config/file.js should have no semicolons"
    -   )
    - }
    - function packageJs() {
    -    console.log(
    -       "package/file.js should have tab width 3"
    -    );
    - }
    - function rcJson() {
    -   console.log.apply(
    -     null,
    -     [
    -       'rc-json/file.js',
    -       'should have trailing comma',
    -       'and single quotes',
    -     ],
    -   );
    - }
    - function rcYaml() {
    -   console.log.apply(
    -     null,
    -     [
    -       'rc-yaml/file.js',
    -       'should have trailing comma',
    -       'and single quotes',
    -     ],
    -   );
    - }
      "
      
      at Object.<anonymous>.test (tests_integration/__tests__/with-config-precedence.js:7:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● CLI overrides take precedence with --config-precedence cli-override

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - Snapshot
    + Received
    
    @@ -5,46 +5,6 @@
        "jest/Component.js should not have semi"
      )
      console.log(
        "jest/Component.test.js should have semi"
      );
    - function js() {
    -         console.log(
    -                 "js/file.js should have tab width 8"
    -         );
    - }
    - "use strict";
    - 
    - module.exports = {
    -         tabWidth: 8
    - };
    - function noConfigJs() {
    -   console.log(
    -     "no-config/file.js should have no semicolons"
    -   )
    - }
    - function packageJs() {
    -    console.log(
    -       "package/file.js should have tab width 3"
    -    );
    - }
    - function rcJson() {
    -   console.log.apply(
    -     null,
    -     [
    -       'rc-json/file.js',
    -       'should have trailing comma',
    -       'and single quotes',
    -     ],
    -   );
    - }
    - function rcYaml() {
    -   console.log.apply(
    -     null,
    -     [
    -       'rc-yaml/file.js',
    -       'should have trailing comma',
    -       'and single quotes',
    -     ],
    -   );
    - }
      "
      
      at Object.<anonymous>.test (tests_integration/__tests__/with-config-precedence.js:19:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● CLI overrides take lower precedence with --config-precedence file-override

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "function js() {
            console.log("js/file.js should have tab width 8");
    }
    "use strict";
    
    module.exports = {
            tabWidth: 8
    };
    "
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/with-config-precedence.js:31:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● CLI overrides gets ignored when config exists with --config-precedence prefer-file

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "function js() {
            console.log("js/file.js should have tab width 8");
    }
    "use strict";
    
    module.exports = {
            tabWidth: 8
    };
    "
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/with-config-precedence.js:57:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● CLI validate options with --config-precedence cli-override

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "Invalid printWidth value.
    Expected an integer, but received: 0.5"
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/with-config-precedence.js:81:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● CLI validate options with --config-precedence file-override

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "Invalid printWidth value.
    Expected an integer, but received: 0.5"
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/with-config-precedence.js:90:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● CLI validate options with --config-precedence prefer-file

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "Invalid printWidth value.
    Expected an integer, but received: 0.5"
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/with-config-precedence.js:99:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

 FAIL  tests_integration/__tests__/config-invalid.js
  ● throw error with invalid config format

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "Error: Invalid configuration file.
    Failed to parse "<cwd>/tests_integration/cli/config/invalid/file/.prettierrc" as JSON, JS, or YAML.
    "
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/config-invalid.js:12:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● throw error with invalid config target (directory)

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "Error: Invalid configuration file.
    EISDIR: illegal operation on a directory, read
    "
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/config-invalid.js:21:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● throw error with invalid config option (int)

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "Invalid tabWidth value.
    Expected an integer, but received: 0.5"
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/config-invalid.js:27:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● throw error with invalid config option (trailingComma)

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "Invalid option for trailingComma.
    Expected "none", "es5" or "all", but received: "wow""
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/config-invalid.js:36:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● show warning with unknown option

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "Ignored unknown option: hello
    "
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/config-invalid.js:54:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

 FAIL  tests_integration/__tests__/stdin-filepath.js
  ● format correctly if stdin content compatible with stdin-filepath

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - ".name {
      display: none;
    }
    "
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/stdin-filepath.js:12:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● throw error if stdin content incompatible with stdin-filepath

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 2.
    
    - "stdin: SyntaxError: Unexpected token (1:1)
    > 1 | .name { display: none; }
        | ^
    "
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/stdin-filepath.js:25:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

 FAIL  tests_integration/__tests__/debug-check.js
  ● checks stdin with --debug-check

    expect(received).toEqual(expected)
    
    Expected value to equal:
      "(stdin)
    "
    Received:
      ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/debug-check.js:21:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

 FAIL  tests_integration/__tests__/debug-print-doc.js
  ● prints doc with --debug-print-doc

    expect(received).toEqual(expected)
    
    Expected value to equal:
      "[\"0\", \";\", hardline, breakParent];
    "
    Received:
      ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/debug-print-doc.js:10:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

 FAIL  tests_integration/__tests__/cursot-offset.js
  ● write cursorOffset to stderr with --cursor-offset <int>

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "1;
    "
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/cursot-offset.js:8:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● write cursorOffset to stderr with --cursor-offset <int>

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 2.
    
    - "1
    "
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/cursot-offset.js:9:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

 FAIL  tests_integration/__tests__/list-different.js
  ● checks stdin with --list-different

    expect(received).toEqual(expected)
    
    Expected value to equal:
      "(stdin)
    "
    Received:
      ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/list-different.js:10:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

 FAIL  tests_integration/__tests__/syntax-error.js
  ● exits with non-zero code when input has a syntax error

    expect(received).toEqual(expected)
    
    Expected value to equal:
      2
    Received:
      0
      
      at Object.<anonymous>.test (tests_integration/__tests__/syntax-error.js:10:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

 FAIL  tests_integration/__tests__/config-resolution.js (27.864s)
  ● resolves configuration from external files

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - Snapshot
    + Received
    
      "console.log("jest/__best-tests__/file.js should have semi");
      console.log("jest/Component.js should not have semi")
      console.log("jest/Component.test.js should have semi");
    - function js() {
    -         console.log("js/file.js should have tab width 8");
    - }
    - "use strict";
    - 
    - module.exports = {
    -         tabWidth: 8
    - };
    - function noConfigJs() {
    -   console.log("no-config/file.js should have no semicolons")
    - }
    - function packageJs() {
    -    console.log("package/file.js should have tab width 3");
    - }
    - function rcJson() {
    -   console.log.apply(null, [
    -     'rc-json/file.js',
    -     'should have trailing comma',
    -     'and single quotes',
    -   ]);
    - }
    - function rcYaml() {
    -   console.log.apply(null, [
    -     'rc-yaml/file.js',
    -     'should have trailing comma',
    -     'and single quotes',
    -   ]);
    - }
      "
      
      at Object.<anonymous>.test (tests_integration/__tests__/config-resolution.js:12:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● CLI overrides take precedence

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - Snapshot
    + Received
    
    @@ -5,46 +5,6 @@
        "jest/Component.js should not have semi"
      )
      console.log(
        "jest/Component.test.js should have semi"
      );
    - function js() {
    -         console.log(
    -                 "js/file.js should have tab width 8"
    -         );
    - }
    - "use strict";
    - 
    - module.exports = {
    -         tabWidth: 8
    - };
    - function noConfigJs() {
    -   console.log(
    -     "no-config/file.js should have no semicolons"
    -   )
    - }
    - function packageJs() {
    -    console.log(
    -       "package/file.js should have tab width 3"
    -    );
    - }
    - function rcJson() {
    -   console.log.apply(
    -     null,
    -     [
    -       'rc-json/file.js',
    -       'should have trailing comma',
    -       'and single quotes',
    -     ],
    -   );
    - }
    - function rcYaml() {
    -   console.log.apply(
    -     null,
    -     [
    -       'rc-yaml/file.js',
    -       'should have trailing comma',
    -       'and single quotes',
    -     ],
    -   );
    - }
      "
      
      at Object.<anonymous>.test (tests_integration/__tests__/config-resolution.js:67:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● API resolveConfig with file arg

    TypeError: Cannot read property 'children' of undefined
      
      at requireFromString (dist/index.js:19737:7)
      at parseJsFile (dist/index.js:19883:8)
          at <anonymous>

  ● API resolveConfig.sync with file arg

    TypeError: Cannot read property 'children' of undefined
      
      at requireFromString (dist/index.js:19737:7)
      at parseJsFile (dist/index.js:19883:8)
      at loadJs (dist/index.js:19890:1)
      at result (dist/index.js:20179:8)
      at chainFuncsSync (dist/index.js:19745:37)
          at Array.reduce (<anonymous>)
      at funcRunner (dist/index.js:19758:14)
      at searchDirectory (dist/index.js:20161:14)
      at load (dist/index.js:20151:1)
      at Function.Object.<anonymous>.resolveConfig.sync (dist/index.js:21536:14)
      at Object.<anonymous>.test (tests_integration/__tests__/config-resolution.js:92:33)
          at Promise (<anonymous>)
          at <anonymous>
</pre>
</details>

With #2930 applied:

```
Test Suites: 8 failed, 736 passed, 744 total
Tests:       15 failed, 2515 passed, 2530 total
Snapshots:   12 failed, 2031 passed, 2043 total
```

<details>
<summary>Details</summary>
<pre>Summary of all failing tests
 FAIL  tests_integration/__tests__/with-config-precedence.js
  ● CLI validate options with --config-precedence cli-override

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "Invalid printWidth value.
    Expected an integer, but received: 0.5"
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/with-config-precedence.js:81:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● CLI validate options with --config-precedence file-override

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "Invalid printWidth value.
    Expected an integer, but received: 0.5"
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/with-config-precedence.js:90:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● CLI validate options with --config-precedence prefer-file

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "Invalid printWidth value.
    Expected an integer, but received: 0.5"
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/with-config-precedence.js:99:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

 FAIL  tests_integration/__tests__/stdin-filepath.js
  ● format correctly if stdin content compatible with stdin-filepath

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - ".name {
      display: none;
    }
    "
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/stdin-filepath.js:12:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● throw error if stdin content incompatible with stdin-filepath

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 2.
    
    - "stdin: SyntaxError: Unexpected token (1:1)
    > 1 | .name { display: none; }
        | ^
    "
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/stdin-filepath.js:25:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

 FAIL  tests_integration/__tests__/debug-check.js
  ● checks stdin with --debug-check

    expect(received).toEqual(expected)
    
    Expected value to equal:
      "(stdin)
    "
    Received:
      ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/debug-check.js:21:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

 FAIL  tests_integration/__tests__/config-invalid.js
  ● throw error with invalid config format

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "Error: Invalid configuration file.
    Failed to parse "<cwd>/tests_integration/cli/config/invalid/file/.prettierrc" as JSON, JS, or YAML.
    "
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/config-invalid.js:12:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● throw error with invalid config target (directory)

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "Error: Invalid configuration file.
    EISDIR: illegal operation on a directory, read
    "
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/config-invalid.js:21:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● throw error with invalid config option (int)

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "Invalid tabWidth value.
    Expected an integer, but received: 0.5"
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/config-invalid.js:27:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● throw error with invalid config option (trailingComma)

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "Invalid option for trailingComma.
    Expected "none", "es5" or "all", but received: "wow""
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/config-invalid.js:36:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● show warning with unknown option

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "Ignored unknown option: hello
    "
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/config-invalid.js:54:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

 FAIL  tests_integration/__tests__/syntax-error.js
  ● exits with non-zero code when input has a syntax error

    expect(received).toEqual(expected)
    
    Expected value to equal:
      2
    Received:
      0
      
      at Object.<anonymous>.test (tests_integration/__tests__/syntax-error.js:10:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

 FAIL  tests_integration/__tests__/cursot-offset.js
  ● write cursorOffset to stderr with --cursor-offset <int>

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 1.
    
    - "1;
    "
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/cursot-offset.js:8:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

  ● write cursorOffset to stderr with --cursor-offset <int>

    expect(value).toMatchSnapshot()
    
    Received value does not match stored snapshot 2.
    
    - "1
    "
    + ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/cursot-offset.js:9:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

 FAIL  tests_integration/__tests__/list-different.js
  ● checks stdin with --list-different

    expect(received).toEqual(expected)
    
    Expected value to equal:
      "(stdin)
    "
    Received:
      ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/list-different.js:10:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)

 FAIL  tests_integration/__tests__/debug-print-doc.js
  ● prints doc with --debug-print-doc

    expect(received).toEqual(expected)
    
    Expected value to equal:
      "[\"0\", \";\", hardline, breakParent];
    "
    Received:
      ""
      
      at Object.<anonymous>.test (tests_integration/__tests__/debug-print-doc.js:10:25)
          at Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)
</pre>
</details>

I have not figured out what causes the test failures yet. Help appreciated! :)
