### PR TITLE
Break parens for binaries in member expression

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -336,7 +336,17 @@ function genericPrintNoParens(path, options, print, args) {
         return concat(parts);
       }
 
-      if (parent.type === "UnaryExpression") {
+      // Break between the parens in unaries or in a member expression, i.e.
+      //
+      //   (
+      //     a &&
+      //     b &&
+      //     c
+      //   ).call()
+      if (
+        parent.type === "UnaryExpression" ||
+        (parent.type === "MemberExpression" && !parent.computed)
+      ) {
         return group(
           concat([indent(concat([softline, concat(parts)])), softline])
         );
@@ -372,22 +382,13 @@ function genericPrintNoParens(path, options, print, args) {
 
       const rest = concat(parts.slice(1));
 
-      // Break the closing paren to keep the chain right after it:
-      // (a &&
-      //   b &&
-      //   c
-      // ).call()
-      const breakClosingParen =
-        parent.type === "MemberExpression" && !parent.computed;
-
       return group(
         concat([
           // Don't include the initial expression in the indentation
           // level. The first item is guaranteed to be the first
           // left-most expression.
           parts.length > 0 ? parts[0] : "",
-          indent(rest),
-          breakClosingParen ? softline : ""
+          indent(rest)
         ])
       );
     }

--- a/tests/member/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/member/__snapshots__/jsfmt.spec.js.snap
@@ -74,7 +74,8 @@ exports[`logical.js 1`] = `
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 (veryLongVeryLongVeryLong || e).prop;
 
-(veryLongVeryLongVeryLong ||
+(
+  veryLongVeryLongVeryLong ||
   anotherVeryLongVeryLongVeryLong ||
   veryVeryVeryLongError
 ).prop;

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -570,6 +570,12 @@ Object.keys(
 `;
 
 exports[`logical.js 1`] = `
+const someLongVariableName = (idx(
+  this.props,
+  props => props.someLongPropertyName
+) || []
+).map(edge => edge.node);
+
 (veryLongVeryLongVeryLong || e).map(tickets =>
   TicketRecord.createFromSomeLongString());
 
@@ -582,6 +588,10 @@ exports[`logical.js 1`] = `
 (veryLongVeryLongVeryLong || anotherVeryLongVeryLongVeryLong || veryVeryVeryLongError).map(tickets =>
   TicketRecord.createFromSomeLongString()).filter(obj => !!obj);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const someLongVariableName = (
+  idx(this.props, props => props.someLongPropertyName) || []
+).map(edge => edge.node);
+
 (veryLongVeryLongVeryLong || e).map(tickets =>
   TicketRecord.createFromSomeLongString()
 );

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -590,12 +590,14 @@ exports[`logical.js 1`] = `
   .map(tickets => TicketRecord.createFromSomeLongString())
   .filter(obj => !!obj);
 
-(veryLongVeryLongVeryLong ||
+(
+  veryLongVeryLongVeryLong ||
   anotherVeryLongVeryLongVeryLong ||
   veryVeryVeryLongError
 ).map(tickets => TicketRecord.createFromSomeLongString());
 
-(veryLongVeryLongVeryLong ||
+(
+  veryLongVeryLongVeryLong ||
   anotherVeryLongVeryLongVeryLong ||
   veryVeryVeryLongError
 )

--- a/tests/method-chain/logical.js
+++ b/tests/method-chain/logical.js
@@ -1,3 +1,9 @@
+const someLongVariableName = (idx(
+  this.props,
+  props => props.someLongPropertyName
+) || []
+).map(edge => edge.node);
+
 (veryLongVeryLongVeryLong || e).map(tickets =>
   TicketRecord.createFromSomeLongString());
 

--- a/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
@@ -519,7 +519,8 @@ helloWorld
 
   .then(t => t);
 
-(veryLongVeryLongVeryLong ||
+(
+  veryLongVeryLongVeryLong ||
   anotherVeryLongVeryLongVeryLong ||
   veryVeryVeryLongError
 )


### PR DESCRIPTION
Fixes #2934 (previous related work: #2786)

This will make binaries break like:
```js
(
  a &&
  b &&
  c
).member
```

The snippet in the issue would be formatted as:

```js
// before
const someLongVariable = (idx(
  this.props,
  props => props.someLongPropertyName
) || []
).map(edge => edge.node);

// after
const someLongVariable = (
  idx(this.props, props => props.someLongPropertyName) || []
).map(edge => edge.node);