### PR TITLE
Add test for #2880

### DIFF
--- a/tests/css_case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_case/__snapshots__/jsfmt.spec.js.snap
@@ -70,6 +70,7 @@ $KeepScssVar: val;
 
     .Keep;
     .Keep();
+    .Keep(4PX)!IMPORTANT;
     .Keep() WHEN (@Keep=Keep);
     .Keep() WHEN (@Keep=12PX);
     .Keep() WHEN (@Keep=Keep12PX);
@@ -156,6 +157,7 @@ $KeepScssVar: val;
 
   .Keep;
   .Keep();
+  .Keep(4px) !important;
   .Keep() when (@Keep=Keep);
   .Keep() when (@Keep=12px);
   .Keep() when (@Keep=Keep12PX);

--- a/tests/css_case/case.less
+++ b/tests/css_case/case.less
@@ -67,6 +67,7 @@ $KeepScssVar: val;
 
     .Keep;
     .Keep();
+    .Keep(4PX)!IMPORTANT;
     .Keep() WHEN (@Keep=Keep);
     .Keep() WHEN (@Keep=12PX);
     .Keep() WHEN (@Keep=Keep12PX);


### PR DESCRIPTION
I added the test in css_case/case.less because it also tests that
`!important` is lowercased in this case.