### PR TITLE
[WIP / RFC] Support expressions in CSS selectors

### DIFF
--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -227,19 +227,23 @@ function replacePlaceholders(quasisDoc, expressionDocs) {
       const rest = parts.slice(2);
       parts = [at + placeholder].concat(rest);
     }
-    if (
-      typeof parts[0] === "string" &&
-      parts[0].startsWith("@prettier-placeholder")
-    ) {
-      const placeholder = parts[0];
-      const rest = parts.slice(1);
-
-      // When the expression has a suffix appended, like:
-      // animation: linear ${time}s ease-out;
-      const suffix = placeholder.slice("@prettier-placeholder".length);
-
-      const expression = expressions.shift();
-      parts = ["${", expression, "}" + suffix].concat(rest);
+    const index = parts.findIndex(
+      p => typeof p === "string" && p.indexOf("@prettier-placeholder") !== -1
+    );
+    if (index > -1) {
+      parts = parts.reduce((acc, part) => {
+        if (
+          typeof part !== "string" ||
+          part.indexOf("@prettier-placeholder") === -1
+        ) {
+          acc.push(part);
+        } else {
+          const affix = part.split("@prettier-placeholder");
+          const expression = expressions.shift();
+          acc = acc.concat([affix[0] + "${", expression, "}" + affix[1]]);
+        }
+        return acc;
+      }, []);
     }
     return Object.assign({}, doc, {
       parts: parts

--- a/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,82 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`selector-expressions.js 1`] = `
+export const foo = css\`
+&.foo .\${bar}::before,&.foo[value="hello"] .\${bar}::before {
+	position: absolute;
+}
+\`;
+
+export const bar = css\`
+a.\${bar}:focus,a.\${bar}:hover {
+  color: red;
+}
+
+a#\${bar} {
+  color: blue;
+}
+\`;
+
+const foobar = css\`
+div[href=\${value}] {
+  color: blue
+}
+
+div[href="\${value}"] {
+  color: blue
+}
+
+div[\${href}="value"] {
+  color: blue
+}
+\`;
+
+export const global = css\`
+button.\${foo}.\${bar} {
+  color: #fff;
+}
+\`;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export const foo = css\`
+  &.foo .\${bar}::before,
+  &.foo[value="hello"] .\${bar}::before {
+    position: absolute;
+  }
+\`;
+
+export const bar = css\`
+  a.\${bar}:focus,
+  a.\${bar}:hover {
+    color: red;
+  }
+
+  a#\${bar} {
+    color: blue;
+  }
+\`;
+
+const foobar = css\`
+  div[href="\${value}"] {
+    color: blue;
+  }
+
+  div[href="\${value}"] {
+    color: blue;
+  }
+
+  div[\${href}="value"] {
+    color: blue;
+  }
+\`;
+
+export const global = css\`
+  button.\${foo}.\${bar} {
+    color: #fff;
+  }
+\`;
+
+`;
+
 exports[`styled-components.js 1`] = `
 const ListItem = styled.li\`\`;
 

--- a/tests/multiparser_js_css/selector-expressions.js
+++ b/tests/multiparser_js_css/selector-expressions.js
@@ -1,0 +1,35 @@
+export const foo = css`
+&.foo .${bar}::before,&.foo[value="hello"] .${bar}::before {
+	position: absolute;
+}
+`;
+
+export const bar = css`
+a.${bar}:focus,a.${bar}:hover {
+  color: red;
+}
+
+a#${bar} {
+  color: blue;
+}
+`;
+
+const foobar = css`
+div[href=${value}] {
+  color: blue
+}
+
+div[href="${value}"] {
+  color: blue
+}
+
+div[${href}="value"] {
+  color: blue
+}
+`;
+
+export const global = css`
+button.${foo}.${bar} {
+  color: #fff;
+}
+`;


### PR DESCRIPTION
Fixes #2883

We don't currently support expressions in CSS selectors because postcss-selector-parser can't parse `@prettier-placeholder` correctly. With this commit we can support expressions in the CSS selector, but I'm not sure... this might be overkill.

I'd like some feedback, please tell me what you think!