### PR TITLE
Use relative paths with CLI

### DIFF
--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -251,12 +251,8 @@ function eachFilename(argv, patterns, callback) {
   try {
     const filePaths = globby
       .sync(patterns, { dot: true })
-      .map(
-        filePath =>
-          path.isAbsolute(filePath)
-            ? path.relative(process.cwd(), filePath)
-            : filePath
-      );
+      .map(filePath => path.relative(process.cwd(), filePath));
+
     if (filePaths.length === 0) {
       console.error(`No matching files. Patterns tried: ${patterns.join(" ")}`);
       process.exitCode = 2;

--- a/tests_integration/__tests__/__snapshots__/ignore-relative-path.js.snap
+++ b/tests_integration/__tests__/__snapshots__/ignore-relative-path.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`support relative paths (stderr) 1`] = `""`;
+
+exports[`support relative paths (stdout) 1`] = `
+"shouldNotBeIgnored.js
+level1-glob/level2-glob/level3-glob/shouldNotBeIgnored.scss
+level1-glob/shouldNotBeIgnored.js
+"
+`;
+
+exports[`support relative paths (write) 1`] = `Array []`;

--- a/tests_integration/__tests__/__snapshots__/multiple-patterns.js.snap
+++ b/tests_integration/__tests__/__snapshots__/multiple-patterns.js.snap
@@ -40,10 +40,10 @@ exports[`multiple patterns by with ignore pattern, ignores node_modules by defau
 exports[`multiple patterns by with ignore pattern, ignores node_modules by with ./**/*.js (stderr) 1`] = `""`;
 
 exports[`multiple patterns by with ignore pattern, ignores node_modules by with ./**/*.js (stdout) 1`] = `
-"./other-directory/file.js
-./other-directory/nested-directory/nested-directory-file.js
-./other-regular-modules.js
-./regular-module.js
+"other-directory/file.js
+other-directory/nested-directory/nested-directory-file.js
+other-regular-modules.js
+regular-module.js
 "
 `;
 

--- a/tests_integration/__tests__/__snapshots__/with-node-modules.js.snap
+++ b/tests_integration/__tests__/__snapshots__/with-node-modules.js.snap
@@ -45,8 +45,8 @@ exports[`ignores node_modules by default for file list (write) 1`] = `Array []`;
 exports[`ignores node_modules by with ./**/*.js (stderr) 1`] = `""`;
 
 exports[`ignores node_modules by with ./**/*.js (stdout) 1`] = `
-"./not_node_modules/file.js
-./regular-module.js
+"not_node_modules/file.js
+regular-module.js
 "
 `;
 

--- a/tests_integration/__tests__/ignore-relative-path.js
+++ b/tests_integration/__tests__/ignore-relative-path.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const runPrettier = require("../runPrettier");
+
+describe("support relative paths", () => {
+  runPrettier("cli/ignore-relative-path", [
+    "./shouldNotBeIgnored.js",
+    "./level1/level2/level3/shouldNotBeFormat.js",
+    "level1-glob/level2-glob/level3-glob/shouldNotBeFormat.js",
+    "./level1-glob/level2-glob/level3-glob/shouldNotBeIgnored.scss",
+    "level1-glob/shouldNotBeIgnored.js",
+    "-l"
+  ]).test({
+    status: 1
+  });
+});

--- a/tests_integration/cli/ignore-relative-path/.prettierignore
+++ b/tests_integration/cli/ignore-relative-path/.prettierignore
@@ -1,0 +1,2 @@
+level1/level2/
+level1-glob/**/level3-glob/*.js

--- a/tests_integration/cli/ignore-relative-path/level1-glob/level2-glob/level3-glob/shouldNotBeFormat.js
+++ b/tests_integration/cli/ignore-relative-path/level1-glob/level2-glob/level3-glob/shouldNotBeFormat.js
@@ -1,0 +1,1 @@
+var x = 'this should not be formatterd';

--- a/tests_integration/cli/ignore-relative-path/level1-glob/level2-glob/level3-glob/shouldNotBeIgnored.scss
+++ b/tests_integration/cli/ignore-relative-path/level1-glob/level2-glob/level3-glob/shouldNotBeIgnored.scss
@@ -1,0 +1,1 @@
+body { color: green }

--- a/tests_integration/cli/ignore-relative-path/level1-glob/shouldNotBeIgnored.js
+++ b/tests_integration/cli/ignore-relative-path/level1-glob/shouldNotBeIgnored.js
@@ -1,0 +1,2 @@
+var x = 'this should be formatterd';
+

--- a/tests_integration/cli/ignore-relative-path/level1/level2/level3/shouldNotBeFormat.js
+++ b/tests_integration/cli/ignore-relative-path/level1/level2/level3/shouldNotBeFormat.js
@@ -1,0 +1,1 @@
+var x = 'this should not be formatterd';

--- a/tests_integration/cli/ignore-relative-path/shouldNotBeIgnored.js
+++ b/tests_integration/cli/ignore-relative-path/shouldNotBeIgnored.js
@@ -1,0 +1,2 @@
+var x = 'this should be formatterd';
+


### PR DESCRIPTION
Fixes #2964

@ikatyang I need some pointers for the tests. I thought about adding another test inside [`tests_integration/__tests__/ignore-absolute-path.js`](https://github.com/prettier/prettier/blob/master/tests_integration/__tests__/ignore-absolute-path.js)