### PR TITLE
Collapse multiple JSX whitespaces

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -4148,11 +4148,16 @@ function printJSXElement(path, options, print) {
       children[i] === jsxWhitespace &&
       children[i + 1] === "" &&
       (children[i + 2] === softline || children[i + 2] === hardline);
+    const isDoubleJSXWhitespace =
+      children[i] === jsxWhitespace &&
+      children[i + 1] === "" &&
+      children[i + 2] === jsxWhitespace;
 
     if (
       (isPairOfHardlines && containsText) ||
       isPairOfEmptyStrings ||
-      isLineFollowedByJSXWhitespace
+      isLineFollowedByJSXWhitespace ||
+      isDoubleJSXWhitespace
     ) {
       children.splice(i, 2);
     } else if (isJSXWhitespaceFollowedByLine) {

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -298,7 +298,16 @@ x =
     </div>
   </div>
 
+x =
+  <div>
+    {" "} <div>text</div>
+  </div>
 
+// NOTE: Multiple JSX whitespaces are collapsed into a single space.
+x =
+  <div>
+    {" "}{" "}{" "}
+  </div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Wrapping text
 x = (
@@ -678,5 +687,15 @@ x = (
     </div>
   </div>
 );
+
+x = (
+  <div>
+    {" "}
+    <div>text</div>
+  </div>
+);
+
+// NOTE: Multiple JSX whitespaces are collapsed into a single space.
+x = <div> </div>;
 
 `;

--- a/tests/jsx-text-wrap/test.js
+++ b/tests/jsx-text-wrap/test.js
@@ -295,4 +295,13 @@ x =
     </div>
   </div>
 
+x =
+  <div>
+    {" "} <div>text</div>
+  </div>
 
+// NOTE: Multiple JSX whitespaces are collapsed into a single space.
+x =
+  <div>
+    {" "}{" "}{" "}
+  </div>


### PR DESCRIPTION
Fix for: https://github.com/prettier/prettier/issues/2680

This fixes up the issue where JSX formatting occasionally needed to be run twice to become stable. This occurred when you had multiple JSX whitespace elements or JSX whitespace followed by a space.

Input:
```jsx
x =
  <div>
    {" "} <Badge src={notificationIconPng} />
  </div>

// NOTE: Multiple JSX whitespaces are collapsed into a single space.
x =
  <div>
    {" "}{" "}{" "}
  </div>
```

Output:
```jsx
x = (
  <div>
    {" "}
    <Badge src={notificationIconPng} />
  </div>
);

// NOTE: Multiple JSX whitespaces are collapsed into a single space.
x = <div> </div>;
```

