### PR TITLE
Prevent formatting GQL template literals with expressions

### DIFF
--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -68,7 +68,7 @@ function fromBabylonFlowOrTypeScript(path) {
        */
       if (
         // We currently don't support expression inside GraphQL template literals
-        parent.quasis.length === 1 &&
+        parent.expressions.length === 0 &&
         parentParent &&
         ((parentParent.type === "TaggedTemplateExpression" &&
           ((parentParent.tag.type === "MemberExpression" &&

--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -67,6 +67,8 @@ function fromBabylonFlowOrTypeScript(path) {
        * gql`...`
        */
       if (
+        // We currently don't support expression inside GraphQL template literals
+        parent.quasis.length === 1 &&
         parentParent &&
         ((parentParent.type === "TaggedTemplateExpression" &&
           parent.quasis.length === 1 &&

--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -71,7 +71,6 @@ function fromBabylonFlowOrTypeScript(path) {
         parent.quasis.length === 1 &&
         parentParent &&
         ((parentParent.type === "TaggedTemplateExpression" &&
-          parent.quasis.length === 1 &&
           ((parentParent.tag.type === "MemberExpression" &&
             parentParent.tag.object.name === "graphql" &&
             parentParent.tag.property.name === "experimental") ||

--- a/tests/multiparser_js_graphql/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_graphql/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,52 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`expressions.js 1`] = `
+// We currently don't support expressions in GraphQL template literals so these templates
+// should not change.
+
+graphql(schema, \`
+query allPartsByManufacturerName($name: String!) {
+  allParts(filter:{manufacturer: {name: $name}}) {
+...    PartAll
+}}
+\${fragments.all}
+\`)
+
+const veryLongVariableNameToMakeTheLineBreak = graphql(schema, \`
+query allPartsByManufacturerName($name: String!) {
+  allParts(filter:{manufacturer: {name: $name}}) {
+...    PartAll
+}}
+\${fragments.all}
+\`)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// We currently don't support expressions in GraphQL template literals so these templates
+// should not change.
+
+graphql(
+  schema,
+  \`
+query allPartsByManufacturerName($name: String!) {
+  allParts(filter:{manufacturer: {name: $name}}) {
+...    PartAll
+}}
+\${fragments.all}
+\`
+);
+
+const veryLongVariableNameToMakeTheLineBreak = graphql(
+  schema,
+  \`
+query allPartsByManufacturerName($name: String!) {
+  allParts(filter:{manufacturer: {name: $name}}) {
+...    PartAll
+}}
+\${fragments.all}
+\`
+);
+
+`;
+
 exports[`graphql.js 1`] = `
 graphql(schema, \`
 mutation     MarkReadNotificationMutation(

--- a/tests/multiparser_js_graphql/expressions.js
+++ b/tests/multiparser_js_graphql/expressions.js
@@ -1,0 +1,18 @@
+// We currently don't support expressions in GraphQL template literals so these templates
+// should not change.
+
+graphql(schema, `
+query allPartsByManufacturerName($name: String!) {
+  allParts(filter:{manufacturer: {name: $name}}) {
+...    PartAll
+}}
+${fragments.all}
+`)
+
+const veryLongVariableNameToMakeTheLineBreak = graphql(schema, `
+query allPartsByManufacturerName($name: String!) {
+  allParts(filter:{manufacturer: {name: $name}}) {
+...    PartAll
+}}
+${fragments.all}
+`)


### PR DESCRIPTION
Related to #2640 and #2857.

I'll take a shot in trying to support expressions in GQL template literals, but anyway, failing to do that, this PR should prevent breaking people's code.