### PR TITLE
Handle comments between function name and open paren

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -298,7 +298,8 @@ function attach(comments, ast, text) {
         handleObjectPropertyAssignment(enclosingNode, precedingNode, comment) ||
         handleCommentInEmptyParens(text, enclosingNode, comment) ||
         handleMethodNameComments(text, enclosingNode, precedingNode, comment) ||
-        handleOnlyComments(enclosingNode, ast, comment, isLastComment)
+        handleOnlyComments(enclosingNode, ast, comment, isLastComment) ||
+        handleFunctionNameComments(text, enclosingNode, precedingNode, comment)
       ) {
         // We're good
       } else if (precedingNode && followingNode) {
@@ -638,6 +639,31 @@ function handleMethodNameComments(text, enclosingNode, precedingNode, comment) {
     return true;
   }
 
+  return false;
+}
+
+function handleFunctionNameComments(
+  text,
+  enclosingNode,
+  precedingNode,
+  comment
+) {
+  if (getNextNonSpaceNonCommentCharacter(text, comment) !== "(") {
+    return false;
+  }
+
+  if (
+    precedingNode &&
+    enclosingNode &&
+    (enclosingNode.type === "FunctionDeclaration" ||
+      enclosingNode.type === "FunctionExpression" ||
+      enclosingNode.type === "ClassMethod" ||
+      enclosingNode.type === "MethodDefinition" ||
+      enclosingNode.type === "ObjectMethod")
+  ) {
+    addTrailingComment(precedingNode, comment);
+    return true;
+  }
   return false;
 }
 

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -294,6 +294,40 @@ call((/*object*/ row) => {});
 KEYPAD_NUMBERS.map(num => ( // Buttons 0-9
   <div />
 ));
+
+function f /* f */() {}
+function f (/* args */) {}
+function f () /* returns */ {}
+function f /* f */(/* args */) /* returns */ {}
+
+function f /* f */(/* a */ a) {}
+function f /* f */(a /* a */) {}
+function f /* f */(/* a */ a) /* returns */ {}
+
+const obj = {
+  f1 /* f */() {},
+  f2 (/* args */) {},
+  f3 () /* returns */ {},
+  f4 /* f */(/* args */) /* returns */ {},
+};
+
+(function f /* f */() {})();
+(function f (/* args */) {})();
+(function f () /* returns */ {})();
+(function f /* f */(/* args */) /* returns */ {})();
+
+class C {
+  f/* f */() {}
+}
+class C {
+  f(/* args */) {}
+}
+class C {
+  f() /* returns */ {}
+}
+class C {
+  f/* f */(/* args */) /* returns */ {}
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function a(/* comment */) {} // comment
 function b() {} // comment
@@ -302,6 +336,49 @@ call((/*object*/ row) => {});
 KEYPAD_NUMBERS.map((
   num // Buttons 0-9
 ) => <div />);
+
+function f /* f */() {}
+function f(/* args */) {}
+function f() /* returns */ {
+}
+function f /* f */(/* args */) /* returns */ {
+}
+
+function f /* f */(/* a */ a) {}
+function f /* f */(a /* a */) {}
+function f /* f */(/* a */ a) /* returns */ {
+}
+
+const obj = {
+  f1 /* f */() {},
+  f2(/* args */) {},
+  f3() /* returns */ {
+  },
+  f4 /* f */(/* args */) /* returns */ {
+  }
+};
+
+(function f /* f */() {})();
+(function f(/* args */) {})();
+(function f() /* returns */ {
+})();
+(function f /* f */(/* args */) /* returns */ {
+})();
+
+class C {
+  f /* f */() {}
+}
+class C {
+  f(/* args */) {}
+}
+class C {
+  f() /* returns */ {
+  }
+}
+class C {
+  f /* f */(/* args */) /* returns */ {
+  }
+}
 
 `;
 

--- a/tests/comments/function-declaration.js
+++ b/tests/comments/function-declaration.js
@@ -5,3 +5,37 @@ call((/*object*/ row) => {});
 KEYPAD_NUMBERS.map(num => ( // Buttons 0-9
   <div />
 ));
+
+function f /* f */() {}
+function f (/* args */) {}
+function f () /* returns */ {}
+function f /* f */(/* args */) /* returns */ {}
+
+function f /* f */(/* a */ a) {}
+function f /* f */(a /* a */) {}
+function f /* f */(/* a */ a) /* returns */ {}
+
+const obj = {
+  f1 /* f */() {},
+  f2 (/* args */) {},
+  f3 () /* returns */ {},
+  f4 /* f */(/* args */) /* returns */ {},
+};
+
+(function f /* f */() {})();
+(function f (/* args */) {})();
+(function f () /* returns */ {})();
+(function f /* f */(/* args */) /* returns */ {})();
+
+class C {
+  f/* f */() {}
+}
+class C {
+  f(/* args */) {}
+}
+class C {
+  f() /* returns */ {}
+}
+class C {
+  f/* f */(/* args */) /* returns */ {}
+}


### PR DESCRIPTION
Fixes #2808

I **wasn't** able to fix anonymous function expressions though, as there's no node to attach the comment to.


**Prettier 1.7.4**
[Playground link](https://prettier.io/playground/#%7B%22content%22%3A%22(%2F*%20before%20*%2F%20function%20%2F*%20anon%20*%2F(%2F*%20args%20*%2F)%20%2F*%20returns%20*%2F%20%7B%7D%20%2F*%20after%20*%2F)%22%2C%22options%22%3A%7B%22printWidth%22%3A80%2C%22tabWidth%22%3A2%2C%22singleQuote%22%3Afalse%2C%22trailingComma%22%3A%22none%22%2C%22bracketSpacing%22%3Atrue%2C%22jsxBracketSameLine%22%3Afalse%2C%22parser%22%3A%22babylon%22%2C%22semi%22%3Atrue%2C%22useTabs%22%3Afalse%2C%22doc%22%3Afalse%2C%22ast%22%3Afalse%2C%22output2%22%3Afalse%7D%7D)

**Input:**
```jsx
(/* before */ function /* anon */(/* args */) /* returns */ {} /* after */)
```

**Output:**
```jsx
/* before */ (function(/* args */) /* anon */ /* returns */ {
}) /* after */;

```

Any ideas on this edge case?