### PR TITLE
fix: support sequential CallExpressions in member chains

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3580,7 +3580,10 @@ function printMemberChain(path, options, print) {
 
   function rec(path) {
     const node = path.getValue();
-    if (node.type === "CallExpression" && isMemberish(node.callee)) {
+    if (
+      node.type === "CallExpression" &&
+      (isMemberish(node.callee) || node.callee.type === "CallExpression")
+    ) {
       printedNodes.unshift({
         node: node,
         printed: comments.printComments(

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -621,6 +621,10 @@ if (testConfig.ENABLE_ONLINE_TESTS === "true") {
     });
   });
 }
+
+wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName')().then(function() {
+  doSomething();
+});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 if (testConfig.ENABLE_ONLINE_TESTS === "true") {
   describe("POST /users/me/pet", function() {
@@ -640,6 +644,13 @@ if (testConfig.ENABLE_ONLINE_TESTS === "true") {
     });
   });
 }
+
+wrapper
+  .find("SomewhatLongNodeName")
+  .prop("longPropFunctionName")()
+  .then(function() {
+    doSomething();
+  });
 
 `;
 

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -625,6 +625,18 @@ if (testConfig.ENABLE_ONLINE_TESTS === "true") {
 wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName')().then(function() {
   doSomething();
 });
+
+wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName')('argument').then(function() {
+  doSomething();
+});
+
+wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName', 'second argument that pushes this group past 80 characters')('argument').then(function() {
+  doSomething();
+});
+
+wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName')('argument', 'second argument that pushes this group past 80 characters').then(function() {
+  doSomething();
+});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 if (testConfig.ENABLE_ONLINE_TESTS === "true") {
   describe("POST /users/me/pet", function() {
@@ -648,6 +660,33 @@ if (testConfig.ENABLE_ONLINE_TESTS === "true") {
 wrapper
   .find("SomewhatLongNodeName")
   .prop("longPropFunctionName")()
+  .then(function() {
+    doSomething();
+  });
+
+wrapper
+  .find("SomewhatLongNodeName")
+  .prop("longPropFunctionName")("argument")
+  .then(function() {
+    doSomething();
+  });
+
+wrapper
+  .find("SomewhatLongNodeName")
+  .prop(
+    "longPropFunctionName",
+    "second argument that pushes this group past 80 characters"
+  )("argument")
+  .then(function() {
+    doSomething();
+  });
+
+wrapper
+  .find("SomewhatLongNodeName")
+  .prop("longPropFunctionName")(
+    "argument",
+    "second argument that pushes this group past 80 characters"
+  )
   .then(function() {
     doSomething();
   });

--- a/tests/method-chain/multiple-members.js
+++ b/tests/method-chain/multiple-members.js
@@ -18,3 +18,15 @@ if (testConfig.ENABLE_ONLINE_TESTS === "true") {
 wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName')().then(function() {
   doSomething();
 });
+
+wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName')('argument').then(function() {
+  doSomething();
+});
+
+wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName', 'second argument that pushes this group past 80 characters')('argument').then(function() {
+  doSomething();
+});
+
+wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName')('argument', 'second argument that pushes this group past 80 characters').then(function() {
+  doSomething();
+});

--- a/tests/method-chain/multiple-members.js
+++ b/tests/method-chain/multiple-members.js
@@ -14,3 +14,7 @@ if (testConfig.ENABLE_ONLINE_TESTS === "true") {
     });
   });
 }
+
+wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName')().then(function() {
+  doSomething();
+});


### PR DESCRIPTION
fixes #2832

This PR fixes the formatting for this input:

**Input:**
```jsx
wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName')().then(function() {
  doSomething();
});
```

**Before:**
```jsx
wrapper
  .find("SomewhatLongNodeName")
  .prop("longPropFunctionName")().then(function() {
  doSomething();
});

```

**After:**
```jsx
wrapper
  .find("SomewhatLongNodeName")
  .prop("longPropFunctionName")()
  .then(function() {
    doSomething();
  });

```

This is my first PR for Prettier, so I'm more than happy to make any adjustments as needed. Thanks!