### PR TITLE
fix: add filenames to flow-verify test descriptions

### DIFF
--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -38,7 +38,7 @@ function run_spec(dirname, options, additionalParsers) {
         rangeEnd: rangeEnd
       });
       const output = prettyprint(source, path, mergedOptions);
-      test(`${mergedOptions.parser} - ${parser.parser}-verify`, () => {
+      test(`${filename} - ${mergedOptions.parser}-verify`, () => {
         expect(raw(source + "~".repeat(80) + "\n" + output)).toMatchSnapshot(
           filename
         );


### PR DESCRIPTION
This PR makes jest's verbose test output more readable; now if one of the flow tests fails, the filename will be included in the test description. This change won't affect any snapshots since those are indexed using the filename.

Before:

```
$ jest method-chain
 PASS  tests/method-chain/jsfmt.spec.js
  ✓ flow - undefined-verify (4ms)
  ✓ bracket_0.js - typescript-verify (263ms)
  ✓ flow - undefined-verify (6ms)
  ✓ break-last-call.js - typescript-verify (27ms)
  ✓ flow - undefined-verify
  ✓ break-last-member.js - typescript-verify (7ms)
  ✓ flow - undefined-verify
  ✓ break-multiple.js - typescript-verify (2ms)
  ✓ flow - undefined-verify
  ✓ comment.js - typescript-verify (16ms)
  ✓ flow - undefined-verify
  ✓ computed-merge.js - typescript-verify (6ms)
  ✓ flow - undefined-verify
  ✓ computed.js - typescript-verify (3ms)
  ✓ flow - undefined-verify
  ✓ conditional.js - typescript-verify (6ms)
  ✓ flow - undefined-verify (1ms)
  ✓ first_long.js - typescript-verify (10ms)
  ✓ flow - undefined-verify (1ms)
  ✓ inline_merge.js - typescript-verify (1ms)
  ✓ flow - undefined-verify
  ✓ logical.js - typescript-verify (4ms)
  ✓ flow - undefined-verify (1ms)
  ✓ multiple-members.js - typescript-verify (4ms)
  ✓ flow - undefined-verify
  ✓ square_0.js - typescript-verify (1ms)
  ✓ flow - undefined-verify
  ✓ test.js - typescript-verify (2ms)
  ✓ flow - undefined-verify (1ms)
  ✓ this.js - typescript-verify (1ms)
```

After:

```
$ jest method-chain
 PASS  tests/method-chain/jsfmt.spec.js
  ✓ bracket_0.js - flow-verify (3ms)
  ✓ bracket_0.js - typescript-verify (255ms)
  ✓ break-last-call.js - flow-verify
  ✓ break-last-call.js - typescript-verify (27ms)
  ✓ break-last-member.js - flow-verify
  ✓ break-last-member.js - typescript-verify (9ms)
  ✓ break-multiple.js - flow-verify (1ms)
  ✓ break-multiple.js - typescript-verify (1ms)
  ✓ comment.js - flow-verify
  ✓ comment.js - typescript-verify (16ms)
  ✓ computed-merge.js - flow-verify
  ✓ computed-merge.js - typescript-verify (5ms)
  ✓ computed.js - flow-verify
  ✓ computed.js - typescript-verify (2ms)
  ✓ conditional.js - flow-verify
  ✓ conditional.js - typescript-verify (6ms)
  ✓ first_long.js - flow-verify
  ✓ first_long.js - typescript-verify (10ms)
  ✓ inline_merge.js - flow-verify
  ✓ inline_merge.js - typescript-verify (2ms)
  ✓ logical.js - flow-verify
  ✓ logical.js - typescript-verify (4ms)
  ✓ multiple-members.js - flow-verify
  ✓ multiple-members.js - typescript-verify (4ms)
  ✓ square_0.js - flow-verify
  ✓ square_0.js - typescript-verify (1ms)
  ✓ test.js - flow-verify
  ✓ test.js - typescript-verify (2ms)
  ✓ this.js - flow-verify
  ✓ this.js - typescript-verify (2ms)
```