### PR TITLE
Add missing "Require pragma" to Table of Contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ conforms to a consistent style. (See this [blog post](http://jlongster.com/A-Pre
   + [Range](#range)
   + [Parser](#parser)
   + [Filepath](#filepath)
+  + [Require pragma](#require-pragma)
 * [Configuration File](#configuration-file)
   + [Basic Configuration](#basic-configuration)
   + [Configuration Overrides](#configuration-overrides)


### PR DESCRIPTION
This was done with `yarn toc`. Maybe we should add a CI step that runs
`yarn toc` and fails if the README changes?