### PR TITLE
Change badge to say “formatted”

### DIFF
--- a/README.md
+++ b/README.md
@@ -894,7 +894,7 @@ More (rough) details can be found in [commands.md](commands.md).
 Show the world you're using *Prettier* → [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 ```md
-[![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+[![formatted with prettier](https://img.shields.io/badge/formatted_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://travis-ci.org/prettier/prettier.svg?branch=master)](https://travis-ci.org/prettier/prettier)
 [![Codecov](https://img.shields.io/codecov/c/github/prettier/prettier.svg)](https://codecov.io/gh/prettier/prettier)
 [![NPM version](https://img.shields.io/npm/v/prettier.svg)](https://www.npmjs.com/package/prettier)
-[![formatted with prettier](https://img.shields.io/badge/formatted_with-prettier-ff69b4.svg)](#badge)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](#badge)
 
 Prettier is an opinionated code formatter with support for:
 * JavaScript, including [ES2017](https://github.com/tc39/proposals/blob/master/finished-proposals.md)
@@ -891,10 +891,10 @@ More (rough) details can be found in [commands.md](commands.md).
 
 ## Badge
 
-Show the world you're using *Prettier* → [![formatted with prettier](https://img.shields.io/badge/formatted_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+Show the world you're using *Prettier* → [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 ```md
-[![formatted with prettier](https://img.shields.io/badge/formatted_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+[![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://travis-ci.org/prettier/prettier.svg?branch=master)](https://travis-ci.org/prettier/prettier)
 [![Codecov](https://img.shields.io/codecov/c/github/prettier/prettier.svg)](https://codecov.io/gh/prettier/prettier)
 [![NPM version](https://img.shields.io/npm/v/prettier.svg)](https://www.npmjs.com/package/prettier)
-[![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](#badge)
+[![formatted with prettier](https://img.shields.io/badge/formatted_with-prettier-ff69b4.svg)](#badge)
 
 Prettier is an opinionated code formatter with support for:
 * JavaScript, including [ES2017](https://github.com/tc39/proposals/blob/master/finished-proposals.md)

--- a/README.md
+++ b/README.md
@@ -891,7 +891,7 @@ More (rough) details can be found in [commands.md](commands.md).
 
 ## Badge
 
-Show the world you're using *Prettier* → [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+Show the world you're using *Prettier* → [![formatted with prettier](https://img.shields.io/badge/formatted_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
 
 ```md
 [![formatted with prettier](https://img.shields.io/badge/formatted_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)


### PR DESCRIPTION
“Styled” sounds like a CSS or CSS-like thing to me — Prettier is a code formatter