### PR TITLE
docs: fix table for `insertPragma`

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -156,7 +156,7 @@ or
 Default | CLI Override | API Override
 --------|--------------|-------------
 `false` | `--require-pragma` | `requirePragma: <bool>`
-<!-->
+<!--
 ## Insert Pragma
 Prettier can insert a special @format marker at the top of files specifying that the file has been formatted
 with prettier.  This works well when used in tandem with the `--require-pragma` option.  If there is already a 
@@ -165,3 +165,4 @@ docblock at the top of the file then this option will add a newline to it with t
 Default | CLI Override | API Override
 --------|--------------|-------------
 `false` | `--insert-pragma` | `insertPragma: <bool>`
+-->

--- a/docs/options.md
+++ b/docs/options.md
@@ -156,7 +156,7 @@ or
 Default | CLI Override | API Override
 --------|--------------|-------------
 `false` | `--require-pragma` | `requirePragma: <bool>`
-
+<!-->
 ## Insert Pragma
 Prettier can insert a special @format marker at the top of files specifying that the file has been formatted
 with prettier.  This works well when used in tandem with the `--require-pragma` option.  If there is already a 

--- a/docs/options.md
+++ b/docs/options.md
@@ -156,7 +156,7 @@ or
 Default | CLI Override | API Override
 --------|--------------|-------------
 `false` | `--require-pragma` | `requirePragma: <bool>`
-<!-->
+
 ## Insert Pragma
 Prettier can insert a special @format marker at the top of files specifying that the file has been formatted
 with prettier.  This works well when used in tandem with the `--require-pragma` option.  If there is already a 
@@ -165,4 +165,3 @@ docblock at the top of the file then this option will add a newline to it with t
 Default | CLI Override | API Override
 --------|--------------|-------------
 `false` | `--insert-pragma` | `insertPragma: <bool>`
--->


### PR DESCRIPTION
I visited https://prettier.io/docs/en/options.html#content and noticed that the Markdown table for the `insertPragma` option is broken:

![Screenshot](https://user-images.githubusercontent.com/469989/31432845-5313ea8c-ae80-11e7-9f49-bc3519d0e3c0.PNG)

So I fixed it. :)
