### PR TITLE
Account for empty lines in long member call chain

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3796,9 +3796,8 @@ function printMemberChain(path, options, print) {
     shouldMerge ? groups.slice(1, 2)[0] : groups[0]
   ).node;
   const shouldHaveEmptyLineBeforeIndent =
-    lastNodeBeforeIndent.type !== "CallExpression"
-      ? shouldInsertEmptyLineAfter(lastNodeBeforeIndent)
-      : false;
+    lastNodeBeforeIndent.type !== "CallExpression" &&
+    shouldInsertEmptyLineAfter(lastNodeBeforeIndent);
 
   const expanded = concat([
     printGroup(groups[0]),

--- a/src/printer.js
+++ b/src/printer.js
@@ -3586,6 +3586,8 @@ function printMemberChain(path, options, print) {
     );
     const nextChar = originalText.charAt(nextCharIndex);
 
+    // if it is cut off by a parenthesis, we only account for one typed empty
+    // line after that parenthesis
     if (nextChar == ")") {
       return util.isNextLineEmptyAfterIndex(originalText, nextCharIndex + 1);
     }

--- a/src/printer.js
+++ b/src/printer.js
@@ -3829,7 +3829,7 @@ function printMemberChain(path, options, print) {
     // naturally
     willBreak(oneLine) || shouldHaveEmptyLineBeforeIndent ? breakParent : "",
     conditionalGroup([oneLine, expanded])
-  ]); // TODO: test - done
+  ]);
 }
 
 function isEmptyJSXElement(node) {

--- a/src/printer.js
+++ b/src/printer.js
@@ -3590,7 +3590,7 @@ function printMemberChain(path, options, print) {
       return util.isNextLineEmptyAfterIndex(originalText, nextCharIndex + 1);
     }
 
-    return util.isNextLineEmpty(originalText, node)
+    return util.isNextLineEmpty(originalText, node);
   }
 
   function rec(path) {
@@ -3792,12 +3792,13 @@ function printMemberChain(path, options, print) {
 
   // Find out the last node in the first group and check if it has an
   // empty line after
-  const lastNodeBeforeIndent =
-    (util.getLast(shouldMerge ? groups.slice(1, 2)[0] : groups[0])).node;
+  const lastNodeBeforeIndent = util.getLast(
+    shouldMerge ? groups.slice(1, 2)[0] : groups[0]
+  ).node;
   const shouldHaveEmptyLineBeforeIndent =
-    lastNodeBeforeIndent.type !== 'CallExpression' ?
-      shouldInsertEmptyLineAfter(lastNodeBeforeIndent) :
-      false;
+    lastNodeBeforeIndent.type !== "CallExpression"
+      ? shouldInsertEmptyLineAfter(lastNodeBeforeIndent)
+      : false;
 
   const expanded = concat([
     printGroup(groups[0]),

--- a/src/printer.js
+++ b/src/printer.js
@@ -3576,6 +3576,8 @@ function printMemberChain(path, options, print) {
   //   [Identifier, CallExpression, MemberExpression, CallExpression]
   const printedNodes = [];
 
+  // Here we try to retain one typed empty line after each call expression or
+  // the first group whether it is in parentheses or not
   function shouldInsertEmptyLineAfter(node) {
     const originalText = options.originalText;
     const nextCharIndex = util.getNextNonSpaceNonCommentCharacterIndex(
@@ -3785,15 +3787,18 @@ function printMemberChain(path, options, print) {
   // If we only have a single `.`, we shouldn't do anything fancy and just
   // render everything concatenated together.
   if (groups.length <= cutoff && !hasComment) {
-    return group(oneLine); // TODO: test
+    return group(oneLine);
   }
 
+  // Find out the last node in the first group and check if it has an
+  // empty line after
   const lastNodeBeforeIndent =
     (util.getLast(shouldMerge ? groups.slice(1, 2)[0] : groups[0])).node;
   const shouldHaveEmptyLineBeforeIndent =
     lastNodeBeforeIndent.type !== 'CallExpression' ?
       shouldInsertEmptyLineAfter(lastNodeBeforeIndent) :
       false;
+
   const expanded = concat([
     printGroup(groups[0]),
     shouldMerge ? concat(groups.slice(1, 2).map(printGroup)) : "",
@@ -3815,7 +3820,7 @@ function printMemberChain(path, options, print) {
     callExpressionCount >= 3 ||
     printedGroups.slice(0, -1).some(willBreak)
   ) {
-    return group(expanded); // TODO: test
+    return group(expanded);
   }
 
   return concat([

--- a/src/util.js
+++ b/src/util.js
@@ -185,7 +185,7 @@ function isNextLineEmpty(text, node) {
   return hasNewline(text, idx);
 }
 
-function getNextNonSpaceNonCommentCharacter(text, node) {
+function getNextNonSpaceNonCommentCharacterIndex(text, node) {
   let oldIdx = null;
   let idx = locEnd(node);
   while (idx !== oldIdx) {
@@ -195,7 +195,11 @@ function getNextNonSpaceNonCommentCharacter(text, node) {
     idx = skipTrailingComment(text, idx);
     idx = skipNewline(text, idx);
   }
-  return text.charAt(idx);
+  return idx;
+}
+
+function getNextNonSpaceNonCommentCharacter(text, node) {
+  return text.charAt(getNextNonSpaceNonCommentCharacterIndex(text, node));
 }
 
 function hasSpaces(text, index, opts) {
@@ -613,6 +617,7 @@ module.exports = {
   getParentExportDeclaration,
   getPenultimate,
   getLast,
+  getNextNonSpaceNonCommentCharacterIndex,
   getNextNonSpaceNonCommentCharacter,
   skipWhitespace,
   skipSpaces,

--- a/src/util.js
+++ b/src/util.js
@@ -170,9 +170,9 @@ function isPreviousLineEmpty(text, node) {
   return idx !== idx2;
 }
 
-function isNextLineEmpty(text, node) {
+function isNextLineEmptyAfterIndex(text, index) {
   let oldIdx = null;
-  let idx = locEnd(node);
+  let idx = index;
   while (idx !== oldIdx) {
     // We need to skip all the potential trailing inline comments
     oldIdx = idx;
@@ -183,6 +183,10 @@ function isNextLineEmpty(text, node) {
   idx = skipTrailingComment(text, idx);
   idx = skipNewline(text, idx);
   return hasNewline(text, idx);
+}
+
+function isNextLineEmpty(text, node) {
+  return isNextLineEmptyAfterIndex(text, locEnd(node));
 }
 
 function getNextNonSpaceNonCommentCharacterIndex(text, node) {
@@ -622,6 +626,7 @@ module.exports = {
   skipWhitespace,
   skipSpaces,
   skipNewline,
+  isNextLineEmptyAfterIndex,
   isNextLineEmpty,
   isPreviousLineEmpty,
   hasNewline,

--- a/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
@@ -414,7 +414,16 @@ function a() {
 `;
 
 exports[`member-chain.js 1`] = `
-bigDeal.doSomething('Hello World')
+fooBar.doSomething('Hello World').doAnotherThing('Foo', { foo: bar })
+
+  // App configuration.
+  .doOneMoreThing(config)
+
+  .run(() => console.log('Bar'));
+
+bigDeal
+
+  .doSomething('Hello World')
 
   // Hello world
   .doAnotherThing('Foo', { foo: bar })
@@ -425,39 +434,57 @@ bigDeal.doSomething('Hello World')
   .run(() => console.log('Bar'));
 
 
-bigDeal()
+foo.bar.baz
 
-// Do something
-.doSomething('Hello World')
-
-  // Hello world
-
-  .doAnotherThing('Foo', { foo: bar }) // Hello world
-  // Hello world
+  .doSomething('Hello World')
 
   // Hello world
+  .foo.bar.doAnotherThing('Foo', { foo: bar })
+
   .doOneMoreThing(config)
-  .run(() => console.log('Bar'));
+  .bar.run(() => console.log('Bar'));
 
-// Hello world
-foo.bar.foo.run()
-
-// Do something
-.bar.doSomething('Hello World')
+(
+  somethingGood ? thisIsIt : maybeNot
+)
 
   // Hello world
+  .doSomething('Hello World')
 
-  .doAnotherThing.hello('Foo', { foo: bar }) // Hello world
+  .doAnotherThing('Foo', { foo: bar }) // Run this
+  .run(() => console.log('Bar')); // Do this
 
-  // Hello world
+helloWorld
 
-  // Hello world
-  .run(() => console.log('Bar'))
+  .text()
 
-  // Here we go
-  .baz;
+  .then(t => t);
+
+(veryLongVeryLongVeryLong ||
+ anotherVeryLongVeryLongVeryLong ||
+ veryVeryVeryLongError
+)
+
+  .map(tickets => TicketRecord.createFromSomeLongString())
+
+  .filter(obj => !!obj);
+
+const sel = this.connections
+
+  .concat(this.activities.concat(this.operators))
+  .filter(x => x.selected);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+fooBar
+  .doSomething("Hello World")
+  .doAnotherThing("Foo", { foo: bar })
+
+  // App configuration.
+  .doOneMoreThing(config)
+
+  .run(() => console.log("Bar"));
+
 bigDeal
+
   .doSomething("Hello World")
 
   // Hello world
@@ -468,34 +495,42 @@ bigDeal
 
   .run(() => console.log("Bar"));
 
-bigDeal()
-  // Do something
+foo.bar.baz
+
   .doSomething("Hello World")
 
   // Hello world
+  .foo.bar.doAnotherThing("Foo", { foo: bar })
 
-  .doAnotherThing("Foo", { foo: bar }) // Hello world
-  // Hello world
-
-  // Hello world
   .doOneMoreThing(config)
-  .run(() => console.log("Bar"));
+  .bar.run(() => console.log("Bar"));
 
-// Hello world
-// Here we go
-foo.bar.foo
-  .run()
-
-  // Do something
-  .bar.doSomething("Hello World")
+(somethingGood ? thisIsIt : maybeNot)
 
   // Hello world
+  .doSomething("Hello World")
 
-  .doAnotherThing.hello("Foo", { foo: bar }) // Hello world
+  .doAnotherThing("Foo", { foo: bar }) // Run this
+  .run(() => console.log("Bar")); // Do this
 
-  // Hello world
+helloWorld
 
-  // Hello world
-  .run(() => console.log("Bar")).baz;
+  .text()
+
+  .then(t => t);
+
+(veryLongVeryLongVeryLong ||
+  anotherVeryLongVeryLongVeryLong ||
+  veryVeryVeryLongError
+)
+
+  .map(tickets => TicketRecord.createFromSomeLongString())
+
+  .filter(obj => !!obj);
+
+const sel = this.connections
+
+  .concat(this.activities.concat(this.operators))
+  .filter(x => x.selected);
 
 `;

--- a/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/preserve_line/__snapshots__/jsfmt.spec.js.snap
@@ -412,3 +412,90 @@ function a() {
 }
 
 `;
+
+exports[`member-chain.js 1`] = `
+bigDeal.doSomething('Hello World')
+
+  // Hello world
+  .doAnotherThing('Foo', { foo: bar })
+
+  // App configuration.
+  .doOneMoreThing(config)
+
+  .run(() => console.log('Bar'));
+
+
+bigDeal()
+
+// Do something
+.doSomething('Hello World')
+
+  // Hello world
+
+  .doAnotherThing('Foo', { foo: bar }) // Hello world
+  // Hello world
+
+  // Hello world
+  .doOneMoreThing(config)
+  .run(() => console.log('Bar'));
+
+// Hello world
+foo.bar.foo.run()
+
+// Do something
+.bar.doSomething('Hello World')
+
+  // Hello world
+
+  .doAnotherThing.hello('Foo', { foo: bar }) // Hello world
+
+  // Hello world
+
+  // Hello world
+  .run(() => console.log('Bar'))
+
+  // Here we go
+  .baz;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+bigDeal
+  .doSomething("Hello World")
+
+  // Hello world
+  .doAnotherThing("Foo", { foo: bar })
+
+  // App configuration.
+  .doOneMoreThing(config)
+
+  .run(() => console.log("Bar"));
+
+bigDeal()
+  // Do something
+  .doSomething("Hello World")
+
+  // Hello world
+
+  .doAnotherThing("Foo", { foo: bar }) // Hello world
+  // Hello world
+
+  // Hello world
+  .doOneMoreThing(config)
+  .run(() => console.log("Bar"));
+
+// Hello world
+// Here we go
+foo.bar.foo
+  .run()
+
+  // Do something
+  .bar.doSomething("Hello World")
+
+  // Hello world
+
+  .doAnotherThing.hello("Foo", { foo: bar }) // Hello world
+
+  // Hello world
+
+  // Hello world
+  .run(() => console.log("Bar")).baz;
+
+`;

--- a/tests/preserve_line/member-chain.js
+++ b/tests/preserve_line/member-chain.js
@@ -1,4 +1,13 @@
-bigDeal.doSomething('Hello World')
+fooBar.doSomething('Hello World').doAnotherThing('Foo', { foo: bar })
+
+  // App configuration.
+  .doOneMoreThing(config)
+
+  .run(() => console.log('Bar'));
+
+bigDeal
+
+  .doSomething('Hello World')
 
   // Hello world
   .doAnotherThing('Foo', { foo: bar })
@@ -9,34 +18,42 @@ bigDeal.doSomething('Hello World')
   .run(() => console.log('Bar'));
 
 
-bigDeal()
+foo.bar.baz
 
-// Do something
-.doSomething('Hello World')
-
-  // Hello world
-
-  .doAnotherThing('Foo', { foo: bar }) // Hello world
-  // Hello world
+  .doSomething('Hello World')
 
   // Hello world
+  .foo.bar.doAnotherThing('Foo', { foo: bar })
+
   .doOneMoreThing(config)
-  .run(() => console.log('Bar'));
+  .bar.run(() => console.log('Bar'));
 
-// Hello world
-foo.bar.foo.run()
-
-// Do something
-.bar.doSomething('Hello World')
+(
+  somethingGood ? thisIsIt : maybeNot
+)
 
   // Hello world
+  .doSomething('Hello World')
 
-  .doAnotherThing.hello('Foo', { foo: bar }) // Hello world
+  .doAnotherThing('Foo', { foo: bar }) // Run this
+  .run(() => console.log('Bar')); // Do this
 
-  // Hello world
+helloWorld
 
-  // Hello world
-  .run(() => console.log('Bar'))
+  .text()
 
-  // Here we go
-  .baz;
+  .then(t => t);
+
+(veryLongVeryLongVeryLong ||
+ anotherVeryLongVeryLongVeryLong ||
+ veryVeryVeryLongError
+)
+
+  .map(tickets => TicketRecord.createFromSomeLongString())
+
+  .filter(obj => !!obj);
+
+const sel = this.connections
+
+  .concat(this.activities.concat(this.operators))
+  .filter(x => x.selected);

--- a/tests/preserve_line/member-chain.js
+++ b/tests/preserve_line/member-chain.js
@@ -1,0 +1,42 @@
+bigDeal.doSomething('Hello World')
+
+  // Hello world
+  .doAnotherThing('Foo', { foo: bar })
+
+  // App configuration.
+  .doOneMoreThing(config)
+
+  .run(() => console.log('Bar'));
+
+
+bigDeal()
+
+// Do something
+.doSomething('Hello World')
+
+  // Hello world
+
+  .doAnotherThing('Foo', { foo: bar }) // Hello world
+  // Hello world
+
+  // Hello world
+  .doOneMoreThing(config)
+  .run(() => console.log('Bar'));
+
+// Hello world
+foo.bar.foo.run()
+
+// Do something
+.bar.doSomething('Hello World')
+
+  // Hello world
+
+  .doAnotherThing.hello('Foo', { foo: bar }) // Hello world
+
+  // Hello world
+
+  // Hello world
+  .run(() => console.log('Bar'))
+
+  // Here we go
+  .baz;


### PR DESCRIPTION
Fixes https://github.com/prettier/prettier/issues/1957, so that for common long chained method call patterns, one empty line will be preserved before each call if there is any originally.

For example, 

```
angular.module('AngularAppModule')

  // Constants.
  .constant('API_URL', 'http://localhost:8080/api')
  
  // App configuration.
  .config(appConfig)
  .run(appRun);
```

will be formatted to 

```
angular
  .module("AngularAppModule")

  // Constants.
  .constant("API_URL", "http://localhost:8080/api")

  // App configuration.
  .config(appConfig)
  .run(appRun);
```

. If two calls are separated by a parenthesis, one of the empty lines outside the parentheses before the next call will be preserved.

Not sure if the decisions I made here are acceptable. 😅  I am happy to make any change regarding the implementation and how we should format this sort of styles. Please let me know if you have any improvement in mind. 😄 