### PR TITLE
Print pipeline and nullish-coalescing operators

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "babel-code-frame": "7.0.0-alpha.12",
-    "babylon": "7.0.0-beta.23",
+    "babylon": "7.0.0-beta.28",
     "camelcase": "4.1.0",
     "chalk": "2.1.0",
     "cosmiconfig": "3.1.0",

--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -334,7 +334,7 @@ FastPath.prototype.needsParens = function(options) {
             return true;
           }
 
-          if (po === "||" && no === "&&") {
+          if ((po === "||" || po === "??") && no === "&&") {
             return true;
           }
 

--- a/src/parser-babylon.js
+++ b/src/parser-babylon.js
@@ -26,7 +26,9 @@ function parse(text, parsers, opts) {
       "importMeta",
       "optionalCatchBinding",
       "optionalChaining",
-      "classPrivateProperties"
+      "classPrivateProperties",
+      "pipelineOperator",
+      "nullishCoalescingOperator"
     ]
   };
 

--- a/src/printer.js
+++ b/src/printer.js
@@ -4359,11 +4359,17 @@ function printBinaryishExpressions(
       parts.push(path.call(print, "left"));
     }
 
-    const right = concat([
-      node.operator,
-      shouldInlineLogicalExpression(node) ? " " : line,
-      path.call(print, "right")
-    ]);
+    const shouldInline = shouldInlineLogicalExpression(node);
+    const lineBeforeOperator = node.operator === "|>";
+
+    const right = shouldInline
+      ? concat([node.operator, " ", path.call(print, "right")])
+      : concat([
+          lineBeforeOperator ? softline : "",
+          node.operator,
+          lineBeforeOperator ? " " : line,
+          path.call(print, "right")
+        ]);
 
     // If there's only a single binary expression, we want to create a group
     // in order to avoid having a small right part like -1 be on its own line.

--- a/src/util.js
+++ b/src/util.js
@@ -295,7 +295,8 @@ function setLocEnd(node, index) {
 
 const PRECEDENCE = {};
 [
-  ["||"],
+  ["|>"],
+  ["||", "??"],
   ["&&"],
   ["|"],
   ["^"],

--- a/tests/nullish_coalescing/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/nullish_coalescing/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`nullish_coalesing_operator.js 1`] = `
+obj.foo ?? "default";
+
+const x = (foo, bar = foo ?? bar) => {};
+
+foo ? bar ?? foo : baz;
+
+foo ?? (bar ?? baz);
+
+foo ?? baz || baz;
+
+(foo && baz) ?? baz;
+foo && (baz ?? baz);
+
+foo |> (bar ?? baz);
+(foo |> bar) ?? baz;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+obj.foo ?? "default";
+
+const x = (foo, bar = foo ?? bar) => {};
+
+foo ? bar ?? foo : baz;
+
+foo ?? (bar ?? baz);
+
+foo ?? baz || baz;
+
+(foo && baz) ?? baz;
+foo && (baz ?? baz);
+
+foo |> bar ?? baz;
+(foo |> bar) ?? baz;
+
+`;

--- a/tests/nullish_coalescing/jsfmt.spec.js
+++ b/tests/nullish_coalescing/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "babylon" });

--- a/tests/nullish_coalescing/nullish_coalesing_operator.js
+++ b/tests/nullish_coalescing/nullish_coalesing_operator.js
@@ -1,0 +1,15 @@
+obj.foo ?? "default";
+
+const x = (foo, bar = foo ?? bar) => {};
+
+foo ? bar ?? foo : baz;
+
+foo ?? (bar ?? baz);
+
+foo ?? baz || baz;
+
+(foo && baz) ?? baz;
+foo && (baz ?? baz);
+
+foo |> (bar ?? baz);
+(foo |> bar) ?? baz;

--- a/tests/pipeline_operator/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/pipeline_operator/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pipeline_operator.js 1`] = `
+a |> b |> c;
+
+a |> (b |> c);
+
+(a |> b) || c;
+a |> (b || c);
+
+let result = "hello"
+  |> doubleSay
+  |> capitalize
+  |> exclaim;
+
+let newScore = person.score
+  |> double
+  |> (_ => add(7, _))
+  |> (_ => subtract(2, _))
+  |> (_ => boundScore(0, 100, _));
+
+function createPerson (attrs) {
+  attrs
+    |> bounded('age', 1, 100)
+    |> format('name', /^[a-z]$/i)
+    |> Person.insertIntoDatabase;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+a |> b |> c;
+
+a |> (b |> c);
+
+(a |> b) || c;
+a |> b || c;
+
+let result = "hello" |> doubleSay |> capitalize |> exclaim;
+
+let newScore =
+  person.score
+  |> double
+  |> (_ => add(7, _))
+  |> (_ => subtract(2, _))
+  |> (_ => boundScore(0, 100, _));
+
+function createPerson(attrs) {
+  attrs
+    |> bounded("age", 1, 100)
+    |> format("name", /^[a-z]$/i)
+    |> Person.insertIntoDatabase;
+}
+
+`;

--- a/tests/pipeline_operator/jsfmt.spec.js
+++ b/tests/pipeline_operator/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "babylon" });

--- a/tests/pipeline_operator/pipeline_operator.js
+++ b/tests/pipeline_operator/pipeline_operator.js
@@ -1,0 +1,24 @@
+a |> b |> c;
+
+a |> (b |> c);
+
+(a |> b) || c;
+a |> (b || c);
+
+let result = "hello"
+  |> doubleSay
+  |> capitalize
+  |> exclaim;
+
+let newScore = person.score
+  |> double
+  |> (_ => add(7, _))
+  |> (_ => subtract(2, _))
+  |> (_ => boundScore(0, 100, _));
+
+function createPerson (attrs) {
+  attrs
+    |> bounded('age', 1, 100)
+    |> format('name', /^[a-z]$/i)
+    |> Person.insertIntoDatabase;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -800,9 +800,9 @@ babel-types@^6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@7.0.0-beta.23:
-  version "7.0.0-beta.23"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.23.tgz#c7e8e7a389b6f6c6212ceac1a3905c7e73d7e45a"
+babylon@7.0.0-beta.28:
+  version "7.0.0-beta.28"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.28.tgz#14521f26a19918db2b5f4aca89e62e02e0644be7"
 
 babylon@^6.13.0, babylon@^6.17.2:
   version "6.17.3"


### PR DESCRIPTION
Adds printer for two new operators!

## Pipeline operator

Proposal: https://github.com/tc39/proposal-pipeline-operator/

This operator makes functional chains much easier to read.

```js
// Before
baz(bar(foo(x)));

// After
x |> foo |> bar |> baz;
```

## Nullish-coalescing operator

Proposal: https://github.com/tc39-transfer/proposal-nullish-coalescing

This operator is much like `||` except it only evaluates the RHS if the LHS is `null` or `undefined`, instead of falsy.

```js
const foo = object.foo ?? "default";
```

----

* Bumps babylon to beta 28