### PR TITLE
Add test for nested ternary with arrow func

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "babel-code-frame": "7.0.0-alpha.12",
-    "babylon": "7.0.0-beta.23",
+    "babylon": "7.0.0-beta.28",
     "camelcase": "4.1.0",
     "chalk": "2.1.0",
     "cjk-regex": "1.0.1",

--- a/tests/ternaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ternaries/__snapshots__/jsfmt.spec.js.snap
@@ -92,6 +92,30 @@ aaaaaaaaaaaaaaa
 
 `;
 
+exports[`nested.js 1`] = `
+let icecream = what == "cone"
+  ? p => !!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`
+  : p => \`here's your \${p} \${what}\`;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+let icecream =
+  what == "cone"
+    ? p => (!!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`)
+    : p => \`here's your \${p} \${what}\`;
+
+`;
+
+exports[`nested.js 2`] = `
+let icecream = what == "cone"
+  ? p => !!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`
+  : p => \`here's your \${p} \${what}\`;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+let icecream =
+    what == "cone"
+        ? p => (!!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`)
+        : p => \`here's your \${p} \${what}\`;
+
+`;
+
 exports[`parenthesis.js 1`] = `
 debug ? this.state.isVisible ? "partially visible" : "hidden" : null;
 debug ? this.state.isVisible && somethingComplex ? "partially visible" : "hidden" : null;

--- a/tests/ternaries/nested.js
+++ b/tests/ternaries/nested.js
@@ -1,0 +1,3 @@
+let icecream = what == "cone"
+  ? p => !!p ? `here's your ${p} cone` : `just the empty cone for you`
+  : p => `here's your ${p} ${what}`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -800,9 +800,9 @@ babel-types@^6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@7.0.0-beta.23:
-  version "7.0.0-beta.23"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.23.tgz#c7e8e7a389b6f6c6212ceac1a3905c7e73d7e45a"
+babylon@7.0.0-beta.28:
+  version "7.0.0-beta.28"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.28.tgz#14521f26a19918db2b5f4aca89e62e02e0644be7"
 
 babylon@^6.13.0, babylon@^6.17.2:
   version "6.17.3"


### PR DESCRIPTION
Fixes #2194.

While looking at https://github.com/prettier/prettier/pull/3036 I was reminded that we _can_ bump Babylon even with the TS/Flow type name split due to `typescript-eslint-parser`.

Sigh, so many things to keep straight in the head :)