### PR TITLE
Making sure playground can have shorter urls

### DIFF
--- a/website/pages/playground/index.html
+++ b/website/pages/playground/index.html
@@ -38,6 +38,7 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/wrap/hardwrap.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/keymap/sublime.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.4.4/lz-string.min.js"></script>
 
   <style type="text/css">
     html {

--- a/website/static/playground.js
+++ b/website/static/playground.js
@@ -1,6 +1,6 @@
 /* eslint-env browser */
 /* eslint no-var: off, strict: off, prefer-arrow-callback: off */
-/* global Clipboard CodeMirror formatMarkdown */
+/* global Clipboard CodeMirror formatMarkdown LZString */
 
 var prettierVersion = "?";
 var inputEditor;

--- a/website/static/playground.js
+++ b/website/static/playground.js
@@ -29,7 +29,12 @@ var IDEMPOTENT_MESSAGE = "✓ Second format is unchanged.";
 var state = (function loadState(hash) {
   var parsed;
   try {
-    parsed = JSON.parse(hash);
+    // providing backwards support for old json encoded URIComponent
+    if (hash.indexOf("%7B%22") !== -1) {
+      parsed = JSON.parse(decodeURIComponent(hash));
+    } else {
+      parsed = LZString.decompressFromEncodedURIComponent(hash);
+    }
   } catch (error) {
     return {
       options: undefined,
@@ -63,7 +68,7 @@ var state = (function loadState(hash) {
     parsed.options.parser = "css";
   }
   return parsed;
-})(decodeURIComponent(location.hash.slice(1)));
+})(location.hash.slice(1));
 
 var worker = new Worker("/worker.js");
 
@@ -84,7 +89,7 @@ worker.onmessage = function(message) {
           : message.data.formatted2 || ""
     );
     document.getElementById("button-report-issue").search =
-      "body=" + encodeURIComponent(createMarkdown(true));
+      "body=" + LZString.compressToEncodedURIComponent(createMarkdown(true));
   }
 };
 
@@ -258,7 +263,7 @@ function formatAsync() {
   var options = getOptions();
   setEditorStyles();
 
-  var value = encodeURIComponent(
+  var value = LZString.compressToEncodedURIComponent(
     JSON.stringify(
       Object.assign({ content: inputEditor.getValue(), options: options })
     )

--- a/website/static/service-worker.js
+++ b/website/static/service-worker.js
@@ -32,6 +32,7 @@ toolbox.precache([
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/addon/wrap/hardwrap.js",
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.26.0/keymap/sublime.js",
   "https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/1.7.1/clipboard.min.js",
+  "https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.4.4/lz-string.min.js",
 
   // Images
   "/prettier.png"


### PR DESCRIPTION
This allow the playground  to have shorter URL's while providing backwards compatibility to the older URI scheme.

playground with content:

```javascript
const a = 1;
```

Used to create uri as:

`
.../#%7B%22content%22%3A%22const%20a%20%3D%201%3B%22%2C%22options%22%3A%7B%22ast%22%3Afalse%2C%22bracketSpacing%22%3Atrue%2C%22doc%22%3Afalse%2C%22jsxBracketSameLine%22%3Afalse%2C%22output2%22%3Afalse%2C%22parser%22%3A%22babylon%22%2C%22printWidth%22%3A80%2C%22semi%22%3Atrue%2C%22singleQuote%22%3Afalse%2C%22tabWidth%22%3A2%2C%22trailingComma%22%3A%22none%22%2C%22useTabs%22%3Afalse%7D%7D
`

the same now is:

`.../#N4Igxg9gdgLgprEAuc0DOMAEBDTBeTARgG4QAaECABxgEt1lRsNkAzbAGzTgoCMAnbGADWcGAGUqQ2lADmyGPwCuPEABMIYNp24UAVmgAeAIUEix47AFs4AGRlxtXVRCUwqbgExPdIKf25+ZBBebF4ATw5ocj9+GRgAdVo1GAALZAAOAAYKbitaBWVVNBlZDjgARSUIeB9VGDCklPSkTwpFbFoOUoBhCCsrbGCoaEcKJW4AFTC0OoBfOaA`

cc @lydell  @ikatyang @azz 