### PR TITLE
Format SCSS maps like CSS rules

### DIFF
--- a/src/printer-postcss.js
+++ b/src/printer-postcss.js
@@ -345,7 +345,10 @@ function genericPrint(path, options, print) {
           indent(
             concat([
               softline,
-              join(concat([",", line]), path.map(print, "groups"))
+              join(
+                concat([",", parent.type === "value-value" ? hardline : line]),
+                path.map(print, "groups")
+              )
             ])
           ),
           softline,

--- a/src/printer-postcss.js
+++ b/src/printer-postcss.js
@@ -339,6 +339,12 @@ function genericPrint(path, options, print) {
         return group(indent(fill(res)));
       }
 
+      const declaration = path.getParentNode(2);
+      const isMap =
+        declaration &&
+        declaration.type === "css-decl" &&
+        declaration.prop.startsWith("$");
+
       return group(
         concat([
           n.open ? path.call(print, "open") : "",
@@ -346,7 +352,7 @@ function genericPrint(path, options, print) {
             concat([
               softline,
               join(
-                concat([",", parent.type === "value-value" ? hardline : line]),
+                concat([",", isMap ? hardline : line]),
                 path.map(print, "groups")
               )
             ])

--- a/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
@@ -18,6 +18,7 @@ div {
   }
 }
 a { margin: 0 { left: 10px; } }
+$map: (color: #111111, text-shadow: 1px 1px 0 salmon);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 @media #{$g-breakpoint-tiny} {
 }
@@ -38,5 +39,9 @@ a {
     left: 10px;
   }
 }
+$map: (
+  color: #111111,
+  text-shadow: 1px 1px 0 salmon
+);
 
 `;

--- a/tests/css_scss/scss.css
+++ b/tests/css_scss/scss.css
@@ -8,3 +8,4 @@ div {
   }
 }
 a { margin: 0 { left: 10px; } }
+$map: (color: #111111, text-shadow: 1px 1px 0 salmon);


### PR DESCRIPTION
Resolves prettier/prettier#3056

This makes prettier format SCSS maps like CSS rules (line breaks after each rule). e.g.

```sass
$map: (color: #111111, text-shadow: 1px 1px 0 salmon)
```

will format to

```sass
$map: (
  color: #111111,
  text-shadow: 1px 1px 0 salmon
);
```