### PR TITLE
Fix calculation of whether doc parts fit

### DIFF
--- a/src/doc-printer.js
+++ b/src/doc-printer.js
@@ -271,7 +271,7 @@ function printDocToString(doc, options) {
           const content = parts[0];
           const contentFlatCmd = [ind, MODE_FLAT, content];
           const contentBreakCmd = [ind, MODE_BREAK, content];
-          const contentFits = fits(contentFlatCmd, [], width - rem, true);
+          const contentFits = fits(contentFlatCmd, [], rem, true);
 
           if (parts.length === 1) {
             if (contentFits) {

--- a/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
@@ -109,9 +109,7 @@ before = (
 
 before_break1 = (
   <span>
-    <span
-      barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar
-    />{" "}
+    <span barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar />{" "}
     foo
   </span>
 );

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -469,7 +469,11 @@ facebook_translation_leave_text_around_tag = (
 
 this_really_should_split_across_lines = (
   <div>
-    before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after
+    before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{
+      stuff
+    }after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{
+      stuff
+    }after
   </div>
 );
 
@@ -651,9 +655,7 @@ jsx_whitespace_after_tag = (
 
 x = (
   <div>
-    ENDS IN <div>
-      text text text text text text text text text text text
-    </div>{" "}
+    ENDS IN <div>text text text text text text text text text text text</div>{" "}
     HRS
   </div>
 );


### PR DESCRIPTION
It turns out there was a subtle bug in the `fill` algorithm that was spotted by @acthp in https://github.com/prettier/prettier/issues/3071.

This PR fixes that issue, and updates the snapshot tests for the few edges cases it changes.