### PR TITLE
Fixing playground report issue button and options parsing

### DIFF
--- a/website/static/playground.js
+++ b/website/static/playground.js
@@ -26,77 +26,80 @@ var OPTIONS = [
 
 var IDEMPOTENT_MESSAGE = "✓ Second format is unchanged.";
 
-var state = (function loadState(hash) {
-  var parsed;
-  try {
-    // providing backwards support for old json encoded URIComponent
-    if (hash.indexOf("%7B%22") !== -1) {
-      parsed = JSON.parse(decodeURIComponent(hash));
-    } else {
-      parsed = LZString.decompressFromEncodedURIComponent(hash);
-    }
-  } catch (error) {
-    return {
-      options: undefined,
-      content: [
-        'function HelloWorld({greeting = "hello", greeted = \'"World"\', silent = false, onMouseOver,}) {',
-        "",
-        "  if(!greeting){return null};",
-        "",
-        "     // TODO: Don't use random in render",
-        '  let num = Math.floor (Math.random() * 1E+7).toString().replace(/\\.\\d+/ig, "")',
-        "",
-        "  return <div className='HelloWorld' title={`You are visitor number ${ num }`} onMouseOver={onMouseOver}>",
-        "",
-        "    <strong>{ greeting.slice( 0, 1 ).toUpperCase() + greeting.slice(1).toLowerCase() }</strong>",
-        '    {greeting.endsWith(",") ? " " : <span style={{color: \'\\grey\'}}>", "</span> }',
-        "    <em>",
-        "\t{ greeted }",
-        "\t</em>",
-        "    { (silent)",
-        '      ? "."',
-        '      : "!"}',
-        "",
-        "    </div>;",
-        "",
-        "}"
-      ].join("\n")
-    };
-  }
-  // Support old links with the deprecated "postcss" value for the parser option.
-  if (parsed && parsed.options && parsed.options.parser === "postcss") {
-    parsed.options.parser = "css";
-  }
-  return parsed;
-})(location.hash.slice(1));
-
 var worker = new Worker("/worker.js");
 
-worker.onmessage = function(message) {
-  if (prettierVersion === "?") {
-    prettierVersion = message.data.version;
-    document.getElementById("version").textContent = prettierVersion;
-  }
-  if (outputEditor && docEditor && astEditor) {
-    outputEditor.setValue(message.data.formatted);
-    docEditor.setValue(message.data.doc || "");
-    astEditor.setValue(message.data.ast || "");
-    output2Editor.setValue(
-      message.data.formatted === ""
-        ? ""
-        : message.data.formatted2 === message.data.formatted
-          ? IDEMPOTENT_MESSAGE
-          : message.data.formatted2 || ""
-    );
-    document.getElementById("button-report-issue").search =
-      "body=" + LZString.compressToEncodedURIComponent(createMarkdown(true));
-  }
+const DEFAULT_OPTIONS = {
+  options: undefined,
+  content: [
+    'function HelloWorld({greeting = "hello", greeted = \'"World"\', silent = false, onMouseOver,}) {',
+    "",
+    "  if(!greeting){return null};",
+    "",
+    "     // TODO: Don't use random in render",
+    '  let num = Math.floor (Math.random() * 1E+7).toString().replace(/\\.\\d+/ig, "")',
+    "",
+    "  return <div className='HelloWorld' title={`You are visitor number ${ num }`} onMouseOver={onMouseOver}>",
+    "",
+    "    <strong>{ greeting.slice( 0, 1 ).toUpperCase() + greeting.slice(1).toLowerCase() }</strong>",
+    '    {greeting.endsWith(",") ? " " : <span style={{color: \'\\grey\'}}>", "</span> }',
+    "    <em>",
+    "\t{ greeted }",
+    "\t</em>",
+    "    { (silent)",
+    '      ? "."',
+    '      : "!"}',
+    "",
+    "    </div>;",
+    "",
+    "}"
+  ].join("\n")
 };
 
-// Warm up the worker (load the current parser while CodeMirror loads)
-worker.postMessage({ text: "", options: state.options });
-
 window.onload = function() {
+  var state = (function loadState(hash) {
+    var parsed;
+    try {
+      // providing backwards support for old json encoded URIComponent
+      if (hash.indexOf("%7B%22") !== -1) {
+        parsed = JSON.parse(decodeURIComponent(hash));
+      } else {
+        parsed = JSON.parse(LZString.decompressFromEncodedURIComponent(hash));
+      }
+    } catch (error) {
+      return DEFAULT_OPTIONS;
+    }
+    // Support old links with the deprecated "postcss" value for the parser option.
+    if (parsed && parsed.options && parsed.options.parser === "postcss") {
+      parsed.options.parser = "css";
+    }
+
+    return parsed || DEFAULT_OPTIONS;
+  })(location.hash.slice(1));
+
+  worker.onmessage = function(message) {
+    if (prettierVersion === "?") {
+      prettierVersion = message.data.version;
+      document.getElementById("version").textContent = prettierVersion;
+    }
+    if (outputEditor && docEditor && astEditor) {
+      outputEditor.setValue(message.data.formatted);
+      docEditor.setValue(message.data.doc || "");
+      astEditor.setValue(message.data.ast || "");
+      output2Editor.setValue(
+        message.data.formatted === ""
+          ? ""
+          : message.data.formatted2 === message.data.formatted
+            ? IDEMPOTENT_MESSAGE
+            : message.data.formatted2 || ""
+      );
+      document.getElementById("button-report-issue").search =
+        "body=" + encodeURIComponent(createMarkdown(true));
+    }
+  };
+
+  // Warm up the worker (load the current parser while CodeMirror loads)
+  worker.postMessage({ text: "", options: state.options });
+
   state.options && setOptions(state.options);
 
   var editorOptions = {


### PR DESCRIPTION
Unfortunately with PR https://github.com/prettier/prettier/pull/3063 I introduced a few bugs to the playground

1. The previous playground could parse config directly from the URL without having to wait any dependency to be available, due to the inclusion of lz-string as a dependencie for URL parsing we should have moved the logic of extracting config to go inside `window.onload`

2. I Naively thought that I could have simply update all encodeUriComponent to the lz-string variant, but that was not the behaviour that we needed for `report-bug` button, that particular one should have kept the old behaviour of encodeUriComponent.

Apologies for leading to a broken PR being merged into `prettier`. Tested this PR and it seems to fix all the above issues.