### PR TITLE
Don't print JSX bracket on same line when it has trailing comments

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1774,6 +1774,14 @@ function genericPrintNoParens(path, options, print, args) {
         );
       }
 
+      const bracketSameLine =
+        options.jsxBracketSameLine &&
+        !(
+          n.name &&
+          ((n.name.trailingComments && n.name.trailingComments.length) ||
+            (n.name.comments && n.name.comments.length))
+        );
+
       return group(
         concat([
           "<",
@@ -1784,9 +1792,9 @@ function genericPrintNoParens(path, options, print, args) {
                 path.map(attr => concat([line, print(attr)]), "attributes")
               )
             ),
-            n.selfClosing ? line : options.jsxBracketSameLine ? ">" : softline
+            n.selfClosing ? line : bracketSameLine ? ">" : softline
           ]),
-          n.selfClosing ? "/>" : options.jsxBracketSameLine ? "" : ">"
+          n.selfClosing ? "/>" : bracketSameLine ? "" : ">"
         ])
       );
     }

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -838,6 +838,13 @@ onClick={() => {}}>
 
 </div>;
 
+<div
+  // comment
+>
+  {foo}
+</div>;
+
+
 <Wrapper>
   {}
   <Component />
@@ -915,6 +922,12 @@ onClick={() => {}}>
    */
   onClick={() => {}}
 />;
+
+<div
+// comment
+>
+  {foo}
+</div>;
 
 <Wrapper>
   {}

--- a/tests/comments/jsx.js
+++ b/tests/comments/jsx.js
@@ -89,6 +89,13 @@ onClick={() => {}}>
 
 </div>;
 
+<div
+  // comment
+>
+  {foo}
+</div>;
+
+
 <Wrapper>
   {}
   <Component />

--- a/tests/comments_jsx_same_line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments_jsx_same_line/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`jsx_same_line.js 1`] = `
+<div
+  // comment
+>
+  {foo}
+</div>;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<div
+// comment
+>
+  {foo}
+</div>;
+
+`;

--- a/tests/comments_jsx_same_line/jsfmt.spec.js
+++ b/tests/comments_jsx_same_line/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { jsxBracketSameLine: true }, ["babylon", "typescript"]);

--- a/tests/comments_jsx_same_line/jsx_same_line.js
+++ b/tests/comments_jsx_same_line/jsx_same_line.js
@@ -1,0 +1,5 @@
+<div
+  // comment
+>
+  {foo}
+</div>;


### PR DESCRIPTION
Fixes #3087 