### PR TITLE
Prevent adding semi in TypeScript interfaces when type has prettier-ignore

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1001,7 +1001,9 @@ function genericPrintNoParens(path, options, print, args) {
       let separatorParts = [];
       const props = propsAndLoc.sort((a, b) => a.loc - b.loc).map(prop => {
         const result = concat(separatorParts.concat(group(prop.printed)));
-        separatorParts = [separator, line];
+        separatorParts = hasNodeIgnoreComment(prop.node)
+          ? [line]
+          : [separator, line];
         if (util.isNextLineEmpty(options.originalText, prop.node)) {
           separatorParts.push(hardline);
         }
@@ -1012,7 +1014,9 @@ function genericPrintNoParens(path, options, print, args) {
 
       const canHaveTrailingSeparator = !(
         lastElem &&
-        (lastElem.type === "RestProperty" || lastElem.type === "RestElement")
+        (lastElem.type === "RestProperty" ||
+          lastElem.type === "RestElement" ||
+          hasNodeIgnoreComment(lastElem))
       );
 
       let content;

--- a/tests/typescript_interface/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_interface/__snapshots__/jsfmt.spec.js.snap
@@ -22,6 +22,35 @@ interface ScreenObject {
 
 `;
 
+exports[`ignore.js 1`] = `
+interface Interface {
+  // prettier-ignore
+  prop: type
+  // prettier-ignore
+  prop: type;
+}
+
+// Last element
+interface Interface {
+  // prettier-ignore
+  prop: type
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+interface Interface {
+  // prettier-ignore
+  prop: type
+  // prettier-ignore
+  prop: type;
+}
+
+// Last element
+interface Interface {
+  // prettier-ignore
+  prop: type
+}
+
+`;
+
 exports[`long-extends.ts 1`] = `
 export interface I extends A, B, C {
   c: string;

--- a/tests/typescript_interface/ignore.js
+++ b/tests/typescript_interface/ignore.js
@@ -1,0 +1,12 @@
+interface Interface {
+  // prettier-ignore
+  prop: type
+  // prettier-ignore
+  prop: type;
+}
+
+// Last element
+interface Interface {
+  // prettier-ignore
+  prop: type
+}


### PR DESCRIPTION
Fixes #3102

Not sure this is the right fix. Let me know what you think!