### PR TITLE
Make the factory detection handle multiple elements

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3790,13 +3790,21 @@ function printMemberChain(path, options, print) {
   // node is just an identifier with the name starting with a capital
   // letter, just a sequence of _$ or this. The rationale is that they are
   // likely to be factories.
+  function isFactory(name) {
+    return name.match(/(^[A-Z])|^[_$]+$/);
+  }
   const shouldMerge =
     groups.length >= 2 &&
     !groups[1][0].node.comments &&
-    groups[0].length === 1 &&
-    (groups[0][0].node.type === "ThisExpression" ||
-      (groups[0][0].node.type === "Identifier" &&
-        (groups[0][0].node.name.match(/(^[A-Z])|^[_$]+$/) ||
+    ((groups[0].length === 1 &&
+      (groups[0][0].node.type === "ThisExpression" ||
+        (groups[0][0].node.type === "Identifier" &&
+          (isFactory(groups[0][0].node.name) ||
+            (groups[1].length && groups[1][0].node.computed))))) ||
+      (groups[0].length > 1 &&
+        groups[0][groups[0].length - 1].node.type === "MemberExpression" &&
+        groups[0][groups[0].length - 1].node.property.type === "Identifier" &&
+        (isFactory(groups[0][groups[0].length - 1].node.property.name) ||
           (groups[1].length && groups[1][0].node.computed))));
 
   function printGroup(printedGroup) {

--- a/tests/member/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/member/__snapshots__/jsfmt.spec.js.snap
@@ -34,6 +34,21 @@ const promises = [
   redis.fetch(),
   other.fetch(),
 ];
+
+window.FooClient.setVars({
+  locale: getFooLocale({ page }),
+  authorizationToken: data.token
+}).initVerify("foo_container");
+
+window.something.FooClient.setVars({
+  locale: getFooLocale({ page }),
+  authorizationToken: data.token
+}).initVerify("foo_container");
+
+window.FooClient.something.setVars({
+  locale: getFooLocale({ page }),
+  authorizationToken: data.token
+}).initVerify("foo_container");
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const veryVeryVeryVeryVeryVeryVeryLong =
   doc.expandedStates[doc.expandedStates.length - 1];
@@ -64,6 +79,23 @@ const promises = [
   redis.fetch(),
   other.fetch()
 ];
+
+window.FooClient.setVars({
+  locale: getFooLocale({ page }),
+  authorizationToken: data.token
+}).initVerify("foo_container");
+
+window.something.FooClient.setVars({
+  locale: getFooLocale({ page }),
+  authorizationToken: data.token
+}).initVerify("foo_container");
+
+window.FooClient.something
+  .setVars({
+    locale: getFooLocale({ page }),
+    authorizationToken: data.token
+  })
+  .initVerify("foo_container");
 
 `;
 

--- a/tests/member/expand.js
+++ b/tests/member/expand.js
@@ -18,3 +18,18 @@ const promises = [
   redis.fetch(),
   other.fetch(),
 ];
+
+window.FooClient.setVars({
+  locale: getFooLocale({ page }),
+  authorizationToken: data.token
+}).initVerify("foo_container");
+
+window.something.FooClient.setVars({
+  locale: getFooLocale({ page }),
+  authorizationToken: data.token
+}).initVerify("foo_container");
+
+window.FooClient.something.setVars({
+  locale: getFooLocale({ page }),
+  authorizationToken: data.token
+}).initVerify("foo_container");

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -400,6 +400,10 @@ exports[`computed-merge.js 1`] = `
     .then(() => console.log('bar'))
     .catch(() => console.log('baz'));
 });
+
+window.Data[key]("foo")
+  .then(() => a)
+  .catch(() => b);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [].forEach(key => {
   data[key]("foo")
@@ -413,6 +417,10 @@ exports[`computed-merge.js 1`] = `
     .then(() => console.log("bar"))
     .catch(() => console.log("baz"));
 });
+
+window.Data[key]("foo")
+  .then(() => a)
+  .catch(() => b);
 
 `;
 

--- a/tests/method-chain/computed-merge.js
+++ b/tests/method-chain/computed-merge.js
@@ -10,3 +10,7 @@
     .then(() => console.log('bar'))
     .catch(() => console.log('baz'));
 });
+
+window.Data[key]("foo")
+  .then(() => a)
+  .catch(() => b);


### PR DESCRIPTION
This was only accounting for a single element in the first group. Now it handles arbitrary elements. Only the last element being capitalized matters.

This fixes one issue in #3107