### PR TITLE
don't break expressions in template string regex constructors

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1934,8 +1934,16 @@ function genericPrintNoParens(path, options, print, args) {
             tabWidth
           );
 
+          const parent = path.getParentNode(1);
+          const shouldBreak = !(
+            parent &&
+            parent.type === "NewExpression" &&
+            parent.callee.type === "Identifier" &&
+            parent.callee.name === "RegExp"
+          );
+
           const aligned = addAlignmentToDoc(
-            expressions[i],
+            shouldBreak ? expressions[i] : docUtils.removeLines(expressions[i]),
             indentSize,
             tabWidth
           );

--- a/tests/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/strings/__snapshots__/jsfmt.spec.js.snap
@@ -166,6 +166,8 @@ const makeBody = (store, assets, html) =>
 const Bar = styled.div\`
   color: \${props => (props.highlight.length > 0 ? palette(['text', 'dark', 'tertiary'])(props) : palette(['text', 'dark', 'primary'])(props))} !important;
 \`
+
+const shouldNotBreak = new RegExp(\`11111111111111111111111111111 should not break here \${this.x.y} 11111111111111111111111111111\`);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 foo(
   \`a long string \${1 +
@@ -292,6 +294,10 @@ const Bar = styled.div\`
       : palette(["text", "dark", "primary"])(props)} !important;
 \`;
 
+const shouldNotBreak = new RegExp(
+  \`11111111111111111111111111111 should not break here \${this.x.y} 11111111111111111111111111111\`
+);
+
 `;
 
 exports[`template-literals.js 2`] = `
@@ -352,6 +358,8 @@ const makeBody = (store, assets, html) =>
 const Bar = styled.div\`
   color: \${props => (props.highlight.length > 0 ? palette(['text', 'dark', 'tertiary'])(props) : palette(['text', 'dark', 'primary'])(props))} !important;
 \`
+
+const shouldNotBreak = new RegExp(\`11111111111111111111111111111 should not break here \${this.x.y} 11111111111111111111111111111\`);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 foo(
   \`a long string \${1 +
@@ -477,5 +485,9 @@ const Bar = styled.div\`
       ? palette(["text", "dark", "tertiary"])(props)
       : palette(["text", "dark", "primary"])(props)} !important;
 \`;
+
+const shouldNotBreak = new RegExp(
+  \`11111111111111111111111111111 should not break here \${this.x.y} 11111111111111111111111111111\`,
+);
 
 `;

--- a/tests/strings/template-literals.js
+++ b/tests/strings/template-literals.js
@@ -55,3 +55,5 @@ const makeBody = (store, assets, html) =>
 const Bar = styled.div`
   color: ${props => (props.highlight.length > 0 ? palette(['text', 'dark', 'tertiary'])(props) : palette(['text', 'dark', 'primary'])(props))} !important;
 `
+
+const shouldNotBreak = new RegExp(`11111111111111111111111111111 should not break here ${this.x.y} 11111111111111111111111111111`);


### PR DESCRIPTION
The line of thinking is that being able to read straight left-to-right is important for a human to 'parse' a regex and keep track of opening/closing markers, especially if there are a few declared at one per line.

Output without this:
```js
const shouldNotBreak = new RegExp(
  \`11111111111111111111111111111 should not break here \${this.x
    .y} 11111111111111111111111111111\`,
);
```

Worth noting that an alternate solution might be to strip newlines for *all* template string expressions unless at least one newline exists in the source expression. This is related to #1893. I'd honestly prefer this and it would arguably fix 1893, but it breaks a few more tests.