### PR TITLE
Add watching for changes to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ conforms to a consistent style. (See this [blog post](http://jlongster.com/A-Pre
   + [Visual Studio](#visual-studio)
   + [Sublime Text](#sublime-text)
   + [JetBrains WebStorm, PHPStorm, PyCharm...](#jetbrains-webstorm-phpstorm-pycharm)
+* [Watching For Changes On The Command Line](#watching-for-changes-on-the-command-line)
 * [Language Support](#language-support)
 * [Related Projects](#related-projects)
   + [ESLint Integrations](#eslint-integrations)

--- a/README.md
+++ b/README.md
@@ -833,6 +833,22 @@ the [JsPrettier](https://packagecontrol.io/packages/JsPrettier) plug-in.
 See the [WebStorm
 guide](https://github.com/jlongster/prettier/tree/master/editors/webstorm/README.md).
 
+## Watching For Changes On The Command Line
+
+If you prefer to have prettier watch for changes from the command line you can use a package like [onchange](https://www.npmjs.com/package/onchange). For example:
+
+```
+npx onchange '**/*.js' -- npx prettier --write {{changed}}
+```
+
+or add the following to your `package.json`
+
+```json
+  "scripts": {
+    "prettier-watch": "onchange '**/*.js' -- prettier --write {{changed}}"
+  },
+```
+
 ## Language Support
 
 Prettier attempts to support all JavaScript language features,


### PR DESCRIPTION
To tie up #575, I thought it would be good to have a note on how to watch for files in the README, considering it is a much requested feature in Issues. However, I feel like a watcher doesn't need to be in the code base considering there are other packages out there that implement this.

Hopefully this pull request will please everyone that wants a watcher.