### PR TITLE
[graphql] Escape strings

### DIFF
--- a/src/printer-graphql.js
+++ b/src/printer-graphql.js
@@ -108,7 +108,7 @@ function genericPrint(path, options, print) {
       return n.value;
     }
     case "StringValue": {
-      return concat(['"', n.value, '"']);
+      return concat(['"', n.value.replace(/["\\]/g, "\\$&"), '"']);
     }
     case "IntValue":
     case "FloatValue":

--- a/tests/graphql_string/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_string/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`string.graphql 1`] = `
+query X($a: Int) @relay(meta: "{\\"lowPri\\": true}") { a }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+query X($a: Int) @relay(meta: "{\\"lowPri\\": true}") {
+  a
+}
+
+`;

--- a/tests/graphql_string/jsfmt.spec.js
+++ b/tests/graphql_string/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "graphql" });

--- a/tests/graphql_string/string.graphql
+++ b/tests/graphql_string/string.graphql
@@ -1,0 +1,1 @@
+query X($a: Int) @relay(meta: "{\"lowPri\": true}") { a }


### PR DESCRIPTION
When I ran it on all the graphql files of fb, none of them had escape, but someone reported this issue!

Fixes #3142