### PR TITLE
Link to correct editor repository url for vscode extension

### DIFF
--- a/docs/editors.md
+++ b/docs/editors.md
@@ -24,7 +24,7 @@ Can be installed using the extension sidebar. Search for `Prettier - JavaScript 
 
 Can also be installed using `ext install prettier-vscode`.
 
-[Check its repository for configuration and shortcuts](https://github.com/esbenp/prettier-vscode)
+[Check its repository for configuration and shortcuts](https://github.com/prettier/prettier-vscode)
 
 ## Visual Studio
 


### PR DESCRIPTION
The repository does a redirect already.
But if you are on mobile, you probably do like 2 roundtrips, so to prevent that, we link the the correct repo.