### PR TITLE
fix(jsx): Break opening elements with single text attribute if there's a comment

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1766,12 +1766,25 @@ function genericPrintNoParens(path, options, print, args) {
     case "JSXOpeningElement": {
       const n = path.getValue();
 
+      const hasComments =
+        (n.name &&
+          ((n.name.trailingComments && n.name.trailingComments.length) ||
+            (n.name.comments && n.name.comments.length))) ||
+        (n.attributes &&
+          n.attributes.length > 0 &&
+          n.attributes.some(
+            attr =>
+              (attr.comments && attr.comments.length) ||
+              (attr.trailingComments && attr.trailingComments.length)
+          ));
+
       // don't break up opening elements with a single long text attribute
       if (
         n.attributes.length === 1 &&
         n.attributes[0].value &&
         isStringLiteral(n.attributes[0].value) &&
-        !n.attributes[0].comments
+        !n.attributes[0].comments &&
+        !hasComments
       ) {
         return group(
           concat([
@@ -1784,13 +1797,7 @@ function genericPrintNoParens(path, options, print, args) {
         );
       }
 
-      const bracketSameLine =
-        options.jsxBracketSameLine &&
-        !(
-          n.name &&
-          ((n.name.trailingComments && n.name.trailingComments.length) ||
-            (n.name.comments && n.name.comments.length))
-        );
+      const bracketSameLine = options.jsxBracketSameLine && !hasComments;
 
       return group(
         concat([

--- a/src/printer.js
+++ b/src/printer.js
@@ -1766,25 +1766,24 @@ function genericPrintNoParens(path, options, print, args) {
     case "JSXOpeningElement": {
       const n = path.getValue();
 
-      const hasComments =
-        (n.name &&
-          ((n.name.trailingComments && n.name.trailingComments.length) ||
-            (n.name.comments && n.name.comments.length))) ||
-        (n.attributes &&
-          n.attributes.length > 0 &&
-          n.attributes.some(
-            attr =>
-              (attr.comments && attr.comments.length) ||
-              (attr.trailingComments && attr.trailingComments.length)
-          ));
-
       // don't break up opening elements with a single long text attribute
       if (
         n.attributes.length === 1 &&
         n.attributes[0].value &&
         isStringLiteral(n.attributes[0].value) &&
-        !n.attributes[0].comments &&
-        !hasComments
+        // We should break for the following cases:
+        // <div
+        //   // comment
+        //   attr="value"
+        // >
+        // <div
+        //   attr="value"
+        //   // comment
+        // >
+        !(
+          (n.name && n.name.comments && n.name.comments.length) ||
+          (n.attributes[0].comments && n.attributes[0].comments.length)
+        )
       ) {
         return group(
           concat([
@@ -1797,7 +1796,24 @@ function genericPrintNoParens(path, options, print, args) {
         );
       }
 
-      const bracketSameLine = options.jsxBracketSameLine && !hasComments;
+      const bracketSameLine =
+        options.jsxBracketSameLine &&
+        // We should print the bracket in a new line for the following cases:
+        // <div
+        //   // comment
+        // >
+        // <div
+        //   attr // comment
+        // >
+        !(
+          (n.name &&
+            !(n.attributes && n.attributes.length) &&
+            n.name.comments &&
+            n.name.comments.length) ||
+          (n.attributes &&
+            n.attributes.length &&
+            hasTrailingComment(util.getLast(n.attributes)))
+        );
 
       return group(
         concat([

--- a/src/printer.js
+++ b/src/printer.js
@@ -1770,7 +1770,8 @@ function genericPrintNoParens(path, options, print, args) {
       if (
         n.attributes.length === 1 &&
         n.attributes[0].value &&
-        isStringLiteral(n.attributes[0].value)
+        isStringLiteral(n.attributes[0].value) &&
+        !n.attributes[0].comments
       ) {
         return group(
           concat([

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -844,6 +844,18 @@ onClick={() => {}}>
   {foo}
 </div>;
 
+<div
+  className="foo" // comment
+>
+  {foo}
+</div>;
+
+<div
+  className="foo"
+  // comment
+>
+  {foo}
+</div>;
 
 <Wrapper>
   {}
@@ -925,6 +937,19 @@ onClick={() => {}}>
 
 <div
 // comment
+>
+  {foo}
+</div>;
+
+<div
+  className="foo" // comment
+>
+  {foo}
+</div>;
+
+<div
+  className="foo"
+  // comment
 >
   {foo}
 </div>;

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -857,6 +857,12 @@ onClick={() => {}}>
   {foo}
 </div>;
 
+<div // comment
+  id="foo"
+>
+  {children}
+</div>;
+
 <Wrapper>
   {}
   <Component />
@@ -952,6 +958,12 @@ onClick={() => {}}>
   // comment
 >
   {foo}
+</div>;
+
+<div // comment
+  id="foo"
+>
+  {children}
 </div>;
 
 <Wrapper>

--- a/tests/comments/jsx.js
+++ b/tests/comments/jsx.js
@@ -108,6 +108,12 @@ onClick={() => {}}>
   {foo}
 </div>;
 
+<div // comment
+  id="foo"
+>
+  {children}
+</div>;
+
 <Wrapper>
   {}
   <Component />

--- a/tests/comments/jsx.js
+++ b/tests/comments/jsx.js
@@ -95,6 +95,18 @@ onClick={() => {}}>
   {foo}
 </div>;
 
+<div
+  className="foo" // comment
+>
+  {foo}
+</div>;
+
+<div
+  className="foo"
+  // comment
+>
+  {foo}
+</div>;
 
 <Wrapper>
   {}

--- a/tests/comments_jsx_same_line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments_jsx_same_line/__snapshots__/jsfmt.spec.js.snap
@@ -6,9 +6,48 @@ exports[`jsx_same_line.js 1`] = `
 >
   {foo}
 </div>;
+
+<div
+  // comment
+  attr="foo"
+>
+  {foo}
+</div>;
+
+<div
+  attr="foo" // comment
+>
+  {foo}
+</div>;
+
+<div
+  attr="foo"
+  // comment
+>
+  {foo}
+</div>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <div
 // comment
+>
+  {foo}
+</div>;
+
+<div
+  // comment
+  attr="foo">
+  {foo}
+</div>;
+
+<div
+  attr="foo" // comment
+>
+  {foo}
+</div>;
+
+<div
+  attr="foo"
+  // comment
 >
   {foo}
 </div>;

--- a/tests/comments_jsx_same_line/jsx_same_line.js
+++ b/tests/comments_jsx_same_line/jsx_same_line.js
@@ -3,3 +3,23 @@
 >
   {foo}
 </div>;
+
+<div
+  // comment
+  attr="foo"
+>
+  {foo}
+</div>;
+
+<div
+  attr="foo" // comment
+>
+  {foo}
+</div>;
+
+<div
+  attr="foo"
+  // comment
+>
+  {foo}
+</div>;


### PR DESCRIPTION
Fix #3152 

**Input:**
```jsx
<div
  className="foo" // comment
>
  {children}
</div>;

<div
  className="foo"
  // comment
>
  {children}
</div>;
```

**Current in master:**
```jsx
<div className="foo"> // comment
  {children}
</div>;

<div className="foo">
// comment
  {children}
</div>;
```