### PR TITLE
fix(markdown): do not break before special prefix

### DIFF
--- a/src/printer-markdown.js
+++ b/src/printer-markdown.js
@@ -74,10 +74,20 @@ function genericPrint(path, options, print) {
         : node.value
             .replace(/(^|[^\\])\*/g, "$1\\*") // escape all unescaped `*` and `_`
             .replace(/\b(^|[^\\])_\b/g, "$1\\_"); // `1_2_3` is not considered emphasis
-    case "whitespace":
+    case "whitespace": {
+      const parentNode = path.getParentNode();
+      const index = parentNode.children.indexOf(node);
+      const nextNode = parentNode.children[index + 1];
+
+      // special prefix that may cause different meaning
+      if (nextNode && nextNode.value.match(/(>|-|\+|\*)$/)) {
+        return node.value === "" ? "" : " ";
+      }
+
       return getAncestorNode(path, SINGLE_LINE_NODE_TYPES)
         ? node.value === "" ? "" : " "
         : node.value === "" ? softline : line;
+    }
     case "emphasis": {
       const parentNode = path.getParentNode();
       const index = parentNode.children.indexOf(node);

--- a/src/printer-markdown.js
+++ b/src/printer-markdown.js
@@ -80,7 +80,7 @@ function genericPrint(path, options, print) {
       const nextNode = parentNode.children[index + 1];
 
       // special prefix that may cause different meaning
-      if (nextNode && nextNode.value.match(/(>|-|\+|\*)$/)) {
+      if (nextNode && nextNode.value.match(/^(#{1,6}|>+)|^(-|\+|\*)$/)) {
         return node.value === "" ? "" : " ";
       }
 

--- a/tests/markdown_paragraph/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_paragraph/__snapshots__/jsfmt.spec.js.snap
@@ -42,3 +42,51 @@ This is a long long long long long long long long long long long long long long
 long paragraph.
 
 `;
+
+exports[`special-prefix.md 1`] = `
+abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc - abc abc abc 
+
+## Supported Rules
+
+- [no-disabled-tests](/packages/eslint-plugin-jest/docs/rules/no-disabled-tests.md) - disallow disabled tests.
+- [no-focused-tests](/packages/eslint-plugin-jest/docs/rules/no-focused-tests.md) - disallow focused tests.
+- [no-identical-title](/packages/eslint-plugin-jest/docs/rules/no-identical-title.md) - disallow identical titles.
+- [valid-expect](/packages/eslint-plugin-jest/docs/rules/valid-expect.md) - ensure expect is called correctly.
+
+## Supported Rules
+
+* [no-disabled-tests](/packages/eslint-plugin-jest/docs/rules/no-disabled-tests.md)
+  - disallow disabled tests.
+* [no-focused-tests](/packages/eslint-plugin-jest/docs/rules/no-focused-tests.md)
+  - disallow focused tests.
+* [no-identical-title](/packages/eslint-plugin-jest/docs/rules/no-identical-title.md)
+  - disallow identical titles.
+* [valid-expect](/packages/eslint-plugin-jest/docs/rules/valid-expect.md) -
+  ensure expect is called correctly.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc
+abc - abc abc abc
+
+## Supported Rules
+
+* [no-disabled-tests](/packages/eslint-plugin-jest/docs/rules/no-disabled-tests.md) -
+  disallow disabled tests.
+* [no-focused-tests](/packages/eslint-plugin-jest/docs/rules/no-focused-tests.md) -
+  disallow focused tests.
+* [no-identical-title](/packages/eslint-plugin-jest/docs/rules/no-identical-title.md) -
+  disallow identical titles.
+* [valid-expect](/packages/eslint-plugin-jest/docs/rules/valid-expect.md) -
+  ensure expect is called correctly.
+
+## Supported Rules
+
+* [no-disabled-tests](/packages/eslint-plugin-jest/docs/rules/no-disabled-tests.md)
+  * disallow disabled tests.
+* [no-focused-tests](/packages/eslint-plugin-jest/docs/rules/no-focused-tests.md)
+  * disallow focused tests.
+* [no-identical-title](/packages/eslint-plugin-jest/docs/rules/no-identical-title.md)
+  * disallow identical titles.
+* [valid-expect](/packages/eslint-plugin-jest/docs/rules/valid-expect.md) -
+  ensure expect is called correctly.
+
+`;

--- a/tests/markdown_paragraph/special-prefix.md
+++ b/tests/markdown_paragraph/special-prefix.md
@@ -1,0 +1,19 @@
+abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc abc - abc abc abc 
+
+## Supported Rules
+
+- [no-disabled-tests](/packages/eslint-plugin-jest/docs/rules/no-disabled-tests.md) - disallow disabled tests.
+- [no-focused-tests](/packages/eslint-plugin-jest/docs/rules/no-focused-tests.md) - disallow focused tests.
+- [no-identical-title](/packages/eslint-plugin-jest/docs/rules/no-identical-title.md) - disallow identical titles.
+- [valid-expect](/packages/eslint-plugin-jest/docs/rules/valid-expect.md) - ensure expect is called correctly.
+
+## Supported Rules
+
+* [no-disabled-tests](/packages/eslint-plugin-jest/docs/rules/no-disabled-tests.md)
+  - disallow disabled tests.
+* [no-focused-tests](/packages/eslint-plugin-jest/docs/rules/no-focused-tests.md)
+  - disallow focused tests.
+* [no-identical-title](/packages/eslint-plugin-jest/docs/rules/no-identical-title.md)
+  - disallow identical titles.
+* [valid-expect](/packages/eslint-plugin-jest/docs/rules/valid-expect.md) -
+  ensure expect is called correctly.


### PR DESCRIPTION
Fixes #3168

The unstable is caused by the AST change, should be stable now.