### PR TITLE
Make files execution order predictive

### DIFF
--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -271,6 +271,8 @@ function eachFilename(argv, patterns, callback) {
       .sync(patterns, { dot: true })
       .map(filePath => path.relative(process.cwd(), filePath));
 
+    filePaths.sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
+
     if (filePaths.length === 0) {
       logger.error(`No matching files. Patterns tried: ${patterns.join(" ")}`);
       process.exitCode = 2;

--- a/tests_integration/__tests__/__snapshots__/ignore-relative-path.js.snap
+++ b/tests_integration/__tests__/__snapshots__/ignore-relative-path.js.snap
@@ -3,9 +3,9 @@
 exports[`support relative paths (stderr) 1`] = `""`;
 
 exports[`support relative paths (stdout) 1`] = `
-"shouldNotBeIgnored.js
-level1-glob/level2-glob/level3-glob/shouldNotBeIgnored.scss
+"level1-glob/level2-glob/level3-glob/shouldNotBeIgnored.scss
 level1-glob/shouldNotBeIgnored.js
+shouldNotBeIgnored.js
 "
 `;
 


### PR DESCRIPTION
Ever since I started contributing to prettier, the `tests_integration` tests fail for me because of file ordering when there's a uppercase filename (e.g. `cli/jest/__best-tests__` and `cli/jest/Component.js`). Also recently a snapshot were rewrited for the same reason (see: https://github.com/prettier/prettier/pull/3187#issuecomment-342487311 and #3189).

Since this effectively affects the CLI (not drastically I hope), we could simply rename the test files, but that's really a temporary fix. Otherwise, I'm not sure how else to prevent this issue.