### PR TITLE
chore(playground): add ruler for inputEditor

### DIFF
--- a/website/static/playground.js
+++ b/website/static/playground.js
@@ -291,6 +291,10 @@ function setEditorStyles() {
   outputEditor.setOption("mode", mode);
   output2Editor.setOption("mode", mode);
 
+  inputEditor.setOption("rulers", [
+    { column: options.printWidth, color: "#eeeeee" }
+  ]);
+
   [outputEditor, output2Editor].forEach(function(editor) {
     editor.setOption("rulers", [
       { column: options.printWidth, color: "#444444" }


### PR DESCRIPTION
Sometimes I'd like to check if the input hit the print width and where are they, but I could only copy-paste it in my editor to see them. Adding a light-gray ruler should be fine I guess.

![image](https://user-images.githubusercontent.com/8341033/32596769-6ca86af8-c56f-11e7-8a95-d2922237ad29.png)
