### PR TITLE
fix(markdown): force print spaces

### DIFF
--- a/src/doc-printer.js
+++ b/src/doc-printer.js
@@ -41,7 +41,7 @@ function makeAlign(ind, n) {
     indent: ind.indent,
     align: {
       spaces: ind.align.spaces + (typeof n === "number" ? " ".repeat(n) : n),
-      tabs: ind.align.tabs + (n ? "\t" : "")
+      tabs: ind.align.tabs + (typeof n === "number" ? (n ? "\t" : "") : n)
     }
   };
 }

--- a/src/printer-markdown.js
+++ b/src/printer-markdown.js
@@ -185,9 +185,10 @@ function genericPrint(path, options, print) {
         )
       ) {
         // indented code block
+        const alignment = " ".repeat(4);
         return align(
-          4,
-          concat([" ".repeat(4), join(hardline, node.value.split("\n"))])
+          alignment,
+          concat([alignment, join(hardline, node.value.split("\n"))])
         );
       }
 
@@ -238,7 +239,10 @@ function genericPrint(path, options, print) {
                 : isGitDiffFriendlyOrderedList ? 1 : node.start + index) +
               (nthSiblingIndex % 2 === 0 ? ". " : ") ")
             : nthSiblingIndex % 2 === 0 ? "* " : "- ";
-          return concat([prefix, align(prefix.length, childPath.call(print))]);
+          return concat([
+            prefix,
+            align(" ".repeat(prefix.length), childPath.call(print))
+          ]);
         }
       });
     }
@@ -247,7 +251,7 @@ function genericPrint(path, options, print) {
         node.checked === null ? "" : node.checked ? "[x] " : "[ ] ";
       return concat([
         prefix,
-        align(prefix.length, printChildren(path, options, print))
+        align(" ".repeat(prefix.length), printChildren(path, options, print))
       ]);
     }
     case "thematicBreak": {

--- a/tests/markdown_indentation/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_indentation/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`example.md 1`] = `
+- Top level list item 1 
+- Top level list item 2
+  - Nested List item 1
+  - Nested List item 2
+    - Sub-Nested List item 1
+    - Sub-Nested List item 2
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Top level list item 1
+* Top level list item 2
+  * Nested List item 1
+  * Nested List item 2
+    * Sub-Nested List item 1
+    * Sub-Nested List item 2
+
+`;

--- a/tests/markdown_indentation/example.md
+++ b/tests/markdown_indentation/example.md
@@ -1,0 +1,6 @@
+- Top level list item 1 
+- Top level list item 2
+  - Nested List item 1
+  - Nested List item 2
+    - Sub-Nested List item 1
+    - Sub-Nested List item 2

--- a/tests/markdown_indentation/jsfmt.spec.js
+++ b/tests/markdown_indentation/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, { parser: "markdown", useTabs: true });


### PR DESCRIPTION
Fixes partial #3223 and also fixes a little bug that I forgot to handle the string type `n` in `align.tabs`.

