### PR TITLE
fix(markdown): no extra whitespace between non-cjk and cjk-punctuation

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -6,7 +6,10 @@ const escapeStringRegexp = require("escape-string-regexp");
 
 const getCjkRegex = require("cjk-regex");
 const cjkRegex = getCjkRegex();
-const cjkPunctuationRegex = getCjkRegex.punctuations();
+
+// the `g` flag is dangerous in RegExp#test()
+// https://stackoverflow.com/a/21373261
+const cjkPunctuationRegex = new RegExp(getCjkRegex.punctuations(), "");
 
 function isExportDeclaration(node) {
   if (node) {

--- a/src/util.js
+++ b/src/util.js
@@ -9,7 +9,7 @@ const cjkRegex = getCjkRegex();
 
 // the `g` flag is dangerous in RegExp#test()
 // https://stackoverflow.com/a/21373261
-const cjkPunctuationRegex = new RegExp(getCjkRegex.punctuations(), "");
+const cjkPunctuationRegex = new RegExp(getCjkRegex.punctuations().source, "");
 
 function isExportDeclaration(node) {
   if (node) {

--- a/tests/markdown_paragraph/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_paragraph/__snapshots__/jsfmt.spec.js.snap
@@ -6,6 +6,8 @@ exports[`cjk.md 1`] = `
 這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！
 
 全　　形　空白全　　形　空白全　　形　空白全　　形　空白全　　形　空白全　　形　空白全　　形　空白全　　形　空白
+
+扩展运算符（spread）是三个点（\`...\`）。
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 這是一段很長很長很長很長很長很長很長很長很長很長很長很長很長很長很長很長很長很長
 很長的段落
@@ -24,6 +26,8 @@ English 混合著中文的一段 Paragraph！
 全　　形　空白全　　形　空白全　　形　空白全　　形　空白全　　形　空白
 全　　形　空白全　　形　空白全　　形　空白
 
+扩展运算符（spread）是三个点（\`...\`）。
+
 `;
 
 exports[`cjk.md 2`] = `
@@ -32,12 +36,16 @@ exports[`cjk.md 2`] = `
 這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！
 
 全　　形　空白全　　形　空白全　　形　空白全　　形　空白全　　形　空白全　　形　空白全　　形　空白全　　形　空白
+
+扩展运算符（spread）是三个点（\`...\`）。
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 這是一段很長很長很長很長很長很長很長很長很長很長很長很長很長很長很長很長很長很長很長的段落
 
 這是一個 English 混合著中文的一段 Paragraph！這是一個 English 混合著中文的一段 Paragraph！這是一個 English 混合著中文的一段 Paragraph！這是一個 English 混合著中文的一段 Paragraph！這是一個 English 混合著中文的一段 Paragraph！這是一個 English 混合著中文的一段 Paragraph！這是一個 English 混合著中文的一段 Paragraph！這是一個 English 混合著中文的一段 Paragraph！這是一個 English 混合著中文的一段 Paragraph！這是一個 English 混合著中文的一段 Paragraph！這是一個 English 混合著中文的一段 Paragraph！這是一個 English 混合著中文的一段 Paragraph！這是一個 English 混合著中文的一段 Paragraph！這是一個 English 混合著中文的一段 Paragraph！這是一個 English 混合著中文的一段 Paragraph！這是一個 English 混合著中文的一段 Paragraph！
 
 全　　形　空白全　　形　空白全　　形　空白全　　形　空白全　　形　空白全　　形　空白全　　形　空白全　　形　空白
+
+扩展运算符（spread）是三个点（\`...\`）。
 
 `;
 

--- a/tests/markdown_paragraph/cjk.md
+++ b/tests/markdown_paragraph/cjk.md
@@ -3,3 +3,5 @@
 這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！這是一個English混合著中文的一段Paragraph！
 
 全　　形　空白全　　形　空白全　　形　空白全　　形　空白全　　形　空白全　　形　空白全　　形　空白全　　形　空白
+
+扩展运算符（spread）是三个点（`...`）。


### PR DESCRIPTION
Fixes #3241

The root cause here is the regex mismatching, I thought `RegExp#lastIndex` only affected `RegExp#exec()`. 😭