### PR TITLE
Skip assertDoc calls in production

### DIFF
--- a/scripts/build/rollup.index.config.js
+++ b/scripts/build/rollup.index.config.js
@@ -16,7 +16,8 @@ export default Object.assign(baseConfig, {
       // with rollup the module is turned into a plain function located directly
       // in index.js so `module.parent` does not exist. Defaulting to `module`
       // instead seems to work.
-      "module.parent": "(module.parent || module)"
+      "module.parent": "(module.parent || module)",
+      "process.env.NODE_ENV": JSON.stringify("production")
     }),
     json(),
     resolve({ preferBuiltins: true }),

--- a/src/doc-builders.js
+++ b/src/doc-builders.js
@@ -2,22 +2,19 @@
 
 function assertDoc(val) {
   /* istanbul ignore if */
-  if (process.env.NODE_ENV !== "production") {
-    if (
-      !(
-        typeof val === "string" ||
-        (val != null && typeof val.type === "string")
-      )
-    ) {
-      throw new Error(
-        "Value " + JSON.stringify(val) + " is not a valid document"
-      );
-    }
+  if (
+    !(typeof val === "string" || (val != null && typeof val.type === "string"))
+  ) {
+    throw new Error(
+      "Value " + JSON.stringify(val) + " is not a valid document"
+    );
   }
 }
 
 function concat(parts) {
-  parts.forEach(assertDoc);
+  if (process.env.NODE_ENV !== "production") {
+    parts.forEach(assertDoc);
+  }
 
   // We cannot do this until we change `printJSXElement` to not
   // access the internals of a document directly.
@@ -29,13 +26,17 @@ function concat(parts) {
 }
 
 function indent(contents) {
-  assertDoc(contents);
+  if (process.env.NODE_ENV !== "production") {
+    assertDoc(contents);
+  }
 
   return { type: "indent", contents };
 }
 
 function align(n, contents) {
-  assertDoc(contents);
+  if (process.env.NODE_ENV !== "production") {
+    assertDoc(contents);
+  }
 
   return { type: "align", contents, n };
 }
@@ -43,7 +44,9 @@ function align(n, contents) {
 function group(contents, opts) {
   opts = opts || {};
 
-  assertDoc(contents);
+  if (process.env.NODE_ENV !== "production") {
+    assertDoc(contents);
+  }
 
   return {
     type: "group",
@@ -61,24 +64,30 @@ function conditionalGroup(states, opts) {
 }
 
 function fill(parts) {
-  parts.forEach(assertDoc);
+  if (process.env.NODE_ENV !== "production") {
+    parts.forEach(assertDoc);
+  }
 
   return { type: "fill", parts };
 }
 
 function ifBreak(breakContents, flatContents) {
-  if (breakContents) {
-    assertDoc(breakContents);
-  }
-  if (flatContents) {
-    assertDoc(flatContents);
+  if (process.env.NODE_ENV !== "production") {
+    if (breakContents) {
+      assertDoc(breakContents);
+    }
+    if (flatContents) {
+      assertDoc(flatContents);
+    }
   }
 
   return { type: "if-break", breakContents, flatContents };
 }
 
 function lineSuffix(contents) {
-  assertDoc(contents);
+  if (process.env.NODE_ENV !== "production") {
+    assertDoc(contents);
+  }
   return { type: "line-suffix", contents };
 }
 

--- a/src/doc-builders.js
+++ b/src/doc-builders.js
@@ -2,7 +2,7 @@
 
 function assertDoc(val) {
   /* istanbul ignore if */
-  if (process.env.NODE_ENV === "production") {
+  if (process.env.NODE_ENV !== "production") {
     if (
       !(
         typeof val === "string" ||

--- a/src/doc-builders.js
+++ b/src/doc-builders.js
@@ -2,12 +2,17 @@
 
 function assertDoc(val) {
   /* istanbul ignore if */
-  if (
-    !(typeof val === "string" || (val != null && typeof val.type === "string"))
-  ) {
-    throw new Error(
-      "Value " + JSON.stringify(val) + " is not a valid document"
-    );
+  if (process.env.NODE_ENV === "production") {
+    if (
+      !(
+        typeof val === "string" ||
+        (val != null && typeof val.type === "string")
+      )
+    ) {
+      throw new Error(
+        "Value " + JSON.stringify(val) + " is not a valid document"
+      );
+    }
   }
 }
 
@@ -55,10 +60,8 @@ function conditionalGroup(states, opts) {
   );
 }
 
-function fill(parts, skipAssertDoc) {
-  if (!skipAssertDoc) {
-    parts.forEach(assertDoc);
-  }
+function fill(parts) {
+  parts.forEach(assertDoc);
 
   return { type: "fill", parts };
 }

--- a/src/doc-builders.js
+++ b/src/doc-builders.js
@@ -55,8 +55,10 @@ function conditionalGroup(states, opts) {
   );
 }
 
-function fill(parts) {
-  parts.forEach(assertDoc);
+function fill(parts, skipAssertDoc) {
+  if (!skipAssertDoc) {
+    parts.forEach(assertDoc);
+  }
 
   return { type: "fill", parts };
 }

--- a/src/doc-printer.js
+++ b/src/doc-printer.js
@@ -298,11 +298,7 @@ function printDocToString(doc, options) {
           }
 
           const remaining = parts.slice(2);
-          const remainingCmd = [
-            ind,
-            mode,
-            fill(remaining, /* skipAssertDoc */ true)
-          ];
+          const remainingCmd = [ind, mode, fill(remaining)];
 
           const secondContent = parts[2];
           const firstAndSecondContentFlatCmd = [

--- a/src/doc-printer.js
+++ b/src/doc-printer.js
@@ -298,7 +298,11 @@ function printDocToString(doc, options) {
           }
 
           const remaining = parts.slice(2);
-          const remainingCmd = [ind, mode, fill(remaining)];
+          const remainingCmd = [
+            ind,
+            mode,
+            fill(remaining, /* skipAssertDoc */ true)
+          ];
 
           const secondContent = parts[2];
           const firstAndSecondContentFlatCmd = [


### PR DESCRIPTION
Context: https://github.com/prettier/prettier/issues/3263#issuecomment-344275152

When `printDocToString` calls `fill`, it's not necessary to call `assertDoc` for all of the remaining elements since they already checked when the doc was originally created (somewhere in `printAstToDoc`).