### PR TITLE
Mutate the doc.parts array when printing fill

### DIFF
--- a/src/doc-printer.js
+++ b/src/doc-printer.js
@@ -297,10 +297,15 @@ function printDocToString(doc, options) {
             break;
           }
 
-          const secondContent = parts[2];
-
+          // At this point we've handled the first pair (context, separator)
+          // and will create a new fill doc for the rest of the content.
+          // Ideally we wouldn't mutate the array here but coping all the
+          // elements to a new array would make this algorithm quadratic,
+          // which is unusable for large arrays (e.g. large texts in JSX).
           parts.splice(0, 2);
           const remainingCmd = [ind, mode, fill(parts)];
+
+          const secondContent = parts[0];
 
           const firstAndSecondContentFlatCmd = [
             ind,

--- a/src/doc-printer.js
+++ b/src/doc-printer.js
@@ -297,10 +297,11 @@ function printDocToString(doc, options) {
             break;
           }
 
-          const remaining = parts.slice(2);
-          const remainingCmd = [ind, mode, fill(remaining)];
-
           const secondContent = parts[2];
+
+          parts.splice(0, 2);
+          const remainingCmd = [ind, mode, fill(parts)];
+
           const firstAndSecondContentFlatCmd = [
             ind,
             MODE_FLAT,


### PR DESCRIPTION
Context: https://github.com/prettier/prettier/issues/3263#issuecomment-344275152

Slicing the array means copying the array's content for every pair, which makes the algorithm quadratic. This PR changes the copying to mutating the array directly to prevent that. It's a more dangerous approach but the way `fill` works it's a valid solution.

I'm not 100% comfortable with that and I'll take suggestions.