### PR TITLE
[flow] Do not break on empty type parameters

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3517,13 +3517,14 @@ function printTypeParameters(path, options, print, paramsKey) {
   }
 
   const shouldInline =
-    n[paramsKey].length === 1 &&
-    (shouldHugType(n[paramsKey][0]) ||
-      (n[paramsKey][0].type === "GenericTypeAnnotation" &&
-        shouldHugType(n[paramsKey][0].id)) ||
-      (n[paramsKey][0].type === "TSTypeReference" &&
-        shouldHugType(n[paramsKey][0].typeName)) ||
-      n[paramsKey][0].type === "NullableTypeAnnotation");
+    n[paramsKey].length === 0 ||
+    (n[paramsKey].length === 1 &&
+      (shouldHugType(n[paramsKey][0]) ||
+        (n[paramsKey][0].type === "GenericTypeAnnotation" &&
+          shouldHugType(n[paramsKey][0].id)) ||
+        (n[paramsKey][0].type === "TSTypeReference" &&
+          shouldHugType(n[paramsKey][0].typeName)) ||
+        n[paramsKey][0].type === "NullableTypeAnnotation"));
 
   if (shouldInline) {
     return concat(["<", join(", ", path.map(print, paramsKey)), ">"]);

--- a/tests/flow_type_parameters/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_type_parameters/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`empty_generic_break.js 1`] = `
+class X {
+	a: B<> = SuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class X {
+  a: B<> = SuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong;
+}
+
+`;

--- a/tests/flow_type_parameters/empty_generic_break.js
+++ b/tests/flow_type_parameters/empty_generic_break.js
@@ -1,0 +1,3 @@
+class X {
+	a: B<> = SuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong;
+}

--- a/tests/flow_type_parameters/jsfmt.spec.js
+++ b/tests/flow_type_parameters/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, null, ["babylon"]);


### PR DESCRIPTION
Not only does breaking look bad but when you have trailing comma enabled, it puts a comma there which is not valid.