### PR TITLE
Fix infinite recursion in the playground

### DIFF
--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -94,8 +94,7 @@ function formatCode(text, options) {
   } catch (e) {
     // Multiparser may throw if we haven't loaded the right parser
     // Load it lazily and retry!
-    if (e.parser && !parsersLoaded[e.parser]) {
-      lazyLoadParser(e.parser);
+    if (e.parser && !lazyLoadParser(e.parser)) {
       return formatCode(text, options);
     }
     return String(e);
@@ -111,8 +110,11 @@ function lazyLoadParser(parser) {
         : parser;
   var script = "parser-" + actualParser + ".js";
 
-  if (!parsersLoaded[actualParser]) {
-    importScripts("lib/" + script);
-    parsersLoaded[actualParser] = true;
+  if (parsersLoaded[actualParser]) {
+    return true;
   }
+
+  importScripts("lib/" + script);
+  parsersLoaded[actualParser] = true;
+  return false;
 }


### PR DESCRIPTION
Fixes #3300

If there's an exception when formatting the code in playground, we check if it's because the parser was not yet loaded. This check was wrong for json and css|less|scss causing the code to recursive infinitely.