### PR TITLE
Don't add trailing comma in object rest spread

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -1016,6 +1016,7 @@ function genericPrintNoParens(path, options, print, args) {
         lastElem &&
         (lastElem.type === "RestProperty" ||
           lastElem.type === "RestElement" ||
+          lastElem.type === "ExperimentalRestProperty" ||
           hasNodeIgnoreComment(lastElem))
       );
 

--- a/tests/typescript_trailing_comma/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_trailing_comma/__snapshots__/jsfmt.spec.js.snap
@@ -10,6 +10,13 @@ enum Enum {
 	x = 1,
 	y = 2,
 }
+
+const {
+  longKeySoThisWillGoOnMultipleLines,
+  longKeySoThisWillGoOnMultipleLines2,
+  longKeySoThisWillGoOnMultipleLines3,
+  ...rest,
+} = something;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 export class BaseSingleLevelProfileTargeting<
   T extends ValidSingleLevelProfileNode
@@ -19,5 +26,12 @@ enum Enum {
   x = 1,
   y = 2,
 }
+
+const {
+  longKeySoThisWillGoOnMultipleLines,
+  longKeySoThisWillGoOnMultipleLines2,
+  longKeySoThisWillGoOnMultipleLines3,
+  ...rest
+} = something;
 
 `;

--- a/tests/typescript_trailing_comma/trailing.ts
+++ b/tests/typescript_trailing_comma/trailing.ts
@@ -7,3 +7,10 @@ enum Enum {
 	x = 1,
 	y = 2,
 }
+
+const {
+  longKeySoThisWillGoOnMultipleLines,
+  longKeySoThisWillGoOnMultipleLines2,
+  longKeySoThisWillGoOnMultipleLines3,
+  ...rest,
+} = something;


### PR DESCRIPTION
For some reason the rest property in objects in typescript is a `ExperimentalRestProperty` node in the AST and we were not checking for it when printing trailing commas in object expressions.

Fixes #3311 