### PR TITLE
Add note about proseWrap option under printWidth for clarity

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -19,6 +19,8 @@ Specify the line length that the printer will wrap on.
 | ------- | --------------------- | ------------------- |
 | `80`    | `--print-width <int>` | `printWidth: <int>` |
 
+(If you don't want line wrapping when formatting Markdown, you can set the [Prose Wrap](#prose-wrap) option to disable it.)
+
 ## Tab Width
 
 Specify the number of spaces per indentation-level.


### PR DESCRIPTION
A user in gitter was wondering how to disable prose wrapping in markdown, but hadn't noticed the option; he was thinking he'd need to set `printWidth` somehow to change this. I added a small note for clarity, since `proseWrap` is at the bottom of the page where some people don't notice it.