### PR TITLE
docs(index): fix links on GitHub

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,4 @@ If you want to learn more, these two conference talks are great introductions:
 
 #### Footnotes
 
-\* _Well actually, some original styling is preserved when practical—see [empty lines] and [multi-line objects]._
-
-[empty lines]: rationale.html#empty-lines
-[multi-line objects]: rationale.html#multi-line-objects
+\* _Well actually, some original styling is preserved when practical—see [empty lines](rationale.md#empty-lines) and [multi-line objects](rationale.md#multi-line-objects)._


### PR DESCRIPTION
Inline links with `*.md` to [get them converted by Docusaurus](https://docusaurus.io/docs/en/doc-markdown.html#linking-other-documents) so as to display properly on both website and GitHub.