### PR TITLE
Fixed website footer on mobile (#3335)

### DIFF
--- a/website/static/overrides.css
+++ b/website/static/overrides.css
@@ -1,3 +1,22 @@
 .post a {
   text-decoration: underline !important;
 }
+
+@media screen and (max-width: 735px) {
+  footer .sitemap {
+    display: block;
+    margin-left: 20px;
+  }
+
+  footer .sitemap .nav-home {
+    margin: 0 auto;
+  }
+
+  footer .sitemap > div {
+    margin-bottom: 20px;
+  }
+
+  footer .sitemap > div h5 {
+    margin: 0;
+  }
+}


### PR DESCRIPTION
The footer was not showing on mobile devices. This was because docusaurus was hiding it. I used `static/overrides.css` to override docusaurus and give the footer some mobile styling. 

I used the exact same size (735) max-width media query that docusaurus uses, that is where that width came from.

![screen shot 2017-12-01 at 15 20 29](https://user-images.githubusercontent.com/1278846/33501714-9433d948-d6ab-11e7-9992-5c30f46dad71.png)
