### PR TITLE
Add support for flow mixins when using babylon

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -3630,6 +3630,14 @@ function printClass(path, options, print) {
     );
   }
 
+  if (n["mixins"] && n["mixins"].length > 0) {
+    partsGroup.push(
+      line,
+      "mixins ",
+      group(indent(join(concat([",", line]), path.map(print, "mixins"))))
+    );
+  }
+
   if (partsGroup.length > 0) {
     parts.push(group(indent(concat(partsGroup))));
   }

--- a/tests/flow_mixins/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_mixins/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`type.js 1`] = `
+declare class A<T> extends B<T> mixins C<T> {}
+declare class D<T> mixins C<T> {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+declare class A<T> extends B<T> mixins C<T> {}
+declare class D<T> mixins C<T> {}
+
+`;

--- a/tests/flow_mixins/jsfmt.spec.js
+++ b/tests/flow_mixins/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["babylon"]);

--- a/tests/flow_mixins/type.js
+++ b/tests/flow_mixins/type.js
@@ -1,0 +1,2 @@
+declare class A<T> extends B<T> mixins C<T> {}
+declare class D<T> mixins C<T> {}


### PR DESCRIPTION
Partially fixes #3390.

Only works with babylon, since flow's parser [doesn't seem to put the mixin into the AST](https://astexplorer.net/#/gist/7e956da8da57d5eafdde0e04de9b95a1/5b6fb6f97bbd1e61134d323f2e8b320a51206e9e) (???).