### PR TITLE
Wrap object values on a newline in parens (refs: #3108)

### DIFF
--- a/tests/object-prop-break-in/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/object-prop-break-in/__snapshots__/jsfmt.spec.js.snap
@@ -23,8 +23,9 @@ const x = {
 };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const x = {
-  ABC:
+  ABC: (
     "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
+  )
 };
 
 `;
@@ -63,8 +64,9 @@ const a = classnames({
 });
 
 const b = classnames({
-  "some-prop":
+  "some-prop": (
     this.state.longLongLongLongLongLongLongLongLongTooLongProp === true
+  )
 });
 
 const c = classnames({
@@ -84,8 +86,9 @@ const f = classnames({
 });
 
 const g = classnames({
-  "some-prop":
+  "some-prop": (
     longLongLongLongLongLongLongLongLongLongLongLongLongTooLongVar || 1337
+  )
 });
 
 `;

--- a/tests/objects/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/objects/__snapshots__/jsfmt.spec.js.snap
@@ -104,18 +104,20 @@ const blablah =
   "dflkadfkladsfklkadlfkladlfkadklfjadlfdfdaf";
 
 const k = {
-  blablah:
+  blablah: (
     "aldkfkladfskladklsfkladklfkaldfadfkdaf" +
     "adlfasdklfkldsklfakldsfkladsfkadsfladsfa" +
     "dflkadfkladsfklkadlfkladlfkadklfjadlfdfdaf"
+  )
 };
 
 somethingThatsAReallyLongPropName =
   this.props.cardType === AwesomizerCardEnum.SEEFIRST;
 
 const o = {
-  somethingThatsAReallyLongPropName:
+  somethingThatsAReallyLongPropName: (
     this.props.cardType === AwesomizerCardEnum.SEEFIRST
+  )
 };
 
 `;


### PR DESCRIPTION
Hi there 👋🏽
This change addresses https://github.com/prettier/prettier/issues/3108. Object values that contain a break will be wrapped in parentheses.

i.e. This is how long values were printed originally:
```javascript
const g = classnames({
  "some-prop":
     longLongLongLongLongLongLongLongLongLongLongLongLongTooLongVar || 1337
});

const x = {
  ABC:
    "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
};

const k = {
  blablah:
     "aldkfkladfskladklsfkladklfkaldfadfkdaf" +
     "adlfasdklfkldsklfakldsfkladsfkadsfladsfa" +
     "dflkadfkladsfklkadlfkladlfkadklfjadlfdfdaf"
};
```
This is how they are printed with this change: 
```javascript 
const g = classnames({
  "some-prop": (
     longLongLongLongLongLongLongLongLongLongLongLongLongTooLongVar || 1337
  )
});

const x = {
  ABC: ( 
    "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
  )
};

const k = {
  blablah: (
     "aldkfkladfskladklsfkladklfkaldfadfkdaf" +
     "adlfasdklfkldsklfakldsfkladsfkadsfladsfa" +
     "dflkadfkladsfklkadlfkladlfkadklfjadlfdfdaf"
  )
}
```
cc. @ljharb, @vjeux