### PR TITLE
Change cursor and remove outline in summaries on playground

### DIFF
--- a/website/pages/playground/index.html
+++ b/website/pages/playground/index.html
@@ -230,6 +230,11 @@
       font-size: 14px;
       font-weight: bold;
       padding-bottom: 5px;
+      cursor: pointer;
+    }
+
+    .sub-options > summary:focus {
+      outline: 0;
     }
 
     .sub-options > * {


### PR DESCRIPTION
The focus outline doesn't makes much sense there