### PR TITLE
Update instructions for File Watcher in WebStorm

### DIFF
--- a/docs/webstorm.md
+++ b/docs/webstorm.md
@@ -42,7 +42,7 @@ Go to _File | Settings | Tools | File Watchers_ for Windows and Linux or _WebSto
 
 * **File Type**: JavaScript
 * **Scope**: Current File
-* **Program** set the full path to a `prettier` executable, such as `/Users/developer/repo/jest/node_modules/.bin/prettier` (on OS X and Linux) or `C:/\Users\developer\repo\jest\node_modules\.bin\prettier.cmd` (on Windows).
+* **Program** set `prettier` (if you have `prettier` installed locally, see ["Configure External Tool"](#configure-external-tool) above)
 * **Arguments** set `--write [other opts] $FilePath$`
 * **Working directory** set `$ProjectFileDir$`
 * **Immediate file synchronization**: Uncheck to reformat on Save only (otherwise code will jump around while you type).


### PR DESCRIPTION
Re-use the instructions for setting the File Watcher program path in WebStorm when prettier is installed locally.