### PR TITLE
Ignore whitespace in docblock right after /**

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function formatWithCursor(text, opts, addAlignmentSize) {
     const pragmas = Object.assign({ format: "" }, parsedDocblock.pragmas);
     const newDocblock = docblock.print({
       pragmas,
-      comments: parsedDocblock.comments.replace(/^(\r?\n)+/, "") // remove leading newlines
+      comments: parsedDocblock.comments.replace(/^(\s+?\r?\n)+/, "") // remove leading newlines
     });
     const strippedText = docblock.strip(text);
     const separatingNewlines = strippedText.startsWith("\n") ? "\n" : "\n\n";

--- a/tests/insert-pragma/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/insert-pragma/__snapshots__/jsfmt.spec.js.snap
@@ -85,3 +85,24 @@ function foo(bar) {
 }
 
 `;
+
+exports[`trailing-spaces-first-line.js 1`] = `
+/**	
+ * Copyright (c) 2015-present, Facebook, Inc.	
+ * All rights reserved.	
+ *	
+ * This source code is licensed under the license found in the LICENSE file in	
+ * the root directory of this source tree.	
+ */	
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the license found in the LICENSE file in
+ * the root directory of this source tree.
+ *
+ * @format
+ */
+
+`;

--- a/tests/insert-pragma/trailing-spaces-first-line.js
+++ b/tests/insert-pragma/trailing-spaces-first-line.js
@@ -1,0 +1,7 @@
+/**	
+ * Copyright (c) 2015-present, Facebook, Inc.	
+ * All rights reserved.	
+ *	
+ * This source code is licensed under the license found in the LICENSE file in	
+ * the root directory of this source tree.	
+ */	


### PR DESCRIPTION
A whitespace right after `/**` is parsed as the docblock comment. Initially I thought we should report this to jest, but I'm not sure this is a bug in jest and since we already strip leading new lines it seemed better we handle this case here.

Fixes #3426

(cc @SimenB, @vjeux)