### PR TITLE
Treat absent .editorconfig correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "dashify": "0.2.2",
     "diff": "3.2.0",
     "editorconfig": "0.14.2",
-    "editorconfig-to-prettier": "0.0.5",
+    "editorconfig-to-prettier": "0.0.6",
     "emoji-regex": "6.5.1",
     "escape-string-regexp": "1.0.5",
     "esutils": "2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1395,9 +1395,9 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-editorconfig-to-prettier@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/editorconfig-to-prettier/-/editorconfig-to-prettier-0.0.5.tgz#65699136079784b7d088191b2cae2aed4a36cd3b"
+editorconfig-to-prettier@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/editorconfig-to-prettier/-/editorconfig-to-prettier-0.0.6.tgz#d79bc1a2574e0a94315dd43da3275f92f9331b27"
 
 editorconfig@0.14.2:
   version "0.14.2"


### PR DESCRIPTION
This fixes https://github.com/prettier/prettier/issues/3432, I think. See https://github.com/josephfrazier/editorconfig-to-prettier/commit/29aa34459dfec238ce179f1eb5a4fdcefb9c4961