### PR TITLE
Fix babylon misplacing comments in class method args

### DIFF
--- a/src/comments.js
+++ b/src/comments.js
@@ -207,7 +207,6 @@ function attach(comments, ast, text, options) {
           comment
         ) ||
         handleImportSpecifierComments(enclosingNode, comment) ||
-        handleObjectPropertyComments(enclosingNode, comment) ||
         handleForComments(enclosingNode, precedingNode, comment) ||
         handleUnionTypeComments(
           precedingNode,
@@ -749,14 +748,6 @@ function handleLastFunctionArgComments(
 
 function handleImportSpecifierComments(enclosingNode, comment) {
   if (enclosingNode && enclosingNode.type === "ImportSpecifier") {
-    addLeadingComment(enclosingNode, comment);
-    return true;
-  }
-  return false;
-}
-
-function handleObjectPropertyComments(enclosingNode, comment) {
-  if (enclosingNode && enclosingNode.type === "ObjectProperty") {
     addLeadingComment(enclosingNode, comment);
     return true;
   }

--- a/src/comments.js
+++ b/src/comments.js
@@ -273,7 +273,6 @@ function attach(comments, ast, text, options) {
         handlePropertyComments(enclosingNode, comment) ||
         handleExportNamedDeclarationComments(enclosingNode, comment) ||
         handleOnlyComments(enclosingNode, ast, comment, isLastComment) ||
-        handleClassMethodComments(enclosingNode, comment) ||
         handleTypeAliasComments(enclosingNode, followingNode, comment) ||
         handleVariableDeclaratorComments(enclosingNode, followingNode, comment)
       ) {
@@ -882,14 +881,6 @@ function handleImportDeclarationComments(
 function handleAssignmentPatternComments(enclosingNode, comment) {
   if (enclosingNode && enclosingNode.type === "AssignmentPattern") {
     addLeadingComment(enclosingNode, comment);
-    return true;
-  }
-  return false;
-}
-
-function handleClassMethodComments(enclosingNode, comment) {
-  if (enclosingNode && enclosingNode.type === "ClassMethod") {
-    addTrailingComment(enclosingNode, comment);
     return true;
   }
   return false;

--- a/tests/class_comment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/class_comment/__snapshots__/jsfmt.spec.js.snap
@@ -41,6 +41,14 @@ class X {
     '<div class="ag-large-textarea"></div>' +
     '</div>';
 }
+
+export class SnapshotLogger {
+  constructor(
+    retentionPeriod: number = 5 * 60 * 1000, // retain past five minutes
+    snapshotInterval: number = 30 * 1000, // snapshot no more than every 30s
+  ) {
+  }
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class A // comment 1
 // comment 2
@@ -85,6 +93,13 @@ class X {
     '<div class="ag-large-text" tabindex="0">' +
       '<div class="ag-large-textarea"></div>' +
       "</div>";
+}
+
+export class SnapshotLogger {
+  constructor(
+    retentionPeriod: number = 5 * 60 * 1000, // retain past five minutes
+    snapshotInterval: number = 30 * 1000 // snapshot no more than every 30s
+  ) {}
 }
 
 `;

--- a/tests/class_comment/comments.js
+++ b/tests/class_comment/comments.js
@@ -38,3 +38,11 @@ class X {
     '<div class="ag-large-textarea"></div>' +
     '</div>';
 }
+
+export class SnapshotLogger {
+  constructor(
+    retentionPeriod: number = 5 * 60 * 1000, // retain past five minutes
+    snapshotInterval: number = 30 * 1000, // snapshot no more than every 30s
+  ) {
+  }
+}

--- a/tests/object_property_comment/jsfmt.spec.js
+++ b/tests/object_property_comment/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, ["flow"]);
+run_spec(__dirname, ["flow", "babylon"]);


### PR DESCRIPTION
Fixes #3429

Looks like that was introduced back in the day to fix issues but they don't seem necessary anymore.

- class method comments: #1074
- obj property comments: #958