### PR TITLE
Consider TSNonNullExpression part of member chain

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -403,7 +403,8 @@ function genericPrintNoParens(path, options, print, args) {
         i++;
       } while (
         firstNonMemberParent &&
-        firstNonMemberParent.type === "MemberExpression"
+        (firstNonMemberParent.type === "MemberExpression" ||
+          firstNonMemberParent.type === "TSNonNullExpression")
       );
 
       const shouldInline =

--- a/tests/typescript_non_null/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_non_null/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`member-chain.js 1`] = `
+const { somePropThatHasAReallyLongName, anotherPropThatHasALongName } = this.props.imReallySureAboutThis!;
+
+const { somePropThatHasAReallyLongName, anotherPropThatHasALongName } = this.props.imReallySureAboutThis!.anotherObject;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const {
+  somePropThatHasAReallyLongName,
+  anotherPropThatHasALongName
+} = this.props.imReallySureAboutThis!;
+
+const {
+  somePropThatHasAReallyLongName,
+  anotherPropThatHasALongName
+} = this.props.imReallySureAboutThis!.anotherObject;
+
+`;
+
 exports[`parens.ts 1`] = `
 (a ? b : c) ![tokenKey];
 (a || b) ![tokenKey];

--- a/tests/typescript_non_null/member-chain.js
+++ b/tests/typescript_non_null/member-chain.js
@@ -1,0 +1,3 @@
+const { somePropThatHasAReallyLongName, anotherPropThatHasALongName } = this.props.imReallySureAboutThis!;
+
+const { somePropThatHasAReallyLongName, anotherPropThatHasALongName } = this.props.imReallySureAboutThis!.anotherObject;


### PR DESCRIPTION
Fixes #3312

When checking if we should inline a member chain, don't consider a `TSNonNullExpression` as a "non member" parent.