### PR TITLE
Fix printing separator in objects with prettier-ignore

### DIFF
--- a/src/printer.js
+++ b/src/printer.js
@@ -974,9 +974,13 @@ function genericPrintNoParens(path, options, print, args) {
       let separatorParts = [];
       const props = propsAndLoc.sort((a, b) => a.loc - b.loc).map(prop => {
         const result = concat(separatorParts.concat(group(prop.printed)));
-        separatorParts = hasNodeIgnoreComment(prop.node)
-          ? [line]
-          : [separator, line];
+        separatorParts = [separator, line];
+        if (
+          hasNodeIgnoreComment(prop.node) &&
+          prop.node.type === "TSPropertySignature"
+        ) {
+          separatorParts.shift();
+        }
         if (util.isNextLineEmpty(options.originalText, prop.node)) {
           separatorParts.push(hardline);
         }

--- a/tests/ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ignore/__snapshots__/jsfmt.spec.js.snap
@@ -64,6 +64,12 @@ function a() {
         )
       }
 }
+
+const response = {
+  // prettier-ignore
+  '_text': 'Turn on the lights',
+  intent: 'lights',
+};
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function a() {
   // prettier-ignore
@@ -127,5 +133,11 @@ function a() {
     );
   }
 }
+
+const response = {
+  // prettier-ignore
+  '_text': 'Turn on the lights',
+  intent: "lights"
+};
 
 `;

--- a/tests/ignore/ignore.js
+++ b/tests/ignore/ignore.js
@@ -61,3 +61,9 @@ function a() {
         )
       }
 }
+
+const response = {
+  // prettier-ignore
+  '_text': 'Turn on the lights',
+  intent: 'lights',
+};

--- a/tests/typescript_interface/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_interface/__snapshots__/jsfmt.spec.js.snap
@@ -9,6 +9,15 @@ abstract interface I {}
 
 `;
 
+exports[`abstract.ts 2`] = `
+abstract interface I {
+
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+abstract interface I {}
+
+`;
+
 exports[`comments.js 1`] = `
 interface ScreenObject {
 	// I make things weird.
@@ -22,17 +31,32 @@ interface ScreenObject {
 
 `;
 
+exports[`comments.js 2`] = `
+interface ScreenObject {
+	// I make things weird.
+	at(point: Point): Screen | undefined;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+interface ScreenObject {
+  // I make things weird.
+  at(point: Point): Screen | undefined
+}
+
+`;
+
 exports[`ignore.js 1`] = `
 interface Interface {
   // prettier-ignore
   prop: type
   // prettier-ignore
   prop: type;
+  prop: type;
 }
 
 // Last element
 interface Interface {
   // prettier-ignore
+  prop: type
   prop: type
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -41,11 +65,46 @@ interface Interface {
   prop: type
   // prettier-ignore
   prop: type;
+  prop: type;
 }
 
 // Last element
 interface Interface {
   // prettier-ignore
+  prop: type
+  prop: type;
+}
+
+`;
+
+exports[`ignore.js 2`] = `
+interface Interface {
+  // prettier-ignore
+  prop: type
+  // prettier-ignore
+  prop: type;
+  prop: type;
+}
+
+// Last element
+interface Interface {
+  // prettier-ignore
+  prop: type
+  prop: type
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+interface Interface {
+  // prettier-ignore
+  prop: type
+  // prettier-ignore
+  prop: type;
+  prop: type
+}
+
+// Last element
+interface Interface {
+  // prettier-ignore
+  prop: type
   prop: type
 }
 
@@ -102,6 +161,57 @@ export interface ThirdVeryLongAndBoringInterfaceName
 
 `;
 
+exports[`long-extends.ts 2`] = `
+export interface I extends A, B, C {
+  c: string;
+}
+
+export interface ThirdVeryLongAndBoringInterfaceName extends ALongAndBoringInterfaceName {
+  c: string;
+}
+
+export interface ThirdVeryLongAndBoringInterfaceName extends ALongAndBoringInterfaceName, AnotherLongAndBoringInterfaceName {
+  c: string;
+}
+
+export interface ThirdVeryLongAndBoringInterfaceName extends AVeryLongAndBoringInterfaceName, AnotherVeryLongAndBoringInterfaceName {
+  c: string;
+}
+
+export interface ThirdVeryLongAndBoringInterfaceName extends A_AVeryLongAndBoringInterfaceName, B_AVeryLongAndBoringInterfaceName, C_AVeryLongAndBoringInterfaceName  {
+  c: string;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export interface I extends A, B, C {
+  c: string
+}
+
+export interface ThirdVeryLongAndBoringInterfaceName
+  extends ALongAndBoringInterfaceName {
+  c: string
+}
+
+export interface ThirdVeryLongAndBoringInterfaceName
+  extends ALongAndBoringInterfaceName,
+    AnotherLongAndBoringInterfaceName {
+  c: string
+}
+
+export interface ThirdVeryLongAndBoringInterfaceName
+  extends AVeryLongAndBoringInterfaceName,
+    AnotherVeryLongAndBoringInterfaceName {
+  c: string
+}
+
+export interface ThirdVeryLongAndBoringInterfaceName
+  extends A_AVeryLongAndBoringInterfaceName,
+    B_AVeryLongAndBoringInterfaceName,
+    C_AVeryLongAndBoringInterfaceName {
+  c: string
+}
+
+`;
+
 exports[`separator.ts 1`] = `
 declare module 'selenium-webdriver' {
   export const until: {
@@ -136,6 +246,44 @@ export interface Edge {
 interface Test {
   one: string;
   two: any[];
+}
+
+`;
+
+exports[`separator.ts 2`] = `
+declare module 'selenium-webdriver' {
+  export const until: {
+    ableToSwitchToFrame(frame: number | WebElement | By): Condition<boolean>;
+    alertIsPresent(): Condition<Alert>;
+  };
+}
+
+export interface Edge {
+  cursor: {};
+  node: {
+    id: {};
+  };
+}
+
+interface Test { one: string, two: any[] }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+declare module "selenium-webdriver" {
+  export const until: {
+    ableToSwitchToFrame(frame: number | WebElement | By): Condition<boolean>
+    alertIsPresent(): Condition<Alert>
+  }
+}
+
+export interface Edge {
+  cursor: {}
+  node: {
+    id: {}
+  }
+}
+
+interface Test {
+  one: string
+  two: any[]
 }
 
 `;

--- a/tests/typescript_interface/ignore.js
+++ b/tests/typescript_interface/ignore.js
@@ -3,10 +3,12 @@ interface Interface {
   prop: type
   // prettier-ignore
   prop: type;
+  prop: type;
 }
 
 // Last element
 interface Interface {
   // prettier-ignore
+  prop: type
   prop: type
 }

--- a/tests/typescript_interface/jsfmt.spec.js
+++ b/tests/typescript_interface/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(__dirname, ["typescript"]);
+run_spec(__dirname, ["typescript"], {semi: false});

--- a/tests/typescript_interface/jsfmt.spec.js
+++ b/tests/typescript_interface/jsfmt.spec.js
@@ -1,2 +1,2 @@
 run_spec(__dirname, ["typescript"]);
-run_spec(__dirname, ["typescript"], {semi: false});
+run_spec(__dirname, ["typescript"], { semi: false });


### PR DESCRIPTION
When trying to fix a bug of double printing separators in TypeScript interfaces in combination with `//prettier-ignore`, #3103 introduced a regression of not printing commas in regular objects. This commit restricts the "not print" the separator for TypeScript only. The problem is the parser considers the trailing `;` part of the node, but not `,` for objects - so when prettier prints the node as-is, sometimes it prints the separator, sometimes it doesn't.

Added a regression test + more tests for the TS bug