### PR TITLE
Fix PostCSS VS Code integration

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -79,9 +79,9 @@ const supportTable = [
     aceMode: "css",
     codemirrorMode: "css",
     codemirrorMimeType: "text/css",
-    extensions: [".css"],
+    extensions: [".css", ".pcss", ".postcss"],
     liguistLanguageId: 50,
-    vscodeLanguageIds: ["css"]
+    vscodeLanguageIds: ["css", "postcss"]
   },
   {
     name: "Less",

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -99,6 +99,8 @@ Object {
       "codemirrorMode": "css",
       "extensions": Array [
         ".css",
+        ".pcss",
+        ".postcss",
       ],
       "group": "CSS",
       "liguistLanguageId": 50,
@@ -110,6 +112,7 @@ Object {
       "tmScope": "source.css",
       "vscodeLanguageIds": Array [
         "css",
+        "postcss",
       ],
     },
     Object {
@@ -460,9 +463,9 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"aceMode\\": \\"css\\",
       \\"codemirrorMode\\": \\"css\\",
       \\"codemirrorMimeType\\": \\"text/css\\",
-      \\"extensions\\": [\\".css\\"],
+      \\"extensions\\": [\\".css\\", \\".pcss\\", \\".postcss\\"],
       \\"liguistLanguageId\\": 50,
-      \\"vscodeLanguageIds\\": [\\"css\\"]
+      \\"vscodeLanguageIds\\": [\\"css\\", \\"postcss\\"]
     },
     {
       \\"name\\": \\"Less\\",


### PR DESCRIPTION
Fixes PostCSS integration for VS Code

Extension ([prettier-vscode](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)) is [querying](https://github.com/prettier/prettier-vscode/blob/master/src/utils.ts#L47) prettier for supported languages, and is not getting any information about `postcss`. As a result engineer sees that is no any formatter for `postcss`:

![image](https://user-images.githubusercontent.com/1272897/33842197-88d0ef10-dea2-11e7-9b2d-68b2c71b12c6.png)

After exposing information that prettier supports `postcss` everything works fine.
