### PR TITLE
Update tsep and apply breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "semver": "5.4.1",
     "string-width": "2.1.1",
     "typescript": "2.6.2",
-    "typescript-eslint-parser": "9.0.1",
+    "typescript-eslint-parser": "10.0.0",
     "unicode-regex": "1.0.1",
     "unified": "6.1.6"
   },

--- a/src/clean-ast.js
+++ b/src/clean-ast.js
@@ -179,7 +179,7 @@ function massageAST(ast, parent) {
     // (TypeScript) bypass TSParenthesizedType
     if (
       ast.type === "TSParenthesizedType" &&
-      ast.typeAnnotation.type === "TypeAnnotation"
+      ast.typeAnnotation.type === "TSTypeAnnotation"
     ) {
       return newObj.typeAnnotation.typeAnnotation;
     }

--- a/src/fast-path.js
+++ b/src/fast-path.js
@@ -373,12 +373,13 @@ FastPath.prototype.needsParens = function(options) {
     case "TSParenthesizedType": {
       const grandParent = this.getParentNode(1);
       if (
-        (parent.type === "TypeParameter" ||
+        (parent.type === "TSTypeParameter" ||
+          parent.type === "TypeParameter" ||
           parent.type === "VariableDeclarator" ||
-          parent.type === "TypeAnnotation" ||
+          parent.type === "TSTypeAnnotation" ||
           parent.type === "GenericTypeAnnotation" ||
           parent.type === "TSTypeReference") &&
-        (node.typeAnnotation.type === "TypeAnnotation" &&
+        (node.typeAnnotation.type === "TSTypeAnnotation" &&
           node.typeAnnotation.typeAnnotation.type !== "TSFunctionType" &&
           grandParent.type !== "TSTypeOperator")
       ) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4411,9 +4411,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript-eslint-parser@9.0.1:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-9.0.1.tgz#1497a565d192ca2a321bc5bbf89dcab0a2da75e8"
+typescript-eslint-parser@10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-10.0.0.tgz#82b550253659c311c2e4a4d18311b94dd08a36d7"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.4.1"


### PR DESCRIPTION
This has not officially been released yet, but I am opening the PR to get an advanced review.

For that reason, it reverts tsep back to using a commit hash as the version. I will update this once an applicable version of tsep has been released.

The relevant PR is here: https://github.com/eslint/typescript-eslint-parser/pull/388