### PR TITLE
Docs: Add info on ignore file to "Ignoring Code"

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -44,7 +44,7 @@ You can also use `--config` if your configuration file lives somewhere where pre
 
 If you don't have a configuration file, or want to ignore it if it does exist, you can pass `--no-config` instead.
 
-### `--ignore-path`
+## `--ignore-path`
 
 Path to a file containing patterns that describe files to ignore. By default, prettier looks for `./.prettierignore`.
 

--- a/docs/ignore.md
+++ b/docs/ignore.md
@@ -3,7 +3,11 @@ id: ignore
 title: Ignoring Code
 ---
 
-Prettier offers an escape hatch to ignore a block of code from being formatted.
+Prettier offers an escape hatch to ignore a block of code or prevent entire files from being formatted.
+
+## Ignoring Files
+
+To exclude files from formatting, add entries to a `.prettierignore` file in the project root or set the `--ignore-path` [CLI](cli.md) option.
 
 ## JavaScript
 


### PR DESCRIPTION
While working on #3321, I needed to ignore an entire file, but the [Ignoring Code](https://prettier.io/docs/en/ignore.html) section of the docs only describes how to ignore blocks of code, so I wasn't aware of the default ignore file.

_(The `.prettierignore` file **is** mentioned in the [CLI](https://prettier.io/docs/en/cli.html) section, but easily overlooked there.)_

* Commit fccf98a extends the introduction sentence of the "Ignoring Code" section and adds a new subsection to explain how to ignore files.

    > Prettier offers an escape hatch to ignore a block of code <ins>or prevent entire files </ins>from being formatted.

    > ## Ignoring Files

    >To exclude files from formatting, add entries to a `.prettierignore` file in the project root or set the `--ignore-path` [CLI](https://prettier.io/docs/en/cli.html) option.

* Commit 420a12b fixes a nesting error in the heading hierarchy of the [CLI](https://prettier.io/docs/en/cli.html) section:

    The `--ignore-path` option currently appears as a third-level subsection of `--find-config-path` and `--config`, but this looks like an error. This commit promotes the `--ignore-path` heading to the same level as the other CLI options (H2).