### PR TITLE
.eslintrc.js: Use `trailingComma: "es5"` with Prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,7 @@
 module.exports = {
   env: {
     es6: true,
-    node: true
+    node: true,
   },
   extends: ["eslint:recommended", "plugin:react/recommended"],
   plugins: ["prettier", "react", "import"],
@@ -11,7 +11,7 @@ module.exports = {
     curly: "error",
     "import/no-extraneous-dependencies": [
       "error",
-      { devDependencies: ["tests*/**", "scripts/**"] }
+      { devDependencies: ["tests*/**", "scripts/**"] },
     ],
     "no-console": "off",
     "no-else-return": "error",
@@ -26,11 +26,11 @@ module.exports = {
     "react/no-deprecated": "off",
     strict: "error",
     "symbol-description": "error",
-    yoda: ["error", "never", { exceptRange: true }]
+    yoda: ["error", "never", { exceptRange: true }],
   },
   parserOptions: {
     ecmaFeatures: {
-      jsx: true
-    }
-  }
+      jsx: true,
+    },
+  },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,7 @@ module.exports = {
     "one-var": ["error", "never"],
     "prefer-arrow-callback": "error",
     "prefer-const": "error",
-    "prettier/prettier": "error",
+    "prettier/prettier": ["error", { trailingComma: "es5" }],
     "react/no-deprecated": "off",
     strict: "error",
     "symbol-description": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,7 @@ module.exports = {
     "one-var": ["error", "never"],
     "prefer-arrow-callback": "error",
     "prefer-const": "error",
-    "prettier/prettier": ["error", { trailingComma: "es5" }],
+    "prettier/prettier": "error",
     "react/no-deprecated": "off",
     strict: "error",
     "symbol-description": "error",

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  trailingComma: "es5",
+}

--- a/docs/api.md
+++ b/docs/api.md
@@ -105,7 +105,7 @@ prettier.format("lodash ( )", {
     const ast = babylon(text);
     ast.program.body[0].expression.callee.name = "_";
     return ast;
-  }
+  },
 });
 // -> "_();\n"
 ```

--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ function formatWithCursor(text, opts, addAlignmentSize) {
     const pragmas = Object.assign({ format: "" }, parsedDocblock.pragmas);
     const newDocblock = docblock.print({
       pragmas,
-      comments: parsedDocblock.comments.replace(/^(\s+?\r?\n)+/, "") // remove leading newlines
+      comments: parsedDocblock.comments.replace(/^(\s+?\r?\n)+/, ""), // remove leading newlines
     });
     const strippedText = docblock.strip(text);
     const separatingNewlines = strippedText.startsWith("\n") ? "\n" : "\n\n";
@@ -126,7 +126,7 @@ function formatWithCursor(text, opts, addAlignmentSize) {
   if (cursorOffset !== undefined) {
     return {
       formatted: str,
-      cursorOffset: cursorOffsetResult + cursorOffset
+      cursorOffset: cursorOffsetResult + cursorOffset,
     };
   }
 
@@ -144,7 +144,7 @@ function findSiblingAncestors(startNodeAndParents, endNodeAndParents) {
   if (resultStartNode === resultEndNode) {
     return {
       startNode: resultStartNode,
-      endNode: resultEndNode
+      endNode: resultEndNode,
     };
   }
 
@@ -174,7 +174,7 @@ function findSiblingAncestors(startNodeAndParents, endNodeAndParents) {
 
   return {
     startNode: resultStartNode,
-    endNode: resultEndNode
+    endNode: resultEndNode,
   };
 }
 
@@ -199,7 +199,7 @@ function findNodeAtOffset(node, offset, predicate, parentNodes) {
     if (predicate(node)) {
       return {
         node: node,
-        parentNodes: parentNodes
+        parentNodes: parentNodes,
       };
     }
   }
@@ -240,7 +240,7 @@ function isSourceElement(opts, node) {
     "InterfaceDeclaration", // Flow, Typescript
     "TypeAliasDeclaration", // Typescript
     "ExportAssignment", // Typescript
-    "ExportDeclaration" // Typescript
+    "ExportDeclaration", // Typescript
   ];
   const jsonSourceElements = [
     "ObjectExpression",
@@ -248,7 +248,7 @@ function isSourceElement(opts, node) {
     "StringLiteral",
     "NumericLiteral",
     "BooleanLiteral",
-    "NullLiteral"
+    "NullLiteral",
   ];
   const graphqlSourceElements = [
     "OperationDefinition",
@@ -266,7 +266,7 @@ function isSourceElement(opts, node) {
     "OperationTypeDefinition",
     "InterfaceTypeDefinition",
     "UnionTypeDefinition",
-    "ScalarTypeDefinition"
+    "ScalarTypeDefinition",
   ];
   switch (opts.parser) {
     case "flow":
@@ -310,7 +310,7 @@ function calculateRange(text, opts, ast) {
   if (!startNodeAndParents || !endNodeAndParents) {
     return {
       rangeStart: 0,
-      rangeEnd: 0
+      rangeEnd: 0,
     };
   }
 
@@ -325,7 +325,7 @@ function calculateRange(text, opts, ast) {
 
   return {
     rangeStart: rangeStart,
-    rangeEnd: rangeEnd
+    rangeEnd: rangeEnd,
   };
 }
 
@@ -355,7 +355,7 @@ function formatRange(text, opts, ast) {
     Object.assign({}, opts, {
       rangeStart: 0,
       rangeEnd: Infinity,
-      printWidth: opts.printWidth - alignmentSize
+      printWidth: opts.printWidth - alignmentSize,
     }),
     alignmentSize
   );
@@ -421,6 +421,6 @@ module.exports = {
       opts = normalizeOptions(opts);
       const str = printDocToString(doc, opts);
       return str;
-    }
-  }
+    },
+  },
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
   coveragePathIgnorePatterns: [
     "<rootDir>/src/doc-debug.js",
     "<rootDir>/src/clean-ast.js",
-    "<rootDir>/src/deprecated.js"
+    "<rootDir>/src/deprecated.js",
   ],
-  transform: {}
+  transform: {},
 };

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "eslint": "4.1.1",
     "eslint-friendly-formatter": "3.0.0",
     "eslint-plugin-import": "2.6.1",
-    "eslint-plugin-prettier": "2.1.2",
+    "eslint-plugin-prettier": "2.3.1",
     "eslint-plugin-react": "7.1.0",
     "jest": "21.1.0",
     "mkdirp": "0.5.1",

--- a/scripts/build/.eslintrc.js
+++ b/scripts/build/.eslintrc.js
@@ -5,8 +5,8 @@ module.exports = {
     {
       files: "rollup.*.config.js",
       parserOptions: {
-        sourceType: "module"
-      }
-    }
-  ]
+        sourceType: "module",
+      },
+    },
+  ],
 };

--- a/scripts/build/build-docs.js
+++ b/scripts/build/build-docs.js
@@ -14,7 +14,7 @@ const parsers = [
   "graphql",
   "postcss",
   "parse5",
-  "markdown"
+  "markdown",
 ];
 
 function pipe(string) {

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -15,7 +15,7 @@ const parsers = [
   "graphql",
   "postcss",
   "parse5",
-  "markdown"
+  "markdown",
 ];
 
 process.env.PATH += path.delimiter + path.join(rootDir, "node_modules", ".bin");
@@ -96,7 +96,7 @@ const pkgWithoutDependencies = Object.assign({}, pkg);
 delete pkgWithoutDependencies.dependencies;
 pkgWithoutDependencies.scripts = {
   prepublishOnly:
-    "node -e \"assert.equal(require('.').version, require('..').version)\""
+    "node -e \"assert.equal(require('.').version, require('..').version)\"",
 };
 pipe(JSON.stringify(pkgWithoutDependencies, null, 2)).to("dist/package.json");
 

--- a/scripts/build/rollup.base.config.js
+++ b/scripts/build/rollup.base.config.js
@@ -5,12 +5,12 @@ export default {
         "EVAL",
         "MISSING_GLOBAL_NAME",
         "MISSING_NODE_BUILTINS",
-        "UNRESOLVED_IMPORT"
+        "UNRESOLVED_IMPORT",
       ].find(code => code === warning.code)
     ) {
       return;
     }
 
     console.warn(warning.message);
-  }
+  },
 };

--- a/scripts/build/rollup.bin.config.js
+++ b/scripts/build/rollup.bin.config.js
@@ -14,7 +14,7 @@ export default Object.assign(baseConfig, {
     replace({ "#!/usr/bin/env node": "" }),
     json(),
     resolve({ preferBuiltins: true }),
-    commonjs()
+    commonjs(),
   ],
   external: [
     "fs",
@@ -24,9 +24,9 @@ export default Object.assign(baseConfig, {
     "assert",
     "util",
     "events",
-    path.resolve("src/third-party.js")
+    path.resolve("src/third-party.js"),
   ],
   paths: {
-    [path.resolve("src/third-party.js")]: "../third-party"
-  }
+    [path.resolve("src/third-party.js")]: "../third-party",
+  },
 });

--- a/scripts/build/rollup.docs.config.js
+++ b/scripts/build/rollup.docs.config.js
@@ -15,5 +15,5 @@ export default Object.assign(baseConfig, {
   plugins: [json(), resolve({ preferBuiltins: true }), commonjs(), globals()],
   useStrict: false,
   moduleName: basename.replace(/.+-/, ""),
-  external: ["assert", "fs", "module"]
+  external: ["assert", "fs", "module"],
 });

--- a/scripts/build/rollup.index.config.js
+++ b/scripts/build/rollup.index.config.js
@@ -17,14 +17,14 @@ export default Object.assign(baseConfig, {
   format: "cjs",
   plugins: [
     replace({
-      "process.env.NODE_ENV": JSON.stringify("production")
+      "process.env.NODE_ENV": JSON.stringify("production"),
     }),
     json(),
     resolve({ preferBuiltins: true }),
-    commonjs()
+    commonjs(),
   ],
   external,
   paths: {
-    [path.resolve("src/third-party.js")]: "./third-party"
-  }
+    [path.resolve("src/third-party.js")]: "./third-party",
+  },
 });

--- a/scripts/build/rollup.parser.config.js
+++ b/scripts/build/rollup.parser.config.js
@@ -15,7 +15,7 @@ export default Object.assign(baseConfig, {
     parser === "typescript"
       ? replace({
           "exports.Syntax =": "1,",
-          include: "node_modules/typescript-eslint-parser/parser.js"
+          include: "node_modules/typescript-eslint-parser/parser.js",
         })
       : {},
     // In flow-parser 0.59.0 there's a dynamic require: `require(s8)` which not
@@ -24,7 +24,7 @@ export default Object.assign(baseConfig, {
     parser === "flow"
       ? replace({
           "require(s8)": 'require("fs")',
-          include: "node_modules/flow-parser/flow_parser.js"
+          include: "node_modules/flow-parser/flow_parser.js",
         })
       : {},
     json(),
@@ -37,8 +37,8 @@ export default Object.assign(baseConfig, {
           throw result.error;
         }
         return result;
-      }
-    }
+      },
+    },
   ],
   external: [
     "fs",
@@ -48,7 +48,7 @@ export default Object.assign(baseConfig, {
     "assert",
     "util",
     "os",
-    "crypto"
+    "crypto",
   ],
-  useStrict: parser !== "flow"
+  useStrict: parser !== "flow",
 });

--- a/scripts/build/rollup.third-party.config.js
+++ b/scripts/build/rollup.third-party.config.js
@@ -16,11 +16,11 @@ export default Object.assign(baseConfig, {
       // with rollup the module is turned into a plain function located directly
       // in index.js so `module.parent` does not exist. Defaulting to `module`
       // instead seems to work.
-      "module.parent": "(module.parent || module)"
+      "module.parent": "(module.parent || module)",
     }),
     json(),
     resolve({ preferBuiltins: true }),
-    commonjs()
+    commonjs(),
   ],
-  external: ["assert"]
+  external: ["assert"],
 });

--- a/scripts/run-external-tests.js
+++ b/scripts/run-external-tests.js
@@ -12,7 +12,7 @@ function tryFormat(file) {
       // Allow specifying the parser via an environment variable:
       parser: process.env.PARSER,
       // Use file extension detection otherwise:
-      filepath: file
+      filepath: file,
     });
   } catch (error) {
     return error;
@@ -30,7 +30,7 @@ function runExternalTests(patterns) {
   const results = {
     good: [],
     skipped: [],
-    bad: []
+    bad: [],
   };
 
   testFiles.forEach(file => {
@@ -62,7 +62,7 @@ function run(argv) {
         "Examples:",
         '  node scripts/run-external-tests.js "../TypeScript/tests/**/*.ts"',
         '  node scripts/run-external-tests.js "../flow/tests/**/*.js"',
-        '  PARSER=flow node scripts/run-external-tests.js "../flow/tests/**/*.js"'
+        '  PARSER=flow node scripts/run-external-tests.js "../flow/tests/**/*.js"',
       ].join("\n")
     );
     return 1;

--- a/scripts/sync-flow-tests.js
+++ b/scripts/sync-flow-tests.js
@@ -15,7 +15,7 @@ function tryParse(file, content) {
   const ast = flowParser.parse(content, {
     esproposal_class_instance_fields: true,
     esproposal_class_static_fields: true,
-    esproposal_export_star_as: true
+    esproposal_export_star_as: true,
   });
 
   if (ast.errors.length > 0) {
@@ -38,7 +38,7 @@ function syncTests(syncDir) {
     throw new Error(
       [
         "Couldn't find any files to copy.",
-        `Please make sure that \`${syncDir}\` exists and contains the flow tests.`
+        `Please make sure that \`${syncDir}\` exists and contains the flow tests.`,
       ].join("\n")
     );
   }
@@ -79,7 +79,7 @@ function run(argv) {
     console.error(
       [
         "You must provide the path to a flow tests directory to sync from!",
-        "Example: node scripts/sync-flow-tests.js ../flow/tests/"
+        "Example: node scripts/sync-flow-tests.js ../flow/tests/",
       ].join("\n")
     );
     return 1;
@@ -102,7 +102,7 @@ function run(argv) {
         "This is expected since flow tests for handling invalid code,",
         "but that's not interesting for Prettier's tests.",
         "This is the skipped stuff:",
-        ""
+        "",
       ]
         .concat(skipped, "")
         .join("\n")
@@ -116,7 +116,7 @@ function run(argv) {
       `1. Optional: Adjust some ${SPEC_FILE_NAME} files.`,
       "2. Run `jest -u` to create snapshots.",
       "3. Run `git diff` to check how tests and snapshots have changed",
-      "4. Take a look at new snapshots to see if they're OK."
+      "4. Take a look at new snapshots to see if they're OK.",
     ].join("\n")
   );
 

--- a/src/clean-ast.js
+++ b/src/clean-ast.js
@@ -54,7 +54,7 @@ function massageAST(ast, parent) {
       "trailingComma",
       "parent",
       "prev",
-      "position"
+      "position",
     ].forEach(name => {
       delete newObj[name];
     });
@@ -163,7 +163,7 @@ function massageAST(ast, parent) {
         type: "Identifier",
         name: ast.parameter.name,
         typeAnnotation: newObj.parameter.typeAnnotation,
-        decorators: newObj.decorators
+        decorators: newObj.decorators,
       };
     }
 

--- a/src/cli-constant.js
+++ b/src/cli-constant.js
@@ -13,7 +13,7 @@ const categoryOrder = [
   CATEGORY_FORMAT,
   CATEGORY_CONFIG,
   CATEGORY_EDITOR,
-  CATEGORY_OTHER
+  CATEGORY_OTHER,
 ];
 
 /**
@@ -85,20 +85,20 @@ const detailedOptions = normalizeDetailedOptions({
     choices: [
       {
         value: "avoid",
-        description: "Omit parens when possible. Example: `x => x`"
+        description: "Omit parens when possible. Example: `x => x`",
       },
       {
         value: "always",
-        description: "Always include parens. Example: `(x) => x`"
-      }
-    ]
+        description: "Always include parens. Example: `(x) => x`",
+      },
+    ],
   },
   "bracket-spacing": {
     type: "boolean",
     category: CATEGORY_FORMAT,
     forwardToApi: true,
     description: "Print spaces between brackets.",
-    oppositeDescription: "Do not print spaces between brackets."
+    oppositeDescription: "Do not print spaces between brackets.",
   },
   color: {
     // The supports-color package (a sub sub dependency) looks directly at
@@ -108,14 +108,14 @@ const detailedOptions = normalizeDetailedOptions({
     type: "boolean",
     default: true,
     description: "Colorize error messages.",
-    oppositeDescription: "Do not colorize error messages."
+    oppositeDescription: "Do not colorize error messages.",
   },
   config: {
     type: "path",
     category: CATEGORY_CONFIG,
     description:
       "Path to a Prettier configuration file (.prettierrc, package.json, prettier.config.js).",
-    oppositeDescription: "Do not look for a configuration file."
+    oppositeDescription: "Do not look for a configuration file.",
   },
   "config-precedence": {
     type: "choice",
@@ -124,22 +124,22 @@ const detailedOptions = normalizeDetailedOptions({
     choices: [
       {
         value: "cli-override",
-        description: "CLI options take precedence over config file"
+        description: "CLI options take precedence over config file",
       },
       {
         value: "file-override",
-        description: "Config file take precedence over CLI options"
+        description: "Config file take precedence over CLI options",
       },
       {
         value: "prefer-file",
         description: dedent(`
           If a config file is found will evaluate it and ignore other CLI options.
           If no config file is found CLI options will evaluate as normal.
-        `)
-      }
+        `),
+      },
     ],
     description:
-      "Define in which order config files and CLI options should be evaluated."
+      "Define in which order config files and CLI options should be evaluated.",
   },
   "cursor-offset": {
     type: "int",
@@ -149,13 +149,13 @@ const detailedOptions = normalizeDetailedOptions({
     description: dedent(`
       Print (to stderr) where a cursor at the given position would move to after formatting.
       This option cannot be used with --range-start and --range-end.
-    `)
+    `),
   },
   "debug-check": {
-    type: "boolean"
+    type: "boolean",
   },
   "debug-print-doc": {
-    type: "boolean"
+    type: "boolean",
   },
   editorconfig: {
     type: "boolean",
@@ -163,19 +163,19 @@ const detailedOptions = normalizeDetailedOptions({
     description: "Take .editorconfig into account when parsing configuration.",
     oppositeDescription:
       "Don't take .editorconfig into account when parsing configuration.",
-    default: true
+    default: true,
   },
   "find-config-path": {
     type: "path",
     category: CATEGORY_CONFIG,
     description:
-      "Find and print the path to a configuration file for the given input file."
+      "Find and print the path to a configuration file for the given input file.",
   },
   "flow-parser": {
     // Deprecated in 0.0.10
     type: "boolean",
     category: CATEGORY_FORMAT,
-    deprecated: "Use `--parser flow` instead."
+    deprecated: "Use `--parser flow` instead.",
   },
   help: {
     type: "flag",
@@ -183,39 +183,39 @@ const detailedOptions = normalizeDetailedOptions({
     description: dedent(`
       Show CLI usage, or details about the given flag.
       Example: --help write
-    `)
+    `),
   },
   "ignore-path": {
     type: "path",
     category: CATEGORY_CONFIG,
     default: ".prettierignore",
-    description: "Path to a file with patterns describing files to ignore."
+    description: "Path to a file with patterns describing files to ignore.",
   },
   "insert-pragma": {
     type: "boolean",
     forwardToApi: true,
     description: dedent(`
       Insert @format pragma into file's first docblock comment.
-    `)
+    `),
   },
   "jsx-bracket-same-line": {
     type: "boolean",
     category: CATEGORY_FORMAT,
     forwardToApi: true,
-    description: "Put > on the last line instead of at a new line."
+    description: "Put > on the last line instead of at a new line.",
   },
   "list-different": {
     type: "boolean",
     category: CATEGORY_OUTPUT,
     alias: "l",
     description:
-      "Print the names of files that are different from Prettier's formatting."
+      "Print the names of files that are different from Prettier's formatting.",
   },
   loglevel: {
     type: "choice",
     description: "What level of logs to report.",
     default: "warn",
-    choices: ["silent", "error", "warn", "debug"]
+    choices: ["silent", "error", "warn", "debug"],
   },
   parser: {
     type: "choice",
@@ -232,16 +232,16 @@ const detailedOptions = normalizeDetailedOptions({
       "scss",
       "json",
       "graphql",
-      "markdown"
+      "markdown",
     ],
     description: "Which parser to use.",
-    getter: (value, argv) => (argv["flow-parser"] ? "flow" : value)
+    getter: (value, argv) => (argv["flow-parser"] ? "flow" : value),
   },
   "print-width": {
     type: "int",
     category: CATEGORY_FORMAT,
     forwardToApi: true,
-    description: "The line length where Prettier will try wrap."
+    description: "The line length where Prettier will try wrap.",
   },
   "prose-wrap": {
     type: "choice",
@@ -251,12 +251,12 @@ const detailedOptions = normalizeDetailedOptions({
     choices: [
       {
         value: "always",
-        description: "Wrap prose if it exceeds the print width."
+        description: "Wrap prose if it exceeds the print width.",
       },
       { value: "never", description: "Do not wrap prose." },
       { value: "preserve", description: "Wrap prose as-is." },
-      { value: false, deprecated: true, redirect: "never" }
-    ]
+      { value: false, deprecated: true, redirect: "never" },
+    ],
   },
   "range-end": {
     type: "int",
@@ -267,7 +267,7 @@ const detailedOptions = normalizeDetailedOptions({
       Format code ending at a given character offset (exclusive).
       The range will extend forwards to the end of the selected statement.
       This option cannot be used with --cursor-offset.
-    `)
+    `),
   },
   "range-start": {
     type: "int",
@@ -277,7 +277,7 @@ const detailedOptions = normalizeDetailedOptions({
       Format code starting at a given character offset.
       The range will extend backwards to the start of the first line containing the selected statement.
       This option cannot be used with --cursor-offset.
-    `)
+    `),
   },
   "require-pragma": {
     type: "boolean",
@@ -285,7 +285,7 @@ const detailedOptions = normalizeDetailedOptions({
     description: dedent(`
       Require either '@prettier' or '@format' to be present in the file's first docblock comment
       in order for it to be formatted.
-    `)
+    `),
   },
   semi: {
     type: "boolean",
@@ -293,32 +293,32 @@ const detailedOptions = normalizeDetailedOptions({
     forwardToApi: true,
     description: "Print semicolons.",
     oppositeDescription:
-      "Do not print semicolons, except at the beginning of lines which may need them."
+      "Do not print semicolons, except at the beginning of lines which may need them.",
   },
   "single-quote": {
     type: "boolean",
     category: CATEGORY_FORMAT,
     forwardToApi: true,
-    description: "Use single quotes instead of double quotes."
+    description: "Use single quotes instead of double quotes.",
   },
   stdin: {
     type: "boolean",
-    description: "Force reading input from stdin."
+    description: "Force reading input from stdin.",
   },
   "stdin-filepath": {
     type: "path",
     forwardToApi: "filepath",
-    description: "Path to the file to pretend that stdin comes from."
+    description: "Path to the file to pretend that stdin comes from.",
   },
   "support-info": {
     type: "boolean",
-    description: "Print support information as JSON."
+    description: "Print support information as JSON.",
   },
   "tab-width": {
     type: "int",
     category: CATEGORY_FORMAT,
     forwardToApi: true,
-    description: "Number of spaces per indentation level."
+    description: "Number of spaces per indentation level.",
   },
   "trailing-comma": {
     type: "choice",
@@ -329,38 +329,38 @@ const detailedOptions = normalizeDetailedOptions({
       {
         value: "es5",
         description:
-          "Trailing commas where valid in ES5 (objects, arrays, etc.)"
+          "Trailing commas where valid in ES5 (objects, arrays, etc.)",
       },
       {
         value: "all",
         description:
-          "Trailing commas wherever possible (including function arguments)."
+          "Trailing commas wherever possible (including function arguments).",
       },
-      { value: "", deprecated: true, redirect: "es5" }
+      { value: "", deprecated: true, redirect: "es5" },
     ],
-    description: "Print trailing commas wherever possible when multi-line."
+    description: "Print trailing commas wherever possible when multi-line.",
   },
   "use-tabs": {
     type: "boolean",
     category: CATEGORY_FORMAT,
     forwardToApi: true,
-    description: "Indent with tabs instead of spaces."
+    description: "Indent with tabs instead of spaces.",
   },
   version: {
     type: "boolean",
     alias: "v",
-    description: "Print Prettier version."
+    description: "Print Prettier version.",
   },
   "with-node-modules": {
     type: "boolean",
     category: CATEGORY_CONFIG,
-    description: "Process files inside 'node_modules' directory."
+    description: "Process files inside 'node_modules' directory.",
   },
   write: {
     type: "boolean",
     category: CATEGORY_OUTPUT,
-    description: "Edit files in-place. (Beware!)"
-  }
+    description: "Edit files in-place. (Beware!)",
+  },
 });
 
 const minimistOptions = {
@@ -383,7 +383,7 @@ const minimistOptions = {
       (current, option) =>
         Object.assign({ [option.name]: option.alias }, current),
       {}
-    )
+    ),
 };
 
 const usageSummary = `
@@ -419,7 +419,7 @@ function normalizeDetailedOptions(rawDetailedOptions) {
             typeof choice === "object" ? choice : { value: choice }
           )
         ),
-      getter: option.getter || (value => value)
+      getter: option.getter || (value => value),
     });
   });
 
@@ -436,5 +436,5 @@ module.exports = {
   minimistOptions,
   detailedOptions,
   detailedOptionMap,
-  usageSummary
+  usageSummary,
 };

--- a/src/cli-logger.js
+++ b/src/cli-logger.js
@@ -44,5 +44,5 @@ module.exports = {
   warn,
   error,
   debug,
-  ENV_LOG_LEVEL
+  ENV_LOG_LEVEL,
 };

--- a/src/cli-util.js
+++ b/src/cli-util.js
@@ -44,7 +44,7 @@ function dashifyObject(object) {
 
 function diff(a, b) {
   return require("diff").createTwoFilesPatch("", "", a, b, "", "", {
-    context: 2
+    context: 2,
   });
 }
 
@@ -160,7 +160,7 @@ function getOptionsOrDie(argv, filePath) {
     );
     const options = resolver.resolveConfig.sync(filePath, {
       editorconfig: argv.editorconfig,
-      config: argv["config"]
+      config: argv["config"],
     });
 
     logger.debug("loaded options `" + JSON.stringify(options) + "`");
@@ -202,7 +202,7 @@ function parseArgsToOptions(argv, overrideDefaults) {
             {},
             dashifyObject(apiDefaultOptions),
             dashifyObject(overrideDefaults)
-          )
+          ),
         })
       ),
       { warning: false }
@@ -393,9 +393,9 @@ function getOptionsWithOpposites(options) {
       ? Object.assign({}, option, {
           name: `no-${option.name}`,
           type: "boolean",
-          description: option.oppositeDescription
+          description: option.oppositeDescription,
         })
-      : null
+      : null,
   ]);
   return flattenArray(optionsWithOpposites).filter(Boolean);
 }
@@ -487,7 +487,7 @@ function getOptionWithLevenSuggestion(options, optionName) {
   const optionNameContainers = flattenArray(
     options.map((option, index) => [
       { value: option.name, index },
-      option.alias ? { value: option.alias, index } : null
+      option.alias ? { value: option.alias, index } : null,
     ])
   ).filter(Boolean);
 
@@ -716,5 +716,5 @@ module.exports = {
   formatFiles,
   createUsage,
   createDetailedUsage,
-  normalizeConfig
+  normalizeConfig,
 };

--- a/src/cli-validator.js
+++ b/src/cli-validator.js
@@ -51,5 +51,5 @@ function validateChoiceOption(type, value, option) {
 module.exports = {
   validateArgv,
   validateIntOption,
-  validateChoiceOption
+  validateChoiceOption,
 };

--- a/src/cli.js
+++ b/src/cli.js
@@ -40,7 +40,7 @@ function run(args) {
   if (argv["support-info"]) {
     console.log(
       prettier.format(JSON.stringify(prettier.getSupportInfo()), {
-        parser: "json"
+        parser: "json",
       })
     );
     process.exit(0);
@@ -62,5 +62,5 @@ function run(args) {
 }
 
 module.exports = {
-  run
+  run,
 };

--- a/src/comments.js
+++ b/src/comments.js
@@ -69,7 +69,7 @@ function getSortedChildNodes(node, text, resultArray) {
   if (!resultArray) {
     Object.defineProperty(node, childNodesCacheKey, {
       value: (resultArray = []),
-      enumerable: false
+      enumerable: false,
     });
   }
 
@@ -968,7 +968,7 @@ function printJsDocComment(comment) {
           (index < lines.length - 1 ? line.trim() : line.trimLeft())
       )
     ),
-    "*/"
+    "*/",
   ]);
 }
 
@@ -1009,7 +1009,7 @@ function printLeadingComment(commentPath, print, options) {
   if (isBlock) {
     return concat([
       contents,
-      util.hasNewline(options.originalText, locEnd(comment)) ? hardline : " "
+      util.hasNewline(options.originalText, locEnd(comment)) ? hardline : " ",
     ]);
   }
 
@@ -1026,7 +1026,7 @@ function printTrailingComment(commentPath, print, options) {
 
   if (
     util.hasNewline(options.originalText, locStart(comment), {
-      backwards: true
+      backwards: true,
     })
   ) {
     // This allows comments at the end of nested structures:
@@ -1138,5 +1138,5 @@ module.exports = {
   attach,
   printComments,
   printDanglingComments,
-  getSortedChildNodes
+  getSortedChildNodes,
 };

--- a/src/deprecated.js
+++ b/src/deprecated.js
@@ -7,7 +7,7 @@ const deprecated = {
   Prettier now treats your configuration as:
   {
     ${'"parser"'}: ${config.useFlowParser ? '"flow"' : '"babylon"'}
-  }`
+  }`,
 };
 
 module.exports = deprecated;

--- a/src/doc-builders.js
+++ b/src/doc-builders.js
@@ -52,7 +52,7 @@ function group(contents, opts) {
     type: "group",
     contents: contents,
     break: !!opts.shouldBreak,
-    expandedStates: opts.expandedStates
+    expandedStates: opts.expandedStates,
   };
 }
 
@@ -98,7 +98,7 @@ const softline = { type: "line", soft: true };
 const hardline = concat([{ type: "line", hard: true }, breakParent]);
 const literalline = concat([
   { type: "line", hard: true, literal: true },
-  breakParent
+  breakParent,
 ]);
 const cursor = { type: "cursor", placeholder: Symbol("cursor") };
 
@@ -149,5 +149,5 @@ module.exports = {
   ifBreak,
   indent,
   align,
-  addAlignmentToDoc
+  addAlignmentToDoc,
 };

--- a/src/doc-debug.js
+++ b/src/doc-debug.js
@@ -22,14 +22,14 @@ function flattenDoc(doc) {
       breakContents:
         doc.breakContents != null ? flattenDoc(doc.breakContents) : null,
       flatContents:
-        doc.flatContents != null ? flattenDoc(doc.flatContents) : null
+        doc.flatContents != null ? flattenDoc(doc.flatContents) : null,
     });
   } else if (doc.type === "group") {
     return Object.assign({}, doc, {
       contents: flattenDoc(doc.contents),
       expandedStates: doc.expandedStates
         ? doc.expandedStates.map(flattenDoc)
-        : doc.expandedStates
+        : doc.expandedStates,
     });
   } else if (doc.contents) {
     return Object.assign({}, doc, { contents: flattenDoc(doc.contents) });
@@ -116,5 +116,5 @@ function printDoc(doc) {
 module.exports = {
   printDocToDebug: function(doc) {
     return printDoc(flattenDoc(doc));
-  }
+  },
 };

--- a/src/doc-printer.js
+++ b/src/doc-printer.js
@@ -12,14 +12,14 @@ const MODE_FLAT = 2;
 function rootIndent() {
   return {
     length: 0,
-    value: ""
+    value: "",
   };
 }
 
 function makeIndent(ind, options) {
   return {
     length: ind.length + options.tabWidth,
-    value: ind.value + (options.useTabs ? "\t" : " ".repeat(options.tabWidth))
+    value: ind.value + (options.useTabs ? "\t" : " ".repeat(options.tabWidth)),
   };
 }
 
@@ -29,13 +29,13 @@ function makeAlign(ind, n, options) {
     : typeof n === "string"
       ? {
           length: ind.length + n.length,
-          value: ind.value + n
+          value: ind.value + n,
         }
       : options.useTabs && n > 0
         ? makeIndent(ind, options)
         : {
             length: ind.length + n,
-            value: ind.value + " ".repeat(n)
+            value: ind.value + " ".repeat(n),
           };
 }
 
@@ -175,7 +175,7 @@ function printDocToString(doc, options) {
                 cmds.push([
                   ind,
                   doc.break ? MODE_BREAK : MODE_FLAT,
-                  doc.contents
+                  doc.contents,
                 ]);
 
                 break;
@@ -303,7 +303,7 @@ function printDocToString(doc, options) {
           const firstAndSecondContentFlatCmd = [
             ind,
             MODE_FLAT,
-            concat([content, whitespace, secondContent])
+            concat([content, whitespace, secondContent]),
           ];
           const firstAndSecondContentFits = fits(
             firstAndSecondContentFlatCmd,
@@ -423,7 +423,7 @@ function printDocToString(doc, options) {
 
     return {
       formatted: beforeCursor + afterCursor,
-      cursor: beforeCursor.length
+      cursor: beforeCursor.length,
     };
   }
 

--- a/src/doc-utils.js
+++ b/src/doc-utils.js
@@ -45,12 +45,12 @@ function mapDoc(doc, func) {
 
   if (doc.type === "concat" || doc.type === "fill") {
     return Object.assign({}, doc, {
-      parts: doc.parts.map(d => mapDoc(d, func))
+      parts: doc.parts.map(d => mapDoc(d, func)),
     });
   } else if (doc.type === "if-break") {
     return Object.assign({}, doc, {
       breakContents: doc.breakContents && mapDoc(doc.breakContents, func),
-      flatContents: doc.flatContents && mapDoc(doc.flatContents, func)
+      flatContents: doc.flatContents && mapDoc(doc.flatContents, func),
     });
   } else if (doc.contents) {
     return Object.assign({}, doc, { contents: mapDoc(doc.contents, func) });
@@ -179,5 +179,5 @@ module.exports = {
   mapDoc,
   propagateBreaks,
   removeLines,
-  rawText
+  rawText,
 };

--- a/src/errors.js
+++ b/src/errors.js
@@ -5,5 +5,5 @@ class DebugError extends Error {}
 
 module.exports = {
   ConfigError,
-  DebugError
+  DebugError,
 };

--- a/src/multiparser.js
+++ b/src/multiparser.js
@@ -26,7 +26,7 @@ function printSubtree(path, print, options) {
 function parseAndPrint(text, partialNextOptions, parentOptions) {
   const nextOptions = Object.assign({}, parentOptions, partialNextOptions, {
     parentParser: parentOptions.parser,
-    originalText: text
+    originalText: text,
   });
   if (nextOptions.parser === "json") {
     nextOptions.trailingComma = "none";
@@ -196,7 +196,7 @@ function fromBabylonFlowOrTypeScript(path, print, options) {
           "`",
           indent(concat([hardline, join(hardline, parts)])),
           hardline,
-          "`"
+          "`",
         ]);
       }
 
@@ -221,7 +221,7 @@ function fromBabylonFlowOrTypeScript(path, print, options) {
           dedent(parent.quasis[0].value.cooked),
           {
             parser: "markdown",
-            __inJsTemplate: true
+            __inJsTemplate: true,
           },
           options
         );
@@ -229,7 +229,7 @@ function fromBabylonFlowOrTypeScript(path, print, options) {
           indent(
             concat([softline, stripTrailingHardline(escapeBackticks(doc))])
           ),
-          softline
+          softline,
         ]);
       }
 
@@ -350,7 +350,7 @@ function fromHtmlParser2(path, print, options) {
             parser: parseJavaScriptExpression,
             // Use singleQuote since HTML attributes use double-quotes.
             // TODO(azz): We still need to do an entity escape on the attribute.
-            singleQuote: true
+            singleQuote: true,
           },
           options
         );
@@ -360,7 +360,7 @@ function fromHtmlParser2(path, print, options) {
           util.hasNewlineInRange(node.value, 0, node.value.length)
             ? doc
             : docUtils.removeLines(doc),
-          '"'
+          '"',
         ]);
       }
     }
@@ -388,7 +388,7 @@ function transformCssDoc(quasisDoc, path, print) {
     "`",
     indent(concat([hardline, stripTrailingHardline(newDoc)])),
     softline,
-    "`"
+    "`",
   ]);
 }
 
@@ -434,7 +434,7 @@ function replacePlaceholders(quasisDoc, expressionDocs) {
       parts = ["${", expression, "}" + suffix].concat(rest);
     }
     return Object.assign({}, doc, {
-      parts: parts
+      parts: parts,
     });
   });
 
@@ -447,7 +447,7 @@ function parseJavaScriptExpression(text, parsers) {
   // Extract expression from the declaration
   return {
     type: "File",
-    program: ast.program.body[0].expression
+    program: ast.program.body[0].expression,
   };
 }
 
@@ -555,5 +555,5 @@ function isStyledIdentifier(node) {
 }
 
 module.exports = {
-  printSubtree
+  printSubtree,
 };

--- a/src/options.js
+++ b/src/options.js
@@ -22,13 +22,13 @@ const defaults = {
   requirePragma: false,
   semi: true,
   proseWrap: "preserve",
-  arrowParens: "avoid"
+  arrowParens: "avoid",
 };
 
 const exampleConfig = Object.assign({}, defaults, {
   filepath: "path/to/Filename",
   printWidth: 80,
-  originalText: "text"
+  originalText: "text",
 });
 
 // Copy options and fill in default values.

--- a/src/parser-babylon.js
+++ b/src/parser-babylon.js
@@ -29,8 +29,8 @@ function parse(text, parsers, opts) {
       "optionalChaining",
       "classPrivateProperties",
       "pipelineOperator",
-      "nullishCoalescingOperator"
-    ]
+      "nullishCoalescingOperator",
+    ],
   };
 
   const parseMethod =
@@ -53,8 +53,8 @@ function parse(text, parsers, opts) {
         {
           start: {
             line: originalError.loc.line,
-            column: originalError.loc.column + 1
-          }
+            column: originalError.loc.column + 1,
+          },
         }
       );
     }

--- a/src/parser-flow.js
+++ b/src/parser-flow.js
@@ -12,14 +12,14 @@ function parse(text /*, parsers, opts*/) {
   const ast = flowParser.parse(text, {
     esproposal_class_instance_fields: true,
     esproposal_class_static_fields: true,
-    esproposal_export_star_as: true
+    esproposal_export_star_as: true,
   });
 
   if (ast.errors.length > 0) {
     const loc = ast.errors[0].loc;
     throw createError(ast.errors[0].message, {
       start: { line: loc.start.line, column: loc.start.column + 1 },
-      end: { line: loc.end.line, column: loc.end.column + 1 }
+      end: { line: loc.end.line, column: loc.end.column + 1 },
     });
   }
 

--- a/src/parser-graphql.js
+++ b/src/parser-graphql.js
@@ -11,7 +11,7 @@ function parseComments(ast) {
       Object.assign(next, {
         // The Comment token's column starts _after_ the `#`,
         // but we need to make sure the node captures the `#`
-        column: next.column - 1
+        column: next.column - 1,
       });
       comments.push(next);
     }
@@ -48,8 +48,8 @@ function parse(text /*, parsers, opts*/) {
       throw createError(error.message, {
         start: {
           line: error.locations[0].line,
-          column: error.locations[0].column
-        }
+          column: error.locations[0].column,
+        },
       });
     } else {
       throw error;

--- a/src/parser-include-shebang.js
+++ b/src/parser-include-shebang.js
@@ -15,13 +15,13 @@ function includeShebang(text, ast) {
       source: null,
       start: {
         line: 1,
-        column: 0
+        column: 0,
       },
       end: {
         line: 1,
-        column: index
-      }
-    }
+        column: index,
+      },
+    },
   };
 
   ast.comments = [comment].concat(ast.comments);

--- a/src/parser-markdown.js
+++ b/src/parser-markdown.js
@@ -50,7 +50,7 @@ function transformInlineCode() {
       }
 
       return Object.assign({}, node, {
-        value: node.value.replace(/\s+/g, " ")
+        value: node.value.replace(/\s+/g, " "),
       });
     });
 }
@@ -70,7 +70,7 @@ function restoreUnescapedCharacter(originalText) {
                     node.position.start.offset,
                     node.position.end.offset
                   )
-                : node.value
+                : node.value,
           });
     });
 }
@@ -89,8 +89,8 @@ function mergeContinuousTexts() {
             value: lastChild.value + child.value,
             position: {
               start: lastChild.position.start,
-              end: child.position.end
-            }
+              end: child.position.end,
+            },
           });
         } else {
           current.push(child);
@@ -122,7 +122,7 @@ function splitText() {
       return {
         type: "sentence",
         position: node.position,
-        children: util.splitText(value)
+        children: util.splitText(value),
       };
     });
 }

--- a/src/parser-parse5.js
+++ b/src/parser-parse5.js
@@ -9,7 +9,7 @@ function parse(text /*, parsers, opts*/) {
     const isFragment = !/^\s*<(!doctype|html|head|body)/i.test(text);
     const ast = (isFragment ? parse5.parseFragment : parse5.parse)(text, {
       treeAdapter: parse5.treeAdapters.htmlparser2,
-      locationInfo: true
+      locationInfo: true,
     });
     return extendAst(ast);
   } catch (error) {
@@ -42,7 +42,7 @@ function convertAttribs(attribs) {
     return {
       type: "attribute",
       key: attributeKey,
-      value: attribs[attributeKey]
+      value: attribs[attributeKey],
     };
   });
 }

--- a/src/parser-postcss.js
+++ b/src/parser-postcss.js
@@ -16,13 +16,13 @@ function parseValueNodes(nodes) {
     open: null,
     close: null,
     groups: [],
-    type: "paren_group"
+    type: "paren_group",
   };
   const parenGroupStack = [parenGroup];
   const rootParenGroup = parenGroup;
   let commaGroup = {
     groups: [],
-    type: "comma_group"
+    type: "comma_group",
   };
   const commaGroupStack = [commaGroup];
 
@@ -33,13 +33,13 @@ function parseValueNodes(nodes) {
         open: node,
         close: null,
         groups: [],
-        type: "paren_group"
+        type: "paren_group",
       };
       parenGroupStack.push(parenGroup);
 
       commaGroup = {
         groups: [],
-        type: "comma_group"
+        type: "comma_group",
       };
       commaGroupStack.push(commaGroup);
     } else if (node.type === "paren" && node.value === ")") {
@@ -62,7 +62,7 @@ function parseValueNodes(nodes) {
       parenGroup.groups.push(commaGroup);
       commaGroup = {
         groups: [],
-        type: "comma_group"
+        type: "comma_group",
       };
       commaGroupStack[commaGroupStack.length - 1] = commaGroup;
     } else {
@@ -173,7 +173,7 @@ function parseNestedCSS(node) {
         // https://github.com/postcss/postcss-scss/issues/39
         node.selector = {
           type: "selector-root-invalid",
-          value: selector
+          value: selector,
         };
       }
     }

--- a/src/parser-typescript.js
+++ b/src/parser-typescript.js
@@ -21,7 +21,7 @@ function parse(text /*, parsers, opts*/) {
     }
 
     throw createError(e.message, {
-      start: { line: e.lineNumber, column: e.column + 1 }
+      start: { line: e.lineNumber, column: e.column + 1 },
     });
   }
 
@@ -43,7 +43,7 @@ function tryParseTypeScript(text, jsx) {
     ecmaFeatures: { jsx },
     // Override logger function with noop,
     // to avoid unsupported version errors being logged
-    loggerFn: () => {}
+    loggerFn: () => {},
   });
 }
 
@@ -56,7 +56,7 @@ function isProbablyJsx(text) {
     [
       "(^[^\"'`]*</)", // Contains "</" when probably not in a string
       "|",
-      "(^[^/]{2}.*/>)" // Contains "/>" on line not starting with "//"
+      "(^[^/]{2}.*/>)", // Contains "/>" on line not starting with "//"
     ].join(""),
     "m"
   ).test(text);

--- a/src/parser.js
+++ b/src/parser.js
@@ -33,7 +33,7 @@ const parsers = {
   },
   get markdown() {
     return eval("require")("./parser-markdown");
-  }
+  },
 };
 
 function resolveParseFunction(opts) {
@@ -66,7 +66,7 @@ function parse(text, opts) {
     if (loc) {
       const codeFrame = require("babel-code-frame");
       error.codeFrame = codeFrame.codeFrameColumns(text, loc, {
-        highlightCode: true
+        highlightCode: true,
       });
       error.message += "\n" + error.codeFrame;
       throw error;

--- a/src/printer-graphql.js
+++ b/src/printer-graphql.js
@@ -26,7 +26,7 @@ function genericPrint(path, options, print) {
     case "Document": {
       return concat([
         join(concat([hardline, hardline]), path.map(print, "definitions")),
-        hardline
+        hardline,
       ]);
     }
     case "OperationDefinition": {
@@ -43,17 +43,17 @@ function genericPrint(path, options, print) {
                     join(
                       concat([ifBreak("", ", "), softline]),
                       path.map(print, "variableDefinitions")
-                    )
+                    ),
                   ])
                 ),
                 softline,
-                ")"
+                ")",
               ])
             )
           : "",
         printDirectives(path, print, n),
         n.selectionSet ? (n.name === null ? "" : " ") : "",
-        path.call(print, "selectionSet")
+        path.call(print, "selectionSet"),
       ]);
     }
     case "FragmentDefinition": {
@@ -64,7 +64,7 @@ function genericPrint(path, options, print) {
         path.call(print, "typeCondition"),
         printDirectives(path, print, n),
         " ",
-        path.call(print, "selectionSet")
+        path.call(print, "selectionSet"),
       ]);
     }
     case "SelectionSet": {
@@ -79,11 +79,11 @@ function genericPrint(path, options, print) {
                 selectionsPath => printSequence(selectionsPath, options, print),
                 "selections"
               )
-            )
+            ),
           ])
         ),
         hardline,
-        "}"
+        "}",
       ]);
     }
     case "Field": {
@@ -104,17 +104,17 @@ function genericPrint(path, options, print) {
                           argsPath => printSequence(argsPath, options, print),
                           "arguments"
                         )
-                      )
+                      ),
                     ])
                   ),
                   softline,
-                  ")"
+                  ")",
                 ])
               )
             : "",
           printDirectives(path, print, n),
           n.selectionSet ? " " : "",
-          path.call(print, "selectionSet")
+          path.call(print, "selectionSet"),
         ])
       );
     }
@@ -148,11 +148,11 @@ function genericPrint(path, options, print) {
               join(
                 concat([ifBreak("", ", "), softline]),
                 path.map(print, "values")
-              )
+              ),
             ])
           ),
           softline,
-          "]"
+          "]",
         ])
       );
     }
@@ -167,12 +167,12 @@ function genericPrint(path, options, print) {
               join(
                 concat([ifBreak("", ", "), softline]),
                 path.map(print, "fields")
-              )
+              ),
             ])
           ),
           softline,
           ifBreak("", options.bracketSpacing && n.fields.length > 0 ? " " : ""),
-          "}"
+          "}",
         ])
       );
     }
@@ -181,7 +181,7 @@ function genericPrint(path, options, print) {
       return concat([
         path.call(print, "name"),
         ": ",
-        path.call(print, "value")
+        path.call(print, "value"),
       ]);
     }
 
@@ -202,14 +202,14 @@ function genericPrint(path, options, print) {
                         argsPath => printSequence(argsPath, options, print),
                         "arguments"
                       )
-                    )
+                    ),
                   ])
                 ),
                 softline,
-                ")"
+                ")",
               ])
             )
-          : ""
+          : "",
       ]);
     }
 
@@ -222,7 +222,7 @@ function genericPrint(path, options, print) {
         path.call(print, "variable"),
         ": ",
         path.call(print, "type"),
-        n.defaultValue ? concat([" = ", path.call(print, "defaultValue")]) : ""
+        n.defaultValue ? concat([" = ", path.call(print, "defaultValue")]) : "",
       ]);
     }
 
@@ -249,12 +249,12 @@ function genericPrint(path, options, print) {
                     fieldsPath => printSequence(fieldsPath, options, print),
                     "fields"
                   )
-                )
+                ),
               ])
             )
           : "",
         hardline,
-        "}"
+        "}",
       ]);
     }
 
@@ -274,17 +274,17 @@ function genericPrint(path, options, print) {
                         argsPath => printSequence(argsPath, options, print),
                         "arguments"
                       )
-                    )
+                    ),
                   ])
                 ),
                 softline,
-                ")"
+                ")",
               ])
             )
           : "",
         ": ",
         path.call(print, "type"),
-        printDirectives(path, print, n)
+        printDirectives(path, print, n),
       ]);
     }
 
@@ -306,15 +306,15 @@ function genericPrint(path, options, print) {
                         argsPath => printSequence(argsPath, options, print),
                         "arguments"
                       )
-                    )
+                    ),
                   ])
                 ),
                 softline,
-                ")"
+                ")",
               ])
             )
           : "",
-        concat([" on ", join(" | ", path.map(print, "locations"))])
+        concat([" on ", join(" | ", path.map(print, "locations"))]),
       ]);
     }
 
@@ -334,19 +334,19 @@ function genericPrint(path, options, print) {
                     valuesPath => printSequence(valuesPath, options, print),
                     "values"
                   )
-                )
+                ),
               ])
             )
           : "",
         hardline,
-        "}"
+        "}",
       ]);
     }
 
     case "EnumValueDefinition": {
       return concat([
         path.call(print, "name"),
-        printDirectives(path, print, n)
+        printDirectives(path, print, n),
       ]);
     }
 
@@ -356,7 +356,7 @@ function genericPrint(path, options, print) {
         ": ",
         path.call(print, "type"),
         n.defaultValue ? concat([" = ", path.call(print, "defaultValue")]) : "",
-        printDirectives(path, print, n)
+        printDirectives(path, print, n),
       ]);
     }
 
@@ -376,12 +376,12 @@ function genericPrint(path, options, print) {
                     fieldsPath => printSequence(fieldsPath, options, print),
                     "fields"
                   )
-                )
+                ),
               ])
             )
           : "",
         hardline,
-        "}"
+        "}",
       ]);
     }
 
@@ -400,12 +400,12 @@ function genericPrint(path, options, print) {
                     opsPath => printSequence(opsPath, options, print),
                     "operationTypes"
                   )
-                )
+                ),
               ])
             )
           : "",
         hardline,
-        "}"
+        "}",
       ]);
     }
 
@@ -413,7 +413,7 @@ function genericPrint(path, options, print) {
       return concat([
         path.call(print, "operation"),
         ": ",
-        path.call(print, "type")
+        path.call(print, "type"),
       ]);
     }
 
@@ -433,12 +433,12 @@ function genericPrint(path, options, print) {
                     fieldsPath => printSequence(fieldsPath, options, print),
                     "fields"
                   )
-                )
+                ),
               ])
             )
           : "",
         hardline,
-        "}"
+        "}",
       ]);
     }
 
@@ -446,7 +446,7 @@ function genericPrint(path, options, print) {
       return concat([
         "...",
         path.call(print, "name"),
-        printDirectives(path, print, n)
+        printDirectives(path, print, n),
       ]);
     }
 
@@ -458,7 +458,7 @@ function genericPrint(path, options, print) {
           : "",
         printDirectives(path, print, n),
         " ",
-        path.call(print, "selectionSet")
+        path.call(print, "selectionSet"),
       ]);
     }
 
@@ -472,9 +472,9 @@ function genericPrint(path, options, print) {
           indent(
             concat([
               ifBreak(concat([line, "  "])),
-              join(concat([line, "| "]), path.map(print, "types"))
+              join(concat([line, "| "]), path.map(print, "types")),
             ])
-          )
+          ),
         ])
       );
     }
@@ -483,7 +483,7 @@ function genericPrint(path, options, print) {
       return concat([
         "scalar ",
         path.call(print, "name"),
-        printDirectives(path, print, n)
+        printDirectives(path, print, n),
       ]);
     }
 
@@ -515,10 +515,10 @@ function printDirectives(path, print, n) {
           join(
             concat([ifBreak("", " "), softline]),
             path.map(print, "directives")
-          )
+          ),
         ])
       )
-    )
+    ),
   ]);
 }
 

--- a/src/printer-htmlparser2.js
+++ b/src/printer-htmlparser2.js
@@ -26,7 +26,7 @@ const voidTags = {
   param: true,
   source: true,
   track: true,
-  wbr: true
+  wbr: true,
 };
 
 function genericPrint(path, options, print) {
@@ -73,7 +73,7 @@ function genericPrint(path, options, print) {
           n.name.toLowerCase() === "html"
             ? concat([hardline, children])
             : indent(children),
-          n.children.length ? concat([softline, "</", n.name, ">"]) : hardline
+          n.children.length ? concat([softline, "</", n.name, ">"]) : hardline,
         ])
       );
     }
@@ -98,7 +98,7 @@ function printAttributes(path, print) {
 
   return concat([
     node.attributes.length ? " " : "",
-    indent(join(line, path.map(print, "attributes")))
+    indent(join(line, path.map(print, "attributes"))),
   ]);
 }
 

--- a/src/printer-markdown.js
+++ b/src/printer-markdown.js
@@ -16,7 +16,7 @@ const SINGLE_LINE_NODE_TYPES = [
   "heading",
   "tableCell",
   "footnoteDefinition",
-  "link"
+  "link",
 ];
 
 const SIBLING_NODE_TYPES = ["listItem", "definition", "footnoteDefinition"];
@@ -35,13 +35,13 @@ const INLINE_NODE_TYPES = [
   "sentence",
   "whitespace",
   "word",
-  "break"
+  "break",
 ];
 
 const INLINE_NODE_WRAPPER_TYPES = INLINE_NODE_TYPES.concat([
   "tableCell",
   "paragraph",
-  "heading"
+  "heading",
 ]);
 
 function genericPrint(path, options, print) {
@@ -69,11 +69,11 @@ function genericPrint(path, options, print) {
     case "root":
       return concat([
         normalizeDoc(printChildren(path, options, print)),
-        hardline
+        hardline,
       ]);
     case "paragraph":
       return printChildren(path, options, print, {
-        postprocessor: fill
+        postprocessor: fill,
       });
     case "sentence":
       return printChildren(path, options, print);
@@ -84,7 +84,7 @@ function genericPrint(path, options, print) {
           new RegExp(
             [
               `(^|[${util.punctuationCharRange}])(_+)`,
-              `(_+)([${util.punctuationCharRange}]|$)`
+              `(_+)([${util.punctuationCharRange}]|$)`,
             ].join("|"),
             "g"
           ),
@@ -148,7 +148,7 @@ function genericPrint(path, options, print) {
             "](",
             printUrl(node.url, ")"),
             node.title ? ` ${printTitle(node.title)}` : "",
-            ")"
+            ")",
           ]);
         default:
           return options.originalText.slice(
@@ -163,14 +163,14 @@ function genericPrint(path, options, print) {
         "](",
         printUrl(node.url, ")"),
         node.title ? ` ${printTitle(node.title)}` : "",
-        ")"
+        ")",
       ]);
     case "blockquote":
       return concat(["> ", align("> ", printChildren(path, options, print))]);
     case "heading":
       return concat([
         "#".repeat(node.depth) + " ",
-        printChildren(path, options, print)
+        printChildren(path, options, print),
       ]);
     case "code": {
       if (
@@ -201,7 +201,7 @@ function genericPrint(path, options, print) {
         hardline,
         join(hardline, node.value.split("\n")),
         hardline,
-        style
+        style,
       ]);
     }
     case "yaml":
@@ -241,9 +241,9 @@ function genericPrint(path, options, print) {
             : nthSiblingIndex % 2 === 0 ? "* " : "- ";
           return concat([
             prefix,
-            align(" ".repeat(prefix.length), childPath.call(print))
+            align(" ".repeat(prefix.length), childPath.call(print)),
           ]);
-        }
+        },
       });
     }
     case "listItem": {
@@ -255,8 +255,8 @@ function genericPrint(path, options, print) {
           processor: (childPath, index) =>
             index === 0 && childPath.getValue().type !== "list"
               ? align(" ".repeat(prefix.length), childPath.call(print))
-              : childPath.call(print)
-        })
+              : childPath.call(print),
+        }),
       ]);
     }
     case "thematicBreak": {
@@ -277,7 +277,7 @@ function genericPrint(path, options, print) {
         "]",
         node.referenceType === "full"
           ? concat(["[", node.identifier, "]"])
-          : node.referenceType === "collapsed" ? "[]" : ""
+          : node.referenceType === "collapsed" ? "[]" : "",
       ]);
     case "imageReference":
       switch (node.referenceType) {
@@ -288,7 +288,7 @@ function genericPrint(path, options, print) {
             "![",
             node.alt,
             "]",
-            node.referenceType === "collapsed" ? "[]" : ""
+            node.referenceType === "collapsed" ? "[]" : "",
           ]);
       }
     case "definition":
@@ -297,7 +297,7 @@ function genericPrint(path, options, print) {
         node.identifier,
         "]: ",
         printUrl(node.url),
-        node.title === null ? "" : ` ${printTitle(node.title)}`
+        node.title === null ? "" : ` ${printTitle(node.title)}`,
       ]);
     case "footnote":
       return concat(["[^", printChildren(path, options, print), "]"]);
@@ -308,7 +308,7 @@ function genericPrint(path, options, print) {
         "[^",
         node.identifier,
         "]: ",
-        printChildren(path, options, print)
+        printChildren(path, options, print),
       ]);
     case "table":
       return printTable(path, options, print);
@@ -319,7 +319,7 @@ function genericPrint(path, options, print) {
         /\s/.test(options.originalText[node.position.start.offset])
           ? "  "
           : "\\",
-        hardline
+        hardline,
       ]);
     case "tableRow": // handled in "table"
     default:
@@ -413,7 +413,7 @@ function printTable(path, options, print) {
   return join(hardline, [
     printRow(contents[0]),
     printSeparator(),
-    join(hardline, contents.slice(1).map(printRow))
+    join(hardline, contents.slice(1).map(printRow)),
   ]);
 
   function printSeparator() {
@@ -434,7 +434,7 @@ function printTable(path, options, print) {
           }
         })
       ),
-      " |"
+      " |",
     ]);
   }
 
@@ -454,7 +454,7 @@ function printTable(path, options, print) {
           }
         })
       ),
-      " |"
+      " |",
     ]);
   }
 
@@ -507,7 +507,7 @@ function printChildren(path, options, print, events) {
         index: counter++,
         prevNode: lastChildNode,
         parentNode: node,
-        options
+        options,
       };
 
       if (!shouldNotPrePrintHardline(childNode, data)) {
@@ -582,7 +582,7 @@ function shouldPrePrintTripleHardline(node, data) {
 function shouldRemainTheSameContent(path) {
   const ancestorNode = getAncestorNode(path, [
     "linkReference",
-    "imageReference"
+    "imageReference",
   ]);
 
   return (
@@ -613,7 +613,7 @@ function normalizeDoc(doc) {
     });
 
     return Object.assign({}, currentDoc, {
-      parts: normalizeParts(parts)
+      parts: normalizeParts(parts),
     });
   });
 }

--- a/src/printer-postcss.js
+++ b/src/printer-postcss.js
@@ -59,9 +59,9 @@ function genericPrint(path, options, print) {
                   )
                 : "",
               hardline,
-              "}"
+              "}",
             ])
-          : ";"
+          : ";",
       ]);
     }
     case "css-decl": {
@@ -95,9 +95,9 @@ function genericPrint(path, options, print) {
                 concat([softline, printNodeSequence(path, options, print)])
               ),
               softline,
-              "}"
+              "}",
             ])
-          : ";"
+          : ";",
       ]);
     }
     case "css-atrule": {
@@ -119,7 +119,7 @@ function genericPrint(path, options, print) {
         hasParams
           ? concat([
               isDetachedRulesetCall ? "" : " ",
-              path.call(print, "params")
+              path.call(print, "params"),
             ])
           : "",
         n.nodes
@@ -128,13 +128,13 @@ function genericPrint(path, options, print) {
               indent(
                 concat([
                   n.nodes.length > 0 ? softline : "",
-                  printNodeSequence(path, options, print)
+                  printNodeSequence(path, options, print),
                 ])
               ),
               softline,
-              "}"
+              "}",
             ])
-          : ";"
+          : ";",
       ]);
     }
     case "css-import": {
@@ -151,9 +151,9 @@ function genericPrint(path, options, print) {
                 concat([softline, printNodeSequence(path, options, print)])
               ),
               softline,
-              "}"
+              "}",
             ])
-          : ";"
+          : ";",
       ]);
     }
     // postcss-media-query-parser
@@ -239,7 +239,7 @@ function genericPrint(path, options, print) {
           ? quoteAttributeValue(adjustStrings(n.value, options), options)
           : "",
         n.insensitive ? " i" : "",
-        "]"
+        "]",
       ]);
     }
     case "selector-combinator": {
@@ -267,7 +267,7 @@ function genericPrint(path, options, print) {
         maybeToLowerCase(n.value),
         n.nodes && n.nodes.length > 0
           ? concat(["(", join(", ", path.map(print, "nodes")), ")"])
-          : ""
+          : "",
       ]);
     }
     case "selector-nesting": {
@@ -345,7 +345,7 @@ function genericPrint(path, options, print) {
         return concat([
           n.open ? path.call(print, "open") : "",
           join(",", path.map(print, "groups")),
-          n.close ? path.call(print, "close") : ""
+          n.close ? path.call(print, "close") : "",
         ]);
       }
 
@@ -377,11 +377,11 @@ function genericPrint(path, options, print) {
               join(
                 concat([",", isMap ? hardline : line]),
                 path.map(print, "groups")
-              )
+              ),
             ])
           ),
           softline,
-          n.close ? path.call(print, "close") : ""
+          n.close ? path.call(print, "close") : "",
         ])
       );
     }

--- a/src/printer.js
+++ b/src/printer.js
@@ -280,7 +280,7 @@ function genericPrintNoParens(path, options, print, args) {
       // Do not append semicolon after the only JSX element in a program
       return concat([
         path.call(print, "expression"),
-        isTheOnlyJSXElementInMarkdown(options, path) ? "" : semi
+        isTheOnlyJSXElementInMarkdown(options, path) ? "" : semi,
       ]); // Babel extension.
     case "ParenthesizedExpression":
       return concat(["(", path.call(print, "expression"), ")"]);
@@ -377,7 +377,7 @@ function genericPrintNoParens(path, options, print, args) {
           // level. The first item is guaranteed to be the first
           // left-most expression.
           parts.length > 0 ? parts[0] : "",
-          indent(rest)
+          indent(rest),
         ])
       );
     }
@@ -385,14 +385,14 @@ function genericPrintNoParens(path, options, print, args) {
       return concat([
         path.call(print, "left"),
         " = ",
-        path.call(print, "right")
+        path.call(print, "right"),
       ]);
     case "TSTypeAssertionExpression":
       return concat([
         "<",
         path.call(print, "typeAnnotation"),
         ">",
-        path.call(print, "expression")
+        path.call(print, "expression"),
       ]);
     case "MemberExpression": {
       const parent = path.getParentNode();
@@ -427,14 +427,14 @@ function genericPrintNoParens(path, options, print, args) {
               indent(
                 concat([softline, printMemberLookup(path, options, print)])
               )
-            )
+            ),
       ]);
     }
     case "MetaProperty":
       return concat([
         path.call(print, "meta"),
         ".",
-        path.call(print, "property")
+        path.call(print, "property"),
       ]);
     case "BindExpression":
       if (n.object) {
@@ -453,7 +453,7 @@ function genericPrintNoParens(path, options, print, args) {
         n.name,
         printOptionalToken(path),
         n.typeAnnotation && !isFunctionDeclarationIdentifier ? ": " : "",
-        path.call(print, "typeAnnotation")
+        path.call(print, "typeAnnotation"),
       ]);
     }
     case "SpreadElement":
@@ -469,7 +469,7 @@ function genericPrintNoParens(path, options, print, args) {
         "...",
         path.call(print, "argument"),
         n.typeAnnotation ? ": " : "",
-        path.call(print, "typeAnnotation")
+        path.call(print, "typeAnnotation"),
       ]);
     case "FunctionDeclaration":
     case "FunctionExpression":
@@ -500,7 +500,7 @@ function genericPrintNoParens(path, options, print, args) {
                   (args.expandLastArg || args.expandFirstArg),
                 /* printTypeParams */ true
               ),
-              printReturnType(path, print)
+              printReturnType(path, print),
             ])
           )
         );
@@ -548,7 +548,7 @@ function genericPrintNoParens(path, options, print, args) {
             concat(parts),
             group(
               concat([" (", indent(concat([softline, body])), softline, ")"])
-            )
+            ),
           ])
         );
       }
@@ -584,14 +584,14 @@ function genericPrintNoParens(path, options, print, args) {
                   line,
                   shouldAddParens ? ifBreak("", "(") : "",
                   body,
-                  shouldAddParens ? ifBreak("", ")") : ""
+                  shouldAddParens ? ifBreak("", ")") : "",
                 ])
               ),
               shouldAddSoftLine
                 ? concat([ifBreak(printTrailingComma ? "," : ""), softline])
-                : ""
+                : "",
             ])
-          )
+          ),
         ])
       );
     }
@@ -720,7 +720,7 @@ function genericPrintNoParens(path, options, print, args) {
               options.bracketSpacing ? " " : "",
               concat(grouped),
               options.bracketSpacing ? " " : "",
-              "}"
+              "}",
             ])
           );
         } else if (grouped.length >= 1) {
@@ -731,12 +731,12 @@ function genericPrintNoParens(path, options, print, args) {
                 indent(
                   concat([
                     options.bracketSpacing ? line : softline,
-                    join(concat([",", line]), grouped)
+                    join(concat([",", line]), grouped),
                   ])
                 ),
                 ifBreak(shouldPrintComma(options) ? "," : ""),
                 options.bracketSpacing ? line : softline,
-                "}"
+                "}",
               ])
             )
           );
@@ -820,7 +820,7 @@ function genericPrintNoParens(path, options, print, args) {
               " (",
               indent(concat([softline, path.call(print, "argument")])),
               line,
-              ")"
+              ")",
             ])
           );
         } else if (
@@ -834,7 +834,7 @@ function genericPrintNoParens(path, options, print, args) {
                 ifBreak(" (", " "),
                 indent(concat([softline, path.call(print, "argument")])),
                 softline,
-                ifBreak(")")
+                ifBreak(")"),
               ])
             )
           );
@@ -876,7 +876,7 @@ function genericPrintNoParens(path, options, print, args) {
           path.call(print, "callee"),
           optional,
           path.call(print, "typeParameters"),
-          concat(["(", join(", ", path.map(print, "arguments")), ")"])
+          concat(["(", join(", ", path.map(print, "arguments")), ")"]),
         ]);
       }
 
@@ -891,7 +891,7 @@ function genericPrintNoParens(path, options, print, args) {
         path.call(print, "callee"),
         optional,
         printFunctionTypeParameters(path, options, print),
-        printArgumentsList(path, options, print)
+        printArgumentsList(path, options, print),
       ]);
     }
     case "TSInterfaceDeclaration":
@@ -916,7 +916,7 @@ function genericPrintNoParens(path, options, print, args) {
                 softline,
                 "extends ",
                 indent(join(concat([",", line]), path.map(print, "heritage"))),
-                " "
+                " ",
               ])
             )
           )
@@ -982,7 +982,7 @@ function genericPrintNoParens(path, options, print, args) {
           propsAndLoc.push({
             node: node,
             printed: print(childPath),
-            loc: util.locStart(node)
+            loc: util.locStart(node),
           });
         }, field);
       });
@@ -1025,7 +1025,7 @@ function genericPrintNoParens(path, options, print, args) {
             comments.printDanglingComments(path, options),
             softline,
             rightBrace,
-            printOptionalToken(path)
+            printOptionalToken(path),
           ])
         );
       } else {
@@ -1043,7 +1043,7 @@ function genericPrintNoParens(path, options, print, args) {
           concat([options.bracketSpacing ? line : softline, rightBrace]),
           printOptionalToken(path),
           n.typeAnnotation ? ": " : "",
-          path.call(print, "typeAnnotation")
+          path.call(print, "typeAnnotation"),
         ]);
       }
 
@@ -1119,7 +1119,7 @@ function genericPrintNoParens(path, options, print, args) {
                 "[",
                 comments.printDanglingComments(path, options),
                 softline,
-                "]"
+                "]",
               ])
             )
           );
@@ -1150,7 +1150,7 @@ function genericPrintNoParens(path, options, print, args) {
               indent(
                 concat([
                   softline,
-                  printArrayItems(path, options, "elements", print)
+                  printArrayItems(path, options, "elements", print),
                 ])
               ),
               needsForcedTrailingComma ? "," : "",
@@ -1167,7 +1167,7 @@ function genericPrintNoParens(path, options, print, args) {
                 /* sameIndent */ true
               ),
               softline,
-              "]"
+              "]",
             ])
           )
         );
@@ -1297,7 +1297,7 @@ function genericPrintNoParens(path, options, print, args) {
             ifBreak("(", ""),
             indent(concat([softline, doc])),
             softline,
-            ifBreak(")", "")
+            ifBreak(")", ""),
           ]);
 
         // The only things we don't wrap are:
@@ -1351,7 +1351,7 @@ function genericPrintNoParens(path, options, print, args) {
         concat([
           path.call(print, "test"),
           forceNoIndent ? concat(parts) : indent(concat(parts)),
-          breakClosingParen ? softline : ""
+          breakClosingParen ? softline : "",
         ])
       );
     }
@@ -1392,7 +1392,7 @@ function genericPrintNoParens(path, options, print, args) {
                 concat([",", hasValue && !isParentForLoop ? hardline : line, p])
               )
           )
-        )
+        ),
       ];
 
       if (!(isParentForLoop && parentNode.body !== n)) {
@@ -1416,7 +1416,7 @@ function genericPrintNoParens(path, options, print, args) {
           "with (",
           path.call(print, "object"),
           ")",
-          adjustClause(n.body, path.call(print, "body"))
+          adjustClause(n.body, path.call(print, "body")),
         ])
       );
     case "IfStatement": {
@@ -1427,11 +1427,11 @@ function genericPrintNoParens(path, options, print, args) {
           group(
             concat([
               indent(concat([softline, path.call(print, "test")])),
-              softline
+              softline,
             ])
           ),
           ")",
-          con
+          con,
         ])
       );
 
@@ -1490,16 +1490,16 @@ function genericPrintNoParens(path, options, print, args) {
                     path.call(print, "test"),
                     ";",
                     line,
-                    path.call(print, "update")
+                    path.call(print, "update"),
                   ])
                 ),
-                softline
+                softline,
               ])
             ),
             ")",
-            body
+            body,
           ])
-        )
+        ),
       ]);
     }
     case "WhileStatement":
@@ -1509,11 +1509,11 @@ function genericPrintNoParens(path, options, print, args) {
           group(
             concat([
               indent(concat([softline, path.call(print, "test")])),
-              softline
+              softline,
             ])
           ),
           ")",
-          adjustClause(n.body, path.call(print, "body"))
+          adjustClause(n.body, path.call(print, "body")),
         ])
       );
     case "ForInStatement":
@@ -1525,7 +1525,7 @@ function genericPrintNoParens(path, options, print, args) {
           " in ",
           path.call(print, "right"),
           ")",
-          adjustClause(n.body, path.call(print, "body"))
+          adjustClause(n.body, path.call(print, "body")),
         ])
       );
 
@@ -1545,7 +1545,7 @@ function genericPrintNoParens(path, options, print, args) {
           " of ",
           path.call(print, "right"),
           ")",
-          adjustClause(n.body, path.call(print, "body"))
+          adjustClause(n.body, path.call(print, "body")),
         ])
       );
     }
@@ -1566,7 +1566,7 @@ function genericPrintNoParens(path, options, print, args) {
         group(
           concat([
             indent(concat([softline, path.call(print, "test")])),
-            softline
+            softline,
           ])
         ),
         ")",
@@ -1605,20 +1605,20 @@ function genericPrintNoParens(path, options, print, args) {
       return concat([
         path.call(print, "label"),
         ": ",
-        path.call(print, "body")
+        path.call(print, "body"),
       ]);
     case "TryStatement":
       return concat([
         "try ",
         path.call(print, "block"),
         n.handler ? concat([" ", path.call(print, "handler")]) : "",
-        n.finalizer ? concat([" finally ", path.call(print, "finalizer")]) : ""
+        n.finalizer ? concat([" finally ", path.call(print, "finalizer")]) : "",
       ]);
     case "CatchClause":
       return concat([
         "catch ",
         n.param ? concat(["(", path.call(print, "param"), ") "]) : "",
-        path.call(print, "body")
+        path.call(print, "body"),
       ]);
     case "ThrowStatement":
       return concat(["throw ", path.call(print, "argument"), semi]);
@@ -1641,15 +1641,15 @@ function genericPrintNoParens(path, options, print, args) {
                       n.cases.indexOf(caseNode) !== n.cases.length - 1 &&
                       util.isNextLineEmpty(options.originalText, caseNode)
                         ? hardline
-                        : ""
+                        : "",
                     ]);
                   }, "cases")
-                )
+                ),
               ])
             )
           : "",
         hardline,
-        "}"
+        "}",
       ]);
     case "SwitchCase": {
       if (n.test) {
@@ -1704,12 +1704,12 @@ function genericPrintNoParens(path, options, print, args) {
     case "JSXNamespacedName":
       return join(":", [
         path.call(print, "namespace"),
-        path.call(print, "name")
+        path.call(print, "name"),
       ]);
     case "JSXMemberExpression":
       return join(".", [
         path.call(print, "object"),
-        path.call(print, "property")
+        path.call(print, "property"),
       ]);
     case "TSQualifiedName":
       return join(".", [path.call(print, "left"), path.call(print, "right")]);
@@ -1727,13 +1727,13 @@ function genericPrintNoParens(path, options, print, args) {
             indent(
               concat([
                 softline,
-                comments.printComments(p, () => printed, options)
+                comments.printComments(p, () => printed, options),
               ])
             ),
-            softline
+            softline,
           ]);
         }, n.type === "JSXSpreadAttribute" ? "argument" : "expression"),
-        "}"
+        "}",
       ]);
     }
     case "JSXExpressionContainer": {
@@ -1770,7 +1770,7 @@ function genericPrintNoParens(path, options, print, args) {
           indent(concat([softline, path.call(print, "expression")])),
           softline,
           lineSuffixBoundary,
-          "}"
+          "}",
         ])
       );
     }
@@ -1819,7 +1819,7 @@ function genericPrintNoParens(path, options, print, args) {
             path.call(print, "name"),
             " ",
             concat(path.map(print, "attributes")),
-            n.selfClosing ? " />" : ">"
+            n.selfClosing ? " />" : ">",
           ])
         );
       }
@@ -1849,9 +1849,9 @@ function genericPrintNoParens(path, options, print, args) {
                 path.map(attr => concat([line, print(attr)]), "attributes")
               )
             ),
-            n.selfClosing ? line : bracketSameLine ? ">" : softline
+            n.selfClosing ? line : bracketSameLine ? ">" : softline,
           ]),
-          n.selfClosing ? "/>" : bracketSameLine ? "" : ">"
+          n.selfClosing ? "/>" : bracketSameLine ? "" : ">",
         ])
       );
     }
@@ -1873,11 +1873,11 @@ function genericPrintNoParens(path, options, print, args) {
             hasOwnLineComment
               ? hardline
               : hasComment && !isOpeningFragment ? " " : "",
-            comments.printDanglingComments(path, options, true)
+            comments.printDanglingComments(path, options, true),
           ])
         ),
         hasOwnLineComment ? hardline : "",
-        ">"
+        ">",
       ]);
     }
     case "JSXText":
@@ -1893,7 +1893,7 @@ function genericPrintNoParens(path, options, print, args) {
           options,
           /* sameIndent */ !requiresHardline
         ),
-        requiresHardline ? hardline : ""
+        requiresHardline ? hardline : "",
       ]);
     }
     case "ClassBody":
@@ -1909,12 +1909,12 @@ function genericPrintNoParens(path, options, print, args) {
                 hardline,
                 path.call(bodyPath => {
                   return printStatementSequence(bodyPath, options, print);
-                }, "body")
+                }, "body"),
               ])
             )
           : comments.printDanglingComments(path, options),
         hardline,
-        "}"
+        "}",
       ]);
     case "ClassProperty":
     case "TSAbstractClassProperty":
@@ -2064,7 +2064,7 @@ function genericPrintNoParens(path, options, print, args) {
           indent(
             concat([
               softline,
-              printArrayItems(path, options, typesField, print)
+              printArrayItems(path, options, typesField, print),
             ])
           ),
           // TypeScript doesn't support trailing commas in tuple types
@@ -2073,7 +2073,7 @@ function genericPrintNoParens(path, options, print, args) {
             : ifBreak(shouldPrintComma(options) ? "," : ""),
           comments.printDanglingComments(path, options, /* sameIndent */ true),
           softline,
-          "]"
+          "]",
         ])
       );
     }
@@ -2101,7 +2101,7 @@ function genericPrintNoParens(path, options, print, args) {
         return concat([
           "declare ",
           printFunctionDeclaration(path, print, options),
-          semi
+          semi,
         ]);
       }
       return printFlowDeclaration(path, [
@@ -2109,21 +2109,21 @@ function genericPrintNoParens(path, options, print, args) {
         path.call(print, "id"),
         n.predicate ? " " : "",
         path.call(print, "predicate"),
-        semi
+        semi,
       ]);
     case "DeclareModule":
       return printFlowDeclaration(path, [
         "module ",
         path.call(print, "id"),
         " ",
-        path.call(print, "body")
+        path.call(print, "body"),
       ]);
     case "DeclareModuleExports":
       return printFlowDeclaration(path, [
         "module.exports",
         ": ",
         path.call(print, "typeAnnotation"),
-        semi
+        semi,
       ]);
     case "DeclareVariable":
       return printFlowDeclaration(path, ["var ", path.call(print, "id"), semi]);
@@ -2230,12 +2230,12 @@ function genericPrintNoParens(path, options, print, args) {
         path.call(print, "name"),
         printOptionalToken(path),
         n.name ? ": " : "",
-        path.call(print, "typeAnnotation")
+        path.call(print, "typeAnnotation"),
       ]);
     case "GenericTypeAnnotation":
       return concat([
         path.call(print, "id"),
-        path.call(print, "typeParameters")
+        path.call(print, "typeParameters"),
       ]);
     case "DeclareInterface":
     case "InterfaceDeclaration": {
@@ -2271,7 +2271,7 @@ function genericPrintNoParens(path, options, print, args) {
     case "InterfaceExtends":
       return concat([
         path.call(print, "id"),
-        path.call(print, "typeParameters")
+        path.call(print, "typeParameters"),
       ]);
     case "TSIntersectionType":
     case "IntersectionTypeAnnotation": {
@@ -2348,7 +2348,7 @@ function genericPrintNoParens(path, options, print, args) {
 
       const code = concat([
         ifBreak(concat([shouldIndent ? line : "", "| "])),
-        join(concat([line, "| "]), printed)
+        join(concat([line, "| "]), printed),
       ]);
 
       let hasParens;
@@ -2399,7 +2399,7 @@ function genericPrintNoParens(path, options, print, args) {
         n.id ? ": " : "",
         path.call(print, "key"),
         "]: ",
-        path.call(print, "value")
+        path.call(print, "value"),
       ]);
     }
     case "ObjectTypeProperty": {
@@ -2412,14 +2412,14 @@ function genericPrintNoParens(path, options, print, args) {
         printPropertyKey(path, options, print),
         printOptionalToken(path),
         isFunctionNotation(n) ? "" : ": ",
-        path.call(print, "value")
+        path.call(print, "value"),
       ]);
     }
     case "QualifiedTypeIdentifier":
       return concat([
         path.call(print, "qualification"),
         ".",
-        path.call(print, "id")
+        path.call(print, "id"),
       ]);
     case "StringLiteralTypeAnnotation":
       return nodeStr(n, options);
@@ -2468,7 +2468,7 @@ function genericPrintNoParens(path, options, print, args) {
         path.call(print, "expression"),
         ": ",
         path.call(print, "typeAnnotation"),
-        ")"
+        ")",
       ]);
     case "TypeParameterDeclaration":
     case "TypeParameterInstantiation":
@@ -2563,7 +2563,7 @@ function genericPrintNoParens(path, options, print, args) {
       return concat([
         path.call(print, "expression"),
         " as ",
-        path.call(print, "typeAnnotation")
+        path.call(print, "typeAnnotation"),
       ]);
     case "TSArrayType":
       return concat([path.call(print, "elementType"), "[]"]);
@@ -2624,7 +2624,7 @@ function genericPrintNoParens(path, options, print, args) {
     case "TSTypeReference":
       return concat([
         path.call(print, "typeName"),
-        printTypeParameters(path, options, print, "typeParameters")
+        printTypeParameters(path, options, print, "typeParameters"),
       ]);
     case "TSTypeQuery":
       return concat(["typeof ", path.call(print, "exprName")]);
@@ -2643,14 +2643,14 @@ function genericPrintNoParens(path, options, print, args) {
         path.call(print, "index"),
         "]: ",
         path.call(print, "typeAnnotation"),
-        parent.type === "ClassBody" ? semi : ""
+        parent.type === "ClassBody" ? semi : "",
       ]);
     }
     case "TSTypePredicate":
       return concat([
         path.call(print, "parameterName"),
         " is ",
-        path.call(print, "typeAnnotation")
+        path.call(print, "typeAnnotation"),
       ]);
     case "TSNonNullExpression":
       return concat([path.call(print, "expression"), "!"]);
@@ -2663,7 +2663,7 @@ function genericPrintNoParens(path, options, print, args) {
         path.call(print, "objectType"),
         "[",
         path.call(print, "indexType"),
-        "]"
+        "]",
       ]);
     case "TSConstructSignature":
     case "TSConstructorType":
@@ -2708,12 +2708,12 @@ function genericPrintNoParens(path, options, print, args) {
               "]",
               n.questionToken ? "?" : "",
               ": ",
-              path.call(print, "typeAnnotation")
+              path.call(print, "typeAnnotation"),
             ])
           ),
           comments.printDanglingComments(path, options, /* sameIndent */ true),
           options.bracketSpacing ? line : softline,
-          "}"
+          "}",
         ])
       );
     case "TSMethodSignature":
@@ -2768,7 +2768,7 @@ function genericPrintNoParens(path, options, print, args) {
               "{",
               comments.printDanglingComments(path, options),
               softline,
-              "}"
+              "}",
             ])
           )
         );
@@ -2781,7 +2781,7 @@ function genericPrintNoParens(path, options, print, args) {
                 concat([
                   hardline,
                   printArrayItems(path, options, "members", print),
-                  shouldPrintComma(options, "es5") ? "," : ""
+                  shouldPrintComma(options, "es5") ? "," : "",
                 ])
               ),
               comments.printDanglingComments(
@@ -2790,7 +2790,7 @@ function genericPrintNoParens(path, options, print, args) {
                 /* sameIndent */ true
               ),
               hardline,
-              "}"
+              "}",
             ])
           )
         );
@@ -2862,7 +2862,7 @@ function genericPrintNoParens(path, options, print, args) {
                   comments.printDanglingComments(bodyPath, options, true),
                 "body"
               ),
-              group(path.call(print, "body"))
+              group(path.call(print, "body")),
             ])
           ),
           line,
@@ -3010,9 +3010,9 @@ function printMethod(path, options, print) {
           group(
             concat([
               printFunctionParams(valuePath, print, options),
-              printReturnType(valuePath, print)
+              printReturnType(valuePath, print),
             ])
-          )
+          ),
         ],
         "value"
       )
@@ -3083,7 +3083,7 @@ function printArgumentsList(path, options, print) {
     return concat([
       "(",
       comments.printDanglingComments(path, options, /* sameIndent */ true),
-      ")"
+      ")",
     ]);
   }
 
@@ -3131,8 +3131,8 @@ function printArgumentsList(path, options, print) {
             argPath.call(p => print(p, { expandFirstArg: true })),
             printedArguments.length > 1 ? "," : "",
             hasEmptyLineFollowingFirstArg ? hardline : line,
-            hasEmptyLineFollowingFirstArg ? hardline : ""
-          ])
+            hasEmptyLineFollowingFirstArg ? hardline : "",
+          ]),
         ].concat(printedArguments.slice(1));
       }
       if (shouldGroupLast && i === args.length - 1) {
@@ -3159,22 +3159,22 @@ function printArgumentsList(path, options, print) {
             somePrintedArgumentsWillBreak
               ? concat([ifBreak(maybeTrailingComma), softline])
               : "",
-            ")"
+            ")",
           ]),
           shouldGroupFirst
             ? concat([
                 "(",
                 group(printedExpanded[0], { shouldBreak: true }),
                 concat(printedExpanded.slice(1)),
-                ")"
+                ")",
               ])
             : concat([
                 "(",
                 concat(printedArguments.slice(0, -1)),
                 group(util.getLast(printedExpanded), {
-                  shouldBreak: true
+                  shouldBreak: true,
                 }),
-                ")"
+                ")",
               ]),
           group(
             concat([
@@ -3182,13 +3182,13 @@ function printArgumentsList(path, options, print) {
               indent(concat([line, concat(printedArguments)])),
               maybeTrailingComma,
               line,
-              ")"
+              ")",
             ]),
             { shouldBreak: true }
-          )
+          ),
         ],
         { shouldBreak }
-      )
+      ),
     ]);
   }
 
@@ -3198,7 +3198,7 @@ function printArgumentsList(path, options, print) {
       indent(concat([softline, concat(printedArguments)])),
       ifBreak(shouldPrintComma(options, "all") ? "," : ""),
       softline,
-      ")"
+      ")",
     ]),
     { shouldBreak: printedArguments.some(willBreak) || anyArgEmptyLine }
   );
@@ -3243,7 +3243,7 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
             comment
           ) === ")"
       ),
-      ")"
+      ")",
     ]);
   }
 
@@ -3268,7 +3268,7 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
         docUtils.removeLines(typeParams),
         "(",
         join(", ", printed.map(docUtils.removeLines)),
-        ")"
+        ")",
       ])
     );
   }
@@ -3302,7 +3302,7 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
     "MixedTypeAnnotation",
     "BooleanTypeAnnotation",
     "BooleanLiteralTypeAnnotation",
-    "StringTypeAnnotation"
+    "StringTypeAnnotation",
   ];
 
   const isFlowShorthandWithOneArg =
@@ -3341,7 +3341,7 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
       canHaveTrailingComma && shouldPrintComma(options, "all") ? "," : ""
     ),
     softline,
-    ")"
+    ")",
   ]);
 }
 
@@ -3396,7 +3396,7 @@ function printFunctionDeclaration(path, print, options) {
     group(
       concat([
         printFunctionParams(path, print, options),
-        printReturnType(path, print)
+        printReturnType(path, print),
       ])
     ),
     n.body ? " " : "",
@@ -3437,7 +3437,7 @@ function printObjectMethod(path, options, print) {
     group(
       concat([
         printFunctionParams(path, print, options),
-        printReturnType(path, print)
+        printReturnType(path, print),
       ])
     ),
     " ",
@@ -3525,12 +3525,12 @@ function printExportDeclaration(path, options, print) {
                 indent(
                   concat([
                     options.bracketSpacing ? line : softline,
-                    join(concat([",", line]), specifiers)
+                    join(concat([",", line]), specifiers),
                   ])
                 ),
                 ifBreak(shouldPrintComma(options) ? "," : ""),
                 options.bracketSpacing ? line : softline,
-                "}"
+                "}",
               ])
             )
           : ""
@@ -3633,7 +3633,7 @@ function printTypeParameters(path, options, print, paramsKey) {
       indent(
         concat([
           softline,
-          join(concat([",", line]), path.map(print, paramsKey))
+          join(concat([",", line]), path.map(print, paramsKey)),
         ])
       ),
       ifBreak(
@@ -3642,7 +3642,7 @@ function printTypeParameters(path, options, print, paramsKey) {
           : ""
       ),
       softline,
-      ">"
+      ">",
     ])
   );
 }
@@ -3674,7 +3674,7 @@ function printClass(path, options, print) {
     const printed = concat([
       "extends ",
       path.call(print, "superClass"),
-      path.call(print, "superTypeParameters")
+      path.call(print, "superTypeParameters"),
     ]);
     parts.push(
       path.call(
@@ -3812,12 +3812,12 @@ function printMemberChain(path, options, print) {
               concat([
                 printOptionalToken(path),
                 printFunctionTypeParameters(path, options, print),
-                printArgumentsList(path, options, print)
+                printArgumentsList(path, options, print),
               ]),
             options
           ),
-          shouldInsertEmptyLineAfter(node) ? hardline : ""
-        ])
+          shouldInsertEmptyLineAfter(node) ? hardline : "",
+        ]),
       });
       path.call(callee => rec(callee), "callee");
     } else if (isMemberish(node)) {
@@ -3830,13 +3830,13 @@ function printMemberChain(path, options, print) {
               ? printMemberLookup(path, options, print)
               : printBindExpressionCallee(path, options, print),
           options
-        )
+        ),
       });
       path.call(object => rec(object), "object");
     } else {
       printedNodes.unshift({
         node: node,
-        printed: path.call(print)
+        printed: path.call(print),
       });
     }
   }
@@ -3849,8 +3849,8 @@ function printMemberChain(path, options, print) {
     printed: concat([
       printOptionalToken(path),
       printFunctionTypeParameters(path, options, print),
-      printArgumentsList(path, options, print)
-    ])
+      printArgumentsList(path, options, print),
+    ]),
   });
   path.call(callee => rec(callee), "callee");
 
@@ -4022,7 +4022,7 @@ function printMemberChain(path, options, print) {
     printGroup(groups[0]),
     shouldMerge ? concat(groups.slice(1, 2).map(printGroup)) : "",
     shouldHaveEmptyLineBeforeIndent ? hardline : "",
-    printIndentedGroup(groups.slice(shouldMerge ? 2 : 1))
+    printIndentedGroup(groups.slice(shouldMerge ? 2 : 1)),
   ]);
 
   const callExpressionCount = printedNodes.filter(
@@ -4047,7 +4047,7 @@ function printMemberChain(path, options, print) {
     // that means that the parent group has already been broken
     // naturally
     willBreak(oneLine) || shouldHaveEmptyLineBeforeIndent ? breakParent : "",
-    conditionalGroup([oneLine, expanded])
+    conditionalGroup([oneLine, expanded]),
   ]);
 }
 
@@ -4346,7 +4346,7 @@ function printJSXElement(path, options, print) {
     return concat([
       openingLines,
       concat(path.map(print, "children")),
-      closingLines
+      closingLines,
     ]);
   }
 
@@ -4358,7 +4358,7 @@ function printJSXElement(path, options, print) {
       return {
         type: "JSXText",
         value: " ",
-        raw: " "
+        raw: " ",
       };
     }
     return child;
@@ -4485,7 +4485,7 @@ function printJSXElement(path, options, print) {
       openingLines,
       indent(concat([hardline, content])),
       hardline,
-      closingLines
+      closingLines,
     ])
   );
 
@@ -4495,7 +4495,7 @@ function printJSXElement(path, options, print) {
 
   return conditionalGroup([
     group(concat([openingLines, concat(children), closingLines])),
-    multiLineElem
+    multiLineElem,
   ]);
 }
 
@@ -4513,7 +4513,7 @@ function maybeWrapJSXElementInParens(path, elem) {
     TSJsxFragment: true,
     ExpressionStatement: true,
     CallExpression: true,
-    ConditionalExpression: true
+    ConditionalExpression: true,
   };
   if (NO_WRAP_PARENTS[parent.type]) {
     return elem;
@@ -4524,7 +4524,7 @@ function maybeWrapJSXElementInParens(path, elem) {
       ifBreak("("),
       indent(concat([softline, elem])),
       softline,
-      ifBreak(")")
+      ifBreak(")"),
     ])
   );
 }
@@ -4623,7 +4623,7 @@ function printBinaryishExpressions(
           lineBeforeOperator ? softline : "",
           node.operator,
           lineBeforeOperator ? " " : line,
-          path.call(print, "right")
+          path.call(print, "right"),
         ]);
 
     // If there's only a single binary expression, we want to create a group

--- a/src/resolve-config-editorconfig.js
+++ b/src/resolve-config-editorconfig.js
@@ -43,5 +43,5 @@ function clearCache() {
 
 module.exports = {
   getLoadFunction,
-  clearCache
+  clearCache,
 };

--- a/src/resolve-config.js
+++ b/src/resolve-config.js
@@ -17,7 +17,7 @@ const getExplorerMemoized = mem(opts =>
         delete result.config.$schema;
       }
       return result;
-    }
+    },
   })
 );
 
@@ -33,7 +33,7 @@ function _resolveConfig(filePath, opts, sync) {
   const loadOpts = {
     cache: !!opts.useCache,
     sync: !!sync,
-    editorconfig: !!opts.editorconfig
+    editorconfig: !!opts.editorconfig,
   };
   const load = getLoadFunction(loadOpts);
   const loadEditorConfig = resolveEditorConfig.getLoadFunction(loadOpts);
@@ -125,5 +125,5 @@ function pathMatchesGlobs(filePath, patterns, excludedPatterns) {
 module.exports = {
   resolveConfig,
   resolveConfigFile,
-  clearCache
+  clearCache,
 };

--- a/src/support.js
+++ b/src/support.js
@@ -37,11 +37,11 @@ const supportTable = [
       ".sjs",
       ".ssjs",
       ".xsjs",
-      ".xsjslib"
+      ".xsjslib",
     ],
     filenames: ["Jakefile"],
     linguistLanguageId: 183,
-    vscodeLanguageIds: ["javascript"]
+    vscodeLanguageIds: ["javascript"],
   },
   {
     name: "JSX",
@@ -54,7 +54,7 @@ const supportTable = [
     codemirrorMode: "jsx",
     codemirrorMimeType: "text/jsx",
     liguistLanguageId: 178,
-    vscodeLanguageIds: ["javascriptreact"]
+    vscodeLanguageIds: ["javascriptreact"],
   },
   {
     name: "TypeScript",
@@ -68,7 +68,7 @@ const supportTable = [
     codemirrorMode: "javascript",
     codemirrorMimeType: "application/typescript",
     liguistLanguageId: 378,
-    vscodeLanguageIds: ["typescript", "typescriptreact"]
+    vscodeLanguageIds: ["typescript", "typescriptreact"],
   },
   {
     name: "CSS",
@@ -81,7 +81,7 @@ const supportTable = [
     codemirrorMimeType: "text/css",
     extensions: [".css"],
     liguistLanguageId: 50,
-    vscodeLanguageIds: ["css"]
+    vscodeLanguageIds: ["css"],
   },
   {
     name: "Less",
@@ -94,7 +94,7 @@ const supportTable = [
     codemirrorMode: "css",
     codemirrorMimeType: "text/css",
     liguistLanguageId: 198,
-    vscodeLanguageIds: ["less"]
+    vscodeLanguageIds: ["less"],
   },
   {
     name: "SCSS",
@@ -107,7 +107,7 @@ const supportTable = [
     codemirrorMimeType: "text/x-scss",
     extensions: [".scss"],
     liguistLanguageId: 329,
-    vscodeLanguageIds: ["scss"]
+    vscodeLanguageIds: ["scss"],
   },
   {
     name: "GraphQL",
@@ -117,7 +117,7 @@ const supportTable = [
     tmScope: "source.graphql",
     aceMode: "text",
     liguistLanguageId: 139,
-    vscodeLanguageIds: ["graphql"]
+    vscodeLanguageIds: ["graphql"],
   },
   {
     name: "JSON",
@@ -133,7 +133,7 @@ const supportTable = [
       ".json5",
       ".geojson",
       ".JSON-tmLanguage",
-      ".topojson"
+      ".topojson",
     ],
     filenames: [
       ".arcconfig",
@@ -142,10 +142,10 @@ const supportTable = [
       ".eslintrc",
       ".prettierrc",
       "composer.lock",
-      "mcmod.info"
+      "mcmod.info",
     ],
     linguistLanguageId: 174,
-    vscodeLanguageIds: ["json"]
+    vscodeLanguageIds: ["json"],
   },
 
   {
@@ -166,12 +166,12 @@ const supportTable = [
       ".mkdn",
       ".mkdown",
       ".ron",
-      ".workbook"
+      ".workbook",
     ],
     filenames: ["README"],
     tmScope: "source.gfm",
     linguistLanguageId: 222,
-    vscodeLanguageIds: ["markdown"]
+    vscodeLanguageIds: ["markdown"],
   },
   {
     name: "HTML",
@@ -185,8 +185,8 @@ const supportTable = [
     aliases: ["xhtml"],
     extensions: [".html", ".htm", ".html.hl", ".inc", ".st", ".xht", ".xhtml"],
     linguistLanguageId: 146,
-    vscodeLanguageIds: ["html"]
-  }
+    vscodeLanguageIds: ["html"],
+  },
 ];
 
 function getSupportInfo(version) {
@@ -201,7 +201,7 @@ function getSupportInfo(version) {
     .map(language => {
       if (usePostCssParser && language.group === "CSS") {
         return Object.assign({}, language, {
-          parsers: ["postcss"]
+          parsers: ["postcss"],
         });
       }
       return language;
@@ -212,5 +212,5 @@ function getSupportInfo(version) {
 
 module.exports = {
   supportTable,
-  getSupportInfo
+  getSupportInfo,
 };

--- a/src/third-party.js
+++ b/src/third-party.js
@@ -5,5 +5,5 @@ const cosmiconfig = require("cosmiconfig");
 
 module.exports = {
   getStream,
-  cosmiconfig
+  cosmiconfig,
 };

--- a/src/util.js
+++ b/src/util.js
@@ -21,7 +21,7 @@ const punctuationCharRange = `${asciiPunctuationCharRange}${getUnicodeRegex([
   "Pf",
   "Pi",
   "Po",
-  "Ps"
+  "Ps",
 ]).source.slice(1, -1)}`; // remove bracket expression `[` and `]`
 
 const punctuationRegex = new RegExp(`[${punctuationCharRange}]`);
@@ -338,7 +338,7 @@ const PRECEDENCE = {};
   [">>", "<<", ">>>"],
   ["+", "-"],
   ["*", "/", "%"],
-  ["**"]
+  ["**"],
 ].forEach((tier, i) => {
   tier.forEach(op => {
     PRECEDENCE[op] = i;
@@ -353,17 +353,17 @@ const equalityOperators = {
   "==": true,
   "!=": true,
   "===": true,
-  "!==": true
+  "!==": true,
 };
 const multiplicativeOperators = {
   "*": true,
   "/": true,
-  "%": true
+  "%": true,
 };
 const bitshiftOperators = {
   ">>": true,
   ">>>": true,
-  "<<": true
+  "<<": true,
 };
 
 function shouldFlatten(parentOp, nodeOp) {
@@ -689,7 +689,7 @@ function splitText(text) {
       if (index % 2 === 1) {
         nodes.push({
           type: "whitespace",
-          value: /\n/.test(token) ? "\n" : " "
+          value: /\n/.test(token) ? "\n" : " ",
         });
         return;
       }
@@ -720,7 +720,7 @@ function splitText(text) {
                 hasLeadingPunctuation: punctuationRegex.test(innerToken[0]),
                 hasTrailingPunctuation: punctuationRegex.test(
                   getLast(innerToken)
-                )
+                ),
               });
             }
             return;
@@ -734,14 +734,14 @@ function splitText(text) {
                   value: innerToken,
                   kind: KIND_CJK_PUNCTUATION,
                   hasLeadingPunctuation: true,
-                  hasTrailingPunctuation: true
+                  hasTrailingPunctuation: true,
                 }
               : {
                   type: "word",
                   value: innerToken,
                   kind: KIND_CJK_CHARACTER,
                   hasLeadingPunctuation: false,
-                  hasTrailingPunctuation: false
+                  hasTrailingPunctuation: false,
                 }
           );
         });
@@ -827,5 +827,5 @@ module.exports = {
   getAlignmentSize,
   getIndentSize,
   printString,
-  printNumber
+  printNumber,
 };

--- a/tests/.eslintrc.js
+++ b/tests/.eslintrc.js
@@ -2,12 +2,12 @@
 
 module.exports = {
   env: {
-    jest: true
+    jest: true,
   },
   rules: {
-    strict: "off"
+    strict: "off",
   },
   globals: {
-    run_spec: false
-  }
+    run_spec: false,
+  },
 };

--- a/tests/comments_jsx_same_line/jsfmt.spec.js
+++ b/tests/comments_jsx_same_line/jsfmt.spec.js
@@ -1,3 +1,3 @@
 run_spec(__dirname, ["flow", "babylon", "typescript"], {
-  jsxBracketSameLine: true
+  jsxBracketSameLine: true,
 });

--- a/tests/cursor/jsfmt.spec.js
+++ b/tests/cursor/jsfmt.spec.js
@@ -3,7 +3,7 @@ const prettier = require("../../tests_config/require_prettier");
 test("translates cursor correctly in basic case", () => {
   expect(prettier.formatWithCursor(" 1", { cursorOffset: 2 })).toEqual({
     formatted: "1;\n",
-    cursorOffset: 1
+    cursorOffset: 1,
   });
 });
 
@@ -11,7 +11,7 @@ test("positions cursor relative to closest node, not SourceElement", () => {
   const code = "return         15";
   expect(prettier.formatWithCursor(code, { cursorOffset: 15 })).toEqual({
     formatted: "return 15;\n",
-    cursorOffset: 7
+    cursorOffset: 7,
   });
 });
 
@@ -19,7 +19,7 @@ test("keeps cursor inside formatted node", () => {
   const code = "return         15";
   expect(prettier.formatWithCursor(code, { cursorOffset: 14 })).toEqual({
     formatted: "return 15;\n",
-    cursorOffset: 14 // TODO fix this
+    cursorOffset: 14, // TODO fix this
   });
 });
 
@@ -33,6 +33,6 @@ foo('bar', cb => {
   console.log("stuff");
 });
 `,
-    cursorOffset: 23
+    cursorOffset: 23,
   });
 });

--- a/tests_config/.eslintrc.js
+++ b/tests_config/.eslintrc.js
@@ -2,6 +2,6 @@
 
 module.exports = {
   env: {
-    jest: true
-  }
+    jest: true,
+  },
 };

--- a/tests_config/raw-serializer.js
+++ b/tests_config/raw-serializer.js
@@ -12,5 +12,5 @@ module.exports = {
       Object.prototype.hasOwnProperty.call(val, RAW) &&
       typeof val[RAW] === "string"
     );
-  }
+  },
 };

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -42,7 +42,7 @@ function run_spec(dirname, parsers, options) {
       const mergedOptions = Object.assign(mergeDefaultOptions(options || {}), {
         parser: parsers[0],
         rangeStart: rangeStart,
-        rangeEnd: rangeEnd
+        rangeEnd: rangeEnd,
       });
       const output = prettyprint(source, path, mergedOptions);
       test(`${filename} - ${mergedOptions.parser}-verify`, () => {
@@ -55,7 +55,7 @@ function run_spec(dirname, parsers, options) {
         parserName => {
           test(`${filename} - ${parserName}-verify`, () => {
             const verifyOptions = Object.assign(mergedOptions, {
-              parser: parserName
+              parser: parserName,
             });
             const verifyOutput = prettyprint(source, path, verifyOptions);
             expect(output).toEqual(verifyOutput);
@@ -124,7 +124,7 @@ function prettyprint(src, filename, options) {
     src,
     Object.assign(
       {
-        filepath: filename
+        filepath: filename,
       },
       options
     )
@@ -150,7 +150,7 @@ function raw(string) {
 function mergeDefaultOptions(parserConfig) {
   return Object.assign(
     {
-      printWidth: 80
+      printWidth: 80,
     },
     parserConfig
   );

--- a/tests_integration/.eslintrc.js
+++ b/tests_integration/.eslintrc.js
@@ -2,6 +2,6 @@
 
 module.exports = {
   env: {
-    jest: true
-  }
+    jest: true,
+  },
 };

--- a/tests_integration/__tests__/arg-parsing.js
+++ b/tests_integration/__tests__/arg-parsing.js
@@ -4,36 +4,36 @@ const runPrettier = require("../runPrettier");
 
 describe("boolean flags do not swallow the next argument", () => {
   runPrettier("cli/arg-parsing", ["--single-quote", "file.js"]).test({
-    status: 0
+    status: 0,
   });
 });
 
 describe("negated options work", () => {
   runPrettier("cli/arg-parsing", ["--no-semi", "file.js"]).test({
-    status: 0
+    status: 0,
   });
 });
 
 describe("unknown options are warned", () => {
   runPrettier("cli/arg-parsing", ["file.js", "--unknown"]).test({
-    status: 0
+    status: 0,
   });
 });
 
 describe("unknown negated options are warned", () => {
   runPrettier("cli/arg-parsing", ["file.js", "--no-unknown"]).test({
-    status: 0
+    status: 0,
   });
 });
 
 describe("deprecated options are warned", () => {
   runPrettier("cli/arg-parsing", ["file.js", "--flow-parser"]).test({
-    status: 0
+    status: 0,
   });
 });
 
 describe("deprecated option values are warned", () => {
   runPrettier("cli/arg-parsing", ["file.js", "--trailing-comma"]).test({
-    status: 0
+    status: 0,
   });
 });

--- a/tests_integration/__tests__/config-invalid.js
+++ b/tests_integration/__tests__/config-invalid.js
@@ -6,42 +6,42 @@ expect.addSnapshotSerializer(require("../path-serializer"));
 
 describe("throw error with invalid config format", () => {
   runPrettier("cli/config/invalid", ["--config", "file/.prettierrc"]).test({
-    status: "non-zero"
+    status: "non-zero",
   });
 });
 
 describe("throw error with invalid config target (directory)", () => {
   runPrettier("cli/config/invalid", [
     "--config",
-    "folder/.prettierrc" // this is a directory
+    "folder/.prettierrc", // this is a directory
   ]).test({
-    status: "non-zero"
+    status: "non-zero",
   });
 });
 
 describe("throw error with invalid config option (int)", () => {
   runPrettier("cli/config/invalid", ["--config", "option/int"]).test({
-    status: "non-zero"
+    status: "non-zero",
   });
 });
 
 describe("throw error with invalid config option (trailingComma)", () => {
   runPrettier("cli/config/invalid", ["--config", "option/trailingComma"]).test({
-    status: "non-zero"
+    status: "non-zero",
   });
 });
 
 describe("throw error with invalid config precedence option (configPrecedence)", () => {
   runPrettier("cli/config/invalid", [
     "--config-precedence",
-    "option/configPrecedence"
+    "option/configPrecedence",
   ]).test({
-    status: "non-zero"
+    status: "non-zero",
   });
 });
 
 describe("show warning with unknown option", () => {
   runPrettier("cli/config/invalid", ["--config", "option/unknown"]).test({
-    status: 0
+    status: 0,
   });
 });

--- a/tests_integration/__tests__/config-resolution.js
+++ b/tests_integration/__tests__/config-resolution.js
@@ -9,50 +9,50 @@ expect.addSnapshotSerializer(require("../path-serializer"));
 
 describe("resolves configuration from external files", () => {
   runPrettier("cli/config/", ["**/*.js"]).test({
-    status: 0
+    status: 0,
   });
 });
 
 describe("resolves configuration from external files and overrides by extname", () => {
   runPrettier("cli/config/", ["**/*.ts"]).test({
-    status: 0
+    status: 0,
   });
 });
 
 describe("accepts configuration from --config", () => {
   runPrettier("cli/config/", ["--config", ".prettierrc", "./js/file.js"]).test({
-    status: 0
+    status: 0,
   });
 });
 
 describe("resolves configuration file with --find-config-path file", () => {
   runPrettier("cli/config/", ["--find-config-path", "no-config/file.js"]).test({
-    status: 0
+    status: 0,
   });
 });
 
 describe("resolves json configuration file with --find-config-path file", () => {
   runPrettier("cli/config/", ["--find-config-path", "rc-json/file.js"]).test({
-    status: 0
+    status: 0,
   });
 });
 
 describe("resolves yaml configuration file with --find-config-path file", () => {
   runPrettier("cli/config/", ["--find-config-path", "rc-yaml/file.js"]).test({
-    status: 0
+    status: 0,
   });
 });
 
 describe("prints nothing when no file found with --find-config-path", () => {
   runPrettier("cli/config/", ["--find-config-path", ".."]).test({
     stdout: "",
-    status: 1
+    status: 1,
   });
 });
 
 describe("CLI overrides take precedence", () => {
   runPrettier("cli/config/", ["--print-width", "1", "**/*.js"]).test({
-    status: 0
+    status: 0,
   });
 });
 
@@ -70,7 +70,7 @@ test("API resolveConfig with file arg", () => {
   const file = path.resolve(path.join(__dirname, "../cli/config/js/file.js"));
   return prettier.resolveConfig(file).then(result => {
     expect(result).toMatchObject({
-      tabWidth: 8
+      tabWidth: 8,
     });
   });
 });
@@ -78,7 +78,7 @@ test("API resolveConfig with file arg", () => {
 test("API resolveConfig.sync with file arg", () => {
   const file = path.resolve(path.join(__dirname, "../cli/config/js/file.js"));
   expect(prettier.resolveConfig.sync(file)).toMatchObject({
-    tabWidth: 8
+    tabWidth: 8,
   });
 });
 
@@ -88,7 +88,7 @@ test("API resolveConfig with file arg and extension override", () => {
   );
   return prettier.resolveConfig(file).then(result => {
     expect(result).toMatchObject({
-      semi: true
+      semi: true,
     });
   });
 });
@@ -98,7 +98,7 @@ test("API resolveConfig.sync with file arg and extension override", () => {
     path.join(__dirname, "../cli/config/no-config/file.ts")
   );
   expect(prettier.resolveConfig.sync(file)).toMatchObject({
-    semi: true
+    semi: true,
   });
 });
 
@@ -110,7 +110,7 @@ test("API resolveConfig with file arg and .editorconfig", () => {
     expect(result).toMatchObject({
       useTabs: true,
       tabWidth: 8,
-      printWidth: 100
+      printWidth: 100,
     });
   });
 });
@@ -121,7 +121,7 @@ test("API resolveConfig.sync with file arg and .editorconfig", () => {
   );
 
   expect(prettier.resolveConfig.sync(file)).toMatchObject({
-    semi: false
+    semi: false,
   });
 
   expect(
@@ -129,7 +129,7 @@ test("API resolveConfig.sync with file arg and .editorconfig", () => {
   ).toMatchObject({
     useTabs: true,
     tabWidth: 8,
-    printWidth: 100
+    printWidth: 100,
   });
 });
 
@@ -141,7 +141,7 @@ test("API resolveConfig with nested file arg and .editorconfig", () => {
     expect(result).toMatchObject({
       useTabs: false,
       tabWidth: 2,
-      printWidth: 100
+      printWidth: 100,
     });
   });
 });
@@ -152,7 +152,7 @@ test("API resolveConfig.sync with nested file arg and .editorconfig", () => {
   );
 
   expect(prettier.resolveConfig.sync(file)).toMatchObject({
-    semi: false
+    semi: false,
   });
 
   expect(
@@ -160,7 +160,7 @@ test("API resolveConfig.sync with nested file arg and .editorconfig", () => {
   ).toMatchObject({
     useTabs: false,
     tabWidth: 2,
-    printWidth: 100
+    printWidth: 100,
   });
 });
 
@@ -172,7 +172,7 @@ test("API resolveConfig with nested file arg and .editorconfig and indent_size =
     expect(result).toMatchObject({
       useTabs: false,
       tabWidth: 8,
-      printWidth: 100
+      printWidth: 100,
     });
   });
 });
@@ -183,7 +183,7 @@ test("API resolveConfig.sync with nested file arg and .editorconfig and indent_s
   );
 
   expect(prettier.resolveConfig.sync(file)).toMatchObject({
-    semi: false
+    semi: false,
   });
 
   expect(
@@ -191,7 +191,7 @@ test("API resolveConfig.sync with nested file arg and .editorconfig and indent_s
   ).toMatchObject({
     useTabs: false,
     tabWidth: 8,
-    printWidth: 100
+    printWidth: 100,
   });
 });
 
@@ -203,7 +203,7 @@ test("API resolveConfig.sync overrides work with absolute paths", () => {
   // Absolute path
   const file = path.join(__dirname, "../cli/config/filepath/subfolder/file.js");
   expect(prettier.resolveConfig.sync(file)).toMatchObject({
-    tabWidth: 6
+    tabWidth: 6,
   });
 });
 
@@ -213,7 +213,7 @@ test("API resolveConfig removes $schema option", () => {
   );
   return prettier.resolveConfig(file).then(result => {
     expect(result).toEqual({
-      tabWidth: 42
+      tabWidth: 42,
     });
   });
 });
@@ -223,6 +223,6 @@ test("API resolveConfig.sync removes $schema option", () => {
     path.join(__dirname, "../cli/config/$schema/index.js")
   );
   expect(prettier.resolveConfig.sync(file)).toEqual({
-    tabWidth: 42
+    tabWidth: 42,
   });
 });

--- a/tests_integration/__tests__/cursor-offset.js
+++ b/tests_integration/__tests__/cursor-offset.js
@@ -4,13 +4,13 @@ const runPrettier = require("../runPrettier");
 
 describe("write cursorOffset to stderr with --cursor-offset <int>", () => {
   runPrettier("cli", ["--cursor-offset", "2"], { input: " 1" }).test({
-    status: 0
+    status: 0,
   });
 });
 
 describe("cursorOffset should not be affected by full-width character", () => {
   runPrettier("cli", ["--cursor-offset", "21"], {
-    input: `const x = ["中文", "中文", "中文", "中文", "中文", "中文", "中文", "中文", "中文", "中文", "中文"];`
+    input: `const x = ["中文", "中文", "中文", "中文", "中文", "中文", "中文", "中文", "中文", "中文", "中文"];`,
     //                              ^ offset = 21                              ^ width = 80
   }).test({
     /**
@@ -30,6 +30,6 @@ describe("cursorOffset should not be affected by full-width character", () => {
      * ];
      */
     stderr: "26\n",
-    status: 0
+    status: 0,
   });
 });

--- a/tests_integration/__tests__/debug-check.js
+++ b/tests_integration/__tests__/debug-check.js
@@ -6,22 +6,22 @@ describe("doesn't crash when --debug-check is passed", () => {
   runPrettier("cli/with-shebang", ["issue1890.js", "--debug-check"]).test({
     stdout: "issue1890.js\n",
     stderr: "",
-    status: 0
+    status: 0,
   });
 });
 
 describe("checks stdin with --debug-check", () => {
   runPrettier("cli/with-shebang", ["--debug-check"], {
-    input: "0"
+    input: "0",
   }).test({
     stdout: "(stdin)\n",
     stderr: "",
-    status: 0
+    status: 0,
   });
 });
 
 describe("show diff for 2+ error files with --debug-check", () => {
   runPrettier("cli/debug-check", ["*.js", "--debug-check"]).test({
-    status: "non-zero"
+    status: "non-zero",
   });
 });

--- a/tests_integration/__tests__/debug-print-doc.js
+++ b/tests_integration/__tests__/debug-print-doc.js
@@ -4,10 +4,10 @@ const runPrettier = require("../runPrettier");
 
 describe("prints doc with --debug-print-doc", () => {
   runPrettier("cli/with-shebang", ["--debug-print-doc"], {
-    input: "0"
+    input: "0",
   }).test({
     stdout: '["0", ";", hardline, breakParent];\n',
     stderr: "",
-    status: 0
+    status: 0,
   });
 });

--- a/tests_integration/__tests__/early-exit.js
+++ b/tests_integration/__tests__/early-exit.js
@@ -7,32 +7,32 @@ const constant = require("../../src/cli-constant");
 describe("show version with --version", () => {
   runPrettier("cli/with-shebang", ["--version"]).test({
     stdout: prettier.version + "\n",
-    status: 0
+    status: 0,
   });
 });
 
 describe("show usage with --help", () => {
   runPrettier("cli", ["--help"]).test({
-    status: 0
+    status: 0,
   });
 });
 
 describe(`show detailed usage with --help l (alias)`, () => {
   runPrettier("cli", ["--help", "l"]).test({
-    status: 0
+    status: 0,
   });
 });
 
 constant.detailedOptions.forEach(option => {
   const optionNames = [
     option.description ? option.name : null,
-    option.oppositeDescription ? `no-${option.name}` : null
+    option.oppositeDescription ? `no-${option.name}` : null,
   ].filter(Boolean);
 
   optionNames.forEach(optionName => {
     describe(`show detailed usage with --help ${optionName}`, () => {
       runPrettier("cli", ["--help", optionName]).test({
-        status: 0
+        status: 0,
       });
     });
   });
@@ -40,30 +40,30 @@ constant.detailedOptions.forEach(option => {
 
 describe("show warning with --help not-found", () => {
   runPrettier("cli", ["--help", "not-found"]).test({
-    status: 0
+    status: 0,
   });
 });
 
 describe("show warning with --help not-found (typo)", () => {
   runPrettier("cli", ["--help", "parserr"]).test({
-    status: 0
+    status: 0,
   });
 });
 
 describe("throw error with --write + --debug-check", () => {
   runPrettier("cli", ["--write", "--debug-check"]).test({
-    status: 1
+    status: 1,
   });
 });
 
 describe("throw error with --find-config-path + multiple files", () => {
   runPrettier("cli", ["--find-config-path", "abc.js", "def.js"]).test({
-    status: 1
+    status: 1,
   });
 });
 
 describe("throw error and show usage with something unexpected", () => {
   runPrettier("cli", [], { isTTY: true }).test({
-    status: "non-zero"
+    status: "non-zero",
   });
 });

--- a/tests_integration/__tests__/ignore-absolute-path.js
+++ b/tests_integration/__tests__/ignore-absolute-path.js
@@ -8,8 +8,8 @@ describe("support absolute filename", () => {
     path.resolve(__dirname, "../cli/ignore-absolute-path/ignored/module.js"),
     path.resolve(__dirname, "../cli/ignore-absolute-path/depth1/ignored/*.js"),
     path.resolve(__dirname, "../cli/ignore-absolute-path/regular-module.js"),
-    "-l"
+    "-l",
   ]).test({
-    status: 1
+    status: 1,
   });
 });

--- a/tests_integration/__tests__/ignore-path.js
+++ b/tests_integration/__tests__/ignore-path.js
@@ -7,14 +7,14 @@ describe("ignore path", () => {
     "**/*.js",
     "--ignore-path",
     ".gitignore",
-    "-l"
+    "-l",
   ]).test({
-    status: 1
+    status: 1,
   });
 });
 
 describe("support .prettierignore", () => {
   runPrettier("cli/ignore-path", ["**/*.js", "-l"]).test({
-    status: 1
+    status: 1,
   });
 });

--- a/tests_integration/__tests__/ignore-relative-path.js
+++ b/tests_integration/__tests__/ignore-relative-path.js
@@ -11,8 +11,8 @@ describe("support relative paths", () => {
     "level1-glob/level2-glob/level3-glob/shouldNotBeFormat.js",
     "./level1-glob/level2-glob/level3-glob/shouldNotBeIgnored.scss",
     "level1-glob/shouldNotBeIgnored.js",
-    "-l"
+    "-l",
   ]).test({
-    status: 1
+    status: 1,
   });
 });

--- a/tests_integration/__tests__/invalid-ignore.js
+++ b/tests_integration/__tests__/invalid-ignore.js
@@ -6,6 +6,6 @@ expect.addSnapshotSerializer(require("../path-serializer"));
 
 describe("throw error with invalid ignore", () => {
   runPrettier("cli/invalid-ignore", ["something.js"]).test({
-    status: "non-zero"
+    status: "non-zero",
   });
 });

--- a/tests_integration/__tests__/list-different.js
+++ b/tests_integration/__tests__/list-different.js
@@ -4,10 +4,10 @@ const runPrettier = require("../runPrettier");
 
 describe("checks stdin with --list-different", () => {
   runPrettier("cli/with-shebang", ["--list-different"], {
-    input: "0"
+    input: "0",
   }).test({
     stdout: "(stdin)\n",
     stderr: "",
-    status: "non-zero"
+    status: "non-zero",
   });
 });

--- a/tests_integration/__tests__/loglevel.js
+++ b/tests_integration/__tests__/loglevel.js
@@ -25,7 +25,7 @@ function runPrettierWithLogLevel(logLevel, patterns) {
     "--unknown-option",
     "--parser",
     "unknown-parser",
-    "not-found.js"
+    "not-found.js",
   ]);
 
   expect(result).not.toEqual(0);

--- a/tests_integration/__tests__/multiple-patterns.js
+++ b/tests_integration/__tests__/multiple-patterns.js
@@ -8,9 +8,9 @@ describe("multiple patterns", () => {
   runPrettier("cli/multiple-patterns", [
     "directory/**/*.js",
     "other-directory/**/*.js",
-    "-l"
+    "-l",
   ]).test({
-    status: 1
+    status: 1,
   });
 });
 
@@ -18,9 +18,9 @@ describe("multiple patterns with non exists pattern", () => {
   runPrettier("cli/multiple-patterns", [
     "directory/**/*.js",
     "non-existent.js",
-    "-l"
+    "-l",
   ]).test({
-    status: 1
+    status: 1,
   });
 });
 
@@ -28,16 +28,16 @@ describe("multiple patterns with ignore nested directories pattern", () => {
   runPrettier("cli/multiple-patterns", [
     "**/*.js",
     "!**/nested-directory/**",
-    "-l"
+    "-l",
   ]).test({
-    status: 1
+    status: 1,
   });
 });
 
 describe("multiple patterns by with ignore pattern, ignores node_modules by default", () => {
   runPrettier("cli/multiple-patterns", ["**/*.js", "!directory/**", "-l"]).test(
     {
-      status: 1
+      status: 1,
     }
   );
 });
@@ -46,9 +46,9 @@ describe("multiple patterns by with ignore pattern, ignores node_modules by with
   runPrettier("cli/multiple-patterns", [
     "./**/*.js",
     "!./directory/**",
-    "-l"
+    "-l",
   ]).test({
-    status: 1
+    status: 1,
   });
 });
 
@@ -57,15 +57,15 @@ describe("multiple patterns by with ignore pattern, doesn't ignore node_modules 
     "**/*.js",
     "!directory/**",
     "-l",
-    "--with-node-modules"
+    "--with-node-modules",
   ]).test({
-    status: 1
+    status: 1,
   });
 });
 
 describe("no errors on empty patterns", () => {
   runPrettier("cli/multiple-patterns").test({
-    status: 0
+    status: 0,
   });
 });
 
@@ -73,8 +73,8 @@ describe("multiple patterns, throw error and exit with non zero code on non exis
   runPrettier("cli/multiple-patterns", [
     "non-existent.js",
     "other-non-existent.js",
-    "-l"
+    "-l",
   ]).test({
-    status: 2
+    status: 2,
   });
 });

--- a/tests_integration/__tests__/parser-api.js
+++ b/tests_integration/__tests__/parser-api.js
@@ -10,9 +10,9 @@ test("allows custom parser provided as object", () => {
       return {
         type: "Literal",
         value: 2,
-        raw: "2"
+        raw: "2",
       };
-    }
+    },
   });
   expect(output).toEqual("2");
 });
@@ -24,7 +24,7 @@ test("allows usage of prettier's supported parsers", () => {
       const ast = parsers.babylon(text);
       ast.program.body[0].expression.callee.name = "bar";
       return ast;
-    }
+    },
   });
   expect(output).toEqual("bar();\n");
 });
@@ -33,8 +33,8 @@ describe("allows passing a string to resolve a parser", () => {
   runPrettier("./custom-parsers/", [
     "./custom-rename-input.js",
     "--parser",
-    "./custom-rename-parser"
+    "./custom-rename-parser",
   ]).test({
-    status: 0
+    status: 0,
   });
 });

--- a/tests_integration/__tests__/piped-output.js
+++ b/tests_integration/__tests__/piped-output.js
@@ -8,7 +8,7 @@ describe("output with --list-different + unformatted differs when piped", () => 
     ["--write", "--list-different", "--no-color", "unformatted.js"],
     { stdoutIsTTY: true }
   ).test({
-    status: 1
+    status: 1,
   });
 
   const result1 = runPrettier(
@@ -16,7 +16,7 @@ describe("output with --list-different + unformatted differs when piped", () => 
     ["--write", "--list-different", "--no-color", "unformatted.js"],
     { stdoutIsTTY: false }
   ).test({
-    status: 1
+    status: 1,
   });
 
   expect(result0.stdout.length).toBeGreaterThan(result1.stdout.length);
@@ -29,7 +29,7 @@ describe("no file diffs with --list-different + formatted file", () => {
     ["--write", "--list-different", "--no-color", "formatted.js"],
     { stdoutIsTTY: true }
   ).test({
-    status: 0
+    status: 0,
   });
 
   const result1 = runPrettier(
@@ -37,7 +37,7 @@ describe("no file diffs with --list-different + formatted file", () => {
     ["--write", "--list-different", "--no-color", "formatted.js"],
     { stdoutIsTTY: false }
   ).test({
-    status: 0
+    status: 0,
   });
 
   expect(result0.stdout).not.toEqual(result1.stdout);

--- a/tests_integration/__tests__/skip-folders.js
+++ b/tests_integration/__tests__/skip-folders.js
@@ -7,7 +7,7 @@ expect.addSnapshotSerializer(require("../path-serializer"));
 describe("skips folders in glob", () => {
   runPrettier("cli/skip-folders", ["**/*", "-l"]).test({
     status: 1,
-    stderr: ""
+    stderr: "",
   });
 });
 
@@ -17,6 +17,6 @@ describe("skip folders passed specifically", () => {
     "a/file.js",
     "b",
     "b/file.js",
-    "-l"
+    "-l",
   ]).test({ status: 1, stderr: "" });
 });

--- a/tests_integration/__tests__/stdin-filepath.js
+++ b/tests_integration/__tests__/stdin-filepath.js
@@ -8,7 +8,7 @@ describe("format correctly if stdin content compatible with stdin-filepath", () 
     ["--stdin-filepath", "abc.css"],
     { input: ".name { display: none; }" } // css
   ).test({
-    status: 0
+    status: 0,
   });
 });
 
@@ -18,15 +18,15 @@ describe("throw error if stdin content incompatible with stdin-filepath", () => 
     ["--stdin-filepath", "abc.js"],
     { input: ".name { display: none; }" } // css
   ).test({
-    status: "non-zero"
+    status: "non-zero",
   });
 });
 
 describe("output nothing if stdin-filepath matched patterns in ignore-path", () => {
   runPrettier("cli/stdin-ignore", ["--stdin-filepath", "ignore/example.js"], {
-    input: "hello_world();"
+    input: "hello_world();",
   }).test({
     stdout: "",
-    status: 0
+    status: 0,
   });
 });

--- a/tests_integration/__tests__/syntax-error.js
+++ b/tests_integration/__tests__/syntax-error.js
@@ -4,8 +4,8 @@ const runPrettier = require("../runPrettier");
 
 describe("exits with non-zero code when input has a syntax error", () => {
   runPrettier("cli/with-shebang", ["--stdin"], {
-    input: "a.2"
+    input: "a.2",
   }).test({
-    status: 2
+    status: 2,
   });
 });

--- a/tests_integration/__tests__/with-config-precedence.js
+++ b/tests_integration/__tests__/with-config-precedence.js
@@ -4,7 +4,7 @@ const runPrettier = require("../runPrettier");
 
 describe("CLI overrides take precedence without --config-precedence", () => {
   runPrettier("cli/config/", ["--print-width", "1", "**/*.js"]).test({
-    status: 0
+    status: 0,
   });
 });
 
@@ -14,9 +14,9 @@ describe("CLI overrides take precedence with --config-precedence cli-override", 
     "1",
     "--config-precedence",
     "cli-override",
-    "**/*.js"
+    "**/*.js",
   ]).test({
-    status: 0
+    status: 0,
   });
 });
 
@@ -26,9 +26,9 @@ describe("CLI overrides take lower precedence with --config-precedence file-over
     "1",
     "--config-precedence",
     "file-override",
-    "**/*.js"
+    "**/*.js",
   ]).test({
-    status: 0
+    status: 0,
   });
 });
 
@@ -38,9 +38,9 @@ describe("CLI overrides are still applied when no config is found with --config-
     "6",
     "--config-precedence",
     "file-override",
-    "**/*.js"
+    "**/*.js",
   ]).test({
-    status: 0
+    status: 0,
   });
 });
 
@@ -52,9 +52,9 @@ describe("CLI overrides gets ignored when config exists with --config-precedence
     "1",
     "--config-precedence",
     "prefer-file",
-    "**/*.js"
+    "**/*.js",
   ]).test({
-    status: 0
+    status: 0,
   });
 });
 
@@ -67,36 +67,36 @@ describe("CLI overrides gets applied when no config exists with --config-precede
     "--no-config",
     "--config-precedence",
     "prefer-file",
-    "**/*.js"
+    "**/*.js",
   ]).test({
-    status: 0
+    status: 0,
   });
 });
 
 describe("CLI validate options with --config-precedence cli-override", () => {
   runPrettier("cli/config-precedence", [
     "--config-precedence",
-    "cli-override"
+    "cli-override",
   ]).test({
-    status: "non-zero"
+    status: "non-zero",
   });
 });
 
 describe("CLI validate options with --config-precedence file-override", () => {
   runPrettier("cli/config-precedence", [
     "--config-precedence",
-    "file-override"
+    "file-override",
   ]).test({
-    status: "non-zero"
+    status: "non-zero",
   });
 });
 
 describe("CLI validate options with --config-precedence prefer-file", () => {
   runPrettier("cli/config-precedence", [
     "--config-precedence",
-    "prefer-file"
+    "prefer-file",
   ]).test({
-    status: "non-zero"
+    status: "non-zero",
   });
 });
 
@@ -107,12 +107,12 @@ describe("CLI --stdin-filepath works with --config-precedence prefer-file", () =
       "--stdin",
       "--stdin-filepath=abc.ts",
       "--no-semi",
-      "--config-precedence=prefer-file"
+      "--config-precedence=prefer-file",
     ],
     { input: "let x: keyof Y = foo<typeof X>()" } // typescript
   ).test({
     stderr: "",
-    status: 0
+    status: 0,
   });
 });
 
@@ -123,12 +123,12 @@ describe("CLI --stdin-filepath works with --config-precedence file-override", ()
       "--stdin",
       "--stdin-filepath=abc.ts",
       "--no-semi",
-      "--config-precedence=file-override"
+      "--config-precedence=file-override",
     ],
     { input: "let x: keyof Y = foo<typeof X>()" } // typescript
   ).test({
     stderr: "",
-    status: 0
+    status: 0,
   });
 });
 
@@ -139,11 +139,11 @@ describe("CLI --stdin-filepath works with --config-precedence cli-override", () 
       "--stdin",
       "--stdin-filepath=abc.ts",
       "--no-semi",
-      "--config-precedence=cli-override"
+      "--config-precedence=cli-override",
     ],
     { input: "let x: keyof Y = foo<typeof X>()" } // typescript
   ).test({
     stderr: "",
-    status: 0
+    status: 0,
   });
 });

--- a/tests_integration/__tests__/with-node-modules.js
+++ b/tests_integration/__tests__/with-node-modules.js
@@ -6,13 +6,13 @@ expect.addSnapshotSerializer(require("../path-serializer"));
 
 describe("ignores node_modules by default", () => {
   runPrettier("cli/with-node-modules", ["**/*.js", "-l"]).test({
-    status: 1
+    status: 1,
   });
 });
 
 describe("ignores node_modules by with ./**/*.js", () => {
   runPrettier("cli/with-node-modules", ["./**/*.js", "-l"]).test({
-    status: 1
+    status: 1,
   });
 });
 
@@ -20,9 +20,9 @@ describe("doesn't ignore node_modules with --with-node-modules flag", () => {
   runPrettier("cli/with-node-modules", [
     "**/*.js",
     "-l",
-    "--with-node-modules"
+    "--with-node-modules",
   ]).test({
-    status: 1
+    status: 1,
   });
 });
 
@@ -31,9 +31,9 @@ describe("ignores node_modules by default for file list", () => {
     "node_modules/node-module.js",
     "not_node_modules/file.js",
     "regular-module.js",
-    "-l"
+    "-l",
   ]).test({
-    status: 1
+    status: 1,
   });
 });
 
@@ -43,8 +43,8 @@ describe("doesn't ignore node_modules with --with-node-modules flag for file lis
     "not_node_modules/file.js",
     "regular-module.js",
     "-l",
-    "--with-node-modules"
+    "--with-node-modules",
   ]).test({
-    status: 1
+    status: 1,
   });
 });

--- a/tests_integration/__tests__/with-parser-inference.js
+++ b/tests_integration/__tests__/with-parser-inference.js
@@ -5,13 +5,13 @@ const prettier = require("../../tests_config/require_prettier");
 
 describe("infers postcss parser", () => {
   runPrettier("cli/with-parser-inference", ["*"]).test({
-    status: 0
+    status: 0,
   });
 });
 
 describe("infers postcss parser with --list-different", () => {
   runPrettier("cli/with-parser-inference", ["--list-different", "*"]).test({
-    status: 0
+    status: 0,
   });
 });
 

--- a/tests_integration/__tests__/with-shebang.js
+++ b/tests_integration/__tests__/with-shebang.js
@@ -4,6 +4,6 @@ const runPrettier = require("../runPrettier");
 
 describe("preserves shebang", () => {
   runPrettier("cli/with-shebang", ["issue1890.js"]).test({
-    status: 0
+    status: 0,
   });
 });

--- a/tests_integration/__tests__/write.js
+++ b/tests_integration/__tests__/write.js
@@ -4,20 +4,20 @@ const runPrettier = require("../runPrettier");
 
 describe("write file with --write + unformatted file", () => {
   runPrettier("cli/write", ["--write", "unformatted.js"]).test({
-    status: 0
+    status: 0,
   });
 });
 
 describe("do not write file with --write + formatted file", () => {
   runPrettier("cli/write", ["--write", "formatted.js"]).test({
     write: [],
-    status: 0
+    status: 0,
   });
 });
 
 describe("do not write file with --write + invalid file", () => {
   runPrettier("cli/write", ["--write", "invalid.js"]).test({
     write: [],
-    status: "non-zero"
+    status: "non-zero",
   });
 });

--- a/tests_integration/path-serializer.js
+++ b/tests_integration/path-serializer.js
@@ -5,5 +5,5 @@ module.exports = {
     typeof value === "string" &&
     (value.indexOf("\\") > -1 || value.indexOf(process.cwd()) > -1),
   print: (value, serializer) =>
-    serializer(value.replace(process.cwd(), "<cwd>").replace(/\\/g, "/"))
+    serializer(value.replace(process.cwd(), "<cwd>").replace(/\\/g, "/")),
 };

--- a/tests_integration/runPrettier.js
+++ b/tests_integration/runPrettier.js
@@ -69,7 +69,7 @@ function runPrettier(dir, args, options) {
   // production build everything is bundled into one file so there is no
   // "get-stream" module to mock.
   jest.spyOn(require(thirdParty), "getStream").mockImplementation(() => ({
-    then: handler => handler(options.input || "")
+    then: handler => handler(options.input || ""),
   }));
   jest
     .spyOn(require(thirdParty), "cosmiconfig")

--- a/website/.eslintrc.js
+++ b/website/.eslintrc.js
@@ -2,6 +2,6 @@
 
 module.exports = {
   rules: {
-    "import/no-extraneous-dependencies": "off"
-  }
+    "import/no-extraneous-dependencies": "off",
+  },
 };

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -17,7 +17,7 @@ const GithubButton = props => (
 );
 
 GithubButton.propTypes = {
-  config: React.PropTypes.object
+  config: React.PropTypes.object,
 };
 
 class Footer extends React.Component {
@@ -79,7 +79,7 @@ class Footer extends React.Component {
 
 Footer.propTypes = {
   language: React.PropTypes.string,
-  config: React.PropTypes.object
+  config: React.PropTypes.object,
 };
 
 module.exports = Footer;

--- a/website/pages/en/help/index.js
+++ b/website/pages/en/help/index.js
@@ -14,16 +14,16 @@ class Help extends React.Component {
       {
         content:
           "Learn more using the [documentation on this site.](/docs/en/why-prettier.html)\n",
-        title: "Browse Docs"
+        title: "Browse Docs",
       },
       {
         content: "Ask questions about the documentation and project\n",
-        title: "Join the community"
+        title: "Join the community",
       },
       {
         content: "Find out what's new with this project\n",
-        title: "Stay up to date"
-      }
+        title: "Stay up to date",
+      },
     ];
 
     return (
@@ -45,7 +45,7 @@ class Help extends React.Component {
 }
 
 Help.defaultProps = {
-  language: "en"
+  language: "en",
 };
 
 module.exports = Help;

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -22,13 +22,13 @@ class Button extends React.Component {
 }
 
 Button.defaultProps = {
-  target: "_self"
+  target: "_self",
 };
 
 Button.propTypes = {
   href: React.PropTypes.string,
   target: React.PropTypes.string,
-  children: React.PropTypes.any
+  children: React.PropTypes.any,
 };
 
 class HomeSplash extends React.Component {
@@ -71,7 +71,7 @@ class HomeSplash extends React.Component {
 }
 
 HomeSplash.propTypes = {
-  language: React.PropTypes.string
+  language: React.PropTypes.string,
 };
 
 class Index extends React.Component {
@@ -108,7 +108,7 @@ class Index extends React.Component {
                   title: language.name,
                   image: language.image,
                   imageAlign: "top",
-                  content: language.variants.join("\n\n")
+                  content: language.variants.join("\n\n"),
                 }))}
                 layout="fourColumn"
               />
@@ -132,7 +132,7 @@ class Index extends React.Component {
                   content: editor.content || "",
                   image: editor.image,
                   imageAlign: "bottom",
-                  title: editor.name
+                  title: editor.name,
                 }))}
                 layout="fourColumn"
               />
@@ -188,7 +188,7 @@ class Index extends React.Component {
 }
 
 Index.propTypes = {
-  language: React.PropTypes.string
+  language: React.PropTypes.string,
 };
 
 module.exports = Index;

--- a/website/pages/en/users/index.js
+++ b/website/pages/en/users/index.js
@@ -51,7 +51,7 @@ class Users extends React.Component {
 }
 
 Users.defaultProps = {
-  language: "en"
+  language: "en",
 };
 
 module.exports = Users;

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -28,7 +28,7 @@ const siteConfig = {
     { doc: "index", label: "About" },
     { doc: "install", label: "Usage" },
     { search: true },
-    { href: GITHUB_URL, label: "GitHub" }
+    { href: GITHUB_URL, label: "GitHub" },
   ],
   /* path to images for header/footer */
   headerIcon: "icon.png",
@@ -37,16 +37,16 @@ const siteConfig = {
   /* colors for website */
   colors: {
     primaryColor: "#1A2B34",
-    secondaryColor: "#808080"
+    secondaryColor: "#808080",
   },
   highlight: {
-    theme: "default"
+    theme: "default",
   },
   useEnglishUrl: true,
   scripts: ["https://buttons.github.io/buttons.js"],
   algolia: {
     apiKey: process.env.ALGOLIA_PRETTIER_API_KEY,
-    indexName: "prettier"
+    indexName: "prettier",
   },
   markdownPlugins: [
     // ignore `<!-- prettier-ignore -->` before passing into Docusaurus to avoid mis-parsing (#3322)
@@ -64,8 +64,8 @@ const siteConfig = {
           return false;
         }
       );
-    }
-  ]
+    },
+  ],
 };
 
 module.exports = siteConfig;

--- a/website/static/install-service-worker.js
+++ b/website/static/install-service-worker.js
@@ -4,6 +4,6 @@
 
 if ("serviceWorker" in navigator) {
   navigator.serviceWorker.register("/service-worker.js", {
-    scope: "/playground/"
+    scope: "/playground/",
   });
 }

--- a/website/static/markdown.js
+++ b/website/static/markdown.js
@@ -28,7 +28,7 @@
       codeBlock(input, syntax),
       "",
       "**Output:**",
-      codeBlock(output, syntax)
+      codeBlock(output, syntax),
     ]
       .concat(
         isIdempotent

--- a/website/static/playground.js
+++ b/website/static/playground.js
@@ -25,7 +25,7 @@ var OPTIONS = [
   "arrowParens",
   "doc",
   "ast",
-  "output2"
+  "output2",
 ];
 
 var IDEMPOTENT_MESSAGE = "✓ Second format is unchanged.";
@@ -55,8 +55,8 @@ const DEFAULT_OPTIONS = {
     "",
     "    </div>;",
     "",
-    "}"
-  ].join("\n")
+    "}",
+  ].join("\n"),
 };
 
 window.onload = function() {
@@ -113,7 +113,7 @@ window.onload = function() {
     matchBrackets: true,
     showCursorWhenSelecting: true,
     tabWidth: 2,
-    mode: "jsx"
+    mode: "jsx",
   };
   inputEditor = CodeMirror.fromTextArea(
     document.getElementById("input-editor"),
@@ -124,19 +124,19 @@ window.onload = function() {
   docEditor = CodeMirror.fromTextArea(document.getElementById("doc-editor"), {
     readOnly: true,
     lineNumbers: false,
-    mode: "jsx"
+    mode: "jsx",
   });
   astEditor = CodeMirror.fromTextArea(document.getElementById("ast-editor"), {
     readOnly: true,
     lineNumbers: false,
-    mode: "jsx"
+    mode: "jsx",
   });
   outputEditor = CodeMirror.fromTextArea(
     document.getElementById("output-editor"),
     {
       readOnly: true,
       lineNumbers: true,
-      mode: "jsx"
+      mode: "jsx",
     }
   );
   output2Editor = CodeMirror.fromTextArea(
@@ -144,7 +144,7 @@ window.onload = function() {
     {
       readOnly: true,
       lineNumbers: true,
-      mode: "jsx"
+      mode: "jsx",
     }
   );
 
@@ -183,7 +183,7 @@ window.onload = function() {
         default:
           return "";
       }
-    }
+    },
   });
   clipboard.on("success", function(e) {
     showTooltip(e.trigger, "Copied!");
@@ -295,7 +295,7 @@ function formatAsync() {
     options: options,
     ast: options.ast,
     doc: options.doc,
-    formatted2: options.output2
+    formatted2: options.output2,
   });
 }
 
@@ -308,12 +308,12 @@ function setEditorStyles() {
   output2Editor.setOption("mode", mode);
 
   inputEditor.setOption("rulers", [
-    { column: options.printWidth, color: "#eeeeee" }
+    { column: options.printWidth, color: "#eeeeee" },
   ]);
 
   [outputEditor, output2Editor].forEach(function(editor) {
     editor.setOption("rulers", [
-      { column: options.printWidth, color: "#444444" }
+      { column: options.printWidth, color: "#444444" },
     ]);
   });
   document.querySelector(".ast").style.display = options.ast ? "" : "none";

--- a/website/static/service-worker.js
+++ b/website/static/service-worker.js
@@ -37,7 +37,7 @@ toolbox.precache([
   "https://cdnjs.cloudflare.com/ajax/libs/lz-string/1.4.4/lz-string.min.js",
 
   // Images
-  "/prettier.png"
+  "/prettier.png",
 ]);
 
 // Default to hit the cache only if there's a network error

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -8,7 +8,7 @@ self.path = {};
 self.Buffer = {
   isBuffer: function() {
     return false;
-  }
+  },
 };
 self.constants = {};
 // eslint-disable-next-line
@@ -97,7 +97,7 @@ self.onmessage = function(message) {
     doc: doc,
     ast: ast,
     formatted2: formatted2,
-    version: prettier.version
+    version: prettier.version,
   });
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1514,14 +1514,7 @@ eslint-plugin-import@2.6.1:
     minimatch "^3.0.3"
     read-pkg-up "^2.0.0"
 
-eslint-plugin-prettier@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.1.2.tgz#4b90f4ee7f92bfbe2e926017e1ca40eb628965ea"
-  dependencies:
-    fast-diff "^1.1.1"
-    jest-docblock "^20.0.1"
-
-eslint-plugin-prettier@^2.2.0:
+eslint-plugin-prettier@2.3.1, eslint-plugin-prettier@^2.2.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-2.3.1.tgz#e7a746c67e716f335274b88295a9ead9f544e44d"
   dependencies:
@@ -2505,10 +2498,6 @@ jest-docblock@21.3.0-beta.11:
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.3.0-beta.11.tgz#feb4de87c55a2f563ac24c5f4861f61921550896"
   dependencies:
     detect-newline "^2.1.0"
-
-jest-docblock@^20.0.1:
-  version "20.0.3"
-  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-20.0.3.tgz#17bea984342cc33d83c50fbe1545ea0efaa44712"
 
 jest-docblock@^21.0.0, jest-docblock@^21.2.0:
   version "21.2.0"


### PR DESCRIPTION
This addresses https://github.com/prettier/prettier/issues/3469
as outlined in https://github.com/prettier/prettier/issues/3469#issuecomment-351758610

There are two commits at the moment, the first is the interesting change to
`.eslintrc.js`, and the second is the resulting formatting changes.