### PR TITLE
Add "JSON with comments" to vscodeLanguageIds

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -145,7 +145,7 @@ const supportTable = [
       "mcmod.info"
     ],
     linguistLanguageId: 174,
-    vscodeLanguageIds: ["json"]
+    vscodeLanguageIds: ["json", "jsonc"]
   },
 
   {

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -197,6 +197,7 @@ Object {
       "tmScope": "source.json",
       "vscodeLanguageIds": Array [
         "json",
+        "jsonc",
       ],
     },
     Object {
@@ -526,7 +527,7 @@ exports[`CLI --support-info (stdout) 1`] = `
         \\"mcmod.info\\"
       ],
       \\"linguistLanguageId\\": 174,
-      \\"vscodeLanguageIds\\": [\\"json\\"]
+      \\"vscodeLanguageIds\\": [\\"json\\", \\"jsonc\\"]
     },
     {
       \\"name\\": \\"Markdown\\",


### PR DESCRIPTION
Without this, the VS Code extension doesn't enable prettier for files of this type (settings.json, tsconfig.json, etc.).