### PR TITLE
Switch to light logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Prettier Banner](https://raw.githubusercontent.com/prettier/prettier-logo/master/images/prettier-banner-dark.png)
+![Prettier Banner](https://raw.githubusercontent.com/prettier/prettier-logo/master/images/prettier-banner-light.png)
 
 <h2 align="center">Opinionated Code Formatter</h2>
 


### PR DESCRIPTION
Light logo doesn't get as much use. Which do we prefer?