### PR TITLE
Add `root: true` to .eslintrc.yml

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,3 +1,4 @@
+root: true
 env:
   es6: true
   node: true


### PR DESCRIPTION
This ensures that peoples’ ESLint configurations in parent directories aren’t used when linting Prettier.