### PR TITLE
chore: use scoped babel package

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=4"
   },
   "dependencies": {
-    "babel-code-frame": "7.0.0-beta.3",
+    "@babel/code-frame": "7.0.0-beta.35",
     "babylon": "7.0.0-beta.34",
     "camelcase": "4.1.0",
     "chalk": "2.1.0",

--- a/src/parser.js
+++ b/src/parser.js
@@ -64,7 +64,7 @@ function parse(text, opts) {
     const loc = error.loc;
 
     if (loc) {
-      const codeFrame = require("babel-code-frame");
+      const codeFrame = require("@babel/code-frame");
       error.codeFrame = codeFrame.codeFrameColumns(text, loc, {
         highlightCode: true
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@7.0.0-beta.35":
+  version "7.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.35.tgz#04eeb6dca7efef8f65776a4c214157303b85ad51"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
 "@types/node@*":
   version "8.0.47"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.47.tgz#968e596f91acd59069054558a00708c445ca30c2"
@@ -245,14 +253,6 @@ babel-cli@6.24.1:
     v8flags "^2.0.10"
   optionalDependencies:
     chokidar "^1.6.1"
-
-babel-code-frame@7.0.0-beta.3:
-  version "7.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-7.0.0-beta.3.tgz#1614a91b2ba0e3848559f410bbacd030726899c9"
-  dependencies:
-    chalk "^2.0.0"
-    esutils "^2.0.2"
-    js-tokens "^3.0.0"
 
 babel-code-frame@^6.22.0:
   version "6.22.0"


### PR DESCRIPTION
This way it shows up when you do `yarn outdated` 🙂 

Only code change in it is https://github.com/babel/babel/pull/6550