### PR TITLE
Add Google Analytics on Playground

### DIFF
--- a/website/pages/playground/index.html
+++ b/website/pages/playground/index.html
@@ -326,6 +326,15 @@
       border-top-color: #000;
     }
   </style>
+
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-111350464-1"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'UA-111350464-1');
+  </script>
 </head>
 
 <body>


### PR DESCRIPTION
Since playground is a different page, we should also include it in the analytics.