### PR TITLE
Support Relay Classic

### DIFF
--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -39,8 +39,10 @@ function embed(path, print, textToDoc /*, options */) {
         parent &&
         ((parent.type === "TaggedTemplateExpression" &&
           ((parent.tag.type === "MemberExpression" &&
-            parent.tag.object.name === "graphql" &&
-            parent.tag.property.name === "experimental") ||
+            ((parent.tag.object.name === "graphql" &&
+              parent.tag.property.name === "experimental") ||
+              (parent.tag.object.name === "Relay" &&
+                parent.tag.property.name === "QL"))) ||
             (parent.tag.type === "Identifier" &&
               (parent.tag.name === "gql" || parent.tag.name === "graphql")))) ||
           (parent.type === "CallExpression" &&

--- a/tests/multiparser_js_graphql/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_graphql/__snapshots__/jsfmt.spec.js.snap
@@ -394,6 +394,7 @@ gql\`
 
 exports[`react-relay.js 1`] = `
 const { graphql } = require("react-relay");
+const Relay = require("react-relay/classic");
 
 graphql\`
  mutation     MarkReadNotificationMutation(
@@ -410,8 +411,17 @@ graphql.experimental\`
   )
 { markReadNotification(data: $input ) { notification {seenState} } }
 \`;
+
+Relay.QL\`
+ mutation     MarkReadNotificationMutation(
+    $input
+    : MarkReadNotificationData!
+  )
+{ markReadNotification(data: $input ) { notification {seenState} } }
+\`;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const { graphql } = require("react-relay");
+const Relay = require("react-relay/classic");
 
 graphql\`
   mutation MarkReadNotificationMutation($input: MarkReadNotificationData!) {
@@ -424,6 +434,16 @@ graphql\`
 \`;
 
 graphql.experimental\`
+  mutation MarkReadNotificationMutation($input: MarkReadNotificationData!) {
+    markReadNotification(data: $input) {
+      notification {
+        seenState
+      }
+    }
+  }
+\`;
+
+Relay.QL\`
   mutation MarkReadNotificationMutation($input: MarkReadNotificationData!) {
     markReadNotification(data: $input) {
       notification {

--- a/tests/multiparser_js_graphql/react-relay.js
+++ b/tests/multiparser_js_graphql/react-relay.js
@@ -1,4 +1,5 @@
 const { graphql } = require("react-relay");
+const Relay = require("react-relay/classic");
 
 graphql`
  mutation     MarkReadNotificationMutation(
@@ -9,6 +10,14 @@ graphql`
 `;
 
 graphql.experimental`
+ mutation     MarkReadNotificationMutation(
+    $input
+    : MarkReadNotificationData!
+  )
+{ markReadNotification(data: $input ) { notification {seenState} } }
+`;
+
+Relay.QL`
  mutation     MarkReadNotificationMutation(
     $input
     : MarkReadNotificationData!


### PR DESCRIPTION
Relay Classic uses `Relay.QL`, which was not previously picked up here.