### PR TITLE
Remove ALL_PARSERS, print ~ printWidth times

### DIFF
--- a/tests/object_colon_bug/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/object_colon_bug/__snapshots__/jsfmt.spec.js.snap
@@ -5,7 +5,7 @@ const foo = {
   bar: props.bar ? props.bar : noop,
   baz: props.baz
 }
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const foo = {
   bar: props.bar
     ? props.bar


### PR DESCRIPTION
VERIFY_ALL_PARSERS doesn't make sense any more, let's delete it.

Also set the amount of `~` to match the print width of the test (only affects one snapshot)

Closes #2845