### PR TITLE
Update GraphQL parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "flow-parser": "0.59.0",
     "get-stream": "3.0.0",
     "globby": "6.1.0",
-    "graphql": "0.10.5",
+    "graphql": "0.12.3",
     "ignore": "3.3.7",
     "jest-docblock": "21.3.0-beta.11",
     "jest-validate": "21.1.0",

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -126,13 +126,9 @@ function genericPrint(path, options, print) {
     }
     case "StringValue": {
       if (n.block) {
-        return concat([
-          '"""',
-          hardline,
-          n.value.replace(/"""/g, "\\$&"),
-          hardline,
-          '"""'
-        ]);
+        // It is not possible to distinguish between """\nabc\n""" and """abc"""
+        // https://github.com/graphql/graphql-js/issues/1188
+        return options.originalText.slice(util.locStart(n), util.locEnd(n));
       }
       return concat(['"', n.value.replace(/["\\]/g, "\\$&"), '"']);
     }

--- a/tests/graphql_directive_decl/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_directive_decl/__snapshots__/jsfmt.spec.js.snap
@@ -1,23 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`directive_decl.graphql 1`] = `
-directive @a on FIELD1
-directive @a(as: String) on FIELD1
-directive @a(as: String = 1) on FIELD1
-directive @a(as: String, b: Int!) on FIELD1
-directive @a(as: String! = 1 @deprecated) on FIELD1
-directive @a(as: String! = 1 @deprecated) on FIELD1 | FIELD2
+directive @a on QUERY
+directive @a(as: String) on QUERY
+directive @a(as: String = 1) on QUERY
+directive @a(as: String, b: Int!) on QUERY
+directive @a(as: String! = 1 @deprecated) on QUERY
+directive @a(as: String! = 1 @deprecated) on QUERY | MUTATION
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-directive @a on FIELD1
+directive @a on QUERY
 
-directive @a(as: String) on FIELD1
+directive @a(as: String) on QUERY
 
-directive @a(as: String = 1) on FIELD1
+directive @a(as: String = 1) on QUERY
 
-directive @a(as: String, b: Int!) on FIELD1
+directive @a(as: String, b: Int!) on QUERY
 
-directive @a(as: String! = 1 @deprecated) on FIELD1
+directive @a(as: String! = 1 @deprecated) on QUERY
 
-directive @a(as: String! = 1 @deprecated) on FIELD1 | FIELD2
+directive @a(as: String! = 1 @deprecated) on QUERY | MUTATION
 
 `;

--- a/tests/graphql_directive_decl/directive_decl.graphql
+++ b/tests/graphql_directive_decl/directive_decl.graphql
@@ -1,6 +1,6 @@
-directive @a on FIELD1
-directive @a(as: String) on FIELD1
-directive @a(as: String = 1) on FIELD1
-directive @a(as: String, b: Int!) on FIELD1
-directive @a(as: String! = 1 @deprecated) on FIELD1
-directive @a(as: String! = 1 @deprecated) on FIELD1 | FIELD2
+directive @a on QUERY
+directive @a(as: String) on QUERY
+directive @a(as: String = 1) on QUERY
+directive @a(as: String, b: Int!) on QUERY
+directive @a(as: String! = 1 @deprecated) on QUERY
+directive @a(as: String! = 1 @deprecated) on QUERY | MUTATION

--- a/tests/graphql_kitchen_sink/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_kitchen_sink/__snapshots__/jsfmt.spec.js.snap
@@ -1,6 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`kitchen_sink.graphql 1`] = `
+# Copyright (c) 2015-present, Facebook, Inc.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 query queryName($foo: ComplexType, $site: Site = MOBILE) {
   whoever123is: node(id: [123, 456]) {
     id ,
@@ -44,18 +49,21 @@ subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) {
 }
 
 fragment frag on Friend {
-  foo(size: $size, bar: $b, obj: {key: "value"})
+  foo(size: $size, bar: $b, obj: {key: "value", block: """
+      block string uses \\"""
+  """})
 }
 
 {
   unnamed(truthy: true, falsey: false, nullish: null),
   query
 }
-
-query {
-  field
-}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Copyright (c) 2015-present, Facebook, Inc.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 query queryName($foo: ComplexType, $site: Site = MOBILE) {
   whoever123is: node(id: [123, 456]) {
     id
@@ -99,7 +107,16 @@ subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) {
 }
 
 fragment frag on Friend {
-  foo(size: $size, bar: $b, obj: { key: "value" })
+  foo(
+    size: $size
+    bar: $b
+    obj: {
+      key: "value"
+      block: """
+      block string uses \\"""
+      """
+    }
+  )
 }
 
 {
@@ -107,8 +124,243 @@ fragment frag on Friend {
   query
 }
 
-query {
-  field
+`;
+
+exports[`schema_kitchen_sink.graphql 1`] = `
+# Copyright (c) 2015-present, Facebook, Inc.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+schema {
+  query: QueryType
+  mutation: MutationType
 }
+
+"""
+This is a description
+of the \`Foo\` type.
+"""
+type Foo implements Bar {
+  one: Type
+  two(argument: InputType!): Type
+  three(argument: InputType, other: String): Int
+  four(argument: String = "string"): String
+  five(argument: [String] = ["string", "string"]): String
+  six(argument: InputType = {key: "value"}): Type
+  seven(argument: Int = null): Type
+}
+
+type AnnotatedObject @onObject(arg: "value") {
+  annotatedField(arg: Type = "default" @onArg): Type @onField
+}
+
+type UndefinedType
+
+extend type Foo {
+  seven(argument: [String]): Type
+}
+
+extend type Foo @onType
+
+"""
+This is a description
+"""
+interface Bar {
+  one: Type
+  four(argument: String = "string"): String
+}
+
+interface AnnotatedInterface @onInterface {
+  annotatedField(arg: Type @onArg): Type @onField
+}
+
+interface UndefinedInterface
+
+extend interface Bar {
+  two(argument: InputType!): Type
+}
+
+extend interface Bar @onInterface
+
+union Feed = Story | Article | Advert
+
+union AnnotatedUnion @onUnion = A | B
+
+union AnnotatedUnionTwo @onUnion = | A | B
+
+union UndefinedUnion
+
+extend union Feed = Photo | Video
+
+extend union Feed @onUnion
+
+scalar CustomScalar
+
+scalar AnnotatedScalar @onScalar
+
+extend scalar CustomScalar @onScalar
+
+enum Site {
+  DESKTOP
+  MOBILE
+}
+
+enum AnnotatedEnum @onEnum {
+  ANNOTATED_VALUE @onEnumValue
+  OTHER_VALUE
+}
+
+enum UndefinedEnum
+
+extend enum Site {
+  VR
+}
+
+extend enum Site @onEnum
+
+input InputType {
+  key: String!
+  answer: Int = 42
+}
+
+input AnnotatedInput @onInputObject {
+  annotatedField: Type @onField
+}
+
+input UndefinedInput
+
+extend input InputType {
+  other: Float = 1.23e4
+}
+
+extend input InputType @onInputObject
+
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @include(if: Boolean!)
+  on FIELD
+   | FRAGMENT_SPREAD
+   | INLINE_FRAGMENT
+
+directive @include2(if: Boolean!) on
+  | FIELD
+  | FRAGMENT_SPREAD
+  | INLINE_FRAGMENT
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Copyright (c) 2015-present, Facebook, Inc.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+schema {
+  query: QueryType
+  mutation: MutationType
+}
+
+"""
+This is a description
+of the \`Foo\` type.
+"""
+type Foo implements Bar {
+  one: Type
+  two(argument: InputType!): Type
+  three(argument: InputType, other: String): Int
+  four(argument: String = "string"): String
+  five(argument: [String] = ["string", "string"]): String
+  six(argument: InputType = { key: "value" }): Type
+  seven(argument: Int = null): Type
+}
+
+type AnnotatedObject @onObject(arg: "value") {
+  annotatedField(arg: Type = "default" @onArg): Type @onField
+}
+
+type UndefinedType
+
+extend type Foo {
+  seven(argument: [String]): Type
+}
+
+extend type Foo @onType
+
+"""
+This is a description
+"""
+interface Bar {
+  one: Type
+  four(argument: String = "string"): String
+}
+
+interface AnnotatedInterface @onInterface {
+  annotatedField(arg: Type @onArg): Type @onField
+}
+
+interface UndefinedInterface
+
+extend interface Bar {
+  two(argument: InputType!): Type
+}
+
+extend interface Bar @onInterface
+
+union Feed = Story | Article | Advert
+
+union AnnotatedUnion @onUnion = A | B
+
+union AnnotatedUnionTwo @onUnion = A | B
+
+union UndefinedUnion
+
+extend union Feed = Photo | Video
+
+extend union Feed @onUnion
+
+scalar CustomScalar
+
+scalar AnnotatedScalar @onScalar
+
+extend scalar CustomScalar @onScalar
+
+enum Site {
+  DESKTOP
+  MOBILE
+}
+
+enum AnnotatedEnum @onEnum {
+  ANNOTATED_VALUE @onEnumValue
+  OTHER_VALUE
+}
+
+enum UndefinedEnum
+
+extend enum Site {
+  VR
+}
+
+extend enum Site @onEnum
+
+input InputType {
+  key: String!
+  answer: Int = 42
+}
+
+input AnnotatedInput @onInputObject {
+  annotatedField: Type @onField
+}
+
+input UndefinedInput
+
+extend input InputType {
+  other: Float = 1.23e4
+}
+
+extend input InputType @onInputObject
+
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @include(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @include2(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
 
 `;

--- a/tests/graphql_kitchen_sink/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_kitchen_sink/__snapshots__/jsfmt.spec.js.snap
@@ -110,12 +110,9 @@ fragment frag on Friend {
   foo(
     size: $size
     bar: $b
-    obj: {
-      key: "value"
-      block: """
+    obj: { key: "value", block: """
       block string uses \\"""
-      """
-    }
+  """ }
   )
 }
 

--- a/tests/graphql_kitchen_sink/kitchen_sink.graphql
+++ b/tests/graphql_kitchen_sink/kitchen_sink.graphql
@@ -1,3 +1,8 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
 query queryName($foo: ComplexType, $site: Site = MOBILE) {
   whoever123is: node(id: [123, 456]) {
     id ,
@@ -41,14 +46,12 @@ subscription StoryLikeSubscription($input: StoryLikeSubscribeInput) {
 }
 
 fragment frag on Friend {
-  foo(size: $size, bar: $b, obj: {key: "value"})
+  foo(size: $size, bar: $b, obj: {key: "value", block: """
+      block string uses \"""
+  """})
 }
 
 {
   unnamed(truthy: true, falsey: false, nullish: null),
   query
-}
-
-query {
-  field
 }

--- a/tests/graphql_kitchen_sink/schema_kitchen_sink.graphql
+++ b/tests/graphql_kitchen_sink/schema_kitchen_sink.graphql
@@ -1,0 +1,120 @@
+# Copyright (c) 2015-present, Facebook, Inc.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+schema {
+  query: QueryType
+  mutation: MutationType
+}
+
+"""
+This is a description
+of the `Foo` type.
+"""
+type Foo implements Bar {
+  one: Type
+  two(argument: InputType!): Type
+  three(argument: InputType, other: String): Int
+  four(argument: String = "string"): String
+  five(argument: [String] = ["string", "string"]): String
+  six(argument: InputType = {key: "value"}): Type
+  seven(argument: Int = null): Type
+}
+
+type AnnotatedObject @onObject(arg: "value") {
+  annotatedField(arg: Type = "default" @onArg): Type @onField
+}
+
+type UndefinedType
+
+extend type Foo {
+  seven(argument: [String]): Type
+}
+
+extend type Foo @onType
+
+"""
+This is a description
+"""
+interface Bar {
+  one: Type
+  four(argument: String = "string"): String
+}
+
+interface AnnotatedInterface @onInterface {
+  annotatedField(arg: Type @onArg): Type @onField
+}
+
+interface UndefinedInterface
+
+extend interface Bar {
+  two(argument: InputType!): Type
+}
+
+extend interface Bar @onInterface
+
+union Feed = Story | Article | Advert
+
+union AnnotatedUnion @onUnion = A | B
+
+union AnnotatedUnionTwo @onUnion = | A | B
+
+union UndefinedUnion
+
+extend union Feed = Photo | Video
+
+extend union Feed @onUnion
+
+scalar CustomScalar
+
+scalar AnnotatedScalar @onScalar
+
+extend scalar CustomScalar @onScalar
+
+enum Site {
+  DESKTOP
+  MOBILE
+}
+
+enum AnnotatedEnum @onEnum {
+  ANNOTATED_VALUE @onEnumValue
+  OTHER_VALUE
+}
+
+enum UndefinedEnum
+
+extend enum Site {
+  VR
+}
+
+extend enum Site @onEnum
+
+input InputType {
+  key: String!
+  answer: Int = 42
+}
+
+input AnnotatedInput @onInputObject {
+  annotatedField: Type @onField
+}
+
+input UndefinedInput
+
+extend input InputType {
+  other: Float = 1.23e4
+}
+
+extend input InputType @onInputObject
+
+directive @skip(if: Boolean!) on FIELD | FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @include(if: Boolean!)
+  on FIELD
+   | FRAGMENT_SPREAD
+   | INLINE_FRAGMENT
+
+directive @include2(if: Boolean!) on
+  | FIELD
+  | FRAGMENT_SPREAD
+  | INLINE_FRAGMENT

--- a/tests/graphql_newline/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_newline/__snapshots__/jsfmt.spec.js.snap
@@ -10,7 +10,7 @@ directive @dir(
   arg2: String
   arg3: String
 
-) on Field
+) on QUERY
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 directive @dir(
   # comment
@@ -19,7 +19,7 @@ directive @dir(
   # comment
   arg2: String
   arg3: String
-) on Field
+) on QUERY
 
 `;
 

--- a/tests/graphql_newline/directive_decl.graphql
+++ b/tests/graphql_newline/directive_decl.graphql
@@ -7,4 +7,4 @@ directive @dir(
   arg2: String
   arg3: String
 
-) on Field
+) on QUERY

--- a/tests/graphql_object_type_def/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_object_type_def/__snapshots__/jsfmt.spec.js.snap
@@ -35,9 +35,11 @@ extend type Feedback {
 
 exports[`implements.graphql 1`] = `
 type VRMConversation implements Node, Entity @foo {
+  a: Int
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 type VRMConversation implements Node, Entity @foo {
+  a: Int
 }
 
 `;

--- a/tests/graphql_object_type_def/implements.graphql
+++ b/tests/graphql_object_type_def/implements.graphql
@@ -1,2 +1,3 @@
 type VRMConversation implements Node, Entity @foo {
+  a: Int
 }

--- a/tests/graphql_string/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_string/__snapshots__/jsfmt.spec.js.snap
@@ -2,9 +2,33 @@
 
 exports[`string.graphql 1`] = `
 query X($a: Int) @relay(meta: "{\\"lowPri\\": true}") { a }
+
+"""abc"""
+type T {
+  a: Int
+}
+
+"""
+abc
+"""
+type T {
+  a: Int
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 query X($a: Int) @relay(meta: "{\\"lowPri\\": true}") {
   a
+}
+
+"""abc"""
+type T {
+  a: Int
+}
+
+"""
+abc
+"""
+type T {
+  a: Int
 }
 
 `;

--- a/tests/graphql_string/string.graphql
+++ b/tests/graphql_string/string.graphql
@@ -1,1 +1,13 @@
 query X($a: Int) @relay(meta: "{\"lowPri\": true}") { a }
+
+"""abc"""
+type T {
+  a: Int
+}
+
+"""
+abc
+"""
+type T {
+  a: Int
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2001,11 +2001,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-graphql@0.10.5:
-  version "0.10.5"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.10.5.tgz#c9be17ca2bdfdbd134077ffd9bbaa48b8becd298"
+graphql@0.12.3:
+  version "0.12.3"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-0.12.3.tgz#11668458bbe28261c0dcb6e265f515ba79f6ce07"
   dependencies:
-    iterall "^1.1.0"
+    iterall "1.1.3"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -2482,9 +2482,9 @@ istanbul-reports@^1.1.1:
   dependencies:
     handlebars "^4.0.3"
 
-iterall@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.1.tgz#f7f0af11e9a04ec6426260f5019d9fcca4d50214"
+iterall@1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.3.tgz#1cbbff96204056dde6656e2ed2e2226d0e6d72c9"
 
 jest-changed-files@^21.2.0:
   version "21.2.0"


### PR DESCRIPTION
Fixes #3601

This adds support for
- description as strings
- extending all the possible types
- block strings
- allow removing {} if there's no implementation for all graphql types

This is a breaking change but shouldn't be a big issue.
- Empty types are no longer allowed (there's an option to enable it but it hasn't been released yet). The fix is to remove `{}`

Something that hasn't been changed because not released:
- Doesn't support the new `&` separator for implementing multiple interfaces

A bug has been fixed:
- Now properly prints @directives for unions.