### PR TITLE
fix(playground): fix report version

### DIFF
--- a/scripts/build/build-docs.js
+++ b/scripts/build/build-docs.js
@@ -24,7 +24,7 @@ const parserPaths = parsers.map(stripLanguageDirectory);
 
 if (isPullRequest) {
   const pkg = require("../../package.json");
-  pkg.prVersion = `pr-${process.env.REVIEW_ID}`;
+  pkg.version = `999.999.999-pr.${process.env.REVIEW_ID}`;
   pipe(JSON.stringify(pkg, null, 2)).to("package.json");
   shell.exec("node scripts/build/build.js");
 }

--- a/website/static/playground.js
+++ b/website/static/playground.js
@@ -85,10 +85,11 @@ window.onload = function() {
       prettierVersion = message.data.version;
 
       var link = document.createElement("a");
-      var match = prettierVersion.match(/^pr-(\d+)$/);
+      var match = prettierVersion.match(/^\d+\.\d+\.\d+-pr.(\d+)$/);
       if (match) {
         link.href = "https://github.com/prettier/prettier/pull/" + match[1];
         link.textContent = "PR #" + match[1];
+        prettierVersion = "pr-" + match[1];
       } else {
         if (prettierVersion.match(/\.0$/)) {
           link.href =

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -103,7 +103,7 @@ self.onmessage = function(message) {
     doc: doc,
     ast: ast,
     formatted2: formatted2,
-    version: prettier.prVersion || prettier.version
+    version: prettier.version
   });
 };
 


### PR DESCRIPTION
Revert #3613 and apply another solution since we don't actually expose `prVersion` from `prettier` module, which cause the wrong version on <kbd>copy markdown</kbd>.  😂

cc @azz