### PR TITLE
Print parens in FunctionTypeAnnotation when arrowParens is "always"

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3285,6 +3285,9 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
     !fun.rest;
 
   if (isFlowShorthandWithOneArg) {
+    if (options.arrowParens === "always") {
+      return concat(["(", concat(printed), ")"]);
+    }
     return concat(printed);
   }
 

--- a/tests/flow_function_parentheses/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_function_parentheses/__snapshots__/jsfmt.spec.js.snap
@@ -34,6 +34,23 @@ const selectorByPath: Path => SomethingSelector<
 
 `;
 
+exports[`single.js 3`] = `
+const selectorByPath:
+  Path
+ => SomethingSelector<
+  SomethingUEditorContextType,
+  SomethingUEditorContextType,
+  SomethingBulkValue<string>
+> = memoizeWithArgs(/* ... */)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const selectorByPath: Path => SomethingSelector<
+  SomethingUEditorContextType,
+  SomethingUEditorContextType,
+  SomethingBulkValue<string>
+> = memoizeWithArgs(/* ... */);
+
+`;
+
 exports[`test.js 1`] = `
 type Banana = {
   eat: string => boolean,
@@ -209,6 +226,99 @@ type f = (?arg) => void;
 class X {
   constructor(
     ideConnectionFactory: child_process$ChildProcess => FlowIDEConnection = defaultIDEConnectionFactory,
+  ) {}
+}
+
+interface F {
+  ideConnectionFactoryLongLongLong: child_process$ChildProcess => FlowIDEConnection;
+}
+
+type ExtractType = <A>(B<C>) => D;
+
+`;
+
+exports[`test.js 3`] = `
+type Banana = {
+  eat: string => boolean,
+};
+
+type Hex = {n: 0x01};
+
+type T = { method: (a) => void };
+
+type T = { method(a): void };
+
+declare class X { method(a): void }
+
+declare function f(a): void;
+
+var f: (a) => void;
+
+interface F { m(string): number }
+
+interface F { m: (string) => number }
+
+function f(o: { f: (string) => void }) {}
+
+function f(o: { f(string): void }) {}
+
+type f = (...arg) => void;
+
+type f = (/* comment */ arg) => void;
+
+type f = (arg /* comment */) => void;
+
+type f = (?arg) => void;
+
+class X {
+  constructor(
+    ideConnectionFactory: child_process$ChildProcess => FlowIDEConnection =
+        defaultIDEConnectionFactory,
+  ) {
+  }
+}
+
+interface F {
+  ideConnectionFactoryLongLongLong: (child_process$ChildProcess) => FlowIDEConnection
+}
+
+type ExtractType = <A>(B<C>) => D
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+type Banana = {
+  eat: string => boolean
+};
+
+type Hex = { n: 0x01 };
+
+type T = { method: a => void };
+
+type T = { method(a): void };
+
+declare class X { method(a): void }
+
+declare function f(a): void;
+
+var f: a => void;
+
+interface F { m(string): number }
+
+interface F { m: string => number }
+
+function f(o: { f: string => void }) {}
+
+function f(o: { f(string): void }) {}
+
+type f = (...arg) => void;
+
+type f = /* comment */ arg => void;
+
+type f = arg /* comment */ => void;
+
+type f = (?arg) => void;
+
+class X {
+  constructor(
+    ideConnectionFactory: child_process$ChildProcess => FlowIDEConnection = defaultIDEConnectionFactory
   ) {}
 }
 

--- a/tests/flow_function_parentheses/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_function_parentheses/__snapshots__/jsfmt.spec.js.snap
@@ -43,7 +43,7 @@ const selectorByPath:
   SomethingBulkValue<string>
 > = memoizeWithArgs(/* ... */)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-const selectorByPath: Path => SomethingSelector<
+const selectorByPath: (Path) => SomethingSelector<
   SomethingUEditorContextType,
   SomethingUEditorContextType,
   SomethingBulkValue<string>
@@ -285,12 +285,12 @@ interface F {
 type ExtractType = <A>(B<C>) => D
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 type Banana = {
-  eat: string => boolean
+  eat: (string) => boolean
 };
 
 type Hex = { n: 0x01 };
 
-type T = { method: a => void };
+type T = { method: (a) => void };
 
 type T = { method(a): void };
 
@@ -298,32 +298,32 @@ declare class X { method(a): void }
 
 declare function f(a): void;
 
-var f: a => void;
+var f: (a) => void;
 
 interface F { m(string): number }
 
-interface F { m: string => number }
+interface F { m: (string) => number }
 
-function f(o: { f: string => void }) {}
+function f(o: { f: (string) => void }) {}
 
 function f(o: { f(string): void }) {}
 
 type f = (...arg) => void;
 
-type f = /* comment */ arg => void;
+type f = (/* comment */ arg) => void;
 
-type f = arg /* comment */ => void;
+type f = (arg /* comment */) => void;
 
 type f = (?arg) => void;
 
 class X {
   constructor(
-    ideConnectionFactory: child_process$ChildProcess => FlowIDEConnection = defaultIDEConnectionFactory
+    ideConnectionFactory: (child_process$ChildProcess) => FlowIDEConnection = defaultIDEConnectionFactory
   ) {}
 }
 
 interface F {
-  ideConnectionFactoryLongLongLong: child_process$ChildProcess => FlowIDEConnection;
+  ideConnectionFactoryLongLongLong: (child_process$ChildProcess) => FlowIDEConnection;
 }
 
 type ExtractType = <A>(B<C>) => D;

--- a/tests/flow_function_parentheses/jsfmt.spec.js
+++ b/tests/flow_function_parentheses/jsfmt.spec.js
@@ -1,2 +1,3 @@
 run_spec(__dirname, ["flow", "babylon"]);
 run_spec(__dirname, ["flow", "babylon"], { trailingComma: "all" });
+run_spec(__dirname, ["flow", "babylon"], { arrowParens: "always" });


### PR DESCRIPTION
Fixes #3550 

See the 2nd commit for the snapshot changes