### PR TITLE
Tweak CSS of the blog section

### DIFF
--- a/website/static/overrides.css
+++ b/website/static/overrides.css
@@ -85,14 +85,14 @@ a {
 }
 
 .blogContainer .posts .post {
-  border-bottom: 1px solid #1A2B34;
+  border-bottom: 1px solid #1b2b35;
   border-radius: 0;
 }
 
 .mainContainer .wrapper .post h2,
 .mainContainer .wrapper .post h3 {
   padding-bottom: 0.3em;
-  border-bottom: 1px solid #1A2B34;
+  border-bottom: 1px solid #1b2b35;
   margin-top: 14px;
   margin-bottom: 16px;
   font-weight: 600;
@@ -113,12 +113,11 @@ a {
   font-size: 13.6px;
   line-height: 1.45;
   border-radius: 3px;
-  background: #1b2b35;
   border-left-color: #eb5d5d;
 }
 
 .hljs, .hljs-subst {
-  color: #c1c4c5;
+  color: #1b2b35;
 }
 
 .hljs-type, .hljs-string, .hljs-number, .hljs-selector-id, .hljs-selector-class, .hljs-quote, .hljs-template-tag, .hljs-deletion,
@@ -138,5 +137,5 @@ a {
 
 .hljs-regexp, .hljs-symbol, .hljs-variable, .hljs-template-variable, .hljs-link, .hljs-selector-attr, .hljs-selector-pseudo,
 .hljs-comment {
-  color: #c692c6;
+  color: #cda144;
 }

--- a/website/static/overrides.css
+++ b/website/static/overrides.css
@@ -41,3 +41,102 @@
 pre {
   overflow-x: scroll;
 }
+
+@media only screen and (min-width: 736px) {
+  .mainContainer .wrapper .post .postHeader h1 {
+    font-size: 32px;
+  }
+}
+
+h1 a {
+  color: #24292e;
+}
+
+a {
+  color: #56b3b4;
+}
+
+.post p a {
+  text-decoration: inherit !important;
+}
+.post p a:hover {
+  text-decoration: underline !important;
+}
+.post a {
+  font-weight: inherit;
+}
+
+.post, .post-content {
+  font-size: 16px;
+}
+
+.post-meta {
+  float: left;
+  margin-right: 10px;
+  font-size: 14px;
+}
+
+.blogContainer .postHeader {
+  margin-bottom: 0;
+}
+
+.read-more {
+  margin-top: 10px;
+}
+
+.blogContainer .posts .post {
+  border-bottom: 1px solid #1A2B34;
+  border-radius: 0;
+}
+
+.mainContainer .wrapper .post h2,
+.mainContainer .wrapper .post h3 {
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid #1A2B34;
+  margin-top: 14px;
+  margin-bottom: 16px;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
+.mainContainer .wrapper .post h4 {
+  font-size: 1.25em;
+  line-height: 24px;
+  font-weight: 500;
+  margin-bottom: 20px;
+  margin-top: 10px;
+}
+
+.hljs {
+  padding: 16px;
+  overflow: auto;
+  font-size: 13.6px;
+  line-height: 1.45;
+  border-radius: 3px;
+  background: #1b2b35;
+  border-left-color: #eb5d5d;
+}
+
+.hljs, .hljs-subst {
+  color: #c1c4c5;
+}
+
+.hljs-type, .hljs-string, .hljs-number, .hljs-selector-id, .hljs-selector-class, .hljs-quote, .hljs-template-tag, .hljs-deletion,
+.hljs-title, .hljs-section {
+  color: #eb5d5d;
+}
+
+.hljs-built_in, .hljs-bullet, .hljs-code, .hljs-addition,
+.hljs-literal {
+  color: #56b3b4;
+}
+
+.hljs-keyword, .hljs-attribute, .hljs-selector-tag, .hljs-meta-keyword, .hljs-doctag, .hljs-name,
+.hljs-title, .hljs-section {
+  font-weight: normal;
+}
+
+.hljs-regexp, .hljs-symbol, .hljs-variable, .hljs-template-variable, .hljs-link, .hljs-selector-attr, .hljs-selector-pseudo,
+.hljs-comment {
+  color: #c692c6;
+}


### PR DESCRIPTION
The default CSS for docusaurus is really terrible. I've long wanted to spend time fixing it upstream but until then, it's easier to just hack the CSS.

I tried to be as close as possible to how github displays it, which looked great.

<img width="1416" alt="screen shot 2018-01-01 at 12 25 19 pm" src="https://user-images.githubusercontent.com/197597/34470833-295a4b5a-eeef-11e7-839d-be5e759aefce.png">
<img width="1416" alt="screen shot 2018-01-01 at 12 25 17 pm" src="https://user-images.githubusercontent.com/197597/34470831-280aff88-eeef-11e7-96c2-ce39180d91b8.png">

<img width="1416" alt="screen shot 2018-01-01 at 12 25 32 pm" src="https://user-images.githubusercontent.com/197597/34470835-2bdadd0e-eeef-11e7-80e6-cccbcb106045.png">
<img width="1416" alt="screen shot 2018-01-01 at 12 25 30 pm" src="https://user-images.githubusercontent.com/197597/34470834-2a8796ae-eeef-11e7-9ae5-6d745fafcb0b.png">

<img width="1416" alt="screen shot 2018-01-01 at 12 26 19 pm" src="https://user-images.githubusercontent.com/197597/34470837-2e44d856-eeef-11e7-918d-4a40293c3ea6.png">
<img width="1416" alt="screen shot 2018-01-01 at 12 26 17 pm" src="https://user-images.githubusercontent.com/197597/34470836-2d10226a-eeef-11e7-90e7-60e6adc8689e.png">
