### PR TITLE
[Plugins] Allow custom getCommentChildNodes

### DIFF
--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -47,8 +47,8 @@ function getSortedChildNodes(node, text, options, resultArray) {
 
   let childNodes;
 
-  if (printer.getChildNodes) {
-    childNodes = printer.getChildNodes(node);
+  if (printer.getCommentChildNodes) {
+    childNodes = printer.getCommentChildNodes(node);
   } else if (node && typeof node === "object") {
     childNodes = Object.keys(node)
       .filter(

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -45,13 +45,22 @@ function getSortedChildNodes(node, text, options, resultArray) {
     return node[childNodesCacheKey];
   }
 
-  let names;
-  if (node && typeof node === "object") {
-    names = Object.keys(node).filter(
-      n =>
-        n !== "enclosingNode" && n !== "precedingNode" && n !== "followingNode"
-    );
-  } else {
+  let childNodes;
+
+  if (printer.getChildNodes) {
+    childNodes = printer.getChildNodes(node);
+  } else if (node && typeof node === "object") {
+    childNodes = Object.keys(node)
+      .filter(
+        n =>
+          n !== "enclosingNode" &&
+          n !== "precedingNode" &&
+          n !== "followingNode"
+      )
+      .map(n => node[n]);
+  }
+
+  if (!childNodes) {
     return;
   }
 
@@ -62,9 +71,9 @@ function getSortedChildNodes(node, text, options, resultArray) {
     });
   }
 
-  for (let i = 0, nameCount = names.length; i < nameCount; ++i) {
-    getSortedChildNodes(node[names[i]], text, options, resultArray);
-  }
+  childNodes.forEach(childNode => {
+    getSortedChildNodes(childNode, text, options, resultArray);
+  });
 
   return resultArray;
 }


### PR DESCRIPTION
I'm working on a plugin that contains all the child nodes in a "layout" array.

While I could somehow generate indexed properties to work around it, it seems cleaner to allow plugins to specify how to traverse their AST.