### PR TITLE
Allow Plugins to preprocess text

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,7 +97,9 @@ function formatWithCursor(text, opts, addAlignmentSize) {
 
   addAlignmentSize = addAlignmentSize || 0;
 
-  const ast = parser.parse(text, opts);
+  const result = parser.parse(text, opts);
+  const ast = result.ast;
+  text = typeof result.text !== "undefined" ? result.text : text;
 
   const formattedRangeOnly = formatRange(text, opts, ast);
   if (formattedRangeOnly) {
@@ -432,7 +434,9 @@ module.exports = {
     },
     printToDoc: function(text, opts) {
       opts = normalizeOptions(opts);
-      const ast = parser.parse(text, opts);
+      const result = parser.parse(text, opts);
+      const ast = result.ast;
+      text = typeof result.text !== "undefined" ? result.text : text;
       attachComments(text, ast, opts);
       const doc = printAstToDoc(ast, opts);
       return doc;

--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ function formatWithCursor(text, opts, addAlignmentSize) {
 
   const result = parser.parse(text, opts);
   const ast = result.ast;
-  text = typeof result.text !== "undefined" ? result.text : text;
+  text = result.text;
 
   const formattedRangeOnly = formatRange(text, opts, ast);
   if (formattedRangeOnly) {
@@ -436,7 +436,7 @@ module.exports = {
       opts = normalizeOptions(opts);
       const result = parser.parse(text, opts);
       const ast = result.ast;
-      text = typeof result.text !== "undefined" ? result.text : text;
+      text = result.text;
       attachComments(text, ast, opts);
       const doc = printAstToDoc(ast, opts);
       return doc;

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -131,8 +131,14 @@ function format(argv, input, opt) {
       );
     } else {
       const normalizedOpts = normalizeOptions(opt);
-      const ast = cleanAST(prettier.__debug.parse(input, opt), normalizedOpts);
-      const past = cleanAST(prettier.__debug.parse(pp, opt), normalizedOpts);
+      const ast = cleanAST(
+        prettier.__debug.parse(input, opt).ast,
+        normalizedOpts
+      );
+      const past = cleanAST(
+        prettier.__debug.parse(pp, opt).ast,
+        normalizedOpts
+      );
 
       if (ast !== past) {
         const MAX_AST_SIZE = 2097152; // 2MB

--- a/src/main/multiparser.js
+++ b/src/main/multiparser.js
@@ -25,7 +25,7 @@ function textToDoc(text, partialNextOptions, parentOptions) {
 
   const result = require("./parser").parse(text, nextOptions);
   const ast = result.ast;
-  text = typeof result.text !== "undefined" ? result.text : text;
+  text = result.text;
 
   const astComments = ast.comments;
   delete ast.comments;

--- a/src/main/multiparser.js
+++ b/src/main/multiparser.js
@@ -23,7 +23,10 @@ function textToDoc(text, partialNextOptions, parentOptions) {
     })
   );
 
-  const ast = require("./parser").parse(text, nextOptions);
+  const result = require("./parser").parse(text, nextOptions);
+  const ast = result.ast;
+  text = typeof result.text !== "undefined" ? result.text : text;
+
   const astComments = ast.comments;
   delete ast.comments;
   comments.attach(astComments, ast, text, nextOptions);

--- a/src/main/parser.js
+++ b/src/main/parser.js
@@ -58,6 +58,10 @@ function parse(text, opts) {
   const parser = resolveParser(opts, parsers);
 
   try {
+    if (parser.preprocess) {
+      text = parser.preprocess(text, opts);
+    }
+
     return parser.parse(text, parsersForCustomParserApi, opts);
   } catch (error) {
     const loc = error.loc;

--- a/src/main/parser.js
+++ b/src/main/parser.js
@@ -62,7 +62,10 @@ function parse(text, opts) {
       text = parser.preprocess(text, opts);
     }
 
-    return parser.parse(text, parsersForCustomParserApi, opts);
+    return {
+      text,
+      ast: parser.parse(text, parsersForCustomParserApi, opts)
+    };
   } catch (error) {
     const loc = error.loc;
 

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -112,7 +112,7 @@ function stripLocation(ast) {
 }
 
 function parse(string, opts) {
-  return stripLocation(prettier.__debug.parse(string, opts));
+  return stripLocation(prettier.__debug.parse(string, opts).ast);
 }
 
 function prettyprint(src, filename, options) {

--- a/tests_integration/__tests__/plugin-preprocess.js
+++ b/tests_integration/__tests__/plugin-preprocess.js
@@ -1,0 +1,12 @@
+"use strict";
+
+const runPrettier = require("../runPrettier");
+
+describe("parser preprocess function is used to reshape input text", () => {
+  runPrettier("plugins/preprocess", ["*.foo", "--plugin=./plugin"]).test({
+    stdout: "preprocessed:contents\n",
+    stderr: "",
+    status: 0,
+    write: []
+  });
+});

--- a/tests_integration/plugins/preprocess/file.foo
+++ b/tests_integration/plugins/preprocess/file.foo
@@ -1,0 +1,1 @@
+contents

--- a/tests_integration/plugins/preprocess/plugin.js
+++ b/tests_integration/plugins/preprocess/plugin.js
@@ -1,7 +1,5 @@
 "use strict";
 
-const concat = require("../../../src/doc").builders.concat;
-
 module.exports = {
   languages: [
     {

--- a/tests_integration/plugins/preprocess/plugin.js
+++ b/tests_integration/plugins/preprocess/plugin.js
@@ -1,0 +1,26 @@
+"use strict";
+
+const concat = require("../../../src/doc").builders.concat;
+
+module.exports = {
+  languages: [
+    {
+      name: "foo",
+      parsers: ["foo-parser"],
+      extensions: [".foo"],
+      since: "1.0.0"
+    }
+  ],
+  parsers: {
+    "foo-parser": {
+      preprocess: text => `preprocessed:${text}`,
+      parse: text => ({ text }),
+      astFormat: "foo-ast"
+    }
+  },
+  printers: {
+    "foo-ast": {
+      print: path => path.getValue().text
+    }
+  }
+};

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -68,7 +68,7 @@ self.onmessage = function(message) {
     var actualAst;
     var errored = false;
     try {
-      actualAst = prettier.__debug.parse(message.data.text, options);
+      actualAst = prettier.__debug.parse(message.data.text, options).ast;
       ast = JSON.stringify(actualAst);
     } catch (e) {
       errored = true;


### PR DESCRIPTION
As noted in prettier/prettier-swift#1

This allows plugins to preprocess the text that get's passed in and have Prettier update its `text` variable that is passed to `parse` and `attachComments` later.