### PR TITLE
Force break if comment in return argument

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -760,8 +760,8 @@ function printPathNoParens(path, options, print, args) {
           parts.push(
             concat([
               " (",
-              indent(concat([softline, path.call(print, "argument")])),
-              line,
+              indent(concat([hardline, path.call(print, "argument")])),
+              hardline,
               ")"
             ])
           );

--- a/tests/return/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/return/__snapshots__/jsfmt.spec.js.snap
@@ -55,9 +55,41 @@ exports[`comment.js 1`] = `
 function f() {
   return /* a */;
 }
+
+function f() {
+  return (
+    foo
+      // comment
+      .bar()
+  );
+}
+
+fn(function f() {
+  return (
+    foo
+      // comment
+      .bar()
+  );
+});
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function f() {
   return /* a */;
 }
+
+function f() {
+  return (
+    foo
+      // comment
+      .bar()
+  );
+}
+
+fn(function f() {
+  return (
+    foo
+      // comment
+      .bar()
+  );
+});
 
 `;

--- a/tests/return/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/return/__snapshots__/jsfmt.spec.js.snap
@@ -56,6 +56,12 @@ function f() {
   return /* a */;
 }
 
+function x() {
+  return func2
+      //comment
+      .bar();
+}
+
 function f() {
   return (
     foo
@@ -74,6 +80,14 @@ fn(function f() {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function f() {
   return /* a */;
+}
+
+function x() {
+  return (
+    func2
+      //comment
+      .bar()
+  );
 }
 
 function f() {

--- a/tests/return/comment.js
+++ b/tests/return/comment.js
@@ -1,3 +1,19 @@
 function f() {
   return /* a */;
 }
+
+function f() {
+  return (
+    foo
+      // comment
+      .bar()
+  );
+}
+
+fn(function f() {
+  return (
+    foo
+      // comment
+      .bar()
+  );
+});

--- a/tests/return/comment.js
+++ b/tests/return/comment.js
@@ -2,6 +2,12 @@ function f() {
   return /* a */;
 }
 
+function x() {
+  return func2
+      //comment
+      .bar();
+}
+
 function f() {
   return (
     foo


### PR DESCRIPTION
This one was kind of tricky, I'm still not sure why it was breaking in `(function () { /* code */ })` but not `fn(function() { /* code */ });`. Either way, if there's a comment in a return argument it probably requires a hardline, instead of a softline/line. Apparently, there weren't any specific tests relying on the softline/line so I guess this should be ok?

Fixes #3648