### PR TITLE
docs(readme): travis master badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
     <img alt="Gitter" src="https://img.shields.io/gitter/room/jlongster/prettier.svg?style=flat-square">
   </a>
   <a href="https://travis-ci.org/prettier/prettier">
-    <img alt="Travis" src="https://img.shields.io/travis/prettier/prettier.svg?style=flat-square">
+    <img alt="Travis" src="https://img.shields.io/travis/prettier/prettier/master.svg?style=flat-square">
   </a>
   <a href="https://codecov.io/gh/prettier/prettier">
     <img alt="Codecov" src="https://img.shields.io/codecov/c/github/prettier/prettier.svg?style=flat-square">


### PR DESCRIPTION
No more ![image](https://user-images.githubusercontent.com/8341033/34648007-5cf9f898-f3cc-11e7-848b-8e6c72e5677f.png) caused by branches other than master.