### PR TITLE
Add pretty-quick pre-commit docs

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -30,29 +30,25 @@ and add this config to your `package.json`:
 
 See https://github.com/okonet/lint-staged#configuration for more details about how you can configure lint-staged.
 
-## Option 2. [pre-commit](https://github.com/observing/pre-commit) (JS version)
+## Option 2. [pretty-quick](https://github.com/azz/pretty-quick)
 
-Install the package:
+Install it along with [husky](https://github.com/typicode/husky):
 
 ```bash
-yarn add pre-commit --dev
+yarn add pretty-quick husky --dev
 ```
 
 and add this config to your `package.json`:
 
-<!-- prettier-ignore -->
 ```json
 {
   "scripts": {
-    "prettier": "prettier \"*/**/*.js\" --ignore-path ./.prettierignore --write && git add . && git status"
-  },
-  "pre-commit": [
-    "prettier"
-  ]
+    "precommit": "pretty-quick --staged"
+  }
 }
 ```
 
-Find more info from [here](https://github.com/observing/pre-commit).
+Find more info from [here](https://github.com/azz/pretty-quick).
 
 ## Option 3. [pre-commit](https://github.com/pre-commit/pre-commit) (Python version)
 


### PR DESCRIPTION
Adding docs for integration with [`pretty-quick`](https://github.com/azz/pretty-quick).

I'm replacing the previous option (`pre-commit`) as it does a `git add .` which it really shouldn't be doing.

As it's a brand new package I'll leave it in the number two spot for now, but I think this could potentially be the recommended pre-commit hook in the future as it should be the fastest, and it's the easiest to set up.

[🌐](https://deploy-preview-3675--prettier.netlify.com/docs/en/precommit.html#option-2-pretty-quick-https-githubcom-azz-pretty-quick)