### PR TITLE
Add reset indent primitive

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -138,7 +138,7 @@ Specify a line break that is **always** included in the output, no matter if the
 declare var literalline: Doc;
 ```
 
-Specify a line break that is **always** included in the output, and don't indent the next line. This is used for template literals.
+Specify a line break that is **always** included in the output, and doesn't trim whitespaces in the end of lines. This is used for template literals.
 
 ### lineSuffix
 
@@ -192,6 +192,16 @@ declare function indent(doc: Doc): Doc;
 ```
 
 Increase the level of indentation.
+
+
+### resetIndent
+
+```ts
+declare function resetIndent(doc: Doc): Doc;
+```
+
+Resets the level of indentation.
+
 
 ### align
 

--- a/commands.md
+++ b/commands.md
@@ -138,7 +138,7 @@ Specify a line break that is **always** included in the output, no matter if the
 declare var literalline: Doc;
 ```
 
-Specify a line break that is **always** included in the output, and doesn't trim whitespaces in the end of lines. This is used for template literals.
+Specify a line break that is **always** included in the output, and doesn't trim whitespaces at the end of lines. This is used for template literals.
 
 ### lineSuffix
 

--- a/commands.md
+++ b/commands.md
@@ -193,7 +193,6 @@ declare function indent(doc: Doc): Doc;
 
 Increase the level of indentation.
 
-
 ### resetIndent
 
 ```ts
@@ -201,7 +200,6 @@ declare function resetIndent(doc: Doc): Doc;
 ```
 
 Resets the level of indentation.
-
 
 ### align
 

--- a/src/doc/doc-builders.js
+++ b/src/doc/doc-builders.js
@@ -33,6 +33,14 @@ function indent(contents) {
   return { type: "indent", contents };
 }
 
+function resetIndent(contents) {
+  if (process.env.NODE_ENV !== "production") {
+    assertDoc(contents);
+  }
+
+  return { type: "indent", contents, reset: true };
+}
+
 function align(n, contents) {
   if (process.env.NODE_ENV !== "production") {
     assertDoc(contents);
@@ -148,6 +156,7 @@ module.exports = {
   breakParent,
   ifBreak,
   indent,
+  resetIndent,
   align,
   addAlignmentToDoc
 };

--- a/src/doc/doc-debug.js
+++ b/src/doc/doc-debug.js
@@ -64,7 +64,12 @@ function printDoc(doc) {
   }
 
   if (doc.type === "indent") {
-    return "indent(" + printDoc(doc.contents) + ")";
+    return (
+      (doc.reset ? "indent" : "resetIndent") +
+      "(" +
+      printDoc(doc.contents) +
+      ")"
+    );
   }
 
   if (doc.type === "align") {

--- a/src/doc/doc-printer.js
+++ b/src/doc/doc-printer.js
@@ -381,7 +381,6 @@ function printDocToString(doc, options) {
 
               if (doc.literal) {
                 out.push(newLine);
-                pos = 0;
               } else {
                 if (out.length > 0) {
                   // Trim whitespace at the end of line
@@ -406,8 +405,8 @@ function printDocToString(doc, options) {
                 }
 
                 out.push(newLine + ind.value);
-                pos = ind.length;
               }
+              pos = ind.length;
               break;
           }
           break;

--- a/src/doc/doc-printer.js
+++ b/src/doc/doc-printer.js
@@ -70,7 +70,11 @@ function fits(next, restCommands, width, options, mustBeFlat) {
 
           break;
         case "indent":
-          cmds.push([doc.reset ? rootIndent() : makeIndent(ind, options), mode, doc.contents]);
+          cmds.push([
+            doc.reset ? rootIndent() : makeIndent(ind, options),
+            mode,
+            doc.contents
+          ]);
 
           break;
         case "align":
@@ -161,7 +165,11 @@ function printDocToString(doc, options) {
 
           break;
         case "indent":
-          cmds.push([doc.reset ? rootIndent() : makeIndent(ind, options), mode, doc.contents]);
+          cmds.push([
+            doc.reset ? rootIndent() : makeIndent(ind, options),
+            mode,
+            doc.contents
+          ]);
 
           break;
         case "align":

--- a/src/doc/doc-printer.js
+++ b/src/doc/doc-printer.js
@@ -70,7 +70,7 @@ function fits(next, restCommands, width, options, mustBeFlat) {
 
           break;
         case "indent":
-          cmds.push([makeIndent(ind, options), mode, doc.contents]);
+          cmds.push([doc.reset ? rootIndent() : makeIndent(ind, options), mode, doc.contents]);
 
           break;
         case "align":
@@ -161,7 +161,7 @@ function printDocToString(doc, options) {
 
           break;
         case "indent":
-          cmds.push([makeIndent(ind, options), mode, doc.contents]);
+          cmds.push([doc.reset ? rootIndent() : makeIndent(ind, options), mode, doc.contents]);
 
           break;
         case "align":

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -19,6 +19,7 @@ const softline = docBuilders.softline;
 const literalline = docBuilders.literalline;
 const group = docBuilders.group;
 const indent = docBuilders.indent;
+const resetIndent = docBuilders.resetIndent;
 const align = docBuilders.align;
 const conditionalGroup = docBuilders.conditionalGroup;
 const fill = docBuilders.fill;
@@ -1915,7 +1916,7 @@ function printPathNoParens(path, options, print, args) {
 
       return concat(parts);
     case "TemplateElement":
-      return join(literalline, n.value.raw.split(/\r?\n/g));
+      return resetIndent(join(literalline, n.value.raw.split(/\r?\n/g)));
     case "TemplateLiteral": {
       const expressions = path.map(print, "expressions");
 


### PR DESCRIPTION
This PR adds a new primitive for reseting indentation (see https://github.com/prettier/prettier/pull/3676#discussion_r160227270 for context).

To test this, I've decided to refactor the `TemplateElement` printing but it seems the `literalline` does more than just "not indenting" the next line (e.g. it also includes trailing whitespaces) so I couldn't simply change those to `hardline` and wrap with a `resetIndent`.

What I did was remove the "not indent the next line" feature of `literalline` and added the `resetIndent`. With that, all tests passed!

Let me know what you think!
  