### PR TITLE
Make `--ignore-path` link more specific in docs

### DIFF
--- a/docs/ignore.md
+++ b/docs/ignore.md
@@ -7,7 +7,7 @@ Prettier offers an escape hatch to ignore a block of code or prevent entire file
 
 ## Ignoring Files
 
-To exclude files from formatting, add entries to a `.prettierignore` file in the project root or set the `--ignore-path` [CLI](cli.md) option.
+To exclude files from formatting, add entries to a `.prettierignore` file in the project root or set the [`--ignore-path` CLI option](cli.md#ignore-path).
 
 ## JavaScript
 


### PR DESCRIPTION
Makes https://prettier.io/docs/en/ignore.html#ignoring-files link directly to https://prettier.io/docs/en/cli.html#ignore-path