### PR TITLE
feat(markdown): respect `tabWidth` for list indentation

### DIFF
--- a/tests/markdown_list/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_list/__snapshots__/jsfmt.spec.js.snap
@@ -22,6 +22,28 @@ exports[`checkbox.md 2`] = `
 
 `;
 
+exports[`checkbox.md 3`] = `
+- [ ] this is a long long long long long long long long long long long long long long paragraph.
+- [x] this is a long long long long long long long long long long long long long long paragraph.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* [ ] this is a long long long long long long long long long long long long long
+      long paragraph.
+* [x] this is a long long long long long long long long long long long long long
+      long paragraph.
+
+`;
+
+exports[`checkbox.md 4`] = `
+- [ ] this is a long long long long long long long long long long long long long long paragraph.
+- [x] this is a long long long long long long long long long long long long long long paragraph.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* [ ] this is a long long long long long long long long long long long long long
+      long paragraph.
+* [x] this is a long long long long long long long long long long long long long
+      long paragraph.
+
+`;
+
 exports[`git-diff-friendly.md 1`] = `
 5. abc
 1. def
@@ -34,6 +56,28 @@ exports[`git-diff-friendly.md 1`] = `
 `;
 
 exports[`git-diff-friendly.md 2`] = `
+5. abc
+1. def
+999. ghi
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+5. abc
+1. def
+1. ghi
+
+`;
+
+exports[`git-diff-friendly.md 3`] = `
+5. abc
+1. def
+999. ghi
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+5. abc
+1. def
+1. ghi
+
+`;
+
+exports[`git-diff-friendly.md 4`] = `
 5. abc
 1. def
 999. ghi
@@ -480,6 +524,442 @@ exports[`indent.md 2`] = `
 
 `;
 
+exports[`indent.md 3`] = `
+- [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+    - a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    - [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+    - a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    - [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+12345678) [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+          b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          - a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          - [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+                    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+                    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+      a a a a a a a a a a a a a a a
+
+     * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+       a a a a a a a a a a a a a a a
+
+          b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+          b b b b b b b b b b b b b b b b b
+
+     * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+           a a a a a a a a a a a a a a a
+
+          b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+          b b b b b b b b b b b b b b b b b
+
+     1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+        a a a a a a a a a a a a a a a a
+
+           b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+           b b b b b b b b b b b b b b b b b
+
+     1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            a a a a a a a a a a a a a a a a
+
+           b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+           b b b b b b b b b b b b b b b b b
+
+     12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+               a a a a a a a a a a a a a a a
+
+                  b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                  b b b b b b b b b b b b b b b b b
+
+     12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                   a a a a a a a a a a a a a a a
+
+                  b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                  b b b b b b b b b b b b b b b b b
+
+     a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+     a a a a a a a a a a a a a a a
+
+1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+       a a a a a a a a a a a a a a a
+
+      * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+        a a a a a a a a a a a a a a a a
+
+           b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+           b b b b b b b b b b b b b b b b b
+
+      * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            a a a a a a a a a a a a a a a a
+
+           b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+           b b b b b b b b b b b b b b b b b
+
+      1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+         a a a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+            b b b b b b b b b b b b b b b b b b
+
+      1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+             a a a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+            b b b b b b b b b b b b b b b b b b
+
+      12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                a a a a a a a a a a a a a a a a
+
+                   b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                   b b b b b b b b b b b b b b b b b
+
+      12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                    a a a a a a a a a a a a a a a a
+
+                   b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                   b b b b b b b b b b b b b b b b b
+
+      a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+      a a a a a a a a a a a a a a a a
+
+12345678) [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+              a a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+             b b b b b b b b b b b b b b b b
+
+             * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+               a a a a a a a a a a a a a a a a
+
+                  b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                  b b b b b b b b b b b b b b b b b b
+
+             * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                   a a a a a a a a a a a a a a a a
+
+                  b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                  b b b b b b b b b b b b b b b b b b
+
+             1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                a a a a a a a a a a a a a a a a a
+
+                   b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                   b b b b b b b b b b b b b b b b b b
+
+             1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                    a a a a a a a a a a a a a a a a a
+
+                   b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                   b b b b b b b b b b b b b b b b b b
+
+             12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                       a a a a a a a a a a a a a a a a
+
+                          b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                          b b b b b b b b b b b b b b b b b b b
+
+             12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                           a a a a a a a a a a a a a a a a
+
+                          b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                          b b b b b b b b b b b b b b b b b b b
+
+             a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+             a a a a a a a a a a a a a a a a
+
+`;
+
+exports[`indent.md 4`] = `
+- [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+    - a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    - [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+    - a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    - [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+12345678) [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+          b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          - a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          - [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+                    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+                    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+      a a a a a a a a a a a a a a a
+
+  * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+    a a a a a a a a a a a a a a
+
+    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+    b b b b b b b b b b b b b b
+
+  * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+        a a a a a a a a a a a a a a
+
+    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+    b b b b b b b b b b b b b b
+
+  1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+     a a a a a a a a a a a a a a
+
+     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+     b b b b b b b b b b b b b b
+
+  1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+         a a a a a a a a a a a a a a
+
+     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+     b b b b b b b b b b b b b b
+
+  12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+            b b b b b b b b b b b b b b
+
+  12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+            b b b b b b b b b b b b b b
+
+  a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+  a a a a a a a a a a a a a a
+
+1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+       a a a a a a a a a a a a a a a
+
+   * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+     a a a a a a a a a a a a a a
+
+     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+     b b b b b b b b b b b b b b
+
+   * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+         a a a a a a a a a a a a a a
+
+     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+     b b b b b b b b b b b b b b
+
+   1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+      a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+      b b b b b b b b b b b b b b b
+
+   1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+          a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+      b b b b b b b b b b b b b b b
+
+   12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+             a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+             b b b b b b b b b b b b b b
+
+   12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                 a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+             b b b b b b b b b b b b b b
+
+   a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+   a a a a a a a a a a a a a a
+
+12345678) [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+              a a a a a a a a a a a a a a a
+
+          b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+          b b b b b b b b b b b b b b b
+
+          * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            a a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+            b b b b b b b b b b b b b b b
+
+          * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                a a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+            b b b b b b b b b b b b b b b
+
+          1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+             a a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+             b b b b b b b b b b b b b b b
+
+          1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                 a a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+             b b b b b b b b b b b b b b b
+
+          12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                    a a a a a a a a a a a a a a a
+
+                    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                    b b b b b b b b b b b b b b b b
+
+          12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                        a a a a a a a a a a a a a a a
+
+                    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                    b b b b b b b b b b b b b b b b
+
+          a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+          a a a a a a a a a a a a a a a
+
+`;
+
 exports[`long-paragraph.md 1`] = `
 - This is a long long long long long long long long long long long long long long paragraph.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -489,6 +969,22 @@ exports[`long-paragraph.md 1`] = `
 `;
 
 exports[`long-paragraph.md 2`] = `
+- This is a long long long long long long long long long long long long long long paragraph.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* This is a long long long long long long long long long long long long long
+  long paragraph.
+
+`;
+
+exports[`long-paragraph.md 3`] = `
+- This is a long long long long long long long long long long long long long long paragraph.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* This is a long long long long long long long long long long long long long
+  long paragraph.
+
+`;
+
+exports[`long-paragraph.md 4`] = `
 - This is a long long long long long long long long long long long long long long paragraph.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * This is a long long long long long long long long long long long long long
@@ -550,6 +1046,60 @@ exports[`loose.md 2`] = `
 
 `;
 
+exports[`loose.md 3`] = `
+- 123
+
+  - abc
+
+- 456
+
+  - def
+
+- 789
+
+  - ghi
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* 123
+
+     * abc
+
+* 456
+
+     * def
+
+* 789
+
+     * ghi
+
+`;
+
+exports[`loose.md 4`] = `
+- 123
+
+  - abc
+
+- 456
+
+  - def
+
+- 789
+
+  - ghi
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* 123
+
+  * abc
+
+* 456
+
+  * def
+
+* 789
+
+  * ghi
+
+`;
+
 exports[`multiline.md 1`] = `
 - 123
   456
@@ -560,6 +1110,24 @@ exports[`multiline.md 1`] = `
 `;
 
 exports[`multiline.md 2`] = `
+- 123
+  456
+  789
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* 123 456 789
+
+`;
+
+exports[`multiline.md 3`] = `
+- 123
+  456
+  789
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* 123 456 789
+
+`;
+
+exports[`multiline.md 4`] = `
 - 123
   456
   789
@@ -587,6 +1155,28 @@ exports[`nested.md 2`] = `
 * Level 1
     * Level 2
         * Level 3
+
+`;
+
+exports[`nested.md 3`] = `
+- Level 1
+  - Level 2
+    - Level 3
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Level 1
+     * Level 2
+          * Level 3
+
+`;
+
+exports[`nested.md 4`] = `
+- Level 1
+  - Level 2
+    - Level 3
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Level 1
+  * Level 2
+    * Level 3
 
 `;
 
@@ -656,6 +1246,72 @@ exports[`nested-checkbox.md 2`] = `
 
 `;
 
+exports[`nested-checkbox.md 3`] = `
+* parent list item parent list item parent list item parent list item parent list item parent list item
+
+     * child list item child list item child list item child list item child list item child list item
+
+    paragraph paragraph paragraph paragraph paragraph paragraph paragraph paragraph paragraph
+
+* [x] parent task list item parent task list item parent task list item parent task list item
+
+     * [x] child task list item child task list item child task list item child task list item
+
+    paragraph paragraph paragraph paragraph paragraph paragraph paragraph paragraph paragraph
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* parent list item parent list item parent list item parent list item parent
+  list item parent list item
+
+     * child list item child list item child list item child list item child
+       list item child list item
+
+     paragraph paragraph paragraph paragraph paragraph paragraph paragraph
+     paragraph paragraph
+
+* [x] parent task list item parent task list item parent task list item parent
+      task list item
+
+     * [x] child task list item child task list item child task list item child
+           task list item
+
+     paragraph paragraph paragraph paragraph paragraph paragraph paragraph
+     paragraph paragraph
+
+`;
+
+exports[`nested-checkbox.md 4`] = `
+* parent list item parent list item parent list item parent list item parent list item parent list item
+
+     * child list item child list item child list item child list item child list item child list item
+
+    paragraph paragraph paragraph paragraph paragraph paragraph paragraph paragraph paragraph
+
+* [x] parent task list item parent task list item parent task list item parent task list item
+
+     * [x] child task list item child task list item child task list item child task list item
+
+    paragraph paragraph paragraph paragraph paragraph paragraph paragraph paragraph paragraph
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* parent list item parent list item parent list item parent list item parent
+  list item parent list item
+
+  * child list item child list item child list item child list item child list
+    item child list item
+
+  paragraph paragraph paragraph paragraph paragraph paragraph paragraph
+  paragraph paragraph
+
+* [x] parent task list item parent task list item parent task list item parent
+      task list item
+
+  * [x] child task list item child task list item child task list item child
+        task list item
+
+  paragraph paragraph paragraph paragraph paragraph paragraph paragraph
+  paragraph paragraph
+
+`;
+
 exports[`ordered.md 1`] = `
 1. 123
 1. 456
@@ -668,6 +1324,28 @@ exports[`ordered.md 1`] = `
 `;
 
 exports[`ordered.md 2`] = `
+1. 123
+1. 456
+1. 789
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1. 123
+1. 456
+1. 789
+
+`;
+
+exports[`ordered.md 3`] = `
+1. 123
+1. 456
+1. 789
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1. 123
+1. 456
+1. 789
+
+`;
+
+exports[`ordered.md 4`] = `
 1. 123
 1. 456
 1. 789
@@ -716,6 +1394,44 @@ exports[`separate.md 2`] = `
 
 `;
 
+exports[`separate.md 3`] = `
+- 123
+- 123
+- 123
+
+* 123
+* 123
+* 123
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* 123
+* 123
+* 123
+
+- 123
+- 123
+- 123
+
+`;
+
+exports[`separate.md 4`] = `
+- 123
+- 123
+- 123
+
+* 123
+* 123
+* 123
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* 123
+* 123
+* 123
+
+- 123
+- 123
+- 123
+
+`;
+
 exports[`simple.md 1`] = `
 - 123
 - 456
@@ -738,6 +1454,28 @@ exports[`simple.md 2`] = `
 
 `;
 
+exports[`simple.md 3`] = `
+- 123
+- 456
+- 789
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* 123
+* 456
+* 789
+
+`;
+
+exports[`simple.md 4`] = `
+- 123
+- 456
+- 789
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* 123
+* 456
+* 789
+
+`;
+
 exports[`start.md 1`] = `
 5. abc
 6. def
@@ -750,6 +1488,28 @@ exports[`start.md 1`] = `
 `;
 
 exports[`start.md 2`] = `
+5. abc
+6. def
+7. ghi
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+5. abc
+6. def
+7. ghi
+
+`;
+
+exports[`start.md 3`] = `
+5. abc
+6. def
+7. ghi
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+5. abc
+6. def
+7. ghi
+
+`;
+
+exports[`start.md 4`] = `
 5. abc
 6. def
 7. ghi

--- a/tests/markdown_list/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_list/__snapshots__/jsfmt.spec.js.snap
@@ -352,86 +352,86 @@ exports[`indent.md 2`] = `
 * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
       a a a a a a a a a a a a a a a
 
-  * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-    a a a a a a a a a a a a a a
+    * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+      a a a a a a a a a a a a a a a
 
-    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-    b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b
 
-  * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-        a a a a a a a a a a a a a a
+    * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+          a a a a a a a a a a a a a a a
 
-    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-    b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b
 
-  1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-     a a a a a a a a a a a a a a
+    1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+       a a a a a a a a a a a a a a a
 
-     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-     b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b
 
-  1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-         a a a a a a a a a a a a a a
+    1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+           a a a a a a a a a a a a a a a
 
-     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-     b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b
 
-  12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-            a a a a a a a a a a a a a a
+    12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+              a a a a a a a a a a a a a a a
 
-            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-            b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b
 
-  12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-                a a a a a a a a a a a a a a
+    12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                  a a a a a a a a a a a a a a a
 
-            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-            b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b
 
-  a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-  a a a a a a a a a a a a a a
+    a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+    a a a a a a a a a a a a a a a
 
 1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
        a a a a a a a a a a a a a a a
 
-   * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-     a a a a a a a a a a a a a a
-
-     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-     b b b b b b b b b b b b b b
-
-   * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-         a a a a a a a a a a a a a a
-
-     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-     b b b b b b b b b b b b b b
-
-   1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+    * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
       a a a a a a a a a a a a a a a
 
-      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-      b b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b
 
-   1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+    * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
           a a a a a a a a a a a a a a a
 
-      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-      b b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b
 
-   12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-             a a a a a a a a a a a a a a
+    1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+       a a a a a a a a a a a a a a a
 
-             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-             b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b
 
-   12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-                 a a a a a a a a a a a a a a
+    1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+           a a a a a a a a a a a a a a a
 
-             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-             b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b
 
-   a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-   a a a a a a a a a a a a a a
+    12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+              a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b
+
+    12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                  a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b
+
+    a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+    a a a a a a a a a a a a a a a
 
 12345678) [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
               a a a a a a a a a a a a a a a
@@ -442,26 +442,26 @@ exports[`indent.md 2`] = `
           * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
             a a a a a a a a a a a a a a a
 
-            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-            b b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b b
 
           * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
                 a a a a a a a a a a a a a a a
 
-            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-            b b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b b
 
           1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
              a a a a a a a a a a a a a a a
 
-             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-             b b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b b
 
           1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
                  a a a a a a a a a a a a a a a
 
-             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-             b b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b b
 
           12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
                     a a a a a a a a a a a a a a a
@@ -538,15 +538,15 @@ exports[`loose.md 2`] = `
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * 123
 
-  * abc
+    * abc
 
 * 456
 
-  * def
+    * def
 
 * 789
 
-  * ghi
+    * ghi
 
 `;
 
@@ -585,8 +585,8 @@ exports[`nested.md 2`] = `
     - Level 3
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Level 1
-  * Level 2
-    * Level 3
+    * Level 2
+        * Level 3
 
 `;
 
@@ -639,20 +639,20 @@ exports[`nested-checkbox.md 2`] = `
 * parent list item parent list item parent list item parent list item parent
   list item parent list item
 
-  * child list item child list item child list item child list item child list
-    item child list item
+    * child list item child list item child list item child list item child list
+      item child list item
 
-  paragraph paragraph paragraph paragraph paragraph paragraph paragraph
-  paragraph paragraph
+    paragraph paragraph paragraph paragraph paragraph paragraph paragraph
+    paragraph paragraph
 
 * [x] parent task list item parent task list item parent task list item parent
       task list item
 
-  * [x] child task list item child task list item child task list item child
-        task list item
+    * [x] child task list item child task list item child task list item child
+          task list item
 
-  paragraph paragraph paragraph paragraph paragraph paragraph paragraph
-  paragraph paragraph
+    paragraph paragraph paragraph paragraph paragraph paragraph paragraph
+    paragraph paragraph
 
 `;
 

--- a/tests/markdown_list/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_list/__snapshots__/jsfmt.spec.js.snap
@@ -11,6 +11,17 @@ exports[`checkbox.md 1`] = `
 
 `;
 
+exports[`checkbox.md 2`] = `
+- [ ] this is a long long long long long long long long long long long long long long paragraph.
+- [x] this is a long long long long long long long long long long long long long long paragraph.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* [ ] this is a long long long long long long long long long long long long long
+      long paragraph.
+* [x] this is a long long long long long long long long long long long long long
+      long paragraph.
+
+`;
+
 exports[`git-diff-friendly.md 1`] = `
 5. abc
 1. def
@@ -22,6 +33,453 @@ exports[`git-diff-friendly.md 1`] = `
 
 `;
 
+exports[`git-diff-friendly.md 2`] = `
+5. abc
+1. def
+999. ghi
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+5. abc
+1. def
+1. ghi
+
+`;
+
+exports[`indent.md 1`] = `
+- [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+    - a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    - [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+    - a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    - [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+12345678) [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+          b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          - a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          - [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+                    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+                    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+      a a a a a a a a a a a a a a a
+
+  * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+    a a a a a a a a a a a a a a
+
+    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+    b b b b b b b b b b b b b b
+
+  * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+        a a a a a a a a a a a a a a
+
+    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+    b b b b b b b b b b b b b b
+
+  1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+     a a a a a a a a a a a a a a
+
+     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+     b b b b b b b b b b b b b b
+
+  1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+         a a a a a a a a a a a a a a
+
+     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+     b b b b b b b b b b b b b b
+
+  12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+            b b b b b b b b b b b b b b
+
+  12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+            b b b b b b b b b b b b b b
+
+  a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+  a a a a a a a a a a a a a a
+
+1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+       a a a a a a a a a a a a a a a
+
+   * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+     a a a a a a a a a a a a a a
+
+     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+     b b b b b b b b b b b b b b
+
+   * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+         a a a a a a a a a a a a a a
+
+     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+     b b b b b b b b b b b b b b
+
+   1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+      a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+      b b b b b b b b b b b b b b b
+
+   1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+          a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+      b b b b b b b b b b b b b b b
+
+   12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+             a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+             b b b b b b b b b b b b b b
+
+   12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                 a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+             b b b b b b b b b b b b b b
+
+   a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+   a a a a a a a a a a a a a a
+
+12345678) [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+              a a a a a a a a a a a a a a a
+
+          b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+          b b b b b b b b b b b b b b b
+
+          * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            a a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+            b b b b b b b b b b b b b b b
+
+          * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                a a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+            b b b b b b b b b b b b b b b
+
+          1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+             a a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+             b b b b b b b b b b b b b b b
+
+          1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                 a a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+             b b b b b b b b b b b b b b b
+
+          12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                    a a a a a a a a a a a a a a a
+
+                    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                    b b b b b b b b b b b b b b b b
+
+          12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                        a a a a a a a a a a a a a a a
+
+                    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                    b b b b b b b b b b b b b b b b
+
+          a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+          a a a a a a a a a a a a a a a
+
+`;
+
+exports[`indent.md 2`] = `
+- [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+    - a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    - [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+    - a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    - [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+12345678) [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+          b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          - a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          - [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+                    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+                    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+      a a a a a a a a a a a a a a a
+
+  * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+    a a a a a a a a a a a a a a
+
+    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+    b b b b b b b b b b b b b b
+
+  * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+        a a a a a a a a a a a a a a
+
+    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+    b b b b b b b b b b b b b b
+
+  1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+     a a a a a a a a a a a a a a
+
+     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+     b b b b b b b b b b b b b b
+
+  1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+         a a a a a a a a a a a a a a
+
+     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+     b b b b b b b b b b b b b b
+
+  12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+            b b b b b b b b b b b b b b
+
+  12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+            b b b b b b b b b b b b b b
+
+  a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+  a a a a a a a a a a a a a a
+
+1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+       a a a a a a a a a a a a a a a
+
+   * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+     a a a a a a a a a a a a a a
+
+     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+     b b b b b b b b b b b b b b
+
+   * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+         a a a a a a a a a a a a a a
+
+     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+     b b b b b b b b b b b b b b
+
+   1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+      a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+      b b b b b b b b b b b b b b b
+
+   1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+          a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+      b b b b b b b b b b b b b b b
+
+   12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+             a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+             b b b b b b b b b b b b b b
+
+   12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                 a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+             b b b b b b b b b b b b b b
+
+   a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+   a a a a a a a a a a a a a a
+
+12345678) [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+              a a a a a a a a a a a a a a a
+
+          b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+          b b b b b b b b b b b b b b b
+
+          * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            a a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+            b b b b b b b b b b b b b b b
+
+          * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                a a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+            b b b b b b b b b b b b b b b
+
+          1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+             a a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+             b b b b b b b b b b b b b b b
+
+          1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                 a a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+             b b b b b b b b b b b b b b b
+
+          12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                    a a a a a a a a a a a a a a a
+
+                    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                    b b b b b b b b b b b b b b b b
+
+          12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                        a a a a a a a a a a a a a a a
+
+                    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                    b b b b b b b b b b b b b b b b
+
+          a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+          a a a a a a a a a a a a a a a
+
+`;
+
 exports[`long-paragraph.md 1`] = `
 - This is a long long long long long long long long long long long long long long paragraph.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -30,7 +488,42 @@ exports[`long-paragraph.md 1`] = `
 
 `;
 
+exports[`long-paragraph.md 2`] = `
+- This is a long long long long long long long long long long long long long long paragraph.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* This is a long long long long long long long long long long long long long
+  long paragraph.
+
+`;
+
 exports[`loose.md 1`] = `
+- 123
+
+  - abc
+
+- 456
+
+  - def
+
+- 789
+
+  - ghi
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* 123
+
+  * abc
+
+* 456
+
+  * def
+
+* 789
+
+  * ghi
+
+`;
+
+exports[`loose.md 2`] = `
 - 123
 
   - abc
@@ -66,7 +559,27 @@ exports[`multiline.md 1`] = `
 
 `;
 
+exports[`multiline.md 2`] = `
+- 123
+  456
+  789
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* 123 456 789
+
+`;
+
 exports[`nested.md 1`] = `
+- Level 1
+  - Level 2
+    - Level 3
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Level 1
+  * Level 2
+    * Level 3
+
+`;
+
+exports[`nested.md 2`] = `
 - Level 1
   - Level 2
     - Level 3
@@ -110,7 +623,51 @@ exports[`nested-checkbox.md 1`] = `
 
 `;
 
+exports[`nested-checkbox.md 2`] = `
+* parent list item parent list item parent list item parent list item parent list item parent list item
+
+     * child list item child list item child list item child list item child list item child list item
+
+    paragraph paragraph paragraph paragraph paragraph paragraph paragraph paragraph paragraph
+
+* [x] parent task list item parent task list item parent task list item parent task list item
+
+     * [x] child task list item child task list item child task list item child task list item
+
+    paragraph paragraph paragraph paragraph paragraph paragraph paragraph paragraph paragraph
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* parent list item parent list item parent list item parent list item parent
+  list item parent list item
+
+  * child list item child list item child list item child list item child list
+    item child list item
+
+  paragraph paragraph paragraph paragraph paragraph paragraph paragraph
+  paragraph paragraph
+
+* [x] parent task list item parent task list item parent task list item parent
+      task list item
+
+  * [x] child task list item child task list item child task list item child
+        task list item
+
+  paragraph paragraph paragraph paragraph paragraph paragraph paragraph
+  paragraph paragraph
+
+`;
+
 exports[`ordered.md 1`] = `
+1. 123
+1. 456
+1. 789
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+1. 123
+1. 456
+1. 789
+
+`;
+
+exports[`ordered.md 2`] = `
 1. 123
 1. 456
 1. 789
@@ -140,6 +697,25 @@ exports[`separate.md 1`] = `
 
 `;
 
+exports[`separate.md 2`] = `
+- 123
+- 123
+- 123
+
+* 123
+* 123
+* 123
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* 123
+* 123
+* 123
+
+- 123
+- 123
+- 123
+
+`;
+
 exports[`simple.md 1`] = `
 - 123
 - 456
@@ -151,7 +727,29 @@ exports[`simple.md 1`] = `
 
 `;
 
+exports[`simple.md 2`] = `
+- 123
+- 456
+- 789
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* 123
+* 456
+* 789
+
+`;
+
 exports[`start.md 1`] = `
+5. abc
+6. def
+7. ghi
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+5. abc
+6. def
+7. ghi
+
+`;
+
+exports[`start.md 2`] = `
 5. abc
 6. def
 7. ghi

--- a/tests/markdown_list/indent.md
+++ b/tests/markdown_list/indent.md
@@ -1,0 +1,85 @@
+- [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+    - a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    - [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+    - a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    - [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+    a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+12345678) [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+          b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          - a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          - [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+                    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+
+                    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+
+          a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a

--- a/tests/markdown_list/jsfmt.spec.js
+++ b/tests/markdown_list/jsfmt.spec.js
@@ -1,2 +1,4 @@
 run_spec(__dirname, ["markdown"], { proseWrap: "always" });
 run_spec(__dirname, ["markdown"], { proseWrap: "always", tabWidth: 4 });
+run_spec(__dirname, ["markdown"], { proseWrap: "always", tabWidth: 999 });
+run_spec(__dirname, ["markdown"], { proseWrap: "always", tabWidth: 0 });

--- a/tests/markdown_list/jsfmt.spec.js
+++ b/tests/markdown_list/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(__dirname, ["markdown"], { proseWrap: "always" });
+run_spec(__dirname, ["markdown"], { proseWrap: "always", tabWidth: 4 });


### PR DESCRIPTION
Fixes #3679

---

**Prettier pr-3694**
[Playground link](https://deploy-preview-3694--prettier.netlify.com/playground/#N4Igxg9gdgLgprEAuEBiABAWQIYCcDWAJhAO5ToAqcAzjADpQMBU6AgugDYCWM6PcAWwboR6FgCEeAIwCuYfHF4C8RUuVxwAjjK4bq6ACzpqAB2xga6AGYRc6KDXiFOXWn3gD9ACgAWMGCbUSAD0wbTm+BAAbnC4VhykAHSQAsHYwQDMAOwArACcBtkATACUzOgAChr+sXxQhAgw+jAQ6EXGZhbeMNhS6CRchDA+6MQ0UADkvNRwgugt6NhWVnBgvDwlIAA0IBAmMFzQ1MigeLikFXgIxyjYURCD2yDYtMhW2BwzO1K4EYoAyp0uFAAObIGC4GRwHbEMBvD5fEDAma4GBVbAg5Twz7QkAAK2oAA9xL95ADsAI4AAZYFwbGIiAyAJMorgyG4sy4FHIEDKAjEMhPEy4YEwADqg2GyAAHAAGHbCiAzMW-Ew84U0WIxJ4abS6ODozHYem4mYCLhsqE7ajAkEcOAARRkEHgJp2PSkEqGPmQBndvy43FBAGEIAIsSgoNA6TsZDMKL0bu8cQBfFNAA)
```sh
--parser markdown
--tab-width 4
```

**Input:**
```markdown
# Markdown Test

* A lit item
    * Bitbucket markdown requires 4 spaces for nested list items (https://stackoverflow.com/a/37594372)
* Pretter indents to 2 spaces (tab width doesn't seem to affect it)
```

**Output:**
```markdown
# Markdown Test

* A lit item
    * Bitbucket markdown requires 4 spaces for nested list items (https://stackoverflow.com/a/37594372)
* Pretter indents to 2 spaces (tab width doesn't seem to affect it)

```