### PR TITLE
fix(scss): `!default` directive

### DIFF
--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -161,6 +161,8 @@ function parseMediaQuery(value) {
   return addTypePrefix(result, "media-");
 }
 
+const DEFAULT_SCSS_DIRECTIVE = "!default";
+
 function parseNestedCSS(node) {
   if (node && typeof node === "object") {
     delete node.parent;
@@ -189,6 +191,11 @@ function parseNestedCSS(node) {
     }
     if (node.type && typeof node.value === "string") {
       try {
+        if (node.value.endsWith(DEFAULT_SCSS_DIRECTIVE)) {
+          node.default = true;
+          node.value = node.value.slice(0, -DEFAULT_SCSS_DIRECTIVE.length);
+        }
+
         node.value = parseValue(node.value);
       } catch (e) {
         throw createError(

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -90,6 +90,7 @@ function genericPrint(path, options, print) {
           ? removeLines(path.call(print, "value"))
           : path.call(print, "value"),
         n.important ? " !important" : "",
+        n.default ? " !default" : "",
         n.nodes
           ? concat([
               " {",

--- a/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
@@ -19,6 +19,20 @@ div {
 }
 a { margin: 0 { left: 10px; } }
 $map: (color: #111111, text-shadow: 1px 1px 0 salmon);
+$theme-checkbox-colors: (
+    default: $theme-color-border,
+    checked: $theme-color-checked,
+    disabled: $theme-color-disabled,
+    disabled-font: $theme-color-font-secondary,
+) !default;
+$default: #111111 !default;
+$default: #111111   !default;
+$default: #111111
+!default;
+$default: "very-long-long-long-long-long-long-long-long-long-long-long-value" !default;
+$default: "very-long-long-long-long-long-long-long-long-long-long-long-value"   !default;
+$default: "very-long-long-long-long-long-long-long-long-long-long-long-value"
+!default;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 @media #{$g-breakpoint-tiny} {
 }
@@ -43,5 +57,17 @@ $map: (
   color: #111111,
   text-shadow: 1px 1px 0 salmon
 );
+$theme-checkbox-colors: (
+  default: $theme-color-border,
+  checked: $theme-color-checked,
+  disabled: $theme-color-disabled,
+  disabled-font: $theme-color-font-secondary
+) !default;
+$default: #111111 !default;
+$default: #111111 !default;
+$default: #111111 !default;
+$default: "very-long-long-long-long-long-long-long-long-long-long-long-value" !default;
+$default: "very-long-long-long-long-long-long-long-long-long-long-long-value" !default;
+$default: "very-long-long-long-long-long-long-long-long-long-long-long-value" !default;
 
 `;

--- a/tests/css_scss/scss.css
+++ b/tests/css_scss/scss.css
@@ -9,3 +9,17 @@ div {
 }
 a { margin: 0 { left: 10px; } }
 $map: (color: #111111, text-shadow: 1px 1px 0 salmon);
+$theme-checkbox-colors: (
+    default: $theme-color-border,
+    checked: $theme-color-checked,
+    disabled: $theme-color-disabled,
+    disabled-font: $theme-color-font-secondary,
+) !default;
+$default: #111111 !default;
+$default: #111111   !default;
+$default: #111111
+!default;
+$default: "very-long-long-long-long-long-long-long-long-long-long-long-value" !default;
+$default: "very-long-long-long-long-long-long-long-long-long-long-long-value"   !default;
+$default: "very-long-long-long-long-long-long-long-long-long-long-long-value"
+!default;


### PR DESCRIPTION
`postcss` add `node.important` when you use `!important`, but don't handle `!default`. 

Just remove `!default` from `value` and add `node.default` to detect when you use `!default`.

Issue: https://github.com/prettier/prettier/issues/2799