### PR TITLE
feat(markdown): trim whitespaces inside link and image alt

### DIFF
--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -107,7 +107,27 @@ function genericPrint(path, options, print) {
           ? "never"
           : options.proseWrap;
 
-      return printLine(path, node.value, { proseWrap });
+      let isLeadingInsideLinkAlt = false;
+      let isTrailingInsideLinkAlt = false;
+
+      const linkNode = getAncestorNode(path, "link");
+
+      if (linkNode) {
+        isLeadingInsideLinkAlt =
+          linkNode.children.indexOf(parentNode) === 0 && index === 0;
+        isTrailingInsideLinkAlt =
+          linkNode.children.indexOf(parentNode) ===
+            linkNode.children.length - 1 &&
+          index === parentNode.children.length - 1;
+      }
+
+      return printLine(
+        path,
+        isLeadingInsideLinkAlt || isTrailingInsideLinkAlt ? "" : node.value,
+        {
+          proseWrap
+        }
+      );
     }
     case "emphasis": {
       const parentNode = path.getParentNode();
@@ -161,7 +181,7 @@ function genericPrint(path, options, print) {
     case "image":
       return concat([
         "![",
-        node.alt || "",
+        node.alt ? node.alt.trim() : "",
         "](",
         printUrl(node.url, ")"),
         printTitle(node.title, options),

--- a/tests/markdown_link/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_link/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,59 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`alt.md 1`] = `
+[hello](#world "title")
+[ hello](#world "title")
+[hello ](#world "title")
+[ hello ](#world "title")
+
+[hello _foo_](#world "title")
+[ hello _foo_](#world "title")
+[hello _foo_ ](#world "title")
+[ hello _foo_ ](#world "title")
+
+![hello](https://example.com)
+![ hello](https://example.com)
+![hello ](https://example.com)
+![ hello ](https://example.com)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[hello](#world "title") [hello](#world "title") [hello](#world "title")
+[hello](#world "title")
+
+[hello _foo_](#world "title") [hello _foo_](#world "title")
+[hello _foo_](#world "title") [hello _foo_](#world "title")
+
+![hello](https://example.com) ![hello](https://example.com)
+![hello](https://example.com) ![hello](https://example.com)
+
+`;
+
+exports[`alt.md 2`] = `
+[hello](#world "title")
+[ hello](#world "title")
+[hello ](#world "title")
+[ hello ](#world "title")
+
+[hello _foo_](#world "title")
+[ hello _foo_](#world "title")
+[hello _foo_ ](#world "title")
+[ hello _foo_ ](#world "title")
+
+![hello](https://example.com)
+![ hello](https://example.com)
+![hello ](https://example.com)
+![ hello ](https://example.com)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[hello](#world 'title') [hello](#world 'title') [hello](#world 'title')
+[hello](#world 'title')
+
+[hello _foo_](#world 'title') [hello _foo_](#world 'title')
+[hello _foo_](#world 'title') [hello _foo_](#world 'title')
+
+![hello](https://example.com) ![hello](https://example.com)
+![hello](https://example.com) ![hello](https://example.com)
+
+`;
+
 exports[`autolink.md 1`] = `
 <https://www.example.com>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/markdown_link/alt.md
+++ b/tests/markdown_link/alt.md
@@ -1,0 +1,14 @@
+[hello](#world "title")
+[ hello](#world "title")
+[hello ](#world "title")
+[ hello ](#world "title")
+
+[hello _foo_](#world "title")
+[ hello _foo_](#world "title")
+[hello _foo_ ](#world "title")
+[ hello _foo_ ](#world "title")
+
+![hello](https://example.com)
+![ hello](https://example.com)
+![hello ](https://example.com)
+![ hello ](https://example.com)


### PR DESCRIPTION
`[ hello ](#world "title")` => `[hello](#world "title")`

`![ hello ](https://example.com)` => `![hello](https://example.com)`