### PR TITLE
Run production tests on npm package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,10 @@ node_js:
 cache:
   yarn: true
   directories:
-  - node_modules
+    - node_modules
 env:
   - NODE_ENV=development
   - NODE_ENV=production
-matrix:
-  fast_finish: true
 install:
   - NODE_ENV=development yarn install
 before_script:
@@ -20,5 +18,9 @@ before_script:
 script:
   - yarn lint
   - yarn lint-docs
-  - AST_COMPARE=1 yarn test -- --runInBand
+  - if [ "${NODE_ENV}" = "production" ]; then yarn test:dist; fi
+  - if [ "${NODE_ENV}" = "development" ]; then AST_COMPARE=1 yarn test -- --runInBand; fi
   - if [ "${NODE_ENV}" = "development" ]; then yarn codecov; fi
+branches:
+  only:
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ cache:
 env:
   - NODE_ENV=development
   - NODE_ENV=production
+matrix:
+  fast_finish: true
 install:
   - NODE_ENV=development yarn install
 before_script:

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "snapshot-diff": "0.2.2",
     "strip-ansi": "4.0.0",
     "sw-toolbox": "3.6.0",
+    "tempy": "0.2.1",
     "uglify-es": "3.0.28",
     "webpack": "2.6.1"
   },
@@ -92,7 +93,7 @@
     "prepublishOnly": "echo \"Error: must publish from dist/\" && exit 1",
     "prepare-release": "yarn && yarn build && yarn test:dist",
     "test": "jest",
-    "test:dist": "cross-env NODE_ENV=production yarn test",
+    "test:dist": "node ./scripts/test-dist.js",
     "test-integration": "jest tests_integration",
     "lint": "cross-env EFF_NO_LINK_RULES=true eslint . --format node_modules/eslint-friendly-formatter",
     "lint-docs": "prettylint {.,docs,website,website/blog}/*.md",

--- a/scripts/test-dist.js
+++ b/scripts/test-dist.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const path = require("path");
+const shell = require("shelljs");
+const tempy = require("tempy");
+
+shell.config.fatal = true;
+
+const rootDir = path.join(__dirname, "..");
+const distDir = path.join(rootDir, "dist");
+
+const file = shell.exec("npm pack", { cwd: distDir }).stdout.trim();
+const tarPath = path.join(distDir, file);
+const tmpDir = tempy.directory();
+
+shell.config.silent = true;
+shell.exec("npm init -y", { cwd: tmpDir });
+shell.exec(`npm install "${tarPath}"`, { cwd: tmpDir });
+shell.config.silent = false;
+
+const code = shell.exec("yarn test --color --runInBand", {
+  cwd: rootDir,
+  env: Object.assign({}, process.env, {
+    NODE_ENV: "production",
+    AST_COMPARE: "1",
+    PRETTIER_DIR: path.join(tmpDir, "node_modules/prettier")
+  }),
+  shell: true
+}).code;
+
+process.exit(code);

--- a/tests_config/require_prettier.js
+++ b/tests_config/require_prettier.js
@@ -1,6 +1,8 @@
 "use strict";
 
 const isProduction = process.env.NODE_ENV === "production";
-const prettier = require(isProduction ? "../dist/" : "../");
+const prettierRootDir = isProduction ? process.env.PRETTIER_DIR : "../";
+
+const prettier = require(prettierRootDir);
 
 module.exports = prettier;

--- a/tests_integration/runPrettier.js
+++ b/tests_integration/runPrettier.js
@@ -6,10 +6,13 @@ const stripAnsi = require("strip-ansi");
 const ENV_LOG_LEVEL = require("../src/cli/logger").ENV_LOG_LEVEL;
 
 const isProduction = process.env.NODE_ENV === "production";
-const prettierCli = isProduction ? "../dist/bin-prettier" : "../bin/prettier";
+const prettierRootDir = isProduction ? process.env.PRETTIER_DIR : "../";
+const prettierPkg = require(path.join(prettierRootDir, "package.json"));
+const prettierCli = path.join(prettierRootDir, prettierPkg.bin.prettier);
+
 const thirdParty = isProduction
-  ? "../dist/third-party"
-  : "../src/common/third-party";
+  ? path.join(prettierRootDir, "./third-party")
+  : path.join(prettierRootDir, "./src/common/third-party");
 
 function runPrettier(dir, args, options) {
   args = args || [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1297,6 +1297,10 @@ crypto-browserify@^3.11.0:
     public-encrypt "^4.0.0"
     randombytes "^2.0.0"
 
+crypto-random-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-1.0.0.tgz#a230f64f568310e1498009940790ec99545bca7e"
+
 cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
@@ -4434,6 +4438,17 @@ tar@^2.2.1:
     fstream "^1.0.2"
     inherits "2"
 
+temp-dir@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/temp-dir/-/temp-dir-1.0.0.tgz#0a7c0ea26d3a39afa7e0ebea9c1fc0bc4daa011d"
+
+tempy@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/tempy/-/tempy-0.2.1.tgz#9038e4dbd1c201b74472214179bc2c6f7776e54c"
+  dependencies:
+    temp-dir "^1.0.0"
+    unique-string "^1.0.0"
+
 test-exclude@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-4.1.1.tgz#4d84964b0966b0087ecc334a2ce002d3d9341e26"
@@ -4607,6 +4622,12 @@ unified@6.1.6:
 uniq@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/uniq/-/uniq-1.0.1.tgz#b31c5ae8254844a3a8281541ce2b04b865a734ff"
+
+unique-string@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
+  dependencies:
+    crypto-random-string "^1.0.0"
 
 unist-util-remove-position@^1.0.0:
   version "1.1.1"


### PR DESCRIPTION
Runs the production tests agains the result of actually installing the package, rather than from the `dist` directory. 


Extracted from #3712
Fixes #3698