### PR TITLE
Added support to specify more than one `ignore-path` entry

### DIFF
--- a/docs/ignore.md
+++ b/docs/ignore.md
@@ -9,6 +9,13 @@ Prettier offers an escape hatch to ignore a block of code or prevent entire file
 
 To exclude files from formatting, add entries to a `.prettierignore` file in the project root or set the [`--ignore-path` CLI option](cli.md#ignore-path).
 
+Multiple `--ignore-path` directives can be specified to ignore entries from multiple files like from
+your `.gitignore` file also:
+
+```
+prettier --ignore-path .gitignore --ignore-path .prettierignore
+```
+
 ## JavaScript
 
 A JavaScript comment of `// prettier-ignore` will exclude the next node in the abstract syntax tree from formatting.

--- a/src/cli/constant.js
+++ b/src/cli/constant.js
@@ -193,7 +193,11 @@ const detailedOptions = normalizeDetailedOptions({
     type: "path",
     category: CATEGORY_CONFIG,
     default: ".prettierignore",
-    description: "Path to a file with patterns describing files to ignore."
+    description: dedent`
+      Path to a file with patterns describing files to ignore. Multiple paths can
+      be passed as separate \`--ignore-path\`s.
+    `,
+    array: true
   },
   "insert-pragma": {
     type: "boolean",

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -269,11 +269,25 @@ function formatStdin(argv) {
 }
 
 function createIgnorer(argv) {
-  const ignoreFilePath = path.resolve(argv["ignore-path"]);
-  let ignoreText = "";
+  let ignorePaths = argv["ignore-path"];
+  if (!Array.isArray(ignorePaths)) {
+    ignorePaths = [ignorePaths];
+  }
+
+  return ignorePaths
+    .map(readIgnoreFile)
+    .reduce(
+      (ignorer, ignoreFileContent) => ignorer.add(ignoreFileContent),
+      ignore()
+    );
+}
+
+function readIgnoreFile(ignorePath) {
+  const ignoreFilePath = path.resolve(ignorePath);
+  let ignoreFileContent = "";
 
   try {
-    ignoreText = fs.readFileSync(ignoreFilePath, "utf8");
+    ignoreFileContent = fs.readFileSync(ignoreFilePath, "utf8");
   } catch (readError) {
     if (readError.code !== "ENOENT") {
       logger.error(`Unable to read ${ignoreFilePath}: ` + readError.message);
@@ -281,7 +295,7 @@ function createIgnorer(argv) {
     }
   }
 
-  return ignore().add(ignoreText);
+  return ignoreFileContent;
 }
 
 function eachFilename(argv, patterns, callback) {

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -130,7 +130,8 @@ exports[`show detailed usage with --help ignore-path (stderr) 1`] = `""`;
 exports[`show detailed usage with --help ignore-path (stdout) 1`] = `
 "--ignore-path <path>
 
-  Path to a file with patterns describing files to ignore.
+  Path to a file with patterns describing files to ignore. Multiple paths can
+  be passed as separate \`--ignore-path\`s.
 
 Default: .prettierignore
 "
@@ -562,7 +563,8 @@ Config options:
   --no-editorconfig        Don't take .editorconfig into account when parsing configuration.
   --find-config-path <path>
                            Find and print the path to a configuration file for the given input file.
-  --ignore-path <path>     Path to a file with patterns describing files to ignore.
+  --ignore-path <path>     Path to a file with patterns describing files to ignore. Multiple paths can
+                           be passed as separate \`--ignore-path\`s.
                            Defaults to .prettierignore.
   --plugin <path>          Add a plugin. Multiple plugins can be passed as separate \`--plugin\`s.
   --with-node-modules      Process files inside 'node_modules' directory.
@@ -703,7 +705,8 @@ Config options:
   --no-editorconfig        Don't take .editorconfig into account when parsing configuration.
   --find-config-path <path>
                            Find and print the path to a configuration file for the given input file.
-  --ignore-path <path>     Path to a file with patterns describing files to ignore.
+  --ignore-path <path>     Path to a file with patterns describing files to ignore. Multiple paths can
+                           be passed as separate \`--ignore-path\`s.
                            Defaults to .prettierignore.
   --plugin <path>          Add a plugin. Multiple plugins can be passed as separate \`--plugin\`s.
   --with-node-modules      Process files inside 'node_modules' directory.

--- a/tests_integration/__tests__/__snapshots__/ignore-path.js.snap
+++ b/tests_integration/__tests__/__snapshots__/ignore-path.js.snap
@@ -26,3 +26,9 @@ exports[`support .prettierignore (stdout) 1`] = `
 `;
 
 exports[`support .prettierignore (write) 1`] = `Array []`;
+
+exports[`support multiple ignore-path (stderr) 1`] = `""`;
+
+exports[`support multiple ignore-path (stdout) 1`] = `""`;
+
+exports[`support multiple ignore-path (write) 1`] = `Array []`;

--- a/tests_integration/__tests__/ignore-path.js
+++ b/tests_integration/__tests__/ignore-path.js
@@ -13,6 +13,19 @@ describe("ignore path", () => {
   });
 });
 
+describe("support multiple ignore-path", () => {
+  runPrettier("cli/ignore-path", [
+    "**/*.js",
+    "--ignore-path",
+    ".gitignore",
+    "--ignore-path",
+    ".prettierignore",
+    "-l"
+  ]).test({
+    status: 0
+  });
+});
+
 describe("support .prettierignore", () => {
   runPrettier("cli/ignore-path", ["**/*.js", "-l"]).test({
     status: 1


### PR DESCRIPTION
Previously, passing multiple ignore paths was not something possible. So if one wanted to use its `.gitignore` file as well as another file defining extra ignored files that should however not be part of the `.gitignore` file, then it was not possible to do so.

Now, the --ignore-path CLI option accepts being specified multiple times to use multiple ignore paths.