### PR TITLE
[vue] fix: *.vue with `lang='tsx'` is not formatted

### DIFF
--- a/src/language-vue/embed.js
+++ b/src/language-vue/embed.js
@@ -28,7 +28,7 @@ function embed(path, print, textToDoc, options) {
     const langAttr = node.attrs.find(attr => attr.name === "lang");
     if (!langAttr) {
       parser = "babylon";
-    } else if (langAttr.value === "ts") {
+    } else if (langAttr.value === "ts" || langAttr.value === "tsx") {
       parser = "typescript";
     }
   }

--- a/tests/multiparser_vue/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_vue/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`lang-ts.vue 1`] = `
+<template>
+  <div>{{foo}}</div>
+</template>
+
+<script lang="ts">
+export default {
+  computed: {  foo( ): string {  return "foo";  },  },
+}
+</script>
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<template>
+  <div>{{foo}}</div>
+</template>
+
+<script lang="ts">
+export default {
+  computed: {
+    foo(): string {
+      return "foo";
+    }
+  }
+};
+</script>
+
+`;
+
+exports[`lang-tsx.vue 1`] = `
+<script lang="tsx">
+import {VNode} from "vue"
+export default {
+  computed: {  foo( ):string { return "foo" }, },
+  render(h):VNode {  return <div>{ this.foo }</div> },
+}
+</script>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<script lang="tsx">
+import { VNode } from "vue";
+export default {
+  computed: {
+    foo(): string {
+      return "foo";
+    }
+  },
+  render(h): VNode {
+    return <div>{this.foo}</div>;
+  }
+};
+</script>
+
+`;
+
 exports[`template-bind.vue 1`] = `
 <template>
     <div v-bind:id=" 'list-'   +  id "></div>

--- a/tests/multiparser_vue/lang-ts.vue
+++ b/tests/multiparser_vue/lang-ts.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>{{foo}}</div>
+</template>
+
+<script lang="ts">
+export default {
+  computed: {  foo( ): string {  return "foo";  },  },
+}
+</script>
+

--- a/tests/multiparser_vue/lang-tsx.vue
+++ b/tests/multiparser_vue/lang-tsx.vue
@@ -1,0 +1,7 @@
+<script lang="tsx">
+import {VNode} from "vue"
+export default {
+  computed: {  foo( ):string { return "foo" }, },
+  render(h):VNode {  return <div>{ this.foo }</div> },
+}
+</script>


### PR DESCRIPTION
vue-language-server requires that lang must be "tsx" when <script> contains TSX syntax, like below:

```jsx
<script lang="tsx">
import { VNode } from "vue";
export default {
  render(): VNode { return <div>foo</div>; }
}
</script>
```

But prettier does not treat this code as TypeScript. This PR will fix this problem.