### PR TITLE
Split out location extraction into plugin config

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,6 @@ function format(text, opts, addAlignmentSize) {
 }
 
 function findSiblingAncestors(startNodeAndParents, endNodeAndParents, opts) {
-  const util = sharedUtil(opts);
   let resultStartNode = startNodeAndParents.node;
   let resultEndNode = endNodeAndParents.node;
 
@@ -164,8 +163,7 @@ function findSiblingAncestors(startNodeAndParents, endNodeAndParents, opts) {
     if (
       endParent.type !== "Program" &&
       endParent.type !== "File" &&
-      util.locStart(endParent, opts.locStart) >=
-        util.locStart(startNodeAndParents.node, opts.locStart)
+      opts.locStart(endParent) >= opts.locStart(startNodeAndParents.node)
     ) {
       resultEndNode = endParent;
     } else {
@@ -177,8 +175,7 @@ function findSiblingAncestors(startNodeAndParents, endNodeAndParents, opts) {
     if (
       startParent.type !== "Program" &&
       startParent.type !== "File" &&
-      util.locEnd(startParent, opts.locEnd) <=
-        util.locEnd(endNodeAndParents.node, opts.locEnd)
+      opts.locEnd(startParent) <= opts.locEnd(endNodeAndParents.node)
     ) {
       resultStartNode = startParent;
     } else {

--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ const docblock = require("jest-docblock");
 
 const version = require("./package.json").version;
 
-const util = require("./src/common/util");
+const sharedUtil = require("./src/common/util-shared");
+const privateUtil = require("./src/common/util");
 const getSupportInfo = require("./src/common/support").getSupportInfo;
 
 const comments = require("./src/main/comments");
@@ -72,6 +73,7 @@ function formatWithCursor(text, opts, addAlignmentSize) {
     return { formatted: text };
   }
 
+  const util = sharedUtil(opts);
   const UTF8BOM = 0xfeff;
   const hasUnicodeBOM = text.charCodeAt(0) === UTF8BOM;
   if (hasUnicodeBOM) {
@@ -147,6 +149,7 @@ function format(text, opts, addAlignmentSize) {
 }
 
 function findSiblingAncestors(startNodeAndParents, endNodeAndParents, opts) {
+  const util = sharedUtil(opts);
   let resultStartNode = startNodeAndParents.node;
   let resultEndNode = endNodeAndParents.node;
 
@@ -190,6 +193,7 @@ function findSiblingAncestors(startNodeAndParents, endNodeAndParents, opts) {
 }
 
 function findNodeAtOffset(node, offset, options, predicate, parentNodes) {
+  const util = sharedUtil(options);
   predicate = predicate || (() => true);
   parentNodes = parentNodes || [];
   const start = util.locStart(node, options.locStart);
@@ -305,6 +309,7 @@ function calculateRange(text, opts, ast) {
     opts.rangeStart + rangeStringOrig.search(/\S/),
     opts.rangeStart
   );
+  const util = sharedUtil(opts);
   let endNonWhitespace;
   for (
     endNonWhitespace = opts.rangeEnd;
@@ -377,7 +382,10 @@ function formatRange(text, opts, ast) {
   );
   const indentString = text.slice(rangeStart2, rangeStart);
 
-  const alignmentSize = util.getAlignmentSize(indentString, opts.tabWidth);
+  const alignmentSize = privateUtil.getAlignmentSize(
+    indentString,
+    opts.tabWidth
+  );
 
   const rangeFormatted = format(
     rangeString,

--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const docblock = require("jest-docblock");
 
 const version = require("./package.json").version;
 
-const sharedUtil = require("./src/common/util-shared");
 const privateUtil = require("./src/common/util");
 const getSupportInfo = require("./src/common/support").getSupportInfo;
 
@@ -73,7 +72,6 @@ function formatWithCursor(text, opts, addAlignmentSize) {
     return { formatted: text };
   }
 
-  const util = sharedUtil(opts);
   const UTF8BOM = 0xfeff;
   const hasUnicodeBOM = text.charCodeAt(0) === UTF8BOM;
   if (hasUnicodeBOM) {
@@ -113,8 +111,7 @@ function formatWithCursor(text, opts, addAlignmentSize) {
     const cursorNodeAndParents = findNodeAtOffset(ast, opts.cursorOffset, opts);
     const cursorNode = cursorNodeAndParents.node;
     if (cursorNode) {
-      cursorOffset =
-        opts.cursorOffset - util.locStart(cursorNode, opts.locStart);
+      cursorOffset = opts.cursorOffset - opts.locStart(cursorNode);
       opts.cursorNode = cursorNode;
     }
   }
@@ -190,11 +187,10 @@ function findSiblingAncestors(startNodeAndParents, endNodeAndParents, opts) {
 }
 
 function findNodeAtOffset(node, offset, options, predicate, parentNodes) {
-  const util = sharedUtil(options);
   predicate = predicate || (() => true);
   parentNodes = parentNodes || [];
-  const start = util.locStart(node, options.locStart);
-  const end = util.locEnd(node, options.locEnd);
+  const start = options.locStart(node, options.locStart);
+  const end = options.locEnd(node, options.locEnd);
   if (start <= offset && offset <= end) {
     for (const childNode of comments.getSortedChildNodes(
       node,
@@ -306,7 +302,6 @@ function calculateRange(text, opts, ast) {
     opts.rangeStart + rangeStringOrig.search(/\S/),
     opts.rangeStart
   );
-  const util = sharedUtil(opts);
   let endNonWhitespace;
   for (
     endNonWhitespace = opts.rangeEnd;
@@ -346,12 +341,12 @@ function calculateRange(text, opts, ast) {
   const startNode = siblingAncestors.startNode;
   const endNode = siblingAncestors.endNode;
   const rangeStart = Math.min(
-    util.locStart(startNode, opts.locStart),
-    util.locStart(endNode, opts.locStart)
+    opts.locStart(startNode, opts.locStart),
+    opts.locStart(endNode, opts.locStart)
   );
   const rangeEnd = Math.max(
-    util.locEnd(startNode, opts.locEnd),
-    util.locEnd(endNode, opts.locEnd)
+    opts.locEnd(startNode, opts.locEnd),
+    opts.locEnd(endNode, opts.locEnd)
   );
 
   return {

--- a/src/common/fast-path.js
+++ b/src/common/fast-path.js
@@ -492,10 +492,7 @@ FastPath.prototype.needsParens = function(options) {
         // See corresponding workaround in printer.js case: "Literal"
         ((options.parser !== "typescript" && !parent.directive) ||
           (options.parser === "typescript" &&
-            options.originalText.substr(
-              util.locStart(node, options.locStart) - 1,
-              1
-            ) === "("))
+            options.originalText.substr(options.locStart(node) - 1, 1) === "("))
       ) {
         // To avoid becoming a directive
         const grandParent = this.getParentNode(1);

--- a/src/common/util-shared.js
+++ b/src/common/util-shared.js
@@ -16,7 +16,11 @@ module.exports = function(options) {
   }
 
   function getNextNonSpaceNonCommentCharacterIndex(text, node) {
-    return util.getNextNonSpaceNonCharacterIndex(text, node, options.locEnd);
+    return util.getNextNonSpaceNonCommentCharacterIndex(
+      text,
+      node,
+      options.locEnd
+    );
   }
 
   return {

--- a/src/common/util-shared.js
+++ b/src/common/util-shared.js
@@ -4,11 +4,11 @@ const util = require("./util");
 
 module.exports = function(options) {
   function locStart(node) {
-    return util.locEnd(node, options.locStart);
+    return options.locStart(node);
   }
 
   function locEnd(node) {
-    return util.locEnd(node, options.locEnd);
+    return options.locEnd(node);
   }
 
   function isNextLineEmpty(text, node) {

--- a/src/common/util-shared.js
+++ b/src/common/util-shared.js
@@ -3,14 +3,6 @@
 const util = require("./util");
 
 module.exports = function(options) {
-  function locStart(node) {
-    return options.locStart(node);
-  }
-
-  function locEnd(node) {
-    return options.locEnd(node);
-  }
-
   function isNextLineEmpty(text, node) {
     return util.isNextLineEmpty(text, node, options.locEnd);
   }
@@ -24,8 +16,6 @@ module.exports = function(options) {
   }
 
   return {
-    locStart,
-    locEnd,
     isNextLineEmpty,
     isNextLineEmptyAfterIndex: util.isNextLineEmptyAfterIndex,
     getNextNonSpaceNonCommentCharacterIndex,

--- a/src/common/util-shared.js
+++ b/src/common/util-shared.js
@@ -4,86 +4,19 @@ const util = require("./util");
 
 module.exports = function(options) {
   function locStart(node) {
-    // Handle nodes with decorators. They should start at the first decorator
-    if (options.locStart) {
-      const result = options.locStart(node);
-      if (result !== null) {
-        return result;
-      }
-    } else if (
-      node.declaration &&
-      node.declaration.decorators &&
-      node.declaration.decorators.length > 0
-    ) {
-      return locStart(node.declaration.decorators[0]);
-    }
-    if (node.decorators && node.decorators.length > 0) {
-      return locStart(node.decorators[0]);
-    }
-
-    if (node.range) {
-      return node.range[0];
-    }
-    if (typeof node.start === "number") {
-      return node.start;
-    }
-    if (node.source) {
-      return (
-        util.lineColumnToIndex(node.source.start, node.source.input.css) - 1
-      );
-    }
-    if (node.loc) {
-      return node.loc.start;
-    }
+    return util.locEnd(node, options.locStart);
   }
 
   function locEnd(node) {
-    if (options.locEnd) {
-      const result = options.locEnd(node);
-      if (result !== null) {
-        return result;
-      }
-    }
-    const endNode = node.nodes && util.getLast(node.nodes);
-    if (endNode && node.source && !node.source.end) {
-      node = endNode;
-    }
-
-    let loc;
-    if (node.range) {
-      loc = node.range[1];
-    } else if (typeof node.end === "number") {
-      loc = node.end;
-    } else if (node.source) {
-      loc = util.lineColumnToIndex(node.source.end, node.source.input.css);
-    }
-
-    if (node.typeAnnotation) {
-      return Math.max(loc, locEnd(node.typeAnnotation));
-    }
-
-    if (node.loc && !loc) {
-      return node.loc.end;
-    }
-
-    return loc;
+    return util.locEnd(node, options.locEnd);
   }
 
   function isNextLineEmpty(text, node) {
-    return util.isNextLineEmptyAfterIndex(text, locEnd(node));
+    return util.isNextLineEmpty(text, node, options.locEnd);
   }
 
   function getNextNonSpaceNonCommentCharacterIndex(text, node) {
-    let oldIdx = null;
-    let idx = locEnd(node);
-    while (idx !== oldIdx) {
-      oldIdx = idx;
-      idx = util.skipSpaces(text, idx);
-      idx = util.skipInlineComment(text, idx);
-      idx = util.skipTrailingComment(text, idx);
-      idx = util.skipNewline(text, idx);
-    }
-    return idx;
+    return util.getNextNonSpaceNonCharacterIndex(text, node, options.locEnd);
   }
 
   return {

--- a/src/common/util-shared.js
+++ b/src/common/util-shared.js
@@ -86,50 +86,13 @@ module.exports = function(options) {
     return idx;
   }
 
-  function getNextNonSpaceNonCommentCharacter(text, node) {
-    return text.charAt(getNextNonSpaceNonCommentCharacterIndex(text, node));
-  }
-
-  // Note: this function doesn't ignore leading comments unlike isNextLineEmpty
-  function isPreviousLineEmpty(text, node) {
-    let idx = locStart(node) - 1;
-    idx = util.skipSpaces(text, idx, { backwards: true });
-    idx = util.skipNewline(text, idx, { backwards: true });
-    idx = util.skipSpaces(text, idx, { backwards: true });
-    const idx2 = util.skipNewline(text, idx, { backwards: true });
-    return idx !== idx2;
-  }
-
-  function hasClosureCompilerTypeCastComment(text, node) {
-    // https://github.com/google/closure-compiler/wiki/Annotating-Types#type-casts
-    // Syntax example: var x = /** @type {string} */ (fruit);
-    return (
-      node.comments &&
-      node.comments.some(
-        comment =>
-          comment.leading &&
-          util.isBlockComment(comment) &&
-          comment.value.match(/^\*\s*@type\s*{[^}]+}\s*$/) &&
-          getNextNonSpaceNonCommentCharacter(text, comment) === "("
-      )
-    );
-  }
-
   return {
     locStart,
     locEnd,
     isNextLineEmpty,
+    isNextLineEmptyAfterIndex: util.isNextLineEmptyAfterIndex,
     getNextNonSpaceNonCommentCharacterIndex,
-    getNextNonSpaceNonCommentCharacter,
-    isPreviousLineEmpty,
-    hasClosureCompilerTypeCastComment,
-    hasIgnoreComment: util.hasIgnoreComment,
-    punctuationCharRange: util.punctuationCharRange,
-    getLast: util.getLast,
-    getMaxContinuousCount: util.getMaxContinuousCount,
-    splitText: util.splitText,
-    getStringWidth: util.getStringWidth,
     mapDoc: util.mapDoc,
-    hasNewlineInRange: util.hasNewlineInRange
+    makeString: util.makeString
   };
 };

--- a/src/common/util-shared.js
+++ b/src/common/util-shared.js
@@ -1,0 +1,135 @@
+"use strict";
+
+const util = require("./util");
+
+module.exports = function(options) {
+  function locStart(node) {
+    // Handle nodes with decorators. They should start at the first decorator
+    if (options.locStart) {
+      const result = options.locStart(node);
+      if (result !== null) {
+        return result;
+      }
+    } else if (
+      node.declaration &&
+      node.declaration.decorators &&
+      node.declaration.decorators.length > 0
+    ) {
+      return locStart(node.declaration.decorators[0]);
+    }
+    if (node.decorators && node.decorators.length > 0) {
+      return locStart(node.decorators[0]);
+    }
+
+    if (node.range) {
+      return node.range[0];
+    }
+    if (typeof node.start === "number") {
+      return node.start;
+    }
+    if (node.source) {
+      return (
+        util.lineColumnToIndex(node.source.start, node.source.input.css) - 1
+      );
+    }
+    if (node.loc) {
+      return node.loc.start;
+    }
+  }
+
+  function locEnd(node) {
+    if (options.locEnd) {
+      const result = options.locEnd(node);
+      if (result !== null) {
+        return result;
+      }
+    }
+    const endNode = node.nodes && util.getLast(node.nodes);
+    if (endNode && node.source && !node.source.end) {
+      node = endNode;
+    }
+
+    let loc;
+    if (node.range) {
+      loc = node.range[1];
+    } else if (typeof node.end === "number") {
+      loc = node.end;
+    } else if (node.source) {
+      loc = util.lineColumnToIndex(node.source.end, node.source.input.css);
+    }
+
+    if (node.typeAnnotation) {
+      return Math.max(loc, locEnd(node.typeAnnotation));
+    }
+
+    if (node.loc && !loc) {
+      return node.loc.end;
+    }
+
+    return loc;
+  }
+
+  function isNextLineEmpty(text, node) {
+    return util.isNextLineEmptyAfterIndex(text, locEnd(node));
+  }
+
+  function getNextNonSpaceNonCommentCharacterIndex(text, node) {
+    let oldIdx = null;
+    let idx = locEnd(node);
+    while (idx !== oldIdx) {
+      oldIdx = idx;
+      idx = util.skipSpaces(text, idx);
+      idx = util.skipInlineComment(text, idx);
+      idx = util.skipTrailingComment(text, idx);
+      idx = util.skipNewline(text, idx);
+    }
+    return idx;
+  }
+
+  function getNextNonSpaceNonCommentCharacter(text, node) {
+    return text.charAt(getNextNonSpaceNonCommentCharacterIndex(text, node));
+  }
+
+  // Note: this function doesn't ignore leading comments unlike isNextLineEmpty
+  function isPreviousLineEmpty(text, node) {
+    let idx = locStart(node) - 1;
+    idx = util.skipSpaces(text, idx, { backwards: true });
+    idx = util.skipNewline(text, idx, { backwards: true });
+    idx = util.skipSpaces(text, idx, { backwards: true });
+    const idx2 = util.skipNewline(text, idx, { backwards: true });
+    return idx !== idx2;
+  }
+
+  function hasClosureCompilerTypeCastComment(text, node) {
+    // https://github.com/google/closure-compiler/wiki/Annotating-Types#type-casts
+    // Syntax example: var x = /** @type {string} */ (fruit);
+    return (
+      node.comments &&
+      node.comments.some(
+        comment =>
+          comment.leading &&
+          util.isBlockComment(comment) &&
+          comment.value.match(/^\*\s*@type\s*{[^}]+}\s*$/) &&
+          getNextNonSpaceNonCommentCharacter(text, comment) === "("
+      )
+    );
+  }
+
+  return {
+    locStart,
+    locEnd,
+    isNextLineEmpty,
+    getNextNonSpaceNonCommentCharacterIndex,
+    getNextNonSpaceNonCommentCharacter,
+    isPreviousLineEmpty,
+    hasClosureCompilerTypeCastComment,
+    hasIgnoreComment: util.hasIgnoreComment,
+    punctuationCharRange: util.punctuationCharRange,
+    getLast: util.getLast,
+    getMaxContinuousCount: util.getMaxContinuousCount,
+    splitText: util.splitText,
+    getStringWidth: util.getStringWidth,
+    mapDoc: util.mapDoc,
+    hasNewlineInRange: util.hasNewlineInRange
+  };
+};

--- a/src/common/util-shared.js
+++ b/src/common/util-shared.js
@@ -2,24 +2,22 @@
 
 const util = require("./util");
 
-module.exports = function(options) {
-  function isNextLineEmpty(text, node) {
-    return util.isNextLineEmpty(text, node, options.locEnd);
-  }
+function isNextLineEmpty(text, node, options) {
+  return util.isNextLineEmpty(text, node, options.locEnd);
+}
 
-  function getNextNonSpaceNonCommentCharacterIndex(text, node) {
-    return util.getNextNonSpaceNonCommentCharacterIndex(
-      text,
-      node,
-      options.locEnd
-    );
-  }
+function getNextNonSpaceNonCommentCharacterIndex(text, node, options) {
+  return util.getNextNonSpaceNonCommentCharacterIndex(
+    text,
+    node,
+    options.locEnd
+  );
+}
 
-  return {
-    isNextLineEmpty,
-    isNextLineEmptyAfterIndex: util.isNextLineEmptyAfterIndex,
-    getNextNonSpaceNonCommentCharacterIndex,
-    mapDoc: util.mapDoc,
-    makeString: util.makeString
-  };
+module.exports = {
+  isNextLineEmpty,
+  isNextLineEmptyAfterIndex: util.isNextLineEmptyAfterIndex,
+  getNextNonSpaceNonCommentCharacterIndex,
+  mapDoc: util.mapDoc,
+  makeString: util.makeString
 };

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -852,5 +852,8 @@ module.exports = {
   printString,
   printNumber,
   hasIgnoreComment,
-  hasNodeIgnoreComment
+  hasNodeIgnoreComment,
+  lineColumnToIndex,
+  skipInlineComment,
+  skipTrailingComment
 };

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -794,5 +794,6 @@ module.exports = {
   printNumber,
   hasIgnoreComment,
   hasNodeIgnoreComment,
-  lineColumnToIndex
+  lineColumnToIndex,
+  makeString
 };

--- a/src/language-css/index.js
+++ b/src/language-css/index.js
@@ -2,7 +2,10 @@
 
 const printer = require("./printer-postcss");
 const options = require("./options");
-const { lineColumnToIndex, getLast } = require("../common/util");
+const privateUtil = require("../common/util");
+
+const lineColumnToIndex = privateUtil.lineColumnToIndex;
+const getLast = privateUtil.getLast;
 
 // Based on:
 // https://github.com/github/linguist/blob/master/lib/linguist/languages.yml

--- a/src/language-css/index.js
+++ b/src/language-css/index.js
@@ -2,6 +2,7 @@
 
 const printer = require("./printer-postcss");
 const options = require("./options");
+const { lineColumnToIndex, getLast } = require("../common/util");
 
 // Based on:
 // https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
@@ -52,7 +53,23 @@ const postcss = {
   get parse() {
     return eval("require")("./parser-postcss");
   },
-  astFormat: "postcss"
+  astFormat: "postcss",
+  locEnd: function(node) {
+    const endNode = node.nodes && getLast(node.nodes);
+    if (endNode && node.source && !node.source.end) {
+      node = endNode;
+    }
+    if (node.source) {
+      return lineColumnToIndex(node.source.end, node.source.input.css);
+    }
+    return null;
+  },
+  locStart: function(node) {
+    if (node.source) {
+      return lineColumnToIndex(node.source.start, node.source.input.css) - 1;
+    }
+    return null;
+  }
 };
 
 // TODO: switch these to just `postcss` and use `language` instead.

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const clean = require("./clean");
-const util = require("../common/util");
+const privateUtil = require("../common/util");
 const doc = require("../doc");
 const docBuilders = doc.builders;
 const concat = docBuilders.concat;
@@ -15,7 +15,7 @@ const indent = docBuilders.indent;
 
 const removeLines = doc.utils.removeLines;
 
-function genericPrint(path, options, print) {
+function genericPrint(path, options, print, args, util) {
   const node = path.getValue();
 
   /* istanbul ignore if */
@@ -31,7 +31,7 @@ function genericPrint(path, options, print) {
     case "css-comment-yaml":
       return node.value;
     case "css-root": {
-      const nodes = printNodeSequence(path, options, print);
+      const nodes = printNodeSequence(path, options, print, util);
 
       if (nodes.parts.length) {
         return concat([nodes, hardline]);
@@ -77,7 +77,10 @@ function genericPrint(path, options, print) {
               " {",
               node.nodes.length > 0
                 ? indent(
-                    concat([hardline, printNodeSequence(path, options, print)])
+                    concat([
+                      hardline,
+                      printNodeSequence(path, options, print, util)
+                    ])
                   )
                 : "",
               hardline,
@@ -123,7 +126,10 @@ function genericPrint(path, options, print) {
           ? concat([
               " {",
               indent(
-                concat([softline, printNodeSequence(path, options, print)])
+                concat([
+                  softline,
+                  printNodeSequence(path, options, print, util)
+                ])
               ),
               softline,
               "}"
@@ -180,7 +186,7 @@ function genericPrint(path, options, print) {
               indent(
                 concat([
                   node.nodes.length > 0 ? softline : "",
-                  printNodeSequence(path, options, print)
+                  printNodeSequence(path, options, print, util)
                 ])
               ),
               softline,
@@ -200,7 +206,10 @@ function genericPrint(path, options, print) {
           ? concat([
               " {",
               indent(
-                concat([softline, printNodeSequence(path, options, print)])
+                concat([
+                  softline,
+                  printNodeSequence(path, options, print, util)
+                ])
               ),
               softline,
               "}"
@@ -575,7 +584,7 @@ function genericPrint(path, options, print) {
       return concat([node.value, " "]);
     }
     case "value-string": {
-      return util.printString(
+      return privateUtil.printString(
         node.raws.quote + node.value + node.raws.quote,
         options
       );
@@ -677,7 +686,7 @@ function getAncestorNode(path, typeOrTypes) {
   return counter === -1 ? null : path.getParentNode(counter);
 }
 
-function printNodeSequence(path, options, print) {
+function printNodeSequence(path, options, print, util) {
   const node = path.getValue();
   const parts = [];
   let i = 0;
@@ -702,7 +711,7 @@ function printNodeSequence(path, options, print) {
     if (i !== node.nodes.length - 1) {
       if (
         (node.nodes[i + 1].type === "css-comment" &&
-          !util.hasNewline(
+          !privateUtil.hasNewline(
             options.originalText,
             util.locStart(node.nodes[i + 1]),
             { backwards: true }
@@ -739,7 +748,9 @@ const ADJUST_NUMBERS_REGEX = RegExp(
 );
 
 function adjustStrings(value, options) {
-  return value.replace(STRING_REGEX, match => util.printString(match, options));
+  return value.replace(STRING_REGEX, match =>
+    privateUtil.printString(match, options)
+  );
 }
 
 function quoteAttributeValue(value, options) {
@@ -761,7 +772,7 @@ function adjustNumbers(value) {
 
 function printNumber(rawNumber) {
   return (
-    util
+    privateUtil
       .printNumber(rawNumber)
       // Remove trailing `.0`.
       .replace(/\.0(?=$|e)/, "")
@@ -789,6 +800,6 @@ function isWideKeywords(value) {
 
 module.exports = {
   print: genericPrint,
-  hasPrettierIgnore: util.hasIgnoreComment,
+  hasPrettierIgnore: privateUtil.hasIgnoreComment,
   massageAstNode: clean
 };

--- a/src/language-graphql/index.js
+++ b/src/language-graphql/index.js
@@ -25,17 +25,17 @@ const parsers = {
       return eval("require")("./parser-graphql");
     },
     astFormat: "graphql",
-    locEnd: function(node) {
-      if (!node.loc) {
-        return null;
-      }
-      return node.loc.end;
-    },
     locStart: function(node) {
       if (!node.loc) {
         return null;
       }
       return node.loc.start;
+    },
+    locEnd: function(node) {
+      if (!node.loc) {
+        return null;
+      }
+      return node.loc.end;
     }
   }
 };

--- a/src/language-graphql/index.js
+++ b/src/language-graphql/index.js
@@ -29,19 +29,13 @@ const parsers = {
       if (typeof node.start === "number") {
         return node.start;
       }
-      if (!node.loc) {
-        return null;
-      }
-      return node.loc.start;
+      return node.loc && node.loc.start;
     },
     locEnd: function(node) {
       if (typeof node.end === "number") {
         return node.end;
       }
-      if (!node.loc) {
-        return null;
-      }
-      return node.loc.end;
+      return node.loc && node.loc.end;
     }
   }
 };

--- a/src/language-graphql/index.js
+++ b/src/language-graphql/index.js
@@ -24,7 +24,19 @@ const parsers = {
     get parse() {
       return eval("require")("./parser-graphql");
     },
-    astFormat: "graphql"
+    astFormat: "graphql",
+    locEnd: function(node) {
+      if (!node.loc) {
+        return null;
+      }
+      return node.loc.end;
+    },
+    locStart: function(node) {
+      if (!node.loc) {
+        return null;
+      }
+      return node.loc.start;
+    }
   }
 };
 

--- a/src/language-graphql/index.js
+++ b/src/language-graphql/index.js
@@ -26,12 +26,18 @@ const parsers = {
     },
     astFormat: "graphql",
     locStart: function(node) {
+      if (typeof node.start === "number") {
+        return node.start;
+      }
       if (!node.loc) {
         return null;
       }
       return node.loc.start;
     },
     locEnd: function(node) {
+      if (typeof node.end === "number") {
+        return node.end;
+      }
       if (!node.loc) {
         return null;
       }

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -9,10 +9,11 @@ const softline = docBuilders.softline;
 const group = docBuilders.group;
 const indent = docBuilders.indent;
 const ifBreak = docBuilders.ifBreak;
-
+const printerOptions = require("./options");
 const privateUtil = require("../common/util");
+const sharedUtil = require("../common/util-shared");
 
-function genericPrint(path, options, print, args, util) {
+function genericPrint(path, options, print) {
   const n = path.getValue();
   if (!n) {
     return "";
@@ -30,7 +31,7 @@ function genericPrint(path, options, print, args, util) {
       ]);
     }
     case "OperationDefinition": {
-      const hasOperation = options.originalText[util.locStart(n)] !== "{";
+      const hasOperation = options.originalText[options.locStart(n)] !== "{";
       const hasName = !!n.name;
       return concat([
         hasOperation ? n.operation : "",
@@ -78,8 +79,7 @@ function genericPrint(path, options, print, args, util) {
             join(
               hardline,
               path.call(
-                selectionsPath =>
-                  printSequence(selectionsPath, options, print, util),
+                selectionsPath => printSequence(selectionsPath, options, print),
                 "selections"
               )
             )
@@ -104,8 +104,7 @@ function genericPrint(path, options, print, args, util) {
                       join(
                         concat([ifBreak("", ", "), softline]),
                         path.call(
-                          argsPath =>
-                            printSequence(argsPath, options, print, util),
+                          argsPath => printSequence(argsPath, options, print),
                           "arguments"
                         )
                       )
@@ -212,8 +211,7 @@ function genericPrint(path, options, print, args, util) {
                     join(
                       concat([ifBreak("", ", "), softline]),
                       path.call(
-                        argsPath =>
-                          printSequence(argsPath, options, print, util),
+                        argsPath => printSequence(argsPath, options, print),
                         "arguments"
                       )
                     )
@@ -293,8 +291,7 @@ function genericPrint(path, options, print, args, util) {
                     join(
                       concat([ifBreak("", ", "), softline]),
                       path.call(
-                        argsPath =>
-                          printSequence(argsPath, options, print, util),
+                        argsPath => printSequence(argsPath, options, print),
                         "arguments"
                       )
                     )
@@ -328,8 +325,7 @@ function genericPrint(path, options, print, args, util) {
                     join(
                       concat([ifBreak("", ", "), softline]),
                       path.call(
-                        argsPath =>
-                          printSequence(argsPath, options, print, util),
+                        argsPath => printSequence(argsPath, options, print),
                         "arguments"
                       )
                     )
@@ -363,8 +359,7 @@ function genericPrint(path, options, print, args, util) {
                   join(
                     hardline,
                     path.call(
-                      valuesPath =>
-                        printSequence(valuesPath, options, print, util),
+                      valuesPath => printSequence(valuesPath, options, print),
                       "values"
                     )
                   )
@@ -416,8 +411,7 @@ function genericPrint(path, options, print, args, util) {
                   join(
                     hardline,
                     path.call(
-                      fieldsPath =>
-                        printSequence(fieldsPath, options, print, util),
+                      fieldsPath => printSequence(fieldsPath, options, print),
                       "fields"
                     )
                   )
@@ -442,7 +436,7 @@ function genericPrint(path, options, print, args, util) {
                 join(
                   hardline,
                   path.call(
-                    opsPath => printSequence(opsPath, options, print, util),
+                    opsPath => printSequence(opsPath, options, print),
                     "operationTypes"
                   )
                 )
@@ -481,8 +475,7 @@ function genericPrint(path, options, print, args, util) {
                   join(
                     hardline,
                     path.call(
-                      fieldsPath =>
-                        printSequence(fieldsPath, options, print, util),
+                      fieldsPath => printSequence(fieldsPath, options, print),
                       "fields"
                     )
                   )
@@ -592,14 +585,18 @@ function printDirectives(path, print, n) {
   ]);
 }
 
-function printSequence(sequencePath, options, print, util) {
+function printSequence(sequencePath, options, print) {
   const count = sequencePath.getValue().length;
 
   return sequencePath.map((path, i) => {
     const printed = print(path);
 
     if (
-      util.isNextLineEmpty(options.originalText, path.getValue()) &&
+      sharedUtil.isNextLineEmpty(
+        options.originalText,
+        path.getValue(),
+        options
+      ) &&
       i < count - 1
     ) {
       return concat([printed, hardline]);

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -9,7 +9,6 @@ const softline = docBuilders.softline;
 const group = docBuilders.group;
 const indent = docBuilders.indent;
 const ifBreak = docBuilders.ifBreak;
-const printerOptions = require("./options");
 const privateUtil = require("../common/util");
 const sharedUtil = require("../common/util-shared");
 

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -10,9 +10,9 @@ const group = docBuilders.group;
 const indent = docBuilders.indent;
 const ifBreak = docBuilders.ifBreak;
 
-const util = require("../common/util");
+const privateUtil = require("../common/util");
 
-function genericPrint(path, options, print) {
+function genericPrint(path, options, print, args, util) {
   const n = path.getValue();
   if (!n) {
     return "";
@@ -78,7 +78,8 @@ function genericPrint(path, options, print) {
             join(
               hardline,
               path.call(
-                selectionsPath => printSequence(selectionsPath, options, print),
+                selectionsPath =>
+                  printSequence(selectionsPath, options, print, util),
                 "selections"
               )
             )
@@ -103,7 +104,8 @@ function genericPrint(path, options, print) {
                       join(
                         concat([ifBreak("", ", "), softline]),
                         path.call(
-                          argsPath => printSequence(argsPath, options, print),
+                          argsPath =>
+                            printSequence(argsPath, options, print, util),
                           "arguments"
                         )
                       )
@@ -210,7 +212,8 @@ function genericPrint(path, options, print) {
                     join(
                       concat([ifBreak("", ", "), softline]),
                       path.call(
-                        argsPath => printSequence(argsPath, options, print),
+                        argsPath =>
+                          printSequence(argsPath, options, print, util),
                         "arguments"
                       )
                     )
@@ -290,7 +293,8 @@ function genericPrint(path, options, print) {
                     join(
                       concat([ifBreak("", ", "), softline]),
                       path.call(
-                        argsPath => printSequence(argsPath, options, print),
+                        argsPath =>
+                          printSequence(argsPath, options, print, util),
                         "arguments"
                       )
                     )
@@ -324,7 +328,8 @@ function genericPrint(path, options, print) {
                     join(
                       concat([ifBreak("", ", "), softline]),
                       path.call(
-                        argsPath => printSequence(argsPath, options, print),
+                        argsPath =>
+                          printSequence(argsPath, options, print, util),
                         "arguments"
                       )
                     )
@@ -358,7 +363,8 @@ function genericPrint(path, options, print) {
                   join(
                     hardline,
                     path.call(
-                      valuesPath => printSequence(valuesPath, options, print),
+                      valuesPath =>
+                        printSequence(valuesPath, options, print, util),
                       "values"
                     )
                   )
@@ -410,7 +416,8 @@ function genericPrint(path, options, print) {
                   join(
                     hardline,
                     path.call(
-                      fieldsPath => printSequence(fieldsPath, options, print),
+                      fieldsPath =>
+                        printSequence(fieldsPath, options, print, util),
                       "fields"
                     )
                   )
@@ -435,7 +442,7 @@ function genericPrint(path, options, print) {
                 join(
                   hardline,
                   path.call(
-                    opsPath => printSequence(opsPath, options, print),
+                    opsPath => printSequence(opsPath, options, print, util),
                     "operationTypes"
                   )
                 )
@@ -474,7 +481,8 @@ function genericPrint(path, options, print) {
                   join(
                     hardline,
                     path.call(
-                      fieldsPath => printSequence(fieldsPath, options, print),
+                      fieldsPath =>
+                        printSequence(fieldsPath, options, print, util),
                       "fields"
                     )
                   )
@@ -584,7 +592,7 @@ function printDirectives(path, print, n) {
   ]);
 }
 
-function printSequence(sequencePath, options, print) {
+function printSequence(sequencePath, options, print, util) {
   const count = sequencePath.getValue().length;
 
   return sequencePath.map((path, i) => {
@@ -618,7 +626,7 @@ function printComment(commentPath) {
 
 module.exports = {
   print: genericPrint,
-  hasPrettierIgnore: util.hasIgnoreComment,
+  hasPrettierIgnore: privateUtil.hasIgnoreComment,
   printComment,
   canAttachComment
 };

--- a/src/language-handlebars/index.js
+++ b/src/language-handlebars/index.js
@@ -24,16 +24,10 @@ const parsers = {
     },
     astFormat: "glimmer",
     locEnd: function(node) {
-      if (!node.loc) {
-        return null;
-      }
-      return node.loc.end;
+      return node.loc && node.loc.end;
     },
     locStart: function(node) {
-      if (!node.loc) {
-        return null;
-      }
-      return node.loc.start;
+      return node.loc && node.loc.start;
     }
   }
 };

--- a/src/language-handlebars/index.js
+++ b/src/language-handlebars/index.js
@@ -22,7 +22,19 @@ const parsers = {
     get parse() {
       return eval("require")("./parser-glimmer");
     },
-    astFormat: "glimmer"
+    astFormat: "glimmer",
+    locEnd: function(node) {
+      if (!node.loc) {
+        return null;
+      }
+      return node.loc.end;
+    },
+    locStart: function(node) {
+      if (!node.loc) {
+        return null;
+      }
+      return node.loc.start;
+    }
   }
 };
 

--- a/src/language-html/embed.js
+++ b/src/language-html/embed.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const util = require("../common/util");
+const privateUtil = require("../common/util");
 const doc = require("../doc");
 const docUtils = doc.utils;
 const docBuilders = doc.builders;
@@ -66,7 +66,7 @@ function embed(path, print, textToDoc, options) {
         return concat([
           node.key,
           '="',
-          util.hasNewlineInRange(node.value, 0, node.value.length)
+          privateUtil.hasNewlineInRange(node.value, 0, node.value.length)
             ? doc
             : docUtils.removeLines(doc),
           '"'
@@ -87,7 +87,10 @@ function parseJavaScriptExpression(text, parsers) {
 }
 
 function getText(options, node) {
-  return options.originalText.slice(util.locStart(node), util.locEnd(node));
+  return options.originalText.slice(
+    options.locStart(node),
+    options.locEnd(node)
+  );
 }
 
 module.exports = embed;

--- a/src/language-html/index.js
+++ b/src/language-html/index.js
@@ -29,16 +29,10 @@ const parsers = {
     },
     astFormat: "htmlparser2",
     locEnd: function(node) {
-      if (!node.__location) {
-        return null;
-      }
-      return node.__location.endOffset;
+      return node.__location && node.__location.endOffset;
     },
     locStart: function(node) {
-      if (!node.__location) {
-        return null;
-      }
-      return node.__location.startOffset;
+      return node.__location && node.__location.startOffset;
     }
   }
 };

--- a/src/language-html/index.js
+++ b/src/language-html/index.js
@@ -27,7 +27,19 @@ const parsers = {
     get parse() {
       return eval("require")("./parser-parse5");
     },
-    astFormat: "htmlparser2"
+    astFormat: "htmlparser2",
+    locEnd: function(node) {
+      if (!node.__location) {
+        return null;
+      }
+      return node.__location.endOffset;
+    },
+    locStart: function(node) {
+      if (!node.__location) {
+        return null;
+      }
+      return node.__location.startOffset;
+    }
   }
 };
 

--- a/src/language-html/printer-htmlparser2.js
+++ b/src/language-html/printer-htmlparser2.js
@@ -29,7 +29,7 @@ const voidTags = {
   wbr: true
 };
 
-function genericPrint(path, options, print, args, util) {
+function genericPrint(path, options, print) {
   const n = path.getValue();
   if (!n) {
     return "";
@@ -57,8 +57,8 @@ function genericPrint(path, options, print, args, util) {
 
       const hasNewline = privateUtil.hasNewlineInRange(
         options.originalText,
-        util.locStart(n),
-        util.locEnd(n)
+        options.locStart(n),
+        options.locEnd(n)
       );
 
       return group(

--- a/src/language-html/printer-htmlparser2.js
+++ b/src/language-html/printer-htmlparser2.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const embed = require("./embed");
-const util = require("../common/util");
 const docBuilders = require("../doc").builders;
 const concat = docBuilders.concat;
 const join = docBuilders.join;
@@ -29,7 +28,7 @@ const voidTags = {
   wbr: true
 };
 
-function genericPrint(path, options, print) {
+function genericPrint(path, options, print, args, util) {
   const n = path.getValue();
   if (!n) {
     return "";
@@ -117,5 +116,5 @@ function printChildren(path, print) {
 module.exports = {
   print: genericPrint,
   embed,
-  hasPrettierIgnore: util.hasIgnoreComment
+  hasPrettierIgnore: (path, util) => util.hasIgnoreComment(path)
 };

--- a/src/language-html/printer-htmlparser2.js
+++ b/src/language-html/printer-htmlparser2.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const embed = require("./embed");
+const util = require("../common/util");
 const docBuilders = require("../doc").builders;
 const concat = docBuilders.concat;
 const join = docBuilders.join;
@@ -28,7 +29,7 @@ const voidTags = {
   wbr: true
 };
 
-function genericPrint(path, options, print, args, util) {
+function genericPrint(path, options, print) {
   const n = path.getValue();
   if (!n) {
     return "";
@@ -116,5 +117,5 @@ function printChildren(path, print) {
 module.exports = {
   print: genericPrint,
   embed,
-  hasPrettierIgnore: (path, util) => util.hasIgnoreComment(path)
+  hasPrettierIgnore: util.hasIgnoreComment
 };

--- a/src/language-html/printer-htmlparser2.js
+++ b/src/language-html/printer-htmlparser2.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const embed = require("./embed");
-const util = require("../common/util");
+const privateUtil = require("../common/util");
 const docBuilders = require("../doc").builders;
 const concat = docBuilders.concat;
 const join = docBuilders.join;
@@ -29,7 +29,7 @@ const voidTags = {
   wbr: true
 };
 
-function genericPrint(path, options, print) {
+function genericPrint(path, options, print, args, util) {
   const n = path.getValue();
   if (!n) {
     return "";
@@ -55,7 +55,7 @@ function genericPrint(path, options, print) {
       const selfClose = voidTags[n.name] ? ">" : " />";
       const children = printChildren(path, print);
 
-      const hasNewline = util.hasNewlineInRange(
+      const hasNewline = privateUtil.hasNewlineInRange(
         options.originalText,
         util.locStart(n),
         util.locEnd(n)
@@ -117,5 +117,5 @@ function printChildren(path, print) {
 module.exports = {
   print: genericPrint,
   embed,
-  hasPrettierIgnore: util.hasIgnoreComment
+  hasPrettierIgnore: privateUtil.hasIgnoreComment
 };

--- a/src/language-js/index.js
+++ b/src/language-js/index.js
@@ -104,14 +104,38 @@ const typescript = {
   get parse() {
     return eval("require")("./parser-typescript");
   },
-  astFormat: "estree"
+  astFormat: "estree",
+  locStart: function(node) {
+    if (!node.range) {
+      return null;
+    }
+    return node.range[0];
+  },
+  locEnd: function(node) {
+    if (!node.range) {
+      return null;
+    }
+    return node.range[1];
+  }
 };
 
 const babylon = {
   get parse() {
     return eval("require")("./parser-babylon");
   },
-  astFormat: "estree"
+  astFormat: "estree",
+  locStart: function(node) {
+    if (typeof node.start === "number") {
+      return node.start;
+    }
+    return null;
+  },
+  locEnd: function(node) {
+    if (typeof node.end === "number") {
+      return node.end;
+    }
+    return null;
+  }
 };
 
 const parsers = {

--- a/src/language-js/index.js
+++ b/src/language-js/index.js
@@ -121,7 +121,19 @@ const parsers = {
     get parse() {
       return eval("require")("./parser-flow");
     },
-    astFormat: "estree"
+    astFormat: "estree",
+    locStart: function(node) {
+      if (!node.loc) {
+        return null;
+      }
+      return node.loc.start;
+    },
+    locEnd: function(node) {
+      if (!node.loc) {
+        return null;
+      }
+      return node.loc.end;
+    }
   },
   "typescript-eslint": typescript,
   // TODO: Delete this in 2.0

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -41,7 +41,7 @@ const INLINE_NODE_WRAPPER_TYPES = INLINE_NODE_TYPES.concat([
   "heading"
 ]);
 
-function genericPrint(path, options, print, args, util) {
+function genericPrint(path, options, print) {
   const node = path.getValue();
 
   if (shouldRemainTheSameContent(path)) {

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const util = require("../common/util");
+const privateUtil = require("../common/util");
 const embed = require("./embed");
 const doc = require("../doc");
 const docBuilders = doc.builders;
@@ -41,12 +41,12 @@ const INLINE_NODE_WRAPPER_TYPES = INLINE_NODE_TYPES.concat([
   "heading"
 ]);
 
-function genericPrint(path, options, print) {
+function genericPrint(path, options, print, args, util) {
   const node = path.getValue();
 
   if (shouldRemainTheSameContent(path)) {
     return concat(
-      util
+      privateUtil
         .splitText(
           options.originalText.slice(
             node.position.start.offset,
@@ -80,8 +80,8 @@ function genericPrint(path, options, print) {
         .replace(
           new RegExp(
             [
-              `(^|[${util.punctuationCharRange}])(_+)`,
-              `(_+)([${util.punctuationCharRange}]|$)`
+              `(^|[${privateUtil.punctuationCharRange}])(_+)`,
+              `(_+)([${privateUtil.punctuationCharRange}]|$)`
             ].join("|"),
             "g"
           ),
@@ -113,8 +113,8 @@ function genericPrint(path, options, print) {
         (prevNode &&
           prevNode.type === "sentence" &&
           prevNode.children.length > 0 &&
-          util.getLast(prevNode.children).type === "word" &&
-          !util.getLast(prevNode.children).hasTrailingPunctuation) ||
+          privateUtil.getLast(prevNode.children).type === "word" &&
+          !privateUtil.getLast(prevNode.children).hasTrailingPunctuation) ||
         (nextNode &&
           nextNode.type === "sentence" &&
           nextNode.children.length > 0 &&
@@ -129,7 +129,7 @@ function genericPrint(path, options, print) {
     case "delete":
       return concat(["~~", printChildren(path, options, print), "~~"]);
     case "inlineCode": {
-      const backtickCount = util.getMaxContinuousCount(node.value, "`");
+      const backtickCount = privateUtil.getMaxContinuousCount(node.value, "`");
       const style = backtickCount === 1 ? "``" : "`";
       const gap = backtickCount ? " " : "";
       return concat([style, gap, node.value, gap, style]);
@@ -190,7 +190,10 @@ function genericPrint(path, options, print) {
       // fenced code block
       const styleUnit = options.__inJsTemplate ? "~" : "`";
       const style = styleUnit.repeat(
-        Math.max(3, util.getMaxContinuousCount(node.value, styleUnit) + 1)
+        Math.max(
+          3,
+          privateUtil.getMaxContinuousCount(node.value, styleUnit) + 1
+        )
       );
       return concat([
         style,
@@ -208,7 +211,7 @@ function genericPrint(path, options, print) {
     case "html": {
       const parentNode = path.getParentNode();
       return parentNode.type === "root" &&
-        util.getLast(parentNode.children) === node
+        privateUtil.getLast(parentNode.children) === node
         ? node.value.trimRight()
         : node.value;
     }
@@ -428,7 +431,7 @@ function printTable(path, options, print) {
   const columnMaxWidths = contents.reduce(
     (currentWidths, rowContents) =>
       currentWidths.map((width, columnIndex) =>
-        Math.max(width, util.getStringWidth(rowContents[columnIndex]))
+        Math.max(width, privateUtil.getStringWidth(rowContents[columnIndex]))
       ),
     contents[0].map(() => 3) // minimum width = 3 (---, :--, :-:, --:)
   );
@@ -482,15 +485,15 @@ function printTable(path, options, print) {
   }
 
   function alignLeft(text, width) {
-    return concat([text, " ".repeat(width - util.getStringWidth(text))]);
+    return concat([text, " ".repeat(width - privateUtil.getStringWidth(text))]);
   }
 
   function alignRight(text, width) {
-    return concat([" ".repeat(width - util.getStringWidth(text)), text]);
+    return concat([" ".repeat(width - privateUtil.getStringWidth(text)), text]);
   }
 
   function alignCenter(text, width) {
-    const spaces = width - util.getStringWidth(text);
+    const spaces = width - privateUtil.getStringWidth(text);
     const left = Math.floor(spaces / 2);
     const right = spaces - left;
     return concat([" ".repeat(left), text, " ".repeat(right)]);
@@ -616,7 +619,7 @@ function shouldRemainTheSameContent(path) {
 }
 
 function normalizeDoc(doc) {
-  return util.mapDoc(doc, currentDoc => {
+  return privateUtil.mapDoc(doc, currentDoc => {
     if (!currentDoc.parts) {
       return currentDoc;
     }
@@ -668,7 +671,7 @@ function printTitle(title, options) {
 
 function normalizeParts(parts) {
   return parts.reduce((current, part) => {
-    const lastPart = util.getLast(current);
+    const lastPart = privateUtil.getLast(current);
 
     if (typeof lastPart === "string" && typeof part === "string") {
       current.splice(-1, 1, lastPart + part);
@@ -699,5 +702,5 @@ module.exports = {
   print: genericPrint,
   embed,
   massageAstNode: clean,
-  hasPrettierIgnore: util.hasIgnoreComment
+  hasPrettierIgnore: privateUtil.hasIgnoreComment
 };

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -4,8 +4,6 @@ const assert = require("assert");
 const comments = require("./comments");
 const FastPath = require("../common/fast-path");
 const multiparser = require("./multiparser");
-const util = require("../common/util");
-const sharedUtil = require("../common/util-shared");
 
 const doc = require("../doc");
 const docBuilders = doc.builders;
@@ -77,8 +75,8 @@ function genericPrint(path, options, printPath, args) {
   // Escape hatch
   if (printer.hasPrettierIgnore && printer.hasPrettierIgnore(path)) {
     return options.originalText.slice(
-      util.locStart(node, options.locStart),
-      util.locEnd(node, options.locEnd)
+      options.locStart(node),
+      options.locEnd(node)
     );
   }
 
@@ -98,7 +96,7 @@ function genericPrint(path, options, printPath, args) {
     }
   }
 
-  return printer.print(path, options, printPath, args, sharedUtil(options));
+  return printer.print(path, options, printPath, args);
 }
 
 module.exports = printAstToDoc;

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -4,6 +4,7 @@ const assert = require("assert");
 const comments = require("./comments");
 const FastPath = require("../common/fast-path");
 const multiparser = require("./multiparser");
+const util = require("../common/util");
 const sharedUtil = require("../common/util-shared");
 
 const doc = require("../doc");
@@ -73,11 +74,12 @@ function genericPrint(path, options, printPath, args) {
   const node = path.getValue();
   const printer = options.printer;
 
-  const util = sharedUtil(options);
-
   // Escape hatch
-  if (printer.hasPrettierIgnore && printer.hasPrettierIgnore(path, util)) {
-    return options.originalText.slice(util.locStart(node), util.locEnd(node));
+  if (printer.hasPrettierIgnore && printer.hasPrettierIgnore(path)) {
+    return options.originalText.slice(
+      util.locStart(node, options.locStart),
+      util.locEnd(node, options.locEnd)
+    );
   }
 
   if (node) {
@@ -96,7 +98,7 @@ function genericPrint(path, options, printPath, args) {
     }
   }
 
-  return printer.print(path, options, printPath, args, util);
+  return printer.print(path, options, printPath, args, sharedUtil(options));
 }
 
 module.exports = printAstToDoc;

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -4,7 +4,7 @@ const assert = require("assert");
 const comments = require("./comments");
 const FastPath = require("../common/fast-path");
 const multiparser = require("./multiparser");
-const util = require("../common/util");
+const sharedUtil = require("../common/util-shared");
 
 const doc = require("../doc");
 const docBuilders = doc.builders;
@@ -73,8 +73,10 @@ function genericPrint(path, options, printPath, args) {
   const node = path.getValue();
   const printer = options.printer;
 
+  const util = sharedUtil(options);
+
   // Escape hatch
-  if (printer.hasPrettierIgnore && printer.hasPrettierIgnore(path)) {
+  if (printer.hasPrettierIgnore && printer.hasPrettierIgnore(path, util)) {
     return options.originalText.slice(util.locStart(node), util.locEnd(node));
   }
 
@@ -94,7 +96,7 @@ function genericPrint(path, options, printPath, args) {
     }
   }
 
-  return printer.print(path, options, printPath, args);
+  return printer.print(path, options, printPath, args, util);
 }
 
 module.exports = printAstToDoc;

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -796,7 +796,11 @@ function handleLastFunctionArgComments(
       enclosingNode.type === "FunctionDeclaration" ||
       enclosingNode.type === "ObjectMethod" ||
       enclosingNode.type === "ClassMethod") &&
-    util.getNextNonSpaceNonCommentCharacter(text, comment) === ")"
+    privateUtil.getNextNonSpaceNonCommentCharacter(
+      text,
+      comment,
+      util.locEnd
+    ) === ")"
   ) {
     addTrailingComment(precedingNode, comment);
     return true;
@@ -961,10 +965,10 @@ function handleVariableDeclaratorComments(
   return false;
 }
 
-function printComment(commentPath, options) {
+function printComment(commentPath, options, util) {
   const comment = commentPath.getValue();
   comment.printed = true;
-  return options.printer.printComment(commentPath, options);
+  return options.printer.printComment(commentPath, options, util);
 }
 
 function findExpressionIndexForComment(quasis, comment, util) {
@@ -1015,7 +1019,7 @@ function printLeadingComment(commentPath, print, options, util) {
 
 function printTrailingComment(commentPath, print, options, util) {
   const comment = commentPath.getValue();
-  const contents = printComment(commentPath, options);
+  const contents = printComment(commentPath, options, util);
   if (!contents) {
     return "";
   }
@@ -1068,6 +1072,7 @@ function printTrailingComment(commentPath, print, options, util) {
 function printDanglingComments(path, options, sameIndent, filter) {
   const parts = [];
   const node = path.getValue();
+  const util = sharedUtil(options);
 
   if (!node || !node.comments) {
     return "";
@@ -1081,7 +1086,7 @@ function printDanglingComments(path, options, sameIndent, filter) {
       !comment.trailing &&
       (!filter || filter(comment))
     ) {
-      parts.push(printComment(commentPath, options));
+      parts.push(printComment(commentPath, options, util));
     }
   }, "comments");
 

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -993,7 +993,7 @@ function getQuasiRange(expr) {
 
 function printLeadingComment(commentPath, print, options, util) {
   const comment = commentPath.getValue();
-  const contents = printComment(commentPath, options);
+  const contents = printComment(commentPath, options, util);
   if (!contents) {
     return "";
   }

--- a/src/main/options.js
+++ b/src/main/options.js
@@ -9,7 +9,9 @@ const getPrinter = require("./get-printer");
 
 const hiddenDefaults = {
   astFormat: "estree",
-  printer: {}
+  printer: {},
+  locStart: null,
+  locEnd: null
 };
 
 // Copy options and fill in default values.
@@ -48,6 +50,8 @@ function normalize(options, opts) {
   }
 
   rawOptions.astFormat = resolveParser(rawOptions).astFormat;
+  rawOptions.locEnd = resolveParser(rawOptions).locEnd;
+  rawOptions.locStart = resolveParser(rawOptions).locStart;
   rawOptions.printer = getPrinter(rawOptions);
 
   Object.keys(defaults).forEach(k => {

--- a/src/main/options.js
+++ b/src/main/options.js
@@ -49,9 +49,10 @@ function normalize(options, opts) {
     }
   }
 
-  rawOptions.astFormat = resolveParser(rawOptions).astFormat;
-  rawOptions.locEnd = resolveParser(rawOptions).locEnd;
-  rawOptions.locStart = resolveParser(rawOptions).locStart;
+  const parser = resolveParser(rawOptions);
+  rawOptions.astFormat = parser.astFormat;
+  rawOptions.locEnd = parser.locEnd;
+  rawOptions.locStart = parser.locStart;
   rawOptions.printer = getPrinter(rawOptions);
 
   Object.keys(defaults).forEach(k => {

--- a/src/main/parser.js
+++ b/src/main/parser.js
@@ -2,6 +2,10 @@
 
 const path = require("path");
 const ConfigError = require("../common/errors").ConfigError;
+const js = require("../language-js/index.js");
+
+const locStart = js.locStart;
+const locEnd = js.locEnd;
 
 function getParsers(options) {
   return options.plugins.reduce(
@@ -17,7 +21,9 @@ function resolveParser(opts, parsers) {
     // Custom parser API always works with JavaScript.
     return {
       parse: opts.parser,
-      astFormat: "estree"
+      astFormat: "estree",
+      locStart,
+      locEnd
     };
   }
 
@@ -28,7 +34,9 @@ function resolveParser(opts, parsers) {
     try {
       return {
         parse: eval("require")(path.resolve(process.cwd(), opts.parser)),
-        astFormat: "estree"
+        astFormat: "estree",
+        locStart,
+        locEnd
       };
     } catch (err) {
       /* istanbul ignore next */

--- a/tests_integration/__tests__/util-shared.js
+++ b/tests_integration/__tests__/util-shared.js
@@ -1,0 +1,13 @@
+"use strict";
+
+const sharedUtil = require("../../src/common/util-shared");
+
+test("shared util has correct structure", () => {
+  expect(typeof sharedUtil.isNextLineEmpty).toEqual("function");
+  expect(typeof sharedUtil.isNextLineEmptyAfterIndex).toEqual("function");
+  expect(typeof sharedUtil.getNextNonSpaceNonCommentCharacterIndex).toEqual(
+    "function"
+  );
+  expect(typeof sharedUtil.mapDoc).toEqual("function");
+  expect(typeof sharedUtil.makeString).toEqual("function");
+});


### PR DESCRIPTION
This is a first attempt to extract the parser-specific location extraction code (`locStart` and `locEnd` in `/common/util.js`) so that it can be configured by plugins - see https://github.com/prettier/prettier-php/pull/14 for more background.

This PR splits `util.js` in a "private" and a "public" part; the public one is configurable by passing `options` to it. It also shows how an example of it's usage for the HTML printer. In order to get this merged, all printers would have to be adapted to use new argument `util` in 
```javascript
genericPrint(path, options, print, args, util)
```
instead of importing it directly.

I thought I'd open this PR already to ask if this is going in the right direction. Thanks!