### PR TITLE
fix(markdown): update remark-parse to v5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "postcss-values-parser": "1.3.1",
     "read-pkg-up": "3.0.0",
     "remark-frontmatter": "1.1.0",
-    "remark-parse": "4.0.0",
+    "remark-parse": "5.0.0",
     "resolve": "1.5.0",
     "semver": "5.4.1",
     "string-width": "2.1.1",

--- a/tests/markdown_link/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_link/__snapshots__/jsfmt.spec.js.snap
@@ -14,6 +14,20 @@ exports[`autolink.md 2`] = `
 
 `;
 
+exports[`entity.md 1`] = `
+[Test](http://localhost:8080/test?language=DE&currency=EUR)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[Test](http://localhost:8080/test?language=DE&currency=EUR)
+
+`;
+
+exports[`entity.md 2`] = `
+[Test](http://localhost:8080/test?language=DE&currency=EUR)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[Test](http://localhost:8080/test?language=DE&currency=EUR)
+
+`;
+
 exports[`long.md 1`] = `
 [podium context](https://github.schibsted.io/finn/podium/tree/master/packages/podium-context)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/markdown_link/entity.md
+++ b/tests/markdown_link/entity.md
@@ -1,0 +1,1 @@
+[Test](http://localhost:8080/test?language=DE&currency=EUR)

--- a/tests/markdown_list/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_list/__snapshots__/jsfmt.spec.js.snap
@@ -960,6 +960,46 @@ exports[`indent.md 4`] = `
 
 `;
 
+exports[`interrupt.md 1`] = `
+* Something
+### Some heading
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Something
+
+### Some heading
+
+`;
+
+exports[`interrupt.md 2`] = `
+* Something
+### Some heading
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Something
+
+### Some heading
+
+`;
+
+exports[`interrupt.md 3`] = `
+* Something
+### Some heading
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Something
+
+### Some heading
+
+`;
+
+exports[`interrupt.md 4`] = `
+* Something
+### Some heading
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+* Something
+
+### Some heading
+
+`;
+
 exports[`long-paragraph.md 1`] = `
 - This is a long long long long long long long long long long long long long long paragraph.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/markdown_list/interrupt.md
+++ b/tests/markdown_list/interrupt.md
@@ -1,0 +1,2 @@
+* Something
+### Some heading

--- a/yarn.lock
+++ b/yarn.lock
@@ -3360,7 +3360,7 @@ parse-asn1@^5.0.0:
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
 
-parse-entities@^1.0.2:
+parse-entities@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.1.1.tgz#8112d88471319f27abae4d64964b122fe4e1b890"
   dependencies:
@@ -3822,9 +3822,9 @@ remark-frontmatter@1.1.0:
     fault "^1.0.1"
     xtend "^4.0.1"
 
-remark-parse@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-4.0.0.tgz#99f1f049afac80382366e2e0d0bd55429dd45d8b"
+remark-parse@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-5.0.0.tgz#4c077f9e499044d1d5c13f80d7a98cf7b9285d95"
   dependencies:
     collapse-white-space "^1.0.2"
     is-alphabetical "^1.0.0"
@@ -3832,7 +3832,7 @@ remark-parse@4.0.0:
     is-whitespace-character "^1.0.0"
     is-word-character "^1.0.0"
     markdown-escapes "^1.0.0"
-    parse-entities "^1.0.2"
+    parse-entities "^1.1.0"
     repeat-string "^1.5.4"
     state-toggle "^1.0.0"
     trim "0.0.1"


### PR DESCRIPTION
Fixes #3470
Fixes #3247