### PR TITLE
Fix deprecation warning from Github Buttons on website

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -7,9 +7,7 @@ const GithubButton = props => (
     className="github-button"
     href={props.config.githubUrl}
     data-icon="octicon-star"
-    data-count-href={`/${props.config.repo}/stargazers`}
-    data-count-api={`/repos/${props.config.repo}#stargazers_count`}
-    data-count-aria-label="# stargazers on GitHub"
+    data-show-count="true"
     aria-label="Star this project on GitHub"
   >
     Star


### PR DESCRIPTION
I get this message in the console when visiting the website:

> GitHub Buttons deprecated `data-count-api`: use `data-show-count="true"` instead. Please refer to https://github.com/ntkme/github-buttons#readme for more info.

I updated the code for the star button in the footer to use the latest syntax.