### PR TITLE
Fix tests on windows

### DIFF
--- a/tests_integration/__tests__/plugin-extensions.js
+++ b/tests_integration/__tests__/plugin-extensions.js
@@ -1,10 +1,11 @@
 "use strict";
 
 const runPrettier = require("../runPrettier");
+const EOL = require("os").EOL;
 
 describe("uses 'extensions' from languages to determine parser", () => {
   runPrettier("plugins/extensions", ["*.foo", "--plugin=./plugin"]).test({
-    stdout: "!contents\n",
+    stdout: "!contents" + EOL,
     stderr: "",
     status: 0,
     write: []

--- a/tests_integration/__tests__/plugin-preprocess.js
+++ b/tests_integration/__tests__/plugin-preprocess.js
@@ -1,10 +1,11 @@
 "use strict";
 
 const runPrettier = require("../runPrettier");
+const EOL = require("os").EOL;
 
 describe("parser preprocess function is used to reshape input text", () => {
   runPrettier("plugins/preprocess", ["*.foo", "--plugin=./plugin"]).test({
-    stdout: "preprocessed:contents\n",
+    stdout: "preprocessed:contents" + EOL,
     stderr: "",
     status: 0,
     write: []

--- a/tests_integration/__tests__/plugin-resolution.js
+++ b/tests_integration/__tests__/plugin-resolution.js
@@ -1,10 +1,11 @@
 "use strict";
 
 const runPrettier = require("../runPrettier");
+const EOL = require("os").EOL;
 
 describe("automatically loads 'prettier-plugin-*' from package.json devDependencies", () => {
   runPrettier("plugins/automatic", ["file.txt", "--parser=foo"]).test({
-    stdout: "foo+contents\n",
+    stdout: "foo+contents" + EOL,
     stderr: "",
     status: 0,
     write: []
@@ -13,7 +14,7 @@ describe("automatically loads 'prettier-plugin-*' from package.json devDependenc
 
 describe("automatically loads '@prettier/plugin-*' from package.json dependencies", () => {
   runPrettier("plugins/automatic", ["file.txt", "--parser=bar"]).test({
-    stdout: "bar+contents\n",
+    stdout: "bar+contents" + EOL,
     stderr: "",
     status: 0,
     write: []


### PR DESCRIPTION
This PR fixes a few failing tests on Windows. There's one remaining test, a snapshot test, that fails, and I'm not sure how to fix it.
```
FAIL  tests_integration\__tests__\debug-check.js
  show diff for 2+ error files with --debug-check › (stderr)

    expect(value).toMatchSnapshot()

    Received value does not match stored snapshot 1.

    - Snapshot
    + Received

    @@ -17,14 +17,18 @@
      [error] ===================================================================
      [error] ---
      [error] +++
      [error] @@ -1,3 +1,3 @@
      [error]  const a = {
    + [error]
      [error] -    'a': 1
    + [error]
      [error] +  a: 1
    + [error]
      [error]  };
      [error]
    + [error]
      [error] b.js: ast(input) !== ast(prettier(input))
      [error] Index:
      [error] ===================================================================
      [error] ---
      [error] +++
    @@ -42,10 +46,14 @@
      [error] ===================================================================
      [error] ---
      [error] +++
      [error] @@ -1,3 +1,3 @@
      [error]  const b = {
    + [error]
      [error] -    'b': 2
    + [error]
      [error] +  b: 2
    + [error]
      [error]  };
      [error]
    + [error]
      "

      at Object.test (tests_integration/runPrettier.js:122:25)
          at new Promise (<anonymous>)
          at <anonymous>
      at process._tickCallback (internal/process/next_tick.js:188:7)
```