### PR TITLE
feat(css): lowercase build-in functions

### DIFF
--- a/src/language-css/clean.js
+++ b/src/language-css/clean.js
@@ -33,6 +33,118 @@ function clean(ast, newObj) {
   ) {
     newObj.value = newObj.value.toLowerCase();
   }
+  if (ast.type === "value-func") {
+    const lowerCasedValue = newObj.value.toLowerCase();
+    const functions = [
+      // URL
+      "url",
+      "local",
+      // Font format
+      "format",
+      // Color
+      "rgb",
+      "rgba",
+      "hsl",
+      "hsla",
+      "hwb",
+      "gray",
+      // Attribute
+      "attr",
+      // Min/max
+      "min",
+      "max",
+      // Toggle
+      "toggle",
+      // Calc
+      "calc",
+      // Animation
+      "cubic-bezier",
+      // Gradient
+      "linear-gradient",
+      "radial-gradient",
+      "repeating-linear-gradient",
+      "repeating-radial-gradient",
+      // Filter
+      "blur",
+      "brightness",
+      "contrast",
+      "drop-shadow",
+      "grayscale",
+      "hue-rotate",
+      "opacity",
+      "saturate",
+      "sepia",
+      // Shape
+      "circle",
+      "ellipse",
+      "inset",
+      "invert",
+      "polygon",
+      // Counter
+      "counter",
+      "counters",
+      // Transition
+      "cubic-bezier",
+      "steps",
+      "frames",
+      // Transform
+      "matrix",
+      "matrix3d",
+      "perspective",
+      "rotate",
+      "rotate3d",
+      "scale",
+      "scale3d",
+      "skew",
+      "translate",
+      "translate3d",
+      // Image
+      "image",
+      // Font variant
+      "stylistic",
+      "styleset",
+      "character-variant",
+      "swash",
+      "ornaments",
+      "annotation",
+      // Clip
+      "rect",
+      // Grid,
+      "minmax",
+      "repeat",
+      "fit-content",
+      // Variables
+      "var"
+    ];
+
+    if (functions.indexOf(lowerCasedValue) !== -1) {
+      return lowerCasedValue;
+    }
+
+    const camelCaseFunctions = [
+      // Transform
+      "rotateX",
+      "rotateY",
+      "rotateZ",
+      "scaleX",
+      "scaleY",
+      "scaleZ",
+      "skewX",
+      "skewY",
+      "translateX",
+      "translateY",
+      "translateZ"
+    ].map(i => ({ [i.toLowerCase()]: i }));
+
+    let index = -1;
+    if (
+      (index = camelCaseFunctions.findIndex(
+        element => element[lowerCasedValue]
+      )) !== -1
+    ) {
+      return camelCaseFunctions[index][lowerCasedValue];
+    }
+  }
   if (ast.type === "css-decl") {
     newObj.prop = newObj.prop.toLowerCase();
   }

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -406,7 +406,10 @@ function genericPrint(path, options, print) {
       return path.call(print, "group");
     }
     case "value-func": {
-      return concat([n.value, path.call(print, "group")]);
+      return concat([
+        maybeToLowerCaseFunction(n.value),
+        path.call(print, "group")
+      ]);
     }
     case "value-paren": {
       if (n.raws.before !== "") {
@@ -557,6 +560,121 @@ function isWideKeywords(value) {
       value.replace().toLowerCase()
     ) !== -1
   );
+}
+
+function maybeToLowerCaseFunction(value) {
+  const lowerCasedValue = value.toLowerCase();
+  const functions = [
+    // URL
+    "url",
+    "local",
+    // Font format
+    "format",
+    // Color
+    "rgb",
+    "rgba",
+    "hsl",
+    "hsla",
+    "hwb",
+    "gray",
+    // Attribute
+    "attr",
+    // Min/max
+    "min",
+    "max",
+    // Toggle
+    "toggle",
+    // Calc
+    "calc",
+    // Animation
+    "cubic-bezier",
+    // Gradient
+    "linear-gradient",
+    "radial-gradient",
+    "repeating-linear-gradient",
+    "repeating-radial-gradient",
+    // Filter
+    "blur",
+    "brightness",
+    "contrast",
+    "drop-shadow",
+    "grayscale",
+    "hue-rotate",
+    "opacity",
+    "saturate",
+    "sepia",
+    // Shape
+    "circle",
+    "ellipse",
+    "inset",
+    "invert",
+    "polygon",
+    // Counter
+    "counter",
+    "counters",
+    // Transition
+    "cubic-bezier",
+    "steps",
+    "frames",
+    // Transform
+    "matrix",
+    "matrix3d",
+    "perspective",
+    "rotate",
+    "rotate3d",
+    "scale",
+    "scale3d",
+    "skew",
+    "translate",
+    "translate3d",
+    // Image
+    "image",
+    // Font variant
+    "stylistic",
+    "styleset",
+    "character-variant",
+    "swash",
+    "ornaments",
+    "annotation",
+    // Clip
+    "rect",
+    // Grid,
+    "minmax",
+    "repeat",
+    "fit-content",
+    // Variables
+    "var"
+  ];
+
+  if (functions.indexOf(lowerCasedValue) !== -1) {
+    return lowerCasedValue;
+  }
+
+  const camelCaseFunctions = [
+    // Transform
+    "rotateX",
+    "rotateY",
+    "rotateZ",
+    "scaleX",
+    "scaleY",
+    "scaleZ",
+    "skewX",
+    "skewY",
+    "translateX",
+    "translateY",
+    "translateZ"
+  ].map(i => ({ [i.toLowerCase()]: i }));
+
+  let index = -1;
+  if (
+    (index = camelCaseFunctions.findIndex(
+      element => element[lowerCasedValue]
+    )) !== -1
+  ) {
+    return camelCaseFunctions[index][lowerCasedValue];
+  }
+
+  return value;
 }
 
 module.exports = {

--- a/tests/css_case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_case/__snapshots__/jsfmt.spec.js.snap
@@ -18,13 +18,14 @@ svg[viewBox] linearGradient,
     BACKGROUND-image: URL("KeepString");
     Margin: 5PX .2E10Em;
     --Keep-custom-Prop: red;
-    background: Var(--Keep-custom-Prop);
+    background: VAR(--Keep-custom-Prop);
     animation-name: KeepAnimationName;
     important: something !IMPORTANT;
     font-family: INITIAL;
     padding: UNSET;
     border: INHERIT;
     all: REVERT;
+    transform: TRANSLATEX(60px);
 }
 
 @keyframes KeepAnimationName {
@@ -107,16 +108,17 @@ a[HREF="KeepAttrValue"]:hover::first-letter,
 svg[viewBox] linearGradient,
 :not(:nth-child(2n + 1)) {
   color: #aabbcc;
-  background-image: URL("KeepString");
+  background-image: url("KeepString");
   margin: 5px 0.2e10em;
   --Keep-custom-Prop: red;
-  background: Var(--Keep-custom-Prop);
+  background: var(--Keep-custom-Prop);
   animation-name: KeepAnimationName;
   important: something !IMPORTANT;
   font-family: initial;
   padding: unset;
   border: inherit;
   all: revert;
+  transform: translateX(60px);
 }
 
 @keyframes KeepAnimationName {
@@ -212,13 +214,14 @@ svg[viewBox] linearGradient,
     BACKGROUND-image: URL("KeepString");
     Margin: 5PX .2E10Em;
     --Keep-custom-Prop: red;
-    background: Var(--Keep-custom-Prop);
+    background: VAR(--Keep-custom-Prop);
     animation-name: KeepAnimationName;
     important: something !IMPORTANT;
     font-family: INITIAL;
     padding: UNSET;
     border: INHERIT;
     all: REVERT;
+    transform: TRANSLATEX(60px);
 }
 
 @keyframes KeepAnimationName {
@@ -303,16 +306,17 @@ a[HREF="KeepAttrValue"]:hover::first-letter,
 svg[viewBox] linearGradient,
 :not(:nth-child(2n + 1)) {
   color: #aabbcc;
-  background-image: URL("KeepString");
+  background-image: url("KeepString");
   margin: 5px 0.2e10em;
   --Keep-custom-Prop: red;
-  background: Var(--Keep-custom-Prop);
+  background: var(--Keep-custom-Prop);
   animation-name: KeepAnimationName;
   important: something !important;
   font-family: initial;
   padding: unset;
   border: inherit;
   all: revert;
+  transform: translateX(60px);
 }
 
 @keyframes KeepAnimationName {

--- a/tests/css_case/case.less
+++ b/tests/css_case/case.less
@@ -15,13 +15,14 @@ svg[viewBox] linearGradient,
     BACKGROUND-image: URL("KeepString");
     Margin: 5PX .2E10Em;
     --Keep-custom-Prop: red;
-    background: Var(--Keep-custom-Prop);
+    background: VAR(--Keep-custom-Prop);
     animation-name: KeepAnimationName;
     important: something !IMPORTANT;
     font-family: INITIAL;
     padding: UNSET;
     border: INHERIT;
     all: REVERT;
+    transform: TRANSLATEX(60px);
 }
 
 @keyframes KeepAnimationName {

--- a/tests/css_case/case.scss
+++ b/tests/css_case/case.scss
@@ -14,13 +14,14 @@ svg[viewBox] linearGradient,
     BACKGROUND-image: URL("KeepString");
     Margin: 5PX .2E10Em;
     --Keep-custom-Prop: red;
-    background: Var(--Keep-custom-Prop);
+    background: VAR(--Keep-custom-Prop);
     animation-name: KeepAnimationName;
     important: something !IMPORTANT;
     font-family: INITIAL;
     padding: UNSET;
     border: INHERIT;
     all: REVERT;
+    transform: TRANSLATEX(60px);
 }
 
 @keyframes KeepAnimationName {

--- a/tests/stylefmt/lowercase/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/stylefmt/lowercase/__snapshots__/jsfmt.spec.js.snap
@@ -46,25 +46,25 @@ $myVar7: linear-gradient(to right, RGBA(0,0,0,0.5), RGB(255,255,255));
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 @charset "UTF-8";
 
-$myVar: TRANSLATEX(0);
-$myVar2: RGB(255, 255, 255);
+$myVar: translateX(0);
+$myVar2: rgb(255, 255, 255);
 $myVar3: MAROON;
-$myVar4: HSLA(120, 100%, 50%, 0.3);
-$myVar5: RGBA(0, 0, 0, 0.5);
-$myVar6: HSL(120, 100%, 50%);
-$myVar7: linear-gradient(to right, RGBA(0, 0, 0, 0.5), RGB(255, 255, 255));
+$myVar4: hsla(120, 100%, 50%, 0.3);
+$myVar5: rgba(0, 0, 0, 0.5);
+$myVar6: hsl(120, 100%, 50%);
+$myVar7: linear-gradient(to right, rgba(0, 0, 0, 0.5), rgb(255, 255, 255));
 
 .class-1 {
-  background: HSL(120, 100%, 50%);
-  background: linear-gradient(to right, $myVar2, RGB(255, 255, 255));
-  color: RGB(0, 0, 0);
-  transform: TRANSLATE(0, 0) TRANSLATEX(0) TRANSLATEY(0) TRANSLATEZ(0)
-    TRANSLATE3D(0, 0, 0) MATRIX(1, 1, 1, 1);
-  transform: TRANSLATE(0, 0);
-  transform: TRANSLATEX(0);
-  transform: TRANSLATEY(0);
-  transform: TRANSLATE3D(0, 0, 0);
-  transform: MATRIX(1, 1, 1, 1);
+  background: hsl(120, 100%, 50%);
+  background: linear-gradient(to right, $myVar2, rgb(255, 255, 255));
+  color: rgb(0, 0, 0);
+  transform: translate(0, 0) translateX(0) translateY(0) translateZ(0)
+    translate3d(0, 0, 0) matrix(1, 1, 1, 1);
+  transform: translate(0, 0);
+  transform: translateX(0);
+  transform: translateY(0);
+  transform: translate3d(0, 0, 0);
+  transform: matrix(1, 1, 1, 1);
   transform: translateY(0) $myVar;
   animation: textAnimation 0.1s;
   animation: tAnimation 0.1s;
@@ -72,22 +72,22 @@ $myVar7: linear-gradient(to right, RGBA(0, 0, 0, 0.5), RGB(255, 255, 255));
 
 .class-2 {
   background-color: INDIGO;
-  background: HSLA(120, 100%, 50%, 0.3);
-  color: RGBA(0, 0, 0, 0.5);
-  transform: ROTATE(1deg) ROTATEX(1deg) ROTATEY(1deg) ROTATEZ(1deg)
-    ROTATE3D(0, 0, 1, 1deg) SKEW(1deg) SKEWX(1deg) SKEWY(1deg) SCALE(1, 1)
-    SCALEX(1) SCALEY(1);
-  transform: ROTATE(1deg);
-  transform: ROTATEX(1deg);
-  transform: ROTATEY(1deg);
-  transform: ROTATEZ(1deg);
-  transform: ROTATE3D(0, 0, 1, 1deg);
-  transform: SKEW(1deg);
-  transform: SKEWX(1deg);
-  transform: SKEWY(1deg);
-  transform: SCALE(1, 1);
-  transform: SCALEX(1);
-  transform: SCALEY(1);
+  background: hsla(120, 100%, 50%, 0.3);
+  color: rgba(0, 0, 0, 0.5);
+  transform: rotate(1deg) rotateX(1deg) rotateY(1deg) rotateZ(1deg)
+    rotate3d(0, 0, 1, 1deg) skew(1deg) skewX(1deg) skewY(1deg) scale(1, 1)
+    scaleX(1) scaleY(1);
+  transform: rotate(1deg);
+  transform: rotateX(1deg);
+  transform: rotateY(1deg);
+  transform: rotateZ(1deg);
+  transform: rotate3d(0, 0, 1, 1deg);
+  transform: skew(1deg);
+  transform: skewX(1deg);
+  transform: skewY(1deg);
+  transform: scale(1, 1);
+  transform: scaleX(1);
+  transform: scaleY(1);
 }
 
 `;


### PR DESCRIPTION
Two question:
1. Can i create `reference` directory and put all `keywords` and build-in `css` stuff there?
2. In theory it can be break this code (only for scss):
```scss
@function URL($some-number, $another-number){
  @return $some-number + $another-number
}

.my-module {
  padding: URL(10px, 5px);
}
```
But it is very very bad practice (i don't see in popular framework this), maybe better use `prettier-ignore` for this and add docs? 