### PR TITLE
fix(css): ignore `media` params with scss interpolation

### DIFF
--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -211,6 +211,14 @@ function parseNestedCSS(node) {
           value: node.params
         };
       } else {
+        if (node.params.includes("#{")) {
+          // Workaround for media at rule with scss interpolation
+          return {
+            type: "media-unknown",
+            value: node.params
+          };
+        }
+
         node.params = parseMediaQuery(node.params);
       }
     }

--- a/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
@@ -317,6 +317,13 @@ p {
   width: AnotherMyCalculationFunction(10px, 5px);
   border: border(25px, 35px);
 }
+
+$sm-only: '(min-width: 768px) and (max-width: 991px)';
+$lg-and-up: '(min-width: 1200px)';
+
+@media screen and #{$sm-only, $lg-and-up} {
+  color: #000;
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 @media #{$g-breakpoint-tiny} {
 }
@@ -646,6 +653,13 @@ p {
   );
   width: AnotherMyCalculationFunction(10px, 5px);
   border: border(25px, 35px);
+}
+
+$sm-only: "(min-width: 768px) and (max-width: 991px)";
+$lg-and-up: "(min-width: 1200px)";
+
+@media screen and #{$sm-only, $lg-and-up} {
+  color: #000;
 }
 
 `;

--- a/tests/css_scss/scss.css
+++ b/tests/css_scss/scss.css
@@ -307,3 +307,10 @@ p {
   width: AnotherMyCalculationFunction(10px, 5px);
   border: border(25px, 35px);
 }
+
+$sm-only: '(min-width: 768px) and (max-width: 991px)';
+$lg-and-up: '(min-width: 1200px)';
+
+@media screen and #{$sm-only, $lg-and-up} {
+  color: #000;
+}


### PR DESCRIPTION
Fixes #3719 

Right now media parser is very buggy for scss, i think better print media params with interpolation as is (it is don't break code).