### PR TITLE
fix(css): handle namespace in attribute selector

### DIFF
--- a/src/language-css/clean.js
+++ b/src/language-css/clean.js
@@ -66,7 +66,17 @@ function clean(ast, newObj) {
   }
 
   if (ast.type === "selector-attribute") {
-    newObj.attribute = newObj.attribute.replace(/\s/g, "");
+    newObj.attribute = newObj.attribute.trim();
+
+    if (newObj.namespace) {
+      if (typeof newObj.namespace === "string") {
+        newObj.namespace = newObj.namespace.trim();
+
+        if (newObj.namespace.length === 0) {
+          newObj.namespace = true;
+        }
+      }
+    }
 
     if (newObj.value) {
       newObj.value = newObj.value.trim().replace(/^['"]|['"]$/g, "");

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -252,6 +252,9 @@ function genericPrint(path, options, print) {
     case "selector-attribute": {
       return concat([
         "[",
+        n.namespace
+          ? concat([n.namespace === true ? "" : n.namespace.trim(), "|"])
+          : "",
         n.attribute.trim(),
         n.operator ? n.operator : "",
         n.value

--- a/tests/css_attribute/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_attribute/__snapshots__/jsfmt.spec.js.snap
@@ -1,27 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`insensitive.css 1`] = `
-input[type="radio" i] {
-}
-img[alt~="person" i][src*="lorem" i] {
-}
+input[type="radio" i] {}
+img[alt~="person" i][src*="lorem" i] {}
+section:has(:not([type="radio" i], [type="checkbox" i])) {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 input[type="radio" i] {
 }
 img[alt~="person" i][src*="lorem" i] {
+}
+section:has(:not([type="radio" i], [type="checkbox" i])) {
 }
 
 `;
 
 exports[`insensitive.css 2`] = `
-input[type="radio" i] {
-}
-img[alt~="person" i][src*="lorem" i] {
-}
+input[type="radio" i] {}
+img[alt~="person" i][src*="lorem" i] {}
+section:has(:not([type="radio" i], [type="checkbox" i])) {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 input[type='radio' i] {
 }
 img[alt~='person' i][src*='lorem' i] {
+}
+section:has(:not([type='radio' i], [type='checkbox' i])) {
+}
+
+`;
+
+exports[`namespaces.css 1`] = `
+@namespace foo "http://www.example.com";
+[foo|att=val] {}
+[*|att] {}
+[|att] {}
+[att] {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@namespace foo "http://www.example.com";
+[foo|att="val"] {
+}
+[*|att] {
+}
+[|att] {
+}
+[att] {
+}
+
+`;
+
+exports[`namespaces.css 2`] = `
+@namespace foo "http://www.example.com";
+[foo|att=val] {}
+[*|att] {}
+[|att] {}
+[att] {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@namespace foo 'http://www.example.com';
+[foo|att='val'] {
+}
+[*|att] {
+}
+[|att] {
+}
+[att] {
 }
 
 `;
@@ -32,6 +72,9 @@ a[id="test"] {}
 a[id='test'] {}
 a[id=func("foo")] {}
 a[class="(╯°□°）╯︵ ┻━┻"]{}
+input:not([type="radio"]):not([type="checkbox"]) {}
+input:not([type="radio"], [type="checkbox"]) {}
+section:has(:not([type="radio"], [type="checkbox"])) {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 a[id="test"] {
 }
@@ -43,6 +86,12 @@ a[id=func("foo")] {
 }
 a[class="(╯°□°）╯︵ ┻━┻"] {
 }
+input:not([type="radio"]):not([type="checkbox"]) {
+}
+input:not([type="radio"], [type="checkbox"]) {
+}
+section:has(:not([type="radio"], [type="checkbox"])) {
+}
 
 `;
 
@@ -52,6 +101,9 @@ a[id="test"] {}
 a[id='test'] {}
 a[id=func("foo")] {}
 a[class="(╯°□°）╯︵ ┻━┻"]{}
+input:not([type="radio"]):not([type="checkbox"]) {}
+input:not([type="radio"], [type="checkbox"]) {}
+section:has(:not([type="radio"], [type="checkbox"])) {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 a[id='test'] {
 }
@@ -62,6 +114,12 @@ a[id='test'] {
 a[id=func('foo')] {
 }
 a[class='(╯°□°）╯︵ ┻━┻'] {
+}
+input:not([type='radio']):not([type='checkbox']) {
+}
+input:not([type='radio'], [type='checkbox']) {
+}
+section:has(:not([type='radio'], [type='checkbox'])) {
 }
 
 `;
@@ -130,6 +188,57 @@ alt
 src
 *=
 'lorem'
+] {}
+section:has(:not([type='radio'], [type='checkbox'])) {}
+section:has(:not([type='radio' i], [type='checkbox' i])) {}
+section:has(:not([ type = 'radio' ], [ type = 'checkbox' ])) {}
+section:has(:not([ type = 'radio' i ], [ type = 'checkbox' i ])) {}
+section:has(:not([  type  =  'radio'  ], [  type  =  'checkbox'  ])) {}
+section:has(:not([  type  =  'radio'  i  ], [  type  =  'checkbox'  i  ])) {}
+section:has(:not([
+type
+=
+'radio'
+], [
+type
+=
+'checkbox'
+])) {}
+section:has(:not([
+type
+=
+'radio'
+i
+], [
+type
+=
+'checkbox'
+i
+])) {}
+[foo|att=val] {}
+[ foo | att = val ] {}
+[  foo  |  att  =  val  ] {}
+[
+foo
+|
+att
+=
+val
+] {}
+[*|att] {}
+[ * | att ] {}
+[  *  |  att  ] {}
+[
+*
+|
+att
+] {}
+[|att] {}
+[ | att ] {}
+[  |  att  ] {}
+[
+|
+att
 ] {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [lang] {
@@ -206,6 +315,46 @@ img[alt~="person"][src*="lorem"] {
 }
 img[alt~="person"][src*="lorem"] {
 }
+section:has(:not([type="radio"], [type="checkbox"])) {
+}
+section:has(:not([type="radio" i], [type="checkbox" i])) {
+}
+section:has(:not([type="radio"], [type="checkbox"])) {
+}
+section:has(:not([type="radio" i], [type="checkbox" i])) {
+}
+section:has(:not([type="radio"], [type="checkbox"])) {
+}
+section:has(:not([type="radio" i], [type="checkbox" i])) {
+}
+section:has(:not([type="radio"], [type="checkbox"])) {
+}
+section:has(:not([type="radio" i], [type="checkbox" i])) {
+}
+[foo|att="val"] {
+}
+[foo|att="val"] {
+}
+[foo|att="val"] {
+}
+[foo|att="val"] {
+}
+[*|att] {
+}
+[*|att] {
+}
+[*|att] {
+}
+[*|att] {
+}
+[|att] {
+}
+[|att] {
+}
+[|att] {
+}
+[|att] {
+}
 
 `;
 
@@ -273,6 +422,57 @@ alt
 src
 *=
 'lorem'
+] {}
+section:has(:not([type='radio'], [type='checkbox'])) {}
+section:has(:not([type='radio' i], [type='checkbox' i])) {}
+section:has(:not([ type = 'radio' ], [ type = 'checkbox' ])) {}
+section:has(:not([ type = 'radio' i ], [ type = 'checkbox' i ])) {}
+section:has(:not([  type  =  'radio'  ], [  type  =  'checkbox'  ])) {}
+section:has(:not([  type  =  'radio'  i  ], [  type  =  'checkbox'  i  ])) {}
+section:has(:not([
+type
+=
+'radio'
+], [
+type
+=
+'checkbox'
+])) {}
+section:has(:not([
+type
+=
+'radio'
+i
+], [
+type
+=
+'checkbox'
+i
+])) {}
+[foo|att=val] {}
+[ foo | att = val ] {}
+[  foo  |  att  =  val  ] {}
+[
+foo
+|
+att
+=
+val
+] {}
+[*|att] {}
+[ * | att ] {}
+[  *  |  att  ] {}
+[
+*
+|
+att
+] {}
+[|att] {}
+[ | att ] {}
+[  |  att  ] {}
+[
+|
+att
 ] {}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [lang] {
@@ -348,6 +548,46 @@ img[alt~='person'][src*='lorem'] {
 img[alt~='person'][src*='lorem'] {
 }
 img[alt~='person'][src*='lorem'] {
+}
+section:has(:not([type='radio'], [type='checkbox'])) {
+}
+section:has(:not([type='radio' i], [type='checkbox' i])) {
+}
+section:has(:not([type='radio'], [type='checkbox'])) {
+}
+section:has(:not([type='radio' i], [type='checkbox' i])) {
+}
+section:has(:not([type='radio'], [type='checkbox'])) {
+}
+section:has(:not([type='radio' i], [type='checkbox' i])) {
+}
+section:has(:not([type='radio'], [type='checkbox'])) {
+}
+section:has(:not([type='radio' i], [type='checkbox' i])) {
+}
+[foo|att='val'] {
+}
+[foo|att='val'] {
+}
+[foo|att='val'] {
+}
+[foo|att='val'] {
+}
+[*|att] {
+}
+[*|att] {
+}
+[*|att] {
+}
+[*|att] {
+}
+[|att] {
+}
+[|att] {
+}
+[|att] {
+}
+[|att] {
 }
 
 `;

--- a/tests/css_attribute/insensitive.css
+++ b/tests/css_attribute/insensitive.css
@@ -1,4 +1,3 @@
-input[type="radio" i] {
-}
-img[alt~="person" i][src*="lorem" i] {
-}
+input[type="radio" i] {}
+img[alt~="person" i][src*="lorem" i] {}
+section:has(:not([type="radio" i], [type="checkbox" i])) {}

--- a/tests/css_attribute/namespaces.css
+++ b/tests/css_attribute/namespaces.css
@@ -1,0 +1,5 @@
+@namespace foo "http://www.example.com";
+[foo|att=val] {}
+[*|att] {}
+[|att] {}
+[att] {}

--- a/tests/css_attribute/quotes.css
+++ b/tests/css_attribute/quotes.css
@@ -3,3 +3,6 @@ a[id="test"] {}
 a[id='test'] {}
 a[id=func("foo")] {}
 a[class="(╯°□°）╯︵ ┻━┻"]{}
+input:not([type="radio"]):not([type="checkbox"]) {}
+input:not([type="radio"], [type="checkbox"]) {}
+section:has(:not([type="radio"], [type="checkbox"])) {}

--- a/tests/css_attribute/spaces.css
+++ b/tests/css_attribute/spaces.css
@@ -62,3 +62,54 @@ src
 *=
 'lorem'
 ] {}
+section:has(:not([type='radio'], [type='checkbox'])) {}
+section:has(:not([type='radio' i], [type='checkbox' i])) {}
+section:has(:not([ type = 'radio' ], [ type = 'checkbox' ])) {}
+section:has(:not([ type = 'radio' i ], [ type = 'checkbox' i ])) {}
+section:has(:not([  type  =  'radio'  ], [  type  =  'checkbox'  ])) {}
+section:has(:not([  type  =  'radio'  i  ], [  type  =  'checkbox'  i  ])) {}
+section:has(:not([
+type
+=
+'radio'
+], [
+type
+=
+'checkbox'
+])) {}
+section:has(:not([
+type
+=
+'radio'
+i
+], [
+type
+=
+'checkbox'
+i
+])) {}
+[foo|att=val] {}
+[ foo | att = val ] {}
+[  foo  |  att  =  val  ] {}
+[
+foo
+|
+att
+=
+val
+] {}
+[*|att] {}
+[ * | att ] {}
+[  *  |  att  ] {}
+[
+*
+|
+att
+] {}
+[|att] {}
+[ | att ] {}
+[  |  att  ] {}
+[
+|
+att
+] {}


### PR DESCRIPTION
Also add tests.
`[foo|att=val] {}` - namespace attribute selector - https://drafts.csswg.org/css-namespaces-3/#css-qnames