### PR TITLE
fix(css): don't handle unquoted url

### DIFF
--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -152,6 +152,30 @@ function parseNestedValue(node) {
 function parseValue(value) {
   const valueParser = require("postcss-values-parser");
   const result = valueParser(value, { loose: true }).parse();
+
+  result.walk(node => {
+    if (node.type !== "func") {
+      return;
+    }
+
+    if (node.nodes && node.nodes[1] && node.nodes[1].value !== "data") {
+      return;
+    }
+
+    let value = "";
+
+    for (let i = 1; i <= node.nodes.length - 2; i++) {
+      const nestedNode = node.nodes[i];
+      const nestedValue = nestedNode ? nestedNode.value : "" + nestedNode.unit;
+      const nestedUnit = nestedNode.unit ? nestedNode.unit : "";
+
+      value += nestedValue + nestedUnit;
+      delete node.nodes[i];
+    }
+
+    node.nodes = ["(", value, ")"];
+  });
+
   const parsedResult = parseNestedValue(result);
   return addTypePrefix(parsedResult, "value-");
 }

--- a/tests/css_inline_url/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_inline_url/__snapshots__/jsfmt.spec.js.snap
@@ -13,19 +13,74 @@ exports[`empty.css 1`] = `
 
 exports[`inline_url.css 1`] = `
 .breadItem {
+  background-image: url("/images/product/simple_product_manager/breadcrumb/chevron_right.png");
+  background-image: url( "/images/product/simple_product_manager/breadcrumb/chevron_right.png" );
+  background-image: url(  "/images/product/simple_product_manager/breadcrumb/chevron_right.png"  );
+  background-image: url(
+    "/images/product/simple_product_manager/breadcrumb/chevron_right.png"
+  );
+  background-image:
+      url("/images/product/simple_product_manager/breadcrumb/chevron_right.png");
+  background-image:
+      url(
+        "/images/product/simple_product_manager/breadcrumb/chevron_right.png"
+      );
   background-image: url('/images/product/simple_product_manager/breadcrumb/chevron_right.png');
   background-image: url(/images/product/simple_product_manager/breadcrumb/chevron_right.png);
   -fb-sprite: url(fbglyph:cross-outline, fig-white);
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=);
+  background-image: url( data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII= );
+  background-image: url(  data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=  );
+  background-image: url(
+    data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=
+  );
+  background-image:
+      url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=);
+  background-image:
+      url(
+        data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=
+      );
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=");
+  background-image: url(data:application/font-woff;charset=utf-8;base64,ThisIsNormalBut/+0ThisIsLowerCased),
+    url(data:application/font-woff;charset=utf-8;base64,ThisIsNormalBut/+0ThisIsLowerCased),
+    url('data:application/font-woff;charset=utf-8;base64,ThisIsNormalBut/+0ThisIsLowerCased'),
+    url("data:application/font-woff;charset=utf-8;base64,ThisIsNormalBut/+0ThisIsLowerCased");
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .breadItem {
   background-image: url("/images/product/simple_product_manager/breadcrumb/chevron_right.png");
+  background-image: url("/images/product/simple_product_manager/breadcrumb/chevron_right.png");
+  background-image: url("/images/product/simple_product_manager/breadcrumb/chevron_right.png");
+  background-image: url("/images/product/simple_product_manager/breadcrumb/chevron_right.png");
+  background-image: url("/images/product/simple_product_manager/breadcrumb/chevron_right.png");
+  background-image: url("/images/product/simple_product_manager/breadcrumb/chevron_right.png");
+  background-image: url("/images/product/simple_product_manager/breadcrumb/chevron_right.png");
   background-image: url(/images/product/simple_product_manager/breadcrumb/chevron_right.png);
   -fb-sprite: url(fbglyph:cross-outline, fig-white);
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=);
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=);
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=);
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=);
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=);
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=);
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=");
+  background-image: url(data:application/font-woff;charset=utf-8;base64,ThisIsNormalBut/+0ThisIsLowerCased),
+    url(data:application/font-woff;charset=utf-8;base64,ThisIsNormalBut/+0ThisIsLowerCased),
+    url("data:application/font-woff;charset=utf-8;base64,ThisIsNormalBut/+0ThisIsLowerCased"),
+    url("data:application/font-woff;charset=utf-8;base64,ThisIsNormalBut/+0ThisIsLowerCased");
+}
+
+`;
+
+exports[`quotes.css 1`] = `
+.breadItem {
+    background-image: url("'");
+    background-image: url('"');
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.breadItem {
+  background-image: url("'");
+  background-image: url('"');
 }
 
 `;

--- a/tests/css_inline_url/inline_url.css
+++ b/tests/css_inline_url/inline_url.css
@@ -1,7 +1,34 @@
 .breadItem {
+  background-image: url("/images/product/simple_product_manager/breadcrumb/chevron_right.png");
+  background-image: url( "/images/product/simple_product_manager/breadcrumb/chevron_right.png" );
+  background-image: url(  "/images/product/simple_product_manager/breadcrumb/chevron_right.png"  );
+  background-image: url(
+    "/images/product/simple_product_manager/breadcrumb/chevron_right.png"
+  );
+  background-image:
+      url("/images/product/simple_product_manager/breadcrumb/chevron_right.png");
+  background-image:
+      url(
+        "/images/product/simple_product_manager/breadcrumb/chevron_right.png"
+      );
   background-image: url('/images/product/simple_product_manager/breadcrumb/chevron_right.png');
   background-image: url(/images/product/simple_product_manager/breadcrumb/chevron_right.png);
   -fb-sprite: url(fbglyph:cross-outline, fig-white);
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=);
+  background-image: url( data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII= );
+  background-image: url(  data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=  );
+  background-image: url(
+    data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=
+  );
+  background-image:
+      url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=);
+  background-image:
+      url(
+        data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=
+      );
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=");
+  background-image: url(data:application/font-woff;charset=utf-8;base64,ThisIsNormalBut/+0ThisIsLowerCased),
+    url(data:application/font-woff;charset=utf-8;base64,ThisIsNormalBut/+0ThisIsLowerCased),
+    url('data:application/font-woff;charset=utf-8;base64,ThisIsNormalBut/+0ThisIsLowerCased'),
+    url("data:application/font-woff;charset=utf-8;base64,ThisIsNormalBut/+0ThisIsLowerCased");
 }

--- a/tests/css_inline_url/quotes.css
+++ b/tests/css_inline_url/quotes.css
@@ -1,0 +1,4 @@
+.breadItem {
+    background-image: url("'");
+    background-image: url('"');
+}


### PR DESCRIPTION
Fixes #2835 

> we can't use url-unquoted because we need parse url func inside to allow usage variables for css, less, scss - example url(var(--somevar))

From https://github.com/prettier/prettier/issues/2835