### PR TITLE
Treat define calls like require

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -802,16 +802,12 @@ function printPathNoParens(path, options, print, args) {
 
       const optional = printOptionalToken(path);
       if (
-        // We want to keep CommonJS require calls as a unit
-        (!isNew &&
-          n.callee.type === "Identifier" &&
-          n.callee.name === "require") ||
-        // As well as AMD-style require and define calls.
-        // Note that the previuos case covers AMD-style require calls as well.
+        // We want to keep CommonJS- and AMD-style require calls, and AMD-style
+        // define calls, as a unit.
         // e.g. `define(["some/lib", (lib) => {`
         (!isNew &&
           n.callee.type === "Identifier" &&
-          n.callee.name === "define") ||
+          (n.callee.name === "require" || n.callee.name === "define")) ||
         n.callee.type === "Import" ||
         // Template literals as single arguments
         (n.arguments.length === 1 &&

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -802,10 +802,16 @@ function printPathNoParens(path, options, print, args) {
 
       const optional = printOptionalToken(path);
       if (
-        // We want to keep require calls as a unit
+        // We want to keep CommonJS require calls as a unit
         (!isNew &&
           n.callee.type === "Identifier" &&
           n.callee.name === "require") ||
+        // As well as AMD-style require and define calls.
+        // Note that the previuos case covers AMD-style require calls as well.
+        // e.g. `define(["some/lib", (lib) => {`
+        (!isNew &&
+          n.callee.type === "Identifier" &&
+          n.callee.name === "define") ||
         n.callee.type === "Import" ||
         // Template literals as single arguments
         (n.arguments.length === 1 &&

--- a/tests/require-amd/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/require-amd/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,82 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`require.js 1`] = `
+require(
+    [
+        'jquery',
+        'common/global.context',
+        'common/log.event',
+        'some_project/square',
+        'some_project/rectangle',
+        'some_project/triangle',
+        'some_project/circle',
+        'some_project/star',
+    ],
+    function($, Context, EventLogger, Square, Rectangle, Triangle, Circle, Star) {
+
+        console.log('some code')
+    }
+);
+
+define(
+    [
+        'jquery',
+        'common/global.context',
+        'common/log.event',
+        'some_project/square',
+        'some_project/rectangle',
+        'some_project/triangle',
+        'some_project/circle',
+        'some_project/star',
+    ],
+    function($, Context, EventLogger, Square, Rectangle, Triangle, Circle, Star) {
+
+        console.log('some code')
+    }
+);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+require([
+  "jquery",
+  "common/global.context",
+  "common/log.event",
+  "some_project/square",
+  "some_project/rectangle",
+  "some_project/triangle",
+  "some_project/circle",
+  "some_project/star"
+], function(
+  $,
+  Context,
+  EventLogger,
+  Square,
+  Rectangle,
+  Triangle,
+  Circle,
+  Star
+) {
+  console.log("some code");
+});
+
+define([
+  "jquery",
+  "common/global.context",
+  "common/log.event",
+  "some_project/square",
+  "some_project/rectangle",
+  "some_project/triangle",
+  "some_project/circle",
+  "some_project/star"
+], function(
+  $,
+  Context,
+  EventLogger,
+  Square,
+  Rectangle,
+  Triangle,
+  Circle,
+  Star
+) {
+  console.log("some code");
+});
+
+`;

--- a/tests/require-amd/jsfmt.spec.js
+++ b/tests/require-amd/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["flow", "typescript"]);

--- a/tests/require-amd/jsfmt.spec.js
+++ b/tests/require-amd/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, ["flow", "typescript"]);
+run_spec(__dirname, ["flow", "typescript", "babylon"]);

--- a/tests/require-amd/require.js
+++ b/tests/require-amd/require.js
@@ -1,0 +1,33 @@
+require(
+    [
+        'jquery',
+        'common/global.context',
+        'common/log.event',
+        'some_project/square',
+        'some_project/rectangle',
+        'some_project/triangle',
+        'some_project/circle',
+        'some_project/star',
+    ],
+    function($, Context, EventLogger, Square, Rectangle, Triangle, Circle, Star) {
+
+        console.log('some code')
+    }
+);
+
+define(
+    [
+        'jquery',
+        'common/global.context',
+        'common/log.event',
+        'some_project/square',
+        'some_project/rectangle',
+        'some_project/triangle',
+        'some_project/circle',
+        'some_project/star',
+    ],
+    function($, Context, EventLogger, Square, Rectangle, Triangle, Circle, Star) {
+
+        console.log('some code')
+    }
+);


### PR DESCRIPTION
See issue #3829. This commit keeps define calls as a unit when possible,
to prevent an extra indent in the body of an AMD-style define.

Rather than adding the "define" check in the same case as the existing
"require" check, I added a separate condition to explicitly call out the
fact that this checks for both AMD and CommonJS modules.

`yarn test -u` yields no changes, and `yarn lint` passes successfully.