### PR TITLE
Ignore package-lock.json and yarn-error.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 .DS_Store
 coverage
 .idea
+package-lock.json
+yarn-error.log


### PR DESCRIPTION
It's happening quite often that these files are making it into PRs by accident, so why not ignoring them in general.