### PR TITLE
add resolveConfigWithFilePath API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -59,7 +59,7 @@ Use `prettier.resolveConfig.sync(filePath [, options])` if you'd like to use syn
 
 ## `prettier.resolveConfigWithFilePath(filePath [, options])`
 
-`resolveConfigWithFilePath` works that same as `resolveConfig` with one difference. The response will include both the configuration that was resolved, along with the file path to the configuration that was used to generate the configuration. However, it will not include the path to the located `.editorconfig` file when used as the core Prettier configuration acts as an override. This is useful for editor integrations, to subscribe to the resolved configuration and reload with any changes.
+`resolveConfigWithFilePath` works that same as `resolveConfig` with one difference. The response will include both the configuration that was resolved, along with the path to the file that was used to generate the configuration. However, it will not include the path any `.editorconfig` file when used, as the configuration file acts as an override. This is useful for editor integrations, to subscribe to the resolved configuration and reload with any changes.
 
 ```js
 prettier.resolveConfigWithFilePath(filePath).then(result => {

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,10 +16,6 @@ prettier.format("foo ( );", { semi: false });
 // -> "foo()"
 ```
 
-## `prettier.check(source [, options])`
-
-`check` checks to see if the file has been formatted with Prettier given those options and returns a `Boolean`. This is similar to the `--list-different` parameter in the CLI and is useful for running Prettier in CI scenarios.
-
 ## `prettier.formatWithCursor(source [, options])`
 
 `formatWithCursor` both formats the code, and translates a cursor position from unformatted code to formatted code. This is useful for editor integrations, to prevent the cursor from moving when code is formatted.
@@ -30,6 +26,10 @@ The `cursorOffset` option should be provided, to specify where the cursor is. Th
 prettier.formatWithCursor(" 1", { cursorOffset: 2 });
 // -> { formatted: '1;\n', cursorOffset: 1 }
 ```
+
+## `prettier.check(source [, options])`
+
+`check` checks to see if the file has been formatted with Prettier given those options and returns a `Boolean`. This is similar to the `--list-different` parameter in the CLI and is useful for running Prettier in CI scenarios.
 
 ## `prettier.resolveConfig(filePath [, options])`
 
@@ -56,6 +56,18 @@ If `options.editorconfig` is `true` and an [`.editorconfig` file](http://editorc
 * `max_line_length`
 
 Use `prettier.resolveConfig.sync(filePath [, options])` if you'd like to use sync version.
+
+## `prettier.resolveConfigWithFilePath(filePath [, options])`
+
+`resolveConfigWithFilePath` works that same as `resolveConfig` with one difference. The response will include both the configuration that was resolved, along with the file path to the configuration that was used to generate the configuration. However, it will not include the path to the located `.editorconfig` file when used as the core Prettier configuration acts as an override. This is useful for editor integrations, to subscribe to the resolved configuration and reload with any changes.
+
+```js
+prettier.resolveConfigWithFilePath(filePath).then(result => {
+  // result -> { config: {}, filePath: '/path/to/resolved/prettier/config' }
+});
+```
+
+Use `prettier.resolveConfigWithFilePath.sync(filePath [, options])` if you'd like to use sync version.
 
 ## `prettier.clearConfigCache()`
 

--- a/index.js
+++ b/index.js
@@ -407,6 +407,7 @@ module.exports = {
   doc,
 
   resolveConfig: config.resolveConfig,
+  resolveConfigWithFilePath: config.resolveConfigWithFilePath,
   clearConfigCache: config.clearCache,
 
   getSupportInfo,

--- a/tests_integration/__tests__/config-resolution.js
+++ b/tests_integration/__tests__/config-resolution.js
@@ -195,10 +195,6 @@ test("API resolveConfig.sync with nested file arg and .editorconfig and indent_s
   });
 });
 
-test("API clearConfigCache", () => {
-  expect(() => prettier.clearConfigCache()).not.toThrowError();
-});
-
 test("API resolveConfig.sync overrides work with absolute paths", () => {
   // Absolute path
   const file = path.join(__dirname, "../cli/config/filepath/subfolder/file.js");
@@ -225,4 +221,241 @@ test("API resolveConfig.sync removes $schema option", () => {
   expect(prettier.resolveConfig.sync(file)).toEqual({
     tabWidth: 42
   });
+});
+
+test("API resolveConfigWithFilePath with no args", () => {
+  return prettier.resolveConfigWithFilePath().then(result => {
+    expect(result).toBeNull();
+  });
+});
+
+test("API resolveConfigWithFilePath.sync with no args", () => {
+  expect(prettier.resolveConfigWithFilePath.sync()).toBeNull();
+});
+
+test("API resolveConfigWithFilePath with file arg", () => {
+  const file = path.resolve(path.join(__dirname, "../cli/config/js/file.js"));
+  const config = path.resolve(
+    path.join(__dirname, "../cli/config/js/prettier.config.js")
+  );
+  return prettier.resolveConfigWithFilePath(file).then(result => {
+    expect(result.config).toMatchObject({
+      tabWidth: 8
+    });
+    expect(result.filePath).toMatch(config);
+  });
+});
+
+test("API resolveConfigWithFilePath.sync with file arg", () => {
+  const file = path.resolve(path.join(__dirname, "../cli/config/js/file.js"));
+  const config = path.resolve(
+    path.join(__dirname, "../cli/config/js/prettier.config.js")
+  );
+  const result = prettier.resolveConfigWithFilePath.sync(file);
+  expect(result.config).toMatchObject({
+    tabWidth: 8
+  });
+  expect(result.filePath).toMatch(config);
+});
+
+test("API resolveConfigWithFilePath with file arg and extension override", () => {
+  const file = path.resolve(
+    path.join(__dirname, "../cli/config/no-config/file.ts")
+  );
+  const config = path.resolve(
+    path.join(__dirname, "../cli/config/.prettierrc")
+  );
+  return prettier.resolveConfigWithFilePath(file).then(result => {
+    expect(result.config).toMatchObject({
+      semi: true
+    });
+    expect(result.filePath).toMatch(config);
+  });
+});
+
+test("API resolveConfigWithFilePath.sync with file arg and extension override", () => {
+  const file = path.resolve(
+    path.join(__dirname, "../cli/config/no-config/file.ts")
+  );
+  const config = path.resolve(
+    path.join(__dirname, "../cli/config/.prettierrc")
+  );
+  const result = prettier.resolveConfigWithFilePath.sync(file);
+  expect(result.config).toMatchObject({
+    semi: true
+  });
+  expect(result.filePath).toMatch(config);
+});
+
+test("API resolveConfigWithFilePath with file arg and .editorconfig", () => {
+  const file = path.resolve(
+    path.join(__dirname, "../cli/config/editorconfig/file.js")
+  );
+  const config = path.resolve(
+    path.join(__dirname, "../cli/config/.prettierrc")
+  );
+
+  return prettier
+    .resolveConfigWithFilePath(file, { editorconfig: true })
+    .then(result => {
+      expect(result.config).toMatchObject({
+        useTabs: true,
+        tabWidth: 8,
+        printWidth: 100
+      });
+      expect(result.filePath).toMatch(config);
+    });
+});
+
+test("API resolveConfigWithFilePath.sync with file arg and .editorconfig", () => {
+  const file = path.resolve(
+    path.join(__dirname, "../cli/config/editorconfig/file.js")
+  );
+  const config = path.resolve(
+    path.join(__dirname, "../cli/config/.prettierrc")
+  );
+
+  const result = prettier.resolveConfigWithFilePath.sync(file);
+  expect(result.config).toMatchObject({
+    semi: false
+  });
+  expect(result.filePath).toMatch(config);
+
+  const resultWithEditorConfig = prettier.resolveConfigWithFilePath.sync(file, {
+    editorconfig: true
+  });
+  expect(resultWithEditorConfig.config).toMatchObject({
+    useTabs: true,
+    tabWidth: 8,
+    printWidth: 100
+  });
+  expect(resultWithEditorConfig.filePath).toMatch(config);
+});
+
+test("API resolveConfigWithFilePath with nested file arg and .editorconfig", () => {
+  const file = path.resolve(
+    path.join(__dirname, "../cli/config/editorconfig/lib/file.js")
+  );
+  const config = path.resolve(
+    path.join(__dirname, "../cli/config/.prettierrc")
+  );
+  return prettier
+    .resolveConfigWithFilePath(file, { editorconfig: true })
+    .then(result => {
+      expect(result.config).toMatchObject({
+        useTabs: false,
+        tabWidth: 2,
+        printWidth: 100
+      });
+      expect(result.filePath).toMatch(config);
+    });
+});
+
+test("API resolveConfigWithFilePath.sync with nested file arg and .editorconfig", () => {
+  const file = path.resolve(
+    path.join(__dirname, "../cli/config/editorconfig/lib/file.js")
+  );
+  const config = path.resolve(
+    path.join(__dirname, "../cli/config/.prettierrc")
+  );
+
+  const result = prettier.resolveConfigWithFilePath.sync(file);
+  expect(result.config).toMatchObject({
+    semi: false
+  });
+  expect(result.filePath).toMatch(config);
+
+  const resultWithEditorConfig = prettier.resolveConfigWithFilePath.sync(file, {
+    editorconfig: true
+  });
+  expect(resultWithEditorConfig.config).toMatchObject({
+    useTabs: false,
+    tabWidth: 2,
+    printWidth: 100
+  });
+  expect(resultWithEditorConfig.filePath).toMatch(config);
+});
+
+test("API resolveConfigWithFilePath with nested file arg and .editorconfig and indent_size = tab", () => {
+  const file = path.resolve(
+    path.join(__dirname, "../cli/config/editorconfig/lib/indent_size=tab.js")
+  );
+  const config = path.resolve(
+    path.join(__dirname, "../cli/config/.prettierrc")
+  );
+  return prettier
+    .resolveConfigWithFilePath(file, { editorconfig: true })
+    .then(result => {
+      expect(result.config).toMatchObject({
+        useTabs: false,
+        tabWidth: 8,
+        printWidth: 100
+      });
+      expect(result.filePath).toMatch(config);
+    });
+});
+
+test("API resolveConfigWithFilePath.sync with nested file arg and .editorconfig and indent_size = tab", () => {
+  const file = path.resolve(
+    path.join(__dirname, "../cli/config/editorconfig/lib/indent_size=tab.js")
+  );
+  const config = path.resolve(
+    path.join(__dirname, "../cli/config/.prettierrc")
+  );
+
+  const result = prettier.resolveConfigWithFilePath.sync(file);
+  expect(result.config).toMatchObject({
+    semi: false
+  });
+  expect(result.filePath).toMatch(config);
+
+  const resultWithEditorConfig = prettier.resolveConfigWithFilePath.sync(file, {
+    editorconfig: true
+  });
+  expect(resultWithEditorConfig.config).toMatchObject({
+    useTabs: false,
+    tabWidth: 8,
+    printWidth: 100
+  });
+  expect(result.filePath).toMatch(config);
+});
+
+test("API resolveConfigWithFilePath.sync overrides work with absolute paths", () => {
+  // Absolute path
+  const file = path.join(__dirname, "../cli/config/filepath/subfolder/file.js");
+  const config = path.join(__dirname, "../cli/config/filepath/.prettierrc");
+  const result = prettier.resolveConfigWithFilePath.sync(file);
+  expect(result.config).toMatchObject({
+    tabWidth: 6
+  });
+  expect(result.filePath).toMatch(config);
+});
+
+test("API resolveConfigWithFilePath removes $schema option", () => {
+  const file = path.resolve(
+    path.join(__dirname, "../cli/config/$schema/index.js")
+  );
+  const config = path.join(__dirname, "../cli/config/$schema/.prettierrc");
+  return prettier.resolveConfigWithFilePath(file).then(result => {
+    expect(result.config).toEqual({
+      tabWidth: 42
+    });
+    expect(result.filePath).toMatch(config);
+  });
+});
+
+test("API resolveConfigWithFilePath.sync removes $schema option", () => {
+  const file = path.resolve(
+    path.join(__dirname, "../cli/config/$schema/index.js")
+  );
+  const config = path.join(__dirname, "../cli/config/$schema/.prettierrc");
+  const result = prettier.resolveConfigWithFilePath.sync(file);
+  expect(result.config).toEqual({
+    tabWidth: 42
+  });
+  expect(result.filePath).toMatch(config);
+});
+
+test("API clearConfigCache", () => {
+  expect(() => prettier.clearConfigCache()).not.toThrowError();
 });


### PR DESCRIPTION
This PR introduces a new API `prettier.resolveConfigWithFilePath`. This method uses the pre-existing internals to find and merge prettier configurations, but exposes the resolved file path for consumers. This will close https://github.com/prettier/prettier/issues/3451 and allow us to solve https://github.com/prettier/prettier-atom/issues/270.

I also reorganized the API docs a bit so that similar API sit next to each other.