### PR TITLE
fix(css): stringify unquoted data urls

### DIFF
--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -466,7 +466,7 @@ function genericPrint(path, options, print) {
             n.groups[0].type === "value-comma_group" &&
             n.groups[0].groups.length > 0 &&
             n.groups[0].groups[0].type === "value-word" &&
-            n.groups[0].groups[0].value === "data"))
+            n.groups[0].groups[0].value.startsWith("data:")))
       ) {
         return concat([
           n.open ? path.call(print, "open") : "",

--- a/tests/css_inline_url/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_inline_url/__snapshots__/jsfmt.spec.js.snap
@@ -18,6 +18,7 @@ exports[`inline_url.css 1`] = `
   -fb-sprite: url(fbglyph:cross-outline, fig-white);
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=);
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=");
+  background-image: url(data:application/font-woff;charset=utf-8;base64,ThisIsNormalBut/+0ThisIsLowerCased);
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .breadItem {
@@ -26,6 +27,7 @@ exports[`inline_url.css 1`] = `
   -fb-sprite: url(fbglyph:cross-outline, fig-white);
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=);
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=");
+  background-image: url(data:application/font-woff;charset=utf-8;base64,ThisIsNormalBut/+0ThisIsLowerCased);
 }
 
 `;

--- a/tests/css_inline_url/inline_url.css
+++ b/tests/css_inline_url/inline_url.css
@@ -4,4 +4,5 @@
   -fb-sprite: url(fbglyph:cross-outline, fig-white);
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=);
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=");
+  background-image: url(data:application/font-woff;charset=utf-8;base64,ThisIsNormalBut/+0ThisIsLowerCased);
 }


### PR DESCRIPTION
Partial fix https://github.com/prettier/prettier/issues/2835, stringify nodes inside unquoted urls.

Need fix in future:
```css
a {
  background-image: url(/data/data/+0ThisIsLowerCased);
}
```