### PR TITLE
Add prettierrc to prettier source code

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "bracketSpacing": true,
+  "jsxBracketSameLine": false,
+  "printWidth": 80,
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2,
+  "trailingComma": "none",
+  "useTabs": false
+}


### PR DESCRIPTION
I have default config in `prettier-atom`, and since this repo doesn't include `.prettierrc`, `prettier-atom` was formatting the code differently.

To avoid this, I added `.prettierrc` with all the `prettier` defaults (as per the JSON schema).