### PR TITLE
Upgrade flow to 0.64

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "escape-string-regexp": "1.0.5",
     "esutils": "2.0.2",
     "find-project-root": "1.1.1",
-    "flow-parser": "0.59.0",
+    "flow-parser": "0.64.0",
     "get-stream": "3.0.0",
     "globby": "6.1.0",
     "graphql": "0.12.3",

--- a/scripts/build/rollup.parser.config.js
+++ b/scripts/build/rollup.parser.config.js
@@ -24,7 +24,7 @@ export default Object.assign(baseConfig, {
     // by its value before bundling.
     parser.endsWith("flow")
       ? replace({
-          "require(s8)": 'require("fs")',
+          "require(tf)": 'require("fs")',
           include: "node_modules/flow-parser/flow_parser.js"
         })
       : {},

--- a/tests/flow/constructor_annots/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/constructor_annots/__snapshots__/jsfmt.spec.js.snap
@@ -19,7 +19,6 @@ interface IFooPrototype {
 interface IFoo extends IFooPrototype {
   x: boolean; // error, should have declared x: number instead
   static (): void;
-  static y: boolean; // error, should have declared static y: number instead
   constructor(): void;
 }
 exports.Foo2 = (Foo: Class<IFoo>);
@@ -45,8 +44,7 @@ interface IFooPrototype {
 }
 interface IFoo extends IFooPrototype {
   x: boolean; // error, should have declared x: number instead
-  static (): void;
-  static y: boolean; // error, should have declared static y: number instead
+  static(): void;
   constructor(): void;
 }
 exports.Foo2 = (Foo: Class<IFoo>);

--- a/tests/flow/constructor_annots/constructors.js
+++ b/tests/flow/constructor_annots/constructors.js
@@ -16,7 +16,6 @@ interface IFooPrototype {
 interface IFoo extends IFooPrototype {
   x: boolean; // error, should have declared x: number instead
   static (): void;
-  static y: boolean; // error, should have declared static y: number instead
   constructor(): void;
 }
 exports.Foo2 = (Foo: Class<IFoo>);

--- a/tests/jsx_spread/jsfmt.spec.js
+++ b/tests/jsx_spread/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, ["babylon"]);
+run_spec(__dirname, ["babylon", "flow"]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1843,9 +1843,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-parser@0.59.0:
-  version "0.59.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.59.0.tgz#f6ebcae61ffa187e420999d40ce0a801f39b2635"
+flow-parser@0.64.0:
+  version "0.64.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.64.0.tgz#858664ef2246880f9a81b05e69fbd308a1b865c9"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This also enables spread operator on jsx on the flow parser:

```js
<div>{...list}</div>
```

I had no idea it was even a thing.

I had to comment out a flow test that no longer parses, but it's no longer in the flow repo and the comment said that it shouldn't be working anyway so I don't think it's going to be a problem.

Fixes #3898