### PR TITLE
Results Dashboard for Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@
 /website/static/lib
 .DS_Store
 coverage
+junit.xml
 .idea
 package-lock.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,10 @@ env:
   - NODE_ENV=production
 matrix:
   fast_finish: true
+before_install:
+  - mkdir -p $HOME/bin
+  - curl -fsSL https://testspace-client.s3.amazonaws.com/testspace-linux.tgz | tar -zxvf- -C $HOME/bin
+  - testspace config url $TS_ORG.testspace.com
 install:
   - NODE_ENV=development yarn install
 before_script:
@@ -23,6 +27,9 @@ script:
   - if [ "${NODE_ENV}" = "production" ]; then yarn test:dist; fi
   - if [ "${NODE_ENV}" = "development" ]; then AST_COMPARE=1 yarn test -- --runInBand; fi
   - if [ "${NODE_ENV}" = "development" ]; then yarn codecov; fi
+after_script:
+  - testspace [node-${TRAVIS_NODE_VERSION}/${NODE_ENV}]junit.xml{.}
 branches:
   only:
     - master
+    - add-test-reporting

--- a/jest.config.js
+++ b/jest.config.js
@@ -21,5 +21,6 @@ module.exports = {
     // If this is removed, see also rollup.bin.config.js and rollup.index.config.js.
     "graceful-fs": "<rootDir>/tests_config/fs.js"
   },
+  testResultsProcessor: "jest-junit",
   transform: {}
 };

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
   "engines": {
     "node": ">=4"
   },
+  "jest-junit": {
+    "classNameTemplate": "{classname}",
+    "titleTemplate": "{title}",
+    "suiteNameTemplate": "{filepath}"
+  },
   "dependencies": {
     "@babel/code-frame": "7.0.0-beta.35",
     "@glimmer/syntax": "0.30.3",
@@ -71,6 +76,7 @@
     "eslint-plugin-prettier": "2.4.0",
     "eslint-plugin-react": "7.1.0",
     "jest": "21.1.0",
+    "jest-junit": "3.4.1",
     "mkdirp": "0.5.1",
     "prettier": "1.10.2",
     "prettylint": "1.0.0",


### PR DESCRIPTION

Hi, `prettier` team. We’ve made a few minor changes to demonstrate how you can better manage your Travis CI build results with [Testspace.com](https://www.testspace.com/). 

YOUR TEST RESULTS, from `our fork`, at https://open.testspace.com/projects/TryTestspace:prettier.

---

 * Triage failures faster with single-click filtering and complete failure context; call stack, timing info, and more.

 * Move beyond a flat, endless window of test output. In Testspace, your test results mirror your test folders and subfolders as defined in your repo. 

 * View historical tracking of all your important metrics; test case and code coverage growth, static analysis issues, and more.  

----

#### Setup is Easy

1. Create a free [Open Source Account](https://signup.testspace.com/?plan_id=open.2)
2. Create a **New Project** from the list of Github repo's
3. Add a Travis **Environment Variable**: Name: `TS_ORG`  Value: `organization name` - based on name selected in step 1
