### PR TITLE
chore(css): update `postcss-values-parser` to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "postcss-media-query-parser": "0.2.3",
     "postcss-scss": "1.0.2",
     "postcss-selector-parser": "2.2.3",
-    "postcss-values-parser": "1.3.1",
+    "postcss-values-parser": "1.3.2",
     "read-pkg-up": "3.0.0",
     "remark-frontmatter": "1.1.0",
     "remark-parse": "5.0.0",

--- a/tests/css_color/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_color/__snapshots__/jsfmt.spec.js.snap
@@ -49,7 +49,7 @@ exports[`hexcolor.css 1`] = `
   -webkit-color: #873;
   -moz-color: #6bcdef;
   -ms-color: #aabbcc;
-  color: #F09F;
+  color: #f09f;
   color: #ff0099ff;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3563,9 +3563,9 @@ postcss-selector-parser@2.2.3:
     indexes-of "^1.0.1"
     uniq "^1.0.1"
 
-postcss-values-parser@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-1.3.1.tgz#2a6ceb39cecbbacd1d060f3b16f4c52dd6720c96"
+postcss-values-parser@1.3.2:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/postcss-values-parser/-/postcss-values-parser-1.3.2.tgz#051aa9619e15fa1b672aaf0f6c1398be961f17fd"
   dependencies:
     flatten "^1.0.2"
     indexes-of "^1.0.1"


### PR DESCRIPTION
Hex `#f09f` now parse correctly