### PR TITLE
feat(css): improve math output

### DIFF
--- a/tests/css_atrule/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_atrule/__snapshots__/jsfmt.spec.js.snap
@@ -3483,19 +3483,19 @@ margin
 
 exports[`return.css 1`] = `
 @function grid-width($n) {
-    @return $n * $grid-width + ($n - 1) * $gutter-width;
+    @return $n * $grid-width + ($n - 1) * $gutter-width / 10;
 }
 @function grid-width($n) {
-@return $n * $grid-width + ($n - 1) * $gutter-width;
+@return $n * $grid-width + ($n - 1) * $gutter-width / 10;
 }
 @function grid-width($n) {
-@return $n*$grid-width+($n-1)*$gutter-width;
+@return $n*$grid-width+($n-1)*$gutter-width/10;
 }
 @function grid-width($n) {
-    @return $n * $grid-width + ( $n - 1 ) * $gutter-width ;
+    @return $n * $grid-width + ( $n - 1 ) * $gutter-width / 10 ;
 }
 @function grid-width($n) {
-    @return  $n   *  $grid-width  +  (  $n  -  1  )  *  $gutter-width  ;
+    @return  $n   *  $grid-width  +  (  $n  -  1  )  *  $gutter-width  /  10  ;
 }
 @function grid-width($n) {
     @return $n
@@ -3507,7 +3507,10 @@ exports[`return.css 1`] = `
             1
         )
         *
-        $gutter-width;
+        $gutter-width
+        /
+        10
+        ;
 }
 @function grid-width($n) {
     @return
@@ -3520,7 +3523,10 @@ exports[`return.css 1`] = `
             1
         )
         *
-        $gutter-width;
+        $gutter-width
+        /
+        10
+        ;
 }
 @function
 grid-width(
@@ -3539,6 +3545,8 @@ $n
 )
 *
 $gutter-width
+/
+10
 ;
 }
 @function
@@ -3574,6 +3582,10 @@ $n
 *
 
 $gutter-width
+
+/
+
+10
 
 ;
 
@@ -3601,31 +3613,31 @@ $gutter-width
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 @function grid-width($n) {
-  @return $n * $grid-width + ($n - 1) * $gutter-width;
+  @return $n * $grid-width + ($n - 1) * $gutter-width / 10;
 }
 @function grid-width($n) {
-  @return $n * $grid-width + ($n - 1) * $gutter-width;
+  @return $n * $grid-width + ($n - 1) * $gutter-width / 10;
 }
 @function grid-width($n) {
-  @return $n*$grid-width+ ($n-1)*$gutter-width;
+  @return $n * $grid-width + ($n-1) * $gutter-width/10;
 }
 @function grid-width($n) {
-  @return $n * $grid-width + ($n - 1) * $gutter-width;
+  @return $n * $grid-width + ($n - 1) * $gutter-width / 10;
 }
 @function grid-width($n) {
-  @return $n * $grid-width + ($n - 1) * $gutter-width;
+  @return $n * $grid-width + ($n - 1) * $gutter-width / 10;
 }
 @function grid-width($n) {
-  @return $n * $grid-width + ($n - 1) * $gutter-width;
+  @return $n * $grid-width + ($n - 1) * $gutter-width / 10;
 }
 @function grid-width($n) {
-  @return $n * $grid-width + ($n - 1) * $gutter-width;
+  @return $n * $grid-width + ($n - 1) * $gutter-width / 10;
 }
 @function grid-width($n) {
-  @return $n * $grid-width + ($n - 1) * $gutter-width;
+  @return $n * $grid-width + ($n - 1) * $gutter-width / 10;
 }
 @function grid-width($n) {
-  @return $n * $grid-width + ($n - 1) * $gutter-width;
+  @return $n * $grid-width + ($n - 1) * $gutter-width / 10;
 }
 @function grid-width($n) {
   @return $very-very-very-very-very-very-vey-long-var *

--- a/tests/css_atrule/return.css
+++ b/tests/css_atrule/return.css
@@ -1,17 +1,17 @@
 @function grid-width($n) {
-    @return $n * $grid-width + ($n - 1) * $gutter-width;
+    @return $n * $grid-width + ($n - 1) * $gutter-width / 10;
 }
 @function grid-width($n) {
-@return $n * $grid-width + ($n - 1) * $gutter-width;
+@return $n * $grid-width + ($n - 1) * $gutter-width / 10;
 }
 @function grid-width($n) {
-@return $n*$grid-width+($n-1)*$gutter-width;
+@return $n*$grid-width+($n-1)*$gutter-width/10;
 }
 @function grid-width($n) {
-    @return $n * $grid-width + ( $n - 1 ) * $gutter-width ;
+    @return $n * $grid-width + ( $n - 1 ) * $gutter-width / 10 ;
 }
 @function grid-width($n) {
-    @return  $n   *  $grid-width  +  (  $n  -  1  )  *  $gutter-width  ;
+    @return  $n   *  $grid-width  +  (  $n  -  1  )  *  $gutter-width  /  10  ;
 }
 @function grid-width($n) {
     @return $n
@@ -23,7 +23,10 @@
             1
         )
         *
-        $gutter-width;
+        $gutter-width
+        /
+        10
+        ;
 }
 @function grid-width($n) {
     @return
@@ -36,7 +39,10 @@
             1
         )
         *
-        $gutter-width;
+        $gutter-width
+        /
+        10
+        ;
 }
 @function
 grid-width(
@@ -55,6 +61,8 @@ $n
 )
 *
 $gutter-width
+/
+10
 ;
 }
 @function
@@ -90,6 +98,10 @@ $n
 *
 
 $gutter-width
+
+/
+
+10
 
 ;
 

--- a/tests/css_parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_parens/__snapshots__/jsfmt.spec.js.snap
@@ -127,6 +127,93 @@ a {
           $image-height  /  (  $image-width-responsive  +  $image-margin-responsive  *  2  )
       );
   padding-top: var(  --paddingC  );
+  margin: 1*1 (1)*1 1*(1) (1)*(1);
+  prop: -1*-1 -(-1)*-1 -1*-(-1) -(-1)*-(-1);
+  prop1: #{($m)*(10)};
+  prop2: #{$m * 10};
+  prop3: #{-(-$m)*-(-10)};
+  prop4: +1;
+  prop5: -1;
+  prop6: word + 1; /* word1 */
+  prop7: word - 1; /* word-1 */
+  prop8: +1 +1 +1 +1; /* +1 +1 +1 +1 */
+  prop9: -1 -1 -1 -1; /* -1 -1 -1 -1 */
+  prop10: (-1);
+  prop11: (+1);
+  prop12: 10px/8px;
+  prop13: round(1.5)/2 round(1.5) /2 round(1.5)/ 2 round(1.5) / 2;
+  prop14: 2/round(1.5) 2 /round(1.5) 2/ round(1.5) 2 / round(1.5);
+  prop15: (round(1.5)/2) (round(1.5) /2) (round(1.5)/ 2) (round(1.5) / 2);
+  prop16: (2/round(1.5)) (2 /round(1.5)) (2/ round(1.5)) (2 / round(1.5));
+  prop17: $width/2 $width /2 $width/ 2 $width / 2;
+  prop18: 2/$width 2 /$width 2/ $width 2 / $width;
+  prop19: ($width/2) ($width /2) ($width/ 2) ($width / 2);
+  prop20: (2/$width) (2 /$width) (2/ $width) (2 / $width);
+  prop21: @width/2 @width /2 @width/ 2 @width / 2;
+  prop22: 2/@width 2 /@width 2/ @width 2 / @width;
+  prop23: (@width/2) (@width /2) (@width/ 2) (@width / 2);
+  prop24: (2/@width) (2 /@width) (2/ @width) (2 / @width);
+  prop25-1: #{$width}/#{$width} #{$width} /#{$width} #{$width}/ #{$width} #{$width} / #{$width};
+  prop25-2: #{$width}*#{$width} #{$width} *#{$width} #{$width}* #{$width} #{$width} * #{$width};
+  prop25-3: #{$width}+#{$width} #{$width} +#{$width} #{$width}+ #{$width} #{$width} + #{$width};
+  prop25-4: #{$width}-#{$width} #{$width} -#{$width} #{$width}- #{$width} #{$width} - #{$width};
+  prop26: 8px/2px 8px /1 1/ 2px 1 / 2;
+  prop27: 8px/2px 8px/1 1/2px 1/2;
+  prop28: 8px / 2px 8px / 1 1 / 2px 1 / 2;
+  prop29: (8px/2px) (8px/1) (1/2px) (1/2);
+  prop30: (8px / 2px) (8px / 1) (1 / 2px) (1 / 2);
+  prop31: (#{$width}/2px) (8px/#{$width}) (#{$width} / 2px) (8px / #{$width});
+  prop32: func(8px/2);
+  prop33: 5px + 8px/2px;
+  prop34: func(+20px, + 20px);
+  prop35: 1+1+1+1;
+  prop36: 1 + 1 + 1 + 1;
+  prop37: 1 +1 1 +1;
+  prop38: ++1;
+  prop39: ++(1);
+  prop40: --1;
+  prop41: --(1);
+  prop42: 1px+1px+1px+1px;
+  prop43: 1px + 1px + 1px + 1px;
+  prop44: -1+-1 -(-1)+-1 -1+-(-1) -(-1)+-(-1);
+  prop45: round(1.5)*2 round(1.5) *2 round(1.5)* 2 round(1.5) * 2;
+  prop46: 2*round(1.5) 2 *round(1.5) 2* round(1.5) 2 * round(1.5);
+  prop47: (round(1.5)*2) (round(1.5) *2) (round(1.5)* 2) (round(1.5) * 2);
+  prop48: (2*round(1.5)) (2 *round(1.5)) (2* round(1.5)) (2 * round(1.5));
+  prop49: $width*2 $width *2 $width* 2 $width * 2;
+  prop50: 2*$width 2 *$width 2* $width 2 * $width;
+  prop51: ($width*2) ($width *2) ($width* 2) ($width * 2);
+  prop52: (2*$width) (2 *$width) (2* $width) (2 * $width);
+  prop53: @width*2 @width *2 @width* 2 @width * 2;
+  prop54: 2*@width 2 *@width 2* @width 2 * @width;
+  prop55: (@width*2) (@width *2) (@width* 2) (@width * 2);
+  prop56: (2*@width) (2 *@width) (2* @width) (2 * @width);
+  prop57: round(1.5)+2 round(1.5) +2 round(1.5)+ 2 round(1.5) + 2;
+  prop58: 2+round(1.5) 2 +round(1.5) 2+ round(1.5) 2 + round(1.5);
+  prop59: (round(1.5)+2) (round(1.5) +2) (round(1.5)+ 2) (round(1.5) + 2);
+  prop60: (2+round(1.5)) (2 +round(1.5)) (2+ round(1.5)) (2 + round(1.5));
+  prop61: $width+2 $width +2 $width+ 2 $width + 2;
+  prop62: 2+$width 2 +$width 2+ $width 2 + $width;
+  prop63: ($width+2) ($width +2) ($width+ 2) ($width + 2);
+  prop64: (2+$width) (2 +$width) (2+ $width) (2 + $width);
+  prop65: @width+2 @width +2 @width+ 2 @width + 2;
+  prop66: 2+@width 2 +@width 2+ @width 2 + @width;
+  prop67: (@width+2) (@width +2) (@width+ 2) (@width + 2);
+  prop68: (2+@width) (2 +@width) (2+ @width) (2 + @width);
+  prop69: "test"+1 "test" +1 "test"+ 1 "test" + 1;
+  prop70: 1+"test" 1 +"test" 1+ "test" 1 + "test";
+  prop71: "test"-1 "test" -1 "test"- 1 "test" - 1;
+  prop72: 1-"test" 1 -"test" 1- "test" 1 - "test";
+  prop73: calc(100%*2px) calc(100% *2px) calc(100%* 2px) calc(100% * 2px);
+  prop74: calc(100%/2px) calc(100% /2px) calc(100%/ 2px) calc(100% / 2px);
+  prop75: calc(100%+2px) calc(100% +2px) calc(100%+ 2px) calc(100% + 2px);
+  prop76: calc(100%-2px) calc(100% -2px) calc(100%- 2px) calc(100% - 2px);
+  prop77: calc(-5px);
+  prop78: calc(+5px);
+  prop79: calc(-100px + 100px);
+  prop80: calc(+100px + 100px);
+  prop81: calc(100px  -  100px);
+  prop82: calc(100px  +  100px);
 }
 
 .bar {
@@ -277,6 +364,97 @@ a {
       ($image-width-responsive + $image-margin-responsive * 2)
   );
   padding-top: var(--paddingC);
+  margin: 1 * 1 (1) * 1 1 * (1) (1) * (1);
+  prop: -1 * -1 - (-1) * -1 -1 * -(-1) - (-1) * -(-1);
+  prop1: #{($m) * (10)};
+  prop2: #{$m * 10};
+  prop3: #{- (-$m) * -(-10)};
+  prop4: +1;
+  prop5: -1;
+  prop6: word + 1; /* word1 */
+  prop7: word - 1; /* word-1 */
+  prop8: +1 +1 +1 +1; /* +1 +1 +1 +1 */
+  prop9: -1 -1 -1 -1; /* -1 -1 -1 -1 */
+  prop10: (-1);
+  prop11: (+1);
+  prop12: 10px/8px;
+  prop13: round(1.5) / 2 round(1.5) / 2 round(1.5) / 2 round(1.5) / 2;
+  prop14: 2 / round(1.5) 2 / round(1.5) 2 / round(1.5) 2 / round(1.5);
+  prop15: (round(1.5) / 2) (round(1.5) / 2) (round(1.5) / 2) (round(1.5) / 2);
+  prop16: (2 / round(1.5)) (2 / round(1.5)) (2 / round(1.5)) (2 / round(1.5));
+  prop17: $width/2 $width / 2 $width/ 2 $width / 2;
+  prop18: 2 / $width 2 / $width 2 / $width 2 / $width;
+  prop19: ($width/2) ($width / 2) ($width/ 2) ($width / 2);
+  prop20: (2 / $width) (2 / $width) (2 / $width) (2 / $width);
+  prop21: @width / 2 @width / 2 @width / 2 @width / 2;
+  prop22: 2 / @width 2 / @width 2 / @width 2 / @width;
+  prop23: (@width / 2) (@width / 2) (@width / 2) (@width / 2);
+  prop24: (2 / @width) (2 / @width) (2 / @width) (2 / @width);
+  prop25-1: #{$width}/#{$width} #{$width} /#{$width} #{$width}/ #{$width} #{$width} /
+    #{$width};
+  prop25-2: #{$width}*#{$width} #{$width} *#{$width} #{$width}* #{$width} #{$width} *
+    #{$width};
+  prop25-3: #{$width}+#{$width} #{$width} +#{$width} #{$width}+ #{$width} #{$width} +
+    #{$width};
+  prop25-4: #{$width}-#{$width} #{$width} -#{$width} #{$width}- #{$width} #{$width} -
+    #{$width};
+  prop26: 8px/2px 8px /1 1/ 2px 1 / 2;
+  prop27: 8px/2px 8px/1 1/2px 1/2;
+  prop28: 8px / 2px 8px / 1 1 / 2px 1 / 2;
+  prop29: (8px/2px) (8px/1) (1/2px) (1/2);
+  prop30: (8px / 2px) (8px / 1) (1 / 2px) (1 / 2);
+  prop31: (#{$width}/ 2px) (8px /#{$width}) (#{$width} / 2px) (8px / #{$width});
+  prop32: func(8px/2);
+  prop33: 5px + 8px/2px;
+  prop34: func(+20px, +20px);
+  prop35: 1+1+1+1;
+  prop36: 1 + 1 + 1 + 1;
+  prop37: 1 +1 1 +1;
+  prop38: ++1;
+  prop39: ++(1);
+  prop40: --1;
+  prop41: --(1);
+  prop42: 1px+1px+1px+1px;
+  prop43: 1px + 1px + 1px + 1px;
+  prop44: -1+-1 - (-1)+-1 -1+-(-1) - (-1)+-(-1);
+  prop45: round(1.5) * 2 round(1.5) * 2 round(1.5) * 2 round(1.5) * 2;
+  prop46: 2 * round(1.5) 2 * round(1.5) 2 * round(1.5) 2 * round(1.5);
+  prop47: (round(1.5) * 2) (round(1.5) * 2) (round(1.5) * 2) (round(1.5) * 2);
+  prop48: (2 * round(1.5)) (2 * round(1.5)) (2 * round(1.5)) (2 * round(1.5));
+  prop49: $width * 2 $width * 2 $width * 2 $width * 2;
+  prop50: 2 * $width 2 * $width 2 * $width 2 * $width;
+  prop51: ($width * 2) ($width * 2) ($width * 2) ($width * 2);
+  prop52: (2 * $width) (2 * $width) (2 * $width) (2 * $width);
+  prop53: @width*2 @width * 2 @width* 2 @width * 2;
+  prop54: 2 * @width 2 * @width 2 * @width 2 * @width;
+  prop55: (@width*2) (@width * 2) (@width* 2) (@width * 2);
+  prop56: (2 * @width) (2 * @width) (2 * @width) (2 * @width);
+  prop57: round(1.5) + 2 round(1.5) + 2 round(1.5) + 2 round(1.5) + 2;
+  prop58: 2 + round(1.5) 2 + round(1.5) 2 + round(1.5) 2 + round(1.5);
+  prop59: (round(1.5) + 2) (round(1.5) + 2) (round(1.5) + 2) (round(1.5) + 2);
+  prop60: (2 + round(1.5)) (2 + round(1.5)) (2 + round(1.5)) (2 + round(1.5));
+  prop61: $width + 2 $width + 2 $width + 2 $width + 2;
+  prop62: 2 + $width 2 + $width 2 + $width 2 + $width;
+  prop63: ($width + 2) ($width + 2) ($width + 2) ($width + 2);
+  prop64: (2 + $width) (2 + $width) (2 + $width) (2 + $width);
+  prop65: @width+2 @width + 2 @width+ 2 @width + 2;
+  prop66: 2 + @width 2 + @width 2 + @width 2 + @width;
+  prop67: (@width+2) (@width + 2) (@width+ 2) (@width + 2);
+  prop68: (2 + @width) (2 + @width) (2 + @width) (2 + @width);
+  prop69: "test"+1 "test" +1 "test"+ 1 "test" + 1;
+  prop70: 1+"test" 1 +"test" 1+ "test" 1 + "test";
+  prop71: "test"-1 "test" -1 "test"- 1 "test" - 1;
+  prop72: 1-"test" 1 -"test" 1- "test" 1 - "test";
+  prop73: calc(100% * 2px) calc(100% * 2px) calc(100% * 2px) calc(100% * 2px);
+  prop74: calc(100% / 2px) calc(100% / 2px) calc(100% / 2px) calc(100% / 2px);
+  prop75: calc(100%+2px) calc(100% +2px) calc(100%+ 2px) calc(100% + 2px);
+  prop76: calc(100%-2px) calc(100% -2px) calc(100%- 2px) calc(100% - 2px);
+  prop77: calc(-5px);
+  prop78: calc(+5px);
+  prop79: calc(-100px + 100px);
+  prop80: calc(+100px + 100px);
+  prop81: calc(100px - 100px);
+  prop82: calc(100px + 100px);
 }
 
 .bar {

--- a/tests/css_parens/parens.css
+++ b/tests/css_parens/parens.css
@@ -124,6 +124,93 @@ a {
           $image-height  /  (  $image-width-responsive  +  $image-margin-responsive  *  2  )
       );
   padding-top: var(  --paddingC  );
+  margin: 1*1 (1)*1 1*(1) (1)*(1);
+  prop: -1*-1 -(-1)*-1 -1*-(-1) -(-1)*-(-1);
+  prop1: #{($m)*(10)};
+  prop2: #{$m * 10};
+  prop3: #{-(-$m)*-(-10)};
+  prop4: +1;
+  prop5: -1;
+  prop6: word + 1; /* word1 */
+  prop7: word - 1; /* word-1 */
+  prop8: +1 +1 +1 +1; /* +1 +1 +1 +1 */
+  prop9: -1 -1 -1 -1; /* -1 -1 -1 -1 */
+  prop10: (-1);
+  prop11: (+1);
+  prop12: 10px/8px;
+  prop13: round(1.5)/2 round(1.5) /2 round(1.5)/ 2 round(1.5) / 2;
+  prop14: 2/round(1.5) 2 /round(1.5) 2/ round(1.5) 2 / round(1.5);
+  prop15: (round(1.5)/2) (round(1.5) /2) (round(1.5)/ 2) (round(1.5) / 2);
+  prop16: (2/round(1.5)) (2 /round(1.5)) (2/ round(1.5)) (2 / round(1.5));
+  prop17: $width/2 $width /2 $width/ 2 $width / 2;
+  prop18: 2/$width 2 /$width 2/ $width 2 / $width;
+  prop19: ($width/2) ($width /2) ($width/ 2) ($width / 2);
+  prop20: (2/$width) (2 /$width) (2/ $width) (2 / $width);
+  prop21: @width/2 @width /2 @width/ 2 @width / 2;
+  prop22: 2/@width 2 /@width 2/ @width 2 / @width;
+  prop23: (@width/2) (@width /2) (@width/ 2) (@width / 2);
+  prop24: (2/@width) (2 /@width) (2/ @width) (2 / @width);
+  prop25-1: #{$width}/#{$width} #{$width} /#{$width} #{$width}/ #{$width} #{$width} / #{$width};
+  prop25-2: #{$width}*#{$width} #{$width} *#{$width} #{$width}* #{$width} #{$width} * #{$width};
+  prop25-3: #{$width}+#{$width} #{$width} +#{$width} #{$width}+ #{$width} #{$width} + #{$width};
+  prop25-4: #{$width}-#{$width} #{$width} -#{$width} #{$width}- #{$width} #{$width} - #{$width};
+  prop26: 8px/2px 8px /1 1/ 2px 1 / 2;
+  prop27: 8px/2px 8px/1 1/2px 1/2;
+  prop28: 8px / 2px 8px / 1 1 / 2px 1 / 2;
+  prop29: (8px/2px) (8px/1) (1/2px) (1/2);
+  prop30: (8px / 2px) (8px / 1) (1 / 2px) (1 / 2);
+  prop31: (#{$width}/2px) (8px/#{$width}) (#{$width} / 2px) (8px / #{$width});
+  prop32: func(8px/2);
+  prop33: 5px + 8px/2px;
+  prop34: func(+20px, + 20px);
+  prop35: 1+1+1+1;
+  prop36: 1 + 1 + 1 + 1;
+  prop37: 1 +1 1 +1;
+  prop38: ++1;
+  prop39: ++(1);
+  prop40: --1;
+  prop41: --(1);
+  prop42: 1px+1px+1px+1px;
+  prop43: 1px + 1px + 1px + 1px;
+  prop44: -1+-1 -(-1)+-1 -1+-(-1) -(-1)+-(-1);
+  prop45: round(1.5)*2 round(1.5) *2 round(1.5)* 2 round(1.5) * 2;
+  prop46: 2*round(1.5) 2 *round(1.5) 2* round(1.5) 2 * round(1.5);
+  prop47: (round(1.5)*2) (round(1.5) *2) (round(1.5)* 2) (round(1.5) * 2);
+  prop48: (2*round(1.5)) (2 *round(1.5)) (2* round(1.5)) (2 * round(1.5));
+  prop49: $width*2 $width *2 $width* 2 $width * 2;
+  prop50: 2*$width 2 *$width 2* $width 2 * $width;
+  prop51: ($width*2) ($width *2) ($width* 2) ($width * 2);
+  prop52: (2*$width) (2 *$width) (2* $width) (2 * $width);
+  prop53: @width*2 @width *2 @width* 2 @width * 2;
+  prop54: 2*@width 2 *@width 2* @width 2 * @width;
+  prop55: (@width*2) (@width *2) (@width* 2) (@width * 2);
+  prop56: (2*@width) (2 *@width) (2* @width) (2 * @width);
+  prop57: round(1.5)+2 round(1.5) +2 round(1.5)+ 2 round(1.5) + 2;
+  prop58: 2+round(1.5) 2 +round(1.5) 2+ round(1.5) 2 + round(1.5);
+  prop59: (round(1.5)+2) (round(1.5) +2) (round(1.5)+ 2) (round(1.5) + 2);
+  prop60: (2+round(1.5)) (2 +round(1.5)) (2+ round(1.5)) (2 + round(1.5));
+  prop61: $width+2 $width +2 $width+ 2 $width + 2;
+  prop62: 2+$width 2 +$width 2+ $width 2 + $width;
+  prop63: ($width+2) ($width +2) ($width+ 2) ($width + 2);
+  prop64: (2+$width) (2 +$width) (2+ $width) (2 + $width);
+  prop65: @width+2 @width +2 @width+ 2 @width + 2;
+  prop66: 2+@width 2 +@width 2+ @width 2 + @width;
+  prop67: (@width+2) (@width +2) (@width+ 2) (@width + 2);
+  prop68: (2+@width) (2 +@width) (2+ @width) (2 + @width);
+  prop69: "test"+1 "test" +1 "test"+ 1 "test" + 1;
+  prop70: 1+"test" 1 +"test" 1+ "test" 1 + "test";
+  prop71: "test"-1 "test" -1 "test"- 1 "test" - 1;
+  prop72: 1-"test" 1 -"test" 1- "test" 1 - "test";
+  prop73: calc(100%*2px) calc(100% *2px) calc(100%* 2px) calc(100% * 2px);
+  prop74: calc(100%/2px) calc(100% /2px) calc(100%/ 2px) calc(100% / 2px);
+  prop75: calc(100%+2px) calc(100% +2px) calc(100%+ 2px) calc(100% + 2px);
+  prop76: calc(100%-2px) calc(100% -2px) calc(100%- 2px) calc(100% - 2px);
+  prop77: calc(-5px);
+  prop78: calc(+5px);
+  prop79: calc(-100px + 100px);
+  prop80: calc(+100px + 100px);
+  prop81: calc(100px  -  100px);
+  prop82: calc(100px  +  100px);
 }
 
 .bar {

--- a/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
@@ -1406,7 +1406,7 @@ $lg-and-up: "(min-width: 1200px)";
   line-height: #{strip-unit($line-height)}em;
   height: 1#{$var};
   width: calc(100% - #{$sidebar-width});
-  max-width: calc(#{$m*100}vw #{$sign} #{$b});
+  max-width: calc(#{$m * 100}vw #{$sign} #{$b});
   font: #{$font-size}/#{$line-height};
   content: "I have #{8 + 2} books on SASS!";
   border: #{$var} #{$var} #{$var};


### PR DESCRIPTION
Feel free to feedback.

In short:
1. Always space before and after `*`.
2. Always space before and after `*` and `/` in calc function.
3. Don't touch `+` and `-` inside in `calc`, spec require always use space, but we don't prettify invalid syntax.
4. Always space before and after `/` if before or after `func`, `word`.
5. Refactor.
6. A lot of tests.
7. Ignore all in `url`.