### PR TITLE
fix: Format Intersection same as Union

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2248,33 +2248,16 @@ function printPathNoParens(path, options, print, args) {
         path.call(print, "typeParameters")
       ]);
     case "TSIntersectionType":
-    case "IntersectionTypeAnnotation": {
-      const types = path.map(print, "types");
-      const result = [];
-      let wasIndented = false;
-      for (let i = 0; i < types.length; ++i) {
-        if (i === 0) {
-          result.push(types[i]);
-        } else if (isObjectType(n.types[i - 1]) && isObjectType(n.types[i])) {
-          // If both are objects, don't indent
-          result.push(
-            concat([" & ", wasIndented ? indent(types[i]) : types[i]])
-          );
-        } else if (!isObjectType(n.types[i - 1]) && !isObjectType(n.types[i])) {
-          // If no object is involved, go to the next line if it breaks
-          result.push(indent(concat([" &", line, types[i]])));
-        } else {
-          // If you go from object to non-object or vis-versa, then inline it
-          if (i > 1) {
-            wasIndented = true;
-          }
-          result.push(" & ", i > 1 ? indent(types[i]) : types[i]);
-        }
-      }
-      return group(concat(result));
-    }
+    case "IntersectionTypeAnnotation":
     case "TSUnionType":
     case "UnionTypeAnnotation": {
+      // The only difference when formatting union and interesection types is
+      // the operator used
+      const operator =
+        n.type === "TSUnionType" || n.type === "UnionTypeAnnotation"
+          ? "|"
+          : "&";
+
       // single-line variation
       // A | B | C
 
@@ -2317,17 +2300,17 @@ function printPathNoParens(path, options, print, args) {
       }, "types");
 
       if (shouldHug) {
-        return join(" | ", printed);
+        return join(` ${operator} `, printed);
       }
 
       const code = concat([
-        ifBreak(concat([shouldIndent ? line : "", "| "])),
-        join(concat([line, "| "]), printed)
+        ifBreak(concat([shouldIndent ? line : "", `${operator} `])),
+        join(concat([line, `${operator} `]), printed)
       ]);
 
       let hasParens;
 
-      if (n.type === "TSUnionType") {
+      if (n.type === "TSUnionType" || n.type === "TSIntersectionType") {
         const greatGrandParent = path.getParentNode(2);
         const greatGreatGrandParent = path.getParentNode(3);
 

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -680,11 +680,13 @@ const rootEpic = (actions, store) =>
     });
 
 // Two extra levels of indentation because of the comment
-export type AsyncExecuteOptions = child_process$execFileOpts & {
-  // The contents to write to stdin.
-  stdin?: ?string,
-  dontLogInNuclide?: ?boolean
-};
+export type AsyncExecuteOptions =
+  & child_process$execFileOpts
+  & {
+      // The contents to write to stdin.
+      stdin?: ?string,
+      dontLogInNuclide?: ?boolean
+    };
 
 // optional trailing comma gets moved all the way to the beginning
 const regex = new RegExp(

--- a/tests/flow/intersection/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/intersection/__snapshots__/jsfmt.spec.js.snap
@@ -79,12 +79,14 @@ function hasObjectMode_ok(options: DuplexStreamOptions): boolean {
  * @flow
  */
 
-type DuplexStreamOptions = ReadableStreamOptions &
-  WritableStreamOptions & {
-    allowHalfOpen?: boolean,
-    readableObjectMode?: boolean,
-    writableObjectMode?: boolean
-  };
+type DuplexStreamOptions =
+  & ReadableStreamOptions
+  & WritableStreamOptions
+  & {
+      allowHalfOpen?: boolean,
+      readableObjectMode?: boolean,
+      writableObjectMode?: boolean
+    };
 
 function hasObjectMode_bad(options: DuplexStreamOptions): boolean {
   return (

--- a/tests/flow/typeapp_perf/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/typeapp_perf/__snapshots__/jsfmt.spec.js.snap
@@ -27,17 +27,19 @@ declare var b: B<any>;
 
 class A {}
 
-type B<T> = A & {
-  +a: () => B<T>,
-  +b: () => B<T>,
-  +c: () => B<T>,
-  +d: () => B<T>,
-  +e: () => B<T>,
-  +f: () => B<T>,
-  +g: () => B<T>,
-  +h: () => B<T>,
-  +i: () => B<T>
-};
+type B<T> =
+  & A
+  & {
+      +a: () => B<T>,
+      +b: () => B<T>,
+      +c: () => B<T>,
+      +d: () => B<T>,
+      +e: () => B<T>,
+      +f: () => B<T>,
+      +g: () => B<T>,
+      +h: () => B<T>,
+      +i: () => B<T>
+    };
 
 declare var b: B<any>;
 
@@ -72,17 +74,19 @@ declare var b: B<any>;
 
 class A {}
 
-type B<T> = A & {
-  +a: (x: B<T>) => void,
-  +b: (x: B<T>) => void,
-  +c: (x: B<T>) => void,
-  +d: (x: B<T>) => void,
-  +e: (x: B<T>) => void,
-  +f: (x: B<T>) => void,
-  +g: (x: B<T>) => void,
-  +h: (x: B<T>) => void,
-  +i: (x: B<T>) => void
-};
+type B<T> =
+  & A
+  & {
+      +a: (x: B<T>) => void,
+      +b: (x: B<T>) => void,
+      +c: (x: B<T>) => void,
+      +d: (x: B<T>) => void,
+      +e: (x: B<T>) => void,
+      +f: (x: B<T>) => void,
+      +g: (x: B<T>) => void,
+      +h: (x: B<T>) => void,
+      +i: (x: B<T>) => void
+    };
 
 declare var b: B<any>;
 

--- a/tests/flow/union_new/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/union_new/__snapshots__/jsfmt.spec.js.snap
@@ -207,15 +207,19 @@ function printAll(val: MyType) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 type Common = {};
 
-type A = Common & {
-  type: "A",
-  foo: number
-};
+type A =
+  & Common
+  & {
+      type: "A",
+      foo: number
+    };
 
-type B = Common & {
-  type: "B",
-  foo: Array<number>
-};
+type B =
+  & Common
+  & {
+      type: "B",
+      foo: Array<number>
+    };
 
 type MyType = A | B;
 
@@ -260,15 +264,19 @@ function printAll(val: MyType) {
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 type Common = {};
 
-type A = {
-  type: "A",
-  foo: number
-} & Common;
+type A =
+  & {
+      type: "A",
+      foo: number
+    }
+  & Common;
 
-type B = {
-  type: "B",
-  foo: Array<number>
-} & Common;
+type B =
+  & {
+      type: "B",
+      foo: Array<number>
+    }
+  & Common;
 
 type MyType = A | B;
 
@@ -321,13 +329,17 @@ type DataBase = {
   name: string
 };
 
-type UserData = DataBase & {
-  kind: "user"
-};
+type UserData =
+  & DataBase
+  & {
+      kind: "user"
+    };
 
-type SystemData = DataBase & {
-  kind: "system"
-};
+type SystemData =
+  & DataBase
+  & {
+      kind: "system"
+    };
 
 type Data = UserData | SystemData;
 
@@ -400,14 +412,18 @@ declare type Entity<T> = {
 
 declare type StringEntity = Entity<string>;
 
-declare type Foo = StringEntity & {
-  bars: Object,
-  kind: 1
-};
-declare type EmptyFoo = StringEntity & {
-  bars: null,
-  kind: 2
-};
+declare type Foo =
+  & StringEntity
+  & {
+      bars: Object,
+      kind: 1
+    };
+declare type EmptyFoo =
+  & StringEntity
+  & {
+      bars: null,
+      kind: 2
+    };
 
 function test(f: Foo | EmptyFoo) {
   if (f.kind === 1) {
@@ -1680,9 +1696,11 @@ type Success = {
   result: string
 };
 
-type Error = {
-  type: "ERROR"
-} & Empty;
+type Error =
+  & {
+      type: "ERROR"
+    }
+  & Empty;
 
 export type T = Success | Error;
 

--- a/tests/flow_intersection/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_intersection/__snapshots__/jsfmt.spec.js.snap
@@ -9,12 +9,14 @@ type State = {
   | { discriminant: "BAZ"; baz: any } 
 );
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-type State = {
-  sharedProperty: any
-} & (
-  | { discriminant: "FOO", foo: any }
-  | { discriminant: "BAR", bar: any }
-  | { discriminant: "BAZ", baz: any }
-);
+type State =
+  & {
+      sharedProperty: any
+    }
+  & (
+      | { discriminant: "FOO", foo: any }
+      | { discriminant: "BAR", bar: any }
+      | { discriminant: "BAZ", baz: any }
+    );
 
 `;

--- a/tests/intersection/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/intersection/__snapshots__/jsfmt.spec.js.snap
@@ -49,53 +49,69 @@ type DuplexStreamOptions = ReadableStreamOptions &
     readableObjectMode?: boolean
   };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-export type ReallyBigSocketServer = ReallyBigSocketServerInterface &
-  ReallyBigSocketServerStatics;
+export type ReallyBigSocketServer =
+  & ReallyBigSocketServerInterface
+  & ReallyBigSocketServerStatics;
 
-type Props = {
-  propA: X
-} & {
-  propB: X
-} & {
-  propC: X
-} & {
-  propD: X
-};
+type Props =
+  & {
+      propA: X
+    }
+  & {
+      propB: X
+    }
+  & {
+      propC: X
+    }
+  & {
+      propD: X
+    };
 
-type Props = {
-  focusedChildren?: React.Children,
-  onClick: () => void,
-  overlayChildren?: React.Children,
-  style?: Object,
-  thumbnail: ImageSource
-} & FooterProps;
+type Props =
+  & {
+      focusedChildren?: React.Children,
+      onClick: () => void,
+      overlayChildren?: React.Children,
+      style?: Object,
+      thumbnail: ImageSource
+    }
+  & FooterProps;
 
-type DuplexStreamOptions = ReadableStreamOptions & {
-  allowHalfOpen?: boolean,
-  readableObjectMode?: boolean
-};
+type DuplexStreamOptions =
+  & ReadableStreamOptions
+  & {
+      allowHalfOpen?: boolean,
+      readableObjectMode?: boolean
+    };
 
-type DuplexStreamOptions = {
-  allowHalfOpen?: boolean,
-  readableObjectMode?: boolean
-} & {
-  allowHalfOpen?: boolean,
-  readableObjectMode?: boolean
-};
+type DuplexStreamOptions =
+  & {
+      allowHalfOpen?: boolean,
+      readableObjectMode?: boolean
+    }
+  & {
+      allowHalfOpen?: boolean,
+      readableObjectMode?: boolean
+    };
 
-type DuplexStreamOptions = ReadableStreamOptions &
-  WritableStreamOptions & {
-    allowHalfOpen?: boolean,
-    readableObjectMode?: boolean
-  };
+type DuplexStreamOptions =
+  & ReadableStreamOptions
+  & WritableStreamOptions
+  & {
+      allowHalfOpen?: boolean,
+      readableObjectMode?: boolean
+    };
 
-type DuplexStreamOptions = ReadableStreamOptions &
-  WritableStreamOptions & {
-    allowHalfOpen?: boolean,
-    readableObjectMode?: boolean
-  } & {
-    allowHalfOpen?: boolean,
-    readableObjectMode?: boolean
-  };
+type DuplexStreamOptions =
+  & ReadableStreamOptions
+  & WritableStreamOptions
+  & {
+      allowHalfOpen?: boolean,
+      readableObjectMode?: boolean
+    }
+  & {
+      allowHalfOpen?: boolean,
+      readableObjectMode?: boolean
+    };
 
 `;

--- a/tests/typescript_union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_union/__snapshots__/jsfmt.spec.js.snap
@@ -63,9 +63,11 @@ type UploadState<E, EM, D> =
   // Uploading to aws3 and CreatePostMutation succeeded
   | D;
 
-type window = Window & {
-  __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: Function;
-};
+type window =
+  & Window
+  & {
+      __REDUX_DEVTOOLS_EXTENSION_COMPOSE__: Function;
+    };
 
 `;
 
@@ -141,12 +143,14 @@ interface Interface {
   j: Partial<X | Y>;
 }
 
-type State = {
-  sharedProperty: any;
-} & (
-  | { discriminant: "FOO"; foo: any }
-  | { discriminant: "BAR"; bar: any }
-  | { discriminant: "BAZ"; baz: any });
+type State =
+  & {
+      sharedProperty: any;
+    }
+  & (
+      | { discriminant: "FOO"; foo: any }
+      | { discriminant: "BAR"; bar: any }
+      | { discriminant: "BAZ"; baz: any });
 
 `;
 


### PR DESCRIPTION
Share the same logic to format Interection and Union types in TypeScript
and Flow.

Closes #3986