### PR TITLE
feat(markdown): respect tabWidth for list items

### DIFF
--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -233,12 +233,15 @@ function genericPrint(path, options, print) {
 
       return printChildren(path, options, print, {
         processor: (childPath, index) => {
-          const prefix = node.ordered
-            ? (index === 0
-                ? node.start
-                : isGitDiffFriendlyOrderedList ? 1 : node.start + index) +
-              (nthSiblingIndex % 2 === 0 ? ". " : ") ")
-            : nthSiblingIndex % 2 === 0 ? "* " : "- ";
+          const prefix = alignListPrefix(
+            node.ordered
+              ? (index === 0
+                  ? node.start
+                  : isGitDiffFriendlyOrderedList ? 1 : node.start + index) +
+                (nthSiblingIndex % 2 === 0 ? ". " : ") ")
+              : nthSiblingIndex % 2 === 0 ? "* " : "- ",
+            options
+          );
           return concat([
             prefix,
             align(
@@ -351,6 +354,22 @@ function printListItem(path, options, print, listPrefix) {
       }
     })
   ]);
+}
+
+function alignListPrefix(prefix, options) {
+  const prefixTrailingSpaces = prefix.match(/ *$/)[0].length;
+  const additionalSpaces = getAdditionalSpaces();
+  return (
+    prefix +
+    " ".repeat(
+      prefixTrailingSpaces + additionalSpaces >= 4 ? 0 : additionalSpaces // 4+ will cause indented code block
+    )
+  );
+
+  function getAdditionalSpaces() {
+    const restSpaces = prefix.length % options.tabWidth;
+    return restSpaces === 0 ? 0 : options.tabWidth - restSpaces;
+  }
 }
 
 function getNthListSiblingIndex(node, parentNode) {

--- a/tests/markdown/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown/__snapshots__/jsfmt.spec.js.snap
@@ -4207,8 +4207,8 @@ This is a paragraph.
 
 > ## This is a header.
 >
-> 1. This is the first list item.
-> 2. This is the second list item.
+> 1.  This is the first list item.
+> 2.  This is the second list item.
 >
 > Here's some example code:
 >
@@ -4248,14 +4248,14 @@ This is a paragraph.
 * Blue
 \`\`\`
 
-1. Buy flour and salt
-1. Mix together with water
-1. Bake
+1.  Buy flour and salt
+1.  Mix together with water
+1.  Bake
 
 \`\`\`markdown
-1. Buy flour and salt
-1. Mix together with water
-1. Bake
+1.  Buy flour and salt
+1.  Mix together with water
+1.  Bake
 \`\`\`
 
 Paragraph:
@@ -4595,8 +4595,8 @@ This is a paragraph.
 
 > ## This is a header.
 >
-> 1. This is the first list item.
-> 2. This is the second list item.
+> 1.  This is the first list item.
+> 2.  This is the second list item.
 >
 > Here's some example code:
 >
@@ -4636,14 +4636,14 @@ This is a paragraph.
 * Blue
 \`\`\`
 
-1. Buy flour and salt
-1. Mix together with water
-1. Bake
+1.  Buy flour and salt
+1.  Mix together with water
+1.  Bake
 
 \`\`\`markdown
-1. Buy flour and salt
-1. Mix together with water
-1. Bake
+1.  Buy flour and salt
+1.  Mix together with water
+1.  Bake
 \`\`\`
 
 Paragraph:

--- a/tests/markdown_code/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_code/__snapshots__/jsfmt.spec.js.snap
@@ -147,6 +147,16 @@ exports[`indent.md 1`] = `
   Fenced Code Block
   Fenced Code Block
   \`\`\`
+
+<!-- prettier/prettier#3459 -->
+
+1. Change to your home directory:
+
+        cd
+
+2. List the contents:
+
+        ls -l
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     Indented Code Block
     Indented Code Block
@@ -161,6 +171,16 @@ exports[`indent.md 1`] = `
   Fenced Code Block
   Fenced Code Block
   \`\`\`
+
+<!-- prettier/prettier#3459 -->
+
+1.  Change to your home directory:
+
+        cd
+
+2.  List the contents:
+
+        ls -l
 
 `;
 

--- a/tests/markdown_code/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_code/__snapshots__/jsfmt.spec.js.snap
@@ -71,31 +71,31 @@ exports[`additional-space.md 1`] = `
     \`\`\`sh
     yarn --version
     \`\`\`~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1. Fork the repo and create your branch from \`master\`.
+1.  Fork the repo and create your branch from \`master\`.
 
-   Open terminal (e.g. Terminal, iTerm, Git Bash or Git Shell) and type:
+    Open terminal (e.g. Terminal, iTerm, Git Bash or Git Shell) and type:
 
-   \`\`\`sh
-   git clone https://github.com/<your_username>/jest
-   cd jest
-   git checkout -b my_branch
-   \`\`\`
+    \`\`\`sh
+    git clone https://github.com/<your_username>/jest
+    cd jest
+    git checkout -b my_branch
+    \`\`\`
 
-   Note: Replace \`<your_username>\` with your GitHub username
+    Note: Replace \`<your_username>\` with your GitHub username
 
-2. Run \`yarn install\`. On Windows: To install
-   [Yarn](https://yarnpkg.com/en/docs/install#windows-tab) on Windows you may
-   need to download either node.js or Chocolatey<br />
+2.  Run \`yarn install\`. On Windows: To install
+    [Yarn](https://yarnpkg.com/en/docs/install#windows-tab) on Windows you may
+    need to download either node.js or Chocolatey<br />
 
-   \`\`\`sh
-   yarn install
-   \`\`\`
+    \`\`\`sh
+    yarn install
+    \`\`\`
 
-   To check your version of Yarn and ensure it's installed you can type:
+    To check your version of Yarn and ensure it's installed you can type:
 
-   \`\`\`sh
-   yarn --version
-   \`\`\`
+    \`\`\`sh
+    yarn --version
+    \`\`\`
 
 `;
 

--- a/tests/markdown_code/indent.md
+++ b/tests/markdown_code/indent.md
@@ -11,3 +11,13 @@
   Fenced Code Block
   Fenced Code Block
   ```
+
+<!-- prettier/prettier#3459 -->
+
+1. Change to your home directory:
+
+        cd
+
+2. List the contents:
+
+        ls -l

--- a/tests/markdown_list/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_list/__snapshots__/jsfmt.spec.js.snap
@@ -15,10 +15,10 @@ exports[`checkbox.md 2`] = `
 - [ ] this is a long long long long long long long long long long long long long long paragraph.
 - [x] this is a long long long long long long long long long long long long long long paragraph.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* [ ] this is a long long long long long long long long long long long long long
-      long paragraph.
-* [x] this is a long long long long long long long long long long long long long
-      long paragraph.
+*   [ ] this is a long long long long long long long long long long long long
+        long long paragraph.
+*   [x] this is a long long long long long long long long long long long long
+        long long paragraph.
 
 `;
 
@@ -49,9 +49,9 @@ exports[`git-diff-friendly.md 1`] = `
 1. def
 999. ghi
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-5. abc
-1. def
-1. ghi
+5.  abc
+1.  def
+1.  ghi
 
 `;
 
@@ -60,9 +60,9 @@ exports[`git-diff-friendly.md 2`] = `
 1. def
 999. ghi
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-5. abc
-1. def
-1. ghi
+5.  abc
+1.  def
+1.  ghi
 
 `;
 
@@ -190,17 +190,17 @@ exports[`indent.md 1`] = `
     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
     b b b b b b b b b b b b b b
 
-  1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-     a a a a a a a a a a a a a a
+  1.  a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+      a a a a a a a a a a a a a a a
 
-     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-     b b b b b b b b b b b b b b
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+      b b b b b b b b b b b b b b b
 
-  1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-         a a a a a a a a a a a a a a
+  1.  [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+          a a a a a a a a a a a a a a a
 
-     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-     b b b b b b b b b b b b b b
+      b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+      b b b b b b b b b b b b b b b
 
   12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
             a a a a a a a a a a a a a a
@@ -217,47 +217,47 @@ exports[`indent.md 1`] = `
   a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
   a a a a a a a a a a a a a a
 
-1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-       a a a a a a a a a a a a a a a
+1.  [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+        a a a a a a a a a a a a a a a a
 
-   * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-     a a a a a a a a a a a a a a
-
-     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-     b b b b b b b b b b b b b b
-
-   * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-         a a a a a a a a a a a a a a
-
-     b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-     b b b b b b b b b b b b b b
-
-   1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+    * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
       a a a a a a a a a a a a a a a
 
       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
       b b b b b b b b b b b b b b b
 
-   1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+    * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
           a a a a a a a a a a a a a a a
 
       b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
       b b b b b b b b b b b b b b b
 
-   12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-             a a a a a a a a a a a a a a
+    1.  a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+        a a a a a a a a a a a a a a a a
 
-             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-             b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b
 
-   12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-                 a a a a a a a a a a a a a a
+    1.  [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            a a a a a a a a a a a a a a a a
 
-             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-             b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b
 
-   a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-   a a a a a a a a a a a a a a
+    12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+              a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b
+
+    12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                  a a a a a a a a a a a a a a a
+
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b
+
+    a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+    a a a a a a a a a a a a a a a
 
 12345678) [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
               a a a a a a a a a a a a a a a
@@ -277,17 +277,17 @@ exports[`indent.md 1`] = `
             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
             b b b b b b b b b b b b b b b
 
-          1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-             a a a a a a a a a a a a a a a
+          1.  a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+              a a a a a a a a a a a a a a a a
 
-             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-             b b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b b
 
-          1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-                 a a a a a a a a a a a a a a a
+          1.  [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                  a a a a a a a a a a a a a a a a
 
-             b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-             b b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+              b b b b b b b b b b b b b b b b
 
           12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
                     a a a a a a a a a a a a a a a
@@ -393,134 +393,134 @@ exports[`indent.md 2`] = `
 
           a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-      a a a a a a a a a a a a a a a
+*   [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+        a a a a a a a a a a a a a a a a
 
-    * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-      a a a a a a a a a a a a a a a
-
-        b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-        b b b b b b b b b b b b b b b b
-
-    * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-          a a a a a a a a a a a a a a a
+    *   a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+        a a a a a a a a a a a a a a a a
 
         b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
         b b b b b b b b b b b b b b b b
 
-    1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-       a a a a a a a a a a a a a a a
+    *   [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            a a a a a a a a a a a a a a a a
 
         b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
         b b b b b b b b b b b b b b b b
 
-    1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-           a a a a a a a a a a a a a a a
+    1.  a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+        a a a a a a a a a a a a a a a a
 
         b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
         b b b b b b b b b b b b b b b b
 
-    12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-              a a a a a a a a a a a a a a a
+    1.  [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            a a a a a a a a a a a a a a a a
 
-              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-              b b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b
 
-    12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-                  a a a a a a a a a a a a a a a
+    12345678)   a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                a a a a a a a a a a a a a a a a
 
-              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-              b b b b b b b b b b b b b b b
+                b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                b b b b b b b b b b b b b b b b
+
+    12345678.   [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                    a a a a a a a a a a a a a a a a
+
+                b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                b b b b b b b b b b b b b b b b
 
     a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
     a a a a a a a a a a a a a a a
 
-1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-       a a a a a a a a a a a a a a a
+1.  [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+        a a a a a a a a a a a a a a a a
 
-    * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-      a a a a a a a a a a a a a a a
-
-        b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-        b b b b b b b b b b b b b b b b
-
-    * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-          a a a a a a a a a a a a a a a
+    *   a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+        a a a a a a a a a a a a a a a a
 
         b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
         b b b b b b b b b b b b b b b b
 
-    1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-       a a a a a a a a a a a a a a a
+    *   [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            a a a a a a a a a a a a a a a a
 
         b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
         b b b b b b b b b b b b b b b b
 
-    1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-           a a a a a a a a a a a a a a a
+    1.  a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+        a a a a a a a a a a a a a a a a
 
         b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
         b b b b b b b b b b b b b b b b
 
-    12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-              a a a a a a a a a a a a a a a
+    1.  [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            a a a a a a a a a a a a a a a a
 
-              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-              b b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+        b b b b b b b b b b b b b b b b
 
-    12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-                  a a a a a a a a a a a a a a a
+    12345678)   a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                a a a a a a a a a a a a a a a a
 
-              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-              b b b b b b b b b b b b b b b
+                b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                b b b b b b b b b b b b b b b b
+
+    12345678.   [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                    a a a a a a a a a a a a a a a a
+
+                b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                b b b b b b b b b b b b b b b b
 
     a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
     a a a a a a a a a a a a a a a
 
-12345678) [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-              a a a a a a a a a a a a a a a
+12345678)   [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                a a a a a a a a a a a a a a a a
 
-          b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-          b b b b b b b b b b b b b b b
+            b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+            b b b b b b b b b b b b b b b b
 
-          * a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-            a a a a a a a a a a a a a a a
+            *   a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                a a a a a a a a a a a a a a a a a
 
-              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-              b b b b b b b b b b b b b b b b
+                b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                b b b b b b b b b b b b b b b b b
 
-          * [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-                a a a a a a a a a a a a a a a
+            *   [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                    a a a a a a a a a a a a a a a a a
 
-              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-              b b b b b b b b b b b b b b b b
+                b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                b b b b b b b b b b b b b b b b b
 
-          1. a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-             a a a a a a a a a a a a a a a
+            1.  a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                a a a a a a a a a a a a a a a a a
 
-              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-              b b b b b b b b b b b b b b b b
+                b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                b b b b b b b b b b b b b b b b b
 
-          1. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-                 a a a a a a a a a a a a a a a
+            1.  [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                    a a a a a a a a a a a a a a a a a
 
-              b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-              b b b b b b b b b b b b b b b b
+                b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                b b b b b b b b b b b b b b b b b
 
-          12345678) a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-                    a a a a a a a a a a a a a a a
+            12345678)   a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+                        a a a a a a a a a a a a a a a a a
 
-                    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-                    b b b b b b b b b b b b b b b b
+                        b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                        b b b b b b b b b b b b b b b b b b
 
-          12345678. [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-                        a a a a a a a a a a a a a a a
+            12345678.   [ ] a a a a a a a a a a a a a a a a a a a a a a a a a a
+                            a a a a a a a a a a a a a a a a a
 
-                    b b b b b b b b b b b b b b b b b b b b b b b b b b b b b b
-                    b b b b b b b b b b b b b b b b
+                        b b b b b b b b b b b b b b b b b b b b b b b b b b b b
+                        b b b b b b b b b b b b b b b b b b
 
-          a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
-          a a a a a a a a a a a a a a a
+            a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a a
+            a a a a a a a a a a a a a a a a
 
 `;
 
@@ -974,7 +974,7 @@ exports[`interrupt.md 2`] = `
 * Something
 ### Some heading
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* Something
+*   Something
 
 ### Some heading
 
@@ -1011,8 +1011,8 @@ exports[`long-paragraph.md 1`] = `
 exports[`long-paragraph.md 2`] = `
 - This is a long long long long long long long long long long long long long long paragraph.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* This is a long long long long long long long long long long long long long
-  long paragraph.
+*   This is a long long long long long long long long long long long long long
+    long paragraph.
 
 `;
 
@@ -1072,17 +1072,17 @@ exports[`loose.md 2`] = `
 
   - ghi
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* 123
+*   123
 
-    * abc
+    *   abc
 
-* 456
+*   456
 
-    * def
+    *   def
 
-* 789
+*   789
 
-    * ghi
+    *   ghi
 
 `;
 
@@ -1154,7 +1154,7 @@ exports[`multiline.md 2`] = `
   456
   789
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* 123 456 789
+*   123 456 789
 
 `;
 
@@ -1192,9 +1192,9 @@ exports[`nested.md 2`] = `
   - Level 2
     - Level 3
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* Level 1
-    * Level 2
-        * Level 3
+*   Level 1
+    *   Level 2
+        *   Level 3
 
 `;
 
@@ -1266,20 +1266,20 @@ exports[`nested-checkbox.md 2`] = `
 
     paragraph paragraph paragraph paragraph paragraph paragraph paragraph paragraph paragraph
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* parent list item parent list item parent list item parent list item parent
-  list item parent list item
+*   parent list item parent list item parent list item parent list item parent
+    list item parent list item
 
-    * child list item child list item child list item child list item child list
-      item child list item
+    *   child list item child list item child list item child list item child
+        list item child list item
 
     paragraph paragraph paragraph paragraph paragraph paragraph paragraph
     paragraph paragraph
 
-* [x] parent task list item parent task list item parent task list item parent
-      task list item
+*   [x] parent task list item parent task list item parent task list item parent
+        task list item
 
-    * [x] child task list item child task list item child task list item child
-          task list item
+    *   [x] child task list item child task list item child task list item child
+            task list item
 
     paragraph paragraph paragraph paragraph paragraph paragraph paragraph
     paragraph paragraph
@@ -1357,9 +1357,9 @@ exports[`ordered.md 1`] = `
 1. 456
 1. 789
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1. 123
-1. 456
-1. 789
+1.  123
+1.  456
+1.  789
 
 `;
 
@@ -1368,9 +1368,9 @@ exports[`ordered.md 2`] = `
 1. 456
 1. 789
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1. 123
-1. 456
-1. 789
+1.  123
+1.  456
+1.  789
 
 `;
 
@@ -1424,13 +1424,13 @@ exports[`separate.md 2`] = `
 * 123
 * 123
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* 123
-* 123
-* 123
+*   123
+*   123
+*   123
 
-- 123
-- 123
-- 123
+-   123
+-   123
+-   123
 
 `;
 
@@ -1488,9 +1488,9 @@ exports[`simple.md 2`] = `
 - 456
 - 789
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-* 123
-* 456
-* 789
+*   123
+*   456
+*   789
 
 `;
 
@@ -1521,9 +1521,9 @@ exports[`start.md 1`] = `
 6. def
 7. ghi
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-5. abc
-6. def
-7. ghi
+5.  abc
+6.  def
+7.  ghi
 
 `;
 
@@ -1532,9 +1532,9 @@ exports[`start.md 2`] = `
 6. def
 7. ghi
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-5. abc
-6. def
-7. ghi
+5.  abc
+6.  def
+7.  ghi
 
 `;
 

--- a/tests/markdown_spec/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_spec/__snapshots__/jsfmt.spec.js.snap
@@ -794,9 +794,9 @@ exports[`example-77.md 1`] = `
 
     - bar
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1. foo
+1.  foo
 
-   * bar
+    * bar
 
 `;
 
@@ -2420,11 +2420,11 @@ exports[`example-214.md 1`] = `
 
     > A block quote.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1. A paragraph with two lines.
+1.  A paragraph with two lines.
 
-       indented code
+        indented code
 
-   > A block quote.
+    > A block quote.
 
 `;
 
@@ -2477,9 +2477,9 @@ exports[`example-219.md 1`] = `
 >>
 >>     two
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-> > 1. one
+> > 1.  one
 > >
-> >    two
+> >     two
 
 `;
 
@@ -2569,15 +2569,15 @@ exports[`example-223.md 1`] = `
 
     > bam
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1. foo
+1.  foo
 
-   \`\`\`
-   bar
-   \`\`\`
+    \`\`\`
+    bar
+    \`\`\`
 
-   baz
+    baz
 
-   > bam
+    > bam
 
 `;
 
@@ -2616,7 +2616,7 @@ exports[`example-225.md 1`] = `
 exports[`example-226.md 1`] = `
 123456789. ok
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-123456789. ok
+123456789.  ok
 
 `;
 
@@ -2630,14 +2630,14 @@ exports[`example-227.md 1`] = `
 exports[`example-228.md 1`] = `
 0. ok
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-0. ok
+0.  ok
 
 `;
 
 exports[`example-229.md 1`] = `
 003. ok
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-3. ok
+3.  ok
 
 `;
 
@@ -2692,11 +2692,11 @@ exports[`example-234.md 1`] = `
 
        more code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1.     indented code
+1.      indented code
 
-   paragraph
+    paragraph
 
-       more code
+        more code
 
 `;
 
@@ -2707,11 +2707,11 @@ exports[`example-235.md 1`] = `
 
        more code
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1.      indented code
+1.       indented code
 
-   paragraph
+    paragraph
 
-       more code
+        more code
 
 `;
 
@@ -2786,9 +2786,9 @@ exports[`example-243.md 1`] = `
 2.
 3. bar
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1. foo
-2.
-3. bar
+1.  foo
+2.  
+3.  bar
 
 `;
 
@@ -2807,11 +2807,11 @@ exports[`example-245.md 1`] = `
 
      > A block quote.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1. A paragraph with two lines.
+1.  A paragraph with two lines.
 
-       indented code
+        indented code
 
-   > A block quote.
+    > A block quote.
 
 `;
 
@@ -2823,11 +2823,11 @@ exports[`example-246.md 1`] = `
 
       > A block quote.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1. A paragraph with two lines.
+1.  A paragraph with two lines.
 
-       indented code
+        indented code
 
-   > A block quote.
+    > A block quote.
 
 `;
 
@@ -2839,11 +2839,11 @@ exports[`example-247.md 1`] = `
 
        > A block quote.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1. A paragraph with two lines.
+1.  A paragraph with two lines.
 
-       indented code
+        indented code
 
-   > A block quote.
+    > A block quote.
 
 `;
 
@@ -2872,11 +2872,11 @@ with two lines.
 
       > A block quote.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1. A paragraph with two lines.
+1.  A paragraph with two lines.
 
-             indented code
+              indented code
 
-         > A block quote.
+          > A block quote.
 
 `;
 
@@ -2884,7 +2884,7 @@ exports[`example-250.md 1`] = `
   1.  A paragraph
     with two lines.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1. A paragraph with two lines.
+1.  A paragraph with two lines.
 
 `;
 
@@ -2892,7 +2892,7 @@ exports[`example-251.md 1`] = `
 > 1. > Blockquote
 continued here.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-> 1. > Blockquote continued here.
+> 1.  > Blockquote continued here.
 
 `;
 
@@ -2900,7 +2900,7 @@ exports[`example-252.md 1`] = `
 > 1. > Blockquote
 > continued here.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-> 1. > Blockquote continued here.
+> 1.  > Blockquote continued here.
 
 `;
 
@@ -2955,7 +2955,7 @@ exports[`example-257.md 1`] = `
 exports[`example-258.md 1`] = `
 1. - 2. foo
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1. * 2. foo
+1.  * 2.  foo
 
 `;
 
@@ -2988,10 +2988,10 @@ exports[`example-261.md 1`] = `
 2. bar
 3) baz
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1. foo
-2. bar
+1.  foo
+2.  bar
 
-3) baz
+3)  baz
 
 `;
 
@@ -3252,11 +3252,11 @@ exports[`example-281.md 1`] = `
 
    bar
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-1. \`\`\`
-   foo
-   \`\`\`
+1.  \`\`\`
+    foo
+    \`\`\`
 
-   bar
+    bar
 
 `;
 


### PR DESCRIPTION
Context: https://github.com/prettier/prettier/issues/3459#issuecomment-366382620

This PR improves the indenting experience in VSCode (probably other editors as well) and also fixes #3459, I'm not sure if this is the proper fix but at least we can see the result and decide if it should be closed/merged.

- align list prefix with `tabWidth`
- it only affect ordered lists if `tabWidth: 2`, otherwise all lists.

![vscode indent demo](https://user-images.githubusercontent.com/8341033/36341800-a976269c-142e-11e8-948d-0bb42527c5f1.gif)

cc @kachkaev

---

**Prettier pr-3990**
[Playground link](https://deploy-preview-3990--prettier.netlify.com/playground/#N4Igxg9gdgLgprEAuEBGAdAAgMIAsCGUA5nJjBJgJ4QCuATprhALakAmAlnXGOXZUgA6UYZjHixYNsOEAmLABkOAZxhlcpSLAQxlQkVAkSANsswBaYyAA0ICAAcYHaMuSh8dOhADuABQ8Irij4AG4QHGw2IPiqyABm+KZwtgBGdPhgANZwMADK9hkcxMgwdDTJIGwQYPGJyhVF9XQwvulEzPi1SbYAVsoAHgBC6Vk5ufisSlBwXfW2tDD2NDCyJWUVBXRNyCAddJlV3lBR9nRFMADqETC4yAAcAAy2pxD1F+n2O6dwTSEzttwAI40LhwVr4dqdJAJbogerMDhrcq2ZRFIjGOAARRoEHgswqMHwKSubBuyFktlK+A4xjR2BYHR2UGg-xANHqABUiUEYfUAL58oA)
```sh
--parser markdown
```

**Input:**
```markdown
1. Change to your home directory:

        cd

2. List the contents:

        ls -l
```

**Output:**
```markdown
1.  Change to your home directory:

        cd

2.  List the contents:

        ls -l

```