### PR TITLE
Respect EditorConfig when `--config` is passed

### DIFF
--- a/src/config/resolve-config-editorconfig.js
+++ b/src/config/resolve-config-editorconfig.js
@@ -9,7 +9,7 @@ const findProjectRoot = require("find-project-root");
 
 const maybeParse = (filePath, config, parse) => {
   const root = findProjectRoot(path.dirname(path.resolve(filePath)));
-  return filePath && !config && parse(filePath, { root });
+  return filePath && parse(filePath, { root });
 };
 
 const editorconfigAsyncNoCache = (filePath, config) => {

--- a/tests_integration/__tests__/__snapshots__/config-resolution.js.snap
+++ b/tests_integration/__tests__/__snapshots__/config-resolution.js.snap
@@ -34,7 +34,7 @@ console.log(
 );
 function js() {
         console.log(
-                \\"js/file.js should have tab width 8\\"
+                \\"js/file.js should have tab width 8 (1 if CLI)\\"
         );
 }
 \\"use strict\\";
@@ -81,7 +81,7 @@ exports[`accepts configuration from --config (stderr) 1`] = `""`;
 
 exports[`accepts configuration from --config (stdout) 1`] = `
 "function js() {
-  console.log(\\"js/file.js should have tab width 8\\")
+ console.log(\\"js/file.js should have tab width 8 (1 if CLI)\\")
 }
 "
 `;
@@ -122,7 +122,7 @@ console.log(\\"jest/__best-tests__/file.js should have semi\\");
 console.log(\\"jest/Component.js should not have semi\\")
 console.log(\\"jest/Component.test.js should have semi\\");
 function js() {
-        console.log(\\"js/file.js should have tab width 8\\");
+        console.log(\\"js/file.js should have tab width 8 (1 if CLI)\\");
 }
 \\"use strict\\";
 

--- a/tests_integration/__tests__/__snapshots__/with-config-precedence.js.snap
+++ b/tests_integration/__tests__/__snapshots__/with-config-precedence.js.snap
@@ -49,7 +49,7 @@ exports[`CLI overrides gets ignored when config exists with --config-precedence 
 
 exports[`CLI overrides gets ignored when config exists with --config-precedence prefer-file (stdout) 1`] = `
 "function js() {
-        console.log(\\"js/file.js should have tab width 8\\");
+        console.log(\\"js/file.js should have tab width 8 (1 if CLI)\\");
 }
 \\"use strict\\";
 
@@ -65,7 +65,7 @@ exports[`CLI overrides take lower precedence with --config-precedence file-overr
 
 exports[`CLI overrides take lower precedence with --config-precedence file-override (stdout) 1`] = `
 "function js() {
-        console.log(\\"js/file.js should have tab width 8\\");
+        console.log(\\"js/file.js should have tab width 8 (1 if CLI)\\");
 }
 \\"use strict\\";
 
@@ -111,7 +111,7 @@ console.log(
 );
 function js() {
         console.log(
-                \\"js/file.js should have tab width 8\\"
+                \\"js/file.js should have tab width 8 (1 if CLI)\\"
         );
 }
 \\"use strict\\";
@@ -188,7 +188,7 @@ console.log(
 );
 function js() {
         console.log(
-                \\"js/file.js should have tab width 8\\"
+                \\"js/file.js should have tab width 8 (1 if CLI)\\"
         );
 }
 \\"use strict\\";

--- a/tests_integration/cli/config/js/file.js
+++ b/tests_integration/cli/config/js/file.js
@@ -1,3 +1,3 @@
 function js() {
-  console.log("js/file.js should have tab width 8");
+  console.log("js/file.js should have tab width 8 (1 if CLI)");
 }


### PR DESCRIPTION
Fixes https://github.com/prettier/prettier/issues/3963#issuecomment-366420997

The test changes look a little strange, but see here for context:
https://github.com/prettier/prettier/pull/3255#issuecomment-348420546