### PR TITLE
Don't format range if required pragma is missing outside range

### DIFF
--- a/src/main/core.js
+++ b/src/main/core.js
@@ -227,14 +227,14 @@ function formatRange(text, opts) {
 }
 
 function format(text, opts) {
-  if (opts.rangeStart > 0 || opts.rangeEnd < text.length) {
-    return formatRange(text, opts);
-  }
-
   const selectedParser = parser.resolveParser(opts);
   const hasPragma = !selectedParser.hasPragma || selectedParser.hasPragma(text);
   if (opts.requirePragma && !hasPragma) {
     return { formatted: text };
+  }
+
+  if (opts.rangeStart > 0 || opts.rangeEnd < text.length) {
+    return formatRange(text, opts);
   }
 
   const hasUnicodeBOM = text.charCodeAt(0) === UTF8BOM;

--- a/tests/require-pragma/js/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/require-pragma/js/__snapshots__/jsfmt.spec.js.snap
@@ -74,6 +74,6 @@ var test = true;
 exports[`range-without-pragma.js 1`] = `
 var test = true
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-var test = true;
+var test = true
 
 `;

--- a/tests/require-pragma/js/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/require-pragma/js/__snapshots__/jsfmt.spec.js.snap
@@ -57,3 +57,23 @@ function      foo(bar)
 }
 
 `;
+
+exports[`range-with-pragma.js 1`] = `
+/**
+ * @prettier
+ */
+var test = true
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/**
+ * @prettier
+ */
+var test = true;
+
+`;
+
+exports[`range-without-pragma.js 1`] = `
+var test = true
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+var test = true;
+
+`;

--- a/tests/require-pragma/js/range-with-pragma.js
+++ b/tests/require-pragma/js/range-with-pragma.js
@@ -1,0 +1,4 @@
+/**
+ * @prettier
+ */
+<<<PRETTIER_RANGE_START>>>var test = true<<<PRETTIER_RANGE_END>>>

--- a/tests/require-pragma/js/range-without-pragma.js
+++ b/tests/require-pragma/js/range-without-pragma.js
@@ -1,0 +1,1 @@
+<<<PRETTIER_RANGE_START>>>var test = true<<<PRETTIER_RANGE_END>>>


### PR DESCRIPTION
Fixes https://github.com/prettier/prettier/issues/3985

`formatRange()` is only called from `formatWithCursor()`,
which already checks for the pragma.

EDIT: @JamesHenry, could you try this out and verify that it's working for you?