### PR TITLE
fix(typescript): properly chain when there is a TSNonNullExpression

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3889,7 +3889,7 @@ function printMemberChain(path, options, print) {
         node: node,
         printed: comments.printComments(
           path,
-          () => printNonNullExpression(path, options),
+          () => printNonNullExpression(),
           options
         )
       });

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2627,7 +2627,7 @@ function printPathNoParens(path, options, print, args) {
         path.call(print, "typeAnnotation")
       ]);
     case "TSNonNullExpression":
-      return concat([path.call(print, "expression"), "!"]);
+      return concat([path.call(print, "expression"), printNonNullExpression()]);
     case "TSThisType":
       return "this";
     case "TSLastTypeNode":
@@ -3800,6 +3800,9 @@ function printBindExpressionCallee(path, options, print) {
   return concat(["::", path.call(print, "callee")]);
 }
 
+function printNonNullExpression() {
+  return "!";
+}
 // We detect calls on member expressions specially to format a
 // common pattern better. The pattern we are looking for is this:
 //
@@ -3881,6 +3884,16 @@ function printMemberChain(path, options, print) {
         )
       });
       path.call(object => rec(object), "object");
+    } else if (node.type === "TSNonNullExpression") {
+      printedNodes.unshift({
+        node: node,
+        printed: comments.printComments(
+          path,
+          () => printNonNullExpression(path, options),
+          options
+        )
+      });
+      path.call(expression => rec(expression), "expression");
     } else {
       printedNodes.unshift({
         node: node,

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3884,11 +3884,7 @@ function printMemberChain(path, options, print) {
     } else if (node.type === "TSNonNullExpression") {
       printedNodes.unshift({
         node: node,
-        printed: comments.printComments(
-          path,
-          () => "!",
-          options
-        )
+        printed: comments.printComments(path, () => "!", options)
       });
       path.call(expression => rec(expression), "expression");
     } else {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2627,7 +2627,7 @@ function printPathNoParens(path, options, print, args) {
         path.call(print, "typeAnnotation")
       ]);
     case "TSNonNullExpression":
-      return concat([path.call(print, "expression"), printNonNullExpression()]);
+      return concat([path.call(print, "expression"), "!"]);
     case "TSThisType":
       return "this";
     case "TSLastTypeNode":
@@ -3800,9 +3800,6 @@ function printBindExpressionCallee(path, options, print) {
   return concat(["::", path.call(print, "callee")]);
 }
 
-function printNonNullExpression() {
-  return "!";
-}
 // We detect calls on member expressions specially to format a
 // common pattern better. The pattern we are looking for is this:
 //
@@ -3889,7 +3886,7 @@ function printMemberChain(path, options, print) {
         node: node,
         printed: comments.printComments(
           path,
-          () => printNonNullExpression(),
+          () => "!",
           options
         )
       });

--- a/tests/typescript_non_null/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_non_null/__snapshots__/jsfmt.spec.js.snap
@@ -4,6 +4,8 @@ exports[`member-chain.js 1`] = `
 const { somePropThatHasAReallyLongName, anotherPropThatHasALongName } = this.props.imReallySureAboutThis!;
 
 const { somePropThatHasAReallyLongName, anotherPropThatHasALongName } = this.props.imReallySureAboutThis!.anotherObject;
+
+this.foo.get("bar")!.doThings().more();
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const {
   somePropThatHasAReallyLongName,
@@ -14,6 +16,11 @@ const {
   somePropThatHasAReallyLongName,
   anotherPropThatHasALongName
 } = this.props.imReallySureAboutThis!.anotherObject;
+
+this.foo
+  .get("bar")!
+  .doThings()
+  .more();
 
 `;
 

--- a/tests/typescript_non_null/member-chain.js
+++ b/tests/typescript_non_null/member-chain.js
@@ -1,3 +1,5 @@
 const { somePropThatHasAReallyLongName, anotherPropThatHasALongName } = this.props.imReallySureAboutThis!;
 
 const { somePropThatHasAReallyLongName, anotherPropThatHasALongName } = this.props.imReallySureAboutThis!.anotherObject;
+
+this.foo.get("bar")!.doThings().more();


### PR DESCRIPTION
Fixes #3999

When encountering a `TSNonNullExpression`, don't abort the chain. Just include it with the current group.