### PR TITLE
Add support for markdown with pre-commit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,5 +2,5 @@
     name: prettier
     entry: prettier --write
     language: node
-    # From https://github.com/prettier/prettier/blob/133303f47a30f6b3e46ffdf9d5c2d6609d65c416/src/options.js#L32-L42
-    files: \.(css|less|scss|html|ts|tsx|graphql|gql|json|js|jsx)$
+    # From https://github.com/prettier/prettier/blob/7a7eb170/docs/index.md
+    files: \.(css|less|scss|html|ts|tsx|graphql|gql|json|js|jsx|md)$


### PR DESCRIPTION
Prettier now runs on markdown files! Let's let pre-commit run on those files!

(There may be additional file extensions that we should also add?)

cc @asottile 