### PR TITLE
refactor: at rules parse

### DIFF
--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -127,10 +127,7 @@ function genericPrint(path, options, print) {
       const hasParams =
         node.params &&
         !(node.params.type === "media-query-list" && node.params.value === "");
-      const isDetachedRulesetCall =
-        hasParams &&
-        node.params.type === "media-query-list" &&
-        /^\(\s*\)$/.test(node.params.value);
+      const isDetachedRulesetCall = hasParams && /^\(\s*\)$/.test(node.params);
       const hasParensAround =
         node.value &&
         node.value.group.group.type === "value-paren_group" &&

--- a/tests/css_quotes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_quotes/__snapshots__/jsfmt.spec.js.snap
@@ -176,11 +176,11 @@ one 'two' three {}
 @import "foo.css" screen and (orientation: landscape);
 
 @foo "one";
-@foo "one";
-@foo "one" two "three";
+@foo 'one';
+@foo "one" two 'three';
 @foo ("one");
-@foo ("one");
-@foo ("one" two "three");
+@foo ('one');
+@foo ("one" two 'three');
 
 one "two" three {
 }
@@ -364,12 +364,12 @@ one 'two' three {}
 @import 'foo.css' screen and (orientation: landscape);
 @import 'foo.css' screen and (orientation: landscape);
 
+@foo "one";
 @foo 'one';
-@foo 'one';
-@foo 'one' two 'three';
+@foo "one" two 'three';
+@foo ("one");
 @foo ('one');
-@foo ('one');
-@foo ('one' two 'three');
+@foo ("one" two 'three');
 
 one 'two' three {
 }


### PR DESCRIPTION
Note:
1. Use `postcss-media-query-parser` only for standard css at rules with params, because we can break other code (example postcss plugin which add own at rules or less).
2. Don't parse unknown at rules, it is also can break code (including change quotes, numbers and etc).
3. Refactor code to improve readability