### PR TITLE
feat: ignore non standard IE filter values

### DIFF
--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -279,6 +279,10 @@ function parseNestedCSS(node) {
           }
         }
 
+        if (value.startsWith("progid:")) {
+          return node;
+        }
+
         node.value = parseValue(value);
       } catch (e) {
         throw createError(

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -391,14 +391,6 @@ function genericPrint(path, options, print) {
 
       const printed = path.map(print, "groups");
       const parts = [];
-      const hasProgidPrefix =
-        declAncestorNode &&
-        declAncestorNode.value.group &&
-        declAncestorNode.value.group.group &&
-        declAncestorNode.value.group.group.groups &&
-        declAncestorNode.value.group.group.groups[0] &&
-        declAncestorNode.value.group.group.groups[0].type === "value-word" &&
-        declAncestorNode.value.group.group.groups[0].value === "progid";
       const functionAncestorNode = getAncestorNode(path, "value-func");
       const insideInFunction =
         functionAncestorNode && functionAncestorNode.value;
@@ -426,15 +418,6 @@ function genericPrint(path, options, print) {
 
         // Ignore colon
         if (iNode.value === ":") {
-          continue;
-        }
-
-        // Ignore `filter: progid:DXImageTransform.Microsoft.Gradient(params);`
-        if (
-          hasProgidPrefix &&
-          iNode.type === "value-word" &&
-          iNode.value.endsWith("=")
-        ) {
           continue;
         }
 
@@ -602,7 +585,7 @@ function genericPrint(path, options, print) {
         return group(indent(concat(parts)));
       }
 
-      return group(hasProgidPrefix ? fill(parts) : indent(fill(parts)));
+      return group(indent(fill(parts)));
     }
     case "value-paren_group": {
       const parentNode = path.getParentNode();
@@ -685,15 +668,7 @@ function genericPrint(path, options, print) {
       return node.value;
     }
     case "value-colon": {
-      const parent = path.getParentNode();
-      const index = getNodeIndex(path, node);
-      const hasProgidPrefix =
-        parent.groups[index - 1] && parent.groups[index - 1].value === "progid";
-
-      return concat([
-        node.value,
-        hasProgidPrefix || insideURLFunctionNode(path) ? "" : line
-      ]);
+      return concat([node.value, insideURLFunctionNode(path) ? "" : line]);
     }
     case "value-comma": {
       return concat([node.value, " "]);
@@ -754,16 +729,6 @@ function insideURLFunctionNode(path) {
     funcAncestorNode &&
     funcAncestorNode.value &&
     funcAncestorNode.value === "url"
-  );
-}
-
-function getNodeIndex(path, node) {
-  const parent = path.getParentNode();
-  return (
-    parent &&
-    parent.groups &&
-    parent.groups.length > 0 &&
-    parent.groups.indexOf(node)
   );
 }
 

--- a/tests/css_parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_parens/__snapshots__/jsfmt.spec.js.snap
@@ -287,6 +287,12 @@ a {
     )
     ;
 }
+
+.bar {
+    filter: progid:DXImageTransform.Microsoft.gradient(enabled='false',startColorstr='#fff',endColorstr='#000');
+    filter: progid:DXImageTransform.Microsoft.Shadow(color='#042b47', Direction=45, Strength=6) progid:DXImageTransform.Microsoft.Shadow(color='#042b47', Direction=135, Strength=6);
+    -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#fad59f, endColorstr=#fa9907)";
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 a {
   prop1: func(1px, 1px, 1px, func(1px, 1px, 1px, func(1px, 1px, 1px)));
@@ -483,6 +489,12 @@ a {
   prop23: attr(data-size em, 20);
   prop24: attr(data-size em, 20);
   prop25: attr(data-size em, 20);
+}
+
+.bar {
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled='false',startColorstr='#fff',endColorstr='#000');
+  filter: progid:DXImageTransform.Microsoft.Shadow(color='#042b47', Direction=45, Strength=6) progid:DXImageTransform.Microsoft.Shadow(color='#042b47', Direction=135, Strength=6);
+  -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#fad59f, endColorstr=#fa9907)";
 }
 
 `;

--- a/tests/css_parens/parens.css
+++ b/tests/css_parens/parens.css
@@ -284,3 +284,9 @@ a {
     )
     ;
 }
+
+.bar {
+    filter: progid:DXImageTransform.Microsoft.gradient(enabled='false',startColorstr='#fff',endColorstr='#000');
+    filter: progid:DXImageTransform.Microsoft.Shadow(color='#042b47', Direction=45, Strength=6) progid:DXImageTransform.Microsoft.Shadow(color='#042b47', Direction=135, Strength=6);
+    -ms-filter: "progid:DXImageTransform.Microsoft.gradient(startColorstr=#fad59f, endColorstr=#fa9907)";
+}

--- a/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
@@ -1478,11 +1478,7 @@ $icons: wifi "\\600", wifi-hotspot "\\601", weather "\\602";
   prop10: #010203 + #040506;
   prop11: #010203 * 2;
   prop12: rgba(255, 0, 0, 0.75) + rgba(0, 255, 0, 0.75);
-  prop13: progid:DXImageTransform.Microsoft.gradient(
-    enabled="false",
-    startColorstr="#{ie-hex-str($green)}",
-    endColorstr="#{ie-hex-str($translucent-red)}"
-  );
+  prop13: progid:DXImageTransform.Microsoft.gradient(enabled='false', startColorstr='#{ie-hex-str($green)}', endColorstr='#{ie-hex-str($translucent-red)}');
   prop14: e + -resize;
   prop15: sans- + "serif";
   prop16: 1em + (2em * 3);


### PR DESCRIPTION
Why?
1. It is non standard.
2. It is break standard css specification.
3. Rare usage.
4. Many logic around this = decrease perf
5. I don't found right syntax. 

In 7-8 IE (with newlines) don't work, in IE 9 work :confused: 
```
progid:DXImageTransform.Microsoft.gradient(
  enabled='false', 
  startColorstr='#fff', 
  endColorstr='#000'
);
```
6. Very buggy property :smile: 

Let's output this property as is