### PR TITLE
Bump own prettier dependency version to 1.11.0-rc.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-react": "7.1.0",
     "jest": "21.1.0",
     "mkdirp": "0.5.1",
-    "prettier": "1.10.2",
+    "prettier": "1.11.0-rc.1",
     "prettylint": "1.0.0",
     "rimraf": "2.6.2",
     "rollup": "0.47.6",
@@ -97,7 +97,8 @@
     "test": "jest",
     "test:dist": "node ./scripts/test-dist.js",
     "test-integration": "jest tests_integration",
-    "lint": "cross-env EFF_NO_LINK_RULES=true eslint . --format node_modules/eslint-friendly-formatter",
+    "lint":
+      "cross-env EFF_NO_LINK_RULES=true eslint . --format node_modules/eslint-friendly-formatter",
     "lint-docs": "prettylint {.,docs,website,website/blog}/*.md",
     "build": "node ./scripts/build/build.js",
     "build-docs": "node ./scripts/build/build-docs.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3600,9 +3600,9 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
-prettier@1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.10.2.tgz#1af8356d1842276a99a5b5529c82dd9e9ad3cc93"
+prettier@1.11.0-rc.1:
+  version "1.11.0-rc.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.11.0-rc.1.tgz#53972a53c13aa4018dff075a9d7353c83748c55f"
 
 pretty-format@21.3.0-beta.15:
   version "21.3.0-beta.15"


### PR DESCRIPTION
Context: https://github.com/prettier/prettier/pull/4035#issuecomment-368173012