### PR TITLE
webpack/webpack now uses Prettier

### DIFF
--- a/website/data/users.yml
+++ b/website/data/users.yml
@@ -23,10 +23,10 @@
   greyImage: /images/users/used_by_babel.svg
   infoLink: https://babeljs.io
   pinned: true
-- caption: Webpack CLI
+- caption: Webpack
   image: /images/users/webpack-200x100.png
   greyImage: /images/users/used_by_webpack.svg
-  infoLink: https://webpack.js.org/api/cli/
+  infoLink: https://webpack.js.org/
   pinned: true
 - caption: Danger
   image: /images/users/danger-200x100.png


### PR DESCRIPTION
[`webpack/webpack-cli`](https://github.com/webpack/webpack-cli) has used Prettier for a while, but now [`webpack/webpack`](https://github.com/webpack/webpack) does, too!

https://github.com/webpack/webpack/pull/6081
