### PR TITLE
refactor(cli): defer default value applying

### DIFF
--- a/src/cli/minimist.js
+++ b/src/cli/minimist.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const minimist = require("minimist");
+
+const PLACEHOLDER = null;
+
+/**
+ * unspecified boolean flag without default value is parsed as `undefined` instead of `false`
+ */
+module.exports = function(args, options) {
+  const boolean = options.boolean || [];
+  const defaults = options.default || {};
+
+  const booleanWithoutDefault = boolean.filter(key => !(key in defaults));
+  const newDefaults = Object.assign(
+    {},
+    defaults,
+    booleanWithoutDefault.reduce(
+      (reduced, key) => Object.assign(reduced, { [key]: PLACEHOLDER }),
+      {}
+    )
+  );
+
+  const parsed = minimist(
+    args,
+    Object.assign({}, options, { default: newDefaults })
+  );
+
+  return Object.keys(parsed).reduce((reduced, key) => {
+    if (parsed[key] !== PLACEHOLDER) {
+      reduced[key] = parsed[key];
+    }
+    return reduced;
+  }, {});
+};

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -3,7 +3,6 @@
 const path = require("path");
 const camelCase = require("camelcase");
 const dashify = require("dashify");
-const minimist = require("minimist");
 const fs = require("fs");
 const globby = require("globby");
 const ignore = require("ignore");
@@ -11,6 +10,7 @@ const chalk = require("chalk");
 const readline = require("readline");
 const leven = require("leven");
 
+const minimist = require("./minimist");
 const prettier = require("../../index");
 const cleanAST = require("../common/clean-ast").cleanAST;
 const errors = require("../common/errors");
@@ -228,11 +228,7 @@ function parseArgsToOptions(context, overrideDefaults) {
         Object.assign({
           string: minimistOptions.string,
           boolean: minimistOptions.boolean,
-          default: Object.assign(
-            {},
-            cliifyOptions(context.apiDefaultOptions, apiDetailedOptionMap),
-            cliifyOptions(overrideDefaults, apiDetailedOptionMap)
-          )
+          default: cliifyOptions(overrideDefaults, apiDetailedOptionMap)
         })
       ),
       context.detailedOptions,
@@ -305,7 +301,7 @@ function createIgnorer(context) {
 }
 
 function eachFilename(context, patterns, callback) {
-  const ignoreNodeModules = context.argv["with-node-modules"] === false;
+  const ignoreNodeModules = context.argv["with-node-modules"] !== true;
   if (ignoreNodeModules) {
     patterns = patterns.concat(["!**/node_modules/**", "!./node_modules/**"]);
   }
@@ -743,6 +739,7 @@ function createMinimistOptions(detailedOptions) {
       .map(option => option.name),
     default: detailedOptions
       .filter(option => !option.deprecated)
+      .filter(option => !option.forwardToApi || option.name === "plugin")
       .filter(option => option.default !== undefined)
       .reduce(
         (current, option) =>


### PR DESCRIPTION
Context: https://github.com/prettier/prettier/pull/3991#discussion_r170453673

https://github.com/prettier/prettier/blob/b6c27893cc32f0ad8800b045d4e88d14e04057ba/src/main/options.js#L58-L62

If add this line before L58:

```js
console.info(Object.keys(rawOptions).filter(x => rawOptions[x] != null));
```

and a test case:

```js
describe.only("test", () => {
  runPrettier("cli", ["--use-tabs"]).test({
    status: 0,
    input: ""
  });
});
```

We'll get:

- before

  ```
  [ 'arrowParens', 'bracketSpacing', 'cursorOffset', 'insertPragma', 'jsxBracketSameLine', 'parser', 'plugins', 'printWidth', 'proseWrap', 'rangeEnd', 'rangeStart', 'requirePragma', 'semi', 'singleQuote', 'tabWidth', 'trailingComma', 'useTabs', 'astFormat', 'locEnd', 'locStart', 'printer' ]
  ```

- after

  ```
  [ 'plugins', 'useTabs', 'astFormat', 'locEnd', 'locStart', 'printer' ]
  ```

Unnecessary cli default applying is removed, it's now handled in `options.js`.

Don't know how to test it in production mode so I didn't add test cases, I just test it manually.

---

cc @czosel