### PR TITLE
Fix TypeScript regression by moving non-null assertion to the end of the line instead of the beginning

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4006,6 +4006,7 @@ function printMemberChain(path, options, print) {
   let i = 1;
   for (; i < printedNodes.length; ++i) {
     if (
+      printedNodes[i].node.type === "TSNonNullExpression" ||
       printedNodes[i].node.type === "CallExpression" ||
       (printedNodes[i].node.type === "MemberExpression" &&
         printedNodes[i].node.computed &&

--- a/tests/typescript_non_null/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_non_null/__snapshots__/jsfmt.spec.js.snap
@@ -6,6 +6,8 @@ const { somePropThatHasAReallyLongName, anotherPropThatHasALongName } = this.pro
 const { somePropThatHasAReallyLongName, anotherPropThatHasALongName } = this.props.imReallySureAboutThis!.anotherObject;
 
 this.foo.get("bar")!.doThings().more();
+
+foo!.bar().baz().what();
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const {
   somePropThatHasAReallyLongName,
@@ -21,6 +23,11 @@ this.foo
   .get("bar")!
   .doThings()
   .more();
+
+foo!
+  .bar()
+  .baz()
+  .what();
 
 `;
 

--- a/tests/typescript_non_null/member-chain.js
+++ b/tests/typescript_non_null/member-chain.js
@@ -3,3 +3,5 @@ const { somePropThatHasAReallyLongName, anotherPropThatHasALongName } = this.pro
 const { somePropThatHasAReallyLongName, anotherPropThatHasALongName } = this.props.imReallySureAboutThis!.anotherObject;
 
 this.foo.get("bar")!.doThings().more();
+
+foo!.bar().baz().what();


### PR DESCRIPTION
Fixes #4051

Tests are failing but its the same tests that are failing on master (see #4053), in typescript conditional code; unrelated to chaining.