### PR TITLE
docs: note on defaults which may change

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -52,6 +52,10 @@ Valid options:
 
 ## Quotes
 
+> **The default for this option may change to "true" in a future major release.**
+>
+> To minimize future changes, it's a good idea to explicitly set this option to your prefered style for now.
+
 Use single quotes instead of double quotes.
 
 Notes:
@@ -64,6 +68,10 @@ Notes:
 | `false` | `--single-quote` | `singleQuote: <bool>` |
 
 ## Trailing Commas
+
+> **The default for this option may change to "es5" in a future major release.**
+>
+> To minimize future changes, it's a good idea to explicitly set this option to your prefered style for now.
 
 Print trailing commas wherever possible when multi-line. (A single-line array, for example, never gets trailing commas.)
 


### PR DESCRIPTION
There seems to be consensus in #3503 that these options will change in Prettier 2.0. I think it's a good idea to point that out.

That issue also mentions removing `--parser postcss`, but I'm not sure how to properly note that.