### PR TITLE
Prevent "over-indenting" class properties values

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -436,6 +436,9 @@ function printPathNoParens(path, options, print, args) {
       const shouldIndentIfInlining =
         parent.type === "AssignmentExpression" ||
         parent.type === "VariableDeclarator" ||
+        parent.type === "ClassProperty" ||
+        parent.type === "TSAbstractClassProperty" ||
+        parent.type === "ClassPrivateProperty" ||
         parent.type === "ObjectProperty" ||
         parent.type === "Property";
 

--- a/tests/class_comment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/class_comment/__snapshots__/jsfmt.spec.js.snap
@@ -91,8 +91,8 @@ class X {
   TEMPLATE =
     // tab index is needed so we can focus, which is needed for keyboard events
     '<div class="ag-large-text" tabindex="0">' +
-      '<div class="ag-large-textarea"></div>' +
-      "</div>";
+    '<div class="ag-large-textarea"></div>' +
+    "</div>";
 }
 
 export class SnapshotLogger {

--- a/tests/classes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/classes/__snapshots__/jsfmt.spec.js.snap
@@ -161,6 +161,25 @@ class C {
 
 `;
 
+exports[`property.js 1`] = `
+class A {
+  foobar =
+    // comment to break
+    1 +
+    // comment to break again
+    2;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class A {
+  foobar =
+    // comment to break
+    1 +
+    // comment to break again
+    2;
+}
+
+`;
+
 exports[`ternary.js 1`] = `
 if (1) (class {}) ? 1 : 2;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/classes/property.js
+++ b/tests/classes/property.js
@@ -1,0 +1,7 @@
+class A {
+  foobar =
+    // comment to break
+    1 +
+    // comment to break again
+    2;
+}

--- a/tests/classes_private_fields/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/classes_private_fields/__snapshots__/jsfmt.spec.js.snap
@@ -173,3 +173,41 @@ class Point {
 }
 
 `;
+
+exports[`with_comments.js 1`] = `
+class A {
+  #foobar =
+    // comment to break
+    1 +
+    // comment to break again
+    2;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class A {
+  #foobar =
+    // comment to break
+    1 +
+    // comment to break again
+    2;
+}
+
+`;
+
+exports[`with_comments.js 2`] = `
+class A {
+  #foobar =
+    // comment to break
+    1 +
+    // comment to break again
+    2;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class A {
+  #foobar =
+    // comment to break
+    1 +
+    // comment to break again
+    2
+}
+
+`;

--- a/tests/classes_private_fields/with_comments.js
+++ b/tests/classes_private_fields/with_comments.js
@@ -1,0 +1,7 @@
+class A {
+  #foobar =
+    // comment to break
+    1 +
+    // comment to break again
+    2;
+}

--- a/tests/typescript/custom/abstract/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/custom/abstract/__snapshots__/jsfmt.spec.js.snap
@@ -61,3 +61,22 @@ abstract class Foo {
 }
 
 `;
+
+exports[`abstractPropertiesWithBreaks.ts 1`] = `
+abstract class Foo {
+    abstract private foobar =
+      // comment to break
+      1 +
+      // another comment to break
+      2;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+abstract class Foo {
+  private abstract foobar =
+    // comment to break
+    1 +
+    // another comment to break
+    2;
+}
+
+`;

--- a/tests/typescript/custom/abstract/abstractPropertiesWithBreaks.ts
+++ b/tests/typescript/custom/abstract/abstractPropertiesWithBreaks.ts
@@ -1,0 +1,7 @@
+abstract class Foo {
+    abstract private foobar =
+      // comment to break
+      1 +
+      // another comment to break
+      2;
+}


### PR DESCRIPTION
When printing a `BinaryExpression` we have a few checks to determine if we should indent when breaking it. One of the checks is if the parent already adds indentation or not (which is the case for assignment expressions) and class properties were not included in this check.

Closes #4079