### PR TITLE
Fix self-closing style tags in vue

### DIFF
--- a/src/language-vue/embed.js
+++ b/src/language-vue/embed.js
@@ -7,7 +7,7 @@ const hardline = docBuilders.hardline;
 function embed(path, print, textToDoc, options) {
   const node = path.getValue();
   const parent = path.getParentNode();
-  if (!parent || parent.tag !== "root") {
+  if (!parent || parent.tag !== "root" || node.unary) {
     return null;
   }
 

--- a/tests/vue_examples/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/vue_examples/__snapshots__/jsfmt.spec.js.snap
@@ -340,6 +340,36 @@ foo();
 
 `;
 
+exports[`self_closing_style.vue 1`] = `
+<template>
+  <span :class="$style.root"><slot /></span>
+</template>
+
+<style src="./style.css" module />
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<template>
+  <span :class="$style.root"><slot /></span>
+</template>
+
+<style src="./style.css" module />
+
+`;
+
+exports[`self_closing_style.vue 2`] = `
+<template>
+  <span :class="$style.root"><slot /></span>
+</template>
+
+<style src="./style.css" module />
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<template>
+  <span :class="$style.root"><slot /></span>
+</template>
+
+<style src="./style.css" module />
+
+`;
+
 exports[`test.vue 1`] = `
 <script>
 </script>

--- a/tests/vue_examples/self_closing_style.vue
+++ b/tests/vue_examples/self_closing_style.vue
@@ -1,0 +1,5 @@
+<template>
+  <span :class="$style.root"><slot /></span>
+</template>
+
+<style src="./style.css" module />


### PR DESCRIPTION
With Vue we special case printing of `style` and `script` tags to format their content, but we shouldn't do that if they're an unary (self-closing) tag.

Closes #4106