### PR TITLE
Break nested ternaries

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -186,7 +186,8 @@ function formatTernaryOperator(path, options, print, operatorOptions) {
       operatorName: "ConditionalExpression",
       consequentNode: "consequent",
       alternateNode: "alternate",
-      testNode: "test"
+      testNode: "test",
+      breakNested: true
     },
     operatorOptions || {}
   );
@@ -274,11 +275,11 @@ function formatTernaryOperator(path, options, print, operatorOptions) {
     );
   }
 
-  // In JSX mode, we want a whole chain of ConditionalExpressions to all
+  // We want a whole chain of ConditionalExpressions to all
   // break if any of them break. That means we should only group around the
   // outer-most ConditionalExpression.
   const maybeGroup = doc =>
-    jsxMode
+    operatorOpts.breakNested
       ? parent === firstNonConditionalParent ? group(doc) : doc
       : group(doc); // Always group in normal mode.
 
@@ -2919,7 +2920,8 @@ function printPathNoParens(path, options, print, args) {
         operatorName: "TSConditionalType",
         consequentNode: "trueType",
         alternateNode: "falseType",
-        testNode: "checkType"
+        testNode: "checkType",
+        breakNested: false
       });
 
     case "TSInferType":

--- a/tests/ternaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ternaries/__snapshots__/jsfmt.spec.js.snap
@@ -313,7 +313,9 @@ aaaaaaaaaaaaaaa
   ? bbbbbbbbbbbbbbbbbb
   : ccccccccccccccc
     ? ddddddddddddddd
-    : eeeeeeeeeeeeeee ? fffffffffffffff : gggggggggggggggg;
+    : eeeeeeeeeeeeeee
+      ? fffffffffffffff
+      : gggggggggggggggg;
 
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -633,7 +635,9 @@ aaaaaaaaaaaaaaa
     ? bbbbbbbbbbbbbbbbbb
     : ccccccccccccccc
         ? ddddddddddddddd
-        : eeeeeeeeeeeeeee ? fffffffffffffff : gggggggggggggggg;
+        : eeeeeeeeeeeeeee
+            ? fffffffffffffff
+            : gggggggggggggggg;
 
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -953,7 +957,9 @@ aaaaaaaaaaaaaaa
 	? bbbbbbbbbbbbbbbbbb
 	: ccccccccccccccc
 		? ddddddddddddddd
-		: eeeeeeeeeeeeeee ? fffffffffffffff : gggggggggggggggg;
+		: eeeeeeeeeeeeeee
+			? fffffffffffffff
+			: gggggggggggggggg;
 
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 	? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -1273,7 +1279,9 @@ aaaaaaaaaaaaaaa
 	? bbbbbbbbbbbbbbbbbb
 	: ccccccccccccccc
 		? ddddddddddddddd
-		: eeeeeeeeeeeeeee ? fffffffffffffff : gggggggggggggggg;
+		: eeeeeeeeeeeeeee
+			? fffffffffffffff
+			: gggggggggggggggg;
 
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 	? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -1482,7 +1490,9 @@ a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
 debug
-  ? this.state.isVisible && somethingComplex ? "partially visible" : "hidden"
+  ? this.state.isVisible && somethingComplex
+    ? "partially visible"
+    : "hidden"
   : null;
 
 a =>
@@ -1509,7 +1519,9 @@ a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
 debug
-    ? this.state.isVisible && somethingComplex ? "partially visible" : "hidden"
+    ? this.state.isVisible && somethingComplex
+        ? "partially visible"
+        : "hidden"
     : null;
 
 a =>
@@ -1536,7 +1548,9 @@ a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
 debug
-	? this.state.isVisible && somethingComplex ? "partially visible" : "hidden"
+	? this.state.isVisible && somethingComplex
+		? "partially visible"
+		: "hidden"
 	: null;
 
 a =>
@@ -1563,7 +1577,9 @@ a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
 debug
-	? this.state.isVisible && somethingComplex ? "partially visible" : "hidden"
+	? this.state.isVisible && somethingComplex
+		? "partially visible"
+		: "hidden"
 	: null;
 
 a =>


### PR DESCRIPTION
We'll reuse the same logic from JSX mode to only group at the outermost ternary, forcing all ternaries in a chain to break if any of them break.

Closes #3018