### PR TITLE
Never print a semicolon after `export default interface Foo {}`

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3575,6 +3575,7 @@ function printExportDeclaration(path, options, print) {
       (decl.declaration.type !== "ClassDeclaration" &&
         decl.declaration.type !== "FunctionDeclaration" &&
         decl.declaration.type !== "TSAbstractClassDeclaration" &&
+        decl.declaration.type !== "TSInterfaceDeclaration" &&
         decl.declaration.type !== "DeclareClass" &&
         decl.declaration.type !== "DeclareFunction")
     ) {

--- a/tests/typescript_export/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_export/__snapshots__/jsfmt.spec.js.snap
@@ -9,6 +9,17 @@ a;
 
 `;
 
+exports[`default.js 1`] = `
+export default interface Foo {
+  readonly bar?: string;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export default interface Foo {
+  readonly bar?: string;
+}
+
+`;
+
 exports[`export.ts 1`] = `
 declare module "hello" {
     export default Hello;

--- a/tests/typescript_export/default.js
+++ b/tests/typescript_export/default.js
@@ -1,0 +1,3 @@
+export default interface Foo {
+  readonly bar?: string;
+}


### PR DESCRIPTION
Fixes #4127.

TODO:

- [x] Tests