### PR TITLE
feat(markdown): support fenced codeblock lang followed by attributes

### DIFF
--- a/src/language-markdown/embed.js
+++ b/src/language-markdown/embed.js
@@ -13,7 +13,9 @@ function embed(path, print, textToDoc, options) {
   const node = path.getValue();
 
   if (node.type === "code") {
-    const parser = getParserName(node.lang);
+    // only look for the first string so as to support [markdown-preview-enhanced](https://shd101wyy.github.io/markdown-preview-enhanced/#/code-chunk)
+    const lang = node.lang.split(/\s/)[0];
+    const parser = getParserName(lang);
     if (parser) {
       const styleUnit = options.__inJsTemplate ? "~" : "`";
       const style = styleUnit.repeat(

--- a/src/language-markdown/embed.js
+++ b/src/language-markdown/embed.js
@@ -14,7 +14,7 @@ function embed(path, print, textToDoc, options) {
 
   if (node.type === "code") {
     // only look for the first string so as to support [markdown-preview-enhanced](https://shd101wyy.github.io/markdown-preview-enhanced/#/code-chunk)
-    const lang = node.lang.split(/\s/)[0];
+    const lang = node.lang.split(/\s/, 1)[0];
     const parser = getParserName(lang);
     if (parser) {
       const styleUnit = options.__inJsTemplate ? "~" : "`";

--- a/tests/multiparser_markdown_js/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_markdown_js/__snapshots__/jsfmt.spec.js.snap
@@ -51,7 +51,7 @@ console.log("hello world");
 ## js block with arguments
 
 \`\`\`js {cmd=node .line-numbers}
-console.log(     "hello world"   );
+console.log("hello world");
 \`\`\`
 
 `;

--- a/tests/multiparser_markdown_js/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_markdown_js/__snapshots__/jsfmt.spec.js.snap
@@ -29,6 +29,33 @@ const Foo = () => {
 
 `;
 
+exports[`markdown-preview-enhanced.md 1`] = `
+## plain js block
+
+\`\`\`js   
+console.log(     "hello world"   );
+\`\`\`
+
+## js block with arguments
+
+\`\`\`js {cmd=node .line-numbers}
+console.log(     "hello world"   );
+\`\`\`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+## plain js block
+
+\`\`\`js
+console.log("hello world");
+\`\`\`
+
+## js block with arguments
+
+\`\`\`js {cmd=node .line-numbers}
+console.log(     "hello world"   );
+\`\`\`
+
+`;
+
 exports[`trailing-comma.md 1`] = `
 ### Some heading
 

--- a/tests/multiparser_markdown_js/markdown-preview-enhanced.md
+++ b/tests/multiparser_markdown_js/markdown-preview-enhanced.md
@@ -1,0 +1,11 @@
+## plain js block
+
+```js   
+console.log(     "hello world"   );
+```
+
+## js block with arguments
+
+```js {cmd=node .line-numbers}
+console.log(     "hello world"   );
+```


### PR DESCRIPTION
Fixes #4150

- support ` ```js {something=something} `
- **does not** support ` ```js{something=something} `