### PR TITLE
feat(typescript): support TSMinusToken and TSPlusToken

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "resolve": "1.5.0",
     "semver": "5.4.1",
     "string-width": "2.1.1",
-    "typescript": "2.8.0-dev.20180222",
+    "typescript": "2.8.0-rc",
     "typescript-eslint-parser": "14.0.0",
     "unicode-regex": "1.0.1",
     "unified": "6.1.6"

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -307,9 +307,8 @@ function getTypeScriptMappedTypeModifier(tokenNode, keyword) {
     return "+" + keyword;
   } else if (tokenNode.type === "TSMinusToken") {
     return "-" + keyword;
-  } else {
-    return keyword;
   }
+  return keyword;
 }
 
 function printPathNoParens(path, options, print, args) {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2722,13 +2722,20 @@ function printPathNoParens(path, options, print, args) {
             concat([
               options.bracketSpacing ? line : softline,
               n.readonlyToken
-                ? concat([path.call(print, "readonlyToken"), " "])
+                ? concat([
+                    n.readonlyToken.type === "TSMinusToken"
+                      ? "-readonly"
+                      : "readonly",
+                    " "
+                  ])
                 : "",
               printTypeScriptModifiers(path, options, print),
               "[",
               path.call(print, "typeParameter"),
               "]",
-              n.questionToken ? "?" : "",
+              n.questionToken
+                ? n.questionToken.type === "TSMinusToken" ? "-?" : "?"
+                : "",
               ": ",
               path.call(print, "typeAnnotation")
             ])

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -302,6 +302,16 @@ function formatTernaryOperator(path, options, print, operatorOptions) {
   );
 }
 
+function getTypeScriptMappedTypeModifier(tokenNode, keyword) {
+  if (tokenNode.type === "TSPlusToken") {
+    return "+" + keyword;
+  } else if (tokenNode.type === "TSMinusToken") {
+    return "-" + keyword;
+  } else {
+    return keyword;
+  }
+}
+
 function printPathNoParens(path, options, print, args) {
   const n = path.getValue();
   const semi = options.semi ? ";" : "";
@@ -2723,9 +2733,10 @@ function printPathNoParens(path, options, print, args) {
               options.bracketSpacing ? line : softline,
               n.readonlyToken
                 ? concat([
-                    n.readonlyToken.type === "TSMinusToken"
-                      ? "-readonly"
-                      : "readonly",
+                    getTypeScriptMappedTypeModifier(
+                      n.readonlyToken,
+                      "readonly"
+                    ),
                     " "
                   ])
                 : "",
@@ -2734,7 +2745,7 @@ function printPathNoParens(path, options, print, args) {
               path.call(print, "typeParameter"),
               "]",
               n.questionToken
-                ? n.questionToken.type === "TSMinusToken" ? "-?" : "?"
+                ? getTypeScriptMappedTypeModifier(n.questionToken, "?")
                 : "",
               ": ",
               path.call(print, "typeAnnotation")

--- a/tests/typescript/custom/modifiers/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/custom/modifiers/__snapshots__/jsfmt.spec.js.snap
@@ -1,11 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`minustoken.ts 1`] = `
-type MutableAndRequired<T> = {
-    -readonly [P in keyof T]-?: T[P]
-}
+type MutableRequired<T> = { 
+-readonly [P in keyof T]-?:T[P] 
+};  // Remove readonly and ?
+
+type ReadonlyPartial<T> = {
++readonly [P in keyof T]+?:T[P] 
+};  // Add readonly and ?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-type MutableAndRequired<T> = { -readonly [P in keyof T]-?: T[P] };
+type MutableRequired<T> = { -readonly [P in keyof T]-?: T[P] }; // Remove readonly and ?
+
+type ReadonlyPartial<T> = { +readonly [P in keyof T]+?: T[P] }; // Add readonly and ?
 
 `;
 

--- a/tests/typescript/custom/modifiers/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/custom/modifiers/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`minustoken.ts 1`] = `
+type MutableAndRequired<T> = {
+    -readonly [P in keyof T]-?: T[P]
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+type MutableAndRequired<T> = { -readonly [P in keyof T]-?: T[P] };
+
+`;
+
 exports[`question.ts 1`] = `
 var x: {
     [A in keyof B]?: any;

--- a/tests/typescript/custom/modifiers/minustoken.ts
+++ b/tests/typescript/custom/modifiers/minustoken.ts
@@ -1,3 +1,7 @@
-type MutableAndRequired<T> = {
-    -readonly [P in keyof T]-?: T[P]
-}
+type MutableRequired<T> = { 
+-readonly [P in keyof T]-?:T[P] 
+};  // Remove readonly and ?
+
+type ReadonlyPartial<T> = {
++readonly [P in keyof T]+?:T[P] 
+};  // Add readonly and ?

--- a/tests/typescript/custom/modifiers/minustoken.ts
+++ b/tests/typescript/custom/modifiers/minustoken.ts
@@ -1,0 +1,3 @@
+type MutableAndRequired<T> = {
+    -readonly [P in keyof T]-?: T[P]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4784,9 +4784,9 @@ typescript-eslint-parser@14.0.0:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@2.8.0-dev.20180222:
-  version "2.8.0-dev.20180222"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.0-dev.20180222.tgz#50ee5fd5c76f2c9817e949803f946d74a559fc01"
+typescript@2.8.0-rc:
+  version "2.8.0-rc"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.0-rc.tgz#a0256b7d1d39fb7493ba0403f55e95d31e8bc374"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
Fixes #4158

TypeScript 2.8 has granular control on mapped type modifiers. Meaning you can also remove modifiers like `readonly` and `?` in mapped types.

This PR adds support for `TSMinusToken` and `TSPlusToken`, so following code could be formatted correctly.

```ts
type MutableRequired<T> = { 
  -readonly [P in keyof T]-?:T[P] 
};  // Remove readonly and ?

type ReadonlyPartial<T> = {
  +readonly [P in keyof T]+?:T[P] 
};  // Add readonly and ?
```