### PR TITLE
Add elm plugin

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -40,10 +40,10 @@ If the plugin is unable to be found automatically, you can load them with:
 
 ## Community Plugins
 
-* [`prettier-plugin-java`](https://github.com/thorbenvh8/prettier-java)
-* [`iamsolankiamit/prettier-ruby`](https://github.com/iamsolankiamit/prettier-ruby)
-* [`benjie/prettier-plugin-pg`](https://github.com/benjie/prettier-plugin-pg)
-* [`prettier-plugin-elm`](https://github.com/gicentre/prettier-plugin-elm)
+* [`prettier-plugin-elm`](https://github.com/gicentre/prettier-plugin-elm) by [**@giCentre**](https://github.com/gicentre)
+* [`prettier-plugin-java`](https://github.com/thorbenvh8/prettier-java) by [**@thorbenvh8**](https://github.com/thorbenvh8)
+* [`prettier-plugin-pg`](https://github.com/benjie/prettier-plugin-pg) by [**@benjie**](https://github.com/benjie)
+* [`prettier-plugin-ruby`](https://github.com/iamsolankiamit/prettier-ruby) by [**@iamsolankiamit**](https://github.com/iamsolankiamit)
 
 ## Developing Plugins
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -43,6 +43,7 @@ If the plugin is unable to be found automatically, you can load them with:
 * [`prettier-plugin-java`](https://github.com/thorbenvh8/prettier-java)
 * [`iamsolankiamit/prettier-ruby`](https://github.com/iamsolankiamit/prettier-ruby)
 * [`benjie/prettier-plugin-pg`](https://github.com/benjie/prettier-plugin-pg)
+* [`prettier-plugin-elm`](https://github.com/gicentre/prettier-plugin-elm)
 
 ## Developing Plugins
 


### PR DESCRIPTION
This PR adds a link to a freshly baked [`prettier-plugin-elm`](https://github.com/gicentre/prettier-plugin-elm) and also reorders community plugins so that the list is easier to glance through 🎉 

I'm really happy to bring Elm support to Prettier given that [its philosophy](https://github.com/prettier/prettier/blob/master/docs/option-philosophy.md) is influenced by how formatting is done in Elm 😄 