### PR TITLE
Require parenthesis around "TSAsExpression" inside an "UpdateExpression"

### DIFF
--- a/src/common/fast-path.js
+++ b/src/common/fast-path.js
@@ -320,6 +320,7 @@ FastPath.prototype.needsParens = function(options) {
         case "AwaitExpression":
         case "TSAsExpression":
         case "TSNonNullExpression":
+        case "UpdateExpression":
           return true;
 
         case "MemberExpression":

--- a/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
@@ -24,6 +24,7 @@ const state = JSON.stringify({
 } as State);
 
 (foo.bar as Baz) = [bar];
+(foo.bar as any)++;
 
 (bValue as boolean) ? 0 : -1;
 <boolean>bValue ? 0 : -1;
@@ -59,6 +60,7 @@ const state = JSON.stringify({
 } as State);
 
 (foo.bar as Baz) = [bar];
+(foo.bar as any)++;
 
 (bValue as boolean) ? 0 : -1;
 <boolean>bValue ? 0 : -1;

--- a/tests/typescript_as/as.js
+++ b/tests/typescript_as/as.js
@@ -21,6 +21,7 @@ const state = JSON.stringify({
 } as State);
 
 (foo.bar as Baz) = [bar];
+(foo.bar as any)++;
 
 (bValue as boolean) ? 0 : -1;
 <boolean>bValue ? 0 : -1;


### PR DESCRIPTION
Add "UpdateExpression" to the list of parent node types that cause a "TSAsExpression" (and similar expressions) to require parenthesis.

Fixes #4167

NOTE: The tests_integration/debug-check unit test is failing. This failure existed before I made any changes, so I did not touch it. I only updated tests related to my change.