### PR TITLE
Don't publish nested tarballs

### DIFF
--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -92,6 +92,7 @@ pkgWithoutDependencies.scripts = {
   prepublishOnly:
     "node -e \"assert.equal(require('.').version, require('..').version)\""
 };
+pkgWithoutDependencies.files = ["*.js"];
 pipe(JSON.stringify(pkgWithoutDependencies, null, 2)).to("dist/package.json");
 
 shell.echo("Copy README.md");


### PR DESCRIPTION
Fixes https://github.com/prettier/prettier/issues/4179

I tried the `.gitignore` idea, but it didn't work, presumably because we
publish from `dist/` instead of the repo root. See here for more details
on how/why this solution works:
https://docs.npmjs.com/files/package.json#files