### PR TITLE
 Improve formatting of TS casts with generics and unions

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -487,13 +487,32 @@ function printPathNoParens(path, options, print, args) {
         " = ",
         path.call(print, "right")
       ]);
-    case "TSTypeAssertionExpression":
+    case "TSTypeAssertionExpression": {
+      const shouldBreakAfterCast = !(
+        n.expression.type === "ArrayExpression" ||
+        n.expression.type === "ObjectExpression"
+      );
+
+      if (shouldBreakAfterCast) {
+        return group(
+          concat([
+            "<",
+            path.call(print, "typeAnnotation"),
+            ">",
+            ifBreak("("),
+            indent(concat([softline, path.call(print, "expression")])),
+            softline,
+            ifBreak(")")
+          ])
+        );
+      }
       return concat([
         "<",
         path.call(print, "typeAnnotation"),
         ">",
         path.call(print, "expression")
       ]);
+    }
     case "MemberExpression": {
       const parent = path.getParentNode();
       let firstNonMemberParent;

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -493,29 +493,30 @@ function printPathNoParens(path, options, print, args) {
         n.expression.type === "ObjectExpression"
       );
 
-      const typeAnnotationGroup = group(
+      const castGroup = group(
         concat([
+          "<",
           indent(concat([softline, path.call(print, "typeAnnotation")])),
-          softline
+          softline,
+          ">"
         ])
       );
 
+      const exprContents = concat([
+        ifBreak("("),
+        indent(concat([softline, path.call(print, "expression")])),
+        softline,
+        ifBreak(")")
+      ]);
+
       if (shouldBreakAfterCast) {
-        return group(
-          concat([
-            "<",
-            typeAnnotationGroup,
-            ">",
-            ifBreak("("),
-            indent(concat([softline, path.call(print, "expression")])),
-            softline,
-            ifBreak(")")
-          ])
-        );
+        return conditionalGroup([
+          concat([castGroup, path.call(print, "expression")]),
+          concat([castGroup, group(exprContents, { shouldBreak: true })]),
+          concat([castGroup, path.call(print, "expression")])
+        ]);
       }
-      return group(
-        concat(["<", typeAnnotationGroup, ">", path.call(print, "expression")])
-      );
+      return group(concat([castGroup, path.call(print, "expression")]));
     }
     case "MemberExpression": {
       const parent = path.getParentNode();

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -493,11 +493,18 @@ function printPathNoParens(path, options, print, args) {
         n.expression.type === "ObjectExpression"
       );
 
+      const typeAnnotationGroup = group(
+        concat([
+          indent(concat([softline, path.call(print, "typeAnnotation")])),
+          softline
+        ])
+      );
+
       if (shouldBreakAfterCast) {
         return group(
           concat([
             "<",
-            path.call(print, "typeAnnotation"),
+            typeAnnotationGroup,
             ">",
             ifBreak("("),
             indent(concat([softline, path.call(print, "expression")])),
@@ -506,12 +513,9 @@ function printPathNoParens(path, options, print, args) {
           ])
         );
       }
-      return concat([
-        "<",
-        path.call(print, "typeAnnotation"),
-        ">",
-        path.call(print, "expression")
-      ]);
+      return group(
+        concat(["<", typeAnnotationGroup, ">", path.call(print, "expression")])
+      );
     }
     case "MemberExpression": {
       const parent = path.getParentNode();
@@ -2525,6 +2529,7 @@ function printPathNoParens(path, options, print, args) {
       // | C
 
       const parent = path.getParentNode();
+      const parentParent = path.getParentNode(1);
 
       // If there's a leading comment, the parent is doing the indentation
       const shouldIndent =
@@ -2533,6 +2538,8 @@ function printPathNoParens(path, options, print, args) {
         parent.type !== "GenericTypeAnnotation" &&
         parent.type !== "TSTypeReference" &&
         !(parent.type === "FunctionTypeParam" && !parent.name) &&
+        parentParent.type !== "TSTypeAssertionExpression" &&
+
         !(
           (parent.type === "TypeAlias" ||
             parent.type === "VariableDeclarator") &&

--- a/tests/typescript_cast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_cast/__snapshots__/jsfmt.spec.js.snap
@@ -49,10 +49,9 @@ function y() {
   const fitsObjLiteral = <Immutable.Map<string, any>>{ a: "test" };
   const fitsArrayLiteral = <Immutable.Map<string, any>>["test", "test2"];
 
-  const breakAfterCast = <Immutable.Map<
-    string,
-    any
-  >>someExistingConfigMap.mergeDeep(fallbackOpts);
+  const breakAfterCast = <Immutable.Map<string, any>>(
+    someExistingConfigMap.mergeDeep(fallbackOpts)
+  );
 
   const stillTooLong = <Immutable.Map<
     string,
@@ -64,7 +63,9 @@ function y() {
     any,
     void,
     never
-  >>someExistingConfigMap.mergeDeep(fallbackOptions);
+  >>(
+    someExistingConfigMap.mergeDeep(fallbackOptions)
+  );
 
   const testObjLiteral = <Immutable.Map<string, any>>{
     property1: "myPropertyVal"
@@ -107,16 +108,18 @@ function x() {
   const fitsObjLiteral = <PermissionsChecker<any> | undefined>{ a: "test" };
   const fitsArrayLiteral = <PermissionsChecker<any> | undefined>["t1", "t2"];
 
-  const breakAfterCast = <
-    | PermissionsChecker<any>
-    | undefined>(<any>permissions)[receiverType];
+  const breakAfterCast = <PermissionsChecker<any> | undefined>(
+    (<any>permissions)[receiverType]
+  );
 
   const stillTooLong = <
     | PermissionsChecker<object>
     | undefined
     | number
     | string
-    | boolean>(<any>permissions)[receiverType];
+    | boolean>(
+    (<any>permissions)[receiverType]
+  );
 
   const testObjLiteral = <PermissionsChecker<any> | undefined>{
     prop1: "myPropVal"

--- a/tests/typescript_cast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_cast/__snapshots__/jsfmt.spec.js.snap
@@ -14,6 +14,10 @@ function y() {
 
   const stillTooLong2 = <Immutable.Map<string, boolean, number, object, null, undefined, any, void, never> | undefined>someExistingConfigMap.mergeDeep(fallbackOptions);
 
+  const stillTooLong3 = <Immutable.Map<string>>someExistingConfigMap.mergeDeep(fallbackOptions.someMethodWithLongName(param1, param2));
+
+  const stillTooLong4 = <Immutable.Map<string, boolean, number, object, null, undefined, any, void, never> | undefined>someExistingConfigMap.mergeDeep(fallbackOptions.someMethodWithLongName(param1, param2));
+  
   const testObjLiteral = <Immutable.Map<string, any>>{ property1: "myPropertyVal" };
 
   const testObjLiteral2 = <Immutable.Map<string, any, number, boolean, object, null, undefined, never, "extra long">>{ property1: "myPropertyVal" };
@@ -36,6 +40,10 @@ function x() {
   const stillTooLong = <PermissionsChecker<object> | undefined | number | string | boolean>(<any>permissions)[receiverType];
 
   const stillTooLong2 = <PermissionsChecker<object> | undefined | number | string | boolean | null | never>(<any>permissions)[receiverType];
+
+  const stillTooLong3 = <PermissionsChecker<object> | undefined>(<any>permissions.someMethodWithLongName(parameter1, parameter2))[receiverTypeLongName];
+
+  const stillTooLong4 = <PermissionsChecker<object> | undefined | number | string | boolean | null | never>(<any>permissions.someMethodWithLongName(parameter1, parameter2))[receiverTypeLongName];
 
   const testObjLiteral =  <PermissionsChecker<any> | undefined>{ prop1: "myPropVal" };
 
@@ -89,6 +97,31 @@ function y() {
     | undefined
   >(
     someExistingConfigMap.mergeDeep(fallbackOptions)
+  );
+
+  const stillTooLong3 = <Immutable.Map<string>>(
+    someExistingConfigMap.mergeDeep(
+      fallbackOptions.someMethodWithLongName(param1, param2)
+    )
+  );
+
+  const stillTooLong4 = <
+    | Immutable.Map<
+        string,
+        boolean,
+        number,
+        object,
+        null,
+        undefined,
+        any,
+        void,
+        never
+      >
+    | undefined
+  >(
+    someExistingConfigMap.mergeDeep(
+      fallbackOptions.someMethodWithLongName(param1, param2)
+    )
   );
 
   const testObjLiteral = <Immutable.Map<string, any>>{
@@ -162,6 +195,26 @@ function x() {
     | never
   >(
     (<any>permissions)[receiverType]
+  );
+
+  const stillTooLong3 = <PermissionsChecker<object> | undefined>(
+    (<any>permissions.someMethodWithLongName(parameter1, parameter2))[
+      receiverTypeLongName
+    ]
+  );
+
+  const stillTooLong4 = <
+    | PermissionsChecker<object>
+    | undefined
+    | number
+    | string
+    | boolean
+    | null
+    | never
+  >(
+    (<any>permissions.someMethodWithLongName(parameter1, parameter2))[
+      receiverTypeLongName
+    ]
   );
 
   const testObjLiteral = <PermissionsChecker<any> | undefined>{

--- a/tests/typescript_cast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_cast/__snapshots__/jsfmt.spec.js.snap
@@ -58,17 +58,19 @@ function y() {
     someExistingConfigMap.mergeDeep(fallbackOpts)
   );
 
-  const stillTooLong = <Immutable.Map<
-    string,
-    boolean,
-    number,
-    object,
-    null,
-    undefined,
-    any,
-    void,
-    never
-  >>(
+  const stillTooLong = <
+    Immutable.Map<
+      string,
+      boolean,
+      number,
+      object,
+      null,
+      undefined,
+      any,
+      void,
+      never
+    >
+  >(
     someExistingConfigMap.mergeDeep(fallbackOptions)
   );
 
@@ -84,7 +86,8 @@ function y() {
         void,
         never
       >
-    | undefined>(
+    | undefined
+  >(
     someExistingConfigMap.mergeDeep(fallbackOptions)
   );
 
@@ -92,17 +95,19 @@ function y() {
     property1: "myPropertyVal"
   };
 
-  const testObjLiteral2 = <Immutable.Map<
-    string,
-    any,
-    number,
-    boolean,
-    object,
-    null,
-    undefined,
-    never,
-    "extra long"
-  >>{ property1: "myPropertyVal" };
+  const testObjLiteral2 = <
+    Immutable.Map<
+      string,
+      any,
+      number,
+      boolean,
+      object,
+      null,
+      undefined,
+      never,
+      "extra long"
+    >
+  >{ property1: "myPropertyVal" };
 
   const testArrayLiteral = <Immutable.Map<string, any>>[
     "first",
@@ -110,17 +115,19 @@ function y() {
     "third"
   ];
 
-  const testArrayLiteral2 = <Immutable.Map<
-    string,
-    any,
-    number,
-    boolean,
-    object,
-    null,
-    undefined,
-    never,
-    "extra long"
-  >>["first", "second", "third"];
+  const testArrayLiteral2 = <
+    Immutable.Map<
+      string,
+      any,
+      number,
+      boolean,
+      object,
+      null,
+      undefined,
+      never,
+      "extra long"
+    >
+  >["first", "second", "third"];
 
   const insideFuncCall = myFunc(
     param1,
@@ -140,11 +147,8 @@ function x() {
   );
 
   const stillTooLong = <
-    | PermissionsChecker<object>
-    | undefined
-    | number
-    | string
-    | boolean>(
+    PermissionsChecker<object> | undefined | number | string | boolean
+  >(
     (<any>permissions)[receiverType]
   );
 
@@ -155,7 +159,8 @@ function x() {
     | string
     | boolean
     | null
-    | never>(
+    | never
+  >(
     (<any>permissions)[receiverType]
   );
 
@@ -171,7 +176,8 @@ function x() {
     | boolean
     | null
     | never
-    | object>{ prop1: "myPropVal" };
+    | object
+  >{ prop1: "myPropVal" };
 
   const testArrayLiteral = <PermissionsChecker<any> | undefined>[
     "first",
@@ -187,7 +193,8 @@ function x() {
     | boolean
     | null
     | never
-    | object>["first", "second", "third"];
+    | object
+  >["first", "second", "third"];
 
   const insideFuncCall = myFunc(
     param1,

--- a/tests/typescript_cast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_cast/__snapshots__/jsfmt.spec.js.snap
@@ -12,13 +12,15 @@ function y() {
 
   const stillTooLong = <Immutable.Map<string, boolean, number, object, null, undefined, any, void, never>>someExistingConfigMap.mergeDeep(fallbackOptions);
 
+  const stillTooLong2 = <Immutable.Map<string, boolean, number, object, null, undefined, any, void, never> | undefined>someExistingConfigMap.mergeDeep(fallbackOptions);
+
   const testObjLiteral = <Immutable.Map<string, any>>{ property1: "myPropertyVal" };
 
-  const testObjLiteral2 = <Immutable.Map<string, any, number, boolean, object, null>>{ property1: "myPropertyVal" };
+  const testObjLiteral2 = <Immutable.Map<string, any, number, boolean, object, null, undefined, never, "extra long">>{ property1: "myPropertyVal" };
 
   const testArrayLiteral = <Immutable.Map<string, any>>["first", "second", "third"];
 
-  const testArrayLiteral2 = <Immutable.Map<string, any, number, boolean, object, null>>["first", "second", "third"];
+  const testArrayLiteral2 = <Immutable.Map<string, any, number, boolean, object, null, undefined, never, "extra long">>["first", "second", "third"];
 
   const insideFuncCall = myFunc(param1, <Immutable.Map<string, any>>param2, param3)
 }
@@ -33,16 +35,19 @@ function x() {
 
   const stillTooLong = <PermissionsChecker<object> | undefined | number | string | boolean>(<any>permissions)[receiverType];
 
+  const stillTooLong2 = <PermissionsChecker<object> | undefined | number | string | boolean | null | never>(<any>permissions)[receiverType];
+
   const testObjLiteral =  <PermissionsChecker<any> | undefined>{ prop1: "myPropVal" };
 
-  const testObjLiteral2 = <PermissionsChecker<object> | undefined | number | string | boolean>{ prop1: "myPropVal" };
+  const testObjLiteral2 = <PermissionsChecker<object> | undefined | number | string | boolean | null | never | object>{ prop1: "myPropVal" };
 
   const testArrayLiteral = <PermissionsChecker<any> | undefined>["first", "second", "third"];
 
-  const testArrayLiteral2 = <PermissionsChecker<object> | undefined | number | string | boolean>["first", "second", "third"];
+  const testArrayLiteral2 = <PermissionsChecker<object> | undefined | number | string | boolean | null | never | object>["first", "second", "third"];
 
   const insideFuncCall = myFunc(param1, <PermissionsChecker<any> | undefined>param2, param3)
-}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // https://github.com/prettier/prettier/issues/4171
 function y() {
   const fits = <Immutable.Map<string, any>>fits();
@@ -67,6 +72,22 @@ function y() {
     someExistingConfigMap.mergeDeep(fallbackOptions)
   );
 
+  const stillTooLong2 = <
+    | Immutable.Map<
+        string,
+        boolean,
+        number,
+        object,
+        null,
+        undefined,
+        any,
+        void,
+        never
+      >
+    | undefined>(
+    someExistingConfigMap.mergeDeep(fallbackOptions)
+  );
+
   const testObjLiteral = <Immutable.Map<string, any>>{
     property1: "myPropertyVal"
   };
@@ -77,7 +98,10 @@ function y() {
     number,
     boolean,
     object,
-    null
+    null,
+    undefined,
+    never,
+    "extra long"
   >>{ property1: "myPropertyVal" };
 
   const testArrayLiteral = <Immutable.Map<string, any>>[
@@ -92,7 +116,10 @@ function y() {
     number,
     boolean,
     object,
-    null
+    null,
+    undefined,
+    never,
+    "extra long"
   >>["first", "second", "third"];
 
   const insideFuncCall = myFunc(
@@ -121,6 +148,17 @@ function x() {
     (<any>permissions)[receiverType]
   );
 
+  const stillTooLong2 = <
+    | PermissionsChecker<object>
+    | undefined
+    | number
+    | string
+    | boolean
+    | null
+    | never>(
+    (<any>permissions)[receiverType]
+  );
+
   const testObjLiteral = <PermissionsChecker<any> | undefined>{
     prop1: "myPropVal"
   };
@@ -130,7 +168,10 @@ function x() {
     | undefined
     | number
     | string
-    | boolean>{ prop1: "myPropVal" };
+    | boolean
+    | null
+    | never
+    | object>{ prop1: "myPropVal" };
 
   const testArrayLiteral = <PermissionsChecker<any> | undefined>[
     "first",
@@ -143,7 +184,10 @@ function x() {
     | undefined
     | number
     | string
-    | boolean>["first", "second", "third"];
+    | boolean
+    | null
+    | never
+    | object>["first", "second", "third"];
 
   const insideFuncCall = myFunc(
     param1,

--- a/tests/typescript_cast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_cast/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,156 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`generic-cast.ts 1`] = `
+// https://github.com/prettier/prettier/issues/4171
+function y() {
+
+  const fits = <Immutable.Map<string, any>>fits();
+  const fitsObjLiteral = <Immutable.Map<string, any>>{ a: "test" };
+  const fitsArrayLiteral = <Immutable.Map<string, any>>["test", "test2"]
+
+  const breakAfterCast = <Immutable.Map<string, any>>someExistingConfigMap.mergeDeep(fallbackOpts);
+
+  const stillTooLong = <Immutable.Map<string, boolean, number, object, null, undefined, any, void, never>>someExistingConfigMap.mergeDeep(fallbackOptions);
+
+  const testObjLiteral = <Immutable.Map<string, any>>{ property1: "myPropertyVal" };
+
+  const testObjLiteral2 = <Immutable.Map<string, any, number, boolean, object, null>>{ property1: "myPropertyVal" };
+
+  const testArrayLiteral = <Immutable.Map<string, any>>["first", "second", "third"];
+
+  const testArrayLiteral2 = <Immutable.Map<string, any, number, boolean, object, null>>["first", "second", "third"];
+
+  const insideFuncCall = myFunc(param1, <Immutable.Map<string, any>>param2, param3)
+}
+
+// https://github.com/prettier/prettier/issues/4168
+function x() {
+  const fits = <PermissionsChecker<any> | undefined>(<any>permissions)[type];
+  const fitsObjLiteral = <PermissionsChecker<any> | undefined>{ a: "test" };
+  const fitsArrayLiteral = <PermissionsChecker<any> | undefined>["t1", "t2"];
+
+  const breakAfterCast = <PermissionsChecker<any> | undefined>(<any>permissions)[receiverType];
+
+  const stillTooLong = <PermissionsChecker<object> | undefined | number | string | boolean>(<any>permissions)[receiverType];
+
+  const testObjLiteral =  <PermissionsChecker<any> | undefined>{ prop1: "myPropVal" };
+
+  const testObjLiteral2 = <PermissionsChecker<object> | undefined | number | string | boolean>{ prop1: "myPropVal" };
+
+  const testArrayLiteral = <PermissionsChecker<any> | undefined>["first", "second", "third"];
+
+  const testArrayLiteral2 = <PermissionsChecker<object> | undefined | number | string | boolean>["first", "second", "third"];
+
+  const insideFuncCall = myFunc(param1, <PermissionsChecker<any> | undefined>param2, param3)
+}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// https://github.com/prettier/prettier/issues/4171
+function y() {
+  const fits = <Immutable.Map<string, any>>fits();
+  const fitsObjLiteral = <Immutable.Map<string, any>>{ a: "test" };
+  const fitsArrayLiteral = <Immutable.Map<string, any>>["test", "test2"];
+
+  const breakAfterCast = <Immutable.Map<
+    string,
+    any
+  >>someExistingConfigMap.mergeDeep(fallbackOpts);
+
+  const stillTooLong = <Immutable.Map<
+    string,
+    boolean,
+    number,
+    object,
+    null,
+    undefined,
+    any,
+    void,
+    never
+  >>someExistingConfigMap.mergeDeep(fallbackOptions);
+
+  const testObjLiteral = <Immutable.Map<string, any>>{
+    property1: "myPropertyVal"
+  };
+
+  const testObjLiteral2 = <Immutable.Map<
+    string,
+    any,
+    number,
+    boolean,
+    object,
+    null
+  >>{ property1: "myPropertyVal" };
+
+  const testArrayLiteral = <Immutable.Map<string, any>>[
+    "first",
+    "second",
+    "third"
+  ];
+
+  const testArrayLiteral2 = <Immutable.Map<
+    string,
+    any,
+    number,
+    boolean,
+    object,
+    null
+  >>["first", "second", "third"];
+
+  const insideFuncCall = myFunc(
+    param1,
+    <Immutable.Map<string, any>>param2,
+    param3
+  );
+}
+
+// https://github.com/prettier/prettier/issues/4168
+function x() {
+  const fits = <PermissionsChecker<any> | undefined>(<any>permissions)[type];
+  const fitsObjLiteral = <PermissionsChecker<any> | undefined>{ a: "test" };
+  const fitsArrayLiteral = <PermissionsChecker<any> | undefined>["t1", "t2"];
+
+  const breakAfterCast = <
+    | PermissionsChecker<any>
+    | undefined>(<any>permissions)[receiverType];
+
+  const stillTooLong = <
+    | PermissionsChecker<object>
+    | undefined
+    | number
+    | string
+    | boolean>(<any>permissions)[receiverType];
+
+  const testObjLiteral = <PermissionsChecker<any> | undefined>{
+    prop1: "myPropVal"
+  };
+
+  const testObjLiteral2 = <
+    | PermissionsChecker<object>
+    | undefined
+    | number
+    | string
+    | boolean>{ prop1: "myPropVal" };
+
+  const testArrayLiteral = <PermissionsChecker<any> | undefined>[
+    "first",
+    "second",
+    "third"
+  ];
+
+  const testArrayLiteral2 = <
+    | PermissionsChecker<object>
+    | undefined
+    | number
+    | string
+    | boolean>["first", "second", "third"];
+
+  const insideFuncCall = myFunc(
+    param1,
+    <PermissionsChecker<any> | undefined>param2,
+    param3
+  );
+}
+
+`;
+
 exports[`hug-args.ts 1`] = `
 postMessage(
   <IActionMessage>{

--- a/tests/typescript_cast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_cast/__snapshots__/jsfmt.spec.js.snap
@@ -78,9 +78,7 @@ function y() {
       void,
       never
     >
-  >(
-    someExistingConfigMap.mergeDeep(fallbackOptions)
-  );
+  >someExistingConfigMap.mergeDeep(fallbackOptions);
 
   const stillTooLong2 = <
     | Immutable.Map<
@@ -95,9 +93,7 @@ function y() {
         never
       >
     | undefined
-  >(
-    someExistingConfigMap.mergeDeep(fallbackOptions)
-  );
+  >someExistingConfigMap.mergeDeep(fallbackOptions);
 
   const stillTooLong3 = <Immutable.Map<string>>(
     someExistingConfigMap.mergeDeep(
@@ -118,10 +114,8 @@ function y() {
         never
       >
     | undefined
-  >(
-    someExistingConfigMap.mergeDeep(
-      fallbackOptions.someMethodWithLongName(param1, param2)
-    )
+  >someExistingConfigMap.mergeDeep(
+    fallbackOptions.someMethodWithLongName(param1, param2)
   );
 
   const testObjLiteral = <Immutable.Map<string, any>>{
@@ -181,9 +175,7 @@ function x() {
 
   const stillTooLong = <
     PermissionsChecker<object> | undefined | number | string | boolean
-  >(
-    (<any>permissions)[receiverType]
-  );
+  >(<any>permissions)[receiverType];
 
   const stillTooLong2 = <
     | PermissionsChecker<object>
@@ -193,9 +185,7 @@ function x() {
     | boolean
     | null
     | never
-  >(
-    (<any>permissions)[receiverType]
-  );
+  >(<any>permissions)[receiverType];
 
   const stillTooLong3 = <PermissionsChecker<object> | undefined>(
     (<any>permissions.someMethodWithLongName(parameter1, parameter2))[
@@ -211,11 +201,9 @@ function x() {
     | boolean
     | null
     | never
-  >(
-    (<any>permissions.someMethodWithLongName(parameter1, parameter2))[
-      receiverTypeLongName
-    ]
-  );
+  >(<any>permissions.someMethodWithLongName(parameter1, parameter2))[
+    receiverTypeLongName
+  ];
 
   const testObjLiteral = <PermissionsChecker<any> | undefined>{
     prop1: "myPropVal"

--- a/tests/typescript_cast/generic-cast.ts
+++ b/tests/typescript_cast/generic-cast.ts
@@ -11,6 +11,10 @@ function y() {
 
   const stillTooLong2 = <Immutable.Map<string, boolean, number, object, null, undefined, any, void, never> | undefined>someExistingConfigMap.mergeDeep(fallbackOptions);
 
+  const stillTooLong3 = <Immutable.Map<string>>someExistingConfigMap.mergeDeep(fallbackOptions.someMethodWithLongName(param1, param2));
+
+  const stillTooLong4 = <Immutable.Map<string, boolean, number, object, null, undefined, any, void, never> | undefined>someExistingConfigMap.mergeDeep(fallbackOptions.someMethodWithLongName(param1, param2));
+  
   const testObjLiteral = <Immutable.Map<string, any>>{ property1: "myPropertyVal" };
 
   const testObjLiteral2 = <Immutable.Map<string, any, number, boolean, object, null, undefined, never, "extra long">>{ property1: "myPropertyVal" };
@@ -33,6 +37,10 @@ function x() {
   const stillTooLong = <PermissionsChecker<object> | undefined | number | string | boolean>(<any>permissions)[receiverType];
 
   const stillTooLong2 = <PermissionsChecker<object> | undefined | number | string | boolean | null | never>(<any>permissions)[receiverType];
+
+  const stillTooLong3 = <PermissionsChecker<object> | undefined>(<any>permissions.someMethodWithLongName(parameter1, parameter2))[receiverTypeLongName];
+
+  const stillTooLong4 = <PermissionsChecker<object> | undefined | number | string | boolean | null | never>(<any>permissions.someMethodWithLongName(parameter1, parameter2))[receiverTypeLongName];
 
   const testObjLiteral =  <PermissionsChecker<any> | undefined>{ prop1: "myPropVal" };
 

--- a/tests/typescript_cast/generic-cast.ts
+++ b/tests/typescript_cast/generic-cast.ts
@@ -1,0 +1,42 @@
+// https://github.com/prettier/prettier/issues/4171
+function y() {
+
+  const fits = <Immutable.Map<string, any>>fits();
+  const fitsObjLiteral = <Immutable.Map<string, any>>{ a: "test" };
+  const fitsArrayLiteral = <Immutable.Map<string, any>>["test", "test2"]
+
+  const breakAfterCast = <Immutable.Map<string, any>>someExistingConfigMap.mergeDeep(fallbackOpts);
+
+  const stillTooLong = <Immutable.Map<string, boolean, number, object, null, undefined, any, void, never>>someExistingConfigMap.mergeDeep(fallbackOptions);
+
+  const testObjLiteral = <Immutable.Map<string, any>>{ property1: "myPropertyVal" };
+
+  const testObjLiteral2 = <Immutable.Map<string, any, number, boolean, object, null>>{ property1: "myPropertyVal" };
+
+  const testArrayLiteral = <Immutable.Map<string, any>>["first", "second", "third"];
+
+  const testArrayLiteral2 = <Immutable.Map<string, any, number, boolean, object, null>>["first", "second", "third"];
+
+  const insideFuncCall = myFunc(param1, <Immutable.Map<string, any>>param2, param3)
+}
+
+// https://github.com/prettier/prettier/issues/4168
+function x() {
+  const fits = <PermissionsChecker<any> | undefined>(<any>permissions)[type];
+  const fitsObjLiteral = <PermissionsChecker<any> | undefined>{ a: "test" };
+  const fitsArrayLiteral = <PermissionsChecker<any> | undefined>["t1", "t2"];
+
+  const breakAfterCast = <PermissionsChecker<any> | undefined>(<any>permissions)[receiverType];
+
+  const stillTooLong = <PermissionsChecker<object> | undefined | number | string | boolean>(<any>permissions)[receiverType];
+
+  const testObjLiteral =  <PermissionsChecker<any> | undefined>{ prop1: "myPropVal" };
+
+  const testObjLiteral2 = <PermissionsChecker<object> | undefined | number | string | boolean>{ prop1: "myPropVal" };
+
+  const testArrayLiteral = <PermissionsChecker<any> | undefined>["first", "second", "third"];
+
+  const testArrayLiteral2 = <PermissionsChecker<object> | undefined | number | string | boolean>["first", "second", "third"];
+
+  const insideFuncCall = myFunc(param1, <PermissionsChecker<any> | undefined>param2, param3)
+}

--- a/tests/typescript_cast/generic-cast.ts
+++ b/tests/typescript_cast/generic-cast.ts
@@ -9,13 +9,15 @@ function y() {
 
   const stillTooLong = <Immutable.Map<string, boolean, number, object, null, undefined, any, void, never>>someExistingConfigMap.mergeDeep(fallbackOptions);
 
+  const stillTooLong2 = <Immutable.Map<string, boolean, number, object, null, undefined, any, void, never> | undefined>someExistingConfigMap.mergeDeep(fallbackOptions);
+
   const testObjLiteral = <Immutable.Map<string, any>>{ property1: "myPropertyVal" };
 
-  const testObjLiteral2 = <Immutable.Map<string, any, number, boolean, object, null>>{ property1: "myPropertyVal" };
+  const testObjLiteral2 = <Immutable.Map<string, any, number, boolean, object, null, undefined, never, "extra long">>{ property1: "myPropertyVal" };
 
   const testArrayLiteral = <Immutable.Map<string, any>>["first", "second", "third"];
 
-  const testArrayLiteral2 = <Immutable.Map<string, any, number, boolean, object, null>>["first", "second", "third"];
+  const testArrayLiteral2 = <Immutable.Map<string, any, number, boolean, object, null, undefined, never, "extra long">>["first", "second", "third"];
 
   const insideFuncCall = myFunc(param1, <Immutable.Map<string, any>>param2, param3)
 }
@@ -30,13 +32,15 @@ function x() {
 
   const stillTooLong = <PermissionsChecker<object> | undefined | number | string | boolean>(<any>permissions)[receiverType];
 
+  const stillTooLong2 = <PermissionsChecker<object> | undefined | number | string | boolean | null | never>(<any>permissions)[receiverType];
+
   const testObjLiteral =  <PermissionsChecker<any> | undefined>{ prop1: "myPropVal" };
 
-  const testObjLiteral2 = <PermissionsChecker<object> | undefined | number | string | boolean>{ prop1: "myPropVal" };
+  const testObjLiteral2 = <PermissionsChecker<object> | undefined | number | string | boolean | null | never | object>{ prop1: "myPropVal" };
 
   const testArrayLiteral = <PermissionsChecker<any> | undefined>["first", "second", "third"];
 
-  const testArrayLiteral2 = <PermissionsChecker<object> | undefined | number | string | boolean>["first", "second", "third"];
+  const testArrayLiteral2 = <PermissionsChecker<object> | undefined | number | string | boolean | null | never | object>["first", "second", "third"];
 
   const insideFuncCall = myFunc(param1, <PermissionsChecker<any> | undefined>param2, param3)
 }


### PR DESCRIPTION
fixes #4171
fixes #4168

Implemented by adding a soft break between the cast and the expression. Also includes wrapping parentheses for clarity as suggested in #4171.

Avoids changing behavior at all though if casting an array or object literal because those already have good behavior where the array or object literal breaks before the cast does so including them would just result in a pointless extra layer of parentheses that would add no clarity because the `{ }` or `[ ]` wrapping the literal serves same purpose as the parentheses would.