### PR TITLE
fix: mangles template literal when you use `prettier-ignore`

### DIFF
--- a/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
@@ -30,6 +30,42 @@ border : rebeccapurple\`;
 
 styled(ExistingComponent).attr({})\`
 border : rebeccapurple\`;
+
+styled.div\`
+  color: \${props => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  \${props => props.small ? 'font-size: 0.8em;' : ''};
+\`
+
+styled.div\`
+  color: \${props => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  \${props => props.small ? 'font-size: 0.8em;' : ''}
+\`
+
+styled.div\`
+   /* prettier-ignore */
+  color: \${props => props.theme.colors.paragraph};
+  \${props => props.small ? 'font-size: 0.8em;' : ''};
+\`
+
+styled.div\`
+  color: \${props => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  \${props => props.small ? 'font-size: 0.8em;' : ''};
+  /* prettier-ignore */
+  \${props => props.red ? 'color: red;' : ''};
+\`
+
+styled.div\`
+  /* prettier-ignore */
+  color: \${props => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  \${props => props.small ? 'font-size: 0.8em;' : ''};
+  /* prettier-ignore */
+  \${props => props.red ? 'color: red;' : ''};
+  /* prettier-ignore */
+\`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const ListItem = styled.li\`\`;
 
@@ -62,6 +98,42 @@ styled.button.attr({})\`
 
 styled(ExistingComponent).attr({})\`
   border: rebeccapurple;
+\`;
+
+styled.div\`
+  color: \${props => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  \${props => (props.small ? "font-size: 0.8em;" : "")};
+\`;
+
+styled.div\`
+  color: \${props => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  \${props => (props.small ? "font-size: 0.8em;" : "")}
+\`;
+
+styled.div\`
+   /* prettier-ignore */
+  color: \${props => props.theme.colors.paragraph};
+  \${props => (props.small ? "font-size: 0.8em;" : "")};
+\`;
+
+styled.div\`
+  color: \${props => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  \${props => (props.small ? "font-size: 0.8em;" : "")};
+  /* prettier-ignore */
+  \${props => (props.red ? "color: red;" : "")};
+\`;
+
+styled.div\`
+  /* prettier-ignore */
+  color: \${props => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  \${props => (props.small ? "font-size: 0.8em;" : "")};
+  /* prettier-ignore */
+  \${props => (props.red ? "color: red;" : "")};
+  /* prettier-ignore */
 \`;
 
 `;

--- a/tests/multiparser_js_css/styled-components.js
+++ b/tests/multiparser_js_css/styled-components.js
@@ -27,3 +27,39 @@ border : rebeccapurple`;
 
 styled(ExistingComponent).attr({})`
 border : rebeccapurple`;
+
+styled.div`
+  color: ${props => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  ${props => props.small ? 'font-size: 0.8em;' : ''};
+`
+
+styled.div`
+  color: ${props => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  ${props => props.small ? 'font-size: 0.8em;' : ''}
+`
+
+styled.div`
+   /* prettier-ignore */
+  color: ${props => props.theme.colors.paragraph};
+  ${props => props.small ? 'font-size: 0.8em;' : ''};
+`
+
+styled.div`
+  color: ${props => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  ${props => props.small ? 'font-size: 0.8em;' : ''};
+  /* prettier-ignore */
+  ${props => props.red ? 'color: red;' : ''};
+`
+
+styled.div`
+  /* prettier-ignore */
+  color: ${props => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  ${props => props.small ? 'font-size: 0.8em;' : ''};
+  /* prettier-ignore */
+  ${props => props.red ? 'color: red;' : ''};
+  /* prettier-ignore */
+`


### PR DESCRIPTION
fixes #4218

Very critical bug, it is affect on multi parser anywhere you use `prettier-ignore` comment(s), including `js` in `markdown`, `css` in `js` and etc. I recommend patch release.