### PR TITLE
Added prettier API for ignored files

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const version = require("./package.json").version;
 
+const createIgnorer = require("./src/common/ignore").createIgnorer;
 const privateUtil = require("./src/common/util");
 const sharedUtil = require("./src/common/util-shared");
 const getSupportInfo = require("./src/common/support").getSupportInfo;
@@ -386,6 +387,14 @@ function formatRange(text, opts, ast) {
 }
 
 module.exports = {
+  createIgnorer: function(ignorePath) {
+    const ignorer = createIgnorer(ignorePath, error => {
+      throw error;
+    });
+
+    return filePath => ignorer.ignores(filePath);
+  },
+
   formatWithCursor: function(text, opts) {
     return formatWithCursor(text, normalizeOptions(opts));
   },

--- a/src/common/ignore.js
+++ b/src/common/ignore.js
@@ -1,0 +1,35 @@
+"use strict";
+
+const fs = require("fs");
+const ignore = require("ignore");
+const path = require("path");
+
+/**
+ * Create the ignorer instance that can be used later to determine if
+ * a given file path is ignored or not.
+ *
+ * @param {string} ignorePath The ignore path to use to create the ignorer.
+ * @param {(error, resolvedIgnorePath) => void} errorHandler An error handler function that will be called when
+ * an error occurred while reading one of the ignored path. The function will be called with the `error`
+ * object as the first argument and the absolutely resolved `ignoredPath` as the second argument.
+ *
+ * @returns An `Ignore` object that can later be used to determine if a path should be ignored of not.
+ */
+function createIgnorer(ignorePath, errorHandler) {
+  const resolvedIgnorePath = path.resolve(ignorePath);
+  let ignoreText = "";
+
+  try {
+    ignoreText = fs.readFileSync(resolvedIgnorePath, "utf8");
+  } catch (readError) {
+    if (readError.code !== "ENOENT") {
+      errorHandler(readError, resolvedIgnorePath);
+    }
+  }
+
+  return ignore().add(ignoreText);
+}
+
+module.exports = {
+  createIgnorer
+};


### PR DESCRIPTION
### Description

The actual logic for creating an ignorer has been moved to `common/ignore.js` so it can be shared easily between CLI and API.

The CLI has been updated to use the new `common/ignore.js` file by creating the ignored via the CLI context.

The API has been added as a factory pattern so that reading the ignored file contents is not repeated for each but only once at the creation of the ignorer.

### Notes

Once agreement has been given about implementation & API scope, I'm going to update the docs and the tests if needed.