### PR TITLE
Improve format when passing ts arrow function with return type as an argument

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3378,6 +3378,7 @@ function couldGroupArg(arg) {
     arg.type === "TSAsExpression" ||
     arg.type === "FunctionExpression" ||
     (arg.type === "ArrowFunctionExpression" &&
+      !arg.returnType &&
       (arg.body.type === "BlockStatement" ||
         arg.body.type === "ArrowFunctionExpression" ||
         arg.body.type === "ObjectExpression" ||

--- a/tests/typescript_typeparams/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_typeparams/__snapshots__/jsfmt.spec.js.snap
@@ -93,21 +93,21 @@ export class Thing22 implements OtherThing {
 }~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // https://github.com/prettier/prettier/issues/4070
 export class Thing implements OtherThing {
-  do: (type: Type) => Provider<Prop> = memoize((type: ObjectType): Provider<
-    Opts
-  > => {});
+  do: (type: Type) => Provider<Prop> = memoize(
+    (type: ObjectType): Provider<Opts> => {}
+  );
 }
 
 export class Thing2 implements OtherThing {
-  do: (type: Type) => Provider<Prop> = memoize((type: ObjectType): Provider<
-    Opts
-  > => {
-    const someVar = doSomething(type);
-    if (someVar) {
-      return someVar.method();
+  do: (type: Type) => Provider<Prop> = memoize(
+    (type: ObjectType): Provider<Opts> => {
+      const someVar = doSomething(type);
+      if (someVar) {
+        return someVar.method();
+      }
+      return false;
     }
-    return false;
-  });
+  );
 }
 
 export class Thing3 implements OtherThing {
@@ -121,9 +121,9 @@ export class Thing3 implements OtherThing {
 }
 
 export class Thing4 implements OtherThing {
-  do: (type: Type) => Provider<Prop> = memoize((type: ObjectType): Provider<
-    Opts
-  > => type.doSomething());
+  do: (type: Type) => Provider<Prop> = memoize(
+    (type: ObjectType): Provider<Opts> => type.doSomething()
+  );
 }
 
 export class Thing5 implements OtherThing {

--- a/tests/typescript_typeparams/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_typeparams/__snapshots__/jsfmt.spec.js.snap
@@ -90,7 +90,15 @@ export class Thing21 implements OtherThing {
 
 export class Thing22 implements OtherThing {
     do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType): Provider {});
-}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+}
+
+
+// case from https://github.com/prettier/prettier/issues/2581
+
+const appIDs = createSelector(
+    PubXURLParams.APP_IDS,
+   (rawAppIDs): Array<AppID> => deserializeList(rawAppIDs),
+);~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // https://github.com/prettier/prettier/issues/4070
 export class Thing implements OtherThing {
   do: (type: Type) => Provider<Prop> = memoize(
@@ -261,6 +269,13 @@ export class Thing22 implements OtherThing {
     type: ObjectType
   ): Provider {});
 }
+
+// case from https://github.com/prettier/prettier/issues/2581
+
+const appIDs = createSelector(
+  PubXURLParams.APP_IDS,
+  (rawAppIDs): Array<AppID> => deserializeList(rawAppIDs)
+);
 
 `;
 

--- a/tests/typescript_typeparams/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_typeparams/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,269 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`class-method.ts 1`] = `
+// https://github.com/prettier/prettier/issues/4070
+export class Thing implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type: ObjectType): Provider<Opts> => {});
+}
+
+export class Thing2 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type: ObjectType): Provider<Opts> => { const someVar = doSomething(type); if (someVar) {return someVar.method()} return false;});
+}
+
+export class Thing3 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type) => { const someVar = doSomething(type); if (someVar) {return someVar.method()} return false;});
+}
+
+export class Thing4 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type: ObjectType): Provider<Opts> => type.doSomething());
+}
+
+export class Thing5 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type: ObjectType): Provider<Opts> => <any>type.doSomething());
+}
+
+export class Thing6 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type: ObjectType): Provider<Opts> => <Provider<Opts>>type.doSomething());
+}
+
+export class Thing7 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type: ObjectType) => <Provider<Opts>>type.doSomething());
+}
+
+export class Thing8 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type: ObjectType) => <Provider<Opts>>type.doSomething(withArgs, soIt, does, not, fit).extraCall());
+}
+
+export class Thing9 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type: ObjectType) => type.doSomething());
+}
+
+export class Thing10 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((veryLongArgName: ObjectType): Provider<Options, MoreOptions> => veryLongArgName );
+}
+
+export class Thing11 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type: ObjectType): Provider => {});
+}
+
+// regular non-arrow functions
+
+export class Thing12 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType): Provider<Opts> {return type});
+}
+
+export class Thing13 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType): Provider<Opts> { const someVar = doSomething(type); if (someVar) {return someVar.method()} return false;});
+}
+
+export class Thing14 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type) { const someVar = doSomething(type); if (someVar) {return someVar.method()} return false;});
+}
+
+export class Thing15 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType): Provider<Opts> {return type.doSomething()});
+}
+
+export class Thing16 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType): Provider<Opts> {return <any>type.doSomething()});
+}
+
+export class Thing17 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType): Provider<Opts>  {return <Provider<Opts>>type.doSomething()});
+}
+
+export class Thing18 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType) {return <Provider<Opts>>type.doSomething()});
+}
+
+export class Thing19 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType) { return <Provider<Opts>>type.doSomething(withArgs, soIt, does, not, fit).extraCall()});
+}
+
+export class Thing20 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType) {return type.doSomething()});
+}
+
+export class Thing21 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(veryLongArgName: ObjectType): Provider<Options, MoreOptions> { return veryLongArgName });
+}
+
+export class Thing22 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType): Provider {});
+}~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// https://github.com/prettier/prettier/issues/4070
+export class Thing implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize((type: ObjectType): Provider<
+    Opts
+  > => {});
+}
+
+export class Thing2 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize((type: ObjectType): Provider<
+    Opts
+  > => {
+    const someVar = doSomething(type);
+    if (someVar) {
+      return someVar.method();
+    }
+    return false;
+  });
+}
+
+export class Thing3 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize(type => {
+    const someVar = doSomething(type);
+    if (someVar) {
+      return someVar.method();
+    }
+    return false;
+  });
+}
+
+export class Thing4 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize((type: ObjectType): Provider<
+    Opts
+  > => type.doSomething());
+}
+
+export class Thing5 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize(
+    (type: ObjectType): Provider<Opts> => <any>type.doSomething()
+  );
+}
+
+export class Thing6 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize(
+    (type: ObjectType): Provider<Opts> => <Provider<Opts>>type.doSomething()
+  );
+}
+
+export class Thing7 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize(
+    (type: ObjectType) => <Provider<Opts>>type.doSomething()
+  );
+}
+
+export class Thing8 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize(
+    (type: ObjectType) =>
+      <Provider<Opts>>(
+        type.doSomething(withArgs, soIt, does, not, fit).extraCall()
+      )
+  );
+}
+
+export class Thing9 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize((type: ObjectType) =>
+    type.doSomething()
+  );
+}
+
+export class Thing10 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize(
+    (veryLongArgName: ObjectType): Provider<Options, MoreOptions> =>
+      veryLongArgName
+  );
+}
+
+export class Thing11 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize(
+    (type: ObjectType): Provider => {}
+  );
+}
+
+// regular non-arrow functions
+
+export class Thing12 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize(function(
+    type: ObjectType
+  ): Provider<Opts> {
+    return type;
+  });
+}
+
+export class Thing13 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize(function(
+    type: ObjectType
+  ): Provider<Opts> {
+    const someVar = doSomething(type);
+    if (someVar) {
+      return someVar.method();
+    }
+    return false;
+  });
+}
+
+export class Thing14 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize(function(type) {
+    const someVar = doSomething(type);
+    if (someVar) {
+      return someVar.method();
+    }
+    return false;
+  });
+}
+
+export class Thing15 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize(function(
+    type: ObjectType
+  ): Provider<Opts> {
+    return type.doSomething();
+  });
+}
+
+export class Thing16 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize(function(
+    type: ObjectType
+  ): Provider<Opts> {
+    return <any>type.doSomething();
+  });
+}
+
+export class Thing17 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize(function(
+    type: ObjectType
+  ): Provider<Opts> {
+    return <Provider<Opts>>type.doSomething();
+  });
+}
+
+export class Thing18 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType) {
+    return <Provider<Opts>>type.doSomething();
+  });
+}
+
+export class Thing19 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType) {
+    return <Provider<Opts>>(
+      type.doSomething(withArgs, soIt, does, not, fit).extraCall()
+    );
+  });
+}
+
+export class Thing20 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType) {
+    return type.doSomething();
+  });
+}
+
+export class Thing21 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize(function(
+    veryLongArgName: ObjectType
+  ): Provider<Options, MoreOptions> {
+    return veryLongArgName;
+  });
+}
+
+export class Thing22 implements OtherThing {
+  do: (type: Type) => Provider<Prop> = memoize(function(
+    type: ObjectType
+  ): Provider {});
+}
+
+`;
+
 exports[`long-function-arg.ts 1`] = `
 export const forwardS = R.curry(
   <V,T>(prop: string, reducer: ReducerFunction<V, T>, value: V, state: {[name: string]: T}) =>

--- a/tests/typescript_typeparams/class-method.ts
+++ b/tests/typescript_typeparams/class-method.ts
@@ -1,0 +1,90 @@
+// https://github.com/prettier/prettier/issues/4070
+export class Thing implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type: ObjectType): Provider<Opts> => {});
+}
+
+export class Thing2 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type: ObjectType): Provider<Opts> => { const someVar = doSomething(type); if (someVar) {return someVar.method()} return false;});
+}
+
+export class Thing3 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type) => { const someVar = doSomething(type); if (someVar) {return someVar.method()} return false;});
+}
+
+export class Thing4 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type: ObjectType): Provider<Opts> => type.doSomething());
+}
+
+export class Thing5 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type: ObjectType): Provider<Opts> => <any>type.doSomething());
+}
+
+export class Thing6 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type: ObjectType): Provider<Opts> => <Provider<Opts>>type.doSomething());
+}
+
+export class Thing7 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type: ObjectType) => <Provider<Opts>>type.doSomething());
+}
+
+export class Thing8 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type: ObjectType) => <Provider<Opts>>type.doSomething(withArgs, soIt, does, not, fit).extraCall());
+}
+
+export class Thing9 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type: ObjectType) => type.doSomething());
+}
+
+export class Thing10 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((veryLongArgName: ObjectType): Provider<Options, MoreOptions> => veryLongArgName );
+}
+
+export class Thing11 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize((type: ObjectType): Provider => {});
+}
+
+// regular non-arrow functions
+
+export class Thing12 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType): Provider<Opts> {return type});
+}
+
+export class Thing13 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType): Provider<Opts> { const someVar = doSomething(type); if (someVar) {return someVar.method()} return false;});
+}
+
+export class Thing14 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type) { const someVar = doSomething(type); if (someVar) {return someVar.method()} return false;});
+}
+
+export class Thing15 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType): Provider<Opts> {return type.doSomething()});
+}
+
+export class Thing16 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType): Provider<Opts> {return <any>type.doSomething()});
+}
+
+export class Thing17 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType): Provider<Opts>  {return <Provider<Opts>>type.doSomething()});
+}
+
+export class Thing18 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType) {return <Provider<Opts>>type.doSomething()});
+}
+
+export class Thing19 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType) { return <Provider<Opts>>type.doSomething(withArgs, soIt, does, not, fit).extraCall()});
+}
+
+export class Thing20 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType) {return type.doSomething()});
+}
+
+export class Thing21 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(veryLongArgName: ObjectType): Provider<Options, MoreOptions> { return veryLongArgName });
+}
+
+export class Thing22 implements OtherThing {
+    do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType): Provider {});
+}

--- a/tests/typescript_typeparams/class-method.ts
+++ b/tests/typescript_typeparams/class-method.ts
@@ -88,3 +88,11 @@ export class Thing21 implements OtherThing {
 export class Thing22 implements OtherThing {
     do: (type: Type) => Provider<Prop> = memoize(function(type: ObjectType): Provider {});
 }
+
+
+// case from https://github.com/prettier/prettier/issues/2581
+
+const appIDs = createSelector(
+    PubXURLParams.APP_IDS,
+   (rawAppIDs): Array<AppID> => deserializeList(rawAppIDs),
+);


### PR DESCRIPTION
fixes #4070; fixes #2581

Probably should not be merged until after #4219 is merged and I have a chance to rebase since I added some test cases here that might be affected by the changes there.