### PR TITLE
fix: don't strip empty jekyll front-matter blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "get-stream": "3.0.0",
     "globby": "6.1.0",
     "graphql": "0.13.2",
-    "gray-matter": "3.1.1",
+    "gray-matter": "4.0.1",
     "html-tag-names": "1.1.2",
     "ignore": "3.3.7",
     "jest-docblock": "22.2.2",

--- a/tests/css_yaml/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_yaml/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`empty.css 1`] = `
+---
+---
+
+body{
+    border: 1px solid red;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---
+---
+
+body {
+  border: 1px solid red;
+}
+
+`;
+
+exports[`multilines.css 1`] = `
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`;
+
+exports[`newlines.css 1`] = `
+---
+
+
+
+---
+
+
+
+body{
+    border: 1px solid red;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---
+---
+
+body {
+  border: 1px solid red;
+}
+
+`;
+
+exports[`without.css 1`] = `
+body{
+    border: 1px solid red;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+body {
+  border: 1px solid red;
+}
+
+`;
+
 exports[`yaml.css 1`] = `
 ---
 title: Title

--- a/tests/css_yaml/empty.css
+++ b/tests/css_yaml/empty.css
@@ -1,0 +1,6 @@
+---
+---
+
+body{
+    border: 1px solid red;
+}

--- a/tests/css_yaml/newlines.css
+++ b/tests/css_yaml/newlines.css
@@ -1,0 +1,11 @@
+---
+
+
+
+---
+
+
+
+body{
+    border: 1px solid red;
+}

--- a/tests/css_yaml/without.css
+++ b/tests/css_yaml/without.css
@@ -1,0 +1,3 @@
+body{
+    border: 1px solid red;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2161,13 +2161,13 @@ graphql@0.13.2:
   dependencies:
     iterall "^1.2.1"
 
-gray-matter@3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/gray-matter/-/gray-matter-3.1.1.tgz#101f80d9e69eeca6765cdce437705b18f40876ac"
+gray-matter@4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/gray-matter/-/gray-matter-4.0.1.tgz#375263c194f0d9755578c277e41b1c1dfdf22c7d"
   dependencies:
-    extend-shallow "^2.0.1"
-    js-yaml "^3.10.0"
-    kind-of "^5.0.2"
+    js-yaml "^3.11.0"
+    kind-of "^6.0.2"
+    section-matter "^1.0.0"
     strip-bom-string "^1.0.0"
 
 growly@^1.3.0:
@@ -2961,9 +2961,9 @@ js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.10.0, js-yaml@^3.9.1:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
+js-yaml@^3.11.0:
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.11.0.tgz#597c1a8bd57152f26d622ce4117851a51f5ebaef"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -2971,6 +2971,13 @@ js-yaml@^3.10.0, js-yaml@^3.9.1:
 js-yaml@^3.7.0, js-yaml@^3.9.0:
   version "3.9.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.1.tgz#08775cebdfdd359209f0d2acd383c8f86a6904a0"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.9.1:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -3084,9 +3091,9 @@ kind-of@^4.0.0:
   dependencies:
     is-buffer "^1.1.5"
 
-kind-of@^5.0.2:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-5.1.0.tgz#729c91e2d857b7a419a1f9aa65685c4c33f5845d"
+kind-of@^6.0.0, kind-of@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -4329,6 +4336,13 @@ sane@^2.0.0:
 sax@^1.2.1:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.2.tgz#fd8631a23bc7826bef5d871bdb87378c95647828"
+
+section-matter@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/section-matter/-/section-matter-1.0.0.tgz#e9041953506780ec01d59f292a19c7b850b84167"
+  dependencies:
+    extend-shallow "^2.0.1"
+    kind-of "^6.0.0"
 
 "semver@2 || 3 || 4 || 5", semver@5.4.1, semver@^5.3.0:
   version "5.4.1"


### PR DESCRIPTION
fixes #4162

Also refactor logic to keep parse logic in one function