### PR TITLE
Handle comments before `else`

### DIFF
--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -206,6 +206,15 @@ function handleIfStatementComments(
     return true;
   }
 
+  // Treat comments before `else` as dangling comments
+  if (
+    precedingNode === enclosingNode.consequent &&
+    followingNode === enclosingNode.alternate
+  ) {
+    addDanglingComment(enclosingNode, comment);
+    return true;
+  }
+
   if (followingNode.type === "BlockStatement") {
     addBlockStatementFirstComment(followingNode, comment);
     return true;

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -206,7 +206,9 @@ function handleIfStatementComments(
     return true;
   }
 
-  // Treat comments before `else` as dangling comments
+  // Comments before `else`:
+  // - treat as trailing comments of the consequent, if it's a BlockStatement
+  // - treat as a dangling comment otherwise
   if (
     precedingNode === enclosingNode.consequent &&
     followingNode === enclosingNode.alternate

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -211,7 +211,11 @@ function handleIfStatementComments(
     precedingNode === enclosingNode.consequent &&
     followingNode === enclosingNode.alternate
   ) {
-    addDanglingComment(enclosingNode, comment);
+    if (precedingNode.type === "BlockStatement") {
+      addTrailingComment(precedingNode, comment);
+    } else {
+      addDanglingComment(enclosingNode, comment);
+    }
     return true;
   }
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1455,13 +1455,27 @@ function printPathNoParens(path, options, print, args) {
       parts.push(opening);
 
       if (n.alternate) {
-        if (n.consequent.type === "BlockStatement") {
-          parts.push(" else");
-        } else {
-          parts.push(hardline, "else");
+        const commentOnOwnLine =
+          hasDanglingComments(n) &&
+          n.comments.some(
+            comment =>
+              !comment.leading &&
+              !comment.trailing &&
+              !privateUtil.isBlockComment(comment)
+          );
+        const elseOnSameLine =
+          n.consequent.type === "BlockStatement" && !commentOnOwnLine;
+        parts.push(elseOnSameLine ? " " : hardline);
+
+        if (hasDanglingComments(n)) {
+          parts.push(
+            comments.printDanglingComments(path, options, true),
+            commentOnOwnLine ? hardline : " "
+          );
         }
 
         parts.push(
+          "else",
           group(
             adjustClause(
               n.alternate,

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1456,13 +1456,18 @@ function printPathNoParens(path, options, print, args) {
 
       if (n.alternate) {
         const commentOnOwnLine =
-          hasDanglingComments(n) &&
-          n.comments.some(
-            comment =>
-              !comment.leading &&
-              !comment.trailing &&
-              !privateUtil.isBlockComment(comment)
-          );
+          (hasTrailingComment(n.consequent) &&
+            n.consequent.comments.some(
+              comment =>
+                comment.trailing && !privateUtil.isBlockComment(comment)
+            )) ||
+          (hasDanglingComments(n) &&
+            n.comments.some(
+              comment =>
+                !comment.leading &&
+                !comment.trailing &&
+                !privateUtil.isBlockComment(comment)
+            ));
         const elseOnSameLine =
           n.consequent.type === "BlockStatement" && !commentOnOwnLine;
         parts.push(elseOnSameLine ? " " : hardline);

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -439,20 +439,21 @@ true
 if (1) {
   // comment
   false;
-} else if (2)
-  // comment
-  true;
+}
+// comment
+else if (2) true;
+// multi
+// ple
+// lines
 else if (3)
-  // multi
-  // ple
-  // lines
   // existing comment
   true;
+// okay?
 else if (4) {
-  // okay?
   // empty with existing comment
-} else {
-  // comment
+}
+// comment
+else {
 }
 
 if (5)
@@ -465,8 +466,8 @@ if (6) {
 } else if (7)
   // comment
   true;
+// comment
 else {
-  // comment
   true;
 }
 
@@ -478,9 +479,9 @@ if (8) {
   // comment
   // comment
   true;
+// comment
+// comment
 else {
-  // comment
-  // comment
   true;
 }
 
@@ -496,8 +497,7 @@ else if (12)
 else if (13)
   /* comment */ /* comment */ // comment
   true;
-else {
-  /* comment */
+/* comment */ else {
   true;
 }
 
@@ -722,8 +722,9 @@ if (1) {
 
 // Comments trigger invalid JavaScript in-between else if
 if (1) {
-} else {
-  // Comment
+}
+// Comment
+else {
 }
 
 // The comment makes the line break in a weird way

--- a/tests/flow/refinements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/refinements/__snapshots__/jsfmt.spec.js.snap
@@ -2571,8 +2571,7 @@ type Breakfast = Apple | Orange | Broccoli | Carrot;
 function bar(x: Breakfast) {
   if (x.kind === "Fruit") {
     (x.taste: "Good");
-  }
-  // error, Apple.taste = Bad
+  } // error, Apple.taste = Bad
   else (x.raw: "No"); // error, Carrot.raw = Maybe
 }
 

--- a/tests/flow/refinements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/refinements/__snapshots__/jsfmt.spec.js.snap
@@ -2571,7 +2571,9 @@ type Breakfast = Apple | Orange | Broccoli | Carrot;
 function bar(x: Breakfast) {
   if (x.kind === "Fruit") {
     (x.taste: "Good");
-  } else (x.raw: "No"); // error, Apple.taste = Bad // error, Carrot.raw = Maybe
+  }
+  // error, Apple.taste = Bad
+  else (x.raw: "No"); // error, Carrot.raw = Maybe
 }
 
 function qux(x: Breakfast) {

--- a/tests/if/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/if/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`comment_before_else.js 1`] = `
+if (cond) {
+  stuff;
+} /* comment */ else if (cond) {
+  stuff;
+}
+// comment
+else {
+  stuff;
+}
+
+if (cond) stuff;
+// comment
+else stuff;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+if (cond) {
+  stuff;
+} /* comment */ else if (cond) {
+  stuff;
+}
+// comment
+else {
+  stuff;
+}
+
+if (cond) stuff;
+// comment
+else stuff;
+
+`;
+
 exports[`else.js 1`] = `
 // Both functions below should be formatted exactly the same
 

--- a/tests/if/comment_before_else.js
+++ b/tests/if/comment_before_else.js
@@ -1,0 +1,13 @@
+if (cond) {
+  stuff;
+} /* comment */ else if (cond) {
+  stuff;
+}
+// comment
+else {
+  stuff;
+}
+
+if (cond) stuff;
+// comment
+else stuff;


### PR DESCRIPTION
I chose to treat comments as:
- trailing comments of the consequent, if it's a `BlockStatement`
- dangling comments of the `IfStatement` otherwise. (I'm not quite sure this is conceptually correct. Thoughts?)

In this PR I'm always printing as:

```js
if (cond) {
}
// comment
else {
}

if (cond) {
} /* comment */ else {
}
```

Should `// comment`s always be printed in their own line or should we detect if they're on the same line? Same for `/* comment */`s should always be printed in the same line?

Closes #2573