### PR TITLE
Fix embedded GraphQL in JS with backticks

### DIFF
--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -77,7 +77,7 @@ function embed(path, print, textToDoc /*, options */) {
           const templateElement = node.quasis[i];
           const isFirst = i === 0;
           const isLast = i === numQuasis - 1;
-          const text = templateElement.value.raw;
+          const text = templateElement.value.cooked;
           const lines = text.split("\n");
           const numLines = lines.length;
           const expressionDoc = expressionDocs[i];
@@ -107,13 +107,17 @@ function embed(path, print, textToDoc /*, options */) {
               doc = docUtils.stripTrailingHardline(
                 textToDoc(text, { parser: "graphql" })
               );
-            } catch (_error) {
+            } catch (error) {
+              if (process.env.PRETTIER_DEBUG) {
+                throw error;
+              }
               // Bail if any part fails to parse.
               return null;
             }
           }
 
           if (doc) {
+            doc = escapeBackticks(doc);
             if (!isFirst && startsWithBlankLine) {
               parts.push("");
             }

--- a/tests/multiparser_js_graphql/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_graphql/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`backticks.js 1`] = `
+gql\`
+  "\\\`foo\\\` mutation payload."
+  type      FooPayload       {
+    	bar: String
+  }
+\`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+gql\`
+  "\\\`foo\\\` mutation payload."
+  type FooPayload {
+    bar: String
+  }
+\`;
+
+`;
+
 exports[`expressions.js 1`] = `
 graphql(schema, \`
 query allPartsByManufacturerName($name: String!) {

--- a/tests/multiparser_js_graphql/backticks.js
+++ b/tests/multiparser_js_graphql/backticks.js
@@ -1,0 +1,6 @@
+gql`
+  "\`foo\` mutation payload."
+  type      FooPayload       {
+    	bar: String
+  }
+`


### PR DESCRIPTION
This one was hard to write the title :sweat_smile:

When we parse embedded GraphQL, we use the `raw` value from the template literal, which includes escape characters, e.g.:

```gql
"\`foo\` mutation payload."
type FooPayload {
  bar: String
}
```

We should probably pass the `cooked` value instead, because they're only meaningful in the JS context, and escape the result of the "foreign" language printer (which is what the markdown embed does).

Closes #4258