### PR TITLE
Break `ObjectPattern`s with nested `ObjectPattern`s

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1039,15 +1039,26 @@ function printPathNoParens(path, options, print, args) {
     case "TSInterfaceBody":
     case "TSTypeLiteral": {
       const isTypeAnnotation = n.type === "ObjectTypeAnnotation";
+      const parent = path.getParentNode(0);
       const shouldBreak =
         n.type === "TSInterfaceBody" ||
+        (n.type === "ObjectPattern" &&
+          parent.type !== "FunctionDeclaration" &&
+          parent.type !== "FunctionExpression" &&
+          parent.type !== "ArrowFunctionExpression" &&
+          parent.type !== "AssignmentPattern" &&
+          n.properties.some(
+            property =>
+              property.value &&
+              (property.value.type === "ObjectPattern" ||
+                property.value.type === "ArrayPattern")
+          )) ||
         (n.type !== "ObjectPattern" &&
           privateUtil.hasNewlineInRange(
             options.originalText,
             options.locStart(n),
             options.locEnd(n)
           ));
-      const parent = path.getParentNode(0);
       const isFlowInterfaceLikeBody =
         isTypeAnnotation &&
         parent &&

--- a/tests/destructuring/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/destructuring/__snapshots__/jsfmt.spec.js.snap
@@ -4,9 +4,56 @@ exports[`destructuring.js 1`] = `
 const [one, two = null, three = null] = arr;
 a = ([s=1,]) => 1
 const { children, ...props } = this.props
+
+const { user: { firstName, lastName } } = this.props;
+
+const {
+  name: { first, last },
+  organisation: { address: { street: orgStreetAddress, postcode: orgPostcode } }
+} = user;
+
+function f({ data: { name } }) {}
+
+const UserComponent = function({
+  name: { first, last },
+  organisation: { address: { street: orgStreetAddress, postcode: orgPostcode } },
+}) {
+  return
+};
+
+const { a, b, c, d: { e } } = someObject;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const [one, two = null, three = null] = arr;
 a = ([s = 1]) => 1;
 const { children, ...props } = this.props;
+
+const {
+  user: { firstName, lastName }
+} = this.props;
+
+const {
+  name: { first, last },
+  organisation: {
+    address: { street: orgStreetAddress, postcode: orgPostcode }
+  }
+} = user;
+
+function f({ data: { name } }) {}
+
+const UserComponent = function({
+  name: { first, last },
+  organisation: {
+    address: { street: orgStreetAddress, postcode: orgPostcode }
+  }
+}) {
+  return;
+};
+
+const {
+  a,
+  b,
+  c,
+  d: { e }
+} = someObject;
 
 `;

--- a/tests/destructuring/destructuring.js
+++ b/tests/destructuring/destructuring.js
@@ -1,3 +1,21 @@
 const [one, two = null, three = null] = arr;
 a = ([s=1,]) => 1
 const { children, ...props } = this.props
+
+const { user: { firstName, lastName } } = this.props;
+
+const {
+  name: { first, last },
+  organisation: { address: { street: orgStreetAddress, postcode: orgPostcode } }
+} = user;
+
+function f({ data: { name } }) {}
+
+const UserComponent = function({
+  name: { first, last },
+  organisation: { address: { street: orgStreetAddress, postcode: orgPostcode } },
+}) {
+  return
+};
+
+const { a, b, c, d: { e } } = someObject;


### PR DESCRIPTION
Context: #2550

After significant demand, this PR introduces an heuristic to always break `ObjectPattern`s if there are any nested `ObjectPattern` (or `ArrayPattern` in that case) properties.

I chose not to use the "always break if any property has a value" for now and not to break the outermost `ObjectPattern` if it's a function argument.

I personally think it's a good compromise, but I didn't mark to close the issue yet.

Let me know what you think!