### PR TITLE
feat(typescript): support generic JSX element

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "resolve": "1.5.0",
     "semver": "5.4.1",
     "string-width": "2.1.1",
-    "typescript": "2.9.0-dev.20180405",
-    "typescript-eslint-parser": "ikatyang/typescript-eslint-parser#feat/support-generic-jsx-element",
+    "typescript": "2.9.0-dev.20180421",
+    "typescript-eslint-parser": "eslint/typescript-eslint-parser#2960b002746c01fb9cb15bb5f4c1e7e925c6519a",
     "unicode-regex": "1.0.1",
     "unified": "6.1.6"
   },

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "resolve": "1.5.0",
     "semver": "5.4.1",
     "string-width": "2.1.1",
-    "typescript": "2.8.0-rc",
-    "typescript-eslint-parser": "14.0.0",
+    "typescript": "2.9.0-dev.20180405",
+    "typescript-eslint-parser": "ikatyang/typescript-eslint-parser#feat/support-generic-jsx-element",
     "unicode-regex": "1.0.1",
     "unified": "6.1.6"
   },

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1820,7 +1820,12 @@ function printPathNoParens(path, options, print, args) {
 
       // Don't break self-closing elements with no attributes and no comments
       if (n.selfClosing && !n.attributes.length && !nameHasComments) {
-        return concat(["<", path.call(print, "name"), " />"]);
+        return concat([
+          "<",
+          path.call(print, "name"),
+          path.call(print, "typeParameters"),
+          " />"
+        ]);
       }
 
       // don't break up opening elements with a single long text attribute
@@ -1846,6 +1851,7 @@ function printPathNoParens(path, options, print, args) {
           concat([
             "<",
             path.call(print, "name"),
+            path.call(print, "typeParameters"),
             " ",
             concat(path.map(print, "attributes")),
             n.selfClosing ? " />" : ">"
@@ -1884,6 +1890,7 @@ function printPathNoParens(path, options, print, args) {
         concat([
           "<",
           path.call(print, "name"),
+          path.call(print, "typeParameters"),
           concat([
             indent(
               concat(
@@ -2696,7 +2703,7 @@ function printPathNoParens(path, options, print, args) {
       return concat([path.call(print, "expression"), "!"]);
     case "TSThisType":
       return "this";
-    case "TSLastTypeNode":
+    case "TSLiteralType":
       return path.call(print, "literal");
     case "TSIndexedAccessType":
       return concat([

--- a/tests/typescript_tsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_tsx/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`generic-component.tsx 1`] = `
+const c1 = <MyComponent<number> data={12} />
+
+const c2 = <MyComponent<number> />
+
+const c3 = <MyComponent<number> attr="value" />
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const c1 = <MyComponent<number> data={12} />;
+
+const c2 = <MyComponent<number> />;
+
+const c3 = <MyComponent<number> attr="value" />;
+
+`;
+
 exports[`keyword.tsx 1`] = `
 <try />;
 <object />

--- a/tests/typescript_tsx/generic-component.tsx
+++ b/tests/typescript_tsx/generic-component.tsx
@@ -1,0 +1,5 @@
+const c1 = <MyComponent<number> data={12} />
+
+const c2 = <MyComponent<number> />
+
+const c3 = <MyComponent<number> attr="value" />

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -20,7 +20,7 @@ self.Buffer = {
   }
 };
 self.constants = {};
-module$1 = module = os = crypto = {};
+module$1 = module = os = crypto = buffer = {};
 self.fs = { readFile: function() {} };
 os.homedir = function() {
   return "/home/prettier";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4783,16 +4783,16 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript-eslint-parser@14.0.0:
+typescript-eslint-parser@ikatyang/typescript-eslint-parser#feat/support-generic-jsx-element:
   version "14.0.0"
-  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-14.0.0.tgz#c90a8f541c1d96e5c55e2807c61d154e788520f9"
+  resolved "https://codeload.github.com/ikatyang/typescript-eslint-parser/tar.gz/36979fc9137408d3279aa2352310075975a723d9"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@2.8.0-rc:
-  version "2.8.0-rc"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.0-rc.tgz#a0256b7d1d39fb7493ba0403f55e95d31e8bc374"
+typescript@2.9.0-dev.20180405:
+  version "2.9.0-dev.20180405"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.0-dev.20180405.tgz#c204f6d1a8e5263dd3e7f153e25a4cdf0d2693ac"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4783,16 +4783,16 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript-eslint-parser@ikatyang/typescript-eslint-parser#feat/support-generic-jsx-element:
+typescript-eslint-parser@eslint/typescript-eslint-parser#2960b002746c01fb9cb15bb5f4c1e7e925c6519a:
   version "14.0.0"
-  resolved "https://codeload.github.com/ikatyang/typescript-eslint-parser/tar.gz/36979fc9137408d3279aa2352310075975a723d9"
+  resolved "https://codeload.github.com/eslint/typescript-eslint-parser/tar.gz/2960b002746c01fb9cb15bb5f4c1e7e925c6519a"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@2.9.0-dev.20180405:
-  version "2.9.0-dev.20180405"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.0-dev.20180405.tgz#c204f6d1a8e5263dd3e7f153e25a4cdf0d2693ac"
+typescript@2.9.0-dev.20180421:
+  version "2.9.0-dev.20180421"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.0-dev.20180421.tgz#b937b164ce73f833f2ed5c36571e238898b264ce"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
Fixes #4259

- [x] Waiting for eslint/typescript-eslint-parser#461.

---

**Prettier pr-4268**
[Playground link](https://deploy-preview-4268--prettier.netlify.com/playground/#N4Igxg9gdgLgprEAuEAeAsgTwMIQLYAO0CMqUArngEZwBOAfAAQAmAhjKwLzACMATAF9GAenogANCAgEYAS2gBnZKAK1ZsAOqzmMABbIAHAAZJHKlp36kfSQvUBzADZwAiuQjxkAM1aOFcU1pWWUcHXDw8VmQQKGIJECogsABrOBgAZQJWMAdkGFpyAJAAKwUADwAhJNSM1jw4ABl1OG9ff0ks2n9aaJhMAjgFMDUZeP88WTyCovJ-ABVWKiUkHz8i9W6YAAUg+0jWtclaOABHclljndY9qJW2otUIfw0ggmjVQboANxbJVlpaBAAO5bf4IZYgVhfCDaeJBKD2ODpDi0GDIEwgeGIgCiUGY6MkzAgYAO7UhCjRd0OUnIMAItL4pLgAgEQA)
```sh
--parser typescript
```

**Input:**
```tsx
<MyComponent<number> data={12} />
```

**Output:**
```tsx
<MyComponent<number> data={12} />;
```