### PR TITLE
feat(markdown): support hasPragma/insertPragma

### DIFF
--- a/src/language-markdown/index.js
+++ b/src/language-markdown/index.js
@@ -2,6 +2,7 @@
 
 const printer = require("./printer-markdown");
 const options = require("./options");
+const pragma = require("./pragma");
 
 // Based on:
 // https://github.com/github/linguist/blob/master/lib/linguist/languages.yml
@@ -38,7 +39,8 @@ const remark = {
   get parse() {
     return eval("require")("./parser-markdown");
   },
-  astFormat: "mdast"
+  astFormat: "mdast",
+  hasPragma: pragma.hasPragma
 };
 
 const parsers = {

--- a/src/language-markdown/pragma.js
+++ b/src/language-markdown/pragma.js
@@ -1,0 +1,12 @@
+"use strict";
+
+const pragmas = ["format", "prettier"];
+const startWithPragmaRegex = new RegExp(
+  `^<!--\\s*@(${pragmas.join("|")})\\s*-->`
+);
+
+module.exports = {
+  startWithPragmaRegex,
+  hasPragma: text => startWithPragmaRegex.test(text.trimLeft()),
+  insertPragma: text => `<!-- @${pragmas[0]} -->\n\n${text}`
+};

--- a/src/language-markdown/pragma.js
+++ b/src/language-markdown/pragma.js
@@ -5,8 +5,25 @@ const startWithPragmaRegex = new RegExp(
   `^<!--\\s*@(${pragmas.join("|")})\\s*-->`
 );
 
+function extract(text) {
+  // yaml (---) and toml (+++)
+  const matched = text.match(
+    /^((---|\+\+\+)(?:\n[\s\S]*?\n|\n)\2(?:\n|$))?([\s\S]*)/
+  );
+  const frontMatter = matched[1];
+  const mainContent = matched[3];
+  return { frontMatter, mainContent };
+}
+
 module.exports = {
   startWithPragmaRegex,
-  hasPragma: text => startWithPragmaRegex.test(text.trimLeft()),
-  insertPragma: text => `<!-- @${pragmas[0]} -->\n\n${text}`
+  hasPragma: text =>
+    startWithPragmaRegex.test(extract(text).mainContent.trimLeft()),
+  insertPragma: text => {
+    const extracted = extract(text);
+    const pragma = `<!-- @${pragmas[0]} -->`;
+    return extracted.frontMatter
+      ? `${extracted.frontMatter}\n\n${pragma}\n\n${extracted.mainContent}`
+      : `${pragma}\n\n${extracted.mainContent}`;
+  }
 };

--- a/src/language-markdown/pragma.js
+++ b/src/language-markdown/pragma.js
@@ -1,9 +1,19 @@
 "use strict";
 
 const pragmas = ["format", "prettier"];
-const startWithPragmaRegex = new RegExp(
-  `^<!--\\s*@(${pragmas.join("|")})\\s*-->`
-);
+
+function startWithPragma(text) {
+  const pragma = `@(${pragmas.join("|")})`;
+  const regex = new RegExp(
+    [
+      `<!--\\s*${pragma}\\s*-->`,
+      `<!--.*\n[\\s\\S]*(^|\n)[^\\S\n]*${pragma}[^\\S\n]*($|\n)[\\s\\S]*\n.*-->`
+    ].join("|"),
+    "m"
+  );
+  const matched = text.match(regex);
+  return matched && matched.index === 0;
+}
 
 function extract(text) {
   // yaml (---) and toml (+++)
@@ -16,9 +26,8 @@ function extract(text) {
 }
 
 module.exports = {
-  startWithPragmaRegex,
-  hasPragma: text =>
-    startWithPragmaRegex.test(extract(text).mainContent.trimLeft()),
+  startWithPragma,
+  hasPragma: text => startWithPragma(extract(text).mainContent.trimLeft()),
   insertPragma: text => {
     const extracted = extract(text);
     const pragma = `<!-- @${pragmas[0]} -->`;

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -2,6 +2,7 @@
 
 const privateUtil = require("../common/util");
 const embed = require("./embed");
+const pragma = require("./pragma");
 const doc = require("../doc");
 const docBuilders = doc.builders;
 const concat = docBuilders.concat;
@@ -784,14 +785,24 @@ function clamp(value, min, max) {
   return value < min ? min : value > max ? max : value;
 }
 
-function clean(ast, newObj) {
-  // for markdown codeblock
+function clean(ast, newObj, parent) {
+  // for codeblock
   if (ast.type === "code") {
     delete newObj.value;
   }
-  // for markdown whitespace: "\n" and " " are considered the same
+  // for whitespace: "\n" and " " are considered the same
   if (ast.type === "whitespace" && ast.value === "\n") {
     newObj.value = " ";
+  }
+  // for insert pragma
+  if (
+    parent &&
+    parent.type === "root" &&
+    parent.children[0] === ast &&
+    ast.type === "html" &&
+    pragma.startWithPragmaRegex.test(ast.value)
+  ) {
+    return null;
   }
 }
 
@@ -799,5 +810,6 @@ module.exports = {
   print: genericPrint,
   embed,
   massageAstNode: clean,
-  hasPrettierIgnore: privateUtil.hasIgnoreComment
+  hasPrettierIgnore: privateUtil.hasIgnoreComment,
+  insertPragma: pragma.insertPragma
 };

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -790,7 +790,7 @@ function clean(ast, newObj, parent) {
         parent.children[0].type === "toml") &&
         parent.children[1] === ast)) &&
     ast.type === "html" &&
-    pragma.startWithPragmaRegex.test(ast.value)
+    pragma.startWithPragma(ast.value)
   ) {
     return null;
   }

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -785,7 +785,10 @@ function clean(ast, newObj, parent) {
   if (
     parent &&
     parent.type === "root" &&
-    parent.children[0] === ast &&
+    (parent.children[0] === ast ||
+      ((parent.children[0].type === "yaml" ||
+        parent.children[0].type === "toml") &&
+        parent.children[1] === ast)) &&
     ast.type === "html" &&
     pragma.startWithPragmaRegex.test(ast.value)
   ) {

--- a/tests/insert-pragma/markdown/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/insert-pragma/markdown/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`simple.md 1`] = `
+
+
+# hello world
+
+some content some content some content some content
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<!-- @format -->
+
+# hello world
+
+some content some content some content some content
+
+`;
+
+exports[`start-with-comment.md 1`] = `
+
+
+<!-- something -->
+
+# hello world
+
+some content some content some content some content
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<!-- @format -->
+
+<!-- something -->
+
+# hello world
+
+some content some content some content some content
+
+`;

--- a/tests/insert-pragma/markdown/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/insert-pragma/markdown/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`front-matter.md 1`] = `
+---
+something
+---
+
+# hello world
+
+some content some content some content some content
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---
+something
+---
+
+<!-- @format -->
+
+# hello world
+
+some content some content some content some content
+
+`;
+
 exports[`simple.md 1`] = `
-
-
 # hello world
 
 some content some content some content some content
@@ -16,8 +35,6 @@ some content some content some content some content
 `;
 
 exports[`start-with-comment.md 1`] = `
-
-
 <!-- something -->
 
 # hello world

--- a/tests/insert-pragma/markdown/front-matter.md
+++ b/tests/insert-pragma/markdown/front-matter.md
@@ -1,3 +1,7 @@
+---
+something
+---
+
 # hello world
 
 some content some content some content some content

--- a/tests/insert-pragma/markdown/jsfmt.spec.js
+++ b/tests/insert-pragma/markdown/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["markdown"], { insertPragma: true });

--- a/tests/insert-pragma/markdown/simple.md
+++ b/tests/insert-pragma/markdown/simple.md
@@ -1,0 +1,5 @@
+
+
+# hello world
+
+some content some content some content some content

--- a/tests/insert-pragma/markdown/start-with-comment.md
+++ b/tests/insert-pragma/markdown/start-with-comment.md
@@ -1,0 +1,7 @@
+
+
+<!-- something -->
+
+# hello world
+
+some content some content some content some content

--- a/tests/insert-pragma/markdown/start-with-comment.md
+++ b/tests/insert-pragma/markdown/start-with-comment.md
@@ -1,5 +1,3 @@
-
-
 <!-- something -->
 
 # hello world

--- a/tests/require-pragma/markdown/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/require-pragma/markdown/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`with-pragma.md 1`] = `
+<!-- @prettier -->
+
+I     should      be      formatted       !!
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<!-- @prettier -->
+
+I should be formatted !!
+
+`;
+
+exports[`without-pragma.md 1`] = `
+I     should      stay      as-is   !!
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+I     should      stay      as-is   !!
+
+`;

--- a/tests/require-pragma/markdown/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/require-pragma/markdown/__snapshots__/jsfmt.spec.js.snap
@@ -76,6 +76,29 @@ I should be formatted !!
 
 `;
 
+exports[`with-pragma-in-multiline.md 1`] = `
+<!--
+  MIT LICENSE 
+  
+  bla bla bla
+
+  @format
+-->
+
+I     should      be      formatted       !!
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<!--
+  MIT LICENSE
+
+  bla bla bla
+
+  @format
+-->
+
+I should be formatted !!
+
+`;
+
 exports[`without-pragma.md 1`] = `
 I     should      stay      as-is   !!
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/require-pragma/markdown/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/require-pragma/markdown/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`empty-front-matter-with-pragma.md 1`] = `
+---
+---
+
+<!-- @prettier -->
+
+I     should      be      formatted       !!
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---
+
+---
+
+<!-- @prettier -->
+
+I should be formatted !!
+
+`;
+
+exports[`empty-front-matter-without-pragma.md 1`] = `
+---
+---
+
+I     should      stay      as-is   !!
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---
+---
+
+I     should      stay      as-is   !!
+
+`;
+
+exports[`front-matter-with-pragma.md 1`] = `
+---
+something
+---
+
+<!-- @prettier -->
+
+I     should      be      formatted       !!
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---
+something
+---
+
+<!-- @prettier -->
+
+I should be formatted !!
+
+`;
+
+exports[`front-matter-without-pragma.md 1`] = `
+---
+something
+---
+
+I     should      stay      as-is   !!
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---
+something
+---
+
+I     should      stay      as-is   !!
+
+`;
+
 exports[`with-pragma.md 1`] = `
 <!-- @prettier -->
 

--- a/tests/require-pragma/markdown/empty-front-matter-with-pragma.md
+++ b/tests/require-pragma/markdown/empty-front-matter-with-pragma.md
@@ -1,0 +1,6 @@
+---
+---
+
+<!-- @prettier -->
+
+I     should      be      formatted       !!

--- a/tests/require-pragma/markdown/empty-front-matter-without-pragma.md
+++ b/tests/require-pragma/markdown/empty-front-matter-without-pragma.md
@@ -1,0 +1,4 @@
+---
+---
+
+I     should      stay      as-is   !!

--- a/tests/require-pragma/markdown/front-matter-with-pragma.md
+++ b/tests/require-pragma/markdown/front-matter-with-pragma.md
@@ -1,0 +1,7 @@
+---
+something
+---
+
+<!-- @prettier -->
+
+I     should      be      formatted       !!

--- a/tests/require-pragma/markdown/front-matter-without-pragma.md
+++ b/tests/require-pragma/markdown/front-matter-without-pragma.md
@@ -1,0 +1,5 @@
+---
+something
+---
+
+I     should      stay      as-is   !!

--- a/tests/require-pragma/markdown/jsfmt.spec.js
+++ b/tests/require-pragma/markdown/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["markdown"], { requirePragma: true });

--- a/tests/require-pragma/markdown/with-pragma-in-multiline.md
+++ b/tests/require-pragma/markdown/with-pragma-in-multiline.md
@@ -1,0 +1,9 @@
+<!--
+  MIT LICENSE 
+  
+  bla bla bla
+
+  @format
+-->
+
+I     should      be      formatted       !!

--- a/tests/require-pragma/markdown/with-pragma.md
+++ b/tests/require-pragma/markdown/with-pragma.md
@@ -1,0 +1,3 @@
+<!-- @prettier -->
+
+I     should      be      formatted       !!

--- a/tests/require-pragma/markdown/without-pragma.md
+++ b/tests/require-pragma/markdown/without-pragma.md
@@ -1,0 +1,1 @@
+I     should      stay      as-is   !!


### PR DESCRIPTION
_hasPragma_

**support**

```md
<!-- @prettier -->
```

```md
---
something
---

<!-- @prettier -->
```

```md
<!--
  MIT LICENSE 
  
  bla bla bla

  @format
-->
```

---

_insertPragma_

**support**

```diff
+ <!-- @prettier -->
+
something something
```

```diff
---
seomthing
---

+ <!-- @prettier -->
+
something something
```

**does not support**

```diff
<!--
  MIT LICENSE 
  
  bla bla bla
+
+ @format
-->
```