### PR TITLE
Prevent formatting GraphQL embedded in JS if it contains invalid escape sequences

### DIFF
--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -78,6 +78,13 @@ function embed(path, print, textToDoc /*, options */) {
           const isFirst = i === 0;
           const isLast = i === numQuasis - 1;
           const text = templateElement.value.cooked;
+
+          // Bail out if any of the quasis have an invalid escape sequence
+          // (which would make the `cooked` value be `null` or `undefined`)
+          if (typeof text !== "string") {
+            return null;
+          }
+
           const lines = text.split("\n");
           const numLines = lines.length;
           const expressionDoc = expressionDocs[i];

--- a/tests/multiparser_js_graphql/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_graphql/__snapshots__/jsfmt.spec.js.snap
@@ -409,6 +409,55 @@ gql\`
 
 `;
 
+exports[`invalid.js 1`] = `
+// none of the embedded GraphQL should be formatted
+// for they have an invalid escape sequence
+
+gql\`
+  "\\x"
+  type   Foo    {
+      a: string
+  }
+\`;
+
+gql\`
+  type   Foo {
+      a:   string
+  }
+
+  \${stuff}
+
+  "\\x"
+  type  Bar   {
+       b :   string
+  }
+\`;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// none of the embedded GraphQL should be formatted
+// for they have an invalid escape sequence
+
+gql\`
+  "\\x"
+  type   Foo    {
+      a: string
+  }
+\`;
+
+gql\`
+  type   Foo {
+      a:   string
+  }
+
+  \${stuff}
+
+  "\\x"
+  type  Bar   {
+       b :   string
+  }
+\`;
+
+`;
+
 exports[`react-relay.js 1`] = `
 const { graphql } = require("react-relay");
 

--- a/tests/multiparser_js_graphql/invalid.js
+++ b/tests/multiparser_js_graphql/invalid.js
@@ -1,0 +1,22 @@
+// none of the embedded GraphQL should be formatted
+// for they have an invalid escape sequence
+
+gql`
+  "\x"
+  type   Foo    {
+      a: string
+  }
+`;
+
+gql`
+  type   Foo {
+      a:   string
+  }
+
+  ${stuff}
+
+  "\x"
+  type  Bar   {
+       b :   string
+  }
+`;


### PR DESCRIPTION
Follow-up to https://github.com/prettier/prettier/pull/4265#issuecomment-379236243

If any of the quasis inside the ``` gql`` ``` template have an invalid escape sequence, its `cooked` value will be `null` and will break formatting. We'll bail out formatting the embedded and print the template as is.