### PR TITLE
Handle ContinueStatement and BreakStatement comments

### DIFF
--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -136,7 +136,7 @@ function handleRemainingComment(comment, text, options, ast, isLastComment) {
       comment,
       options
     ) ||
-    handleContinueStatementComments(enclosingNode, comment)
+    handleBreakAndContinueStatementComments(enclosingNode, comment)
   ) {
     return true;
   }
@@ -554,10 +554,11 @@ function handleLabeledStatementComments(enclosingNode, comment) {
   return false;
 }
 
-function handleContinueStatementComments(enclosingNode, comment) {
+function handleBreakAndContinueStatementComments(enclosingNode, comment) {
   if (
     enclosingNode &&
-    enclosingNode.type === "ContinueStatement" &&
+    (enclosingNode.type === "ContinueStatement" ||
+      enclosingNode.type === "BreakStatement") &&
     !enclosingNode.label
   ) {
     addTrailingComment(enclosingNode, comment);

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -135,7 +135,8 @@ function handleRemainingComment(comment, text, options, ast, isLastComment) {
       precedingNode,
       comment,
       options
-    )
+    ) ||
+    handleContinueStatementComments(enclosingNode, comment)
   ) {
     return true;
   }
@@ -548,6 +549,18 @@ function handleImportSpecifierComments(enclosingNode, comment) {
 function handleLabeledStatementComments(enclosingNode, comment) {
   if (enclosingNode && enclosingNode.type === "LabeledStatement") {
     addLeadingComment(enclosingNode, comment);
+    return true;
+  }
+  return false;
+}
+
+function handleContinueStatementComments(enclosingNode, comment) {
+  if (
+    enclosingNode &&
+    enclosingNode.type === "ContinueStatement" &&
+    !enclosingNode.label
+  ) {
+    addTrailingComment(enclosingNode, comment);
     return true;
   }
   return false;

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -146,6 +146,27 @@ function returnValue() {
 
 `;
 
+exports[`continue-statement.js 1`] = `
+for (;;) {
+  continue /* comment */;
+}
+
+loop: for (;;) {
+  continue /* comment */ loop;
+  continue loop /* comment */;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+for (;;) {
+  continue; /* comment */
+}
+
+loop: for (;;) {
+  continue /* comment */ loop;
+  continue loop /* comment */;
+}
+
+`;
+
 exports[`dangling.js 1`] = `
 var x = {/* dangling */};
 var x = {

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -82,6 +82,33 @@ exports[`blank.js 1`] = `
 
 `;
 
+exports[`break-continue-statements.js 1`] = `
+for (;;) {
+  break /* comment */;
+  continue /* comment */;
+}
+
+loop: for (;;) {
+  break /* comment */ loop;
+  break loop /* comment */;
+  continue /* comment */ loop;
+  continue loop /* comment */;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+for (;;) {
+  break; /* comment */
+  continue; /* comment */
+}
+
+loop: for (;;) {
+  break /* comment */ loop;
+  break loop /* comment */;
+  continue /* comment */ loop;
+  continue loop /* comment */;
+}
+
+`;
+
 exports[`call_comment.js 1`] = `
 render( // Warm any cache
   <ChildUpdates renderAnchor={true} anchorClassOn={true} />,
@@ -142,27 +169,6 @@ functionCall(1 + /** @type {string} */ (value), /** @type {!Foo} */ ({}));
 
 function returnValue() {
   return /** @type {!Array.<string>} */ (["hello", "you"]);
-}
-
-`;
-
-exports[`continue-statement.js 1`] = `
-for (;;) {
-  continue /* comment */;
-}
-
-loop: for (;;) {
-  continue /* comment */ loop;
-  continue loop /* comment */;
-}
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-for (;;) {
-  continue; /* comment */
-}
-
-loop: for (;;) {
-  continue /* comment */ loop;
-  continue loop /* comment */;
 }
 
 `;

--- a/tests/comments/break-continue-statements.js
+++ b/tests/comments/break-continue-statements.js
@@ -1,8 +1,11 @@
 for (;;) {
+  break /* comment */;
   continue /* comment */;
 }
 
 loop: for (;;) {
+  break /* comment */ loop;
+  break loop /* comment */;
   continue /* comment */ loop;
   continue loop /* comment */;
 }

--- a/tests/comments/continue-statement.js
+++ b/tests/comments/continue-statement.js
@@ -1,0 +1,8 @@
+for (;;) {
+  continue /* comment */;
+}
+
+loop: for (;;) {
+  continue /* comment */ loop;
+  continue loop /* comment */;
+}


### PR DESCRIPTION
A comment between `continue` and `;` was treated as a dangling comment of a `ContinueStatement`. I'm not sure there's that much value in keeping it like this so I chose treat as a trailing comment instead, which will move it to after the `;` (and will be stable afterwards).

Same for `break`

Closes #4276