### PR TITLE
Nicer line wrapping for d3

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4108,9 +4108,9 @@ function printMemberChain(path, options, print) {
   //
   // In order to detect those cases, we use an heuristic: if the first
   // node is an identifier with the name starting with a capital letter,
-  // containing only _ and $, or shorter than tabWidth. The rationale
-  // is that they are likely to be factories.
-  function isFactory(name) {
+  // or shorter than tabWidth. The rationale is that they are likely 
+  // to be factories.
+  function isFactoryOrShort(name) {
     return name.match(/(^[A-Z])/) || name.length <= options.tabWidth;
   }
   const shouldMerge =
@@ -4119,12 +4119,12 @@ function printMemberChain(path, options, print) {
     ((groups[0].length === 1 &&
       (groups[0][0].node.type === "ThisExpression" ||
         (groups[0][0].node.type === "Identifier" &&
-          (isFactory(groups[0][0].node.name) ||
+          (isFactoryOrShort(groups[0][0].node.name) ||
             (groups[1].length && groups[1][0].node.computed))))) ||
       (groups[0].length > 1 &&
         groups[0][groups[0].length - 1].node.type === "MemberExpression" &&
         groups[0][groups[0].length - 1].node.property.type === "Identifier" &&
-        (isFactory(groups[0][groups[0].length - 1].node.property.name) ||
+        (isFactoryOrShort(groups[0][groups[0].length - 1].node.property.name) ||
           (groups[1].length && groups[1][0].node.computed))));
 
   function printGroup(printedGroup) {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4108,7 +4108,7 @@ function printMemberChain(path, options, print) {
   //
   // In order to detect those cases, we use an heuristic: if the first
   // node is an identifier with the name starting with a capital letter,
-  // containing only _ and $, or shorter than tabWidth. The rationale 
+  // containing only _ and $, or shorter than tabWidth. The rationale
   // is that they are likely to be factories.
   function isFactory(name) {
     return name.match(/(^[A-Z])|^[_$]+$/) || name.length <= options.tabWidth;

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4107,8 +4107,8 @@ function printMemberChain(path, options, print) {
   //     .map(x => x)
   //
   // In order to detect those cases, we use an heuristic: if the first
-  // node is just an identifier with the name starting with a capital
-  // letter, like a sequence of _$, or as short as tabWidth. The rationale 
+  // node is an identifier with the name starting with a capital letter,
+  // containing only _ and $, or shorter than tabWidth. The rationale 
   // is that they are likely to be factories.
   function isFactory(name) {
     return name.match(/(^[A-Z])|^[_$]+$/) || name.length <= options.tabWidth;

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4108,7 +4108,7 @@ function printMemberChain(path, options, print) {
   //
   // In order to detect those cases, we use an heuristic: if the first
   // node is an identifier with the name starting with a capital letter,
-  // or shorter than tabWidth. The rationale is that they are likely 
+  // or shorter than tabWidth. The rationale is that they are likely
   // to be factories.
   function isNoWrap(name) {
     return name.match(/(^[A-Z])/) || name.length <= options.tabWidth;

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4111,7 +4111,7 @@ function printMemberChain(path, options, print) {
   // containing only _ and $, or shorter than tabWidth. The rationale
   // is that they are likely to be factories.
   function isFactory(name) {
-    return name.match(/(^[A-Z])|^[_$]+$/) || name.length <= options.tabWidth;
+    return name.match(/(^[A-Z])/) || name.length <= options.tabWidth;
   }
   const shouldMerge =
     groups.length >= 2 &&

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4110,7 +4110,7 @@ function printMemberChain(path, options, print) {
   // node is an identifier with the name starting with a capital letter,
   // or shorter than tabWidth. The rationale is that they are likely 
   // to be factories.
-  function isFactoryOrShort(name) {
+  function isNoWrap(name) {
     return name.match(/(^[A-Z])/) || name.length <= options.tabWidth;
   }
   const shouldMerge =
@@ -4119,12 +4119,12 @@ function printMemberChain(path, options, print) {
     ((groups[0].length === 1 &&
       (groups[0][0].node.type === "ThisExpression" ||
         (groups[0][0].node.type === "Identifier" &&
-          (isFactoryOrShort(groups[0][0].node.name) ||
+          (isNoWrap(groups[0][0].node.name) ||
             (groups[1].length && groups[1][0].node.computed))))) ||
       (groups[0].length > 1 &&
         groups[0][groups[0].length - 1].node.type === "MemberExpression" &&
         groups[0][groups[0].length - 1].node.property.type === "Identifier" &&
-        (isFactoryOrShort(groups[0][groups[0].length - 1].node.property.name) ||
+        (isNoWrap(groups[0][groups[0].length - 1].node.property.name) ||
           (groups[1].length && groups[1][0].node.computed))));
 
   function printGroup(printedGroup) {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4108,8 +4108,8 @@ function printMemberChain(path, options, print) {
   //
   // In order to detect those cases, we use an heuristic: if the first
   // node is just an identifier with the name starting with a capital
-  // letter, just a sequence of _$ or this. The rationale is that they are
-  // likely to be factories.
+  // letter, like a sequence of _$, or as short as tabWidth. The rationale 
+  // is that they are likely to be factories.
   function isFactory(name) {
     return name.match(/(^[A-Z])|^[_$]+$/) || name.length <= options.tabWidth;
   }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4111,7 +4111,7 @@ function printMemberChain(path, options, print) {
   // letter, just a sequence of _$ or this. The rationale is that they are
   // likely to be factories.
   function isFactory(name) {
-    return name.match(/(^[A-Z])|^[_$]+$/);
+    return name.match(/(^[A-Z])|^[_$]+$/) || name.length <= options.tabWidth;
   }
   const shouldMerge =
     groups.length >= 2 &&

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1281,7 +1281,7 @@ function memberOutside() {
 function memberInAndOutWithCalls() {
   return (
     // Reason for a
-    a.b()
+    aFunction.b()
   ).c.d()
 }
 
@@ -1409,8 +1409,9 @@ function memberOutside() {
 
 function memberInAndOutWithCalls() {
   return (
-    a.b// Reason for a
-    ()
+    aFunction
+      .b// Reason for a
+      ()
       .c.d()
   );
 }

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1409,9 +1409,8 @@ function memberOutside() {
 
 function memberInAndOutWithCalls() {
   return (
-    a
-      .b// Reason for a
-      ()
+    a.b// Reason for a
+    ()
       .c.d()
   );
 }

--- a/tests/comments/return-statement.js
+++ b/tests/comments/return-statement.js
@@ -82,7 +82,7 @@ function memberOutside() {
 function memberInAndOutWithCalls() {
   return (
     // Reason for a
-    a.b()
+    aFunction.b()
   ).c.d()
 }
 

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -485,6 +485,28 @@ object[
 
 `;
 
+exports[`d3.js 1`] = `
+d3.select('body')
+  .append('circle')
+  .at({ width: 30, fill: '#f0f' })
+  .st({ fontWeight: 600 })
+
+d3.scaleLinear()
+  .domain([1950, 1980])
+  .range([0, width])
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+d3.select("body")
+  .append("circle")
+  .at({ width: 30, fill: "#f0f" })
+  .st({ fontWeight: 600 });
+
+d3.scaleLinear()
+  .domain([1950, 1980])
+  .range([0, width]);
+
+`;
+
 exports[`first_long.js 1`] = `
 export default function theFunction(action$, store) {
   return action$.ofType(THE_ACTION).switchMap(action => Observable

--- a/tests/method-chain/d3.js
+++ b/tests/method-chain/d3.js
@@ -1,0 +1,9 @@
+d3.select('body')
+  .append('circle')
+  .at({ width: 30, fill: '#f0f' })
+  .st({ fontWeight: 600 })
+
+d3.scaleLinear()
+  .domain([1950, 1980])
+  .range([0, width])
+


### PR DESCRIPTION
#1283 

```
d3.select('body')
  .append('circle')
  .at({width: 30, fill: '#f0f'})
  .st({fontWeight: 600})
```

instead of 

```
d3
  .select('body')
  .append('circle')
  .at({ width: 30, fill: '#f0f' })
  .st({ fontWeight: 600 })
```

I'm not familiar with `jsfmt` and I'm not sure how to add a test for this; please let me know what changes are needed.