### PR TITLE
Stop marking all comments in named exports as leading comments

### DIFF
--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -95,7 +95,6 @@ function handleEndOfLineComment(comment, text, options, ast, isLastComment) {
     handleLabeledStatementComments(enclosingNode, comment) ||
     handleCallExpressionComments(precedingNode, enclosingNode, comment) ||
     handlePropertyComments(enclosingNode, comment) ||
-    handleExportNamedDeclarationComments(enclosingNode, comment) ||
     handleOnlyComments(enclosingNode, ast, comment, isLastComment) ||
     handleTypeAliasComments(enclosingNode, followingNode, comment) ||
     handleVariableDeclaratorComments(enclosingNode, followingNode, comment)
@@ -604,14 +603,6 @@ function handlePropertyComments(enclosingNode, comment) {
     (enclosingNode.type === "Property" ||
       enclosingNode.type === "ObjectProperty")
   ) {
-    addLeadingComment(enclosingNode, comment);
-    return true;
-  }
-  return false;
-}
-
-function handleExportNamedDeclarationComments(enclosingNode, comment) {
-  if (enclosingNode && enclosingNode.type === "ExportNamedDeclaration") {
     addLeadingComment(enclosingNode, comment);
     return true;
   }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1472,13 +1472,7 @@ function printPathNoParens(path, options, print, args) {
               comment =>
                 comment.trailing && !privateUtil.isBlockComment(comment)
             )) ||
-          (hasDanglingComments(n) &&
-            n.comments.some(
-              comment =>
-                !comment.leading &&
-                !comment.trailing &&
-                !privateUtil.isBlockComment(comment)
-            ));
+          needsHardlineAfterDanglingComment(n);
         const elseOnSameLine =
           n.consequent.type === "BlockStatement" && !commentOnOwnLine;
         parts.push(elseOnSameLine ? " " : hardline);
@@ -3622,6 +3616,10 @@ function printExportDeclaration(path, options, print) {
     comments.printDanglingComments(path, options, /* sameIndent */ true)
   );
 
+  if (needsHardlineAfterDanglingComment(decl)) {
+    parts.push(hardline);
+  }
+
   if (decl.declaration) {
     parts.push(path.call(print, "declaration"));
 
@@ -5300,6 +5298,18 @@ function hasDanglingComments(node) {
   return (
     node.comments &&
     node.comments.some(comment => !comment.leading && !comment.trailing)
+  );
+}
+
+function needsHardlineAfterDanglingComment(node) {
+  if (!node.comments) {
+    return false;
+  }
+  const lastDanglingComment = privateUtil.getLast(
+    node.comments.filter(comment => !comment.leading && !comment.trailing)
+  );
+  return (
+    lastDanglingComment && !privateUtil.isBlockComment(lastDanglingComment)
   );
 }
 

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -255,9 +255,41 @@ import("something" /* Hello */ + "else");
 exports[`export.js 1`] = `
 export //comment
 {}
+
+export /* comment */ {};
+
+export {
+  foo // comment
+}
+
+export {
+  // comment
+  bar
+}
+
+export {
+  fooo, // comment
+  barr, // comment
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-//comment
-export {};
+export //comment
+{};
+
+export /* comment */{};
+
+export {
+  foo // comment
+};
+
+export {
+  // comment
+  bar
+};
+
+export {
+  fooo, // comment
+  barr // comment
+};
 
 `;
 

--- a/tests/comments/export.js
+++ b/tests/comments/export.js
@@ -1,2 +1,18 @@
 export //comment
 {}
+
+export /* comment */ {};
+
+export {
+  foo // comment
+}
+
+export {
+  // comment
+  bar
+}
+
+export {
+  fooo, // comment
+  barr, // comment
+}


### PR DESCRIPTION
The underlying bug in #4291 is actually because we were attaching every comment inside a named export as leading comments of that export. Leading and trailing comments are not ignored with `// prettier-ignore` so they are printed twice.

This PR removes the special handling of comments inside named exports and simply print them correctly in the printer.

Closes #4291