### PR TITLE
refactor(doc-utils): move `rawText` to printer-estree

### DIFF
--- a/src/doc/doc-utils.js
+++ b/src/doc/doc-utils.js
@@ -182,10 +182,6 @@ function stripTrailingHardline(doc) {
   return doc;
 }
 
-function rawText(node) {
-  return node.extra ? node.extra.raw : node.raw;
-}
-
 module.exports = {
   isEmpty,
   willBreak,
@@ -194,6 +190,5 @@ module.exports = {
   mapDoc,
   propagateBreaks,
   removeLines,
-  stripTrailingHardline,
-  rawText
+  stripTrailingHardline
 };

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -35,7 +35,6 @@ const docUtils = doc.utils;
 const willBreak = docUtils.willBreak;
 const isLineNext = docUtils.isLineNext;
 const isEmpty = docUtils.isEmpty;
-const rawText = docUtils.rawText;
 
 function shouldPrintComma(options, level) {
   level = level || "es5";
@@ -5525,6 +5524,10 @@ function printJsDocComment(comment) {
     ),
     "*/"
   ]);
+}
+
+function rawText(node) {
+  return node.extra ? node.extra.raw : node.raw;
 }
 
 module.exports = {


### PR DESCRIPTION
I couldn't think of a reason why `rawText` should live in `doc-utils`, it's probably misplaced.