### PR TITLE
Wrap awaits in unary expressions with parens

### DIFF
--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -317,6 +317,7 @@ function needsParens(path, options) {
     case "AwaitExpression":
       switch (parent.type) {
         case "TaggedTemplateExpression":
+        case "UnaryExpression":
         case "BinaryExpression":
         case "LogicalExpression":
         case "SpreadElement":

--- a/tests/async/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/async/__snapshots__/jsfmt.spec.js.snap
@@ -35,7 +35,7 @@ function *f(){
   !(yield a);
 }
 async function f() {
-  a = !(await f());
+  a = !await f();
 }
 async () => {
   new A(await x);
@@ -52,7 +52,7 @@ function* f() {
   !(yield a);
 }
 async function f() {
-  a = !await f();
+  a = !(await f());
 }
 async () => {
   new A(await x);

--- a/tests/async/await_parse.js
+++ b/tests/async/await_parse.js
@@ -8,7 +8,7 @@ function *f(){
   !(yield a);
 }
 async function f() {
-  a = !(await f());
+  a = !await f();
 }
 async () => {
   new A(await x);

--- a/tests/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
@@ -53,9 +53,9 @@ async function f() {
 // @target: es6
 async function f() {
   <number>await 0;
-  typeof await 0;
-  void await 0;
-  await void (<string>typeof (<number>void await 0));
+  typeof (await 0);
+  void (await 0);
+  await void (<string>typeof (<number>void (await 0)));
   await await 0;
 }
 


### PR DESCRIPTION
Fixes #4138 by wrapping await expressions inside of unary expressions.  ([list of unary operators](https://scotch.io/tutorials/javascript-unary-operators-simple-and-useful#toc-summary-of-all-unary-operators))

Sample input (currently prettier would leave this unchanged):
```javascript
const w = !await resolveIdentity(false);
const x = -await resolveIdentity(3);
const y = +await resolveIdentity('3');
const z = typeof await resolveIdentity(false);
```

Output:
```javascript
const w = !(await resolveIdentity(false));
const x = -(await resolveIdentity(3));
const y = +(await resolveIdentity('3'));
const z = typeof (await resolveIdentity(false));
```