### PR TITLE
Run Travis tests in parallel unless they fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ cache:
   - node_modules
 script:
   - yarn lint
-  - AST_COMPARE=1 yarn test -- --runInBand
+  - AST_COMPARE=1 yarn test || AST_COMPARE yarn test -- --runInBand


### PR DESCRIPTION
If the tests pass, this will give us faster feedback from Travis. If
they fail, they're run again in-band, for clearer output.