### PR TITLE
[flow] Fix union indent inside of function param with a name

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2384,7 +2384,7 @@ function printPathNoParens(path, options, print, args) {
         parent.type !== "TSTypeParameterInstantiation" &&
         parent.type !== "GenericTypeAnnotation" &&
         parent.type !== "TSTypeReference" &&
-        parent.type !== "FunctionTypeParam" &&
+        !(parent.type === "FunctionTypeParam" && !parent.name) &&
         !(
           (parent.type === "TypeAlias" ||
             parent.type === "VariableDeclarator") &&

--- a/tests/union_intersection/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/union_intersection/__snapshots__/jsfmt.spec.js.snap
@@ -49,6 +49,17 @@ type Props = {
       }
   ) => void
 };
+
+declare class FormData {
+  append(
+    options?:
+      | string
+      | {
+          filepath?: string,
+          filename?: string
+        }
+  ): void;
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 type T5 =
   | "1"
@@ -117,5 +128,16 @@ type Props = {
       }
   ) => void
 };
+
+declare class FormData {
+  append(
+    options?:
+      | string
+      | {
+          filepath?: string,
+          filename?: string
+        }
+  ): void;
+}
 
 `;

--- a/tests/union_intersection/test.js
+++ b/tests/union_intersection/test.js
@@ -46,3 +46,14 @@ type Props = {
       }
   ) => void
 };
+
+declare class FormData {
+  append(
+    options?:
+      | string
+      | {
+          filepath?: string,
+          filename?: string
+        }
+  ): void;
+}


### PR DESCRIPTION
Fixes #4323

See #4323 for all the context.

I'd love to get it merged and ship a dot release if possible with it. It's affecting a bunch of code and prevents upgrading to the latest version of prettier at Facebook. I know it's been there for a while (since 1.9.3...)