### PR TITLE
Bump flow to 0.70

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "escape-string-regexp": "1.0.5",
     "esutils": "2.0.2",
     "find-project-root": "1.1.1",
-    "flow-parser": "0.69",
+    "flow-parser": "0.70",
     "get-stream": "3.0.0",
     "globby": "6.1.0",
     "graphql": "0.13.2",

--- a/scripts/build/rollup.parser.config.js
+++ b/scripts/build/rollup.parser.config.js
@@ -19,15 +19,6 @@ export default Object.assign(baseConfig, {
           include: "node_modules/typescript-eslint-parser/parser.js"
         })
       : {},
-    // In flow-parser 0.59.0 there's a dynamic require: `require(s8)` which not
-    // supported by rollup-plugin-commonjs, so we have to replace the variable
-    // by its value before bundling.
-    parser.endsWith("flow")
-      ? replace({
-          "require(tf)": 'require("fs")',
-          include: "node_modules/flow-parser/flow_parser.js"
-        })
-      : {},
     json(),
     resolve({ preferBuiltins: true }),
     commonjs(

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3852,6 +3852,14 @@ function printClass(path, options, print) {
     parts.push(" extends ", join(", ", path.map(print, "extends")));
   }
 
+  if (n["mixins"] && n["mixins"].length > 0) {
+    partsGroup.push(
+      line,
+      "mixins ",
+      group(indent(join(concat([",", line]), path.map(print, "mixins"))))
+    );
+  }
+
   if (n["implements"] && n["implements"].length > 0) {
     partsGroup.push(
       line,
@@ -3864,14 +3872,6 @@ function printClass(path, options, print) {
           ])
         )
       )
-    );
-  }
-
-  if (n["mixins"] && n["mixins"].length > 0) {
-    partsGroup.push(
-      line,
-      "mixins ",
-      group(indent(join(concat([",", line]), path.map(print, "mixins"))))
     );
   }
 

--- a/tests/flow/traits/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/traits/__snapshots__/jsfmt.spec.js.snap
@@ -22,7 +22,7 @@ declare class Baz<T> {
 ((new Foo).y: string); // error: Bar wins
 ((new Foo).z: number); // error: Qux wins
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-declare class Foo extends Qux<string> {
+declare class Foo extends Qux<string> mixins Bar<number> {
   // KeyedCollection <: Collection
   // ...KeyedIterable
 }
@@ -51,6 +51,6 @@ declare interface I { }
 declare class C mixins I { }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 declare interface I {}
-declare class C {}
+declare class C mixins I {}
 
 `;

--- a/tests/flow_implements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_implements/__snapshots__/jsfmt.spec.js.snap
@@ -10,7 +10,7 @@ declare class A implements B, C {}
 class A implements B {}
 class A implements B, C {}
 declare class A implements B {}
-declare class A implements C mixins B {}
+declare class A mixins B implements C {}
 declare class A implements B, C {}
 
 `;

--- a/tests/flow_implements/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_implements/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`implements.js 1`] = `
+class A implements B {}
+class A implements B, C {}
+declare class A implements B {}
+declare class A mixins B implements C {}
+declare class A implements B, C {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class A implements B {}
+class A implements B, C {}
+declare class A implements B {}
+declare class A implements C mixins B {}
+declare class A implements B, C {}
+
+`;

--- a/tests/flow_implements/implements.js
+++ b/tests/flow_implements/implements.js
@@ -1,0 +1,5 @@
+class A implements B {}
+class A implements B, C {}
+declare class A implements B {}
+declare class A mixins B implements C {}
+declare class A implements B, C {}

--- a/tests/flow_implements/jsfmt.spec.js
+++ b/tests/flow_implements/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["flow"]);

--- a/tests/flow_mixins/jsfmt.spec.js
+++ b/tests/flow_mixins/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, ["babylon"]);
+run_spec(__dirname, ["babylon", "flow"]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1971,9 +1971,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-parser@0.69:
-  version "0.69.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.69.0.tgz#378b5128d6d0b554a8b2f16a4ca3e1ab9649f00e"
+flow-parser@0.70:
+  version "0.70.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.70.0.tgz#9c310187efe4380ba9a251284e9b83b95c49e857"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Fixes #4240.

Followup to https://github.com/prettier/prettier/pull/4244, now that @duailibe's fix is published.

EDIT: Just for reference, PR for support of implements in Babylon/Babel is https://github.com/babel/babel/pull/7741, will update tests when it lands.