### PR TITLE
Fix pragma detection/insertion for JSON

### DIFF
--- a/src/language-js/index.js
+++ b/src/language-js/index.js
@@ -181,7 +181,7 @@ const parsers = {
   babylon,
   json: Object.assign({}, babylon, {
     hasPragma() {
-      return false;
+      return true;
     }
   }),
   flow: {

--- a/tests/insert-pragma/json/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/insert-pragma/json/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`does-nothing.json 1`] = `
+{"allOn": "Single", "Line": "example",
+"noSpace":true,
+  "quote": {
+    "singleQuote": "example",
+                  "indented": true,
+  },
+  "phoneNumbers": [
+    {"type": "home",
+      "number": "212 555-1234"},
+    {"type": "office",
+      "trailing": "commas by accident"},
+  ],
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{
+  "allOn": "Single",
+  "Line": "example",
+  "noSpace": true,
+  "quote": {
+    "singleQuote": "example",
+    "indented": true
+  },
+  "phoneNumbers": [
+    {
+      "type": "home",
+      "number": "212 555-1234"
+    },
+    {
+      "type": "office",
+      "trailing": "commas by accident"
+    }
+  ]
+}
+
+`;

--- a/tests/insert-pragma/json/does-nothing.json
+++ b/tests/insert-pragma/json/does-nothing.json
@@ -1,0 +1,13 @@
+{"allOn": "Single", "Line": "example",
+"noSpace":true,
+  "quote": {
+    "singleQuote": "example",
+                  "indented": true,
+  },
+  "phoneNumbers": [
+    {"type": "home",
+      "number": "212 555-1234"},
+    {"type": "office",
+      "trailing": "commas by accident"},
+  ],
+}

--- a/tests/insert-pragma/json/jsfmt.spec.js
+++ b/tests/insert-pragma/json/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["json"], { insertPragma: true });

--- a/tests/require-pragma/json/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/require-pragma/json/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`format-anyway.json 1`] = `
+{"allOn": "Single", "Line": "example",
+"noSpace":true,
+  "quote": {
+     "singleQuote": "example",
+                  "indented": true,
+  },
+  "phoneNumbers": [
+    {"type": "home",
+      "number": "212 555-1234"},
+    {"type": "office",
+      "trailing": "commas by accident"},
+  ],
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+{
+  "allOn": "Single",
+  "Line": "example",
+  "noSpace": true,
+  "quote": {
+    "singleQuote": "example",
+    "indented": true
+  },
+  "phoneNumbers": [
+    {
+      "type": "home",
+      "number": "212 555-1234"
+    },
+    {
+      "type": "office",
+      "trailing": "commas by accident"
+    }
+  ]
+}
+
+`;

--- a/tests/require-pragma/json/format-anyway.json
+++ b/tests/require-pragma/json/format-anyway.json
@@ -1,0 +1,13 @@
+{"allOn": "Single", "Line": "example",
+"noSpace":true,
+  "quote": {
+     "singleQuote": "example",
+                  "indented": true,
+  },
+  "phoneNumbers": [
+    {"type": "home",
+      "number": "212 555-1234"},
+    {"type": "office",
+      "trailing": "commas by accident"},
+  ],
+}

--- a/tests/require-pragma/json/jsfmt.spec.js
+++ b/tests/require-pragma/json/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["json"], { requirePragma: true });


### PR DESCRIPTION
Following https://github.com/prettier/prettier/issues/3557#issuecomment-356280409 we should always format JSON even with `--require-pragma` and never add a comment even with `--insert-pragma`.

Making `hasPragma` for JSON always return true makes Prettier always format the JSON file, and stop trying to insert pragma because it thinks the code already has a pragma.