### PR TITLE
feat(typescript): support TaggedTemplateExpression typeParameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
     "resolve": "1.5.0",
     "semver": "5.4.1",
     "string-width": "2.1.1",
-    "typescript": "2.8.0-rc",
-    "typescript-eslint-parser": "14.0.0",
+    "typescript": "2.9.0-dev.20180421",
+    "typescript-eslint-parser": "ikatyang/typescript-eslint-parser#feat/support-tagged-template-expression-type-arguments",
     "unicode-regex": "1.0.1",
     "unified": "6.1.6"
   },

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "semver": "5.4.1",
     "string-width": "2.1.1",
     "typescript": "2.9.0-dev.20180421",
-    "typescript-eslint-parser": "ikatyang/typescript-eslint-parser#feat/support-tagged-template-expression-type-arguments",
+    "typescript-eslint-parser": "eslint/typescript-eslint-parser#2960b002746c01fb9cb15bb5f4c1e7e925c6519a",
     "unicode-regex": "1.0.1",
     "unified": "6.1.6"
   },

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2095,7 +2095,11 @@ function printPathNoParens(path, options, print, args) {
     // These types are unprintable because they serve as abstract
     // supertypes for other (printable) types.
     case "TaggedTemplateExpression":
-      return concat([path.call(print, "tag"), path.call(print, "quasi")]);
+      return concat([
+        path.call(print, "tag"),
+        path.call(print, "typeParameters"),
+        path.call(print, "quasi")
+      ]);
     case "Node":
     case "Printable":
     case "SourceLocation":
@@ -2723,7 +2727,7 @@ function printPathNoParens(path, options, print, args) {
       return concat([path.call(print, "expression"), "!"]);
     case "TSThisType":
       return "this";
-    case "TSLastTypeNode":
+    case "TSLiteralType":
       return path.call(print, "literal");
     case "TSIndexedAccessType":
       return concat([

--- a/tests/typescript_typeparams/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_typeparams/__snapshots__/jsfmt.spec.js.snap
@@ -34,3 +34,19 @@ export const forwardS = R.curry(
 );
 
 `;
+
+exports[`tagged-template-expression.ts 1`] = `
+export const RedBox = styled.div<{foo: string}>\`
+  background: red;
+  \${props => props.foo}
+\`;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+export const RedBox =
+  styled.div <
+  { foo: string } >
+  \`
+  background: red;
+  \${props => props.foo}
+\`;
+
+`;

--- a/tests/typescript_typeparams/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_typeparams/__snapshots__/jsfmt.spec.js.snap
@@ -41,12 +41,9 @@ export const RedBox = styled.div<{foo: string}>\`
   \${props => props.foo}
 \`;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-export const RedBox =
-  styled.div <
-  { foo: string } >
-  \`
+export const RedBox = styled.div<{ foo: string }>\`
   background: red;
-  \${props => props.foo}
+  \${props => props.foo};
 \`;
 
 `;

--- a/tests/typescript_typeparams/tagged-template-expression.ts
+++ b/tests/typescript_typeparams/tagged-template-expression.ts
@@ -1,0 +1,4 @@
+export const RedBox = styled.div<{foo: string}>`
+  background: red;
+  ${props => props.foo}
+`;

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -20,7 +20,7 @@ self.Buffer = {
   }
 };
 self.constants = {};
-module$1 = module = os = crypto = {};
+module$1 = module = os = crypto = buffer = {};
 self.fs = { readFile: function() {} };
 os.homedir = function() {
   return "/home/prettier";

--- a/yarn.lock
+++ b/yarn.lock
@@ -4762,9 +4762,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript-eslint-parser@ikatyang/typescript-eslint-parser#feat/support-tagged-template-expression-type-arguments:
+typescript-eslint-parser@eslint/typescript-eslint-parser#2960b002746c01fb9cb15bb5f4c1e7e925c6519a:
   version "14.0.0"
-  resolved "https://codeload.github.com/ikatyang/typescript-eslint-parser/tar.gz/d69eecee99f8297be3fd5e03338b79d32dadefe6"
+  resolved "https://codeload.github.com/eslint/typescript-eslint-parser/tar.gz/2960b002746c01fb9cb15bb5f4c1e7e925c6519a"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4762,16 +4762,16 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript-eslint-parser@14.0.0:
+typescript-eslint-parser@ikatyang/typescript-eslint-parser#feat/support-tagged-template-expression-type-arguments:
   version "14.0.0"
-  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-14.0.0.tgz#c90a8f541c1d96e5c55e2807c61d154e788520f9"
+  resolved "https://codeload.github.com/ikatyang/typescript-eslint-parser/tar.gz/d69eecee99f8297be3fd5e03338b79d32dadefe6"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@2.8.0-rc:
-  version "2.8.0-rc"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.0-rc.tgz#a0256b7d1d39fb7493ba0403f55e95d31e8bc374"
+typescript@2.9.0-dev.20180421:
+  version "2.9.0-dev.20180421"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.0-dev.20180421.tgz#b937b164ce73f833f2ed5c36571e238898b264ce"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
Fixes #4352

- [x] Waiting for eslint/typescript-eslint-parser#469.

---

**Prettier pr-4353**
[Playground link](https://deploy-preview-4353--prettier.netlify.com/playground/#N4Igxg9gdgLgprEAuEcAeAHCAnGACSKAZ3wCU4ATAIQjTwF48SBPAG0oDoKBLANwB5gAMwgQkTGNm5QA5gF8AfAAMAOlDx4ARgEMwAaxnYIAVygVx2SgG41GgCTAMRjEQYK8TiC44iIctUpWIAA0IF4w3NBEyKDa2EYA7gAKcQjRKNq8ENwUISCa2Lp6cDAAyhi60jLIksZwodJEcLhJhTIAttrIQtqsTaEAVkRoVIX6JaXa7XAAMtJw3b39IBXYTdjIIDDMGHBEYFIYMHlO0jAA6jkwABbIABwADKGeTeeFGJtOe828C6GWAEdjNxLK1tB0ukgen16iAmu1uDVsHVQkQquwAIrGCDwRYw0IwbSaS4UG7IABMBMK3FYVQAwhB2p1NlBoH8QMYmgAVInpaFNORyIA)
```sh
--parser typescript
```

**Input:**
```tsx
export const RedBox = styled.div<{foo: string}>`
  background: red;
  ${props => props.foo}
`;
```

**Output:**
```tsx
export const RedBox = styled.div<{ foo: string }>`
  background: red;
  ${props => props.foo};
`;

```