### PR TITLE
New: Format Angular Component styles

### DIFF
--- a/src/language-js/clean.js
+++ b/src/language-js/clean.js
@@ -122,6 +122,24 @@ function clean(ast, newObj, parent) {
     newObj.value.expression.quasis.forEach(q => delete q.value);
   }
 
+  // CSS template literals in Angular Component decorator
+  if (
+    ast.type === "Decorator" &&
+    ast.expression.type === "CallExpression" &&
+    ast.expression.callee.name === "Component" &&
+    ast.expression.arguments.length === 1 &&
+    ast.expression.arguments[0].properties.some(
+      prop =>
+        prop.key.name === "styles" && prop.value.type === "ArrayExpression"
+    )
+  ) {
+    newObj.expression.arguments[0].properties.forEach(prop => {
+      if (prop.value.type === "ArrayExpression") {
+        prop.value.elements[0].quasis.forEach(q => delete q.value);
+      }
+    });
+  }
+
   // styled-components, graphql, markdown
   if (
     ast.type === "TaggedTemplateExpression" &&

--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -18,9 +18,12 @@ function embed(path, print, textToDoc /*, options */) {
 
   switch (node.type) {
     case "TemplateLiteral": {
-      const isCss = [isStyledJsx, isStyledComponents, isCssProp].some(isIt =>
-        isIt(path)
-      );
+      const isCss = [
+        isStyledJsx,
+        isStyledComponents,
+        isCssProp,
+        isAngularComponentStyles
+      ].some(isIt => isIt(path));
 
       if (isCss) {
         // Get full template literal with expressions replaced by placeholders
@@ -37,6 +40,35 @@ function embed(path, print, textToDoc /*, options */) {
         }, "");
         const doc = textToDoc(text, { parser: "css" });
         return transformCssDoc(doc, path, print);
+      }
+
+      const isWithinArrayValueFromProperty = !!(
+        parent &&
+        (parent.type === "ArrayExpression" && parentParent.type === "Property")
+      );
+      /**
+       * CSS Styles
+       */
+      if (
+        isWithinArrayValueFromProperty &&
+        isPropertyWithinAngularComponentDecorator(path, 4)
+      ) {
+        if (parentParent.key && parentParent.key.name === "styles") {
+          // Get full template literal with expressions replaced by placeholders
+          const rawQuasis = node.quasis.map(q => q.value.raw);
+          let placeholderID = 0;
+          const text = rawQuasis.reduce((prevVal, currVal, idx) => {
+            return idx == 0
+              ? currVal
+              : prevVal +
+                  "@prettier-placeholder-" +
+                  placeholderID++ +
+                  "-id" +
+                  currVal;
+          }, "");
+          const doc = textToDoc(text, { parser: "css" });
+          return transformCssDoc(doc, path, print);
+        }
       }
 
       /*
@@ -174,6 +206,18 @@ function embed(path, print, textToDoc /*, options */) {
     const doc = textToDoc(text, { parser: "markdown", __inJsTemplate: true });
     return docUtils.stripTrailingHardline(escapeBackticks(doc));
   }
+}
+
+function isPropertyWithinAngularComponentDecorator(path, parentIndexToCheck) {
+  const parent = path.getParentNode(parentIndexToCheck);
+  return !!(
+    parent &&
+    parent.type === "Decorator" &&
+    parent.expression &&
+    parent.expression.type === "CallExpression" &&
+    parent.expression.callee &&
+    parent.expression.callee.name === "Component"
+  );
 }
 
 function getIndentation(str) {
@@ -332,6 +376,41 @@ function isStyledJsx(path) {
       attribute => attribute.name.name === "jsx"
     )
   );
+}
+
+/**
+ * Angular Components can have:
+ * - Inline HTML template
+ * - Inline CSS styles
+ *
+ * ...which are both within template literals somewhere
+ * inside of the Component decorator factory.
+ *
+ * TODO: Format HTML template once prettier's HTML
+ * formatting is "ready"
+ *
+ * E.g.
+ * @Component({
+ *  template: `<div>...</div>`,
+ *  styles: [`h1 { color: blue; }`]
+ * })
+ */
+function isAngularComponentStyles(path) {
+  const parent = path.getParentNode();
+  const parentParent = path.getParentNode(1);
+  const isWithinArrayValueFromProperty = !!(
+    parent &&
+    (parent.type === "ArrayExpression" && parentParent.type === "Property")
+  );
+  if (
+    isWithinArrayValueFromProperty &&
+    isPropertyWithinAngularComponentDecorator(path, 4)
+  ) {
+    if (parentParent.key && parentParent.key.name === "styles") {
+      return true;
+    }
+  }
+  return false;
 }
 
 /**

--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -42,35 +42,6 @@ function embed(path, print, textToDoc /*, options */) {
         return transformCssDoc(doc, path, print);
       }
 
-      const isWithinArrayValueFromProperty = !!(
-        parent &&
-        (parent.type === "ArrayExpression" && parentParent.type === "Property")
-      );
-      /**
-       * CSS Styles
-       */
-      if (
-        isWithinArrayValueFromProperty &&
-        isPropertyWithinAngularComponentDecorator(path, 4)
-      ) {
-        if (parentParent.key && parentParent.key.name === "styles") {
-          // Get full template literal with expressions replaced by placeholders
-          const rawQuasis = node.quasis.map(q => q.value.raw);
-          let placeholderID = 0;
-          const text = rawQuasis.reduce((prevVal, currVal, idx) => {
-            return idx == 0
-              ? currVal
-              : prevVal +
-                  "@prettier-placeholder-" +
-                  placeholderID++ +
-                  "-id" +
-                  currVal;
-          }, "");
-          const doc = textToDoc(text, { parser: "css" });
-          return transformCssDoc(doc, path, print);
-        }
-      }
-
       /*
        * react-relay and graphql-tag
        * graphql`...`

--- a/tests/angular_component_examples/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/angular_component_examples/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test.component.ts 1`] = `
+@Component({
+       selector: 'app-test',
+  template: \`<ul>   <li>test</li>
+  </ul>
+  \`,
+  styles: [   \`
+  
+ :host {
+   color: red;
+ } 
+ div { background: blue
+ }
+\`
+
+]
+})
+class     TestComponent {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@Component({
+  selector: "app-test",
+  template: \`<ul>   <li>test</li>
+  </ul>
+  \`,
+  styles: [
+    \`
+      :host {
+        color: red;
+      }
+      div {
+        background: blue;
+      }
+    \`
+  ]
+})
+class TestComponent {}
+
+`;
+
+exports[`test.component.ts 2`] = `
+@Component({
+       selector: 'app-test',
+  template: \`<ul>   <li>test</li>
+  </ul>
+  \`,
+  styles: [   \`
+  
+ :host {
+   color: red;
+ } 
+ div { background: blue
+ }
+\`
+
+]
+})
+class     TestComponent {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@Component({
+  selector: "app-test",
+  template: \`<ul>   <li>test</li>
+  </ul>
+  \`,
+  styles: [
+    \`
+      :host {
+        color: red;
+      }
+      div {
+        background: blue;
+      }
+    \`,
+  ],
+})
+class TestComponent {}
+
+`;

--- a/tests/angular_component_examples/jsfmt.spec.js
+++ b/tests/angular_component_examples/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname, ["typescript"]);
+run_spec(__dirname, ["typescript"], { trailingComma: "es5" });

--- a/tests/angular_component_examples/test.component.ts
+++ b/tests/angular_component_examples/test.component.ts
@@ -1,0 +1,17 @@
+@Component({
+       selector: 'app-test',
+  template: `<ul>   <li>test</li>
+  </ul>
+  `,
+  styles: [   `
+  
+ :host {
+   color: red;
+ } 
+ div { background: blue
+ }
+`
+
+]
+})
+class     TestComponent {}


### PR DESCRIPTION
I had a free couple of hours on the flight back from ng-conf and so put together a POC for Angular Component inline template and style formatting. Would love feedback! More than a couple of folks at the conference asked me if this was something we could add to Prettier.

I can see from recent comments on issues that HTML support is not classed as stable yet? If this has to go in in two stages (first inline styles, then inline template once HTML is no longer experimental) then that would still be great.

The implementation is a little bit hacky as I did not have a WIFI connection and just did my best to emulate existing patterns from Vue formatting etc. so happy to make any updates you want me to. 

Example test case:

**UPDATED TO REMOVE HTML SUPPORT**

**Before:**
```ts
@Component({
       selector: 'app-test',
  styles: [   `
  
 :host {
   color: red;
 } 
 div { background: blue
 }
`

]
})
class     TestComponent {}
```

**After:**
```ts
@Component({
  selector: "app-test",
  styles: [
    `
      :host {
        color: red;
      }
      div {
        background: blue;
      }
    `,
  ],
})
class TestComponent {}
```