### PR TITLE
feat: use `postcss-values-parser` for `@namespace` at rule

### DIFF
--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -378,6 +378,8 @@ function parseNestedCSS(node) {
 
       if (
         [
+          "namespace",
+          "supports",
           "if",
           "else",
           "for",
@@ -389,8 +391,7 @@ function parseNestedCSS(node) {
           "function",
           "return",
           "define-mixin",
-          "add-mixin",
-          "supports"
+          "add-mixin"
         ].indexOf(name) !== -1
       ) {
         // Remove unnecessary spaces in SCSS variable arguments
@@ -415,7 +416,7 @@ function parseNestedCSS(node) {
       }
 
       if (
-        ["namespace", "import", "media", "custom-media"].indexOf(
+        ["import", "media", "custom-media"].indexOf(
           lowercasedName
         ) !== -1
       ) {

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -603,7 +603,8 @@ function genericPrint(path, options, print) {
           isNextRelationalOperator ||
           isNextIfElseKeyword ||
           isForKeyword ||
-          isEachKeyword
+          isEachKeyword ||
+          (atRuleAncestorNode && atRuleAncestorNode.name === "namespace")
         ) {
           parts.push(" ");
         } else if (


### PR DESCRIPTION
Part of https://github.com/prettier/prettier/pull/4181. `postcss-value-parser` is abadoned and bad parser many bleeding edge in `at-rules`