### PR TITLE
fix(json): jsonc is considered JSON instead of JSON5

### DIFF
--- a/src/language-js/index.js
+++ b/src/language-js/index.js
@@ -160,7 +160,7 @@ const languages = [
     extensions: [".json5"],
     filenames: [".babelrc"],
     linguistLanguageId: 175,
-    vscodeLanguageIds: []
+    vscodeLanguageIds: ["json5"]
   }
 ];
 

--- a/src/language-js/index.js
+++ b/src/language-js/index.js
@@ -146,7 +146,7 @@ const languages = [
       "mcmod.info"
     ],
     linguistLanguageId: 174,
-    vscodeLanguageIds: ["json"]
+    vscodeLanguageIds: ["json", "jsonc"]
   },
   {
     name: "JSON5",
@@ -160,7 +160,7 @@ const languages = [
     extensions: [".json5"],
     filenames: [".babelrc"],
     linguistLanguageId: 175,
-    vscodeLanguageIds: ["jsonc"]
+    vscodeLanguageIds: []
   }
 ];
 

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -547,7 +547,7 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"parsers\\": [\\"json\\"],
       \\"since\\": \\"1.5.0\\",
       \\"tmScope\\": \\"source.json\\",
-      \\"vscodeLanguageIds\\": [\\"json\\"]
+      \\"vscodeLanguageIds\\": [\\"json\\", \\"jsonc\\"]
     },
     {
       \\"aceMode\\": \\"css\\",


### PR DESCRIPTION
Just noticed that jsonc (JSON with Comments) in VSCode is indeed just JSON + comments...

![image](https://user-images.githubusercontent.com/8341033/39258388-7d626b00-48e6-11e8-94bb-adf6a1701415.png)
