### PR TITLE
fix(playground): add missing `input` code sample for `copy markdown`

### DIFF
--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -90,7 +90,7 @@ class Playground extends React.Component {
     const { availableOptions, version } = this.props;
 
     return formatMarkdown(
-      content,
+      content || getCodeSample(options.parser),
       formatted,
       reformatted || "",
       version,


### PR DESCRIPTION
Fixes the following case:

> **Prettier 1.12.1**
> [Playground link](https://prettier.io/playground/)
> 
> **Input:**
> ```jsx
> 
> ```
> 
> **Output:**
> ```jsx
> function HelloWorld({
>   greeting = "hello",
>   greeted = '"World"',
>   silent = false,
>   onMouseOver
> }) {
>   if (!greeting) {
>     return null;
>   }
> 
>   // TODO: Don't use random in render
>   let num = Math.floor(Math.random() * 1e7)
>     .toString()
>     .replace(/\.\d+/gi, "");
> 
>   return (
>     <div
>       className="HelloWorld"
>       title={`You are visitor number ${num}`}
>       onMouseOver={onMouseOver}
>     >
>       <strong>
>         {greeting.slice(0, 1).toUpperCase() + greeting.slice(1).toLowerCase()}
>       </strong>
>       {greeting.endsWith(",") ? (
>         " "
>       ) : (
>         <span style={{ color: "grey" }}>", "</span>
>       )}
>       <em>{greeted}</em>
>       {silent ? "." : "!"}
>     </div>
>   );
> }
> 
> ```