### PR TITLE
Apply destructuring rules in functions to catch param

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1048,6 +1048,7 @@ function printPathNoParens(path, options, print, args) {
           parent.type !== "FunctionExpression" &&
           parent.type !== "ArrowFunctionExpression" &&
           parent.type !== "AssignmentPattern" &&
+          parent.type !== "CatchClause" &&
           n.properties.some(
             property =>
               property.value &&

--- a/tests/destructuring/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/destructuring/__snapshots__/jsfmt.spec.js.snap
@@ -22,6 +22,18 @@ const UserComponent = function({
 };
 
 const { a, b, c, d: { e } } = someObject;
+
+try {
+  // code
+} catch ({ data: { message }}) {
+  // code
+}
+
+try {
+  // code
+} catch ({ data: { message: { errors }}}) {
+  // code
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const [one, two = null, three = null] = arr;
 a = ([s = 1]) => 1;
@@ -55,5 +67,21 @@ const {
   c,
   d: { e }
 } = someObject;
+
+try {
+  // code
+} catch ({ data: { message } }) {
+  // code
+}
+
+try {
+  // code
+} catch ({
+  data: {
+    message: { errors }
+  }
+}) {
+  // code
+}
 
 `;

--- a/tests/destructuring/destructuring.js
+++ b/tests/destructuring/destructuring.js
@@ -19,3 +19,15 @@ const UserComponent = function({
 };
 
 const { a, b, c, d: { e } } = someObject;
+
+try {
+  // code
+} catch ({ data: { message }}) {
+  // code
+}
+
+try {
+  // code
+} catch ({ data: { message: { errors }}}) {
+  // code
+}


### PR DESCRIPTION
In #4267 we started to break destructuring with "nested destructurings", except for function arguments which ignored the "first level". This PR applies the same exception to catch clauses parameters.

Context: #4384

---

**Prettier pr-4385**
[Playground link](https://5ae1d2908df8940c97484a26--prettier.netlify.com/playground/#N4Igxg9gdgLgprEAuEMBOBPABMAvlsAQxjAAssAKYAE2MKRwFs4BnFwgczl1wEodcAHSjD02PAWJlKNOg2DM2nOPLho0ENCx58BIADQgIABxgBLaC2ShC6iAHcACrYRWUhAG4Qz1AyABGaIRgANZwMADKxsFmUBzI6ACucIaxLGowjkEcjITIAGaEADbphgBWLAAeAEJBoeERhMwAMrFwBcWlINFaasgBhP4YRdB+xmixMADqPjCkyAAcAAyG4xDpU0HG-eOsah7thmhwAI6JZsdZnLkdJSkg6YxmCWjJhiyxHEVwAIqJEPBbl0YIMZtQ5sgAEyGdCEMxFT4AYQgjBuKCg0EOIES6QAKoM3IU7jwgA)

**Input:**
```jsx
try {} catch ({data: {message}}) {}

try {} catch ({data: {message: {errors}}}) {}
```

**Output:**
```jsx
try {
} catch ({ data: { message } }) {}

try {
} catch ({
  data: {
    message: { errors }
  }
}) {}

```