### PR TITLE
Fix cannot read property 'type' of undefined bug

### DIFF
--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -805,6 +805,7 @@ function clean(ast, newObj, parent) {
   if (
     parent &&
     parent.type === "root" &&
+    parent.children.length > 0 &&
     (parent.children[0] === ast ||
       ((parent.children[0].type === "yaml" ||
         parent.children[0].type === "toml") &&


### PR DESCRIPTION
# Summary:
Fix "cannot read property 'type' of undefined" bug

# Changes proposed in this pull request:
- Add a condition check for `function clean` in `src/language-markdown/printer-markdown.js`.