### PR TITLE
avoid overflow in playground-container

### DIFF
--- a/website/static/separate-css/playground.css
+++ b/website/static/separate-css/playground.css
@@ -21,6 +21,7 @@ body {
   display: flex;
   flex: 1;
   flex-direction: column;
+  overflow: hidden;
 }
 
 header {
@@ -198,7 +199,6 @@ pre.CodeMirror-placeholder {
 
 .sub-options {
   flex: 1;
-  display: flex;
   padding: 15px 0 10px;
   border-bottom: 1px solid #ddd;
 }


### PR DESCRIPTION
fixes #4350

playground-container
overflow hidden forces the container to don't outgrow its space

sub-options
fixes Problem in Edge
