### PR TITLE
Fix trailing JSDoc comments with trailing regular comments

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5508,7 +5508,21 @@ function printComment(commentPath, options) {
     case "CommentBlock":
     case "Block": {
       if (isJsDocComment(comment)) {
-        return printJsDocComment(comment);
+        const printed = printJsDocComment(comment);
+        // We need to prevent an edge case of a previous trailing comment
+        // printed as a `lineSuffix` which causes the comments to be
+        // interleaved. See https://github.com/prettier/prettier/issues/4412
+        if (
+          comment.trailing &&
+          !privateUtil.hasNewline(
+            options.originalText,
+            options.locStart(comment),
+            { backwards: true }
+          )
+        ) {
+          return concat([hardline, printed]);
+        }
+        return printed;
       }
 
       const isInsideFlowComment =

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1644,8 +1644,7 @@ const CONNECTION_STATUS = exports.CONNECTION_STATUS = {
   CONNECTING: Object.freeze({ kind: 'CONNECTING' }),
   NOT_CONNECTED: Object.freeze({ kind: 'NOT_CONNECTED' }) };
 
-/* A comment */
-/**
+/* A comment */ /**
 * A type that can be written to a buffer.
 */ /**
 * Describes the connection status of a ReactiveSocket/DuplexConnection.

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1637,6 +1637,61 @@ exports[`trailing_space.js 1`] = `
 
 `;
 
+exports[`trailing-jsdocs.js 1`] = `
+const CONNECTION_STATUS = exports.CONNECTION_STATUS = {
+  CLOSED: Object.freeze({ kind: 'CLOSED' }),
+  CONNECTED: Object.freeze({ kind: 'CONNECTED' }),
+  CONNECTING: Object.freeze({ kind: 'CONNECTING' }),
+  NOT_CONNECTED: Object.freeze({ kind: 'NOT_CONNECTED' }) };
+
+/* A comment */
+/**
+* A type that can be written to a buffer.
+*/ /**
+* Describes the connection status of a ReactiveSocket/DuplexConnection.
+* - NOT_CONNECTED: no connection established or pending.
+* - CONNECTING: when \`connect()\` has been called but a connection is not yet
+*   established.
+* - CONNECTED: when a connection is established.
+* - CLOSED: when the connection has been explicitly closed via \`close()\`.
+* - ERROR: when the connection has been closed for any other reason.
+*/ /**
+* A contract providing different interaction models per the [ReactiveSocket protocol]
+* (https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md).
+*/ /**
+* A single unit of data exchanged between the peers of a \`ReactiveSocket\`.
+*/
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const CONNECTION_STATUS = (exports.CONNECTION_STATUS = {
+  CLOSED: Object.freeze({ kind: "CLOSED" }),
+  CONNECTED: Object.freeze({ kind: "CONNECTED" }),
+  CONNECTING: Object.freeze({ kind: "CONNECTING" }),
+  NOT_CONNECTED: Object.freeze({ kind: "NOT_CONNECTED" })
+});
+
+/* A comment */
+/**
+ * A type that can be written to a buffer.
+ */
+/**
+ * Describes the connection status of a ReactiveSocket/DuplexConnection.
+ * - NOT_CONNECTED: no connection established or pending.
+ * - CONNECTING: when \`connect()\` has been called but a connection is not yet
+ *   established.
+ * - CONNECTED: when a connection is established.
+ * - CLOSED: when the connection has been explicitly closed via \`close()\`.
+ * - ERROR: when the connection has been closed for any other reason.
+ */
+/**
+ * A contract providing different interaction models per the [ReactiveSocket protocol]
+ * (https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md).
+ */
+/**
+ * A single unit of data exchanged between the peers of a \`ReactiveSocket\`.
+ */
+
+`;
+
 exports[`try.js 1`] = `
 // comment 1
 try {

--- a/tests/comments/trailing-jsdocs.js
+++ b/tests/comments/trailing-jsdocs.js
@@ -4,8 +4,7 @@ const CONNECTION_STATUS = exports.CONNECTION_STATUS = {
   CONNECTING: Object.freeze({ kind: 'CONNECTING' }),
   NOT_CONNECTED: Object.freeze({ kind: 'NOT_CONNECTED' }) };
 
-/* A comment */
-/**
+/* A comment */ /**
 * A type that can be written to a buffer.
 */ /**
 * Describes the connection status of a ReactiveSocket/DuplexConnection.

--- a/tests/comments/trailing-jsdocs.js
+++ b/tests/comments/trailing-jsdocs.js
@@ -1,0 +1,23 @@
+const CONNECTION_STATUS = exports.CONNECTION_STATUS = {
+  CLOSED: Object.freeze({ kind: 'CLOSED' }),
+  CONNECTED: Object.freeze({ kind: 'CONNECTED' }),
+  CONNECTING: Object.freeze({ kind: 'CONNECTING' }),
+  NOT_CONNECTED: Object.freeze({ kind: 'NOT_CONNECTED' }) };
+
+/* A comment */
+/**
+* A type that can be written to a buffer.
+*/ /**
+* Describes the connection status of a ReactiveSocket/DuplexConnection.
+* - NOT_CONNECTED: no connection established or pending.
+* - CONNECTING: when `connect()` has been called but a connection is not yet
+*   established.
+* - CONNECTED: when a connection is established.
+* - CLOSED: when the connection has been explicitly closed via `close()`.
+* - ERROR: when the connection has been closed for any other reason.
+*/ /**
+* A contract providing different interaction models per the [ReactiveSocket protocol]
+* (https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md).
+*/ /**
+* A single unit of data exchanged between the peers of a `ReactiveSocket`.
+*/


### PR DESCRIPTION
Closes #4412

We print trailing comments in their own line with a `lineSuffix` which buffers the comment until it finds a `hardline`. When we have a following JSDoc comment, we print each line with a `hardline` at the end. So what happens is:
- prints the node;
- buffers the trailing comment;
- prints the 1st line of the JSDoc `/**`;
- print the trailing comment;
- print the rest of the JSDoc

This PR changes the behavior for JSDoc as trailing comments (uncommon I guess) to print a hardline before it.