### PR TITLE
revert changes to code mirror gutter styles

### DIFF
--- a/website/static/separate-css/playground.css
+++ b/website/static/separate-css/playground.css
@@ -145,10 +145,6 @@ pre.CodeMirror-placeholder {
   color: #888888;
 }
 
-.editors .CodeMirror-scroll {
-  position: static;
-}
-
 .bottom-bar {
   position: relative;
 }


### PR DESCRIPTION
As discussed in https://github.com/prettier/prettier/pull/4406 the changes to the code mirror gutter styles cause problems during vertical scrolling. So this change reverts that changes.