### PR TITLE
Don't default parser to babylon

### DIFF
--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -13,7 +13,8 @@ function loadPlugins(plugins) {
     require("../language-graphql"),
     require("../language-markdown"),
     require("../language-html"),
-    require("../language-vue")
+    require("../language-vue"),
+    require("../language-raw")
   ];
 
   const externalPlugins = plugins

--- a/src/language-raw/index.js
+++ b/src/language-raw/index.js
@@ -13,7 +13,13 @@ const parsers = {
     parse(text) {
       return { type: "Raw", text: text };
     },
-    astFormat: "raw"
+    astFormat: "raw",
+    locStart() {
+      return 0;
+    },
+    locEnd(node) {
+      return node.text.length;
+    }
   }
 };
 

--- a/src/language-raw/index.js
+++ b/src/language-raw/index.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const languages = [
+  {
+    name: "Raw (no-op)",
+    since: "1.13.0",
+    parsers: ["raw"]
+  }
+];
+
+const parsers = {
+  raw: {
+    parse(text) {
+      return { type: "Raw", text: text };
+    },
+    astFormat: "raw"
+  }
+};
+
+const printers = {
+  raw: {
+    print(path) {
+      const node = path.getValue();
+      switch (node.type) {
+        case "Raw": {
+          return node.text;
+        }
+        default: {
+          throw new Error("Unknown node type provided to raw printer");
+        }
+      }
+    }
+  }
+};
+
+module.exports = {
+  languages,
+  parsers,
+  printers
+};

--- a/src/main/core-options.js
+++ b/src/main/core-options.js
@@ -85,8 +85,9 @@ const options = {
     since: "0.0.10",
     category: CATEGORY_GLOBAL,
     type: "choice",
-    default: "babylon",
-    description: "Which parser to use.",
+    default: "raw",
+    description:
+      "Override which parser to use. Without this option, the parser is inferred from the filepath.",
     exception: value =>
       typeof value === "string" || typeof value === "function",
     choices: [
@@ -107,7 +108,8 @@ const options = {
       { value: "json5", since: "1.13.0", description: "JSON5" },
       { value: "graphql", since: "1.5.0", description: "GraphQL" },
       { value: "markdown", since: "1.8.0", description: "Markdown" },
-      { value: "vue", since: "1.10.0", description: "Vue" }
+      { value: "vue", since: "1.10.0", description: "Vue" },
+      { value: "raw", since: "1.13.0", description: "Raw (no-op)" }
     ]
   },
   plugins: {

--- a/src/main/core-options.js
+++ b/src/main/core-options.js
@@ -85,7 +85,10 @@ const options = {
     since: "0.0.10",
     category: CATEGORY_GLOBAL,
     type: "choice",
-    default: "raw",
+    default: [
+      { since: "0.0.10", value: "babylon" },
+      { since: "1.13.0", value: "raw" }
+    ],
     description:
       "Override which parser to use. Without this option, the parser is inferred from the filepath.",
     exception: value =>

--- a/src/main/parser.js
+++ b/src/main/parser.js
@@ -44,7 +44,7 @@ function resolveParser(opts, parsers) {
     }
   }
   /* istanbul ignore next */
-  return parsers.babylon;
+  return parsers.raw;
 }
 
 function parse(text, opts) {

--- a/tests/cursor/jsfmt.spec.js
+++ b/tests/cursor/jsfmt.spec.js
@@ -3,7 +3,9 @@ run_spec(__dirname, ["babylon", "typescript", "flow"]);
 const prettier = require("../../tests_config/require_prettier");
 
 test("translates cursor correctly in basic case", () => {
-  expect(prettier.formatWithCursor(" 1", { cursorOffset: 2 })).toEqual({
+  expect(
+    prettier.formatWithCursor(" 1", { parser: "babylon", cursorOffset: 2 })
+  ).toEqual({
     formatted: "1;\n",
     cursorOffset: 1
   });
@@ -11,7 +13,9 @@ test("translates cursor correctly in basic case", () => {
 
 test("positions cursor relative to closest node, not SourceElement", () => {
   const code = "return         15";
-  expect(prettier.formatWithCursor(code, { cursorOffset: 15 })).toEqual({
+  expect(
+    prettier.formatWithCursor(code, { parser: "babylon", cursorOffset: 15 })
+  ).toEqual({
     formatted: "return 15;\n",
     cursorOffset: 7
   });
@@ -19,7 +23,9 @@ test("positions cursor relative to closest node, not SourceElement", () => {
 
 test("keeps cursor inside formatted node", () => {
   const code = "return         15";
-  expect(prettier.formatWithCursor(code, { cursorOffset: 14 })).toEqual({
+  expect(
+    prettier.formatWithCursor(code, { parser: "babylon", cursorOffset: 14 })
+  ).toEqual({
     formatted: "return 15;\n",
     cursorOffset: 7
   });
@@ -30,7 +36,9 @@ test("doesn't insert second placeholder for nonexistent TypeAnnotation", () => {
 foo('bar', cb => {
   console.log('stuff')
 })`;
-  expect(prettier.formatWithCursor(code, { cursorOffset: 24 })).toEqual({
+  expect(
+    prettier.formatWithCursor(code, { parser: "babylon", cursorOffset: 24 })
+  ).toEqual({
     formatted: `foo("bar", cb => {
   console.log("stuff");
 });

--- a/tests/cursor/jsfmt.spec.js
+++ b/tests/cursor/jsfmt.spec.js
@@ -46,3 +46,12 @@ foo('bar', cb => {
     cursorOffset: 23
   });
 });
+
+test("leaves cursor position alone when using raw parser", () => {
+  expect(
+    prettier.formatWithCursor(" 1 2 3   ;", { parser: "raw", cursorOffset: 5 })
+  ).toEqual({
+    formatted: " 1 2 3   ;",
+    cursorOffset: 5
+  });
+});

--- a/tests/range_raw/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/range_raw/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sample.txt 1`] = `
+bla bla bla
+bla bla bla
+foo bar
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+bla bla bla
+bla bla bla
+foo bar
+
+`;

--- a/tests/range_raw/jsfmt.spec.js
+++ b/tests/range_raw/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["raw"]);

--- a/tests/range_raw/sample.txt
+++ b/tests/range_raw/sample.txt
@@ -1,0 +1,3 @@
+bla bla bla
+<<<PRETTIER_RANGE_START>>>bl<<<PRETTIER_RANGE_END>>>a bla bla
+foo bar

--- a/tests_integration/__tests__/__snapshots__/cursor-offset.js.snap
+++ b/tests_integration/__tests__/__snapshots__/cursor-offset.js.snap
@@ -20,13 +20,10 @@ exports[`cursorOffset should not be affected by full-width character (stdout) 1`
 exports[`cursorOffset should not be affected by full-width character (write) 1`] = `Array []`;
 
 exports[`write cursorOffset to stderr with --cursor-offset <int> (stderr) 1`] = `
-"1
+"2
 "
 `;
 
-exports[`write cursorOffset to stderr with --cursor-offset <int> (stdout) 1`] = `
-"1;
-"
-`;
+exports[`write cursorOffset to stderr with --cursor-offset <int> (stdout) 1`] = `" 1"`;
 
 exports[`write cursorOffset to stderr with --cursor-offset <int> (write) 1`] = `Array []`;

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -265,9 +265,9 @@ exports[`show detailed usage with --help no-semi (write) 1`] = `Array []`;
 exports[`show detailed usage with --help parser (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help parser (stdout) 1`] = `
-"--parser <flow|babylon|typescript|css|less|scss|json|json5|graphql|markdown|vue>
+"--parser <flow|babylon|typescript|css|less|scss|json|json5|graphql|markdown|vue|raw>
 
-  Which parser to use.
+  Override which parser to use. Without this option, the parser is inferred from the filepath.
 
 Valid options:
 
@@ -282,8 +282,9 @@ Valid options:
   graphql      GraphQL
   markdown     Markdown
   vue          Vue
+  raw          Raw (no-op)
 
-Default: babylon
+Default: raw
 "
 `;
 
@@ -566,9 +567,9 @@ Format options:
   --no-bracket-spacing     Do not print spaces between brackets.
   --jsx-bracket-same-line  Put > on the last line instead of at a new line.
                            Defaults to false.
-  --parser <flow|babylon|typescript|css|less|scss|json|json5|graphql|markdown|vue>
-                           Which parser to use.
-                           Defaults to babylon.
+  --parser <flow|babylon|typescript|css|less|scss|json|json5|graphql|markdown|vue|raw>
+                           Override which parser to use. Without this option, the parser is inferred from the filepath.
+                           Defaults to raw.
   --print-width <int>      The line length where Prettier will try wrap.
                            Defaults to 80.
   --prose-wrap <always|never|preserve>
@@ -662,9 +663,9 @@ exports[`show warning with --help not-found (typo) (stderr) 1`] = `
 `;
 
 exports[`show warning with --help not-found (typo) (stdout) 1`] = `
-"--parser <flow|babylon|typescript|css|less|scss|json|json5|graphql|markdown|vue>
+"--parser <flow|babylon|typescript|css|less|scss|json|json5|graphql|markdown|vue|raw>
 
-  Which parser to use.
+  Override which parser to use. Without this option, the parser is inferred from the filepath.
 
 Valid options:
 
@@ -679,8 +680,9 @@ Valid options:
   graphql      GraphQL
   markdown     Markdown
   vue          Vue
+  raw          Raw (no-op)
 
-Default: babylon
+Default: raw
 "
 `;
 
@@ -709,9 +711,9 @@ Format options:
   --no-bracket-spacing     Do not print spaces between brackets.
   --jsx-bracket-same-line  Put > on the last line instead of at a new line.
                            Defaults to false.
-  --parser <flow|babylon|typescript|css|less|scss|json|json5|graphql|markdown|vue>
-                           Which parser to use.
-                           Defaults to babylon.
+  --parser <flow|babylon|typescript|css|less|scss|json|json5|graphql|markdown|vue|raw>
+                           Override which parser to use. Without this option, the parser is inferred from the filepath.
+                           Defaults to raw.
   --print-width <int>      The line length where Prettier will try wrap.
                            Defaults to 80.
   --prose-wrap <always|never|preserve>

--- a/tests_integration/__tests__/__snapshots__/plugin-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/plugin-options.js.snap
@@ -15,9 +15,9 @@ exports[` 1`] = `
 +                            Defaults to bar.
     --jsx-bracket-same-line  Put > on the last line instead of at a new line.
                              Defaults to false.
-    --parser <flow|babylon|typescript|css|less|scss|json|json5|graphql|markdown|vue>
-                             Which parser to use.
-                             Defaults to babylon."
+    --parser <flow|babylon|typescript|css|less|scss|json|json5|graphql|markdown|vue|raw>
+                             Override which parser to use. Without this option, the parser is inferred from the filepath.
+                             Defaults to raw."
 `;
 
 exports[`show detailed external option with \`--help foo-option\` (stderr) 1`] = `""`;

--- a/tests_integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests_integration/__tests__/__snapshots__/schema.js.snap
@@ -59,8 +59,8 @@ This option cannot be used with --range-start and --range-end.",
           "type": "boolean",
         },
         "parser": Object {
-          "default": "babylon",
-          "description": "Which parser to use.",
+          "default": "raw",
+          "description": "Override which parser to use. Without this option, the parser is inferred from the filepath.",
           "oneOf": Array [
             Object {
               "description": "Flow",

--- a/tests_integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests_integration/__tests__/__snapshots__/schema.js.snap
@@ -59,7 +59,7 @@ This option cannot be used with --range-start and --range-end.",
           "type": "boolean",
         },
         "parser": Object {
-          "default": "raw",
+          "default": "babylon",
           "description": "Override which parser to use. Without this option, the parser is inferred from the filepath.",
           "oneOf": Array [
             Object {

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -20,7 +20,7 @@ exports[`API getSupportInfo() with version 0.0.0 -> 1.0.0 1`] = `
 +         \\"flow\\",
 +         \\"babylon\\",
 +       ],
-+       \\"default\\": \\"raw\\",
++       \\"default\\": \\"babylon\\",
 +       \\"type\\": \\"choice\\",
 +     },
       \\"printWidth\\": Object {
@@ -179,7 +179,7 @@ exports[`API getSupportInfo() with version 1.0.0 -> 1.4.0 1`] = `
 +         \\"typescript\\",
 +         \\"postcss\\",
         ],
-        \\"default\\": \\"raw\\",
+        \\"default\\": \\"babylon\\",
         \\"type\\": \\"choice\\",
       },
       \\"printWidth\\": Object {
@@ -245,7 +245,7 @@ exports[`API getSupportInfo() with version 1.4.0 -> 1.5.0 1`] = `
 +         \\"json\\",
 +         \\"graphql\\",
         ],
-        \\"default\\": \\"raw\\",
+        \\"default\\": \\"babylon\\",
         \\"type\\": \\"choice\\",
       },
       \\"printWidth\\": Object {"
@@ -297,7 +297,7 @@ exports[`API getSupportInfo() with version 1.5.0 -> 1.7.1 1`] = `
           \\"json\\",
           \\"graphql\\",
         ],
-        \\"default\\": \\"raw\\",
+        \\"default\\": \\"babylon\\",
         \\"type\\": \\"choice\\",
 @@ -86,10 +88,14 @@
           \\"start\\": 0,
@@ -358,7 +358,7 @@ exports[`API getSupportInfo() with version 1.7.1 -> 1.8.0 1`] = `
           \\"graphql\\",
 +         \\"markdown\\",
         ],
-        \\"default\\": \\"raw\\",
+        \\"default\\": \\"babylon\\",
         \\"type\\": \\"choice\\",
       },
       \\"printWidth\\": Object {"
@@ -427,7 +427,7 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
           \\"markdown\\",
 +         \\"vue\\",
         ],
-        \\"default\\": \\"raw\\",
+        \\"default\\": \\"babylon\\",
         \\"type\\": \\"choice\\",
       },
 +     \\"plugins\\": Object {
@@ -725,7 +725,7 @@ exports[`CLI --support-info (stdout) 1`] = `
         { \\"description\\": \\"Markdown\\", \\"since\\": \\"1.8.0\\", \\"value\\": \\"markdown\\" },
         { \\"description\\": \\"Vue\\", \\"since\\": \\"1.10.0\\", \\"value\\": \\"vue\\" }
       ],
-      \\"default\\": \\"raw\\",
+      \\"default\\": \\"babylon\\",
       \\"description\\":
         \\"Override which parser to use. Without this option, the parser is inferred from the filepath.\\",
       \\"name\\": \\"parser\\",

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -20,7 +20,7 @@ exports[`API getSupportInfo() with version 0.0.0 -> 1.0.0 1`] = `
 +         \\"flow\\",
 +         \\"babylon\\",
 +       ],
-+       \\"default\\": \\"babylon\\",
++       \\"default\\": \\"raw\\",
 +       \\"type\\": \\"choice\\",
 +     },
       \\"printWidth\\": Object {
@@ -179,7 +179,7 @@ exports[`API getSupportInfo() with version 1.0.0 -> 1.4.0 1`] = `
 +         \\"typescript\\",
 +         \\"postcss\\",
         ],
-        \\"default\\": \\"babylon\\",
+        \\"default\\": \\"raw\\",
         \\"type\\": \\"choice\\",
       },
       \\"printWidth\\": Object {
@@ -245,7 +245,7 @@ exports[`API getSupportInfo() with version 1.4.0 -> 1.5.0 1`] = `
 +         \\"json\\",
 +         \\"graphql\\",
         ],
-        \\"default\\": \\"babylon\\",
+        \\"default\\": \\"raw\\",
         \\"type\\": \\"choice\\",
       },
       \\"printWidth\\": Object {"
@@ -297,7 +297,7 @@ exports[`API getSupportInfo() with version 1.5.0 -> 1.7.1 1`] = `
           \\"json\\",
           \\"graphql\\",
         ],
-        \\"default\\": \\"babylon\\",
+        \\"default\\": \\"raw\\",
         \\"type\\": \\"choice\\",
 @@ -86,10 +88,14 @@
           \\"start\\": 0,
@@ -358,7 +358,7 @@ exports[`API getSupportInfo() with version 1.7.1 -> 1.8.0 1`] = `
           \\"graphql\\",
 +         \\"markdown\\",
         ],
-        \\"default\\": \\"babylon\\",
+        \\"default\\": \\"raw\\",
         \\"type\\": \\"choice\\",
       },
       \\"printWidth\\": Object {"
@@ -427,7 +427,7 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
           \\"markdown\\",
 +         \\"vue\\",
         ],
-        \\"default\\": \\"babylon\\",
+        \\"default\\": \\"raw\\",
         \\"type\\": \\"choice\\",
       },
 +     \\"plugins\\": Object {
@@ -725,8 +725,9 @@ exports[`CLI --support-info (stdout) 1`] = `
         { \\"description\\": \\"Markdown\\", \\"since\\": \\"1.8.0\\", \\"value\\": \\"markdown\\" },
         { \\"description\\": \\"Vue\\", \\"since\\": \\"1.10.0\\", \\"value\\": \\"vue\\" }
       ],
-      \\"default\\": \\"babylon\\",
-      \\"description\\": \\"Which parser to use.\\",
+      \\"default\\": \\"raw\\",
+      \\"description\\":
+        \\"Override which parser to use. Without this option, the parser is inferred from the filepath.\\",
       \\"name\\": \\"parser\\",
       \\"pluginDefaults\\": {},
       \\"since\\": \\"0.0.10\\",

--- a/tests_integration/__tests__/cursor-offset.js
+++ b/tests_integration/__tests__/cursor-offset.js
@@ -9,7 +9,7 @@ describe("write cursorOffset to stderr with --cursor-offset <int>", () => {
 });
 
 describe("cursorOffset should not be affected by full-width character", () => {
-  runPrettier("cli", ["--cursor-offset", "21"], {
+  runPrettier("cli", ["--cursor-offset", "21", "--parser", "babylon"], {
     input: `const x = ["中文", "中文", "中文", "中文", "中文", "中文", "中文", "中文", "中文", "中文", "中文"];`
     //                              ^ offset = 21                              ^ width = 80
   }).test({

--- a/tests_integration/__tests__/debug-print-doc.js
+++ b/tests_integration/__tests__/debug-print-doc.js
@@ -3,10 +3,12 @@
 const runPrettier = require("../runPrettier");
 
 describe("prints doc with --debug-print-doc", () => {
-  runPrettier("cli/with-shebang", ["--debug-print-doc"], {
-    input: "0"
-  }).test({
-    stdout: '["0", ";", hardline, breakParent];\n',
+  runPrettier(
+    "cli/with-shebang",
+    ["--parser", "babylon", "--debug-print-doc"],
+    { input: "0" }
+  ).test({
+    stdout: '["0", ";", hardline, breakParent]',
     stderr: "",
     status: 0
   });

--- a/tests_integration/__tests__/list-different.js
+++ b/tests_integration/__tests__/list-different.js
@@ -3,7 +3,7 @@
 const runPrettier = require("../runPrettier");
 
 describe("checks stdin with --list-different", () => {
-  runPrettier("cli/with-shebang", ["--list-different"], {
+  runPrettier("cli/with-shebang", ["--list-different", "--parser", "babylon"], {
     input: "0"
   }).test({
     stdout: "(stdin)\n",

--- a/tests_integration/__tests__/syntax-error.js
+++ b/tests_integration/__tests__/syntax-error.js
@@ -3,7 +3,7 @@
 const runPrettier = require("../runPrettier");
 
 describe("exits with non-zero code when input has a syntax error", () => {
-  runPrettier("cli/with-shebang", ["--stdin"], {
+  runPrettier("cli/with-shebang", ["--stdin", "--parser", "babylon"], {
     input: "a.2"
   }).test({
     status: 2

--- a/website/playground/util.js
+++ b/website/playground/util.js
@@ -10,7 +10,11 @@ export function getDefaults(availableOptions, optionNames) {
   const defaults = {};
   for (const option of availableOptions) {
     if (optionNames.includes(option.name)) {
-      defaults[option.name] = option.default;
+      if (option.name === "parser") {
+        defaults[option.name] = "babylon";
+      } else {
+        defaults[option.name] = option.default;
+      }
     }
   }
   return defaults;


### PR DESCRIPTION
Fixes #2884

I couldn't figure out where to put the warning message; the `inferParser` logic is buried in `normalizeOptions`, but the logger is in the `context` at the util-level. Could I get some help on that part?

Also, another consideration for the warning message is that it should be slightly different when they are using stdin (should probably mention using --stdin-filepath, etc).