### PR TITLE
refactor(massageAst): move target props to corresponding plugins

### DIFF
--- a/src/language-css/clean.js
+++ b/src/language-css/clean.js
@@ -3,6 +3,12 @@
 const htmlTagNames = require("html-tag-names");
 
 function clean(ast, newObj) {
+  ["raws", "sourceIndex", "source", "before", "after", "trailingComma"].forEach(
+    name => {
+      delete newObj[name];
+    }
+  );
+
   if (
     ast.type === "media-query" ||
     ast.type === "media-query-list" ||

--- a/src/language-js/clean.js
+++ b/src/language-js/clean.js
@@ -1,6 +1,17 @@
 "use strict";
 
 function clean(ast, newObj, parent) {
+  [
+    "leadingComments",
+    "trailingComments",
+    "extra",
+    "start",
+    "end",
+    "flags"
+  ].forEach(name => {
+    delete newObj[name];
+  });
+
   // We remove extra `;` and add them when needed
   if (ast.type === "EmptyStatement") {
     return null;

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -796,6 +796,8 @@ function clamp(value, min, max) {
 }
 
 function clean(ast, newObj, parent) {
+  delete newObj.position;
+
   // for codeblock
   if (ast.type === "code") {
     delete newObj.value;

--- a/src/language-vue/printer-vue.js
+++ b/src/language-vue/printer-vue.js
@@ -31,6 +31,8 @@ function genericPrint(path, options, print) {
 }
 
 const clean = (ast, newObj) => {
+  delete newObj.start;
+  delete newObj.end;
   delete newObj.contentStart;
   delete newObj.contentEnd;
 };

--- a/src/main/massage-ast.js
+++ b/src/main/massage-ast.js
@@ -16,32 +16,6 @@ function massageAST(ast, options, parent) {
     }
   }
 
-  [
-    "loc",
-    "range",
-    "raw",
-    "comments",
-    "leadingComments",
-    "trailingComments",
-    "extra",
-    "start",
-    "end",
-    "tokens",
-    "flags",
-    "raws",
-    "sourceIndex",
-    "id",
-    "source",
-    "before",
-    "after",
-    "trailingComma",
-    "parent",
-    "prev",
-    "position"
-  ].forEach(name => {
-    delete newObj[name];
-  });
-
   if (options.printer.massageAstNode) {
     const result = options.printer.massageAstNode(ast, newObj, parent);
     if (result === null) {


### PR DESCRIPTION
I'm not sure why but it seems some of them are unnecessary.

```js
[
  "loc",
  "range",
  "raw",
  "comments",
  "leadingComments",   // js
  "trailingComments",  // js
  "extra",             // js
  "start",             // js, vue
  "end",               // js, vue
  "tokens",
  "flags",             // js
  "raws",              // css
  "sourceIndex",       // css
  "id",
  "source",            // css
  "before",            // css
  "after",             // css
  "trailingComma",     // css
  "parent",
  "prev",
  "position"           // md
].forEach(name => {
  delete newObj[name];
});
```