### PR TITLE
Add /coverage/ to .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -3,6 +3,7 @@
 !/tests/**/jsfmt.spec.js
 !/**/.eslintrc.js
 /test.js
+/coverage/
 /dist/
 **/node_modules/**
 /website/build/


### PR DESCRIPTION
I generated coverage reports and then ran `yarn lint`. The script took ages to run and printed lots of useless errors.

Adding `/coverage/` to `.eslintignore` fixes `yarn lint`'s performance.