### PR TITLE
fix(typescript): add missing `qualifier` and `typeof` in TSImportType

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2854,7 +2854,13 @@ function printPathNoParens(path, options, print, args) {
     case "TSThisType":
       return "this";
     case "TSLastTypeNode": // TSImportType
-      return concat(["import(", path.call(print, "argument"), ")"]);
+      return concat([
+        !n.isTypeOf ? "" : "typeof ",
+        "import(",
+        path.call(print, "argument"),
+        ")",
+        !n.qualifier ? "" : concat([".", path.call(print, "qualifier")])
+      ]);
     case "TSLiteralType":
       return path.call(print, "literal");
     case "TSIndexedAccessType":

--- a/tests/typescript_import_type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_import_type/__snapshots__/jsfmt.spec.js.snap
@@ -15,9 +15,9 @@ export let shim: typeof import("./foo2") = {
 
 export const x: import("./foo") = { x: 0, y: 0 };
 
-export let y: import("./foo2") = { a: "", b: 0 };
+export let y: import("./foo2").Bar.I = { a: "", b: 0 };
 
-export let shim: import("./foo2") = {
+export let shim: typeof import("./foo2") = {
   Bar: Bar2
 };
 
@@ -38,9 +38,9 @@ export let shim: typeof import("./foo2") = {
 
 export const x: import('./foo') = { x: 0, y: 0 };
 
-export let y: import('./foo2') = { a: '', b: 0 };
+export let y: import('./foo2').Bar.I = { a: '', b: 0 };
 
-export let shim: import('./foo2') = {
+export let shim: typeof import('./foo2') = {
   Bar: Bar2
 };
 


### PR DESCRIPTION
Just noticed that we forgot to add `qualifier` and `typeof` in #4429 but no error occurred until #4430.

My eyes... 🙈