### PR TITLE
Fix: Correctly break class property initializers

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2023,9 +2023,9 @@ function printPathNoParens(path, options, print, args) {
         parts.push(
           " =",
           printAssignmentRight(
+            n.key,
             n.value,
             path.call(print, "value"),
-            false, // canBreak
             options
           )
         );
@@ -2033,7 +2033,7 @@ function printPathNoParens(path, options, print, args) {
 
       parts.push(semi);
 
-      return concat(parts);
+      return group(concat(parts));
     }
     case "ClassDeclaration":
     case "ClassExpression":
@@ -2638,12 +2638,10 @@ function printPathNoParens(path, options, print, args) {
         parts.push("declare ");
       }
 
-      const canBreak = n.right.type === "StringLiteralTypeAnnotation";
-
       const printed = printAssignmentRight(
+        n.id,
         n.right,
         path.call(print, "right"),
-        canBreak,
         options
       );
 
@@ -4984,10 +4982,21 @@ function printBinaryishExpressions(
   return parts;
 }
 
-function printAssignmentRight(rightNode, printedRight, canBreak, options) {
+function printAssignmentRight(leftNode, rightNode, printedRight, options) {
   if (hasLeadingOwnLineComment(options.originalText, rightNode, options)) {
     return indent(concat([hardline, printedRight]));
   }
+
+  const canBreak =
+    (isBinaryish(rightNode) && !shouldInlineLogicalExpression(rightNode)) ||
+    (rightNode.type === "ConditionalExpression" &&
+      isBinaryish(rightNode.test) &&
+      !shouldInlineLogicalExpression(rightNode.test)) ||
+    rightNode.type === "StringLiteralTypeAnnotation" ||
+    ((leftNode.type === "Identifier" ||
+      isStringLiteral(leftNode) ||
+      leftNode.type === "MemberExpression") &&
+      (isStringLiteral(rightNode) || isMemberExpressionChain(rightNode)));
 
   if (canBreak) {
     return indent(concat([line, printedRight]));
@@ -5008,20 +5017,10 @@ function printAssignment(
     return printedLeft;
   }
 
-  const canBreak =
-    (isBinaryish(rightNode) && !shouldInlineLogicalExpression(rightNode)) ||
-    (rightNode.type === "ConditionalExpression" &&
-      isBinaryish(rightNode.test) &&
-      !shouldInlineLogicalExpression(rightNode.test)) ||
-    ((leftNode.type === "Identifier" ||
-      isStringLiteral(leftNode) ||
-      leftNode.type === "MemberExpression") &&
-      (isStringLiteral(rightNode) || isMemberExpressionChain(rightNode)));
-
   const printed = printAssignmentRight(
+    leftNode,
     rightNode,
     printedRight,
-    canBreak,
     options
   );
 

--- a/tests/classes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/classes/__snapshots__/jsfmt.spec.js.snap
@@ -169,6 +169,17 @@ class A {
     // comment to break again
     2;
 }
+
+class B {
+  someInstanceProperty = this.props.foofoofoofoofoofoo &&
+    this.props.barbarbarbar;
+  
+  someInstanceProperty2 = { foo: this.props.foofoofoofoofoofoo &&
+    this.props.barbarbarbar };
+  
+    someInstanceProperty3 =
+  "foo";
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class A {
   foobar =
@@ -176,6 +187,17 @@ class A {
     1 +
     // comment to break again
     2;
+}
+
+class B {
+  someInstanceProperty =
+    this.props.foofoofoofoofoofoo && this.props.barbarbarbar;
+
+  someInstanceProperty2 = {
+    foo: this.props.foofoofoofoofoofoo && this.props.barbarbarbar
+  };
+
+  someInstanceProperty3 = "foo";
 }
 
 `;

--- a/tests/classes/property.js
+++ b/tests/classes/property.js
@@ -5,3 +5,14 @@ class A {
     // comment to break again
     2;
 }
+
+class B {
+  someInstanceProperty = this.props.foofoofoofoofoofoo &&
+    this.props.barbarbarbar;
+  
+  someInstanceProperty2 = { foo: this.props.foofoofoofoofoofoo &&
+    this.props.barbarbarbar };
+  
+    someInstanceProperty3 =
+  "foo";
+}


### PR DESCRIPTION
This PR moves the `canBreak` check from `printAssignment` to `printAssignmentRight`, so that it can be used in class properties.

Fixes https://github.com/prettier/prettier/issues/4437