### PR TITLE
refactor(javascript): remove unnecessary exposing

### DIFF
--- a/src/language-js/index.js
+++ b/src/language-js/index.js
@@ -214,7 +214,5 @@ module.exports = {
   languages,
   options,
   parsers,
-  printers,
-  locStart,
-  locEnd
+  printers
 };

--- a/src/main/parser.js
+++ b/src/main/parser.js
@@ -2,10 +2,10 @@
 
 const path = require("path");
 const ConfigError = require("../common/errors").ConfigError;
-const js = require("../language-js/index.js");
+const babylon = require("../language-js/index").parsers.babylon;
 
-const locStart = js.locStart;
-const locEnd = js.locEnd;
+const locStart = babylon.locStart;
+const locEnd = babylon.locEnd;
 
 function getParsers(options) {
   return options.plugins.reduce(


### PR DESCRIPTION
Just noticed that `locStart` and `locEnd` shouldn't be exposed from plugin-level, it confused me that it might be a part of the plugin api.