### PR TITLE
(refactor): Move common options out of JS plugin

### DIFF
--- a/src/common/common-options.js
+++ b/src/common/common-options.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const CATEGORY_COMMON = "Common";
+
+// format based on https://github.com/prettier/prettier/blob/master/src/main/core-options.js
+module.exports = {
+  bracketSpacing: {
+    since: "0.0.0",
+    category: CATEGORY_COMMON,
+    type: "boolean",
+    default: true,
+    description: "Print spaces between brackets.",
+    oppositeDescription: "Do not print spaces between brackets."
+  },
+  singleQuote: {
+    since: "0.0.0",
+    category: CATEGORY_COMMON,
+    type: "boolean",
+    default: false,
+    description: "Use single quotes instead of double quotes."
+  }
+};

--- a/src/language-css/options.js
+++ b/src/language-css/options.js
@@ -1,8 +1,8 @@
 "use strict";
 
-const jsOptions = require("../language-js/options");
+const commonOptions = require("../common/common-options");
 
 // format based on https://github.com/prettier/prettier/blob/master/src/main/core-options.js
 module.exports = {
-  singleQuote: jsOptions.singleQuote
+  singleQuote: commonOptions.singleQuote
 };

--- a/src/language-graphql/options.js
+++ b/src/language-graphql/options.js
@@ -1,8 +1,8 @@
 "use strict";
 
-const jsOptions = require("../language-js/options");
+const commonOptions = require("../common/common-options");
 
 // format based on https://github.com/prettier/prettier/blob/master/src/main/core-options.js
 module.exports = {
-  bracketSpacing: jsOptions.bracketSpacing
+  bracketSpacing: commonOptions.bracketSpacing
 };

--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const commonOptions = require("../common/common-options");
+
 const CATEGORY_JAVASCRIPT = "JavaScript";
 
 // format based on https://github.com/prettier/prettier/blob/master/src/main/core-options.js
@@ -21,14 +23,7 @@ module.exports = {
       }
     ]
   },
-  bracketSpacing: {
-    since: "0.0.0",
-    category: CATEGORY_JAVASCRIPT,
-    type: "boolean",
-    default: true,
-    description: "Print spaces between brackets.",
-    oppositeDescription: "Do not print spaces between brackets."
-  },
+  bracketSpacing: commonOptions.bracketSpacing,
   jsxBracketSameLine: {
     since: "0.17.0",
     category: CATEGORY_JAVASCRIPT,
@@ -45,13 +40,7 @@ module.exports = {
     oppositeDescription:
       "Do not print semicolons, except at the beginning of lines which may need them."
   },
-  singleQuote: {
-    since: "0.0.0",
-    category: CATEGORY_JAVASCRIPT,
-    type: "boolean",
-    default: false,
-    description: "Use single quotes instead of double quotes."
-  },
+  singleQuote: commonOptions.singleQuote,
   trailingComma: {
     since: "0.0.0",
     category: CATEGORY_JAVASCRIPT,

--- a/src/language-markdown/options.js
+++ b/src/language-markdown/options.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const jsOptions = require("../language-js/options");
+const commonOptions = require("../common/common-options");
 
 const CATEGORY_MARKDOWN = "Markdown";
 
@@ -35,5 +35,5 @@ module.exports = {
       { value: true, deprecated: "1.9.0", redirect: "always" }
     ]
   },
-  singleQuote: jsOptions.singleQuote
+  singleQuote: commonOptions.singleQuote
 };

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -659,7 +659,7 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"type\\": \\"choice\\"
     },
     {
-      \\"category\\": \\"JavaScript\\",
+      \\"category\\": \\"Common\\",
       \\"default\\": true,
       \\"description\\": \\"Print spaces between brackets.\\",
       \\"name\\": \\"bracketSpacing\\",
@@ -823,7 +823,7 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"type\\": \\"boolean\\"
     },
     {
-      \\"category\\": \\"JavaScript\\",
+      \\"category\\": \\"Common\\",
       \\"default\\": false,
       \\"description\\": \\"Use single quotes instead of double quotes.\\",
       \\"name\\": \\"singleQuote\\",

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -15,7 +15,13 @@ import SidebarOptions from "./sidebar/SidebarOptions";
 import Option from "./sidebar/options";
 import { Checkbox } from "./sidebar/inputs";
 
-const CATEGORIES_ORDER = ["Global", "JavaScript", "Markdown", "Special"];
+const CATEGORIES_ORDER = [
+  "Global",
+  "Common",
+  "JavaScript",
+  "Markdown",
+  "Special"
+];
 const ENABLED_OPTIONS = [
   "parser",
   "printWidth",


### PR DESCRIPTION
While seeing where we were at with web, I tried to make a build containing only the markdown plugin, and was surprised to see files from the JS plugin get pulled in. This refactor just makes it a bit more obvious that these settings are shared across plugins.