### PR TITLE
Simplify `build-docs.js`

### DIFF
--- a/scripts/build/build-docs.js
+++ b/scripts/build/build-docs.js
@@ -68,15 +68,6 @@ shell.cd("website");
 shell.echo("Building website...");
 shell.exec("yarn install");
 
-shell.echo("Copy sw-toolbox.js to docs");
-shell.cp("node_modules/sw-toolbox/sw-toolbox.js", `${docs}/sw-toolbox.js`);
-
-shell.echo("Copy prettier-animated-logo CSS file to docs");
-shell.cp(
-  "node_modules/@sandhose/prettier-animated-logo/dist/wide.css",
-  `${docs}/prettier-animated-logo.css`
-);
-
 shell.exec("yarn build");
 
 shell.echo();

--- a/website/package.json
+++ b/website/package.json
@@ -15,8 +15,7 @@
     "lz-string": "1.4.4",
     "prop-types": "15.6.1",
     "react": "16.3.1",
-    "react-dom": "16.3.1",
-    "sw-toolbox": "3.6.0"
+    "react-dom": "16.3.1"
   },
   "devDependencies": {
     "@sandhose/prettier-animated-logo": "1.0.3",

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -53,6 +53,9 @@ const siteConfig = {
   },
   useEnglishUrl: true,
   scripts: ["https://buttons.github.io/buttons.js"],
+  stylesheets: [
+    "//unpkg.com/@sandhose/prettier-animated-logo@1.0.3/dist/wide.css"
+  ],
   algolia: {
     apiKey: process.env.ALGOLIA_PRETTIER_API_KEY,
     indexName: "prettier"

--- a/website/static/service-worker.js
+++ b/website/static/service-worker.js
@@ -3,7 +3,7 @@
 
 "use strict";
 
-importScripts("lib/sw-toolbox.js");
+importScripts("https://unpkg.com/sw-toolbox@3.6.0/sw-toolbox.js");
 
 toolbox.precache([
   // Scripts
@@ -16,7 +16,7 @@ toolbox.precache([
   "lib/parser-graphql.js",
   "lib/parser-markdown.js",
   "playground.js",
-  "lib/sw-toolbox.js",
+  "https://unpkg.com/sw-toolbox@3.6.0/sw-toolbox.js",
 
   // CodeMirror
   "https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.36.0/codemirror.css",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -3272,10 +3272,6 @@ is2@0.0.9:
   dependencies:
     deep-is "0.1.2"
 
-isarray@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
-
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -4240,12 +4236,6 @@ path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
 
-path-to-regexp@^1.0.1:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.7.0.tgz#59fde0f435badacba103a84e9d3bc64e96b9937d"
-  dependencies:
-    isarray "0.0.1"
-
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
@@ -4894,10 +4884,6 @@ serve-static@1.12.3:
     parseurl "~1.3.1"
     send "0.15.3"
 
-serviceworker-cache-polyfill@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/serviceworker-cache-polyfill/-/serviceworker-cache-polyfill-4.0.0.tgz#de19ee73bef21ab3c0740a37b33db62464babdeb"
-
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -5304,13 +5290,6 @@ svgo@1.0.4:
     stable "~0.1.6"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
-
-sw-toolbox@3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/sw-toolbox/-/sw-toolbox-3.6.0.tgz#26df1d1c70348658e4dea2884319149b7b3183b5"
-  dependencies:
-    path-to-regexp "^1.0.1"
-    serviceworker-cache-polyfill "^4.0.0"
 
 symbol-observable@1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Leverage use of unpkg.com instead of manually copying stuff to `static/`

This is motivated by #4449 to simplify build processes