### PR TITLE
Fix playground

### DIFF
--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -43,7 +43,7 @@ self.require = function require(path) {
     return { PassThrough() {} };
   }
   if (path === "./third-party") {
-    return {};
+    return { findParentDir() {}};
   }
 
   if (~path.indexOf("parser-")) {
@@ -56,6 +56,10 @@ self.require = function require(path) {
   }
 
   return self[path];
+};
+self.__dirname = "";
+self.events = {
+  EventEmitter: function() {}
 };
 /* eslint-enable */
 


### PR DESCRIPTION
After #4341, because of `find-parent-dir`, the playground from master was broken

This is the kind of thing that makes me wish for #4449