### PR TITLE
update doc with example for JSX Brackets config

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -94,6 +94,28 @@ Valid options:
 
 Put the `>` of a multi-line JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
 
+Valid options:
+
+* `true` - Example:
+```
+<button
+  className="prettier-class"
+  id="prettier-id"
+  onClick={this.handleClick}>
+  Click Here
+</button>
+```
+* `false` - Example:
+```
+<button
+  className="prettier-class"
+  id="prettier-id"
+  onClick={this.handleClick}
+>
+  Click Here
+</button>
+```
+
 | Default | CLI Override              | API Override                 |
 | ------- | ------------------------- | ---------------------------- |
 | `false` | `--jsx-bracket-same-line` | `jsxBracketSameLine: <bool>` |

--- a/docs/options.md
+++ b/docs/options.md
@@ -97,6 +97,7 @@ Put the `>` of a multi-line JSX element at the end of the last line instead of b
 Valid options:
 
 * `true` - Example:
+
 <!-- prettier-ignore -->
 ```
 <button
@@ -106,7 +107,9 @@ Valid options:
   Click Here
 </button>
 ```
+
 * `false` - Example:
+
 <!-- prettier-ignore -->
 ```
 <button

--- a/docs/options.md
+++ b/docs/options.md
@@ -97,6 +97,7 @@ Put the `>` of a multi-line JSX element at the end of the last line instead of b
 Valid options:
 
 * `true` - Example:
+<!-- prettier-ignore -->
 ```
 <button
   className="prettier-class"
@@ -106,6 +107,7 @@ Valid options:
 </button>
 ```
 * `false` - Example:
+<!-- prettier-ignore -->
 ```
 <button
   className="prettier-class"


### PR DESCRIPTION
update the docs to give example for JSX brackets rule. All the options have examples and it makes sense to have one this use case as well.