### PR TITLE
Introduce 'ternary' config and extend 'arrowParens' config with 'requireForBlockBody' option

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -98,6 +98,19 @@ Put the `>` of a multi-line JSX element at the end of the last line instead of b
 | ------- | ------------------------- | ---------------------------- |
 | `false` | `--jsx-bracket-same-line` | `jsxBracketSameLine: <bool>` |
 
+## Ternary
+
+Control ternary expressions.
+
+Valid options:
+
+* `"newline"` - place both expressions on new lines
+* `"parens"` - wrap expressions in parentheses
+
+| Default     | CLI Override                                 | API Override                                  |
+| ----------- | -------------------------------------------- | --------------------------------------------- |
+| `"newline"` | <code>--ternary <newline&#124;parens></code> | <code>ternary: "<newline&#124;parens>"</code> |
+
 ## Arrow Function Parentheses
 
 _available in v1.9.0+_

--- a/docs/options.md
+++ b/docs/options.md
@@ -108,6 +108,7 @@ Valid options:
 
 * `"avoid"` - Omit parens when possible. Example: `x => x`
 * `"always"` - Always include parens. Example: `(x) => x`
+* `"requireForBlockBody"` - Omit parens when possible, except for block body case. Example: `(x) => { return x }`
 
 | Default   | CLI Override                                    | API Override                                    |
 | --------- | ----------------------------------------------- | ----------------------------------------------- |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "prettier",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Prettier is an opinionated code formatter",
   "bin": {
     "prettier": "./bin/prettier.js"

--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -18,6 +18,12 @@ module.exports = {
       {
         value: "always",
         description: "Always include parens. Example: `(x) => x`"
+      },
+      {
+        value: "requireForBlockBody",
+        description:
+          "Omit parens when possible, except for block body case. " +
+          "Example: `(x) => { return x }`"
       }
     ]
   },

--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -27,6 +27,23 @@ module.exports = {
       }
     ]
   },
+  ternary: {
+    since: "1.12.2",
+    category: CATEGORY_JAVASCRIPT,
+    type: "choice",
+    default: "newline",
+    description: "Control ternary expressions.",
+    choices: [
+      {
+        value: "newline",
+        description: "place both expressions on new lines"
+      },
+      {
+        value: "parens",
+        description: "wrap expressions in parentheses"
+      }
+    ]
+  },
   bracketSpacing: {
     since: "0.0.0",
     category: CATEGORY_JAVASCRIPT,

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -216,6 +216,7 @@ function formatTernaryOperator(path, options, print, operatorOptions) {
   const lastConditionalParent = previousParent;
 
   if (
+    options.ternary === "parens" ||
     (operatorOpts.shouldCheckJsx && isJSXNode(n[operatorOpts.testNode])) ||
     isJSXNode(n[operatorOpts.consequentNode]) ||
     isJSXNode(n[operatorOpts.alternateNode]) ||

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3705,6 +3705,15 @@ function shouldPrintParamsWithoutParens(path, options) {
     return canPrintParamsWithoutParens(node);
   }
 
+  if (options.arrowParens === "requireForBlockBody") {
+    const node = path.getValue();
+    if (node.body && node.body.type === "BlockStatement") {
+      return false;
+    }
+
+    return canPrintParamsWithoutParens(node);
+  }
+
   // Fallback default; should be unreachable
   return false;
 }

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -3,14 +3,15 @@
 exports[`show detailed usage with --help arrow-parens (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help arrow-parens (stdout) 1`] = `
-"--arrow-parens <avoid|always>
+"--arrow-parens <avoid|always|requireForBlockBody>
 
   Include parentheses around a sole arrow function parameter.
 
 Valid options:
 
-  avoid    Omit parens when possible. Example: \`x => x\`
-  always   Always include parens. Example: \`(x) => x\`
+  avoid                 Omit parens when possible. Example: \`x => x\`
+  always                Always include parens. Example: \`(x) => x\`
+  requireForBlockBody   Omit parens when possible, except for block body case. Example: \`(x) => { return x }\`
 
 Default: avoid
 "
@@ -465,6 +466,24 @@ Default: 2
 
 exports[`show detailed usage with --help tab-width (write) 1`] = `Array []`;
 
+exports[`show detailed usage with --help ternary (stderr) 1`] = `""`;
+
+exports[`show detailed usage with --help ternary (stdout) 1`] = `
+"--ternary <newline|parens>
+
+  Control ternary expressions.
+
+Valid options:
+
+  newline   place both expressions on new lines
+  parens    wrap expressions in parentheses
+
+Default: newline
+"
+`;
+
+exports[`show detailed usage with --help ternary (write) 1`] = `Array []`;
+
 exports[`show detailed usage with --help trailing-comma (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help trailing-comma (stdout) 1`] = `
@@ -575,7 +594,7 @@ Output options:
 
 Format options:
 
-  --arrow-parens <avoid|always>
+  --arrow-parens <avoid|always|requireForBlockBody>
                            Include parentheses around a sole arrow function parameter.
                            Defaults to avoid.
   --no-bracket-spacing     Do not print spaces between brackets.
@@ -594,6 +613,9 @@ Format options:
                            Defaults to false.
   --tab-width <int>        Number of spaces per indentation level.
                            Defaults to 2.
+  --ternary <newline|parens>
+                           Control ternary expressions.
+                           Defaults to newline.
   --trailing-comma <none|es5|all>
                            Print trailing commas wherever possible when multi-line.
                            Defaults to none.
@@ -723,7 +745,7 @@ Output options:
 
 Format options:
 
-  --arrow-parens <avoid|always>
+  --arrow-parens <avoid|always|requireForBlockBody>
                            Include parentheses around a sole arrow function parameter.
                            Defaults to avoid.
   --no-bracket-spacing     Do not print spaces between brackets.
@@ -742,6 +764,9 @@ Format options:
                            Defaults to false.
   --tab-width <int>        Number of spaces per indentation level.
                            Defaults to 2.
+  --ternary <newline|parens>
+                           Control ternary expressions.
+                           Defaults to newline.
   --trailing-comma <none|es5|all>
                            Print trailing commas wherever possible when multi-line.
                            Defaults to none.

--- a/tests_integration/__tests__/__snapshots__/plugin-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/plugin-options.js.snap
@@ -7,7 +7,7 @@ exports[` 1`] = `
 
 @@ -12,10 +12,12 @@
   
-    --arrow-parens <avoid|always>
+    --arrow-parens <avoid|always|requireForBlockBody>
                              Include parentheses around a sole arrow function parameter.
                              Defaults to avoid.
     --no-bracket-spacing     Do not print spaces between brackets.

--- a/tests_integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests_integration/__tests__/__snapshots__/schema.js.snap
@@ -30,6 +30,12 @@ Object {
                 "always",
               ],
             },
+            Object {
+              "description": "Omit parens when possible, except for block body case. Example: \`(x) => { return x }\`",
+              "enum": Array [
+                "requireForBlockBody",
+              ],
+            },
           ],
         },
         "bracketSpacing": Object {
@@ -195,6 +201,24 @@ in order for it to be formatted.",
           "default": 2,
           "description": "Number of spaces per indentation level.",
           "type": "integer",
+        },
+        "ternary": Object {
+          "default": "newline",
+          "description": "Control ternary expressions.",
+          "oneOf": Array [
+            Object {
+              "description": "place both expressions on new lines",
+              "enum": Array [
+                "newline",
+              ],
+            },
+            Object {
+              "description": "wrap expressions in parentheses",
+              "enum": Array [
+                "parens",
+              ],
+            },
+          ],
         },
         "trailingComma": Object {
           "default": "none",

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -395,7 +395,7 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
 - First value
 + Second value
 
-@@ -27,12 +27,23 @@
+@@ -27,12 +27,24 @@
         \\"scss\\",
       ],
       \\"TypeScript\\": Array [
@@ -410,6 +410,7 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
 +       \\"choices\\": Array [
 +         \\"avoid\\",
 +         \\"always\\",
++         \\"requireForBlockBody\\",
 +       ],
 +       \\"default\\": \\"avoid\\",
 +       \\"type\\": \\"choice\\",
@@ -419,7 +420,7 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
         \\"type\\": \\"boolean\\",
       },
       \\"cursorOffset\\": Object {
-@@ -65,14 +76,19 @@
+@@ -65,14 +77,19 @@
           \\"less\\",
           \\"scss\\",
           \\"json\\",
@@ -439,7 +440,7 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
         \\"range\\": Object {
           \\"end\\": Infinity,
           \\"start\\": 0,
-@@ -80,14 +96,15 @@
+@@ -80,14 +97,15 @@
         },
         \\"type\\": \\"int\\",
       },
@@ -457,7 +458,26 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
       },
       \\"rangeEnd\\": Object {
         \\"default\\": Infinity,
-        \\"range\\": Object {"
+        \\"range\\": Object {
+@@ -125,10 +143,18 @@
+          \\"start\\": 0,
+          \\"step\\": 1,
+        },
+        \\"type\\": \\"int\\",
+      },
++     \\"ternary\\": Object {
++       \\"choices\\": Array [
++         \\"newline\\",
++         \\"parens\\",
++       ],
++       \\"default\\": \\"newline\\",
++       \\"type\\": \\"choice\\",
++     },
+      \\"trailingComma\\": Object {
+        \\"choices\\": Array [
+          \\"none\\",
+          \\"es5\\",
+          \\"all\\","
 `;
 
 exports[`CLI --support-info (stderr) 1`] = `""`;
@@ -648,6 +668,11 @@ exports[`CLI --support-info (stdout) 1`] = `
         {
           \\"description\\": \\"Always include parens. Example: \`(x) => x\`\\",
           \\"value\\": \\"always\\"
+        },
+        {
+          \\"description\\":
+            \\"Omit parens when possible, except for block body case. Example: \`(x) => { return x }\`\\",
+          \\"value\\": \\"requireForBlockBody\\"
         }
       ],
       \\"default\\": \\"avoid\\",
@@ -839,6 +864,22 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"pluginDefaults\\": {},
       \\"range\\": { \\"end\\": null, \\"start\\": 0, \\"step\\": 1 },
       \\"type\\": \\"int\\"
+    },
+    {
+      \\"category\\": \\"JavaScript\\",
+      \\"choices\\": [
+        {
+          \\"description\\": \\"place both expressions on new lines\\",
+          \\"value\\": \\"newline\\"
+        },
+        { \\"description\\": \\"wrap expressions in parentheses\\", \\"value\\": \\"parens\\" }
+      ],
+      \\"default\\": \\"newline\\",
+      \\"description\\": \\"Control ternary expressions.\\",
+      \\"name\\": \\"ternary\\",
+      \\"pluginDefaults\\": {},
+      \\"since\\": \\"1.12.2\\",
+      \\"type\\": \\"choice\\"
     },
     {
       \\"category\\": \\"JavaScript\\",


### PR DESCRIPTION
Hello,

What do you think of adding these configs in order to make prettier more flexible?

By the way, it addresses some of the wishes of prettier users (an alternative to changing eslint rules):
https://github.com/prettier/prettier-atom/issues/329
https://github.com/prettier/prettier/issues/812

Cheers,