### PR TITLE
New primitive for whether parent groups broke

### DIFF
--- a/src/doc/doc-builders.js
+++ b/src/doc/doc-builders.js
@@ -68,6 +68,11 @@ function group(contents, opts) {
   if (opts.visible) {
     ret.visible = !!opts.visible;
   }
+  if (opts.shouldBreakIfVisibleGroupBroke) {
+    ret.breakIfVisibleGroupBroke = {
+      count: opts.shouldBreakIfVisibleGroupBroke.count || 0
+    };
+  }
   return ret;
   // blockVisible: !!opts.blockVisible
 }

--- a/src/doc/doc-builders.js
+++ b/src/doc/doc-builders.js
@@ -52,7 +52,8 @@ function group(contents, opts) {
     type: "group",
     contents: contents,
     break: !!opts.shouldBreak,
-    expandedStates: opts.expandedStates
+    expandedStates: opts.expandedStates,
+    visible: !!opts.visible
   };
 }
 
@@ -94,6 +95,19 @@ function ifBreak(breakContents, flatContents) {
   }
 
   return { type: "if-break", breakContents, flatContents };
+}
+
+function ifVisibleGroupBroke(breakContents, flatContents, { count = 0 } = {}) {
+  if (process.env.NODE_ENV !== "production") {
+    if (breakContents) {
+      assertDoc(breakContents);
+    }
+    if (flatContents) {
+      assertDoc(flatContents);
+    }
+  }
+
+  return { type: "if-visible-group-broke", breakContents, flatContents, count };
 }
 
 function lineSuffix(contents) {
@@ -159,6 +173,7 @@ module.exports = {
   cursor,
   breakParent,
   ifBreak,
+  ifVisibleGroupBroke,
   indent,
   align,
   addAlignmentToDoc,

--- a/src/doc/doc-builders.js
+++ b/src/doc/doc-builders.js
@@ -11,7 +11,9 @@ function assertDoc(val) {
   }
 }
 
-function concat(parts) {
+function concat(parts, opts) {
+  opts = opts || {};
+
   if (process.env.NODE_ENV !== "production") {
     parts.forEach(assertDoc);
   }
@@ -22,7 +24,14 @@ function concat(parts) {
   //   // If it's a single document, no need to concat it.
   //   return parts[0];
   // }
-  return { type: "concat", parts };
+  const ret = {
+    type: "concat",
+    parts
+  };
+  if (opts.blockVisible) {
+    ret.blockVisible = !!opts.blockVisible;
+  }
+  return ret;
 }
 
 function indent(contents) {
@@ -48,13 +57,19 @@ function group(contents, opts) {
     assertDoc(contents);
   }
 
-  return {
+  const ret = {
     type: "group",
     contents: contents,
-    break: !!opts.shouldBreak,
-    expandedStates: opts.expandedStates,
-    visible: !!opts.visible
+    break: !!opts.shouldBreak
   };
+  if (opts.expandedStates) {
+    ret.expandedStates = opts.expandedStates;
+  }
+  if (opts.visible) {
+    ret.visible = !!opts.visible;
+  }
+  return ret;
+  // blockVisible: !!opts.blockVisible
 }
 
 function dedentToRoot(contents) {

--- a/src/doc/doc-printer.js
+++ b/src/doc/doc-printer.js
@@ -277,6 +277,17 @@ function printDocToString(doc, options) {
 
           break;
         case "group": {
+          if (doc.breakIfVisibleGroupBroke) {
+            const { count } = doc.breakIfVisibleGroupBroke;
+            if (
+              doc.visibleGroups &&
+              doc.visibleGroups.length >= count + 1 &&
+              doc.visibleGroups[doc.visibleGroups.length - (1 + count)] ===
+                MODE_BREAK
+            ) {
+              doc.break = true;
+            }
+          }
           switch (mode) {
             case MODE_FLAT:
               if (!shouldRemeasure) {

--- a/src/doc/doc-printer.js
+++ b/src/doc/doc-printer.js
@@ -173,6 +173,24 @@ function fits(next, restCommands, width, options, mustBeFlat) {
           }
 
           break;
+        case "if-visible-group-broke":
+          const { count } = doc;
+          if (
+            doc.visibleGroups &&
+            doc.visibleGroups.length >= count + 1 &&
+            doc.visibleGroups[doc.visibleGroups.length - (1 + count)] ===
+              MODE_BREAK
+          ) {
+            if (doc.breakContents) {
+              cmds.push([ind, mode, doc.breakContents]);
+            }
+          } else {
+            if (doc.flatContents) {
+              cmds.push([ind, mode, doc.flatContents]);
+            }
+          }
+
+          break;
         case "line":
           switch (mode) {
             // fallthrough

--- a/src/doc/doc-printer.js
+++ b/src/doc/doc-printer.js
@@ -275,12 +275,13 @@ function printDocToString(doc, options) {
                 cmds.push([
                   ind,
                   doc.break ? MODE_BREAK : MODE_FLAT,
-                  doc.visible
-                    ? markVisible(
-                        doc.contents,
-                        doc.break ? MODE_BREAK : MODE_FLAT
-                      )
-                    : doc.contents
+                  // doc.visible
+                  //   ? markVisible(
+                  //       doc.contents,
+                  //       doc.break ? MODE_BREAK : MODE_FLAT
+                  //     )
+                  //   : doc.contents
+                  doc.contents
                 ]);
 
                 break;
@@ -296,6 +297,7 @@ function printDocToString(doc, options) {
               if (!doc.break && fits(next, cmds, rem, options)) {
                 if (doc.visible) {
                   next[2] = markVisible(doc.contents, MODE_FLAT);
+                  // if (doc.visible) dump({ fits: doc.contents });
                 }
                 cmds.push(next);
               } else {
@@ -340,6 +342,7 @@ function printDocToString(doc, options) {
                       ? markVisible(doc.contents, MODE_BREAK)
                       : doc.contents
                   ]);
+                  // if (doc.visible) dump({ breaks: doc.contents });
                 }
               }
 
@@ -458,6 +461,7 @@ function printDocToString(doc, options) {
           break;
         case "if-visible-group-broke": {
           const { count } = doc;
+          // dump({ doc });
           if (
             doc.visibleGroups &&
             doc.visibleGroups.length >= count + 1 &&
@@ -579,4 +583,5 @@ function printDocToString(doc, options) {
   return { formatted: out.join("") };
 }
 
+// const dump = obj => console.log(require("util").inspect(obj, false, null));
 module.exports = { printDocToString };

--- a/src/doc/doc-utils.js
+++ b/src/doc/doc-utils.js
@@ -14,7 +14,10 @@ function traverseDoc(doc, onEnter, onExit, shouldTraverseConditionalGroups) {
         for (let i = 0; i < doc.parts.length; i++) {
           traverseDocRec(doc.parts[i]);
         }
-      } else if (doc.type === "if-break") {
+      } else if (
+        doc.type === "if-break" ||
+        doc.type === "if-visible-group-broke"
+      ) {
         if (doc.breakContents) {
           traverseDocRec(doc.breakContents);
         }
@@ -44,7 +47,7 @@ function mapDoc(doc, cb) {
   if (doc.type === "concat" || doc.type === "fill") {
     const parts = doc.parts.map(part => mapDoc(part, cb));
     return cb(Object.assign({}, doc, { parts }));
-  } else if (doc.type === "if-break") {
+  } else if (doc.type === "if-break" || doc.type === "if-visible-group-broke") {
     const breakContents = doc.breakContents && mapDoc(doc.breakContents, cb);
     const flatContents = doc.flatContents && mapDoc(doc.flatContents, cb);
     return cb(Object.assign({}, doc, { breakContents, flatContents }));


### PR DESCRIPTION
I've been working on a plugin for Coffeescript and came across some formatting needs that I believe aren't achievable with the current set of formatting primitives

For background, Coffeescript allows omitting function call parens and object braces in a lot of instances. And an opinionated Coffeescript formatter should (in my opinion) omit them in most cases when it's allowed. They can usually be omitted at the end of a line, so when a construct like a call or array breaks its arguments/elements onto separate lines, those arguments/elements can safely omit braces/parens. To illustrate:
```
[a(b), c] # Need parens in a(b) to avoid parsing [a b, c] as [a(b, c)]
[
  a b # Omitting parens is fine here
  c
]
```
I didn't see a way to achieve this type of rule using existing primitives. Since eg in this example the inner call needs to know whether the enclosing array broke or not to decide whether it's safe to omit parens

So I added a concept of "visible" parent/ancestor groups. Here's the "API" I've added so far:
- a new `visible` option to `group()` that declares this group to be one that's "visible" to descendants (as far as whether it broke or not)
- a new `ifVisibleGroupBroke()` primitive that like `ifBreak()` takes a `breakContents` and `flatContents`. But instead of choosing based on whether the current group broke, it chooses based on whether an enclosing "visible" group broke (defaults to the first enclosing "visible" group but takes a `count` option that specifies the offset up the visible group ancestor stack - in most of the use cases so far for Coffeescript, I'm passing `{count: 1}` since eg for `[{a: 1}, {b: 2}]` the `ifVisibleGroupBroke()` needs to be inside the visible `group()` for the objects but needs to check if the array's visible group broke)
- a `shouldBreakIfVisibleGroupBroke` option to `group()` (that similarly takes an optional eg `{count: 1}` as its value, otherwise `count` defaults to `0` (ie immediately enclosing visible group) if you just pass `shouldBreakIfVisibleGroupBroke: true`. I'd naively thought I could do something like `ifVisibleGroupBroke(breakParent)` for the use case where I wanted an object argument to a call to itself break if the call args break ie do this:
```
f(
  a
  b: 1
  c: 2
)
```
instead of
```
f(
  a
  b: 1, c: 2
)
```
But found that `breakParent` isn't "dynamic" like that, so `shouldBreakIfVisibleGroupBroke` handles this use case
- a new `blockVisible` option to `concat()`, which "blocks"/hides visibility of outer visible groups for everything inside the `concat()` (possible that you could need this exposed on something other than `concat()` as well, or I guess you could model it as its own wrapping primitive eg `blockVisibleGroups(concat(...))`). Used for telling non-final methods of a method chain that they shouldn't omit parens if the chain doesn't break. It's possible this one isn't strictly necessary but I haven't fully wrapped my head around it. And seems like a useful concept

It's been working quite well so far for adding these types of rules to the Coffeescript printer. There may be some hairier eg nested cases that I haven't covered but visible groups has so far proven to be a useful and sufficient mechanism for smartly omitting parens/braces eg inside call args, arrays, objects and method chains. If you're curious to see examples (or of the overall progress of the Coffeescript plugin) check out my [prettier-plugin-coffeescript](https://github.com/helixbass/prettier-plugin-coffeescript) repo, which uses my [prettier](https://github.com/helixbass/copheescript/tree/prettier) Coffeescript branch to generate Coffeescript AST (original point of that branch was for the compiler backend to target the `babylon` AST and then be able to use Prettier as a toolchain backend to generate compiled JS, which actually works well but that's a separate topic - but now am leveraging that work to be able to generate Coffeescript AST nodes that are as close as possible to their corresponding `babylon` AST types, which has allowed me to effectively reuse/copy a lot of code from `printer-estree.js`)

I've tried to keep the implementation somewhat clean while avoiding incurring any real additional cost for docs that don't use this feature. The mechanism I've used for keeping track of visible outer groups is to add a `doc.visibleGroups` "stack" when necessary. I don't know if it seems weird/dirty to mutate `doc` inside `doc-printer.js` like that (especially with state that assumes that it starts from scratch and only gets used for a single pass over the doc), but it seemed easier (and less presumptuous) than eg adding new fields to the `cmds` items

Modeling `visibleGroups` as a stack has sufficed for all the cases I've encountered in Coffeescript so far, but conceptually you could picture tagging visible groups with "types" eg `group(..., {visible: {type: 'call'}})` and allowing `ifParentGroupBroke()` to specify a particular type of visible group that it's interested in

The code should be considered WIP. But if this seems viable and necessary for these formatting needs, I'd appreciate pointers on how I should go about adding tests for it and/or suggestions re the implementation details