### PR TITLE
refactor(massageAst): move stripLocation to corresponding plugins

### DIFF
--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -643,8 +643,14 @@ function determineInterfaceSeparator(originalSource) {
   return originalSource.substr(start, end).includes("&") ? " & " : ", ";
 }
 
+function clean(node, newNode /*, parent*/) {
+  delete newNode.loc;
+  delete newNode.comments;
+}
+
 module.exports = {
   print: genericPrint,
+  massageAstNode: clean,
   hasPrettierIgnore: privateUtil.hasIgnoreComment,
   printComment,
   canAttachComment

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -309,6 +309,8 @@ function printCloseBlock(path, print) {
 }
 
 function clean(ast, newObj) {
+  delete newObj.loc;
+
   // (Glimmer/HTML) ignore TextNode whitespace
   if (ast.type === "TextNode") {
     if (ast.chars.replace(/\s+/, "") === "") {

--- a/src/language-html/clean.js
+++ b/src/language-html/clean.js
@@ -1,6 +1,8 @@
 "use strict";
 
-module.exports = function(ast) {
+module.exports = function(ast, newNode) {
+  delete newNode.__location;
+
   if (ast.type === "text") {
     return null;
   }

--- a/src/language-js/clean.js
+++ b/src/language-js/clean.js
@@ -2,6 +2,9 @@
 
 function clean(ast, newObj, parent) {
   [
+    "range",
+    "raw",
+    "comments",
     "leadingComments",
     "trailingComments",
     "extra",

--- a/src/language-js/printer-estree-json.js
+++ b/src/language-js/printer-estree-json.js
@@ -61,6 +61,8 @@ function clean(node, newNode /*, parent*/) {
   delete newNode.start;
   delete newNode.end;
   delete newNode.extra;
+  delete newNode.loc;
+  delete newNode.comments;
 
   if (node.type === "Identifier") {
     return { type: "StringLiteral", value: node.name };

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -89,37 +89,8 @@ function run_spec(dirname, parsers, options) {
 
 global.run_spec = run_spec;
 
-function stripLocation(ast) {
-  if (Array.isArray(ast)) {
-    return ast.map(e => stripLocation(e));
-  }
-  if (typeof ast === "object") {
-    const newObj = {};
-    for (const key in ast) {
-      if (
-        [
-          "loc",
-          "range",
-          "raw",
-          "comments",
-          "parent",
-          "prev",
-          "__location"
-        ].indexOf(key) !== -1
-      ) {
-        continue;
-      }
-      newObj[key] = stripLocation(ast[key]);
-    }
-    return newObj;
-  }
-  return ast;
-}
-
 function parse(string, opts) {
-  return stripLocation(
-    prettier.__debug.parse(string, opts, /* massage */ true).ast
-  );
+  return prettier.__debug.parse(string, opts, /* massage */ true).ast;
 }
 
 function prettyprint(src, filename, options) {


### PR DESCRIPTION
`stripLocation` should not exist since we do have `massageAst`, and also there's a bug in `stripLocation` that `null` will be transformed into `{}`.