### PR TITLE
fix: scss interpolation in string

### DIFF
--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -417,6 +417,7 @@ function genericPrint(path, options, print) {
       const parts = [];
       const insideURLFunction = insideValueFunctionNode(path, "url");
 
+      let insideSCSSInterpolationInString = false;
       let didBreak = false;
       for (let i = 0; i < node.groups.length; ++i) {
         parts.push(printed[i]);
@@ -433,6 +434,27 @@ function genericPrint(path, options, print) {
 
         // Ignore after latest node (i.e. before semicolon)
         if (!iNextNode) {
+          continue;
+        }
+
+        // Ignore spaces before/after string interpolation (i.e. `"#{my-fn("_")}"`)
+        const isStartSCSSinterpolationInString =
+          iNode.type === "value-string" && iNode.value.startsWith("#{");
+        const isEndingSCSSinterpolationInString =
+          insideSCSSInterpolationInString &&
+          iNextNode.type === "value-string" &&
+          iNextNode.value.endsWith("}");
+
+        if (
+          isStartSCSSinterpolationInString ||
+          isEndingSCSSinterpolationInString
+        ) {
+          insideSCSSInterpolationInString = !insideSCSSInterpolationInString;
+
+          continue;
+        }
+
+        if (insideSCSSInterpolationInString) {
           continue;
         }
 

--- a/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
@@ -952,6 +952,52 @@ $map: (
 key: (value),
 other-key: (key: other-other-value)
 );
+
+a {
+  content: "#{".5"}";
+  content: my-fn("_");
+  content: "#{my-fn("_")}";
+  content: my-fn("-");
+  content: "#{my-fn("-")}";
+  content: my-fn("-a");
+  content: "#{my-fn("-a")}";
+  content: my-fn("a-");
+  content: "#{my-fn("a-")}";
+  content: my-fn("foo");
+  content: "#{my-fn("foo")}";
+  content: 1 "#{my-fn("foo")}" 2;
+  content: foo "#{my-fn("foo")}" bar;
+  content: "foo #{$description} bar";
+
+  content: "#{my-fn("foo","bar")}";
+  content: "#{my-fn( "foo" , "bar" )}";
+  content: "#{my-fn(  "foo"  ,  "bar"  )}";
+
+  content: '#{my-fn("foo")}';
+  content: '#{my-fn('foo')}';
+  content: "#{my-fn('foo')}";
+  content: "#{my-fn("foo")}";
+}
+
+mixin theme($css-property, $css-value, $theme-classes: t) {
+  @each $selector in & {
+    @each $class in $theme-classes {
+      @each $theme, $theme-properties in c(themes) {
+      $value: $css-value;
+
+        @each $theme-name, $theme-value in $theme-properties {
+          $rgba-value: "rgba(#{red($theme-value)}, #{green($theme-value)}, #{blue($theme-value)}";
+          $value: str-replace($value, "rgba(\${#{$theme-name}}", $rgba-value);
+          $value: str-replace($value, "\${#{$theme-name}}", $theme-value);
+        }
+
+        @at-root .#{$class}-#{join($theme, $selector)} {
+          #{$css-property}: unquote($value);
+        }
+      }
+    }
+  }
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 @media #{$g-breakpoint-tiny} {
 }
@@ -1807,5 +1853,51 @@ $map: (
     key: other-other-value
   )
 );
+
+a {
+  content: "#{"0.5"}";
+  content: my-fn("_");
+  content: "#{my-fn("_")}";
+  content: my-fn("-");
+  content: "#{my-fn("-")}";
+  content: my-fn("-a");
+  content: "#{my-fn("-a")}";
+  content: my-fn("a-");
+  content: "#{my-fn("a-")}";
+  content: my-fn("foo");
+  content: "#{my-fn("foo")}";
+  content: 1 "#{my-fn("foo")}" 2;
+  content: foo "#{my-fn("foo")}" bar;
+  content: "foo #{$description} bar";
+
+  content: "#{my-fn("foo","bar")}";
+  content: "#{my-fn( "foo" , "bar" )}";
+  content: "#{my-fn(  "foo"  ,  "bar"  )}";
+
+  content: '#{my-fn("foo")}';
+  content: "#{my-fn("foo")}";
+  content: "#{my-fn('foo')}";
+  content: "#{my-fn("foo")}";
+}
+
+mixin theme($css-property, $css-value, $theme-classes: t) {
+  @each $selector in & {
+    @each $class in $theme-classes {
+      @each $theme, $theme-properties in c(themes) {
+        $value: $css-value;
+
+        @each $theme-name, $theme-value in $theme-properties {
+          $rgba-value: "rgba(#{red($theme-value)}, #{green($theme-value)}, #{blue($theme-value)}";
+          $value: str-replace($value, "rgba(\${#{$theme-name}}", $rgba-value);
+          $value: str-replace($value, "\${#{$theme-name}}", $theme-value);
+        }
+
+        @at-root .#{$class}-#{join($theme, $selector)} {
+          #{$css-property}: unquote($value);
+        }
+      }
+    }
+  }
+}
 
 `;

--- a/tests/css_scss/scss.css
+++ b/tests/css_scss/scss.css
@@ -942,3 +942,49 @@ $map: (
 key: (value),
 other-key: (key: other-other-value)
 );
+
+a {
+  content: "#{".5"}";
+  content: my-fn("_");
+  content: "#{my-fn("_")}";
+  content: my-fn("-");
+  content: "#{my-fn("-")}";
+  content: my-fn("-a");
+  content: "#{my-fn("-a")}";
+  content: my-fn("a-");
+  content: "#{my-fn("a-")}";
+  content: my-fn("foo");
+  content: "#{my-fn("foo")}";
+  content: 1 "#{my-fn("foo")}" 2;
+  content: foo "#{my-fn("foo")}" bar;
+  content: "foo #{$description} bar";
+
+  content: "#{my-fn("foo","bar")}";
+  content: "#{my-fn( "foo" , "bar" )}";
+  content: "#{my-fn(  "foo"  ,  "bar"  )}";
+
+  content: '#{my-fn("foo")}';
+  content: '#{my-fn('foo')}';
+  content: "#{my-fn('foo')}";
+  content: "#{my-fn("foo")}";
+}
+
+mixin theme($css-property, $css-value, $theme-classes: t) {
+  @each $selector in & {
+    @each $class in $theme-classes {
+      @each $theme, $theme-properties in c(themes) {
+      $value: $css-value;
+
+        @each $theme-name, $theme-value in $theme-properties {
+          $rgba-value: "rgba(#{red($theme-value)}, #{green($theme-value)}, #{blue($theme-value)}";
+          $value: str-replace($value, "rgba(${#{$theme-name}}", $rgba-value);
+          $value: str-replace($value, "${#{$theme-name}}", $theme-value);
+        }
+
+        @at-root .#{$class}-#{join($theme, $selector)} {
+          #{$css-property}: unquote($value);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
fixes #4294

We ignore all inside in string (no pretty output, print as is) with interpolation. 

Why?
1. It it feature and will be done in other PR
2. It is dangerous in some case:

Input:
```scss
a {
 content: "#{my-fn("_")}";
}
```

If `my-fn` function found, output:
```scss
a {
 content: "result-of-function";
}
```

If `my-fn` not found, output:
```scss
a {
 content: "my-fn("_")";
}
```

IMHO, better don't touch right now this.