### PR TITLE
Set up CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,97 @@
+aliases:
+  # Cache management
+  - &restore_yarn_cache
+    restore_cache:
+      keys:
+        - v1-yarn-cache
+
+  - &save_yarn_cache
+    save_cache:
+      paths:
+        - ~/.cache/yarn
+      key: v1-yarn-cache
+
+  - &restore_deps_cache
+    restore_cache:
+      keys:
+        - v1-deps-cache-{{ checksum "yarn.lock" }}
+
+  - &save_deps_cache
+    save_cache:
+      paths:
+        - node_modules
+      key: v1-yarn-deps-{{ checksum "yarn.lock" }}
+
+  # Default
+  - &defaults
+    working_directory: ~/prettier
+    docker:
+      - image: circleci/node:9
+
+version: 2
+jobs:
+  # Install dependencies and cache everything
+  checkout_code:
+    <<: *defaults
+    steps:
+      - checkout
+      - *restore_yarn_cache
+      - *restore_deps_cache
+      - run: yarn install
+      - run: yarn check-deps
+      - *save_deps_cache
+      - *save_yarn_cache
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+
+  # Create the production bundle and cache
+  build_prod:
+    <<: *defaults
+    environment:
+      NODE_ENV: production
+    steps:
+      - attach_workspace:
+          at: ~/prettier
+      - run: yarn build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - dist
+
+  # Run tests on the production bundle
+  test_prod_node4:
+    <<: *defaults
+    docker:
+      - image: circleci/node:4
+    steps:
+      - attach_workspace:
+          at: ~/prettier
+      - run: yarn test:dist
+
+  # Run tests on the production bundle
+  test_prod_node9:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/prettier
+      - run: yarn test:dist
+
+workflows:
+  version: 2
+  branches:
+    only:
+      - master
+  prod:
+    jobs:
+      - checkout_code
+      - build_prod:
+          requires:
+            - checkout_code
+      - test_prod_node4:
+          requires:
+            - build_prod
+      - test_prod_node9:
+          requires:
+            - build_prod

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,38 @@
 ---
 language: node_js
+
 node_js:
-  - 4
-  - stable
+  - node
+  - "4"
+
 cache:
   yarn: true
   directories:
     - node_modules
+
 env:
-  - NODE_ENV=development
-  - NODE_ENV=production
+  global:
+    - NODE_ENV=development
+  matrix:
+    - JOB=test AST_COMPARE=1
+
 matrix:
   fast_finish: true
+  include:
+    - node_js: "node"
+      env: JOB=lint
+
 install:
-  - NODE_ENV=development yarn install
+  - yarn install
+
 before_script:
   - yarn check-deps
-  - if [ "${NODE_ENV}" = "production" ]; then yarn build; fi
+
 script:
-  - yarn lint
-  - yarn lint-docs
-  - if [ "${NODE_ENV}" = "production" ]; then yarn test:dist; fi
-  - if [ "${NODE_ENV}" = "development" ]; then AST_COMPARE=1 yarn test -- --runInBand; fi
-  - if [ "${NODE_ENV}" = "development" ]; then yarn codecov; fi
+  - if [ "${JOB}" = "lint" ]; then yarn lint && yarn lint-docs; fi
+  - if [ "${JOB}" = "test" ]; then yarn test --maxWorkers=4 --ci; fi
+  - if [ "${JOB}" = "test" ]; then yarn codecov; fi
+
 branches:
   only:
     - master


### PR DESCRIPTION
Context: #3919

With CircleCI we can make a "pipeline" that first builds the production bundle in a modern Node environment, then uses the built artifact to run test suites in other node versions (in parallel).

This opens up some new interesting possibilities that I'm really excited to explore in the near future