### PR TITLE
Inline AngularJS tests that use `inject`

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5581,30 +5581,31 @@ const unitTestRe = /^(skip|[fx]?(it|describe|test))$/;
 
 // eg; `describe("some string", (done) => {})`
 function isTestCall(n, parent) {
-  if (n.type === "CallExpression") {
-    if (n.arguments.length === 1) {
-      if (isAngularTestWrapper(n) && parent && isTestCall(parent)) {
-        return isFunctionOrArrowExpression(n.arguments[0].type);
-      }
+  if (n.type !== "CallExpression") {
+    return false;
+  }
+  if (n.arguments.length === 1) {
+    if (isAngularTestWrapper(n) && parent && isTestCall(parent)) {
+      return isFunctionOrArrowExpression(n.arguments[0].type);
+    }
 
-      if (isUnitTestSetUp(n)) {
-        return (
-          isFunctionOrArrowExpression(n.arguments[0].type) ||
-          isAngularTestWrapper(n.arguments[0])
-        );
-      }
-    } else if (n.arguments.length === 2) {
-      if (
-        ((n.callee.type === "Identifier" && unitTestRe.test(n.callee.name)) ||
-          isSkipOrOnlyBlock(n)) &&
-        (isTemplateLiteral(n.arguments[0]) || isStringLiteral(n.arguments[0]))
-      ) {
-        return (
-          (isFunctionOrArrowExpression(n.arguments[1].type) &&
-            n.arguments[1].params.length <= 1) ||
-          isAngularTestWrapper(n.arguments[1])
-        );
-      }
+    if (isUnitTestSetUp(n)) {
+      return (
+        isFunctionOrArrowExpression(n.arguments[0].type) ||
+        isAngularTestWrapper(n.arguments[0])
+      );
+    }
+  } else if (n.arguments.length === 2) {
+    if (
+      ((n.callee.type === "Identifier" && unitTestRe.test(n.callee.name)) ||
+        isSkipOrOnlyBlock(n)) &&
+      (isTemplateLiteral(n.arguments[0]) || isStringLiteral(n.arguments[0]))
+    ) {
+      return (
+        (isFunctionOrArrowExpression(n.arguments[1].type) &&
+          n.arguments[1].params.length <= 1) ||
+        isAngularTestWrapper(n.arguments[1])
+      );
     }
   }
   return false;

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3984,9 +3984,7 @@ function printTypeParameters(path, options, print, paramsKey) {
 
   const grandparent = path.getNode(2);
 
-  const isParameterInTestCall =
-    grandparent != null &&
-    isTestCall(grandparent);
+  const isParameterInTestCall = grandparent != null && isTestCall(grandparent);
 
   const shouldInline =
     isParameterInTestCall ||

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5577,7 +5577,7 @@ function isObjectType(n) {
   return n.type === "ObjectTypeAnnotation" || n.type === "TSTypeLiteral";
 }
 
-const unitTestRe = /^(skip|(f|x)?(it|describe|test))$/;
+const unitTestRe = /^(skip|[fx]?(it|describe|test))$/;
 
 // eg; `describe("some string", (done) => {})`
 function isTestCall(n, parent) {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5587,7 +5587,7 @@ function isTestCall(n, parent) {
   if (n.arguments.length === 1) {
     if (
       n.callee.type === "Identifier" &&
-      n.callee.name === "async" &&
+      (n.callee.name === "async" || n.callee.name === "inject") &&
       parent &&
       parent.type === "CallExpression" &&
       isTestCall(parent)
@@ -5598,7 +5598,7 @@ function isTestCall(n, parent) {
     if (isUnitTestSetUp(n)) {
       return (
         isFunctionOrArrowExpression(n.arguments[0].type) ||
-        isIdentiferAsync(n.arguments[0])
+        isIdentiferInjectOrAsync(n.arguments[0])
       );
     }
   } else if (n.arguments.length === 2) {
@@ -5610,7 +5610,7 @@ function isTestCall(n, parent) {
       return (
         (isFunctionOrArrowExpression(n.arguments[1].type) &&
           n.arguments[1].params.length <= 1) ||
-        isIdentiferAsync(n.arguments[1])
+        isIdentiferInjectOrAsync(n.arguments[1])
       );
     }
   }
@@ -5633,11 +5633,13 @@ function isTemplateLiteral(node) {
   return node.type === "TemplateLiteral";
 }
 
-function isIdentiferAsync(node) {
+// `inject` is used in AngularJS 1.x, `async` in Angular 2+
+// example: https://docs.angularjs.org/guide/unit-testing#using-beforeall-
+function isIdentiferInjectOrAsync(node) {
   return (
     node.type === "CallExpression" &&
     node.callee.type === "Identifier" &&
-    node.callee.name === "async"
+    (node.callee.name === "async" || node.callee.name === "inject")
   );
 }
 

--- a/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
@@ -102,6 +102,130 @@ function x() {
 
 `;
 
+exports[`angularjs_inject.js 1`] = `
+beforeEach(inject(($fooService, $barService) => {
+  // code
+}));
+
+afterAll(inject(($fooService, $barService) => {
+  console.log('Hello');
+}));
+
+it('should create the app', inject(($fooService, $barService) => {
+  //code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", inject(() => {
+  // code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", inject(($fooServiceLongName, $barServiceLongName) => {
+  // code
+}));
+
+/*
+* isTestCall(parent) should only be called when parent exists
+* and parent.type is CallExpression. This test makes sure that
+* no errors are thrown when calling isTestCall(parent)
+*/
+function x() { inject(() => {}) }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+beforeEach(inject(($fooService, $barService) => {
+  // code
+}));
+
+afterAll(inject(($fooService, $barService) => {
+  console.log("Hello");
+}));
+
+it("should create the app", inject(($fooService, $barService) => {
+  //code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", inject(() => {
+  // code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", inject((
+  $fooServiceLongName,
+  $barServiceLongName
+) => {
+  // code
+}));
+
+/*
+* isTestCall(parent) should only be called when parent exists
+* and parent.type is CallExpression. This test makes sure that
+* no errors are thrown when calling isTestCall(parent)
+*/
+function x() {
+  inject(() => {});
+}
+
+`;
+
+exports[`angularjs_inject.js 2`] = `
+beforeEach(inject(($fooService, $barService) => {
+  // code
+}));
+
+afterAll(inject(($fooService, $barService) => {
+  console.log('Hello');
+}));
+
+it('should create the app', inject(($fooService, $barService) => {
+  //code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", inject(() => {
+  // code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", inject(($fooServiceLongName, $barServiceLongName) => {
+  // code
+}));
+
+/*
+* isTestCall(parent) should only be called when parent exists
+* and parent.type is CallExpression. This test makes sure that
+* no errors are thrown when calling isTestCall(parent)
+*/
+function x() { inject(() => {}) }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+beforeEach(inject(($fooService, $barService) => {
+  // code
+}));
+
+afterAll(inject(($fooService, $barService) => {
+  console.log("Hello");
+}));
+
+it("should create the app", inject(($fooService, $barService) => {
+  //code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", inject(() => {
+  // code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", inject((
+  $fooServiceLongName,
+  $barServiceLongName
+) => {
+  // code
+}));
+
+/*
+* isTestCall(parent) should only be called when parent exists
+* and parent.type is CallExpression. This test makes sure that
+* no errors are thrown when calling isTestCall(parent)
+*/
+function x() {
+  inject(() => {});
+}
+
+`;
+
 exports[`jest-each.js 1`] = `
 describe.each\`
 a|b|expected

--- a/tests/test_declarations/angularjs_inject.js
+++ b/tests/test_declarations/angularjs_inject.js
@@ -1,0 +1,26 @@
+beforeEach(inject(($fooService, $barService) => {
+  // code
+}));
+
+afterAll(inject(($fooService, $barService) => {
+  console.log('Hello');
+}));
+
+it('should create the app', inject(($fooService, $barService) => {
+  //code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", inject(() => {
+  // code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", inject(($fooServiceLongName, $barServiceLongName) => {
+  // code
+}));
+
+/*
+* isTestCall(parent) should only be called when parent exists
+* and parent.type is CallExpression. This test makes sure that
+* no errors are thrown when calling isTestCall(parent)
+*/
+function x() { inject(() => {}) }


### PR DESCRIPTION
Like #4241, but for the older Angular.

A code example (from [here](https://docs.angularjs.org/guide/unit-testing#using-beforeall-)):
```js
  it("has calculated the answer correctly", inject(function(DeepThought) {
    expect(DeepThought.answer).toBe(42);
  }));
```