### PR TITLE
Remove unnecessary check for PRETTIER_DEBUG

### DIFF
--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -98,17 +98,9 @@ function embed(path, print, textToDoc /*, options */) {
           if (commentsAndWhitespaceOnly) {
             doc = printGraphqlComments(lines);
           } else {
-            try {
-              doc = docUtils.stripTrailingHardline(
-                textToDoc(text, { parser: "graphql" })
-              );
-            } catch (error) {
-              if (process.env.PRETTIER_DEBUG) {
-                throw error;
-              }
-              // Bail if any part fails to parse.
-              return null;
-            }
+            doc = docUtils.stripTrailingHardline(
+              textToDoc(text, { parser: "graphql" })
+            );
           }
 
           if (doc) {


### PR DESCRIPTION
Minor refactor, removes unnecessary check `if (process.env.PRETTIER_DEBUG) throw error;` since the multiparser will already catch any error thrown in `embed`.