### PR TITLE
Rename all uses of frontmatter to frontMatter or front-matter

### DIFF
--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const createError = require("../common/parser-create-error");
-const parseFrontmatter = require("../utils/front-matter");
+const parseFrontMatter = require("../utils/front-matter");
 
 // utils
 const utils = require("./utils");
@@ -474,8 +474,8 @@ function parseNestedCSS(node) {
 }
 
 function parseWithParser(parser, text) {
-  const parsed = parseFrontmatter(text);
-  const frontmatter = parsed.frontmatter;
+  const parsed = parseFrontMatter(text);
+  const frontMatter = parsed.frontMatter;
   text = parsed.content;
 
   let result;
@@ -491,10 +491,10 @@ function parseWithParser(parser, text) {
 
   result = parseNestedCSS(addTypePrefix(result, "css-"));
 
-  if (frontmatter) {
+  if (frontMatter) {
     result.nodes.unshift({
-      type: "frontmatter",
-      value: frontmatter
+      type: "front-matter",
+      value: frontMatter
     });
   }
 

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -77,7 +77,7 @@ function genericPrint(path, options, print) {
   }
 
   switch (node.type) {
-    case "frontmatter":
+    case "front-matter":
       return concat([node.value, hardline]);
     case "css-root": {
       const nodes = printNodeSequence(path, options, print);

--- a/src/language-markdown/parser-markdown.js
+++ b/src/language-markdown/parser-markdown.js
@@ -2,7 +2,7 @@
 
 const remarkParse = require("remark-parse");
 const unified = require("unified");
-const parseFrontmatter = require("../utils/front-matter");
+const parseFrontMatter = require("../utils/front-matter");
 const util = require("../common/util");
 
 /**
@@ -22,7 +22,7 @@ const util = require("../common/util");
 function parse(text, parsers, opts) {
   const processor = unified()
     .use(remarkParse, { footnotes: true, commonmark: true })
-    .use(frontmatter)
+    .use(frontMatter)
     .use(liquid)
     .use(restoreUnescapedCharacter(text))
     .use(mergeContinuousTexts)
@@ -128,18 +128,18 @@ function splitText(options) {
     });
 }
 
-function frontmatter() {
+function frontMatter() {
   const proto = this.Parser.prototype;
-  proto.blockMethods = ["frontmatter"].concat(proto.blockMethods);
-  proto.blockTokenizers.frontmatter = tokenizer;
+  proto.blockMethods = ["frontMatter"].concat(proto.blockMethods);
+  proto.blockTokenizers.frontMatter = tokenizer;
 
   function tokenizer(eat, value) {
-    const parsed = parseFrontmatter(value);
+    const parsed = parseFrontMatter(value);
 
-    if (parsed.frontmatter) {
-      return eat(parsed.frontmatter)({
-        type: "frontmatter",
-        value: parsed.frontmatter
+    if (parsed.frontMatter) {
+      return eat(parsed.frontMatter)({
+        type: "front-matter",
+        value: parsed.frontMatter
       });
     }
   }

--- a/src/language-markdown/pragma.js
+++ b/src/language-markdown/pragma.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const parseFrontmatter = require("../utils/front-matter");
+const parseFrontMatter = require("../utils/front-matter");
 
 const pragmas = ["format", "prettier"];
 
@@ -19,12 +19,12 @@ function startWithPragma(text) {
 
 module.exports = {
   startWithPragma,
-  hasPragma: text => startWithPragma(parseFrontmatter(text).content.trimLeft()),
+  hasPragma: text => startWithPragma(parseFrontMatter(text).content.trimLeft()),
   insertPragma: text => {
-    const extracted = parseFrontmatter(text);
+    const extracted = parseFrontMatter(text);
     const pragma = `<!-- @${pragmas[0]} -->`;
-    return extracted.frontmatter
-      ? `${extracted.frontmatter}\n\n${pragma}\n\n${extracted.content}`
+    return extracted.frontMatter
+      ? `${extracted.frontMatter}\n\n${pragma}\n\n${extracted.content}`
       : `${pragma}\n\n${extracted.content}`;
   }
 };

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -211,7 +211,7 @@ function genericPrint(path, options, print) {
         style
       ]);
     }
-    case "frontmatter":
+    case "front-matter":
       return node.value;
     case "html": {
       const parentNode = path.getParentNode();
@@ -828,7 +828,7 @@ function clean(ast, newObj, parent) {
     parent.type === "root" &&
     parent.children.length > 0 &&
     (parent.children[0] === ast ||
-      (parent.children[0].type === "frontmatter" &&
+      (parent.children[0].type === "front-matter" &&
         parent.children[1] === ast)) &&
     ast.type === "html" &&
     pragma.startWithPragma(ast.value)

--- a/src/utils/front-matter.js
+++ b/src/utils/front-matter.js
@@ -12,13 +12,13 @@ function parse(text) {
   let end = -1;
 
   if (!delimiter || (end = text.indexOf(`\n${delimiter}`, 3)) === -1) {
-    return { frontmatter: null, content: text };
+    return { frontMatter: null, content: text };
   }
 
   end = end + 4;
 
   return {
-    frontmatter: text.slice(0, end),
+    frontMatter: text.slice(0, end),
     content: text.slice(end)
   };
 }


### PR DESCRIPTION
A quick web [search](https://duckduckgo.com/?q=frontmatter) shows many matches for “front matter,” but few for “frontmatter.” Also, [Grammarly](https://www.grammarly.com) suggests that I use “front matter:”

<img width="226" alt="screen shot 2018-05-21 at 06 38 24" src="https://user-images.githubusercontent.com/25517624/40303661-b4264a14-5cc1-11e8-834c-2902b78d696b.png">
