### PR TITLE
feat: handle `composer.json` as `package.json`

### DIFF
--- a/src/language-js/index.js
+++ b/src/language-js/index.js
@@ -138,7 +138,7 @@ const languages = [
     codemirrorMode: "javascript",
     codemirrorMimeType: "application/json",
     extensions: [], // .json file defaults to json instead of json-stringify
-    filenames: ["package.json", "package-lock.json"],
+    filenames: ["package.json", "package-lock.json", "composer.json"],
     linguistLanguageId: 174,
     vscodeLanguageIds: ["json"]
   },


### PR DESCRIPTION
Many `PHP` projects use `composer` https://getcomposer.org/ (package manager for `PHP`) and many of this projects use `prettier` (I hope :smile:), also we have official `plugin-php`. Let's use same logic for `composer.json` as for `package.json`.