### PR TITLE
Update babylon & flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "esutils": "2.0.2",
     "find-parent-dir": "0.3.0",
     "find-project-root": "1.1.1",
-    "flow-parser": "0.70",
+    "flow-parser": "0.72.0",
     "get-stream": "3.0.0",
     "globby": "6.1.0",
     "graphql": "0.13.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@babel/code-frame": "7.0.0-beta.40",
     "@glimmer/syntax": "0.30.3",
-    "babylon": "7.0.0-beta.34",
+    "babylon": "7.0.0-beta.47",
     "camelcase": "4.1.0",
     "chalk": "2.1.0",
     "cjk-regex": "1.0.2",

--- a/src/language-js/clean.js
+++ b/src/language-js/clean.js
@@ -128,7 +128,7 @@ function clean(ast, newObj, parent) {
   }
 
   // CSS template literals in Angular Component decorator
-  var expression = ast.expression || ast.callee;
+  const expression = ast.expression || ast.callee;
   if (
     ast.type === "Decorator" &&
     expression.type === "CallExpression" &&

--- a/src/language-js/clean.js
+++ b/src/language-js/clean.js
@@ -89,6 +89,11 @@ function clean(ast, newObj, parent) {
     delete newObj.key;
   }
 
+  if (ast.type === "OptionalMemberExpression" && ast.optional === false) {
+    newObj.type = "MemberExpression";
+    delete newObj.optional;
+  }
+
   // Remove raw and cooked values from TemplateElement when it's CSS
   // styled-jsx
   if (
@@ -123,12 +128,13 @@ function clean(ast, newObj, parent) {
   }
 
   // CSS template literals in Angular Component decorator
+  var expression = ast.expression || ast.callee;
   if (
     ast.type === "Decorator" &&
-    ast.expression.type === "CallExpression" &&
-    ast.expression.callee.name === "Component" &&
-    ast.expression.arguments.length === 1 &&
-    ast.expression.arguments[0].properties.some(
+    expression.type === "CallExpression" &&
+    expression.callee.name === "Component" &&
+    expression.arguments.length === 1 &&
+    expression.arguments[0].properties.some(
       prop =>
         prop.key.name === "styles" && prop.value.type === "ArrayExpression"
     )

--- a/src/language-js/parser-babylon.js
+++ b/src/language-js/parser-babylon.js
@@ -17,7 +17,7 @@ function parse(text, parsers, opts) {
       "flow",
       "doExpressions",
       "objectRestSpread",
-      "decorators",
+      "decorators-legacy",
       "classProperties",
       "exportDefaultFrom",
       "exportNamespaceFrom",

--- a/src/language-js/parser-flow.js
+++ b/src/language-js/parser-flow.js
@@ -15,7 +15,8 @@ function parse(text /*, parsers, opts*/) {
     esproposal_class_instance_fields: true,
     esproposal_class_static_fields: true,
     esproposal_export_star_as: true,
-    esproposal_optional_chaining: true
+    esproposal_optional_chaining: true,
+    esproposal_nullish_coalescing: true
   });
 
   if (ast.errors.length > 0) {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -76,11 +76,11 @@ function genericPrint(path, options, printPath, args) {
   ) {
     let separator = hardline;
     path.each(decoratorPath => {
-      let prefix = "@";
       let decorator = decoratorPath.getValue();
       if (decorator.expression) {
         decorator = decorator.expression;
-        prefix = "";
+      } else {
+        decorator = decorator.callee;
       }
 
       if (
@@ -100,7 +100,7 @@ function genericPrint(path, options, printPath, args) {
         separator = line;
       }
 
-      decorators.push(prefix, printPath(decoratorPath), separator);
+      decorators.push(printPath(decoratorPath), separator);
     }, "decorators");
   } else if (
     privateUtil.isExportDeclaration(node) &&
@@ -331,6 +331,7 @@ function printPathNoParens(path, options, print, args) {
   let parts = [];
   switch (n.type) {
     case "File":
+    // console.log(JSON.stringify(n, null, 2));
       return path.call(print, "program");
     case "Program":
       // Babel 6
@@ -1262,7 +1263,7 @@ function printPathNoParens(path, options, print, args) {
     case "ObjectMethod":
       return printObjectMethod(path, options, print);
     case "Decorator":
-      return concat(["@", path.call(print, "expression")]);
+      return concat(["@", path.call(print, "expression"), path.call(print, "callee")]);
     case "ArrayExpression":
     case "ArrayPattern":
       if (n.elements.length === 0) {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -91,8 +91,8 @@ function genericPrint(path, options, printPath, args) {
         (decorator.type === "Identifier" ||
           decorator.type === "MemberExpression" ||
           decorator.type === "OptionalMemberExpression" ||
-          (decorator.type === "CallExpression" &&
-            decorator.type === "OptionalCallExpression" &&
+          ((decorator.type === "CallExpression" ||
+            decorator.type === "OptionalCallExpression") &&
             (decorator.arguments.length === 0 ||
               (decorator.arguments.length === 1 &&
                 (isStringLiteral(decorator.arguments[0]) ||
@@ -5680,8 +5680,8 @@ function isTestCall(n, parent) {
 
 function isSkipOrOnlyBlock(node) {
   return (
-    node.callee.type === "MemberExpression" &&
-    node.callee.type === "OptionalMemberExpression" &&
+    (node.callee.type === "MemberExpression" ||
+    node.callee.type === "OptionalMemberExpression") &&
     node.callee.object.type === "Identifier" &&
     node.callee.property.type === "Identifier" &&
     unitTestRe.test(node.callee.object.name) &&

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -338,7 +338,6 @@ function printPathNoParens(path, options, print, args) {
   let parts = [];
   switch (n.type) {
     case "File":
-    // console.log(JSON.stringify(n, null, 2));
       return path.call(print, "program");
     case "Program":
       // Babel 6
@@ -1276,7 +1275,11 @@ function printPathNoParens(path, options, print, args) {
     case "ObjectMethod":
       return printObjectMethod(path, options, print);
     case "Decorator":
-      return concat(["@", path.call(print, "expression"), path.call(print, "callee")]);
+      return concat([
+        "@",
+        path.call(print, "expression"),
+        path.call(print, "callee")
+      ]);
     case "ArrayExpression":
     case "ArrayPattern":
       if (n.elements.length === 0) {
@@ -4433,7 +4436,8 @@ function printMemberChain(path, options, print) {
 
     const lastNode = privateUtil.getLast(groups[0]).node;
     return (
-      (lastNode.type === "MemberExpression" || lastNode.type === "OptionalMemberExpression") &&
+      (lastNode.type === "MemberExpression" ||
+        lastNode.type === "OptionalMemberExpression") &&
       lastNode.property.type === "Identifier" &&
       (isFactory(lastNode.property.name) ||
         (isExpression && isShort(lastNode.property.name)) ||
@@ -5681,7 +5685,7 @@ function isTestCall(n, parent) {
 function isSkipOrOnlyBlock(node) {
   return (
     (node.callee.type === "MemberExpression" ||
-    node.callee.type === "OptionalMemberExpression") &&
+      node.callee.type === "OptionalMemberExpression") &&
     node.callee.object.type === "Identifier" &&
     node.callee.property.type === "Identifier" &&
     unitTestRe.test(node.callee.object.name) &&

--- a/tests/literal-numeric-separator/jsfmt.spec.js
+++ b/tests/literal-numeric-separator/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, ["babylon", "typescript"]);
+run_spec(__dirname, ["babylon", "flow", "typescript"]);

--- a/tests/nullish_coalescing/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/nullish_coalescing/__snapshots__/jsfmt.spec.js.snap
@@ -13,9 +13,6 @@ foo ?? baz || baz;
 
 (foo && baz) ?? baz;
 foo && (baz ?? baz);
-
-foo |> (bar ?? baz);
-(foo |> bar) ?? baz;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 obj.foo ?? "default";
 
@@ -29,8 +26,5 @@ foo ?? baz || baz;
 
 (foo && baz) ?? baz;
 foo && (baz ?? baz);
-
-foo |> bar ?? baz;
-(foo |> bar) ?? baz;
 
 `;

--- a/tests/nullish_coalescing/jsfmt.spec.js
+++ b/tests/nullish_coalescing/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, ["babylon"]);
+run_spec(__dirname, ["babylon", "flow"]);

--- a/tests/nullish_coalescing/nullish_coalesing_operator.js
+++ b/tests/nullish_coalescing/nullish_coalesing_operator.js
@@ -10,6 +10,3 @@ foo ?? baz || baz;
 
 (foo && baz) ?? baz;
 foo && (baz ?? baz);
-
-foo |> (bar ?? baz);
-(foo |> bar) ?? baz;

--- a/tests/pipeline_operator/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/pipeline_operator/__snapshots__/jsfmt.spec.js.snap
@@ -25,6 +25,9 @@ function createPerson (attrs) {
     |> format('name', /^[a-z]$/i)
     |> Person.insertIntoDatabase;
 }
+
+foo |> (bar ?? baz);
+(foo |> bar) ?? baz;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 a |> b |> c;
 
@@ -48,5 +51,8 @@ function createPerson(attrs) {
     |> format("name", /^[a-z]$/i)
     |> Person.insertIntoDatabase;
 }
+
+foo |> bar ?? baz;
+(foo |> bar) ?? baz;
 
 `;

--- a/tests/pipeline_operator/pipeline_operator.js
+++ b/tests/pipeline_operator/pipeline_operator.js
@@ -22,3 +22,6 @@ function createPerson (attrs) {
     |> format('name', /^[a-z]$/i)
     |> Person.insertIntoDatabase;
 }
+
+foo |> (bar ?? baz);
+(foo |> bar) ?? baz;

--- a/yarn.lock
+++ b/yarn.lock
@@ -962,9 +962,9 @@ babel-types@^6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@7.0.0-beta.34:
-  version "7.0.0-beta.34"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.34.tgz#2ccdf97bb4fbc1617619a030a6c0390b2c8f16d6"
+babylon@7.0.0-beta.47:
+  version "7.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.47.tgz#6d1fa44f0abec41ab7c780481e62fd9aafbdea80"
 
 babylon@7.0.0-beta.40:
   version "7.0.0-beta.40"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2094,9 +2094,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-parser@0.70:
-  version "0.70.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.70.0.tgz#9c310187efe4380ba9a251284e9b83b95c49e857"
+flow-parser@0.72.0:
+  version "0.72.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.72.0.tgz#6c8041e76ac7d0be1a71ce29c00cd1435fb6013c"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This updates babylon and flow. The motivation is that we want to start using `?.` and `??` at Facebook :)

The two big changes are:
- Babylon shipped the new decorator spec in master and you need to use the legacy one which has a slightly different API.
- The new `?.` spec adds "OptionalXXX" nodes, so we need to update all the call sites to support it. Thankfully @xixixao did most of the hard work in #4463 

