### PR TITLE
Drop node 4 support for development "build"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 
 node_js:
   - node
-  - "4"
+  - "6"
 
 cache:
   yarn: true

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "main": "./index.js",
   "engines": {
-    "node": ">=4"
+    "node": ">=6"
   },
   "dependencies": {
     "@babel/code-frame": "7.0.0-beta.40",

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -201,6 +201,7 @@ async function createBundle(bundle) {
 async function createPackageJson() {
   const pkg = await util.readJson("package.json");
   pkg.bin = "./bin-prettier.js";
+  pkg.engines.node = ">=4";
   delete pkg.dependencies;
   delete pkg.devDependencies;
   pkg.scripts = {


### PR DESCRIPTION
Let's skip testing node 4 for the dev build. CircleCI tests the prod build