### PR TITLE
Add support for flow explicit type arguments

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1030,7 +1030,7 @@ function printPathNoParens(path, options, print, args) {
           isNew ? "new " : "",
           path.call(print, "callee"),
           optional,
-          path.call(print, "typeParameters"),
+          printFunctionTypeParameters(path, options, print),
           concat(["(", join(", ", path.map(print, "arguments")), ")"])
         ]);
       }
@@ -3583,6 +3583,9 @@ function printTypeAnnotation(path, options, print) {
 
 function printFunctionTypeParameters(path, options, print) {
   const fun = path.getValue();
+  if (fun.typeArguments) {
+    return path.call(print, "typeArguments");
+  }
   if (fun.typeParameters) {
     return path.call(print, "typeParameters");
   }

--- a/tests/flow_typeapp_call/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_typeapp_call/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`typeapp_call.js 1`] = `
+//@flow
+f<T>();
+f<T><U></U>;
+new C<T>;
+f<T>(e);
+o[e]<T>();
+f<T>(x)<U>(y);
+async <T>() => {};
+async <T>(): T => {}
+new C<T>(e);
+f<T>[e];
+new C<T>();
+o.m<T>();
+f<T>.0;
+o?.m<T>(e);
+o.m?.<T>(e);
+async<T>();
+f?.<T>(e);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+//@flow
+f<T>();
+f < T > <U />;
+new C<T>();
+f<T>(e);
+o[e]<T>();
+f<T>(x)<U>(y);
+async <T>() => {};
+async <T>(): T => {};
+new C<T>(e);
+f < T > [e];
+new C<T>();
+o.m<T>();
+f < T > 0.0;
+o?.m<T>(e);
+o.m?.<T>(e);
+async<T>();
+f?.<T>(e);
+
+`;

--- a/tests/flow_typeapp_call/jsfmt.spec.js
+++ b/tests/flow_typeapp_call/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["flow"]);

--- a/tests/flow_typeapp_call/typeapp_call.js
+++ b/tests/flow_typeapp_call/typeapp_call.js
@@ -1,0 +1,18 @@
+//@flow
+f<T>();
+f<T><U></U>;
+new C<T>;
+f<T>(e);
+o[e]<T>();
+f<T>(x)<U>(y);
+async <T>() => {};
+async <T>(): T => {}
+new C<T>(e);
+f<T>[e];
+new C<T>();
+o.m<T>();
+f<T>.0;
+o?.m<T>(e);
+o.m?.<T>(e);
+async<T>();
+f?.<T>(e);


### PR DESCRIPTION
Fixes #4489.

Babylon support landed in `beta.48` just now but requires a few other fixture changes, so I'm going to follow this up with another PR.