### PR TITLE
Add support for flow inline interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "esutils": "2.0.2",
     "find-parent-dir": "0.3.0",
     "find-project-root": "1.1.1",
-    "flow-parser": "0.72.0",
+    "flow-parser": "0.73.0",
     "get-stream": "3.0.0",
     "globby": "6.1.0",
     "graphql": "0.13.2",

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2485,8 +2485,11 @@ function printPathNoParens(path, options, print, args) {
         path.call(print, "id"),
         path.call(print, "typeParameters")
       ]);
+
     case "DeclareInterface":
-    case "InterfaceDeclaration": {
+    case "InterfaceDeclaration":
+    case "InterfaceType":
+    case "InterfaceTypeAnnotation": {
       if (
         n.type === "DeclareInterface" ||
         isNodeStartingWithDeclare(n, options)
@@ -2494,11 +2497,15 @@ function printPathNoParens(path, options, print, args) {
         parts.push("declare ");
       }
 
-      parts.push(
-        "interface ",
-        path.call(print, "id"),
-        path.call(print, "typeParameters")
-      );
+      parts.push("interface");
+
+      if (n.type === "DeclareInterface" || n.type === "InterfaceDeclaration") {
+        parts.push(
+          " ",
+          path.call(print, "id"),
+          path.call(print, "typeParameters")
+        );
+      }
 
       if (n["extends"].length > 0) {
         parts.push(
@@ -2510,8 +2517,7 @@ function printPathNoParens(path, options, print, args) {
         );
       }
 
-      parts.push(" ");
-      parts.push(path.call(print, "body"));
+      parts.push(" ", path.call(print, "body"));
 
       return group(concat(parts));
     }

--- a/tests/flow_interface_types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_interface_types/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`interface_types.js 1`] = `
+type A = interface { p: string };
+type B = interface extends X { p: string };
+type C = interface extends X, Y { p: string };
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+type A = interface { p: string };
+type B = interface extends X { p: string };
+type C = interface extends X, Y { p: string };
+
+`;

--- a/tests/flow_interface_types/interface_types.js
+++ b/tests/flow_interface_types/interface_types.js
@@ -1,0 +1,3 @@
+type A = interface { p: string };
+type B = interface extends X { p: string };
+type C = interface extends X, Y { p: string };

--- a/tests/flow_interface_types/jsfmt.spec.js
+++ b/tests/flow_interface_types/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["flow"]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -962,13 +962,13 @@ babel-types@^6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babylon@7.0.0-beta.47:
-  version "7.0.0-beta.47"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.47.tgz#6d1fa44f0abec41ab7c780481e62fd9aafbdea80"
-
 babylon@7.0.0-beta.40:
   version "7.0.0-beta.40"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.40.tgz#91fc8cd56d5eb98b28e6fde41045f2957779940a"
+
+babylon@7.0.0-beta.47:
+  version "7.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.47.tgz#6d1fa44f0abec41ab7c780481e62fd9aafbdea80"
 
 babylon@^6.13.0, babylon@^6.17.2:
   version "6.17.3"
@@ -2094,9 +2094,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-parser@0.72.0:
-  version "0.72.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.72.0.tgz#6c8041e76ac7d0be1a71ce29c00cd1435fb6013c"
+flow-parser@0.73.0:
+  version "0.73.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.73.0.tgz#525ac0776f743e16b6dca1a3dd6c602260b15773"
 
 for-in@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Flow commit: https://github.com/facebook/flow/commit/4f93f3adb7a5fedd3d572d62d718cf48c15a08ce

Babel commit: https://github.com/babel/babel/pull/7973

Will follow up w/ flow team on making `InterfaceType` -> `InterfaceTypeAnnotation`, since it seems a bit inconsistent.