### PR TITLE
Add formatWithCursor, check, doc, and util to the standalone build

### DIFF
--- a/standalone.js
+++ b/standalone.js
@@ -5,6 +5,8 @@ const version = require("./package.json").version;
 const core = require("./src/main/core");
 const getSupportInfo = require("./src/main/support").getSupportInfo;
 
+const doc = require("./src/doc");
+
 const internalPlugins = [
   require("./src/language-js"),
   require("./src/language-css"),
@@ -34,10 +36,21 @@ function withPlugins(fn) {
   };
 }
 
+const formatWithCursor = withPlugins(core.formatWithCursor);
+
 module.exports = {
+  formatWithCursor: formatWithCursor,
+
   format(text, opts) {
-    return withPlugins(core.formatWithCursor)(text, opts).formatted;
+    return formatWithCursor(text, opts).formatted;
   },
+
+  check(text, opts) {
+    const formatted = formatWithCursor(text, opts).formatted;
+    return formatted === text;
+  },
+
+  doc,
 
   getSupportInfo: withPlugins(getSupportInfo),
 

--- a/standalone.js
+++ b/standalone.js
@@ -4,6 +4,7 @@ const version = require("./package.json").version;
 
 const core = require("./src/main/core");
 const getSupportInfo = require("./src/main/support").getSupportInfo;
+const sharedUtil = require("./src/common/util-shared");
 
 const doc = require("./src/doc");
 
@@ -55,6 +56,8 @@ module.exports = {
   getSupportInfo: withPlugins(getSupportInfo),
 
   version,
+
+  util: sharedUtil,
 
   __debug: {
     parse: withPlugins(core.parse),


### PR DESCRIPTION
I added `doc` and `util` because plugins will need them when running in the browser.