### PR TITLE
Update docs for default parser

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -174,9 +174,11 @@ Built-in parsers:
 
 [Custom parsers](api.md#custom-parser-api) are also supported. _Since v1.5.0_
 
-| Default   | CLI Override                                    | API Override                                               |
-| --------- | ----------------------------------------------- | ---------------------------------------------------------- |
-| `babylon` | `--parser <string>`<br />`--parser ./my-parser` | `parser: "<string>"`<br />`parser: require("./my-parser")` |
+| Default | CLI Override                                    | API Override                                               |
+| ------- | ----------------------------------------------- | ---------------------------------------------------------- |
+| None    | `--parser <string>`<br />`--parser ./my-parser` | `parser: "<string>"`<br />`parser: require("./my-parser")` |
+
+Note: the default value was `"babylon"` until v1.13.0.
 
 ## FilePath
 


### PR DESCRIPTION
Context: #4528

I don't know how to communicate the change between versions.

Related: do you think we should start versioning docs (supported by docusaurus)? Would this be enough to communicate changed values?

(versioning docs are also useful for "hiding" unreleased features anyway. so we should keep the `since v1.XX.X` we use and use docs versioning)