### PR TITLE
website: Change pre overflow-x to auto

### DIFF
--- a/website/static/overrides.css
+++ b/website/static/overrides.css
@@ -395,7 +395,7 @@ html body {
 }
 
 pre {
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 
 @media only screen and (min-width: 736px) {


### PR DESCRIPTION
`overflow-x: scroll` shows scrollbars under every code block even if they aren't scrollable:

![scrollbar](https://user-images.githubusercontent.com/1341513/40591633-f0e85540-61d1-11e8-9906-c0c67d432d26.png)

