### PR TITLE
docs(misc): add `prettier-chrome` project

### DIFF
--- a/docs/related-projects.md
+++ b/docs/related-projects.md
@@ -35,3 +35,4 @@ title: Related Projects
 - [`rollup-plugin-prettier`](https://github.com/mjeanroy/rollup-plugin-prettier) allows you to use Prettier with Rollup
 - [`markdown-magic-prettier`](https://github.com/camacho/markdown-magic-prettier) allows you to use Prettier to format JS [codeblocks](https://help.github.com/articles/creating-and-highlighting-code-blocks/) in Markdown files via [Markdown Magic](https://github.com/DavidWells/markdown-magic)
 - [`pretty-quick`](https://github.com/azz/pretty-quick) formats your changed files with Prettier
+- [`prettier-chrome`](https://github.com/u3u/prettier-chrome) an extension that can be formatted using Prettier in Chrome


### PR DESCRIPTION
I really like prettier. I have recently continued to pay attention to prettier updates, waiting for prettier support to run in the browser. Today finally released version 1.3, so I wrote a chrome extension based on this version, thanks prettier!

🎨 An extension that can be formatted using Prettier in Chrome: 
https://github.com/u3u/prettier-chrome