### PR TITLE
remove lint-staged command warning

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -12,7 +12,7 @@ You can use Prettier with a pre-commit tool. This can re-format your files that 
 Install it along with [husky](https://github.com/typicode/husky):
 
 ```bash
-yarn add lint-staged husky --dev
+yarn add lint-staged husky --only=dev
 ```
 
 and add this config to your `package.json`:


### PR DESCRIPTION
fixes the warning
```
$ npm i --save-dev --save-exact prettier
+ prettier@1.13.2
added 1 package in 5.847s
H9435:middleware hmoreno$ npm add lint-staged husky --dev
npm WARN install Usage of the `--dev` option is deprecated. Use `--only=dev` instead.

> husky@0.14.3 install foo/node_modules/husky
> node ./bin/install.js

husky
setting up Git hooks
done

+ husky@0.14.3
+ lint-staged@7.1.2
added 221 packages in 22.332s
```