### PR TITLE
fix(cli): regression for --debug-check + --list-different

### DIFF
--- a/tests_integration/__tests__/__snapshots__/debug-check.js.snap
+++ b/tests_integration/__tests__/__snapshots__/debug-check.js.snap
@@ -4,6 +4,15 @@ exports[`checks stdin with --debug-check (write) 1`] = `Array []`;
 
 exports[`doesn't crash when --debug-check is passed (write) 1`] = `Array []`;
 
+exports[`should not exit non-zero for already prettified code with --debug-check + --list-different (stderr) 1`] = `""`;
+
+exports[`should not exit non-zero for already prettified code with --debug-check + --list-different (stdout) 1`] = `
+"issue-4599.js
+"
+`;
+
+exports[`should not exit non-zero for already prettified code with --debug-check + --list-different (write) 1`] = `Array []`;
+
 exports[`show diff for 2+ error files with --debug-check (stderr) 1`] = `
 "[error] a.debug-check: prettier(input) !== prettier(prettier(input))
 [error] Index: 

--- a/tests_integration/__tests__/debug-check.js
+++ b/tests_integration/__tests__/debug-check.js
@@ -30,3 +30,13 @@ describe("show diff for 2+ error files with --debug-check", () => {
     status: "non-zero"
   });
 });
+
+describe("should not exit non-zero for already prettified code with --debug-check + --list-different", () => {
+  runPrettier("cli/debug-check", [
+    "issue-4599.js",
+    "--debug-check",
+    "--list-different"
+  ]).test({
+    status: 0
+  });
+});

--- a/tests_integration/cli/debug-check/issue-4599.js
+++ b/tests_integration/cli/debug-check/issue-4599.js
@@ -1,0 +1,1 @@
+console.log("…");


### PR DESCRIPTION
Fixes #4599

The regression was introduced in #4528, `output` is actually not prettified code under `--debug-check`, e.g. the check `output !== input` is actually `"index.js" !== "console.log("…");"` in #4599.

The returned value from `format()` is really confusing, we should refactor it.