### PR TITLE
fix(markdown): respect blank line between block htmls

### DIFF
--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -705,9 +705,20 @@ function shouldPrePrintDoubleHardline(node, data) {
 
   const isPrevNodePrettierIgnore = isPrettierIgnore(data.prevNode) === "next";
 
+  const isBlockHtmlWithoutBlankLineBetweenPrevHtml =
+    node.type === "html" &&
+    data.prevNode &&
+    data.prevNode.type === "html" &&
+    data.prevNode.position.end.line + 1 === node.position.start.line;
+
   return (
     isPrevNodeLooseListItem ||
-    !(isSiblingNode || isInTightListItem || isPrevNodePrettierIgnore)
+    !(
+      isSiblingNode ||
+      isInTightListItem ||
+      isPrevNodePrettierIgnore ||
+      isBlockHtmlWithoutBlankLineBetweenPrevHtml
+    )
   );
 }
 

--- a/tests/markdown_html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_html/__snapshots__/jsfmt.spec.js.snap
@@ -6,7 +6,6 @@ exports[`blank-line-between-htmls.md 1`] = `
 <!--lint enable no-html-->
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <!--lint disable no-html-->
-
 <p align="center"><img src="logo/vertical.png" alt="labelify" height="150px"></p>
 <!--lint enable no-html-->
 

--- a/tests/markdown_html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_html/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`blank-line-between-htmls.md 1`] = `
+<!--lint disable no-html-->
+<p align="center"><img src="logo/vertical.png" alt="labelify" height="150px"></p>
+<!--lint enable no-html-->
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<!--lint disable no-html-->
+
+<p align="center"><img src="logo/vertical.png" alt="labelify" height="150px"></p>
+<!--lint enable no-html-->
+
+`;
+
 exports[`multiline.md 1`] = `
 1.  Some test text, the goal is to have the html table below nested within this number. When formating on save Prettier will continue to add an indent each time pushing the table further and further out of sync. 
 

--- a/tests/markdown_html/blank-line-between-htmls.md
+++ b/tests/markdown_html/blank-line-between-htmls.md
@@ -1,0 +1,3 @@
+<!--lint disable no-html-->
+<p align="center"><img src="logo/vertical.png" alt="labelify" height="150px"></p>
+<!--lint enable no-html-->

--- a/tests/markdown_ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_ignore/__snapshots__/jsfmt.spec.js.snap
@@ -63,7 +63,6 @@ exports[`top-level-range.md 1`] = `
 <!-- prettier-ignore-end -->
 
 > <!-- prettier-ignore-start -->
->
 > <!-- some tool start (this shouldn't be ignored) -->
 >
 > | some | table |
@@ -72,7 +71,6 @@ exports[`top-level-range.md 1`] = `
 > | 2    | b     |
 >
 > <!-- some tool end -->
->
 > <!-- prettier-ignore-end -->
 
 `;


### PR DESCRIPTION
Fixes #4605 

The AST here is actually two `html`s and it did follow the [CommonMark spec](https://spec.commonmark.org/0.28/#html-blocks), so I ended up with respecting the blank line between block `html`s.