### PR TITLE
fix(multiparser): no additional trailing newline for graphql in js

### DIFF
--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -28,15 +28,16 @@ function genericPrint(path, options, print) {
       const parts = [];
       path.map((pathChild, index) => {
         parts.push(concat([pathChild.call(print)]));
-        parts.push(hardline);
-        if (
-          index !== n.definitions.length - 1 &&
-          isNextLineEmpty(options.originalText, pathChild.getValue(), options)
-        ) {
+        if (index !== n.definitions.length - 1) {
           parts.push(hardline);
+          if (
+            isNextLineEmpty(options.originalText, pathChild.getValue(), options)
+          ) {
+            parts.push(hardline);
+          }
         }
       }, "definitions");
-      return concat(parts, hardline);
+      return concat([concat(parts), hardline]);
     }
     case "OperationDefinition": {
       const hasOperation = options.originalText[options.locStart(n)] !== "{";

--- a/tests/multiparser_js_graphql/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_graphql/__snapshots__/jsfmt.spec.js.snap
@@ -59,7 +59,6 @@ graphql\`
   fragment a on b {
     c
   }
-
 \`;
 
 `;

--- a/tests/multiparser_js_graphql/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_graphql/__snapshots__/jsfmt.spec.js.snap
@@ -40,6 +40,30 @@ const query = /* GraphQL */ \`
 
 `;
 
+exports[`definitions.js 1`] = `
+graphql\`
+  fragment x on y {
+    z
+  }
+
+  fragment a on b {
+    c
+  }
+\`;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+graphql\`
+  fragment x on y {
+    z
+  }
+
+  fragment a on b {
+    c
+  }
+
+\`;
+
+`;
+
 exports[`expressions.js 1`] = `
 graphql(schema, \`
 query allPartsByManufacturerName($name: String!) {

--- a/tests/multiparser_js_graphql/definitions.js
+++ b/tests/multiparser_js_graphql/definitions.js
@@ -1,0 +1,9 @@
+graphql`
+  fragment x on y {
+    z
+  }
+
+  fragment a on b {
+    c
+  }
+`;


### PR DESCRIPTION
Fixes #4615

The root cause is the output doc from graphql printer does not match the desired input from `stripTrailingHardline`.

https://github.com/prettier/prettier/blob/a9b21a01e2d352aab06332e8e545e33efacc4f97/src/doc/doc-utils.js#L167-L180

---

**Prettier pr-4616**
[Playground link](https://deploy-preview-4616--prettier.netlify.com/playground/#N4Igxg9gdgLgprEAuEBzATgQwA4AsCOANgAYA6UABBQGZaoC2CMFAHhdBQJ4XDlVUAvPhQC+5YbUwMmFTO0oAjHsKphhYqMQDcIADQgI2GAEtoAZ2ShM6dBADuABWsILKTADcIxgCZ6QCrDAAazgYAGVsTDBjKFRkGHQAVzh9GLM4dBgHOnpMZGpMQnT9ACszFgAhQJDwzEYAGRi4fMLikEj0dPRkf0wFTkJoP2x0GJgAdR8YXGQADgAGfRGIdPGsbB6RuC73Zv10OHxE4wPsqVyWopSQdPpjeKTrsxjUQjgARUSIeEu2mD7Jt5psgAEz6BKYYyEF4AYQg9AuKCg0D2IES6QAKn1XAUriIREA)
```sh
--parser babylon
```

**Input:**
```jsx
graphql`
  fragment x on y {
    z
  }

  fragment a on b {
    c
  }
`;
```

**Output:**
```jsx
graphql`
  fragment x on y {
    z
  }

  fragment a on b {
    c
  }
`;

```