### PR TITLE
fix(javascript): preserve parens for type casting for sub-item

### DIFF
--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -151,6 +151,10 @@ functionCall(1 + /** @type {string} */ (value), /** @type {!Foo} */ ({}));
 function returnValue() {
   return /** @type {!Array.<string>} */ (['hello', 'you']);
 }
+
+var newArray = /** @type {array} */ (numberOrString).map(x => x);
+var newArray = /** @type {array} */ ((numberOrString)).map(x => x);
+var newArray = /** @type {array} */ ((numberOrString).map(x => x));
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // test to make sure comments are attached correctly
 let inlineComment = /* some comment */ someReallyLongFunctionCall(
@@ -170,6 +174,10 @@ functionCall(1 + /** @type {string} */ (value), /** @type {!Foo} */ ({}));
 function returnValue() {
   return /** @type {!Array.<string>} */ (["hello", "you"]);
 }
+
+var newArray = /** @type {array} */ (numberOrString).map(x => x);
+var newArray = /** @type {array} */ (numberOrString).map(x => x);
+var newArray = /** @type {array} */ (numberOrString.map(x => x));
 
 `;
 

--- a/tests/comments/closure-compiler-type-cast.js
+++ b/tests/comments/closure-compiler-type-cast.js
@@ -14,3 +14,7 @@ functionCall(1 + /** @type {string} */ (value), /** @type {!Foo} */ ({}));
 function returnValue() {
   return /** @type {!Array.<string>} */ (['hello', 'you']);
 }
+
+var newArray = /** @type {array} */ (numberOrString).map(x => x);
+var newArray = /** @type {array} */ ((numberOrString)).map(x => x);
+var newArray = /** @type {array} */ ((numberOrString).map(x => x));


### PR DESCRIPTION
Fixes #4287