### PR TITLE
Plugin: fix array option support

### DIFF
--- a/src/main/core-options.js
+++ b/src/main/core-options.js
@@ -119,7 +119,7 @@ const options = {
     since: "1.10.0",
     type: "path",
     array: true,
-    default: [{ value: [] }],
+    default: [],
     category: CATEGORY_GLOBAL,
     description:
       "Add a plugin. Multiple plugins can be passed as separate `--plugin`s.",
@@ -131,7 +131,7 @@ const options = {
     since: "1.13.0",
     type: "path",
     array: true,
-    default: [{ value: [] }],
+    default: [],
     category: CATEGORY_GLOBAL,
     description: dedent`
       Custom directory that contains prettier plugins in node_modules subdirectory.

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -41,7 +41,7 @@ function getSupportInfo(version, opts) {
     .map(option => {
       const newOption = Object.assign({}, option);
 
-      if (Array.isArray(newOption.default)) {
+      if (Array.isArray(newOption.default) && !newOption.array) {
         newOption.default =
           newOption.default.length === 1
             ? newOption.default[0].value


### PR DESCRIPTION
In working on the Coffeescript plugin, I was pleased to see (by inspecting `main/options-validator.js`, specifically `validateOptionType()`) that array-style options are supported (apparently by setting `array: true` on the option definition). But when trying to actually use an array option, I ran into a clash:

The default value of the array option is an array. But then `getSupportInfo()` has [logic](https://github.com/prettier/prettier/blob/master/src/main/support.js#L44) that interprets an array default value as a list of version-related alternatives. So since I wanted to define an array default value with more than one item, it failed here

Adding `&& !newOption.array` to the condition guarding that logic seems to make sense, but then things related to `plugins` and `pluginSearchDirs` (which as far as I can tell are the only array-style options in core) were failing. Updating their default values from `[{ value: [] }]` to `[]` seemed to resolve that as all tests pass

And then with this change applied I'm seeing the expected behavior when using the array option in the Coffeescript plugin

DISCLAIMER: I don't have any real understanding of the internals of eg the plugin system, I just poked around until I got it working. Hopefully this three-liner is safe, but I have no idea whether eg the `[{ value: [] }]` defaults for `plugins` and `pluginSearchDirs` were effectively just there to guard against this or serve some other purpose