### PR TITLE
fix(typescript): preserve type parameters of import-types (#4656)

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2941,7 +2941,8 @@ function printPathNoParens(path, options, print, args) {
         "import(",
         path.call(print, "argument"),
         ")",
-        !n.qualifier ? "" : concat([".", path.call(print, "qualifier")])
+        !n.qualifier ? "" : concat([".", path.call(print, "qualifier")]),
+        printTypeParameters(path, options, print, "typeParameters")
       ]);
     case "TSLiteralType":
       return path.call(print, "literal");

--- a/tests/typescript_import_type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_import_type/__snapshots__/jsfmt.spec.js.snap
@@ -10,6 +10,10 @@ export let y: import("./foo2").Bar.I = { a: "", b: 0 };
 export let shim: typeof import("./foo2") = {
     Bar: Bar2
 };
+
+export interface Foo {
+    bar: import('immutable').Map<string, int>;
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // ref: https://github.com/Microsoft/TypeScript/pull/22592
 
@@ -20,6 +24,10 @@ export let y: import("./foo2").Bar.I = { a: "", b: 0 };
 export let shim: typeof import("./foo2") = {
   Bar: Bar2
 };
+
+export interface Foo {
+  bar: import("immutable").Map<string, int>;
+}
 
 `;
 
@@ -33,6 +41,10 @@ export let y: import("./foo2").Bar.I = { a: "", b: 0 };
 export let shim: typeof import("./foo2") = {
     Bar: Bar2
 };
+
+export interface Foo {
+    bar: import('immutable').Map<string, int>;
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // ref: https://github.com/Microsoft/TypeScript/pull/22592
 
@@ -43,5 +55,9 @@ export let y: import('./foo2').Bar.I = { a: '', b: 0 };
 export let shim: typeof import('./foo2') = {
   Bar: Bar2
 };
+
+export interface Foo {
+  bar: import('immutable').Map<string, int>;
+}
 
 `;

--- a/tests/typescript_import_type/import-type.ts
+++ b/tests/typescript_import_type/import-type.ts
@@ -7,3 +7,7 @@ export let y: import("./foo2").Bar.I = { a: "", b: 0 };
 export let shim: typeof import("./foo2") = {
     Bar: Bar2
 };
+
+export interface Foo {
+    bar: import('immutable').Map<string, int>;
+}


### PR DESCRIPTION
Fixes #4656