### PR TITLE
Run tests using the standalone build in an empty context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,6 +80,17 @@ jobs:
           at: ~/prettier
       - run: yarn test:dist
 
+  # Run tests using the standalone build
+  test_prod_standalone:
+    <<: *defaults
+    steps:
+      - attach_workspace:
+          at: ~/prettier
+      - run:
+          command: yarn test:dist
+          environment:
+            TEST_STANDALONE: 1
+
 workflows:
   version: 2
   prod:
@@ -92,5 +103,8 @@ workflows:
           requires:
             - build_prod
       - test_prod_node9:
+          requires:
+            - build_prod
+      - test_prod_standalone:
           requires:
             - build_prod

--- a/jest.config.js
+++ b/jest.config.js
@@ -31,7 +31,8 @@ module.exports = {
     // If this is removed, see also scripts/build/build.js.
     "graceful-fs": "<rootDir>/tests_config/fs.js",
 
-    "prettier/local": "<rootDir>/tests_config/require_prettier.js"
+    "prettier/local": "<rootDir>/tests_config/require_prettier.js",
+    "prettier/standalone": "<rootDir>/tests_config/require_standalone.js"
   },
   transform: {}
 };

--- a/scripts/build/shims/assert.js
+++ b/scripts/build/shims/assert.js
@@ -1,4 +1,2 @@
-module.exports = {
-  ok() {},
-  strictEqual() {}
-};
+export function ok() {}
+export function strictEqual() {}

--- a/scripts/build/shims/os.js
+++ b/scripts/build/shims/os.js
@@ -1,0 +1,1 @@
+export const EOL = "\n";

--- a/scripts/test-dist.js
+++ b/scripts/test-dist.js
@@ -20,7 +20,11 @@ shell.exec("npm init -y", { cwd: tmpDir });
 shell.exec(`npm install "${tarPath}"`, { cwd: tmpDir });
 shell.config.silent = false;
 
-const code = shell.exec("yarn test --color --runInBand", {
+const cmd = `yarn test --color --runInBand ${
+  process.env.TEST_STANDALONE ? "tests/" : ""
+}`;
+
+const code = shell.exec(cmd, {
   cwd: rootDir,
   env: Object.assign({}, process.env, {
     NODE_ENV: "production",

--- a/tests_config/require_standalone.js
+++ b/tests_config/require_standalone.js
@@ -18,7 +18,7 @@ const sources = [
 );
 
 const sandbox = vm.createContext();
-vm.runInContext(sources.join(""), sandbox);
+vm.runInContext(sources.join(";"), sandbox);
 
 module.exports = {
   formatWithCursor(input, options) {

--- a/tests_config/require_standalone.js
+++ b/tests_config/require_standalone.js
@@ -1,0 +1,52 @@
+"use strict";
+
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+const files = [
+  "standalone.js",
+  "parser-babylon.js",
+  "parser-flow.js",
+  "parser-typescript.js",
+  "parser-postcss.js",
+  "parser-graphql.js",
+  "parser-markdown.js",
+  "parser-vue.js"
+];
+const base = files
+  .map(filename =>
+    fs.readFileSync(path.join(process.env.PRETTIER_DIR, filename), "utf-8")
+  )
+  .join("\n");
+
+const formatScript = new vm.Script(
+  base +
+    `$$$g.output = (function(input, options) {
+        options = Object.assign({ plugins: prettierPlugins }, options);
+        return prettier.formatWithCursor(input, options);
+      })($$$g.input, $$$g.options);`
+);
+
+const parseScript = new vm.Script(
+  base +
+    `$$$g.parsed = (function(input, options, massage) {
+        options = Object.assign({ plugins: prettierPlugins }, options);
+        return prettier.__debug.parse(input, options, massage);
+      })($$$g.input, $$$g.options,  $$$g.massage);`
+);
+
+module.exports = {
+  formatWithCursor(input, options) {
+    const g = { input, options };
+    formatScript.runInNewContext({ $$$g: g });
+    return g.output;
+  },
+  __debug: {
+    parse(input, options, massage) {
+      const g = { input, options, massage };
+      parseScript.runInNewContext({ $$$g: g });
+      return g.parsed;
+    }
+  }
+};

--- a/tests_config/require_standalone.js
+++ b/tests_config/require_standalone.js
@@ -25,10 +25,7 @@ vm.runInContext(base, sandbox);
 
 function makeContext(base, input, options) {
   return vm.createContext(
-    Object.assign(
-      { $$$input: input, $$$options: options },
-      base
-    )
+    Object.assign({ $$$input: input, $$$options: options }, base)
   );
 }
 

--- a/tests_config/require_standalone.js
+++ b/tests_config/require_standalone.js
@@ -23,31 +23,36 @@ const base = files
 const sandbox = vm.createContext();
 vm.runInContext(base, sandbox);
 
+function makeContext(base, input, options) {
+  return vm.createContext(
+    Object.assign(
+      { $$$input: input, $$$options: options },
+      base
+    )
+  );
+}
+
 module.exports = {
   formatWithCursor(input, options) {
-    vm.runInContext(
-      `output = prettier.formatWithCursor(
-        ${JSON.stringify(input)},
-        Object.assign({ plugins: prettierPlugins }, ${JSON.stringify(options)})
+    return vm.runInContext(
+      `prettier.formatWithCursor(
+        $$$input,
+        Object.assign({ plugins: prettierPlugins }, $$$options)
       );`,
-      sandbox
+      makeContext(sandbox, input, options)
     );
-    return sandbox.output;
   },
 
   __debug: {
     parse(input, options, massage) {
-      vm.runInContext(
-        `output = prettier.__debug.parse(
-          ${JSON.stringify(input)},
-          Object.assign({ plugins: prettierPlugins }, ${JSON.stringify(
-            options
-          )}),
+      return vm.runInContext(
+        `prettier.__debug.parse(
+          $$$input,
+          Object.assign({ plugins: prettierPlugins }, $$$options),
           ${JSON.stringify(massage)}
         );`,
-        sandbox
+        makeContext(sandbox, input, options)
       );
-      return sandbox.output;
     }
   }
 };

--- a/tests_config/require_standalone.js
+++ b/tests_config/require_standalone.js
@@ -20,6 +20,8 @@ const sources = [
 const sandbox = vm.createContext();
 vm.runInContext(sources.join(";"), sandbox);
 
+// TODO: maybe expose (and write tests) for `format`, `utils`, and
+// `__debug` methods
 module.exports = {
   formatWithCursor(input, options) {
     return vm.runInNewContext(

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -2,7 +2,10 @@
 
 const fs = require("fs");
 const extname = require("path").extname;
-const prettier = require("prettier/local");
+
+const prettier = !process.env.TEST_STANDALONE
+  ? require("prettier/local")
+  : require("prettier/standalone");
 
 const AST_COMPARE = process.env["AST_COMPARE"];
 


### PR DESCRIPTION
This uses the [`vm.Script`](https://nodejs.org/api/vm.html) API to run the standalone build in an empty context. This is mostly to validate that our build is stripping all the "native" dependencies (native modules and env vars).

It might not be necessary to run *all* `run_spec` tests, but I figured why not?