### PR TITLE
Example: Never break if it would introduce JSX whitespace

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4912,7 +4912,7 @@ function printJSXElement(path, options, print) {
     containsMultipleExpressions;
 
   const rawJsxWhitespace = options.singleQuote ? "{' '}" : '{" "}';
-  const jsxWhitespace = ifBreak(concat([rawJsxWhitespace, softline]), " ");
+  const jsxWhitespace = " ";
 
   const children = printJSXChildren(path, options, print, jsxWhitespace);
 

--- a/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
@@ -109,8 +109,7 @@ before = (
 
 before_break1 = (
   <span>
-    <span barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar />{" "}
-    foo
+    <span barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar /> foo
   </span>
 );
 
@@ -118,15 +117,15 @@ before_break2 = (
   <span>
     <span
       barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar
-    />{" "}
-    foo
+    /> foo
   </span>
 );
 
 after_break = (
   <span>
-    foo{" "}
-    <span barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar />
+    foo <span
+      barbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbarbar
+    />
   </span>
 );
 

--- a/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
@@ -132,8 +132,7 @@ const render6 = ({ styles }) => (
         attr4
       >
         ddd d dd d d dddd dddd <strong>hello</strong>
-      </div>{" "}
-      <strong>hello</strong>
+      </div> <strong>hello</strong>
     </div>
   </div>
 );

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -327,8 +327,9 @@ x = (
 // Wrapping tags
 x = (
   <div>
-    <first>f</first> <first>f</first> <first>f</first> <first>f</first>{" "}
-    <first>f</first> <first>f</first>
+    <first>f</first> <first>f</first> <first>f</first> <first>f</first> <first>
+      f
+    </first> <first>f</first>
   </div>
 );
 
@@ -350,16 +351,18 @@ x = (
     <a />
     <b />
     <c />
-    <first>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</first>{" "}
-    <first>f</first>
+    <first>aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa</first> <first>
+      f
+    </first>
   </div>
 );
 
 // Wrapping tags
 x = (
   <div>
-    <sadashdkjahsdkjhaskjdhaksjdhkashdkashdkasjhdkajshdkashdkashd />{" "}
-    <first>f</first>
+    <sadashdkjahsdkjhaskjdhaksjdhkashdkashdkasjhdkajshdkashdkashd /> <first>
+      f
+    </first>
   </div>
 );
 
@@ -382,15 +385,17 @@ x = (
 
 x = (
   <div>
-    before {stuff} after {stuff} after {stuff} after {stuff} after {stuff} after{" "}
-    {stuff} {stuff} {stuff} after {stuff} after
+    before {stuff} after {stuff} after {stuff} after {stuff} after {stuff} after {
+      stuff
+    } {stuff} {stuff} after {stuff} after
   </div>
 );
 
 x = (
   <div>
-    Please state your <b>name</b> and <b>occupation</b> for the board of{" "}
-    <b>school</b> directors.
+    Please state your <b>name</b> and <b>occupation</b> for the board of <b>
+      school
+    </b> directors.
   </div>
 );
 
@@ -416,9 +421,9 @@ function DiffOverview(props) {
 x = (
   <font size={-3}>
     <i>
-      Starting at minute {graphActivity.startTime}, running for{" "}
-      {graphActivity.length} to minute{" "}
-      {graphActivity.startTime + graphActivity.length}
+      Starting at minute {graphActivity.startTime}, running for {
+        graphActivity.length
+      } to minute {graphActivity.startTime + graphActivity.length}
     </i>
   </font>
 );
@@ -486,19 +491,17 @@ this_really_should_split_across_lines = (
 
 unstable_before = (
   <div className="yourScore">
-    Your score:{" "}
-    <span className="score">{\`\${mini.crosstable.users[sessionUserId]} - \${
-      mini.crosstable.users[user.id]
-    }\`}</span>
+    Your score: <span className="score">{\`\${
+      mini.crosstable.users[sessionUserId]
+    } - \${mini.crosstable.users[user.id]}\`}</span>
   </div>
 );
 
 unstable_after_first_run = (
   <div className="yourScore">
-    Your score:{" "}
-    <span className="score">{\`\${mini.crosstable.users[sessionUserId]} - \${
-      mini.crosstable.users[user.id]
-    }\`}</span>
+    Your score: <span className="score">{\`\${
+      mini.crosstable.users[sessionUserId]
+    } - \${mini.crosstable.users[user.id]}\`}</span>
   </div>
 );
 
@@ -523,25 +526,21 @@ jsx_whitespace_on_newline = (
 
 jsx_around_multiline_element = (
   <div>
-    Before{" "}
-    <div>
+    Before <div>
       {
         "Enough text to make this element wrap on to multiple lines when formatting"
       }
-    </div>{" "}
-    After
+    </div> After
   </div>
 );
 
 jsx_around_multiline_element_second_pass = (
   <div>
-    Before{" "}
-    <div>
+    Before <div>
       {
         "Enough text to make this element wrap on to multiple lines when formatting"
       }
-    </div>{" "}
-    After
+    </div> After
   </div>
 );
 
@@ -631,15 +630,17 @@ multiple_expressions = (
 
 single_expression_child_tags = (
   <div>
-    You currently have <strong>{dashboardStr}</strong> and{" "}
-    <strong>{userStr}</strong>
+    You currently have <strong>{dashboardStr}</strong> and <strong>
+      {userStr}
+    </strong>
   </div>
 );
 
 expression_does_not_break = (
   <div>
-    texty text text text text text text text text text text text{" "}
-    {this.props.type}{" "}
+    texty text text text text text text text text text text text {
+      this.props.type
+    }{" "}
   </div>
 );
 
@@ -657,15 +658,13 @@ jsx_whitespace_after_tag = (
   <div>
     <span a="a" b="b">
       {variable}
-    </span>{" "}
-    ({variable})
+    </span> ({variable})
   </div>
 );
 
 x = (
   <div>
-    ENDS IN <div>text text text text text text text text text text text</div>{" "}
-    HRS
+    ENDS IN <div>text text text text text text text text text text text</div> HRS
   </div>
 );
 
@@ -689,8 +688,8 @@ x = (
       <div>
         <div>
           <div>
-            Line {startRange.row + 1}:{startRange.column + 1} -{" "}
-            {endRange.row + 1}:{endRange.column + 1}
+            Line {startRange.row + 1}:{startRange.column + 1} - {endRange.row +
+              1}:{endRange.column + 1}
             {caller}
           </div>
         </div>


### PR DESCRIPTION
In https://github.com/prettier/prettier/issues/4223 there is some discussion around only breaking in JSX if it *won't* introduce `{" "}`.

While I personally prefer the way Prettier currently works (where it introduces `{" "}` to separate text from tags when near the character limit) I thought it would be useful to show the kind of changes the would occur if we never introduced `{" "}`.

Take a look at the updated test snapshots to see the difference this change would make.