### PR TITLE
refactor: remove redundant call to normalizeOptions

### DIFF
--- a/src/main/core.js
+++ b/src/main/core.js
@@ -259,7 +259,7 @@ function format(text, opts) {
 module.exports = {
   formatWithCursor(text, opts) {
     opts = normalizeOptions(opts);
-    return format(text, normalizeOptions(opts));
+    return format(text, opts);
   },
 
   parse(text, opts, massage) {


### PR DESCRIPTION
Removes redundant call to `normalizeOptions` (already done in preceding line)

https://github.com/prettier/prettier/blob/8ec543276838f66f0a84824a39c215a3039e9071/src/main/core.js#L260-L263