### PR TITLE
Allow `originalText` to be passed to `formatAST()`

### DIFF
--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -13,9 +13,7 @@ const addAlignmentToDoc = docBuilders.addAlignmentToDoc;
 const docUtils = doc.utils;
 
 function printAstToDoc(ast, options, addAlignmentSize) {
-  options = Object.assign({}, options, {
-    originalText: options.originalText || ""
-  });
+  options = Object.assign({ originalText: "" }, options);
   addAlignmentSize = addAlignmentSize || 0;
 
   const printer = options.printer;

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -13,6 +13,9 @@ const addAlignmentToDoc = docBuilders.addAlignmentToDoc;
 const docUtils = doc.utils;
 
 function printAstToDoc(ast, options, addAlignmentSize) {
+  options = Object.assign({}, options, {
+    originalText: options.originalText || ""
+  });
   addAlignmentSize = addAlignmentSize || 0;
 
   const printer = options.printer;

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -13,9 +13,6 @@ const addAlignmentToDoc = docBuilders.addAlignmentToDoc;
 const docUtils = doc.utils;
 
 function printAstToDoc(ast, options, addAlignmentSize) {
-  options = Object.assign({}, options, {
-    originalText: options.originalText || ""
-  });
   addAlignmentSize = addAlignmentSize || 0;
 
   const printer = options.printer;

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -13,7 +13,9 @@ const addAlignmentToDoc = docBuilders.addAlignmentToDoc;
 const docUtils = doc.utils;
 
 function printAstToDoc(ast, options, addAlignmentSize) {
-  options = Object.assign({ originalText: "" }, options);
+  options = Object.assign({}, options, {
+    originalText: options.originalText || ""
+  });
   addAlignmentSize = addAlignmentSize || 0;
 
   const printer = options.printer;

--- a/src/main/options.js
+++ b/src/main/options.js
@@ -9,6 +9,7 @@ const resolveParser = require("./parser").resolveParser;
 const hiddenDefaults = {
   astFormat: "estree",
   printer: {},
+  originalText: undefined,
   locStart: null,
   locEnd: null
 };


### PR DESCRIPTION
This allows `prettier.__debug.formatAST` to not crash when given the AST
for the below code (taken from https://astexplorer.net/), which is
useful when trying to use Prettier as a code generator for an AST
without corresponding source code (https://github.com/prettier/prettier/issues/4675)

```js
let tips = [
  "Click on any AST node with a '+' to expand it",

  "Hovering over a node highlights the \
   corresponding part in the source code",

  "Shift click on an AST node expands the whole substree"
];

function printTips() {
  tips.forEach((tip, i) => console.log(`Tip ${i}:` + tip));
}
```