### PR TITLE
Add require-pragma scss tests

### DIFF
--- a/tests/require-pragma/scss/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/require-pragma/scss/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`scss-with-pragma.scss 1`] = `
+/**
+ * @prettier
+ */
+div,.class,#id{/*empty declaration block*/}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/**
+ * @prettier
+ */
+div,
+.class,
+#id {
+  /*empty declaration block*/
+}
+
+`;
+
+exports[`scss-without-pragma.scss 1`] = `
+div,.class,#id{/*empty declaration block*/}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+div,
+.class,
+#id {
+  /*empty declaration block*/
+}
+
+`;

--- a/tests/require-pragma/scss/jsfmt.spec.js
+++ b/tests/require-pragma/scss/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["scss"], { requirePragma: true });

--- a/tests/require-pragma/scss/scss-with-pragma.scss
+++ b/tests/require-pragma/scss/scss-with-pragma.scss
@@ -1,0 +1,4 @@
+/**
+ * @prettier
+ */
+div,.class,#id{/*empty declaration block*/}

--- a/tests/require-pragma/scss/scss-without-pragma.scss
+++ b/tests/require-pragma/scss/scss-without-pragma.scss
@@ -1,0 +1,1 @@
+div,.class,#id{/*empty declaration block*/}


### PR DESCRIPTION
Prettier does not appear to respect pragmas in scss files (https://github.com/Automattic/wp-calypso/pull/24906#issuecomment-396833896)

Add `require-pragma` tests demonstrating this behavior.

Note that the tests will pass as the snapshots are auto-generated. However, the `scss-without-pragma.scss 1` test output is different from the input, demonstrating that require-pragma is not respected.