### PR TITLE
Fix `prettier` installed in a directory not named prettier

### DIFF
--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -18,10 +18,7 @@ function loadPlugins(plugins, pluginSearchDirs) {
   }
   // unless pluginSearchDirs are provided, auto-load plugins from node_modules that are parent to Prettier
   if (!pluginSearchDirs.length) {
-    const autoLoadDir = thirdParty.findParentDir(
-      thirdParty.findParentDir(__dirname, "prettier"),
-      "node_modules"
-    );
+    const autoLoadDir = thirdParty.findParentDir(__dirname, "node_modules");
     if (autoLoadDir) {
       pluginSearchDirs = [autoLoadDir];
     }


### PR DESCRIPTION
Resolves #4637 

Verified via:

```bash
git clone git@github.com:prettier/prettier /tmp/wat
cd /tmp/wat
nodeenv nenv
. nenv/bin/activate
npm install -g .
# code was modified here!
prettier --help
```