### PR TITLE
Bump globby

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "find-project-root": "1.1.1",
     "flow-parser": "0.74.0",
     "get-stream": "3.0.0",
-    "globby": "6.1.0",
+    "globby": "8.0.1",
     "graphql": "0.13.2",
     "html-tag-names": "1.1.2",
     "ignore": "3.3.7",

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -348,7 +348,7 @@ function eachFilename(context, patterns, callback) {
 
   try {
     const filePaths = globby
-      .sync(patterns, { dot: true, nodir: true })
+      .sync(patterns, { dot: true })
       .map(filePath => path.relative(process.cwd(), filePath));
 
     if (filePaths.length === 0) {

--- a/tests_integration/__tests__/__snapshots__/config-resolution.js.snap
+++ b/tests_integration/__tests__/__snapshots__/config-resolution.js.snap
@@ -8,24 +8,6 @@ exports[`CLI overrides take precedence (stdout) 1`] = `
 		\\"should have tab width 8\\"
 	)
 }
-function f() {
-  console.log(
-    \\"should have space width 2\\"
-  )
-}
-function f() {
-        console.log(
-                \\"should have space width 8\\"
-        )
-}
-function f() {
-  console.log(
-    \\"should have space width 2 despite ../.editorconfig specifying 8, because ./.hg is present\\"
-  )
-}
-console.log(
-  \\"jest/__best-tests__/file.js should have semi\\"
-);
 console.log(
   \\"jest/Component.js should not have semi\\"
 )
@@ -72,6 +54,24 @@ function rcYaml() {
     ],
   );
 }
+function f() {
+  console.log(
+    \\"should have space width 2\\"
+  )
+}
+function f() {
+        console.log(
+                \\"should have space width 8\\"
+        )
+}
+function f() {
+  console.log(
+    \\"should have space width 2 despite ../.editorconfig specifying 8, because ./.hg is present\\"
+  )
+}
+console.log(
+  \\"jest/__best-tests__/file.js should have semi\\"
+);
 "
 `;
 
@@ -107,18 +107,6 @@ exports[`resolves configuration from external files (stdout) 1`] = `
 "function f() {
 	console.log(\\"should have tab width 8\\")
 }
-function f() {
-  console.log(\\"should have space width 2\\")
-}
-function f() {
-        console.log(\\"should have space width 8\\")
-}
-function f() {
-  console.log(
-    \\"should have space width 2 despite ../.editorconfig specifying 8, because ./.hg is present\\"
-  )
-}
-console.log(\\"jest/__best-tests__/file.js should have semi\\");
 console.log(\\"jest/Component.js should not have semi\\")
 console.log(\\"jest/Component.test.js should have semi\\");
 function js() {
@@ -149,6 +137,18 @@ function rcYaml() {
     'and single quotes',
   ]);
 }
+function f() {
+  console.log(\\"should have space width 2\\")
+}
+function f() {
+        console.log(\\"should have space width 8\\")
+}
+function f() {
+  console.log(
+    \\"should have space width 2 despite ../.editorconfig specifying 8, because ./.hg is present\\"
+  )
+}
+console.log(\\"jest/__best-tests__/file.js should have semi\\");
 "
 `;
 

--- a/tests_integration/__tests__/__snapshots__/multiple-patterns.js.snap
+++ b/tests_integration/__tests__/__snapshots__/multiple-patterns.js.snap
@@ -15,11 +15,11 @@ exports[`multiple patterns (write) 1`] = `Array []`;
 exports[`multiple patterns by with ignore pattern, doesn't ignore node_modules with --with-node-modules flag (stderr) 1`] = `""`;
 
 exports[`multiple patterns by with ignore pattern, doesn't ignore node_modules with --with-node-modules flag (stdout) 1`] = `
-"node_modules/node-module.js
+"other-regular-modules.js
+regular-module.js
+node_modules/node-module.js
 other-directory/file.js
 other-directory/nested-directory/nested-directory-file.js
-other-regular-modules.js
-regular-module.js
 "
 `;
 
@@ -28,10 +28,10 @@ exports[`multiple patterns by with ignore pattern, doesn't ignore node_modules w
 exports[`multiple patterns by with ignore pattern, ignores node_modules by default (stderr) 1`] = `""`;
 
 exports[`multiple patterns by with ignore pattern, ignores node_modules by default (stdout) 1`] = `
-"other-directory/file.js
-other-directory/nested-directory/nested-directory-file.js
-other-regular-modules.js
+"other-regular-modules.js
 regular-module.js
+other-directory/file.js
+other-directory/nested-directory/nested-directory-file.js
 "
 `;
 
@@ -40,10 +40,10 @@ exports[`multiple patterns by with ignore pattern, ignores node_modules by defau
 exports[`multiple patterns by with ignore pattern, ignores node_modules by with ./**/*.js (stderr) 1`] = `""`;
 
 exports[`multiple patterns by with ignore pattern, ignores node_modules by with ./**/*.js (stdout) 1`] = `
-"other-directory/file.js
-other-directory/nested-directory/nested-directory-file.js
-other-regular-modules.js
+"other-regular-modules.js
 regular-module.js
+other-directory/file.js
+other-directory/nested-directory/nested-directory-file.js
 "
 `;
 
@@ -52,10 +52,10 @@ exports[`multiple patterns by with ignore pattern, ignores node_modules by with 
 exports[`multiple patterns with ignore nested directories pattern (stderr) 1`] = `""`;
 
 exports[`multiple patterns with ignore nested directories pattern (stdout) 1`] = `
-"directory/file.js
-other-directory/file.js
-other-regular-modules.js
+"other-regular-modules.js
 regular-module.js
+directory/file.js
+other-directory/file.js
 "
 `;
 

--- a/tests_integration/__tests__/__snapshots__/with-config-precedence.js.snap
+++ b/tests_integration/__tests__/__snapshots__/with-config-precedence.js.snap
@@ -85,24 +85,6 @@ exports[`CLI overrides take precedence with --config-precedence cli-override (st
 		\\"should have tab width 8\\"
 	)
 }
-function f() {
-  console.log(
-    \\"should have space width 2\\"
-  )
-}
-function f() {
-        console.log(
-                \\"should have space width 8\\"
-        )
-}
-function f() {
-  console.log(
-    \\"should have space width 2 despite ../.editorconfig specifying 8, because ./.hg is present\\"
-  )
-}
-console.log(
-  \\"jest/__best-tests__/file.js should have semi\\"
-);
 console.log(
   \\"jest/Component.js should not have semi\\"
 )
@@ -149,6 +131,24 @@ function rcYaml() {
     ],
   );
 }
+function f() {
+  console.log(
+    \\"should have space width 2\\"
+  )
+}
+function f() {
+        console.log(
+                \\"should have space width 8\\"
+        )
+}
+function f() {
+  console.log(
+    \\"should have space width 2 despite ../.editorconfig specifying 8, because ./.hg is present\\"
+  )
+}
+console.log(
+  \\"jest/__best-tests__/file.js should have semi\\"
+);
 "
 `;
 
@@ -162,24 +162,6 @@ exports[`CLI overrides take precedence without --config-precedence (stdout) 1`] 
 		\\"should have tab width 8\\"
 	)
 }
-function f() {
-  console.log(
-    \\"should have space width 2\\"
-  )
-}
-function f() {
-        console.log(
-                \\"should have space width 8\\"
-        )
-}
-function f() {
-  console.log(
-    \\"should have space width 2 despite ../.editorconfig specifying 8, because ./.hg is present\\"
-  )
-}
-console.log(
-  \\"jest/__best-tests__/file.js should have semi\\"
-);
 console.log(
   \\"jest/Component.js should not have semi\\"
 )
@@ -226,6 +208,24 @@ function rcYaml() {
     ],
   );
 }
+function f() {
+  console.log(
+    \\"should have space width 2\\"
+  )
+}
+function f() {
+        console.log(
+                \\"should have space width 8\\"
+        )
+}
+function f() {
+  console.log(
+    \\"should have space width 2 despite ../.editorconfig specifying 8, because ./.hg is present\\"
+  )
+}
+console.log(
+  \\"jest/__best-tests__/file.js should have semi\\"
+);
 "
 `;
 

--- a/tests_integration/__tests__/__snapshots__/with-node-modules.js.snap
+++ b/tests_integration/__tests__/__snapshots__/with-node-modules.js.snap
@@ -3,9 +3,9 @@
 exports[`doesn't ignore node_modules with --with-node-modules flag (stderr) 1`] = `""`;
 
 exports[`doesn't ignore node_modules with --with-node-modules flag (stdout) 1`] = `
-"node_modules/node-module.js
+"regular-module.js
+node_modules/node-module.js
 not_node_modules/file.js
-regular-module.js
 "
 `;
 
@@ -25,8 +25,8 @@ exports[`doesn't ignore node_modules with --with-node-modules flag for file list
 exports[`ignores node_modules by default (stderr) 1`] = `""`;
 
 exports[`ignores node_modules by default (stdout) 1`] = `
-"not_node_modules/file.js
-regular-module.js
+"regular-module.js
+not_node_modules/file.js
 "
 `;
 
@@ -45,8 +45,8 @@ exports[`ignores node_modules by default for file list (write) 1`] = `Array []`;
 exports[`ignores node_modules by with ./**/*.js (stderr) 1`] = `""`;
 
 exports[`ignores node_modules by with ./**/*.js (stdout) 1`] = `
-"not_node_modules/file.js
-regular-module.js
+"regular-module.js
+not_node_modules/file.js
 "
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -563,6 +563,17 @@
   dependencies:
     "@glimmer/util" "^0.30.3"
 
+"@mrmlnc/readdir-enhanced@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"
+  dependencies:
+    call-me-maybe "^1.0.1"
+    glob-to-regexp "^0.3.0"
+
+"@nodelib/fs.stat@^1.0.1":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@nodelib/fs.stat/-/fs.stat-1.1.0.tgz#50c1e2260ac0ed9439a181de3725a0168d59c48a"
+
 "@types/commander@^2.11.0":
   version "2.12.2"
   resolved "https://registry.yarnpkg.com/@types/commander/-/commander-2.12.2.tgz#183041a23842d4281478fa5d23c5ca78e6fd08ae"
@@ -1292,6 +1303,10 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+call-me-maybe@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/call-me-maybe/-/call-me-maybe-1.0.1.tgz#26d208ea89e37b5cbde60250a15f031c16a4d66b"
+
 caller-path@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
@@ -1845,6 +1860,13 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+dir-glob@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
+  dependencies:
+    arrify "^1.0.1"
+    path-type "^3.0.0"
+
 doctrine@1.5.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
@@ -2368,6 +2390,17 @@ fast-diff@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.1.1.tgz#0aea0e4e605b6a2189f0e936d4b7fbaf1b7cfd9b"
 
+fast-glob@^2.0.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.2.tgz#71723338ac9b4e0e2fff1d6748a2a13d5ed352bf"
+  dependencies:
+    "@mrmlnc/readdir-enhanced" "^2.2.1"
+    "@nodelib/fs.stat" "^1.0.1"
+    glob-parent "^3.1.0"
+    is-glob "^4.0.0"
+    merge2 "^1.2.1"
+    micromatch "^3.1.10"
+
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -2641,6 +2674,10 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
+glob-to-regexp@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz#8c5a1494d2066c570cc3bfe4496175acc4d502ab"
+
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
@@ -2664,15 +2701,17 @@ globals@^9.0.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
 
-globby@6.1.0, globby@^6.1.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+globby@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-8.0.1.tgz#b5ad48b8aa80b35b814fc1281ecc851f1d2b5b50"
   dependencies:
     array-union "^1.0.1"
-    glob "^7.0.3"
-    object-assign "^4.0.1"
-    pify "^2.0.0"
-    pinkie-promise "^2.0.0"
+    dir-glob "^2.0.0"
+    fast-glob "^2.0.2"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
 
 globby@^5.0.0:
   version "5.0.0"
@@ -2680,6 +2719,16 @@ globby@^5.0.0:
   dependencies:
     array-union "^1.0.1"
     arrify "^1.0.0"
+    glob "^7.0.3"
+    object-assign "^4.0.1"
+    pify "^2.0.0"
+    pinkie-promise "^2.0.0"
+
+globby@^6.1.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-6.1.0.tgz#f5a6d70e8395e21c858fb0489d64df02424d506c"
+  dependencies:
+    array-union "^1.0.1"
     glob "^7.0.3"
     object-assign "^4.0.1"
     pify "^2.0.0"
@@ -3925,6 +3974,10 @@ meow@^3.7.0:
     redent "^1.0.0"
     trim-newlines "^1.0.0"
 
+merge2@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.2.2.tgz#03212e3da8d86c4d8523cebd6318193414f94e34"
+
 merge@^1.1.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
@@ -3947,7 +4000,7 @@ micromatch@^2.1.5, micromatch@^2.3.11:
     parse-glob "^3.0.4"
     regex-cache "^0.4.2"
 
-micromatch@^3.1.4:
+micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   dependencies:
@@ -4469,6 +4522,12 @@ path-type@^2.0.0:
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
   dependencies:
     pify "^2.0.0"
+
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  dependencies:
+    pify "^3.0.0"
 
 pbkdf2@^3.0.3:
   version "3.0.12"


### PR DESCRIPTION
It uses `fast-glob`, which is supposed to be a lot faster than `node-glob`. There shouldn't be any noticeable improvement, but there's no harm in updating either way.