### PR TITLE
Handle JSX whitespace separately from fbt whitespace

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4774,7 +4774,7 @@ function printJSXChildren(
               isFacebookTranslationTag
                 ? hardline
                 : words[1].length === 1
-                  ? ""
+                  ? softline
                   : hardline
             );
           } else {
@@ -4809,7 +4809,7 @@ function printJSXChildren(
               isFacebookTranslationTag
                 ? hardline
                 : getLast(children).length === 1
-                  ? ""
+                  ? softline
                   : hardline
             );
           } else {
@@ -4817,7 +4817,7 @@ function printJSXChildren(
           }
         } else {
           children.push(
-            getLast(children).length === 1 ? "" : textAndTagSeparator
+            getLast(children).length === 1 ? softline : textAndTagSeparator
           );
         }
       } else if (/\n/.test(text)) {
@@ -4842,7 +4842,7 @@ function printJSXChildren(
         const firstWord = rawText(next)
           .trim()
           .split(matchJsxWhitespaceRegex)[0];
-        children.push(firstWord.length === 1 ? "" : textAndTagSeparator);
+        children.push(firstWord.length === 1 ? softline : textAndTagSeparator);
       } else {
         children.push(hardline);
       }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4731,6 +4731,30 @@ function isJSXWhitespaceExpression(node) {
   );
 }
 
+function separatorNoWhitespace(isFacebookTranslationTag, child) {
+  if (isFacebookTranslationTag) {
+    return "";
+  }
+
+  if (child.length === 1) {
+    return softline;
+  }
+
+  return hardline;
+}
+
+function separatorWithWhitespace(isFacebookTranslationTag, child) {
+  if (isFacebookTranslationTag) {
+    return hardline;
+  }
+
+  if (child.length === 1) {
+    return softline;
+  }
+
+  return hardline;
+}
+
 // JSX Children are strange, mostly for two reasons:
 // 1. JSX reads newlines into string values, instead of skipping them like JS
 // 2. up to one whitespace between elements within a line is significant,
@@ -4750,8 +4774,6 @@ function printJSXChildren(
   jsxWhitespace,
   isFacebookTranslationTag
 ) {
-  const textAndTagSeparator = isFacebookTranslationTag ? "" : hardline;
-
   const n = path.getValue();
   const children = [];
 
@@ -4771,11 +4793,7 @@ function printJSXChildren(
           words.shift();
           if (/\n/.test(words[0])) {
             children.push(
-              isFacebookTranslationTag
-                ? hardline
-                : words[1].length === 1
-                  ? softline
-                  : hardline
+              separatorWithWhitespace(isFacebookTranslationTag, words[1])
             );
           } else {
             children.push(jsxWhitespace);
@@ -4806,18 +4824,17 @@ function printJSXChildren(
         if (endWhitespace !== undefined) {
           if (/\n/.test(endWhitespace)) {
             children.push(
-              isFacebookTranslationTag
-                ? hardline
-                : getLast(children).length === 1
-                  ? softline
-                  : hardline
+              separatorWithWhitespace(
+                isFacebookTranslationTag,
+                getLast(children)
+              )
             );
           } else {
             children.push(jsxWhitespace);
           }
         } else {
           children.push(
-            getLast(children).length === 1 ? softline : textAndTagSeparator
+            separatorNoWhitespace(isFacebookTranslationTag, getLast(children))
           );
         }
       } else if (/\n/.test(text)) {
@@ -4842,7 +4859,9 @@ function printJSXChildren(
         const firstWord = rawText(next)
           .trim()
           .split(matchJsxWhitespaceRegex)[0];
-        children.push(firstWord.length === 1 ? softline : textAndTagSeparator);
+        children.push(
+          separatorNoWhitespace(isFacebookTranslationTag, firstWord)
+        );
       } else {
         children.push(hardline);
       }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4743,7 +4743,15 @@ function isJSXWhitespaceExpression(node) {
 // This requires that we give it an array of alternating
 // content and whitespace elements.
 // To ensure this we add dummy `""` content elements as needed.
-function printJSXChildren(path, options, print, jsxWhitespace) {
+function printJSXChildren(
+  path,
+  options,
+  print,
+  jsxWhitespace,
+  isFacebookTranslationTag
+) {
+  const textAndTagSeparator = isFacebookTranslationTag ? "" : hardline;
+
   const n = path.getValue();
   const children = [];
 
@@ -4762,7 +4770,11 @@ function printJSXChildren(path, options, print, jsxWhitespace) {
           children.push("");
           words.shift();
           if (/\n/.test(words[0])) {
-            children.push(hardline);
+            children.push(
+              isFacebookTranslationTag || words[1].length !== 1
+                ? hardline
+                : softline
+            );
           } else {
             children.push(jsxWhitespace);
           }
@@ -4791,21 +4803,18 @@ function printJSXChildren(path, options, print, jsxWhitespace) {
 
         if (endWhitespace !== undefined) {
           if (/\n/.test(endWhitespace)) {
-            children.push(hardline);
+            children.push(
+              isFacebookTranslationTag || getLast(children).length !== 1
+                ? hardline
+                : softline
+            );
           } else {
             children.push(jsxWhitespace);
           }
         } else {
-          // Ideally this would be a `hardline` to allow a break between
-          // tags and text.
-          // Unfortunately Facebook have a custom translation pipeline
-          // (https://github.com/prettier/prettier/issues/1581#issuecomment-300975032)
-          // that uses the JSX syntax, but does not follow the React whitespace
-          // rules.
-          // Ensuring that we never have a break between tags and text in JSX
-          // will allow Facebook to adopt Prettier without too much of an
-          // adverse effect on formatting algorithm.
-          children.push("");
+          children.push(
+            getLast(children).length === 1 ? "" : textAndTagSeparator
+          );
         }
       } else if (/\n/.test(text)) {
         // Keep (up to one) blank line between tags/expressions/text.
@@ -4824,12 +4833,12 @@ function printJSXChildren(path, options, print, jsxWhitespace) {
 
       const next = n.children[i + 1];
       const directlyFollowedByMeaningfulText =
-        next && isMeaningfulJSXText(next) && !/^[ \n\r\t]/.test(rawText(next));
+        next && isMeaningfulJSXText(next);
       if (directlyFollowedByMeaningfulText) {
-        // Potentially this could be a hardline as well.
-        // See the comment above about the Facebook translation pipeline as
-        // to why this is an empty string.
-        children.push("");
+        const firstWord = rawText(next)
+          .trim()
+          .split(matchJsxWhitespaceRegex)[0];
+        children.push(firstWord.length === 1 ? "" : textAndTagSeparator);
       } else {
         children.push(hardline);
       }
@@ -4916,7 +4925,18 @@ function printJSXElement(path, options, print) {
   const rawJsxWhitespace = options.singleQuote ? "{' '}" : '{" "}';
   const jsxWhitespace = ifBreak(concat([rawJsxWhitespace, softline]), " ");
 
-  const children = printJSXChildren(path, options, print, jsxWhitespace);
+  const isFacebookTranslationTag =
+    n.openingElement &&
+    n.openingElement.name &&
+    n.openingElement.name.name === "fbt";
+
+  const children = printJSXChildren(
+    path,
+    options,
+    print,
+    jsxWhitespace,
+    isFacebookTranslationTag
+  );
 
   const containsText =
     n.children.filter(child => isMeaningfulJSXText(child)).length > 0;

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4771,9 +4771,11 @@ function printJSXChildren(
           words.shift();
           if (/\n/.test(words[0])) {
             children.push(
-              isFacebookTranslationTag || words[1].length !== 1
+              isFacebookTranslationTag
                 ? hardline
-                : softline
+                : words[1].length === 1
+                  ? ""
+                  : hardline
             );
           } else {
             children.push(jsxWhitespace);
@@ -4804,9 +4806,11 @@ function printJSXChildren(
         if (endWhitespace !== undefined) {
           if (/\n/.test(endWhitespace)) {
             children.push(
-              isFacebookTranslationTag || getLast(children).length !== 1
+              isFacebookTranslationTag
                 ? hardline
-                : softline
+                : getLast(children).length === 1
+                  ? ""
+                  : hardline
             );
           } else {
             children.push(jsxWhitespace);

--- a/tests/jsx-fbt/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-fbt/__snapshots__/jsfmt.spec.js.snap
@@ -23,6 +23,20 @@ x =
   </fbt>
 
 x =
+  <fbt>
+    <fbt:param>First</fbt:param>,<fbt:param>Second</fbt:param>
+  </fbt>
+
+x =
+  <fbt>
+    <fbt:param>
+      First
+    </fbt:param>,<fbt:param>
+      Second
+    </fbt:param>
+  </fbt>
+
+x =
   <fbt desc="example 1">
     Prefix comes before
     <fbt:param>
@@ -66,6 +80,18 @@ x = (
     <fbt:param>First</fbt:param>
     ,
     <fbt:param>Second</fbt:param>
+  </fbt>
+);
+
+x = (
+  <fbt>
+    <fbt:param>First</fbt:param>,<fbt:param>Second</fbt:param>
+  </fbt>
+);
+
+x = (
+  <fbt>
+    <fbt:param>First</fbt:param>,<fbt:param>Second</fbt:param>
   </fbt>
 );
 

--- a/tests/jsx-fbt/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-fbt/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test.js 1`] = `
+x =
+  <fbt>
+    <fbt:param>
+      First
+    </fbt:param>,
+    <fbt:param>
+      Second
+    </fbt:param>
+  </fbt>
+
+x =
+  <fbt>
+    <fbt:param>
+      First
+    </fbt:param>
+    ,
+    <fbt:param>
+      Second
+    </fbt:param>
+  </fbt>
+
+x =
+  <fbt desc="example 1">
+    Prefix comes before
+    <fbt:param>
+      <b>
+        suffix
+      </b>
+    </fbt:param>
+  </fbt>
+
+x =
+  <fbt desc="example 2">
+    Prefix comes before
+    <fbt:param name="bold stuff">
+      <b>
+      suffix
+      </b>
+    </fbt:param>
+    <fbt:param name="a link">
+      <link href="#">
+        suffix
+      </link>
+    </fbt:param>
+  </fbt>
+
+x =
+  <fbt desc="example 3">
+    Count Chocula knows the the number
+    <fbt:enum enum-range={['one', 'two', 'three']} value={getValue()} />
+    is awesome
+  </fbt>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+x = (
+  <fbt>
+    <fbt:param>First</fbt:param>,
+    <fbt:param>Second</fbt:param>
+  </fbt>
+);
+
+x = (
+  <fbt>
+    <fbt:param>First</fbt:param>
+    ,
+    <fbt:param>Second</fbt:param>
+  </fbt>
+);
+
+x = (
+  <fbt desc="example 1">
+    Prefix comes before
+    <fbt:param>
+      <b>suffix</b>
+    </fbt:param>
+  </fbt>
+);
+
+x = (
+  <fbt desc="example 2">
+    Prefix comes before
+    <fbt:param name="bold stuff">
+      <b>suffix</b>
+    </fbt:param>
+    <fbt:param name="a link">
+      <link href="#">suffix</link>
+    </fbt:param>
+  </fbt>
+);
+
+x = (
+  <fbt desc="example 3">
+    Count Chocula knows the the number
+    <fbt:enum enum-range={["one", "two", "three"]} value={getValue()} />
+    is awesome
+  </fbt>
+);
+
+`;

--- a/tests/jsx-fbt/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-fbt/__snapshots__/jsfmt.spec.js.snap
@@ -67,6 +67,55 @@ x =
     <fbt:enum enum-range={['one', 'two', 'three']} value={getValue()} />
     is awesome
   </fbt>
+
+x = (
+  <fbt>
+    {hour}:{minute}:{second}
+  </fbt>
+);
+
+x = (
+  <fbt>
+    {hour}
+    :
+    {minute}
+    :
+    {second}
+  </fbt>
+);
+
+x = (
+  <fbt>
+    {hour}:
+    {minute}:
+    {second}
+  </fbt>
+);
+
+first = (
+  <fbt>
+    Text<br />
+    More text<br />
+    And more<br />
+  </fbt>
+);
+
+second = (
+  <fbt>
+    Text<br />More text<br />And more<br />
+  </fbt>
+);
+
+third = (
+  <fbt>
+    Text
+    <br />
+    More text
+    <br />
+    And more
+    <br />
+  </fbt>
+);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 x = (
   <fbt>
@@ -121,6 +170,55 @@ x = (
     Count Chocula knows the the number
     <fbt:enum enum-range={["one", "two", "three"]} value={getValue()} />
     is awesome
+  </fbt>
+);
+
+x = (
+  <fbt>
+    {hour}:{minute}:{second}
+  </fbt>
+);
+
+x = (
+  <fbt>
+    {hour}
+    :
+    {minute}
+    :
+    {second}
+  </fbt>
+);
+
+x = (
+  <fbt>
+    {hour}:
+    {minute}:
+    {second}
+  </fbt>
+);
+
+first = (
+  <fbt>
+    Text<br />
+    More text<br />
+    And more<br />
+  </fbt>
+);
+
+second = (
+  <fbt>
+    Text<br />More text<br />And more<br />
+  </fbt>
+);
+
+third = (
+  <fbt>
+    Text
+    <br />
+    More text
+    <br />
+    And more
+    <br />
   </fbt>
 );
 

--- a/tests/jsx-fbt/jsfmt.spec.js
+++ b/tests/jsx-fbt/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["flow"]);

--- a/tests/jsx-fbt/test.js
+++ b/tests/jsx-fbt/test.js
@@ -64,3 +64,52 @@ x =
     <fbt:enum enum-range={['one', 'two', 'three']} value={getValue()} />
     is awesome
   </fbt>
+
+x = (
+  <fbt>
+    {hour}:{minute}:{second}
+  </fbt>
+);
+
+x = (
+  <fbt>
+    {hour}
+    :
+    {minute}
+    :
+    {second}
+  </fbt>
+);
+
+x = (
+  <fbt>
+    {hour}:
+    {minute}:
+    {second}
+  </fbt>
+);
+
+first = (
+  <fbt>
+    Text<br />
+    More text<br />
+    And more<br />
+  </fbt>
+);
+
+second = (
+  <fbt>
+    Text<br />More text<br />And more<br />
+  </fbt>
+);
+
+third = (
+  <fbt>
+    Text
+    <br />
+    More text
+    <br />
+    And more
+    <br />
+  </fbt>
+);

--- a/tests/jsx-fbt/test.js
+++ b/tests/jsx-fbt/test.js
@@ -1,0 +1,52 @@
+x =
+  <fbt>
+    <fbt:param>
+      First
+    </fbt:param>,
+    <fbt:param>
+      Second
+    </fbt:param>
+  </fbt>
+
+x =
+  <fbt>
+    <fbt:param>
+      First
+    </fbt:param>
+    ,
+    <fbt:param>
+      Second
+    </fbt:param>
+  </fbt>
+
+x =
+  <fbt desc="example 1">
+    Prefix comes before
+    <fbt:param>
+      <b>
+        suffix
+      </b>
+    </fbt:param>
+  </fbt>
+
+x =
+  <fbt desc="example 2">
+    Prefix comes before
+    <fbt:param name="bold stuff">
+      <b>
+      suffix
+      </b>
+    </fbt:param>
+    <fbt:param name="a link">
+      <link href="#">
+        suffix
+      </link>
+    </fbt:param>
+  </fbt>
+
+x =
+  <fbt desc="example 3">
+    Count Chocula knows the the number
+    <fbt:enum enum-range={['one', 'two', 'three']} value={getValue()} />
+    is awesome
+  </fbt>

--- a/tests/jsx-fbt/test.js
+++ b/tests/jsx-fbt/test.js
@@ -20,6 +20,20 @@ x =
   </fbt>
 
 x =
+  <fbt>
+    <fbt:param>First</fbt:param>,<fbt:param>Second</fbt:param>
+  </fbt>
+
+x =
+  <fbt>
+    <fbt:param>
+      First
+    </fbt:param>,<fbt:param>
+      Second
+    </fbt:param>
+  </fbt>
+
+x =
   <fbt desc="example 1">
     Prefix comes before
     <fbt:param>

--- a/tests/jsx-newlines/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-newlines/__snapshots__/jsfmt.spec.js.snap
@@ -145,10 +145,12 @@ regression_extra_newline = (
 
 regression_extra_newline_2 = (
   <div>
-    (<FormattedMessage
+    (
+    <FormattedMessage
       id="some-id"
       defaultMessage="some loooooooooooooooooooooooooooong default"
-    />)
+    />
+    )
   </div>
 );
 

--- a/tests/jsx-newlines/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-newlines/__snapshots__/jsfmt.spec.js.snap
@@ -145,12 +145,10 @@ regression_extra_newline = (
 
 regression_extra_newline_2 = (
   <div>
-    (
-    <FormattedMessage
+    (<FormattedMessage
       id="some-id"
       defaultMessage="some loooooooooooooooooooooooooooong default"
-    />
-    )
+    />)
   </div>
 );
 

--- a/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
@@ -141,7 +141,8 @@ break_components = (
     <Foo />
     <Bar>
       <p>
-        foo<span>bar bar bar</span>
+        foo
+        <span>bar bar bar</span>
       </p>
       <h1>
         <span>
@@ -209,7 +210,8 @@ not_broken_end = (
 not_broken_begin = (
   <div>
     <br /> long text long text long text long text long text long text long text
-    long text<link>url</link> long text long text
+    long text
+    <link>url</link> long text long text
   </div>
 );
 

--- a/tests/jsx-split-attrs/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-split-attrs/__snapshots__/jsfmt.spec.js.snap
@@ -132,7 +132,8 @@ long_open_long_children = (
         colour="blue"
         size="large"
         submitLabel="Sign in with Google"
-      />d
+      />
+      d
     </BaseForm>
     <BaseForm
       url="/auth/google"

--- a/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-stateless-arrow-fn/__snapshots__/jsfmt.spec.js.snap
@@ -161,10 +161,12 @@ const render7B = () => (
       <span /> Dont break plz
     </span>
     <span>
-      <span />Dont break plz
+      <span />
+      Dont break plz
     </span>
     <span>
-      Dont break plz<span />
+      Dont break plz
+      <span />
     </span>
   </div>
 );

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -479,7 +479,8 @@ function DiffOverview(props) {
       <div className="alert alert-info">
         <p>
           This diff overview is computed against the current list of records in
-          this collection and the list it contained on <b>{humanDate(since)}</b>.
+          this collection and the list it contained on <b>{humanDate(since)}</b>
+          .
         </p>
         <p>
           <b>Note:</b> <code>last_modified</code> and <code>schema</code> record
@@ -554,9 +555,8 @@ facebook_translation_leave_text_around_tag = (
 
 x = (
   <div>
-    <span>First second third fourth fifth sixth seventh</span>, (<span>
-      Second
-    </span>)
+    <span>First second third fourth fifth sixth seventh</span>, (
+    <span>Second</span>)
   </div>
 );
 
@@ -853,7 +853,9 @@ x = (
   <div>
     <div className="first" tabIndex="1">
       First
-    </div>-<div className="second" tabIndex="2">
+    </div>
+    -
+    <div className="second" tabIndex="2">
       Second
     </div>
   </div>
@@ -863,7 +865,9 @@ x = (
   <div>
     <div className="first" tabIndex="1">
       First
-    </div>-<div className="second" tabIndex="2">
+    </div>
+    -
+    <div className="second" tabIndex="2">
       Second
     </div>
   </div>
@@ -873,7 +877,9 @@ x = (
   <div>
     <div className="first" tabIndex="1">
       First
-    </div>-<div className="second" tabIndex="2">
+    </div>
+    -
+    <div className="second" tabIndex="2">
       Second
     </div>
   </div>

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -231,6 +231,21 @@ line_after_br =
     And more<br />
   </div>
 
+line_after_br =
+  <div>
+    Text<br />More text<br />And more<br />
+  </div>
+
+line_after_br =
+  <div>
+    Text
+    <br />
+    More text
+    <br />
+    And more
+    <br />
+  </div>
+
 line_after_br_2 = <div>A<br />B<br />C</div>
 
 br_followed_by_whitespace = <div><br /> text</div>
@@ -708,6 +723,28 @@ line_after_br = (
     Text
     <br />
     More text <br />
+    And more
+    <br />
+  </div>
+);
+
+line_after_br = (
+  <div>
+    Text
+    <br />
+    More text
+    <br />
+    And more
+    <br />
+  </div>
+);
+
+line_after_br = (
+  <div>
+    Text
+    <br />
+    More text
+    <br />
     And more
     <br />
   </div>

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -116,6 +116,16 @@ facebook_translation_leave_text_around_tag =
     </span>)
   </div>
 
+x =
+  <div>
+    <span>
+      First second third fourth fifth sixth seventh
+    </span>,
+    (<span>
+      Second
+    </span>)
+  </div>
+
 this_really_should_split_across_lines =
   <div>
     before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after
@@ -315,6 +325,32 @@ x =
   <p>
     text text text text text text text text text text text text text text text<br />text text text text text text
   </p>;
+
+x =
+  <div>
+    <div>
+      First
+    </div>-
+    <div>
+      Second
+    </div>
+  </div>
+
+x =
+  <div>
+    <div>
+      First
+    </div>
+    -
+    <div>
+      Second
+    </div>
+  </div>
+
+x =
+  <div>
+    <div>First</div>-<div>Second</div>
+  </div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Wrapping text
 x = (
@@ -365,18 +401,34 @@ x = (
 
 x = (
   <div>
-    before<div>
+    before
+    <div>
       Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur at
       mollis lorem.
-    </div>after
+    </div>
+    after
   </div>
 );
 
 x = (
   <div>
-    before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}
+    before
     {stuff}
-    {stuff}after{stuff}after
+    after
+    {stuff}
+    after
+    {stuff}
+    after
+    {stuff}
+    after
+    {stuff}
+    after
+    {stuff}
+    {stuff}
+    {stuff}
+    after
+    {stuff}
+    after
   </div>
 );
 
@@ -474,13 +526,45 @@ facebook_translation_leave_text_around_tag = (
   </div>
 );
 
+x = (
+  <div>
+    <span>First second third fourth fifth sixth seventh</span>, (<span>
+      Second
+    </span>)
+  </div>
+);
+
 this_really_should_split_across_lines = (
   <div>
-    before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{
-      stuff
-    }after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{
-      stuff
-    }after
+    before
+    {stuff}
+    after
+    {stuff}
+    after
+    {stuff}
+    after
+    {stuff}
+    after
+    {stuff}
+    after
+    {stuff}
+    after
+    {stuff}
+    after
+    {stuff}
+    after
+    {stuff}
+    after
+    {stuff}
+    after
+    {stuff}
+    after
+    {stuff}
+    after
+    {stuff}
+    after
+    {stuff}
+    after
   </div>
 );
 
@@ -595,9 +679,11 @@ with_text_fill_line = (
 
 line_after_br = (
   <div>
-    Text<br />
+    Text
+    <br />
     More text <br />
-    And more<br />
+    And more
+    <br />
   </div>
 );
 
@@ -713,9 +799,28 @@ x = <div> </div>;
 // ----------
 x = (
   <p>
-    text text text text text text text text text text text text text text text<br />text
-    text text text text text
+    text text text text text text text text text text text text text text text
+    <br />
+    text text text text text text
   </p>
+);
+
+x = (
+  <div>
+    <div>First</div>-<div>Second</div>
+  </div>
+);
+
+x = (
+  <div>
+    <div>First</div>-<div>Second</div>
+  </div>
+);
+
+x = (
+  <div>
+    <div>First</div>-<div>Second</div>
+  </div>
 );
 
 `;

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -351,6 +351,32 @@ x =
   <div>
     <div>First</div>-<div>Second</div>
   </div>
+
+x =
+  <div>
+    <div className="first" tabIndex="1">
+      First
+    </div>-
+    <div className="second" tabIndex="2">
+      Second
+    </div>
+  </div>
+
+x =
+  <div>
+    <div className="first" tabIndex="1">
+      First
+    </div>
+    -
+    <div className="second" tabIndex="2">
+      Second
+    </div>
+  </div>
+
+x =
+  <div>
+    <div className="first" tabIndex="1">First</div>-<div className="second" tabIndex="2">Second</div>
+  </div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Wrapping text
 x = (
@@ -820,6 +846,36 @@ x = (
 x = (
   <div>
     <div>First</div>-<div>Second</div>
+  </div>
+);
+
+x = (
+  <div>
+    <div className="first" tabIndex="1">
+      First
+    </div>-<div className="second" tabIndex="2">
+      Second
+    </div>
+  </div>
+);
+
+x = (
+  <div>
+    <div className="first" tabIndex="1">
+      First
+    </div>-<div className="second" tabIndex="2">
+      Second
+    </div>
+  </div>
+);
+
+x = (
+  <div>
+    <div className="first" tabIndex="1">
+      First
+    </div>-<div className="second" tabIndex="2">
+      Second
+    </div>
   </div>
 );
 

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -227,7 +227,7 @@ with_text_fill_line =
 line_after_br =
   <div>
     Text<br />
-    More text <br />
+    More text<br />
     And more<br />
   </div>
 
@@ -391,6 +391,27 @@ x =
 x =
   <div>
     <div className="first" tabIndex="1">First</div>-<div className="second" tabIndex="2">Second</div>
+  </div>
+
+x =
+  <div>
+    {hour}:{minute}:{second}
+  </div>
+
+x =
+  <div>
+    {hour}
+    :
+    {minute}
+    :
+    {second}
+  </div>
+
+x =
+  <div>
+    {hour}:
+    {minute}:
+    {second}
   </div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Wrapping text
@@ -722,7 +743,8 @@ line_after_br = (
   <div>
     Text
     <br />
-    More text <br />
+    More text
+    <br />
     And more
     <br />
   </div>
@@ -919,6 +941,24 @@ x = (
     <div className="second" tabIndex="2">
       Second
     </div>
+  </div>
+);
+
+x = (
+  <div>
+    {hour}:{minute}:{second}
+  </div>
+);
+
+x = (
+  <div>
+    {hour}:{minute}:{second}
+  </div>
+);
+
+x = (
+  <div>
+    {hour}:{minute}:{second}
   </div>
 );
 

--- a/tests/jsx-text-wrap/test.js
+++ b/tests/jsx-text-wrap/test.js
@@ -224,7 +224,7 @@ with_text_fill_line =
 line_after_br =
   <div>
     Text<br />
-    More text <br />
+    More text<br />
     And more<br />
   </div>
 
@@ -388,4 +388,25 @@ x =
 x =
   <div>
     <div className="first" tabIndex="1">First</div>-<div className="second" tabIndex="2">Second</div>
+  </div>
+
+x =
+  <div>
+    {hour}:{minute}:{second}
+  </div>
+
+x =
+  <div>
+    {hour}
+    :
+    {minute}
+    :
+    {second}
+  </div>
+
+x =
+  <div>
+    {hour}:
+    {minute}:
+    {second}
   </div>

--- a/tests/jsx-text-wrap/test.js
+++ b/tests/jsx-text-wrap/test.js
@@ -348,3 +348,29 @@ x =
   <div>
     <div>First</div>-<div>Second</div>
   </div>
+
+x =
+  <div>
+    <div className="first" tabIndex="1">
+      First
+    </div>-
+    <div className="second" tabIndex="2">
+      Second
+    </div>
+  </div>
+
+x =
+  <div>
+    <div className="first" tabIndex="1">
+      First
+    </div>
+    -
+    <div className="second" tabIndex="2">
+      Second
+    </div>
+  </div>
+
+x =
+  <div>
+    <div className="first" tabIndex="1">First</div>-<div className="second" tabIndex="2">Second</div>
+  </div>

--- a/tests/jsx-text-wrap/test.js
+++ b/tests/jsx-text-wrap/test.js
@@ -228,6 +228,21 @@ line_after_br =
     And more<br />
   </div>
 
+line_after_br =
+  <div>
+    Text<br />More text<br />And more<br />
+  </div>
+
+line_after_br =
+  <div>
+    Text
+    <br />
+    More text
+    <br />
+    And more
+    <br />
+  </div>
+
 line_after_br_2 = <div>A<br />B<br />C</div>
 
 br_followed_by_whitespace = <div><br /> text</div>

--- a/tests/jsx-text-wrap/test.js
+++ b/tests/jsx-text-wrap/test.js
@@ -113,6 +113,16 @@ facebook_translation_leave_text_around_tag =
     </span>)
   </div>
 
+x =
+  <div>
+    <span>
+      First second third fourth fifth sixth seventh
+    </span>,
+    (<span>
+      Second
+    </span>)
+  </div>
+
 this_really_should_split_across_lines =
   <div>
     before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after
@@ -312,3 +322,29 @@ x =
   <p>
     text text text text text text text text text text text text text text text<br />text text text text text text
   </p>;
+
+x =
+  <div>
+    <div>
+      First
+    </div>-
+    <div>
+      Second
+    </div>
+  </div>
+
+x =
+  <div>
+    <div>
+      First
+    </div>
+    -
+    <div>
+      Second
+    </div>
+  </div>
+
+x =
+  <div>
+    <div>First</div>-<div>Second</div>
+  </div>


### PR DESCRIPTION
This is partial progress towards https://github.com/prettier/prettier/issues/2279

With this PR we now detect Facebook `fbt` tags and handle whitespace for them differently from other JSX tags.

This lets us tweak how we format whitespace in JSX tags without breaking the Facebook translation pipeline. This means we can now fix up some small JSX formatting edge cases that have always bugged me 😀

The main benefit here is improved consistency across different but equivalent inputs.

For example the current version of Prettier leaves these unchanged ([Playground link](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAzAlgJwM4wAQC8eAFADpR54A8AJugG4B85llAKnAB4xUBGmeAPTMKrALIRMcPPG58BwlqwCCUGngC2kuPKEjKVQXSbkAlAG5y5bHEhrCJJbQb7WHOfz0SpMrj0-CqupaUrqKoobGIhZWsAAWWOpEZBFRSux+6dQBrpTe0rIwWWG5eEGa2sU5TkYuZuYgADQgEAAOMOjQ2MigAIaYmBAA7gAK-QjdKL30EOg0TSD8vWAA1nAwAMqty+hQAObIMJgArnDNuzaYMCOYvXsavciovQA2Ns0AVticAEK3q+sNr0NHAADK7OBPV7vEDbHBwTDIRa9XgATxe0AWrUwuxgAHU5jA4sgABwABma2IgNjxt1aSOxcEu9EhzSkAEdjlg4Dc7g8oW8ziAbBp0IcTkLsLs9i84ABFY4QeACmEwFEEmhE5AAJmaR166Be0oAwhANPyUFBoKyQMcbGwUZNnoKAL4uoA)):

```jsx
first = (
  <div>
    Text<br />
    More text<br />
    And more<br />
  </div>
);

second = (
  <div>
    Text<br />More text<br />And more<br />
  </div>
);

third = (
  <div>
    Text
    <br />
    More text
    <br />
    And more
    <br />
  </div>
);
```

And with this PR they become:

```jsx
first = (
  <div>
    Text
    <br />
    More text
    <br />
    And more
    <br />
  </div>
);

second = (
  <div>
    Text
    <br />
    More text
    <br />
    And more
    <br />
  </div>
);

third = (
  <div>
    Text
    <br />
    More text
    <br />
    And more
    <br />
  </div>
);
```

When the text separating tags or expressions is just a single character we display it on a single line where possible.

With the current version of Prettier ([Playground link](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAPABAXnQCgDpTroA8AJgJYBuAfAUUcABYQCuATgL5LAC25ULeF2ABnOJCikOdEgHoKNAgEoA3AQIZs+QiQW0dDZu2kH0SGQz4ChFs7dHjoUmcXlV9q9VE24Xe+0ac5qa8-IJwXPZiEs46rv5QqiAANCAQAA4w5NAiyKAAhmxsEADuAAqFCLko+ZQQ5KQpIABGbPlgANZwMADK6e38AObIMGwscKn8YmwwZW2DPPnIAGb5ADZiqQBWIqgAQm2d3T35PHAAMvxwK+ubIP1s08gt+c0AnmvQTels-DAA6g0YIxkAAOAAMqR+EDE-za6WePzg00o11SbDgAEcWOQMXN8gslkhVhsJiAxHwRmMySIhms4ABFFgQeA3UmpGCvQGkYHIABMHLa5DWQwAwhAeItnlBoGiQCwxAAVV7VEliDgcIA)):

```jsx
x = (
  <div>
    {hour}:{minute}:{second}
  </div>
);

x = (
  <div>
    {hour}
    :
    {minute}
    :
    {second}
  </div>
);

x = (
  <div>
    {hour}:
    {minute}:
    {second}
  </div>
);
```

With this PR:

```jsx
x = (
  <div>
    {hour}:{minute}:{second}
  </div>
);

x = (
  <div>
    {hour}:{minute}:{second}
  </div>
);

x = (
  <div>
    {hour}:{minute}:{second}
  </div>
);
```

And finally I feel this PR improves the output of edges cases like this:

Input:

```jsx
this_really_should_split_across_lines =
  <div>
    before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after
  </div>
```

Output in current version of Prettier ([Playground link](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEMAWBLAzgfQE5wCGANsQJ45ZoQCuxAJpQA7EYw6Fh4Ra6tRwsAAgC8AHShChAHnoYAbgD4JUqQCM4AMwgFgWGDU2aAvoU3w8eg0dPm4l-YZNmLVp7deObL+2+92Ha2cAv2DPII9fLzCoiJ9A93jQyIT-CxUZAHo5JQkQABoQCCYYDGgsZFBCPG4AdwAFaoQKlEJ5CAx6ApA1PE4AazgYAGUmTgwoAHNkGDwaOEKJrHsYer7JgFtCZE0SZcKAKywADwAhPrBBkcINuAAZCbgdvYWQMbxlvGQewjUyYmg3SYeAmMAA6p10MgABwABkKwJ4cDBfSY32Bgns8iehQIAEcaBgCGtCJttkhdsR9iBlhsMDM5q8sBNJsQ4ABFGgQeDPKmvGC-CH0KFIABMhVmhAw-EmAGEIBstt8oNAcSAaMsACq-FqU5bGYxAA
)):

```jsx
this_really_should_split_across_lines = (
  <div>
    before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{
      stuff
    }after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{
      stuff
    }after
  </div>
);
```

Output with this PR:

```jsx
this_really_should_split_across_lines = (
  <div>
    before
    {stuff}
    after
    {stuff}
    after
    {stuff}
    after
    {stuff}
    after
    {stuff}
    after
    {stuff}
    after
    {stuff}
    after
    {stuff}
    after
    {stuff}
    after
    {stuff}
    after
    {stuff}
    after
    {stuff}
    after
    {stuff}
    after
    {stuff}
    after
  </div>
);
```