### PR TITLE
fix(inferParser): filepath in standalone

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "mem": "1.1.0",
     "minimatch": "3.0.4",
     "minimist": "1.2.0",
+    "normalize-path": "3.0.0",
     "parse5": "3.0.3",
     "postcss-less": "1.1.5",
     "postcss-media-query-parser": "0.2.3",

--- a/src/main/options.js
+++ b/src/main/options.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const path = require("path");
+const normalizePath = require("normalize-path");
 const UndefinedParserError = require("../common/errors").UndefinedParserError;
 const getSupportInfo = require("../main/support").getSupportInfo;
 const normalizer = require("./options-normalizer");
@@ -113,8 +113,9 @@ function getPlugin(options) {
 }
 
 function inferParser(filepath, plugins) {
-  const extension = path.extname(filepath);
-  const filename = path.basename(filepath).toLowerCase();
+  const filepathParts = normalizePath(filepath).split("/");
+  const filename = filepathParts[filepathParts.length - 1].toLowerCase();
+  const extension = filename.match(/((\.[^.]*)?)$/)[1];
 
   const language = getSupportInfo(null, {
     plugins

--- a/yarn.lock
+++ b/yarn.lock
@@ -4193,6 +4193,10 @@ normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
+normalize-path@3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
+
 normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"


### PR DESCRIPTION
Context: https://github.com/prettier/prettier/issues/4720#issuecomment-398757044

I think it'd be better to keep consistent in node/browser if possible.