### PR TITLE
Upgrade flow-parser to 0.75.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "esutils": "2.0.2",
     "find-parent-dir": "0.3.0",
     "find-project-root": "1.1.1",
-    "flow-parser": "0.74.0",
+    "flow-parser": "0.75.0",
     "get-stream": "3.0.0",
     "globby": "6.1.0",
     "graphql": "0.13.2",

--- a/tests/optional_catch_binding/jsfmt.spec.js
+++ b/tests/optional_catch_binding/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, ["babylon", "typescript"]);
+run_spec(__dirname, ["flow", "babylon", "typescript"]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2479,9 +2479,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flow-parser@0.74.0:
-  version "0.74.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.74.0.tgz#4acc8f55bdce5fa4da43c72c28ef8a9600ace87c"
+flow-parser@0.75.0:
+  version "0.75.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.75.0.tgz#9a1891c48051c73017b6b5cc07b3681fda3fdfb0"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
The main change in the parser is the support for optional catch bindings (which were a syntax error previously).