### PR TITLE
Ternary Operators in JSX Expression Containers

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -243,7 +243,8 @@ function formatTernaryOperator(path, options, print, operatorOptions) {
     (operatorOpts.shouldCheckJsx && isJSXNode(n[operatorOpts.testNode])) ||
     isJSXNode(n[operatorOpts.consequentNode]) ||
     isJSXNode(n[operatorOpts.alternateNode]) ||
-    conditionalExpressionChainContainsJSX(lastConditionalParent)
+    conditionalExpressionChainContainsJSX(lastConditionalParent) ||
+    firstNonConditionalParent.type === "JSXExpressionContainer"
   ) {
     jsxMode = true;
     forceNoIndent = true;

--- a/tests/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -241,6 +241,8 @@ cable ? (
   ) : null}
 </div>;
 
+// This ConditionalExpression prints in JSX mode because the first 
+// non-conditional parent is a JSX expression container.
 <div>
   {data.length > 1 ? (
     "This is a really long non-jsx element inside of a ternary-operator that in turn is inside of a JSX expression container."
@@ -393,6 +395,8 @@ cable ? (
   ) : null}
 </div>;
 
+// This ConditionalExpression prints in JSX mode because the first
+// non-conditional parent is a JSX expression container.
 <div>
   {data.length > 1 ? (
     "This is a really long non-jsx element inside of a ternary-operator that in turn is inside of a JSX expression container."

--- a/tests/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -240,6 +240,14 @@ cable ? (
     )
   ) : null}
 </div>;
+
+<div>
+  {data.length > 1 ? (
+    "This is a really long non-jsx element inside of a ternary-operator that in turn is inside of a JSX expression container."
+  ) : (
+    "This is string however, is not as long as the previous one."
+  )}
+</div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // There are two ways to print ConditionalExpressions: "normal mode" and
 // "JSX mode". This is normal mode (when breaking):
@@ -383,6 +391,14 @@ cable ? (
       <MigrationPropertyListItem apps={Immutable.List()} />
     )
   ) : null}
+</div>;
+
+<div>
+  {data.length > 1 ? (
+    "This is a really long non-jsx element inside of a ternary-operator that in turn is inside of a JSX expression container."
+  ) : (
+    "This is string however, is not as long as the previous one."
+  )}
 </div>;
 
 `;

--- a/tests/jsx/conditional-expression.js
+++ b/tests/jsx/conditional-expression.js
@@ -129,3 +129,11 @@ cable ? (
     )
   ) : null}
 </div>;
+
+<div>
+  {data.length > 1 ? (
+    "This is a really long non-jsx element inside of a ternary-operator that in turn is inside of a JSX expression container."
+  ) : (
+    "This is string however, is not as long as the previous one."
+  )}
+</div>

--- a/tests/jsx/conditional-expression.js
+++ b/tests/jsx/conditional-expression.js
@@ -130,6 +130,8 @@ cable ? (
   ) : null}
 </div>;
 
+// This ConditionalExpression prints in JSX mode because the first 
+// non-conditional parent is a JSX expression container.
 <div>
   {data.length > 1 ? (
     "This is a really long non-jsx element inside of a ternary-operator that in turn is inside of a JSX expression container."


### PR DESCRIPTION
This pull request aims to fix the issue of excessive nesting brought up in the following comment: https://github.com/prettier/prettier/issues/737#issuecomment-392541493

This "fix" is very simple. It adds a new possible way to activate JSX mode for ternary operators. If the first non-conditional parent of the expression is a JSX expression container, then JSX mode gets activated.

This branch also contains a test case for said scenario.