### PR TITLE
Update postcss-scss dependency to 1.0.6.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "parse5": "3.0.3",
     "postcss-less": "1.1.5",
     "postcss-media-query-parser": "0.2.3",
-    "postcss-scss": "1.0.5",
+    "postcss-scss": "1.0.6",
     "postcss-selector-parser": "2.2.3",
     "postcss-values-parser": "1.5.0",
     "remark-parse": "5.0.0",


### PR DESCRIPTION
https://github.com/postcss/postcss-scss/issues/92

https://github.com/prettier/prettier/issues/4635

Updating the postcss-scss parser dependency allows us to fix bug #4635 (bug #92 in postcss-scss).