### PR TITLE
Update postcss-scss parser version to 1.0.6 (with test for it).

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "parse5": "3.0.3",
     "postcss-less": "1.1.5",
     "postcss-media-query-parser": "0.2.3",
-    "postcss-scss": "1.0.5",
+    "postcss-scss": "1.0.6",
     "postcss-selector-parser": "2.2.3",
     "postcss-values-parser": "1.5.0",
     "remark-parse": "5.0.0",

--- a/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
@@ -1034,6 +1034,16 @@ $my-map: (
   // Comment
   'bar',
   'tabs';
+
+@mixin placeholder {
+  &::placeholder {@content}
+}
+
+.container {
+  @include placeholder {
+    color: $color-silver;
+  }
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 @media #{$g-breakpoint-tiny} {
 }
@@ -1971,5 +1981,17 @@ $my-map: (
   // Comment
     "bar",
   "tabs";
+
+@mixin placeholder {
+  &::placeholder {
+    @content;
+  }
+}
+
+.container {
+  @include placeholder {
+    color: $color-silver;
+  }
+}
 
 `;

--- a/tests/css_scss/scss.scss
+++ b/tests/css_scss/scss.scss
@@ -1024,3 +1024,13 @@ $my-map: (
   // Comment
   'bar',
   'tabs';
+
+@mixin placeholder {
+  &::placeholder {@content}
+}
+
+.container {
+  @include placeholder {
+    color: $color-silver;
+  }
+}


### PR DESCRIPTION
This PR updates the postcss-scss dependency (see https://github.com/postcss/postcss-scss/issues/92).

Fixes #4635.