### PR TITLE
fix(markdown): preserve email autolink

### DIFF
--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -147,8 +147,19 @@ function genericPrint(path, options, print) {
     }
     case "link":
       switch (options.originalText[node.position.start.offset]) {
-        case "<":
-          return concat(["<", node.url, ">"]);
+        case "<": {
+          const mailto = "mailto:";
+          const url =
+            // <hello@example.com> is parsed as { url: "mailto:hello@example.com" }
+            node.url.startsWith(mailto) &&
+            options.originalText.slice(
+              node.position.start.offset + 1,
+              node.position.start.offset + 1 + mailto.length
+            ) !== mailto
+              ? node.url.slice(mailto.length)
+              : node.url;
+          return concat(["<", url, ">"]);
+        }
         case "[":
           return concat([
             "[",

--- a/tests/markdown_link/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_link/__snapshots__/jsfmt.spec.js.snap
@@ -2,15 +2,31 @@
 
 exports[`autolink.md 1`] = `
 <https://www.example.com>
+
+<hello@example.com>
+
+<mailto:hello@example.com>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <https://www.example.com>
+
+<mailto:hello@example.com>
+
+<mailto:hello@example.com>
 
 `;
 
 exports[`autolink.md 2`] = `
 <https://www.example.com>
+
+<hello@example.com>
+
+<mailto:hello@example.com>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <https://www.example.com>
+
+<mailto:hello@example.com>
+
+<mailto:hello@example.com>
 
 `;
 

--- a/tests/markdown_link/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_link/__snapshots__/jsfmt.spec.js.snap
@@ -9,7 +9,7 @@ exports[`autolink.md 1`] = `
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <https://www.example.com>
 
-<mailto:hello@example.com>
+<hello@example.com>
 
 <mailto:hello@example.com>
 
@@ -24,7 +24,7 @@ exports[`autolink.md 2`] = `
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <https://www.example.com>
 
-<mailto:hello@example.com>
+<hello@example.com>
 
 <mailto:hello@example.com>
 

--- a/tests/markdown_link/autolink.md
+++ b/tests/markdown_link/autolink.md
@@ -1,1 +1,5 @@
 <https://www.example.com>
+
+<hello@example.com>
+
+<mailto:hello@example.com>

--- a/tests/markdown_spec/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_spec/__snapshots__/jsfmt.spec.js.snap
@@ -5549,21 +5549,21 @@ exports[`example-566.md 1`] = `
 exports[`example-567.md 1`] = `
 <foo@bar.example.com>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-<mailto:foo@bar.example.com>
+<foo@bar.example.com>
 
 `;
 
 exports[`example-568.md 1`] = `
 <foo+special@Bar.baz-bar0.com>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-<mailto:foo+special@Bar.baz-bar0.com>
+<foo+special@Bar.baz-bar0.com>
 
 `;
 
 exports[`example-569.md 1`] = `
 <foo\\+@bar.example.com>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-<mailto:foo\\+@bar.example.com>
+<foo\\+@bar.example.com>
 
 `;
 


### PR DESCRIPTION
```diff
 <hello@example.com>
 <mailto:hello@example.com>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-<mailto:hello@example.com>
+<hello@example.com>
 <mailto:hello@example.com>
```