### PR TITLE
Adjust indentation of nested ternaries

### DIFF
--- a/tests/binary-expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/binary-expressions/__snapshots__/jsfmt.spec.js.snap
@@ -516,16 +516,16 @@ function foo() {
 
 function foo() {
   return this.hasPlugin("dynamicImports") &&
-    this.lookahead().type === tt.parenLeft.right
-    ? true
-    : false;
+    this.lookahead().type === tt.parenLeft.right ?
+    true :
+    false;
 }
 
 function foo() {
   return this.calculate().compute().first.numberOfThings >
-    this.calculate().compute().last.numberOfThings
-    ? true
-    : false;
+    this.calculate().compute().last.numberOfThings ?
+    true :
+    false;
 }
 
 `;
@@ -645,9 +645,9 @@ const x =
   longVariable > longint && longVariable === 0 + longVariable * longVariable;
 
 foo(
-  obj.property * new Class() && obj instanceof Class && longVariable
-    ? number + 5
-    : false
+  obj.property * new Class() && obj instanceof Class && longVariable ?
+    number + 5 :
+    false
 );
 
 `;

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1439,18 +1439,18 @@ function binaryInBinaryRight() {
 function conditional() {
   return (
     // Reason for 42
-    42
-      ? 1
-      : 2
+    42 ?
+      1 :
+      2
   );
 }
 
 function binaryInConditional() {
   return (
     // Reason for 42
-    42 * 3
-      ? 1
-      : 2
+    42 * 3 ?
+      1 :
+      2
   );
 }
 

--- a/tests/conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/conditional/__snapshots__/jsfmt.spec.js.snap
@@ -40,45 +40,45 @@ const { configureStore } = process.env.NODE_ENV === "production"
   : require("./configureDevStore"); // b
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var inspect =
-  4 === util.inspect.length
-    ? // node <= 0.8.x
-      function(v, colors) {
-        return util.inspect(v, void 0, void 0, colors);
-      }
-    : // node > 0.8.x
-      function(v, colors) {
-        return util.inspect(v, { colors: colors });
-      };
+  4 === util.inspect.length ?
+    // node <= 0.8.x
+    function(v, colors) {
+      return util.inspect(v, void 0, void 0, colors);
+    } :
+    // node > 0.8.x
+    function(v, colors) {
+      return util.inspect(v, { colors: colors });
+    };
 
 var inspect =
-  4 === util.inspect.length
-    ? // node <= 0.8.x
-      function(v, colors) {
-        return util.inspect(v, void 0, void 0, colors);
-      }
-    : // node > 0.8.x
-      function(v, colors) {
-        return util.inspect(v, { colors: colors });
-      };
+  4 === util.inspect.length ?
+    // node <= 0.8.x
+    function(v, colors) {
+      return util.inspect(v, void 0, void 0, colors);
+    } :
+    // node > 0.8.x
+    function(v, colors) {
+      return util.inspect(v, { colors: colors });
+    };
 
-const extractTextPluginOptions = shouldUseRelativeAssetPaths
-  ? // Making sure that the publicPath goes back to to build folder.
-    { publicPath: Array(cssFilename.split("/").length).join("../") }
-  : {};
+const extractTextPluginOptions = shouldUseRelativeAssetPaths ?
+  // Making sure that the publicPath goes back to to build folder.
+  { publicPath: Array(cssFilename.split("/").length).join("../") } :
+  {};
 
-const extractTextPluginOptions = shouldUseRelativeAssetPaths
-  ? // Making sure that the publicPath goes back to to build folder.
-    { publicPath: Array(cssFilename.split("/").length).join("../") }
-  : {};
+const extractTextPluginOptions = shouldUseRelativeAssetPaths ?
+  // Making sure that the publicPath goes back to to build folder.
+  { publicPath: Array(cssFilename.split("/").length).join("../") } :
+  {};
 
-const extractTextPluginOptions = shouldUseRelativeAssetPaths // Making sure that the publicPath goes back to to build folder.
-  ? { publicPath: Array(cssFilename.split("/").length).join("../") }
-  : {};
+const extractTextPluginOptions = shouldUseRelativeAssetPaths ? // Making sure that the publicPath goes back to to build folder.
+  { publicPath: Array(cssFilename.split("/").length).join("../") } :
+  {};
 
 const { configureStore } =
-  process.env.NODE_ENV === "production"
-    ? require("./configureProdStore") // a
-    : require("./configureDevStore"); // b
+  process.env.NODE_ENV === "production" ?
+    require("./configureProdStore") : // a
+    require("./configureDevStore"); // b
 
 `;
 

--- a/tests/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -270,9 +270,9 @@ normalModeNonBreaking ? "a" : "b";
 
 // This ConditionalExpression has no JSXElements so it prints in normal mode.
 // Its consequent is very long, so it breaks out to multiple lines.
-normalModeBreaking
-  ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
-  : "c";
+normalModeBreaking ?
+  johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa :
+  "c";
 
 // This ConditionalExpression prints in JSX mode because its test is a
 // JSXElement. It is non-breaking.

--- a/tests/member/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/member/__snapshots__/jsfmt.spec.js.snap
@@ -6,9 +6,9 @@ exports[`conditional.js 1`] = `
   : helper.responseBody(this.defaultUser))
 .prop;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-(valid
-  ? helper.responseBody(this.currentUser)
-  : helper.responseBody(this.defaultUser)
+(valid ?
+  helper.responseBody(this.currentUser) :
+  helper.responseBody(this.defaultUser)
 ).prop;
 
 `;

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -336,16 +336,16 @@ this.doWriteConfiguration(target, value, options) // queue up writes to prevent 
   .then(
     () => null,
     error => {
-      return options.donotNotifyError
-        ? TPromise.wrapError(error)
-        : this.onError(error, target, value);
+      return options.donotNotifyError ?
+        TPromise.wrapError(error) :
+        this.onError(error, target, value);
     }
   );
 
-ret = __DEV__
-  ? // $FlowFixMe: this type differs according to the env
-    vm.runInContext(source, ctx)
-  : a;
+ret = __DEV__ ?
+  // $FlowFixMe: this type differs according to the env
+    vm.runInContext(source, ctx) :
+  a;
 
 this.firebase
   .object(\`/shops/\${shopLocation.shop}\`)
@@ -460,27 +460,27 @@ object[valid
   .e()
   .f();
 
-(valid
-  ? helper.responseBody(this.currentUser)
-  : helper.responseBody(this.defaultUser)
+(valid ?
+  helper.responseBody(this.currentUser) :
+  helper.responseBody(this.defaultUser)
 ).map();
 
-(valid
-  ? helper.responseBody(this.currentUser)
-  : helper.responseBody(this.defaultUser)
+(valid ?
+  helper.responseBody(this.currentUser) :
+  helper.responseBody(this.defaultUser)
 )
   .map()
   .filter();
 
-(valid
-  ? helper.responseBody(this.currentUser)
-  : helper.responseBody(defaultUser)
+(valid ?
+  helper.responseBody(this.currentUser) :
+  helper.responseBody(defaultUser)
 ).map();
 
 object[
-  valid
-    ? helper.responseBody(this.currentUser)
-    : helper.responseBody(defaultUser)
+  valid ?
+    helper.responseBody(this.currentUser) :
+    helper.responseBody(defaultUser)
 ].map();
 
 `;

--- a/tests/object_colon_bug/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/object_colon_bug/__snapshots__/jsfmt.spec.js.snap
@@ -7,9 +7,9 @@ const foo = {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const foo = {
-  bar: props.bar
-    ? props.bar
-    : noop,
+  bar: props.bar ?
+    props.bar :
+    noop,
   baz: props.baz
 };
 

--- a/tests/return/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/return/__snapshots__/jsfmt.spec.js.snap
@@ -37,9 +37,9 @@ function f() {
   return (
     chalk.bold("No tests found related to files changed since last commit.\\n") +
     chalk.dim(
-      patternInfo.watch
-        ? "Press \`a\` to run all tests, or run Jest with \`--watchAll\`."
-        : "Run Jest without \`-o\` to run all tests."
+      patternInfo.watch ?
+        "Press \`a\` to run all tests, or run Jest with \`--watchAll\`." :
+        "Run Jest without \`-o\` to run all tests."
     )
   );
 

--- a/tests/sequence_break/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/sequence_break/__snapshots__/jsfmt.spec.js.snap
@@ -48,30 +48,30 @@ for (
   test;
   update
 ) {}
-(a = b
-  ? c
-  : function() {
+(a = b ?
+  c :
+  function() {
+    return 0;
+  }),
+  (a = b ?
+    c :
+    function() {
       return 0;
     }),
-  (a = b
-    ? c
-    : function() {
-        return 0;
-      }),
-  (a = b
-    ? c
-    : function() {
-        return 0;
-      }),
-  (a = b
-    ? c
-    : function() {
-        return 0;
-      }),
-  (a = b
-    ? c
-    : function() {
-        return 0;
-      });
+  (a = b ?
+    c :
+    function() {
+      return 0;
+    }),
+  (a = b ?
+    c :
+    function() {
+      return 0;
+    }),
+  (a = b ?
+    c :
+    function() {
+      return 0;
+    });
 
 `;

--- a/tests/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/strings/__snapshots__/jsfmt.spec.js.snap
@@ -287,9 +287,9 @@ const makeBody = (store, assets, html) =>
 // https://github.com/prettier/prettier/issues/1626#issue-229655106
 const Bar = styled.div\`
   color: \${props =>
-    props.highlight.length > 0
-      ? palette(["text", "dark", "tertiary"])(props)
-      : palette(["text", "dark", "primary"])(props)} !important;
+    props.highlight.length > 0 ?
+      palette(["text", "dark", "tertiary"])(props) :
+      palette(["text", "dark", "primary"])(props)} !important;
 \`;
 
 `;
@@ -473,9 +473,9 @@ const makeBody = (store, assets, html) =>
 // https://github.com/prettier/prettier/issues/1626#issue-229655106
 const Bar = styled.div\`
   color: \${props =>
-    props.highlight.length > 0
-      ? palette(["text", "dark", "tertiary"])(props)
-      : palette(["text", "dark", "primary"])(props)} !important;
+    props.highlight.length > 0 ?
+      palette(["text", "dark", "tertiary"])(props) :
+      palette(["text", "dark", "primary"])(props)} !important;
 \`;
 
 `;

--- a/tests/ternaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ternaries/__snapshots__/jsfmt.spec.js.snap
@@ -27,9 +27,9 @@ room = room.map((row, rowIndex) =>
       rowIndex === 0 ||
       colIndex === 0 ||
       rowIndex === height ||
-      colIndex === width
-        ? 1
-        : 0
+      colIndex === width ?
+        1 :
+        0
   )
 );
 
@@ -62,9 +62,9 @@ room = room.map((row, rowIndex) =>
             rowIndex === 0 ||
             colIndex === 0 ||
             rowIndex === height ||
-            colIndex === width
-                ? 1
-                : 0
+            colIndex === width ?
+                1 :
+                0
     )
 );
 
@@ -97,9 +97,9 @@ room = room.map((row, rowIndex) =>
 			rowIndex === 0 ||
 			colIndex === 0 ||
 			rowIndex === height ||
-			colIndex === width
-				? 1
-				: 0
+			colIndex === width ?
+				1 :
+				0
 	)
 );
 
@@ -132,9 +132,9 @@ room = room.map((row, rowIndex) =>
 			rowIndex === 0 ||
 			colIndex === 0 ||
 			rowIndex === height ||
-			colIndex === width
-				? 1
-				: 0
+			colIndex === width ?
+				1 :
+				0
 	)
 );
 
@@ -309,156 +309,156 @@ a
 	  }
     : a;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-aaaaaaaaaaaaaaa
-  ? bbbbbbbbbbbbbbbbbb
-  : ccccccccccccccc
-    ? ddddddddddddddd
-    : eeeeeeeeeeeeeee
-      ? fffffffffffffff
-      : gggggggggggggggg;
+aaaaaaaaaaaaaaa ?
+  bbbbbbbbbbbbbbbbbb :
+ccccccccccccccc ?
+  ddddddddddddddd :
+eeeeeeeeeeeeeee ?
+  fffffffffffffff :
+gggggggggggggggg;
 
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-  ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-      ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-      : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-  : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ?
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ?
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ?
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
 
-a
-  ? {
+a ?
+  {
+    a: 0
+  } :
+  {
+    a: {
       a: 0
-    }
-  : {
-      a: {
+    } ?
+      {
         a: 0
-      }
-        ? {
+      } :
+      {
+        y: {
+          a: 0
+        } ?
+          {
+            a: 0
+          } :
+          {
             a: 0
           }
-        : {
-            y: {
-              a: 0
-            }
-              ? {
-                  a: 0
-                }
-              : {
-                  a: 0
-                }
-          }
-    };
+      }
+  };
 
-a
-  ? {
-      a: function() {
-        return a
-          ? {
-              a: [
-                a
-                  ? {
-                      a: 0,
-                      b: [a ? [0, 1] : []]
-                    }
-                  : [
+a ?
+  {
+    a: function() {
+      return a ?
+        {
+          a: [
+            a ?
+              {
+                a: 0,
+                b: [a ? [0, 1] : []]
+              } :
+              [
+                [
+                  0,
+                  {
+                    a: 0
+                  },
+                  a ? 0 : 1
+                ],
+                function() {
+                  return a ?
+                    {
+                      a: 0
+                    } :
+                    [
+                      {
+                        a: 0
+                      },
+                      {}
+                    ];
+                }
+              ]
+          ]
+        } :
+        [
+          a ?
+            function() {
+              a ?
+                a(
+                    a ?
+                      {
+                        a: a({
+                          a: 0
+                        })
+                      } :
                       [
                         0,
-                        {
-                          a: 0
-                        },
-                        a ? 0 : 1
-                      ],
-                      function() {
-                        return a
-                          ? {
-                              a: 0
-                            }
-                          : [
-                              {
+                        a(),
+                        a(
+                          a(),
+                          {
+                            a: 0
+                          },
+                          a ?
+                            a() :
+                            a({
                                 a: 0
-                              },
-                              {}
-                            ];
-                      }
-                    ]
-              ]
-            }
-          : [
-              a
-                ? function() {
-                    a
-                      ? a(
-                          a
-                            ? {
-                                a: a({
-                                  a: 0
-                                })
+                              })
+                        ),
+                        a() ?
+                          {
+                            a: a(),
+                            b: []
+                          } :
+                          {}
+                      ]
+                  ) :
+                a(
+                    a() ?
+                      {
+                        a: 0
+                      } :
+                      (function(a) {
+                          return a() ?
+                            [
+                              {
+                                a: 0,
+                                b: a()
                               }
-                            : [
-                                0,
-                                a(),
-                                a(
-                                  a(),
+                            ] :
+                            a([
+                                a ?
                                   {
                                     a: 0
-                                  },
-                                  a
-                                    ? a()
-                                    : a({
-                                        a: 0
-                                      })
-                                ),
-                                a()
-                                  ? {
-                                      a: a(),
-                                      b: []
-                                    }
-                                  : {}
-                              ]
+                                  } :
+                                  {},
+                                {
+                                  a: 0
+                                }
+                              ]);
+                        })(
+                          a ?
+                            function(a) {
+                              return function() {
+                                return 0;
+                              };
+                            } :
+                            function(a) {
+                              return function() {
+                                return 1;
+                              };
+                            }
                         )
-                      : a(
-                          a()
-                            ? {
-                                a: 0
-                              }
-                            : (function(a) {
-                                return a()
-                                  ? [
-                                      {
-                                        a: 0,
-                                        b: a()
-                                      }
-                                    ]
-                                  : a([
-                                      a
-                                        ? {
-                                            a: 0
-                                          }
-                                        : {},
-                                      {
-                                        a: 0
-                                      }
-                                    ]);
-                              })(
-                                a
-                                  ? function(a) {
-                                      return function() {
-                                        return 0;
-                                      };
-                                    }
-                                  : function(a) {
-                                      return function() {
-                                        return 1;
-                                      };
-                                    }
-                              )
-                        );
-                  }
-                : function() {}
-            ];
-      }
+                  );
+            } :
+            function() {}
+        ];
     }
-  : a;
+  } :
+  a;
 
 `;
 
@@ -631,156 +631,156 @@ a
 	  }
     : a;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-aaaaaaaaaaaaaaa
-    ? bbbbbbbbbbbbbbbbbb
-    : ccccccccccccccc
-        ? ddddddddddddddd
-        : eeeeeeeeeeeeeee
-            ? fffffffffffffff
-            : gggggggggggggggg;
+aaaaaaaaaaaaaaa ?
+    bbbbbbbbbbbbbbbbbb :
+ccccccccccccccc ?
+    ddddddddddddddd :
+eeeeeeeeeeeeeee ?
+    fffffffffffffff :
+gggggggggggggggg;
 
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-        ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-            ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-            : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-        : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ?
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ?
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ?
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
 
-a
-    ? {
-          a: 0
-      }
-    : {
-          a: {
-              a: 0
-          }
-              ? {
+a ?
+    {
+        a: 0
+    } :
+    {
+        a: {
+            a: 0
+        } ?
+            {
+                a: 0
+            } :
+            {
+                y: {
                     a: 0
-                }
-              : {
-                    y: {
+                } ?
+                    {
+                        a: 0
+                    } :
+                    {
                         a: 0
                     }
-                        ? {
-                              a: 0
-                          }
-                        : {
-                              a: 0
-                          }
-                }
-      };
+            }
+    };
 
-a
-    ? {
-          a: function() {
-              return a
-                  ? {
-                        a: [
-                            a
-                                ? {
-                                      a: 0,
-                                      b: [a ? [0, 1] : []]
-                                  }
-                                : [
-                                      [
-                                          0,
+a ?
+    {
+        a: function() {
+            return a ?
+                {
+                    a: [
+                        a ?
+                            {
+                                a: 0,
+                                b: [a ? [0, 1] : []]
+                            } :
+                            [
+                                [
+                                    0,
+                                    {
+                                        a: 0
+                                    },
+                                    a ? 0 : 1
+                                ],
+                                function() {
+                                    return a ?
+                                        {
+                                            a: 0
+                                        } :
+                                        [
+                                            {
+                                                a: 0
+                                            },
+                                            {}
+                                        ];
+                                }
+                            ]
+                    ]
+                } :
+                [
+                    a ?
+                        function() {
+                            a ?
+                                a(
+                                      a ?
+                                          {
+                                              a: a({
+                                                  a: 0
+                                              })
+                                          } :
+                                          [
+                                              0,
+                                              a(),
+                                              a(
+                                                  a(),
+                                                  {
+                                                      a: 0
+                                                  },
+                                                  a ?
+                                                      a() :
+                                                      a({
+                                                            a: 0
+                                                        })
+                                              ),
+                                              a() ?
+                                                  {
+                                                      a: a(),
+                                                      b: []
+                                                  } :
+                                                  {}
+                                          ]
+                                  ) :
+                                a(
+                                      a() ?
                                           {
                                               a: 0
-                                          },
-                                          a ? 0 : 1
-                                      ],
-                                      function() {
-                                          return a
-                                              ? {
-                                                    a: 0
-                                                }
-                                              : [
-                                                    {
-                                                        a: 0
-                                                    },
-                                                    {}
-                                                ];
-                                      }
-                                  ]
-                        ]
-                    }
-                  : [
-                        a
-                            ? function() {
-                                  a
-                                      ? a(
-                                            a
-                                                ? {
-                                                      a: a({
-                                                          a: 0
-                                                      })
-                                                  }
-                                                : [
-                                                      0,
-                                                      a(),
-                                                      a(
-                                                          a(),
+                                          } :
+                                          (function(a) {
+                                                return a() ?
+                                                    [
+                                                        {
+                                                            a: 0,
+                                                            b: a()
+                                                        }
+                                                    ] :
+                                                    a([
+                                                          a ?
+                                                              {
+                                                                  a: 0
+                                                              } :
+                                                              {},
                                                           {
                                                               a: 0
-                                                          },
-                                                          a
-                                                              ? a()
-                                                              : a({
-                                                                    a: 0
-                                                                })
-                                                      ),
-                                                      a()
-                                                          ? {
-                                                                a: a(),
-                                                                b: []
-                                                            }
-                                                          : {}
-                                                  ]
-                                        )
-                                      : a(
-                                            a()
-                                                ? {
-                                                      a: 0
-                                                  }
-                                                : (function(a) {
-                                                      return a()
-                                                          ? [
-                                                                {
-                                                                    a: 0,
-                                                                    b: a()
-                                                                }
-                                                            ]
-                                                          : a([
-                                                                a
-                                                                    ? {
-                                                                          a: 0
-                                                                      }
-                                                                    : {},
-                                                                {
-                                                                    a: 0
-                                                                }
-                                                            ]);
-                                                  })(
-                                                      a
-                                                          ? function(a) {
-                                                                return function() {
-                                                                    return 0;
-                                                                };
-                                                            }
-                                                          : function(a) {
-                                                                return function() {
-                                                                    return 1;
-                                                                };
-                                                            }
-                                                  )
-                                        );
-                              }
-                            : function() {}
-                    ];
-          }
-      }
-    : a;
+                                                          }
+                                                      ]);
+                                            })(
+                                                a ?
+                                                    function(a) {
+                                                        return function() {
+                                                            return 0;
+                                                        };
+                                                    } :
+                                                    function(a) {
+                                                        return function() {
+                                                            return 1;
+                                                        };
+                                                    }
+                                            )
+                                  );
+                        } :
+                        function() {}
+                ];
+        }
+    } :
+    a;
 
 `;
 
@@ -953,156 +953,156 @@ a
 	  }
     : a;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-aaaaaaaaaaaaaaa
-	? bbbbbbbbbbbbbbbbbb
-	: ccccccccccccccc
-		? ddddddddddddddd
-		: eeeeeeeeeeeeeee
-			? fffffffffffffff
-			: gggggggggggggggg;
+aaaaaaaaaaaaaaa ?
+	bbbbbbbbbbbbbbbbbb :
+ccccccccccccccc ?
+	ddddddddddddddd :
+eeeeeeeeeeeeeee ?
+	fffffffffffffff :
+gggggggggggggggg;
 
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-	? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-		? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-			? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-			: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-		: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-	: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ?
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ?
+		aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ?
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+		aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
 
-a
-	? {
+a ?
+	{
+		a: 0
+	} :
+	{
+		a: {
 			a: 0
-	  }
-	: {
-			a: {
+		} ?
+			{
 				a: 0
-			}
-				? {
+			} :
+			{
+				y: {
+					a: 0
+				} ?
+					{
 						a: 0
-				  }
-				: {
-						y: {
-							a: 0
-						}
-							? {
-									a: 0
-							  }
-							: {
-									a: 0
-							  }
-				  }
-	  };
+					} :
+					{
+						a: 0
+					}
+			}
+	};
 
-a
-	? {
-			a: function() {
-				return a
-					? {
-							a: [
-								a
-									? {
-											a: 0,
-											b: [a ? [0, 1] : []]
-									  }
-									: [
+a ?
+	{
+		a: function() {
+			return a ?
+				{
+					a: [
+						a ?
+							{
+								a: 0,
+								b: [a ? [0, 1] : []]
+							} :
+							[
+								[
+									0,
+									{
+										a: 0
+									},
+									a ? 0 : 1
+								],
+								function() {
+									return a ?
+										{
+											a: 0
+										} :
+										[
+											{
+												a: 0
+											},
+											{}
+										];
+								}
+							]
+					]
+				} :
+				[
+					a ?
+						function() {
+							a ?
+								a(
+										a ?
+											{
+												a: a({
+													a: 0
+												})
+											} :
 											[
 												0,
-												{
-													a: 0
-												},
-												a ? 0 : 1
-											],
-											function() {
-												return a
-													? {
-															a: 0
-													  }
-													: [
-															{
+												a(),
+												a(
+													a(),
+													{
+														a: 0
+													},
+													a ?
+														a() :
+														a({
 																a: 0
-															},
-															{}
-													  ];
-											}
-									  ]
-							]
-					  }
-					: [
-							a
-								? function() {
-										a
-											? a(
-													a
-														? {
-																a: a({
-																	a: 0
-																})
-														  }
-														: [
-																0,
-																a(),
-																a(
-																	a(),
+														  })
+												),
+												a() ?
+													{
+														a: a(),
+														b: []
+													} :
+													{}
+											]
+								  ) :
+								a(
+										a() ?
+											{
+												a: 0
+											} :
+											(function(a) {
+													return a() ?
+														[
+															{
+																a: 0,
+																b: a()
+															}
+														] :
+														a([
+																a ?
 																	{
 																		a: 0
-																	},
-																	a
-																		? a()
-																		: a({
-																				a: 0
-																		  })
-																),
-																a()
-																	? {
-																			a: a(),
-																			b: []
-																	  }
-																	: {}
-														  ]
+																	} :
+																	{},
+																{
+																	a: 0
+																}
+														  ]);
+											  })(
+													a ?
+														function(a) {
+															return function() {
+																return 0;
+															};
+														} :
+														function(a) {
+															return function() {
+																return 1;
+															};
+														}
 											  )
-											: a(
-													a()
-														? {
-																a: 0
-														  }
-														: (function(a) {
-																return a()
-																	? [
-																			{
-																				a: 0,
-																				b: a()
-																			}
-																	  ]
-																	: a([
-																			a
-																				? {
-																						a: 0
-																				  }
-																				: {},
-																			{
-																				a: 0
-																			}
-																	  ]);
-														  })(
-																a
-																	? function(a) {
-																			return function() {
-																				return 0;
-																			};
-																	  }
-																	: function(a) {
-																			return function() {
-																				return 1;
-																			};
-																	  }
-														  )
-											  );
-								  }
-								: function() {}
-					  ];
-			}
-	  }
-	: a;
+								  );
+						} :
+						function() {}
+				];
+		}
+	} :
+	a;
 
 `;
 
@@ -1275,160 +1275,156 @@ a
 	  }
     : a;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-aaaaaaaaaaaaaaa
-	? bbbbbbbbbbbbbbbbbb
-	: ccccccccccccccc
-		? ddddddddddddddd
-		: eeeeeeeeeeeeeee
-			? fffffffffffffff
-			: gggggggggggggggg;
+aaaaaaaaaaaaaaa ?
+	bbbbbbbbbbbbbbbbbb :
+ccccccccccccccc ?
+	ddddddddddddddd :
+eeeeeeeeeeeeeee ?
+	fffffffffffffff :
+gggggggggggggggg;
 
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-	? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-		? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-			? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-			: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-		: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-	: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ?
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ?
+		aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ?
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+		aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa :
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
 
-a
-	? {
+a ?
+	{
+		a: 0
+	} :
+	{
+		a: {
 			a: 0
-	  }
-	: {
-			a: {
+		} ?
+			{
 				a: 0
-			}
-				? {
+			} :
+			{
+				y: {
+					a: 0
+				} ?
+					{
 						a: 0
-				  }
-				: {
-						y: {
-							a: 0
-						}
-							? {
-									a: 0
-							  }
-							: {
-									a: 0
-							  }
-				  }
-	  };
+					} :
+					{
+						a: 0
+					}
+			}
+	};
 
-a
-	? {
-			a: function() {
-				return a
-					? {
-							a: [
-								a
-									? {
-											a: 0,
-											b: [a ? [0, 1] : []]
-									  }
-									: [
+a ?
+	{
+		a: function() {
+			return a ?
+				{
+					a: [
+						a ?
+							{
+								a: 0,
+								b: [a ? [0, 1] : []]
+							} :
+							[
+								[
+									0,
+									{
+										a: 0
+									},
+									a ? 0 : 1
+								],
+								function() {
+									return a ?
+										{
+											a: 0
+										} :
+										[
+											{
+												a: 0
+											},
+											{}
+										];
+								}
+							]
+					]
+				} :
+				[
+					a ?
+						function() {
+							a ?
+								a(
+										a ?
+											{
+												a: a({
+													a: 0
+												})
+											} :
 											[
 												0,
-												{
-													a: 0
-												},
-												a ? 0 : 1
-											],
-											function() {
-												return a
-													? {
-															a: 0
-													  }
-													: [
-															{
+												a(),
+												a(
+													a(),
+													{
+														a: 0
+													},
+													a ?
+														a() :
+														a({
 																a: 0
-															},
-															{}
-													  ];
-											}
-									  ]
-							]
-					  }
-					: [
-							a
-								? function() {
-										a
-											? a(
-													a
-														? {
-																a: a({
-																	a: 0
-																})
-														  }
-														: [
-																0,
-																a(),
-																a(
-																	a(),
+														  })
+												),
+												a() ?
+													{
+														a: a(),
+														b: []
+													} :
+													{}
+											]
+								  ) :
+								a(
+										a() ?
+											{
+												a: 0
+											} :
+											(function(a) {
+													return a() ?
+														[
+															{
+																a: 0,
+																b: a()
+															}
+														] :
+														a([
+																a ?
 																	{
 																		a: 0
-																	},
-																	a
-																		? a()
-																		: a({
-																				a: 0
-																		  })
-																),
-																a()
-																	? {
-																			a: a(),
-																			b: []
-																	  }
-																	: {}
-														  ]
+																	} :
+																	{},
+																{
+																	a: 0
+																}
+														  ]);
+											  })(
+													a ?
+														function(a) {
+															return function() {
+																return 0;
+															};
+														} :
+														function(a) {
+															return function() {
+																return 1;
+															};
+														}
 											  )
-											: a(
-													a()
-														? {
-																a: 0
-														  }
-														: (function(a) {
-																return a()
-																	? [
-																			{
-																				a: 0,
-																				b: a()
-																			}
-																	  ]
-																	: a([
-																			a
-																				? {
-																						a: 0
-																				  }
-																				: {},
-																			{
-																				a: 0
-																			}
-																	  ]);
-														  })(
-																a
-																	? function(
-																			a
-																	  ) {
-																			return function() {
-																				return 0;
-																			};
-																	  }
-																	: function(
-																			a
-																	  ) {
-																			return function() {
-																				return 1;
-																			};
-																	  }
-														  )
-											  );
-								  }
-								: function() {}
-					  ];
-			}
-	  }
-	: a;
+								  );
+						} :
+						function() {}
+				];
+		}
+	} :
+	a;
 
 `;
 
@@ -1438,9 +1434,9 @@ let icecream = what == "cone"
   : p => \`here's your \${p} \${what}\`;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 let icecream =
-  what == "cone"
-    ? p => (!!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`)
-    : p => \`here's your \${p} \${what}\`;
+  what == "cone" ?
+    p => (!!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`) :
+    p => \`here's your \${p} \${what}\`;
 
 `;
 
@@ -1450,9 +1446,9 @@ let icecream = what == "cone"
   : p => \`here's your \${p} \${what}\`;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 let icecream =
-    what == "cone"
-        ? p => (!!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`)
-        : p => \`here's your \${p} \${what}\`;
+    what == "cone" ?
+        p => (!!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`) :
+        p => \`here's your \${p} \${what}\`;
 
 `;
 
@@ -1462,9 +1458,9 @@ let icecream = what == "cone"
   : p => \`here's your \${p} \${what}\`;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 let icecream =
-	what == "cone"
-		? p => (!!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`)
-		: p => \`here's your \${p} \${what}\`;
+	what == "cone" ?
+		p => (!!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`) :
+		p => \`here's your \${p} \${what}\`;
 
 `;
 
@@ -1474,9 +1470,9 @@ let icecream = what == "cone"
   : p => \`here's your \${p} \${what}\`;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 let icecream =
-	what == "cone"
-		? p => (!!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`)
-		: p => \`here's your \${p} \${what}\`;
+	what == "cone" ?
+		p => (!!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`) :
+		p => \`here's your \${p} \${what}\`;
 
 `;
 
@@ -1489,20 +1485,20 @@ a => a ? a : a
 a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
-debug
-  ? this.state.isVisible && somethingComplex
-    ? "partially visible"
-    : "hidden"
-  : null;
+debug ?
+  this.state.isVisible && somethingComplex ?
+    "partially visible" :
+  "hidden" :
+null;
 
 a =>
-  a
-    ? () => {
-        a;
-      }
-    : () => {
-        a;
-      };
+  a ?
+    () => {
+      a;
+    } :
+    () => {
+      a;
+    };
 a => (a ? a : a);
 a =>
   a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a;
@@ -1518,20 +1514,20 @@ a => a ? a : a
 a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
-debug
-    ? this.state.isVisible && somethingComplex
-        ? "partially visible"
-        : "hidden"
-    : null;
+debug ?
+    this.state.isVisible && somethingComplex ?
+        "partially visible" :
+    "hidden" :
+null;
 
 a =>
-    a
-        ? () => {
-              a;
-          }
-        : () => {
-              a;
-          };
+    a ?
+        () => {
+            a;
+        } :
+        () => {
+            a;
+        };
 a => (a ? a : a);
 a =>
     a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a;
@@ -1547,20 +1543,20 @@ a => a ? a : a
 a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
-debug
-	? this.state.isVisible && somethingComplex
-		? "partially visible"
-		: "hidden"
-	: null;
+debug ?
+	this.state.isVisible && somethingComplex ?
+		"partially visible" :
+	"hidden" :
+null;
 
 a =>
-	a
-		? () => {
-				a;
-		  }
-		: () => {
-				a;
-		  };
+	a ?
+		() => {
+			a;
+		} :
+		() => {
+			a;
+		};
 a => (a ? a : a);
 a =>
 	a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a;
@@ -1576,20 +1572,20 @@ a => a ? a : a
 a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
-debug
-	? this.state.isVisible && somethingComplex
-		? "partially visible"
-		: "hidden"
-	: null;
+debug ?
+	this.state.isVisible && somethingComplex ?
+		"partially visible" :
+	"hidden" :
+null;
 
 a =>
-	a
-		? () => {
-				a;
-		  }
-		: () => {
-				a;
-		  };
+	a ?
+		() => {
+			a;
+		} :
+		() => {
+			a;
+		};
 a => (a ? a : a);
 a =>
 	a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a;
@@ -1611,40 +1607,40 @@ const obj5 = conditionIsTruthy ? { some: 'long', object: 'with', lots: 'of', stu
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const obj0 = conditionIsTruthy ? shortThing : otherShortThing;
 
-const obj1 = conditionIsTruthy
-  ? { some: "long", object: "with", lots: "of", stuff }
-  : shortThing;
+const obj1 = conditionIsTruthy ?
+  { some: "long", object: "with", lots: "of", stuff } :
+  shortThing;
 
-const obj2 = conditionIsTruthy
-  ? shortThing
-  : { some: "long", object: "with", lots: "of", stuff };
+const obj2 = conditionIsTruthy ?
+  shortThing :
+  { some: "long", object: "with", lots: "of", stuff };
 
-const obj3 = conditionIsTruthy
-  ? {
-      some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
-      object: "with",
-      lots: "of",
-      stuff
-    }
-  : shortThing;
+const obj3 = conditionIsTruthy ?
+  {
+    some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
+    object: "with",
+    lots: "of",
+    stuff
+  } :
+  shortThing;
 
-const obj4 = conditionIsTruthy
-  ? shortThing
-  : {
-      some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
-      object: "with",
-      lots: "of",
-      stuff
-    };
+const obj4 = conditionIsTruthy ?
+  shortThing :
+  {
+    some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
+    object: "with",
+    lots: "of",
+    stuff
+  };
 
-const obj5 = conditionIsTruthy
-  ? { some: "long", object: "with", lots: "of", stuff }
-  : {
-      some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
-      object: "with",
-      lots: "of",
-      stuff
-    };
+const obj5 = conditionIsTruthy ?
+  { some: "long", object: "with", lots: "of", stuff } :
+  {
+    some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
+    object: "with",
+    lots: "of",
+    stuff
+  };
 
 `;
 
@@ -1663,40 +1659,40 @@ const obj5 = conditionIsTruthy ? { some: 'long', object: 'with', lots: 'of', stu
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const obj0 = conditionIsTruthy ? shortThing : otherShortThing;
 
-const obj1 = conditionIsTruthy
-    ? { some: "long", object: "with", lots: "of", stuff }
-    : shortThing;
+const obj1 = conditionIsTruthy ?
+    { some: "long", object: "with", lots: "of", stuff } :
+    shortThing;
 
-const obj2 = conditionIsTruthy
-    ? shortThing
-    : { some: "long", object: "with", lots: "of", stuff };
+const obj2 = conditionIsTruthy ?
+    shortThing :
+    { some: "long", object: "with", lots: "of", stuff };
 
-const obj3 = conditionIsTruthy
-    ? {
-          some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
-          object: "with",
-          lots: "of",
-          stuff
-      }
-    : shortThing;
+const obj3 = conditionIsTruthy ?
+    {
+        some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
+        object: "with",
+        lots: "of",
+        stuff
+    } :
+    shortThing;
 
-const obj4 = conditionIsTruthy
-    ? shortThing
-    : {
-          some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
-          object: "with",
-          lots: "of",
-          stuff
-      };
+const obj4 = conditionIsTruthy ?
+    shortThing :
+    {
+        some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
+        object: "with",
+        lots: "of",
+        stuff
+    };
 
-const obj5 = conditionIsTruthy
-    ? { some: "long", object: "with", lots: "of", stuff }
-    : {
-          some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
-          object: "with",
-          lots: "of",
-          stuff
-      };
+const obj5 = conditionIsTruthy ?
+    { some: "long", object: "with", lots: "of", stuff } :
+    {
+        some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
+        object: "with",
+        lots: "of",
+        stuff
+    };
 
 `;
 
@@ -1715,40 +1711,40 @@ const obj5 = conditionIsTruthy ? { some: 'long', object: 'with', lots: 'of', stu
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const obj0 = conditionIsTruthy ? shortThing : otherShortThing;
 
-const obj1 = conditionIsTruthy
-	? { some: "long", object: "with", lots: "of", stuff }
-	: shortThing;
+const obj1 = conditionIsTruthy ?
+	{ some: "long", object: "with", lots: "of", stuff } :
+	shortThing;
 
-const obj2 = conditionIsTruthy
-	? shortThing
-	: { some: "long", object: "with", lots: "of", stuff };
+const obj2 = conditionIsTruthy ?
+	shortThing :
+	{ some: "long", object: "with", lots: "of", stuff };
 
-const obj3 = conditionIsTruthy
-	? {
-			some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
-			object: "with",
-			lots: "of",
-			stuff
-	  }
-	: shortThing;
+const obj3 = conditionIsTruthy ?
+	{
+		some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
+		object: "with",
+		lots: "of",
+		stuff
+	} :
+	shortThing;
 
-const obj4 = conditionIsTruthy
-	? shortThing
-	: {
-			some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
-			object: "with",
-			lots: "of",
-			stuff
-	  };
+const obj4 = conditionIsTruthy ?
+	shortThing :
+	{
+		some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
+		object: "with",
+		lots: "of",
+		stuff
+	};
 
-const obj5 = conditionIsTruthy
-	? { some: "long", object: "with", lots: "of", stuff }
-	: {
-			some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
-			object: "with",
-			lots: "of",
-			stuff
-	  };
+const obj5 = conditionIsTruthy ?
+	{ some: "long", object: "with", lots: "of", stuff } :
+	{
+		some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
+		object: "with",
+		lots: "of",
+		stuff
+	};
 
 `;
 
@@ -1767,39 +1763,39 @@ const obj5 = conditionIsTruthy ? { some: 'long', object: 'with', lots: 'of', stu
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const obj0 = conditionIsTruthy ? shortThing : otherShortThing;
 
-const obj1 = conditionIsTruthy
-	? { some: "long", object: "with", lots: "of", stuff }
-	: shortThing;
+const obj1 = conditionIsTruthy ?
+	{ some: "long", object: "with", lots: "of", stuff } :
+	shortThing;
 
-const obj2 = conditionIsTruthy
-	? shortThing
-	: { some: "long", object: "with", lots: "of", stuff };
+const obj2 = conditionIsTruthy ?
+	shortThing :
+	{ some: "long", object: "with", lots: "of", stuff };
 
-const obj3 = conditionIsTruthy
-	? {
-			some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
-			object: "with",
-			lots: "of",
-			stuff
-	  }
-	: shortThing;
+const obj3 = conditionIsTruthy ?
+	{
+		some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
+		object: "with",
+		lots: "of",
+		stuff
+	} :
+	shortThing;
 
-const obj4 = conditionIsTruthy
-	? shortThing
-	: {
-			some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
-			object: "with",
-			lots: "of",
-			stuff
-	  };
+const obj4 = conditionIsTruthy ?
+	shortThing :
+	{
+		some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
+		object: "with",
+		lots: "of",
+		stuff
+	};
 
-const obj5 = conditionIsTruthy
-	? { some: "long", object: "with", lots: "of", stuff }
-	: {
-			some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
-			object: "with",
-			lots: "of",
-			stuff
-	  };
+const obj5 = conditionIsTruthy ?
+	{ some: "long", object: "with", lots: "of", stuff } :
+	{
+		some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
+		object: "with",
+		lots: "of",
+		stuff
+	};
 
 `;

--- a/tests/throw_expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/throw_expressions/__snapshots__/jsfmt.spec.js.snap
@@ -27,13 +27,13 @@ lint(ast, {
 
 function getEncoder(encoding) {
   const encoder =
-    encoding === "utf8"
-      ? new UTF8Encoder()
-      : encoding === "utf16le"
-        ? new UTF16Encoder(false)
-        : encoding === "utf16be"
-          ? new UTF16Encoder(true)
-          : throw new Error("Unsupported encoding");
+    encoding === "utf8" ?
+      new UTF8Encoder() :
+    encoding === "utf16le" ?
+      new UTF16Encoder(false) :
+    encoding === "utf16be" ?
+      new UTF16Encoder(true) :
+    throw new Error("Unsupported encoding");
 }
 
 class Product {

--- a/tests/typescript/webhost/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/webhost/__snapshots__/jsfmt.spec.js.snap
@@ -150,9 +150,9 @@ namespace TypeScript.WebTsc {
             fileStream.Charset =
               bom.length >= 2 &&
               ((bom.charCodeAt(0) === 0xff && bom.charCodeAt(1) === 0xfe) ||
-                (bom.charCodeAt(0) === 0xfe && bom.charCodeAt(1) === 0xff))
-                ? "unicode"
-                : "utf-8";
+                (bom.charCodeAt(0) === 0xfe && bom.charCodeAt(1) === 0xff)) ?
+                "unicode" :
+                "utf-8";
           }
           // ReadText method always strips byte order mark from resulting string
           return fileStream.ReadText();

--- a/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
@@ -32,9 +32,9 @@ const state = JSON.stringify({
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const name = (description as DescriptionObject).name || (description as string);
 this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
-(originalError
-  ? wrappedError(errMsg, originalError)
-  : Error(errMsg)) as InjectionError;
+(originalError ?
+  wrappedError(errMsg, originalError) :
+  Error(errMsg)) as InjectionError;
 "current" in (props.pagination as Object);
 start + (yearSelectTotal as number);
 scrollTop > (visibilityHeight as number);

--- a/tests/typescript_conditional_types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_conditional_types/__snapshots__/jsfmt.spec.js.snap
@@ -11,9 +11,11 @@ type DeepReadonlyObject<T> = {
     readonly [P in NonFunctionPropertyNames<T>]: DeepReadonly<T[P]>;
 };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-export type DeepReadonly<T> = T extends any[]
-  ? DeepReadonlyArray<T[number]>
-  : T extends object ? DeepReadonlyObject<T> : T;
+export type DeepReadonly<T> = T extends any[] ?
+  DeepReadonlyArray<T[number]> :
+T extends object ?
+  DeepReadonlyObject<T> :
+T;
 
 type NonFunctionPropertyNames<T> = {
   [K in keyof T]: T[K] extends Function ? never : K
@@ -32,8 +34,8 @@ type TestReturnType<T extends (...args: any[]) => any> = T extends (...args: any
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 type TestReturnType<T extends (...args: any[]) => any> = T extends (
   ...args: any[]
-) => infer R
-  ? R
-  : any;
+) => infer R ?
+  R :
+  any;
 
 `;


### PR DESCRIPTION
See https://github.com/prettier/prettier/issues/737 for the issue that sparked the discussion.

Primarily, it changes ternaries that were of the form (nesting in alternate sub-expressions):
```js
aaaaaaaaaaaaaaa
  ? bbbbbbbbbbbbbbbbbb
  : ccccccccccccccc
    ? ddddddddddddddd
    : eeeeeeeeeeeeeee
      ? fffffffffffffff
      : gggggggggggggggg;
```
into:
```js
aaaaaaaaaaaaaaa ?
  bbbbbbbbbbbbbbbbbb :
ccccccccccccccc ?
  ddddddddddddddd :
eeeeeeeeeeeeeee ?
  fffffffffffffff :
gggggggggggggggg;
```
as suggested in https://github.com/prettier/prettier/issues/737#issuecomment-363314699.

It also changes ternaries that nested consequent sub-expressions slightly to be more consistent with the new alternate form.

See the changes to ` tests/ternaries/__snapshots__/jsfmt.spec.js.snap` for a great overview of the new format.

JSX-mode ternaries were not changed.