### PR TITLE
Do not require space after markdown block language name

### DIFF
--- a/src/language-markdown/embed.js
+++ b/src/language-markdown/embed.js
@@ -12,7 +12,7 @@ function embed(path, print, textToDoc, options) {
 
   if (node.type === "code" && node.lang !== null) {
     // only look for the first string so as to support [markdown-preview-enhanced](https://shd101wyy.github.io/markdown-preview-enhanced/#/code-chunk)
-    const lang = node.lang.split(/\s/, 1)[0];
+    const lang = (node.lang.match(/^[A-Za-z0-9_-]+/) || [])[0];
     const parser = getParserName(lang);
     if (parser) {
       const styleUnit = options.__inJsTemplate ? "~" : "`";

--- a/tests/multiparser_markdown_js/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_markdown_js/__snapshots__/jsfmt.spec.js.snap
@@ -41,6 +41,12 @@ console.log(     "hello world"   );
 \`\`\`js {cmd=node .line-numbers}
 console.log(     "hello world"   );
 \`\`\`
+
+## js block with arguments and no space
+
+\`\`\`js{cmd=node .line-numbers}
+console.log(     "hello world"   );
+\`\`\`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ## plain js block
 
@@ -51,6 +57,12 @@ console.log("hello world");
 ## js block with arguments
 
 \`\`\`js {cmd=node .line-numbers}
+console.log("hello world");
+\`\`\`
+
+## js block with arguments and no space
+
+\`\`\`js{cmd=node .line-numbers}
 console.log("hello world");
 \`\`\`
 

--- a/tests/multiparser_markdown_js/markdown-preview-enhanced.md
+++ b/tests/multiparser_markdown_js/markdown-preview-enhanced.md
@@ -9,3 +9,9 @@ console.log(     "hello world"   );
 ```js {cmd=node .line-numbers}
 console.log(     "hello world"   );
 ```
+
+## js block with arguments and no space
+
+```js{cmd=node .line-numbers}
+console.log(     "hello world"   );
+```


### PR DESCRIPTION
https://github.com/prettier/prettier/pull/4153 made it possible to detect fenced code block language when it is followed by arguments (e.g. ` ```js {something=something} `). This PR makes it also possible to detect language in cases cases like ` ```js{something=something} ` (no space).

The reason for this change is that Atom highlights code blocks regardless of a space after the language name, which makes the editor wonder why the correctly detected code block is not being formatted:

<img width="324" alt="screen shot 2018-06-28 at 22 08 13" src="https://user-images.githubusercontent.com/608862/42060780-db11f5b6-7b1f-11e8-9f43-fe91843f7d89.png">

PR background: https://github.com/prettier/prettier/pull/4153#issuecomment-401174999 