### PR TITLE
Correctly replace 'process.env.NODE_ENV'

### DIFF
--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -98,7 +98,7 @@ async function run(params) {
     await execa("rm", ["-rf", ".cache"]);
   }
 
-  const bundleCache = new Cache(".cache/", "v1");
+  const bundleCache = new Cache(".cache/", "v2");
   await bundleCache.load();
 
   console.log(chalk.inverse(" Building packages "));

--- a/scripts/build/bundler.js
+++ b/scripts/build/bundler.js
@@ -94,7 +94,7 @@ function getRollupConfig(bundle) {
   };
 
   const replaceStrings = {
-    "proces.env.NODE_ENV": JSON.stringify("production")
+    "process.env.NODE_ENV": JSON.stringify("production")
   };
   if (bundle.target === "universal") {
     // We can't reference `process` in UMD bundles and this is


### PR DESCRIPTION
Closes #4779

The bundle comes out as:

```js
function concat$1(parts) {
  return {
    type: "concat",
    parts
  };
}

function indent$1(contents) {
  return {
    type: "indent",
    contents
  };
}

function align(n, contents) {
  return {
    type: "align",
    contents,
    n
  };
}
```