### PR TITLE
feat(benchmark): add options to measure performance (#4776)

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@babel/core": "7.0.0-beta.49",
     "@babel/preset-env": "7.0.0-beta.49",
     "babel-loader": "8.0.0-beta.3",
+    "benchmark": "2.1.4",
     "builtin-modules": "2.0.0",
     "codecov": "2.2.0",
     "cross-env": "5.0.5",

--- a/src/cli/constant.js
+++ b/src/cli/constant.js
@@ -111,11 +111,21 @@ const options = {
     description:
       "Define in which order config files and CLI options should be evaluated."
   },
+  "debug-benchmark": {
+    // Run the formatting benchmarks. Requires 'benchmark' module to be installed.
+    type: "boolean"
+  },
   "debug-check": {
+    // Run the formatting once again on the formatted output, throw if different.
     type: "boolean"
   },
   "debug-print-doc": {
     type: "boolean"
+  },
+  "debug-repeat": {
+    // Repeat the formatting a few times and measure the average duration.
+    type: "number",
+    default: 0
   },
   editorconfig: {
     type: "boolean",

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -200,6 +200,54 @@ function format(context, input, opt) {
     return { formatted: pp, filepath: opt.filepath || "(stdin)\n" };
   }
 
+  if (context.argv["debug-benchmark"]) {
+    context.logger.debug(
+      "'--debug-benchmark' option found, measuring formatWithCursor with 'benchmark' module."
+    );
+    const suite = new require("benchmark").Suite();
+    suite
+      .add("format", () => {
+        prettier.formatWithCursor(input, opt);
+      })
+      .on("cycle", event => {
+        const results = {
+          benchmark: String(event.target),
+          hz: event.target.hz,
+          ms: event.target.times.cycle * 1000
+        };
+        context.logger.debug(
+          "'--debug-benchmark' measurements for formatWithCursor: " +
+            JSON.stringify(results, null, 2)
+        );
+      })
+      .run({ async: false });
+  } else if (+context.argv["debug-repeat"] > 0) {
+    const repeat = +context.argv["debug-repeat"];
+    context.logger.debug(
+      "'--debug-repeat' option found, running formatWithCursor " +
+        repeat +
+        " times."
+    );
+    // should be using `performance.now()`, but only `Date` is cross-platform enough
+    const now = Date.now ? () => Date.now() : () => +new Date();
+    let totalMs = 0;
+    for (let i = 0; i < repeat; ++i) {
+      const startMs = now();
+      prettier.formatWithCursor(input, opt);
+      totalMs += now() - startMs;
+    }
+    const averageMs = totalMs / repeat;
+    const results = {
+      repeat: repeat,
+      hz: 1000 / averageMs,
+      ms: averageMs
+    };
+    context.logger.debug(
+      "'--debug-repeat' measurements for formatWithCursor: " +
+        JSON.stringify(results, null, 2)
+    );
+  }
+
   return prettier.formatWithCursor(input, opt);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1033,6 +1033,13 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+benchmark@2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/benchmark/-/benchmark-2.1.4.tgz#09f3de31c916425d498cc2ee565a0ebf3c2a5629"
+  dependencies:
+    lodash "^4.17.4"
+    platform "^1.3.3"
+
 big.js@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
@@ -4283,6 +4290,10 @@ pkg-dir@^2.0.0:
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
   dependencies:
     find-up "^2.1.0"
+
+platform@^1.3.3:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.5.tgz#fb6958c696e07e2918d2eeda0f0bc9448d733444"
 
 plur@^2.1.2:
   version "2.1.2"


### PR DESCRIPTION
- `--debug-benchmark` uses `benchmark` module to produce statistically significant time measurements.
- `--debug-repeat` uses a naive loop and measures just the average run time, but useful for profiling to highlight hot functions.

Refs https://github.com/prettier/prettier/issues/4776