### PR TITLE
fix(perf): shortcut getStringWidth for ASCII-only strings (#4776)

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -6,6 +6,9 @@ const escapeStringRegexp = require("escape-string-regexp");
 const getCjkRegex = require("cjk-regex");
 const getUnicodeRegex = require("unicode-regex");
 
+// eslint-disable-next-line no-control-regex
+const notAsciiRegex = /[^\x20-\x7F]/;
+
 const cjkPattern = getCjkRegex().source;
 
 // http://spec.commonmark.org/0.25/#ascii-punctuation-character
@@ -711,6 +714,11 @@ function splitText(text, options) {
 function getStringWidth(text) {
   if (!text) {
     return 0;
+  }
+
+  // shortcut to avoid needless string `RegExp`s, replacements, and allocations within `string-width`
+  if (!notAsciiRegex.test(text)) {
+    return text.length;
   }
 
   // emojis are considered 2-char width for consistency

--- a/src/doc/doc-printer.js
+++ b/src/doc/doc-printer.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const util = require("../common/util");
+const { getStringWidth } = require("../common/util");
 const { concat, fill, cursor } = require("./doc-builders");
 
 /** @type {{[groupId: PropertyKey]: MODE}} */
@@ -130,7 +130,7 @@ function fits(next, restCommands, width, options, mustBeFlat) {
     const doc = x[2];
 
     if (typeof doc === "string") {
-      width -= util.getStringWidth(doc);
+      width -= getStringWidth(doc);
     } else {
       switch (doc.type) {
         case "concat":
@@ -224,7 +224,7 @@ function printDocToString(doc, options) {
     if (typeof doc === "string") {
       out.push(doc);
 
-      pos += util.getStringWidth(doc);
+      pos += getStringWidth(doc);
     } else {
       switch (doc.type) {
         case "cursor":


### PR DESCRIPTION
### Before
Total run time for 1000 repetitions for `LspLanguageService.js` is **182276ms**, average run is **181.80ms**.
```
$ cat LspLanguageService.js | NODE_ENV=production node --inspect-brk ./bin/prettier.js --stdin-filepath LspLanguageService.js --loglevel debug --debug-repeat 1000 > /dev/null
Debugger listening on ws://127.0.0.1:9229/d085f49d-a12c-432e-ad7e-acf322152bd3
For help see https://nodejs.org/en/docs/inspector
Debugger attached.
[debug] normalized argv: {"color":true,"editorconfig":true,"stdin-filepath":"LspLanguageService.js","loglevel":"debug","debug-repeat":"1000","plugin-search-dir":[],"plugin":[],"ignore-path":".prettierignore","config-precedence":"cli-override","_":[]}
[debug] resolve config from '/Users/ivanbabak/_sompylasar/_github/prettier/LspLanguageService.js'
[debug] loaded options `null`
[debug] applied config-precedence (cli-override): {"filepath":"LspLanguageService.js"}
[debug] '--debug-repeat' option found, running formatWithCursor 1000 times.
[debug] '--debug-repeat' measurements for formatWithCursor: {
[debug]   "repeat": 1000,
[debug]   "hz": 5.500298017789999,
[debug]   "ms": 181.80833052420616
[debug] }
Waiting for the debugger to disconnect...
```

### After
Total run time for 1000 repetitions for `LspLanguageService.js` is **145246ms**, average run is **144.85ms (20.32% speed-up)**.
```
$ cat LspLanguageService.js | NODE_ENV=production node --inspect-brk ./bin/prettier.js --stdin-filepath LspLanguageService.js --loglevel debug --debug-repeat 1000 > /dev/null
Debugger listening on ws://127.0.0.1:9229/1a338c30-c52c-4ae7-8e11-9aac0a2b736a
For help see https://nodejs.org/en/docs/inspector
Debugger attached.
[debug] normalized argv: {"color":true,"editorconfig":true,"stdin-filepath":"LspLanguageService.js","loglevel":"debug","debug-repeat":"1000","plugin-search-dir":[],"plugin":[],"ignore-path":".prettierignore","config-precedence":"cli-override","_":[]}
[debug] resolve config from '/Users/ivanbabak/_sompylasar/_github/prettier/LspLanguageService.js'
[debug] loaded options `null`
[debug] applied config-precedence (cli-override): {"filepath":"LspLanguageService.js"}
[debug] '--debug-repeat' option found, running formatWithCursor 1000 times.
[debug] '--debug-repeat' measurements for formatWithCursor: {
[debug]   "repeat": 1000,
[debug]   "hz": 6.903349947385214,
[debug]   "ms": 144.85720811223985
[debug] }
Waiting for the debugger to disconnect...
```

Refs https://github.com/prettier/prettier/issues/4776