### PR TITLE
Fix benchmark require

### DIFF
--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -200,6 +200,7 @@ function format(context, input, opt) {
     return { formatted: pp, filepath: opt.filepath || "(stdin)\n" };
   }
 
+  /* istanbul ignore if */
   if (context.argv["debug-benchmark"]) {
     let benchmark;
     try {

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -201,10 +201,19 @@ function format(context, input, opt) {
   }
 
   if (context.argv["debug-benchmark"]) {
+    let benchmark;
+    try {
+      benchmark = eval("require")("benchmark");
+    } catch (err) {
+      context.logger.debug(
+        "'--debug-benchmark' requires the 'benchmark' to be installed."
+      );
+      process.exit(2);
+    }
     context.logger.debug(
       "'--debug-benchmark' option found, measuring formatWithCursor with 'benchmark' module."
     );
-    const suite = new require("benchmark").Suite();
+    const suite = new benchmark.Suite();
     suite
       .add("format", () => {
         prettier.formatWithCursor(input, opt);

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -206,7 +206,7 @@ function format(context, input, opt) {
       benchmark = eval("require")("benchmark");
     } catch (err) {
       context.logger.debug(
-        "'--debug-benchmark' requires the 'benchmark' to be installed."
+        "'--debug-benchmark' requires the 'benchmark' package to be installed."
       );
       process.exit(2);
     }


### PR DESCRIPTION
`benchmark` would either get bundled in the production build or unable to be required, this PR prevents both from happening.

cc @sompylasar