### PR TITLE
Lock closed issues and PRs after 3 months of inactivity

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -7,4 +7,3 @@ lockComment: >
   any recent activity after it was closed. Please open a new issue for
   related bugs.
 setLockReason: true
-only: issues

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,4 +1,5 @@
 # Configuration for lock-threads - https://github.com/dessant/lock-threads
 daysUntilLock: 90
 lockLabel: locked-due-to-inactivity
+lockComment: false
 setLockReason: true

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,0 +1,8 @@
+# Configuration for lock-threads - https://github.com/dessant/lock-threads
+daysUntilLock: 90
+exemptLabels: []
+lockLabel: false
+lockComment: >
+  This thread has been automatically locked since there has not been
+  any recent activity after it was closed. Please open a new issue for
+  related bugs.

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,5 +1,4 @@
 # Configuration for lock-threads - https://github.com/dessant/lock-threads
 daysUntilLock: 90
-exemptLabels: []
 lockLabel: locked-due-to-inactivity
 setLockReason: true

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -6,3 +6,5 @@ lockComment: >
   This thread has been automatically locked since there has not been
   any recent activity after it was closed. Please open a new issue for
   related bugs.
+setLockReason: true
+only: issues

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -1,9 +1,5 @@
 # Configuration for lock-threads - https://github.com/dessant/lock-threads
 daysUntilLock: 90
 exemptLabels: []
-lockLabel: false
-lockComment: >
-  This thread has been automatically locked since there has not been
-  any recent activity after it was closed. Please open a new issue for
-  related bugs.
+lockLabel: locked-due-to-inactivity
 setLockReason: true


### PR DESCRIPTION
Mostly to avoid random notifications from people "me too"ing on stuff that no one has touched in ages.