### PR TITLE
Update precommit docs to be compatible with latest husky version

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -19,8 +19,10 @@ and add this config to your `package.json`:
 
 ```json
 {
-  "scripts": {
-    "precommit": "lint-staged"
+  "husky": {
+    "hooks: {
+      "pre-commit": "lint-staged"
+    }
   },
   "lint-staged": {
     "*.{js,json,css,md}": ["prettier --write", "git add"]
@@ -46,8 +48,10 @@ and add this config to your `package.json`:
 
 ```json
 {
-  "scripts": {
-    "precommit": "pretty-quick --staged"
+  "husky": {
+    "hooks: {
+      "pre-commit": "pretty-quick --staged"
+    }
   }
 }
 ```
@@ -83,8 +87,10 @@ and add this config to your `package.json`:
 
 ```json
 {
-  "scripts": {
-    "precommit": "precise-commits"
+  "husky": {
+    "hooks: {
+      "pre-commit": "precise-commits"
+    }
   }
 }
 ```


### PR DESCRIPTION
The current docs are not compatible with the latest husky API, which changed with the version bump from 0.1.x to 1.x.x.
This updates the docs to provide valid examples with husky version 1.x.x.