### PR TITLE
Fix example of husky pre-commit hook to include next version tag

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -12,7 +12,7 @@ You can use Prettier with a pre-commit tool. This can re-format your files that 
 Install it along with [husky](https://github.com/typicode/husky):
 
 ```bash
-yarn add lint-staged husky --dev
+yarn add lint-staged husky@next --dev
 ```
 
 and add this config to your `package.json`:


### PR DESCRIPTION
Tried to install prettier with current installation description here: https://prettier.io/docs/en/precommit.html

Unfortunately `husky` was not updated on npm yet, so you need to install the pre-release version which is more or less fine I guess. Still should be added to the instructions there.