### PR TITLE
Fix precommit configuration in docs

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -66,7 +66,7 @@ Copy the following config into your `.pre-commit-config.yaml` file:
 
 ```yaml
     -   repo: https://github.com/prettier/prettier
-        sha: ''  # Use the sha or tag you want to point at
+        rev: ''  # Use the sha or tag you want to point at
         hooks:
         -   id: prettier
 ```


### PR DESCRIPTION
The "sha" option has been renamed to "rev"

See https://pre-commit.com/#pre-commit-configyaml---repos