### PR TITLE
Blacklist this in functional composition heuristics

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3440,11 +3440,27 @@ const functionCompositionFunctionNames = new Set([
   "connect" // Redux
 ]);
 
+function isThisExpression(node) {
+  switch (node.type) {
+    case "OptionalMemberExpression":
+    case "MemberExpression": {
+      return isThisExpression(node.object);
+    }
+    case "ThisExpression":
+    case "Super": {
+      return true;
+    }
+  }
+}
+
 function isFunctionCompositionFunction(node) {
   switch (node.type) {
     case "OptionalMemberExpression":
     case "MemberExpression": {
-      return isFunctionCompositionFunction(node.property);
+      return (
+        !isThisExpression(node.object) &&
+        isFunctionCompositionFunction(node.property)
+      );
     }
     case "Identifier": {
       return functionCompositionFunctionNames.has(node.name);

--- a/tests/functional_composition/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/functional_composition/__snapshots__/jsfmt.spec.js.snap
@@ -27,6 +27,18 @@ somelib.composeFlipped(
 
 // no regression (#4602)
 const hasValue = hasOwnProperty(a, b);
+
+// filter out ThisExpression
+this.compose(sortBy(x => x), flatten);
+this.a.b.c.compose(sortBy(x => x), flatten);
+someObj.someMethod(this.field.compose(a, b));
+
+// filter out Super
+class A extends B {
+  compose() {
+    super.compose(sortBy(x => x), flatten);
+  }
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 compose(
   sortBy(x => x),
@@ -54,6 +66,18 @@ somelib.composeFlipped(
 
 // no regression (#4602)
 const hasValue = hasOwnProperty(a, b);
+
+// filter out ThisExpression
+this.compose(sortBy(x => x), flatten);
+this.a.b.c.compose(sortBy(x => x), flatten);
+someObj.someMethod(this.field.compose(a, b));
+
+// filter out Super
+class A extends B {
+  compose() {
+    super.compose(sortBy(x => x), flatten);
+  }
+}
 
 `;
 

--- a/tests/functional_composition/functional_compose.js
+++ b/tests/functional_composition/functional_compose.js
@@ -24,3 +24,15 @@ somelib.composeFlipped(
 
 // no regression (#4602)
 const hasValue = hasOwnProperty(a, b);
+
+// filter out ThisExpression
+this.compose(sortBy(x => x), flatten);
+this.a.b.c.compose(sortBy(x => x), flatten);
+someObj.someMethod(this.field.compose(a, b));
+
+// filter out Super
+class A extends B {
+  compose() {
+    super.compose(sortBy(x => x), flatten);
+  }
+}


### PR DESCRIPTION
As filtering out `this` and `super` cases in #4758 didn't seem to get any objections, here's that part as a separate PR:

Do not react when `MemberExpression` object type is `ThisExpression` or `Super`
Filters out cases like 
```js
this.compose(a(), b);
super.compose(a(), b);
```

cc @suchipi