### PR TITLE
Add stylelint-prettier to related projects

### DIFF
--- a/docs/related-projects.md
+++ b/docs/related-projects.md
@@ -19,8 +19,9 @@ title: Related Projects
 
 ## stylelint Integrations
 
+- [`stylelint-prettier`](https://github.com/BPScott/stylelint-prettier) runs Prettier as a stylelint rule and reports differences as individual stylelint issues
+- [`stylelint-config-prettier`](https://github.com/prettier/stylelint-config-prettier) turns off all rules that are unnecessary or might conflict with Prettier.
 - [`prettier-stylelint`](https://github.com/hugomrdias/prettier-stylelint) passes `prettier` output to `stylelint --fix`
-- [`stylelint-config-prettier`](https://github.com/shannonmoeller/stylelint-config-prettier) turns off all rules that are unnecessary or might conflict with Prettier.
 
 ## Forks
 


### PR DESCRIPTION
Tweak order of stylelint integrations to match ordering of eslint/tslint and update url of stylelint-config-prettier