### PR TITLE
Fixes #3101: Break JSX attributes onto their own lines if any newlines are present.

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1921,6 +1921,12 @@ function printPathNoParens(path, options, print, args) {
         ]);
       }
 
+      const alreadyHasNewline = hasNewlineInRange(
+        options.originalText,
+        options.locStart(n),
+        options.locEnd(n)
+      );
+
       // don't break up opening elements with a single long text attribute
       if (
         n.attributes &&
@@ -1930,6 +1936,9 @@ function printPathNoParens(path, options, print, args) {
         !n.attributes[0].value.value.includes("\n") &&
         // We should break for the following cases:
         // <div
+        //   attr="value"
+        // >
+        // <div
         //   // comment
         //   attr="value"
         // >
@@ -1937,6 +1946,7 @@ function printPathNoParens(path, options, print, args) {
         //   attr="value"
         //   // comment
         // >
+        !alreadyHasNewline &&
         !nameHasComments &&
         (!n.attributes[0].comments || !n.attributes[0].comments.length)
       ) {
@@ -1967,16 +1977,7 @@ function printPathNoParens(path, options, print, args) {
         (!nameHasComments || n.attributes.length) &&
         !lastAttrHasTrailingComments;
 
-      // We should print the opening element expanded if any prop value is a
-      // string literal with newlines
-      const shouldBreak =
-        n.attributes &&
-        n.attributes.some(
-          attr =>
-            attr.value &&
-            isStringLiteral(attr.value) &&
-            attr.value.value.includes("\n")
-        );
+      const shouldBreak = n.attributes && alreadyHasNewline;
 
       return group(
         concat([

--- a/tests/flow/new_react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/new_react/__snapshots__/jsfmt.spec.js.snap
@@ -66,7 +66,12 @@ var FeedUFI = React.createClass({
     };
     var ignored = <UFILikeCount {...props} />;
     return (
-      <UFILikeCount className="" key="" feedback={feedback} permalink="" />
+      <UFILikeCount
+        className=""
+        key=""
+        feedback={feedback}
+        permalink=""
+      />
     );
   },
 
@@ -530,7 +535,9 @@ var C = React.createClass({
   }
 });
 
-<C statistics={[{}, { label: "", value: undefined }]} />; // error (label is required, value not required)
+<C
+  statistics={[{}, { label: "", value: undefined }]}
+/>; // error (label is required, value not required)
 
 var props: Array<{ label: string, value?: number }> = [
   {},

--- a/tests/jsx-newlines/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-newlines/__snapshots__/jsfmt.spec.js.snap
@@ -77,9 +77,7 @@ newlines_elems =
 
 regression_extra_newline = (
   <div>
-    <span
-      className="nuclide-console-new-messages-notification-icon icon icon-nuclicon-arrow-down"
-    />
+    <span className="nuclide-console-new-messages-notification-icon icon icon-nuclicon-arrow-down"/>
     New Messages
   </div>
 );

--- a/tests/jsx-newlines/test.js
+++ b/tests/jsx-newlines/test.js
@@ -74,9 +74,7 @@ newlines_elems =
 
 regression_extra_newline = (
   <div>
-    <span
-      className="nuclide-console-new-messages-notification-icon icon icon-nuclicon-arrow-down"
-    />
+    <span className="nuclide-console-new-messages-notification-icon icon icon-nuclicon-arrow-down"/>
     New Messages
   </div>
 );

--- a/tests/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -571,7 +571,9 @@ exports[`expression.js - flow-verify 1`] = `
   value={option}
 />;
 
-<ParentComponent prop={<Child>test</Child>} />;
+<ParentComponent
+  prop={<Child>test</Child>}
+/>;
 
 <BookingIntroPanel
   prop="long_string_make_to_force_break"
@@ -903,6 +905,40 @@ a = [
 ];
 
 <div {...(foo || foo === null ? { foo } : null)} />;
+
+`;
+
+exports[`preserve-expanded-elements.js - flow-verify 1`] = `
+<Element prop="value"/>;
+
+<Element
+  prop="value"
+/>;
+
+<Element
+  prop1="value1" prop2="value2"
+/>;
+
+<Element
+  prop1="value1"
+  prop2="value2"
+/>;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<Element prop="value" />;
+
+<Element
+  prop="value"
+/>;
+
+<Element
+  prop1="value1"
+  prop2="value2"
+/>;
+
+<Element
+  prop1="value1"
+  prop2="value2"
+/>;
 
 `;
 

--- a/tests/jsx/preserve-expanded-elements.js
+++ b/tests/jsx/preserve-expanded-elements.js
@@ -1,0 +1,14 @@
+<Element prop="value"/>;
+
+<Element
+  prop="value"
+/>;
+
+<Element
+  prop1="value1" prop2="value2"
+/>;
+
+<Element
+  prop1="value1"
+  prop2="value2"
+/>;


### PR DESCRIPTION
Per https://github.com/prettier/prettier/issues/3101#issuecomment-339132007, loosely based on #495.