### PR TITLE
fix(yaml): no wrong loc info for CRLF

### DIFF
--- a/src/language-yaml/parser-yaml.js
+++ b/src/language-yaml/parser-yaml.js
@@ -65,6 +65,8 @@ const parser = {
   hasPragma,
   locStart: node => node.position.start.offset,
   locEnd: node => node.position.end.offset,
+
+  // workaround for https://github.com/eemeli/yaml/issues/20
   preprocess: text =>
     text.indexOf("\r") === -1 ? text : text.replace(/\r\n?/g, "\n")
 };

--- a/src/language-yaml/parser-yaml.js
+++ b/src/language-yaml/parser-yaml.js
@@ -64,7 +64,9 @@ const parser = {
   parse,
   hasPragma,
   locStart: node => node.position.start.offset,
-  locEnd: node => node.position.end.offset
+  locEnd: node => node.position.end.offset,
+  preprocess: text =>
+    text.indexOf("\r") === -1 ? text : text.replace(/\r\n?/g, "\n")
 };
 
 module.exports = {

--- a/tests_integration/__tests__/__snapshots__/format.js.snap
+++ b/tests_integration/__tests__/__snapshots__/format.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`yaml parser should handle CRLF correclty 1`] = `
+exports[`yaml parser should handle CRLF correctly 1`] = `
 "a: 123
 "
 `;

--- a/tests_integration/__tests__/__snapshots__/format.js.snap
+++ b/tests_integration/__tests__/__snapshots__/format.js.snap
@@ -1,0 +1,6 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`yaml parser should handle CRLF correclty 1`] = `
+"a:  12
+"
+`;

--- a/tests_integration/__tests__/__snapshots__/format.js.snap
+++ b/tests_integration/__tests__/__snapshots__/format.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`yaml parser should handle CRLF correclty 1`] = `
-"a:  12
+"a: 123
 "
 `;

--- a/tests_integration/__tests__/format.js
+++ b/tests_integration/__tests__/format.js
@@ -2,7 +2,7 @@
 
 const prettier = require("prettier/local");
 
-test("yaml parser should handle CRLF correclty", () => {
+test("yaml parser should handle CRLF correctly", () => {
   const input = "a:\r\n  123\r\n";
   expect(prettier.format(input, { parser: "yaml" })).toMatchSnapshot();
 });

--- a/tests_integration/__tests__/format.js
+++ b/tests_integration/__tests__/format.js
@@ -1,0 +1,8 @@
+"use strict";
+
+const prettier = require("prettier/local");
+
+test("yaml parser should handle CRLF correclty", () => {
+  const input = "a:\r\n  123\r\n";
+  expect(prettier.format(input, { parser: "yaml" })).toMatchSnapshot();
+});


### PR DESCRIPTION
Context: https://github.com/prettier/prettier/issues/4856#issuecomment-405982539

Workaround for eemeli/yaml#20