### PR TITLE
Print ObjectTypeInternalSlot with both flow/babel parsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
     "node": ">=6"
   },
   "dependencies": {
-    "@babel/code-frame": "7.0.0-beta.46",
-    "@babel/parser": "7.0.0-beta.49",
+    "@babel/code-frame": "7.0.0-beta.54",
+    "@babel/parser": "7.0.0-beta.54",
     "@glimmer/syntax": "0.30.3",
     "camelcase": "4.1.0",
     "chalk": "2.1.0",
@@ -31,7 +31,7 @@
     "esutils": "2.0.2",
     "find-parent-dir": "0.3.0",
     "find-project-root": "1.1.1",
-    "flow-parser": "0.75.0",
+    "flow-parser": "0.77.0",
     "get-stream": "3.0.0",
     "globby": "6.1.0",
     "graphql": "0.13.2",

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1086,6 +1086,18 @@ function printPathNoParens(path, options, print, args) {
       parts.push(path.call(print, "body"));
 
       return concat(parts);
+
+    case "ObjectTypeInternalSlot":
+      return concat([
+        n.static ? "static " : "",
+        "[[",
+        path.call(print, "id"),
+        "]]",
+        printOptionalToken(path),
+        n.method ? "" : ": ",
+        path.call(print, "value")
+      ]);
+
     case "ObjectExpression":
     case "ObjectPattern":
     case "ObjectTypeAnnotation":
@@ -1140,7 +1152,7 @@ function printPathNoParens(path, options, print, args) {
       }
 
       if (isTypeAnnotation) {
-        fields.push("indexers", "callProperties");
+        fields.push("indexers", "callProperties", "internalSlots");
       }
       fields.push(propertiesField);
 
@@ -2414,7 +2426,8 @@ function printPathNoParens(path, options, print, args) {
       let isArrowFunctionTypeAnnotation =
         n.type === "TSFunctionType" ||
         !(
-          (parent.type === "ObjectTypeProperty" &&
+          ((parent.type === "ObjectTypeProperty" ||
+            parent.type === "ObjectTypeInternalSlot") &&
             !getFlowVariance(parent) &&
             !parent.optional &&
             options.locStart(parent) === options.locStart(n)) ||
@@ -5569,7 +5582,8 @@ function isMemberExpressionChain(node) {
 // type T = { method(): void };
 function isObjectTypePropertyAFunction(node, options) {
   return (
-    node.type === "ObjectTypeProperty" &&
+    (node.type === "ObjectTypeProperty" ||
+      node.type === "ObjectTypeInternalSlot") &&
     node.value.type === "FunctionTypeAnnotation" &&
     !node.static &&
     !isFunctionNotation(node, options)

--- a/tests/flow_internal_slot/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_internal_slot/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`internal_slot.js - babylon-verify 1`] = `
+declare class C { static [[foo]]: T }
+declare class C { [[foo]]: T }
+interface T { [[foo]]: X }
+interface T { [[foo]](): X }
+type T = { [[foo]]: X }
+type T = { [[foo]](): X }
+type T = { [[foo]]?: X }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+declare class C { static [[foo]]: T }
+declare class C { [[foo]]: T }
+interface T { [[foo]]: X }
+interface T { [[foo]](): X }
+type T = { [[foo]]: X };
+type T = { [[foo]](): X };
+type T = { [[foo]]?: X };
+
+`;
+
+exports[`internal_slot.js - flow-verify 1`] = `
+declare class C { static [[foo]]: T }
+declare class C { [[foo]]: T }
+interface T { [[foo]]: X }
+interface T { [[foo]](): X }
+type T = { [[foo]]: X }
+type T = { [[foo]](): X }
+type T = { [[foo]]?: X }
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+declare class C { static [[foo]]: T }
+declare class C { [[foo]]: T }
+interface T { [[foo]]: X }
+interface T { [[foo]](): X }
+type T = { [[foo]]: X };
+type T = { [[foo]](): X };
+type T = { [[foo]]?: X };
+
+`;

--- a/tests/flow_internal_slot/internal_slot.js
+++ b/tests/flow_internal_slot/internal_slot.js
@@ -1,0 +1,7 @@
+declare class C { static [[foo]]: T }
+declare class C { [[foo]]: T }
+interface T { [[foo]]: X }
+interface T { [[foo]](): X }
+type T = { [[foo]]: X }
+type T = { [[foo]](): X }
+type T = { [[foo]]?: X }

--- a/tests/flow_internal_slot/jsfmt.spec.js
+++ b/tests/flow_internal_slot/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["flow", "babylon"]);


### PR DESCRIPTION
Now that https://github.com/facebook/flow/pull/6320 has landed, we can add support for `ObjectTypeInternalSlot`!

WIP while waiting for `flow-parser@0.77` to hit npm (it's tagged).

Ref:
https://github.com/facebook/flow/commit/732eae55e102cdb7dfa7b6a85f0147d48c3afed7
https://github.com/babel/babel/pull/7947
https://github.com/babel/babel/pull/7959