### PR TITLE
fix(typescript): support jsx spread child

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "semver": "5.4.1",
     "string-width": "2.1.1",
     "typescript": "3.0.0-dev.20180626",
-    "typescript-eslint-parser": "ikatyang/typescript-eslint-parser#fix/support-jsx-spread-child",
+    "typescript-eslint-parser": "17.0.0",
     "unicode-regex": "1.0.1",
     "unified": "6.1.6",
     "yaml": "1.0.0-rc.7",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "semver": "5.4.1",
     "string-width": "2.1.1",
     "typescript": "3.0.0-dev.20180626",
-    "typescript-eslint-parser": "eslint/typescript-eslint-parser#6eec85b1466fbef087838203b246f70fa71ac0ac",
+    "typescript-eslint-parser": "ikatyang/typescript-eslint-parser#fix/support-jsx-spread-child",
     "unicode-regex": "1.0.1",
     "unified": "6.1.6",
     "yaml": "1.0.0-rc.7",

--- a/tests/jsx_spread/jsfmt.spec.js
+++ b/tests/jsx_spread/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, ["babylon", "flow"]);
+run_spec(__dirname, ["babylon", "flow", "typescript"]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5617,9 +5617,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript-eslint-parser@ikatyang/typescript-eslint-parser#fix/support-jsx-spread-child:
-  version "16.0.1"
-  resolved "https://codeload.github.com/ikatyang/typescript-eslint-parser/tar.gz/c34f1aa4f34b0ec3cd9d282787aab1d6f6587eeb"
+typescript-eslint-parser@17.0.0:
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/typescript-eslint-parser/-/typescript-eslint-parser-17.0.0.tgz#0e2b5c0d15f2e2cfdf43dd024c96b10d016bef26"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5617,9 +5617,9 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript-eslint-parser@eslint/typescript-eslint-parser#6eec85b1466fbef087838203b246f70fa71ac0ac:
+typescript-eslint-parser@ikatyang/typescript-eslint-parser#fix/support-jsx-spread-child:
   version "16.0.1"
-  resolved "https://codeload.github.com/eslint/typescript-eslint-parser/tar.gz/6eec85b1466fbef087838203b246f70fa71ac0ac"
+  resolved "https://codeload.github.com/ikatyang/typescript-eslint-parser/tar.gz/c34f1aa4f34b0ec3cd9d282787aab1d6f6587eeb"
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"


### PR DESCRIPTION
Fixes #4872

- [x] waiting for eslint/typescript-eslint-parser#501