### PR TITLE
fix(glimmer): do not strip block params on <Component>

### DIFF
--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -82,6 +82,7 @@ function print(path, options, print) {
             "<",
             n.tag,
             getParams(path, print),
+            n.blockParams.length ? ` as |${n.blockParams.join(" ")}|` : "",
             ifBreak(softline, ""),
             closeTag
           ])

--- a/tests/html_glimmer/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_glimmer/__snapshots__/jsfmt.spec.js.snap
@@ -29,6 +29,14 @@ exports[`block-statement.hbs - glimmer-verify 1`] = `
    hello
   {{/block}}
 {{/block}}
+
+<MyComponent as |firstName|>
+  {{firstName}}
+</MyComponent>
+
+<MyComponent as |firstName lastName|>
+  {{firstName}} {{lastName}}
+</MyComponent>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 {{#block param hashKey=hashValue as |blockParam|}}
   Hello
@@ -90,6 +98,13 @@ exports[`block-statement.hbs - glimmer-verify 1`] = `
   Hello
 {{/block}}
 {{#block}}{{#block}}hello{{/block}}{{/block}}
+<MyComponent as |firstName|>
+  {{firstName}}
+</MyComponent>
+<MyComponent as |firstName lastName|>
+  {{firstName}}
+  {{lastName}}
+</MyComponent>
 `;
 
 exports[`component.hbs - glimmer-verify 1`] = `

--- a/tests/html_glimmer/block-statement.hbs
+++ b/tests/html_glimmer/block-statement.hbs
@@ -26,3 +26,11 @@
    hello
   {{/block}}
 {{/block}}
+
+<MyComponent as |firstName|>
+  {{firstName}}
+</MyComponent>
+
+<MyComponent as |firstName lastName|>
+  {{firstName}} {{lastName}}
+</MyComponent>


### PR DESCRIPTION
fix #4887