### PR TITLE
fix(glimmer): remove extra space from sub-expressions without params

### DIFF
--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -158,14 +158,13 @@ function print(path, options, print) {
       );
     }
     case "SubExpression": {
+      const params = getParams(path, print);
+      const printedParams =
+        params.length > 0
+          ? indent(concat([line, group(join(line, getParams(path, print)))]))
+          : "";
       return group(
-        concat([
-          "(",
-          printPath(path, print),
-          indent(concat([line, group(join(line, getParams(path, print)))])),
-          softline,
-          ")"
-        ])
+        concat(["(", printPath(path, print), printedParams, softline, ")"])
       );
     }
     case "AttrNode": {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -161,7 +161,7 @@ function print(path, options, print) {
       const params = getParams(path, print);
       const printedParams =
         params.length > 0
-          ? indent(concat([line, group(join(line, getParams(path, print)))]))
+          ? indent(concat([line, group(join(line, params))]))
           : "";
       return group(
         concat(["(", printPath(path, print), printedParams, softline, ")"])

--- a/tests/html_glimmer/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_glimmer/__snapshots__/jsfmt.spec.js.snap
@@ -479,6 +479,7 @@ exports[`sub-expressions.hbs - glimmer-verify 1`] = `
 <div
   {{mustache
     (concat
+      (service)
       (helper param hashPair=Value)
       (largeNameHelper param param param param hashPair=value hashPair=value hashPair=Value)
       hashPair=(helper param param param param param param hashPair=value hashPair=value hashPair=value)
@@ -489,6 +490,7 @@ exports[`sub-expressions.hbs - glimmer-verify 1`] = `
 
 {{#block
   (concat
+    (service)
     (helper param hashPair=Value)
     (largeNameHelper param param param param hashPair=value hashPair=value hashPair=Value)
     hashPair=(helper param param param param param param hashPair=value hashPair=value hashPair=value)
@@ -510,6 +512,7 @@ exports[`sub-expressions.hbs - glimmer-verify 1`] = `
 <div
   {{mustache
     (concat
+      (service)
       (helper param hashPair=Value)
       (largeNameHelper
         param param param param hashPair=value hashPair=value hashPair=Value
@@ -531,6 +534,7 @@ exports[`sub-expressions.hbs - glimmer-verify 1`] = `
 ></div>
 {{#block
   (concat
+    (service)
     (helper param hashPair=Value)
     (largeNameHelper
       param param param param hashPair=value hashPair=value hashPair=Value

--- a/tests/html_glimmer/sub-expressions.hbs
+++ b/tests/html_glimmer/sub-expressions.hbs
@@ -1,6 +1,7 @@
 <div
   {{mustache
     (concat
+      (service)
       (helper param hashPair=Value)
       (largeNameHelper param param param param hashPair=value hashPair=value hashPair=Value)
       hashPair=(helper param param param param param param hashPair=value hashPair=value hashPair=value)
@@ -11,6 +12,7 @@
 
 {{#block
   (concat
+    (service)
     (helper param hashPair=Value)
     (largeNameHelper param param param param hashPair=value hashPair=value hashPair=Value)
     hashPair=(helper param param param param param param hashPair=value hashPair=value hashPair=value)


### PR DESCRIPTION
*before*
```handlebars
{{foo (bar )}}
```
*after*
```handlebars
{{foo (bar)}}
```