### PR TITLE
fix(glimmer): better formatting of boolean attributes

### DIFF
--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -168,7 +168,11 @@ function print(path, options, print) {
       );
     }
     case "AttrNode": {
-      const quote = n.value.type === "TextNode" ? '"' : "";
+      const isText = n.value.type === "TextNode";
+      if (isText && n.value.chars === "") {
+        return concat([n.name]);
+      }
+      const quote = isText ? '"' : "";
       return concat([n.name, "=", quote, path.call(print, "value"), quote]);
     }
     case "ConcatStatement": {

--- a/tests/html_glimmer/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_glimmer/__snapshots__/jsfmt.spec.js.snap
@@ -112,6 +112,12 @@ exports[`component.hbs - glimmer-verify 1`] = `
 {{@greeting}}, {{@name}}!
 
 <button onclick={{action next}}>Next</button>
+
+<button disabled class="disabled"></button>
+
+<button disabled=disabled class="disabled"></button>
+
+<div ...attributes>Hello</div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <user-greeting @name="Ricardo" @greeting="Olá"></user-greeting>
 {{@greeting}}
@@ -121,6 +127,11 @@ exports[`component.hbs - glimmer-verify 1`] = `
 <button onclick={{action next}}>
   Next
 </button>
+<button disabled class="disabled"></button>
+<button disabled="disabled" class="disabled"></button>
+<div ...attributes>
+  Hello
+</div>
 `;
 
 exports[`concat-statement.hbs - glimmer-verify 1`] = `

--- a/tests/html_glimmer/component.hbs
+++ b/tests/html_glimmer/component.hbs
@@ -2,3 +2,9 @@
 {{@greeting}}, {{@name}}!
 
 <button onclick={{action next}}>Next</button>
+
+<button disabled class="disabled"></button>
+
+<button disabled=disabled class="disabled"></button>
+
+<div ...attributes>Hello</div>


### PR DESCRIPTION
I hope this is not controversial...

*input*
```handlebars
<button disabled>Click</button>
<button disabled=disabled>Click</button>
<button ...attributes>Click</button>
```

*before*
```handlebars
<button disabled="">Click</button>
<button disabled="disabled">Click</button>
<button ...attributes="">Click</button>
```

*after*
```handlebars
<button disabled>Click</button>
<button disabled="disabled">Click</button>
<button ...attributes>Click</button>
```