### PR TITLE
feat(yaml): do not put singleline values on a separate line from the key

### DIFF
--- a/src/language-yaml/printer-yaml.js
+++ b/src/language-yaml/printer-yaml.js
@@ -348,36 +348,52 @@ function _print(node, parentNode, path, options, print) {
             ": ",
             align(2, value)
           ])
-        : conditionalGroup([
-            concat([
-              group(
-                concat([ifBreak("? "), group(align(2, key), { id: groupId })])
-              ),
-              ifBreak(
-                concat([hardline, ": ", align(2, value)]),
-                indent(
-                  concat([
-                    needsSpaceInFrontOfMappingValue(node) ? " " : "",
-                    ":",
-                    hasLeadingComments(node.value.node) ||
-                    (parentNode.type === "mapping" &&
-                      hasTrailingComments(node.key.node) &&
-                      isInlineNode(node.value.node)) ||
-                    ((node.value.node.type === "mapping" ||
-                      node.value.node.type === "sequence") &&
-                      node.value.node.tag.type === "null" &&
-                      node.value.node.anchor.type === "null")
-                      ? hardline
-                      : node.value.node.type === "null"
-                        ? ""
-                        : line,
-                    value
-                  ])
-                ),
-                { groupId }
-              )
+        : // force singleline
+          isSingleLineNode(node.key.node) &&
+          !hasLeadingComments(node.key.node) &&
+          !hasMiddleComments(node.key.node) &&
+          !hasTrailingComments(node.key.node) &&
+          !hasEndComments(node.key) &&
+          !hasLeadingComments(node.value.node) &&
+          !hasMiddleComments(node.value.node) &&
+          !hasEndComments(node.value) &&
+          isAbsolutelyPrintedAsSingleLineNode(node.value.node, options)
+          ? concat([
+              key,
+              needsSpaceInFrontOfMappingValue(node) ? " " : "",
+              ": ",
+              value
             ])
-          ]);
+          : conditionalGroup([
+              concat([
+                group(
+                  concat([ifBreak("? "), group(align(2, key), { id: groupId })])
+                ),
+                ifBreak(
+                  concat([hardline, ": ", align(2, value)]),
+                  indent(
+                    concat([
+                      needsSpaceInFrontOfMappingValue(node) ? " " : "",
+                      ":",
+                      hasLeadingComments(node.value.node) ||
+                      (parentNode.type === "mapping" &&
+                        hasTrailingComments(node.key.node) &&
+                        isInlineNode(node.value.node)) ||
+                      ((node.value.node.type === "mapping" ||
+                        node.value.node.type === "sequence") &&
+                        node.value.node.tag.type === "null" &&
+                        node.value.node.anchor.type === "null")
+                        ? hardline
+                        : node.value.node.type === "null"
+                          ? ""
+                          : line,
+                      value
+                    ])
+                  ),
+                  { groupId }
+                )
+              ])
+            ]);
     }
     case "flowMapping":
     case "flowSequence": {
@@ -457,6 +473,58 @@ function isInlineNode(node) {
     case "flowSequence":
     case "null":
       return true;
+    default:
+      return false;
+  }
+}
+
+function isSingleLineNode(node) {
+  switch (node.type) {
+    case "plain":
+    case "quoteDouble":
+    case "quoteSingle":
+      return node.position.start.line === node.position.end.line;
+    case "alias":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function isAbsolutelyPrintedAsSingleLineNode(node, options) {
+  switch (node.type) {
+    case "plain":
+    case "quoteSingle":
+    case "quoteDouble":
+      break;
+    case "alias":
+      return true;
+    default:
+      return false;
+  }
+
+  if (options.proseWrap === "preserve") {
+    return node.position.start.line === node.position.end.line;
+  }
+
+  if (
+    // backslash-newline
+    /\\$/m.test(
+      options.originalText.slice(
+        node.position.start.offset,
+        node.position.end.offset
+      )
+    )
+  ) {
+    return false;
+  }
+
+  switch (options.proseWrap) {
+    case "never":
+      return node.value.indexOf("\n") === -1;
+    case "always":
+      return !/[\n ]/.test(node.value);
+    // istanbul ignore next
     default:
       return false;
   }

--- a/tests/yaml_flow_mapping/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/yaml_flow_mapping/__snapshots__/jsfmt.spec.js.snap
@@ -571,12 +571,9 @@ exports[`long-key-long-value.yml - yaml-verify 1`] = `
 {longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong1: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong2: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong3: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 {
-  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong1:
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
-  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong2:
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
-  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong3:
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong1: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong2: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong3: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
 }
 
 `;
@@ -585,12 +582,9 @@ exports[`long-key-long-value.yml - yaml-verify 2`] = `
 {longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong1: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong2: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong3: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 {
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong1:
-        longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong2:
-        longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong3:
-        longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
+    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong1: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
+    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong2: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
+    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong3: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
 }
 
 `;
@@ -599,12 +593,9 @@ exports[`long-key-long-value.yml - yaml-verify 3`] = `
 {longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong1: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong2: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong3: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 {
-  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong1:
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
-  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong2:
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
-  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong3:
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong1: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong2: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong3: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
 }
 
 `;

--- a/tests/yaml_flow_sequence/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/yaml_flow_sequence/__snapshots__/jsfmt.spec.js.snap
@@ -562,12 +562,9 @@ exports[`long-key-long-value.yml - yaml-verify 1`] = `
 [longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [
-  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong:
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
-  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong:
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
-  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong:
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
 ]
 
 `;
@@ -576,12 +573,9 @@ exports[`long-key-long-value.yml - yaml-verify 2`] = `
 [longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong:
-        longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong:
-        longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong:
-        longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
+    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
+    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
+    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
 ]
 
 `;
@@ -590,12 +584,9 @@ exports[`long-key-long-value.yml - yaml-verify 3`] = `
 [longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [
-  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong:
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
-  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong:
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
-  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong:
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglong,
 ]
 
 `;

--- a/tests/yaml_mapping/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/yaml_mapping/__snapshots__/jsfmt.spec.js.snap
@@ -107,8 +107,7 @@ key1: value
 key2: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 key1: value
-key2:
-  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+key2: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
 
 `;
 
@@ -117,8 +116,7 @@ key1: value
 key2: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 key1: value
-key2:
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+key2: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
 
 `;
 
@@ -131,10 +129,8 @@ exports[`explicit-key.yml - yaml-verify 1`] = `
 : value
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 key1: value
-key2:
-  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
-? longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
-: value
+key2: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: value
 
 `;
 
@@ -147,10 +143,8 @@ exports[`explicit-key.yml - yaml-verify 2`] = `
 : value
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 key1: value
-key2:
-    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
-? longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
-: value
+key2: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: value
 
 `;
 

--- a/tests/yaml_plain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/yaml_plain/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,88 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`force-singleline-in-mapping-value.yml - yaml-verify 1`] = `
+no-whitesapce: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+
+whitespace: longlonglonglonglonglonglonglonglonglonglong longlonglonglonglonglonglonglonglonglonglong
+
+literal-newline: longlonglonglonglonglonglonglonglonglonglong
+  longlonglonglonglonglonglonglonglonglonglong
+
+newline: longlonglonglonglonglonglonglonglonglonglong
+
+  longlonglonglonglonglonglonglonglonglonglong
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+no-whitesapce:
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+
+whitespace:
+  longlonglonglonglonglonglonglonglonglonglong longlonglonglonglonglonglonglonglonglonglong
+
+literal-newline: longlonglonglonglonglonglonglonglonglonglong
+  longlonglonglonglonglonglonglonglonglonglong
+
+newline: longlonglonglonglonglonglonglonglonglonglong
+
+  longlonglonglonglonglonglonglonglonglonglong
+
+`;
+
+exports[`force-singleline-in-mapping-value.yml - yaml-verify 2`] = `
+no-whitesapce: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+
+whitespace: longlonglonglonglonglonglonglonglonglonglong longlonglonglonglonglonglonglonglonglonglong
+
+literal-newline: longlonglonglonglonglonglonglonglonglonglong
+  longlonglonglonglonglonglonglonglonglonglong
+
+newline: longlonglonglonglonglonglonglonglonglonglong
+
+  longlonglonglonglonglonglonglonglonglonglong
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+no-whitesapce:
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+
+whitespace:
+  longlonglonglonglonglonglonglonglonglonglong longlonglonglonglonglonglonglonglonglonglong
+
+literal-newline:
+  longlonglonglonglonglonglonglonglonglonglong longlonglonglonglonglonglonglonglonglonglong
+
+newline: longlonglonglonglonglonglonglonglonglonglong
+
+  longlonglonglonglonglonglonglonglonglonglong
+
+`;
+
+exports[`force-singleline-in-mapping-value.yml - yaml-verify 3`] = `
+no-whitesapce: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+
+whitespace: longlonglonglonglonglonglonglonglonglonglong longlonglonglonglonglonglonglonglonglonglong
+
+literal-newline: longlonglonglonglonglonglonglonglonglonglong
+  longlonglonglonglonglonglonglonglonglonglong
+
+newline: longlonglonglonglonglonglonglonglonglonglong
+
+  longlonglonglonglonglonglonglonglonglonglong
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+no-whitesapce:
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+
+whitespace:
+  longlonglonglonglonglonglonglonglonglonglong
+  longlonglonglonglonglonglonglonglonglonglong
+
+literal-newline:
+  longlonglonglonglonglonglonglonglonglonglong
+  longlonglonglonglonglonglonglonglonglonglong
+
+newline: longlonglonglonglonglonglonglonglonglonglong
+
+  longlonglonglonglonglonglonglonglonglonglong
+
+`;
+
 exports[`middle-comment.yml - yaml-verify 1`] = `
 !!str # comment
 hello

--- a/tests/yaml_plain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/yaml_plain/__snapshots__/jsfmt.spec.js.snap
@@ -12,11 +12,9 @@ newline: longlonglonglonglonglonglonglonglonglonglong
 
   longlonglonglonglonglonglonglonglonglonglong
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-no-whitesapce:
-  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+no-whitesapce: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
 
-whitespace:
-  longlonglonglonglonglonglonglonglonglonglong longlonglonglonglonglonglonglonglonglonglong
+whitespace: longlonglonglonglonglonglonglonglonglonglong longlonglonglonglonglonglonglonglonglonglong
 
 literal-newline: longlonglonglonglonglonglonglonglonglonglong
   longlonglonglonglonglonglonglonglonglonglong
@@ -39,14 +37,11 @@ newline: longlonglonglonglonglonglonglonglonglonglong
 
   longlonglonglonglonglonglonglonglonglonglong
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-no-whitesapce:
-  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+no-whitesapce: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
 
-whitespace:
-  longlonglonglonglonglonglonglonglonglonglong longlonglonglonglonglonglonglonglonglonglong
+whitespace: longlonglonglonglonglonglonglonglonglonglong longlonglonglonglonglonglonglonglonglonglong
 
-literal-newline:
-  longlonglonglonglonglonglonglonglonglonglong longlonglonglonglonglonglonglonglonglonglong
+literal-newline: longlonglonglonglonglonglonglonglonglonglong longlonglonglonglonglonglonglonglonglonglong
 
 newline: longlonglonglonglonglonglonglonglonglonglong
 
@@ -66,8 +61,7 @@ newline: longlonglonglonglonglonglonglonglonglonglong
 
   longlonglonglonglonglonglonglonglonglonglong
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-no-whitesapce:
-  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+no-whitesapce: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
 
 whitespace:
   longlonglonglonglonglonglonglonglonglonglong

--- a/tests/yaml_plain/force-singleline-in-mapping-value.yml
+++ b/tests/yaml_plain/force-singleline-in-mapping-value.yml
@@ -1,0 +1,10 @@
+no-whitesapce: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+
+whitespace: longlonglonglonglonglonglonglonglonglonglong longlonglonglonglonglonglonglonglonglonglong
+
+literal-newline: longlonglonglonglonglonglonglonglonglonglong
+  longlonglonglonglonglonglonglonglonglonglong
+
+newline: longlonglonglonglonglonglonglonglonglonglong
+
+  longlonglonglonglonglonglonglonglonglonglong


### PR DESCRIPTION
Fixes #4913

Only apply to `alias` and `plain`/`quoteSingle`/`quoteDouble` with

- no backslash newline
- or no literal newline and `proseWrap: preserve`
- or no newline and `proseWrap: never`
- or no whitespace and `proseWrap: always`

in mapping items with implicit key, otherwise it's impossible to do prose wrapping.