### PR TITLE
[assignment] proper group

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5262,7 +5262,7 @@ function printAssignmentRight(leftNode, rightNode, printedRight, options) {
       options.parser !== "json5");
 
   if (canBreak) {
-    return indent(concat([line, printedRight]));
+    return group(indent(concat([line, printedRight])));
   }
 
   return concat([" ", printedRight]);

--- a/tests/assignment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/assignment/__snapshots__/jsfmt.spec.js.snap
@@ -21,6 +21,33 @@ computedDescriptionLines =
 
 `;
 
+exports[`destructuring.js - flow-verify 1`] = `
+let {
+  bottom: offsetBottom,
+  left: offsetLeft,
+  right: offsetRight,
+  top: offsetTop,
+} = getPressRectOffset == null ? DEFAULT_PRESS_RECT : getPressRectOffset();
+
+const { accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule,
+      } = foo || {};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+let {
+  bottom: offsetBottom,
+  left: offsetLeft,
+  right: offsetRight,
+  top: offsetTop
+} = getPressRectOffset == null ? DEFAULT_PRESS_RECT : getPressRectOffset();
+
+const {
+  accessibilityModule: FooAccessibilityModule,
+  accessibilityModule: FooAccessibilityModule,
+  accessibilityModule: FooAccessibilityModule,
+  accessibilityModule: FooAccessibilityModule
+} = foo || {};
+
+`;
+
 exports[`sequence.js - flow-verify 1`] = `
 for ((i = 0), (len = arr.length); i < len; i++) {
   console.log(arr[i])

--- a/tests/assignment/destructuring.js
+++ b/tests/assignment/destructuring.js
@@ -1,0 +1,9 @@
+let {
+  bottom: offsetBottom,
+  left: offsetLeft,
+  right: offsetRight,
+  top: offsetTop,
+} = getPressRectOffset == null ? DEFAULT_PRESS_RECT : getPressRectOffset();
+
+const { accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule,
+      } = foo || {};

--- a/tests/assignment_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/assignment_comments/__snapshots__/jsfmt.spec.js.snap
@@ -102,8 +102,7 @@ var fnString = // Comment
   // Comment
   "some" + "long" + "string";
 
-var fnString = // Comment
-  "some" + "long" + "string";
+var fnString = "some" + "long" + "string"; // Comment
 
 let f = (
   //comment


### PR DESCRIPTION
If you have

```js
a = b
```

we used to do

```js
group[a = b]
```

which works most of the time but has the unfortunate side effect that if the left part breaks, we're going to break the `=` as well. So you get

```js
{
  a
} = \n
  b
```

What this PR does it to add a group

```js
group[a group[= b]]
```

so that if the right hand side fits in one line, it should stay that way.

Note that there's a change with a comment being move but I think that it's fine. If I remember correctly, this test was to make sure that we didn't print invalid code, not that it had to be respected (that comment position is not something we really want to support in the first place).

Fixes #4645