### PR TITLE
chore: improve release scripts

### DIFF
--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -2,8 +2,10 @@
 
 ## Usage
 
-```
-./scripts/release/release.js --version NEW_VERSION
+```sh
+# set environment variable GITHUB_API_TOKEN if it's a patch release
+# since we need to get merged PRs from GitHub to generate changelog
+node ./scripts/release/release.js --version NEW_VERSION
 ```
 
 The script its own `package.json` so we can reinstall the root's `node_modules/` while making the release.

--- a/scripts/release/release.js
+++ b/scripts/release/release.js
@@ -2,10 +2,13 @@
 
 "use strict";
 
+const { exec, execSync } = require("child_process");
+
 async function run() {
   const chalk = require("chalk");
   const dedent = require("dedent");
   const minimist = require("minimist");
+  const semver = require("semver");
 
   const { readJson } = require("./utils");
 
@@ -14,7 +17,17 @@ async function run() {
     boolean: ["dry"],
     alias: { v: "version" }
   });
-  params.previousVersion = (await readJson("package.json")).version;
+
+  const previousVersion = execSync("git describe --tags --abbrev=0")
+    .toString()
+    .trim();
+
+  if (semver.parse(previousVersion) === null) {
+    throw new Error(`Unexpected previousVersion: ${previousVersion}`);
+  } else {
+    params.previousVersion = previousVersion;
+    params.previousVersionOnMaster = (await readJson("package.json")).version;
+  }
 
   const steps = [
     require("./steps/validate-new-version"),
@@ -42,13 +55,18 @@ async function run() {
   }
 }
 
-// Install script's dependencies before any require
-const { exec } = require("child_process");
-exec("yarn install", { cwd: __dirname }, error => {
-  if (error) {
-    console.error(error);
-    process.exit(1);
-  } else {
-    run();
+exec(
+  [
+    "git fetch --tags", // Fetch git tags to get the previous version number (i.e. the latest tag)
+    "yarn install" // Install script's dependencies before any require
+  ].join(" && "),
+  { cwd: __dirname },
+  error => {
+    if (error) {
+      console.error(error);
+      process.exit(1);
+    } else {
+      run();
+    }
   }
-});
+);

--- a/scripts/release/steps/bump-prettier.js
+++ b/scripts/release/steps/bump-prettier.js
@@ -1,7 +1,8 @@
 "use strict";
 
 const execa = require("execa");
-const { logPromise } = require("../utils");
+const semver = require("semver");
+const { logPromise, readJson, writeJson } = require("../utils");
 
 async function format() {
   await execa("yarn", ["lint", "--fix"]);
@@ -17,7 +18,19 @@ async function commit(version) {
   await execa("git", ["push"]);
 }
 
-module.exports = async function({ dry, version }) {
+async function bump({ version, previousVersion, previousVersionOnMaster }) {
+  const pkg = await readJson("package.json");
+  if (semver.diff(version, previousVersion) === "patch") {
+    pkg.version = previousVersionOnMaster; // restore the `-dev` version
+  } else {
+    pkg.version = semver.inc(version, "minor") + "-dev";
+  }
+  await writeJson("package.json", pkg, { spaces: 2 });
+}
+
+module.exports = async function(params) {
+  const { dry, version } = params;
+
   if (dry) {
     return;
   }
@@ -28,5 +41,6 @@ module.exports = async function({ dry, version }) {
   );
 
   await logPromise("Updating files", format());
+  await logPromise("Bump master version", bump(params));
   await logPromise("Committing changed files", commit(version));
 };

--- a/scripts/release/steps/publish-to-npm.js
+++ b/scripts/release/steps/publish-to-npm.js
@@ -12,7 +12,10 @@ module.exports = async function({ dry, version }) {
 
   await logPromise(
     "Publishing to npm",
-    execa("npm", ["publish"], { cwd: "./dist" })
+    execa("npm", ["publish"], {
+      cwd: "./dist",
+      stdio: "inherit" // we need to input OTP if 2FA enabled
+    })
   );
 
   console.log(
@@ -24,7 +27,6 @@ module.exports = async function({ dry, version }) {
       {bold.underline Create a GitHub Release}
       - Go to {cyan.underline https://github.com/prettier/prettier/releases/new?tag=${version}}
       - Copy release notes from {yellow CHANGELOG.md}
-      - Attach all files in {yellow dist/} folder.
       - Press {bgGreen.black  Publish release }
 
       {bold.underline Test the new releae}

--- a/scripts/release/steps/update-changelog.js
+++ b/scripts/release/steps/update-changelog.js
@@ -36,7 +36,7 @@ function writeChangelog({ version, previousVersion, releaseNotes }) {
   const newEntry = dedent`
     # ${version}
 
-    [link](https://github.com/prettier/prettier/compare/${previousVersion}...${version})
+    [diff](https://github.com/prettier/prettier/compare/${previousVersion}...${version})
 
     ${releaseNotes}
   `;
@@ -51,7 +51,7 @@ module.exports = async function({ version, previousVersion }) {
     writeChangelog({
       version,
       previousVersion,
-      releaseNotes: `- [Release Notes](https://prettier.io/${blogPost.path})`
+      releaseNotes: `🔗 [Release Notes](https://prettier.io/${blogPost.path})`
     });
     if (fs.existsSync(blogPost.file)) {
       // Everything is fine, this step is finished

--- a/scripts/release/steps/update-version.js
+++ b/scripts/release/steps/update-version.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const execa = require("execa");
 const { logPromise, readJson, writeJson, processFile } = require("../utils");
 
 async function bump({ version }) {
@@ -19,8 +18,4 @@ async function bump({ version }) {
 
 module.exports = async function(params) {
   await logPromise("Bumping version", bump(params));
-  await logPromise(
-    "Updating integration snapshots",
-    execa("yarn", ["test-integration", "-u"])
-  );
 };

--- a/scripts/test-dist.js
+++ b/scripts/test-dist.js
@@ -20,9 +20,9 @@ shell.exec("npm init -y", { cwd: tmpDir });
 shell.exec(`npm install "${tarPath}"`, { cwd: tmpDir });
 shell.config.silent = false;
 
-const cmd = `yarn test --color --runInBand ${
-  process.env.TEST_STANDALONE ? "tests/" : ""
-}`;
+const runInBand = process.env.CI ? "--runInBand" : "";
+const testPath = process.env.TEST_STANDALONE ? "tests/" : "";
+const cmd = `yarn test --color ${runInBand} ${testPath}`;
 
 const code = shell.exec(cmd, {
   cwd: rootDir,


### PR DESCRIPTION
Fixes #4905 

- use the latest git tag as the previous version
- restore/bump the version on master in `bump-prettier.js`
- use `stdio: "inherit"` for `npm publish` so that we could input the OTP
- do not use `--runInBand` for local `test:dist`
- remove `Updating integration snapshots`
- remove `Attach all files in dist/ folder`