### PR TITLE
fix: guess line ending before preprocess

### DIFF
--- a/src/main/core.js
+++ b/src/main/core.js
@@ -71,6 +71,8 @@ function coreFormat(text, opts, addAlignmentSize) {
 
   const parsed = parser.parse(text, opts);
   const ast = parsed.ast;
+
+  const originalText = text;
   text = parsed.text;
 
   if (opts.cursorOffset >= 0) {
@@ -82,7 +84,7 @@ function coreFormat(text, opts, addAlignmentSize) {
 
   const astComments = attachComments(text, ast, opts);
   const doc = printAstToDoc(ast, opts, addAlignmentSize);
-  opts.newLine = guessLineEnding(text);
+  opts.newLine = guessLineEnding(originalText);
 
   const result = printDocToString(doc, opts);
 

--- a/tests_integration/__tests__/__snapshots__/format.js.snap
+++ b/tests_integration/__tests__/__snapshots__/format.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`yaml parser should handle CRLF correctly 1`] = `"\\"a: 123\\\\n\\""`;
+exports[`yaml parser should handle CRLF correctly 1`] = `"\\"a: 123\\\\r\\\\n\\""`;

--- a/tests_integration/__tests__/__snapshots__/format.js.snap
+++ b/tests_integration/__tests__/__snapshots__/format.js.snap
@@ -1,6 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`yaml parser should handle CRLF correctly 1`] = `
-"a: 123
-"
-`;
+exports[`yaml parser should handle CRLF correctly 1`] = `"\\"a: 123\\\\n\\""`;

--- a/tests_integration/__tests__/format.js
+++ b/tests_integration/__tests__/format.js
@@ -4,5 +4,8 @@ const prettier = require("prettier/local");
 
 test("yaml parser should handle CRLF correctly", () => {
   const input = "a:\r\n  123\r\n";
-  expect(prettier.format(input, { parser: "yaml" })).toMatchSnapshot();
+  expect(
+    // use JSON.stringify to observe CRLF
+    JSON.stringify(prettier.format(input, { parser: "yaml" }))
+  ).toMatchSnapshot();
 });


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fixes #4956 

I originally thought it worked this way, but apparently not.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

cc @kachkaev