### PR TITLE
remove redundant ASI protection for BindExpression

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5359,7 +5359,7 @@ function hasNakedLeftSide(node) {
     node.type === "OptionalMemberExpression" ||
     node.type === "SequenceExpression" ||
     node.type === "TaggedTemplateExpression" ||
-    (node.type === "BindExpression" && !node.object) ||
+    node.type === "BindExpression" ||
     (node.type === "UpdateExpression" && !node.prefix)
   );
 }
@@ -5395,11 +5395,11 @@ function getLeftSidePathName(path, node) {
   if (node.test) {
     return ["test"];
   }
-  if (node.callee) {
-    return ["callee"];
-  }
   if (node.object) {
     return ["object"];
+  }
+  if (node.callee) {
+    return ["callee"];
   }
   if (node.tag) {
     return ["tag"];
@@ -5430,7 +5430,7 @@ function exprNeedsASIProtection(path, options) {
     node.type === "TemplateLiteral" ||
     node.type === "TemplateElement" ||
     isJSXNode(node) ||
-    node.type === "BindExpression" ||
+    (node.type === "BindExpression" && !node.object) ||
     node.type === "RegExpLiteral" ||
     (node.type === "Literal" && node.pattern) ||
     (node.type === "Literal" && node.regex);

--- a/tests/bind_expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/bind_expressions/__snapshots__/jsfmt.spec.js.snap
@@ -128,29 +128,29 @@ a || b::c
 ;::obj.prop
 ;(void 0)::func()
 ;(+0)::is(-0)
-;a::b.c
-;a::(b.c())
-;a::b.c()
-;a::(b.c()())
-;a::(b.c()())
-;a::(b.c())()
-;a::(b.c().d)
-;a::(c().d.e)
-;a::(b())
-;a::(b::c())
-;a::(b()::c)
-;a::(b().c::d)
-;a::(b.c::d)
-;a::(b::c.d)
-;a::(b.c::d::e)
-;a::(b::c::d)
-;a::(b::c::d.e)
-;a::(b::c::d).e
-;a::(void 0)
-;a::(b.c()::d.e)
-;a::(b.c::d.e)
-;a::(b.c::d.e)::f.g
-;b.c::d.e
+a::b.c
+a::(b.c())
+a::b.c()
+a::(b.c()())
+a::(b.c()())
+a::(b.c())()
+a::(b.c().d)
+a::(c().d.e)
+a::(b())
+a::(b::c())
+a::(b()::c)
+a::(b().c::d)
+a::(b.c::d)
+a::(b::c.d)
+a::(b.c::d::e)
+a::(b::c::d)
+a::(b::c::d.e)
+a::(b::c::d).e
+a::(void 0)
+a::(b.c()::d.e)
+a::(b.c::d.e)
+a::(b.c::d.e)::f.g
+b.c::d.e
 ;(b.c::d).e
 ;(b::c::d).e
 


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
