### PR TITLE
feat: support MDX

### DIFF
--- a/src/common/internal-plugins.js
+++ b/src/common/internal-plugins.js
@@ -25,6 +25,10 @@ module.exports = [
           "json-stringify"
         ];
       },
+      get __js_expression() {
+        return eval("require")("../language-js/parser-babylon").parsers
+          .__js_expression;
+      },
       // JS - Flow
       get flow() {
         return eval("require")("../language-js/parser-flow").parsers.flow;
@@ -93,6 +97,10 @@ module.exports = [
       get markdown() {
         return eval("require")("../language-markdown/parser-markdown").parsers
           .remark;
+      },
+      get mdx() {
+        return eval("require")("../language-markdown/parser-markdown").parsers
+          .mdx;
       }
     }
   },

--- a/src/language-js/parser-babylon.js
+++ b/src/language-js/parser-babylon.js
@@ -40,7 +40,10 @@ function parse(text, parsers, opts) {
   };
 
   const parseMethod =
-    opts && (opts.parser === "json" || opts.parser === "json5")
+    opts &&
+    (opts.parser === "json" ||
+      opts.parser === "json5" ||
+      opts.parser === "__js_expression")
       ? "parseExpression"
       : "parse";
 
@@ -159,6 +162,8 @@ module.exports = {
         astFormat: "estree-json"
       },
       locFns
-    )
+    ),
+    /** @internal for mdx to print jsx without semicolon */
+    __js_expression: babylon
   }
 };

--- a/src/language-markdown/embed.js
+++ b/src/language-markdown/embed.js
@@ -48,6 +48,14 @@ function embed(path, print, textToDoc, options) {
     );
   }
 
+  // MDX
+  switch (node.type) {
+    case "importExport":
+      return textToDoc(node.value, { parser: "babylon" });
+    case "jsx":
+      return textToDoc(node.value, { parser: "__js_expression" });
+  }
+
   return null;
 
   function getParserName(lang) {

--- a/src/language-markdown/index.js
+++ b/src/language-markdown/index.js
@@ -10,7 +10,14 @@ const languages = [
     parsers: ["remark"],
     filenames: ["README"],
     vscodeLanguageIds: ["markdown"]
-  })
+  }),
+  {
+    name: "MDX",
+    since: "1.15.0",
+    parsers: ["mdx"],
+    extensions: [".mdx"],
+    vscodeLanguageIds: ["mdx"]
+  }
 ];
 
 const printers = {

--- a/src/language-markdown/mdx.js
+++ b/src/language-markdown/mdx.js
@@ -1,0 +1,64 @@
+"use strict";
+
+/**
+ * modified from https://github.com/mdx-js/mdx/blob/master/packages/mdx
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017-2018 Compositor and Zeit, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+const IMPORT_REGEX = /^import/;
+const EXPORT_REGEX = /^export/;
+const BLOCKS_REGEX = "[a-z\\.]+(\\.){0,1}[a-z\\.]";
+const EMPTY_NEWLINE = "\n\n";
+
+const isImport = text => IMPORT_REGEX.test(text);
+const isExport = text => EXPORT_REGEX.test(text);
+
+const tokenizeEsSyntax = (eat, value) => {
+  const index = value.indexOf(EMPTY_NEWLINE);
+  const subvalue = value.slice(0, index);
+
+  if (isExport(subvalue) || isImport(subvalue)) {
+    return eat(subvalue)({
+      type: "importExport",
+      value: subvalue
+    });
+  }
+};
+
+tokenizeEsSyntax.locator = (value /*, fromIndex*/) => {
+  return isExport(value) || isImport(value) ? -1 : 1;
+};
+
+function esSyntax() {
+  const Parser = this.Parser;
+  const tokenizers = Parser.prototype.blockTokenizers;
+  const methods = Parser.prototype.blockMethods;
+
+  tokenizers.esSyntax = tokenizeEsSyntax;
+
+  methods.splice(methods.indexOf("paragraph"), 0, "esSyntax");
+}
+
+module.exports = {
+  esSyntax,
+  BLOCKS_REGEX
+};

--- a/src/main/core-options.js
+++ b/src/main/core-options.js
@@ -115,6 +115,7 @@ const options = {
       },
       { value: "graphql", since: "1.5.0", description: "GraphQL" },
       { value: "markdown", since: "1.8.0", description: "Markdown" },
+      { value: "mdx", since: "1.15.0", description: "MDX" },
       { value: "vue", since: "1.10.0", description: "Vue" },
       { value: "yaml", since: "1.14.0", description: "YAML" },
       {

--- a/tests/mdx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/mdx/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,365 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`import-export.mdx - mdx-verify 1`] = `
+import A from 'a'
+import {A,B,C}    from "hello-world"
+import {AAAAAAAAAAAAAAAAAAAAAAAA, BBBBBBBBBBBBBBBBBBBBBB, CCCCCCCCCCCCCCCCCCCCCCC}   from  'xyz';
+
+---
+
+import A from 'a'
+
+
+import {A,B,C}    from "hello-world"
+
+
+import {AAAAAAAAAAAAAAAAAAAAAAAA, BBBBBBBBBBBBBBBBBBBBBB, CCCCCCCCCCCCCCCCCCCCCCC}   from  'xyz';
+
+---
+
+export const meta = {
+authors: [fred, sue],
+layout: Layout
+}
+
+export default () =>
+  <Doc     components={{
+        h1: ui.Heading,
+         p:    ui.Text,
+      code:     ui.Code
+         }}
+      />
+
+---
+
+export const a = 1;
+export const b = 1;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import A from "a";
+import { A, B, C } from "hello-world";
+import {
+  AAAAAAAAAAAAAAAAAAAAAAAA,
+  BBBBBBBBBBBBBBBBBBBBBB,
+  CCCCCCCCCCCCCCCCCCCCCCC
+} from "xyz";
+
+---
+
+import A from "a";
+
+import { A, B, C } from "hello-world";
+
+import {
+  AAAAAAAAAAAAAAAAAAAAAAAA,
+  BBBBBBBBBBBBBBBBBBBBBB,
+  CCCCCCCCCCCCCCCCCCCCCCC
+} from "xyz";
+
+---
+
+export const meta = {
+  authors: [fred, sue],
+  layout: Layout
+};
+
+export default () => (
+  <Doc
+    components={{
+      h1: ui.Heading,
+      p: ui.Text,
+      code: ui.Code
+    }}
+  />
+);
+
+---
+
+export const a = 1;
+export const b = 1;
+
+`;
+
+exports[`import-export.mdx - mdx-verify 2`] = `
+import A from 'a'
+import {A,B,C}    from "hello-world"
+import {AAAAAAAAAAAAAAAAAAAAAAAA, BBBBBBBBBBBBBBBBBBBBBB, CCCCCCCCCCCCCCCCCCCCCCC}   from  'xyz';
+
+---
+
+import A from 'a'
+
+
+import {A,B,C}    from "hello-world"
+
+
+import {AAAAAAAAAAAAAAAAAAAAAAAA, BBBBBBBBBBBBBBBBBBBBBB, CCCCCCCCCCCCCCCCCCCCCCC}   from  'xyz';
+
+---
+
+export const meta = {
+authors: [fred, sue],
+layout: Layout
+}
+
+export default () =>
+  <Doc     components={{
+        h1: ui.Heading,
+         p:    ui.Text,
+      code:     ui.Code
+         }}
+      />
+
+---
+
+export const a = 1;
+export const b = 1;
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import A from "a"
+import { A, B, C } from "hello-world"
+import {
+  AAAAAAAAAAAAAAAAAAAAAAAA,
+  BBBBBBBBBBBBBBBBBBBBBB,
+  CCCCCCCCCCCCCCCCCCCCCCC
+} from "xyz"
+
+---
+
+import A from "a"
+
+import { A, B, C } from "hello-world"
+
+import {
+  AAAAAAAAAAAAAAAAAAAAAAAA,
+  BBBBBBBBBBBBBBBBBBBBBB,
+  CCCCCCCCCCCCCCCCCCCCCCC
+} from "xyz"
+
+---
+
+export const meta = {
+  authors: [fred, sue],
+  layout: Layout
+}
+
+export default () => (
+  <Doc
+    components={{
+      h1: ui.Heading,
+      p: ui.Text,
+      code: ui.Code
+    }}
+  />
+)
+
+---
+
+export const a = 1
+export const b = 1
+
+`;
+
+exports[`jsx.mdx - mdx-verify 1`] = `
+<Heading hi='there'>Hello, world!
+</Heading>
+
+---
+
+<Hello>
+    test   <World />   test
+</Hello>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<Heading hi="there">Hello, world!</Heading>
+
+---
+
+<Hello>
+  test <World /> test
+</Hello>
+
+`;
+
+exports[`jsx.mdx - mdx-verify 2`] = `
+<Heading hi='there'>Hello, world!
+</Heading>
+
+---
+
+<Hello>
+    test   <World />   test
+</Hello>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<Heading hi="there">Hello, world!</Heading>
+
+---
+
+<Hello>
+  test <World /> test
+</Hello>
+
+`;
+
+exports[`mixed.mdx - mdx-verify 1`] = `
+import     {     Baz } from     './Fixture'
+import { Buz  }   from './Fixture'
+
+export  const   foo    = {
+  hi:     \`Fudge \${Baz.displayName || 'Baz'}\`,
+  authors: [
+     'fred',
+           'sally'
+    ]
+}
+
+# Hello,    world!
+
+
+ I'm an awesome   paragraph.
+
+<!-- I'm a comment -->
+
+<Foo bg='red'>
+      <Bar    >hi    </Bar>
+       {  hello       }
+       {     /* another commment */}
+</Foo>
+
+\`\`\`
+test codeblock
+\`\`\`
+
+\`\`\`js
+module.exports = 'test'
+\`\`\`
+
+\`\`\`sh
+npm i -g foo
+\`\`\`
+
+| Test  | Table   |
+|    :---     | :----  |
+|   Col1  | Col2    |
+
+export   default     ({children   }) => < div>{    children}</div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import { Baz } from "./Fixture";
+import { Buz } from "./Fixture";
+
+export const foo = {
+  hi: \`Fudge \${Baz.displayName || "Baz"}\`,
+  authors: ["fred", "sally"]
+};
+
+# Hello, world!
+
+I'm an awesome paragraph.
+
+<!-- I'm a comment -->
+
+<Foo bg="red">
+  <Bar>hi </Bar>
+  {hello}
+  {/* another commment */}
+</Foo>
+
+\`\`\`
+test codeblock
+\`\`\`
+
+\`\`\`js
+module.exports = "test";
+\`\`\`
+
+\`\`\`sh
+npm i -g foo
+\`\`\`
+
+| Test | Table |
+| :--- | :---- |
+| Col1 | Col2  |
+
+export default ({ children }) => <div>{children}</div>;
+
+`;
+
+exports[`mixed.mdx - mdx-verify 2`] = `
+import     {     Baz } from     './Fixture'
+import { Buz  }   from './Fixture'
+
+export  const   foo    = {
+  hi:     \`Fudge \${Baz.displayName || 'Baz'}\`,
+  authors: [
+     'fred',
+           'sally'
+    ]
+}
+
+# Hello,    world!
+
+
+ I'm an awesome   paragraph.
+
+<!-- I'm a comment -->
+
+<Foo bg='red'>
+      <Bar    >hi    </Bar>
+       {  hello       }
+       {     /* another commment */}
+</Foo>
+
+\`\`\`
+test codeblock
+\`\`\`
+
+\`\`\`js
+module.exports = 'test'
+\`\`\`
+
+\`\`\`sh
+npm i -g foo
+\`\`\`
+
+| Test  | Table   |
+|    :---     | :----  |
+|   Col1  | Col2    |
+
+export   default     ({children   }) => < div>{    children}</div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import { Baz } from "./Fixture"
+import { Buz } from "./Fixture"
+
+export const foo = {
+  hi: \`Fudge \${Baz.displayName || "Baz"}\`,
+  authors: ["fred", "sally"]
+}
+
+# Hello, world!
+
+I'm an awesome paragraph.
+
+<!-- I'm a comment -->
+
+<Foo bg="red">
+  <Bar>hi </Bar>
+  {hello}
+  {/* another commment */}
+</Foo>
+
+\`\`\`
+test codeblock
+\`\`\`
+
+\`\`\`js
+module.exports = "test"
+\`\`\`
+
+\`\`\`sh
+npm i -g foo
+\`\`\`
+
+| Test | Table |
+| :--- | :---- |
+| Col1 | Col2  |
+
+export default ({ children }) => <div>{children}</div>
+
+`;

--- a/tests/mdx/import-export.mdx
+++ b/tests/mdx/import-export.mdx
@@ -1,0 +1,33 @@
+import A from 'a'
+import {A,B,C}    from "hello-world"
+import {AAAAAAAAAAAAAAAAAAAAAAAA, BBBBBBBBBBBBBBBBBBBBBB, CCCCCCCCCCCCCCCCCCCCCCC}   from  'xyz';
+
+---
+
+import A from 'a'
+
+
+import {A,B,C}    from "hello-world"
+
+
+import {AAAAAAAAAAAAAAAAAAAAAAAA, BBBBBBBBBBBBBBBBBBBBBB, CCCCCCCCCCCCCCCCCCCCCCC}   from  'xyz';
+
+---
+
+export const meta = {
+authors: [fred, sue],
+layout: Layout
+}
+
+export default () =>
+  <Doc     components={{
+        h1: ui.Heading,
+         p:    ui.Text,
+      code:     ui.Code
+         }}
+      />
+
+---
+
+export const a = 1;
+export const b = 1;

--- a/tests/mdx/jsfmt.spec.js
+++ b/tests/mdx/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname, ["mdx"]);
+run_spec(__dirname, ["mdx"], { semi: false });

--- a/tests/mdx/jsx.mdx
+++ b/tests/mdx/jsx.mdx
@@ -1,0 +1,8 @@
+<Heading hi='there'>Hello, world!
+</Heading>
+
+---
+
+<Hello>
+    test   <World />   test
+</Hello>

--- a/tests/mdx/mixed.mdx
+++ b/tests/mdx/mixed.mdx
@@ -1,0 +1,41 @@
+import     {     Baz } from     './Fixture'
+import { Buz  }   from './Fixture'
+
+export  const   foo    = {
+  hi:     `Fudge ${Baz.displayName || 'Baz'}`,
+  authors: [
+     'fred',
+           'sally'
+    ]
+}
+
+# Hello,    world!
+
+
+ I'm an awesome   paragraph.
+
+<!-- I'm a comment -->
+
+<Foo bg='red'>
+      <Bar    >hi    </Bar>
+       {  hello       }
+       {     /* another commment */}
+</Foo>
+
+```
+test codeblock
+```
+
+```js
+module.exports = 'test'
+```
+
+```sh
+npm i -g foo
+```
+
+| Test  | Table   |
+|    :---     | :----  |
+|   Col1  | Col2    |
+
+export   default     ({children   }) => < div>{    children}</div>

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -62,7 +62,7 @@ Format options:
   --no-bracket-spacing     Do not print spaces between brackets.
   --jsx-bracket-same-line  Put > on the last line instead of at a new line.
                            Defaults to false.
-  --parser <flow|babylon|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|vue|yaml>
+  --parser <flow|babylon|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml>
                            Which parser to use.
   --print-width <int>      The line length where Prettier will try wrap.
                            Defaults to 80.
@@ -165,7 +165,7 @@ exports[`show warning with --help not-found (typo) (stderr) 1`] = `
 `;
 
 exports[`show warning with --help not-found (typo) (stdout) 1`] = `
-"--parser <flow|babylon|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|vue|yaml>
+"--parser <flow|babylon|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml>
 
   Which parser to use.
 
@@ -182,6 +182,7 @@ Valid options:
   json-stringify   JSON.stringify
   graphql          GraphQL
   markdown         Markdown
+  mdx              MDX
   vue              Vue
   yaml             YAML
 "
@@ -212,7 +213,7 @@ Format options:
   --no-bracket-spacing     Do not print spaces between brackets.
   --jsx-bracket-same-line  Put > on the last line instead of at a new line.
                            Defaults to false.
-  --parser <flow|babylon|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|vue|yaml>
+  --parser <flow|babylon|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml>
                            Which parser to use.
   --print-width <int>      The line length where Prettier will try wrap.
                            Defaults to 80.

--- a/tests_integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/help-options.js.snap
@@ -267,7 +267,7 @@ exports[`show detailed usage with --help no-semi (write) 1`] = `Array []`;
 exports[`show detailed usage with --help parser (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help parser (stdout) 1`] = `
-"--parser <flow|babylon|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|vue|yaml>
+"--parser <flow|babylon|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml>
 
   Which parser to use.
 
@@ -284,6 +284,7 @@ Valid options:
   json-stringify   JSON.stringify
   graphql          GraphQL
   markdown         Markdown
+  mdx              MDX
   vue              Vue
   yaml             YAML
 "

--- a/tests_integration/__tests__/__snapshots__/plugin-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/plugin-options.js.snap
@@ -15,7 +15,7 @@ exports[` 1`] = `
 +                            Defaults to bar.
     --jsx-bracket-same-line  Put > on the last line instead of at a new line.
                              Defaults to false.
-    --parser <flow|babylon|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|vue|yaml>
+    --parser <flow|babylon|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml>
                              Which parser to use.
     --print-width <int>      The line length where Prettier will try wrap."
 `;

--- a/tests_integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests_integration/__tests__/__snapshots__/schema.js.snap
@@ -129,6 +129,12 @@ This option cannot be used with --range-start and --range-end.",
               ],
             },
             Object {
+              "description": "MDX",
+              "enum": Array [
+                "mdx",
+              ],
+            },
+            Object {
               "description": "Vue",
               "enum": Array [
                 "vue",

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -429,7 +429,21 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
         \\"flow\\",
       ],
       \\"JavaScript\\": Array [
-@@ -37,12 +43,26 @@
+@@ -25,10 +31,13 @@
+        \\"flow\\",
+      ],
+      \\"Less\\": Array [
+        \\"less\\",
+      ],
++     \\"MDX\\": Array [
++       \\"mdx\\",
++     ],
+      \\"Markdown\\": Array [
+        \\"markdown\\",
+      ],
+      \\"PostCSS\\": Array [
+        \\"css\\",
+@@ -37,12 +46,26 @@
         \\"scss\\",
       ],
       \\"TypeScript\\": Array [
@@ -456,7 +470,7 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
         \\"type\\": \\"boolean\\",
       },
       \\"cursorOffset\\": Object {
-@@ -73,16 +93,28 @@
+@@ -73,16 +96,29 @@
           \\"typescript\\",
           \\"css\\",
           \\"less\\",
@@ -466,6 +480,7 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
 +         \\"json-stringify\\",
           \\"graphql\\",
           \\"markdown\\",
++         \\"mdx\\",
 +         \\"vue\\",
 +         \\"yaml\\",
         ],
@@ -486,7 +501,7 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
         \\"range\\": Object {
           \\"end\\": Infinity,
           \\"start\\": 0,
-@@ -90,14 +122,15 @@
+@@ -90,14 +126,15 @@
         },
         \\"type\\": \\"int\\",
       },
@@ -791,6 +806,13 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"wrap\\": true
     },
     {
+      \\"extensions\\": [\\".mdx\\"],
+      \\"name\\": \\"MDX\\",
+      \\"parsers\\": [\\"mdx\\"],
+      \\"since\\": \\"1.15.0\\",
+      \\"vscodeLanguageIds\\": [\\"mdx\\"]
+    },
+    {
       \\"aceMode\\": \\"html\\",
       \\"color\\": \\"#2c3e50\\",
       \\"extensions\\": [\\".vue\\"],
@@ -916,6 +938,7 @@ exports[`CLI --support-info (stdout) 1`] = `
         },
         { \\"description\\": \\"GraphQL\\", \\"since\\": \\"1.5.0\\", \\"value\\": \\"graphql\\" },
         { \\"description\\": \\"Markdown\\", \\"since\\": \\"1.8.0\\", \\"value\\": \\"markdown\\" },
+        { \\"description\\": \\"MDX\\", \\"since\\": \\"1.15.0\\", \\"value\\": \\"mdx\\" },
         { \\"description\\": \\"Vue\\", \\"since\\": \\"1.10.0\\", \\"value\\": \\"vue\\" },
         { \\"description\\": \\"YAML\\", \\"since\\": \\"1.14.0\\", \\"value\\": \\"yaml\\" }
       ],

--- a/website/data/languages.yml
+++ b/website/data/languages.yml
@@ -29,6 +29,7 @@
   variants:
   - "[`CommonMark`](http://commonmark.org/)"
   - "[`GitHub Flavored Markdown`](https://github.github.com/gfm/)"
+  - "[`MDX`](https://mdxjs.com/)"
 - name: YAML
   showName: false
   image: /images/languages/tools_yaml.svg

--- a/website/playground/codeSamples.js
+++ b/website/playground/codeSamples.js
@@ -169,6 +169,52 @@ export default function(parser) {
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
         "Curabitur consectetur maximus risus, sed maximus tellus tincidunt et."
       ].join("\n");
+    case "mdx":
+      // modified from https://github.com/mdx-js/mdx/blob/master/packages/mdx/test/fixtures/blog-post.md
+      return [
+        "import     {     Baz } from     './Fixture'",
+        "import { Buz  }   from './Fixture'",
+        "",
+        "export  const   foo    = {",
+        "  hi:     `Fudge ${Baz.displayName || 'Baz'}`,",
+        "  authors: [",
+        "     'fred',",
+        "           'sally'",
+        "    ]",
+        "}",
+        "",
+        "# Hello,    world!",
+        "",
+        "",
+        " I'm an awesome   paragraph.",
+        "",
+        "<!-- I'm a comment -->",
+        "",
+        "<Foo bg='red'>",
+        "      <Bar    >hi    </Bar>",
+        "       {  hello       }",
+        "       {     /* another commment */}",
+        "</Foo>",
+        "",
+        "```",
+        "test codeblock",
+        "```",
+        "",
+        "```js",
+        "module.exports = 'test'",
+        "```",
+        "",
+        "```sh",
+        "npm i -g foo",
+        "```",
+        "",
+        "| Test  | Table   |",
+        "|    :---     | :----  |",
+        "|   Col1  | Col2    |",
+        "",
+        "export   default     ({children   }) => < div>{    children}</div>",
+        ""
+      ].join("\n");
     case "vue":
       return [
         "<template>",

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -29,6 +29,10 @@ var parsers = {
     importScriptOnce("lib/parser-babylon.js");
     return prettierPlugins.babylon.parsers["json-stringify"];
   },
+  get __js_expression() {
+    importScriptOnce("lib/parser-babylon.js");
+    return prettierPlugins.babylon.parsers.__js_expression;
+  },
   // JS - Flow
   get flow() {
     importScriptOnce("lib/parser-flow.js");
@@ -64,6 +68,10 @@ var parsers = {
   get markdown() {
     importScriptOnce("lib/parser-markdown.js");
     return prettierPlugins.markdown.parsers.remark;
+  },
+  get mdx() {
+    importScriptOnce("lib/parser-markdown.js");
+    return prettierPlugins.markdown.parsers.mdx;
   },
 
   // Vue


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fixes #4960

- format block html (`jsx`)
- format `import`/`export`
- does not support `<!-- comment -->` in jsx
- inline `html`s are printed as-is

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
