### PR TITLE
Add a label that exempts issues from auto-locking

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -5,3 +5,4 @@ lockComment: false
 setLockReason: true
 exemptLabels:
   - keep-unlocked
+  - status:awaiting response

--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -3,3 +3,5 @@ daysUntilLock: 90
 lockLabel: locked-due-to-inactivity
 lockComment: false
 setLockReason: true
+exemptLabels:
+  - keep-unlocked


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

This allows us to track 👍s on closed issues so we can perhaps reopen them if there’s strong enough support. (inspired by & closes #4986)

- [ ] After merging, unlock all [locked awaiting-response issues](https://github.com/prettier/prettier/issues?q=is%3Aissue+label%3A%22status%3Aawaiting+response%22+is%3Aclosed+label%3Alocked-due-to-inactivity).