### PR TITLE
Update configuration to be clearer about js config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ title: Configuration File
 
 Prettier uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) for configuration file support. This means you can configure prettier via:
 
-- A `.prettierrc` file, written in YAML or JSON, with optional extensions: `.yaml/.yml/.json/.js`.
+- A `.prettierrc` file, written in YAML or JSON, with optional extensions: `.yaml/.yml/.json`.
 - A `.prettierrc.toml` file, written in TOML (the `.toml` extension is _required_).
 - A `prettier.config.js` or `.prettierrc.js` file that exports an object.
 - A `"prettier"` key in your `package.json` file.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@ Prettier uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) for co
 
 - A `.prettierrc` file, written in YAML or JSON, with optional extensions: `.yaml/.yml/.json/.js`.
 - A `.prettierrc.toml` file, written in TOML (the `.toml` extension is _required_).
-- A `prettier.config.js` file that exports an object.
+- A `prettier.config.js` file that exports an object, note is interchangeable with `.prettierrc.js`.
 - A `"prettier"` key in your `package.json` file.
 
 The configuration file will be resolved starting from the location of the file being formatted, and searching up the file tree until a config file is (or isn't) found.
@@ -28,7 +28,7 @@ JSON:
 JS:
 
 ```js
-// .prettierrc.js
+// prettier.config.js or .prettierrc.js
 module.exports = {
   printWidth: 100,
   parser: "flow"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@ Prettier uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) for co
 
 - A `.prettierrc` file, written in YAML or JSON, with optional extensions: `.yaml/.yml/.json/.js`.
 - A `.prettierrc.toml` file, written in TOML (the `.toml` extension is _required_).
-- A `prettier.config.js` file that exports an object, note is interchangeable with `.prettierrc.js`.
+- A `prettier.config.js` or `.prettierrc.js` file that exports an object.
 - A `"prettier"` key in your `package.json` file.
 
 The configuration file will be resolved starting from the location of the file being formatted, and searching up the file tree until a config file is (or isn't) found.


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
So in the list, it says to use `prettier.config.js` as your file name for configuring prettier in js. But in the example it has `//.prettierrc.js`. This confused me so I tried both file names. Both these file names work to configure prettier so I updated the docs to reflect that.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works. **n/a**
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory) **n/a**
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
