### PR TITLE
fix: splitting jsx text correctly

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4741,9 +4741,6 @@ function separatorNoWhitespace(
     return "";
   }
 
-  // console.log("child", child);
-  // console.log("childNode", childNode);
-  // console.log("nextNode", nextNode);
   if (
     (childNode.type === "JSXElement" && !childNode.closingElement) ||
     (nextNode && (nextNode.type === "JSXElement" && !nextNode.closingElement))
@@ -4793,19 +4790,16 @@ function printJSXChildren(
     const child = childPath.getValue();
     if (isLiteral(child)) {
       const text = rawText(child);
-      // console.log("literal child", child);
 
       // Contains a non-whitespace character
       if (isMeaningfulJSXText(child)) {
         const words = text.split(matchJsxWhitespaceRegex);
-        // console.log("WORDS 1", words);
 
         // Starts with whitespace
         if (words[0] === "") {
           children.push("");
           words.shift();
           if (/\n/.test(words[0])) {
-            // console.log("separatorWithWhitespace", words[1]);
             children.push(
               separatorWithWhitespace(isFacebookTranslationTag, words[1])
             );
@@ -4828,7 +4822,6 @@ function printJSXChildren(
         }
 
         words.forEach((word, i) => {
-          // console.log("WORDS", words);
           if (i % 2 === 1) {
             children.push(line);
           } else {
@@ -4848,7 +4841,6 @@ function printJSXChildren(
             children.push(jsxWhitespace);
           }
         } else {
-          // console.log("CHILD", child);
           const next = n.children[i + 1];
           children.push(
             separatorNoWhitespace(
@@ -4873,19 +4865,14 @@ function printJSXChildren(
     } else {
       const printedChild = print(childPath);
       children.push(printedChild);
-      // console.log("printedChild", printedChild);
 
       const next = n.children[i + 1];
-      // console.log('child', child);
-      // console.log("next", next);
       const directlyFollowedByMeaningfulText =
         next && isMeaningfulJSXText(next);
       if (directlyFollowedByMeaningfulText) {
         const firstWord = rawText(next)
           .trim()
           .split(matchJsxWhitespaceRegex)[0];
-        // console.log('firstWord', firstWord);
-        // console.log("n.children", n.children[i - 1]);
         children.push(
           separatorNoWhitespace(
             isFacebookTranslationTag,
@@ -4895,7 +4882,6 @@ function printJSXChildren(
           )
         );
       } else {
-        // console.log('else', next);
         children.push(hardline);
       }
     }
@@ -5038,9 +5024,6 @@ function printJSXElement(path, options, print) {
     } else if (isJSXWhitespaceFollowedByLine) {
       children.splice(i + 1, 2);
     }
-
-    // console.log("i", i);
-    // console.log("children", children);
   }
 
   // Trim trailing lines (or empty strings)

--- a/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-significant-space/__snapshots__/jsfmt.spec.js.snap
@@ -141,8 +141,7 @@ break_components = (
     <Foo />
     <Bar>
       <p>
-        foo
-        <span>bar bar bar</span>
+        foo<span>bar bar bar</span>
       </p>
       <h1>
         <span>
@@ -210,8 +209,7 @@ not_broken_end = (
 not_broken_begin = (
   <div>
     <br /> long text long text long text long text long text long text long text
-    long text
-    <link>url</link> long text long text
+    long text<link>url</link> long text long text
   </div>
 );
 

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -416,12 +416,6 @@ x =
 
 x = <div><strong>text here</strong>.<br /></div>
 
-x = <div><strong>{name}</strong>’s{' '}</div>
-
-x = <Text>You {type}ed this shipment to</Text>
-
-x = <HelpBlock>{parameter.Description}: {errorMsg}</HelpBlock>
-
 x = <div>Sales tax estimated using a rate of {salesTax * 100}%.</div>
 
 x = <div>
@@ -429,6 +423,35 @@ x = <div>
 </div>
 
 x = <div><span/>bar</div>
+  
+x = <div>
+  <span>
+    <strong>{name}</strong>’s{' '}
+  </span>
+  Hello <strong>world</strong>.<br />
+  <Text>You {type}ed this shipment to</Text>
+</div>
+
+x = <HelpBlock>
+  {parameter.Description}: {errorMsg}
+</HelpBlock>
+  
+x = <label>
+  {value} solution{plural}
+</label>
+  
+x = <span>Copy &quot;{name}&quot;</span>
+  
+x = <BasicText light>(avg. {value}/5)</BasicText>
+  
+x = <p>
+  Use the <code>Button</code>'s
+</p>;
+
+this_really_should_split_across_lines =
+  <div>
+    before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after
+  </div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Wrapping text
 x = (
@@ -949,20 +972,6 @@ x = (
   </div>
 );
 
-x = (
-  <div>
-    <strong>{name}</strong>’s{" "}
-  </div>
-);
-
-x = <Text>You {type}ed this shipment to</Text>;
-
-x = (
-  <HelpBlock>
-    {parameter.Description}: {errorMsg}
-  </HelpBlock>
-);
-
 x = <div>Sales tax estimated using a rate of {salesTax * 100}%.</div>;
 
 x = <div>{title}&nbsp;</div>;
@@ -971,6 +980,46 @@ x = (
   <div>
     <span />
     bar
+  </div>
+);
+
+x = (
+  <div>
+    <span>
+      <strong>{name}</strong>’s{" "}
+    </span>
+    Hello <strong>world</strong>.
+    <br />
+    <Text>You {type}ed this shipment to</Text>
+  </div>
+);
+
+x = (
+  <HelpBlock>
+    {parameter.Description}: {errorMsg}
+  </HelpBlock>
+);
+
+x = (
+  <label>
+    {value} solution{plural}
+  </label>
+);
+
+x = <span>Copy &quot;{name}&quot;</span>;
+
+x = <BasicText light>(avg. {value}/5)</BasicText>;
+
+x = (
+  <p>
+    Use the <code>Button</code>'s
+  </p>
+);
+
+this_really_should_split_across_lines = (
+  <div>
+    before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}
+    after{stuff}after
   </div>
 );
 

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -413,6 +413,22 @@ x =
     {minute}:
     {second}
   </div>
+
+x = <div><strong>text here</strong>.<br /></div>
+
+x = <div><strong>{name}</strong>’s{' '}</div>
+
+x = <Text>You {type}ed this shipment to</Text>
+
+x = <HelpBlock>{parameter.Description}: {errorMsg}</HelpBlock>
+
+x = <div>Sales tax estimated using a rate of {salesTax * 100}%.</div>
+
+x = <div>
+  {title}&nbsp;
+</div>
+
+x = <div><span/>bar</div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Wrapping text
 x = (
@@ -474,23 +490,9 @@ x = (
 
 x = (
   <div>
-    before
+    before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}
     {stuff}
-    after
-    {stuff}
-    after
-    {stuff}
-    after
-    {stuff}
-    after
-    {stuff}
-    after
-    {stuff}
-    {stuff}
-    {stuff}
-    after
-    {stuff}
-    after
+    {stuff}after{stuff}after
   </div>
 );
 
@@ -598,35 +600,9 @@ x = (
 
 this_really_should_split_across_lines = (
   <div>
-    before
-    {stuff}
-    after
-    {stuff}
-    after
-    {stuff}
-    after
-    {stuff}
-    after
-    {stuff}
-    after
-    {stuff}
-    after
-    {stuff}
-    after
-    {stuff}
-    after
-    {stuff}
-    after
-    {stuff}
-    after
-    {stuff}
-    after
-    {stuff}
-    after
-    {stuff}
-    after
-    {stuff}
-    after
+    before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}
+    after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}
+    after{stuff}after{stuff}after
   </div>
 );
 
@@ -774,7 +750,11 @@ line_after_br = (
 
 line_after_br_2 = (
   <div>
-    A<br />B<br />C
+    A
+    <br />
+    B
+    <br />
+    C
   </div>
 );
 
@@ -959,6 +939,38 @@ x = (
 x = (
   <div>
     {hour}:{minute}:{second}
+  </div>
+);
+
+x = (
+  <div>
+    <strong>text here</strong>.
+    <br />
+  </div>
+);
+
+x = (
+  <div>
+    <strong>{name}</strong>’s{" "}
+  </div>
+);
+
+x = <Text>You {type}ed this shipment to</Text>;
+
+x = (
+  <HelpBlock>
+    {parameter.Description}: {errorMsg}
+  </HelpBlock>
+);
+
+x = <div>Sales tax estimated using a rate of {salesTax * 100}%.</div>;
+
+x = <div>{title}&nbsp;</div>;
+
+x = (
+  <div>
+    <span />
+    bar
   </div>
 );
 

--- a/tests/jsx-text-wrap/test.js
+++ b/tests/jsx-text-wrap/test.js
@@ -413,12 +413,6 @@ x =
 
 x = <div><strong>text here</strong>.<br /></div>
 
-x = <div><strong>{name}</strong>’s{' '}</div>
-
-x = <Text>You {type}ed this shipment to</Text>
-
-x = <HelpBlock>{parameter.Description}: {errorMsg}</HelpBlock>
-
 x = <div>Sales tax estimated using a rate of {salesTax * 100}%.</div>
 
 x = <div>
@@ -426,3 +420,32 @@ x = <div>
 </div>
 
 x = <div><span/>bar</div>
+  
+x = <div>
+  <span>
+    <strong>{name}</strong>’s{' '}
+  </span>
+  Hello <strong>world</strong>.<br />
+  <Text>You {type}ed this shipment to</Text>
+</div>
+
+x = <HelpBlock>
+  {parameter.Description}: {errorMsg}
+</HelpBlock>
+  
+x = <label>
+  {value} solution{plural}
+</label>
+  
+x = <span>Copy &quot;{name}&quot;</span>
+  
+x = <BasicText light>(avg. {value}/5)</BasicText>
+  
+x = <p>
+  Use the <code>Button</code>'s
+</p>;
+
+this_really_should_split_across_lines =
+  <div>
+    before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after
+  </div>

--- a/tests/jsx-text-wrap/test.js
+++ b/tests/jsx-text-wrap/test.js
@@ -410,3 +410,19 @@ x =
     {minute}:
     {second}
   </div>
+
+x = <div><strong>text here</strong>.<br /></div>
+
+x = <div><strong>{name}</strong>’s{' '}</div>
+
+x = <Text>You {type}ed this shipment to</Text>
+
+x = <HelpBlock>{parameter.Description}: {errorMsg}</HelpBlock>
+
+x = <div>Sales tax estimated using a rate of {salesTax * 100}%.</div>
+
+x = <div>
+  {title}&nbsp;
+</div>
+
+x = <div><span/>bar</div>


### PR DESCRIPTION
Fixes: #4941
- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
