### PR TITLE
Bugfix/ Don't inline pipeline operator with leading ownline comment

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5204,7 +5204,9 @@ function printBinaryishExpressions(
     }
 
     const shouldInline = shouldInlineLogicalExpression(node);
-    const lineBeforeOperator = node.operator === "|>";
+    const lineBeforeOperator =
+      node.operator === "|>" &&
+      !hasLeadingOwnLineComment(options.originalText, node.right, options);
 
     const right = shouldInline
       ? concat([node.operator, " ", path.call(print, "right")])

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -35,6 +35,153 @@ const foo = {
 
 `;
 
+exports[`binary-expressions.js - flow-verify 1`] = `
+function addition() {
+	0
+	// Comment
+	+ x
+}
+
+function multiplication() {
+	0
+	// Comment
+	* x
+}
+
+function division() {
+	0
+	// Comment
+	/ x
+}
+
+function substraction() {
+	0
+	// Comment
+	- x
+}
+
+function remainder() {
+	0
+	// Comment
+	% x
+}
+
+function exponentiation() {
+	0
+	// Comment
+	** x
+}
+
+function leftShift() {
+	0
+	// Comment
+	<< x
+}
+
+function rightShift() {
+	0
+	// Comment
+	>> x
+}
+
+function unsignedRightShift() {
+	0
+	// Comment
+	>>> x
+}
+
+function bitwiseAnd() {
+	0
+	// Comment
+	& x
+}
+
+function bitwiseOr() {
+	0
+	// Comment
+	| x
+}
+
+function bitwiseXor() {
+	0
+	// Comment
+	^ x
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+function addition() {
+  0 +
+    // Comment
+    x;
+}
+
+function multiplication() {
+  0 *
+    // Comment
+    x;
+}
+
+function division() {
+  0 /
+    // Comment
+    x;
+}
+
+function substraction() {
+  0 -
+    // Comment
+    x;
+}
+
+function remainder() {
+  0 %
+    // Comment
+    x;
+}
+
+function exponentiation() {
+  0 **
+    // Comment
+    x;
+}
+
+function leftShift() {
+  0 <<
+    // Comment
+    x;
+}
+
+function rightShift() {
+  0 >>
+    // Comment
+    x;
+}
+
+function unsignedRightShift() {
+  0 >>>
+    // Comment
+    x;
+}
+
+function bitwiseAnd() {
+  0 &
+    // Comment
+    x;
+}
+
+function bitwiseOr() {
+  0 |
+    // Comment
+    x;
+}
+
+function bitwiseXor() {
+  0 ^
+    // Comment
+    x;
+}
+
+`;
+
 exports[`blank.js - flow-verify 1`] = `
 // This file only
 // has comments. This comment

--- a/tests/comments/binary-expressions.js
+++ b/tests/comments/binary-expressions.js
@@ -1,0 +1,71 @@
+function addition() {
+	0
+	// Comment
+	+ x
+}
+
+function multiplication() {
+	0
+	// Comment
+	* x
+}
+
+function division() {
+	0
+	// Comment
+	/ x
+}
+
+function substraction() {
+	0
+	// Comment
+	- x
+}
+
+function remainder() {
+	0
+	// Comment
+	% x
+}
+
+function exponentiation() {
+	0
+	// Comment
+	** x
+}
+
+function leftShift() {
+	0
+	// Comment
+	<< x
+}
+
+function rightShift() {
+	0
+	// Comment
+	>> x
+}
+
+function unsignedRightShift() {
+	0
+	// Comment
+	>>> x
+}
+
+function bitwiseAnd() {
+	0
+	// Comment
+	& x
+}
+
+function bitwiseOr() {
+	0
+	// Comment
+	| x
+}
+
+function bitwiseXor() {
+	0
+	// Comment
+	^ x
+}

--- a/tests/comments_pipeline_own_line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments_pipeline_own_line/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pipeline_own_line.js - babylon-verify 1`] = `
+function pipeline() {
+	0
+	// Comment
+	|> x
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+function pipeline() {
+  0 |>
+    // Comment
+    x;
+}
+
+`;

--- a/tests/comments_pipeline_own_line/jsfmt.spec.js
+++ b/tests/comments_pipeline_own_line/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["babylon"]);

--- a/tests/comments_pipeline_own_line/pipeline_own_line.js
+++ b/tests/comments_pipeline_own_line/pipeline_own_line.js
@@ -1,0 +1,5 @@
+function pipeline() {
+	0
+	// Comment
+	|> x
+}


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Resolves #5009 .
The pipeline operator now doesn't get inlined with an leading ownLineComment, but is instead treated as any other binary expression. Thus, the pipeline operator gets moven above the ownLineComment.

I also added tests for all other binary expressions as well as a separate test for the pipeline operator binary expression as this can only be run with babylon.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
