### PR TITLE
verify the precedingNode type when handling import declaration comments

### DIFF
--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -659,6 +659,7 @@ function handleImportDeclarationComments(
 ) {
   if (
     precedingNode &&
+    precedingNode.type === "ImportSpecifier" &&
     enclosingNode &&
     enclosingNode.type === "ImportDeclaration" &&
     privateUtil.hasNewline(text, options.locEnd(comment))

--- a/tests/import/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/import/__snapshots__/jsfmt.spec.js.snap
@@ -95,6 +95,11 @@ import {
   SelectionSetNode,
   /* tslint:enable */
 } from 'graphql';
+
+import x, {
+  // comment
+  y
+} from 'z';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import {
   //comment1
@@ -138,6 +143,11 @@ import {
   SelectionSetNode
   /* tslint:enable */
 } from "graphql";
+
+import x, {
+  // comment
+  y
+} from "z";
 
 `;
 
@@ -182,6 +192,11 @@ import {
   SelectionSetNode,
   /* tslint:enable */
 } from 'graphql';
+
+import x, {
+  // comment
+  y
+} from 'z';
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import {
   //comment1
@@ -225,6 +240,11 @@ import {
   SelectionSetNode
   /* tslint:enable */
 } from "graphql";
+
+import x, {
+  // comment
+  y
+} from "z";
 
 `;
 

--- a/tests/import/comments.js
+++ b/tests/import/comments.js
@@ -38,3 +38,8 @@ import {
   SelectionSetNode,
   /* tslint:enable */
 } from 'graphql';
+
+import x, {
+  // comment
+  y
+} from 'z';


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fixes #4847 by making sure that the `precedingNode` is of type `ImportSpecifier`. 

In the example mentioned in the original issue, where the comment should not be moved outside the block, `precedingNode.type` is `ImportDefaultSpecifier`.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
