### PR TITLE
refactor: move cli leven suggestion to options-normalizer

### DIFF
--- a/src/cli/constant.js
+++ b/src/cli/constant.js
@@ -156,7 +156,8 @@ const options = {
     description: dedent`
       Show CLI usage, or details about the given flag.
       Example: --help write
-    `
+    `,
+    exception: value => value === ""
   },
   "ignore-path": {
     type: "path",

--- a/src/main/options-normalizer.js
+++ b/src/main/options-normalizer.js
@@ -1,6 +1,8 @@
 "use strict";
 
 const vnopts = require("vnopts");
+const leven = require("leven");
+const chalk = require("chalk");
 
 const cliDescriptor = {
   key: key => (key.length === 1 ? `-${key}` : `--${key}`),
@@ -14,6 +16,32 @@ const cliDescriptor = {
           ? `${cliDescriptor.key(key)} without an argument`
           : `${cliDescriptor.key(key)}=${value}`
 };
+
+class FlagSchema extends vnopts.ChoiceSchema {
+  constructor({ name, flags }) {
+    super({ name, choices: flags });
+    this._flags = flags.slice().sort();
+  }
+  preprocess(value, utils) {
+    if (
+      typeof value === "string" &&
+      value.length !== 0 &&
+      this._flags.indexOf(value) === -1
+    ) {
+      const suggestion = this._flags.find(flag => leven(flag, value) < 3);
+      if (suggestion) {
+        utils.logger.warn(
+          [
+            `Unknown flag ${chalk.yellow(utils.descriptor.value(value))},`,
+            `did you mean ${chalk.blue(utils.descriptor.value(suggestion))}?`
+          ].join(" ")
+        );
+        return suggestion;
+      }
+    }
+    return value;
+  }
+}
 
 function normalizeOptions(
   options,
@@ -40,7 +68,7 @@ function optionInfosToSchemas(optionInfos, { isCLI }) {
   }
 
   for (const optionInfo of optionInfos) {
-    schemas.push(optionInfoToSchema(optionInfo, { isCLI }));
+    schemas.push(optionInfoToSchema(optionInfo, { isCLI, optionInfos }));
 
     if (optionInfo.alias && isCLI) {
       schemas.push(
@@ -55,7 +83,7 @@ function optionInfosToSchemas(optionInfos, { isCLI }) {
   return schemas;
 }
 
-function optionInfoToSchema(optionInfo, { isCLI }) {
+function optionInfoToSchema(optionInfo, { isCLI, optionInfos }) {
   let SchemaConstructor;
   const parameters = { name: optionInfo.name };
   const handlers = {};
@@ -84,6 +112,17 @@ function optionInfoToSchema(optionInfo, { isCLI }) {
       SchemaConstructor = vnopts.BooleanSchema;
       break;
     case "flag":
+      SchemaConstructor = FlagSchema;
+      parameters.flags = optionInfos
+        .map(optionInfo =>
+          [].concat(
+            optionInfo.alias || [],
+            optionInfo.description ? optionInfo.name : [],
+            optionInfo.oppositeDescription ? `no-${optionInfo.name}` : []
+          )
+        )
+        .reduce((a, b) => a.concat(b), []);
+      break;
     case "path":
       SchemaConstructor = vnopts.StringSchema;
       break;

--- a/src/main/options-normalizer.js
+++ b/src/main/options-normalizer.js
@@ -41,6 +41,9 @@ class FlagSchema extends vnopts.ChoiceSchema {
     }
     return value;
   }
+  expected() {
+    return "a flag";
+  }
 }
 
 function normalizeOptions(

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -146,21 +146,8 @@ exports[`show version with --version (stderr) 1`] = `""`;
 
 exports[`show version with --version (write) 1`] = `Array []`;
 
-exports[`show warning with --help not-found (stderr) 1`] = `
-"[warn] Unknown option name \\"not-found\\"
-"
-`;
-
-exports[`show warning with --help not-found (stdout) 1`] = `
-"-h, --help <flag>
-
-  Show CLI usage, or details about the given flag.
-  Example: --help write
-"
-`;
-
 exports[`show warning with --help not-found (typo) (stderr) 1`] = `
-"[warn] Unknown option name \\"parserr\\", did you mean \\"parser\\"?
+"[warn] Unknown flag \\"parserr\\", did you mean \\"parser\\"?
 "
 `;
 
@@ -189,8 +176,6 @@ Valid options:
 `;
 
 exports[`show warning with --help not-found (typo) (write) 1`] = `Array []`;
-
-exports[`show warning with --help not-found (write) 1`] = `Array []`;
 
 exports[`throw error and show usage with something unexpected (stderr) 1`] = `""`;
 
@@ -310,6 +295,15 @@ exports[`throw error with --find-config-path + multiple files (stderr) 1`] = `
 exports[`throw error with --find-config-path + multiple files (stdout) 1`] = `""`;
 
 exports[`throw error with --find-config-path + multiple files (write) 1`] = `Array []`;
+
+exports[`throw error with --help not-found (stderr) 1`] = `
+"[error] Invalid --help value. Expected \\"arrow-parens\\", \\"bracket-spacing\\", \\"color\\", \\"config\\", \\"config-precedence\\", \\"cursor-offset\\", \\"editorconfig\\", \\"file-info\\", \\"find-config-path\\", \\"h\\", \\"help\\", \\"ignore-path\\", \\"insert-pragma\\", \\"jsx-bracket-same-line\\", \\"l\\", \\"list-different\\", \\"loglevel\\", \\"no-bracket-spacing\\", \\"no-color\\", \\"no-config\\", \\"no-editorconfig\\", \\"no-semi\\", \\"parser\\", \\"plugin\\", \\"plugin-search-dir\\", \\"print-width\\", \\"prose-wrap\\", \\"range-end\\", \\"range-start\\", \\"require-pragma\\", \\"semi\\", \\"single-quote\\", \\"stdin\\", \\"stdin-filepath\\", \\"support-info\\", \\"tab-width\\", \\"trailing-comma\\", \\"use-tabs\\", \\"v\\", \\"version\\", \\"with-node-modules\\" or \\"write\\", but received \\"not-found\\".
+"
+`;
+
+exports[`throw error with --help not-found (stdout) 1`] = `""`;
+
+exports[`throw error with --help not-found (write) 1`] = `Array []`;
 
 exports[`throw error with --write + --debug-check (stderr) 1`] = `
 "[error] Cannot use --write and --debug-check together.

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -297,7 +297,7 @@ exports[`throw error with --find-config-path + multiple files (stdout) 1`] = `""
 exports[`throw error with --find-config-path + multiple files (write) 1`] = `Array []`;
 
 exports[`throw error with --help not-found (stderr) 1`] = `
-"[error] Invalid --help value. Expected \\"arrow-parens\\", \\"bracket-spacing\\", \\"color\\", \\"config\\", \\"config-precedence\\", \\"cursor-offset\\", \\"editorconfig\\", \\"file-info\\", \\"find-config-path\\", \\"h\\", \\"help\\", \\"ignore-path\\", \\"insert-pragma\\", \\"jsx-bracket-same-line\\", \\"l\\", \\"list-different\\", \\"loglevel\\", \\"no-bracket-spacing\\", \\"no-color\\", \\"no-config\\", \\"no-editorconfig\\", \\"no-semi\\", \\"parser\\", \\"plugin\\", \\"plugin-search-dir\\", \\"print-width\\", \\"prose-wrap\\", \\"range-end\\", \\"range-start\\", \\"require-pragma\\", \\"semi\\", \\"single-quote\\", \\"stdin\\", \\"stdin-filepath\\", \\"support-info\\", \\"tab-width\\", \\"trailing-comma\\", \\"use-tabs\\", \\"v\\", \\"version\\", \\"with-node-modules\\" or \\"write\\", but received \\"not-found\\".
+"[error] Invalid --help value. Expected a flag, but received \\"not-found\\".
 "
 `;
 

--- a/tests_integration/__tests__/early-exit.js
+++ b/tests_integration/__tests__/early-exit.js
@@ -44,9 +44,9 @@ describe(`show detailed usage with plugin options (manual resolution)`, () => {
   });
 });
 
-describe("show warning with --help not-found", () => {
+describe("throw error with --help not-found", () => {
   runPrettier("cli", ["--help", "not-found"]).test({
-    status: 0
+    status: 1
   });
 });
 


### PR DESCRIPTION
Option-related processing should be done in `options-normalizer`.

- unknown flag suggestions are colored
  ![image](https://user-images.githubusercontent.com/8341033/45103027-866c7900-b161-11e8-8ee3-6467a9ca0090.png)
- unknown flags with no suggestion are now errors:
  ```
  $ bin/prettier.js --help noseminosemi
  [error] Invalid `--help` value. Expected `a flag`, but received `"noseminosemi"`.
  ```

---

- I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
