### PR TITLE
fix(typescript): add parens for TSAsExpression in ClassExpression

### DIFF
--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -230,6 +230,7 @@ function needsParens(path, options) {
         case "NewExpression":
           return name === "callee" && parent.callee === node;
 
+        case "ClassExpression":
         case "ClassDeclaration":
         case "TSAbstractClassDeclaration":
           return name === "superClass" && parent.superClass === node;

--- a/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
@@ -45,7 +45,7 @@ export default class Column<T> extends (RcTable.Column as React.ComponentClass<
   ColumnProps<T>,
   ColumnProps<T>
 >) {}
-export const MobxTypedForm = class extends Form as { new (): any } {};
+export const MobxTypedForm = class extends (Form as { new (): any }) {};
 export abstract class MobxTypedForm extends (Form as { new (): any }) {}
 ({} as {});
 function* g() {

--- a/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
@@ -8,6 +8,7 @@ this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
 start + (yearSelectTotal as number)
 scrollTop > (visibilityHeight as number)
 export default class Column<T> extends (RcTable.Column as React.ComponentClass<ColumnProps<T>,ColumnProps<T>,ColumnProps<T>,ColumnProps<T>>) {}
+export const MobxTypedForm = class extends (Form as { new (): any }) {}
 export abstract class MobxTypedForm extends (Form as { new (): any }) {}
 ({}) as {};
 function*g() {
@@ -44,6 +45,7 @@ export default class Column<T> extends (RcTable.Column as React.ComponentClass<
   ColumnProps<T>,
   ColumnProps<T>
 >) {}
+export const MobxTypedForm = class extends Form as { new (): any } {};
 export abstract class MobxTypedForm extends (Form as { new (): any }) {}
 ({} as {});
 function* g() {

--- a/tests/typescript_as/as.js
+++ b/tests/typescript_as/as.js
@@ -5,6 +5,7 @@ this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
 start + (yearSelectTotal as number)
 scrollTop > (visibilityHeight as number)
 export default class Column<T> extends (RcTable.Column as React.ComponentClass<ColumnProps<T>,ColumnProps<T>,ColumnProps<T>,ColumnProps<T>>) {}
+export const MobxTypedForm = class extends (Form as { new (): any }) {}
 export abstract class MobxTypedForm extends (Form as { new (): any }) {}
 ({}) as {};
 function*g() {


### PR DESCRIPTION
Fixes #5073

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
