### PR TITLE
Keep simple JSXOpeningTag's unbroken

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1957,16 +1957,19 @@ function printPathNoParens(path, options, print, args) {
         n.attributes.length && hasTrailingComment(getLast(n.attributes));
 
       const bracketSameLine =
-        options.jsxBracketSameLine &&
-        // We should print the bracket in a new line for the following cases:
-        // <div
-        //   // comment
-        // >
-        // <div
-        //   attr // comment
-        // >
-        (!nameHasComments || n.attributes.length) &&
-        !lastAttrHasTrailingComments;
+        // Simple tags (no attributes and no comment in tag name) should be
+        // kept unbroken regardless of `jsxBracketSameLine`
+        (!n.attributes.length && !nameHasComments) ||
+        (options.jsxBracketSameLine &&
+          // We should print the bracket in a new line for the following cases:
+          // <div
+          //   // comment
+          // >
+          // <div
+          //   attr // comment
+          // >
+          (!nameHasComments || n.attributes.length) &&
+          !lastAttrHasTrailingComments);
 
       // We should print the opening element expanded if any prop value is a
       // string literal with newlines

--- a/tests/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -884,6 +884,8 @@ onClick={() => {
 onClick={() => {
   a
 }}>{header}<showSort attr="long long long long long long long long long long long"/></td>;
+
+<Foo>{\`    a    very    long    text    that    does    not    break    \`}</Foo>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <td
   onClick={() => {
@@ -902,6 +904,8 @@ onClick={() => {
   {header}
   <showSort attr="long long long long long long long long long long long" />
 </td>;
+
+<Foo>{\`    a    very    long    text    that    does    not    break    \`}</Foo>;
 
 `;
 

--- a/tests/jsx/open-break.js
+++ b/tests/jsx/open-break.js
@@ -7,3 +7,5 @@ onClick={() => {
 onClick={() => {
   a
 }}>{header}<showSort attr="long long long long long long long long long long long"/></td>;
+
+<Foo>{`    a    very    long    text    that    does    not    break    `}</Foo>;


### PR DESCRIPTION
Closes #5075

The bug happens because single line template literals don't break and we inline template literals if they're the only children of a JSX tag because of #1090. The simplest fix is to prevent simple `<Tag>` from breaking.