### PR TITLE
fix(typescript): no-semi for class props with modifiers

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5529,6 +5529,13 @@ function classChildNeedsASIProtection(node) {
     return;
   }
 
+  if (
+    node.static ||
+    node.accessibility // TypeScript
+  ) {
+    return false;
+  }
+
   if (!node.computed) {
     const name = node.key && node.key.name;
     if (name === "in" || name === "instanceof") {
@@ -5545,12 +5552,7 @@ function classChildNeedsASIProtection(node) {
       // Babylon
       const isAsync = node.value ? node.value.async : node.async;
       const isGenerator = node.value ? node.value.generator : node.generator;
-      if (
-        isAsync ||
-        node.static ||
-        node.kind === "get" ||
-        node.kind === "set"
-      ) {
+      if (isAsync || node.kind === "get" || node.kind === "set") {
         return false;
       }
       if (node.computed || isGenerator) {

--- a/tests/no-semi-typescript/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/no-semi-typescript/__snapshots__/jsfmt.spec.js.snap
@@ -44,7 +44,7 @@ class A {
   // none of the semicolons above this comment can be omitted.
   // none of the semicolons below this comment are necessary.
 
-  bar: A;
+  bar: A
   private [baz]
 }
 

--- a/tests/no-semi-typescript/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/no-semi-typescript/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`no-semi.ts - typescript-verify 1`] = `
+class A {
+  bar: A;
+  [baz]
+
+  // none of the semicolons above this comment can be omitted.
+  // none of the semicolons below this comment are necessary.
+
+  bar: A;
+  private [baz]
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class A {
+  bar: A;
+  [baz];
+
+  // none of the semicolons above this comment can be omitted.
+  // none of the semicolons below this comment are necessary.
+
+  bar: A;
+  private [baz];
+}
+
+`;
+
+exports[`no-semi.ts - typescript-verify 2`] = `
+class A {
+  bar: A;
+  [baz]
+
+  // none of the semicolons above this comment can be omitted.
+  // none of the semicolons below this comment are necessary.
+
+  bar: A;
+  private [baz]
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class A {
+  bar: A;
+  [baz]
+
+  // none of the semicolons above this comment can be omitted.
+  // none of the semicolons below this comment are necessary.
+
+  bar: A;
+  private [baz]
+}
+
+`;

--- a/tests/no-semi-typescript/jsfmt.spec.js
+++ b/tests/no-semi-typescript/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname, ["typescript"]);
+run_spec(__dirname, ["typescript"], { semi: false });

--- a/tests/no-semi-typescript/no-semi.ts
+++ b/tests/no-semi-typescript/no-semi.ts
@@ -1,0 +1,10 @@
+class A {
+  bar: A;
+  [baz]
+
+  // none of the semicolons above this comment can be omitted.
+  // none of the semicolons below this comment are necessary.
+
+  bar: A;
+  private [baz]
+}


### PR DESCRIPTION
Fixes #5082

---

**Prettier pr-5083**
[Playground link](https://deploy-preview-5083--prettier.netlify.com/playground/#N4Igxg9gdgLgprEAuc0DOMAEBrAQgVwDNC4AnTAXkwGUBPAWwCMIAbACgHJGiTSOBKADpRIUDDgDyxNHCxU6TVpwjTZA4cLAsAhmjSYASnG0ATMpmDDMmAA6kAlgDdt8TAG08PMgF0kmAsTmAPRBmAA8ALQRmAAWZHBWtg7Orh5ShDIwvphQ+ExkwgC+IAA0IBA2MPboyKDapKQQAO4ACvUIaMgg2o4Q9ialIIyk2mDYstQ2o-ZQAObIMKT4cGUzMqQwLSOz9NrIhNosMmUAVmgAHrgjYxPa9HAAMjNw+4fHIFOk610wtDZwaDADkqgzsMxgAHV+jAYsgABwABjKdggMghIxsXTsALIjheZVIcAAjvh7ISttodnskAcjisQDJ6PZXnSymgZrMWHAAIr4CDwFnvGDaRhQkww5AAJjKi209hYHIAwhB6LsulBoPiQPgZAAVEWdGlvOCFQpAA)
```sh
--parser typescript
--no-semi
```

**Input:**
```tsx
const kBuffer = Symbol('buffer')
const kOffset = Symbol('offset')

class Reader {
  private [kBuffer]: Buffer // <-- here
  private [kOffset]: number
}
```

**Output:**
```tsx
const kBuffer = Symbol("buffer")
const kOffset = Symbol("offset")

class Reader {
  private [kBuffer]: Buffer // <-- here
  private [kOffset]: number
}

```

---

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
