### PR TITLE
Add support for timeouts passed as integers to test functions

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5813,7 +5813,7 @@ function isTestCall(n, parent) {
     ) {
       // it("name", () => { ... }, 2500)
       if (n.arguments[2] && !isNumericLiteral(n.arguments[2])) {
-        return false
+        return false;
       }
       return (
         (isFunctionOrArrowExpression(n.arguments[1].type) &&

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5805,12 +5805,16 @@ function isTestCall(n, parent) {
     if (isUnitTestSetUp(n)) {
       return isAngularTestWrapper(n.arguments[0]);
     }
-  } else if (n.arguments.length === 2) {
+  } else if (n.arguments.length === 2 || n.arguments.length === 3) {
     if (
       ((n.callee.type === "Identifier" && unitTestRe.test(n.callee.name)) ||
         isSkipOrOnlyBlock(n)) &&
       (isTemplateLiteral(n.arguments[0]) || isStringLiteral(n.arguments[0]))
     ) {
+      // it("name", () => { ... }, 2500)
+      if (n.arguments[2] && !isNumericLiteral(n.arguments[2])) {
+        return false
+      }
       return (
         (isFunctionOrArrowExpression(n.arguments[1].type) &&
           n.arguments[1].params.length <= 1) ||

--- a/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
@@ -679,6 +679,19 @@ it.only.only("does something really long and complicated so I have to write a ve
 });
 
 xskip("does something really long and complicated so I have to write a very long name for the test", () => {});
+
+// timeout
+
+it(\`handles
+  some
+    newlines
+  does something really long and complicated so I have to write a very long name for the test\`, () => {
+  console.log("hello!");
+}, 2500)
+
+it("does something quick", () => {
+  console.log("hello!")
+}, 1000000000)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Shouldn't break
 
@@ -800,6 +813,19 @@ xskip(
   () => {}
 );
 
+// timeout
+
+it(\`handles
+  some
+    newlines
+  does something really long and complicated so I have to write a very long name for the test\`, () => {
+  console.log("hello!");
+}, 2500);
+
+it("does something quick", () => {
+  console.log("hello!");
+}, 1000000000);
+
 `;
 
 exports[`test_declarations.js - flow-verify 2`] = `
@@ -909,6 +935,19 @@ it.only.only("does something really long and complicated so I have to write a ve
 });
 
 xskip("does something really long and complicated so I have to write a very long name for the test", () => {});
+
+// timeout
+
+it(\`handles
+  some
+    newlines
+  does something really long and complicated so I have to write a very long name for the test\`, () => {
+  console.log("hello!");
+}, 2500)
+
+it("does something quick", () => {
+  console.log("hello!")
+}, 1000000000)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Shouldn't break
 
@@ -1029,5 +1068,18 @@ xskip(
   "does something really long and complicated so I have to write a very long name for the test",
   () => {}
 );
+
+// timeout
+
+it(\`handles
+  some
+    newlines
+  does something really long and complicated so I have to write a very long name for the test\`, () => {
+  console.log("hello!");
+}, 2500);
+
+it("does something quick", () => {
+  console.log("hello!");
+}, 1000000000);
 
 `;

--- a/tests/test_declarations/test_declarations.js
+++ b/tests/test_declarations/test_declarations.js
@@ -104,3 +104,16 @@ it.only.only("does something really long and complicated so I have to write a ve
 });
 
 xskip("does something really long and complicated so I have to write a very long name for the test", () => {});
+
+// timeout
+
+it(`handles
+  some
+    newlines
+  does something really long and complicated so I have to write a very long name for the test`, () => {
+  console.log("hello!");
+}, 2500)
+
+it("does something quick", () => {
+  console.log("hello!")
+}, 1000000000)


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

Fixes #5061 