### PR TITLE
fix(typescript): no invalid parens for destructuring with default value

### DIFF
--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -487,6 +487,8 @@ function needsParens(path, options) {
         (grandParent.init === parent || grandParent.update === parent)
       ) {
         return false;
+      } else if (parent.type === "Property" && parent.value === node) {
+        return false;
       }
       return true;
     }

--- a/tests/assignment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/assignment/__snapshots__/jsfmt.spec.js.snap
@@ -31,6 +31,8 @@ let {
 
 const { accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule,
       } = foo || {};
+
+({ prop: toAssign = "default" } = { prop: "propval" });
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 let {
   bottom: offsetBottom,
@@ -45,6 +47,8 @@ const {
   accessibilityModule: FooAccessibilityModule,
   accessibilityModule: FooAccessibilityModule
 } = foo || {};
+
+({ prop: toAssign = "default" } = { prop: "propval" });
 
 `;
 

--- a/tests/assignment/destructuring.js
+++ b/tests/assignment/destructuring.js
@@ -7,3 +7,5 @@ let {
 
 const { accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule,
       } = foo || {};
+
+({ prop: toAssign = "default" } = { prop: "propval" });


### PR DESCRIPTION
Fixes #4813

---

**Prettier pr-5096**
[Playground link](https://deploy-preview-5096--prettier.netlify.com/playground/#N4Igxg9gdgLgprEAuEAbOMAEMIEEDO+AlgOZRKb4wBORUJA3ADpQAUwmADtRJxTgWJlMAXkxMQAEzgAzAIYBXVDAmYAvqMwduvChJ2cAbnNSq1ASgYgANCF4wi0fMlBzqPAO4AFNwmco5QwgiSRsQACNqOTAAawwAZU5ouhJkGgU4Wzp8OGoYLyiSAFs5ZHlUHNsAK3wADwAhKNiEuSK4ABk6ODKTSpAk6hzqZBAYAE9OOHwwWk4YMO46GAB1EJgAC2QADgAGWx0c5ajOEe4p3MNu22o4AEcFIhuCuWLSpHK+nKKiNOoM22I9HQAEUFBB4D0KplRnJwqtJBtkAAmWw0OREVApADCECKJRGUGgVxAChyABVYf4PnA1GogA)
```sh
--parser typescript
```

**Input:**
```tsx
let toAssign: string;
({ prop: toAssign = "default" } = { prop: "propval" });
```

**Output:**
```tsx
let toAssign: string;
({ prop: toAssign = "default" } = { prop: "propval" });

```

---

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
