### PR TITLE
fix(html): exclude comments from fragment detection

### DIFF
--- a/src/language-html/parser-parse5.js
+++ b/src/language-html/parser-parse5.js
@@ -1,12 +1,15 @@
 "use strict";
 
+const nonFragmentRegex = /^\s*(<!--[\s\S]*?-->\s*)*<(!doctype|html|head|body)/i;
+
 function parse(text /*, parsers, opts*/) {
   // Inline the require to avoid loading all the JS if we don't use it
   const parse5 = require("parse5");
   const htmlparser2TreeAdapter = require("parse5-htmlparser2-tree-adapter");
 
   try {
-    const isFragment = !/^\s*<(!doctype|html|head|body|!--)/i.test(text);
+    const isFragment = !nonFragmentRegex.test(text);
+
     const ast = (isFragment ? parse5.parseFragment : parse5.parse)(text, {
       treeAdapter: htmlparser2TreeAdapter,
       sourceCodeLocationInfo: true

--- a/src/language-html/parser-parse5.js
+++ b/src/language-html/parser-parse5.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const nonFragmentRegex = /^\s*(<!--[\s\S]*?-->\s*)*<(!doctype|html|head|body)/i;
+const nonFragmentRegex = /^\s*(<!--[\s\S]*?-->\s*)*<(!doctype|html|head|body)[\s>]/i;
 
 function parse(text /*, parsers, opts*/) {
   // Inline the require to avoid loading all the JS if we don't use it

--- a/tests/html_basics/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_basics/__snapshots__/jsfmt.spec.js.snap
@@ -4,10 +4,6 @@ exports[`comment.html - parse5-verify 1`] = `
 <!--hello world-->
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <!--hello world-->
-<html>
-  <head></head>
-  <body></body>
-</html>
 
 `;
 

--- a/tests/html_basics/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_basics/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`comment.html - parse5-verify 1`] = `
+<!--hello world-->
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<!--hello world-->
+<html>
+  <head></head>
+  <body></body>
+</html>
+
+`;
+
 exports[`empty.html - parse5-verify 1`] = `
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/tests/html_basics/comment.html
+++ b/tests/html_basics/comment.html
@@ -1,0 +1,1 @@
+<!--hello world-->


### PR DESCRIPTION
Context: https://github.com/prettier/prettier/pull/4753#discussion_r200848784

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
