### PR TITLE
fix(css): no wrong loc info caused by front matter

### DIFF
--- a/src/utils/front-matter.js
+++ b/src/utils/front-matter.js
@@ -26,7 +26,7 @@ function parse(text) {
 
   return {
     frontMatter: { type: DELIMITER_MAP[delimiter], value, raw },
-    content: text.slice(raw.length)
+    content: match[0].replace(/[^\n]/g, " ") + text.slice(match[0].length)
   };
 }
 

--- a/tests/css_yaml/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_yaml/__snapshots__/jsfmt.spec.js.snap
@@ -98,7 +98,7 @@ hello: world
 ---
 
 /* prettier-ignore */
- pretti
+.foo {}
 
 `;
 
@@ -137,6 +137,7 @@ foo: bar
 a {
   color: blue;
 }
+
 --- .b {
   color: red;
 }

--- a/tests/css_yaml/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_yaml/__snapshots__/jsfmt.spec.js.snap
@@ -85,6 +85,23 @@ a {
 
 `;
 
+exports[`ignore.css - css-verify 1`] = `
+---
+hello: world
+---
+
+/* prettier-ignore */
+.foo {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---
+hello: world
+---
+
+/* prettier-ignore */
+ pretti
+
+`;
+
 exports[`malformed.css - css-verify 1`] = `
 ---
 aaa

--- a/tests/css_yaml/ignore.css
+++ b/tests/css_yaml/ignore.css
@@ -1,0 +1,6 @@
+---
+hello: world
+---
+
+/* prettier-ignore */
+.foo {}

--- a/tests/insert-pragma/css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/insert-pragma/css/__snapshots__/jsfmt.spec.js.snap
@@ -12,6 +12,7 @@ something
 ---
 
 /** @format */
+
 .class {
   display: none;
 }

--- a/tests/require-pragma/css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/require-pragma/css/__snapshots__/jsfmt.spec.js.snap
@@ -12,6 +12,7 @@ exports[`empty-front-matter-with-pragma.css - css-verify 1`] = `
 ---
 
 /** @prettier */
+
 .class {
   display: none;
 }
@@ -45,6 +46,7 @@ something
 ---
 
 /** @prettier */
+
 .class {
   display: none;
 }


### PR DESCRIPTION
Replace front matter with whitespaces to maintain the loc info.

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
