### PR TITLE
fix(html): preserve case-sensitive attributes

### DIFF
--- a/src/language-html/parser-parse5.js
+++ b/src/language-html/parser-parse5.js
@@ -22,12 +22,15 @@ function normalize(node, text) {
   delete node.next;
   delete node.prev;
 
+  let isCaseSensitiveTag = false;
+
   // preserve case-sensitive tag names
   if (
     node.type === "tag" &&
     node.sourceCodeLocation &&
     htmlTagNames.indexOf(node.name) === -1
   ) {
+    isCaseSensitiveTag = true;
     node.name = text.slice(
       node.sourceCodeLocation.startOffset + 1, // <
       node.sourceCodeLocation.startOffset + 1 + node.name.length
@@ -36,10 +39,19 @@ function normalize(node, text) {
 
   if (node.attribs) {
     node.attributes = Object.keys(node.attribs).map(attributeKey => {
+      const sourceCodeLocation = node.sourceCodeLocation.attrs[attributeKey];
       return {
         type: "attribute",
-        key: attributeKey,
-        value: node.attribs[attributeKey]
+        key: isCaseSensitiveTag
+          ? text
+              .slice(
+                sourceCodeLocation.startOffset,
+                sourceCodeLocation.endOffset
+              )
+              .split("=", 1)[0]
+          : attributeKey,
+        value: node.attribs[attributeKey],
+        sourceCodeLocation
       };
     });
   }

--- a/src/language-html/printer-htmlparser2.js
+++ b/src/language-html/printer-htmlparser2.js
@@ -182,11 +182,9 @@ function genericPrint(path, options, print) {
           return n.key;
         }
 
-        const attributeSourceCodeLocation =
-          parentNode.sourceCodeLocation.attrs[n.key];
         const originalAttributeSourceCode = options.originalText.slice(
-          attributeSourceCodeLocation.startOffset,
-          attributeSourceCodeLocation.endOffset
+          n.sourceCodeLocation.startOffset,
+          n.sourceCodeLocation.endOffset
         );
         const hasEqualSign = originalAttributeSourceCode.indexOf("=") !== -1;
 

--- a/tests/html_tags/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_tags/__snapshots__/jsfmt.spec.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`case-sensitive.html - parse5-verify 1`] = `
-<CaseSensitive>hello world</CaseSensitive>
+<CaseSensitive CaseSensitive="true">hello world</CaseSensitive>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-<CaseSensitive>hello world</CaseSensitive>
+<CaseSensitive casesensitive="true">hello world</CaseSensitive>
 
 `;
 

--- a/tests/html_tags/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_tags/__snapshots__/jsfmt.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`case-sensitive.html - parse5-verify 1`] = `
 <CaseSensitive CaseSensitive="true">hello world</CaseSensitive>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-<CaseSensitive casesensitive="true">hello world</CaseSensitive>
+<CaseSensitive CaseSensitive="true">hello world</CaseSensitive>
 
 `;
 

--- a/tests/html_tags/case-sensitive.html
+++ b/tests/html_tags/case-sensitive.html
@@ -1,1 +1,1 @@
-<CaseSensitive>hello world</CaseSensitive>
+<CaseSensitive CaseSensitive="true">hello world</CaseSensitive>


### PR DESCRIPTION
Attributes in non-HTML tags are considered case-sensitive.

---

**Prettier pr-5109**
[Playground link](https://deploy-preview-5109--prettier.netlify.com/playground/#N4Igxg9gdgLgprEAuEAeAwgQwM5wMoLYCWMRAbnAARa4FTGkUB8AFnADbsSUDuEATuwAmqAPQ18hEuThMAOlFQARctRxwAkvSmNZbTtz6CRolWSYgANCAgAHUtGzJQmfvwg8ACq8LIQmMggiISsQACN+TDAAazgYPFsooigAc2QYfgBXOGtk3H4YT0iUgFtMZAAzTHZcawArbAAPACFImLi8TBK4ABlkuErq2pBE-ny-UdwAVlDbfmSYAHVgmBZkAA4ABms5iFxFyNsJ-jh8ilCTgEdMohOizFLypCqanJBcEqJ0rLfiVPY4ABFTIQeCDV7WGCYMLLISrZAAJkhkSI7GSKXQEBKZT8UGgA2smVwABVoU5nkM4ABfKlAA)
```sh
--parser parse5
```

**Input:**
```html
<CaseSensitive CaseSensitive>hello world</CaseSensitive>
<Div CaseInsensitive>hello world</Div>
```

**Output:**
```html
<CaseSensitive CaseSensitive>hello world</CaseSensitive>
<div caseinsensitive>hello world</div>

```

---

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
