### PR TITLE
feat(html): support front matter

### DIFF
--- a/src/language-html/clean.js
+++ b/src/language-html/clean.js
@@ -6,4 +6,9 @@ module.exports = function(ast, newNode) {
   if (ast.type === "text") {
     return null;
   }
+
+  // may be formatted by multiparser
+  if (ast.type === "yaml") {
+    return null;
+  }
 };

--- a/src/language-html/parser-parse5.js
+++ b/src/language-html/parser-parse5.js
@@ -1,6 +1,8 @@
 "use strict";
 
 const htmlTagNames = require("html-tag-names");
+const parseFrontMatter = require("../utils/front-matter");
+
 const nonFragmentRegex = /^\s*(<!--[\s\S]*?-->\s*)*<(!doctype|html|head|body)[\s>]/i;
 
 function parse(text /*, parsers, opts*/) {
@@ -8,13 +10,21 @@ function parse(text /*, parsers, opts*/) {
   const parse5 = require("parse5");
   const htmlparser2TreeAdapter = require("parse5-htmlparser2-tree-adapter");
 
-  const isFragment = !nonFragmentRegex.test(text);
-  const ast = (isFragment ? parse5.parseFragment : parse5.parse)(text, {
+  const { frontMatter, content } = parseFrontMatter(text);
+
+  const isFragment = !nonFragmentRegex.test(content);
+  const ast = (isFragment ? parse5.parseFragment : parse5.parse)(content, {
     treeAdapter: htmlparser2TreeAdapter,
     sourceCodeLocationInfo: true
   });
 
-  return normalize(extendAst(ast), text);
+  const normalizedAst = normalize(extendAst(ast), content);
+
+  if (frontMatter) {
+    normalizedAst.children.unshift(frontMatter);
+  }
+
+  return normalizedAst;
 }
 
 function normalize(ast, text) {

--- a/src/language-html/printer-htmlparser2.js
+++ b/src/language-html/printer-htmlparser2.js
@@ -195,7 +195,10 @@ function genericPrint(path, options, print) {
 
       return concat([n.key, '="', n.value.replace(/"/g, "&quot;"), '"']);
     }
-
+    // front matter
+    case "yaml":
+    case "toml":
+      return concat([n.raw, hardline]);
     default:
       /* istanbul ignore next */
       throw new Error("unknown htmlparser2 type: " + n.type);

--- a/tests/html_yaml/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_yaml/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`invalid.html - parse5-verify 1`] = `
+---
+    invalid:
+invalid:
+---
+
+
+
+<html><head></head><body></body></html>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+---
+    invalid:
+invalid:
+---
+
+<html>
+  <head></head>
+  <body></body>
+</html>
+
+`;
+
 exports[`yaml.html - parse5-verify 1`] = `
 ---
 hello:     world

--- a/tests/html_yaml/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_yaml/__snapshots__/jsfmt.spec.js.snap
@@ -12,5 +12,13 @@ hello:     world
 
 <html><head></head><body></body></html>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
---- hello: world ---
+---
+hello: world
+---
+
+<html>
+  <head></head>
+  <body></body>
+</html>
+
 `;

--- a/tests/html_yaml/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_yaml/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`yaml.html - parse5-verify 1`] = `
+---
+hello:     world
+---
+
+
+
+
+
+
+<html><head></head><body></body></html>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+--- hello: world ---
+`;

--- a/tests/html_yaml/invalid.html
+++ b/tests/html_yaml/invalid.html
@@ -1,0 +1,8 @@
+---
+    invalid:
+invalid:
+---
+
+
+
+<html><head></head><body></body></html>

--- a/tests/html_yaml/jsfmt.spec.js
+++ b/tests/html_yaml/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["parse5"]);

--- a/tests/html_yaml/yaml.html
+++ b/tests/html_yaml/yaml.html
@@ -1,0 +1,10 @@
+---
+hello:     world
+---
+
+
+
+
+
+
+<html><head></head><body></body></html>


### PR DESCRIPTION
- format yaml front matter
- preserve toml front matter

---

**Prettier pr-5110**
[Playground link](https://deploy-preview-5110--prettier.netlify.com/playground/#N4Igxg9gdgLgprEAuEBadAdKALOAbPCJAAlLIHcIAnPAEy3VS1KwB5sYBbPAPnbgCGtPgHpcQvgCMItAJ6jpc0R248sIADQgIABxgBLaAGdkoAVSoRyABXMITKAQDcI+2ppCSqAsAGs4MADKOj76UADmyDBUAK5wWmFGcFQw1t7hnALIAGYCeElaAFZGAB4AQt5+AYECnHAAMmFwOXkFICFUSVTI7eZJAKweOlRhMADqbjDYyAAcAAxawxBJY946PcNwXU7NWlRwAI4x+vtpAhlZSLn58SBJnPpRsbdGYeF4cACKMRDwLTdaGACSQTWhTZAAJkB3n0eDeAGEIJxMj0oNBdiAYkkACrAhzXJIAX0JQA)
```sh
--parser parse5
```

**Input:**
```html
---
hello:      world
---
  
<html><head></head><body></body></html>

```

**Output:**
```html
---
hello: world
---

<html>
  <head></head>
  <body></body>
</html>

```

---

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
