### PR TITLE
fix(html): no need to strip newline for text in script-like tag

### DIFF
--- a/src/doc/doc-utils.js
+++ b/src/doc/doc-utils.js
@@ -184,16 +184,24 @@ function removeLines(doc) {
 
 function stripTrailingHardline(doc) {
   // HACK remove ending hardline, original PR: #1984
-  if (
-    doc.type === "concat" &&
-    doc.parts.length === 2 &&
-    doc.parts[1].type === "concat" &&
-    doc.parts[1].parts.length === 2 &&
-    doc.parts[1].parts[0].hard &&
-    doc.parts[1].parts[1].type === "break-parent"
-  ) {
-    return doc.parts[0];
+  if (doc.type === "concat" && doc.parts.length !== 0) {
+    const lastPart = doc.parts[doc.parts.length - 1];
+    if (lastPart.type === "concat") {
+      if (
+        lastPart.parts.length === 2 &&
+        lastPart.parts[0].hard &&
+        lastPart.parts[1].type === "break-parent"
+      ) {
+        return { type: "concat", parts: doc.parts.slice(0, -1) };
+      }
+
+      return {
+        type: "concat",
+        parts: doc.parts.slice(0, -1).concat(stripTrailingHardline(lastPart))
+      };
+    }
   }
+
   return doc;
 }
 

--- a/src/language-html/embed.js
+++ b/src/language-html/embed.js
@@ -3,7 +3,7 @@
 const { hasNewlineInRange } = require("../common/util");
 const {
   builders: { hardline, concat },
-  utils: { stripTrailingHardline, removeLines }
+  utils: { removeLines, stripTrailingHardline }
 } = require("../doc");
 
 function embed(path, print, textToDoc, options) {
@@ -21,7 +21,7 @@ function embed(path, print, textToDoc, options) {
       ) {
         const parser = options.parser === "flow" ? "flow" : "babylon";
         const doc = textToDoc(getText(options, node), { parser });
-        return concat([hardline, stripTrailingHardline(doc)]);
+        return concat([hardline, stripTrailingHardline(doc), hardline]);
       }
 
       // Inline TypeScript
@@ -35,13 +35,13 @@ function embed(path, print, textToDoc, options) {
           { parser: "typescript" },
           options
         );
-        return concat([hardline, stripTrailingHardline(doc)]);
+        return concat([hardline, stripTrailingHardline(doc), hardline]);
       }
 
       // Inline Styles
       if (parent.type === "style") {
         const doc = textToDoc(getText(options, node), { parser: "css" });
-        return concat([hardline, stripTrailingHardline(doc)]);
+        return concat([hardline, stripTrailingHardline(doc), hardline]);
       }
 
       break;

--- a/src/language-html/embed.js
+++ b/src/language-html/embed.js
@@ -3,7 +3,7 @@
 const { hasNewlineInRange } = require("../common/util");
 const {
   builders: { hardline, concat },
-  utils: { removeLines, stripTrailingHardline }
+  utils: { removeLines }
 } = require("../doc");
 
 function embed(path, print, textToDoc, options) {
@@ -21,7 +21,7 @@ function embed(path, print, textToDoc, options) {
       ) {
         const parser = options.parser === "flow" ? "flow" : "babylon";
         const doc = textToDoc(getText(options, node), { parser });
-        return concat([hardline, stripTrailingHardline(doc), hardline]);
+        return concat([hardline, doc]);
       }
 
       // Inline TypeScript
@@ -35,13 +35,13 @@ function embed(path, print, textToDoc, options) {
           { parser: "typescript" },
           options
         );
-        return concat([hardline, stripTrailingHardline(doc), hardline]);
+        return concat([hardline, doc]);
       }
 
       // Inline Styles
       if (parent.type === "style") {
         const doc = textToDoc(getText(options, node), { parser: "css" });
-        return concat([hardline, stripTrailingHardline(doc), hardline]);
+        return concat([hardline, doc]);
       }
 
       break;

--- a/tests/html_css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_css/__snapshots__/jsfmt.spec.js.snap
@@ -32,7 +32,8 @@ exports[`less.html - parse5-verify 1`] = `
 
 #header {
   color: @light-blue;
-}</style>
+}
+</style>
 
 <style lang="less">
 @nice-blue: #5B83AD;
@@ -40,7 +41,8 @@ exports[`less.html - parse5-verify 1`] = `
 
 #header {
   color: @light-blue;
-}</style>
+}
+</style>
 
 `;
 
@@ -57,13 +59,15 @@ exports[`postcss.html - parse5-verify 1`] = `
 body {
   background: navy;
   color: yellow;
-}</style>
+}
+</style>
 
 <style lang="postcss">
 body {
   background: navy;
   color: yellow;
-}</style>
+}
+</style>
 
 `;
 
@@ -95,7 +99,8 @@ $primary-color: #333;
 body {
   font: 100% $font-stack;
   color: $primary-color;
-}</style>
+}
+</style>
 
 <style lang="scss">
 $font-stack: Helvetica, sans-serif;
@@ -104,7 +109,8 @@ $primary-color: #333;
 body {
   font: 100% $font-stack;
   color: $primary-color;
-}</style>
+}
+</style>
 
 `;
 
@@ -131,12 +137,14 @@ exports[`simple.html - parse5-verify 1`] = `
     <style>
     a {
       color: red;
-    }</style>
+    }
+    </style>
     <style>
     body {
       background: navy;
       color: yellow;
-    }</style>
+    }
+    </style>
   </head>
   <body>
     <h1>Sample styled page</h1>
@@ -159,12 +167,14 @@ exports[`single-style.html - parse5-verify 1`] = `
 <style>
 a {
   color: red;
-}</style>
+}
+</style>
 <style>
 h1 {
   font-size: 120%;
   font-family: Verdana, Arial, Helvetica, sans-serif;
   color: #333366;
-}</style>
+}
+</style>
 
 `;

--- a/tests/multiparser_html_css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_html_css/__snapshots__/jsfmt.spec.js.snap
@@ -20,7 +20,8 @@ exports[`html-with-css-style.html - parse5-verify 1`] = `
     <style>
     blink {
       display: none;
-    }</style>
+    }
+    </style>
   </head>
   <body></body>
 </html>


### PR DESCRIPTION
The issue here is that the `stripTrailingHardline` does not work for js/ts, I fixed it and then I realized that we always print trailing newline in every language, so there's no need to strip newline for text in script-like tag.

---

**Prettier pr-5111**
[Playground link](https://deploy-preview-5111--prettier.netlify.com/playground/#N4Igxg9gdgLgprEAuEAeAzjAngGzgPgB0oACEgOgDMIITgBfY1Aek1wJABoQIAHGAJbR0yUAEMAThIgB3AAqSEIlGIBuEAQBMuIAEYSxYANZwYAZV6GBUAObIYEgK5xu19HAkw5BmwFsxyJRiOO7cAFboAB4AQgbGpmZivnAAMtZwgcGhIJYS7hLIOZLuAKw6vBLWMADqWjAAFsgAHAAM3BUQ7tUGvIUVcPmqGdwScACOjgKj3mJ+AUhBIS4g7r4C9k7L6NY2eACKjhDwmUvcMGK6tZoNyABMZwYCODsAwhC+-oVQ0MMgju4AFQuykW7no9CAA)
```sh
--parser parse5
```

**Input:**
```html
<style>
  .foo {}
</style>
```

**Output:**
```html
<style>
.foo {
}
</style>

```

---

- I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
