### PR TITLE
refactor(html): simplify/extract code

### DIFF
--- a/src/language-html/embed.js
+++ b/src/language-html/embed.js
@@ -57,7 +57,7 @@ function embed(path, print, textToDoc, options) {
        */
       if (/(^@)|(^v-)|:/.test(node.key) && !/^\w+$/.test(node.value)) {
         const doc = textToDoc(node.value, {
-          parser: parseJavaScriptExpression,
+          parser: "__js_expression",
           // Use singleQuote since HTML attributes use double-quotes.
           // TODO(azz): We still need to do an entity escape on the attribute.
           singleQuote: true
@@ -73,16 +73,6 @@ function embed(path, print, textToDoc, options) {
       }
     }
   }
-}
-
-function parseJavaScriptExpression(text, parsers) {
-  // Force parsing as an expression
-  const ast = parsers.babylon(`(${text})`);
-  // Extract expression from the declaration
-  return {
-    type: "File",
-    program: ast.program.body[0].expression
-  };
 }
 
 function getText(options, node) {

--- a/src/language-html/printer-htmlparser2.js
+++ b/src/language-html/printer-htmlparser2.js
@@ -57,14 +57,14 @@ function genericPrint(path, options, print) {
     case "style":
     case "tag": {
       const isVoid = isVoidTagNode(n);
-      const openingPrinted = printOpeningPart(path, print);
+      const openingPrinted = printOpeningTag(path, print, isVoid);
 
       // Print self closing tag
       if (isVoid) {
         return concat([openingPrinted]);
       }
 
-      const closingPrinted = printClosingPart(n);
+      const closingPrinted = printClosingTag(n);
       const hasChildren = n.children.length > 0;
 
       // Print tags without children
@@ -203,9 +203,8 @@ function genericPrint(path, options, print) {
   }
 }
 
-function printOpeningPart(path, print) {
+function printOpeningTag(path, print, isVoid) {
   const n = path.getValue();
-  const isVoid = isVoidTagNode(n);
 
   // Don't break self-closing elements with no attributes
   if (isVoid && !n.attributes.length) {
@@ -234,7 +233,7 @@ function printOpeningPart(path, print) {
   );
 }
 
-function printClosingPart(node) {
+function printClosingTag(node) {
   return concat(["</", node.name, ">"]);
 }
 

--- a/src/language-html/printer-htmlparser2.js
+++ b/src/language-html/printer-htmlparser2.js
@@ -17,7 +17,14 @@ const {
   },
   utils: { willBreak, isLineNext, isEmpty }
 } = require("../doc");
-const { hasPrettierIgnore } = require("./utils");
+const {
+  hasPrettierIgnore,
+  isBooleanAttributeNode,
+  isPreTagNode,
+  isScriptTagNode,
+  isTextAreaTagNode,
+  isVoidTagNode
+} = require("./utils");
 
 function genericPrint(path, options, print) {
   const n = path.getValue();
@@ -194,78 +201,6 @@ function genericPrint(path, options, print) {
       /* istanbul ignore next */
       throw new Error("unknown htmlparser2 type: " + n.type);
   }
-}
-
-// https://html.spec.whatwg.org/multipage/indices.html#attributes-3
-function isBooleanAttributeNode(node) {
-  return (
-    node.type === "attribute" &&
-    [
-      "allowfullscreen",
-      "allowpaymentrequest",
-      "async",
-      "autofocus",
-      "autoplay",
-      "checked",
-      "controls",
-      "default",
-      "defer",
-      "disabled",
-      "formnovalidate",
-      "hidden",
-      "ismap",
-      "itemscope",
-      "loop",
-      "multiple",
-      "muted",
-      "nomodule",
-      "novalidate",
-      "open",
-      "readonly",
-      "required",
-      "reversed",
-      "selected",
-      "typemustmatch"
-    ].indexOf(node.key) !== -1
-  );
-}
-
-// http://w3c.github.io/html/single-page.html#void-elements
-function isVoidTagNode(node) {
-  return (
-    node.type === "tag" &&
-    [
-      "area",
-      "base",
-      "br",
-      "col",
-      "embed",
-      "hr",
-      "img",
-      "input",
-      "link",
-      "meta",
-      "param",
-      "source",
-      "track",
-      "wbr"
-    ].indexOf(node.name) !== -1
-  );
-}
-
-function isPreTagNode(node) {
-  return node.type === "tag" && node.name === "pre";
-}
-
-function isTextAreaTagNode(node) {
-  return node.type === "tag" && node.name === "textarea";
-}
-
-function isScriptTagNode(node) {
-  return (
-    (node.type === "script" || node.type === "style") &&
-    ["script", "style"].indexOf(node.name) !== -1
-  );
 }
 
 function printOpeningPart(path, print) {

--- a/src/language-html/utils.js
+++ b/src/language-html/utils.js
@@ -1,0 +1,46 @@
+"use strict";
+
+function hasPrettierIgnore(path) {
+  const node = path.getValue();
+
+  if (isWhitespaceOnlyText(node) || node.type === "attribute") {
+    return false;
+  }
+
+  const parentNode = path.getParentNode();
+
+  if (!parentNode) {
+    return false;
+  }
+
+  const index = path.getName();
+
+  if (index === 0) {
+    return false;
+  }
+
+  const prevNode = parentNode.children[index - 1];
+
+  if (isPrettierIgnore(prevNode)) {
+    return true;
+  }
+
+  if (!isWhitespaceOnlyText(prevNode)) {
+    return false;
+  }
+
+  const prevPrevNode = parentNode.children[index - 2];
+  return prevPrevNode && isPrettierIgnore(prevPrevNode);
+}
+
+function isPrettierIgnore(node) {
+  return node.type === "comment" && node.data.trim() === "prettier-ignore";
+}
+
+function isWhitespaceOnlyText(node) {
+  return node.type === "text" && node.data.trim().length === 0;
+}
+
+module.exports = {
+  hasPrettierIgnore
+};

--- a/src/language-html/utils.js
+++ b/src/language-html/utils.js
@@ -62,7 +62,7 @@ function hasPrettierIgnore(path) {
 
   const index = path.getName();
 
-  if (index === 0) {
+  if (typeof index !== "number" || index === 0) {
     return false;
   }
 
@@ -113,6 +113,7 @@ function isScriptTagNode(node) {
 module.exports = {
   hasPrettierIgnore,
   isBooleanAttributeNode,
+  isWhitespaceOnlyText,
   isPreTagNode,
   isScriptTagNode,
   isTextAreaTagNode,

--- a/src/language-html/utils.js
+++ b/src/language-html/utils.js
@@ -1,5 +1,52 @@
 "use strict";
 
+// https://html.spec.whatwg.org/multipage/indices.html#attributes-3
+const BOOLEAN_ATTRIBUTES = [
+  "allowfullscreen",
+  "allowpaymentrequest",
+  "async",
+  "autofocus",
+  "autoplay",
+  "checked",
+  "controls",
+  "default",
+  "defer",
+  "disabled",
+  "formnovalidate",
+  "hidden",
+  "ismap",
+  "itemscope",
+  "loop",
+  "multiple",
+  "muted",
+  "nomodule",
+  "novalidate",
+  "open",
+  "readonly",
+  "required",
+  "reversed",
+  "selected",
+  "typemustmatch"
+];
+
+// http://w3c.github.io/html/single-page.html#void-elements
+const VOID_TAGS = [
+  "area",
+  "base",
+  "br",
+  "col",
+  "embed",
+  "hr",
+  "img",
+  "input",
+  "link",
+  "meta",
+  "param",
+  "source",
+  "track",
+  "wbr"
+];
+
 function hasPrettierIgnore(path) {
   const node = path.getValue();
 
@@ -41,6 +88,33 @@ function isWhitespaceOnlyText(node) {
   return node.type === "text" && node.data.trim().length === 0;
 }
 
+function isBooleanAttributeNode(node) {
+  return (
+    node.type === "attribute" && BOOLEAN_ATTRIBUTES.indexOf(node.key) !== -1
+  );
+}
+
+function isVoidTagNode(node) {
+  return node.type === "tag" && VOID_TAGS.indexOf(node.name) !== -1;
+}
+
+function isPreTagNode(node) {
+  return node.type === "tag" && node.name === "pre";
+}
+
+function isTextAreaTagNode(node) {
+  return node.type === "tag" && node.name === "textarea";
+}
+
+function isScriptTagNode(node) {
+  return node.type === "script" || node.type === "style";
+}
+
 module.exports = {
-  hasPrettierIgnore
+  hasPrettierIgnore,
+  isBooleanAttributeNode,
+  isPreTagNode,
+  isScriptTagNode,
+  isTextAreaTagNode,
+  isVoidTagNode
 };


### PR DESCRIPTION
- extract utilities
- use built-in hasPrettierIgnore
- simplify some functions
- remove dead code

---

- I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
