### PR TITLE
fix(html): non-HTML attributes are considered case-sensitive

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "get-stream": "3.0.0",
     "globby": "6.1.0",
     "graphql": "0.13.2",
+    "html-element-attributes": "2.0.0",
     "html-tag-names": "1.1.2",
     "htmlparser2": "3.9.2",
     "ignore": "3.3.7",

--- a/src/language-html/utils.js
+++ b/src/language-html/utils.js
@@ -1,8 +1,10 @@
 "use strict";
 
 const htmlTagNames = require("html-tag-names");
+const htmlElementAttributes = require("html-element-attributes");
 
 const HTML_TAGS = arrayToMap(htmlTagNames);
+const HTML_ELEMENT_ATTRIBUTES = mapObject(htmlElementAttributes, arrayToMap);
 
 // NOTE: must be same as the one in htmlparser2 so that the parsing won't be inconsistent
 //       https://github.com/fb55/htmlparser2/blob/v3.9.2/lib/Parser.js#L59-L91
@@ -44,6 +46,14 @@ function arrayToMap(array) {
     map[value] = true;
   }
   return map;
+}
+
+function mapObject(object, fn) {
+  const newObject = Object.create(null);
+  for (const key of Object.keys(object)) {
+    newObject[key] = fn(object[key], key);
+  }
+  return newObject;
 }
 
 function hasPrettierIgnore(path) {
@@ -100,6 +110,7 @@ function isScriptTagNode(node) {
 }
 
 module.exports = {
+  HTML_ELEMENT_ATTRIBUTES,
   HTML_TAGS,
   VOID_TAGS,
   hasPrettierIgnore,

--- a/tests/html_attributes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_attributes/__snapshots__/jsfmt.spec.js.snap
@@ -194,6 +194,13 @@ exports[`boolean.html - html-verify 1`] = `
 
 `;
 
+exports[`case-sensitive.html - html-verify 1`] = `
+<div CaseSensitive></div>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<div casesensitive></div>
+
+`;
+
 exports[`dobule-quotes.html - html-verify 1`] = `
 <img src="test.png" alt="John 'ShotGun' Nelson">
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/html_attributes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_attributes/__snapshots__/jsfmt.spec.js.snap
@@ -88,9 +88,9 @@ and HTML5 Apps. It also documents Mozilla products, like Firefox OS."
 <div attribute="">String</div>
 <div attribute="">String</div>
 <div attribute="attribute = attribute"></div>
-<div attribute>String</div>
-<div attribute="">String</div>
-<div attribute="">String</div>
+<div ATTRIBUTE>String</div>
+<div ATTRIBUTE="">String</div>
+<div ATTRIBUTE="">String</div>
 <article
   id="electriccars"
   data-columns="3"
@@ -197,7 +197,7 @@ exports[`boolean.html - html-verify 1`] = `
 exports[`case-sensitive.html - html-verify 1`] = `
 <div CaseSensitive></div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-<div casesensitive></div>
+<div CaseSensitive></div>
 
 `;
 

--- a/tests/html_attributes/case-sensitive.html
+++ b/tests/html_attributes/case-sensitive.html
@@ -1,0 +1,1 @@
+<div CaseSensitive></div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2739,6 +2739,10 @@ hosted-git-info@^2.1.4:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.4.2.tgz#0076b9f46a270506ddbaaea56496897460612a67"
 
+html-element-attributes@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/html-element-attributes/-/html-element-attributes-2.0.0.tgz#2c9fcbd4738c560b357d0232aa3449676b10ab77"
+
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz#e70d84b94da53aa375e11fe3a351be6642ca46f8"


### PR DESCRIPTION
- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
