### PR TITLE
docs: remove next tag for husky

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -12,7 +12,7 @@ You can use Prettier with a pre-commit tool. This can re-format your files that 
 Install it along with [husky](https://github.com/typicode/husky):
 
 ```bash
-yarn add lint-staged husky@next --dev
+yarn add lint-staged husky --dev
 ```
 
 and add this config to your `package.json`:
@@ -41,7 +41,7 @@ See https://github.com/okonet/lint-staged#configuration for more details about h
 Install it along with [husky](https://github.com/typicode/husky):
 
 ```bash
-yarn add pretty-quick husky@next --dev
+yarn add pretty-quick husky --dev
 ```
 
 and add this config to your `package.json`:
@@ -80,7 +80,7 @@ Find more info from [here](https://pre-commit.com).
 Install it along with [husky](https://github.com/typicode/husky):
 
 ```bash
-yarn add precise-commits husky@next --dev
+yarn add precise-commits husky --dev
 ```
 
 and add this config to your `package.json`:


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Husky 1.0 was released and isn't behind a `@next` tag anymore :)

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
