### PR TITLE
fix(js) Break args when second arg is a ternary (#5046)

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3423,6 +3423,7 @@ function shouldGroupFirstArg(args) {
         firstArg.body.type === "BlockStatement")) &&
     secondArg.type !== "FunctionExpression" &&
     secondArg.type !== "ArrowFunctionExpression" &&
+    secondArg.type !== "ConditionalExpression" &&
     !couldGroupArg(secondArg)
   );
 }

--- a/tests/first_argument_expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/first_argument_expansion/__snapshots__/jsfmt.spec.js.snap
@@ -37,6 +37,28 @@ func(() => {
   thing();
 }, /regex.*?/);
 
+func(() => {
+  thing();
+}, 1 ? 2 : 3);
+
+func(function() {
+  return thing()
+}, 1 ? 2 : 3);
+
+func(() => {
+  thing();
+}, something() ? someOtherThing() : somethingElse(true, 0));
+
+
+func(() => {
+  thing();
+}, something(longArgumentName, anotherLongArgumentName) ? someOtherThing() : somethingElse(true, 0));
+
+
+func(() => {
+  thing();
+}, something(longArgumentName, anotherLongArgumentName, anotherLongArgumentName, anotherLongArgumentName) ? someOtherThing() : somethingElse(true, 0));
+
 compose((a) => {
   return a.thing;
 }, b => b * b);
@@ -128,6 +150,50 @@ func(() => {
 func(() => {
   thing();
 }, /regex.*?/);
+
+func(
+  () => {
+    thing();
+  },
+  1 ? 2 : 3
+);
+
+func(
+  function() {
+    return thing();
+  },
+  1 ? 2 : 3
+);
+
+func(
+  () => {
+    thing();
+  },
+  something() ? someOtherThing() : somethingElse(true, 0)
+);
+
+func(
+  () => {
+    thing();
+  },
+  something(longArgumentName, anotherLongArgumentName)
+    ? someOtherThing()
+    : somethingElse(true, 0)
+);
+
+func(
+  () => {
+    thing();
+  },
+  something(
+    longArgumentName,
+    anotherLongArgumentName,
+    anotherLongArgumentName,
+    anotherLongArgumentName
+  )
+    ? someOtherThing()
+    : somethingElse(true, 0)
+);
 
 compose(
   a => {

--- a/tests/first_argument_expansion/test.js
+++ b/tests/first_argument_expansion/test.js
@@ -34,6 +34,28 @@ func(() => {
   thing();
 }, /regex.*?/);
 
+func(() => {
+  thing();
+}, 1 ? 2 : 3);
+
+func(function() {
+  return thing()
+}, 1 ? 2 : 3);
+
+func(() => {
+  thing();
+}, something() ? someOtherThing() : somethingElse(true, 0));
+
+
+func(() => {
+  thing();
+}, something(longArgumentName, anotherLongArgumentName) ? someOtherThing() : somethingElse(true, 0));
+
+
+func(() => {
+  thing();
+}, something(longArgumentName, anotherLongArgumentName, anotherLongArgumentName, anotherLongArgumentName) ? someOtherThing() : somethingElse(true, 0));
+
 compose((a) => {
   return a.thing;
 }, b => b * b);


### PR DESCRIPTION
Fixes: #5046 

To prevent ugly output when the first argument is a `[Function|ArrowFunction]Expression` and the second is a `ConditionalExpression`, arguments are broken.
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
