### PR TITLE
fix(js): quote property name as es5 compatible

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -28,7 +28,7 @@ const {
   isNextLineEmptyAfterIndex,
   getNextNonSpaceNonCommentCharacterIndex
 } = require("../common/util-shared");
-const isIdentifierName = require("esutils").keyword.isIdentifierNameES6;
+const isIdentifierName = require("esutils").keyword.isIdentifierNameES5;
 const embed = require("./embed");
 const clean = require("./clean");
 const insertPragma = require("./pragma").insertPragma;

--- a/tests/quotes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/quotes/__snapshots__/jsfmt.spec.js.snap
@@ -30,6 +30,36 @@ function b(object, key) {
 
 `;
 
+exports[`objects.js - flow-verify 1`] = `
+const obj = {
+ 'a': true,
+ b: true,
+ "𐊧": true,
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const obj = {
+  a: true,
+  b: true,
+  "𐊧": true
+};
+
+`;
+
+exports[`objects.js - flow-verify 2`] = `
+const obj = {
+ 'a': true,
+ b: true,
+ "𐊧": true,
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const obj = {
+  a: true,
+  b: true,
+  '𐊧': true
+};
+
+`;
+
 exports[`strings.js - flow-verify 1`] = `
 // Prevent strings from being parsed as directives
 // See https://github.com/prettier/prettier/pull/1560#issue-227225960

--- a/tests/quotes/objects.js
+++ b/tests/quotes/objects.js
@@ -1,0 +1,5 @@
+const obj = {
+ 'a': true,
+ b: true,
+ "𐊧": true,
+}


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Currently, Prettier quotes property names if the name isn't es6 compatible.
It means that Prettier might strip the quote for a property name that is es6 compatible but is not es5 compatible.
So this might break scripts on ES5 environments.

For example, the following example doesn't work on some ES5 environments.
You can try the script on Node v0.12.

**Prettier 1.14.3**
[Playground link](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEA3AhgJwAQQEYBW2AvNsADpTbkiAAG4OV7NS2A5BANYuUC+A3JZUhQAzhAA2cAHRiIAcwAU+AgEp+UEABoQEAA4wAltGHJQWTBADuABSwJjKdKgj6AJppB5M6MOzgwAyjre+lCyyDCYAK5wWiHCcJgwVl6yALboyABm6GLxWgTCAB4AQl4+fv7oqXAAMiFwWTl5IEGY8ZjIHuh4AJ4y6lo6mCEwAOquMAAWyAAcAAyD5vGjXjqdQ3DtqA1amHAAjpH6e8noaRlI2bkxIPGp+uFRN8IhshIAipEQ8I3XWjDdcYuKbIABM-y8+jErwAwhBUulOlBoDsQJF4gAVbr2K7xbjcIA)
```sh
--parser babylon
```

**Input:**
```jsx
var obj = {
 "𐊧": 'ok'
};

console.log(obj);

```

**Output:**
```jsx
var obj = {
  𐊧: "ok"
};

console.log(obj);

```

This PR is to fix this.
<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
