### PR TITLE
fix(typescript) Do not add extra semicolon to `TSMethodSignature` when `prettier-ignore` is used (#5140)

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1180,7 +1180,8 @@ function printPathNoParens(path, options, print, args) {
         const result = concat(separatorParts.concat(group(prop.printed)));
         separatorParts = [separator, line];
         if (
-          prop.node.type === "TSPropertySignature" &&
+          (prop.node.type === "TSPropertySignature" ||
+            prop.node.type === "TSMethodSignature") &&
           hasNodeIgnoreComment(prop.node)
         ) {
           separatorParts.shift();

--- a/tests/typescript_interface/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_interface/__snapshots__/jsfmt.spec.js.snap
@@ -59,6 +59,14 @@ interface Interface {
   prop: type
   prop: type
 }
+
+interface foo extends bar {
+  // prettier-ignore
+  f(): void;
+  // prettier-ignore
+  g(): void;
+  h(): void;
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 interface Interface {
   // prettier-ignore
@@ -73,6 +81,14 @@ interface Interface {
   // prettier-ignore
   prop: type
   prop: type;
+}
+
+interface foo extends bar {
+  // prettier-ignore
+  f(): void;
+  // prettier-ignore
+  g(): void;
+  h(): void;
 }
 
 `;
@@ -92,6 +108,14 @@ interface Interface {
   prop: type
   prop: type
 }
+
+interface foo extends bar {
+  // prettier-ignore
+  f(): void;
+  // prettier-ignore
+  g(): void;
+  h(): void;
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 interface Interface {
   // prettier-ignore
@@ -106,6 +130,14 @@ interface Interface {
   // prettier-ignore
   prop: type
   prop: type
+}
+
+interface foo extends bar {
+  // prettier-ignore
+  f(): void;
+  // prettier-ignore
+  g(): void;
+  h(): void
 }
 
 `;

--- a/tests/typescript_interface/ignore.js
+++ b/tests/typescript_interface/ignore.js
@@ -12,3 +12,11 @@ interface Interface {
   prop: type
   prop: type
 }
+
+interface foo extends bar {
+  // prettier-ignore
+  f(): void;
+  // prettier-ignore
+  g(): void;
+  h(): void;
+}


### PR DESCRIPTION
Fixes: #5140 

Separator paths are shifted for `TSMethodSignature`s when `prettier-ignore` is used, just as `TSPropertySignature`s.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
