### PR TITLE
Improve glimmer parse errors

### DIFF
--- a/src/language-handlebars/parser-glimmer.js
+++ b/src/language-handlebars/parser-glimmer.js
@@ -34,8 +34,7 @@ function parse(text) {
     const matches = error.message.match(/on line (\d+)/);
     if (matches) {
       throw createError(error.message, {
-        start: { line: +matches[1], column: 0 },
-        end: { line: +matches[1], column: 80 }
+        start: { line: Number(matches[1]), column: 0 }
       });
     } else {
       throw error;


### PR DESCRIPTION
Instead of showing 80 carets, point out just which line the error was
on, and rely on the original message to point out the "column".

I thought about matching the `----^` in the original message with a
regex and use the length of it as the column number, but unfortunately
the original message does not show the original code (in this example
some whitespace is missing), so it wouldn't work.

Before:

```
$ ./bin/prettier.js test.hbs --parser glimmer
[error] test.hbs: SyntaxError: Parse error on line 2:
[error] {{one}}{{
[error] ---------^
[error] Expecting 'ID', 'STRING', 'NUMBER', 'BOOLEAN', 'UNDEFINED', 'NULL', 'DATA', got 'EOF' (2:0)
[error]   1 | {{one}}
[error] > 2 | {{
[error]     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]   3 |
```

After:

```
$ ./bin/prettier.js test.hbs --parser glimmer
[error] test.hbs: SyntaxError: Parse error on line 2:
[error] {{one}}{{
[error] ---------^
[error] Expecting 'ID', 'STRING', 'NUMBER', 'BOOLEAN', 'UNDEFINED', 'NULL', 'DATA', got 'EOF' (2:0)
[error]   1 | {{one}}
[error] > 2 | {{
[error]   3 |
```

<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works. – Do we test these things? Couldn't find anything.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory) – n/a
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
