### PR TITLE
support script type of text/babel in language-html

### DIFF
--- a/src/language-html/embed.js
+++ b/src/language-html/embed.js
@@ -17,6 +17,7 @@ function embed(path, print, textToDoc, options) {
         parent.type === "script" &&
         ((!parent.attribs.lang && !parent.attribs.type) ||
           parent.attribs.type === "text/javascript" ||
+          parent.attribs.type === "text/babel" ||
           parent.attribs.type === "application/javascript")
       ) {
         const parser = options.parser === "flow" ? "flow" : "babylon";

--- a/tests/html_js/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_js/__snapshots__/jsfmt.spec.js.snap
@@ -23,6 +23,9 @@ exports[`js.html - html-verify 1`] = `
 
   alert(message);
 </script>
+<script type="text/babel">
+            const    someJS    =   'this should be formatted'
+</script>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <script type="text/javascript">
 var message = "Alert!";
@@ -38,6 +41,9 @@ alert(message);
 var message = "Alert!";
 
 alert(message);
+</script>
+<script type="text/babel">
+const someJS = "this should be formatted";
 </script>
 
 `;

--- a/tests/html_js/js.html
+++ b/tests/html_js/js.html
@@ -13,3 +13,6 @@
 
   alert(message);
 </script>
+<script type="text/babel">
+            const    someJS    =   'this should be formatted'
+</script>


### PR DESCRIPTION
Closes #5166

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
