### PR TITLE
Add YAML file extensions to pre-commit hooks config

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,15 @@
--   id: prettier
-    name: prettier
-    entry: prettier --write
-    language: node
-    # From https://github.com/prettier/prettier/blob/7a7eb170/docs/index.md
-    files: \.(css|less|scss|ts|tsx|graphql|gql|json|js|jsx|md)$
+- id: prettier
+  name: prettier
+  entry: prettier --write
+  language: node
+  files: "\\.(\
+    css|less|scss\
+    |graphql|gql\
+    |js|jsx\
+    |json\
+    |md|markdown|mdown|mkdn\
+    |mdx\
+    |ts|tsx\
+    |vue\
+    |yaml|yml\
+    )$"


### PR DESCRIPTION
- Prettier support YAML but pre-commit hook was not checking those
  files so added file extensions to hooks config.
- Used double-quoted flow scalar style to make the list of file
  extensions easier to read. Backslash for regex needed escaping and
  backslash each line to prevent YAML including spaces.
- Added alternative markdown file extensions.
- Formatted with prettier.

<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. 

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
-->