### PR TITLE
Keep decorators inline if they were written inline

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5294,6 +5294,9 @@ function printAssignmentRight(leftNode, rightNode, printedRight, options) {
       isBinaryish(rightNode.test) &&
       !shouldInlineLogicalExpression(rightNode.test)) ||
     rightNode.type === "StringLiteralTypeAnnotation" ||
+    (rightNode.type === "ClassExpression" &&
+      rightNode.decorators &&
+      rightNode.decorators.length) ||
     ((leftNode.type === "Identifier" ||
       isStringLiteral(leftNode) ||
       leftNode.type === "MemberExpression") &&

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -96,10 +96,11 @@ function genericPrint(path, options, printPath, args) {
     !getParentExportDeclaration(path)
   ) {
     const shouldBreak =
+      node.type === "ClassDeclaration" ||
       hasNewlineInRange(
         options.originalText,
         options.locStart(node.decorators[0]),
-        options.locStart(getLast(node.decorators))
+        options.locEnd(getLast(node.decorators))
       ) ||
       hasNewline(
         options.originalText,

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -20,8 +20,7 @@ const {
   getPenultimate,
   startsWithNoLookaheadToken,
   getIndentSize,
-  matchAncestorTypes,
-  isWithinParentArrayProperty
+  matchAncestorTypes
 } = require("../common/util");
 const {
   isNextLineEmpty,
@@ -96,11 +95,18 @@ function genericPrint(path, options, printPath, args) {
     // responsible for printing node.decorators.
     !getParentExportDeclaration(path)
   ) {
-    const separator =
-      node.decorators.length === 1 &&
-      isWithinParentArrayProperty(path, "params")
-        ? line
-        : hardline;
+    const shouldBreak =
+      hasNewlineInRange(
+        options.originalText,
+        options.locStart(node.decorators[0]),
+        options.locStart(getLast(node.decorators))
+      ) ||
+      hasNewline(
+        options.originalText,
+        options.locEnd(getLast(node.decorators))
+      );
+
+    const separator = shouldBreak ? hardline : line;
 
     path.each(decoratorPath => {
       let decorator = decoratorPath.getValue();

--- a/tests/decorators-ts/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators-ts/__snapshots__/jsfmt.spec.js.snap
@@ -161,8 +161,7 @@ class Greeter {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class Greeter {
-  @format("Hello, %s")
-  greeting: string;
+  @format("Hello, %s") greeting: string;
 
   constructor(message: string) {
     this.greeting = message;

--- a/tests/decorators-ts/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators-ts/__snapshots__/jsfmt.spec.js.snap
@@ -41,6 +41,27 @@ class Point {
 
 `;
 
+exports[`angular.ts - typescript-verify 1`] = `
+@Component({
+  selector: 'toh-hero-button',
+  template: \`<button>{{label}}</button>\`
+})
+export class HeroButtonComponent {
+  @Output() change = new EventEmitter<any>();
+  @Input() label: string;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@Component({
+  selector: "toh-hero-button",
+  template: \`<button>{{label}}</button>\`
+})
+export class HeroButtonComponent {
+  @Output() change = new EventEmitter<any>();
+  @Input() label: string;
+}
+
+`;
+
 exports[`class-decorator.ts - typescript-verify 1`] = `
 @sealed
 class Greeter {

--- a/tests/decorators-ts/angular.ts
+++ b/tests/decorators-ts/angular.ts
@@ -1,0 +1,8 @@
+@Component({
+  selector: 'toh-hero-button',
+  template: `<button>{{label}}</button>`
+})
+export class HeroButtonComponent {
+  @Output() change = new EventEmitter<any>();
+  @Input() label: string;
+}

--- a/tests/decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators/__snapshots__/jsfmt.spec.js.snap
@@ -138,22 +138,35 @@ const dog = {
   @readonly
   @nonenumerable
   @doubledValue
-  legs: 4
+  legs: 4,
+
+  @readonly
+  @nonenumerable
+  @doubledValue
+  eyes: 2
 };
 
-const dog = {
-  @readonly @nonenumerable @doubledValue legs: 4
+const foo = {
+  @multipleDecorators @inline @theyWontAllFitInOneline aVeryLongPropName: "A very long string as value"
 };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const dog = {
   @readonly
   @nonenumerable
   @doubledValue
-  legs: 4
+  legs: 4,
+
+  @readonly
+  @nonenumerable
+  @doubledValue
+  eyes: 2
 };
 
-const dog = {
-  @readonly @nonenumerable @doubledValue legs: 4
+const foo = {
+  @multipleDecorators
+  @inline
+  @theyWontAllFitInOneline
+  aVeryLongPropName: "A very long string as value"
 };
 
 `;

--- a/tests/decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators/__snapshots__/jsfmt.spec.js.snap
@@ -72,6 +72,8 @@ class Yo {
 
   @anotherDecoratorWithALongName("and a very long string as a first argument")
   async plip() {}
+
+  @anotherDecoratorWithALongName("another very long string, but now inline") async plip() {}
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class Yo {
@@ -79,6 +81,9 @@ class Yo {
   async plop() {}
 
   @anotherDecoratorWithALongName("and a very long string as a first argument")
+  async plip() {}
+
+  @anotherDecoratorWithALongName("another very long string, but now inline")
   async plip() {}
 }
 
@@ -135,12 +140,20 @@ const dog = {
   @doubledValue
   legs: 4
 };
+
+const dog = {
+  @readonly @nonenumerable @doubledValue legs: 4
+};
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const dog = {
   @readonly
   @nonenumerable
   @doubledValue
   legs: 4
+};
+
+const dog = {
+  @readonly @nonenumerable @doubledValue legs: 4
 };
 
 `;

--- a/tests/decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators/__snapshots__/jsfmt.spec.js.snap
@@ -6,6 +6,16 @@ exports[`classes.js - babylon-verify 1`] = `
 @deco export class Bar {}
 
 @deco export default class Baz {}
+
+const foo = @deco class {
+  //
+};
+
+const foo =
+  @deco
+  class {
+    //
+  };
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 @deco
 class Foo {}
@@ -15,6 +25,18 @@ export class Bar {}
 
 @deco
 export default class Baz {}
+
+const foo =
+  @deco
+  class {
+    //
+  };
+
+const foo =
+  @deco
+  class {
+    //
+  };
 
 `;
 

--- a/tests/decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators/__snapshots__/jsfmt.spec.js.snap
@@ -108,10 +108,8 @@ import { observable } from "mobx";
 
 @observer
 class OrderLine {
-  @observable
-  price: number = 0;
-  @observable
-  amount: number = 1;
+  @observable price: number = 0;
+  @observable amount: number = 1;
 
   constructor(price) {
     this.price = price;

--- a/tests/decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`classes.js - babylon-verify 1`] = `
+@deco class Foo {}
+
+@deco export class Bar {}
+
+@deco export default class Baz {}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+@deco
+class Foo {}
+
+@deco
+export class Bar {}
+
+@deco
+export default class Baz {}
+
+`;
+
 exports[`comments.js - babylon-verify 1`] = `
 var x = 100
 
@@ -129,6 +147,21 @@ class OrderLine {
   setPrice(price) {
     this.price = price;
   }
+}
+
+`;
+
+exports[`multiline.js - babylon-verify 1`] = `
+class Foo {
+  @deco([
+    foo,
+    bar
+  ]) prop = value;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class Foo {
+  @deco([foo, bar])
+  prop = value;
 }
 
 `;

--- a/tests/decorators/classes.js
+++ b/tests/decorators/classes.js
@@ -3,3 +3,13 @@
 @deco export class Bar {}
 
 @deco export default class Baz {}
+
+const foo = @deco class {
+  //
+};
+
+const foo =
+  @deco
+  class {
+    //
+  };

--- a/tests/decorators/classes.js
+++ b/tests/decorators/classes.js
@@ -1,0 +1,5 @@
+@deco class Foo {}
+
+@deco export class Bar {}
+
+@deco export default class Baz {}

--- a/tests/decorators/methods.js
+++ b/tests/decorators/methods.js
@@ -5,4 +5,6 @@ class Yo {
 
   @anotherDecoratorWithALongName("and a very long string as a first argument")
   async plip() {}
+
+  @anotherDecoratorWithALongName("another very long string, but now inline") async plip() {}
 }

--- a/tests/decorators/multiline.js
+++ b/tests/decorators/multiline.js
@@ -1,0 +1,6 @@
+class Foo {
+  @deco([
+    foo,
+    bar
+  ]) prop = value;
+}

--- a/tests/decorators/multiple.js
+++ b/tests/decorators/multiple.js
@@ -4,3 +4,7 @@ const dog = {
   @doubledValue
   legs: 4
 };
+
+const dog = {
+  @readonly @nonenumerable @doubledValue legs: 4
+};

--- a/tests/decorators/multiple.js
+++ b/tests/decorators/multiple.js
@@ -2,9 +2,14 @@ const dog = {
   @readonly
   @nonenumerable
   @doubledValue
-  legs: 4
+  legs: 4,
+
+  @readonly
+  @nonenumerable
+  @doubledValue
+  eyes: 2
 };
 
-const dog = {
-  @readonly @nonenumerable @doubledValue legs: 4
+const foo = {
+  @multipleDecorators @inline @theyWontAllFitInOneline aVeryLongPropName: "A very long string as value"
 };

--- a/tests/typescript_decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_decorators/__snapshots__/jsfmt.spec.js.snap
@@ -233,7 +233,8 @@ class Class3 {
   ) {}
 }
 
-@decorated class Foo {}
+@decorated
+class Foo {}
 
 class Bar {
   @decorated method() {}

--- a/tests/typescript_decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_decorators/__snapshots__/jsfmt.spec.js.snap
@@ -49,8 +49,7 @@ export class TabCompletionController {}
   selector: "angular-component"
 })
 class AngularComponent {
-  @Input()
-  myInput: string;
+  @Input() myInput: string;
 }
 
 `;
@@ -218,14 +217,10 @@ class Class2 {
 }
 
 class Class3 {
-  @d1
-  fieldA;
-  @d2(foo)
-  fieldB;
-  @d3.bar
-  fieldC;
-  @d4.baz()
-  fieldD;
+  @d1 fieldA;
+  @d2(foo) fieldB;
+  @d3.bar fieldC;
+  @d4.baz() fieldD;
 
   constructor(
     @d1 private x: number,
@@ -238,12 +233,10 @@ class Class3 {
   ) {}
 }
 
-@decorated
-class Foo {}
+@decorated class Foo {}
 
 class Bar {
-  @decorated
-  method() {}
+  @decorated method() {}
 }
 
 class MyContainerComponent {


### PR DESCRIPTION
Implements @lydell's suggestions: https://github.com/prettier/prettier/issues/4924#issuecomment-425659254

Closes #4924
Closes #5088

What this PR does is select the separator for each decorator by checking:
  - is there a new line between the start of the first decorator and the start of the last decorator
  - is there a new line right after the end of the last decorator

If either of those are true, we should use a `hardline` separator, otherwise it's a `line`. If they are separated with `line` they will be the in the same line, unless they don't fit, then they'll break; `hardline` will force a break.

"Breaking", in this case, means each decorator is printed in a separate line and the thing they decorate too.

I'll navigate to the threads now to see if I can't find any case not covered in our tests.