### PR TITLE
fix(markdown): preserve inline math style

### DIFF
--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -409,8 +409,15 @@ function genericPrint(path, options, print) {
           : "",
         "$$"
       ]);
-    case "inlineMath":
-      return concat(["$", node.value, "$"]);
+    case "inlineMath": {
+      // $$math$$ can be block math in some variants
+      // see https://github.com/Rokt33r/remark-math#double-dollars-in-inline
+      const style =
+        options.originalText[node.position.start.offset + 1] === "$"
+          ? "$$"
+          : "$";
+      return concat([style, node.value, style]);
+    }
 
     case "tableRow": // handled in "table"
     case "listItem": // handled in "list"

--- a/tests/markdown_math/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_math/__snapshots__/jsfmt.spec.js.snap
@@ -145,11 +145,11 @@ $$
 
 ---
 
-$\\\\alpha$
+$$\\\\alpha$$
 
 ---
 
-$\\alpha$
+$$\\alpha$$
 
 $$
 \\alpha\\beta


### PR DESCRIPTION
Fixes #5199

- I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
