### PR TITLE
fix(css-in-js) Keep newlines in CSS-in-JS Templates (Fixes: #5147)

### DIFF
--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -59,6 +59,7 @@ const {
   isKeyValuePairNode,
   isDetachedRulesetCallNode,
   isTemplatePlaceholderNode,
+  isTemplatePropNode,
   isPostcssSimpleVarNode,
   isSCSSMapItemNode,
   isInlineValueCommentNode,
@@ -178,7 +179,9 @@ function genericPrint(path, options, print) {
               softline,
               "}"
             ])
-          : ";"
+          : isTemplatePropNode(node)
+            ? ""
+            : ";"
       ]);
     }
     case "css-atrule": {

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -238,7 +238,9 @@ function genericPrint(path, options, print) {
               softline,
               "}"
             ])
-          : isTemplatePlaceholderNode(node) && !parentNode.raws.semicolon ? "" : ";"
+          : isTemplatePlaceholderNode(node) && !parentNode.raws.semicolon
+            ? ""
+            : ";"
       ]);
     }
     // postcss-media-query-parser

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -58,6 +58,7 @@ const {
   hasEmptyRawBefore,
   isKeyValuePairNode,
   isDetachedRulesetCallNode,
+  isTemplatePlaceholderNode,
   isPostcssSimpleVarNode,
   isSCSSMapItemNode,
   isInlineValueCommentNode,
@@ -191,7 +192,11 @@ function genericPrint(path, options, print) {
           : maybeToLowerCase(node.name),
         node.params
           ? concat([
-              isDetachedRulesetCallNode(node) ? "" : " ",
+              isDetachedRulesetCallNode(node)
+                ? ""
+                : isTemplatePlaceholderNode(node)
+                  ? node.raws.afterName
+                  : " ",
               path.call(print, "params")
             ])
           : "",

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -147,6 +147,8 @@ function genericPrint(path, options, print) {
       ]);
     }
     case "css-decl": {
+      const parentNode = path.getParentNode();
+
       return concat([
         node.raws.before.replace(/[\s;]/g, ""),
         insideICSSRuleNode(path) ? node.prop : maybeToLowerCase(node.prop),
@@ -179,12 +181,14 @@ function genericPrint(path, options, print) {
               softline,
               "}"
             ])
-          : isTemplatePropNode(node)
+          : isTemplatePropNode(node) && !parentNode.raws.semicolon
             ? ""
             : ";"
       ]);
     }
     case "css-atrule": {
+      const parentNode = path.getParentNode();
+
       return concat([
         "@",
         // If a Less file ends up being parsed with the SCSS parser, Less
@@ -234,7 +238,7 @@ function genericPrint(path, options, print) {
               softline,
               "}"
             ])
-          : ";"
+          : isTemplatePlaceholderNode(node) && !parentNode.raws.semicolon ? "" : ";"
       ]);
     }
     // postcss-media-query-parser

--- a/src/language-css/utils.js
+++ b/src/language-css/utils.js
@@ -257,6 +257,10 @@ function isTemplatePlaceholderNode(node) {
   return node.name.startsWith("prettier-placeholder");
 }
 
+function isTemplatePropNode(node) {
+  return node.prop.startsWith("@prettier-placeholder");
+}
+
 function isPostcssSimpleVarNode(currentNode, nextNode) {
   return (
     currentNode.value === "$$" &&
@@ -420,6 +424,7 @@ module.exports = {
   isSCSSNestedPropertyNode,
   isDetachedRulesetCallNode,
   isTemplatePlaceholderNode,
+  isTemplatePropNode,
   isPostcssSimpleVarNode,
   isKeyValuePairNode,
   isKeyValuePairInParenGroupNode,

--- a/src/language-css/utils.js
+++ b/src/language-css/utils.js
@@ -253,6 +253,10 @@ function isDetachedRulesetCallNode(node) {
   return node.raws && node.raws.params && /^\(\s*\)$/.test(node.raws.params);
 }
 
+function isTemplatePlaceholderNode(node) {
+  return node.name.startsWith("prettier-placeholder");
+}
+
 function isPostcssSimpleVarNode(currentNode, nextNode) {
   return (
     currentNode.value === "$$" &&
@@ -415,6 +419,7 @@ module.exports = {
   hasEmptyRawBefore,
   isSCSSNestedPropertyNode,
   isDetachedRulesetCallNode,
+  isTemplatePlaceholderNode,
   isPostcssSimpleVarNode,
   isKeyValuePairNode,
   isKeyValuePairInParenGroupNode,

--- a/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
@@ -213,7 +213,7 @@ styled.div\`
 
 styled.div\`
   \${bar}
-  baz;
+  baz
 \`;
 
 styled.span\`
@@ -230,11 +230,11 @@ styled.div\`
 
 styled.span\`
   \${foo}
-  \${bar};
+  \${bar}
 \`;
 
 styled.div\`
-  \${foo} bar;
+  \${foo} bar
 \`;
 
 styled.span\`
@@ -248,7 +248,7 @@ styled.span\`
 \`;
 
 styled.span\`
-  \${foo}: \${bar}
+  \${foo}: \${bar};
 \`;
 
 styled.span\`
@@ -260,7 +260,7 @@ styled.span\`
 \`;
 
 styled.span\`
-  \${foo}: \${bar}
+  \${foo}: \${bar};
 \`;
 
 `;

--- a/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
@@ -248,19 +248,19 @@ styled.span\`
 \`;
 
 styled.span\`
-  \${foo}: \${bar};
+  \${foo}: \${bar}
 \`;
 
 styled.span\`
-  \${foo}: \${bar};
+  \${foo}: \${bar}
 \`;
 
 styled.span\`
-  \${foo}: \${bar};
+  \${foo}: \${bar}
 \`;
 
 styled.span\`
-  \${foo}: \${bar};
+  \${foo}: \${bar}
 \`;
 
 `;

--- a/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
@@ -107,6 +107,29 @@ styled.div\`
 styled.span\`
   \${foo} \${bar}
   baz: \${foo}
+\`
+
+styled.span\`
+\${foo};
+\${bar};
+\`
+
+styled.span\`
+\${foo}: \${bar};
+\`
+
+styled.span\`
+\${foo}: \${bar}
+\`
+
+styled.span\`
+\${foo}:
+\${bar}
+\`
+
+styled.span\`
+\${foo}:
+\${bar};
 \`~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const ListItem = styled.li\`\`;
 
@@ -217,6 +240,27 @@ styled.div\`
 styled.span\`
   \${foo} \${bar}
   baz: \${foo}
+\`;
+
+styled.span\`
+  \${foo};
+  \${bar};
+\`;
+
+styled.span\`
+  \${foo}: \${bar};
+\`;
+
+styled.span\`
+  \${foo}: \${bar};
+\`;
+
+styled.span\`
+  \${foo}: \${bar};
+\`;
+
+styled.span\`
+  \${foo}: \${bar};
 \`;
 
 `;

--- a/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
@@ -77,7 +77,37 @@ styled.div\`
     margin: 0;
   }
 \`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+styled.div\`
+  \${bar}
+  baz
+\`
+
+styled.span\`
+  foo
+  \${bar}
+  baz
+\`
+
+styled.div\`
+  foo
+  \${bar}
+  \${baz}
+\`
+
+styled.span\`
+  \${foo}
+  \${bar}
+\`
+
+styled.div\`
+  \${foo} bar
+\`
+
+styled.span\`
+  \${foo} \${bar}
+  baz: \${foo}
+\`~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const ListItem = styled.li\`\`;
 
 const ListItem = styled.li\`\`;
@@ -156,6 +186,37 @@ styled.div\`
   html {
     margin: 0;
   }
+\`;
+
+styled.div\`
+  \${bar}
+  baz;
+\`;
+
+styled.span\`
+  foo
+  \${bar}
+  baz
+\`;
+
+styled.div\`
+  foo
+  \${bar}
+  \${baz}
+\`;
+
+styled.span\`
+  \${foo}
+  \${bar};
+\`;
+
+styled.div\`
+  \${foo} bar;
+\`;
+
+styled.span\`
+  \${foo} \${bar}
+  baz: \${foo}
 \`;
 
 `;

--- a/tests/multiparser_js_css/styled-components.js
+++ b/tests/multiparser_js_css/styled-components.js
@@ -105,3 +105,26 @@ styled.span`
   ${foo} ${bar}
   baz: ${foo}
 `
+
+styled.span`
+${foo};
+${bar};
+`
+
+styled.span`
+${foo}: ${bar};
+`
+
+styled.span`
+${foo}: ${bar}
+`
+
+styled.span`
+${foo}:
+${bar}
+`
+
+styled.span`
+${foo}:
+${bar};
+`

--- a/tests/multiparser_js_css/styled-components.js
+++ b/tests/multiparser_js_css/styled-components.js
@@ -74,3 +74,34 @@ styled.div`
     margin: 0;
   }
 `
+
+styled.div`
+  ${bar}
+  baz
+`
+
+styled.span`
+  foo
+  ${bar}
+  baz
+`
+
+styled.div`
+  foo
+  ${bar}
+  ${baz}
+`
+
+styled.span`
+  ${foo}
+  ${bar}
+`
+
+styled.div`
+  ${foo} bar
+`
+
+styled.span`
+  ${foo} ${bar}
+  baz: ${foo}
+`

--- a/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
@@ -395,7 +395,7 @@ exports[`styled-jsx-with-expressions.js - flow-verify 1`] = `
     }
   }
   @font-face {
-    \${expr};
+    \${expr}
   }
 \`}</style>;
 

--- a/tests/typescript_typeparams/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_typeparams/__snapshots__/jsfmt.spec.js.snap
@@ -322,7 +322,7 @@ export const RedBox = styled.div<{foo: string}>\`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 export const RedBox = styled.div<{ foo: string }>\`
   background: red;
-  \${props => props.foo};
+  \${props => props.foo}
 \`;
 
 `;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fixes: #5147 

Keep newlines after CSS-in-JS quasi-literal substitutes. 
<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
