### PR TITLE
Fixed unstable comment between function declaration and block statement

### DIFF
--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -554,6 +554,17 @@ function handleLastFunctionArgComments(
     addTrailingComment(precedingNode, comment);
     return true;
   }
+
+  if (
+    enclosingNode &&
+    enclosingNode.type === "FunctionDeclaration" &&
+    followingNode &&
+    followingNode.type === "BlockStatement"
+  ) {
+    addBlockStatementFirstComment(followingNode, comment);
+    return true;
+  }
+
   return false;
 }
 

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -546,6 +546,26 @@ class C {
 class C {
   f/* f */(/* args */) /* returns */ {}
 }
+
+function foo() 
+// this is a function
+{
+  return 42
+}
+
+function foo() // this is a function
+{
+  return 42
+}
+
+function foo() { // this is a function
+  return 42
+}
+
+function foo() {
+  // this is a function
+  return 42;
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 function a(/* comment */) {} // comment
 function b() {} // comment
@@ -587,6 +607,26 @@ class C {
 }
 class C {
   f /* f */(/* args */) /* returns */ {}
+}
+
+function foo() {
+  // this is a function
+  return 42;
+}
+
+function foo() {
+  // this is a function
+  return 42;
+}
+
+function foo() {
+  // this is a function
+  return 42;
+}
+
+function foo() {
+  // this is a function
+  return 42;
 }
 
 `;

--- a/tests/comments/function-declaration.js
+++ b/tests/comments/function-declaration.js
@@ -39,3 +39,23 @@ class C {
 class C {
   f/* f */(/* args */) /* returns */ {}
 }
+
+function foo() 
+// this is a function
+{
+  return 42
+}
+
+function foo() // this is a function
+{
+  return 42
+}
+
+function foo() { // this is a function
+  return 42
+}
+
+function foo() {
+  // this is a function
+  return 42;
+}


### PR DESCRIPTION
Fixes #5241

<!-- Please provide a brief summary of your changes: -->
Fixed the Issues with unstable comments between function declaration and block statements described in #5241 by adding a clause that checks if a comment is enclosed by a function declaration and followed by a block statement it will move the comment inside the block statement as the first line.
This is the same way comments are handled in if statements before a block statement.

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
