### PR TITLE
Fix comment issue with try finally

### DIFF
--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -93,6 +93,12 @@ function handleEndOfLineComment(comment, text, options, ast, isLastComment) {
       comment,
       options
     ) ||
+    handleTryStatementComments(
+      enclosingNode,
+      precedingNode,
+      followingNode,
+      comment
+    ) ||
     handleClassComments(enclosingNode, precedingNode, followingNode, comment) ||
     handleLabeledStatementComments(enclosingNode, comment) ||
     handleCallExpressionComments(precedingNode, enclosingNode, comment) ||

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1851,30 +1851,34 @@ const CONNECTION_STATUS = (exports.CONNECTION_STATUS = {
 `;
 
 exports[`try.js - flow-verify 1`] = `
-// comment 1
-try {
-  // comment 2
+// Comment 1
+try { // Comment 2
+  // Comment 3
 }
-// comment 3
-catch(e) {
-  // comment 4
+// Comment 4
+catch(e) { // Comment 5
+  // Comment 6
 }
-// comment 5
-finally // comment 6
-{
-  // comment 7
+// Comment 7
+finally { // Comment 8
+  // Comment 9
 }
+// Comment 10
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-// comment 1
+// Comment 1
 try {
-  // comment 2
+  // Comment 2
+  // Comment 3
 } catch (e) {
-  // comment 3
-  // comment 4
-} finally { // comment 6
-  // comment 5
-  // comment 7
+  // Comment 4
+  // Comment 5
+  // Comment 6
+} finally {
+  // Comment 7
+  // Comment 8
+  // Comment 9
 }
+// Comment 10
 
 `;
 

--- a/tests/comments/try.js
+++ b/tests/comments/try.js
@@ -1,13 +1,13 @@
-// comment 1
-try {
-  // comment 2
+// Comment 1
+try { // Comment 2
+  // Comment 3
 }
-// comment 3
-catch(e) {
-  // comment 4
+// Comment 4
+catch(e) { // Comment 5
+  // Comment 6
 }
-// comment 5
-finally // comment 6
-{
-  // comment 7
+// Comment 7
+finally { // Comment 8
+  // Comment 9
 }
+// Comment 10


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fixes #5192 - comment ordering within try / catch / finally blocks

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
