### PR TITLE
fix: detect more styled template literals

### DIFF
--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -426,7 +426,13 @@ function isStyledComponents(path) {
 
     case "Identifier":
       // css``
-      return tag.name === "css";
+      return (
+        tag.name === "css" ||
+        tag.name === "createGlobalStyle" ||
+        // deprecated, but used by emotion
+        tag.name === "injectGlobal" ||
+        tag.name === "keyframes"
+      );
 
     default:
       return false;

--- a/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
@@ -216,6 +216,29 @@ margin: 0;
 	left: 0;right: 0;
 }
 \`;
+
+const GlobalStyle = createGlobalStyle\`
+a {
+
+color:   red;
+}
+\`;
+
+injectGlobal\`
+a {
+
+color:   red;
+}
+\`;
+
+const fadeIn = keyframes\`
+0% {
+opacity: 0;
+}
+100% {
+opacity: 1;
+}
+\`;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const Button = styled.a\`
   /* Comment */
@@ -261,6 +284,27 @@ const header = css\`
     position: absolute;
     left: 0;
     right: 0;
+  }
+\`;
+
+const GlobalStyle = createGlobalStyle\`
+  a {
+    color: red;
+  }
+\`;
+
+injectGlobal\`
+  a {
+    color: red;
+  }
+\`;
+
+const fadeIn = keyframes\`
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
   }
 \`;
 

--- a/tests/template_literals/styled-components-with-expressions.js
+++ b/tests/template_literals/styled-components-with-expressions.js
@@ -41,3 +41,26 @@ margin: 0;
 	left: 0;right: 0;
 }
 `;
+
+const GlobalStyle = createGlobalStyle`
+a {
+
+color:   red;
+}
+`;
+
+injectGlobal`
+a {
+
+color:   red;
+}
+`;
+
+const fadeIn = keyframes`
+0% {
+opacity: 0;
+}
+100% {
+opacity: 1;
+}
+`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3187,6 +3187,7 @@ html-encoding-sniffer@^1.0.2:
 html-styles@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/html-styles/-/html-styles-1.0.0.tgz#a18061fd651f99c6b75c45c8e0549a3bc3e01a75"
+  integrity sha1-oYBh/WUfmca3XEXI4FSaO8PgGnU=
 
 html-tag-names@1.1.2:
   version "1.1.2"
@@ -4735,6 +4736,7 @@ mute-stream@0.0.7:
 n-readlines@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/n-readlines/-/n-readlines-1.0.0.tgz#c353797f216c253fdfef7e91da4e8b17c29a91a6"
+  integrity sha512-ISDqGcspVu6U3VKqtJZG1uR55SmNNF9uK0EMq1IvNVVZOui6MW6VR0+pIZhqz85ORAGp+4zW+5fJ/SE7bwEibA==
 
 nan@^2.9.2:
   version "2.10.0"


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Styled components has a couple more template literals than just `css` (see https://www.styled-components.com/docs/api). This detects them

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
