### PR TITLE
Update husky integration code for husky v1.0.0

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -301,8 +301,8 @@ class GetStartedSection extends React.Component {
                   Then add this config to <code>package.json</code>:
                   <MarkdownBlock>
                     {json({
-                      "husky": {
-                        "hooks": {
+                      husky: {
+                        hooks: {
                           "pre-commit": "pretty-quick --staged"
                         }
                       }

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -298,11 +298,11 @@ class GetStartedSection extends React.Component {
                       {bash`npm install pretty-quick husky --save-dev`}
                     </MarkdownBlock>
                   </div>
-                  Then edit <code>package.json</code>:
+                  Then add this config to <code>package.json</code>:
                   <MarkdownBlock>
-                    {json({
-                      scripts: {
-                        precommit: "pretty-quick --staged"
+                    {json("husky": {
+                      "hooks": {
+                        "pre-commit": "pretty-quick --staged"
                       }
                     })}
                   </MarkdownBlock>

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -300,9 +300,11 @@ class GetStartedSection extends React.Component {
                   </div>
                   Then add this config to <code>package.json</code>:
                   <MarkdownBlock>
-                    {json("husky": {
-                      "hooks": {
-                        "pre-commit": "pretty-quick --staged"
+                    {json({
+                      "husky": {
+                        "hooks": {
+                          "pre-commit": "pretty-quick --staged"
+                        }
                       }
                     })}
                   </MarkdownBlock>


### PR DESCRIPTION
Latest husky (version 1.0.0) moved its hooks config from the `scripts` field to a new `husky` field in `package.json` ([ChangeLog](https://github.com/typicode/husky/blob/master/CHANGELOG.md)).

The `scripts` syntax described here, although shorter, will be deprecated soon. This change replaces it with the new husky syntax.

The new syntax is already used in [precommit.md](https://github.com/prettier/prettier/blob/master/docs/precommit.md).

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
