### PR TITLE
Remove HTML from pre-commit hooks until available

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,4 +3,4 @@
     entry: prettier --write
     language: node
     # From https://github.com/prettier/prettier/blob/7a7eb170/docs/index.md
-    files: \.(css|less|scss|html|ts|tsx|graphql|gql|json|js|jsx|md)$
+    files: \.(css|less|scss|ts|tsx|graphql|gql|json|js|jsx|md)$


### PR DESCRIPTION
The pre-commit hook registers for HTML files but that will always fail until #5098 is completed. This means that anyone following [the instructions](https://prettier.io/docs/en/precommit.html#option-3-pre-commit-https-githubcom-pre-commit-pre-commit) will have the hook fail any time they attempt to commit an HTML file.

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
