### PR TITLE
Add support for flow typecast comments

### DIFF
--- a/src/language-js/flow-comments.js
+++ b/src/language-js/flow-comments.js
@@ -1,0 +1,15 @@
+"use strict";
+
+function hasFlowShorthandAnnotationComment(node) {
+  // https://flow.org/en/docs/types/comments/
+  // Syntax example: const r = new (window.Request /*: Class<Request> */)("");
+
+  return (
+    node.extra &&
+    node.extra.parenthesized &&
+    !!node.trailingComments &&
+    node.trailingComments[0].value.startsWith(":")
+  );
+}
+
+module.exports = hasFlowShorthandAnnotationComment;

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -4,7 +4,7 @@ const assert = require("assert");
 
 const util = require("../common/util");
 const comments = require("./comments");
-const hasFlowShorthandAnnotationComment = require("./flow-comments");
+const { hasFlowShorthandAnnotationComment } = require("./utils");
 
 function hasClosureCompilerTypeCastComment(text, path, locStart, locEnd) {
   // https://github.com/google/closure-compiler/wiki/Annotating-Types#type-casts

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -4,6 +4,7 @@ const assert = require("assert");
 
 const util = require("../common/util");
 const comments = require("./comments");
+const hasFlowShorthandAnnotationComment = require("./flow-comments");
 
 function hasClosureCompilerTypeCastComment(text, path, locStart, locEnd) {
   // https://github.com/google/closure-compiler/wiki/Annotating-Types#type-casts
@@ -70,6 +71,16 @@ function needsParens(path, options) {
       options.locStart,
       options.locEnd
     )
+  ) {
+    return true;
+  }
+
+  if (
+    // Preserve parens if we have a Flow annotation comment, unless we're using the Flow
+    // parser. The Flow parser turns Flow comments into type annotation nodes in its
+    // AST, which we handle separately.
+    options.parser !== "flow" &&
+    hasFlowShorthandAnnotationComment(path.getValue())
   ) {
     return true;
   }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -158,10 +158,9 @@ function genericPrint(path, options, printPath, args) {
       parts.push(node.trailingComments[0].value.trimLeft());
       parts.push("*/");
       node.trailingComments[0].printed = true;
-      parts.push(")");
-    } else {
-      parts.push(")");
     }
+
+    parts.push(")");
   }
 
   if (decorators.length > 0) {
@@ -2834,9 +2833,11 @@ function printPathNoParens(path, options, print, args) {
       return concat([
         "(",
         path.call(print, "expression"),
-        commentSyntax ? " /*: " : ": ",
+        commentSyntax ? " /*" : "",
+        ": ",
         path.call(print, "typeAnnotation"),
-        commentSyntax ? " */)" : ")"
+        commentSyntax ? " */" : "",
+        ")",
       ]);
     }
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -32,9 +32,9 @@ const embed = require("./embed");
 const clean = require("./clean");
 const insertPragma = require("./pragma").insertPragma;
 const handleComments = require("./comments");
-const hasFlowShorthandAnnotationComment = require("./flow-comments");
 const pathNeedsParens = require("./needs-parens");
 const preprocess = require("./preprocess");
+const { hasFlowShorthandAnnotationComment } = require("./utils");
 
 const {
   builders: {
@@ -2823,7 +2823,9 @@ function printPathNoParens(path, options, print, args) {
         value &&
         value.typeAnnotation &&
         value.typeAnnotation.range &&
-        options.originalText.substr(value.typeAnnotation.range[0], 3) === "/*:";
+        options.originalText
+          .substring(value.typeAnnotation.range[0])
+          .match(/^\/\*\s*:/);
       return concat([
         "(",
         path.call(print, "expression"),

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2837,7 +2837,7 @@ function printPathNoParens(path, options, print, args) {
         ": ",
         path.call(print, "typeAnnotation"),
         commentSyntax ? " */" : "",
-        ")",
+        ")"
       ]);
     }
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -155,7 +155,7 @@ function genericPrint(path, options, printPath, args) {
     const node = path.getValue();
     if (hasFlowShorthandAnnotationComment(node)) {
       parts.push(" /*");
-      parts.push(node.trailingComments[0].value);
+      parts.push(node.trailingComments[0].value.trimLeft());
       parts.push("*/");
       node.trailingComments[0].printed = true;
       parts.push(")");

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2819,6 +2819,11 @@ function printPathNoParens(path, options, print, args) {
       // annotations when producing an AST. So to preserve parentheses around type casts that use
       // the comment syntax, we need to hackily read the source itself to see if the code contains
       // a type annotation comment.
+      //
+      // Note that we're able to use the normal whitespace regex here because the Flow parser has
+      // already deemed this AST node to be a type cast. Only the Babylon parser needs the
+      // non-line-break whitespace regex, which is why hasFlowShorthandAnnotationComment() is
+      // implemented differently.
       const commentSyntax =
         value &&
         value.typeAnnotation &&

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -16,7 +16,7 @@ function hasFlowShorthandAnnotationComment(node) {
     //
     // is not picked up by Flow, so removing the newline would create a type annotation
     // that the user did not intend to create.
-    node.trailingComments[0].value.match(/^[ \t]*:/)
+    node.trailingComments[0].value.match(/^(?:(?=.)\s)*:/)
   );
 }
 

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -8,7 +8,15 @@ function hasFlowShorthandAnnotationComment(node) {
     node.extra &&
     node.extra.parenthesized &&
     node.trailingComments &&
-    node.trailingComments[0].value.trimLeft().startsWith(":")
+    // We intentionally only match spaces and tabs here instead of any whitespace because
+    // Flow annotation comments cannot be split across lines. For example:
+    //
+    // (this /*
+    // : any */).foo = 5;
+    //
+    // is not picked up by Flow, so removing the newline would create a type annotation
+    // that the user did not intend to create.
+    node.trailingComments[0].value.match(/^[ \t]*:/)
   );
 }
 

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -7,9 +7,11 @@ function hasFlowShorthandAnnotationComment(node) {
   return (
     node.extra &&
     node.extra.parenthesized &&
-    !!node.trailingComments &&
-    node.trailingComments[0].value.startsWith(":")
+    node.trailingComments &&
+    node.trailingComments[0].value.trimLeft().startsWith(":")
   );
 }
 
-module.exports = hasFlowShorthandAnnotationComment;
+module.exports = {
+  hasFlowShorthandAnnotationComment
+};

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -14,8 +14,9 @@ function hasFlowShorthandAnnotationComment(node) {
     // (this /*
     // : any */).foo = 5;
     //
-    // is not picked up by Flow, so removing the newline would create a type annotation
-    // that the user did not intend to create.
+    // is not picked up by Flow (see https://github.com/facebook/flow/issues/7050), so
+    // removing the newline would create a type annotation that the user did not intend
+    // to create.
     node.trailingComments[0].value.match(/^(?:(?=.)\s)*:/)
   );
 }

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -8,7 +8,7 @@ function hasFlowShorthandAnnotationComment(node) {
     node.extra &&
     node.extra.parenthesized &&
     node.trailingComments &&
-    // We intentionally only match spaces and tabs here instead of any whitespace because
+    // We match any whitespace except line terminators because
     // Flow annotation comments cannot be split across lines. For example:
     //
     // (this /*

--- a/tests/flow_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_comments/__snapshots__/jsfmt.spec.js.snap
@@ -91,11 +91,25 @@ new (window.Request/*: Class<Request> */)("");
 
 (this/*: any */).foo = 5;
 
+(this/*    : any */).foo = 5;
+
+// This next example illustrates that Prettier will not remove a line break
+// and unintentionally create a type annotation that was not there before.
+(this/*
+: any */).foo = 5;
+
 const x = (input /*: string */) /*: string */ => {};
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 new (window.Request /*: Class<Request> */)("");
 
 (this /*: any */).foo = 5;
+
+(this /*: any */).foo = 5;
+
+// This next example illustrates that Prettier will not remove a line break
+// and unintentionally create a type annotation that was not there before.
+this /*
+: any */.foo = 5;
 
 const x = (input /*: string */) /*: string */ => {};
 

--- a/tests/flow_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_comments/__snapshots__/jsfmt.spec.js.snap
@@ -85,3 +85,18 @@ type Props = {
 };
 
 `;
+
+exports[`type_annotations.js - flow-verify 1`] = `
+new (window.Request/*: Class<Request> */)("");
+
+(this/*: any */).foo = 5;
+
+const x = (input /*: string */) /*: string */ => {};
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+new (window.Request /*: Class<Request> */)("");
+
+(this /*: any */).foo = 5;
+
+const x = (input /*: string */) /*: string */ => {};
+
+`;

--- a/tests/flow_comments/type_annotations.js
+++ b/tests/flow_comments/type_annotations.js
@@ -2,4 +2,11 @@ new (window.Request/*: Class<Request> */)("");
 
 (this/*: any */).foo = 5;
 
+(this/*    : any */).foo = 5;
+
+// This next example illustrates that Prettier will not remove a line break
+// and unintentionally create a type annotation that was not there before.
+(this/*
+: any */).foo = 5;
+
 const x = (input /*: string */) /*: string */ => {};

--- a/tests/flow_comments/type_annotations.js
+++ b/tests/flow_comments/type_annotations.js
@@ -1,0 +1,5 @@
+new (window.Request/*: Class<Request> */)("");
+
+(this/*: any */).foo = 5;
+
+const x = (input /*: string */) /*: string */ => {};


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

This attempts to fix the bug described in #719. Previously, Prettier was removing parentheses in expressions like: 

```
new (window.Request /*: Class<Request> */)("")
```

turning them into:

```
new window.Request /*: Class<Request> */("")
```

which no longer satisfies Flow's syntax. With this change, we detect these typecast expressions and attempt to keep the parentheses intact in such cases.

This is my first time contributing to Prettier, so I'm probably making some egregious mistakes!

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
