### PR TITLE
Fix Flow generic comment positioning

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -34,7 +34,10 @@ const insertPragma = require("./pragma").insertPragma;
 const handleComments = require("./comments");
 const pathNeedsParens = require("./needs-parens");
 const preprocess = require("./preprocess");
-const { hasFlowShorthandAnnotationComment } = require("./utils");
+const {
+  hasFlowAnnotationComment,
+  hasFlowShorthandAnnotationComment
+} = require("./utils");
 
 const {
   builders: {
@@ -1115,6 +1118,19 @@ function printPathNoParens(path, options, print, args) {
         ]);
       }
 
+      // Inline Flow annotation comments following Identifiers in Call nodes need to
+      // stay with the Identifier. For example:
+      //
+      // foo /*:: <SomeGeneric> */(bar);
+      //
+      // Here, we ensure that such comments stay between the Identifier and the Callee.
+      const isIdentifierWithFlowAnnotation =
+        n.callee.type === "Identifier" &&
+        hasFlowAnnotationComment(n.callee.trailingComments);
+      if (isIdentifierWithFlowAnnotation) {
+        n.callee.trailingComments[0].printed = true;
+      }
+
       // We detect calls on member lookups and possibly print them in a
       // special chain format. See `printMemberChain` for more info.
       if (!isNew && isMemberish(n.callee)) {
@@ -1125,6 +1141,9 @@ function printPathNoParens(path, options, print, args) {
         isNew ? "new " : "",
         path.call(print, "callee"),
         optional,
+        isIdentifierWithFlowAnnotation
+          ? `/*:: ${n.callee.trailingComments[0].value.substring(2).trim()} */`
+          : "",
         printFunctionTypeParameters(path, options, print),
         printArgumentsList(path, options, print)
       ]);
@@ -2876,7 +2895,27 @@ function printPathNoParens(path, options, print, args) {
     }
 
     case "TypeParameterDeclaration":
-    case "TypeParameterInstantiation":
+    case "TypeParameterInstantiation": {
+      const value = path.getValue();
+      const commentStart = value.range
+        ? options.originalText.substring(0, value.range[0]).lastIndexOf("/*")
+        : -1;
+      // As noted in the TypeCastExpression comments above, we're able to use a normal whitespace regex here
+      // because we know for sure that this is a type definition.
+      const commentSyntax =
+        commentStart >= 0 &&
+        options.originalText.substring(commentStart).match(/^\/\*\s*::/);
+      if (commentSyntax) {
+        return concat([
+          "/*:: ",
+          printTypeParameters(path, options, print, "params"),
+          " */"
+        ]);
+      }
+
+      return printTypeParameters(path, options, print, "params");
+    }
+
     case "TSTypeParameterDeclaration":
     case "TSTypeParameterInstantiation":
       return printTypeParameters(path, options, print, "params");
@@ -6025,7 +6064,13 @@ function willPrintOwnComments(path) {
   const parent = path.getParentNode();
 
   return (
-    ((node && (isJSXNode(node) || hasFlowShorthandAnnotationComment(node))) ||
+    ((node &&
+      (isJSXNode(node) ||
+        hasFlowShorthandAnnotationComment(node) ||
+        (parent &&
+          parent.type === "CallExpression" &&
+          (hasFlowAnnotationComment(node.leadingComments) ||
+            hasFlowAnnotationComment(node.trailingComments))))) ||
       (parent &&
         (parent.type === "JSXSpreadAttribute" ||
           parent.type === "JSXSpreadChild" ||

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -1,5 +1,20 @@
 "use strict";
 
+// We match any whitespace except line terminators because
+// Flow annotation comments cannot be split across lines. For example:
+//
+// (this /*
+// : any */).foo = 5;
+//
+// is not picked up by Flow (see https://github.com/facebook/flow/issues/7050), so
+// removing the newline would create a type annotation that the user did not intend
+// to create.
+const NON_LINE_TERMINATING_WHITE_SPACE = "(?:(?=.)\\s)";
+const FLOW_SHORTHAND_ANNOTATION = new RegExp(
+  `^${NON_LINE_TERMINATING_WHITE_SPACE}*:`
+);
+const FLOW_ANNOTATION = new RegExp(`^${NON_LINE_TERMINATING_WHITE_SPACE}*::`);
+
 function hasFlowShorthandAnnotationComment(node) {
   // https://flow.org/en/docs/types/comments/
   // Syntax example: const r = new (window.Request /*: Class<Request> */)("");
@@ -8,19 +23,15 @@ function hasFlowShorthandAnnotationComment(node) {
     node.extra &&
     node.extra.parenthesized &&
     node.trailingComments &&
-    // We match any whitespace except line terminators because
-    // Flow annotation comments cannot be split across lines. For example:
-    //
-    // (this /*
-    // : any */).foo = 5;
-    //
-    // is not picked up by Flow (see https://github.com/facebook/flow/issues/7050), so
-    // removing the newline would create a type annotation that the user did not intend
-    // to create.
-    node.trailingComments[0].value.match(/^(?:(?=.)\s)*:/)
+    node.trailingComments[0].value.match(FLOW_SHORTHAND_ANNOTATION)
   );
 }
 
+function hasFlowAnnotationComment(comments) {
+  return comments && comments[0].value.match(FLOW_ANNOTATION);
+}
+
 module.exports = {
-  hasFlowShorthandAnnotationComment
+  hasFlowShorthandAnnotationComment,
+  hasFlowAnnotationComment
 };

--- a/tests/flow_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_comments/__snapshots__/jsfmt.spec.js.snap
@@ -45,6 +45,29 @@ function foo<T>(bar /*: T[] */, baz /*: T */) /*: S */ {}
 
 `;
 
+exports[`generics.js - flow-verify 1`] = `
+const Component = branch/*::     <Props, ExternalProps> */(
+  ({ src }) => !src,
+  // $FlowFixMe
+  renderNothing,
+)(BaseComponent);
+
+const C = b/*:: <A> */(foo) + c/*:: <B> */(bar);
+
+foo/*::<bar>*/(baz);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+const Component = branch/*:: <Props, ExternalProps> */(
+  ({ src }) => !src,
+  // $FlowFixMe
+  renderNothing
+)(BaseComponent);
+
+const C = b/*:: <A> */(foo) + c/*:: <B> */(bar);
+
+foo/*:: <bar> */(baz);
+
+`;
+
 exports[`let.js - flow-verify 1`] = `
 let foo /*: Groups<T> */;
 let foo /*: string */ = 'a';

--- a/tests/flow_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_comments/__snapshots__/jsfmt.spec.js.snap
@@ -55,6 +55,8 @@ const Component = branch/*::     <Props, ExternalProps> */(
 const C = b/*:: <A> */(foo) + c/*:: <B> */(bar);
 
 foo/*::<bar>*/(baz);
+
+foo/*::<bar>*/();
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const Component = branch/*:: <Props, ExternalProps> */(
   ({ src }) => !src,
@@ -65,6 +67,8 @@ const Component = branch/*:: <Props, ExternalProps> */(
 const C = b/*:: <A> */(foo) + c/*:: <B> */(bar);
 
 foo/*:: <bar> */(baz);
+
+foo/*:: <bar> */();
 
 `;
 

--- a/tests/flow_comments/babylon_only/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_comments/babylon_only/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`class_with_generics.js - babylon-verify 1`] = `
+import React from 'react';
+
+/*:: type Props = {
+  foo?: ?string,
+  bar: number,
+}; */
+
+/*:: type State = { baz: number }; */
+
+class Component extends React.Component/*:: <Props, State> */ {
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import React from "react";
+
+/*:: type Props = {
+  foo?: ?string,
+  bar: number,
+}; */
+
+/*:: type State = { baz: number }; */
+
+class Component extends React.Component /*:: <Props, State> */ {
+}
+
+`;

--- a/tests/flow_comments/babylon_only/class_with_generics.js
+++ b/tests/flow_comments/babylon_only/class_with_generics.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+/*:: type Props = {
+  foo?: ?string,
+  bar: number,
+}; */
+
+/*:: type State = { baz: number }; */
+
+class Component extends React.Component/*:: <Props, State> */ {
+}

--- a/tests/flow_comments/babylon_only/jsfmt.spec.js
+++ b/tests/flow_comments/babylon_only/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["babylon"]);

--- a/tests/flow_comments/generics.js
+++ b/tests/flow_comments/generics.js
@@ -1,0 +1,9 @@
+const Component = branch/*::     <Props, ExternalProps> */(
+  ({ src }) => !src,
+  // $FlowFixMe
+  renderNothing,
+)(BaseComponent);
+
+const C = b/*:: <A> */(foo) + c/*:: <B> */(bar);
+
+foo/*::<bar>*/(baz);

--- a/tests/flow_comments/generics.js
+++ b/tests/flow_comments/generics.js
@@ -7,3 +7,5 @@ const Component = branch/*::     <Props, ExternalProps> */(
 const C = b/*:: <A> */(foo) + c/*:: <B> */(bar);
 
 foo/*::<bar>*/(baz);
+
+foo/*::<bar>*/();


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

This fixes a bug in Prettier where Flow generic comments get repositioned, breaking Flow's syntax. An example:

```
foo /*:: <bar> */ (baz);
```

Currently, Prettier will rewrite this ([source](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAzCEAEB6AVEpTAHgCMBDAJwD5NdtMAKcgLwEoBuEAGhAgAcYAS2gBnZKEoUIAdwAKlBGJRkAbhEEATbiBIUyYANZwYAZT77BUAObIYFAK5welkXAoxZeqwFsyyVGQANq48AFYiAB4AQnqGxiZk3nAAMpZw-kEhIOYUrhTIOmQkAJ6B0Np8FJYwAOqaMAAWyAAcAAw8lRCuNXp8BZVweSrpPBRwAI72gmOeZD5+SAHBTiCu3oK2DisillaBcACK9hDwGcs8MEV1Go3IAEwXeoKBuwDCEN6+BVDQIyD2rgAKkUlEtXABfcFAA)) as:

```
foo(/*:: <bar> */ baz);
```

This PR attempts to fix this behavior. One issue that I ran into was dealing with the Flow parser's AST that it generates from the comment syntax. Code like this:

```
/*:: type Props = {
  foo?: ?string,
  bar: number,
}; */
```

gets turned into this ([source](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEB6AVEpACGBPABzmwAUAnCAgZ2wF5tgAdKbbAMwggH4cuqYyASygBzADTNWAIwCGZHFACuAWylwyEqAF8A3NnSoQYkJRiDoVZKDkUA7iTkJLKGQDcIggCZGQUsjLAAazgYAGUCAOERZAFFOGNhKnUYchkRZRlkNhkAGyTjACsqAA8AIX8gkNCZZTgAGWE4LNz8kAiyJLJkEDYciFsfAiFYAHUvGAALZAAOAAZjIYgkkf8CbqG4Ttcm4zI4AEdFQT3U9MykbLz4kCTlQRiyOOMqKJy4AEVFCHhmq+MYGRSMaeSbIABM-38ghyUQAwhBlBlulBoDsQIokgAVQHOS5JLRaIA)):

```
type Props = {
  foo?: ?string,
  bar: number
};
```

I wasn't able to find an easy way to have Prettier reliably traverse the code backward to see if the annotation is inside a comment block. Since it's not in the AST at all ([source](https://astexplorer.net/#/gist/9fca72f6e760daf48cde1d63c6b829f6/efcab9538dd88de8ea1ac8b7980f374a2cae3a54)), the options seem limited, particularly since the comment block could have begun many lines above the type definition. For this reason, this PR only ensures the correct behavior for non-inline type definitions like these for the Babylon parser. The Flow parser's behavior here remains the same as before.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
