### PR TITLE
User can copy JSON config from Playground

### DIFF
--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -218,6 +218,9 @@ class Playground extends React.Component {
                       {editorState.showSidebar ? "Hide" : "Show"} options
                     </Button>
                     <Button onClick={this.clearContent}>Clear</Button>
+                    <ClipboardButton copy={JSON.stringify(options, null, 2)}>
+                      Copy config JSON
+                    </ClipboardButton>
                   </div>
                   <div className="bottom-bar-buttons bottom-bar-buttons-right">
                     <ClipboardButton copy={window.location.href}>


### PR DESCRIPTION
After using the playground, it would be nice to have a single click action to copy the JSON config to place into the `.prettierrc` file.

<img width="934" alt="prettier-copy-config" src="https://user-images.githubusercontent.com/28444/47479023-85aaa780-d7e0-11e8-84ef-89d814259f1c.png">

Clicking `Copy JSON` will copy the current options to the clipboard. Here's an example:

```json
{
  "arrowParens": "avoid",
  "bracketSpacing": false,
  "insertPragma": false,
  "jsxBracketSameLine": false,
  "parser": "babylon",
  "printWidth": 80,
  "proseWrap": "preserve",
  "requirePragma": false,
  "semi": false,
  "singleQuote": true,
  "tabWidth": 2,
  "trailingComma": "es5",
  "useTabs": false
}
```

Here's a video showing how it works:

![prettier-copy-config](https://user-images.githubusercontent.com/28444/47479480-2d74a500-d7e2-11e8-8578-466e796d6256.gif)

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
