### PR TITLE
docs: Remove the warning about partially staged files

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -30,8 +30,6 @@ and add this config to your `package.json`:
 }
 ```
 
-**Warning:** Currently there is a limitation where if you stage specific lines this approach will stage the whole file after formatting. See this [issue](https://github.com/okonet/lint-staged/issues/62) for more info.
-
 See https://github.com/okonet/lint-staged#configuration for more details about how you can configure lint-staged.
 
 ## Option 2. [pretty-quick](https://github.com/azz/pretty-quick)


### PR DESCRIPTION
Since partially staged files are [now officially supported](https://medium.com/@okonetchnikov/announcing-lint-staged-with-support-for-partially-staged-files-abc24a40d3ff), this isn't up to date anymore.