### PR TITLE
Add a preview playground redirect page

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,3 +6,5 @@
 - [ ] I’ve added tests to confirm my change works.
 - [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
 - [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
+
+**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**

--- a/website/pages/playground-redirect.html
+++ b/website/pages/playground-redirect.html
@@ -1,22 +1,32 @@
 <!DOCTYPE html>
 <html>
-<head>
-  <meta charset="utf-8">
-  <title>Redirecting…</title>
-</head>
-<body>
-  <h1>Redirecting…</h1>
-  <p>Redirecting you to the appropriate playground. If the redirect doesn’t work, <a href="javascript:history.back()">go back to the PR</a> and click the appropriate link.</p>
-  <script>
-    const match = /^https:\/\/github\.com\/prettier\/prettier\/pull\/(\d+)/.exec(document.referrer)
-    if (match != null) {
-      const [/* url */, pr] = match
-      location.replace(`https://deploy-preview-${pr}--prettier.netlify.com/playground`)
-    } else {
-      const el = document.createElement('p')
-      el.textContent = `The referrer URL (${document.referrer}) was not recognized. Sorry :(`
-      document.body.appendChild(el)
-    }
-  </script>
-</body>
+  <head>
+    <meta charset="utf-8" />
+    <title>Redirecting…</title>
+  </head>
+  <body>
+    <h1>Redirecting…</h1>
+    <p>
+      Redirecting you to the appropriate playground. If the redirect doesn’t
+      work, <a href="javascript:history.back()">go back to the PR</a> and click
+      the appropriate link.
+    </p>
+    <script>
+      const match = /^https:\/\/github\.com\/prettier\/prettier\/pull\/(\d+)/.exec(
+        document.referrer
+      );
+      if (match != null) {
+        const [, /* url */ pr] = match;
+        location.replace(
+          `https://deploy-preview-${pr}--prettier.netlify.com/playground`
+        );
+      } else {
+        const el = document.createElement("p");
+        el.textContent = `The referrer URL (${
+          document.referrer
+        }) was not recognized. Sorry :(`;
+        document.body.appendChild(el);
+      }
+    </script>
+  </body>
 </html>

--- a/website/pages/playground-redirect.html
+++ b/website/pages/playground-redirect.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting…</title>
+</head>
+<body>
+  <h1>Redirecting…</h1>
+  <p>Redirecting you to the appropriate playground. If the redirect doesn’t work, <a href="javascript:history.back()">go back to the PR</a> and click the appropriate link.</p>
+  <script>
+    const match = /^https:\/\/github\.com\/pull\/(\d+)/.exec(document.referrer)
+    if (match != null) {
+      const [/* url */, pr] = match
+      location.href = `https://deploy-preview-${pr}--prettier.netlify.com/playground`
+    } else {
+      const el = document.createElement('p')
+      el.textContent = `The referrer URL (${document.referrer}) was not recognized. Sorry :(`
+    }
+  </script>
+</body>
+</html>

--- a/website/pages/playground-redirect.html
+++ b/website/pages/playground-redirect.html
@@ -9,7 +9,11 @@
     <p>
       Redirecting you to the appropriate playground. If the redirect doesn’t
       work, <a href="javascript:history.back()">go back to the PR</a> and click
-      the appropriate link.
+      the appropriate link:<br />
+      <img
+        src="https://cdn.netlify.com/f0b93f3003d5669924b6e73540bbfe07bc3d8d95/34c5d/img/blog/deploy-preview-workflow.gif"
+        alt="click on the link next to 'deploy/netlify'"
+      />
     </p>
     <script>
       const match = /^https:\/\/github\.com\/prettier\/prettier\/pull\/(\d+)/.exec(

--- a/website/pages/playground-redirect.html
+++ b/website/pages/playground-redirect.html
@@ -11,7 +11,7 @@
     const match = /^https:\/\/github\.com\/prettier\/prettier\/pull\/(\d+)/.exec(document.referrer)
     if (match != null) {
       const [/* url */, pr] = match
-      location.href = `https://deploy-preview-${pr}--prettier.netlify.com/playground`
+      location.replace(`https://deploy-preview-${pr}--prettier.netlify.com/playground`)
     } else {
       const el = document.createElement('p')
       el.textContent = `The referrer URL (${document.referrer}) was not recognized. Sorry :(`

--- a/website/pages/playground-redirect.html
+++ b/website/pages/playground-redirect.html
@@ -8,7 +8,7 @@
   <h1>Redirecting…</h1>
   <p>Redirecting you to the appropriate playground. If the redirect doesn’t work, <a href="javascript:history.back()">go back to the PR</a> and click the appropriate link.</p>
   <script>
-    const match = /^https:\/\/github\.com\/pull\/(\d+)/.exec(document.referrer)
+    const match = /^https:\/\/github\.com\/prettier\/prettier\/pull\/(\d+)/.exec(document.referrer)
     if (match != null) {
       const [/* url */, pr] = match
       location.href = `https://deploy-preview-${pr}--prettier.netlify.com/playground`

--- a/website/pages/playground-redirect.html
+++ b/website/pages/playground-redirect.html
@@ -15,6 +15,7 @@
     } else {
       const el = document.createElement('p')
       el.textContent = `The referrer URL (${document.referrer}) was not recognized. Sorry :(`
+      document.body.appendChild(el)
     }
   </script>
 </body>


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).


This should allow the PR template to link to https://prettier.io/playground-redirect and have it redirect to the appropriate preview playground.