### PR TITLE
Never put spaces to the right of stars in indentable block comments

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -6165,8 +6165,9 @@ function printIndentableBlockComment(comment) {
       hardline,
       lines.map(
         (line, index) =>
-          (index === 0 ? "" : " ") +
-          (index < lines.length - 1 ? line.trim() : line.trimLeft())
+          index === 0
+            ? line.trimRight()
+            : " " + (index < lines.length - 1 ? line.trim() : line.trimLeft())
       )
     ),
     "*/"

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -6165,7 +6165,7 @@ function printIndentableBlockComment(comment) {
       hardline,
       lines.map(
         (line, index) =>
-          (index === 0 && line[0] === "*" ? "" : " ") +
+          (index === 0 ? "" : " ") +
           (index < lines.length - 1 ? line.trim() : line.trimLeft())
       )
     ),

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1123,21 +1123,21 @@ onClick={() => {}}>
 <div>{/* comment */}</div>;
 
 <div>
-  {/*comment
+  {/* comment
    */}
 </div>;
 
 <div>
   {
     a
-    /*comment
+    /* comment
      */
   }
 </div>;
 
 <div>
   {
-    /*comment
+    /* comment
      */
     a
   }
@@ -1364,7 +1364,7 @@ var x = {
   getSectionMode(
     pageMetaData: PageMetaData,
     sectionMetaData: SectionMetaData
-    /*$FlowFixMe This error was exposed while converting keyMirror
+    /* $FlowFixMe This error was exposed while converting keyMirror
      * to keyMirrorRecursive */
   ): $Enum<SectionMode> {}
 };
@@ -1373,7 +1373,7 @@ class X {
   getSectionMode(
     pageMetaData: PageMetaData,
     sectionMetaData: SectionMetaData = ["unknown"]
-    /*$FlowFixMe This error was exposed while converting keyMirror
+    /* $FlowFixMe This error was exposed while converting keyMirror
      * to keyMirrorRecursive */
   ): $Enum<SectionMode> {}
 }
@@ -1763,7 +1763,7 @@ if (true) {
  * second line
  * third line */
 
-/*first line
+/* first line
  * second line
  * third line */
 

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1123,21 +1123,21 @@ onClick={() => {}}>
 <div>{/* comment */}</div>;
 
 <div>
-  {/* comment
+  {/*comment
    */}
 </div>;
 
 <div>
   {
     a
-    /* comment
+    /*comment
      */
   }
 </div>;
 
 <div>
   {
-    /* comment
+    /*comment
      */
     a
   }
@@ -1364,7 +1364,7 @@ var x = {
   getSectionMode(
     pageMetaData: PageMetaData,
     sectionMetaData: SectionMetaData
-    /* $FlowFixMe This error was exposed while converting keyMirror
+    /*$FlowFixMe This error was exposed while converting keyMirror
      * to keyMirrorRecursive */
   ): $Enum<SectionMode> {}
 };
@@ -1373,7 +1373,7 @@ class X {
   getSectionMode(
     pageMetaData: PageMetaData,
     sectionMetaData: SectionMetaData = ["unknown"]
-    /* $FlowFixMe This error was exposed while converting keyMirror
+    /*$FlowFixMe This error was exposed while converting keyMirror
      * to keyMirrorRecursive */
   ): $Enum<SectionMode> {}
 }
@@ -1735,6 +1735,19 @@ if(true) {
   /* first line
 * second line
    * third line */
+
+  /*! first line
+*second line
+   *  third line */
+
+/*!
+* Extracted from vue codebase
+* https://github.com/vuejs/vue/blob/cfd73c2386623341fdbb3ac636c4baf84ea89c2c/src/compiler/parser/html-parser.js
+* HTML Parser By John Resig (ejohn.org)
+* Modified by Juriy "kangax" Zaytsev
+* Original code by Erik Arvidsson, Mozilla Public License
+* http://erik.eae.net/simplehtmlparser/simplehtmlparser.js
+*/
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 /*
  * Looking good!
@@ -1750,9 +1763,22 @@ if (true) {
  * second line
  * third line */
 
-/* first line
+/*first line
  * second line
  * third line */
+
+/*! first line
+ *second line
+ *  third line */
+
+/*!
+ * Extracted from vue codebase
+ * https://github.com/vuejs/vue/blob/cfd73c2386623341fdbb3ac636c4baf84ea89c2c/src/compiler/parser/html-parser.js
+ * HTML Parser By John Resig (ejohn.org)
+ * Modified by Juriy "kangax" Zaytsev
+ * Original code by Erik Arvidsson, Mozilla Public License
+ * http://erik.eae.net/simplehtmlparser/simplehtmlparser.js
+ */
 
 `;
 

--- a/tests/comments/single-star-jsdoc.js
+++ b/tests/comments/single-star-jsdoc.js
@@ -15,3 +15,16 @@ if(true) {
   /* first line
 * second line
    * third line */
+
+  /*! first line
+*second line
+   *  third line */
+
+/*!
+* Extracted from vue codebase
+* https://github.com/vuejs/vue/blob/cfd73c2386623341fdbb3ac636c4baf84ea89c2c/src/compiler/parser/html-parser.js
+* HTML Parser By John Resig (ejohn.org)
+* Modified by Juriy "kangax" Zaytsev
+* Original code by Erik Arvidsson, Mozilla Public License
+* http://erik.eae.net/simplehtmlparser/simplehtmlparser.js
+*/


### PR DESCRIPTION
Fixes #5323. Previously we added space after `/*` _on the first line
only,_ but the intent is to only fix the indentation of comments, not
changing their "contents". Besides, this was inconsistent with the
handling of every following line. Finally, it broke `/*!` comments which
some minifiers look for to know which (license) comments to keep.

People can use https://eslint.org/docs/rules/spaced-comment to enforce
when to start comments with spaces.

@j-f1 Does this feel like the right approach to you?