### PR TITLE
Support config files that have `.prettierrc` extension with `--config` option

### DIFF
--- a/src/config/resolve-config.js
+++ b/src/config/resolve-config.js
@@ -35,7 +35,10 @@ const getExplorerMemoized = mem(opts => {
       ".prettierrc.toml"
     ],
     loaders: {
-      ".toml": loadToml
+      ".toml": loadToml,
+      // default parser of cosmiconfig (see: https://github.com/davidtheclark/cosmiconfig/blob/c6f0953b808a9046a23f6e8983e6cbb455dd03c7/README.md#loaders)
+      // if this setting is missing, prettier cannot recognize a configuration file that has `.prettierrc` extension (e.g. `foo.prettierrc`)
+      ".prettierrc": thirdParty.cosmiconfig.loadYaml
     }
   });
 


### PR DESCRIPTION
Problem:

- when passing a configuration file that has a name with `.prettierrc` extension (e.g. `foo.prettierrc`), the runtime gives up with `[error] Invalid configuration file: No sync loader specified for extension ".prettierrc"`

This commit fixes this problem.

example: `prettier --config foo.prettierrc index.js`

<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

--

- [ ] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
