### PR TITLE
fix(less): remove CRs from inline comments

### DIFF
--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -110,7 +110,11 @@ function genericPrint(path, options, print) {
     }
     case "css-comment": {
       if (node.raws.content) {
-        return node.raws.content;
+        return (
+          node.raws.content
+            // there's a bug in the less parser that trailing `\r`s are included in inline comments
+            .replace(/^(\/\/[^]+)\r+$/, "$1")
+        );
       }
       const text = options.originalText.slice(
         options.locStart(node),


### PR DESCRIPTION
Fixes #5315

The issue is that less parser somehow included CRs in `comment.raws.content`, but it was hidden by the wrong trailing space elimination previously, which was fixed by #5165.

- ~~I’ve added tests to confirm my change works.~~
  We already have such tests but it's not reproducible in AppVeyor since they use LF ([`core.autocrlf=input`](https://stackoverflow.com/a/20653073)).
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
