### PR TITLE
fix(javascript): no regression for jsx in arrow function in jsx

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4860,11 +4860,9 @@ function printMemberChain(path, options, print) {
     printIndentedGroup(groups.slice(shouldMerge ? 2 : 1))
   ]);
 
-  const callExpressionCount = printedNodes.filter(
-    tuple =>
-      tuple.node.type === "CallExpression" ||
-      tuple.node.type === "OptionalCallExpression"
-  ).length;
+  const callExpressions = printedNodes
+    .map(({ node }) => node)
+    .filter(isCallOrOptionalCallExpression);
 
   // We don't want to print in one line if there's:
   //  * A comment.
@@ -4873,8 +4871,21 @@ function printMemberChain(path, options, print) {
   // If the last group is a function it's okay to inline if it fits.
   if (
     hasComment ||
-    callExpressionCount >= 3 ||
-    printedGroups.slice(0, -1).some(willBreak)
+    callExpressions.length >= 3 ||
+    printedGroups.slice(0, -1).some(willBreak) ||
+    /**
+     *     scopes.filter(scope => scope.value !== '').map((scope, i) => {
+     *       // multi line content
+     *     })
+     */
+    (((lastGroupDoc, lastGroupNode) =>
+      isCallOrOptionalCallExpression(lastGroupNode) && willBreak(lastGroupDoc))(
+      getLast(printedGroups),
+      getLast(getLast(groups)).node
+    ) &&
+      callExpressions
+        .slice(0, -1)
+        .some(n => n.arguments.some(isFunctionOrArrowExpression)))
   ) {
     return group(expanded);
   }
@@ -4886,6 +4897,12 @@ function printMemberChain(path, options, print) {
     willBreak(oneLine) || shouldHaveEmptyLineBeforeIndent ? breakParent : "",
     conditionalGroup([oneLine, expanded])
   ]);
+}
+
+function isCallOrOptionalCallExpression(node) {
+  return (
+    node.type === "CallExpression" || node.type === "OptionalCallExpression"
+  );
 }
 
 function isJSXNode(node) {
@@ -5429,12 +5446,11 @@ function maybeWrapJSXElementInParens(path, elem) {
     return elem;
   }
 
-  const shouldBreak =
-    matchAncestorTypes(path, [
-      "ArrowFunctionExpression",
-      "CallExpression",
-      "JSXExpressionContainer"
-    ]) && isMemberExpressionChain(path.getParentNode(1).callee);
+  const shouldBreak = matchAncestorTypes(path, [
+    "ArrowFunctionExpression",
+    "CallExpression",
+    "JSXExpressionContainer"
+  ]);
 
   return group(
     concat([
@@ -6130,7 +6146,7 @@ function isTestCall(n, parent) {
   }
   if (n.arguments.length === 1) {
     if (isAngularTestWrapper(n) && parent && isTestCall(parent)) {
-      return isFunctionOrArrowExpression(n.arguments[0].type);
+      return isFunctionOrArrowExpression(n.arguments[0]);
     }
 
     if (isUnitTestSetUp(n)) {
@@ -6147,7 +6163,7 @@ function isTestCall(n, parent) {
         return false;
       }
       return (
-        (isFunctionOrArrowExpression(n.arguments[1].type) &&
+        (isFunctionOrArrowExpression(n.arguments[1]) &&
           n.arguments[1].params.length <= 1) ||
         isAngularTestWrapper(n.arguments[1])
       );
@@ -6185,8 +6201,11 @@ function isAngularTestWrapper(node) {
   );
 }
 
-function isFunctionOrArrowExpression(type) {
-  return type === "FunctionExpression" || type === "ArrowFunctionExpression";
+function isFunctionOrArrowExpression(node) {
+  return (
+    node.type === "FunctionExpression" ||
+    node.type === "ArrowFunctionExpression"
+  );
 }
 
 function isUnitTestSetUp(n) {

--- a/tests/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -1782,6 +1782,16 @@ exports[`expression.js - flow-verify 1`] = `
     });
   }}
 </Component>;
+
+<SuspendyTree>
+  <div style={{ height: 200, overflow: "scroll" }}>
+    {Array(20)
+      .fill()
+      .map((_, i) => (
+        <h2 key={i}>{i + 1}</h2>
+      ))}
+  </div>
+</SuspendyTree>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <View
   style={{
@@ -1916,6 +1926,14 @@ exports[`expression.js - flow-verify 1`] = `
     });
   }}
 </Component>;
+
+<SuspendyTree>
+  <div style={{ height: 200, overflow: "scroll" }}>
+    {Array(20)
+      .fill()
+      .map((_, i) => <h2 key={i}>{i + 1}</h2>)}
+  </div>
+</SuspendyTree>;
 
 `;
 
@@ -2041,6 +2059,16 @@ exports[`expression.js - flow-verify 2`] = `
     });
   }}
 </Component>;
+
+<SuspendyTree>
+  <div style={{ height: 200, overflow: "scroll" }}>
+    {Array(20)
+      .fill()
+      .map((_, i) => (
+        <h2 key={i}>{i + 1}</h2>
+      ))}
+  </div>
+</SuspendyTree>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <View
   style={{
@@ -2176,6 +2204,14 @@ exports[`expression.js - flow-verify 2`] = `
   }}
 </Component>;
 
+<SuspendyTree>
+  <div style={{ height: 200, overflow: "scroll" }}>
+    {Array(20)
+      .fill()
+      .map((_, i) => <h2 key={i}>{i + 1}</h2>)}
+  </div>
+</SuspendyTree>;
+
 `;
 
 exports[`expression.js - flow-verify 3`] = `
@@ -2300,6 +2336,16 @@ exports[`expression.js - flow-verify 3`] = `
     });
   }}
 </Component>;
+
+<SuspendyTree>
+  <div style={{ height: 200, overflow: "scroll" }}>
+    {Array(20)
+      .fill()
+      .map((_, i) => (
+        <h2 key={i}>{i + 1}</h2>
+      ))}
+  </div>
+</SuspendyTree>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <View
   style={{
@@ -2435,6 +2481,14 @@ exports[`expression.js - flow-verify 3`] = `
   }}
 </Component>;
 
+<SuspendyTree>
+  <div style={{ height: 200, overflow: 'scroll' }}>
+    {Array(20)
+      .fill()
+      .map((_, i) => <h2 key={i}>{i + 1}</h2>)}
+  </div>
+</SuspendyTree>;
+
 `;
 
 exports[`expression.js - flow-verify 4`] = `
@@ -2559,6 +2613,16 @@ exports[`expression.js - flow-verify 4`] = `
     });
   }}
 </Component>;
+
+<SuspendyTree>
+  <div style={{ height: 200, overflow: "scroll" }}>
+    {Array(20)
+      .fill()
+      .map((_, i) => (
+        <h2 key={i}>{i + 1}</h2>
+      ))}
+  </div>
+</SuspendyTree>;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <View
   style={{
@@ -2693,6 +2757,14 @@ exports[`expression.js - flow-verify 4`] = `
     });
   }}
 </Component>;
+
+<SuspendyTree>
+  <div style={{ height: 200, overflow: 'scroll' }}>
+    {Array(20)
+      .fill()
+      .map((_, i) => <h2 key={i}>{i + 1}</h2>)}
+  </div>
+</SuspendyTree>;
 
 `;
 

--- a/tests/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -1931,7 +1931,9 @@ exports[`expression.js - flow-verify 1`] = `
   <div style={{ height: 200, overflow: "scroll" }}>
     {Array(20)
       .fill()
-      .map((_, i) => <h2 key={i}>{i + 1}</h2>)}
+      .map((_, i) => (
+        <h2 key={i}>{i + 1}</h2>
+      ))}
   </div>
 </SuspendyTree>;
 
@@ -2208,7 +2210,9 @@ exports[`expression.js - flow-verify 2`] = `
   <div style={{ height: 200, overflow: "scroll" }}>
     {Array(20)
       .fill()
-      .map((_, i) => <h2 key={i}>{i + 1}</h2>)}
+      .map((_, i) => (
+        <h2 key={i}>{i + 1}</h2>
+      ))}
   </div>
 </SuspendyTree>;
 
@@ -2485,7 +2489,9 @@ exports[`expression.js - flow-verify 3`] = `
   <div style={{ height: 200, overflow: 'scroll' }}>
     {Array(20)
       .fill()
-      .map((_, i) => <h2 key={i}>{i + 1}</h2>)}
+      .map((_, i) => (
+        <h2 key={i}>{i + 1}</h2>
+      ))}
   </div>
 </SuspendyTree>;
 
@@ -2762,7 +2768,9 @@ exports[`expression.js - flow-verify 4`] = `
   <div style={{ height: 200, overflow: 'scroll' }}>
     {Array(20)
       .fill()
-      .map((_, i) => <h2 key={i}>{i + 1}</h2>)}
+      .map((_, i) => (
+        <h2 key={i}>{i + 1}</h2>
+      ))}
   </div>
 </SuspendyTree>;
 

--- a/tests/jsx/expression.js
+++ b/tests/jsx/expression.js
@@ -119,3 +119,13 @@
     });
   }}
 </Component>;
+
+<SuspendyTree>
+  <div style={{ height: 200, overflow: "scroll" }}>
+    {Array(20)
+      .fill()
+      .map((_, i) => (
+        <h2 key={i}>{i + 1}</h2>
+      ))}
+  </div>
+</SuspendyTree>;


### PR DESCRIPTION
Fixes #5337

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
