### PR TITLE
fix(jsx): consistent quotes in JSX expression

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5280,7 +5280,7 @@ function printJSXElement(path, options, print) {
     containsMultipleAttributes ||
     containsMultipleExpressions;
 
-  const rawJsxWhitespace = options.jsxSingleQuote ? "{' '}" : '{" "}';
+  const rawJsxWhitespace = options.singleQuote ? "{' '}" : '{" "}';
   const jsxWhitespace = ifBreak(concat([rawJsxWhitespace, softline]), " ");
 
   const isFacebookTranslationTag =

--- a/tests/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -3785,6 +3785,12 @@ exports[`quotes.js - flow-verify 1`] = `
   doubleBoth2={"\\" '"}
   doubleBoth3="&quot; &apos; '"
 />;
+
+<p>
+  GitHub Desktop has encountered an unrecoverable error and will need to 1231231
+  restart. This has been reported to the team, but if youencounter this121312331
+  repeatedly please report this issue to the GitHub 12312312312312313{'  '}{' '}
+</p>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <div id="&quot;'<>&amp;quot;" />;
 <div id='"&#39;<>&amp;quot;' />;
@@ -3814,6 +3820,12 @@ exports[`quotes.js - flow-verify 1`] = `
   doubleBoth2={"\\" '"}
   doubleBoth3="&quot; ' '"
 />;
+
+<p>
+  GitHub Desktop has encountered an unrecoverable error and will need to 1231231
+  restart. This has been reported to the team, but if youencounter this121312331
+  repeatedly please report this issue to the GitHub 12312312312312313{"  "}{" "}
+</p>;
 
 `;
 
@@ -3854,6 +3866,12 @@ exports[`quotes.js - flow-verify 2`] = `
   doubleBoth2={"\\" '"}
   doubleBoth3="&quot; &apos; '"
 />;
+
+<p>
+  GitHub Desktop has encountered an unrecoverable error and will need to 1231231
+  restart. This has been reported to the team, but if youencounter this121312331
+  repeatedly please report this issue to the GitHub 12312312312312313{'  '}{' '}
+</p>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <div id='"&apos;<>&amp;quot;' />;
 <div id='"&#39;<>&amp;quot;' />;
@@ -3883,6 +3901,12 @@ exports[`quotes.js - flow-verify 2`] = `
   doubleBoth2={"\\" '"}
   doubleBoth3="&quot; ' '"
 />;
+
+<p>
+  GitHub Desktop has encountered an unrecoverable error and will need to 1231231
+  restart. This has been reported to the team, but if youencounter this121312331
+  repeatedly please report this issue to the GitHub 12312312312312313{"  "}{' '}
+</p>;
 
 `;
 
@@ -3923,6 +3947,12 @@ exports[`quotes.js - flow-verify 3`] = `
   doubleBoth2={"\\" '"}
   doubleBoth3="&quot; &apos; '"
 />;
+
+<p>
+  GitHub Desktop has encountered an unrecoverable error and will need to 1231231
+  restart. This has been reported to the team, but if youencounter this121312331
+  repeatedly please report this issue to the GitHub 12312312312312313{'  '}{' '}
+</p>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <div id="&quot;'<>&amp;quot;" />;
 <div id='"&#39;<>&amp;quot;' />;
@@ -3952,6 +3982,12 @@ exports[`quotes.js - flow-verify 3`] = `
   doubleBoth2={'" \\''}
   doubleBoth3="&quot; ' '"
 />;
+
+<p>
+  GitHub Desktop has encountered an unrecoverable error and will need to 1231231
+  restart. This has been reported to the team, but if youencounter this121312331
+  repeatedly please report this issue to the GitHub 12312312312312313{'  '}{" "}
+</p>;
 
 `;
 
@@ -3992,6 +4028,12 @@ exports[`quotes.js - flow-verify 4`] = `
   doubleBoth2={"\\" '"}
   doubleBoth3="&quot; &apos; '"
 />;
+
+<p>
+  GitHub Desktop has encountered an unrecoverable error and will need to 1231231
+  restart. This has been reported to the team, but if youencounter this121312331
+  repeatedly please report this issue to the GitHub 12312312312312313{'  '}{' '}
+</p>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <div id='"&apos;<>&amp;quot;' />;
 <div id='"&#39;<>&amp;quot;' />;
@@ -4021,6 +4063,12 @@ exports[`quotes.js - flow-verify 4`] = `
   doubleBoth2={'" \\''}
   doubleBoth3="&quot; ' '"
 />;
+
+<p>
+  GitHub Desktop has encountered an unrecoverable error and will need to 1231231
+  restart. This has been reported to the team, but if youencounter this121312331
+  repeatedly please report this issue to the GitHub 12312312312312313{'  '}{' '}
+</p>;
 
 `;
 

--- a/tests/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -3905,7 +3905,7 @@ exports[`quotes.js - flow-verify 2`] = `
 <p>
   GitHub Desktop has encountered an unrecoverable error and will need to 1231231
   restart. This has been reported to the team, but if youencounter this121312331
-  repeatedly please report this issue to the GitHub 12312312312312313{"  "}{' '}
+  repeatedly please report this issue to the GitHub 12312312312312313{"  "}{" "}
 </p>;
 
 `;
@@ -3986,7 +3986,7 @@ exports[`quotes.js - flow-verify 3`] = `
 <p>
   GitHub Desktop has encountered an unrecoverable error and will need to 1231231
   restart. This has been reported to the team, but if youencounter this121312331
-  repeatedly please report this issue to the GitHub 12312312312312313{'  '}{" "}
+  repeatedly please report this issue to the GitHub 12312312312312313{'  '}{' '}
 </p>;
 
 `;

--- a/tests/jsx/quotes.js
+++ b/tests/jsx/quotes.js
@@ -34,3 +34,9 @@
   doubleBoth2={"\" '"}
   doubleBoth3="&quot; &apos; '"
 />;
+
+<p>
+  GitHub Desktop has encountered an unrecoverable error and will need to 1231231
+  restart. This has been reported to the team, but if youencounter this121312331
+  repeatedly please report this issue to the GitHub 12312312312312313{'  '}{' '}
+</p>

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -31,6 +31,7 @@ const ENABLED_OPTIONS = [
   "semi",
   "singleQuote",
   "bracketSpacing",
+  "jsxSingleQuote",
   "jsxBracketSameLine",
   "arrowParens",
   "trailingComma",


### PR DESCRIPTION
Fixes #5348

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
