### PR TITLE
fix(css-in-js): do not remove semicolon

### DIFF
--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -556,7 +556,7 @@ const parser = {
     if (endNode && node.source && !node.source.end) {
       node = endNode;
     }
-    if (node.source) {
+    if (node.source && node.source.end) {
       return lineColumnToIndex(node.source.end, node.source.input.css);
     }
     return null;

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -185,7 +185,9 @@ function genericPrint(path, options, print) {
               softline,
               "}"
             ])
-          : isTemplatePropNode(node) && !parentNode.raws.semicolon
+          : isTemplatePropNode(node) &&
+            !parentNode.raws.semicolon &&
+            options.originalText[options.locEnd(node) - 1] !== ";"
             ? ""
             : ";"
       ]);
@@ -242,7 +244,9 @@ function genericPrint(path, options, print) {
               softline,
               "}"
             ])
-          : isTemplatePlaceholderNode(node) && !parentNode.raws.semicolon
+          : isTemplatePlaceholderNode(node) &&
+            !parentNode.raws.semicolon &&
+            options.originalText[options.locEnd(node) - 1] !== ";"
             ? ""
             : ";"
       ]);

--- a/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
@@ -275,7 +275,7 @@ styled.span\`
 
 styled.a\`
   \${feedbackCountBlockCss}
-  text-decoration: none
+  text-decoration: none;
 
   \${FeedbackCount} {
     margin: 0;

--- a/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
@@ -130,7 +130,17 @@ styled.span\`
 styled.span\`
 \${foo}:
 \${bar};
-\`~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+\`
+
+styled.a\`
+  \${feedbackCountBlockCss}
+  text-decoration: none;
+
+  \${FeedbackCount} {
+    margin: 0;
+  }
+\`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const ListItem = styled.li\`\`;
 
 const ListItem = styled.li\`\`;
@@ -261,6 +271,15 @@ styled.span\`
 
 styled.span\`
   \${foo}: \${bar};
+\`;
+
+styled.a\`
+  \${feedbackCountBlockCss}
+  text-decoration: none
+
+  \${FeedbackCount} {
+    margin: 0;
+  }
 \`;
 
 `;

--- a/tests/multiparser_js_css/styled-components.js
+++ b/tests/multiparser_js_css/styled-components.js
@@ -128,3 +128,12 @@ styled.span`
 ${foo}:
 ${bar};
 `
+
+styled.a`
+  ${feedbackCountBlockCss}
+  text-decoration: none;
+
+  ${FeedbackCount} {
+    margin: 0;
+  }
+`


### PR DESCRIPTION
Fixes #5344

Not sure if this is the correct fix but at least it works.

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
