### PR TITLE
fix(jsx): do not move trailing char to the next line as leading char

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5096,8 +5096,7 @@ function separatorWithWhitespace(
 
   if (child.length === 1) {
     return (childNode.type === "JSXElement" && !childNode.closingElement) ||
-      (nextNode &&
-        (nextNode.type === "JSXElement" && !nextNode.closingElement))
+      (nextNode && nextNode.type === "JSXElement" && !nextNode.closingElement)
       ? hardline
       : softline;
   }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5078,19 +5078,28 @@ function separatorNoWhitespace(
     (childNode.type === "JSXElement" && !childNode.closingElement) ||
     (nextNode && (nextNode.type === "JSXElement" && !nextNode.closingElement))
   ) {
-    return hardline;
+    return child.length === 1 ? softline : hardline;
   }
 
   return softline;
 }
 
-function separatorWithWhitespace(isFacebookTranslationTag, child) {
+function separatorWithWhitespace(
+  isFacebookTranslationTag,
+  child,
+  childNode,
+  nextNode
+) {
   if (isFacebookTranslationTag) {
     return hardline;
   }
 
   if (child.length === 1) {
-    return softline;
+    return (childNode.type === "JSXElement" && !childNode.closingElement) ||
+      (nextNode &&
+        (nextNode.type === "JSXElement" && !nextNode.closingElement))
+      ? hardline
+      : softline;
   }
 
   return hardline;
@@ -5133,8 +5142,14 @@ function printJSXChildren(
           children.push("");
           words.shift();
           if (/\n/.test(words[0])) {
+            const next = n.children[i + 1];
             children.push(
-              separatorWithWhitespace(isFacebookTranslationTag, words[1])
+              separatorWithWhitespace(
+                isFacebookTranslationTag,
+                words[1],
+                child,
+                next
+              )
             );
           } else {
             children.push(jsxWhitespace);
@@ -5164,10 +5179,13 @@ function printJSXChildren(
 
         if (endWhitespace !== undefined) {
           if (/\n/.test(endWhitespace)) {
+            const next = n.children[i + 1];
             children.push(
               separatorWithWhitespace(
                 isFacebookTranslationTag,
-                getLast(children)
+                getLast(children),
+                child,
+                next
               )
             );
           } else {

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -780,11 +780,7 @@ line_after_br = (
 
 line_after_br_2 = (
   <div>
-    A
-    <br />
-    B
-    <br />
-    C
+    A<br />B<br />C
   </div>
 );
 
@@ -974,8 +970,7 @@ x = (
 
 x = (
   <div>
-    <strong>text here</strong>.
-    <br />
+    <strong>text here</strong>.<br />
   </div>
 );
 
@@ -995,8 +990,7 @@ x = (
     <span>
       <strong>{name}</strong>’s{" "}
     </span>
-    Hello <strong>world</strong>.
-    <br />
+    Hello <strong>world</strong>.<br />
     <Text>You {type}ed this shipment to</Text>
   </div>
 );
@@ -1032,8 +1026,8 @@ this_really_should_split_across_lines = (
 
 let myDiv = ReactTestUtils.renderIntoDocument(
   <div>
-    <div key="theDog" className="dog" />
-    ,<div key="theBird" className="bird" />
+    <div key="theDog" className="dog" />,
+    <div key="theBird" className="bird" />
   </div>
 );
 

--- a/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -452,6 +452,13 @@ this_really_should_split_across_lines =
   <div>
     before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after
   </div>
+
+let myDiv = ReactTestUtils.renderIntoDocument(
+  <div>
+    <div key="theDog" className="dog" />,
+    <div key="theBird" className="bird" />
+  </div>
+);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Wrapping text
 x = (
@@ -1020,6 +1027,13 @@ this_really_should_split_across_lines = (
   <div>
     before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}
     after{stuff}after
+  </div>
+);
+
+let myDiv = ReactTestUtils.renderIntoDocument(
+  <div>
+    <div key="theDog" className="dog" />
+    ,<div key="theBird" className="bird" />
   </div>
 );
 

--- a/tests/jsx-text-wrap/test.js
+++ b/tests/jsx-text-wrap/test.js
@@ -449,3 +449,10 @@ this_really_should_split_across_lines =
   <div>
     before{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after{stuff}after
   </div>
+
+let myDiv = ReactTestUtils.renderIntoDocument(
+  <div>
+    <div key="theDog" className="dog" />,
+    <div key="theBird" className="bird" />
+  </div>
+);


### PR DESCRIPTION
Fixes #5336

Though I'm not sure why we should special-case self-closing tags, the changes look OK to me.

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
