### PR TITLE
fix(html-in-js): do not break empty content

### DIFF
--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -626,7 +626,19 @@ function printHtmlTemplateLiteral(path, print, textToDoc, parser) {
     }
   );
 
-  return concat(["`", indent(concat([hardline, contentDoc])), softline, "`"]);
+  return group(
+    concat([
+      "`",
+      indent(
+        concat([
+          text.trim().length !== 0 ? hardline : softline,
+          group(contentDoc)
+        ])
+      ),
+      softline,
+      "`"
+    ])
+  );
 }
 
 module.exports = embed;

--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -582,6 +582,10 @@ function printHtmlTemplateLiteral(path, print, textToDoc, parser) {
 
   const expressionDocs = path.map(print, "expressions");
 
+  if (expressionDocs.length === 0 && text.trim().length === 0) {
+    return "``";
+  }
+
   const contentDoc = mapDoc(
     stripTrailingHardline(textToDoc(text, { parser })),
     doc => {
@@ -627,17 +631,7 @@ function printHtmlTemplateLiteral(path, print, textToDoc, parser) {
   );
 
   return group(
-    concat([
-      "`",
-      indent(
-        concat([
-          text.trim().length !== 0 ? hardline : softline,
-          group(contentDoc)
-        ])
-      ),
-      softline,
-      "`"
-    ])
+    concat(["`", indent(concat([hardline, group(contentDoc)])), softline, "`"])
   );
 }
 

--- a/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
@@ -84,8 +84,6 @@ const someHtml2 = /* HTML */ \`
   <div>hello \${world}</div>
 \`;
 
-html\`
-
-\`;
+html\`\`;
 
 `;

--- a/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
@@ -45,6 +45,8 @@ customElements.define('my-element', MyElement);
 
 const someHtml1 = html\`<div       > hello \${world} </div     >\`;
 const someHtml2 = /* HTML */ \`<div      > hello \${world} </div     >\`;
+
+html\`\`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import { LitElement, html } from "@polymer/lit-element";
 
@@ -80,6 +82,10 @@ const someHtml1 = html\`
 \`;
 const someHtml2 = /* HTML */ \`
   <div>hello \${world}</div>
+\`;
+
+html\`
+
 \`;
 
 `;

--- a/tests/multiparser_js_html/lit-html.js
+++ b/tests/multiparser_js_html/lit-html.js
@@ -42,3 +42,5 @@ customElements.define('my-element', MyElement);
 
 const someHtml1 = html`<div       > hello ${world} </div     >`;
 const someHtml2 = /* HTML */ `<div      > hello ${world} </div     >`;
+
+html``


### PR DESCRIPTION
This one should be the final fix in 1.15.

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
