### PR TITLE
fix(javascript): inline property decorator should stay inline

### DIFF
--- a/tests/decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators/__snapshots__/jsfmt.spec.js.snap
@@ -174,13 +174,11 @@ class OrderLine {
     this.price = price;
   }
 
-  @computed
-  get total() {
+  @computed get total() {
     return this.price * this.amount;
   }
 
-  @action.bound
-  setPrice(price) {
+  @action.bound setPrice(price) {
     this.price = price;
   }
 

--- a/tests/decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators/__snapshots__/jsfmt.spec.js.snap
@@ -147,6 +147,20 @@ import {observable} from "mobx";
   @action.bound setPrice(price) {
     this.price = price;
   }
+
+  @computed
+  get total() {
+    return this.price * this.amount;
+  }
+
+  @action.bound
+  setPrice(price) {
+    this.price = price;
+  }
+  
+  @computed @computed @computed @computed @computed @computed @computed get total() {
+    return this.price * this.amount;
+  }
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import { observable } from "mobx";
@@ -168,6 +182,27 @@ class OrderLine {
   @action.bound
   setPrice(price) {
     this.price = price;
+  }
+
+  @computed
+  get total() {
+    return this.price * this.amount;
+  }
+
+  @action.bound
+  setPrice(price) {
+    this.price = price;
+  }
+
+  @computed
+  @computed
+  @computed
+  @computed
+  @computed
+  @computed
+  @computed
+  get total() {
+    return this.price * this.amount;
   }
 }
 

--- a/tests/decorators/mobx.js
+++ b/tests/decorators/mobx.js
@@ -15,4 +15,18 @@ import {observable} from "mobx";
   @action.bound setPrice(price) {
     this.price = price;
   }
+
+  @computed
+  get total() {
+    return this.price * this.amount;
+  }
+
+  @action.bound
+  setPrice(price) {
+    this.price = price;
+  }
+  
+  @computed @computed @computed @computed @computed @computed @computed get total() {
+    return this.price * this.amount;
+  }
 }


### PR DESCRIPTION
Fixes the `@action` part in #5360

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
