### PR TITLE
fix(javascript): do not apply test call formatting to arrow without body

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -6200,8 +6200,10 @@ function isTestCall(n, parent) {
         return false;
       }
       return (
-        (isFunctionOrArrowExpressionWithBody(n.arguments[1]) &&
-          n.arguments[1].params.length <= 1) ||
+        (n.arguments.length === 2
+          ? isFunctionOrArrowExpression(n.arguments[1])
+          : isFunctionOrArrowExpressionWithBody(n.arguments[1]) &&
+            n.arguments[1].params.length <= 1) ||
         isAngularTestWrapper(n.arguments[1])
       );
     }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -6183,7 +6183,7 @@ function isTestCall(n, parent) {
   }
   if (n.arguments.length === 1) {
     if (isAngularTestWrapper(n) && parent && isTestCall(parent)) {
-      return isFunctionOrArrowExpressionWithBody(n.arguments[0]);
+      return isFunctionOrArrowExpression(n.arguments[0]);
     }
 
     if (isUnitTestSetUp(n)) {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -6183,7 +6183,7 @@ function isTestCall(n, parent) {
   }
   if (n.arguments.length === 1) {
     if (isAngularTestWrapper(n) && parent && isTestCall(parent)) {
-      return isFunctionOrArrowExpression(n.arguments[0]);
+      return isFunctionOrArrowExpressionWithBody(n.arguments[0]);
     }
 
     if (isUnitTestSetUp(n)) {
@@ -6200,7 +6200,7 @@ function isTestCall(n, parent) {
         return false;
       }
       return (
-        (isFunctionOrArrowExpression(n.arguments[1]) &&
+        (isFunctionOrArrowExpressionWithBody(n.arguments[1]) &&
           n.arguments[1].params.length <= 1) ||
         isAngularTestWrapper(n.arguments[1])
       );
@@ -6242,6 +6242,14 @@ function isFunctionOrArrowExpression(node) {
   return (
     node.type === "FunctionExpression" ||
     node.type === "ArrowFunctionExpression"
+  );
+}
+
+function isFunctionOrArrowExpressionWithBody(node) {
+  return (
+    node.type === "FunctionExpression" ||
+    (node.type === "ArrowFunctionExpression" &&
+      node.body.type === "BlockStatement")
   );
 }
 

--- a/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
@@ -847,10 +847,8 @@ it("does something quick", () => {
   console.log("hello!");
 }, 1000000000);
 
-it(
-  "succeeds if the test finishes in time",
-  () => new Promise(resolve => setTimeout(resolve, 10))
-);
+it("succeeds if the test finishes in time", () =>
+  new Promise(resolve => setTimeout(resolve, 10)));
 
 it(
   "succeeds if the test finishes in time",
@@ -1125,10 +1123,8 @@ it("does something quick", () => {
   console.log("hello!");
 }, 1000000000);
 
-it(
-  "succeeds if the test finishes in time",
-  () => new Promise((resolve) => setTimeout(resolve, 10))
-);
+it("succeeds if the test finishes in time", () =>
+  new Promise((resolve) => setTimeout(resolve, 10)));
 
 it(
   "succeeds if the test finishes in time",

--- a/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
@@ -167,6 +167,8 @@ it("does something really long and complicated so I have to write a very long na
   // code
 }));
 
+it("does something really long and complicated so I have to write a very long name for the test", fakeAsync(() => new SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS));
+
 /*
 * isTestCall(parent) should only be called when parent exists
 * and parent.type is CallExpression. This test makes sure that
@@ -189,6 +191,11 @@ it("should create the app", fakeAsync(() => {
 it("does something really long and complicated so I have to write a very long name for the test", fakeAsync(() => {
   // code
 }));
+
+it("does something really long and complicated so I have to write a very long name for the test", fakeAsync(
+  () =>
+    new SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS()
+));
 
 /*
  * isTestCall(parent) should only be called when parent exists
@@ -218,6 +225,8 @@ it("does something really long and complicated so I have to write a very long na
   // code
 }));
 
+it("does something really long and complicated so I have to write a very long name for the test", fakeAsync(() => new SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS));
+
 /*
 * isTestCall(parent) should only be called when parent exists
 * and parent.type is CallExpression. This test makes sure that
@@ -240,6 +249,11 @@ it("should create the app", fakeAsync(() => {
 it("does something really long and complicated so I have to write a very long name for the test", fakeAsync(() => {
   // code
 }));
+
+it("does something really long and complicated so I have to write a very long name for the test", fakeAsync(
+  () =>
+    new SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS()
+));
 
 /*
  * isTestCall(parent) should only be called when parent exists

--- a/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
@@ -832,8 +832,11 @@ it("does something quick", () => {
   console.log("hello!");
 }, 1000000000);
 
-it("succeeds if the test finishes in time", () =>
-  new Promise(resolve => setTimeout(resolve, 10)), 250);
+it(
+  "succeeds if the test finishes in time",
+  () => new Promise(resolve => setTimeout(resolve, 10)),
+  250
+);
 
 `;
 
@@ -1097,7 +1100,10 @@ it("does something quick", () => {
   console.log("hello!");
 }, 1000000000);
 
-it("succeeds if the test finishes in time", () =>
-  new Promise((resolve) => setTimeout(resolve, 10)), 250);
+it(
+  "succeeds if the test finishes in time",
+  () => new Promise((resolve) => setTimeout(resolve, 10)),
+  250
+);
 
 `;

--- a/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
@@ -692,6 +692,12 @@ it(\`handles
 it("does something quick", () => {
   console.log("hello!")
 }, 1000000000)
+
+it(
+  'succeeds if the test finishes in time',
+  () => new Promise(resolve => setTimeout(resolve, 10)),
+  250
+);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Shouldn't break
 
@@ -826,6 +832,9 @@ it("does something quick", () => {
   console.log("hello!");
 }, 1000000000);
 
+it("succeeds if the test finishes in time", () =>
+  new Promise(resolve => setTimeout(resolve, 10)), 250);
+
 `;
 
 exports[`test_declarations.js - flow-verify 2`] = `
@@ -948,6 +957,12 @@ it(\`handles
 it("does something quick", () => {
   console.log("hello!")
 }, 1000000000)
+
+it(
+  'succeeds if the test finishes in time',
+  () => new Promise(resolve => setTimeout(resolve, 10)),
+  250
+);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 // Shouldn't break
 
@@ -1081,5 +1096,8 @@ it(\`handles
 it("does something quick", () => {
   console.log("hello!");
 }, 1000000000);
+
+it("succeeds if the test finishes in time", () =>
+  new Promise((resolve) => setTimeout(resolve, 10)), 250);
 
 `;

--- a/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
@@ -192,10 +192,8 @@ it("does something really long and complicated so I have to write a very long na
   // code
 }));
 
-it("does something really long and complicated so I have to write a very long name for the test", fakeAsync(
-  () =>
-    new SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS()
-));
+it("does something really long and complicated so I have to write a very long name for the test", fakeAsync(() =>
+  new SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS()));
 
 /*
  * isTestCall(parent) should only be called when parent exists
@@ -250,10 +248,8 @@ it("does something really long and complicated so I have to write a very long na
   // code
 }));
 
-it("does something really long and complicated so I have to write a very long name for the test", fakeAsync(
-  () =>
-    new SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS()
-));
+it("does something really long and complicated so I have to write a very long name for the test", fakeAsync(() =>
+  new SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS()));
 
 /*
  * isTestCall(parent) should only be called when parent exists

--- a/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/test_declarations/__snapshots__/jsfmt.spec.js.snap
@@ -705,6 +705,11 @@ it("does something quick", () => {
 
 it(
   'succeeds if the test finishes in time',
+  () => new Promise(resolve => setTimeout(resolve, 10))
+);
+
+it(
+  'succeeds if the test finishes in time',
   () => new Promise(resolve => setTimeout(resolve, 10)),
   250
 );
@@ -844,6 +849,11 @@ it("does something quick", () => {
 
 it(
   "succeeds if the test finishes in time",
+  () => new Promise(resolve => setTimeout(resolve, 10))
+);
+
+it(
+  "succeeds if the test finishes in time",
   () => new Promise(resolve => setTimeout(resolve, 10)),
   250
 );
@@ -970,6 +980,11 @@ it(\`handles
 it("does something quick", () => {
   console.log("hello!")
 }, 1000000000)
+
+it(
+  'succeeds if the test finishes in time',
+  () => new Promise(resolve => setTimeout(resolve, 10))
+);
 
 it(
   'succeeds if the test finishes in time',
@@ -1109,6 +1124,11 @@ it(\`handles
 it("does something quick", () => {
   console.log("hello!");
 }, 1000000000);
+
+it(
+  "succeeds if the test finishes in time",
+  () => new Promise((resolve) => setTimeout(resolve, 10))
+);
 
 it(
   "succeeds if the test finishes in time",

--- a/tests/test_declarations/angular_fakeAsync.js
+++ b/tests/test_declarations/angular_fakeAsync.js
@@ -14,6 +14,8 @@ it("does something really long and complicated so I have to write a very long na
   // code
 }));
 
+it("does something really long and complicated so I have to write a very long name for the test", fakeAsync(() => new SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS));
+
 /*
 * isTestCall(parent) should only be called when parent exists
 * and parent.type is CallExpression. This test makes sure that

--- a/tests/test_declarations/test_declarations.js
+++ b/tests/test_declarations/test_declarations.js
@@ -120,6 +120,11 @@ it("does something quick", () => {
 
 it(
   'succeeds if the test finishes in time',
+  () => new Promise(resolve => setTimeout(resolve, 10))
+);
+
+it(
+  'succeeds if the test finishes in time',
   () => new Promise(resolve => setTimeout(resolve, 10)),
   250
 );

--- a/tests/test_declarations/test_declarations.js
+++ b/tests/test_declarations/test_declarations.js
@@ -117,3 +117,9 @@ it(`handles
 it("does something quick", () => {
   console.log("hello!")
 }, 1000000000)
+
+it(
+  'succeeds if the test finishes in time',
+  () => new Promise(resolve => setTimeout(resolve, 10)),
+  250
+);


### PR DESCRIPTION
Fixes #5365

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
