### PR TITLE
fix(angular): handle parens in ng expression correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@babel/parser": "7.1.5",
     "@glimmer/syntax": "0.30.3",
     "@iarna/toml": "2.0.0",
-    "angular-estree-parser": "1.1.3",
+    "angular-estree-parser": "1.1.4",
     "angular-html-parser": "1.0.0",
     "camelcase": "4.1.0",
     "chalk": "2.1.0",

--- a/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
@@ -190,9 +190,9 @@ exports[`attributes.component.html - angular-verify 1`] = `
   [error]="'We couldn\\\\\\'t find anything with that name.'"
   *ngIf="form.controls.details?.controls.amount?.errors.min"
   [ngClass]="{
-    '-success\\': ': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
-    '-warning\\': ': (dialog$ | async).level === dialogLevelEnum.WARNING,
-    '-svg\\': ': (dialog$ | async).level === dialogLevelEnum.DANGER
+    'btn-success': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
+    'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
+    'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER
   }"
 ></div>
 
@@ -388,9 +388,9 @@ exports[`attributes.component.html - angular-verify 2`] = `
   [error]="'We couldn\\\\\\'t find anything with that name.'"
   *ngIf="form.controls.details?.controls.amount?.errors.min"
   [ngClass]="{
-    '-success\\': ': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
-    '-warning\\': ': (dialog$ | async).level === dialogLevelEnum.WARNING,
-    '-svg\\': ': (dialog$ | async).level === dialogLevelEnum.DANGER
+    'btn-success': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
+    'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
+    'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER
   }"
 ></div>
 
@@ -790,21 +790,21 @@ exports[`attributes.component.html - angular-verify 3`] = `
       .min
   "
   [ngClass]="{
-    '-success\\': ':
+    'btn-success':
       (
         dialog$
         | async
       )
         .level ===
       dialogLevelEnum.SUCCESS,
-    '-warning\\': ':
+    'btn-warning':
       (
         dialog$
         | async
       )
         .level ===
       dialogLevelEnum.WARNING,
-    '-svg\\': ':
+    'btn-svg':
       (
         dialog$
         | async

--- a/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
@@ -81,6 +81,10 @@ exports[`attributes.component.html - angular-verify 1`] = `
     [target]="{ longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true }"
     [error]="'We couldn\\\\\\'t find anything with that name.'"
     *ngIf="form.controls.details?.controls.amount?.errors.min"
+    [ngClass]="
+    {'btn-success': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
+      'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
+      'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
 ></div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <div
@@ -185,6 +189,11 @@ exports[`attributes.component.html - angular-verify 1`] = `
   }"
   [error]="'We couldn\\\\\\'t find anything with that name.'"
   *ngIf="form.controls.details?.controls.amount?.errors.min"
+  [ngClass]="{
+    '-success\\': ': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
+    '-warning\\': ': (dialog$ | async).level === dialogLevelEnum.WARNING,
+    '-svg\\': ': (dialog$ | async).level === dialogLevelEnum.DANGER
+  }"
 ></div>
 
 `;
@@ -270,6 +279,10 @@ exports[`attributes.component.html - angular-verify 2`] = `
     [target]="{ longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true }"
     [error]="'We couldn\\\\\\'t find anything with that name.'"
     *ngIf="form.controls.details?.controls.amount?.errors.min"
+    [ngClass]="
+    {'btn-success': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
+      'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
+      'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
 ></div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <div
@@ -374,6 +387,11 @@ exports[`attributes.component.html - angular-verify 2`] = `
   }"
   [error]="'We couldn\\\\\\'t find anything with that name.'"
   *ngIf="form.controls.details?.controls.amount?.errors.min"
+  [ngClass]="{
+    '-success\\': ': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
+    '-warning\\': ': (dialog$ | async).level === dialogLevelEnum.WARNING,
+    '-svg\\': ': (dialog$ | async).level === dialogLevelEnum.DANGER
+  }"
 ></div>
 
 `;
@@ -459,6 +477,10 @@ exports[`attributes.component.html - angular-verify 3`] = `
     [target]="{ longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true }"
     [error]="'We couldn\\\\\\'t find anything with that name.'"
     *ngIf="form.controls.details?.controls.amount?.errors.min"
+    [ngClass]="
+    {'btn-success': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
+      'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
+      'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
 ></div>
 ~
 <div
@@ -767,6 +789,29 @@ exports[`attributes.component.html - angular-verify 3`] = `
       ?.errors
       .min
   "
+  [ngClass]="{
+    '-success\\': ':
+      (
+        dialog$
+        | async
+      )
+        .level ===
+      dialogLevelEnum.SUCCESS,
+    '-warning\\': ':
+      (
+        dialog$
+        | async
+      )
+        .level ===
+      dialogLevelEnum.WARNING,
+    '-svg\\': ':
+      (
+        dialog$
+        | async
+      )
+        .level ===
+      dialogLevelEnum.DANGER
+  }"
 ></div>
 
 `;

--- a/tests/html_angular/attributes.component.html
+++ b/tests/html_angular/attributes.component.html
@@ -78,4 +78,8 @@
     [target]="{ longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true }"
     [error]="'We couldn\\\'t find anything with that name.'"
     *ngIf="form.controls.details?.controls.amount?.errors.min"
+    [ngClass]="
+    {'btn-success': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
+      'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
+      'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
 ></div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -704,9 +704,9 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-angular-estree-parser@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/angular-estree-parser/-/angular-estree-parser-1.1.3.tgz#679b7a1ab57e56cd484b5c44e380bcec7633df58"
+angular-estree-parser@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/angular-estree-parser/-/angular-estree-parser-1.1.4.tgz#173fd2a9a30ccd38864e879e66b83cbbbdfd45db"
   dependencies:
     lines-and-columns "^1.1.6"
     tslib "^1.9.3"


### PR DESCRIPTION
Fixes #5367

See ikatyang/angular-estree-parser#22.

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
