### PR TITLE
fix(html): preserve content for `<template>` with unknown lang

### DIFF
--- a/src/language-html/utils.js
+++ b/src/language-html/utils.js
@@ -40,6 +40,15 @@ function hasPrettierIgnore(path) {
     return false;
   }
 
+  if (
+    node.type === "element" &&
+    node.fullName === "template" &&
+    node.attrMap.lang &&
+    node.attrMap.lang !== "html"
+  ) {
+    return true;
+  }
+
   // TODO: handle non-text children in <pre>
   if (
     isPreLikeNode(node) &&

--- a/src/language-html/utils.js
+++ b/src/language-html/utils.js
@@ -34,11 +34,8 @@ function mapObject(object, fn) {
   return newObject;
 }
 
-function hasPrettierIgnore(path) {
+function shouldPreserveElementContent(path) {
   const node = path.getValue();
-  if (node.type === "attribute" || node.type === "text") {
-    return false;
-  }
 
   if (
     node.type === "element" &&
@@ -57,6 +54,15 @@ function hasPrettierIgnore(path) {
     )
   ) {
     return true;
+  }
+
+  return false;
+}
+
+function hasPrettierIgnore(path) {
+  const node = path.getValue();
+  if (node.type === "attribute" || node.type === "text") {
+    return false;
   }
 
   const parentNode = path.getParentNode();
@@ -623,5 +629,6 @@ module.exports = {
   preferHardlineAsLeadingSpaces,
   preferHardlineAsTrailingSpaces,
   replaceDocNewlines,
-  replaceNewlines
+  replaceNewlines,
+  shouldPreserveElementContent
 };

--- a/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
@@ -850,11 +850,7 @@ exports[`pre-child.vue - vue-verify 1`] = `
 <!--
   copied from https://github.com/gitlabhq/gitlabhq/blob/master/app/assets/javascripts/ide/components/jobs/detail.vue
 -->
-<pre
-  ref="buildTrace"
-  class="build-trace mb-0 h-100"
-  @scroll="scrollBuildLog"
->
+<pre ref="buildTrace" class="build-trace mb-0 h-100" @scroll="scrollBuildLog">
   <code
     v-show="!detailJob.isLoading"
     class="bash"
@@ -952,11 +948,7 @@ exports[`pre-child.vue - vue-verify 2`] = `
 <!--
   copied from https://github.com/gitlabhq/gitlabhq/blob/master/app/assets/javascripts/ide/components/jobs/detail.vue
 -->
-<pre
-  ref="buildTrace"
-  class="build-trace mb-0 h-100"
-  @scroll="scrollBuildLog"
->
+<pre ref="buildTrace" class="build-trace mb-0 h-100" @scroll="scrollBuildLog">
   <code
     v-show="!detailJob.isLoading"
     class="bash"
@@ -1265,11 +1257,7 @@ exports[`template-lang.vue - vue-verify 1`] = `
   .bla
 </template>
 
-<template 
-
-
-   
-   lang='pug'>
+<template lang="pug">
   .test
     #foo
   .bla
@@ -1300,11 +1288,7 @@ exports[`template-lang.vue - vue-verify 2`] = `
   .bla
 </template>
 
-<template 
-
-
-   
-   lang='pug'>
+<template lang="pug">
   .test
     #foo
   .bla

--- a/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
@@ -1140,6 +1140,32 @@ exports[`template.vue - vue-verify 2`] = `
 
 `;
 
+exports[`template-lang.vue - vue-verify 1`] = `
+<template lang="pug">
+  .test
+    #foo
+  .bla
+</template>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<template lang="pug">
+  .test #foo .bla
+</template>
+
+`;
+
+exports[`template-lang.vue - vue-verify 2`] = `
+<template lang="pug">
+  .test
+    #foo
+  .bla
+</template>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<template lang="pug">
+  .test #foo .bla
+</template>
+
+`;
+
 exports[`test.vue - vue-verify 1`] = `
 <script>
 </script>

--- a/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
@@ -1148,7 +1148,9 @@ exports[`template-lang.vue - vue-verify 1`] = `
 </template>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <template lang="pug">
-  .test #foo .bla
+  .test
+    #foo
+  .bla
 </template>
 
 `;
@@ -1161,7 +1163,9 @@ exports[`template-lang.vue - vue-verify 2`] = `
 </template>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <template lang="pug">
-  .test #foo .bla
+  .test
+    #foo
+  .bla
 </template>
 
 `;

--- a/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
@@ -1248,8 +1248,28 @@ exports[`template-lang.vue - vue-verify 1`] = `
     #foo
   .bla
 </template>
+
+<template 
+
+
+   
+   lang='pug'>
+  .test
+    #foo
+  .bla
+</template>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <template lang="pug">
+  .test
+    #foo
+  .bla
+</template>
+
+<template 
+
+
+   
+   lang='pug'>
   .test
     #foo
   .bla
@@ -1263,8 +1283,28 @@ exports[`template-lang.vue - vue-verify 2`] = `
     #foo
   .bla
 </template>
+
+<template 
+
+
+   
+   lang='pug'>
+  .test
+    #foo
+  .bla
+</template>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <template lang="pug">
+  .test
+    #foo
+  .bla
+</template>
+
+<template 
+
+
+   
+   lang='pug'>
   .test
     #foo
   .bla

--- a/tests/html_vue/template-lang.vue
+++ b/tests/html_vue/template-lang.vue
@@ -1,0 +1,5 @@
+<template lang="pug">
+  .test
+    #foo
+  .bla
+</template>

--- a/tests/html_vue/template-lang.vue
+++ b/tests/html_vue/template-lang.vue
@@ -3,3 +3,13 @@
     #foo
   .bla
 </template>
+
+<template 
+
+
+   
+   lang='pug'>
+  .test
+    #foo
+  .bla
+</template>


### PR DESCRIPTION
Fixes #5371

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
