### PR TITLE
feat(html): treat capital element as custom element

### DIFF
--- a/src/language-html/utils.js
+++ b/src/language-html/utils.js
@@ -252,7 +252,11 @@ function isCustomElementWithSurroundingLineBreak(node) {
 }
 
 function isCustomElement(node) {
-  return node.type === "element" && !node.namespace && node.name.includes("-");
+  return (
+    node.type === "element" &&
+    !node.namespace &&
+    (node.name.includes("-") || /[A-Z]/.test(node.name[0]))
+  );
 }
 
 function hasSurroundingLineBreak(node) {

--- a/tests/html_attributes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_attributes/__snapshots__/jsfmt.spec.js.snap
@@ -141,7 +141,10 @@ and HTML5 Apps. It also documents Mozilla products, like Firefox OS."
   data-index-number="12314"
   data-parent="cars"
 ></article>
-<X> </X> <X a="1"> </X> <X a="1" b="2"> </X> <X a="1" b="2" c="3"> </X>
+<X> </X>
+<X a="1"> </X>
+<X a="1" b="2"> </X>
+<X a="1" b="2" c="3"> </X>
 <p
   class="
     foo

--- a/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
@@ -976,7 +976,12 @@ foo( )
 foo();
 </script>
 
-<div class="container"><HomeH /> <HomeA /> <HomeX /> <HomeY /></div>
+<div class="container">
+  <HomeH />
+  <HomeA />
+  <HomeX />
+  <HomeY />
+</div>
 
 `;
 
@@ -1004,7 +1009,12 @@ foo( )
 foo();
 </script>
 
-<div class="container"><HomeH /> <HomeA /> <HomeX /> <HomeY /></div>
+<div class="container">
+  <HomeH />
+  <HomeA />
+  <HomeX />
+  <HomeY />
+</div>
 
 `;
 

--- a/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
@@ -960,6 +960,13 @@ exports[`self_closing.vue - vue-verify 1`] = `
 <script>
 foo( )
 </script>
+
+<div class="container">
+  <HomeH />
+  <HomeA />
+  <HomeX />
+  <HomeY />
+</div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <template>
   <div />
@@ -968,6 +975,8 @@ foo( )
 <script>
 foo();
 </script>
+
+<div class="container"><HomeH /> <HomeA /> <HomeX /> <HomeY /></div>
 
 `;
 
@@ -979,6 +988,13 @@ exports[`self_closing.vue - vue-verify 2`] = `
 <script>
 foo( )
 </script>
+
+<div class="container">
+  <HomeH />
+  <HomeA />
+  <HomeX />
+  <HomeY />
+</div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <template>
   <div />
@@ -987,6 +1003,8 @@ foo( )
 <script>
 foo();
 </script>
+
+<div class="container"><HomeH /> <HomeA /> <HomeX /> <HomeY /></div>
 
 `;
 

--- a/tests/html_vue/self_closing.vue
+++ b/tests/html_vue/self_closing.vue
@@ -5,3 +5,10 @@
 <script>
 foo( )
 </script>
+
+<div class="container">
+  <HomeH />
+  <HomeA />
+  <HomeX />
+  <HomeY />
+</div>


### PR DESCRIPTION
Fixes #5385

Custom element: keep it on its own line if both leading/trailing line breaks exist

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
