### PR TITLE
fix(angular): add missing parens for pipe in ternary

### DIFF
--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -513,6 +513,7 @@ function needsParens(path, options) {
         case "SpreadProperty":
         case "BinaryExpression":
         case "LogicalExpression":
+        case "NGPipeExpression":
         case "ExportDefaultDeclaration":
         case "AwaitExpression":
         case "JSXSpreadAttribute":

--- a/tests/angular_interpolation/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/angular_interpolation/__snapshots__/jsfmt.spec.js.snap
@@ -36,7 +36,8 @@ exports[`pipe-expression.ng - __ng_interpolation-verify 1`] = `
         keyA: reallySuperLongValue,
         keyB: shortValue | pipeB | pipeC: valueToPipeC
       }
-      | aaa
+      | aaa,
+   (hideLinqPanel ? "ReportSelection.HideShowLabel_Show.String" : "ReportSelection.HideShowLabel_Hide.String") | localize:(localizationSection) 
 ]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [
@@ -63,6 +64,10 @@ exports[`pipe-expression.ng - __ng_interpolation-verify 1`] = `
           keyA: reallySuperLongValue,
           keyB: shortValue | pipeB | pipeC: valueToPipeC
         }
-    | aaa
+    | aaa,
+  hideLinqPanel
+    ? "ReportSelection.HideShowLabel_Show.String"
+    : "ReportSelection.HideShowLabel_Hide.String"
+    | localize: localizationSection
 ]
 `;

--- a/tests/angular_interpolation/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/angular_interpolation/__snapshots__/jsfmt.spec.js.snap
@@ -65,9 +65,9 @@ exports[`pipe-expression.ng - __ng_interpolation-verify 1`] = `
           keyB: shortValue | pipeB | pipeC: valueToPipeC
         }
     | aaa,
-  hideLinqPanel
+  (hideLinqPanel
     ? "ReportSelection.HideShowLabel_Show.String"
-    : "ReportSelection.HideShowLabel_Hide.String"
+    : "ReportSelection.HideShowLabel_Hide.String")
     | localize: localizationSection
 ]
 `;

--- a/tests/angular_interpolation/pipe-expression.ng
+++ b/tests/angular_interpolation/pipe-expression.ng
@@ -20,5 +20,6 @@
         keyA: reallySuperLongValue,
         keyB: shortValue | pipeB | pipeC: valueToPipeC
       }
-      | aaa
+      | aaa,
+   (hideLinqPanel ? "ReportSelection.HideShowLabel_Show.String" : "ReportSelection.HideShowLabel_Hide.String") | localize:(localizationSection) 
 ]


### PR DESCRIPTION
Fixes #5389

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
