### PR TITLE
fix(angular): correctly print unary expression with `+`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@babel/parser": "7.1.5",
     "@glimmer/syntax": "0.30.3",
     "@iarna/toml": "2.0.0",
-    "angular-estree-parser": "1.1.4",
+    "angular-estree-parser": "1.1.5",
     "angular-html-parser": "1.0.0",
     "camelcase": "4.1.0",
     "chalk": "2.1.0",

--- a/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
@@ -85,6 +85,7 @@ exports[`attributes.component.html - angular-verify 1`] = `
     {'btn-success': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
       'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
       'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
+    [stickout]="+toolAssembly.stickoutMm"
 ></div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <div
@@ -194,6 +195,7 @@ exports[`attributes.component.html - angular-verify 1`] = `
     'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
     'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER
   }"
+  [stickout]="toolAssembly.stickoutMm - "
 ></div>
 
 `;
@@ -283,6 +285,7 @@ exports[`attributes.component.html - angular-verify 2`] = `
     {'btn-success': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
       'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
       'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
+    [stickout]="+toolAssembly.stickoutMm"
 ></div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <div
@@ -392,6 +395,7 @@ exports[`attributes.component.html - angular-verify 2`] = `
     'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
     'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER
   }"
+  [stickout]="toolAssembly.stickoutMm - "
 ></div>
 
 `;
@@ -481,6 +485,7 @@ exports[`attributes.component.html - angular-verify 3`] = `
     {'btn-success': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
       'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
       'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
+    [stickout]="+toolAssembly.stickoutMm"
 ></div>
 ~
 <div
@@ -812,6 +817,10 @@ exports[`attributes.component.html - angular-verify 3`] = `
         .level ===
       dialogLevelEnum.DANGER
   }"
+  [stickout]="
+    toolAssembly.stickoutMm -
+
+  "
 ></div>
 
 `;

--- a/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
@@ -195,7 +195,7 @@ exports[`attributes.component.html - angular-verify 1`] = `
     'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
     'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER
   }"
-  [stickout]="toolAssembly.stickoutMm - "
+  [stickout]="+toolAssembly.stickoutMm"
 ></div>
 
 `;
@@ -395,7 +395,7 @@ exports[`attributes.component.html - angular-verify 2`] = `
     'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
     'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER
   }"
-  [stickout]="toolAssembly.stickoutMm - "
+  [stickout]="+toolAssembly.stickoutMm"
 ></div>
 
 `;
@@ -818,8 +818,7 @@ exports[`attributes.component.html - angular-verify 3`] = `
       dialogLevelEnum.DANGER
   }"
   [stickout]="
-    toolAssembly.stickoutMm -
-
+    +toolAssembly.stickoutMm
   "
 ></div>
 

--- a/tests/html_angular/attributes.component.html
+++ b/tests/html_angular/attributes.component.html
@@ -82,4 +82,5 @@
     {'btn-success': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
       'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
       'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
+    [stickout]="+toolAssembly.stickoutMm"
 ></div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -704,9 +704,9 @@ amdefine@>=0.0.4:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
 
-angular-estree-parser@1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/angular-estree-parser/-/angular-estree-parser-1.1.4.tgz#173fd2a9a30ccd38864e879e66b83cbbbdfd45db"
+angular-estree-parser@1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/angular-estree-parser/-/angular-estree-parser-1.1.5.tgz#f278e03e648a2bfb6c5dcdf17ba3273f3251b74a"
   dependencies:
     lines-and-columns "^1.1.6"
     tslib "^1.9.3"


### PR DESCRIPTION
Fixes #5404

Ref: ikatyang/angular-estree-parser#23

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
