### PR TITLE
fix(markdown): handle CRLF correctly

### DIFF
--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -209,7 +209,7 @@ function genericPrint(path, options, print) {
         const alignment = " ".repeat(4);
         return align(
           alignment,
-          concat([alignment, join(hardline, node.value.split("\n"))])
+          concat([alignment, replaceNewlinesWith(node.value, hardline)])
         );
       }
 
@@ -225,9 +225,9 @@ function genericPrint(path, options, print) {
         style,
         node.lang || "",
         hardline,
-        join(
-          hardline,
-          getFencedCodeBlockValue(node, options.originalText).split("\n")
+        replaceNewlinesWith(
+          getFencedCodeBlockValue(node, options.originalText),
+          hardline
         ),
         hardline,
         style
@@ -469,7 +469,7 @@ function getNthListSiblingIndex(node, parentNode) {
 }
 
 function replaceNewlinesWith(str, doc) {
-  return join(doc, str.split("\n"));
+  return join(doc, str.replace(/\r\n?/g, "\n").split("\n"));
 }
 
 function getNthSiblingIndex(node, parentNode, condition) {

--- a/src/language-markdown/utils.js
+++ b/src/language-markdown/utils.js
@@ -148,7 +148,7 @@ function getFencedCodeBlockValue(node, originalText) {
   const leadingSpaceCount = text.match(/^\s*/)[0].length;
   const replaceRegex = new RegExp(`^\\s{0,${leadingSpaceCount}}`);
 
-  const lineContents = text.split("\n");
+  const lineContents = text.replace(/\r\n?/g, "\n").split("\n");
 
   const markerStyle = text[leadingSpaceCount]; // ` or ~
   const marker = text

--- a/tests_integration/__tests__/__snapshots__/format.js.snap
+++ b/tests_integration/__tests__/__snapshots__/format.js.snap
@@ -2,7 +2,7 @@
 
 exports[`html parser should handle CRLF correctly 1`] = `"\\"<!--\\\\r\\\\n  test\\\\r\\\\n  test\\\\r\\\\n-->\\\\r\\\\n\\""`;
 
-exports[`markdown parser should handle CRLF correctly 1`] = `"\\"\`\`\`\\\\r\\\\n\\\\r\\\\r\\\\n\\\\r\\\\r\\\\n\`\`\`\\\\r\\\\n\\""`;
+exports[`markdown parser should handle CRLF correctly 1`] = `"\\"\`\`\`\\\\r\\\\n\\\\r\\\\n\\\\r\\\\n\`\`\`\\\\r\\\\n\\""`;
 
 exports[`typescript parser should throw the first error when both JSX and non-JSX mode failed 1`] = `
 "Expression expected. (9:7)

--- a/tests_integration/__tests__/__snapshots__/format.js.snap
+++ b/tests_integration/__tests__/__snapshots__/format.js.snap
@@ -2,6 +2,8 @@
 
 exports[`html parser should handle CRLF correctly 1`] = `"\\"<!--\\\\r\\\\n  test\\\\r\\\\n  test\\\\r\\\\n-->\\\\r\\\\n\\""`;
 
+exports[`markdown parser should handle CRLF correctly 1`] = `"\\"\`\`\`\\\\r\\\\n\\\\r\\\\r\\\\n\\\\r\\\\r\\\\n\`\`\`\\\\r\\\\n\\""`;
+
 exports[`typescript parser should throw the first error when both JSX and non-JSX mode failed 1`] = `
 "Expression expected. (9:7)
    7 | );

--- a/tests_integration/__tests__/format.js
+++ b/tests_integration/__tests__/format.js
@@ -33,3 +33,11 @@ test("html parser should handle CRLF correctly", () => {
     JSON.stringify(prettier.format(input, { parser: "html" }))
   ).toMatchSnapshot();
 });
+
+test("markdown parser should handle CRLF correctly", () => {
+  const input = "```\r\n\r\n\r\n```";
+  expect(
+    // use JSON.stringify to observe CRLF
+    JSON.stringify(prettier.format(input, { parser: "markdown" }))
+  ).toMatchSnapshot();
+});


### PR DESCRIPTION
Fixes #5413

We should figure out a better way to completely get rid of CRLF, but I think it needs more time since we don't want to break something like rangeFormat or cusorOffset.

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
