### PR TITLE
fix(css-in-js): do not duplicate comments

### DIFF
--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -207,8 +207,11 @@ function genericPrint(path, options, print) {
           ? concat([
               isDetachedRulesetCallNode(node)
                 ? ""
-                : isTemplatePlaceholderNode(node)
-                ? node.raws.afterName
+                : isTemplatePlaceholderNode(node) &&
+                  /^\s*\n/.test(node.raws.afterName)
+                ? /^\s*\n\s*\n/.test(node.raws.afterName)
+                  ? concat([hardline, hardline])
+                  : hardline
                 : " ",
               path.call(print, "params")
             ])

--- a/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
@@ -140,6 +140,25 @@ styled.a\`
     margin: 0;
   }
 \`
+
+const StyledComponent = styled.div\`
+  \${anInterpolation}
+  /* a comment */
+
+  .aRule {
+    color: red
+  }
+\`;
+
+const StyledComponent = styled.div\`
+  \${anInterpolation}
+
+  /* a comment */
+
+  .aRule {
+    color: red
+  }
+\`;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 const ListItem = styled.li\`\`;
 
@@ -279,6 +298,29 @@ styled.a\`
 
   \${FeedbackCount} {
     margin: 0;
+  }
+\`;
+
+const StyledComponent = styled.div\`
+  \${anInterpolation}
+  /* a comment */
+
+  /* a comment */
+
+  .aRule {
+    color: red;
+  }
+\`;
+
+const StyledComponent = styled.div\`
+  \${anInterpolation}
+
+  /* a comment */
+
+  /* a comment */
+
+  .aRule {
+    color: red;
   }
 \`;
 

--- a/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
@@ -305,8 +305,6 @@ const StyledComponent = styled.div\`
   \${anInterpolation}
   /* a comment */
 
-  /* a comment */
-
   .aRule {
     color: red;
   }
@@ -314,8 +312,6 @@ const StyledComponent = styled.div\`
 
 const StyledComponent = styled.div\`
   \${anInterpolation}
-
-  /* a comment */
 
   /* a comment */
 

--- a/tests/multiparser_js_css/styled-components.js
+++ b/tests/multiparser_js_css/styled-components.js
@@ -137,3 +137,22 @@ styled.a`
     margin: 0;
   }
 `
+
+const StyledComponent = styled.div`
+  ${anInterpolation}
+  /* a comment */
+
+  .aRule {
+    color: red
+  }
+`;
+
+const StyledComponent = styled.div`
+  ${anInterpolation}
+
+  /* a comment */
+
+  .aRule {
+    color: red
+  }
+`;


### PR DESCRIPTION
Fixes #5381

The original behavior was introduced by #5240. Since the original intent is to keep line breaks so I guess we can simply preserve at most 2 line breaks (next empty line)?

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
