### PR TITLE
fix(vue): do not add invalid semicolon for event attr

### DIFF
--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -873,7 +873,9 @@ function printEmbeddedAttributeValue(node, originalTextToDoc, options) {
       const fnExpRE = /^([\w$_]+|\([^)]*?\))\s*=>|^function\s*\(/;
       const simplePathRE = /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*|\['[^']*?']|\["[^"]*?"]|\[\d+]|\[[A-Za-z_$][\w$]*])*$/;
 
-      const value = getValue();
+      const value = getValue()
+        // https://github.com/vuejs/vue/blob/v2.5.17/src/compiler/helpers.js#L104
+        .trim();
       return printMaybeHug(
         simplePathRE.test(value) || fnExpRE.test(value)
           ? textToDoc(value, { parser: "__js_expression" })

--- a/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
@@ -25,6 +25,12 @@ exports[`attributes.vue - vue-verify 1`] = `
   :class="(() => { return 'hello' })()"
   :key="index /* hello */ "
   :key="index // hello "
+  @click="() => {console.log(test)}"
+  @click="
+    () => {
+      console.log(test);
+    }
+  "
 ></div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <div
@@ -71,6 +77,16 @@ exports[`attributes.vue - vue-verify 1`] = `
   :key="
     index // hello
   "
+  @click="
+    () => {
+      console.log(test);
+    }
+  "
+  @click="
+    () => {
+      console.log(test);
+    };
+  "
 ></div>
 
 `;
@@ -100,6 +116,12 @@ exports[`attributes.vue - vue-verify 2`] = `
   :class="(() => { return 'hello' })()"
   :key="index /* hello */ "
   :key="index // hello "
+  @click="() => {console.log(test)}"
+  @click="
+    () => {
+      console.log(test);
+    }
+  "
 ></div>
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 <div
@@ -145,6 +167,16 @@ exports[`attributes.vue - vue-verify 2`] = `
   :key="index /* hello */"
   :key="
     index // hello
+  "
+  @click="
+    () => {
+      console.log(test);
+    }
+  "
+  @click="
+    () => {
+      console.log(test);
+    };
   "
 ></div>
 

--- a/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
@@ -85,7 +85,7 @@ exports[`attributes.vue - vue-verify 1`] = `
   @click="
     () => {
       console.log(test);
-    };
+    }
   "
 ></div>
 
@@ -176,7 +176,7 @@ exports[`attributes.vue - vue-verify 2`] = `
   @click="
     () => {
       console.log(test);
-    };
+    }
   "
 ></div>
 

--- a/tests/html_vue/attributes.vue
+++ b/tests/html_vue/attributes.vue
@@ -22,4 +22,10 @@
   :class="(() => { return 'hello' })()"
   :key="index /* hello */ "
   :key="index // hello "
+  @click="() => {console.log(test)}"
+  @click="
+    () => {
+      console.log(test);
+    }
+  "
 ></div>


### PR DESCRIPTION
Fixes #5406

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
