### PR TITLE
Handle reselect's createSelector as function composition

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3780,7 +3780,8 @@ const functionCompositionFunctionNames = new Set([
   "composeK", // Ramda
   "flow", // Lodash
   "flowRight", // Lodash
-  "connect" // Redux
+  "connect", // Redux
+  "createSelector" // Reselect
 ]);
 
 function isFunctionCompositionFunction(node) {

--- a/tests/functional_composition/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/functional_composition/__snapshots__/jsfmt.spec.js.snap
@@ -390,6 +390,35 @@ const ArtistInput = connect(
 
 `;
 
+exports[`reselect_createselector.js - flow-verify 1`] = `
+import { createSelector } from 'reselect';
+
+const resolve = createSelector(
+  getIds,
+  getObjects,
+  (ids, objects) => ids.map(id => objects[id])
+);
+
+const resolve = createSelector(
+  [getIds, getObjects],
+  (ids, objects) => ids.map(id => objects[id])
+);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+import { createSelector } from "reselect";
+
+const resolve = createSelector(
+  getIds,
+  getObjects,
+  (ids, objects) => ids.map(id => objects[id])
+);
+
+const resolve = createSelector(
+  [getIds, getObjects],
+  (ids, objects) => ids.map(id => objects[id])
+);
+
+`;
+
 exports[`rxjs_pipe.js - flow-verify 1`] = `
 import { range } from 'rxjs/observable/range';
 import { map, filter, scan } from 'rxjs/operators';

--- a/tests/functional_composition/reselect_createselector.js
+++ b/tests/functional_composition/reselect_createselector.js
@@ -1,0 +1,12 @@
+import { createSelector } from 'reselect';
+
+const resolve = createSelector(
+  getIds,
+  getObjects,
+  (ids, objects) => ids.map(id => objects[id])
+);
+
+const resolve = createSelector(
+  [getIds, getObjects],
+  (ids, objects) => ids.map(id => objects[id])
+);


### PR DESCRIPTION
This fixes #5285; initially I thought this was a feature but after seeing that #4431 already added special handling for similar function composition functions, including one from redux, I think adding support for [reselect's `createSelector`](https://github.com/reduxjs/reselect) could be considered a fix (especially since it's an official library in the same github org as redux)

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
