### PR TITLE
fix(typescript): inline method decorators should stay inlined

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -102,7 +102,9 @@ function genericPrint(path, options, printPath, args) {
     node.type === "ClassMethod" ||
     node.type === "ClassProperty" ||
     node.type === "TSAbstractClassProperty" ||
-    node.type === "ClassPrivateProperty"
+    node.type === "ClassPrivateProperty" ||
+    node.type === "MethodDefinition" ||
+    node.type === "TSAbstractMethodDefinition"
   ) {
     // their decorators are handled themselves
   } else if (
@@ -875,6 +877,9 @@ function printPathNoParens(path, options, print, args) {
     }
     case "MethodDefinition":
     case "TSAbstractMethodDefinition":
+      if (n.decorators && n.decorators.length !== 0) {
+        parts.push(printDecorators(path, options, print));
+      }
       if (n.accessibility) {
         parts.push(n.accessibility + " ");
       }

--- a/tests/decorators-ts/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators-ts/__snapshots__/jsfmt.spec.js.snap
@@ -116,6 +116,29 @@ class Greeter {
 
 `;
 
+exports[`mobx.ts - typescript-verify 1`] = `
+class X {
+	@deco x() {
+      return this.count * 2;
+	}
+	@deco get x() {
+      return this.count * 2;
+	}
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+class X {
+  @deco
+  x() {
+    return this.count * 2;
+  }
+  @deco
+  get x() {
+    return this.count * 2;
+  }
+}
+
+`;
+
 exports[`multiple.ts - typescript-verify 1`] = `
 class C {
   @f()

--- a/tests/decorators-ts/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators-ts/__snapshots__/jsfmt.spec.js.snap
@@ -127,12 +127,10 @@ class X {
 }
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 class X {
-  @deco
-  x() {
+  @deco x() {
     return this.count * 2;
   }
-  @deco
-  get x() {
+  @deco get x() {
     return this.count * 2;
   }
 }

--- a/tests/decorators-ts/mobx.ts
+++ b/tests/decorators-ts/mobx.ts
@@ -1,0 +1,8 @@
+class X {
+	@deco x() {
+      return this.count * 2;
+	}
+	@deco get x() {
+      return this.count * 2;
+	}
+}


### PR DESCRIPTION
Fixes #5443

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
