### PR TITLE
Add more information on how to configure ALE

### DIFF
--- a/docs/vim.md
+++ b/docs/vim.md
@@ -71,7 +71,8 @@ let g:ale_fixers = {
 \}
 ```
 
-ALE supports both *linters* and *fixers*. If you don't specify which *linters* to run, **all available tools for all supported languages will be run**, and you might get a correctly formatted file with a bunch of lint errors. To disable this behavior you can tell ALE to run only linters you've explicitly configured (more info in the [FAQ](https://github.com/w0rp/ale/blob/ed8104b6ab10f63c78e49b60d2468ae2656250e9/README.md#faq-disable-linters)):
+ALE supports both _linters_ and _fixers_. If you don't specify which _linters_ to run, **all available tools for all supported languages will be run**, and you might get a correctly formatted file with a bunch of lint errors. To disable this behavior you can tell ALE to run only linters you've explicitly configured (more info in the [FAQ](https://github.com/w0rp/ale/blob/ed8104b6ab10f63c78e49b60d2468ae2656250e9/README.md#faq-disable-linters)):
+
 ```
 let g:ale_linters_explicit = 1
 ```

--- a/docs/vim.md
+++ b/docs/vim.md
@@ -71,6 +71,11 @@ let g:ale_fixers = {
 \}
 ```
 
+ALE supports both *linters* and *fixers*. If you don't specify which *linters* to run, **all available tools for all supported languages will be run**, and you might get a correctly formatted file with a bunch of lint errors. To disable this behavior you can tell ALE to run only linters you've explicitly configured (more info in the [FAQ](https://github.com/w0rp/ale/blob/ed8104b6ab10f63c78e49b60d2468ae2656250e9/README.md#faq-disable-linters)):
+```
+let g:ale_linters_explicit = 1
+```
+
 You can then run `:ALEFix` in a JavaScript or CSS file to run Prettier.
 
 To have ALE run Prettier on save:


### PR DESCRIPTION
Docs on how to configure Prettier with ALE didn't work out of the box for me, since multiple linters with conflicting configurations were run. This PR invite users to explicitly disable default linters.

Fix #5447 

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
