### PR TITLE
fix(typescript): do not add invalid semi for construct in interface with prettier-ignore

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1338,7 +1338,8 @@ function printPathNoParens(path, options, print, args) {
           separatorParts = [separator, line];
           if (
             (prop.node.type === "TSPropertySignature" ||
-              prop.node.type === "TSMethodSignature") &&
+              prop.node.type === "TSMethodSignature" ||
+              prop.node.type === "TSConstructSignature") &&
             hasNodeIgnoreComment(prop.node)
           ) {
             separatorParts.shift();

--- a/tests/typescript_interface/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_interface/__snapshots__/jsfmt.spec.js.snap
@@ -67,6 +67,12 @@ interface foo extends bar {
   g(): void;
   h(): void;
 }
+
+interface T<T> {
+  // prettier-ignore
+  new<T>(): T<T>;
+  new<T>(): T<T>;
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 interface Interface {
   // prettier-ignore
@@ -89,6 +95,12 @@ interface foo extends bar {
   // prettier-ignore
   g(): void;
   h(): void;
+}
+
+interface T<T> {
+  // prettier-ignore
+  new<T>(): T<T>;;
+  new <T>(): T<T>;
 }
 
 `;
@@ -116,6 +128,12 @@ interface foo extends bar {
   g(): void;
   h(): void;
 }
+
+interface T<T> {
+  // prettier-ignore
+  new<T>(): T<T>;
+  new<T>(): T<T>;
+}
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 interface Interface {
   // prettier-ignore
@@ -138,6 +156,12 @@ interface foo extends bar {
   // prettier-ignore
   g(): void;
   h(): void
+}
+
+interface T<T> {
+  // prettier-ignore
+  new<T>(): T<T>;
+  new <T>(): T<T>
 }
 
 `;

--- a/tests/typescript_interface/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_interface/__snapshots__/jsfmt.spec.js.snap
@@ -99,7 +99,7 @@ interface foo extends bar {
 
 interface T<T> {
   // prettier-ignore
-  new<T>(): T<T>;;
+  new<T>(): T<T>;
   new <T>(): T<T>;
 }
 

--- a/tests/typescript_interface/ignore.js
+++ b/tests/typescript_interface/ignore.js
@@ -20,3 +20,9 @@ interface foo extends bar {
   g(): void;
   h(): void;
 }
+
+interface T<T> {
+  // prettier-ignore
+  new<T>(): T<T>;
+  new<T>(): T<T>;
+}


### PR DESCRIPTION
Fixes #5451

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
