### PR TITLE
chore: update yaml parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "unicode-regex": "2.0.0",
     "unified": "6.1.6",
     "vnopts": "1.0.2",
-    "yaml": "1.0.0-rc.8",
-    "yaml-unist-parser": "1.0.0-rc.4"
+    "yaml": "1.0.2",
+    "yaml-unist-parser": "1.0.0"
   },
   "devDependencies": {
     "@babel/cli": "7.1.5",

--- a/src/language-yaml/parser-yaml.js
+++ b/src/language-yaml/parser-yaml.js
@@ -29,11 +29,7 @@ const parser = {
   parse,
   hasPragma,
   locStart: node => node.position.start.offset,
-  locEnd: node => node.position.end.offset,
-
-  // workaround for https://github.com/eemeli/yaml/issues/20
-  preprocess: text =>
-    text.indexOf("\r") === -1 ? text : text.replace(/\r\n?/g, "\n")
+  locEnd: node => node.position.end.offset
 };
 
 module.exports = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6242,16 +6242,16 @@ yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.0.2.tgz#8452b4bb7e83c7c188d8041c1a837c773d6d8bb9"
 
-yaml-unist-parser@1.0.0-rc.4:
-  version "1.0.0-rc.4"
-  resolved "https://registry.yarnpkg.com/yaml-unist-parser/-/yaml-unist-parser-1.0.0-rc.4.tgz#d8fb9c673d59a4f7d532840b120abd6400237014"
+yaml-unist-parser@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yaml-unist-parser/-/yaml-unist-parser-1.0.0.tgz#060def481d2319a8def3b6a06cb8ae3848b0aed3"
   dependencies:
     lines-and-columns "^1.1.6"
     tslib "^1.9.1"
 
-yaml@1.0.0-rc.8:
-  version "1.0.0-rc.8"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.0.0-rc.8.tgz#e5604c52b7b07b16e469bcf875ab0dfe08c50d42"
+yaml@1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.0.2.tgz#77941a457090e17b8ca65b53322e68a050e090d4"
 
 yargs-parser@^7.0.0:
   version "7.0.0"


### PR DESCRIPTION
Ref: https://github.com/ikatyang/yaml-unist-parser/blob/master/CHANGELOG.md#100-2018-11-15

Remove the CRLF workaround.

+ [ ] rebase after #5494 merged

---

- I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
