### PR TITLE
demonstrate bug with `css` parsers and tests

### DIFF
--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -478,7 +478,8 @@ function parseNestedCSS(node) {
   return node;
 }
 
-function parseWithParser(parser, text) {
+function parseWithParser(isSCSSParser, text, opts) {
+  const parser = requireParser(isSCSSParser);
   const parsed = parseFrontMatter(text);
   const { frontMatter } = parsed;
   text = parsed.content;
@@ -494,6 +495,7 @@ function parseWithParser(parser, text) {
     throw createError("(postcss) " + e.name + " " + e.reason, { start: e });
   }
 
+  result.parser = isSCSSParser ? "scss" : "less";
   result = parseNestedCSS(addTypePrefix(result, "css-"));
 
   if (frontMatter) {
@@ -527,14 +529,14 @@ function parse(text, parsers, opts) {
   const isSCSSParser = isSCSS(opts.parser, text);
 
   try {
-    return parseWithParser(requireParser(isSCSSParser), text);
+    return parseWithParser(isSCSSParser, text, opts);
   } catch (originalError) {
     if (hasExplicitParserChoice) {
       throw originalError;
     }
 
     try {
-      return parseWithParser(requireParser(!isSCSSParser), text);
+      return parseWithParser(!isSCSSParser, text, opts);
     } catch (_secondError) {
       throw originalError;
     }

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -38,7 +38,6 @@ const {
   isKeyframeAtRuleKeywords,
   isHTMLTag,
   isWideKeywords,
-  isSCSS,
   isLastNode,
   isSCSSControlDirectiveNode,
   isDetachedRulesetDeclarationNode,
@@ -103,7 +102,7 @@ function genericPrint(path, options, print) {
       const nodes = printNodeSequence(path, options, print);
 
       if (nodes.parts.length) {
-        return concat([nodes, hardline]);
+        return concat([nodes, hardline, node.parser]);
       }
 
       return nodes;
@@ -764,13 +763,7 @@ function genericPrint(path, options, print) {
               )
             ])
           ),
-          ifBreak(
-            isSCSS(options.parser, options.originalText) &&
-              isSCSSMapItem &&
-              shouldPrintComma(options)
-              ? ","
-              : ""
-          ),
+          ifBreak(isSCSSMapItem && shouldPrintComma(options) ? "," : ""),
           softline,
           node.close ? path.call(print, "close") : ""
         ]),

--- a/src/language-css/utils.js
+++ b/src/language-css/utils.js
@@ -62,7 +62,7 @@ function getPropOfDeclNode(path) {
 
 function isSCSS(parser, text) {
   const hasExplicitParserChoice = parser === "less" || parser === "scss";
-  const IS_POSSIBLY_SCSS = /(\w\s*: [^}:]+|#){|@import[^\n]+(url|,)/;
+  const IS_POSSIBLY_SCSS = /(\w\s*: [^}:]+|#|:\s*\(){|@import[^\n]+(url|,)/;
   return hasExplicitParserChoice
     ? parser === "scss"
     : IS_POSSIBLY_SCSS.test(text);
@@ -315,6 +315,14 @@ function isKeyValuePairInParenGroupNode(node) {
 }
 
 function isSCSSMapItemNode(path) {
+  const rootNode = getAncestorNode(path, "css-root");
+
+  console.log(rootNode.parser)
+
+  if (rootNode.parser !== "scss") {
+    return false;
+  }
+
   const node = path.getValue();
 
   // Ignore empty item (i.e. `$key: ()`)

--- a/tests/css_parser/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_parser/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test.css - css-verify 1`] = `
+a {
+    color: red;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+a {
+  color: red;
+}
+less
+`;
+
+exports[`test.less - css-verify 1`] = `
+a {
+  color: red;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+a {
+  color: red;
+}
+less
+`;
+
+exports[`test.scss - css-verify 1`] = `
+a {
+  color: red;
+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+a {
+  color: red;
+}
+less
+`;

--- a/tests/css_parser/jsfmt.spec.js
+++ b/tests/css_parser/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["css"]);

--- a/tests/css_parser/test.css
+++ b/tests/css_parser/test.css
@@ -1,0 +1,3 @@
+a {
+    color: red;
+}

--- a/tests/css_parser/test.less
+++ b/tests/css_parser/test.less
@@ -1,0 +1,3 @@
+a {
+  color: red;
+}

--- a/tests/css_parser/test.scss
+++ b/tests/css_parser/test.scss
@@ -1,0 +1,3 @@
+a {
+  color: red;
+}


### PR DESCRIPTION
Some tests are invalid because used invalid parser. 

Tests not respected extension of file. It is expected? Because using this through CLI we have right value in `opts.parser`.
