### PR TITLE
fix(html): do not add extra indent for js template in script

### DIFF
--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -68,7 +68,7 @@ function embed(path, print, textToDoc, options) {
             concat([
               breakParent,
               printOpeningTagPrefix(node),
-              markAsRoot(stripTrailingHardline(textToDoc(value, { parser }))),
+              stripTrailingHardline(textToDoc(value, { parser })),
               printClosingTagSuffix(node)
             ])
           ]);

--- a/tests/html_js/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_js/__snapshots__/jsfmt.spec.js.snap
@@ -127,6 +127,42 @@ exports[`something-else.html - html-verify 1`] = `
 
 `;
 
+exports[`template-literal.html - html-verify 1`] = `
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+    </head>
+    <body>
+        <script>
+            function foo() {
+                return \`
+                    <div>
+                        <p>Text</p>
+                    </div>
+                \`;
+            }
+        </script>
+    </body>
+</html>
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<!DOCTYPE html>
+<html lang="en">
+  <head> </head>
+  <body>
+    <script>
+      function foo() {
+        return \`
+                          <div>
+                              <p>Text</p>
+                          </div>
+                      \`;
+      }
+    </script>
+  </body>
+</html>
+
+`;
+
 exports[`typescript.html - html-verify 1`] = `
 <script type="application/x-typescript">
   class Student {

--- a/tests/html_js/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_js/__snapshots__/jsfmt.spec.js.snap
@@ -152,10 +152,10 @@ exports[`template-literal.html - html-verify 1`] = `
     <script>
       function foo() {
         return \`
-                          <div>
-                              <p>Text</p>
-                          </div>
-                      \`;
+                    <div>
+                        <p>Text</p>
+                    </div>
+                \`;
       }
     </script>
   </body>

--- a/tests/html_js/template-literal.html
+++ b/tests/html_js/template-literal.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+    </head>
+    <body>
+        <script>
+            function foo() {
+                return `
+                    <div>
+                        <p>Text</p>
+                    </div>
+                `;
+            }
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Fixes #5499

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
