### PR TITLE
fix(javascript): add missing parens for binary in optionalMember

### DIFF
--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -258,6 +258,7 @@ function needsParens(path, options) {
           return true;
 
         case "MemberExpression":
+        case "OptionalMemberExpression":
           return name === "object" && parent.object === node;
 
         case "AssignmentExpression":

--- a/tests/optional_chaining/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/optional_chaining/__snapshots__/jsfmt.spec.js.snap
@@ -23,6 +23,9 @@ a?.b[3].c?.(x).d.e?.f[3].g?.(y).h;
 
 (a?.b)?.c.d?.e;
 (a ? b : c)?.d;
+
+(list || list2)?.length;
+(list || list2)?.[(list || list2)];
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 var street = user.address?.street;
 var fooValue = myForm.querySelector("input[name=foo]")?.value;
@@ -46,5 +49,8 @@ a?.b[3].c?.(x).d.e?.f[3].g?.(y).h;
 
 a?.b?.c.d?.e;
 (a ? b : c)?.d;
+
+list || list2?.length;
+list || list2?.[list || list2];
 
 `;

--- a/tests/optional_chaining/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/optional_chaining/__snapshots__/jsfmt.spec.js.snap
@@ -50,7 +50,7 @@ a?.b[3].c?.(x).d.e?.f[3].g?.(y).h;
 a?.b?.c.d?.e;
 (a ? b : c)?.d;
 
-list || list2?.length;
-list || list2?.[list || list2];
+(list || list2)?.length;
+(list || list2)?.[list || list2];
 
 `;

--- a/tests/optional_chaining/chaining.js
+++ b/tests/optional_chaining/chaining.js
@@ -20,3 +20,6 @@ a?.b[3].c?.(x).d.e?.f[3].g?.(y).h;
 
 (a?.b)?.c.d?.e;
 (a ? b : c)?.d;
+
+(list || list2)?.length;
+(list || list2)?.[(list || list2)];


### PR DESCRIPTION
Fixes #5535

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
