### PR TITLE
fix(html-in-js): do not add quotes for interpolation-only attributes

### DIFF
--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -101,6 +101,18 @@ function embed(path, print, textToDoc, options) {
         break;
       }
 
+      // lit-html: html`<my-element obj=${obj}></my-element>`
+      if (
+        /^PRETTIER_PLACEHOLDER_\d+$/.test(
+          options.originalText.slice(
+            node.valueSpan.start.offset,
+            node.valueSpan.end.offset
+          )
+        )
+      ) {
+        return concat([node.rawName, "=", node.value]);
+      }
+
       const embeddedAttributeValueDoc = printEmbeddedAttributeValue(
         node,
         (code, opts) =>

--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -567,10 +567,9 @@ function isHtml(path) {
 function printHtmlTemplateLiteral(path, print, textToDoc, parser) {
   const node = path.getValue();
 
-  const placeholderPattern =
-    "prettierhtmlplaceholder(\\d+)redlohecalplmthreitterp";
+  const placeholderPattern = "PRETTIER_PLACEHOLDER_(\\d+)";
   const placeholders = node.expressions.map(
-    (_, i) => `prettierhtmlplaceholder${i}redlohecalplmthreitterp`
+    (_, i) => `PRETTIER_PLACEHOLDER_${i}`
   );
 
   const text = node.quasis

--- a/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
@@ -47,6 +47,8 @@ const someHtml1 = html\`<div       > hello \${world} </div     >\`;
 const someHtml2 = /* HTML */ \`<div      > hello \${world} </div     >\`;
 
 html\`\`
+
+html\`<my-element obj=\${obj}></my-element>\`;
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 import { LitElement, html } from "@polymer/lit-element";
 
@@ -85,5 +87,9 @@ const someHtml2 = /* HTML */ \`
 \`;
 
 html\`\`;
+
+html\`
+  <my-element obj="\${obj}"></my-element>
+\`;
 
 `;

--- a/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
@@ -89,7 +89,7 @@ const someHtml2 = /* HTML */ \`
 html\`\`;
 
 html\`
-  <my-element obj="\${obj}"></my-element>
+  <my-element obj=\${obj}></my-element>
 \`;
 
 `;

--- a/tests/multiparser_js_html/lit-html.js
+++ b/tests/multiparser_js_html/lit-html.js
@@ -44,3 +44,5 @@ const someHtml1 = html`<div       > hello ${world} </div     >`;
 const someHtml2 = /* HTML */ `<div      > hello ${world} </div     >`;
 
 html``
+
+html`<my-element obj=${obj}></my-element>`;


### PR DESCRIPTION
Fixes #5538

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
