### PR TITLE
fix(ng,vue): do not normalize attribute names

### DIFF
--- a/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,66 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`attr-name.component.html 1`] = `
+====================================options=====================================
+parsers: ["angular"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<div someDirective itemType="x"></div>
+
+=====================================output=====================================
+<div someDirective itemtype="x"></div>
+
+================================================================================
+`;
+
+exports[`attr-name.component.html 2`] = `
+====================================options=====================================
+parsers: ["angular"]
+printWidth: 80
+trailingComma: "es5"
+                                                                                | printWidth
+=====================================input======================================
+<div someDirective itemType="x"></div>
+
+=====================================output=====================================
+<div someDirective itemtype="x"></div>
+
+================================================================================
+`;
+
+exports[`attr-name.component.html 3`] = `
+====================================options=====================================
+parsers: ["angular"]
+printWidth: 1
+ | printWidth
+=====================================input======================================
+<div someDirective itemType="x"></div>
+
+=====================================output=====================================
+<div
+  someDirective
+  itemtype="x"
+></div>
+
+================================================================================
+`;
+
+exports[`attr-name.component.html 4`] = `
+====================================options=====================================
+htmlWhitespaceSensitivity: "ignore"
+parsers: ["angular"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<div someDirective itemType="x"></div>
+
+=====================================output=====================================
+<div someDirective itemtype="x"></div>
+
+================================================================================
+`;
+
 exports[`attributes.component.html 1`] = `
 ====================================options=====================================
 parsers: ["angular"]

--- a/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
@@ -9,7 +9,7 @@ printWidth: 80
 <div someDirective itemType="x"></div>
 
 =====================================output=====================================
-<div someDirective itemtype="x"></div>
+<div someDirective itemType="x"></div>
 
 ================================================================================
 `;
@@ -24,7 +24,7 @@ trailingComma: "es5"
 <div someDirective itemType="x"></div>
 
 =====================================output=====================================
-<div someDirective itemtype="x"></div>
+<div someDirective itemType="x"></div>
 
 ================================================================================
 `;
@@ -40,7 +40,7 @@ printWidth: 1
 =====================================output=====================================
 <div
   someDirective
-  itemtype="x"
+  itemType="x"
 ></div>
 
 ================================================================================
@@ -56,7 +56,7 @@ printWidth: 80
 <div someDirective itemType="x"></div>
 
 =====================================output=====================================
-<div someDirective itemtype="x"></div>
+<div someDirective itemType="x"></div>
 
 ================================================================================
 `;

--- a/tests/html_angular/attr-name.component.html
+++ b/tests/html_angular/attr-name.component.html
@@ -1,0 +1,1 @@
+<div someDirective itemType="x"></div>


### PR DESCRIPTION
Fixes #5547 

I don't know if this happens to vue as well but I also disabled it for vue since it does not look like a good idea to apply normalization for these template languages.

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
