### PR TITLE
fix: update editorconfig-to-prettier

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "dedent": "0.7.0",
     "diff": "3.2.0",
     "editorconfig": "0.15.2",
-    "editorconfig-to-prettier": "0.1.0",
+    "editorconfig-to-prettier": "0.1.1",
     "emoji-regex": "6.5.1",
     "escape-string-regexp": "1.0.5",
     "esutils": "2.0.2",

--- a/tests_integration/__tests__/config-resolution.js
+++ b/tests_integration/__tests__/config-resolution.js
@@ -157,7 +157,7 @@ test("API resolveConfig.sync with file arg and .editorconfig (key = unset)", () 
 
   expect(
     prettier.resolveConfig.sync(file, { editorconfig: true })
-  ).toMatchObject({ tabWidth: "unset" });
+  ).not.toMatchObject({ tabWidth: "unset" });
 });
 
 test("API resolveConfig with nested file arg and .editorconfig", () => {

--- a/tests_integration/__tests__/config-resolution.js
+++ b/tests_integration/__tests__/config-resolution.js
@@ -150,6 +150,16 @@ test("API resolveConfig.sync with file arg and .editorconfig", () => {
   });
 });
 
+test("API resolveConfig.sync with file arg and .editorconfig (key = unset)", () => {
+  const file = path.resolve(
+    path.join(__dirname, "../cli/config/editorconfig/tab_width=unset.js")
+  );
+
+  expect(
+    prettier.resolveConfig.sync(file, { editorconfig: true })
+  ).toMatchObject({ tabWidth: "unset" });
+});
+
 test("API resolveConfig with nested file arg and .editorconfig", () => {
   const file = path.resolve(
     path.join(__dirname, "../cli/config/editorconfig/lib/file.js")

--- a/tests_integration/cli/config/editorconfig/.editorconfig
+++ b/tests_integration/cli/config/editorconfig/.editorconfig
@@ -13,3 +13,6 @@ indent_size = 2
 
 [lib/indent_size=tab.js]
 indent_size = tab
+
+[tab_width=unset.js]
+tab_width = unset

--- a/yarn.lock
+++ b/yarn.lock
@@ -1815,9 +1815,9 @@ ecc-jsbn@~0.1.1:
   dependencies:
     jsbn "~0.1.0"
 
-editorconfig-to-prettier@0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/editorconfig-to-prettier/-/editorconfig-to-prettier-0.1.0.tgz#c31d2ceea2ef922835c53f6ca0e5ba2930b8940d"
+editorconfig-to-prettier@0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/editorconfig-to-prettier/-/editorconfig-to-prettier-0.1.1.tgz#7391c7067dfd68ffee65afc2c4fbe4fba8d4219a"
 
 editorconfig@0.15.2:
   version "0.15.2"


### PR DESCRIPTION
Fixes #5351

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
