### PR TITLE
fix(html): correct column for error code frame

### DIFF
--- a/src/language-html/parser-html.js
+++ b/src/language-html/parser-html.js
@@ -33,7 +33,7 @@ function ngHtmlParser(input, { recognizeSelfClosing, normalizeTagName }) {
   if (errors.length !== 0) {
     const { msg, span } = errors[0];
     const { line, col } = span.start;
-    throw createError(msg, { start: { line: line + 1, column: col } });
+    throw createError(msg, { start: { line: line + 1, column: col + 1 } });
   }
 
   const addType = node => {


### PR DESCRIPTION
Found in #5552

- before
  ```html
  [error] test.html: SyntaxError: Unexpected character "/" (1:26)
  [error] > 1 | <div>footer content here<//>
  [error]     |                          ^
  ```
- after
  ```html
  [error] test.html: SyntaxError: Unexpected character "/" (1:27)
  [error] > 1 | <div>footer content here<//>
  [error]     |                           ^
  ```

---

- I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
