### PR TITLE
fix(api): normalize file path for `getFileInfo`

### DIFF
--- a/src/common/get-file-info.js
+++ b/src/common/get-file-info.js
@@ -2,6 +2,7 @@
 
 const createIgnorer = require("./create-ignorer");
 const options = require("../main/options");
+const path = require("path");
 
 /**
  * @typedef {{ ignorePath?: string, withNodeModules?: boolean, plugins: object }} FileInfoOptions
@@ -19,7 +20,11 @@ const options = require("../main/options");
  */
 function getFileInfo(filePath, opts) {
   return createIgnorer(opts.ignorePath, opts.withNodeModules).then(ignorer =>
-    _getFileInfo(ignorer, filePath, opts.plugins)
+    _getFileInfo(
+      ignorer,
+      normalizeFilePath(filePath, opts.ignorePath),
+      opts.plugins
+    )
   );
 }
 
@@ -30,7 +35,11 @@ function getFileInfo(filePath, opts) {
  */
 getFileInfo.sync = function(filePath, opts) {
   const ignorer = createIgnorer.sync(opts.ignorePath, opts.withNodeModules);
-  return _getFileInfo(ignorer, filePath, opts.plugins);
+  return _getFileInfo(
+    ignorer,
+    normalizeFilePath(filePath, opts.ignorePath),
+    opts.plugins
+  );
 };
 
 function _getFileInfo(ignorer, filePath, plugins) {
@@ -41,6 +50,12 @@ function _getFileInfo(ignorer, filePath, plugins) {
     ignored,
     inferredParser
   };
+}
+
+function normalizeFilePath(filePath, ignorePath) {
+  return ignorePath
+    ? path.relative(path.dirname(ignorePath), filePath)
+    : filePath;
 }
 
 module.exports = getFileInfo;

--- a/tests_integration/__tests__/file-info.js
+++ b/tests_integration/__tests__/file-info.js
@@ -1,6 +1,8 @@
 "use strict";
 
 const path = require("path");
+const tempy = require("tempy");
+const fs = require("fs");
 
 const runPrettier = require("../runPrettier");
 const prettier = require("prettier/local");
@@ -173,6 +175,40 @@ test("API getFileInfo.sync with ignorePath", () => {
   ).toMatchObject({
     ignored: true,
     inferredParser: "babylon"
+  });
+});
+
+describe("API getFileInfo.sync with ignorePath", () => {
+  let cwd;
+  let filePath;
+  let options;
+  beforeAll(() => {
+    cwd = process.cwd();
+    const tempDir = tempy.directory();
+    process.chdir(tempDir);
+    const fileDir = "src";
+    filePath = `${fileDir}/should-be-ignored.js`;
+    const ignorePath = path.join(tempDir, ".prettierignore");
+    fs.writeFileSync(ignorePath, filePath, "utf8");
+    options = { ignorePath };
+  });
+  afterAll(() => {
+    process.chdir(cwd);
+  });
+  test("with relative filePath", () => {
+    expect(
+      prettier.getFileInfo.sync(filePath, options).ignored
+    ).toMatchInlineSnapshot(`true`);
+  });
+  test("with relative filePath starts with dot", () => {
+    expect(
+      prettier.getFileInfo.sync(`./${filePath}`, options).ignored
+    ).toMatchInlineSnapshot(`false`);
+  });
+  test("with absolute filePath", () => {
+    expect(
+      prettier.getFileInfo.sync(path.resolve(filePath), options).ignored
+    ).toMatchInlineSnapshot(`false`);
   });
 });
 

--- a/tests_integration/__tests__/file-info.js
+++ b/tests_integration/__tests__/file-info.js
@@ -203,12 +203,12 @@ describe("API getFileInfo.sync with ignorePath", () => {
   test("with relative filePath starts with dot", () => {
     expect(
       prettier.getFileInfo.sync(`./${filePath}`, options).ignored
-    ).toMatchInlineSnapshot(`false`);
+    ).toMatchInlineSnapshot(`true`);
   });
   test("with absolute filePath", () => {
     expect(
       prettier.getFileInfo.sync(path.resolve(filePath), options).ignored
-    ).toMatchInlineSnapshot(`false`);
+    ).toMatchInlineSnapshot(`true`);
   });
 });
 


### PR DESCRIPTION
Fixes #5513

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
