### PR TITLE
feat(angular): support interpolation in attributes

### DIFF
--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -1004,6 +1004,38 @@ function printEmbeddedAttributeValue(node, originalTextToDoc, options) {
         ngTextToDoc(getValue(), { parser: "__ng_directive" })
       );
     }
+
+    const interpolationRegex = /\{\{([\s\S]+?)\}\}/g;
+    const value = getValue();
+    if (interpolationRegex.test(value)) {
+      const parts = [];
+      value.split(interpolationRegex).forEach((part, index) => {
+        if (index % 2 === 0) {
+          parts.push(concat(replaceNewlines(part, literalline)));
+        } else {
+          try {
+            parts.push(
+              group(
+                concat([
+                  "{{",
+                  indent(
+                    concat([
+                      line,
+                      ngTextToDoc(part, { parser: "__ng_interpolation" })
+                    ])
+                  ),
+                  line,
+                  "}}"
+                ])
+              )
+            );
+          } catch (e) {
+            parts.push("{{", concat(replaceNewlines(part, literalline)), "}}");
+          }
+        }
+      });
+      return group(concat(parts));
+    }
   }
 
   return null;

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -103,7 +103,7 @@ function embed(path, print, textToDoc, options) {
 
       // lit-html: html`<my-element obj=${obj}></my-element>`
       if (
-        /^PRETTIER_PLACEHOLDER_\d+$/.test(
+        /^PRETTIER_HTML_PLACEHOLDER_\d+_IN_JS$/.test(
           options.originalText.slice(
             node.valueSpan.start.offset,
             node.valueSpan.end.offset

--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -567,9 +567,9 @@ function isHtml(path) {
 function printHtmlTemplateLiteral(path, print, textToDoc, parser) {
   const node = path.getValue();
 
-  const placeholderPattern = "PRETTIER_PLACEHOLDER_(\\d+)";
+  const placeholderPattern = "PRETTIER_HTML_PLACEHOLDER_(\\d+)_IN_JS";
   const placeholders = node.expressions.map(
-    (_, i) => `PRETTIER_PLACEHOLDER_${i}`
+    (_, i) => `PRETTIER_HTML_PLACEHOLDER_${i}_IN_JS`
   );
 
   const text = node.quasis

--- a/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
@@ -153,6 +153,7 @@ printWidth: 80
       'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
       'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
     [stickout]="+toolAssembly.stickoutMm"
+    test='{{ "test" | translate }}'
 ></div>
 
 =====================================output=====================================
@@ -265,6 +266,7 @@ printWidth: 80
     'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER
   }"
   [stickout]="+toolAssembly.stickoutMm"
+  test="{{ &quot;test&quot; | translate }}"
 ></div>
 
 ================================================================================
@@ -363,6 +365,7 @@ trailingComma: "es5"
       'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
       'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
     [stickout]="+toolAssembly.stickoutMm"
+    test='{{ "test" | translate }}'
 ></div>
 
 =====================================output=====================================
@@ -475,6 +478,7 @@ trailingComma: "es5"
     'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER
   }"
   [stickout]="+toolAssembly.stickoutMm"
+  test="{{ &quot;test&quot; | translate }}"
 ></div>
 
 ================================================================================
@@ -572,6 +576,7 @@ printWidth: 1
       'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
       'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
     [stickout]="+toolAssembly.stickoutMm"
+    test='{{ "test" | translate }}'
 ></div>
 
 =====================================output=====================================
@@ -911,6 +916,7 @@ printWidth: 1
   [stickout]="
     +toolAssembly.stickoutMm
   "
+  test="{{ &quot;test&quot; | translate }}"
 ></div>
 
 ================================================================================
@@ -1009,6 +1015,7 @@ printWidth: 80
       'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
       'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
     [stickout]="+toolAssembly.stickoutMm"
+    test='{{ "test" | translate }}'
 ></div>
 
 =====================================output=====================================
@@ -1121,6 +1128,7 @@ printWidth: 80
     'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER
   }"
   [stickout]="+toolAssembly.stickoutMm"
+  test="{{ &quot;test&quot; | translate }}"
 ></div>
 
 ================================================================================

--- a/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
@@ -277,8 +277,8 @@ printWidth: 80
     'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER
   }"
   [stickout]="+toolAssembly.stickoutMm"
-  test="{{ &quot;test&quot; | translate }}"
-  test="foo {{       invalid invalid       }} bar {{       valid       }} baz"
+  test="{{ 'test' | translate }}"
+  test="foo {{       invalid invalid       }} bar {{ valid }} baz"
   test="foo
     
     {{       invalid
@@ -286,7 +286,7 @@ printWidth: 80
     
     bar 
     
-          {{       valid       }} 
+          {{ valid }} 
     
     baz"
 ></div>
@@ -511,8 +511,8 @@ trailingComma: "es5"
     'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER
   }"
   [stickout]="+toolAssembly.stickoutMm"
-  test="{{ &quot;test&quot; | translate }}"
-  test="foo {{       invalid invalid       }} bar {{       valid       }} baz"
+  test="{{ 'test' | translate }}"
+  test="foo {{       invalid invalid       }} bar {{ valid }} baz"
   test="foo
     
     {{       invalid
@@ -520,7 +520,7 @@ trailingComma: "es5"
     
     bar 
     
-          {{       valid       }} 
+          {{ valid }} 
     
     baz"
 ></div>
@@ -971,8 +971,13 @@ printWidth: 1
   [stickout]="
     +toolAssembly.stickoutMm
   "
-  test="{{ &quot;test&quot; | translate }}"
-  test="foo {{       invalid invalid       }} bar {{       valid       }} baz"
+  test="{{
+    'test'
+      | translate
+  }}"
+  test="foo {{       invalid invalid       }} bar {{
+    valid
+  }} baz"
   test="foo
     
     {{       invalid
@@ -980,7 +985,9 @@ printWidth: 1
     
     bar 
     
-          {{       valid       }} 
+          {{
+    valid
+  }} 
     
     baz"
 ></div>
@@ -1205,8 +1212,8 @@ printWidth: 80
     'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER
   }"
   [stickout]="+toolAssembly.stickoutMm"
-  test="{{ &quot;test&quot; | translate }}"
-  test="foo {{       invalid invalid       }} bar {{       valid       }} baz"
+  test="{{ 'test' | translate }}"
+  test="foo {{       invalid invalid       }} bar {{ valid }} baz"
   test="foo
     
     {{       invalid
@@ -1214,7 +1221,7 @@ printWidth: 80
     
     bar 
     
-          {{       valid       }} 
+          {{ valid }} 
     
     baz"
 ></div>
@@ -3451,7 +3458,7 @@ can be found in the LICENSE file at http://angular.io/license
 
 <p>My current hero is {{ currentHero.name }}</p>
 
-<h3>{{ title }} <img src="{{heroImageUrl}}" style="height:30px" /></h3>
+<h3>{{ title }} <img src="{{ heroImageUrl }}" style="height:30px" /></h3>
 
 <!-- "The sum of 1 + 1 is 2" -->
 <p>The sum of 1 + 1 is {{ 1 + 1 }}</p>
@@ -3600,7 +3607,7 @@ can be found in the LICENSE file at http://angular.io/license
 <div *ngIf="false"><app-hero-detail hero="currentHero"></app-hero-detail></div>
 <app-hero-detail prefix="You are my" [hero]="currentHero"></app-hero-detail>
 
-<p><img src="{{heroImageUrl}}" /> is the <i>interpolated</i> image.</p>
+<p><img src="{{ heroImageUrl }}" /> is the <i>interpolated</i> image.</p>
 <p><img [src]="heroImageUrl" /> is the <i>property bound</i> image.</p>
 
 <p>
@@ -4942,7 +4949,7 @@ can be found in the LICENSE file at http://angular.io/license
 
 <p>My current hero is {{ currentHero.name }}</p>
 
-<h3>{{ title }} <img src="{{heroImageUrl}}" style="height:30px" /></h3>
+<h3>{{ title }} <img src="{{ heroImageUrl }}" style="height:30px" /></h3>
 
 <!-- "The sum of 1 + 1 is 2" -->
 <p>The sum of 1 + 1 is {{ 1 + 1 }}</p>
@@ -5091,7 +5098,7 @@ can be found in the LICENSE file at http://angular.io/license
 <div *ngIf="false"><app-hero-detail hero="currentHero"></app-hero-detail></div>
 <app-hero-detail prefix="You are my" [hero]="currentHero"></app-hero-detail>
 
-<p><img src="{{heroImageUrl}}" /> is the <i>interpolated</i> image.</p>
+<p><img src="{{ heroImageUrl }}" /> is the <i>interpolated</i> image.</p>
 <p><img [src]="heroImageUrl" /> is the <i>property bound</i> image.</p>
 
 <p>
@@ -6571,7 +6578,9 @@ can be found in the LICENSE file at http://angular.io/license
     title
   }}
   <img
-    src="{{heroImageUrl}}"
+    src="{{
+      heroImageUrl
+    }}"
     style="height:30px"
   />
 </h3>
@@ -7134,7 +7143,9 @@ can be found in the LICENSE file at http://angular.io/license
 
 <p>
   <img
-    src="{{heroImageUrl}}"
+    src="{{
+      heroImageUrl
+    }}"
   />
   is
   the
@@ -9864,7 +9875,7 @@ can be found in the LICENSE file at http://angular.io/license
 
 <h3>
   {{ title }}
-  <img src="{{heroImageUrl}}" style="height:30px" />
+  <img src="{{ heroImageUrl }}" style="height:30px" />
 </h3>
 
 <!-- "The sum of 1 + 1 is 2" -->
@@ -10040,7 +10051,7 @@ can be found in the LICENSE file at http://angular.io/license
 <app-hero-detail prefix="You are my" [hero]="currentHero"></app-hero-detail>
 
 <p>
-  <img src="{{heroImageUrl}}" />
+  <img src="{{ heroImageUrl }}" />
   is the
   <i>interpolated</i>
   image.

--- a/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
@@ -154,6 +154,17 @@ printWidth: 80
       'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
     [stickout]="+toolAssembly.stickoutMm"
     test='{{ "test" | translate }}'
+    test='foo {{       invalid invalid       }} bar {{       valid       }} baz'
+    test='foo
+    
+    {{       invalid
+             invalid       }} 
+    
+    bar 
+    
+          {{       valid       }} 
+    
+    baz'
 ></div>
 
 =====================================output=====================================
@@ -267,6 +278,17 @@ printWidth: 80
   }"
   [stickout]="+toolAssembly.stickoutMm"
   test="{{ &quot;test&quot; | translate }}"
+  test="foo {{       invalid invalid       }} bar {{       valid       }} baz"
+  test="foo
+    
+    {{       invalid
+             invalid       }} 
+    
+    bar 
+    
+          {{       valid       }} 
+    
+    baz"
 ></div>
 
 ================================================================================
@@ -366,6 +388,17 @@ trailingComma: "es5"
       'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
     [stickout]="+toolAssembly.stickoutMm"
     test='{{ "test" | translate }}'
+    test='foo {{       invalid invalid       }} bar {{       valid       }} baz'
+    test='foo
+    
+    {{       invalid
+             invalid       }} 
+    
+    bar 
+    
+          {{       valid       }} 
+    
+    baz'
 ></div>
 
 =====================================output=====================================
@@ -479,6 +512,17 @@ trailingComma: "es5"
   }"
   [stickout]="+toolAssembly.stickoutMm"
   test="{{ &quot;test&quot; | translate }}"
+  test="foo {{       invalid invalid       }} bar {{       valid       }} baz"
+  test="foo
+    
+    {{       invalid
+             invalid       }} 
+    
+    bar 
+    
+          {{       valid       }} 
+    
+    baz"
 ></div>
 
 ================================================================================
@@ -577,6 +621,17 @@ printWidth: 1
       'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
     [stickout]="+toolAssembly.stickoutMm"
     test='{{ "test" | translate }}'
+    test='foo {{       invalid invalid       }} bar {{       valid       }} baz'
+    test='foo
+    
+    {{       invalid
+             invalid       }} 
+    
+    bar 
+    
+          {{       valid       }} 
+    
+    baz'
 ></div>
 
 =====================================output=====================================
@@ -917,6 +972,17 @@ printWidth: 1
     +toolAssembly.stickoutMm
   "
   test="{{ &quot;test&quot; | translate }}"
+  test="foo {{       invalid invalid       }} bar {{       valid       }} baz"
+  test="foo
+    
+    {{       invalid
+             invalid       }} 
+    
+    bar 
+    
+          {{       valid       }} 
+    
+    baz"
 ></div>
 
 ================================================================================
@@ -1016,6 +1082,17 @@ printWidth: 80
       'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
     [stickout]="+toolAssembly.stickoutMm"
     test='{{ "test" | translate }}'
+    test='foo {{       invalid invalid       }} bar {{       valid       }} baz'
+    test='foo
+    
+    {{       invalid
+             invalid       }} 
+    
+    bar 
+    
+          {{       valid       }} 
+    
+    baz'
 ></div>
 
 =====================================output=====================================
@@ -1129,6 +1206,17 @@ printWidth: 80
   }"
   [stickout]="+toolAssembly.stickoutMm"
   test="{{ &quot;test&quot; | translate }}"
+  test="foo {{       invalid invalid       }} bar {{       valid       }} baz"
+  test="foo
+    
+    {{       invalid
+             invalid       }} 
+    
+    bar 
+    
+          {{       valid       }} 
+    
+    baz"
 ></div>
 
 ================================================================================

--- a/tests/html_angular/attributes.component.html
+++ b/tests/html_angular/attributes.component.html
@@ -85,4 +85,15 @@
       'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
     [stickout]="+toolAssembly.stickoutMm"
     test='{{ "test" | translate }}'
+    test='foo {{       invalid invalid       }} bar {{       valid       }} baz'
+    test='foo
+    
+    {{       invalid
+             invalid       }} 
+    
+    bar 
+    
+          {{       valid       }} 
+    
+    baz'
 ></div>

--- a/tests/html_angular/attributes.component.html
+++ b/tests/html_angular/attributes.component.html
@@ -84,4 +84,5 @@
       'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
       'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
     [stickout]="+toolAssembly.stickoutMm"
+    test='{{ "test" | translate }}'
 ></div>


### PR DESCRIPTION
Fixes #5477

(Vue: _"Interpolation inside attributes has been removed. Use v-bind or the colon shorthand instead."_)

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
