### PR TITLE
fix(printer-postcss): ignore escape \ and escaped / in Less

### DIFF
--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -515,6 +515,27 @@ function genericPrint(path, options, print) {
           continue;
         }
 
+        // Ignore escape `\` in Less
+        if (
+          options.parser === "less" &&
+          iNode.value &&
+          iNode.value.indexOf("\\") !== -1
+        ) {
+          continue;
+        }
+
+        // Ignore escaped `/` in Less
+        if (
+          options.parser === "less" &&
+          iPrevNode &&
+          iPrevNode.value &&
+          iPrevNode.value.indexOf("\\") === iPrevNode.value.length - 1 &&
+          iNode.type === "value-operator" &&
+          iNode.value === "/"
+        ) {
+          continue;
+        }
+
         // Ignore `\` (i.e. `$variable: \@small;`)
         if (iNode.value === "\\") {
           continue;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Avoid messing up Less files containing \/ (escaped /).
Ignore escape \ and escaped / in Less.
Fix #5208 issue.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
