### PR TITLE
Fix formatting with --range-start

### DIFF
--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -78,7 +78,7 @@ function printAstToDoc(ast, options, alignmentSize = 0) {
     // Add a hardline to make the indents take effect
     // It should be removed in index.js format()
     doc = addAlignmentToDoc(
-      docUtils.removeLines(concat([hardline, doc])),
+      concat([hardline, doc]),
       alignmentSize,
       options.tabWidth
     );

--- a/tests/range/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/range/__snapshots__/jsfmt.spec.js.snap
@@ -88,6 +88,34 @@ function ugly ( {a=1,     b     =   2     }      ) {
 ================================================================================
 `;
 
+exports[`large-dict.js 1`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function ugly() {
+  const dictWithSeveralEntries = {
+    key:          "value",
+    anotherKey:   "another value",
+    firstNumber:  1,
+    secondNumber: 2
+  };
+}
+
+=====================================output=====================================
+function ugly() {
+  const dictWithSeveralEntries = {
+    key: "value",
+    anotherKey: "another value",
+    firstNumber: 1,
+    secondNumber: 2
+  };
+}
+
+================================================================================
+`;
+
 exports[`module-export1.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "typescript"]

--- a/tests/range/large-dict.js
+++ b/tests/range/large-dict.js
@@ -1,0 +1,8 @@
+function ugly() {
+  const dictWithSeveralEntries = {
+    key:          "value",
+<<<PRETTIER_RANGE_START>>>    anotherKey:   "another value",
+    firstNumber:  1,
+    secondNumber: 2<<<PRETTIER_RANGE_END>>>
+  };
+}


### PR DESCRIPTION
This change avoids collapsing an already-formatted range into a single
overlong line when --range-start is provided and the range starts on a
line that has a non-zero amount of leading whitespace.

Fixes: #4923

- [X] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
