### PR TITLE
Tests the right directory

### DIFF
--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -53,7 +53,7 @@ function loadPlugins(plugins, pluginSearchDirs) {
 
       if (!isDirectory(nodeModulesDir)) {
         throw new Error(
-          `${pluginSearchDir} does not exist or is not a directory`
+          `${nodeModulesDir} does not exist or is not a directory`
         );
       }
 

--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -46,16 +46,16 @@ function loadPlugins(plugins, pluginSearchDirs) {
         pluginSearchDir
       );
 
-      if (!isDirectory(resolvedPluginSearchDir)) {
-        throw new Error(
-          `${pluginSearchDir} does not exist or is not a directory`
-        );
-      }
-
       const nodeModulesDir = path.resolve(
         resolvedPluginSearchDir,
         "node_modules"
       );
+
+      if (!isDirectory(nodeModulesDir)) {
+        throw new Error(
+          `${pluginSearchDir} does not exist or is not a directory`
+        );
+      }
 
       return findPluginsInNodeModules(nodeModulesDir).map(pluginName => ({
         name: pluginName,


### PR DESCRIPTION
This is just a simple fix to ensure that prettier tests that the actual `node_modules` folder is a folder, rather than the parent folder. It doesn't change anything in 99.99% of the cases, but it doesn't hurt 🙂 