### PR TITLE
fix(flow,ts): format `/* HTML */` templates

### DIFF
--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -858,9 +858,20 @@ function isBlockComment(comment) {
   return comment.type === "Block" || comment.type === "CommentBlock";
 }
 
+function hasLeadingComment(node, fn = () => true) {
+  if (node.leadingComments) {
+    return node.leadingComments.some(fn);
+  }
+  if (node.comments) {
+    return node.comments.some(comment => comment.leading && fn(comment));
+  }
+  return false;
+}
+
 module.exports = {
   handleOwnLineComment,
   handleEndOfLineComment,
   handleRemainingComment,
+  hasLeadingComment,
   isBlockComment
 };

--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { isBlockComment } = require("./comments");
+const { isBlockComment, hasLeadingComment } = require("./comments");
 
 const {
   builders: {
@@ -510,11 +510,9 @@ function hasLanguageComment(node, languageName) {
   // we will not trim the comment value and we will expect exactly one space on
   // either side of the GraphQL string
   // Also see ./clean.js
-  const isLanguageComment = comment =>
-    isBlockComment(comment) && comment.value === ` ${languageName} `;
-  return (
-    (node.comments && node.comments.some(isLanguageComment)) ||
-    (node.leadingComments && node.leadingComments.some(isLanguageComment))
+  return hasLeadingComment(
+    node,
+    comment => isBlockComment(comment) && comment.value === ` ${languageName} `
   );
 }
 

--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { isBlockComment } = require("./comments");
+
 const {
   builders: {
     indent,
@@ -508,12 +510,11 @@ function hasLanguageComment(node, languageName) {
   // we will not trim the comment value and we will expect exactly one space on
   // either side of the GraphQL string
   // Also see ./clean.js
+  const isLanguageComment = comment =>
+    isBlockComment(comment) && comment.value === ` ${languageName} `;
   return (
-    node.leadingComments &&
-    node.leadingComments.some(
-      comment =>
-        comment.type === "CommentBlock" && comment.value === ` ${languageName} `
-    )
+    (node.comments && node.comments.some(isLanguageComment)) ||
+    (node.leadingComments && node.leadingComments.some(isLanguageComment))
   );
 }
 

--- a/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`lit-html.js 1`] = `
 ====================================options=====================================
-parsers: ["babylon"]
+parsers: ["babylon", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/multiparser_js_html/jsfmt.spec.js
+++ b/tests/multiparser_js_html/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, ["babylon"]);
+run_spec(__dirname, ["babylon", "flow", "typescript"]);


### PR DESCRIPTION
Fixes #5623

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
