### PR TITLE
fix(angular): Format <pre> in template strings properly.

### DIFF
--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -244,10 +244,11 @@ function genericPrint(path, options, print) {
                           node.isIndentationSensitive)) &&
                       new RegExp(
                         `\\n\\s{${options.tabWidth *
-                          countParents(
+                          (countParents(
                             path,
                             n => n.parent && n.parent.type !== "root"
-                          )}}$`
+                          ) +
+                            (options.parentParser ? 2 : 0))}}$`
                       ).test(node.lastChild.value)
                     ? /**
                        *     <div>

--- a/tests/angular_component_examples/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/angular_component_examples/__snapshots__/jsfmt.spec.js.snap
@@ -10,6 +10,13 @@ printWidth: 80
        selector: 'app-test',
   template: \`<ul>   <li>test</li>
   </ul>
+
+  <div>
+    <pre>
+        test
+      </pre>
+    ~
+</div>
   \`,
   styles: [   \`
   
@@ -31,6 +38,13 @@ class     TestComponent {}
     <ul>
       <li>test</li>
     </ul>
+
+    <div>
+      <pre>
+        test
+      </pre>
+      ~
+    </div>
   \`,
   styles: [
     \`
@@ -59,6 +73,13 @@ trailingComma: "es5"
        selector: 'app-test',
   template: \`<ul>   <li>test</li>
   </ul>
+
+  <div>
+    <pre>
+        test
+      </pre>
+    ~
+</div>
   \`,
   styles: [   \`
   
@@ -80,6 +101,13 @@ class     TestComponent {}
     <ul>
       <li>test</li>
     </ul>
+
+    <div>
+      <pre>
+        test
+      </pre>
+      ~
+    </div>
   \`,
   styles: [
     \`

--- a/tests/angular_component_examples/test.component.ts
+++ b/tests/angular_component_examples/test.component.ts
@@ -2,6 +2,13 @@
        selector: 'app-test',
   template: `<ul>   <li>test</li>
   </ul>
+
+  <div>
+    <pre>
+        test
+      </pre>
+    ~
+</div>
   `,
   styles: [   `
   


### PR DESCRIPTION
The current logic doesn't take into account <pre> in a template string. This updates the logic to add additional base indentation to compare the alignment of the opening and closing pre tags if it's in a template string since it should be indented twice (once for the indentation of the template property itself, and once for the indentation of the string contents.

Because of the way <pre> works, this will only work properly if the closing </pre> tag was already indented to where it was supposed to be. Otherwise, the closing caret is dropped to the newline to align with the opening tag in order to keep whitespace consistent.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).