### PR TITLE
Temporary remove --check docs until 1.16 is released to avoid confusion

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -18,7 +18,7 @@ prettier.format("foo ( );", { semi: false, parser: "babylon" });
 
 ## `prettier.check(source [, options])`
 
-`check` checks to see if the file has been formatted with Prettier given those options and returns a `Boolean`. This is similar to the `--check` or `--list-different` parameter in the CLI and is useful for running Prettier in CI scenarios.
+`check` checks to see if the file has been formatted with Prettier given those options and returns a `Boolean`. This is similar to the `--list-different` parameter in the CLI and is useful for running Prettier in CI scenarios.
 
 ## `prettier.formatWithCursor(source [, options])`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -21,38 +21,6 @@ Don't forget the quotes around the globs! The quotes make sure that Prettier exp
 
 Prettier CLI will ignore files located in `node_modules` directory. To opt-out from this behavior use `--with-node-modules` flag.
 
-## `--check`
-
-When you want to check if your files are formatted, you can run Prettier with the `--check` flag (or `-c`).
-This will output a human-friendly message and a list of unformatted files, if any.
-
-```bash
-prettier --check "src/**/*.js"
-```
-
-Console output if all files are formatted:
-
-```
-Checking formatting...
-All matched files use Prettier code style!
-```
-
-Console output if some of the files require re-formatting:
-
-```
-Checking formatting...
-src/fileA.js
-src/fileB.js
-Code style issues found in the above file(s). Forgot to run Prettier?
-```
-
-The command will return exit code 1 in the second case, which is helpful inside the CI pipelines.
-Human-friendly status messages help project contributors react on possible problems.
-To minimise the number of times `prettier --check` finds unformatted files, you may be interested in configuring a [pre-commit hook](precommit.md) in your repo.
-Applying this practice will minimise the number of times the CI fails because of code formatting problems.
-
-If you need to pipe the list of unformatted files to another command, you can use [`--list-different`](./cli.md#list-different) flag instead of `--check`.
-
 ## `--debug-check`
 
 If you're worried that Prettier will change the correctness of your code, add `--debug-check` to the command. This will cause Prettier to print an error message if it detects that code correctness might have changed. Note that `--write` cannot be used with `--debug-check`.
@@ -103,8 +71,6 @@ Another useful flag is `--list-different` (or `-l`) which prints the filenames o
 ```bash
 prettier --single-quote --list-different "src/**/*.js"
 ```
-
-You can also use [`--check`](./cli.md#check) flag, which works the same way as `--list-different`, but also prints a human-friendly summary message to stdout.
 
 ## `--no-config`
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -310,7 +310,7 @@ If you want to make sure that your git repository only contains Linux-style line
 
 1. Set `endOfLine` option to `lf`
 1. Configure [a pre-commit hook](./precommit.md) that will run Prettier
-1. Configure Prettier to run in your CI pipeline using [`--check` flag](./cli.md#check)
+1. Configure Prettier to run in your CI pipeline (e.g. using [`prettier-check` npm package](https://www.npmjs.com/package/prettier-check))
 1. Ask Windows users to run `git config core.autocrlf false` before working on your repo so that git did not convert `LF` to `CRLF` on checkout.
    Alternatively, you can add `* text=auto eol=lf` to the repo's `.gitattributes` file to achieve this.
 


### PR DESCRIPTION
Context: https://github.com/prettier/prettier/pull/5629#issuecomment-448933238

It'd be great if the current docs were based on the current version of prettier to avoid confusion. How about using `master` branch for patches / current docs and `canary` for the future stuff? Next.js folks do that (https://github.com/zeit/next.js/).

<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
