### PR TITLE
fix(playground): backward compatibility for --parser babylon

### DIFF
--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -17,6 +17,11 @@ var parsers = {
     importScriptOnce("lib/parser-babylon.js");
     return prettierPlugins.babylon.parsers.babel;
   },
+  // backward compatibility for v1.15 playground
+  get babylon() {
+    importScriptOnce("lib/parser-babylon.js");
+    return prettierPlugins.babylon.parsers.babylon;
+  },
   get json() {
     importScriptOnce("lib/parser-babylon.js");
     return prettierPlugins.babylon.parsers.json;


### PR DESCRIPTION
Fixes #5687

- I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
