### PR TITLE
fix(playground): backward compatibility for --parser babylon

### DIFF
--- a/website/playground/codeSamples.js
+++ b/website/playground/codeSamples.js
@@ -1,7 +1,7 @@
 export default function(parser) {
   switch (parser) {
     case "babel":
-    case "babylon": // backward compatibility for v1.15 playground
+    case "babylon": // backward compatibility
       return [
         'function HelloWorld({greeting = "hello", greeted = \'"World"\', silent = false, onMouseOver,}) {',
         "",

--- a/website/playground/markdown.js
+++ b/website/playground/markdown.js
@@ -36,6 +36,7 @@ function formatMarkdown(
 function getMarkdownSyntax(options) {
   switch (options.parser) {
     case "babel":
+    case "babylon": // backward compatibility
     case "flow":
       return "jsx";
     case "typescript":

--- a/website/playground/util.js
+++ b/website/playground/util.js
@@ -11,7 +11,9 @@ export function getDefaults(availableOptions, optionNames) {
   for (const option of availableOptions) {
     if (optionNames.includes(option.name)) {
       defaults[option.name] =
-        option.name === "parser" ? "babel" : option.default;
+        option.name === "parser"
+          ? "babylon" // TODO(1.16): replace with `babel`
+          : option.default;
     }
   }
   return defaults;

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -17,7 +17,7 @@ var parsers = {
     importScriptOnce("lib/parser-babylon.js");
     return prettierPlugins.babylon.parsers.babel;
   },
-  // backward compatibility for v1.15 playground
+  // backward compatibility
   get babylon() {
     importScriptOnce("lib/parser-babylon.js");
     return prettierPlugins.babylon.parsers.babylon;


### PR DESCRIPTION
Fixes #5689

We need a versioned playground (similar to how versioned docs work) so that the preview playground won't affect the current playground.

- I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
