### PR TITLE
Update Webstorm integration docs

### DIFF
--- a/website/versioned_docs/version-stable/webstorm.md
+++ b/website/versioned_docs/version-stable/webstorm.md
@@ -18,9 +18,9 @@ For older IDE versions, please follow the instructions below.
 
 To automatically format your files using `prettier` on save, you can use a [File Watcher](https://plugins.jetbrains.com/plugin/7177-file-watchers).
 
-Go to _Preferences | Tools | File Watchers_ and click **+** to add a new watcher.
+Go to _File | Settings | Tools | File Watchers_ and click **+** to add a new watcher.
 
-In Webstorm 2018.2, select Prettier from the list, review the configuration, add any additional arguments if needed, and click OK.
+In Webstorm 2018.3, select Prettier from the list, review the configuration, add any additional arguments if needed, and click OK.
 
 In older IDE versions, select Custom and do the following configuration:
 
@@ -41,11 +41,11 @@ In older IDE versions, select Custom and do the following configuration:
 
 If you are using ESLint with [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier), use the `Fix ESLint Problems` action to reformat the currect file – find it using _Find Action_ (`Cmd/Ctrl-Shift-A`) or [add a keyboard shortcut](https://www.jetbrains.com/help/webstorm/configuring-keyboard-shortcuts.html) to it in _Preferences | Keymap_ and then use it.
 
-Make sure that the ESLint integration is enabled in _Preferences | Languages & Frameworks | JavaScript | Code Quality Tools | ESLint_.
+Make sure that the ESLint integration is enabled in _File | Settings | Languages & Frameworks | JavaScript | Code Quality Tools | ESLint_.
 
 ### Using Prettier as External Tool
 
-Go to _Preferences | Tools | External Tools_ and click **+** to add a new tool. Let’s name it **Prettier**.
+Go to _File | Settings | Tools | External Tools_ and click **+** to add a new tool. Let’s name it **Prettier**.
 
 - **Program**: `prettier` on macOS and Linux or `C:\Users\user_name\AppData\Roaming\npm\prettier.cmd` on Windows (or whatever `npm prefix -g` returns), if Prettier is installed globally
 - **Parameters**: `--write [other options] $FilePathRelativeToProjectRoot$`
@@ -59,4 +59,4 @@ Press `Cmd/Ctrl-Shift-A` (_Find Action_), search for _Prettier_, and then hit `E
 
 It will run `prettier` for the current file.
 
-You can [add a keyboard shortcut](https://www.jetbrains.com/help/webstorm/configuring-keyboard-shortcuts.html) to run this External tool configuration in _Preferences | Keymap_.
+You can [add a keyboard shortcut](https://www.jetbrains.com/help/webstorm/configuring-keyboard-shortcuts.html) to run this External tool configuration in _File | Settings | Keymap_.

--- a/website/versioned_docs/version-stable/webstorm.md
+++ b/website/versioned_docs/version-stable/webstorm.md
@@ -18,9 +18,9 @@ For older IDE versions, please follow the instructions below.
 
 To automatically format your files using `prettier` on save, you can use a [File Watcher](https://plugins.jetbrains.com/plugin/7177-file-watchers).
 
-In the _Settings/Preferences_ dialog (`⌘,` on Mac or `Ctrl+Alt+S` on Windows), click **File Watchers** under **Tools** and click **+** to add a new watcher.
+In the _Settings/Preferences_ dialog (`⌘,` on Mac or `Ctrl+Alt+S` on Windows and Linux), click **File Watchers** under **Tools** and click **+** to add a new watcher.
 
-In Webstorm 2018.3, select Prettier from the list, review the configuration, add any additional arguments if needed, and click OK.
+Select Prettier from the list, review the configuration, add any additional arguments if needed, and click OK.
 
 In older IDE versions, select Custom and do the following configuration:
 
@@ -45,7 +45,7 @@ Make sure that the ESLint integration is enabled in the _Settings/Preferences_ d
 
 ### Using Prettier as External Tool
 
-In the _Settings/Preferences_ dialog (`⌘,` on Mac or `Ctrl+Alt+S` on Windows) click **External Tools** under **Tools** and click **+** to add a new tool. Let’s name it **Prettier**.
+In the _Settings/Preferences_ dialog (`⌘,` on Mac or `Ctrl+Alt+S` on Windows and Linux) click **External Tools** under **Tools** and click **+** to add a new tool. Let’s name it **Prettier**.
 
 - **Program**: `prettier` on macOS and Linux or `C:\Users\user_name\AppData\Roaming\npm\prettier.cmd` on Windows (or whatever `npm prefix -g` returns), if Prettier is installed globally
 - **Parameters**: `--write [other options] $FilePathRelativeToProjectRoot$`
@@ -59,4 +59,4 @@ Press `Cmd/Ctrl-Shift-A` (_Find Action_), search for _Prettier_, and then hit `E
 
 It will run `prettier` for the current file.
 
-You can [add a keyboard shortcut](https://www.jetbrains.com/help/webstorm/configuring-keyboard-shortcuts.html) to run this External tool configuration in _File | Settings | Keymap_.
+You can [add a keyboard shortcut](https://www.jetbrains.com/help/webstorm/configuring-keyboard-shortcuts.html) to run this External tool configuration in the _Settings/Preferences_ dialog (`⌘,` on Mac or `Ctrl+Alt+S` on Windows and Linux) click **Keymap**.

--- a/website/versioned_docs/version-stable/webstorm.md
+++ b/website/versioned_docs/version-stable/webstorm.md
@@ -18,7 +18,7 @@ For older IDE versions, please follow the instructions below.
 
 To automatically format your files using `prettier` on save, you can use a [File Watcher](https://plugins.jetbrains.com/plugin/7177-file-watchers).
 
-Go to _File | Settings | Tools | File Watchers_ and click **+** to add a new watcher.
+In the _Settings/Preferences_ dialog (`⌘,` on Mac or `Ctrl+Alt+S` on Windows), click **File Watchers** under **Tools** and click **+** to add a new watcher.
 
 In Webstorm 2018.3, select Prettier from the list, review the configuration, add any additional arguments if needed, and click OK.
 
@@ -41,11 +41,11 @@ In older IDE versions, select Custom and do the following configuration:
 
 If you are using ESLint with [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier), use the `Fix ESLint Problems` action to reformat the currect file – find it using _Find Action_ (`Cmd/Ctrl-Shift-A`) or [add a keyboard shortcut](https://www.jetbrains.com/help/webstorm/configuring-keyboard-shortcuts.html) to it in _Preferences | Keymap_ and then use it.
 
-Make sure that the ESLint integration is enabled in _File | Settings | Languages & Frameworks | JavaScript | Code Quality Tools | ESLint_.
+Make sure that the ESLint integration is enabled in the _Settings/Preferences_ dialog (`⌘,` on Mac or `Ctrl+Alt+S` on Windows) click **ESLint** under **Languages & Frameworks | JavaScript | Code Quality Tools**
 
 ### Using Prettier as External Tool
 
-Go to _File | Settings | Tools | External Tools_ and click **+** to add a new tool. Let’s name it **Prettier**.
+In the _Settings/Preferences_ dialog (`⌘,` on Mac or `Ctrl+Alt+S` on Windows) click **External Tools** under **Tools** and click **+** to add a new tool. Let’s name it **Prettier**.
 
 - **Program**: `prettier` on macOS and Linux or `C:\Users\user_name\AppData\Roaming\npm\prettier.cmd` on Windows (or whatever `npm prefix -g` returns), if Prettier is installed globally
 - **Parameters**: `--write [other options] $FilePathRelativeToProjectRoot$`


### PR DESCRIPTION
This is where I found File Watchers (File -> Settings). Couldn't find Preferences anywhere. Working with Windows 10. WS 2018.3

- [] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
