### PR TITLE
chore(website): upgrade react-dom to 16.3.3

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,7 @@
     "lz-string": "1.4.4",
     "prop-types": "15.6.1",
     "react": "16.3.1",
-    "react-dom": "16.3.1"
+    "react-dom": "16.3.3"
   },
   "devDependencies": {
     "@sandhose/prettier-animated-logo": "1.0.3",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -6932,9 +6932,10 @@ react-dev-utils@^5.0.2:
     strip-ansi "3.0.1"
     text-table "0.2.0"
 
-react-dom@16.3.1:
-  version "16.3.1"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.1.tgz#6a3c90a4fb62f915bdbcf6204422d93a7d4ca573"
+react-dom@16.3.3:
+  version "16.3.3"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.3.3.tgz#af4c2aef9f6a66251a46da50253c860a67ae66d9"
+  integrity sha512-ALCp7ZbSGkqRDtQoZozKVNgwXMxbxf/IGOUMC2A0yF6JHeZrS8e2cOotPT87Vf4b7PKCuUVKU4/RDEXxToA/yA==
   dependencies:
     fbjs "^0.8.16"
     loose-envify "^1.1.0"


### PR DESCRIPTION
Context: https://nvd.nist.gov/vuln/detail/CVE-2018-6341 (Though we're not affected.)

- I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
