### PR TITLE
Fix pre-commit hook script

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -103,14 +103,14 @@ Alternately you can save this script as `.git/hooks/pre-commit` and give it exec
 
 ```bash
 #!/bin/sh
-jsfiles=$(git diff --cached --name-only --diff-filter=ACM "*.js" "*.jsx" | tr '\n' ' ')
-[ -z "$jsfiles" ] && exit 0
+FILES=$(git diff --cached --name-only --diff-filter=ACM "*.js" "*.jsx" | sed 's| |\\ |g')
+[ -z "$FILES" ] && exit 0
 
-# Prettify all staged .js files
-echo "$jsfiles" | xargs ./node_modules/.bin/prettier --write
+# Prettify all selected files
+echo "$FILES" | xargs ./node_modules/.bin/prettier --write
 
 # Add back the modified/prettified files to staging
-echo "$jsfiles" | xargs git add
+echo "$FILES" | xargs git add
 
 exit 0
 ```


### PR DESCRIPTION
I played around with the pre-commit hook script a bit and found out that it doesn't work correctly with files with unusual characters in the file name like spaces or line breaks.

I created the following files and added them to the index via `git add`.

```bash
$ touch 'file
with
newlines.js'
$ touch 'file with spaces.js'
$ touch 'just_a_file.js'
```

Then I executed these commands from the script manually. Instead of `prettier` `ls` was used.

```bash
$ jsfiles=$(git diff --cached --name-only --diff-filter=ACM "*.js" "*.jsx" | tr '\n' ' ')
$ echo "$jsfiles" | xargs ls
ls: cannot access 'file': No such file or directory
ls: cannot access 'with': No such file or directory
ls: cannot access 'spaces.js': No such file or directory
ls: cannot access 'file\357\200\212with\357\200\212newlines.js': No such file or directory
 just_a_file.js
```

The solution is basically simple. For `git diff` the `-z` option must be added. Accordingly, `xargs` must also use `-0` option to read the input properly.
Unfortunately, the subshell removes `\0` characters from strings. Therefore it is encoded with base64 and decoded later.

```bash
$ jsfiles=$(git diff -z --cached --name-only --diff-filter=ACM "*.js" "*.jsx" | base64 -w0 -)
$ echo "$jsfiles" | base64 -d | xargs -0r ls
'file with spaces.js'  'file'$'\357\200\212''with'$'\357\200\212''newlines.js'   just_a_file.js
```

Furthermore I renamed the variable `jsfiles` to `FILES` to reflect the fact that not only JS files can be handled by `prettier`.

The script was tested with `git version 2.20.1.windows.1` under Windows 10.

- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
