### PR TITLE
Introduce standard.js compatibility flag

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -77,6 +77,14 @@ Use single quotes instead of double quotes in JSX.
 | ------- | -------------------- | ------------------------ |
 | `false` | `--jsx-single-quote` | `jsxSingleQuote: <bool>` |
 
+## Standard.js compatibility
+
+Configure prettier to be compatible with Standard.js
+
+| Default | CLI Override | API Override       |
+| ------- | ------------ | ------------------ |
+| `false` | `--standard` | `standard: <bool>` |
+
 ## Trailing Commas
 
 Print trailing commas wherever possible when multi-line. (A single-line array, for example, never gets trailing commas.)

--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -72,5 +72,12 @@ module.exports = {
       { value: true, deprecated: "0.19.0", redirect: "es5" },
       { value: false, deprecated: "0.19.0", redirect: "none" }
     ]
+  },
+  standard: {
+    since: "1.16.0",
+    category: CATEGORY_JAVASCRIPT,
+    type: "boolean",
+    default: false,
+    description: "Use standard rules for formatting."
   }
 };

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -916,6 +916,9 @@ function printPathNoParens(path, options, print, args) {
       parts.push("yield");
 
       if (n.delegate) {
+        if (options.standard) {
+          parts.push(" ");
+        }
         parts.push("*");
       }
       if (n.argument) {
@@ -3723,6 +3726,9 @@ function printMethod(path, options, print) {
   if (!kind || kind === "init" || kind === "method" || kind === "constructor") {
     if (node.value.generator) {
       parts.push("*");
+      if (options.standard) {
+        parts.push(" ");
+      }
     }
   } else {
     assert.ok(kind === "get" || kind === "set");
@@ -3744,6 +3750,7 @@ function printMethod(path, options, print) {
           printFunctionTypeParameters(valuePath, options, print),
           group(
             concat([
+              options.standard ? " " : "",
               printFunctionParams(valuePath, print, options),
               printReturnType(valuePath, print, options)
             ])
@@ -4224,6 +4231,9 @@ function printFunctionDeclaration(path, print, options) {
   parts.push("function");
 
   if (n.generator) {
+    if (options.standard) {
+      parts.push(" ");
+    }
     parts.push("*");
   }
   if (n.id) {
@@ -4234,6 +4244,7 @@ function printFunctionDeclaration(path, print, options) {
     printFunctionTypeParameters(path, options, print),
     group(
       concat([
+        options.standard ? " " : "",
         printFunctionParams(path, print, options),
         printReturnType(path, print, options)
       ])
@@ -4254,6 +4265,9 @@ function printObjectMethod(path, options, print) {
   }
   if (objMethod.generator) {
     parts.push("*");
+    if (options.standard) {
+      parts.push(" ");
+    }
   }
   if (
     objMethod.method ||
@@ -4269,6 +4283,9 @@ function printObjectMethod(path, options, print) {
     parts.push("[", key, "]");
   } else {
     parts.push(key);
+    if (options.standard) {
+      parts.push(" ");
+    }
   }
 
   parts.push(

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -34,6 +34,12 @@ const docUtils = doc.utils;
  * the path to the current node through the Abstract Syntax Tree.
  */
 function printAstToDoc(ast, options, alignmentSize = 0) {
+  if (options.standard) {
+    options.semi = false;
+    options.singleQuote = true;
+    options.jsxSingleQuote = true;
+  }
+
   const printer = options.printer;
 
   if (printer.preprocess) {

--- a/tests/standard/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/standard/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,1415 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`correct.js 1`] = `
+====================================options=====================================
+parsers: ["babel"]
+printWidth: 80
+standard: true
+                                                                                | printWidth
+=====================================input======================================
+// Needs to be at the top but belongs to object-curly-spacing
+import { foo } from 'bar'
+
+// Needs to be at the top but belongs to indent rule
+import {
+  foosjdfhalsjkdhflasjdhfajashdlfjahsdlfjashdlfjaksdsadfaso,
+  barsjdfhalsjkdhflasjdhfajashdlfjahsdlfjashdlfjaksdsadfaso,
+  bazsjdfhalsjkdhflasjdhfajashdlfjahsdlfjashdlfjaksdsadfaso
+} from 'qux'
+
+// "arrow-spacing": ["error", { "before": true, "after": true }]
+a => {}
+;() => {}
+a => a
+;() => {
+  '\\n'
+}
+
+// "block-spacing": [ "error", "always" ],
+function foo () {
+  return true
+}
+if (foo) {
+  bar = 0
+}
+
+// "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+function foo () {
+  return true
+}
+if (foo) {
+  bar()
+}
+if (foo) {
+  bar()
+} else {
+  baz()
+}
+try {
+  somethingRisky()
+} catch (e) {
+  handleError()
+}
+
+// "comma-spacing": [ "error", { "before": false, "after": true } ],
+var foo = 1
+var baz = 3
+var arr = [1, 2]
+var arr = [1, , 3]
+var obj = { foo: 'bar', baz: 'qur' }
+foo(a, b)
+new Foo(a, b)
+function foo (a, b) {}
+a, b
+
+// "eol-last": "error",
+// cannot be tested here, but true (Unix-style new lines)
+
+// "func-call-spacing": [ "error", "never" ],
+fn()
+
+// "generator-star-spacing": [ "error", { "before": true, "after": true } ],
+function * generator () {}
+var anonymous = function * () {}
+var shorthand = { * generator () {} }
+class Example {
+  async * foo () {}
+}
+
+// "indent": [
+//   "error",
+//   2,
+//   {
+//     "SwitchCase": 1,
+//     "VariableDeclarator": 1,
+//     "outerIIFEBody": 1,
+//     "MemberExpression": 1,
+//     "FunctionDeclaration": { "parameters": 1, "body": 1 },
+//     "FunctionExpression": { "parameters": 1, "body": 1 },
+//     "CallExpression": { "arguments": 1 },
+//     "ArrayExpression": 1,
+//     "ObjectExpression": 1,
+//     "ImportDeclaration": 1,
+//     "flatTernaryExpressions": false,
+//     "ignoreComments": false
+//   }
+// ],
+
+switch (a) {
+  case 'a':
+    break
+  case 'b':
+    break
+}
+
+var aajshdfaljskdhflakjshdflkjashdlfjkhasldkjfhlasjkdfhlaskjdhfalsjkdfha,
+  bajshdfaljskdhflakjshdflkjashdlfjkhasldkjfhlasjkdfhlaskjdhfalsjkdfha,
+  bajshdfaljskdhflakjshdflkjashdlfjkhasldkjfhlasjkdfhlaskjdhfalsjkdfha
+let aajshdfaljskdhflakjshdflkjashdlfjkhasldkjfhlasjkdfhlaskjdhfalsjkdfha,
+  bajshdfaljskdhflakjshdflkjashdlfjkhasldkjfhlasjkdfhlaskjdhfalsjkdfha,
+  bajshdfaljskdhflakjshdflkjashdlfjkhasldkjfhlasjkdfhlaskjdhfalsjkdfha
+const a = 1
+const b = 2
+const c = 3
+;(function () {
+  function foo (x) {
+    return x + 1
+  }
+})()
+if (y) {
+  console.log('foo')
+}
+function foo (
+  barverylongverylongverylongverylongverylongverylongverylongverylong,
+  bazverylongverylongverylongverylongverylongverylongverylongverylong,
+  quxverylongverylongverylongverylongverylongverylongverylongverylong
+) {
+  qux()
+}
+foo(
+  barverylongverylongverylongverylongverylongverylongverylongverylong,
+  bazverylongverylongverylongverylongverylongverylongverylongverylong,
+  quxverylongverylongverylongverylongverylongverylongverylongverylong
+)
+var foo = [
+  barverylongverylongverylongverylongverylongverylongverylongverylong,
+  bazverylongverylongverylongverylongverylongverylongverylongverylong,
+  quxverylongverylongverylongverylongverylongverylongverylongverylong
+]
+var foo = {
+  barverylongverylongverylongverylongverylongverylongverylongverylong: 1,
+  bazverylongverylongverylongverylongverylongverylongverylongverylong: 2,
+  quxverylongverylongverylongverylongverylongverylongverylongverylong: 3
+}
+var a = barverylongverylongverylongverylongverylongverylongverylongverylong
+  ? bar
+  : barverylongverylongverylongverylongverylongverylongverylongverylong
+
+// "key-spacing": [ "error", { "beforeColon": false, "afterColon": true } ],
+var obj = { foo: 42 }
+
+// "keyword-spacing": [ "error", { "before": true, "after": true } ],
+if (foo) {
+  // ...
+} else if (bar) {
+  // ...
+} else {
+  // ...
+}
+
+// "no-multi-spaces": "error",
+var a = 1
+if (foo === 'bar') {
+}
+a << b
+var arr = [1, 2]
+a ? b : c
+
+// "no-multiple-empty-lines": [ "error", { "max": 1, "maxEOF": 0 } ],
+// cannot be tested here, but true
+
+// "no-trailing-spaces": "error",
+// cannot be tested here, but true
+
+// "no-whitespace-before-property": "error",
+foo.bar
+foo[bar]
+foo.bar.baz
+foo.bar().baz()
+
+// "object-curly-spacing": [ "error", "always" ],
+var obj = {}
+var obj = { foo: 'bar' }
+var obj = { foo: { bar: 'baz' }, qux: 'quxx' }
+var obj = {
+  foo: 'bar'
+}
+var { x } = y
+
+// "object-property-newline": [ "error", { "allowMultiplePropertiesPerLine": true } ],
+const obj = { foo: 'foo', bar: 'bar' }
+const obj2 = {
+  foo: 'foo',
+  bar: 'bar',
+  baz: 'baz'
+}
+const user = process.argv[2]
+const obj3 = {
+  user,
+  [process.argv[3] ? 'foo' : 'bar']: 0,
+  baz: [1, 2, 4, 8]
+}
+
+// "padded-blocks": [ "error", { "blocks": "never", "switches": "never", "classes": "never" } ],
+if (a) {
+  b()
+}
+if (a) {
+  b()
+}
+class A {
+  constructor () {
+    // ...
+  }
+}
+switch (a) {
+  case 0:
+    foo()
+}
+
+// "rest-spread-spacing": [ "error", "never" ],
+fn(...args)
+function fn (...args) {
+  console.log(args)
+}
+let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 }
+let n = { x, y, ...z }
+
+// "semi-spacing": [ "error", { "before": false, "after": true } ],
+for (;;) {}
+
+// "space-before-blocks": [ "error", "always" ],
+if (a) {
+  b()
+}
+if (a) {
+  b()
+} else {
+  c()
+}
+function a () {}
+for (;;) {
+  b()
+}
+try {
+} catch (a) {}
+
+// "space-before-function-paren": [ "error", "always" ],
+function foo () {
+  // ...
+}
+
+var bar = function () {
+  // ...
+}
+
+var bar = function foo () {
+  // ...
+}
+
+class Foo {
+  constructor () {
+    // ...
+  }
+
+  get foo () {
+    // ...
+  }
+
+  set bar (param) {
+    // ...
+  }
+}
+
+var foo = {
+  bar () {
+    // ...
+  }
+}
+
+var foo = async () => 1
+
+// "space-in-parens": [ "error", "never" ],
+foo()
+
+foo('bar')
+
+var foo = (1 + 2) * 3
+;(function () {
+  return 'bar'
+})()
+
+// "space-infix-ops": "error",
+a + b
+a + b
+a ? b : c
+const a = { b: 1 }
+var { a = 0 } = bar
+function foo (a = 0) {}
+
+// "space-unary-ops": [ "error", { "words": true, "nonwords": false } ],
+delete foo.bar
+new Foo()
+void 0
+;-foo
+;+'3'
+++foo
+foo--
+
+// "spaced-comment": [
+//   "error",
+//   "always",
+//   {
+//     "line": { "markers": [ "*package", "!", "/", ",", "=" ] },
+//     "block": {
+//       "balanced": true,
+//       "markers": [ "*package", "!", ",", ":", "::", "flow-include" ],
+//       "exceptions": [ "*" ]
+//     }
+//   }
+// ],
+
+/* eslint spaced-comment: ["error", "always"] */
+// This is a comment with a whitespace at the beginning
+/* This is a comment with a whitespace at the beginning */
+/*
+ * This is a comment with a whitespace at the beginning
+ */
+/*
+This comment has a newline
+*/
+
+// "template-curly-spacing": [ "error", "never" ],
+;\`hello, \${people.name}!\`
+;\`hello, \${
+  people.name.some.long.property.that.cannot.fit.in[80].characters.limit.for
+    .prettier
+}!\`
+
+// "template-tag-spacing": [ "error", "never" ],
+func\`Hello world\`
+
+// "unicode-bom": [ "error", "never" ],
+var abc
+
+// "yield-star-spacing": [ "error", "both" ]
+function * generator () {
+  yield * other()
+}
+
+// "jsx-quotes": ["error", "prefer-single"],
+;() => <div foo='bar' />
+
+=====================================output=====================================
+// Needs to be at the top but belongs to object-curly-spacing
+import { foo } from 'bar'
+
+// Needs to be at the top but belongs to indent rule
+import {
+  foosjdfhalsjkdhflasjdhfajashdlfjahsdlfjashdlfjaksdsadfaso,
+  barsjdfhalsjkdhflasjdhfajashdlfjahsdlfjashdlfjaksdsadfaso,
+  bazsjdfhalsjkdhflasjdhfajashdlfjahsdlfjashdlfjaksdsadfaso
+} from 'qux'
+
+// "arrow-spacing": ["error", { "before": true, "after": true }]
+a => {}
+;() => {}
+a => a
+;() => {
+  '\\n'
+}
+
+// "block-spacing": [ "error", "always" ],
+function foo () {
+  return true
+}
+if (foo) {
+  bar = 0
+}
+
+// "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+function foo () {
+  return true
+}
+if (foo) {
+  bar()
+}
+if (foo) {
+  bar()
+} else {
+  baz()
+}
+try {
+  somethingRisky()
+} catch (e) {
+  handleError()
+}
+
+// "comma-spacing": [ "error", { "before": false, "after": true } ],
+var foo = 1
+var baz = 3
+var arr = [1, 2]
+var arr = [1, , 3]
+var obj = { foo: 'bar', baz: 'qur' }
+foo(a, b)
+new Foo(a, b)
+function foo (a, b) {}
+a, b
+
+// "eol-last": "error",
+// cannot be tested here, but true (Unix-style new lines)
+
+// "func-call-spacing": [ "error", "never" ],
+fn()
+
+// "generator-star-spacing": [ "error", { "before": true, "after": true } ],
+function * generator () {}
+var anonymous = function * () {}
+var shorthand = { * generator () {} }
+class Example {
+  async * foo () {}
+}
+
+// "indent": [
+//   "error",
+//   2,
+//   {
+//     "SwitchCase": 1,
+//     "VariableDeclarator": 1,
+//     "outerIIFEBody": 1,
+//     "MemberExpression": 1,
+//     "FunctionDeclaration": { "parameters": 1, "body": 1 },
+//     "FunctionExpression": { "parameters": 1, "body": 1 },
+//     "CallExpression": { "arguments": 1 },
+//     "ArrayExpression": 1,
+//     "ObjectExpression": 1,
+//     "ImportDeclaration": 1,
+//     "flatTernaryExpressions": false,
+//     "ignoreComments": false
+//   }
+// ],
+
+switch (a) {
+  case 'a':
+    break
+  case 'b':
+    break
+}
+
+var aajshdfaljskdhflakjshdflkjashdlfjkhasldkjfhlasjkdfhlaskjdhfalsjkdfha,
+  bajshdfaljskdhflakjshdflkjashdlfjkhasldkjfhlasjkdfhlaskjdhfalsjkdfha,
+  bajshdfaljskdhflakjshdflkjashdlfjkhasldkjfhlasjkdfhlaskjdhfalsjkdfha
+let aajshdfaljskdhflakjshdflkjashdlfjkhasldkjfhlasjkdfhlaskjdhfalsjkdfha,
+  bajshdfaljskdhflakjshdflkjashdlfjkhasldkjfhlasjkdfhlaskjdhfalsjkdfha,
+  bajshdfaljskdhflakjshdflkjashdlfjkhasldkjfhlasjkdfhlaskjdhfalsjkdfha
+const a = 1
+const b = 2
+const c = 3
+;(function () {
+  function foo (x) {
+    return x + 1
+  }
+})()
+if (y) {
+  console.log('foo')
+}
+function foo (
+  barverylongverylongverylongverylongverylongverylongverylongverylong,
+  bazverylongverylongverylongverylongverylongverylongverylongverylong,
+  quxverylongverylongverylongverylongverylongverylongverylongverylong
+) {
+  qux()
+}
+foo(
+  barverylongverylongverylongverylongverylongverylongverylongverylong,
+  bazverylongverylongverylongverylongverylongverylongverylongverylong,
+  quxverylongverylongverylongverylongverylongverylongverylongverylong
+)
+var foo = [
+  barverylongverylongverylongverylongverylongverylongverylongverylong,
+  bazverylongverylongverylongverylongverylongverylongverylongverylong,
+  quxverylongverylongverylongverylongverylongverylongverylongverylong
+]
+var foo = {
+  barverylongverylongverylongverylongverylongverylongverylongverylong: 1,
+  bazverylongverylongverylongverylongverylongverylongverylongverylong: 2,
+  quxverylongverylongverylongverylongverylongverylongverylongverylong: 3
+}
+var a = barverylongverylongverylongverylongverylongverylongverylongverylong
+  ? bar
+  : barverylongverylongverylongverylongverylongverylongverylongverylong
+
+// "key-spacing": [ "error", { "beforeColon": false, "afterColon": true } ],
+var obj = { foo: 42 }
+
+// "keyword-spacing": [ "error", { "before": true, "after": true } ],
+if (foo) {
+  // ...
+} else if (bar) {
+  // ...
+} else {
+  // ...
+}
+
+// "no-multi-spaces": "error",
+var a = 1
+if (foo === 'bar') {
+}
+a << b
+var arr = [1, 2]
+a ? b : c
+
+// "no-multiple-empty-lines": [ "error", { "max": 1, "maxEOF": 0 } ],
+// cannot be tested here, but true
+
+// "no-trailing-spaces": "error",
+// cannot be tested here, but true
+
+// "no-whitespace-before-property": "error",
+foo.bar
+foo[bar]
+foo.bar.baz
+foo.bar().baz()
+
+// "object-curly-spacing": [ "error", "always" ],
+var obj = {}
+var obj = { foo: 'bar' }
+var obj = { foo: { bar: 'baz' }, qux: 'quxx' }
+var obj = {
+  foo: 'bar'
+}
+var { x } = y
+
+// "object-property-newline": [ "error", { "allowMultiplePropertiesPerLine": true } ],
+const obj = { foo: 'foo', bar: 'bar' }
+const obj2 = {
+  foo: 'foo',
+  bar: 'bar',
+  baz: 'baz'
+}
+const user = process.argv[2]
+const obj3 = {
+  user,
+  [process.argv[3] ? 'foo' : 'bar']: 0,
+  baz: [1, 2, 4, 8]
+}
+
+// "padded-blocks": [ "error", { "blocks": "never", "switches": "never", "classes": "never" } ],
+if (a) {
+  b()
+}
+if (a) {
+  b()
+}
+class A {
+  constructor () {
+    // ...
+  }
+}
+switch (a) {
+  case 0:
+    foo()
+}
+
+// "rest-spread-spacing": [ "error", "never" ],
+fn(...args)
+function fn (...args) {
+  console.log(args)
+}
+let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 }
+let n = { x, y, ...z }
+
+// "semi-spacing": [ "error", { "before": false, "after": true } ],
+for (;;) {}
+
+// "space-before-blocks": [ "error", "always" ],
+if (a) {
+  b()
+}
+if (a) {
+  b()
+} else {
+  c()
+}
+function a () {}
+for (;;) {
+  b()
+}
+try {
+} catch (a) {}
+
+// "space-before-function-paren": [ "error", "always" ],
+function foo () {
+  // ...
+}
+
+var bar = function () {
+  // ...
+}
+
+var bar = function foo () {
+  // ...
+}
+
+class Foo {
+  constructor () {
+    // ...
+  }
+
+  get foo () {
+    // ...
+  }
+
+  set bar (param) {
+    // ...
+  }
+}
+
+var foo = {
+  bar () {
+    // ...
+  }
+}
+
+var foo = async () => 1
+
+// "space-in-parens": [ "error", "never" ],
+foo()
+
+foo('bar')
+
+var foo = (1 + 2) * 3
+;(function () {
+  return 'bar'
+})()
+
+// "space-infix-ops": "error",
+a + b
+a + b
+a ? b : c
+const a = { b: 1 }
+var { a = 0 } = bar
+function foo (a = 0) {}
+
+// "space-unary-ops": [ "error", { "words": true, "nonwords": false } ],
+delete foo.bar
+new Foo()
+void 0
+;-foo
+;+'3'
+++foo
+foo--
+
+// "spaced-comment": [
+//   "error",
+//   "always",
+//   {
+//     "line": { "markers": [ "*package", "!", "/", ",", "=" ] },
+//     "block": {
+//       "balanced": true,
+//       "markers": [ "*package", "!", ",", ":", "::", "flow-include" ],
+//       "exceptions": [ "*" ]
+//     }
+//   }
+// ],
+
+/* eslint spaced-comment: ["error", "always"] */
+// This is a comment with a whitespace at the beginning
+/* This is a comment with a whitespace at the beginning */
+/*
+ * This is a comment with a whitespace at the beginning
+ */
+/*
+This comment has a newline
+*/
+
+// "template-curly-spacing": [ "error", "never" ],
+;\`hello, \${people.name}!\`
+;\`hello, \${
+  people.name.some.long.property.that.cannot.fit.in[80].characters.limit.for
+    .prettier
+}!\`
+
+// "template-tag-spacing": [ "error", "never" ],
+func\`Hello world\`
+
+// "unicode-bom": [ "error", "never" ],
+var abc
+
+// "yield-star-spacing": [ "error", "both" ]
+function * generator () {
+  yield * other()
+}
+
+// "jsx-quotes": ["error", "prefer-single"],
+;() => <div foo='bar' />
+
+================================================================================
+`;
+
+exports[`incorrect.js 1`] = `
+====================================options=====================================
+parsers: ["babel"]
+printWidth: 80
+standard: true
+                                                                                | printWidth
+=====================================input======================================
+// "arrow-spacing": ["error", { "before": true, "after": true }]
+
+()=> {};
+() =>{};
+(a)=> {};
+(a) =>{};
+a =>a;
+a=> a;
+()=> {'\\n'};
+() =>{'\\n'};
+
+// "block-spacing": [ "error", "always" ],
+
+function foo() {return true;}
+if (foo) { bar = 0;}
+function baz() {let i = 0;
+  return i;
+}
+
+// "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+
+function foo()
+{
+  return true;
+}
+
+if (foo)
+{
+  bar();
+}
+
+try
+{
+  somethingRisky();
+} catch(e)
+{
+  handleError();
+}
+
+if (foo) {
+  bar();
+}
+else {
+  baz();
+}
+
+// "comma-spacing": [ "error", { "before": false, "after": true } ],
+
+var foo = 1 ,bar = 2;
+var arr = [1 , 2];
+var obj = {"foo": "bar" ,"baz": "qur"};
+foo(a ,b);
+new Foo(a ,b);
+function foo(a ,b){}
+a ,b
+
+// "eol-last": "error",
+// cannot be tested here, but true (Unix-style new lines)
+
+// "func-call-spacing": [ "error", "never" ],
+fn ();
+
+fn
+();
+
+// "generator-star-spacing": [ "error", { "before": true, "after": true } ],
+
+function* generator() {}
+var anonymous = function* () {};
+var shorthand = { * generator() {} };
+function *generator() {}
+var anonymous = function *() {};
+var shorthand = { *generator() {} };
+
+
+// "indent": [
+//   "error",
+//   2,
+//   {
+//     "SwitchCase": 1,
+//     "VariableDeclarator": 1,
+//     "outerIIFEBody": 1,
+//     "MemberExpression": 1,
+//     "FunctionDeclaration": { "parameters": 1, "body": 1 },
+//     "FunctionExpression": { "parameters": 1, "body": 1 },
+//     "CallExpression": { "arguments": 1 },
+//     "ArrayExpression": 1,
+//     "ObjectExpression": 1,
+//     "ImportDeclaration": 1,
+//     "flatTernaryExpressions": false,
+//     "ignoreComments": false
+//   }
+// ],
+
+// "key-spacing": [ "error", { "beforeColon": false, "afterColon": true } ],
+
+var obj = { "foo" : 42 };
+var obj = { "foo":42 };
+
+// "keyword-spacing": [ "error", { "before": true, "after": true } ],
+
+if (foo) {
+  //...
+}else if (bar) {
+  //...
+}else {
+  //...
+}
+
+// "no-multi-spaces": "error",
+
+var a =  1;
+if(foo   === "bar") {}
+a <<  b
+var arr = [1,  2];
+a ?  b: c
+
+// "no-multiple-empty-lines": [ "error", { "max": 1, "maxEOF": 0 } ],
+// cannot be tested here, but true
+
+// "no-trailing-spaces": "error",
+// cannot be tested here, but true
+
+// "no-whitespace-before-property": "error",
+
+foo [bar]
+foo. bar
+foo .bar
+foo. bar. baz
+foo. bar()
+  .baz()
+foo
+  .bar(). baz()
+
+// "object-curly-spacing": [ "error", "always" ],
+
+var obj = {'foo': 'bar'};
+var obj = {'foo': 'bar' };
+var obj = { baz: {'foo': 'qux'}, bar};
+var obj = {baz: { 'foo': 'qux' }, bar};
+var obj = {'foo': 'bar'
+};
+var obj = {
+  'foo':'bar'};
+var {x} = y;
+import {foo } from 'bar';
+
+// "object-property-newline": [ "error", { "allowMultiplePropertiesPerLine": true } ],
+
+const obj0 = { foo: "foo", bar: "bar", baz: "baz" };
+const obj1 = {
+  foo: "foo", bar: "bar", baz: "baz"
+};
+const obj2 = {
+  foo: "foo", bar: "bar",
+  baz: "baz"
+};
+const obj3 = {
+  [process.argv[3] ? "foo" : "bar"]: 0, baz: [
+    1,
+    2,
+    4,
+    8
+  ]
+};
+const a = "antidisestablishmentarianistically";
+const b = "yugoslavyalılaştırabildiklerimizdenmişsiniz";
+const obj4 = {a, b};
+const domain = process.argv[4];
+const obj5 = {
+  foo: "foo", [
+    domain.includes(":") ? "complexdomain" : "simpledomain"
+  ]: true};
+
+// "padded-blocks": [ "error", { "blocks": "never", "switches": "never", "classes": "never" } ],
+
+
+if (a) {
+
+  b();
+
+}
+
+if (a)
+{
+
+  b();
+
+}
+
+if (a) {
+
+  b();
+}
+
+if (a) {
+  b();
+
+}
+
+class  A {
+
+  constructor(){
+  }
+
+}
+
+switch (a) {
+
+  case 0: foo();
+
+}
+
+// "rest-spread-spacing": [ "error", "never" ],
+
+fn(... args)
+function fn(... args) { console.log(args); }
+let { x, y, ... z } = { x: 1, y: 2, a: 3, b: 4 };
+let n = { x, y, ... z };
+
+// "semi-spacing": [ "error", { "before": false, "after": true } ],
+
+var foo ;
+var foo;var bar;
+throw new Error("error") ;
+while (a) { break ; }
+for (i = 0 ; i < 10 ; i++) {}
+for (i = 0;i < 10;i++) {}
+
+// "space-before-blocks": [ "error", "always" ],
+
+if (a){
+    b();
+}
+
+function a(){}
+
+for (;;){
+    b();
+}
+
+try {} catch(a){}
+
+class Foo{
+  constructor(){}
+}
+
+// "space-before-function-paren": [ "error", "always" ],
+
+function foo() {
+    // ...
+}
+
+var bar = function() {
+    // ...
+};
+
+var bar = function foo() {
+    // ...
+};
+
+class Foo {
+    constructor() {
+        // ...
+    }
+}
+
+var foo = {
+    bar() {
+        // ...
+    }
+};
+
+var foo = async() => 1
+
+// "space-in-parens": [ "error", "never" ],
+
+foo( 'bar');
+foo('bar' );
+foo( 'bar' );
+
+var foo = ( 1 + 2 ) * 3;
+( function () { return 'bar'; }() );
+
+// "space-infix-ops": "error",
+
+a+b
+a+ b
+a +b
+a?b:c
+const a={b:1};
+var {a=0}=bar;
+function foo(a=0) { }
+
+// "space-unary-ops": [ "error", { "words": true, "nonwords": false } ],
+
+typeof!foo;
+void{foo:0};
+new[foo][0];
+delete(foo.bar);
+++ foo;
+foo --;
+- foo;
++ "3";
+
+// "spaced-comment": [
+//   "error",
+//   "always",
+//   {
+//     "line": { "markers": [ "*package", "!", "/", ",", "=" ] },
+//     "block": {
+//       "balanced": true,
+//       "markers": [ "*package", "!", ",", ":", "::", "flow-include" ],
+//       "exceptions": [ "*" ]
+//     }
+//   }
+// ],
+
+/*eslint spaced-comment: ["error", "always"]*/
+//This is a comment with no whitespace at the beginning
+/*This is a comment with no whitespace at the beginning */
+/* eslint spaced-comment: ["error", "always", { "block": { "balanced": true } }] */
+/* This is a comment with whitespace at the beginning but not the end*/
+
+// "template-curly-spacing": [ "error", "never" ],
+
+\`hello, \${ people.name}!\`;
+\`hello, \${people.name }!\`;
+\`hello, \${ people.name }!\`;
+
+// "template-tag-spacing": [ "error", "never" ],
+
+func \`Hello world\`;
+
+// "unicode-bom": [ "error", "never" ],
+
+U+FEFF
+var abc;
+
+// "yield-star-spacing": [ "error", "both" ]
+
+
+function *generator() {
+  yield *other();
+}
+function* generator() {
+  yield* other();
+}
+function*generator() {
+  yield*other();
+}
+
+// "jsx-quotes": ["error", "prefer-single"],
+;() => <div foo="bar" />
+
+=====================================output=====================================
+// "arrow-spacing": ["error", { "before": true, "after": true }]
+
+;() => {}
+;() => {}
+a => {}
+a => {}
+a => a
+a => a
+;() => {
+  '\\n'
+}
+;() => {
+  '\\n'
+}
+
+// "block-spacing": [ "error", "always" ],
+
+function foo () {
+  return true
+}
+if (foo) {
+  bar = 0
+}
+function baz () {
+  let i = 0
+  return i
+}
+
+// "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+
+function foo () {
+  return true
+}
+
+if (foo) {
+  bar()
+}
+
+try {
+  somethingRisky()
+} catch (e) {
+  handleError()
+}
+
+if (foo) {
+  bar()
+} else {
+  baz()
+}
+
+// "comma-spacing": [ "error", { "before": false, "after": true } ],
+
+var foo = 1,
+  bar = 2
+var arr = [1, 2]
+var obj = { foo: 'bar', baz: 'qur' }
+foo(a, b)
+new Foo(a, b)
+function foo (a, b) {}
+a, b
+
+// "eol-last": "error",
+// cannot be tested here, but true (Unix-style new lines)
+
+// "func-call-spacing": [ "error", "never" ],
+fn()
+
+fn()
+
+// "generator-star-spacing": [ "error", { "before": true, "after": true } ],
+
+function * generator () {}
+var anonymous = function * () {}
+var shorthand = { * generator () {} }
+function * generator () {}
+var anonymous = function * () {}
+var shorthand = { * generator () {} }
+
+// "indent": [
+//   "error",
+//   2,
+//   {
+//     "SwitchCase": 1,
+//     "VariableDeclarator": 1,
+//     "outerIIFEBody": 1,
+//     "MemberExpression": 1,
+//     "FunctionDeclaration": { "parameters": 1, "body": 1 },
+//     "FunctionExpression": { "parameters": 1, "body": 1 },
+//     "CallExpression": { "arguments": 1 },
+//     "ArrayExpression": 1,
+//     "ObjectExpression": 1,
+//     "ImportDeclaration": 1,
+//     "flatTernaryExpressions": false,
+//     "ignoreComments": false
+//   }
+// ],
+
+// "key-spacing": [ "error", { "beforeColon": false, "afterColon": true } ],
+
+var obj = { foo: 42 }
+var obj = { foo: 42 }
+
+// "keyword-spacing": [ "error", { "before": true, "after": true } ],
+
+if (foo) {
+  //...
+} else if (bar) {
+  //...
+} else {
+  //...
+}
+
+// "no-multi-spaces": "error",
+
+var a = 1
+if (foo === 'bar') {
+}
+a << b
+var arr = [1, 2]
+a ? b : c
+
+// "no-multiple-empty-lines": [ "error", { "max": 1, "maxEOF": 0 } ],
+// cannot be tested here, but true
+
+// "no-trailing-spaces": "error",
+// cannot be tested here, but true
+
+// "no-whitespace-before-property": "error",
+
+foo[bar]
+foo.bar
+foo.bar
+foo.bar.baz
+foo.bar().baz()
+foo.bar().baz()
+
+// "object-curly-spacing": [ "error", "always" ],
+
+var obj = { foo: 'bar' }
+var obj = { foo: 'bar' }
+var obj = { baz: { foo: 'qux' }, bar }
+var obj = { baz: { foo: 'qux' }, bar }
+var obj = { foo: 'bar' }
+var obj = {
+  foo: 'bar'
+}
+var { x } = y
+import { foo } from 'bar'
+
+// "object-property-newline": [ "error", { "allowMultiplePropertiesPerLine": true } ],
+
+const obj0 = { foo: 'foo', bar: 'bar', baz: 'baz' }
+const obj1 = {
+  foo: 'foo',
+  bar: 'bar',
+  baz: 'baz'
+}
+const obj2 = {
+  foo: 'foo',
+  bar: 'bar',
+  baz: 'baz'
+}
+const obj3 = {
+  [process.argv[3] ? 'foo' : 'bar']: 0,
+  baz: [1, 2, 4, 8]
+}
+const a = 'antidisestablishmentarianistically'
+const b = 'yugoslavyalılaştırabildiklerimizdenmişsiniz'
+const obj4 = { a, b }
+const domain = process.argv[4]
+const obj5 = {
+  foo: 'foo',
+  [domain.includes(':') ? 'complexdomain' : 'simpledomain']: true
+}
+
+// "padded-blocks": [ "error", { "blocks": "never", "switches": "never", "classes": "never" } ],
+
+if (a) {
+  b()
+}
+
+if (a) {
+  b()
+}
+
+if (a) {
+  b()
+}
+
+if (a) {
+  b()
+}
+
+class A {
+  constructor () {}
+}
+
+switch (a) {
+  case 0:
+    foo()
+}
+
+// "rest-spread-spacing": [ "error", "never" ],
+
+fn(...args)
+function fn (...args) {
+  console.log(args)
+}
+let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 }
+let n = { x, y, ...z }
+
+// "semi-spacing": [ "error", { "before": false, "after": true } ],
+
+var foo
+var foo
+var bar
+throw new Error('error')
+while (a) {
+  break
+}
+for (i = 0; i < 10; i++) {}
+for (i = 0; i < 10; i++) {}
+
+// "space-before-blocks": [ "error", "always" ],
+
+if (a) {
+  b()
+}
+
+function a () {}
+
+for (;;) {
+  b()
+}
+
+try {
+} catch (a) {}
+
+class Foo {
+  constructor () {}
+}
+
+// "space-before-function-paren": [ "error", "always" ],
+
+function foo () {
+  // ...
+}
+
+var bar = function () {
+  // ...
+}
+
+var bar = function foo () {
+  // ...
+}
+
+class Foo {
+  constructor () {
+    // ...
+  }
+}
+
+var foo = {
+  bar () {
+    // ...
+  }
+}
+
+var foo = async () => 1
+
+// "space-in-parens": [ "error", "never" ],
+
+foo('bar')
+foo('bar')
+foo('bar')
+
+var foo = (1 + 2) * 3
+;(function () {
+  return 'bar'
+})()
+
+// "space-infix-ops": "error",
+
+a + b
+a + b
+a + b
+a ? b : c
+const a = { b: 1 }
+var { a = 0 } = bar
+function foo (a = 0) {}
+
+// "space-unary-ops": [ "error", { "words": true, "nonwords": false } ],
+
+typeof !foo
+void { foo: 0 }
+new [foo][0]()
+delete foo.bar
+++foo
+foo--
+;-foo
+;+'3'
+
+// "spaced-comment": [
+//   "error",
+//   "always",
+//   {
+//     "line": { "markers": [ "*package", "!", "/", ",", "=" ] },
+//     "block": {
+//       "balanced": true,
+//       "markers": [ "*package", "!", ",", ":", "::", "flow-include" ],
+//       "exceptions": [ "*" ]
+//     }
+//   }
+// ],
+
+/*eslint spaced-comment: ["error", "always"]*/
+//This is a comment with no whitespace at the beginning
+/*This is a comment with no whitespace at the beginning */
+/* eslint spaced-comment: ["error", "always", { "block": { "balanced": true } }] */
+/* This is a comment with whitespace at the beginning but not the end*/
+
+// "template-curly-spacing": [ "error", "never" ],
+
+;\`hello, \${people.name}!\`
+;\`hello, \${people.name}!\`
+;\`hello, \${people.name}!\`
+
+// "template-tag-spacing": [ "error", "never" ],
+
+func\`Hello world\`
+
+// "unicode-bom": [ "error", "never" ],
+
+U + FEFF
+var abc
+
+// "yield-star-spacing": [ "error", "both" ]
+
+function * generator () {
+  yield * other()
+}
+function * generator () {
+  yield * other()
+}
+function * generator () {
+  yield * other()
+}
+
+// "jsx-quotes": ["error", "prefer-single"],
+;() => <div foo='bar' />
+
+================================================================================
+`;

--- a/tests/standard/correct.js
+++ b/tests/standard/correct.js
@@ -1,0 +1,342 @@
+// Needs to be at the top but belongs to object-curly-spacing
+import { foo } from 'bar'
+
+// Needs to be at the top but belongs to indent rule
+import {
+  foosjdfhalsjkdhflasjdhfajashdlfjahsdlfjashdlfjaksdsadfaso,
+  barsjdfhalsjkdhflasjdhfajashdlfjahsdlfjashdlfjaksdsadfaso,
+  bazsjdfhalsjkdhflasjdhfajashdlfjahsdlfjashdlfjaksdsadfaso
+} from 'qux'
+
+// "arrow-spacing": ["error", { "before": true, "after": true }]
+a => {}
+;() => {}
+a => a
+;() => {
+  '\n'
+}
+
+// "block-spacing": [ "error", "always" ],
+function foo () {
+  return true
+}
+if (foo) {
+  bar = 0
+}
+
+// "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+function foo () {
+  return true
+}
+if (foo) {
+  bar()
+}
+if (foo) {
+  bar()
+} else {
+  baz()
+}
+try {
+  somethingRisky()
+} catch (e) {
+  handleError()
+}
+
+// "comma-spacing": [ "error", { "before": false, "after": true } ],
+var foo = 1
+var baz = 3
+var arr = [1, 2]
+var arr = [1, , 3]
+var obj = { foo: 'bar', baz: 'qur' }
+foo(a, b)
+new Foo(a, b)
+function foo (a, b) {}
+a, b
+
+// "eol-last": "error",
+// cannot be tested here, but true (Unix-style new lines)
+
+// "func-call-spacing": [ "error", "never" ],
+fn()
+
+// "generator-star-spacing": [ "error", { "before": true, "after": true } ],
+function * generator () {}
+var anonymous = function * () {}
+var shorthand = { * generator () {} }
+class Example {
+  async * foo () {}
+}
+
+// "indent": [
+//   "error",
+//   2,
+//   {
+//     "SwitchCase": 1,
+//     "VariableDeclarator": 1,
+//     "outerIIFEBody": 1,
+//     "MemberExpression": 1,
+//     "FunctionDeclaration": { "parameters": 1, "body": 1 },
+//     "FunctionExpression": { "parameters": 1, "body": 1 },
+//     "CallExpression": { "arguments": 1 },
+//     "ArrayExpression": 1,
+//     "ObjectExpression": 1,
+//     "ImportDeclaration": 1,
+//     "flatTernaryExpressions": false,
+//     "ignoreComments": false
+//   }
+// ],
+
+switch (a) {
+  case 'a':
+    break
+  case 'b':
+    break
+}
+
+var aajshdfaljskdhflakjshdflkjashdlfjkhasldkjfhlasjkdfhlaskjdhfalsjkdfha,
+  bajshdfaljskdhflakjshdflkjashdlfjkhasldkjfhlasjkdfhlaskjdhfalsjkdfha,
+  bajshdfaljskdhflakjshdflkjashdlfjkhasldkjfhlasjkdfhlaskjdhfalsjkdfha
+let aajshdfaljskdhflakjshdflkjashdlfjkhasldkjfhlasjkdfhlaskjdhfalsjkdfha,
+  bajshdfaljskdhflakjshdflkjashdlfjkhasldkjfhlasjkdfhlaskjdhfalsjkdfha,
+  bajshdfaljskdhflakjshdflkjashdlfjkhasldkjfhlasjkdfhlaskjdhfalsjkdfha
+const a = 1
+const b = 2
+const c = 3
+;(function () {
+  function foo (x) {
+    return x + 1
+  }
+})()
+if (y) {
+  console.log('foo')
+}
+function foo (
+  barverylongverylongverylongverylongverylongverylongverylongverylong,
+  bazverylongverylongverylongverylongverylongverylongverylongverylong,
+  quxverylongverylongverylongverylongverylongverylongverylongverylong
+) {
+  qux()
+}
+foo(
+  barverylongverylongverylongverylongverylongverylongverylongverylong,
+  bazverylongverylongverylongverylongverylongverylongverylongverylong,
+  quxverylongverylongverylongverylongverylongverylongverylongverylong
+)
+var foo = [
+  barverylongverylongverylongverylongverylongverylongverylongverylong,
+  bazverylongverylongverylongverylongverylongverylongverylongverylong,
+  quxverylongverylongverylongverylongverylongverylongverylongverylong
+]
+var foo = {
+  barverylongverylongverylongverylongverylongverylongverylongverylong: 1,
+  bazverylongverylongverylongverylongverylongverylongverylongverylong: 2,
+  quxverylongverylongverylongverylongverylongverylongverylongverylong: 3
+}
+var a = barverylongverylongverylongverylongverylongverylongverylongverylong
+  ? bar
+  : barverylongverylongverylongverylongverylongverylongverylongverylong
+
+// "key-spacing": [ "error", { "beforeColon": false, "afterColon": true } ],
+var obj = { foo: 42 }
+
+// "keyword-spacing": [ "error", { "before": true, "after": true } ],
+if (foo) {
+  // ...
+} else if (bar) {
+  // ...
+} else {
+  // ...
+}
+
+// "no-multi-spaces": "error",
+var a = 1
+if (foo === 'bar') {
+}
+a << b
+var arr = [1, 2]
+a ? b : c
+
+// "no-multiple-empty-lines": [ "error", { "max": 1, "maxEOF": 0 } ],
+// cannot be tested here, but true
+
+// "no-trailing-spaces": "error",
+// cannot be tested here, but true
+
+// "no-whitespace-before-property": "error",
+foo.bar
+foo[bar]
+foo.bar.baz
+foo.bar().baz()
+
+// "object-curly-spacing": [ "error", "always" ],
+var obj = {}
+var obj = { foo: 'bar' }
+var obj = { foo: { bar: 'baz' }, qux: 'quxx' }
+var obj = {
+  foo: 'bar'
+}
+var { x } = y
+
+// "object-property-newline": [ "error", { "allowMultiplePropertiesPerLine": true } ],
+const obj = { foo: 'foo', bar: 'bar' }
+const obj2 = {
+  foo: 'foo',
+  bar: 'bar',
+  baz: 'baz'
+}
+const user = process.argv[2]
+const obj3 = {
+  user,
+  [process.argv[3] ? 'foo' : 'bar']: 0,
+  baz: [1, 2, 4, 8]
+}
+
+// "padded-blocks": [ "error", { "blocks": "never", "switches": "never", "classes": "never" } ],
+if (a) {
+  b()
+}
+if (a) {
+  b()
+}
+class A {
+  constructor () {
+    // ...
+  }
+}
+switch (a) {
+  case 0:
+    foo()
+}
+
+// "rest-spread-spacing": [ "error", "never" ],
+fn(...args)
+function fn (...args) {
+  console.log(args)
+}
+let { x, y, ...z } = { x: 1, y: 2, a: 3, b: 4 }
+let n = { x, y, ...z }
+
+// "semi-spacing": [ "error", { "before": false, "after": true } ],
+for (;;) {}
+
+// "space-before-blocks": [ "error", "always" ],
+if (a) {
+  b()
+}
+if (a) {
+  b()
+} else {
+  c()
+}
+function a () {}
+for (;;) {
+  b()
+}
+try {
+} catch (a) {}
+
+// "space-before-function-paren": [ "error", "always" ],
+function foo () {
+  // ...
+}
+
+var bar = function () {
+  // ...
+}
+
+var bar = function foo () {
+  // ...
+}
+
+class Foo {
+  constructor () {
+    // ...
+  }
+
+  get foo () {
+    // ...
+  }
+
+  set bar (param) {
+    // ...
+  }
+}
+
+var foo = {
+  bar () {
+    // ...
+  }
+}
+
+var foo = async () => 1
+
+// "space-in-parens": [ "error", "never" ],
+foo()
+
+foo('bar')
+
+var foo = (1 + 2) * 3
+;(function () {
+  return 'bar'
+})()
+
+// "space-infix-ops": "error",
+a + b
+a + b
+a ? b : c
+const a = { b: 1 }
+var { a = 0 } = bar
+function foo (a = 0) {}
+
+// "space-unary-ops": [ "error", { "words": true, "nonwords": false } ],
+delete foo.bar
+new Foo()
+void 0
+;-foo
+;+'3'
+++foo
+foo--
+
+// "spaced-comment": [
+//   "error",
+//   "always",
+//   {
+//     "line": { "markers": [ "*package", "!", "/", ",", "=" ] },
+//     "block": {
+//       "balanced": true,
+//       "markers": [ "*package", "!", ",", ":", "::", "flow-include" ],
+//       "exceptions": [ "*" ]
+//     }
+//   }
+// ],
+
+/* eslint spaced-comment: ["error", "always"] */
+// This is a comment with a whitespace at the beginning
+/* This is a comment with a whitespace at the beginning */
+/*
+ * This is a comment with a whitespace at the beginning
+ */
+/*
+This comment has a newline
+*/
+
+// "template-curly-spacing": [ "error", "never" ],
+;`hello, ${people.name}!`
+;`hello, ${
+  people.name.some.long.property.that.cannot.fit.in[80].characters.limit.for
+    .prettier
+}!`
+
+// "template-tag-spacing": [ "error", "never" ],
+func`Hello world`
+
+// "unicode-bom": [ "error", "never" ],
+var abc
+
+// "yield-star-spacing": [ "error", "both" ]
+function * generator () {
+  yield * other()
+}
+
+// "jsx-quotes": ["error", "prefer-single"],
+;() => <div foo='bar' />

--- a/tests/standard/flow/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/standard/flow/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,119 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`correct.js 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+standard: true
+                                                                                | printWidth
+=====================================input======================================
+type IdentityWrapper = {
+  func<T>(T): T
+}
+
+const identity2 = <T>(t: T): T => t
+
+const a = 1
+
+function identity<T> (value: T): T {
+  return value
+}
+
+interface Foo<T> {
+  getter(value: T): T;
+}
+
+class Example<T> implements Foo<T> {
+  value: T
+  getter (value: T): T {
+    return this.value
+  }
+  set setter (value: T) {
+    this.value = value
+  }
+}
+
+=====================================output=====================================
+type IdentityWrapper = {
+  func<T>(T): T
+}
+
+const identity2 = <T>(t: T): T => t
+
+const a = 1
+
+function identity<T> (value: T): T {
+  return value
+}
+
+interface Foo<T> {
+  getter(value: T): T;
+}
+
+class Example<T> implements Foo<T> {
+  value: T
+  getter (value: T): T {
+    return this.value
+  }
+  set setter (value: T) {
+    this.value = value
+  }
+}
+
+================================================================================
+`;
+
+exports[`incorrect.js 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+standard: true
+                                                                                | printWidth
+=====================================input======================================
+type IdentityWrapper = {
+  func <T>(T) :T
+}
+
+function identity <T>(value :T) :T {
+  return value
+}
+
+interface Foo <T>{
+  getter(value:T):T
+}
+
+class Example<T> implements Foo <T>{
+  value:T;
+  getter(value :T) :T {
+    return this.value
+  }
+  set setter(value :T) {
+    this.value = value
+  }
+}
+
+=====================================output=====================================
+type IdentityWrapper = {
+  func<T>(T): T
+}
+
+function identity<T> (value: T): T {
+  return value
+}
+
+interface Foo<T> {
+  getter(value: T): T;
+}
+
+class Example<T> implements Foo<T> {
+  value: T
+  getter (value: T): T {
+    return this.value
+  }
+  set setter (value: T) {
+    this.value = value
+  }
+}
+
+================================================================================
+`;

--- a/tests/standard/flow/correct.js
+++ b/tests/standard/flow/correct.js
@@ -1,0 +1,25 @@
+type IdentityWrapper = {
+  func<T>(T): T
+}
+
+const identity2 = <T>(t: T): T => t
+
+const a = 1
+
+function identity<T> (value: T): T {
+  return value
+}
+
+interface Foo<T> {
+  getter(value: T): T;
+}
+
+class Example<T> implements Foo<T> {
+  value: T
+  getter (value: T): T {
+    return this.value
+  }
+  set setter (value: T) {
+    this.value = value
+  }
+}

--- a/tests/standard/flow/incorrect.js
+++ b/tests/standard/flow/incorrect.js
@@ -1,0 +1,21 @@
+type IdentityWrapper = {
+  func <T>(T) :T
+}
+
+function identity <T>(value :T) :T {
+  return value
+}
+
+interface Foo <T>{
+  getter(value:T):T
+}
+
+class Example<T> implements Foo <T>{
+  value:T;
+  getter(value :T) :T {
+    return this.value
+  }
+  set setter(value :T) {
+    this.value = value
+  }
+}

--- a/tests/standard/flow/jsfmt.spec.js
+++ b/tests/standard/flow/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["flow"], { standard: true });

--- a/tests/standard/incorrect.js
+++ b/tests/standard/incorrect.js
@@ -1,0 +1,354 @@
+// "arrow-spacing": ["error", { "before": true, "after": true }]
+
+()=> {};
+() =>{};
+(a)=> {};
+(a) =>{};
+a =>a;
+a=> a;
+()=> {'\n'};
+() =>{'\n'};
+
+// "block-spacing": [ "error", "always" ],
+
+function foo() {return true;}
+if (foo) { bar = 0;}
+function baz() {let i = 0;
+  return i;
+}
+
+// "brace-style": [ "error", "1tbs", { "allowSingleLine": true } ],
+
+function foo()
+{
+  return true;
+}
+
+if (foo)
+{
+  bar();
+}
+
+try
+{
+  somethingRisky();
+} catch(e)
+{
+  handleError();
+}
+
+if (foo) {
+  bar();
+}
+else {
+  baz();
+}
+
+// "comma-spacing": [ "error", { "before": false, "after": true } ],
+
+var foo = 1 ,bar = 2;
+var arr = [1 , 2];
+var obj = {"foo": "bar" ,"baz": "qur"};
+foo(a ,b);
+new Foo(a ,b);
+function foo(a ,b){}
+a ,b
+
+// "eol-last": "error",
+// cannot be tested here, but true (Unix-style new lines)
+
+// "func-call-spacing": [ "error", "never" ],
+fn ();
+
+fn
+();
+
+// "generator-star-spacing": [ "error", { "before": true, "after": true } ],
+
+function* generator() {}
+var anonymous = function* () {};
+var shorthand = { * generator() {} };
+function *generator() {}
+var anonymous = function *() {};
+var shorthand = { *generator() {} };
+
+
+// "indent": [
+//   "error",
+//   2,
+//   {
+//     "SwitchCase": 1,
+//     "VariableDeclarator": 1,
+//     "outerIIFEBody": 1,
+//     "MemberExpression": 1,
+//     "FunctionDeclaration": { "parameters": 1, "body": 1 },
+//     "FunctionExpression": { "parameters": 1, "body": 1 },
+//     "CallExpression": { "arguments": 1 },
+//     "ArrayExpression": 1,
+//     "ObjectExpression": 1,
+//     "ImportDeclaration": 1,
+//     "flatTernaryExpressions": false,
+//     "ignoreComments": false
+//   }
+// ],
+
+// "key-spacing": [ "error", { "beforeColon": false, "afterColon": true } ],
+
+var obj = { "foo" : 42 };
+var obj = { "foo":42 };
+
+// "keyword-spacing": [ "error", { "before": true, "after": true } ],
+
+if (foo) {
+  //...
+}else if (bar) {
+  //...
+}else {
+  //...
+}
+
+// "no-multi-spaces": "error",
+
+var a =  1;
+if(foo   === "bar") {}
+a <<  b
+var arr = [1,  2];
+a ?  b: c
+
+// "no-multiple-empty-lines": [ "error", { "max": 1, "maxEOF": 0 } ],
+// cannot be tested here, but true
+
+// "no-trailing-spaces": "error",
+// cannot be tested here, but true
+
+// "no-whitespace-before-property": "error",
+
+foo [bar]
+foo. bar
+foo .bar
+foo. bar. baz
+foo. bar()
+  .baz()
+foo
+  .bar(). baz()
+
+// "object-curly-spacing": [ "error", "always" ],
+
+var obj = {'foo': 'bar'};
+var obj = {'foo': 'bar' };
+var obj = { baz: {'foo': 'qux'}, bar};
+var obj = {baz: { 'foo': 'qux' }, bar};
+var obj = {'foo': 'bar'
+};
+var obj = {
+  'foo':'bar'};
+var {x} = y;
+import {foo } from 'bar';
+
+// "object-property-newline": [ "error", { "allowMultiplePropertiesPerLine": true } ],
+
+const obj0 = { foo: "foo", bar: "bar", baz: "baz" };
+const obj1 = {
+  foo: "foo", bar: "bar", baz: "baz"
+};
+const obj2 = {
+  foo: "foo", bar: "bar",
+  baz: "baz"
+};
+const obj3 = {
+  [process.argv[3] ? "foo" : "bar"]: 0, baz: [
+    1,
+    2,
+    4,
+    8
+  ]
+};
+const a = "antidisestablishmentarianistically";
+const b = "yugoslavyalılaştırabildiklerimizdenmişsiniz";
+const obj4 = {a, b};
+const domain = process.argv[4];
+const obj5 = {
+  foo: "foo", [
+    domain.includes(":") ? "complexdomain" : "simpledomain"
+  ]: true};
+
+// "padded-blocks": [ "error", { "blocks": "never", "switches": "never", "classes": "never" } ],
+
+
+if (a) {
+
+  b();
+
+}
+
+if (a)
+{
+
+  b();
+
+}
+
+if (a) {
+
+  b();
+}
+
+if (a) {
+  b();
+
+}
+
+class  A {
+
+  constructor(){
+  }
+
+}
+
+switch (a) {
+
+  case 0: foo();
+
+}
+
+// "rest-spread-spacing": [ "error", "never" ],
+
+fn(... args)
+function fn(... args) { console.log(args); }
+let { x, y, ... z } = { x: 1, y: 2, a: 3, b: 4 };
+let n = { x, y, ... z };
+
+// "semi-spacing": [ "error", { "before": false, "after": true } ],
+
+var foo ;
+var foo;var bar;
+throw new Error("error") ;
+while (a) { break ; }
+for (i = 0 ; i < 10 ; i++) {}
+for (i = 0;i < 10;i++) {}
+
+// "space-before-blocks": [ "error", "always" ],
+
+if (a){
+    b();
+}
+
+function a(){}
+
+for (;;){
+    b();
+}
+
+try {} catch(a){}
+
+class Foo{
+  constructor(){}
+}
+
+// "space-before-function-paren": [ "error", "always" ],
+
+function foo() {
+    // ...
+}
+
+var bar = function() {
+    // ...
+};
+
+var bar = function foo() {
+    // ...
+};
+
+class Foo {
+    constructor() {
+        // ...
+    }
+}
+
+var foo = {
+    bar() {
+        // ...
+    }
+};
+
+var foo = async() => 1
+
+// "space-in-parens": [ "error", "never" ],
+
+foo( 'bar');
+foo('bar' );
+foo( 'bar' );
+
+var foo = ( 1 + 2 ) * 3;
+( function () { return 'bar'; }() );
+
+// "space-infix-ops": "error",
+
+a+b
+a+ b
+a +b
+a?b:c
+const a={b:1};
+var {a=0}=bar;
+function foo(a=0) { }
+
+// "space-unary-ops": [ "error", { "words": true, "nonwords": false } ],
+
+typeof!foo;
+void{foo:0};
+new[foo][0];
+delete(foo.bar);
+++ foo;
+foo --;
+- foo;
++ "3";
+
+// "spaced-comment": [
+//   "error",
+//   "always",
+//   {
+//     "line": { "markers": [ "*package", "!", "/", ",", "=" ] },
+//     "block": {
+//       "balanced": true,
+//       "markers": [ "*package", "!", ",", ":", "::", "flow-include" ],
+//       "exceptions": [ "*" ]
+//     }
+//   }
+// ],
+
+/*eslint spaced-comment: ["error", "always"]*/
+//This is a comment with no whitespace at the beginning
+/*This is a comment with no whitespace at the beginning */
+/* eslint spaced-comment: ["error", "always", { "block": { "balanced": true } }] */
+/* This is a comment with whitespace at the beginning but not the end*/
+
+// "template-curly-spacing": [ "error", "never" ],
+
+`hello, ${ people.name}!`;
+`hello, ${people.name }!`;
+`hello, ${ people.name }!`;
+
+// "template-tag-spacing": [ "error", "never" ],
+
+func `Hello world`;
+
+// "unicode-bom": [ "error", "never" ],
+
+U+FEFF
+var abc;
+
+// "yield-star-spacing": [ "error", "both" ]
+
+
+function *generator() {
+  yield *other();
+}
+function* generator() {
+  yield* other();
+}
+function*generator() {
+  yield*other();
+}
+
+// "jsx-quotes": ["error", "prefer-single"],
+;() => <div foo="bar" />

--- a/tests/standard/jsfmt.spec.js
+++ b/tests/standard/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["babel"], { standard: true });

--- a/tests/standard/typescript/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/standard/typescript/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,95 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`correct.ts 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+standard: true
+                                                                                | printWidth
+=====================================input======================================
+function identity<T> (value: T): T {
+  return value
+}
+
+interface Foo<T> {
+  getter(value: T): T
+}
+
+class Example<T> implements Foo<T> {
+  value: T
+  getter (value: T): T {
+    return this.value
+  }
+  set setter (value: T) {
+    this.value = value
+  }
+}
+
+=====================================output=====================================
+function identity<T> (value: T): T {
+  return value
+}
+
+interface Foo<T> {
+  getter(value: T): T
+}
+
+class Example<T> implements Foo<T> {
+  value: T
+  getter (value: T): T {
+    return this.value
+  }
+  set setter (value: T) {
+    this.value = value
+  }
+}
+
+================================================================================
+`;
+
+exports[`incorrect.ts 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+standard: true
+                                                                                | printWidth
+=====================================input======================================
+function identity <T>(value :T) :T {
+  return value
+}
+
+interface Foo <T>{
+  getter(value:T):T
+}
+
+class Example<T> implements Foo <T>{
+  value:T;
+  getter(value :T) :T {
+    return this.value
+  }
+  set setter(value :T) {
+    this.value = value
+  }
+}
+
+=====================================output=====================================
+function identity<T> (value: T): T {
+  return value
+}
+
+interface Foo<T> {
+  getter(value: T): T
+}
+
+class Example<T> implements Foo<T> {
+  value: T
+  getter (value: T): T {
+    return this.value
+  }
+  set setter (value: T) {
+    this.value = value
+  }
+}
+
+================================================================================
+`;

--- a/tests/standard/typescript/correct.ts
+++ b/tests/standard/typescript/correct.ts
@@ -1,0 +1,17 @@
+function identity<T> (value: T): T {
+  return value
+}
+
+interface Foo<T> {
+  getter(value: T): T
+}
+
+class Example<T> implements Foo<T> {
+  value: T
+  getter (value: T): T {
+    return this.value
+  }
+  set setter (value: T) {
+    this.value = value
+  }
+}

--- a/tests/standard/typescript/incorrect.ts
+++ b/tests/standard/typescript/incorrect.ts
@@ -1,0 +1,17 @@
+function identity <T>(value :T) :T {
+  return value
+}
+
+interface Foo <T>{
+  getter(value:T):T
+}
+
+class Example<T> implements Foo <T>{
+  value:T;
+  getter(value :T) :T {
+    return this.value
+  }
+  set setter(value :T) {
+    this.value = value
+  }
+}

--- a/tests/standard/typescript/jsfmt.spec.js
+++ b/tests/standard/typescript/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["typescript"], { standard: true });

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -82,6 +82,8 @@ Format options:
   --no-semi                Do not print semicolons, except at the beginning of lines which may need them.
   --single-quote           Use single quotes instead of double quotes.
                            Defaults to false.
+  --standard               Use standard rules for formatting.
+                           Defaults to false.
   --tab-width <int>        Number of spaces per indentation level.
                            Defaults to 2.
   --trailing-comma <none|es5|all>
@@ -230,6 +232,8 @@ Format options:
                            Defaults to preserve.
   --no-semi                Do not print semicolons, except at the beginning of lines which may need them.
   --single-quote           Use single quotes instead of double quotes.
+                           Defaults to false.
+  --standard               Use standard rules for formatting.
                            Defaults to false.
   --tab-width <int>        Number of spaces per indentation level.
                            Defaults to 2.

--- a/tests_integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/help-options.js.snap
@@ -490,6 +490,19 @@ Default: false
 
 exports[`show detailed usage with --help single-quote (write) 1`] = `Array []`;
 
+exports[`show detailed usage with --help standard (stderr) 1`] = `""`;
+
+exports[`show detailed usage with --help standard (stdout) 1`] = `
+"--standard
+
+  Use standard rules for formatting.
+
+Default: false
+"
+`;
+
+exports[`show detailed usage with --help standard (write) 1`] = `Array []`;
+
 exports[`show detailed usage with --help stdin (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help stdin (stdout) 1`] = `

--- a/tests_integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests_integration/__tests__/__snapshots__/schema.js.snap
@@ -303,6 +303,11 @@ in order for it to be formatted.",
           "description": "Use single quotes instead of double quotes.",
           "type": "boolean",
         },
+        "standard": Object {
+          "default": false,
+          "description": "Use standard rules for formatting.",
+          "type": "boolean",
+        },
         "tabWidth": Object {
           "default": 2,
           "description": "Number of spaces per indentation level.",

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -586,7 +586,22 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
       },
       \\"rangeEnd\\": Object {
         \\"default\\": Infinity,
-        \\"range\\": Object {"
+        \\"range\\": Object {
+@@ -126,10 +195,14 @@
+      },
+      \\"singleQuote\\": Object {
+        \\"default\\": false,
+        \\"type\\": \\"boolean\\",
+      },
++     \\"standard\\": Object {
++       \\"default\\": false,
++       \\"type\\": \\"boolean\\",
++     },
+      \\"tabWidth\\": Object {
+        \\"default\\": 2,
+        \\"range\\": Object {
+          \\"end\\": Infinity,
+          \\"start\\": 0,"
 `;
 
 exports[`CLI --support-info (stderr) 1`] = `""`;
@@ -1219,6 +1234,15 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"name\\": \\"singleQuote\\",
       \\"pluginDefaults\\": {},
       \\"since\\": \\"0.0.0\\",
+      \\"type\\": \\"boolean\\"
+    },
+    {
+      \\"category\\": \\"JavaScript\\",
+      \\"default\\": false,
+      \\"description\\": \\"Use standard rules for formatting.\\",
+      \\"name\\": \\"standard\\",
+      \\"pluginDefaults\\": {},
+      \\"since\\": \\"1.16.0\\",
       \\"type\\": \\"boolean\\"
     },
     {


### PR DESCRIPTION
- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

Hello prettier,

I am the author of [prettier-standard](https://github.com/sheerun/prettier-standard) library that tries to be similar to prettier while maintaining compatibility with [standard](https://standardjs.com/) that has been present for some time before prettier. Standard is still used by many developers and its rules are preferred by many developers (equivalents of --no-semi --single-quote --jsx-single-quote like + not implemented --space-before-function-paren).

While I enjoy github stars \s prettier-standard is not a perfect solution because it needs to pass every file first through prettier and then though eslint with standard whitespace rules. This makes this process very slow. Ideally this functionality would be embedded within prettier itself so developers can just write `prettier --standard` instead of `prettier-standard`. I would gladly deprecate my package and point to new prettier version if you agreed to merge this PR.

[There's](https://github.com/prettier/prettier/issues/3845) [discussion](https://github.com/prettier/prettier/issues/3847) [whether](https://github.com/prettier/prettier/issues/1139) introduce extra flag for inserting space before function name or anonymous function, this won't make prettier compatible with standard as there are many more nuances like spaces around generator stars. This PR introduces `--standard` flag that has single purpose: make prettier format code as such running `standard` after it won't complain about formatting of code. I think it's good measure to not introduce many flags into prettier and at the same time satisfy people who even start to [fork](https://github.com/brodybits/prettierx) [this](https://github.com/arijs/prettier-miscellaneous) project.

I've gathered all whitespace-related rules of standard and added tests for each of them from straight from eslint docs (both correct ones and incorrect ones). I've also included compatibility with the way standard wants to format typescript and flow. You can verify that with this flag formatting is compatible with standard by running following commands or visually inspecting new tests:

```bash
# verifies that es6 example is compatible with standard (nothing changes)
standard --parser babel-eslint --fix tests/standard/correct.js # nothing changes
diff tests/standard/correct.js <(node bin/prettier.js --standard tests/standard/correct.js)
```

```bash
# verifies that typescript example is compatible with standard (nothing changes)
standard --parser typescript-eslint-parser --plugin typescript --fix tests/standard/typescript/correct.ts 
diff tests/standard/typescript/correct.ts <(node bin/prettier.js --standard tests/standard/typescript/correct.ts)
```

```bash
# verifies that flow example is compatible with standard (nothing changes)
standard --parser babel-eslint --plugin flowtype --fix tests/standard/flow/correct.js
diff tests/standard/flow/correct.js <(node bin/prettier.js --standard tests/standard/flow/correct.js)
```

You can find more information how to configure standard for flow & typescript on their home page.

What do you think? This could potentially be last and final flag to satisfy standard.js camp.