### PR TITLE
typescript: remove unneeded parentheses around type annotation

### DIFF
--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -339,7 +339,6 @@ function needsParens(path, options) {
           parent.type === "GenericTypeAnnotation" ||
           parent.type === "TSTypeReference") &&
         (node.typeAnnotation.type === "TSTypeAnnotation" &&
-          node.typeAnnotation.typeAnnotation.type !== "TSFunctionType" &&
           grandParent.type !== "TSTypeOperator" &&
           grandParent.type !== "TSOptionalType")
       ) {

--- a/tests/typescript/conformance/types/functions/TSFunctionTypeNoUnnecessaryParentheses.ts
+++ b/tests/typescript/conformance/types/functions/TSFunctionTypeNoUnnecessaryParentheses.ts
@@ -1,0 +1,3 @@
+class Foo {
+  bar: (() => boolean);
+}

--- a/tests/typescript/conformance/types/functions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/functions/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TSFunctionTypeNoUnnecessaryParentheses.ts 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+class Foo {
+  bar: (() => boolean);
+}
+=====================================output=====================================
+class Foo {
+  bar: () => boolean;
+}
+
+================================================================================
+`;
+
 exports[`functionImplementationErrors.ts 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fixes  #5247. I added a test, not sure I put it in the right folder though.
<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
