### PR TITLE
chore(azure): test node v6 in dev build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,12 +28,16 @@ jobs:
       - template: .azure-pipelines/jobs/dev-test.yml
 
   - job: Dev_Test_macOS
-    displayName: Dev Test on macOS Node v10
+    displayName: Dev Test on macOS
     pool:
       vmImage: macos-10.13
-    variables:
-      node_version: 10
-      ENABLE_CODE_COVERAGE: true
+    strategy:
+      matrix:
+        Node_v6: # node v6 is the min supported version in development
+          node_version: 6
+        Node_v10:
+          node_version: 10
+          ENABLE_CODE_COVERAGE: true
     steps:
       - template: .azure-pipelines/jobs/dev-test.yml
 
@@ -82,7 +86,7 @@ jobs:
       vmImage: macos-10.13
     strategy:
       matrix:
-        Node_v4:
+        Node_v4: # node v4 is the min supported version in production
           node_version: 4
           ENABLE_TEST_RESULTS: "" # jest-junit requires node v6+
         Node_v10:


### PR DESCRIPTION
Ensure `npm install prettier/prettier` works for node v6.

https://github.com/prettier/prettier/blob/e83490a90e1bff03fe52d2e83be0799d430444c9/package.json#L14

- I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
