### PR TITLE
fix(javascript): skip .connect() method when composing fun

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3852,12 +3852,18 @@ const functionCompositionFunctionNames = new Set([
   "connect", // Redux
   "createSelector" // Reselect
 ]);
+const ordinaryMethodNames = new Set([
+  "connect" // GObject, MongoDB
+]);
 
 function isFunctionCompositionFunction(node) {
   switch (node.type) {
     case "OptionalMemberExpression":
     case "MemberExpression": {
-      return isFunctionCompositionFunction(node.property);
+      return (
+        isFunctionCompositionFunction(node.property) &&
+        !ordinaryMethodNames.has(node.property.name)
+      );
     }
     case "Identifier": {
       return functionCompositionFunctionNames.has(node.name);

--- a/tests/functional_composition/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/functional_composition/__snapshots__/jsfmt.spec.js.snap
@@ -115,6 +115,34 @@ this.subscriptions.add(
 ================================================================================
 `;
 
+exports[`gobject_connect.js 1`] = `
+====================================options=====================================
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+button.connect(
+  "clicked",
+  () => doSomething()
+);
+app.connect(
+  "activate",
+  async () => {
+    await data.load();
+    win.show_all();
+  }
+);
+
+=====================================output=====================================
+button.connect("clicked", () => doSomething());
+app.connect("activate", async () => {
+  await data.load();
+  win.show_all();
+});
+
+================================================================================
+`;
+
 exports[`lodash_flow.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "babel", "typescript"]
@@ -211,6 +239,29 @@ const foo = _.flowRight(
 );
 
 foo(6);
+
+================================================================================
+`;
+
+exports[`mongo_connect.js 1`] = `
+====================================options=====================================
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+MongoClient.connect(
+  "mongodb://localhost:27017/posts",
+  (err, db) => {
+    assert.equal(null, err);
+    db.close();
+  }
+);
+
+=====================================output=====================================
+MongoClient.connect("mongodb://localhost:27017/posts", (err, db) => {
+  assert.equal(null, err);
+  db.close();
+});
 
 ================================================================================
 `;

--- a/tests/functional_composition/gobject_connect.js
+++ b/tests/functional_composition/gobject_connect.js
@@ -1,0 +1,11 @@
+button.connect(
+  "clicked",
+  () => doSomething()
+);
+app.connect(
+  "activate",
+  async () => {
+    await data.load();
+    win.show_all();
+  }
+);

--- a/tests/functional_composition/mongo_connect.js
+++ b/tests/functional_composition/mongo_connect.js
@@ -1,0 +1,7 @@
+MongoClient.connect(
+  "mongodb://localhost:27017/posts",
+  (err, db) => {
+    assert.equal(null, err);
+    db.close();
+  }
+);


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fixes #4935. Checks a member expression property against an ordinary method name blacklist, after the property has found a match in the existing set of function composer names.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**