### PR TITLE
docs: remove redundant "./" from relative links (#5740)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -86,7 +86,7 @@ As you repeatedly call `resolveConfig`, the file system structure will be cached
 
 Setting `options.ignorePath` (`string`) and `options.withNodeModules` (`boolean`) influence the value of `ignored` (`false` by default).
 
-Providing [plugin](./plugins.md) paths in `options.plugins` (`string[]`) helps extract `inferredParser` for files that are not supported by Prettier core.
+Providing [plugin](plugins.md) paths in `options.plugins` (`string[]`) helps extract `inferredParser` for files that are not supported by Prettier core.
 
 Use `prettier.getFileInfo.sync(filePath [, options])` if you'd like to use sync version.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,7 +51,7 @@ Human-friendly status messages help project contributors react on possible probl
 To minimise the number of times `prettier --check` finds unformatted files, you may be interested in configuring a [pre-commit hook](precommit.md) in your repo.
 Applying this practice will minimise the number of times the CI fails because of code formatting problems.
 
-If you need to pipe the list of unformatted files to another command, you can use [`--list-different`](./cli.md#list-different) flag instead of `--check`.
+If you need to pipe the list of unformatted files to another command, you can use [`--list-different`](cli.md#list-different) flag instead of `--check`.
 
 ## `--debug-check`
 
@@ -104,7 +104,7 @@ Another useful flag is `--list-different` (or `-l`) which prints the filenames o
 prettier --single-quote --list-different "src/**/*.js"
 ```
 
-You can also use [`--check`](./cli.md#check) flag, which works the same way as `--list-different`, but also prints a human-friendly summary message to stdout.
+You can also use [`--check`](cli.md#check) flag, which works the same way as `--list-different`, but also prints a human-friendly summary message to stdout.
 
 ## `--no-config`
 
@@ -130,7 +130,7 @@ This option adds support to editor integrations where users define their default
 
 ## `--no-editorconfig`
 
-Don't take .editorconfig into account when parsing configuration. See the [`prettier.resolveConfig` docs](./api.md) for details.
+Don't take .editorconfig into account when parsing configuration. See the [`prettier.resolveConfig` docs](api.md) for details.
 
 ## `--with-node-modules`
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -310,8 +310,8 @@ Doing so produces a large `git diff`, and if it get unnoticed during code review
 If you want to make sure that your git repository only contains Linux-style line endings in files covered by Prettier:
 
 1. Set `endOfLine` option to `lf`
-1. Configure [a pre-commit hook](./precommit.md) that will run Prettier
-1. Configure Prettier to run in your CI pipeline using [`--check` flag](./cli.md#check)
+1. Configure [a pre-commit hook](precommit.md) that will run Prettier
+1. Configure Prettier to run in your CI pipeline using [`--check` flag](cli.md#check)
 1. Ask Windows users to run `git config core.autocrlf false` before working on your repo so that git did not convert `LF` to `CRLF` on checkout.
    Alternatively, you can add `* text=auto eol=lf` to the repo's `.gitattributes` file to achieve this.
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -15,7 +15,7 @@ Plugins are automatically loaded if you have them installed in the same `node_mo
 
 When plugins cannot be found automatically, you can load them with:
 
-- The [CLI](./cli.md), via the `--plugin` and `--plugin-search-dir`:
+- The [CLI](cli.md), via the `--plugin` and `--plugin-search-dir`:
 
   ```bash
   prettier --write main.foo --plugin-search-dir=./dir-with-plugins --plugin=./foo-plugin
@@ -23,7 +23,7 @@ When plugins cannot be found automatically, you can load them with:
 
   > Tip: You can set `--plugin` or `--plugin-search-dir` options multiple times.
 
-- Or the [API](./api.md), via the `plugins` and `pluginSearchDirs` options:
+- Or the [API](api.md), via the `plugins` and `pluginSearchDirs` options:
 
   ```js
   prettier.format("code", {
@@ -64,7 +64,7 @@ Prettier plugins are regular JavaScript modules with five exports:
 
 ### `languages`
 
-Languages is an array of language definitions that your plugin will contribute to Prettier. It can include all of the fields specified in [`prettier.getSupportInfo()`](./api.md#prettiergetsupportinfo-version).
+Languages is an array of language definitions that your plugin will contribute to Prettier. It can include all of the fields specified in [`prettier.getSupportInfo()`](api.md#prettiergetsupportinfo-version).
 
 It **must** include `name` and `parsers`.
 

--- a/website/versioned_docs/version-stable/api.md
+++ b/website/versioned_docs/version-stable/api.md
@@ -87,7 +87,7 @@ As you repeatedly call `resolveConfig`, the file system structure will be cached
 
 Setting `options.ignorePath` (`string`) and `options.withNodeModules` (`boolean`) influence the value of `ignored` (`false` by default).
 
-Providing [plugin](./plugins.md) paths in `options.plugins` (`string[]`) helps extract `inferredParser` for files that are not supported by Prettier core.
+Providing [plugin](plugins.md) paths in `options.plugins` (`string[]`) helps extract `inferredParser` for files that are not supported by Prettier core.
 
 Use `prettier.getFileInfo.sync(filePath [, options])` if you'd like to use sync version.
 

--- a/website/versioned_docs/version-stable/cli.md
+++ b/website/versioned_docs/version-stable/cli.md
@@ -97,7 +97,7 @@ This option adds support to editor integrations where users define their default
 
 ## `--no-editorconfig`
 
-Don't take .editorconfig into account when parsing configuration. See the [`prettier.resolveConfig` docs](./api.md) for details.
+Don't take .editorconfig into account when parsing configuration. See the [`prettier.resolveConfig` docs](api.md) for details.
 
 ## `--with-node-modules`
 

--- a/website/versioned_docs/version-stable/options.md
+++ b/website/versioned_docs/version-stable/options.md
@@ -310,7 +310,7 @@ Doing so produces a large `git diff`, and if it get unnoticed during code review
 If you want to make sure that your git repository only contains Linux-style line endings in files covered by Prettier:
 
 1. Set `endOfLine` option to `lf`
-1. Configure [a pre-commit hook](./precommit.md) that will run Prettier
+1. Configure [a pre-commit hook](precommit.md) that will run Prettier
 1. Configure Prettier to run in your CI pipeline (e.g. using [`prettier-check` npm package](https://www.npmjs.com/package/prettier-check))
 1. Ask Windows users to run `git config core.autocrlf false` before working on your repo so that git did not convert `LF` to `CRLF` on checkout.
    Alternatively, you can add `* text=auto eol=lf` to the repo's `.gitattributes` file to achieve this.

--- a/website/versioned_docs/version-stable/plugins.md
+++ b/website/versioned_docs/version-stable/plugins.md
@@ -16,7 +16,7 @@ Plugins are automatically loaded if you have them installed in the same `node_mo
 
 When plugins cannot be found automatically, you can load them with:
 
-- The [CLI](./cli.md), via the `--plugin` and `--plugin-search-dir`:
+- The [CLI](cli.md), via the `--plugin` and `--plugin-search-dir`:
 
   ```bash
   prettier --write main.foo --plugin-search-dir=./dir-with-plugins --plugin=./foo-plugin
@@ -24,7 +24,7 @@ When plugins cannot be found automatically, you can load them with:
 
   > Tip: You can set `--plugin` or `--plugin-search-dir` options multiple times.
 
-- Or the [API](./api.md), via the `plugins` and `pluginSearchDirs` options:
+- Or the [API](api.md), via the `plugins` and `pluginSearchDirs` options:
 
   ```js
   prettier.format("code", {
@@ -64,7 +64,7 @@ Prettier plugins are regular JavaScript modules with five exports:
 
 ### `languages`
 
-Languages is an array of language definitions that your plugin will contribute to Prettier. It can include all of the fields specified in [`prettier.getSupportInfo()`](./api.md#prettiergetsupportinfo-version).
+Languages is an array of language definitions that your plugin will contribute to Prettier. It can include all of the fields specified in [`prettier.getSupportInfo()`](api.md#prettiergetsupportinfo-version).
 
 It **must** include `name` and `parsers`.
 


### PR DESCRIPTION
Removed the redundant relative paths to fix broken links on build. This was done with the following command:
```sh
sed -i "s#(\./#(#" docs/*.md website/versioned_docs/version-stable/*.md
```

This commit also removed the following warnings thrown by the `yarn run build-docs` script:

```
 [WARN] unresolved links in file 'version-stable/cli.md' > [ './api.md' ]
 [WARN] unresolved links in file 'version-stable/options.md' > [ './precommit.md' ]
 [WARN] unresolved links in file 'version-stable/api.md' > [ './plugins.md' ]
 [WARN] unresolved links in file 'version-stable/cli.md' > [ './api.md' ]
```

Maybe a `build-docs` job should be added to the CI to catch these warnings in the future?

- [ ] ~~I’ve added tests to confirm my change works.~~
- [ ] ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~~
- [x] I’ve built the site locally to make sure the links now work
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

~~**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**~~
