### PR TITLE
docs: fix Windows build (#5742)

### DIFF
--- a/scripts/build-docs.js
+++ b/scripts/build-docs.js
@@ -29,8 +29,8 @@ if (isPullRequest) {
   shell.exec("yarn build");
   pipe(JSON.stringify(pkg, null, 2)).to("package.json"); // restore
 }
-shell.exec(`cp ${prettierPath}/standalone.js ${docs}/`);
-shell.exec(`cp ${prettierPath}/parser-*.js ${docs}/`);
+shell.cp(`${prettierPath}/standalone.js`, `${docs}/`);
+shell.cp(`${prettierPath}/parser-*.js`, `${docs}/`);
 
 // --- Site ---
 shell.cd("website");


### PR DESCRIPTION
Fixes #5742. Instead of relying on the Linux style `cp` command, this commits takes advantage of the multi-platform [`shelljs.cp`](http://documentup.com/shelljs/shelljs#cpoptions-source--source--dest) command. 

This also fixes building from a path containing spaces, as `__dirname` was not previously escaped.

- [ ] ~~I’ve added tests to confirm my change works.~~
- [ ] ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

~~**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**~~
