### PR TITLE
fix(ignore): ignore nodes preceded by comment with @prettier-ignore

### DIFF
--- a/docs/ignore.md
+++ b/docs/ignore.md
@@ -44,6 +44,20 @@ matrix(
 )
 ```
 
+To ensure compatibility with JSDoc, `@prettier-ignore` in a multi-line comment block will also exclude the next node.
+
+For example:
+
+<!-- prettier-ignore -->
+```js
+/**
+ * @param {string} str 
+ * @return string
+ * @prettier-ignore
+ */
+function  uglyUpperCase  (  str ) { return str.toUpperCase()   }
+```
+
 ## JSX
 
 ```jsx

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -606,7 +606,11 @@ function hasNodeIgnoreComment(node) {
     node &&
     node.comments &&
     node.comments.length > 0 &&
-    node.comments.some(comment => comment.value.trim() === "prettier-ignore")
+    node.comments.some(
+      comment =>
+        comment.value.trim() === "prettier-ignore" ||
+        comment.value.includes("@prettier-ignore")
+    )
   );
 }
 

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -34,7 +34,10 @@ function ensureAllCommentsPrinted(astComments) {
   }
 
   for (let i = 0; i < astComments.length; ++i) {
-    if (astComments[i].value.trim() === "prettier-ignore") {
+    if (
+      astComments[i].value.trim() === "prettier-ignore" ||
+      astComments[i].value.includes("@prettier-ignore")
+    ) {
       // If there's a prettier-ignore, we're not printing that sub-tree so we
       // don't know if the comments was printed or not.
       return;

--- a/tests/ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ignore/__snapshots__/jsfmt.spec.js.snap
@@ -75,6 +75,50 @@ const response = {
   '_text': 'Turn on the lights',
   intent: 'lights',
 };
+/**
+ * @param {string} str
+ * @return string
+ * @prettier-ignore
+ */
+function  uglyUpperCase  (  str ) { return str.toUpperCase()   }
+
+/**
+ * Constants of ranking
+ * @prettier-ignore
+ * @deprecated
+ */
+export const RankingConstant = {
+  KEY_DAILY_RANKING  : 'DAILY_RANKING',   // Key of daily ranking
+  KEY_WEEKLY_RANKING : 'WEEKLY_RANKING',  // Key of weekly ranking
+  KEY_MONTHLY_RANKING: 'MONTHLY_RANKING', // Key of monthly ranking
+  LIMIT_OF_PAGE      : 50,                // Limit of page
+  MAX_PAGE           : 100,               // Max page
+};
+
+/* some text @prettier-ignore around the ignore */
+const moreCommentsWithPrettierIgnore =   {
+  "ewww":
+    "gross-formatting",
+};
+
+// you can use @prettier-ignore to have a more lenient parsing
+const evenMorecommentsWithPrettierIgnore =   {
+  "ewww":
+    "gross-formatting",
+};
+
+// this doesn't work without prefixing with an @ prettier-ignore
+const fixedGrossFormatting =   {
+  "ewww":
+    "gross-formatting",
+};
+
+// prettier-ignore even if the comments starts out with it
+const moreFixedGrossFormatting =   {
+  "ewww":
+    "gross-formatting",
+};
+
 
 =====================================output=====================================
 function a() {
@@ -144,6 +188,47 @@ const response = {
   // prettier-ignore
   '_text': 'Turn on the lights',
   intent: "lights"
+};
+/**
+ * @param {string} str
+ * @return string
+ * @prettier-ignore
+ */
+function  uglyUpperCase  (  str ) { return str.toUpperCase()   }
+
+/**
+ * Constants of ranking
+ * @prettier-ignore
+ * @deprecated
+ */
+export const RankingConstant = {
+  KEY_DAILY_RANKING  : 'DAILY_RANKING',   // Key of daily ranking
+  KEY_WEEKLY_RANKING : 'WEEKLY_RANKING',  // Key of weekly ranking
+  KEY_MONTHLY_RANKING: 'MONTHLY_RANKING', // Key of monthly ranking
+  LIMIT_OF_PAGE      : 50,                // Limit of page
+  MAX_PAGE           : 100,               // Max page
+};
+
+/* some text @prettier-ignore around the ignore */
+const moreCommentsWithPrettierIgnore =   {
+  "ewww":
+    "gross-formatting",
+};
+
+// you can use @prettier-ignore to have a more lenient parsing
+const evenMorecommentsWithPrettierIgnore =   {
+  "ewww":
+    "gross-formatting",
+};
+
+// this doesn't work without prefixing with an @ prettier-ignore
+const fixedGrossFormatting = {
+  ewww: "gross-formatting"
+};
+
+// prettier-ignore even if the comments starts out with it
+const moreFixedGrossFormatting = {
+  ewww: "gross-formatting"
 };
 
 ================================================================================

--- a/tests/ignore/ignore.js
+++ b/tests/ignore/ignore.js
@@ -67,3 +67,47 @@ const response = {
   '_text': 'Turn on the lights',
   intent: 'lights',
 };
+/**
+ * @param {string} str
+ * @return string
+ * @prettier-ignore
+ */
+function  uglyUpperCase  (  str ) { return str.toUpperCase()   }
+
+/**
+ * Constants of ranking
+ * @prettier-ignore
+ * @deprecated
+ */
+export const RankingConstant = {
+  KEY_DAILY_RANKING  : 'DAILY_RANKING',   // Key of daily ranking
+  KEY_WEEKLY_RANKING : 'WEEKLY_RANKING',  // Key of weekly ranking
+  KEY_MONTHLY_RANKING: 'MONTHLY_RANKING', // Key of monthly ranking
+  LIMIT_OF_PAGE      : 50,                // Limit of page
+  MAX_PAGE           : 100,               // Max page
+};
+
+/* some text @prettier-ignore around the ignore */
+const moreCommentsWithPrettierIgnore =   {
+  "ewww":
+    "gross-formatting",
+};
+
+// you can use @prettier-ignore to have a more lenient parsing
+const evenMorecommentsWithPrettierIgnore =   {
+  "ewww":
+    "gross-formatting",
+};
+
+// this doesn't work without prefixing with an @ prettier-ignore
+const fixedGrossFormatting =   {
+  "ewww":
+    "gross-formatting",
+};
+
+// prettier-ignore even if the comments starts out with it
+const moreFixedGrossFormatting =   {
+  "ewww":
+    "gross-formatting",
+};
+


### PR DESCRIPTION
Fixes #5268. Ignores nodes that were preceded by any comment containing `@prettier-ignore`:

```js
/**
 * @param {string} str
 * @return string
 * @prettier-ignore
 */
function  uglyUpperCase  (  str ) { return str.toUpperCase()   }
```

To simplify the docs, I've only mentioned the only JSDoc use case. However, this change also includes `// single line comments` and `/* single line block comments */`.

- [x] I’ve added tests to confirm my change works.
- [x] I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
