### PR TITLE
fix(javascript): remove unnecessary linebreaks from html templates

### DIFF
--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -610,18 +610,8 @@ function printHtmlTemplateLiteral(path, print, textToDoc, parser) {
         }
 
         const placeholderIndex = +component;
-
         parts.push(
-          concat([
-            "${",
-            group(
-              concat([
-                indent(concat([softline, expressionDocs[placeholderIndex]])),
-                softline
-              ])
-            ),
-            "}"
-          ])
+          concat(["${", group(expressionDocs[placeholderIndex]), "}"])
         );
       }
 

--- a/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
@@ -122,13 +122,11 @@ html\`
 function HelloWorld() {
   return html\`
     <h3>Bar List</h3>
-    \${
-      bars.map(
-        bar => html\`
-          <p>\${bar}</p>
-        \`
-      )
-    }
+    \${bars.map(
+      bar => html\`
+        <p>\${bar}</p>
+      \`
+    )}
   \`;
 }
 

--- a/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
@@ -59,6 +59,15 @@ html\`  <\${Footer}  >footer      content<//     >  \`
 
 html\`  <div />  \`
 
+function HelloWorld() {
+  return html\`
+    <h3>Bar List</h3>
+    \${bars.map(bar => html\`
+       <p>\${bar}</p>
+    \`)}
+  \`;
+}
+
 =====================================output=====================================
 import { LitElement, html } from "@polymer/lit-element";
 
@@ -109,6 +118,19 @@ html\`
 html\`
   <div />
 \`;
+
+function HelloWorld() {
+  return html\`
+    <h3>Bar List</h3>
+    \${
+      bars.map(
+        bar => html\`
+          <p>\${bar}</p>
+        \`
+      )
+    }
+  \`;
+}
 
 ================================================================================
 `;

--- a/tests/multiparser_js_html/lit-html.js
+++ b/tests/multiparser_js_html/lit-html.js
@@ -50,3 +50,12 @@ html`<my-element obj=${obj}></my-element>`;
 html`  <${Footer}  >footer      content<//     >  `
 
 html`  <div />  `
+
+function HelloWorld() {
+  return html`
+    <h3>Bar List</h3>
+    ${bars.map(bar => html`
+       <p>${bar}</p>
+    `)}
+  `;
+}


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fixes #5672
<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
