### PR TITLE
fix(api): do not report the same deprecation warning more than once

### DIFF
--- a/src/main/options-normalizer.js
+++ b/src/main/options-normalizer.js
@@ -46,6 +46,8 @@ class FlagSchema extends vnopts.ChoiceSchema {
   }
 }
 
+let hasDeprecationWarned;
+
 function normalizeOptions(
   options,
   optionInfos,
@@ -60,7 +62,25 @@ function normalizeOptions(
 
   const descriptor = isCLI ? cliDescriptor : vnopts.apiDescriptor;
   const schemas = optionInfosToSchemas(optionInfos, { isCLI });
-  return vnopts.normalize(options, schemas, { logger, unknown, descriptor });
+  const normalizer = new vnopts.Normalizer(schemas, {
+    logger,
+    unknown,
+    descriptor
+  });
+
+  const shouldSuppressDuplicateDeprecationWarnings = logger !== false;
+
+  if (shouldSuppressDuplicateDeprecationWarnings && hasDeprecationWarned) {
+    normalizer._hasDeprecationWarned = hasDeprecationWarned;
+  }
+
+  const normalized = normalizer.normalize(options);
+
+  if (shouldSuppressDuplicateDeprecationWarnings) {
+    hasDeprecationWarned = normalizer._hasDeprecationWarned;
+  }
+
+  return normalized;
 }
 
 function optionInfosToSchemas(optionInfos, { isCLI }) {

--- a/tests_integration/__tests__/__snapshots__/deprecated-parser.js.snap
+++ b/tests_integration/__tests__/__snapshots__/deprecated-parser.js.snap
@@ -1,10 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`API format with deprecated parser (babylon) should work 1`] = `
-"{ parser: \\"babylon\\" } is deprecated; we now treat it as { parser: \\"babel\\" }.
-"
-`;
-
 exports[`API format with deprecated parser (postcss) should work 1`] = `
 "{ parser: \\"postcss\\" } is deprecated; we now treat it as { parser: \\"css\\" }.
 "

--- a/tests_integration/__tests__/deprecated-parser.js
+++ b/tests_integration/__tests__/deprecated-parser.js
@@ -25,9 +25,14 @@ test("API format with deprecated parser (postcss) should work", () => {
   expect(warnings).toMatchSnapshot();
 });
 
-test("API format with deprecated parser (babylon) should work", () => {
-  expect(() =>
-    prettier.format("hello_world( )", { parser: "babylon" })
-  ).not.toThrowError();
-  expect(warnings).toMatchSnapshot();
+test("API format with deprecated parser (babylon) should work and do not report the same deprecation warning more than once", () => {
+  expect(() => {
+    prettier.format("hello_world( )", { parser: "babylon" });
+    prettier.format("hello_world( )", { parser: "babylon" });
+  }).not.toThrowError();
+  expect(warnings).toMatchInlineSnapshot(`
+"{ parser: \\"babylon\\" } is deprecated; we now treat it as { parser: \\"babel\\" }.
+{ parser: \\"babylon\\" } is deprecated; we now treat it as { parser: \\"babel\\" }.
+"
+`);
 });

--- a/tests_integration/__tests__/deprecated-parser.js
+++ b/tests_integration/__tests__/deprecated-parser.js
@@ -32,7 +32,6 @@ test("API format with deprecated parser (babylon) should work and do not report 
   }).not.toThrowError();
   expect(warnings).toMatchInlineSnapshot(`
 "{ parser: \\"babylon\\" } is deprecated; we now treat it as { parser: \\"babel\\" }.
-{ parser: \\"babylon\\" } is deprecated; we now treat it as { parser: \\"babel\\" }.
 "
 `);
 });


### PR DESCRIPTION
A quick fix for suppressing duplicate deprecation warnings.

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
