### PR TITLE
Fix typo

### DIFF
--- a/website/blog/2019-01-20-1.16.0.md
+++ b/website/blog/2019-01-20-1.16.0.md
@@ -409,7 +409,7 @@ issue in Prettier 1.16.
 
 ### CSS
 
-#### Fix broken output for lists casued by comments ([#5710] by [@jsnajdr])
+#### Fix broken output for lists caused by comments ([#5710] by [@jsnajdr])
 
 <!-- prettier-ignore -->
 ```scss


### PR DESCRIPTION
Thanks for your continued effort on Prettier!

This PR just fixes a typo in the blog post for the 1.16 release notes.
