### PR TITLE
fix(typescript): stable parens for function type in arrow return type

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -121,8 +121,34 @@ Examples:
   _foo <InlineJSX /> bar_
   ```
 
+- TypeScript: Stable parentheses for function type in the return type of arrow function ([#5790] by [@ikatyang])
+
+  There's a regression introduced in 1.16 that
+  parentheses for function type in the return type of arrow function were kept adding/removing.
+  Their parentheses are always printed now.
+
+  <!-- prettier-ignore -->
+  ```ts
+  // Input
+  const foo = (): (() => void) => (): void => null;
+  const bar = (): () => void => (): void => null;
+
+  // First Output (Prettier stable)
+  const foo = (): () => void => (): void => null;
+  const bar = (): (() => void) => (): void => null;
+
+  // Second Output (Prettier stable)
+  const foo = (): (() => void) => (): void => null;
+  const bar = (): () => void => (): void => null;
+
+  // Output (Prettier master)
+  const foo = (): (() => void) => (): void => null;
+  const bar = (): (() => void) => (): void => null;
+  ```
+
 [@ikatyang]: https://github.com/ikatyang
 [@simenb]: https://github.com/SimenB
 [#5778]: https://github.com/prettier/prettier/pull/5778
 [#5783]: https://github.com/prettier/prettier/pull/5783
 [#5785]: https://github.com/prettier/prettier/pull/5785
+[#5790]: https://github.com/prettier/prettier/pull/5790

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -353,6 +353,20 @@ function needsParens(path, options) {
 
     case "TSParenthesizedType": {
       const grandParent = path.getParentNode(1);
+
+      /**
+       * const foo = (): (() => void) => (): void => null;
+       *                 ^          ^
+       */
+      if (
+        getUnparenthesizedNode(node).type === "TSFunctionType" &&
+        parent.type === "TSTypeAnnotation" &&
+        grandParent.type === "ArrowFunctionExpression" &&
+        grandParent.returnType === parent
+      ) {
+        return true;
+      }
+
       if (
         (parent.type === "TSTypeParameter" ||
           parent.type === "TypeParameter" ||
@@ -717,6 +731,12 @@ function isStatement(node) {
     node.type === "WhileStatement" ||
     node.type === "WithStatement"
   );
+}
+
+function getUnparenthesizedNode(node) {
+  return node.type === "TSParenthesizedType"
+    ? getUnparenthesizedNode(node.typeAnnotation)
+    : node;
 }
 
 function endsWithRightBracket(node) {

--- a/tests/typescript_function_type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_function_type/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`type-annotation.ts 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const foo = (): () => void => (): void => null;
+const bar = (): (() => void) => (): void => null;
+const baz = (): ((() => void)) => (): void => null;
+
+=====================================output=====================================
+const foo = (): (() => void) => (): void => null;
+const bar = (): () => void => (): void => null;
+const baz = (): () => void => (): void => null;
+
+================================================================================
+`;

--- a/tests/typescript_function_type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_function_type/__snapshots__/jsfmt.spec.js.snap
@@ -12,8 +12,8 @@ const baz = (): ((() => void)) => (): void => null;
 
 =====================================output=====================================
 const foo = (): (() => void) => (): void => null;
-const bar = (): () => void => (): void => null;
-const baz = (): () => void => (): void => null;
+const bar = (): (() => void) => (): void => null;
+const baz = (): (() => void) => (): void => null;
 
 ================================================================================
 `;

--- a/tests/typescript_function_type/jsfmt.spec.js
+++ b/tests/typescript_function_type/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["typescript"]);

--- a/tests/typescript_function_type/type-annotation.ts
+++ b/tests/typescript_function_type/type-annotation.ts
@@ -1,0 +1,3 @@
+const foo = (): () => void => (): void => null;
+const bar = (): (() => void) => (): void => null;
+const baz = (): ((() => void)) => (): void => null;


### PR DESCRIPTION
Fixes #5789

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If not an internal change) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
