### PR TITLE
fix(html): do not format non-normal whitespaces as normal whitespaces

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -41,3 +41,30 @@ Examples:
   ```
 
 -->
+
+- HTML: Do not format non-normal whitespaces as normal whitespaces ([#5797] by [@ikatyang])
+
+  Previously, only non-breaking whitespaces (U+00A0) are marked as non-normal whitespace,
+  which means other non-normal whitespaces such as non-breaking narrow whitespaces (U+202F)
+  could be formatted as normal whitespaces, which breaks the output. Instead of using blacklist,
+  we now use whitelist to mark every whitespace that is not
+
+  - standard whitespace
+  - line break
+  - tab
+
+  as non-normal whitespace.
+
+  (`·` represents a non-breaking narrow whitespace)
+
+  <!-- prettier-ignore -->
+  ```html
+  <!-- Input -->
+  Prix·:·32·€
+
+  <!-- Output (Prettier stable) -->
+  Prix : 32 €
+
+  <!-- Output (Prettier master) -->
+  Prix·:·32·€
+  ```

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -900,8 +900,7 @@ function getTextValueParts(node, value = node.value) {
           dedentString(value.replace(/^\s*?\n|\n\s*?$/g, "")),
           hardline
         )
-    : // non-breaking whitespace: 0xA0
-      join(line, value.split(/[^\S\xA0]+/)).parts;
+    : join(line, value.split(/[ \t\n]+/)).parts;
 }
 
 function printEmbeddedAttributeValue(node, originalTextToDoc, options) {

--- a/tests/html_whitespace/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_whitespace/__snapshots__/jsfmt.spec.js.snap
@@ -203,6 +203,8 @@ printWidth: 80
 <span>Nihil aut odit omnis. Quam maxime est molestiae. Maxime dolorem dolores voluptas quaerat ut qui sunt vitae error.</span>
 <!-- non-breaking whitespaces -->
 <span>Nihil aut odit omnis. Quam maxime est molestiae. Maxime dolorem dolores voluptas quaerat ut qui sunt vitae error.</span>
+<!-- non-breaking narrow whitespaces -->
+<span>Prix : 32 €</span>
 
 =====================================output=====================================
 <!-- normal whitespaces -->
@@ -214,6 +216,8 @@ printWidth: 80
 <span
   >Nihil aut odit omnis. Quam maxime est molestiae. Maxime dolorem dolores voluptas quaerat ut qui sunt vitae error.</span
 >
+<!-- non-breaking narrow whitespaces -->
+<span>Prix : 32 €</span>
 
 ================================================================================
 `;

--- a/tests/html_whitespace/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_whitespace/__snapshots__/jsfmt.spec.js.snap
@@ -217,7 +217,7 @@ printWidth: 80
   >Nihil aut odit omnis. Quam maxime est molestiae. Maxime dolorem dolores voluptas quaerat ut qui sunt vitae error.</span
 >
 <!-- non-breaking narrow whitespaces -->
-<span>Prix : 32 €</span>
+<span>Prix : 32 €</span>
 
 ================================================================================
 `;

--- a/tests/html_whitespace/non-breaking-whitespace.html
+++ b/tests/html_whitespace/non-breaking-whitespace.html
@@ -2,3 +2,5 @@
 <span>Nihil aut odit omnis. Quam maxime est molestiae. Maxime dolorem dolores voluptas quaerat ut qui sunt vitae error.</span>
 <!-- non-breaking whitespaces -->
 <span>Nihil aut odit omnis. Quam maxime est molestiae. Maxime dolorem dolores voluptas quaerat ut qui sunt vitae error.</span>
+<!-- non-breaking narrow whitespaces -->
+<span>Prix : 32 €</span>


### PR DESCRIPTION
Fixes #5796

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If not an internal change) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
