### PR TITLE
Add tutorials section to plugins doc

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -245,6 +245,10 @@ isPreviousLineEmpty(text: string, node: object, options: object): boolean;
 mapDoc(doc: object, callback: function): void;
 ```
 
+### Tutorials
+
+- [How to write a plugin for Prettier](https://medium.com/@fvictorio/how-to-write-a-plugin-for-prettier-a0d98c845e70): Teaches you how to write a very basic Prettier plugin for TOML.
+
 ## Testing Plugins
 
 Since plugins can be resolved using relative paths, when working on one you can do:


### PR DESCRIPTION
Hi, I wrote a tutorial on how to build a plugin for Prettier and @j-f1 (who kindly proofread it) suggested that I add it to the docs. I don't know if the way I did it is the best one though, let me know if you'd prefer it in some other part.