### PR TITLE
Tweaks the plugin directory search

### DIFF
--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -52,16 +52,19 @@ function loadPlugins(plugins, pluginSearchDirs) {
         pluginSearchDir
       );
 
-      if (!isDirectory(resolvedPluginSearchDir)) {
-        throw new Error(
-          `${pluginSearchDir} does not exist or is not a directory`
-        );
-      }
-
       const nodeModulesDir = path.resolve(
         resolvedPluginSearchDir,
         "node_modules"
       );
+
+      // In some fringe cases (ex: files "mounted" as virtual directories), the
+      // isDirectory(resolvedPluginSearchDir) check might be false even though
+      // the node_modules actually exists.
+      if (!isDirectory(nodeModulesDir) && !isDirectory(resolvedPluginSearchDir)) {
+        throw new Error(
+          `${pluginSearchDir} does not exist or is not a directory`
+        );
+      }
 
       return findPluginsInNodeModules(nodeModulesDir).map(pluginName => ({
         name: pluginName,

--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -60,7 +60,10 @@ function loadPlugins(plugins, pluginSearchDirs) {
       // In some fringe cases (ex: files "mounted" as virtual directories), the
       // isDirectory(resolvedPluginSearchDir) check might be false even though
       // the node_modules actually exists.
-      if (!isDirectory(nodeModulesDir) && !isDirectory(resolvedPluginSearchDir)) {
+      if (
+        !isDirectory(nodeModulesDir) &&
+        !isDirectory(resolvedPluginSearchDir)
+      ) {
         throw new Error(
           `${pluginSearchDir} does not exist or is not a directory`
         );

--- a/tests_integration/__tests__/plugin-virtual-directory.js
+++ b/tests_integration/__tests__/plugin-virtual-directory.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const runPrettier = require("../runPrettier");
+
+describe("plugin search should not crash when prettier isn't inside a directory", () => {
+  runPrettier(
+    "plugins/virtualDirectory",
+    ["--stdin-filepath", "example.js", "--plugin-search-dir=."],
+    { input: "" }
+  ).test({
+    stdout: "",
+    stderr: "",
+    status: 0,
+    write: [],
+  });
+});

--- a/tests_integration/__tests__/plugin-virtual-directory.js
+++ b/tests_integration/__tests__/plugin-virtual-directory.js
@@ -11,6 +11,6 @@ describe("plugin search should not crash when prettier isn't inside a directory"
     stdout: "",
     stderr: "",
     status: 0,
-    write: [],
+    write: []
   });
 });

--- a/tests_integration/runPrettier.js
+++ b/tests_integration/runPrettier.js
@@ -60,9 +60,8 @@ function runPrettier(dir, args, options) {
   jest.spyOn(fs, "statSync").mockImplementation(filename => {
     if (path.basename(filename) === `virtualDirectory`) {
       return origStatSync(path.join(__dirname, __filename));
-    } else {
-      return origStatSync(filename);
     }
+    return origStatSync(filename);
   });
 
   const originalCwd = process.cwd();

--- a/tests_integration/runPrettier.js
+++ b/tests_integration/runPrettier.js
@@ -55,6 +55,16 @@ function runPrettier(dir, args, options) {
     write.push({ filename, content });
   });
 
+  const origStatSync = fs.statSync;
+
+  jest.spyOn(fs, "statSync").mockImplementation(filename => {
+    if (path.basename(filename) === `virtualDirectory`) {
+      return origStatSync(path.join(__dirname, __filename));
+    } else {
+      return origStatSync(filename);
+    }
+  });
+
   const originalCwd = process.cwd();
   const originalArgv = process.argv;
   const originalExitCode = process.exitCode;


### PR DESCRIPTION
Basically with Yarn v2 we'll make it possible to load files directly from within the zip archive. For now this will be implemented by patching the fs module so that Node is able to see the files within the archive. The problem is that in order to work well with rimraf and similar crawlers, the archive itself mustn't be stat'd as a directory. This is problematic in Prettier because you actually check it by default.

With this change the node_modules isDirectory check will succeed, and will shortcut the one to check whether its parent directory is a directory.
