### PR TITLE
Fixup getSupportInfo for babylon parser prior to 1.16.0

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -84,3 +84,7 @@ Examples:
   // Output (Prettier master)
   <my-element data-for={value}></my-element>
   ```
+
+- Fix `prettier.getSupportInfo()` reporting babel parser for older versions of Prettier. ([#5826] by [@azz])
+
+  In version `1.16.0` of Prettier, the `babylon` parser was renamed to `babel`. Unfortunately this lead to a minor breaking change: `prettier.getSupportInfo('1.15.0')` would report that it supported `babel`, not `babylon`, which breaks text-editor integrations. This has now been fixed.

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -94,7 +94,7 @@ function getSupportInfo(version, opts) {
       }
 
       // "babylon" was renamed to "babel" in 1.16.0
-      if (useBabylonParser && language.parsers.includes("babel")) {
+      if (useBabylonParser && language.parsers.indexOf("babel") !== -1) {
         return Object.assign({}, language, {
           parsers: language.parsers.map(parser =>
             parser === "babel" ? "babylon" : parser

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -96,8 +96,8 @@ function getSupportInfo(version, opts) {
       // "babylon" was renamed to "babel" in 1.16.0
       if (useBabylonParser && language.parsers.includes("babel")) {
         return Object.assign({}, language, {
-          parsers: language.parsers.map(
-            parser => (parser === "babel" ? "babylon" : parser)
+          parsers: language.parsers.map(parser =>
+            parser === "babel" ? "babylon" : parser
           )
         });
       }

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -75,6 +75,7 @@ function getSupportInfo(version, opts) {
     });
 
   const usePostCssParser = semver.lt(version, "1.7.1");
+  const useBabylonParser = semver.lt(version, "1.16.0");
 
   const languages = plugins
     .reduce((all, plugin) => all.concat(plugin.languages || []), [])
@@ -89,6 +90,15 @@ function getSupportInfo(version, opts) {
       if (language.name === "TypeScript") {
         return Object.assign({}, language, {
           parsers: ["typescript"]
+        });
+      }
+
+      // "babylon" was renamed to "babel" in 1.16.0
+      if (useBabylonParser && language.parsers.includes("babel")) {
+        return Object.assign({}, language, {
+          parsers: language.parsers.map(
+            parser => (parser === "babel" ? "babylon" : parser)
+          )
         });
       }
 

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -67,15 +67,15 @@ exports[`API getSupportInfo() with version 0.0.0 1`] = `
 Object {
   "languages": Object {
     "Flow": Array [
-      "babel",
+      "babylon",
       "flow",
     ],
     "JSX": Array [
-      "babel",
+      "babylon",
       "flow",
     ],
     "JavaScript": Array [
-      "babel",
+      "babylon",
       "flow",
     ],
   },
@@ -137,14 +137,14 @@ exports[`API getSupportInfo() with version 1.0.0 -> 1.4.0 1`] = `
 +       \\"postcss\\",
 +     ],
       \\"Flow\\": Array [
-        \\"babel\\",
+        \\"babylon\\",
         \\"flow\\",
       ],
       \\"JSX\\": Array [
 @@ -10,24 +13,51 @@
       ],
       \\"JavaScript\\": Array [
-        \\"babel\\",
+        \\"babylon\\",
         \\"flow\\",
       ],
 +     \\"Less\\": Array [
@@ -232,7 +232,7 @@ exports[`API getSupportInfo() with version 1.4.0 -> 1.5.0 1`] = `
 @@ -5,10 +5,19 @@
       ],
       \\"Flow\\": Array [
-        \\"babel\\",
+        \\"babylon\\",
         \\"flow\\",
       ],
 +     \\"GraphQL\\": Array [
@@ -245,7 +245,7 @@ exports[`API getSupportInfo() with version 1.4.0 -> 1.5.0 1`] = `
 +       \\"json\\",
 +     ],
       \\"JSX\\": Array [
-        \\"babel\\",
+        \\"babylon\\",
         \\"flow\\",
       ],
       \\"JavaScript\\": Array [
@@ -277,12 +277,12 @@ exports[`API getSupportInfo() with version 1.5.0 -> 1.7.1 1`] = `
 +       \\"css\\",
       ],
       \\"Flow\\": Array [
-        \\"babel\\",
+        \\"babylon\\",
         \\"flow\\",
       ],
 @@ -23,17 +23,17 @@
       \\"JavaScript\\": Array [
-        \\"babel\\",
+        \\"babylon\\",
         \\"flow\\",
       ],
       \\"Less\\": Array [
@@ -407,12 +407,12 @@ exports[`API getSupportInfo() with version 1.8.0 -> 1.8.2 1`] = `
           \\"start\\": 0,"
 `;
 
-exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
+exports[`API getSupportInfo() with version 1.8.2 -> 1.16.0 1`] = `
 "Snapshot Diff:
 - First value
 + Second value
 
-@@ -1,23 +1,35 @@
+@@ -1,34 +1,49 @@
   Object {
     \\"languages\\": Object {
 +     \\"Angular\\": Array [
@@ -422,7 +422,8 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
         \\"css\\",
       ],
       \\"Flow\\": Array [
-        \\"babel\\",
+-       \\"babylon\\",
++       \\"babel\\",
         \\"flow\\",
       ],
       \\"GraphQL\\": Array [
@@ -444,19 +445,18 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
 +       \\"json5\\",
 +     ],
       \\"JSX\\": Array [
-        \\"babel\\",
+-       \\"babylon\\",
++       \\"babel\\",
         \\"flow\\",
       ],
       \\"JavaScript\\": Array [
-@@ -25,10 +37,16 @@
+-       \\"babylon\\",
++       \\"babel\\",
         \\"flow\\",
       ],
       \\"Less\\": Array [
         \\"less\\",
       ],
-+     \\"Lightning Web Components\\": Array [
-+       \\"lwc\\",
-+     ],
 +     \\"MDX\\": Array [
 +       \\"mdx\\",
 +     ],
@@ -465,7 +465,7 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
       ],
       \\"PostCSS\\": Array [
         \\"css\\",
-@@ -37,12 +55,26 @@
+@@ -37,12 +52,26 @@
         \\"scss\\",
       ],
       \\"TypeScript\\": Array [
@@ -492,7 +492,7 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
         \\"type\\": \\"boolean\\",
       },
       \\"cursorOffset\\": Object {
-@@ -52,37 +84,77 @@
+@@ -52,37 +81,76 @@
           \\"start\\": -1,
           \\"step\\": 1,
         },
@@ -553,7 +553,6 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
 +         \\"yaml\\",
 +         \\"html\\",
 +         \\"angular\\",
-+         \\"lwc\\",
         ],
 -       \\"default\\": \\"babylon\\",
 +       \\"default\\": undefined,
@@ -572,7 +571,7 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
         \\"range\\": Object {
           \\"end\\": Infinity,
           \\"start\\": 0,
-@@ -90,14 +162,15 @@
+@@ -90,14 +158,15 @@
         },
         \\"type\\": \\"int\\",
       },
@@ -591,6 +590,39 @@ exports[`API getSupportInfo() with version 1.8.2 -> undefined 1`] = `
       \\"rangeEnd\\": Object {
         \\"default\\": Infinity,
         \\"range\\": Object {"
+`;
+
+exports[`API getSupportInfo() with version 1.16.0 -> undefined 1`] = `
+"Snapshot Diff:
+- First value
++ Second value
+
+@@ -37,10 +37,13 @@
+        \\"flow\\",
+      ],
+      \\"Less\\": Array [
+        \\"less\\",
+      ],
++     \\"Lightning Web Components\\": Array [
++       \\"lwc\\",
++     ],
+      \\"MDX\\": Array [
+        \\"mdx\\",
+      ],
+      \\"Markdown\\": Array [
+        \\"markdown\\",
+@@ -135,10 +138,11 @@
+          \\"mdx\\",
+          \\"vue\\",
+          \\"yaml\\",
+          \\"html\\",
+          \\"angular\\",
++         \\"lwc\\",
+        ],
+        \\"default\\": undefined,
+        \\"type\\": \\"choice\\",
+      },
+      \\"pluginSearchDirs\\": Object {"
 `;
 
 exports[`CLI --support-info (stderr) 1`] = `""`;

--- a/tests_integration/__tests__/support-info.js
+++ b/tests_integration/__tests__/support-info.js
@@ -13,6 +13,7 @@ describe("API getSupportInfo()", () => {
     "1.7.1",
     "1.8.0",
     "1.8.2",
+    "1.16.0",
     undefined
   ];
 


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

This undoes an accidental breaking change where `prettier.getSupportInfo('1.0.0')` would report supporting the `babel` parser instead of `babylon`.

Fixes #5822 

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If not an internal change) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

