### PR TITLE
Honor stdin-filepath when outputting error messages.

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -42,6 +42,8 @@ Examples:
 
 -->
 
+- CLI: Honor stdin-filepath when outputting error messages.
+
 - Markdown: Do not align table contents if it exceeds the print width and `--prose-wrap never` is set ([#5701] by [@chenshuai2144])
 
   The aligned table is less readable than the compact one

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -383,7 +383,7 @@ function formatStdin(context) {
 
       writeOutput(context, format(context, input, options), options);
     } catch (error) {
-      handleError(context, "stdin", error);
+      handleError(context, relativeFilepath || "stdin", error);
     }
   });
 }

--- a/tests_integration/__tests__/__snapshots__/stdin-filepath.js.snap
+++ b/tests_integration/__tests__/__snapshots__/stdin-filepath.js.snap
@@ -16,7 +16,7 @@ exports[`output file as-is if stdin-filepath matched patterns in ignore-path (st
 exports[`output file as-is if stdin-filepath matched patterns in ignore-path (write) 1`] = `Array []`;
 
 exports[`throw error if stdin content incompatible with stdin-filepath (stderr) 1`] = `
-"[error] stdin: SyntaxError: Unexpected token (1:1)
+"[error] abc.js: SyntaxError: Unexpected token (1:1)
 [error] > 1 | .name { display: none; }
 [error]     | ^
 "


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Honor stdin-filepath when outputting error messages.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If not an internal change) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
