### PR TITLE
Change --check output to be warnings

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -42,6 +42,8 @@ Examples:
 
 -->
 
+- CLI: Output warnings instead of log statements for `--check`.
+
 - CLI: Honor stdin-filepath when outputting error messages.
 
 - Markdown: Do not align table contents if it exceeds the print width and `--prose-wrap never` is set ([#5701] by [@chenshuai2144])

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -25,6 +25,7 @@ Prettier CLI will ignore files located in `node_modules` directory. To opt-out f
 
 When you want to check if your files are formatted, you can run Prettier with the `--check` flag (or `-c`).
 This will output a human-friendly message and a list of unformatted files, if any.
+As this is meant to be human readable the output will be warnings in stderr. If you want to process the files please use `--list-different`
 
 ```bash
 prettier --check "src/**/*.js"

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -540,24 +540,30 @@ function formatFiles(context) {
       writeOutput(context, result, options);
     }
 
-    if (
-      (context.argv["check"] || context.argv["list-different"]) &&
-      isDifferent
-    ) {
-      context.logger.log(filename);
+    if (isDifferent) {
       numberOfUnformattedFilesFound += 1;
+
+      if (context.argv["check"]) {
+        context.logger.warn(filename);
+      } else if (context.argv["list-different"]) {
+        context.logger.log(filename);
+      }
     }
   });
 
   // Print check summary based on expected exit code
   if (context.argv["check"]) {
-    context.logger.log(
-      numberOfUnformattedFilesFound === 0
-        ? "All matched files use Prettier code style!"
-        : context.argv["write"]
-        ? "Code style issues fixed in the above file(s)."
-        : "Code style issues found in the above file(s). Forgot to run Prettier?"
-    );
+    if (numberOfUnformattedFilesFound === 0) {
+      context.logger.log("All matched files use Prettier code style!");
+    } else {
+      if (context.args["write"]) {
+        context.logger.log("Code style issues fixed in the above file(s).");
+      } else {
+        context.logger.warn(
+          "Code style issues found in the above file(s). Forgot to run Prettier?"
+        );
+      }
+    }
   }
 
   // Ensure non-zero exitCode when using --check/list-different is not combined with --write

--- a/tests_integration/__tests__/__snapshots__/check.js.snap
+++ b/tests_integration/__tests__/__snapshots__/check.js.snap
@@ -1,20 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`--checks works in CI just as in a non-TTY mode (stderr) 1`] = `""`;
+exports[`--checks works in CI just as in a non-TTY mode (stderr) 1`] = `
+"[warn] unformatted.js
+[warn] Code style issues found in the above file(s). Forgot to run Prettier?
+"
+`;
 
-exports[`--checks works in CI just as in a non-TTY mode (stderr) 2`] = `""`;
+exports[`--checks works in CI just as in a non-TTY mode (stderr) 2`] = `
+"[warn] unformatted.js
+[warn] Code style issues found in the above file(s). Forgot to run Prettier?
+"
+`;
 
 exports[`--checks works in CI just as in a non-TTY mode (stdout) 1`] = `
 "Checking formatting...
-unformatted.js
-Code style issues found in the above file(s). Forgot to run Prettier?
 "
 `;
 
 exports[`--checks works in CI just as in a non-TTY mode (stdout) 2`] = `
 "Checking formatting...
-unformatted.js
-Code style issues found in the above file(s). Forgot to run Prettier?
 "
 `;
 

--- a/tests_integration/__tests__/__snapshots__/infer-parser.js.snap
+++ b/tests_integration/__tests__/__snapshots__/infer-parser.js.snap
@@ -2,13 +2,13 @@
 
 exports[`--check with unknown path and no parser multiple files (stderr) 1`] = `
 "[error] No parser could be inferred for file: FOO
+[warn] foo.js
+[warn] Code style issues found in the above file(s). Forgot to run Prettier?
 "
 `;
 
 exports[`--check with unknown path and no parser multiple files (stdout) 1`] = `
 "Checking formatting...
-foo.js
-Code style issues found in the above file(s). Forgot to run Prettier?
 "
 `;
 
@@ -35,13 +35,13 @@ exports[`--list-different with unknown path and no parser specific file (stderr)
 
 exports[`--write and --check with unknown path and no parser multiple files (stderr) 1`] = `
 "[error] No parser could be inferred for file: FOO
+[warn] foo.js
+[warn] Code style issues found in the above file(s). Forgot to run Prettier?
 "
 `;
 
 exports[`--write and --check with unknown path and no parser multiple files (stdout) 1`] = `
 "Checking formatting...
-foo.js
-Code style issues fixed in the above file(s).
 "
 `;
 

--- a/tests_integration/__tests__/__snapshots__/piped-output.js.snap
+++ b/tests_integration/__tests__/__snapshots__/piped-output.js.snap
@@ -32,21 +32,25 @@ exports[`no file diffs with --list-different + formatted file (write) 1`] = `Arr
 
 exports[`no file diffs with --list-different + formatted file (write) 2`] = `Array []`;
 
-exports[`output with --check + unformatted differs when piped (stderr) 1`] = `""`;
+exports[`output with --check + unformatted differs when piped (stderr) 1`] = `
+"[warn] unformatted.js
+[warn] Code style issues found in the above file(s). Forgot to run Prettier?
+"
+`;
 
-exports[`output with --check + unformatted differs when piped (stderr) 2`] = `""`;
+exports[`output with --check + unformatted differs when piped (stderr) 2`] = `
+"[warn] unformatted.js
+[warn] Code style issues found in the above file(s). Forgot to run Prettier?
+"
+`;
 
 exports[`output with --check + unformatted differs when piped (stdout) 1`] = `
 "Checking formatting...
-unformatted.jsunformatted.js
-Code style issues fixed in the above file(s).
-"
+unformatted.js"
 `;
 
 exports[`output with --check + unformatted differs when piped (stdout) 2`] = `
 "Checking formatting...
-unformatted.js
-Code style issues fixed in the above file(s).
 "
 `;
 


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Changed --checkout to be warnings instead of standard logs so that they are easier to spot during CI failures.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If not an internal change) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
