### PR TITLE
Fix trailing comment output when the printer returns a doc instead of a string

### DIFF
--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -443,7 +443,10 @@ function printTrailingComment(commentPath, print, options) {
     return concat([" ", contents]);
   }
 
-  return concat([lineSuffix(" " + contents), !isBlock ? breakParent : ""]);
+  return concat([
+    lineSuffix(concat([" ", contents])),
+    !isBlock ? breakParent : ""
+  ]);
 }
 
 function printDanglingComments(path, options, sameIndent, filter) {


### PR DESCRIPTION
When a printer exposes its own `printComment` function and returns a doc (eg. `concat([])`) instead of a string, and a comments turns out to be trailing, Prettier printed `[Object object]`.

I spent a considerable amount of time trying to add a test for this bug fix, but it requires a test case with a custom parser supporting comments. I see that there are some test plugin in `tests_integration/plugins`, but nothing as fancy. Please tell me if you require new tests for this bug fix, and I'll try to come up with something.

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If not an internal change) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
