### PR TITLE
Fixes #5446 Do not convert type parameter to comment type

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3064,9 +3064,24 @@ function printPathNoParens(path, options, print, args) {
     case "TypeParameterDeclaration":
     case "TypeParameterInstantiation": {
       const value = path.getValue();
+<<<<<<< HEAD
       const commentStart = value.range
         ? options.originalText.slice(0, value.range[0]).lastIndexOf("/*")
         : -1;
+=======
+      const parentNodeType = path.getParentNode().type;
+      const isParentTypeLevelNode =
+        parentNodeType === "TypeAlias" ||
+        parentNodeType === "ClassDeclaration" ||
+        parentNodeType === "GenericTypeAnnotation";
+
+      // When parent node of this node defined in the context of the type,
+      // It's up to the parent node whether this node defined internal comment type.
+      const commentStart =
+        value.range && !isParentTypeLevelNode
+          ? options.originalText.substring(0, value.range[0]).lastIndexOf("/*")
+          : -1;
+>>>>>>> 5e9f41a6e... Do not comment out when type application occurred at type level context
       // As noted in the TypeCastExpression comments above, we're able to use a normal whitespace regex here
       // because we know for sure that this is a type definition.
       const commentSyntax =

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3064,11 +3064,6 @@ function printPathNoParens(path, options, print, args) {
     case "TypeParameterDeclaration":
     case "TypeParameterInstantiation": {
       const value = path.getValue();
-<<<<<<< HEAD
-      const commentStart = value.range
-        ? options.originalText.slice(0, value.range[0]).lastIndexOf("/*")
-        : -1;
-=======
       const parentNodeType = path.getParentNode().type;
       const isParentTypeLevelNode =
         parentNodeType === "TypeAlias" ||
@@ -3079,9 +3074,8 @@ function printPathNoParens(path, options, print, args) {
       // It's up to the parent node whether this node defined internal comment type.
       const commentStart =
         value.range && !isParentTypeLevelNode
-          ? options.originalText.substring(0, value.range[0]).lastIndexOf("/*")
+          ? options.originalText.slice(0, value.range[0]).lastIndexOf("/*")
           : -1;
->>>>>>> 5e9f41a6e... Do not comment out when type application occurred at type level context
       // As noted in the TypeCastExpression comments above, we're able to use a normal whitespace regex here
       // because we know for sure that this is a type definition.
       const commentSyntax =

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3074,7 +3074,11 @@ function printPathNoParens(path, options, print, args) {
       // It's up to the parent node whether this node defined internal comment type.
       const commentStart =
         value.range && !isParentTypeLevelNode
+<<<<<<< HEAD
           ? options.originalText.slice(0, value.range[0]).lastIndexOf("/*")
+=======
+          ? options.originalText.substring(0, value.range[0]).lastIndexOf("/*")
+>>>>>>> 5e9f41a6e... Do not comment out when type application occurred at type level context
           : -1;
       // As noted in the TypeCastExpression comments above, we're able to use a normal whitespace regex here
       // because we know for sure that this is a type definition.

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3074,11 +3074,7 @@ function printPathNoParens(path, options, print, args) {
       // It's up to the parent node whether this node defined internal comment type.
       const commentStart =
         value.range && !isParentTypeLevelNode
-<<<<<<< HEAD
           ? options.originalText.slice(0, value.range[0]).lastIndexOf("/*")
-=======
-          ? options.originalText.substring(0, value.range[0]).lastIndexOf("/*")
->>>>>>> 5e9f41a6e... Do not comment out when type application occurred at type level context
           : -1;
       // As noted in the TypeCastExpression comments above, we're able to use a normal whitespace regex here
       // because we know for sure that this is a type definition.

--- a/tests/flow/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/comments/__snapshots__/jsfmt.spec.js.snap
@@ -124,6 +124,98 @@ interface Foo {
 ================================================================================
 `;
 
+exports[`issue-5446.js format 1`] = `
+====================================options=====================================
+parsers: ["flow", "babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+const mapDispatch: MapDispatch<*> = (dispatch, props) => ({
+  ...props,
+  onInit: ({ user }: { user: Some_user }) => {
+    if (user) {
+      const { name } = user;
+      switch (user.__typename) {
+        case "A": {
+          dispatch(user.onInitByQuery("A"));
+          break;
+        }
+        case "B":
+          dispatch(user.onInitByQuery("B"));
+          break;
+        case "C":
+          dispatch(user.onInitByQuery("C"));
+          break;
+        default:
+          /* :: (user.__typename: empty); */ // eslint-disable-line
+          break;
+      }
+      dispatch(
+        user.onInitByQuery({
+          user: { firstName: first_name, lastName: last_name },
+        }),
+      );
+    }
+  },
+});
+
+type Props = {|
+  ...$Exact<PropsWithTFn>,
+  ...$Exact<$Call<typeof mapStateToProps, *, *>>,
+  ...$Exact<$Call<typeof mapDispatch, *, *>>,
+  ...$Exact<withResponse.WithQueryProps<RootQuery>>,
+|};
+
+/* :: (kind: empty);*/
+export const A: T<V> = 0;
+
+=====================================output=====================================
+// @flow
+
+const mapDispatch: MapDispatch<*> = (dispatch, props) => ({
+  ...props,
+  onInit: ({ user }: { user: Some_user }) => {
+    if (user) {
+      const { name } = user;
+      switch (user.__typename) {
+        case "A": {
+          dispatch(user.onInitByQuery("A"));
+          break;
+        }
+        case "B":
+          dispatch(user.onInitByQuery("B"));
+          break;
+        case "C":
+          dispatch(user.onInitByQuery("C"));
+          break;
+        default:
+          (user.__typename: empty); // eslint-disable-line
+          break;
+      }
+      dispatch(
+        user.onInitByQuery({
+          user: { firstName: first_name, lastName: last_name },
+        })
+      );
+    }
+  },
+});
+
+type Props = {|
+  ...$Exact<PropsWithTFn>,
+  ...$Exact<$Call<typeof mapStateToProps, *, *>>,
+  ...$Exact<$Call<typeof mapDispatch, *, *>>,
+  ...$Exact<withResponse.WithQueryProps<RootQuery>>,
+|};
+
+(kind: empty);
+export const A: T<V> = 0;
+
+================================================================================
+`;
+
 exports[`issues.js format 1`] = `
 ====================================options=====================================
 parsers: ["flow", "babel"]
@@ -289,6 +381,32 @@ this /*
 : any */.foo = 5;
 
 const x = (input /*: string */) /*: string */ => {};
+
+================================================================================
+`;
+
+exports[`type_parameter.js format 1`] = `
+====================================options=====================================
+parsers: ["flow", "babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type A<B> = B;
+
+foo/*::<bar>*/(baz);
+
+type C<D> = D;
+class E<F> {}
+type G = $Exact<string>;
+
+=====================================output=====================================
+type A<B> = B;
+
+foo/*:: <bar> */(baz);
+
+type C<D> = D;
+class E<F> {}
+type G = $Exact<string>;
 
 ================================================================================
 `;

--- a/tests/flow/comments/issue-5446.js
+++ b/tests/flow/comments/issue-5446.js
@@ -1,0 +1,40 @@
+// @flow
+
+const mapDispatch: MapDispatch<*> = (dispatch, props) => ({
+  ...props,
+  onInit: ({ user }: { user: Some_user }) => {
+    if (user) {
+      const { name } = user;
+      switch (user.__typename) {
+        case "A": {
+          dispatch(user.onInitByQuery("A"));
+          break;
+        }
+        case "B":
+          dispatch(user.onInitByQuery("B"));
+          break;
+        case "C":
+          dispatch(user.onInitByQuery("C"));
+          break;
+        default:
+          /* :: (user.__typename: empty); */ // eslint-disable-line
+          break;
+      }
+      dispatch(
+        user.onInitByQuery({
+          user: { firstName: first_name, lastName: last_name },
+        }),
+      );
+    }
+  },
+});
+
+type Props = {|
+  ...$Exact<PropsWithTFn>,
+  ...$Exact<$Call<typeof mapStateToProps, *, *>>,
+  ...$Exact<$Call<typeof mapDispatch, *, *>>,
+  ...$Exact<withResponse.WithQueryProps<RootQuery>>,
+|};
+
+/* :: (kind: empty);*/
+export const A: T<V> = 0;

--- a/tests/flow/comments/type_parameter.js
+++ b/tests/flow/comments/type_parameter.js
@@ -1,0 +1,7 @@
+type A<B> = B;
+
+foo/*::<bar>*/(baz);
+
+type C<D> = D;
+class E<F> {}
+type G = $Exact<string>;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fixes #5446

When once comment type of Flow occurred at the code, unintentional converting from type parameter like `A<B>` to `A/*:: <B> */` applied.

As commented at [here](https://github.com/prettier/prettier/blob/b38319740af7721873ada5e3b97b0eb34e759b4a/src/language-js/printer-estree.js#L3011), due to lack of information whether the current node declared internal comment type or not, differences this PR proposed to do not fully ideal.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
