### PR TITLE
Support shared Prettier configuration

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -64,7 +64,7 @@ Examples:
 
   ```js
   module.exports = {
-    ...require("@company/prettierc"),
+    ...require("@company/prettier-config"),
     semi: false
   };
   ```

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -42,6 +42,33 @@ Examples:
 
 -->
 
+- Config: Support shared configurations ([#5963] by [@azz])
+
+  Sharing a Prettier configuration is simple: just publish a module that exports a configuration object, say `@company/prettier-config`, and reference it in your `package.json`:
+
+  ```json
+  {
+    "name": "my-cool-library",
+    "version": "9000.0.1",
+    "prettier": "@company/prettier-config"
+  }
+  ```
+
+  If you don't want to use `package.json`, you can use any of the supported extensions to export a string, e.g. `.prettierrc.json`:
+
+  ```json
+  "@company/prettier-config"
+  ```
+
+  This method does **not** offer a way to _extend_ the configuration to overwrite some properties from the shared configuration. If you need to do that, import the file in a `.prettierrc.js` file and export the modifications, e.g:
+
+  ```js
+  module.exports = {
+    ...require("@company/prettierc"),
+    semi: false
+  };
+  ```
+
 - JavaScript: Add an option to modify when Prettier quotes object properties ([#5934] by [@azz])
   **`--quote-props <as-needed|preserve|consistent>`**
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -60,14 +60,16 @@ Examples:
   "@company/prettier-config"
   ```
 
-  This method does **not** offer a way to _extend_ the configuration to overwrite some properties from the shared configuration. If you need to do that, import the file in a `.prettierrc.js` file and export the modifications, e.g:
+  An example configuration repository is available [here](https://github.com/azz/prettier-config).
 
-  ```js
-  module.exports = {
-    ...require("@company/prettier-config"),
-    semi: false
-  };
-  ```
+  > Note: This method does **not** offer a way to _extend_ the configuration to overwrite some properties from the shared configuration. If you need to do that, import the file in a `.prettierrc.js` file and export the modifications, e.g:
+  >
+  > ```js
+  > module.exports = {
+  >   ...require("@company/prettier-config"),
+  >   semi: false
+  > };
+  > ```
 
 - JavaScript: Add an option to modify when Prettier quotes object properties ([#5934] by [@azz])
   **`--quote-props <as-needed|preserve|consistent>`**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,14 +109,16 @@ If you don't want to use `package.json`, you can use any of the supported extens
 "@company/prettier-config"
 ```
 
-This method does **not** offer a way to _extend_ the configuration to overwrite some properties from the shared configuration. If you need to do that, import the file in a `.prettierrc.js` file and export the modifications, e.g:
+An example configuration repository is available [here](https://github.com/azz/prettier-config).
 
-```js
-module.exports = {
-  ...require("@company/prettier-config"),
-  semi: false
-};
-```
+> Note: This method does **not** offer a way to _extend_ the configuration to overwrite some properties from the shared configuration. If you need to do that, import the file in a `.prettierrc.js` file and export the modifications, e.g:
+>
+> ```js
+> module.exports = {
+>   ...require("@company/prettier-config"),
+>   semi: false
+> };
+> ```
 
 ## Setting the [parser](options.md#parser) option
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,33 @@ overrides:
 
 `files` is required for each override, and may be a string or array of strings. `excludeFiles` may be optionally provided to exclude files for a given rule, and may also be a string or array of strings.
 
+## Sharing configurations
+
+Sharing a Prettier configuration is simple: just publish a module that exports a configuration object, say `@company/prettier-config`, and reference it in your `package.json`:
+
+```json
+{
+  "name": "my-cool-library",
+  "version": "9000.0.1",
+  "prettier": "@company/prettier-config"
+}
+```
+
+If you don't want to use `package.json`, you can use any of the supported extensions to export a string, e.g. `.prettierrc.json`:
+
+```json
+"@company/prettier-config"
+```
+
+This method does **not** offer a way to _extend_ the configuration to overwrite some properties from the shared configuration. If you need to do that, import the file in a `.prettierrc.js` file and export the modifications, e.g:
+
+```js
+module.exports = {
+  ...require("@company/prettierc"),
+  semi: false
+};
+```
+
 ## Setting the [parser](options.md#parser) option
 
 By default, Prettier automatically infers which parser to use based on the input file extension. Combined with `overrides` you can teach Prettier how to parse files it does not recognize.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,7 +113,7 @@ This method does **not** offer a way to _extend_ the configuration to overwrite 
 
 ```js
 module.exports = {
-  ...require("@company/prettierc"),
+  ...require("@company/prettier-config"),
   semi: false
 };
 ```

--- a/src/config/resolve-config.js
+++ b/src/config/resolve-config.js
@@ -2,6 +2,7 @@
 
 const thirdParty = require("../common/third-party");
 const minimatch = require("minimatch");
+const resolve = require("resolve");
 const path = require("path");
 const mem = require("mem");
 
@@ -13,6 +14,13 @@ const getExplorerMemoized = mem(opts => {
     cache: opts.cache,
     transform: result => {
       if (result && result.config) {
+        if (typeof result.config === "string") {
+          const modulePath = resolve.sync(result.config, {
+            basedir: path.dirname(result.filepath)
+          });
+          result.config = eval("require")(modulePath);
+        }
+
         if (typeof result.config !== "object") {
           throw new Error(
             `Config is only allowed to be an object, ` +

--- a/tests_integration/__tests__/__snapshots__/config-invalid.js.snap
+++ b/tests_integration/__tests__/__snapshots__/config-invalid.js.snap
@@ -28,7 +28,7 @@ exports[`throw error for unsupported extension (stdout) 1`] = `""`;
 exports[`throw error for unsupported extension (write) 1`] = `Array []`;
 
 exports[`throw error with invalid config format (stderr) 1`] = `
-"[error] Invalid configuration file: Config is only allowed to be an object, but received string in \\"<cwd>/tests_integration/cli/config/invalid/file/.prettierrc\\"
+"[error] Invalid configuration file: Cannot find module '--invalid--' from '<cwd>/tests_integration/cli/config/invalid/file'
 "
 `;
 

--- a/tests_integration/__tests__/__snapshots__/config-resolution.js.snap
+++ b/tests_integration/__tests__/__snapshots__/config-resolution.js.snap
@@ -24,6 +24,9 @@ function f() {
   )
 }
 console.log(
+  \\"should have no semi\\"
+)
+console.log(
   \\"jest/__best-tests__/file.js should have semi\\"
 );
 console.log(
@@ -130,6 +133,7 @@ function f() {
     \\"should have space width 2 despite ../.editorconfig specifying 8, because ./.hg is present\\"
   )
 }
+console.log(\\"should have no semi\\")
 console.log(\\"jest/__best-tests__/file.js should have semi\\");
 console.log(\\"jest/Component.js should not have semi\\")
 console.log(\\"jest/Component.test.js should have semi\\");
@@ -191,6 +195,15 @@ function packageTs() {
 `;
 
 exports[`resolves configuration from external files and overrides by extname (write) 1`] = `Array []`;
+
+exports[`resolves external configuration from package.json (stderr) 1`] = `""`;
+
+exports[`resolves external configuration from package.json (stdout) 1`] = `
+"console.log(\\"should have no semi\\")
+"
+`;
+
+exports[`resolves external configuration from package.json (write) 1`] = `Array []`;
 
 exports[`resolves json configuration file with --find-config-path file (stderr) 1`] = `""`;
 

--- a/tests_integration/__tests__/__snapshots__/with-config-precedence.js.snap
+++ b/tests_integration/__tests__/__snapshots__/with-config-precedence.js.snap
@@ -103,6 +103,9 @@ function f() {
   )
 }
 console.log(
+  \\"should have no semi\\"
+)
+console.log(
   \\"jest/__best-tests__/file.js should have semi\\"
 );
 console.log(
@@ -191,6 +194,9 @@ function f() {
     \\"should have space width 2 despite ../.editorconfig specifying 8, because ./.hg is present\\"
   )
 }
+console.log(
+  \\"should have no semi\\"
+)
 console.log(
   \\"jest/__best-tests__/file.js should have semi\\"
 );

--- a/tests_integration/__tests__/config-resolution.js
+++ b/tests_integration/__tests__/config-resolution.js
@@ -25,6 +25,12 @@ describe("accepts configuration from --config", () => {
   });
 });
 
+describe("resolves external configuration from package.json", () => {
+  runPrettier("cli/config/", ["external-config/index.js"]).test({
+    status: 0
+  });
+});
+
 describe("resolves configuration file with --find-config-path file", () => {
   runPrettier("cli/config/", ["--find-config-path", "no-config/file.js"]).test({
     status: 0
@@ -260,5 +266,13 @@ test("API resolveConfig resolves relative path values based on config filepath",
   expect(prettier.resolveConfig.sync(`${currentDir}/index.js`)).toMatchObject({
     plugins: [path.join(parentDir, "path-to-plugin")],
     pluginSearchDirs: [path.join(parentDir, "path-to-plugin-search-dir")]
+  });
+});
+
+test("API resolveConfig de-references to an external module", () => {
+  const currentDir = path.join(__dirname, "../cli/config/external-config");
+  expect(prettier.resolveConfig.sync(`${currentDir}/index.js`)).toEqual({
+    printWidth: 77,
+    semi: false
   });
 });

--- a/tests_integration/cli/config/external-config/index.js
+++ b/tests_integration/cli/config/external-config/index.js
@@ -1,0 +1,1 @@
+console.log("should have no semi");

--- a/tests_integration/cli/config/external-config/node_modules/@company/prettier-config/index.json
+++ b/tests_integration/cli/config/external-config/node_modules/@company/prettier-config/index.json
@@ -1,0 +1,4 @@
+{
+  "printWidth": 77,
+  "semi": false
+}

--- a/tests_integration/cli/config/external-config/node_modules/@company/prettier-config/package.json
+++ b/tests_integration/cli/config/external-config/node_modules/@company/prettier-config/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@company/prettier-config",
+  "main": "index.json",
+  "version": "0.0.0"
+}

--- a/tests_integration/cli/config/external-config/package.json
+++ b/tests_integration/cli/config/external-config/package.json
@@ -1,0 +1,3 @@
+{
+  "prettier": "@company/prettier-config"
+}


### PR DESCRIPTION
This PR introduces support for external/shared configurations for Prettier.

Sharing a Prettier configuration is simple, just publish a module that exports a configuration object, say `@azz/prettier-config`, and reference it in your `package.json`:

```json
{
  "name": "my-cool-library",
  "version": "9000.0.1",
  "prettier": "@azz/prettier-config"
}
```

If you don't want to use `package.json`, you can use any of the supported extensions, e.g. `.prettierrc.json`:

```json
"@azz/prettier-config"
```

This PR does **not** offer a way to _extend_ the configuration to overwrite some properties from the shared configuration. If you need to do that, import the file in a `.prettierrc.js` file and export the modifications, e.g:

```js
module.exports = {
  ...require('@azz/prettier-config'),
  semi: false,
};
```

Closes #3146

----


- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
