### PR TITLE
Add option neverIndentImports to skip import statements formatting

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -190,3 +190,25 @@ Examples:
   // Output (Prettier master)
   <div *ngIf="isRendered | async"></div>
   ```
+
+- JavaScript: Add option neverIndentImports to skip import statements formatting ([] by [@DmitryKoterov])
+
+  People sometimes prefer to use VSCode's built-in source.organizeImports feature which, among other things, places all imports on the same line. Adding neverIndentImports to Prettier to optionally disable import statements indentation.
+
+  <!-- prettier-ignore -->
+  ```html
+  // Input (assuming the line is long)
+  import { Lorem, ipsum, ..., amet, consectetur } from "some-module";
+
+  // Output (Prettier stable)
+  import {
+    Lorem,
+    ipsum,
+    ...
+    amet,
+    consectetur
+  } from "some-module";
+
+  // Output (Prettier master with neverIndentImports=true)
+  import { Lorem, ipsum, ..., amet, consectetur } from "some-module";
+  ```

--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -24,6 +24,15 @@ module.exports = {
     ]
   },
   bracketSpacing: commonOptions.bracketSpacing,
+  neverIndentImports: {
+    since: "1.16.5",
+    category: CATEGORY_JAVASCRIPT,
+    type: "boolean",
+    default: false,
+    description:
+      "Never indent import statements, so the built-in VSCode" +
+      ' "Organize Imports" feature may do its job.'
+  },
   jsxBracketSameLine: {
     since: "0.17.0",
     category: CATEGORY_JAVASCRIPT,

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1001,10 +1001,11 @@ function printPathNoParens(path, options, print, args) {
         }
 
         if (
-          grouped.length === 1 &&
-          standalones.length === 0 &&
-          n.specifiers &&
-          !n.specifiers.some(node => node.comments)
+          options.neverIndentImports ||
+          (grouped.length === 1 &&
+            standalones.length === 0 &&
+            n.specifiers &&
+            !n.specifiers.some(node => node.comments))
         ) {
           parts.push(
             concat([

--- a/tests/js_never_indent_imports/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js_never_indent_imports/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`long_import.js 1`] = `
+====================================options=====================================
+neverIndentImports: true
+parsers: ["flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+import abc, { Lorem, ipsum, dolor, sit, amet, consectetur, adipiscing, elit, sed, eiusmod, tempor, incididunt, ut, labore, et, magna } from "some-module";
+import { Lorem, ipsum, dolor, sit, amet, consectetur, adipiscing, elit, sed, eiusmod, tempor, incididunt, ut, labore, et, magna } from "some-module";
+
+=====================================output=====================================
+import abc, { Loremipsumdolorsitametconsecteturadipiscingelitsedeiusmodtemporincididuntutlaboreetmagna } from "some-module";
+import { Loremipsumdolorsitametconsecteturadipiscingelitsedeiusmodtemporincididuntutlaboreetmagna } from "some-module";
+
+================================================================================
+`;
+
+exports[`long_import.js 2`] = `
+====================================options=====================================
+neverIndentImports: false
+parsers: ["flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+import abc, { Lorem, ipsum, dolor, sit, amet, consectetur, adipiscing, elit, sed, eiusmod, tempor, incididunt, ut, labore, et, magna } from "some-module";
+import { Lorem, ipsum, dolor, sit, amet, consectetur, adipiscing, elit, sed, eiusmod, tempor, incididunt, ut, labore, et, magna } from "some-module";
+
+=====================================output=====================================
+import abc, {
+  Lorem,
+  ipsum,
+  dolor,
+  sit,
+  amet,
+  consectetur,
+  adipiscing,
+  elit,
+  sed,
+  eiusmod,
+  tempor,
+  incididunt,
+  ut,
+  labore,
+  et,
+  magna
+} from "some-module";
+import {
+  Lorem,
+  ipsum,
+  dolor,
+  sit,
+  amet,
+  consectetur,
+  adipiscing,
+  elit,
+  sed,
+  eiusmod,
+  tempor,
+  incididunt,
+  ut,
+  labore,
+  et,
+  magna
+} from "some-module";
+
+================================================================================
+`;

--- a/tests/js_never_indent_imports/jsfmt.spec.js
+++ b/tests/js_never_indent_imports/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname, ["flow", "typescript"], { neverIndentImports: true });
+run_spec(__dirname, ["flow", "typescript"], { neverIndentImports: false });

--- a/tests/js_never_indent_imports/long_import.js
+++ b/tests/js_never_indent_imports/long_import.js
@@ -1,0 +1,2 @@
+import abc, { Lorem, ipsum, dolor, sit, amet, consectetur, adipiscing, elit, sed, eiusmod, tempor, incididunt, ut, labore, et, magna } from "some-module";
+import { Lorem, ipsum, dolor, sit, amet, consectetur, adipiscing, elit, sed, eiusmod, tempor, incididunt, ut, labore, et, magna } from "some-module";

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -72,6 +72,8 @@ Format options:
                            Defaults to false.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.
+  --never-indent-imports   Never indent import statements, so the built-in VSCode \\"Organize Imports\\" feature may do its job.
+                           Defaults to false.
   --parser <flow|babel|babel-flow|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|html|angular|lwc>
                            Which parser to use.
   --print-width <int>      The line length where Prettier will try wrap.
@@ -224,6 +226,8 @@ Format options:
   --jsx-bracket-same-line  Put > on the last line instead of at a new line.
                            Defaults to false.
   --jsx-single-quote       Use single quotes in JSX.
+                           Defaults to false.
+  --never-indent-imports   Never indent import statements, so the built-in VSCode \\"Organize Imports\\" feature may do its job.
                            Defaults to false.
   --parser <flow|babel|babel-flow|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|html|angular|lwc>
                            Which parser to use.

--- a/tests_integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/help-options.js.snap
@@ -274,6 +274,19 @@ Default: log
 
 exports[`show detailed usage with --help loglevel (write) 1`] = `Array []`;
 
+exports[`show detailed usage with --help never-indent-imports (stderr) 1`] = `""`;
+
+exports[`show detailed usage with --help never-indent-imports (stdout) 1`] = `
+"--never-indent-imports
+
+  Never indent import statements, so the built-in VSCode \\"Organize Imports\\" feature may do its job.
+
+Default: false
+"
+`;
+
+exports[`show detailed usage with --help never-indent-imports (write) 1`] = `Array []`;
+
 exports[`show detailed usage with --help no-bracket-spacing (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help no-bracket-spacing (stdout) 1`] = `

--- a/tests_integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests_integration/__tests__/__snapshots__/schema.js.snap
@@ -118,6 +118,11 @@ This option cannot be used with --range-start and --range-end.",
           "description": "Use single quotes in JSX.",
           "type": "boolean",
         },
+        "neverIndentImports": Object {
+          "default": false,
+          "description": "Never indent import statements, so the built-in VSCode \\"Organize Imports\\" feature may do its job.",
+          "type": "boolean",
+        },
         "parser": Object {
           "default": undefined,
           "description": "Which parser to use.",

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -611,7 +611,22 @@ exports[`API getSupportInfo() with version 1.16.0 -> undefined 1`] = `
       ],
       \\"Markdown\\": Array [
         \\"markdown\\",
-@@ -135,10 +138,11 @@
+@@ -116,10 +119,14 @@
+      },
+      \\"jsxSingleQuote\\": Object {
+        \\"default\\": false,
+        \\"type\\": \\"boolean\\",
+      },
++     \\"neverIndentImports\\": Object {
++       \\"default\\": false,
++       \\"type\\": \\"boolean\\",
++     },
+      \\"parser\\": Object {
+        \\"choices\\": Array [
+          \\"flow\\",
+          \\"babel\\",
+          \\"babel-flow\\",
+@@ -135,10 +142,11 @@
           \\"mdx\\",
           \\"vue\\",
           \\"yaml\\",
@@ -623,7 +638,7 @@ exports[`API getSupportInfo() with version 1.16.0 -> undefined 1`] = `
         \\"type\\": \\"choice\\",
       },
       \\"pluginSearchDirs\\": Object {
-@@ -165,10 +169,19 @@
+@@ -165,10 +173,19 @@
           \\"preserve\\",
         ],
         \\"default\\": \\"preserve\\",
@@ -1152,6 +1167,15 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"name\\": \\"jsxSingleQuote\\",
       \\"pluginDefaults\\": {},
       \\"since\\": \\"1.15.0\\",
+      \\"type\\": \\"boolean\\"
+    },
+    {
+      \\"category\\": \\"JavaScript\\",
+      \\"default\\": false,
+      \\"description\\": \\"Never indent import statements, so the built-in VSCode \\\\\\"Organize Imports\\\\\\" feature may do its job.\\",
+      \\"name\\": \\"neverIndentImports\\",
+      \\"pluginDefaults\\": {},
+      \\"since\\": \\"1.16.5\\",
       \\"type\\": \\"boolean\\"
     },
     {


### PR DESCRIPTION
People sometimes prefer to use VSCode's built-in source.organizeImports feature which, among other things, places all imports on the same line. Adding neverIndentImports to Prettier to optionally disable import statements indentation.

- [x] I’ve added tests to confirm my change works.
- [x] I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
