### PR TITLE
Add doc build

### DIFF
--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -112,6 +112,13 @@ const coreBundles = [
     external: [path.resolve("src/common/third-party.js")]
   },
   {
+    input: "src/doc/index.js",
+    name: "doc",
+    type: "core",
+    output: "doc.js",
+    target: "universal"
+  },
+  {
     input: "standalone.js",
     name: "prettier",
     type: "core",


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fixes https://github.com/prettier/prettier/issues/6008

I ran `yarn build` locally, and was then able to do this: 
```
> const {builders: b, printer: p} = require('./dist/doc.js')
undefined
> p.printDocToString(b.concat(['hello', 'world']), {})
{ formatted: 'helloworld' }
```
The file is 58kb 🎉

I wasn't sure if this warranted docs or tests; please advise. 

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
