### PR TITLE
Enable using custom parser with languages other than JS

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -134,7 +134,8 @@ prettier.format("lodash ( )", {
     const ast = babel(text);
     ast.program.body[0].expression.callee.name = "_";
     return ast;
-  }
+  },
+  astFormat: 'babel',
 });
 // -> "_();\n"
 ```

--- a/src/main/parser.js
+++ b/src/main/parser.js
@@ -29,10 +29,10 @@ function resolveParser(opts, parsers) {
   parsers = parsers || getParsers(opts);
 
   if (typeof opts.parser === "function") {
-    // Custom parser API always works with JavaScript.
+    const astFormat = opts.astFormat || "estree";
     return {
       parse: opts.parser,
-      astFormat: "estree",
+      astFormat,
       locStart,
       locEnd
     };

--- a/tests_integration/__tests__/__snapshots__/format.js.snap
+++ b/tests_integration/__tests__/__snapshots__/format.js.snap
@@ -4,8 +4,6 @@ exports[`html parser should handle CRLF correctly 1`] = `"\\"<!--\\\\r\\\\n  tes
 
 exports[`markdown parser should handle CRLF correctly 1`] = `"\\"\`\`\`\\\\r\\\\n\\\\r\\\\n\\\\r\\\\n\`\`\`\\\\r\\\\n\\""`;
 
-exports[`should work with foo plugin instance 1`] = `"\\"tabWidth:8\\""`;
-
 exports[`typescript parser should throw the first error when both JSX and non-JSX mode failed 1`] = `
 "Expression expected. (9:7)
    7 | );

--- a/tests_integration/__tests__/parser-api.js
+++ b/tests_integration/__tests__/parser-api.js
@@ -30,6 +30,19 @@ test("allows usage of prettier's supported parsers", () => {
   expect(output).toEqual("bar();\n");
 });
 
+test("allows customizing both parser and AST formatter", () => {
+  const output = prettier.format("query Foo { node }", {
+    parser(text, parsers) {
+      expect(typeof parsers.graphql).toEqual("function");
+      const ast = parsers.graphql(text);
+      ast.definitions[0].name.value = "Bar"
+      return ast;
+    },
+    astFormat: "graphql",
+  });
+  expect(output).toEqual("query Bar {\n  node\n}\n");
+})
+
 describe("allows passing a string to resolve a parser", () => {
   runPrettier("./custom-parsers/", [
     "--end-of-line",


### PR DESCRIPTION
Currently using custom parser API implies using ASTFormatter "estree".
This does not allow for using prettier for simple GraphQL codemodding or using
custom GraphQL parser.

<!-- Please provide a brief summary of your changes: -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
