### PR TITLE
WIP: Add option to choose between 1TBS and Stroustrup brace style

### DIFF
--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -70,6 +70,23 @@ module.exports = {
       }
     ]
   },
+  braceStyle: {
+    since: "1.17.0",
+    category: CATEGORY_JAVASCRIPT,
+    type: "choice",
+    default: "1tbs",
+    description: "Choose style of braced statements",
+    choices: [
+      {
+        value: "1tbs",
+        description: "Put all braces on the same line"
+      },
+      {
+        value: "stroustrup",
+        description: "Put closing brace on it's own line."
+      }
+    ]
+  },
   trailingComma: {
     since: "0.0.0",
     category: CATEGORY_JAVASCRIPT,

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1764,7 +1764,9 @@ function printPathNoParens(path, options, print, args) {
             )) ||
           needsHardlineAfterDanglingComment(n);
         const elseOnSameLine =
-          n.consequent.type === "BlockStatement" && !commentOnOwnLine;
+          options.braceStyle === "1tbs" &&
+          n.consequent.type === "BlockStatement" &&
+          !commentOnOwnLine;
         parts.push(elseOnSameLine ? " " : hardline);
 
         if (hasDanglingComments(n)) {
@@ -1886,7 +1888,7 @@ function printPathNoParens(path, options, print, args) {
       const doBody = group(concat(["do", clause]));
       parts = [doBody];
 
-      if (n.body.type === "BlockStatement") {
+      if (n.body.type === "BlockStatement" && options.braceStyle === "1tbs") {
         parts.push(" ");
       } else {
         parts.push(hardline);
@@ -1943,7 +1945,13 @@ function printPathNoParens(path, options, print, args) {
         "try ",
         path.call(print, "block"),
         n.handler ? concat([" ", path.call(print, "handler")]) : "",
-        n.finalizer ? concat([" finally ", path.call(print, "finalizer")]) : ""
+        n.finalizer
+          ? concat([
+              options.braceStyle !== "1tbs" ? hardline : " ",
+              "finally ",
+              path.call(print, "finalizer")
+            ])
+          : ""
       ]);
     case "CatchClause":
       if (n.param) {
@@ -1962,6 +1970,7 @@ function printPathNoParens(path, options, print, args) {
         const param = path.call(print, "param");
 
         return concat([
+          options.braceStyle !== "1tbs" ? hardline : "",
           "catch ",
           hasComments
             ? concat(["(", indent(concat([softline, param])), softline, ") "])

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -61,6 +61,9 @@ Format options:
   --arrow-parens <avoid|always>
                            Include parentheses around a sole arrow function parameter.
                            Defaults to avoid.
+  --brace-style <1tbs|stroustrup>
+                           Choose style of braced statements
+                           Defaults to 1tbs.
   --no-bracket-spacing     Do not print spaces between brackets.
   --end-of-line <auto|lf|crlf|cr>
                            Which end of line characters to apply.
@@ -214,6 +217,9 @@ Format options:
   --arrow-parens <avoid|always>
                            Include parentheses around a sole arrow function parameter.
                            Defaults to avoid.
+  --brace-style <1tbs|stroustrup>
+                           Choose style of braced statements
+                           Defaults to 1tbs.
   --no-bracket-spacing     Do not print spaces between brackets.
   --end-of-line <auto|lf|crlf|cr>
                            Which end of line characters to apply.

--- a/tests_integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/help-options.js.snap
@@ -18,6 +18,24 @@ Default: avoid
 
 exports[`show detailed usage with --help arrow-parens (write) 1`] = `Array []`;
 
+exports[`show detailed usage with --help brace-style (stderr) 1`] = `""`;
+
+exports[`show detailed usage with --help brace-style (stdout) 1`] = `
+"--brace-style <1tbs|stroustrup>
+
+  Choose style of braced statements
+
+Valid options:
+
+  1tbs         Put all braces on the same line
+  stroustrup   Put closing brace on it's own line.
+
+Default: 1tbs
+"
+`;
+
+exports[`show detailed usage with --help brace-style (write) 1`] = `Array []`;
+
 exports[`show detailed usage with --help bracket-spacing (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help bracket-spacing (stdout) 1`] = `

--- a/tests_integration/__tests__/__snapshots__/plugin-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/plugin-options.js.snap
@@ -5,8 +5,8 @@ exports[` 1`] = `
 - First value
 + Second value
 
-@@ -17,10 +17,12 @@
-                             Defaults to avoid.
+@@ -20,10 +20,12 @@
+                             Defaults to 1tbs.
     --no-bracket-spacing     Do not print spaces between brackets.
     --end-of-line <auto|lf|crlf|cr>
                              Which end of line characters to apply.

--- a/tests_integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests_integration/__tests__/__snapshots__/schema.js.snap
@@ -32,6 +32,24 @@ Object {
             },
           ],
         },
+        "braceStyle": Object {
+          "default": "1tbs",
+          "description": "Choose style of braced statements",
+          "oneOf": Array [
+            Object {
+              "description": "Put all braces on the same line",
+              "enum": Array [
+                "1tbs",
+              ],
+            },
+            Object {
+              "description": "Put closing brace on it's own line.",
+              "enum": Array [
+                "stroustrup",
+              ],
+            },
+          ],
+        },
         "bracketSpacing": Object {
           "default": true,
           "description": "Print spaces between brackets.",

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -611,7 +611,26 @@ exports[`API getSupportInfo() with version 1.16.0 -> undefined 1`] = `
       ],
       \\"Markdown\\": Array [
         \\"markdown\\",
-@@ -135,10 +138,11 @@
+@@ -68,10 +71,18 @@
+          \\"always\\",
+        ],
+        \\"default\\": \\"avoid\\",
+        \\"type\\": \\"choice\\",
+      },
++     \\"braceStyle\\": Object {
++       \\"choices\\": Array [
++         \\"1tbs\\",
++         \\"stroustrup\\",
++       ],
++       \\"default\\": \\"1tbs\\",
++       \\"type\\": \\"choice\\",
++     },
+      \\"bracketSpacing\\": Object {
+        \\"default\\": true,
+        \\"type\\": \\"boolean\\",
+      },
+      \\"cursorOffset\\": Object {
+@@ -135,10 +146,11 @@
           \\"mdx\\",
           \\"vue\\",
           \\"yaml\\",
@@ -623,7 +642,7 @@ exports[`API getSupportInfo() with version 1.16.0 -> undefined 1`] = `
         \\"type\\": \\"choice\\",
       },
       \\"pluginSearchDirs\\": Object {
-@@ -165,10 +169,19 @@
+@@ -165,10 +177,19 @@
           \\"preserve\\",
         ],
         \\"default\\": \\"preserve\\",
@@ -1047,6 +1066,22 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"name\\": \\"arrowParens\\",
       \\"pluginDefaults\\": {},
       \\"since\\": \\"1.9.0\\",
+      \\"type\\": \\"choice\\"
+    },
+    {
+      \\"category\\": \\"JavaScript\\",
+      \\"choices\\": [
+        { \\"description\\": \\"Put all braces on the same line\\", \\"value\\": \\"1tbs\\" },
+        {
+          \\"description\\": \\"Put closing brace on it's own line.\\",
+          \\"value\\": \\"stroustrup\\"
+        }
+      ],
+      \\"default\\": \\"1tbs\\",
+      \\"description\\": \\"Choose style of braced statements\\",
+      \\"name\\": \\"braceStyle\\",
+      \\"pluginDefaults\\": {},
+      \\"since\\": \\"1.17.0\\",
       \\"type\\": \\"choice\\"
     },
     {


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Add option for Stroustrup brace style:
```js
if (foo) {
  bar()
}
else {
  baz()
}
```

Fixes #840 

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
