### PR TITLE
Javascript: Use function literals in arguments to detect function composition

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -286,52 +286,26 @@ foo;
 
 ### Javascript: Use function literals in arguments to detect function composition ([#6033] by [@brainkim])
 
-Previously, we used function/method names to detect function composition, so
-that we could split the arguments onto multiple lines. We now use the presence
-of function literals in arguments.
+Previously, we used names of functions and methods to detect function
+composition, so that we could split their arguments onto multiple lines. We now
+use the presence of function literals in arguments instead.
 
 <!-- prettier-ignore -->
 ```js
-const source$ = range(0, 10);
-source$.pipe(filter(x => x % 2 === 0), map(x => x + x), scan((acc, x) => acc + x, 0)).subscribe(x => console.log(x));
-const isEven = x => x % 2 === 0;
-const double = x => x + x;
-const add = (acc, x) => acc + x;
-source$.pipe(filter(isEven), map(double), scan(add, 0)).subscribe(x => console.log(x))
+// Input
+eventStore.update(id, _.flow(updater, incrementVersion));
+
 // Output (Prettier stable)
-const source$ = range(0, 10);
-source$
-  .pipe(
-    filter(x => x % 2 === 0),
-    map(x => x + x),
-    scan((acc, x) => acc + x, 0)
+eventStore.update(
+  id,
+  _.flow(
+    updater,
+    incrementVersion
   )
-  .subscribe(x => console.log(x));
-const isEven = x => x % 2 === 0;
-const double = x => x + x;
-const add = (acc, x) => acc + x;
-source$
-  .pipe(
-    filter(isEven),
-    map(double),
-    scan(add, 0)
-  )
-  .subscribe(x => console.log(x));
+);
+
 // Output (Prettier master)
-const source$ = range(0, 10);
-source$
-  .pipe(
-    filter(x => x % 2 === 0),
-    map(x => x + x),
-    scan((acc, x) => acc + x, 0)
-  )
-  .subscribe(x => console.log(x));
-const isEven = x => x % 2 === 0;
-const double = x => x + x;
-const add = (acc, x) => acc + x;
-source$
-  .pipe(filter(isEven), map(double), scan(add, 0))
-  .subscribe(x => console.log(x));
+eventStore.update(id, _.flow(updater, incrementVersion));
 ```
 
 ### Handlebars: Improve comment formatting ([#6234] by [@gavinjoyce])

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -284,6 +284,56 @@ foo;
 );
 ```
 
+### Javascript: Use function literals in arguments to detect function composition ([#6033] by [@brainkim])
+
+Previously, we used function/method names to detect function composition, so
+that we could split the arguments onto multiple lines. We now use the presence
+of function literals in arguments.
+
+<!-- prettier-ignore -->
+```js
+const source$ = range(0, 10);
+source$.pipe(filter(x => x % 2 === 0), map(x => x + x), scan((acc, x) => acc + x, 0)).subscribe(x => console.log(x));
+const isEven = x => x % 2 === 0;
+const double = x => x + x;
+const add = (acc, x) => acc + x;
+source$.pipe(filter(isEven), map(double), scan(add, 0)).subscribe(x => console.log(x))
+// Output (Prettier stable)
+const source$ = range(0, 10);
+source$
+  .pipe(
+    filter(x => x % 2 === 0),
+    map(x => x + x),
+    scan((acc, x) => acc + x, 0)
+  )
+  .subscribe(x => console.log(x));
+const isEven = x => x % 2 === 0;
+const double = x => x + x;
+const add = (acc, x) => acc + x;
+source$
+  .pipe(
+    filter(isEven),
+    map(double),
+    scan(add, 0)
+  )
+  .subscribe(x => console.log(x));
+// Output (Prettier master)
+const source$ = range(0, 10);
+source$
+  .pipe(
+    filter(x => x % 2 === 0),
+    map(x => x + x),
+    scan((acc, x) => acc + x, 0)
+  )
+  .subscribe(x => console.log(x));
+const isEven = x => x % 2 === 0;
+const double = x => x + x;
+const add = (acc, x) => acc + x;
+source$
+  .pipe(filter(isEven), map(double), scan(add, 0))
+  .subscribe(x => console.log(x));
+```
+
 ### Handlebars: Improve comment formatting ([#6234] by [@gavinjoyce])
 
 Previously, Prettier would incorrectly decode HTML entiites.
@@ -696,6 +746,7 @@ Previously, the flag was not applied on html attributes.
 ````
 
 [#5910]: https://github.com/prettier/prettier/pull/5910
+[#6033]: https://github.com/prettier/prettier/pull/6033
 [#6186]: https://github.com/prettier/prettier/pull/6186
 [#6206]: https://github.com/prettier/prettier/pull/6206
 [#6209]: https://github.com/prettier/prettier/pull/6209
@@ -704,10 +755,10 @@ Previously, the flag was not applied on html attributes.
 [#6236]: https://github.com/prettier/prettier/pull/6236
 [#6270]: https://github.com/prettier/prettier/pull/6270
 [#6289]: https://github.com/prettier/prettier/pull/6289
-[#6332]: https://github.com/prettier/prettier/pull/6332
 [#6284]: https://github.com/prettier/prettier/pull/6284
 [#6301]: https://github.com/prettier/prettier/pull/6301
 [#6307]: https://github.com/prettier/prettier/pull/6307
+[#6332]: https://github.com/prettier/prettier/pull/6332
 [#6340]: https://github.com/prettier/prettier/pull/6340
 [#6412]: https://github.com/prettier/prettier/pull/6412
 [#6423]: https://github.com/prettier/prettier/pull/6423
@@ -720,6 +771,7 @@ Previously, the flag was not applied on html attributes.
 [#6514]: https://github.com/prettier/prettier/pull/6514
 [#6467]: https://github.com/prettier/prettier/pull/6467
 [#6377]: https://github.com/prettier/prettier/pull/6377
+[@brainkim]: https://github.com/brainkim
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
 [@sosukesuzuki]: https://github.com/sosukesuzuki

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -286,9 +286,36 @@ foo;
 
 ### Javascript: Use function literals in arguments to detect function composition ([#6033] by [@brainkim])
 
-Previously, we used names of functions and methods to detect function
-composition, so that we could split their arguments onto multiple lines. We now
-use the presence of function literals in arguments instead.
+Previously, we used a set of hard-coded names related to functional programming
+(`compose`, `flow`, `pipe`, etc.) to detect function composition and chaining
+patterns in code. This was done so that prettier would not put code like the
+following call to `pipe` on the same line even if it fit within the allotted
+column budget:
+
+<!-- prettier-ignore -->
+```js
+source$
+  .pipe(
+    filter(x => x % 2 === 0),
+    map(x => x + x),
+    scan((acc, x) => acc + x, 0),
+  )
+  .subscribe(x => console.log(x));
+```
+
+However, this heuristic caused people to complain because of false positives
+where calls to functions or methods matching the hard-coded names would always
+be split on multiple lines, even if the calls did not contain function
+arguments (https://github.com/prettier/prettier/issues/5769,
+https://github.com/prettier/prettier/issues/5969). For many, this blanket
+decision to split functions based on name was both surprising and sub-optimal.
+
+We now use a refined heuristic which uses the presence of function literals to
+detect function composition. This heuristic preserves the line-splitting
+behavior above and eliminates many if not all of the false positives caused by
+the older heuristic.
+
+We encourage prettier users to try out the new heuristic and provide feedback.
 
 <!-- prettier-ignore -->
 ```js

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4049,8 +4049,8 @@ function isLongCurriedCall(path) {
   const node = path.getValue();
   const parent = path.getParentNode();
   return (
-    node.type === "CallExpression" &&
-    parent.type === "CallExpression" &&
+    isCallOrOptionalCallExpression(node) &&
+    isCallOrOptionalCallExpression(parent) &&
     parent.callee === node &&
     node.arguments.length > parent.arguments.length &&
     parent.arguments.length > 0
@@ -5219,6 +5219,9 @@ function printMemberChain(path, options, print) {
   // If we only have a single `.`, we shouldn't do anything fancy and just
   // render everything concatenated together.
   if (groups.length <= cutoff && !hasComment) {
+    if (isLongCurriedCall(path)) {
+      return oneLine;
+    }
     return group(oneLine);
   }
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4021,24 +4021,16 @@ function isFunctionCompositionArgs(args) {
   if (args.length <= 1) {
     return false;
   }
-  let functionCount = 0;
-  for (let i = 0; i < args.length; i++) {
-    const arg = args[i];
-    if (
-      arg.type === "FunctionExpression" ||
-      arg.type === "ArrowFunctionExpression"
-    ) {
-      functionCount++;
-      if (functionCount > 1) {
+  let count = 0;
+  for (const arg of args) {
+    if (isFunctionOrArrowExpression(arg)) {
+      count += 1;
+      if (count > 1) {
         return true;
       }
-    } else if (arg.type === "CallExpression") {
-      for (let j = 0; j < arg.arguments.length; j++) {
-        const childArg = arg.arguments[j];
-        if (
-          childArg.type === "FunctionExpression" ||
-          childArg.type === "ArrowFunctionExpression"
-        ) {
+    } else if (isCallOrOptionalCallExpression(arg)) {
+      for (const childArg of arg.arguments) {
+        if (isFunctionOrArrowExpression(childArg)) {
           return true;
         }
       }

--- a/tests/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -1084,7 +1084,10 @@ foo(c, a => b, d)
 foo(a => b, d)
 
 =====================================output=====================================
-promise.then(result => result, err => err);
+promise.then(
+  result => result,
+  err => err
+);
 
 promise.then(
   result => {
@@ -1132,7 +1135,10 @@ foo(c, a => b, d)
 foo(a => b, d)
 
 =====================================output=====================================
-promise.then((result) => result, (err) => err);
+promise.then(
+  (result) => result,
+  (err) => err
+);
 
 promise.then(
   (result) => {

--- a/tests/decorators-ts/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators-ts/__snapshots__/jsfmt.spec.js.snap
@@ -321,7 +321,10 @@ export class Board {
   @Column()
   description: string;
 
-  @OneToMany(type => Topic, topic => topic.board)
+  @OneToMany(
+    type => Topic,
+    topic => topic.board
+  )
   topics: Topic[];
 }
 

--- a/tests/decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators/__snapshots__/jsfmt.spec.js.snap
@@ -344,10 +344,7 @@ export class MyApp extends React.Component {}
 export class Home extends React.Component {}
 
 =====================================output=====================================
-@connect(
-  mapStateToProps,
-  mapDispatchToProps
-)
+@connect(mapStateToProps, mapDispatchToProps)
 export class MyApp extends React.Component {}
 
 @connect(state => ({ todos: state.todos }))

--- a/tests/functional_composition/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/functional_composition/__snapshots__/jsfmt.spec.js.snap
@@ -314,11 +314,7 @@ var classyGreeting = (firstName, lastName) =>
 var yellGreeting = R.compose(R.toUpper, classyGreeting);
 yellGreeting("James", "Bond"); //=> "THE NAME'S BOND, JAMES BOND"
 
-R.compose(
-  Math.abs,
-  R.add(1),
-  R.multiply(2)
-)(-4); //=> 7
+R.compose(Math.abs, R.add(1), R.multiply(2))(-4); //=> 7
 
 //  get :: String -> Object -> Maybe *
 var get = R.curry((propName, obj) => Maybe(obj[propName]));

--- a/tests/functional_composition/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/functional_composition/__snapshots__/jsfmt.spec.js.snap
@@ -303,13 +303,22 @@ var followersForUser = R.composeP(lookupFollowers, lookupUser);
 followersForUser("JOE").then(followers => console.log("Followers:", followers));
 // Followers: ["STEVE","SUZY"]
 
+const mapStateToProps = state => ({
+  users: R.compose( R.filter(R.propEq('status', 'active')),
+    R.values)(state.users)
+});
+
 =====================================output=====================================
 var classyGreeting = (firstName, lastName) =>
   "The name's " + lastName + ", " + firstName + " " + lastName;
 var yellGreeting = R.compose(R.toUpper, classyGreeting);
 yellGreeting("James", "Bond"); //=> "THE NAME'S BOND, JAMES BOND"
 
-R.compose(Math.abs, R.add(1), R.multiply(2))(-4); //=> 7
+R.compose(
+  Math.abs,
+  R.add(1),
+  R.multiply(2)
+)(-4); //=> 7
 
 //  get :: String -> Object -> Maybe *
 var get = R.curry((propName, obj) => Maybe(obj[propName]));
@@ -342,6 +351,13 @@ lookupUser("JOE").then(lookupFollowers);
 var followersForUser = R.composeP(lookupFollowers, lookupUser);
 followersForUser("JOE").then(followers => console.log("Followers:", followers));
 // Followers: ["STEVE","SUZY"]
+
+const mapStateToProps = state => ({
+  users: R.compose(
+    R.filter(R.propEq("status", "active")),
+    R.values
+  )(state.users)
+});
 
 ================================================================================
 `;

--- a/tests/functional_composition/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/functional_composition/__snapshots__/jsfmt.spec.js.snap
@@ -447,9 +447,11 @@ printWidth: 80
 const ArtistInput = connect(mapStateToProps, mapDispatchToProps, mergeProps)(Component);
 
 =====================================output=====================================
-const ArtistInput = connect(mapStateToProps, mapDispatchToProps, mergeProps)(
-  Component
-);
+const ArtistInput = connect(
+  mapStateToProps,
+  mapDispatchToProps,
+  mergeProps
+)(Component);
 
 ================================================================================
 `;

--- a/tests/functional_composition/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/functional_composition/__snapshots__/jsfmt.spec.js.snap
@@ -87,12 +87,7 @@ this.a.b.c.compose(
   sortBy(x => x),
   flatten
 );
-someObj.someMethod(
-  this.field.compose(
-    a,
-    b
-  )
-);
+someObj.someMethod(this.field.compose(a, b));
 
 class A extends B {
   compose() {
@@ -105,10 +100,7 @@ class A extends B {
 
 this.subscriptions.add(
   this.componentUpdates
-    .pipe(
-      startWith(this.props),
-      distinctUntilChanged(isEqual)
-    )
+    .pipe(startWith(this.props), distinctUntilChanged(isEqual))
     .subscribe(props => {})
 );
 
@@ -314,27 +306,17 @@ followersForUser("JOE").then(followers => console.log("Followers:", followers));
 =====================================output=====================================
 var classyGreeting = (firstName, lastName) =>
   "The name's " + lastName + ", " + firstName + " " + lastName;
-var yellGreeting = R.compose(
-  R.toUpper,
-  classyGreeting
-);
+var yellGreeting = R.compose(R.toUpper, classyGreeting);
 yellGreeting("James", "Bond"); //=> "THE NAME'S BOND, JAMES BOND"
 
-R.compose(
-  Math.abs,
-  R.add(1),
-  R.multiply(2)
-)(-4); //=> 7
+R.compose(Math.abs, R.add(1), R.multiply(2))(-4); //=> 7
 
 //  get :: String -> Object -> Maybe *
 var get = R.curry((propName, obj) => Maybe(obj[propName]));
 
 //  getStateCode :: Maybe String -> Maybe String
 var getStateCode = R.composeK(
-  R.compose(
-    Maybe.of,
-    R.toUpper
-  ),
+  R.compose(Maybe.of, R.toUpper),
   get("state"),
   get("address"),
   get("user")
@@ -357,10 +339,7 @@ var lookupFollowers = user => Promise.resolve(user.followers);
 lookupUser("JOE").then(lookupFollowers);
 
 //  followersForUser :: String -> Promise [UserId]
-var followersForUser = R.composeP(
-  lookupFollowers,
-  lookupUser
-);
+var followersForUser = R.composeP(lookupFollowers, lookupUser);
 followersForUser("JOE").then(followers => console.log("Followers:", followers));
 // Followers: ["STEVE","SUZY"]
 
@@ -398,11 +377,7 @@ getStateCode("[Invalid JSON]");
 var followersForUser = R.pipeP(db.getUserById, db.getFollowers);
 
 =====================================output=====================================
-var f = R.pipe(
-  Math.pow,
-  R.negate,
-  R.inc
-);
+var f = R.pipe(Math.pow, R.negate, R.inc);
 
 f(3, 4); // -(3^4) + 1
 
@@ -415,10 +390,7 @@ var getStateCode = R.pipeK(
   get("user"),
   get("address"),
   get("state"),
-  R.compose(
-    Maybe.of,
-    R.toUpper
-  )
+  R.compose(Maybe.of, R.toUpper)
 );
 
 getStateCode('{"user":{"address":{"state":"ny"}}}');
@@ -427,10 +399,7 @@ getStateCode("[Invalid JSON]");
 //=> Nothing()
 
 //  followersForUser :: String -> Promise [User]
-var followersForUser = R.pipeP(
-  db.getUserById,
-  db.getFollowers
-);
+var followersForUser = R.pipeP(db.getUserById, db.getFollowers);
 
 ================================================================================
 `;
@@ -463,10 +432,7 @@ import reducer from "../reducers";
 
 const store = createStore(
   reducer,
-  compose(
-    applyMiddleware(thunk),
-    DevTools.instrument()
-  )
+  compose(applyMiddleware(thunk), DevTools.instrument())
 );
 
 ================================================================================
@@ -481,11 +447,9 @@ printWidth: 80
 const ArtistInput = connect(mapStateToProps, mapDispatchToProps, mergeProps)(Component);
 
 =====================================output=====================================
-const ArtistInput = connect(
-  mapStateToProps,
-  mapDispatchToProps,
-  mergeProps
-)(Component);
+const ArtistInput = connect(mapStateToProps, mapDispatchToProps, mergeProps)(
+  Component
+);
 
 ================================================================================
 `;
@@ -512,15 +476,12 @@ const resolve = createSelector(
 =====================================output=====================================
 import { createSelector } from "reselect";
 
-const resolve = createSelector(
-  getIds,
-  getObjects,
-  (ids, objects) => ids.map(id => objects[id])
+const resolve = createSelector(getIds, getObjects, (ids, objects) =>
+  ids.map(id => objects[id])
 );
 
-const resolve = createSelector(
-  [getIds, getObjects],
-  (ids, objects) => ids.map(id => objects[id])
+const resolve = createSelector([getIds, getObjects], (ids, objects) =>
+  ids.map(id => objects[id])
 );
 
 ================================================================================

--- a/tests/functional_composition/ramda_compose.js
+++ b/tests/functional_composition/ramda_compose.js
@@ -36,3 +36,8 @@ lookupUser("JOE").then(lookupFollowers);
 var followersForUser = R.composeP(lookupFollowers, lookupUser);
 followersForUser("JOE").then(followers => console.log("Followers:", followers));
 // Followers: ["STEVE","SUZY"]
+
+const mapStateToProps = state => ({
+  users: R.compose( R.filter(R.propEq('status', 'active')),
+    R.values)(state.users)
+});

--- a/tests/typescript_arrow/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_arrow/__snapshots__/jsfmt.spec.js.snap
@@ -27,7 +27,12 @@ const bar = (...varargs: any[]) => {
   console.log(varargs);
 };
 
-const foo = (x: string): void => bar(x, () => {}, () => {});
+const foo = (x: string): void =>
+  bar(
+    x,
+    () => {},
+    () => {}
+  );
 
 app.get("/", (req, res): void => {
   res.send("Hello world");


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
This PR removes the hard-coded strings used to detect function composition in favor of a heuristic which counts the number of function literals passed as arguments.

In my opinion, the counter-examples are all places where it would be unreasonable to expect line-breaks (e.g. redux connect functions) or where line-breaks should occur anyways (the most common example is calling `Promise.prototype.then` with two short functions).

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

Related issues:
- Long curried function calls #1420
- RxJS pipe chaining get formatted on a single line #4172
- Add heuristic to format functional composition more nicely #4431
- Functional composition heuristics false positives #4751
- Improve functional composition heuristics #4758
- Codes format unexpected with function "pipe" #4858
- Composed functions not put on own line anymore after 1.14.0 update #4925
- Strange behavior with word `connect` #4935
- Functional Composition Heuristic Is Too Broad #5060
- fix(javascript): skip .connect() method when composing fun #5739
- Prettier formats a sensible one-liner into seven lines #5769
- Inconsitent formatting for one specific line (always the same line) #5898
- Ugly object destructing and function #5928
- Calls to functions or methods named “compose” are always split into multiple lines. #5969
- Add a way to disable functional composition rule #6030

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**

fixes #4751 fixes #4858 fixes #5060 fixes #5769 fixes #5928 fixes #5969