### PR TITLE
fix: nested embeds (JS in HTML in JS)

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -367,7 +367,7 @@ new e[f().x].y();
 
 Previously, if JS code embedded in HTML (via `<script>`) embedded in JS (via a template literal) contained template literals, the inner JS was not formatted.
 
-<!-- prettier-ignore --\>
+<!-- prettier-ignore -->
 ```js
 // Input
 const html = /* HTML */ `<script>var a=\`\`</script>`;

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -341,6 +341,26 @@ const b = new c()!();
 const b = new (c()!)();
 ```
 
+### TypeScript: fix nested embeds (JS in HTML in JS) ([#6038] by [@thorn0])
+
+Previously, if JS code embedded in HTML (via `<script>`) embedded in JS (via a template literal) contained template literals, the inner JS was not formatted.
+
+<!-- prettier-ignore --\>
+```js
+// Input
+const html = /* HTML */ `<script>var a=\`\`</script>`;
+
+// Output (Prettier stable)
+// SyntaxError: Expecting Unicode escape sequence \uXXXX (1:8)
+
+// Output (Prettier master)
+const html = /* HTML */ `
+  <script>
+    var a = \`\`;
+  </script>
+`;
+```
+
 [#5979]: https://github.com/prettier/prettier/pull/5979
 [#6086]: https://github.com/prettier/prettier/pull/6086
 [#6088]: https://github.com/prettier/prettier/pull/6088
@@ -357,6 +377,7 @@ const b = new (c()!)();
 [#6133]: https://github.com/prettier/prettier/pull/6133
 [#6136]: https://github.com/prettier/prettier/pull/6136
 [#6140]: https://github.com/prettier/prettier/pull/6140
+[#6038]: https://github.com/prettier/prettier/pull/6038
 [@belochub]: https://github.com/belochub
 [@brainkim]: https://github.com/brainkim
 [@duailibe]: https://github.com/duailibe

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -500,10 +500,7 @@ function printString(raw, options, isDirectiveLiteral) {
       options.parser === "css" ||
       options.parser === "less" ||
       options.parser === "scss" ||
-      options.parentParser === "html" ||
-      options.parentParser === "vue" ||
-      options.parentParser === "angular" ||
-      options.parentParser === "lwc"
+      options.embeddedInHtml
     )
   );
 }

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -113,7 +113,7 @@ function embed(path, print, textToDoc, options) {
 
       // lit-html: html`<my-element obj=${obj}></my-element>`
       if (
-        /^PRETTIER_HTML_PLACEHOLDER_\d+_IN_JS$/.test(
+        /^PRETTIER_HTML_PLACEHOLDER_\d+_\d+_IN_JS$/.test(
           options.originalText.slice(
             node.valueSpan.start.offset,
             node.valueSpan.end.offset

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -129,6 +129,18 @@ function needsParens(path, options) {
 
   // Identifiers never need parentheses.
   if (node.type === "Identifier") {
+    // ...unless those identifiers are embed placeholders. They might be substituted by complex
+    // expressions, so the parens around them should not be dropped. Example (JS-in-HTML-in-JS):
+    //     let tpl = html`<script> f((${expr}) / 2); </script>`;
+    // If the inner JS formatter removes the parens, the expression might change its meaning:
+    //     f((a + b) / 2)  vs  f(a + b / 2)
+    if (
+      node.extra &&
+      node.extra.parenthesized &&
+      /^PRETTIER_HTML_PLACEHOLDER_\d+_\d+_IN_JS$/.test(node.name)
+    ) {
+      return true;
+    }
     return false;
   }
 

--- a/src/main/multiparser.js
+++ b/src/main/multiparser.js
@@ -19,6 +19,13 @@ function textToDoc(text, partialNextOptions, parentOptions, printAstToDoc) {
   const nextOptions = normalize(
     Object.assign({}, parentOptions, partialNextOptions, {
       parentParser: parentOptions.parser,
+      embeddedInHtml: !!(
+        parentOptions.embeddedInHtml ||
+        parentOptions.parser === "html" ||
+        parentOptions.parser === "vue" ||
+        parentOptions.parser === "angular" ||
+        parentOptions.parser === "lwc"
+      ),
       originalText: text
     }),
     { passThrough: true }

--- a/tests/multiparser_html_js/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_html_js/__snapshots__/jsfmt.spec.js.snap
@@ -31,3 +31,47 @@ printWidth: 80
 
 ================================================================================
 `;
+
+exports[`script-tag-escaping.html 1`] = `
+====================================options=====================================
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<script>
+  document.write(/* HTML */ \`
+    <script>
+      document.write(/* HTML */ \\\`
+        <!-- foo1 -->
+        <script>
+          document.write(/* HTML */ \\\\\\\`<!-- bar1 --> bar <!-- bar2 -->\\\\\\\`);
+        <\\\\/script>
+        <!-- foo2 -->
+      \\\`);
+    <\\/script>
+  \`);
+</script>
+
+=====================================output=====================================
+<script>
+  document.write(/* HTML */ \`
+    <script>
+      document.write(/* HTML */ \\\`
+        <!-- foo1 -->
+        <script>
+          document.write(
+            /* HTML */ \\\\\\\`
+              <!-- bar1 -->
+              bar
+              <!-- bar2 -->
+            \\\\\\\`
+          );
+        <\\\\/script>
+        <!-- foo2 -->
+      \\\`);
+    <\\/script>
+  \`);
+</script>
+
+================================================================================
+`;

--- a/tests/multiparser_html_js/script-tag-escaping.html
+++ b/tests/multiparser_html_js/script-tag-escaping.html
@@ -1,0 +1,13 @@
+<script>
+  document.write(/* HTML */ `
+    <script>
+      document.write(/* HTML */ \`
+        <!-- foo1 -->
+        <script>
+          document.write(/* HTML */ \\\`<!-- bar1 --> bar <!-- bar2 -->\\\`);
+        <\\/script>
+        <!-- foo2 -->
+      \`);
+    <\/script>
+  `);
+</script>

--- a/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
@@ -68,6 +68,9 @@ function HelloWorld() {
   \`;
 }
 
+const trickyParens = html\`<script> f((\${expr}) / 2); </script>\`;
+const nestedFun = /* HTML */ \`\${outerExpr( 1 )} <script>const tpl = html\\\`<div>\\\${innerExpr( 1 )} \${outerExpr( 2 )}</div>\\\`</script>\`;
+
 =====================================output=====================================
 import { LitElement, html } from "@polymer/lit-element";
 
@@ -129,6 +132,20 @@ function HelloWorld() {
     )}
   \`;
 }
+
+const trickyParens = html\`
+  <script>
+    f((\${expr}) / 2);
+  </script>
+\`;
+const nestedFun = /* HTML */ \`
+  \${outerExpr(1)}
+  <script>
+    const tpl = html\\\`
+      <div>\\\${innerExpr(1)} \${outerExpr(2)}</div>
+    \\\`;
+  </script>
+\`;
 
 ================================================================================
 `;

--- a/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
@@ -77,7 +77,7 @@ const closingScriptTagShouldBeEscapedProperly = /* HTML */ \`
   </script>
 \`;
 
-const closingStringTag2 = /* HTML */ \`<script>const  scriptTag='<\\\\/script>'; <\\/script>\`;
+const closingScriptTag2 = /* HTML */ \`<script>const  scriptTag='<\\\\/script>'; <\\/script>\`;
 
 =====================================output=====================================
 import { LitElement, html } from "@polymer/lit-element";
@@ -163,7 +163,7 @@ const closingScriptTagShouldBeEscapedProperly = /* HTML */ \`
   </script>
 \`;
 
-const closingStringTag2 = /* HTML */ \`
+const closingScriptTag2 = /* HTML */ \`
   <script>
     const scriptTag = "<\\\\/script>";
   </script>

--- a/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
@@ -71,6 +71,14 @@ function HelloWorld() {
 const trickyParens = html\`<script> f((\${expr}) / 2); </script>\`;
 const nestedFun = /* HTML */ \`\${outerExpr( 1 )} <script>const tpl = html\\\`<div>\\\${innerExpr( 1 )} \${outerExpr( 2 )}</div>\\\`</script>\`;
 
+const closingScriptTagShouldBeEscapedProperly = /* HTML */ \`
+  <script>
+    const html = /* HTML */ \\\`<script><\\\\/script>\\\`;
+  </script>
+\`;
+
+const closingStringTag2 = /* HTML */ \`<script>const  scriptTag='<\\\\/script>'; <\\/script>\`;
+
 =====================================output=====================================
 import { LitElement, html } from "@polymer/lit-element";
 
@@ -144,6 +152,20 @@ const nestedFun = /* HTML */ \`
     const tpl = html\\\`
       <div>\\\${innerExpr(1)} \${outerExpr(2)}</div>
     \\\`;
+  </script>
+\`;
+
+const closingScriptTagShouldBeEscapedProperly = /* HTML */ \`
+  <script>
+    const html = /* HTML */ \\\`
+      <script><\\\\/script>
+    \\\`;
+  </script>
+\`;
+
+const closingStringTag2 = /* HTML */ \`
+  <script>
+    const scriptTag = "<\\\\/script>";
   </script>
 \`;
 

--- a/tests/multiparser_js_html/lit-html.js
+++ b/tests/multiparser_js_html/lit-html.js
@@ -69,4 +69,4 @@ const closingScriptTagShouldBeEscapedProperly = /* HTML */ `
   </script>
 `;
 
-const closingStringTag2 = /* HTML */ `<script>const  scriptTag='<\\/script>'; <\/script>`;
+const closingScriptTag2 = /* HTML */ `<script>const  scriptTag='<\\/script>'; <\/script>`;

--- a/tests/multiparser_js_html/lit-html.js
+++ b/tests/multiparser_js_html/lit-html.js
@@ -62,3 +62,11 @@ function HelloWorld() {
 
 const trickyParens = html`<script> f((${expr}) / 2); </script>`;
 const nestedFun = /* HTML */ `${outerExpr( 1 )} <script>const tpl = html\`<div>\${innerExpr( 1 )} ${outerExpr( 2 )}</div>\`</script>`;
+
+const closingScriptTagShouldBeEscapedProperly = /* HTML */ `
+  <script>
+    const html = /* HTML */ \`<script><\\/script>\`;
+  </script>
+`;
+
+const closingStringTag2 = /* HTML */ `<script>const  scriptTag='<\\/script>'; <\/script>`;

--- a/tests/multiparser_js_html/lit-html.js
+++ b/tests/multiparser_js_html/lit-html.js
@@ -59,3 +59,6 @@ function HelloWorld() {
     `)}
   `;
 }
+
+const trickyParens = html`<script> f((${expr}) / 2); </script>`;
+const nestedFun = /* HTML */ `${outerExpr( 1 )} <script>const tpl = html\`<div>\${innerExpr( 1 )} ${outerExpr( 2 )}</div>\`</script>`;


### PR DESCRIPTION
Currently, if JS code embedded in HTML (via `<script>`) embedded in JS (via a template literal) contains template literals, the inner JS isn't formatted.
```js
const html = /* HTML */ `<script>var a=\`\`</script>`;
```
([playground](https://prettier.io/playground/#N4Igxg9gdgLgprEAuc0DOMAEALGBbAG0wF5MB6AKkwAkAVAWQBlMKzMADAHjTACcBLAA4wAfADcAhr0wTiAHTnsFXMjwHCR7ANwgANCAjD+6ZKCm8IAdwAKUhGmQgJYiPwAmekACNeEsAGs4GABlQT9+KABzZBheAFc4fVxCAHVsfng0MLA4YPsM-jEMgE9HMDQHfQi0OF4Ya19IvAlkADMJAhr9ACs0AA8AIV8AoOCJPDhGCLg2jq6QXr7giMiCOABFOIh4Wc7EkDDeGt5HLwkvOAJPQQFYFPcYbGQADgAGfRuIGpTfQUcbuDHMQzfS8OAARzi-DBDQkTRaSHae30NTw-Bi8X2aBWa022xmiLm+xg53ubkeyAATPpYhJ+AQVgBhCB4ZqOKDQEEgOI1WjnByEvYAXyFQA))

This fix has been extracted from #5993.

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
