### PR TITLE
Add exit code information to cli docs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,7 +54,7 @@ Applying this practice will minimise the number of times the CI fails because of
 If you need to pipe the list of unformatted files to another command, you can use [`--list-different`](cli.md#list-different) flag instead of `--check`.
 
 ### Exit codes
-                      
+
 | Code | Information                         |
 | ---- | ----------------------------------- |
 | 0    | Everything formatted properly       |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,12 +54,12 @@ Applying this practice will minimise the number of times the CI fails because of
 If you need to pipe the list of unformatted files to another command, you can use [`--list-different`](cli.md#list-different) flag instead of `--check`.
 
 ### Exit codes
-
-| Code | Information |
-| ---- | ----------- |
-| 0 | Everything formatted properly |
-| 1 | Something wasn't formatted properly |
-| 2 | Something's wrong with Prettier |
+                      
+| Code | Information                         |
+| ---- | ----------------------------------- |
+| 0    | Everything formatted properly       |
+| 1    | Something wasn't formatted properly |
+| 2    | Something's wrong with Prettier     |
 
 ## `--debug-check`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -53,6 +53,14 @@ Applying this practice will minimise the number of times the CI fails because of
 
 If you need to pipe the list of unformatted files to another command, you can use [`--list-different`](cli.md#list-different) flag instead of `--check`.
 
+### Exit codes
+
+| Code | Information |
+| ---- | ----------- |
+| 0 | Everything formatted properly |
+| 1 | Something wasn't formatted properly |
+| 2 | Something's wrong with Prettier |
+
 ## `--debug-check`
 
 If you're worried that Prettier will change the correctness of your code, add `--debug-check` to the command. This will cause Prettier to print an error message if it detects that code correctness might have changed. Note that `--write` cannot be used with `--debug-check`.


### PR DESCRIPTION
Closes #5896 

> Add CLI existing status information the the docs.

<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
