### PR TITLE
Use same print width for range formatting as normal formatting.

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -42,6 +42,44 @@ Examples:
 
 -->
 
+- Range: Fix ranged formatting not using the correct line width ([#6050] by [@mathieulj])
+
+  <!-- prettier-ignore -->
+  ```js
+  // Input
+  function f() {
+    if (true) {
+      call("this line is 79 chars", "long", "it should", "stay as single line");
+    }
+  }
+
+  // Output (Prettier stable run with --range-start 30 --range-end 110)
+  function f() {
+    if (true) {
+      call(
+        "this line is 79 chars",
+        "long",
+        "it should",
+        "stay as single line"
+      );
+    }
+  }
+
+  // Output (Prettier stable run without range)
+  function f() {
+    if (true) {
+      call("this line is 79 chars", "long", "it should", "stay as single line");
+    }
+  }
+
+  // Output (Prettier master with and without range)
+  function f() {
+    if (true) {
+      call("this line is 79 chars", "long", "it should", "stay as single line");
+    }
+  }
+  ```
+
 - JavaScript: Fix closure compiler typecasts ([#5947] by [@jridgewell])
 
   If a closing parenthesis follows after a typecast in an inner expression, the typecast would wrap everything to the that following parenthesis.

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -210,7 +210,6 @@ function formatRange(text, opts) {
     Object.assign({}, opts, {
       rangeStart: 0,
       rangeEnd: Infinity,
-      printWidth: opts.printWidth - alignmentSize,
       // track the cursor offset only if it's within our range
       cursorOffset:
         opts.cursorOffset >= rangeStart && opts.cursorOffset < rangeEnd

--- a/tests/range/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/range/__snapshots__/jsfmt.spec.js.snap
@@ -334,6 +334,28 @@ try {
 ================================================================================
 `;
 
+exports[`nested-print-width.js 1`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function f() {
+  if (true) {
+    call("this line is 79 chars", "long", "it should", "stay as single line");
+  }
+}
+
+=====================================output=====================================
+function f() {
+  if (true) {
+    call("this line is 79 chars", "long", "it should", "stay as single line");
+  }
+}
+
+================================================================================
+`;
+
 exports[`nested2.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "typescript"]

--- a/tests/range/nested-print-width.js
+++ b/tests/range/nested-print-width.js
@@ -1,0 +1,5 @@
+function f() {
+  if (true) {<<<PRETTIER_RANGE_START>>>
+    call("this line is 79 chars", "long", "it should", "stay as single line");
+  <<<PRETTIER_RANGE_END>>>}
+}


### PR DESCRIPTION
Fixes an issue were a file would end up formatted differently with ranged formatting (--range-start & --range-end) versus normal whole file formatting.

Fixes #6046 

- [x] I’ve added tests to confirm my change works.
- [x] (n/a) (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
