### PR TITLE
Improved multiline closure comment detection

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -151,4 +151,40 @@ Examples:
     {{/if}}
     e
   {{/if}}
+
+
+- JavaScript: Improved multiline closure compiler typecast comment detection ([#6070] by [@yangsu])
+
+  Previously, multiline closure compiler typecast comments with lines that
+  start with \* weren't flagged correctly and the subsequent parenthesis were
+  stripped. Prettier master fixes this issue.
+
+  <!-- prettier-ignore --\>
+  ```js
+  // Input
+  const style =/**
+   * @type {{
+   *   width: number,
+   * }}
+  */({
+    width,
+  });
+  
+  // Output (Prettier stable)
+  const style =/**
+   * @type {{
+   *   width: number,
+   * }}
+  */ {
+    width,
+  };
+  
+  // Output (Prettier master)
+  const style =/**
+   * @type {{
+   *   width: number,
+   * }}
+  */({
+    width,
+  });
   ```

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -152,8 +152,7 @@ Examples:
     e
   {{/if}}
 
-
-- JavaScript: Improved multiline closure compiler typecast comment detection ([#6070] by [@yangsu])
+* JavaScript: Improved multiline closure compiler typecast comment detection ([#6070] by [@yangsu])
 
   Previously, multiline closure compiler typecast comments with lines that
   start with \* weren't flagged correctly and the subsequent parenthesis were

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -45,13 +45,18 @@ function hasClosureCompilerTypeCastComment(text, path) {
   }
 
   function isTypeCastComment(comment) {
-    const trimmed = comment.trim();
-    if (!/^\*\s*@type\s*\{[^]+\}$/.test(trimmed)) {
+    const cleaned = comment
+      .trim()
+      .split("\n")
+      .map(line => line.replace(/^[\s*]+/, ""))
+      .join(" ")
+      .trim();
+    if (!/^@type\s+\{[^]+\}$/.test(cleaned)) {
       return false;
     }
     let isCompletelyClosed = false;
     let unpairedBracketCount = 0;
-    for (const char of trimmed) {
+    for (const char of cleaned) {
       if (char === "{") {
         if (isCompletelyClosed) {
           return false;

--- a/tests/comments_closure_typecast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments_closure_typecast/__snapshots__/jsfmt.spec.js.snap
@@ -65,6 +65,14 @@ const style = /** @type {{
   ...margins,
 });
 
+const style =/**
+ * @type {{
+ *   width: number,
+ * }}
+*/({
+  width,
+});
+
 =====================================output=====================================
 // test to make sure comments are attached correctly
 let inlineComment = /* some comment */ someReallyLongFunctionCall(
@@ -126,6 +134,14 @@ const style = /** @type {{
   width,
   height,
   ...margins
+});
+
+const style = /**
+ * @type {{
+ *   width: number,
+ * }}
+ */ ({
+  width
 });
 
 ================================================================================

--- a/tests/comments_closure_typecast/closure-compiler-type-cast.js
+++ b/tests/comments_closure_typecast/closure-compiler-type-cast.js
@@ -56,3 +56,11 @@ const style = /** @type {{
   height,
   ...margins,
 });
+
+const style =/**
+ * @type {{
+ *   width: number,
+ * }}
+*/({
+  width,
+});


### PR DESCRIPTION
Fixes https://github.com/prettier/prettier/issues/6067

<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
