### PR TITLE
Pass options to willPrintOwnComments()

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -6431,7 +6431,7 @@ function isTheOnlyJSXElementInMarkdown(options, path) {
   return parent.type === "Program" && parent.body.length == 1;
 }
 
-function willPrintOwnComments(path) {
+function willPrintOwnComments(path /*, options */) {
   const node = path.getValue();
   const parent = path.getParentNode();
 

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -53,7 +53,10 @@ function printAstToDoc(ast, options, alignmentSize = 0) {
     // We let JSXElement print its comments itself because it adds () around
     // UnionTypeAnnotation has to align the child without the comments
     let res;
-    if (printer.willPrintOwnComments && printer.willPrintOwnComments(path)) {
+    if (
+      printer.willPrintOwnComments &&
+      printer.willPrintOwnComments(path, options)
+    ) {
       res = callPluginPrintFunction(path, options, printGenerically, args);
     } else {
       // printComments will call the plugin print function and check for


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

In the [Coffeescript plugin](https://github.com/helixbass/prettier-plugin-coffeescript), I've found the need to have `options` passed to `willPrintOwnComments()` (specifically, I'd want access to `options.originalText`/`options.locStart()`/`options.locEnd()`)

So this PR adds `options` as a second argument passed to `willPrintOwnComments()`

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
