### PR TITLE
Add support for styled-jsx external styles

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -262,7 +262,9 @@ Atom has a security feature where code containing `eval` is not allowed to be ru
 
 ### JavaScript: Add support for styled-jsx external styles ([#6089] by [@hongrich])
 
-Add support for all 3 external styles tags in `styled-jsx/css`: `css`, `css.global`, and `css.resolve`. https://github.com/zeit/styled-jsx/#external-css-and-styles-outside-of-the-component
+Add support for 2 external styles tags in `styled-jsx/css`: `css.global`, and `css.resolve`. https://github.com/zeit/styled-jsx/#external-css-and-styles-outside-of-the-component
+
+The `css` template tag is already supported by Prettier.
 
 Fixes https://github.com/zeit/styled-jsx/issues/548
 

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -260,9 +260,36 @@ function Foo() {
 
 Atom has a security feature where code containing `eval` is not allowed to be run. One of Prettier's dependencies uses `eval` to prevent bundlers from including debug code. We've now made sure that this `eval` does not end up in the code we ship to npm, making Prettier play nice with Atom again.
 
+### JavaScript: Add support for styled-jsx external styles ([#6089] by [@hongrich])
+
+Add support for all 3 external styles tags in `styled-jsx/css`: `css`, `css.global`, and `css.resolve`. https://github.com/zeit/styled-jsx/#external-css-and-styles-outside-of-the-component
+
+Fixes https://github.com/zeit/styled-jsx/issues/548
+
+<!-- prettier-ignore -->
+```js
+// Input
+const styles = css.resolve`
+.box {background:black;
+}`;
+
+// Output (Prettier stable)
+const styles = css.resolve`
+.box {background:black;
+}`;
+
+// Output (prettier master)
+const styles = css.resolve`
+  .box {
+    background: black;
+  }
+`;
+```
+
 [#5979]: https://github.com/prettier/prettier/pull/5979
 [#6086]: https://github.com/prettier/prettier/pull/6086
 [#6088]: https://github.com/prettier/prettier/pull/6088
+[#6089]: https://github.com/prettier/prettier/pull/6089
 [#6106]: https://github.com/prettier/prettier/pull/6106
 [#6110]: https://github.com/prettier/prettier/pull/6110
 [#6115]: https://github.com/prettier/prettier/pull/6115
@@ -275,6 +302,7 @@ Atom has a security feature where code containing `eval` is not allowed to be ru
 [@brainkim]: https://github.com/brainkim
 [@duailibe]: https://github.com/duailibe
 [@evilebottnawi]: https://github.com/evilebottnawi
+[@hongrich]: https://github.com/hongrich
 [@jridgewell]: https://github.com/jridgewell
 [@jwbay]: https://github.com/jwbay
 [@sosukesuzuki]: https://github.com/sosukesuzuki

--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -335,22 +335,35 @@ function printGraphqlComments(lines) {
 }
 
 /**
- * Template literal in this context:
+ * Template literal in these contexts:
  * <style jsx>{`div{color:red}`}</style>
+ * css``
+ * css.global``
+ * css.resolve``
  */
 function isStyledJsx(path) {
   const node = path.getValue();
   const parent = path.getParentNode();
   const parentParent = path.getParentNode(1);
   return (
-    parentParent &&
-    node.quasis &&
-    parent.type === "JSXExpressionContainer" &&
-    parentParent.type === "JSXElement" &&
-    parentParent.openingElement.name.name === "style" &&
-    parentParent.openingElement.attributes.some(
-      attribute => attribute.name.name === "jsx"
-    )
+    (parentParent &&
+      node.quasis &&
+      parent.type === "JSXExpressionContainer" &&
+      parentParent.type === "JSXElement" &&
+      parentParent.openingElement.name.name === "style" &&
+      parentParent.openingElement.attributes.some(
+        attribute => attribute.name.name === "jsx"
+      )) ||
+    (parent &&
+      parent.type === "TaggedTemplateExpression" &&
+      parent.tag.type === "Identifier" &&
+      parent.tag.name === "css") ||
+    (parent &&
+      parent.type === "TaggedTemplateExpression" &&
+      parent.tag.type === "MemberExpression" &&
+      parent.tag.object.name === "css" &&
+      (parent.tag.property.name === "global" ||
+        parent.tag.property.name === "resolve"))
   );
 }
 

--- a/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
@@ -323,6 +323,63 @@ color: red; display: none
             Shouldn't be formatted.\`}</style>
 </div>;
 
+const header = css\`
+.top-bar {background:black;
+margin: 0;
+    position: fixed;
+	top: 0;left:0;
+	width: 100%;
+    text-align: center     ;
+	padding: 15px  0  0  1em;
+		z-index: 9999;
+}
+
+.top-bar .logo {
+  height: 30px;
+  margin: auto; 
+    position: absolute;
+	left: 0;right: 0;
+}
+\`;
+
+const headerResolve = css.resolve\`
+.top-bar {background:black;
+margin: 0;
+    position: fixed;
+	top: 0;left:0;
+	width: 100%;
+    text-align: center     ;
+	padding: 15px  0  0  1em;
+		z-index: 9999;
+}
+
+.top-bar .logo {
+  height: 30px;
+  margin: auto; 
+    position: absolute;
+	left: 0;right: 0;
+}
+\`;
+
+const headerGlobal = css.global\`
+.top-bar {background:black;
+margin: 0;
+    position: fixed;
+	top: 0;left:0;
+	width: 100%;
+    text-align: center     ;
+	padding: 15px  0  0  1em;
+		z-index: 9999;
+}
+
+.top-bar .logo {
+  height: 30px;
+  margin: auto; 
+    position: absolute;
+	left: 0;right: 0;
+}
+\`;
+
 =====================================output=====================================
 <style jsx>{\`
   /* a comment */
@@ -355,6 +412,72 @@ color: red; display: none
       Shouldn't fail.
             Shouldn't be formatted.\`}</style>
 </div>;
+
+const header = css\`
+  .top-bar {
+    background: black;
+    margin: 0;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    text-align: center;
+    padding: 15px 0 0 1em;
+    z-index: 9999;
+  }
+
+  .top-bar .logo {
+    height: 30px;
+    margin: auto;
+    position: absolute;
+    left: 0;
+    right: 0;
+  }
+\`;
+
+const headerResolve = css.resolve\`
+  .top-bar {
+    background: black;
+    margin: 0;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    text-align: center;
+    padding: 15px 0 0 1em;
+    z-index: 9999;
+  }
+
+  .top-bar .logo {
+    height: 30px;
+    margin: auto;
+    position: absolute;
+    left: 0;
+    right: 0;
+  }
+\`;
+
+const headerGlobal = css.global\`
+  .top-bar {
+    background: black;
+    margin: 0;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    text-align: center;
+    padding: 15px 0 0 1em;
+    z-index: 9999;
+  }
+
+  .top-bar .logo {
+    height: 30px;
+    margin: auto;
+    position: absolute;
+    left: 0;
+    right: 0;
+  }
+\`;
 
 ================================================================================
 `;

--- a/tests/template_literals/styled-jsx.js
+++ b/tests/template_literals/styled-jsx.js
@@ -22,3 +22,60 @@ color: red; display: none
       Shouldn't fail.
             Shouldn't be formatted.`}</style>
 </div>;
+
+const header = css`
+.top-bar {background:black;
+margin: 0;
+    position: fixed;
+	top: 0;left:0;
+	width: 100%;
+    text-align: center     ;
+	padding: 15px  0  0  1em;
+		z-index: 9999;
+}
+
+.top-bar .logo {
+  height: 30px;
+  margin: auto; 
+    position: absolute;
+	left: 0;right: 0;
+}
+`;
+
+const headerResolve = css.resolve`
+.top-bar {background:black;
+margin: 0;
+    position: fixed;
+	top: 0;left:0;
+	width: 100%;
+    text-align: center     ;
+	padding: 15px  0  0  1em;
+		z-index: 9999;
+}
+
+.top-bar .logo {
+  height: 30px;
+  margin: auto; 
+    position: absolute;
+	left: 0;right: 0;
+}
+`;
+
+const headerGlobal = css.global`
+.top-bar {background:black;
+margin: 0;
+    position: fixed;
+	top: 0;left:0;
+	width: 100%;
+    text-align: center     ;
+	padding: 15px  0  0  1em;
+		z-index: 9999;
+}
+
+.top-bar .logo {
+  height: 30px;
+  margin: auto; 
+    position: absolute;
+	left: 0;right: 0;
+}
+`;


### PR DESCRIPTION
Supports all 3 tags in `styled-jsx/css`: `css`, `css.global`, and `css.resolve`.
https://github.com/zeit/styled-jsx/#external-css-and-styles-outside-of-the-component

Fixes https://github.com/zeit/styled-jsx/issues/548

Formatting template literal with `css` was already working because it
happens to be the same as what styled-components was using.
https://www.styled-components.com/docs/api#css

So this change just adds support for `css.global` and `css.resolve`.

<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
