### PR TITLE
Export doc.utils.findInDoc

### DIFF
--- a/src/doc/doc-utils.js
+++ b/src/doc/doc-utils.js
@@ -210,6 +210,7 @@ module.exports = {
   willBreak,
   isLineNext,
   traverseDoc,
+  findInDoc,
   mapDoc,
   propagateBreaks,
   removeLines,


### PR DESCRIPTION
Fixes https://github.com/prettier/prettier/issues/6095

- [ ] I’ve added tests to confirm my change works.
  - Unnecessary I think
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
  - `prettier.doc` does not have `docs`
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
  - Not user facing
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
