### PR TITLE
Keep a trailing comma in tsx type parameter

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -212,3 +212,22 @@ Examples:
     )
   );
   ```
+
+- TypeScript: Keep trailing comma in tsx type parameters ([#6115] by [@sosukesuzuki])
+
+  Previously, a trailing comma after single type parameter in arrow function was cleaned up. The formatted result is valid as ts, but is invalid as tsx. Prettier master fixes this issue.
+
+  <!-- prettier-ignore -->
+  ```tsx
+  // Input
+  type G<T> = any;
+  const myFunc = <T,>(arg1: G<T>) => false;
+
+  // Output (Prettier stable)
+  type G<T> = any;
+  const myFunc = <T>(arg1: G<T>) => false;
+
+  // Output (prettier master)
+  type G<T> = any;
+  const myFunc = <T,>(arg1: G<T>) => false;
+  ```

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3003,6 +3003,7 @@ function printPathNoParens(path, options, print, args) {
       if (
         parent.params &&
         parent.params.length === 1 &&
+        options.filepath &&
         options.filepath.match(/\.tsx/) &&
         !n.constraint
       ) {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3000,6 +3000,15 @@ function printPathNoParens(path, options, print, args) {
         parts.push(" = ", path.call(print, "default"));
       }
 
+      if (
+        parent.params &&
+        parent.params.length === 1 &&
+        options.filepath.match(/\.tsx/) &&
+        !n.constraint
+      ) {
+        parts.push(",");
+      }
+
       return concat(parts);
     }
     case "TypeofTypeAnnotation":

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3000,6 +3000,9 @@ function printPathNoParens(path, options, print, args) {
         parts.push(" = ", path.call(print, "default"));
       }
 
+      // Keep comma if the file extension is .tsx and
+      // has one type parameter that isn't extend with any types.
+      // Because, otherwise formatted result will be invalid as tsx.
       if (
         parent.params &&
         parent.params.length === 1 &&

--- a/tests/typescript_tsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_tsx/__snapshots__/jsfmt.spec.js.snap
@@ -103,6 +103,24 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`type-parameters.tsx 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const functionName1 = <T,>(arg) => false;
+const functionName2 = <T extends any>(arg) => false;
+const functionName3 = <T, S>(arg) => false;
+
+=====================================output=====================================
+const functionName1 = <T,>(arg) => false;
+const functionName2 = <T extends any>(arg) => false;
+const functionName3 = <T, S>(arg) => false;
+
+================================================================================
+`;
+
 exports[`url.tsx 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/typescript_tsx/type-parameters.tsx
+++ b/tests/typescript_tsx/type-parameters.tsx
@@ -1,0 +1,3 @@
+const functionName1 = <T,>(arg) => false;
+const functionName2 = <T extends any>(arg) => false;
+const functionName3 = <T, S>(arg) => false;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Previously, a trailing comma after single type parameter in arrow function was cleaned up. The formatted result is valid as ts, but is invalid as tsx. This pr is fix to keep a trailing comma for formatting to valid tsx.

Fixes #6114 

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
