### PR TITLE
Fix closure type cast without spaces

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -87,7 +87,25 @@ type G<T> = any;
 const myFunc = <T,>(arg1: G<T>) => false;
 ```
 
+### JavaScript: Fix closure typecasts without spaces ([#6116] by [@jridgewell])
+
+Previously, a space was required between the `@type` and opening `{` of a closure typecast, or else the enclosing parenthesis would be removed. Closure itself does not require a space.
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+const v = /** @type{string} */(value);
+
+// Output (Prettier stable)
+const v = /** @type{string} */ value;
+
+// Output (prettier master)
+const v = /** @type{string} */ (value);
+```
+
 [#5979]: https://github.com/prettier/prettier/pull/5979
-[#6115]: https://github.com/prettier/prettier/pull/5979
+[#6115]: https://github.com/prettier/prettier/pull/6115
+[#6116]: https://github.com/prettier/prettier/pull/6116
+[@jridgewell]: https://github.com/jridgewell
 [@jwbay]: https://github.com/jwbay
 [@sosukesuzuki]: https://github.com/sosukesuzuki

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -51,7 +51,7 @@ function hasClosureCompilerTypeCastComment(text, path) {
       .map(line => line.replace(/^[\s*]+/, ""))
       .join(" ")
       .trim();
-    if (!/^@type\s+\{[^]+\}$/.test(cleaned)) {
+    if (!/^@type\s*\{[^]+\}$/.test(cleaned)) {
       return false;
     }
     let isCompletelyClosed = false;

--- a/tests/comments_closure_typecast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments_closure_typecast/__snapshots__/jsfmt.spec.js.snap
@@ -73,8 +73,10 @@ const style =/**
   width,
 });
 
-// Space isn't necessary between @type and {
+// Spaces aren't necessary
+const v = /**@type {string} */(value);
 const v = /** @type{string} */(value);
+const v = /**@type{string} */(value);
 
 =====================================output=====================================
 // test to make sure comments are attached correctly
@@ -147,8 +149,10 @@ const style = /**
   width
 });
 
-// Space isn't necessary between @type and {
+// Spaces aren't necessary
+const v = /**@type {string} */ (value);
 const v = /** @type{string} */ (value);
+const v = /**@type{string} */ (value);
 
 ================================================================================
 `;

--- a/tests/comments_closure_typecast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments_closure_typecast/__snapshots__/jsfmt.spec.js.snap
@@ -73,6 +73,9 @@ const style =/**
   width,
 });
 
+// Space isn't necessary between @type and {
+const v = /** @type{string} */(value);
+
 =====================================output=====================================
 // test to make sure comments are attached correctly
 let inlineComment = /* some comment */ someReallyLongFunctionCall(
@@ -143,6 +146,9 @@ const style = /**
  */ ({
   width
 });
+
+// Space isn't necessary between @type and {
+const v = /** @type{string} */ (value);
 
 ================================================================================
 `;

--- a/tests/comments_closure_typecast/closure-compiler-type-cast.js
+++ b/tests/comments_closure_typecast/closure-compiler-type-cast.js
@@ -64,3 +64,6 @@ const style =/**
 */({
   width,
 });
+
+// Space isn't necessary between @type and {
+const v = /** @type{string} */(value);

--- a/tests/comments_closure_typecast/closure-compiler-type-cast.js
+++ b/tests/comments_closure_typecast/closure-compiler-type-cast.js
@@ -65,5 +65,7 @@ const style =/**
   width,
 });
 
-// Space isn't necessary between @type and {
+// Spaces aren't necessary
+const v = /**@type {string} */(value);
 const v = /** @type{string} */(value);
+const v = /**@type{string} */(value);


### PR DESCRIPTION
Closure typecasts don't require a space between the `@type` and opening `{`.

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
