### PR TITLE
Stop handling 'global' in the Node-specific bundles

### DIFF
--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -99,7 +99,7 @@ async function run(params) {
     await execa("rm", ["-rf", ".cache"]);
   }
 
-  const bundleCache = new Cache(".cache/", "v10");
+  const bundleCache = new Cache(".cache/", "v11");
   await bundleCache.load();
 
   console.log(chalk.inverse(" Building packages "));

--- a/scripts/build/bundler.js
+++ b/scripts/build/bundler.js
@@ -119,7 +119,12 @@ function getRollupConfig(bundle) {
       extensions: [".js", ".json"],
       preferBuiltins: bundle.target === "node"
     }),
-    commonjs(bundle.commonjs || {}),
+    commonjs(
+      Object.assign(
+        bundle.target === "node" ? { ignoreGlobal: true } : {},
+        bundle.commonjs
+      )
+    ),
     bundle.target === "universal" && nodeGlobals(),
     babelConfig && babel(babelConfig),
     bundle.type === "plugin" && uglify()


### PR DESCRIPTION
For some reason, in Vue testing Prettier runs in an environment that polyfills `window` (#5018). A better description of the situation is in #5662

In `index.js` bundle, the TOML parser we use for config uses `global.Date` and Rollup replaces all uses of `global` for something that evaluates to the equivalent of `window || global || self || {}`. In the cases listed above, `global` will evaluate to the `window` polyfill and `global.Date` evaluates to `undefined`.

This PR will remove the `global` replacement since `index.js` is only intended to be used in a Node environment, not in the browser; this will break all uses of `index.js` in the browser, which is not supported already.

Fixes #5018
Fixes #5662

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
