### PR TITLE
[TS] keep a pair of parentheses where there extra pairs.

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -260,6 +260,22 @@ function Foo() {
 
 Atom has a security feature where code containing `eval` is not allowed to be run. One of Prettier's dependencies uses `eval` to prevent bundlers from including debug code. We've now made sure that this `eval` does not end up in the code we ship to npm, making Prettier play nice with Atom again.
 
+### TypeScript: Keep a pair of parentheses when there are extra pairs. ([] by [@sosukesuzuki])
+
+Previously, Prettier removes the necessary parentheses when trying to remove unnecessary parentheses, in TypeScript.
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+type G = ((keyof T))[];
+
+// Output (Prettier stable)
+type G = keyof T[];
+
+// Output (prettier master)
+type G = (keyof T)[];
+```
+
 [#5979]: https://github.com/prettier/prettier/pull/5979
 [#6086]: https://github.com/prettier/prettier/pull/6086
 [#6088]: https://github.com/prettier/prettier/pull/6088

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -260,7 +260,7 @@ function Foo() {
 
 Atom has a security feature where code containing `eval` is not allowed to be run. One of Prettier's dependencies uses `eval` to prevent bundlers from including debug code. We've now made sure that this `eval` does not end up in the code we ship to npm, making Prettier play nice with Atom again.
 
-### TypeScript: Keep a pair of parentheses when there are extra pairs. ([] by [@sosukesuzuki])
+### TypeScript: Keep a pair of parentheses when there are extra pairs. ([#6131] by [@sosukesuzuki])
 
 Previously, Prettier removes the necessary parentheses when trying to remove unnecessary parentheses, in TypeScript.
 
@@ -287,6 +287,7 @@ type G = (keyof T)[];
 [#6127]: https://github.com/prettier/prettier/pull/6127
 [#6129]: https://github.com/prettier/prettier/pull/6129
 [#6130]: https://github.com/prettier/prettier/pull/6130
+[#6131]: https://github.com/prettier/prettier/pull/6131
 [@belochub]: https://github.com/belochub
 [@brainkim]: https://github.com/brainkim
 [@duailibe]: https://github.com/duailibe

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -265,7 +265,7 @@ Atom has a security feature where code containing `eval` is not allowed to be ru
 Previously, Prettier removes the necessary parentheses when trying to remove unnecessary parentheses, in TypeScript.
 
 <!-- prettier-ignore -->
-```tsx
+```ts
 // Input
 type G = ((keyof T))[];
 

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -408,7 +408,10 @@ function needsParens(path, options) {
         return false;
       }
       // Delegate to inner TSParenthesizedType
-      if (node.typeAnnotation.type === "TSParenthesizedType") {
+      if (
+        node.typeAnnotation.type === "TSParenthesizedType" &&
+        parent.type !== "TSArrayType"
+      ) {
         return false;
       }
       return true;

--- a/tests/typescript_keyof/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_keyof/__snapshots__/jsfmt.spec.js.snap
@@ -10,6 +10,8 @@ type A = keyof (T | U);
 type B = keyof (X & Y);
 type C = keyof T | U;
 type D = keyof X & Y;
+type E = (keyof T)[];
+type F = ((keyof T))[];
 
 
 =====================================output=====================================
@@ -17,6 +19,8 @@ type A = keyof (T | U);
 type B = keyof (X & Y);
 type C = keyof T | U;
 type D = keyof X & Y;
+type E = (keyof T)[];
+type F = (keyof T)[];
 
 ================================================================================
 `;

--- a/tests/typescript_keyof/keyof.ts
+++ b/tests/typescript_keyof/keyof.ts
@@ -2,4 +2,6 @@ type A = keyof (T | U);
 type B = keyof (X & Y);
 type C = keyof T | U;
 type D = keyof X & Y;
+type E = (keyof T)[];
+type F = ((keyof T))[];
 


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fix #6111
Previously, Prettier removes the necessary parentheses when trying to remove unnecessary parentheses, in TypeScript. So, I fixed to keep a pair of parentheses.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
