### PR TITLE
Keep parens around non-null assertions for new-expressions only

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -325,9 +325,9 @@ export default (function log() {}).toString();
 export default (function log() {} as typeof console.log);
 ```
 
-### TypeScript: Keep necessary parentheses around non-null assertions. ([6136] by [@sosukesuzuki])
+### TypeScript: Keep necessary parentheses around non-null assertions. ([#6136] by [@sosukesuzuki], [#6140] by [@thorn0])
 
-Previously, Prettier could remove necessary parentheses around an expression with non-null assertion. It happened when the expression result was called as a constructor.
+Previously, Prettier removed necessary parentheses around non-null assertions if the result of the assertion expression was called as a constructor.
 
 <!-- prettier-ignore -->
 ```ts
@@ -337,7 +337,7 @@ const b = new (c()!)();
 // Output (Prettier stable)
 const b = new c()!();
 
-// Output (prettier master)
+// Output (Prettier master)
 const b = new (c()!)();
 ```
 
@@ -356,6 +356,7 @@ const b = new (c()!)();
 [#6131]: https://github.com/prettier/prettier/pull/6131
 [#6133]: https://github.com/prettier/prettier/pull/6133
 [#6136]: https://github.com/prettier/prettier/pull/6136
+[#6140]: https://github.com/prettier/prettier/pull/6140
 [@belochub]: https://github.com/belochub
 [@brainkim]: https://github.com/brainkim
 [@duailibe]: https://github.com/duailibe
@@ -364,3 +365,4 @@ const b = new (c()!)();
 [@jridgewell]: https://github.com/jridgewell
 [@jwbay]: https://github.com/jwbay
 [@sosukesuzuki]: https://github.com/sosukesuzuki
+[@thorn0]: https://github.com/thorn0

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -325,22 +325,19 @@ export default (function log() {}).toString();
 export default (function log() {} as typeof console.log);
 ```
 
-### TypeScript: Keep parentheses around a function called with non-null assertion. ([6136] by [@sosukesuzuki])
+### TypeScript: Keep necessary parentheses around non-null assertions. ([6136] by [@sosukesuzuki])
 
-Previously, Prettier removes necessary parentheses around a call expression with non-null assertion. It happens when it's return value is called as function.
+Previously, Prettier could remove necessary parentheses around an expression with non-null assertion. It happened when the expression result was called as a constructor.
 
 <!-- prettier-ignore -->
 ```ts
 // Input
-const a = (b()!)();
 const b = new (c()!)();
 
 // Output (Prettier stable)
-const a = b()!();
 const b = new c()!();
 
 // Output (prettier master)
-const a = (b()!)();
 const b = new (c()!)();
 ```
 

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -725,14 +725,11 @@ function needsParens(path, options) {
         return false;
       }
       return true;
+
     case "TSNonNullExpression": {
-      if (
-        node.expression.type !== "Identifier" &&
-        (parent.type === "CallExpression" || parent.type === "NewExpression")
-      ) {
-        return true;
-      }
-      return false;
+      return (
+        node.expression.type !== "Identifier" && parent.type === "NewExpression"
+      );
     }
   }
 

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -728,7 +728,8 @@ function needsParens(path, options) {
 
     case "TSNonNullExpression": {
       return (
-        node.expression.type !== "Identifier" && parent.type === "NewExpression"
+        node.expression.type === "CallExpression" &&
+        parent.type === "NewExpression"
       );
     }
   }

--- a/tests/typescript_non_null/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_non_null/__snapshots__/jsfmt.spec.js.snap
@@ -56,9 +56,12 @@ function* g() {
     return (yield * foo())!;
 }
 
-const a = (b()!)();
+const a = (b()!)(); // parens aren't necessary
 const b = c!();
+
+// parens are necessary if the expression result is called as a constructor
 const c = new (d()!)();
+const c = new (d()!);
 
 =====================================output=====================================
 (a ? b : c)![tokenKey];
@@ -73,8 +76,11 @@ function* g() {
   return (yield* foo())!;
 }
 
-const a = (b()!)();
+const a = b()!(); // parens aren't necessary
 const b = c!();
+
+// parens are necessary if the expression result is called as a constructor
+const c = new (d()!)();
 const c = new (d()!)();
 
 ================================================================================

--- a/tests/typescript_non_null/parens.ts
+++ b/tests/typescript_non_null/parens.ts
@@ -10,6 +10,9 @@ function* g() {
     return (yield * foo())!;
 }
 
-const a = (b()!)();
+const a = (b()!)(); // parens aren't necessary
 const b = c!();
+
+// parens are necessary if the expression result is called as a constructor
 const c = new (d()!)();
+const c = new (d()!);


### PR DESCRIPTION
Correction for #6136.

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
