### PR TITLE
Disable Ctrl + L shortcut in CodeMirror

### DIFF
--- a/website/playground/panels.js
+++ b/website/playground/panels.js
@@ -28,6 +28,9 @@ class CodeMirrorPanel extends React.Component {
     this._codeMirror.on("change", this.handleChange);
     this._codeMirror.on("focus", this.handleFocus);
 
+    window.CodeMirror.keyMap.pcSublime["Ctrl-L"] = false;
+    window.CodeMirror.keyMap.sublime["Ctrl-L"] = false;
+
     this.updateValue(this.props.value || "");
     this.updateOverlay();
   }


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
I followed the suggested best practice from the CodeMirror docs of changing the value of the CodeMirror.keyMap['keymap_name'] property to false for the Sublime shortcut that was overriding Ctrl + L to select a line rather than the browser default of selectitng the URL bar.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**

Unsure if this issue is considered "user-facing" or not; if it is, please let me know and I will update the CHANGELOG file along with any other requested adjustments. 

Fixes #6105 
