### PR TITLE
TypeScript: Keep line breaks within mapped types.

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -363,6 +363,26 @@ new (x())!.y();
 new e[f().x].y();
 ```
 
+### TypeScript: Keep line breaks within mapped types.([#] by [@sosukesuzuki])
+
+Previously, Prettier has removed line breaks within mapped types.This change keeps it, similar to how it treats other object types.
+
+<!-- prettier-ignore -->
+```ts
+// Input
+type A<T> = {
+  readonly [P in keyof T]: T[P];
+};
+
+// Output (Prettier stable)
+type A<T> = { readonly [P in keyof T]: T[P] };
+
+// Output (Prettier master)
+type A<T> = {
+  readonly [P in keyof T]: T[P];
+};
+```
+
 [#5979]: https://github.com/prettier/prettier/pull/5979
 [#6086]: https://github.com/prettier/prettier/pull/6086
 [#6088]: https://github.com/prettier/prettier/pull/6088

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -363,7 +363,7 @@ new (x())!.y();
 new e[f().x].y();
 ```
 
-### TypeScript: Keep line breaks within mapped types.([#] by [@sosukesuzuki])
+### TypeScript: Keep line breaks within mapped types.([#6146] by [@sosukesuzuki])
 
 Previously, Prettier has removed line breaks within mapped types.This change keeps it, similar to how it treats other object types.
 
@@ -400,6 +400,7 @@ type A<T> = {
 [#6136]: https://github.com/prettier/prettier/pull/6136
 [#6140]: https://github.com/prettier/prettier/pull/6140
 [#6148]: https://github.com/prettier/prettier/pull/6148
+[#6146]: https://github.com/prettier/prettier/pull/6146
 [@belochub]: https://github.com/belochub
 [@brainkim]: https://github.com/brainkim
 [@duailibe]: https://github.com/duailibe

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3238,7 +3238,7 @@ function printPathNoParens(path, options, print, args) {
                 : "",
               ": ",
               path.call(print, "typeAnnotation"),
-              shouldBreak ? ";" : ""
+              shouldBreak && options.semi ? ";" : ""
             ])
           ),
           comments.printDanglingComments(path, options, /* sameIndent */ true),

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3213,7 +3213,12 @@ function printPathNoParens(path, options, print, args) {
     }
     case "TSTypeOperator":
       return concat([n.operator, " ", path.call(print, "typeAnnotation")]);
-    case "TSMappedType":
+    case "TSMappedType": {
+      const shouldBreak = hasNewlineInRange(
+        options.originalText,
+        options.locStart(n),
+        options.locEnd(n)
+      );
       return group(
         concat([
           "{",
@@ -3238,8 +3243,10 @@ function printPathNoParens(path, options, print, args) {
           comments.printDanglingComments(path, options, /* sameIndent */ true),
           options.bracketSpacing ? line : softline,
           "}"
-        ])
+        ]),
+        { shouldBreak }
       );
+    }
     case "TSMethodSignature":
       parts.push(
         n.accessibility ? concat([n.accessibility, " "]) : "",

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3237,7 +3237,8 @@ function printPathNoParens(path, options, print, args) {
                 ? getTypeScriptMappedTypeModifier(n.optional, "?")
                 : "",
               ": ",
-              path.call(print, "typeAnnotation")
+              path.call(print, "typeAnnotation"),
+              shouldBreak ? ";" : ""
             ])
           ),
           comments.printDanglingComments(path, options, /* sameIndent */ true),

--- a/tests/multiparser_html_ts/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_html_ts/__snapshots__/jsfmt.spec.js.snap
@@ -32,7 +32,9 @@ printWidth: 80
 <html lang="en">
   <head>
     <script lang="ts">
-      type X = { [K in keyof Y]: Partial<K> };
+      type X = {
+        [K in keyof Y]: Partial<K>;
+      };
 
       class Foo<T> {
         constructor(private foo: keyof Apple) {}

--- a/tests/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
@@ -617,7 +617,7 @@ type Meta<T, A> = {
     value: T[P];
     also: A;
     readonly children: Meta<T[P], A>;
-  }
+  };
 };
 
 interface Input {

--- a/tests/typescript/custom/modifiers/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/custom/modifiers/__snapshots__/jsfmt.spec.js.snap
@@ -15,9 +15,13 @@ type ReadonlyPartial<T> = {
 };  // Add readonly and ?
 
 =====================================output=====================================
-type MutableRequired<T> = { -readonly [P in keyof T]-?: T[P] }; // Remove readonly and ?
+type MutableRequired<T> = {
+  -readonly [P in keyof T]-?: T[P];
+}; // Remove readonly and ?
 
-type ReadonlyPartial<T> = { +readonly [P in keyof T]+?: T[P] }; // Add readonly and ?
+type ReadonlyPartial<T> = {
+  +readonly [P in keyof T]+?: T[P];
+}; // Add readonly and ?
 
 ================================================================================
 `;
@@ -33,7 +37,9 @@ var x: {
 };
 
 =====================================output=====================================
-var x: { [A in keyof B]?: any };
+var x: {
+  [A in keyof B]?: any;
+};
 
 ================================================================================
 `;
@@ -49,7 +55,9 @@ var x: {
 };
 
 =====================================output=====================================
-var x: { readonly [A in keyof B]: any };
+var x: {
+  readonly [A in keyof B]: any;
+};
 
 ================================================================================
 `;

--- a/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
@@ -175,20 +175,32 @@ type G = {
 =====================================output=====================================
 type A = {
   // commentA
-  [a in A]: string
+  [a in A]: string;
 };
 
-type B = { /* commentB */ [b in B]: string };
+type B = {
+  /* commentB */ [b in B]: string;
+};
 
-type C = { [/* commentC */ c in C]: string };
+type C = {
+  [/* commentC */ c in C]: string;
+};
 
-type D = { [d /* commentD */ in D]: string };
+type D = {
+  [d /* commentD */ in D]: string;
+};
 
-type E = { [e in /* commentE */ E]: string };
+type E = {
+  [e in /* commentE */ E]: string;
+};
 
-type F = { [f in F /* commentF */]: string };
+type F = {
+  [f in F /* commentF */]: string;
+};
 
-type G = { [g in G /* commentG */]: string };
+type G = {
+  [g in G /* commentG */]: string;
+};
 
 ================================================================================
 `;

--- a/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
@@ -172,6 +172,18 @@ type G = {
   [g in G] /* commentG */: string
 }
 
+type H = { /* commentH */ [h in H]: string }
+
+type I = { [/* commentI */ i in I]: string }
+
+type J = { [j /* commentJ */ in J]: string }
+
+type K = { [k in /* commentK */ K]: string }
+
+type L = { [l in L /* commentL */]: string }
+
+type M = { [m in M] /* commentG */: string }
+
 =====================================output=====================================
 type A = {
   // commentA
@@ -201,6 +213,18 @@ type F = {
 type G = {
   [g in G /* commentG */]: string;
 };
+
+type H = { [/* commentH */ h in H]: string };
+
+type I = { [/* commentI */ i in I]: string };
+
+type J = { [j /* commentJ */ in J]: string };
+
+type K = { [k in /* commentK */ K]: string };
+
+type L = { [l in L /* commentL */]: string };
+
+type M = { [m in M /* commentG */]: string };
 
 ================================================================================
 `;

--- a/tests/typescript_comments/mapped_types.ts
+++ b/tests/typescript_comments/mapped_types.ts
@@ -26,3 +26,15 @@ type F = {
 type G = {
   [g in G] /* commentG */: string
 }
+
+type H = { /* commentH */ [h in H]: string }
+
+type I = { [/* commentI */ i in I]: string }
+
+type J = { [j /* commentJ */ in J]: string }
+
+type K = { [k in /* commentK */ K]: string }
+
+type L = { [l in L /* commentL */]: string }
+
+type M = { [m in M] /* commentG */: string }

--- a/tests/typescript_conditional_types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_conditional_types/__snapshots__/jsfmt.spec.js.snap
@@ -38,7 +38,7 @@ type NonFunctionPropertyNames<T> = {
 interface DeepReadonlyArray<T> extends ReadonlyArray<DeepReadonly<T>> {}
 
 type DeepReadonlyObject<T> = {
-  readonly [P in NonFunctionPropertyNames<T>]: DeepReadonly<T[P]>
+  readonly [P in NonFunctionPropertyNames<T>]: DeepReadonly<T[P]>;
 };
 
 type TypeName<T> = T extends string


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fix #5725

Previously, Prettier has removed line breaks within mapped types.This change keeps it, similar to how it treats other object types.

And, this change modify to add trailing semicolon to mapped types that include line breaks like below:
(I don't know if it is the best)

```ts
// Input
type A<T> = {
  readonly [P in keyof T]: T[P]
};

// Output
type A<T> = {
  readonly [P in keyof T]: T[P];
};
```

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
