### PR TITLE
Playground: Remove `parser` from Copy config JSON

### DIFF
--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -222,7 +222,7 @@ class Playground extends React.Component {
                     <Button onClick={this.clearContent}>Clear</Button>
                     <ClipboardButton
                       copy={JSON.stringify(
-                        // Remove `parser` since people usually paste the this
+                        // Remove `parser` since people usually paste this
                         // into their .prettierrc and specifying a toplevel
                         // parser there is an anti-pattern. Note:
                         // `JSON.stringify` omits keys whose values are

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -220,7 +220,18 @@ class Playground extends React.Component {
                       {editorState.showSidebar ? "Hide" : "Show"} options
                     </Button>
                     <Button onClick={this.clearContent}>Clear</Button>
-                    <ClipboardButton copy={JSON.stringify(options, null, 2)}>
+                    <ClipboardButton
+                      copy={JSON.stringify(
+                        // Remove `parser` since people usually paste the this
+                        // into their .prettierrc and specifying a toplevel
+                        // parser there is an anti-pattern. Note:
+                        // `JSON.stringify` omits keys whose values are
+                        // `undefined`.
+                        Object.assign({}, options, { parser: undefined }),
+                        null,
+                        2
+                      )}
+                    >
                       Copy config JSON
                     </ClipboardButton>
                   </div>


### PR DESCRIPTION
Fixes #6093.

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
