### PR TITLE
ignore.md: add link to gitignore docs

### DIFF
--- a/docs/ignore.md
+++ b/docs/ignore.md
@@ -7,7 +7,7 @@ Prettier offers an escape hatch to ignore a block of code or prevent entire file
 
 ## Ignoring Files
 
-To exclude files from formatting, add entries to a `.prettierignore` file in the project root or set the [`--ignore-path` CLI option](cli.md#ignore-path).
+To exclude files from formatting, add entries to a `.prettierignore` file in the project root or set the [`--ignore-path` CLI option](cli.md#ignore-path). `.prettierignore` uses [gitignore syntax](https://git-scm.com/docs/gitignore#_pattern_format).
 
 ## JavaScript
 


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

I recently spent some time debugging a `.prettierignore` file. There's a
bit of docs about the existence of `.prettierignore`, but what's the
syntax? Is each line a regex?

Prettier uses the `ignore` package, which implements gitignore syntax.
So add a link to gitignore syntax.

----

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
