### PR TITLE
[TypeScript]Keep a trailing comma on tuple types

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -433,7 +433,9 @@ f[(a::b)];
 f[a::b];
 ```
 
-### TypeScript: Keep a trailing comma on tuple types when `trailing-commma` options is `all` ([#6172] by [@sosukesuzuki])
+### TypeScript: Add trailing comma on tuple types when `trailing-commma` options is `all` ([#6172] by [@sosukesuzuki])
+
+TypeScript supports a trailing comma on tuple types since version 3.3.
 
 <!-- prettier-ignore -->
 ```ts

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -433,7 +433,7 @@ f[(a::b)];
 f[a::b];
 ```
 
-### TypeScript: Keep a trailing comma on tuple types when `trailing-commma` options is `all` ([#] by [@sosukesuzuki])
+### TypeScript: Keep a trailing comma on tuple types when `trailing-commma` options is `all` ([#6172] by [@sosukesuzuki])
 
 <!-- prettier-ignore -->
 ```ts
@@ -477,6 +477,7 @@ export type Foo = [
 [#6146]: https://github.com/prettier/prettier/pull/6146
 [#6152]: https://github.com/prettier/prettier/pull/6152
 [#6159]: https://github.com/prettier/prettier/pull/6159
+[#6172]: https://github.com/prettier/prettier/pull/6172
 [@belochub]: https://github.com/belochub
 [@brainkim]: https://github.com/brainkim
 [@duailibe]: https://github.com/duailibe

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -433,6 +433,29 @@ f[(a::b)];
 f[a::b];
 ```
 
+### TypeScript: Keep a trailing comma on tuple types when `trailing-commma` options is `all` ([#] by [@sosukesuzuki])
+
+<!-- prettier-ignore -->
+```ts
+// Input
+export type Foo = [
+  number,
+  number, // comment
+];
+
+// Output (Prettier stable)
+export type Foo = [
+  number,
+  number // comment
+];
+
+// Output (Prettier master);
+export type Foo = [
+  number,
+  number, // comment
+];
+```
+
 [#5979]: https://github.com/prettier/prettier/pull/5979
 [#6086]: https://github.com/prettier/prettier/pull/6086
 [#6088]: https://github.com/prettier/prettier/pull/6088

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2487,10 +2487,7 @@ function printPathNoParens(path, options, print, args) {
               printArrayItems(path, options, typesField, print)
             ])
           ),
-          // TypeScript doesn't support trailing commas in tuple types
-          n.type === "TSTupleType"
-            ? ""
-            : ifBreak(shouldPrintComma(options) ? "," : ""),
+          ifBreak(shouldPrintComma(options) ? "," : ""),
           comments.printDanglingComments(path, options, /* sameIndent */ true),
           softline,
           "]"

--- a/tests/typescript_tuple/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_tuple/__snapshots__/jsfmt.spec.js.snap
@@ -40,6 +40,47 @@ export interface ShopQueryResult {
 ================================================================================
 `;
 
+exports[`trailing-comma.ts 2`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+export interface ShopQueryResult {
+  chic: boolean;
+  location: number[];
+  menus: Menu[];
+  openingDays: number[];
+  closingDays: [
+    {
+      from: string,
+      to: string,
+    }, // <== this one
+  ];
+  shop: string;
+  distance: number;
+}
+
+=====================================output=====================================
+export interface ShopQueryResult {
+  chic: boolean;
+  location: number[];
+  menus: Menu[];
+  openingDays: number[];
+  closingDays: [
+    {
+      from: string;
+      to: string;
+    }, // <== this one
+  ];
+  shop: string;
+  distance: number;
+}
+
+================================================================================
+`;
+
 exports[`tuple.ts 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -64,6 +105,36 @@ export type SCMRawResource = [
   string[] /*icons: light, dark*/,
   boolean /*strike through*/,
   boolean /*faded*/
+];
+
+================================================================================
+`;
+
+exports[`tuple.ts 2`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+
+export type SCMRawResource = [
+	number /*handle*/,
+	string /*resourceUri*/,
+	modes.Command /*command*/,
+	string[] /*icons: light, dark*/,
+	boolean /*strike through*/,
+	boolean /*faded*/
+];
+
+=====================================output=====================================
+export type SCMRawResource = [
+  number /*handle*/,
+  string /*resourceUri*/,
+  modes.Command /*command*/,
+  string[] /*icons: light, dark*/,
+  boolean /*strike through*/,
+  boolean /*faded*/,
 ];
 
 ================================================================================

--- a/tests/typescript_tuple/jsfmt.spec.js
+++ b/tests/typescript_tuple/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(__dirname, ["typescript"]);
+run_spec(__dirname, ["typescript"], { trailingComma: "all" });


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fix #5846.

TypeScript trailing comma on tuple types is allowed from https://github.com/microsoft/TypeScript/pull/28919.
Keep a trailing comma on tuple types when `trailing-comma` option is `all`.

```ts
// Input
export type Foo = [
  number,
  number, // comment
];
 // Output (Before)
export type Foo = [
  number,
  number // comment
];
 // Output (After);
export type Foo = [
  number,
  number, // comment
];
```

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
