### PR TITLE
Fix (Glimmer): don't self-close void elements

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -458,7 +458,7 @@ export type Foo = [
 ];
 ```
 
-### Handlebars: Avoid adding unwanted whitespace after components ([#6178] by [@GavinJoyce])
+### Handlebars: Avoid adding unwanted whitespace after components ([#6178] by [@gavinjoyce])
 
 Previously, Prettier added a space before `/>` and a line break after, even when at the start of a line. Now, that extra space and line break is no longer present.
 
@@ -487,6 +487,25 @@ Previously, Prettier added a space before `/>` and a line break after, even when
 </div>
 ```
 
+### Handlebars: Don't self close void elements ([#6179] by [@gavinjoyce])
+
+Making Prettier consistent with default Ember app linting rules, void elements are no longer self closing.
+
+<!-- prettier-ignore -->
+```hbs
+// Input
+<img src=".." />
+<br />
+
+// Output (Prettier stable)
+<img src=".." />
+<br />
+
+// Output (Prettier master)
+<img src="..">
+<br>
+```
+
 [#5979]: https://github.com/prettier/prettier/pull/5979
 [#6038]: https://github.com/prettier/prettier/pull/6038
 [#6086]: https://github.com/prettier/prettier/pull/6086
@@ -511,6 +530,7 @@ Previously, Prettier added a space before `/>` and a line break after, even when
 [#6159]: https://github.com/prettier/prettier/pull/6159
 [#6172]: https://github.com/prettier/prettier/pull/6172
 [#6178]: https://github.com/prettier/prettier/pull/6178
+[#6179]: https://github.com/prettier/prettier/pull/6179
 [@belochub]: https://github.com/belochub
 [@brainkim]: https://github.com/brainkim
 [@duailibe]: https://github.com/duailibe
@@ -521,4 +541,4 @@ Previously, Prettier added a space before `/>` and a line break after, even when
 [@sosukesuzuki]: https://github.com/sosukesuzuki
 [@thorn0]: https://github.com/thorn0
 [@bakkot]: https://github.com/bakkot
-[@gavinjoyce]: https://github.com/GavinJoyce
+[@gavinjoyce]: https://github.com/gavinjoyce

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -49,13 +49,20 @@ function print(path, options, print) {
     case "ElementNode": {
       const tagFirstChar = n.tag[0];
       const isLocal = n.tag.indexOf(".") !== -1;
-      const isGlimmerComponent =
+      const isComponent =
         tagFirstChar.toUpperCase() === tagFirstChar || isLocal;
       const hasChildren = n.children.length > 0;
-      const isVoid =
-        (isGlimmerComponent && !hasChildren) || voidTags.indexOf(n.tag) !== -1;
-      const closeTagForNoBreak = isVoid ? concat([" />", softline]) : ">";
-      const closeTagForBreak = isVoid ? "/>" : ">";
+      const isVoidTag = voidTags.indexOf(n.tag) !== -1;
+      const isVoidComponent = isComponent && !hasChildren;
+      const isVoidTagOrComponent = isVoidTag || isVoidComponent;
+      const selfClosingTagForNoBreak = isComponent ? " />" : ">";
+      const selfClosingTagForBreak = isComponent ? "/>" : ">";
+      const closeTagForNoBreak = isVoidTagOrComponent
+        ? concat([selfClosingTagForNoBreak, softline])
+        : ">";
+      const closeTagForBreak = isVoidTagOrComponent
+        ? selfClosingTagForBreak
+        : ">";
       const getParams = (path, print) =>
         indent(
           concat([
@@ -85,7 +92,7 @@ function print(path, options, print) {
           concat([
             indent(join(softline, [""].concat(path.map(print, "children")))),
             ifBreak(hasChildren ? hardline : "", ""),
-            !isVoid ? concat(["</", n.tag, ">"]) : ""
+            !isVoidTagOrComponent ? concat(["</", n.tag, ">"]) : ""
           ])
         )
       ]);

--- a/tests/glimmer/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/glimmer/__snapshots__/jsfmt.spec.js.snap
@@ -338,7 +338,7 @@ printWidth: 80
 </button>
 <button disabled class="disabled"></button>
 <button disabled="disabled" class="disabled"></button>
-<img alt="" />
+<img alt="">
 <div ...attributes>
   Hello
 </div>
@@ -401,7 +401,7 @@ singleQuote: true
 </button>
 <button disabled class="disabled"></button>
 <button disabled="disabled" class="disabled"></button>
-<img alt="" />
+<img alt="">
 <div ...attributes>
   Hello
 </div>
@@ -714,6 +714,7 @@ printWidth: 80
 
 <div></div>
 <img />
+<img data-this-is-really-long-to-force-a-line-break-to-happen-so-that-we-can-test-it />
 
 =====================================output=====================================
 <div class="attribute" {{modifier}} {{! comment}}>
@@ -741,7 +742,10 @@ printWidth: 80
   {{hello}}
 </div>
 <div></div>
-<img />
+<img>
+<img
+  data-this-is-really-long-to-force-a-line-break-to-happen-so-that-we-can-test-it
+>
 ================================================================================
 `;
 
@@ -788,6 +792,7 @@ singleQuote: true
 
 <div></div>
 <img />
+<img data-this-is-really-long-to-force-a-line-break-to-happen-so-that-we-can-test-it />
 
 =====================================output=====================================
 <div class="attribute" {{modifier}} {{! comment}}>
@@ -815,7 +820,10 @@ singleQuote: true
   {{hello}}
 </div>
 <div></div>
-<img />
+<img>
+<img
+  data-this-is-really-long-to-force-a-line-break-to-happen-so-that-we-can-test-it
+>
 ================================================================================
 `;
 

--- a/tests/glimmer/element-node.hbs
+++ b/tests/glimmer/element-node.hbs
@@ -34,3 +34,4 @@
 
 <div></div>
 <img />
+<img data-this-is-really-long-to-force-a-line-break-to-happen-so-that-we-can-test-it />


### PR DESCRIPTION
Fixes https://github.com/prettier/prettier/issues/6079

[ember-template-lint](https://github.com/ember-template-lint/ember-template-lint) (which is included by default in new ember apps) has a [`self-closing-void-elements`](https://github.com/ember-template-lint/ember-template-lint/blob/3d0c797969369be62d5e1799adf7c35a61ab4583/docs/rule/self-closing-void-elements.md) rule which is enabled by default. This PR makes the  prettier output consistent with this rule.

```hbs
<img src=".." />
<br />
```
becomes:

```hbs
<img src="..">
<br>
```

- [x] I’ve added tests to confirm my change works.
- [x] ~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
