### PR TITLE
[TypeScript] Add trailing comma for only arrow functions in tsx.

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -43,3 +43,37 @@ const link = <a href="example.com">http://example.com</a>;
 ```
 
 -->
+
+#### TypeScript: Add trailing comma in tsx, only for arrow function ([#PR] by [@sosukesuzuki])
+
+Prettier inserts a trailing comma to single type parameter for arrow functions in tsx, since v 1.18. But, this feature inserts a trailing comma to type parameter for besides arrow functions too (e.g, function , interface). This change fix it.
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+interface Interface1<T> {
+  one: "one";
+}
+function function1<T>() {
+  return "one";
+}
+
+// Output (Prettier stable)
+interface Interface1<T,> {
+  one: "one";
+}
+function function1<T,>() {
+  return "one";
+}
+
+// Output (Prettier master)
+interface Interface1<T> {
+  one: "one";
+}
+function function1<T>() {
+  return "one";
+}
+```
+
+[#PR]: https://github.com/prettier/prettier/pull/#PR
+[@sosukesuzuki]: https://github.com/sosukesuzuki

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -44,7 +44,7 @@ const link = <a href="example.com">http://example.com</a>;
 
 -->
 
-#### TypeScript: Add trailing comma in tsx, only for arrow function ([#PR] by [@sosukesuzuki])
+#### TypeScript: Add trailing comma in tsx, only for arrow function ([#6190] by [@sosukesuzuki])
 
 Prettier inserts a trailing comma to single type parameter for arrow functions in tsx, since v 1.18. But, this feature inserts a trailing comma to type parameter for besides arrow functions too (e.g, function , interface). This change fix it.
 
@@ -75,5 +75,5 @@ function function1<T>() {
 }
 ```
 
-[#PR]: https://github.com/prettier/prettier/pull/#PR
+[#6190]: https://github.com/prettier/prettier/pull/6190
 [@sosukesuzuki]: https://github.com/sosukesuzuki

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3003,12 +3003,14 @@ function printPathNoParens(path, options, print, args) {
       // Keep comma if the file extension is .tsx and
       // has one type parameter that isn't extend with any types.
       // Because, otherwise formatted result will be invalid as tsx.
+      const grandParent = path.getNode(2);
       if (
         parent.params &&
         parent.params.length === 1 &&
         options.filepath &&
         options.filepath.match(/\.tsx/) &&
-        !n.constraint
+        !n.constraint &&
+        grandParent.type === "ArrowFunctionExpression"
       ) {
         parts.push(",");
       }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3008,7 +3008,7 @@ function printPathNoParens(path, options, print, args) {
         parent.params &&
         parent.params.length === 1 &&
         options.filepath &&
-        options.filepath.match(/\.tsx/) &&
+        /\.tsx$/i.test(options.filepath) &&
         !n.constraint &&
         grandParent.type === "ArrowFunctionExpression"
       ) {

--- a/tests/typescript_tsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_tsx/__snapshots__/jsfmt.spec.js.snap
@@ -113,10 +113,46 @@ const functionName1 = <T,>(arg) => false;
 const functionName2 = <T extends any>(arg) => false;
 const functionName3 = <T, S>(arg) => false;
 
+function functionName4<T>() {
+  return false;
+}
+
+functionName5<T>();
+
+interface Interface1<T> {
+  one: "one";
+}
+
+interface Interface2 {
+  two: Two<T>;
+}
+
+type Type1<T> = "type1";
+
+type Type2 = Two<T>;
+
 =====================================output=====================================
 const functionName1 = <T,>(arg) => false;
 const functionName2 = <T extends any>(arg) => false;
 const functionName3 = <T, S>(arg) => false;
+
+function functionName4<T>() {
+  return false;
+}
+
+functionName5<T>();
+
+interface Interface1<T> {
+  one: "one";
+}
+
+interface Interface2 {
+  two: Two<T>;
+}
+
+type Type1<T> = "type1";
+
+type Type2 = Two<T>;
 
 ================================================================================
 `;

--- a/tests/typescript_tsx/type-parameters.tsx
+++ b/tests/typescript_tsx/type-parameters.tsx
@@ -1,3 +1,21 @@
 const functionName1 = <T,>(arg) => false;
 const functionName2 = <T extends any>(arg) => false;
 const functionName3 = <T, S>(arg) => false;
+
+function functionName4<T>() {
+  return false;
+}
+
+functionName5<T>();
+
+interface Interface1<T> {
+  one: "one";
+}
+
+interface Interface2 {
+  two: Two<T>;
+}
+
+type Type1<T> = "type1";
+
+type Type2 = Two<T>;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fix #6189 .
Prettier inserts a trailing comma to single type parameter for arrow functions in tsx, since v 1.18 (#6115 ). But, this feature inserts a trailing comma to type parameter for besides arrow functions too (e.g, function , interface ).

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
