### PR TITLE
docs: fix typos and stuff in the 1.18 release blog post

### DIFF
--- a/website/blog/2019-06-06-1.18.0.md
+++ b/website/blog/2019-06-06-1.18.0.md
@@ -72,19 +72,19 @@ function Foo() {
 
 #### Fix closure compiler typecasts ([#5947] by [@jridgewell])
 
-If a closing parenthesis follows after a typecast in an inner expression, the typecast would wrap everything to the that following parenthesis.
+If a closing parenthesis follows after a typecast in an inner expression, the typecast would wrap everything to that following parenthesis.
 
 <!-- prettier-ignore -->
 ```js
 // Input
-test(/** @type {!Array} */ (arrOrString.length));
-test(/** @type {!Array} */ (arrOrString.length + 1));
+test(/** @type {!Array} */(arrOrString).length);
+test(/** @type {!Array} */((arrOrString)).length + 1);
 // Output (Prettier stable)
 test(/** @type {!Array} */ (arrOrString.length));
 test(/** @type {!Array} */ (arrOrString.length + 1));
 // Output (Prettier master)
-test(/** @type {!Array} */ (arrOrString.length));
-test(/** @type {!Array} */ (arrOrString.length + 1));
+test(/** @type {!Array} */ (arrOrString).length);
+test(/** @type {!Array} */ (arrOrString).length + 1);
 ```
 
 #### Fix closure typecasts without spaces ([#6116] by [@jridgewell])
@@ -243,7 +243,7 @@ export default (function log() {}).toString();
 export default (function log() {} as typeof console.log);
 ```
 
-#### Address parentheses bugs for edge cases with call and new. ([#6148] by [@bakkot])
+#### Address parentheses bugs for edge cases with call and `new` ([#6148] by [@bakkot])
 
 Adding all and only the necessary parentheses when mixing `new` with function calls is tricky. This change fixes two issues where necessary parentheses were omitted and one when redundant parentheses were added.
 
@@ -285,9 +285,9 @@ const html = /* HTML */ `
 `;
 ```
 
-#### Keep necessary parentheses around the bind expression passed to "new" expression.([#6152] by [@sosukesuzuki])
+#### Keep necessary parentheses around bind expressions passed to `new` expressions ([#6152] by [@sosukesuzuki])
 
-Previously, Prettier has removed necessary parentheses around the bind expression if the result is passed to "new" expression.
+Previously, Prettier removed necessary parentheses around a bind expression if it was passed to a `new` expression.
 
 <!-- prettier-ignore -->
 ```js
@@ -319,7 +319,7 @@ f[a::b];
 
 #### Keep trailing comma in TSX type parameters ([#6115] by [@sosukesuzuki])
 
-Previously, a trailing comma after single type parameter in arrow function was cleaned up. The formatted result is valid as TSX, but is invalid as TSX. This is now fixed in 1.19.
+Previously, a trailing comma after single type parameter in arrow function was cleaned up. The formatted result is valid as TS, but is invalid as TSX. This is now fixed in 1.19.
 
 <!-- prettier-ignore -->
 ```tsx
@@ -338,9 +338,10 @@ const myFunc = <T,>(arg1: G<T>) => false;
 
 #### Don’t breakup call expressions when the last argument is an arrow function with a simple return type ([#6106] by [@brainkim])
 
+Fixes [an edge case][#6099] where we were splitting up call expressions containing arrow functions with simple return types.
+
 <!-- prettier-ignore -->
 ```js
-Fixes [an edge-case](#6099) where we were splitting up call expressions containing arrow functions with simple return types.
 app.get("/", (req, res): void => {
   res.send("Hello World!");
 });
@@ -359,9 +360,9 @@ app.get("/", (req, res): void => {
 });
 ```
 
-#### Keep a pair of parentheses when there are extra pairs. ([#6131] by [@sosukesuzuki])
+#### Keep a pair of parentheses when there are extra pairs ([#6131] by [@sosukesuzuki])
 
-Previously, Prettier removes the necessary parentheses when trying to remove unnecessary parentheses, in TypeScript.
+Previously, Prettier removed necessary parentheses when trying to remove unnecessary parentheses, in TypeScript.
 
 <!-- prettier-ignore -->
 ```ts
@@ -375,7 +376,7 @@ type G = keyof T[];
 type G = (keyof T)[];
 ```
 
-#### Keep necessary parentheses around non-null assertions. ([#6136] by [@sosukesuzuki], [#6140] by [@thorn0], [#6148] by [@bakkot])
+#### Keep necessary parentheses around non-null assertions ([#6136] by [@sosukesuzuki], [#6140] by [@thorn0], [#6148] by [@bakkot])
 
 Previously, Prettier removed necessary parentheses around non-null assertions if the result of the assertion expression was called as a constructor.
 
@@ -411,7 +412,7 @@ type A<T> = {
 };
 ```
 
-#### Add trailing comma on tuple types with `--trailing-commma=all` ([#6172] by [@sosukesuzuki])
+#### Add trailing comma on tuple types with `--trailing-comma=all` ([#6172] by [@sosukesuzuki])
 
 TypeScript supports a trailing comma on tuple types since version 3.3.
 
@@ -501,11 +502,13 @@ Previously, Prettier added a space before `/>` and a line break after, even when
 
 Atom has a security feature where code containing `eval` is not allowed to be run. One of Prettier's dependencies uses `eval` to prevent bundlers from including debug code. We've now made sure that this `eval` does not end up in the code we ship to npm, making Prettier play nice with Atom again.
 
+[#5947]: https://github.com/prettier/prettier/pull/5947
 [#5979]: https://github.com/prettier/prettier/pull/5979
 [#6038]: https://github.com/prettier/prettier/pull/6038
 [#6086]: https://github.com/prettier/prettier/pull/6086
 [#6088]: https://github.com/prettier/prettier/pull/6088
 [#6089]: https://github.com/prettier/prettier/pull/6089
+[#6099]: https://github.com/prettier/prettier/pull/6099
 [#6106]: https://github.com/prettier/prettier/pull/6106
 [#6110]: https://github.com/prettier/prettier/pull/6110
 [#6115]: https://github.com/prettier/prettier/pull/6115


### PR DESCRIPTION
[preview](https://deploy-preview-6191--prettier.netlify.com/blog/2019/06/06/1.18.0.html)