### PR TITLE
Fix method name in comment

### DIFF
--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -455,11 +455,11 @@ function isStyledComponents(path) {
         isStyledIdentifier(tag.callee) ||
         (tag.callee.type === "MemberExpression" &&
           ((tag.callee.object.type === "MemberExpression" &&
-            // styled.foo.attr({})``
+            // styled.foo.attrs({})``
             (isStyledIdentifier(tag.callee.object.object) ||
-              // Component.extend.attr({)``
+              // Component.extend.attrs({})``
               isStyledExtend(tag.callee.object))) ||
-            // styled(Component).attr({})``
+            // styled(Component).attrs({})``
             (tag.callee.object.type === "CallExpression" &&
               isStyledIdentifier(tag.callee.object.callee))))
       );


### PR DESCRIPTION
Fix the `styled-components` method name and missing curly brace in the comments.

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).