### PR TITLE
Use ES5-compatible syntax in `.prettierrc.js`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,10 +114,11 @@ An example configuration repository is available [here](https://github.com/azz/p
 > Note: This method does **not** offer a way to _extend_ the configuration to overwrite some properties from the shared configuration. If you need to do that, import the file in a `.prettierrc.js` file and export the modifications, e.g:
 >
 > ```js
-> module.exports = {
->   ...require("@company/prettier-config"),
+> const companyConfig = require("@company/prettier-config");
+>
+> module.exports = Object.assign(companyConfig, {
 >   semi: false
-> };
+> });
 > ```
 
 ## Setting the [parser](options.md#parser) option


### PR DESCRIPTION
VSCode-Prettier is not able to parse the configuration example because it uses the spread operator. I presume that this is because VSCode uses an old version of Node under the hood.

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
