### PR TITLE
#6151 -- Allow plugin to specify option with type `string`

### DIFF
--- a/src/main/options-normalizer.js
+++ b/src/main/options-normalizer.js
@@ -118,6 +118,9 @@ function optionInfoToSchema(optionInfo, { isCLI, optionInfos }) {
         parameters.preprocess = value => Number(value);
       }
       break;
+    case "string":
+      SchemaConstructor = vnopts.StringSchema;
+      break;
     case "choice":
       SchemaConstructor = vnopts.ChoiceSchema;
       parameters.choices = optionInfo.choices.map(choiceInfo =>

--- a/tests_integration/__tests__/__snapshots__/plugin-options-string.js.snap
+++ b/tests_integration/__tests__/__snapshots__/plugin-options-string.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[` 1`] = `
+"Snapshot Diff:
+- First value
++ Second value
+
+@@ -17,10 +17,12 @@
+                             Defaults to avoid.
+    --no-bracket-spacing     Do not print spaces between brackets.
+    --end-of-line <auto|lf|crlf|cr>
+                             Which end of line characters to apply.
+                             Defaults to auto.
++   --foo-string <string>    foo description
++                            Defaults to bar.
+    --html-whitespace-sensitivity <css|strict|ignore>
+                             How to handle whitespaces in HTML.
+                             Defaults to css.
+    --jsx-bracket-same-line  Put > on the last line instead of at a new line.
+                             Defaults to false."
+`;
+
+exports[`show detailed external option with \`--help foo-string\` (stderr) 1`] = `""`;
+
+exports[`show detailed external option with \`--help foo-string\` (stdout) 1`] = `
+"--foo-string <string>
+
+  foo description
+
+Default: bar
+"
+`;
+
+exports[`show detailed external option with \`--help foo-string\` (write) 1`] = `Array []`;

--- a/tests_integration/__tests__/plugin-options-string.js
+++ b/tests_integration/__tests__/plugin-options-string.js
@@ -1,0 +1,56 @@
+"use strict";
+
+const runPrettier = require("../runPrettier");
+const snapshotDiff = require("snapshot-diff");
+
+describe("show external options with `--help`", () => {
+  const originalStdout = runPrettier("plugins/options-string", ["--help"])
+    .stdout;
+  const pluggedStdout = runPrettier("plugins/options-string", [
+    "--help",
+    "--plugin=./plugin"
+  ]).stdout;
+  expect(snapshotDiff(originalStdout, pluggedStdout)).toMatchSnapshot();
+});
+
+describe("show detailed external option with `--help foo-string`", () => {
+  runPrettier("plugins/options-string", [
+    "--plugin=./plugin",
+    "--help",
+    "foo-string"
+  ]).test({
+    status: 0
+  });
+});
+
+describe("external options from CLI should work", () => {
+  runPrettier(
+    "plugins/options-string",
+    [
+      "--plugin=./plugin",
+      "--stdin-filepath",
+      "example.foo",
+      "--foo-string",
+      "baz"
+    ],
+    { input: "hello-world" }
+  ).test({
+    stdout: "foo:baz",
+    stderr: "",
+    status: 0,
+    write: []
+  });
+});
+
+describe("external options from config file should work", () => {
+  runPrettier(
+    "plugins/options-string",
+    ["--config=./config.json", "--stdin-filepath", "example.foo"],
+    { input: "hello-world" }
+  ).test({
+    stdout: "foo:baz",
+    stderr: "",
+    status: 0,
+    write: []
+  });
+});

--- a/tests_integration/plugins/options-string/config.json
+++ b/tests_integration/plugins/options-string/config.json
@@ -1,0 +1,4 @@
+{
+    "plugins": ["./plugin"],
+    "fooString": "baz"
+}

--- a/tests_integration/plugins/options-string/plugin.js
+++ b/tests_integration/plugins/options-string/plugin.js
@@ -1,0 +1,31 @@
+"use strict";
+
+module.exports = {
+  languages: [
+    {
+      name: "foo",
+      parsers: ["foo-parser"],
+      extensions: [".foo"],
+      since: "1.0.0"
+    }
+  ],
+  options: {
+    fooString: {
+      type: "string",
+      default: "bar",
+      description: "foo description"
+    }
+  },
+  parsers: {
+    "foo-parser": {
+      parse: text => ({ text }),
+      astFormat: "foo-ast"
+    }
+  },
+  printers: {
+    "foo-ast": {
+      print: (path, options) =>
+        options.fooString ? `foo:${options.fooString}` : path.getValue().text
+    }
+  }
+};


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
This PR allows plugins to specify option with type `string`. Currently (as can be seen in #6151), Prettier only accepts option types `int`, `choice`, `boolean`, `flag`, `path`, and rejects type `string`.

Fixes #6151.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
