### PR TITLE
Printing arguments: short circuiting some cases

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4128,20 +4128,15 @@ function printArgumentsList(path, options, print) {
 
     const somePrintedArgumentsWillBreak = printedArguments.some(willBreak);
 
+    const simpleConcat = concat(["(", concat(printedExpanded), ")"]);
+
     return concat([
       somePrintedArgumentsWillBreak ? breakParent : "",
       conditionalGroup(
         [
-          concat([
-            ifBreak(
-              indent(concat(["(", softline, concat(printedExpanded)])),
-              concat(["(", concat(printedExpanded)])
-            ),
-            somePrintedArgumentsWillBreak
-              ? concat([ifBreak(maybeTrailingComma), softline])
-              : "",
-            ")"
-          ]),
+          !somePrintedArgumentsWillBreak
+            ? simpleConcat
+            : ifBreak(allArgsBrokenOut(), simpleConcat),
           shouldGroupFirst
             ? concat([
                 "(",


### PR DESCRIPTION
So when investigating #4784, I've managed to verify the issue was in `printArgumentsList()`, more specifically the part where we check if it should hug the first of the last argument, and later, verified the issue was in the `conditionalGroup`, and more specifically, the first possible group, with a combination of `ifBreak()` and `softline`.

The previous code had the following meaning: if the group breaks, print all arguments broken down; else, just concat the arguments with the wrapping parenthesis (note that there are some cases where we print a new line but the group doesn't break!). 

So the first thing I changed was: if none of the arguments break beforehand (this is before printing, so this means the argument "doc" already includes something that makes it break. It can break later when printing if it exceeds the print width), we can try a simple concat. If it fails, it will continue to the next cases in the conditional group. And only if one of the arguments break beforehand, we use the `ifBreak()`.. another change is instead of using `softline` for the ifBreak case, just print a hardline instead.

These changes didn't break any existing tests and fix the performance degradation.

```js
var prettier = require("./");
var code = `
var render = function () {var _vm=this;var _h=_vm.$createElement;var _c=_vm._self._c||_h;return _c('layout-manager',[_c('p',[_vm._v("Hello!")]),_vm._v(" "),_c('p',{staticClass:"katex-block"},[_c('span',{staticClass:"katex-display"},[_c('span',{staticClass:"katex"},[_c('span',{staticClass:"katex-mathml"},[_c('math',[_c('semantics',[_c('mrow',[_c('mfrac',[_c('mrow',[_c('msub',[_c('mi',[_vm._v("A")]),_c('mn',[_vm._v("1")])],1),_c('msub',[_c('mi',[_vm._v("B")]),_c('mn',[_vm._v("2")])],1)],1),_c('mi',[_vm._v("C")])],1)],1),_c('annotation',{attrs:{"encoding":"application/x-tex"}},[_vm._v("\\frac{A_1B_2}{C}")])],1)],1)],1),_c('span',{staticClass:"katex-html",attrs:{"aria-hidden":"true"}},[_c('span',{staticClass:"base"},[_c('span',{staticClass:"strut",staticStyle:{"height":"2.04633em","vertical-align":"-0.686em"}}),_c('span',{staticClass:"mord"},[_c('span',{staticClass:"mopen nulldelimiter"}),_c('span',{staticClass:"mfrac"},[_c('span',{staticClass:"vlist-t vlist-t2"},[_c('span',{staticClass:"vlist-r"},[_c('span',{staticClass:"vlist",staticStyle:{"height":"1.36033em"}},[_c('span',{staticStyle:{"top":"-2.314em"}},[_c('span',{staticClass:"pstrut",staticStyle:{"height":"3em"}}),_c('span',{staticClass:"mord"},[_c('span',{staticClass:"mord mathdefault",staticStyle:{"margin-right":"0.07153em"}},[_vm._v("C")])])]),_c('span',{staticStyle:{"top":"-3.23em"}},[_c('span',{staticClass:"pstrut",staticStyle:{"height":"3em"}}),_c('span',{staticClass:"frac-line",staticStyle:{"border-bottom-width":"0.04em"}})]),_c('span',{staticStyle:{"top":"-3.677em"}},[_c('span',{staticClass:"pstrut",staticStyle:{"height":"3em"}}),_c('span',{staticClass:"mord"},[_c('span',{staticClass:"mord"},[_c('span',{staticClass:"mord mathdefault"},[_vm._v("A")]),_c('span',{staticClass:"msupsub"},[_c('span',{staticClass:"vlist-t vlist-t2"},[_c('span',{staticClass:"vlist-r"},[_c('span',{staticClass:"vlist",staticStyle:{"height":"0.30110799999999993em"}},[_c('span',{staticStyle:{"top":"-2.5500000000000003em","margin-left":"0em","margin-right":"0.05em"}},[_c('span',{staticClass:"pstrut",staticStyle:{"height":"2.7em"}}),_c('span',{staticClass:"sizing reset-size6 size3 mtight"},[_c('span',{staticClass:"mord mtight"},[_vm._v("1")])])])]),_c('span',{staticClass:"vlist-s"},[_vm._v("​")])]),_c('span',{staticClass:"vlist-r"},[_c('span',{staticClass:"vlist",staticStyle:{"height":"0.15em"}},[_c('span')])])])])]),_c('span',{staticClass:"mord"},[_c('span',{staticClass:"mord mathdefault",staticStyle:{"margin-right":"0.05017em"}},[_vm._v("B")]),_c('span',{staticClass:"msupsub"},[_c('span',{staticClass:"vlist-t vlist-t2"},[_c('span',{staticClass:"vlist-r"},[_c('span',{staticClass:"vlist",staticStyle:{"height":"0.30110799999999993em"}},[_c('span',{staticStyle:{"top":"-2.5500000000000003em","margin-left":"-0.05017em","margin-right":"0.05em"}},[_c('span',{staticClass:"pstrut",staticStyle:{"height":"2.7em"}}),_c('span',{staticClass:"sizing reset-size6 size3 mtight"},[_c('span',{staticClass:"mord mtight"},[_vm._v("2")])])])]),_c('span',{staticClass:"vlist-s"},[_vm._v("​")])]),_c('span',{staticClass:"vlist-r"},[_c('span',{staticClass:"vlist",staticStyle:{"height":"0.15em"}},[_c('span')])])])])])])])]),_c('span',{staticClass:"vlist-s"},[_vm._v("​")])]),_c('span',{staticClass:"vlist-r"},[_c('span',{staticClass:"vlist",staticStyle:{"height":"0.686em"}},[_c('span')])])])]),_c('span',{staticClass:"mclose nulldelimiter"})])])])])])])])}
var staticRenderFns = []
render._withStripped = true
`;

prettier.format(code, { parser: "babel", trailingComma: "all" });
```

The execution time comes down to 0.58s.

```
> time node test.js
node test.js  0.58s user 0.14s system 89% cpu 0.799 total
```

Closes #4784