### PR TITLE
Fix markdown syntax highlighting for babel-flow

### DIFF
--- a/website/playground/markdown.js
+++ b/website/playground/markdown.js
@@ -37,6 +37,7 @@ function getMarkdownSyntax(options) {
   switch (options.parser) {
     case "babel":
     case "babylon": // backward compatibility
+    case "babel-flow":
     case "flow":
       return "jsx";
     case "typescript":


### PR DESCRIPTION
Previously, the "Copy markdown" button in the playground generated
markdown containing this when having selected "babel-flow" as parser:

    ```babel-flow

This commit changes it to:

    ```jsx

So that the code blocks get syntax highlighting on GitHub.

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
