### PR TITLE
Config should not be evaluated for ignored files

### DIFF
--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -420,14 +420,7 @@ function eachFilename(context, patterns, callback) {
       process.exitCode = 2;
       return;
     }
-    filePaths.forEach(filePath =>
-      callback(
-        filePath,
-        Object.assign(getOptionsForFile(context, filePath), {
-          filepath: filePath
-        })
-      )
-    );
+    filePaths.forEach(filePath => callback(filePath));
   } catch (error) {
     context.logger.error(
       `Unable to expand glob patterns: ${patterns.join(" ")}\n${error.message}`
@@ -448,7 +441,7 @@ function formatFiles(context) {
     context.logger.log("Checking formatting...");
   }
 
-  eachFilename(context, context.filePatterns, (filename, options) => {
+  eachFilename(context, context.filePatterns, filename => {
     const fileIgnored = ignorer.filter([filename]).length === 0;
     if (
       fileIgnored &&
@@ -459,6 +452,10 @@ function formatFiles(context) {
     ) {
       return;
     }
+
+    const options = Object.assign(getOptionsForFile(context, filename), {
+      filepath: filename
+    });
 
     if (isTTY()) {
       // Don't use `console.log` here since we need to replace this line.

--- a/tests_integration/cli/ignore-absolute-path/ignored/.prettierrc.js
+++ b/tests_integration/cli/ignore-absolute-path/ignored/.prettierrc.js
@@ -1,0 +1,1 @@
+throw Error('This config should not be evaluated since the directory is ignored');

--- a/tests_integration/cli/ignore-relative-path/level1/level2/.prettierrc.js
+++ b/tests_integration/cli/ignore-relative-path/level1/level2/.prettierrc.js
@@ -1,0 +1,1 @@
+throw Error('This config should not be evaluated since the directory is ignored');


### PR DESCRIPTION
Fix #5955.

Prior to this change, the CLI would resolve the config for a file before checking it against the ignored list. If the config was invalid, the CLI would report a failure.

This change relocates the config-resolution phase until after the file is confirmed to not be ignored.

- [X] I’ve added tests to confirm my change works.
- [x] ~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~
- [x] ~(If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.~
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).