### PR TITLE
WIP: Glimmer: Fix whitespaces between text and helpers

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -146,8 +146,52 @@ Previously, Prettier would sometimes ignore whitespace when formatting comments.
 </div>
 ```
 
+### Handlebars: Fix whitespaces between text and helpers ([#6206] by [@dcyriller])
+
+Previously, Prettier was a bit eager regarding regular text whitespaces,
+especially around handlebars helpers.
+
+<!-- prettier-ignore -->
+```hbs
+// Input
+{{#component propA}}
+    for {{propB}}  do {{propC}} f
+{{/component}}
+
+// Output (Prettier stable)
+{{#component propA}}
+  for{{propB}}do{{propC}}f
+{{/component}}
+
+// Output (Prettier master)
+{{#component propA}}
+  for {{propB}}  do {{propC}} f
+{{/component}}
+```
+
+Notice the whitespaces in TextNodes:
+
+```hbs
+// Input
+{{#component propA}}
+˽˽˽˽for˽{{propB}}˽˽do˽{{propC}}˽f
+{{/component}}
+
+// Output (Prettier stable)
+{{#component propA}}
+˽˽for{{propB}}do{{propC}}f
+{{/component}}
+
+// Output (Prettier master)
+{{#component propA}}
+˽˽for˽{{propB}}˽˽do˽{{propC}}˽f
+{{/component}}
+```
+
 [#6209]: https://github.com/prettier/prettier/pull/6209
 [#6186]: https://github.com/prettier/prettier/pull/6186
 [#6186]: https://github.com/prettier/prettier/pull/6206
+[#6239]: https://github.com/prettier/prettier/pull/6239
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
+[@dcyriller]: https://github.com/dcyriller

--- a/src/language-handlebars/parser-glimmer.js
+++ b/src/language-handlebars/parser-glimmer.js
@@ -8,7 +8,8 @@ function parse(text) {
     return glimmer(text, {
       plugins: {
         ast: []
-      }
+      },
+      mode: "codemod"
     });
     /* istanbul ignore next */
   } catch (error) {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -233,7 +233,7 @@ function print(path, options, print) {
       let leadingSpace = "";
       let trailingSpace = "";
 
-      if (isNextNodeOfType(path, "MustacheStatement")) {
+      if (isNextNodeOfSomeType(path, ["MustacheStatement"])) {
         trailingSpace = " ";
       }
 
@@ -432,9 +432,13 @@ function isPreviousNodeOfSomeType(path, types) {
   return false;
 }
 
-function isNextNodeOfType(path, type) {
+function isNextNodeOfSomeType(path, types) {
   const nextNode = getNextNode(path);
-  return nextNode && nextNode.type === type;
+
+  if (nextNode) {
+    return types.some(type => nextNode.type === type);
+  }
+  return false;
 }
 
 function clean(ast, newObj) {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -422,7 +422,8 @@ function getPreviousNode(path) {
   const node = path.getValue();
   const parentNode = path.getParentNode(0);
 
-  const children = parentNode.children;
+  // NodeElement has `children` and BlockStatement has a `body`
+  const children = parentNode.children || parentNode.body;
   if (children) {
     const nodeIndex = children.indexOf(node);
     if (nodeIndex > 0) {
@@ -436,7 +437,8 @@ function getNextNode(path) {
   const node = path.getValue();
   const parentNode = path.getParentNode(0);
 
-  const children = parentNode.children;
+  // NodeElement has `children` and BlockStatement has a `body`
+  const children = parentNode.children || parentNode.body;
   if (children) {
     const nodeIndex = children.indexOf(node);
     if (nodeIndex < children.length) {

--- a/tests/glimmer/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/glimmer/__snapshots__/jsfmt.spec.js.snap
@@ -1648,7 +1648,7 @@ hey
 
 =====================================output=====================================
 <p>
-  Hi {{firstName}} {{lastName}}, welcome!
+  Hi  {{firstName}}  {{lastName}}   , welcome!
 </p>
 {{#component propA}}
   for{{propB}}do{{propC}}f
@@ -1688,7 +1688,7 @@ hey
 
 =====================================output=====================================
 <p>
-  Hi {{firstName}} {{lastName}}, welcome!
+  Hi  {{firstName}}  {{lastName}}   , welcome!
 </p>
 {{#component propA}}
   for{{propB}}do{{propC}}f

--- a/tests/glimmer/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/glimmer/__snapshots__/jsfmt.spec.js.snap
@@ -1627,3 +1627,82 @@ singleQuote: true
 }}
 ================================================================================
 `;
+
+exports[`whitespaces.hbs 1`] = `
+====================================options=====================================
+parsers: ["glimmer"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<p>Hi  {{firstName}}  {{lastName}}   , welcome!</p>
+{{#component propA}}
+    for {{propB}}  do {{propC}} f
+{{/component}}
+{{#component propA}}
+    for {{propB}}  <span>name</span>do {{propC}} f
+{{/component}}
+
+  
+
+hey
+
+=====================================output=====================================
+<p>
+  Hi {{firstName}} {{lastName}}, welcome!
+</p>
+{{#component propA}}
+  for{{propB}}do{{propC}}f
+{{/component}}
+{{#component propA}}
+  for
+  {{propB}}
+  <span>
+    name
+  </span>
+  do
+  {{propC}}
+  f
+{{/component}}
+hey
+================================================================================
+`;
+
+exports[`whitespaces.hbs 2`] = `
+====================================options=====================================
+parsers: ["glimmer"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+<p>Hi  {{firstName}}  {{lastName}}   , welcome!</p>
+{{#component propA}}
+    for {{propB}}  do {{propC}} f
+{{/component}}
+{{#component propA}}
+    for {{propB}}  <span>name</span>do {{propC}} f
+{{/component}}
+
+  
+
+hey
+
+=====================================output=====================================
+<p>
+  Hi {{firstName}} {{lastName}}, welcome!
+</p>
+{{#component propA}}
+  for{{propB}}do{{propC}}f
+{{/component}}
+{{#component propA}}
+  for
+  {{propB}}
+  <span>
+    name
+  </span>
+  do
+  {{propC}}
+  f
+{{/component}}
+hey
+================================================================================
+`;

--- a/tests/glimmer/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/glimmer/__snapshots__/jsfmt.spec.js.snap
@@ -1651,7 +1651,7 @@ hey
   Hi  {{firstName}}  {{lastName}}   , welcome!
 </p>
 {{#component propA}}
-  for{{propB}}do{{propC}}f
+  for {{propB}}  do {{propC}} f
 {{/component}}
 {{#component propA}}
   for
@@ -1661,7 +1661,7 @@ hey
   </span>
   do
   {{propC}}
-  f
+   f
 {{/component}}
 hey
 ================================================================================
@@ -1691,7 +1691,7 @@ hey
   Hi  {{firstName}}  {{lastName}}   , welcome!
 </p>
 {{#component propA}}
-  for{{propB}}do{{propC}}f
+  for {{propB}}  do {{propC}} f
 {{/component}}
 {{#component propA}}
   for
@@ -1701,7 +1701,7 @@ hey
   </span>
   do
   {{propC}}
-  f
+   f
 {{/component}}
 hey
 ================================================================================

--- a/tests/glimmer/whitespaces.hbs
+++ b/tests/glimmer/whitespaces.hbs
@@ -1,0 +1,11 @@
+<p>Hi  {{firstName}}  {{lastName}}   , welcome!</p>
+{{#component propA}}
+    for {{propB}}  do {{propC}} f
+{{/component}}
+{{#component propA}}
+    for {{propB}}  <span>name</span>do {{propC}} f
+{{/component}}
+
+  
+
+hey


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
This PR is an iteration on how glimmer printer handles `TextNode` surrounding whitespaces. 

Previously, Prettier was a bit eager regarding regular text whitespaces, especially around handlebars helpers. It would remove leading and trailing whitespaces for every `TextNode` siblings. With this PR, it will remove leading whitespaces for the first `TextNode` and remove trailing whitespaces for the last `TextNode`.

It adds a `whitespaces` test file.

```hbs
// Input
{{#component propA}}
    for {{propB}}  do {{propC}} f
{{/component}}

// Output (Prettier stable)
{{#component propA}}
  for{{propB}}do{{propC}}f
{{/component}}

// Output (Prettier this PR)
{{#component propA}}
  for {{propB}}  do {{propC}} f
{{/component}}
```
Notice the whitespaces in TextNodes:
```hbs
// Input
{{#component propA}}
˽˽˽˽for˽{{propB}}˽˽do˽{{propC}}˽f
{{/component}}

// Output (Prettier stable)
{{#component propA}}
˽˽for{{propB}}do{{propC}}f
{{/component}}

// Output (Prettier this PR)
{{#component propA}}
˽˽for˽{{propB}}˽˽do˽{{propC}}˽f
{{/component}}
```


**Changes**:
- glimmer printer: Modify `TextNode` section
- glimmer printer: Turn `isNextNodeOfType` util function into `isNextNodeOfSomeType`
- glimmer printer: Adjust `getPreviousNode` and `getNextNode` util functions to handle not only `ElementNode`s but also `BlockStatement`s
- tests: Add `tests/glimmer/whitespaces.hbs` file

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
