### PR TITLE
Add `jsxSelfClosing` option

### DIFF
--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -48,6 +48,13 @@ module.exports = {
     default: false,
     description: "Use single quotes in JSX."
   },
+  jsxSelfClosing: {
+    since: "1.19.0",
+    category: CATEGORY_JAVASCRIPT,
+    type: "boolean",
+    default: false,
+    description: "Self-close empty JSX elements"
+  },
   quoteProps: {
     since: "1.17.0",
     category: CATEGORY_JAVASCRIPT,

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5514,6 +5514,10 @@ function printJSXElement(path, options, print) {
   const n = path.getValue();
 
   if (n.type === "JSXElement" && isEmptyJSXElement(n)) {
+    if (options.jsxSelfClosing) {
+      n.openingElement.selfClosing = true;
+      return path.call(print, "openingElement");
+    }
     return concat([
       path.call(print, "openingElement"),
       path.call(print, "closingElement")

--- a/tests/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -312,6 +312,85 @@ const TodoList = ({ todos }) => (
 ================================================================================
 `;
 
+exports[`array-iter.js 5`] = `
+====================================options=====================================
+jsxSelfClosing: true
+jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: false
+                                                                                | printWidth
+=====================================input======================================
+const UsersList = ({ users }) => (
+  <section>
+    <h2>Users list</h2>
+    <ul>
+      {users.map(user => (
+        <li key={user.id}>{user.name}</li>
+      ))}
+    </ul>
+  </section>
+)
+
+const TodoList = ({ todos }) => (
+  <div className="TodoList">
+    <ul>{_.map(todos, (todo, i) => <TodoItem key={i} {...todo} />)}</ul>
+  </div>
+);
+
+<div className="search-filter-chips">
+    {scopes
+        .filter(scope => scope.value !== '')
+        .map((scope, i) => (
+            <FilterChip
+                query={this.props.query}
+                onFilterChosen={this.onSearchScopeClicked}
+                key={i}
+                value={scope.value}
+                name={scope.name}
+            />
+        ))}
+</div>
+
+=====================================output=====================================
+const UsersList = ({ users }) => (
+  <section>
+    <h2>Users list</h2>
+    <ul>
+      {users.map(user => (
+        <li key={user.id}>{user.name}</li>
+      ))}
+    </ul>
+  </section>
+);
+
+const TodoList = ({ todos }) => (
+  <div className="TodoList">
+    <ul>
+      {_.map(todos, (todo, i) => (
+        <TodoItem key={i} {...todo} />
+      ))}
+    </ul>
+  </div>
+);
+
+<div className="search-filter-chips">
+  {scopes
+    .filter(scope => scope.value !== "")
+    .map((scope, i) => (
+      <FilterChip
+        query={this.props.query}
+        onFilterChosen={this.onSearchScopeClicked}
+        key={i}
+        value={scope.value}
+        name={scope.name}
+      />
+    ))}
+</div>;
+
+================================================================================
+`;
+
 exports[`attr-comments.js 1`] = `
 ====================================options=====================================
 jsxSingleQuote: false
@@ -546,6 +625,83 @@ jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
 singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+<Component
+  propFn={
+    // comment
+    function(arg) {
+      fn(arg);
+    }
+  }
+  propArrowFn={
+    // comment
+    arg => fn(arg)
+  }
+  propArrowWithBreak={
+    // comment
+    arg =>
+      fn({
+        makeItBreak
+      })
+  }
+  propArray={
+    // comment
+    [el1, el2]
+  }
+  propObj={
+    // comment
+    { key: val }
+  }
+  propTemplate={
+    // comment
+    \`text\`
+  }
+/>;
+
+=====================================output=====================================
+<Component
+  propFn={
+    // comment
+    function(arg) {
+      fn(arg);
+    }
+  }
+  propArrowFn={
+    // comment
+    arg => fn(arg)
+  }
+  propArrowWithBreak={
+    // comment
+    arg =>
+      fn({
+        makeItBreak
+      })
+  }
+  propArray={
+    // comment
+    [el1, el2]
+  }
+  propObj={
+    // comment
+    { key: val }
+  }
+  propTemplate={
+    // comment
+    \`text\`
+  }
+/>;
+
+================================================================================
+`;
+
+exports[`attr-comments.js 5`] = `
+====================================options=====================================
+jsxSelfClosing: true
+jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: false
                                                                                 | printWidth
 =====================================input======================================
 <Component
@@ -1768,6 +1924,295 @@ cable ? (
 ================================================================================
 `;
 
+exports[`conditional-expression.js 5`] = `
+====================================options=====================================
+jsxSelfClosing: true
+jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: false
+                                                                                | printWidth
+=====================================input======================================
+// There are two ways to print ConditionalExpressions: "normal mode" and
+// "JSX mode". This is normal mode (when breaking):
+//
+//   test
+//     ? consequent
+//     : alternate;
+//
+// And this is JSX mode (when breaking):
+//
+//   test ? (
+//     consequent
+//   ) : (
+//     alternate
+//   );
+//
+// When non-breaking, they look the same:
+//
+//  test ? consequent : alternate;
+//
+// We only print a conditional expression in JSX mode if its test,
+// consequent, or alternate are JSXElements.
+// Otherwise, we print in normal mode.
+
+// This ConditionalExpression has no JSXElements so it prints in normal mode.
+// The line does not break.
+normalModeNonBreaking ? "a" : "b";
+
+// This ConditionalExpression has no JSXElements so it prints in normal mode.
+// Its consequent is very long, so it breaks out to multiple lines.
+normalModeBreaking
+  ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
+  : "c";
+
+// This ConditionalExpression prints in JSX mode because its test is a
+// JSXElement. It is non-breaking.
+// Note: I have never, ever seen someone use a JSXElement as the test in a
+// ConditionalExpression. But this test is included for completeness.
+<div /> ? jsxModeFromElementNonBreaking : "a";
+
+// This ConditionalExpression prints in JSX mode because its consequent is a
+// JSXElement. It is non-breaking.
+jsxModeFromElementNonBreaking ? <div /> : "a";
+
+// This ConditionalExpression prints in JSX mode because its alternate is a
+// JSXElement. It is non-breaking.
+jsxModeFromElementNonBreaking ? "a" : <div />;
+
+// This ConditionalExpression prints in JSX mode because its test is a
+// JSXElement. It is breaking.
+// Note: I have never, ever seen someone use a JSXElement as the test in a
+// ConditionalExpression. But this test is included for completeness.
+<div>
+  <span>thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo</span>
+</div>  ? (
+  "jsx mode from element breaking"
+) : (
+  "a"
+);
+
+// This ConditionalExpression prints in JSX mode because its consequent is a
+// JSXElement. It is breaking.
+jsxModeFromElementBreaking ? (
+  <div>
+    <span>thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo</span>
+  </div>
+) : (
+  "a"
+);
+
+// This ConditionalExpression prints in JSX mode because its alternate is a
+// JSXElement. It is breaking.
+jsxModeFromElementBreaking ? (
+  "a"
+) : (
+  <div>
+    <span>thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo</span>
+  </div>
+);
+
+// This chain of ConditionalExpressions prints in JSX mode because the parent of
+// the outermost ConditionalExpression is a JSXExpressionContainer. It is
+// non-breaking.
+<div>
+  {a ? "a" : b ? "b" : "c"}
+</div>;
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain. It is non-breaking.
+cable ? "satellite" : public ? "affairs" : network ? <span id="c" /> : "dunno";
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain (in this case, at the end). It is
+// breaking; notice the consequents and alternates in the entire chain get
+// wrapped in parens.
+cable ? (
+  "satellite"
+) : public ? (
+  "affairs"
+) : network ? (
+  <div>
+    <span>thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo</span>
+  </div>
+) : "dunno";
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain (in this case, at the beginning). It is
+// breaking; notice the consequents and alternates in the entire chain get
+// wrapped in parens.
+cable ? (
+  <div>
+    <span>thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo</span>
+  </div>
+) : sateline ? (
+  "public"
+) : affairs ? (
+  "network"
+) : "dunno";
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain. It is breaking; notice the consequents
+// and alternates in the entire chain get wrapped in parens.
+<div>
+  {properties.length > 1 ||
+  (properties.length === 1 && properties[0].apps.size > 1) ? (
+    draggingApp == null || newPropertyName == null ? (
+      <MigrationPropertyListItem />
+    ) : (
+      <MigrationPropertyListItem apps={Immutable.List()} />
+    )
+  ) : null}
+</div>;
+
+=====================================output=====================================
+// There are two ways to print ConditionalExpressions: "normal mode" and
+// "JSX mode". This is normal mode (when breaking):
+//
+//   test
+//     ? consequent
+//     : alternate;
+//
+// And this is JSX mode (when breaking):
+//
+//   test ? (
+//     consequent
+//   ) : (
+//     alternate
+//   );
+//
+// When non-breaking, they look the same:
+//
+//  test ? consequent : alternate;
+//
+// We only print a conditional expression in JSX mode if its test,
+// consequent, or alternate are JSXElements.
+// Otherwise, we print in normal mode.
+
+// This ConditionalExpression has no JSXElements so it prints in normal mode.
+// The line does not break.
+normalModeNonBreaking ? "a" : "b";
+
+// This ConditionalExpression has no JSXElements so it prints in normal mode.
+// Its consequent is very long, so it breaks out to multiple lines.
+normalModeBreaking
+  ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
+  : "c";
+
+// This ConditionalExpression prints in JSX mode because its test is a
+// JSXElement. It is non-breaking.
+// Note: I have never, ever seen someone use a JSXElement as the test in a
+// ConditionalExpression. But this test is included for completeness.
+<div /> ? jsxModeFromElementNonBreaking : "a";
+
+// This ConditionalExpression prints in JSX mode because its consequent is a
+// JSXElement. It is non-breaking.
+jsxModeFromElementNonBreaking ? <div /> : "a";
+
+// This ConditionalExpression prints in JSX mode because its alternate is a
+// JSXElement. It is non-breaking.
+jsxModeFromElementNonBreaking ? "a" : <div />;
+
+// This ConditionalExpression prints in JSX mode because its test is a
+// JSXElement. It is breaking.
+// Note: I have never, ever seen someone use a JSXElement as the test in a
+// ConditionalExpression. But this test is included for completeness.
+<div>
+  <span>
+    thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo
+  </span>
+</div> ? (
+  "jsx mode from element breaking"
+) : (
+  "a"
+);
+
+// This ConditionalExpression prints in JSX mode because its consequent is a
+// JSXElement. It is breaking.
+jsxModeFromElementBreaking ? (
+  <div>
+    <span>
+      thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo
+    </span>
+  </div>
+) : (
+  "a"
+);
+
+// This ConditionalExpression prints in JSX mode because its alternate is a
+// JSXElement. It is breaking.
+jsxModeFromElementBreaking ? (
+  "a"
+) : (
+  <div>
+    <span>
+      thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo
+    </span>
+  </div>
+);
+
+// This chain of ConditionalExpressions prints in JSX mode because the parent of
+// the outermost ConditionalExpression is a JSXExpressionContainer. It is
+// non-breaking.
+<div>{a ? "a" : b ? "b" : "c"}</div>;
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain. It is non-breaking.
+cable ? "satellite" : public ? "affairs" : network ? <span id="c" /> : "dunno";
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain (in this case, at the end). It is
+// breaking; notice the consequents and alternates in the entire chain get
+// wrapped in parens.
+cable ? (
+  "satellite"
+) : public ? (
+  "affairs"
+) : network ? (
+  <div>
+    <span>
+      thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo
+    </span>
+  </div>
+) : (
+  "dunno"
+);
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain (in this case, at the beginning). It is
+// breaking; notice the consequents and alternates in the entire chain get
+// wrapped in parens.
+cable ? (
+  <div>
+    <span>
+      thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo
+    </span>
+  </div>
+) : sateline ? (
+  "public"
+) : affairs ? (
+  "network"
+) : (
+  "dunno"
+);
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain. It is breaking; notice the consequents
+// and alternates in the entire chain get wrapped in parens.
+<div>
+  {properties.length > 1 ||
+  (properties.length === 1 && properties[0].apps.size > 1) ? (
+    draggingApp == null || newPropertyName == null ? (
+      <MigrationPropertyListItem />
+    ) : (
+      <MigrationPropertyListItem apps={Immutable.List()} />
+    )
+  ) : null}
+</div>;
+
+================================================================================
+`;
+
 exports[`expression.js 1`] = `
 ====================================options=====================================
 jsxSingleQuote: false
@@ -2920,6 +3365,295 @@ singleQuote: true
 ================================================================================
 `;
 
+exports[`expression.js 5`] = `
+====================================options=====================================
+jsxSelfClosing: true
+jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: false
+                                                                                | printWidth
+=====================================input======================================
+<View
+  style={
+    {
+      someVeryLongStyle1: "true",
+      someVeryLongStyle2: "true",
+      someVeryLongStyle3: "true",
+      someVeryLongStyle4: "true"
+    }
+  }
+/>;
+
+<View
+  style={
+    [
+      {
+        someVeryLongStyle1: "true",
+        someVeryLongStyle2: "true",
+        someVeryLongStyle3: "true",
+        someVeryLongStyle4: "true"
+      }
+    ]
+  }
+/>;
+
+<Something>
+  {() => (
+    <SomethingElse>
+      <span />
+    </SomethingElse>
+  )}
+</Something>;
+
+<Something>
+  {items.map(item => (
+    <SomethingElse>
+      <span />
+    </SomethingElse>
+  ))}
+</Something>;
+
+<Something>
+  {function() {
+    return (
+      <SomethingElse>
+        <span />
+      </SomethingElse>
+    );
+  }}
+</Something>;
+
+<RadioListItem
+  key={option}
+  imageSource={this.props.veryBigItemImageSourceFunc &&
+    this.props.veryBigItemImageSourceFunc(option)}
+  imageSize={this.props.veryBigItemImageSize}
+  imageView={this.props.veryBigItemImageViewFunc &&
+    this.props.veryBigItemImageViewFunc(option)}
+  heading={this.props.displayTextFunc(option)}
+  value={option}
+/>;
+
+<ParentComponent prop={
+  <Child>
+    test
+  </Child>
+}/>;
+
+<BookingIntroPanel
+  prop="long_string_make_to_force_break"
+  logClick={data => doLogClick("short", "short", data)}
+/>;
+
+<BookingIntroPanel
+  logClick={data =>
+    doLogClick("long_name_long_name_long_name", "long_name_long_name_long_name", data)
+  }
+/>;
+
+<BookingIntroPanel
+  logClick={data => {
+    doLogClick("long_name_long_name_long_name", "long_name_long_name_long_name", data)
+  }}
+/>;
+
+<Component
+  onChange={(
+    key: "possible_key_1" | "possible_key_2" | "possible_key_3",
+    value: string | Immutable.List<string>,
+  ) => {
+    this.setState({
+      updatedTask: this.state.updatedTask.set(key, value)
+    });
+  }}
+/>;
+
+<BookingIntroPanel>
+  {data => doLogClick("short", "short", data)}
+</BookingIntroPanel>;
+
+<BookingIntroPanel>
+  {data =>
+    doLogClick("long_name_long_name_long_name", "long_name_long_name_long_name", data)
+  }
+</BookingIntroPanel>;
+
+<BookingIntroPanel>
+  {data => {
+    doLogClick("long_name_long_name_long_name", "long_name_long_name_long_name", data)
+  }}
+</BookingIntroPanel>;
+
+<Component>
+  {(
+    key: "possible_key_1" | "possible_key_2" | "possible_key_3",
+    value: string | Immutable.List<string>,
+  ) => {
+    this.setState({
+      updatedTask: this.state.updatedTask.set(key, value)
+    });
+  }}
+</Component>;
+
+<SuspendyTree>
+  <div style={{ height: 200, overflow: "scroll" }}>
+    {Array(20)
+      .fill()
+      .map((_, i) => (
+        <h2 key={i}>{i + 1}</h2>
+      ))}
+  </div>
+</SuspendyTree>;
+
+=====================================output=====================================
+<View
+  style={{
+    someVeryLongStyle1: "true",
+    someVeryLongStyle2: "true",
+    someVeryLongStyle3: "true",
+    someVeryLongStyle4: "true"
+  }}
+/>;
+
+<View
+  style={[
+    {
+      someVeryLongStyle1: "true",
+      someVeryLongStyle2: "true",
+      someVeryLongStyle3: "true",
+      someVeryLongStyle4: "true"
+    }
+  ]}
+/>;
+
+<Something>
+  {() => (
+    <SomethingElse>
+      <span />
+    </SomethingElse>
+  )}
+</Something>;
+
+<Something>
+  {items.map(item => (
+    <SomethingElse>
+      <span />
+    </SomethingElse>
+  ))}
+</Something>;
+
+<Something>
+  {function() {
+    return (
+      <SomethingElse>
+        <span />
+      </SomethingElse>
+    );
+  }}
+</Something>;
+
+<RadioListItem
+  key={option}
+  imageSource={
+    this.props.veryBigItemImageSourceFunc &&
+    this.props.veryBigItemImageSourceFunc(option)
+  }
+  imageSize={this.props.veryBigItemImageSize}
+  imageView={
+    this.props.veryBigItemImageViewFunc &&
+    this.props.veryBigItemImageViewFunc(option)
+  }
+  heading={this.props.displayTextFunc(option)}
+  value={option}
+/>;
+
+<ParentComponent prop={<Child>test</Child>} />;
+
+<BookingIntroPanel
+  prop="long_string_make_to_force_break"
+  logClick={data => doLogClick("short", "short", data)}
+/>;
+
+<BookingIntroPanel
+  logClick={data =>
+    doLogClick(
+      "long_name_long_name_long_name",
+      "long_name_long_name_long_name",
+      data
+    )
+  }
+/>;
+
+<BookingIntroPanel
+  logClick={data => {
+    doLogClick(
+      "long_name_long_name_long_name",
+      "long_name_long_name_long_name",
+      data
+    );
+  }}
+/>;
+
+<Component
+  onChange={(
+    key: "possible_key_1" | "possible_key_2" | "possible_key_3",
+    value: string | Immutable.List<string>
+  ) => {
+    this.setState({
+      updatedTask: this.state.updatedTask.set(key, value)
+    });
+  }}
+/>;
+
+<BookingIntroPanel>
+  {data => doLogClick("short", "short", data)}
+</BookingIntroPanel>;
+
+<BookingIntroPanel>
+  {data =>
+    doLogClick(
+      "long_name_long_name_long_name",
+      "long_name_long_name_long_name",
+      data
+    )
+  }
+</BookingIntroPanel>;
+
+<BookingIntroPanel>
+  {data => {
+    doLogClick(
+      "long_name_long_name_long_name",
+      "long_name_long_name_long_name",
+      data
+    );
+  }}
+</BookingIntroPanel>;
+
+<Component>
+  {(
+    key: "possible_key_1" | "possible_key_2" | "possible_key_3",
+    value: string | Immutable.List<string>
+  ) => {
+    this.setState({
+      updatedTask: this.state.updatedTask.set(key, value)
+    });
+  }}
+</Component>;
+
+<SuspendyTree>
+  <div style={{ height: 200, overflow: "scroll" }}>
+    {Array(20)
+      .fill()
+      .map((_, i) => (
+        <h2 key={i}>{i + 1}</h2>
+      ))}
+  </div>
+</SuspendyTree>;
+
+================================================================================
+`;
+
 exports[`flow_fix_me.js 1`] = `
 ====================================options=====================================
 jsxSingleQuote: false
@@ -3016,6 +3750,31 @@ const aDiv = (
 ================================================================================
 `;
 
+exports[`flow_fix_me.js 5`] = `
+====================================options=====================================
+jsxSelfClosing: true
+jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: false
+                                                                                | printWidth
+=====================================input======================================
+const aDiv = (
+  /* $FlowFixMe */
+  <div className="foo">
+    Foo bar
+  </div>
+);
+
+=====================================output=====================================
+const aDiv = (
+  /* $FlowFixMe */
+  <div className="foo">Foo bar</div>
+);
+
+================================================================================
+`;
+
 exports[`html_escape.js 1`] = `
 ====================================options=====================================
 jsxSingleQuote: false
@@ -3092,6 +3851,27 @@ export default () => <a href="https://foo.bar?q1=foo&q2=bar" />;
 export default () => <a href='https://foo.bar?q1=foo&q2=bar' />;
 
 () => <img src='https://bar.foo?param1=1&param2=2' />;
+
+================================================================================
+`;
+
+exports[`html_escape.js 5`] = `
+====================================options=====================================
+jsxSelfClosing: true
+jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: false
+                                                                                | printWidth
+=====================================input======================================
+export default () => <a href="https://foo.bar?q1=foo&q2=bar" />;
+
+() => <img src="https://bar.foo?param1=1&param2=2" />;
+
+=====================================output=====================================
+export default () => <a href="https://foo.bar?q1=foo&q2=bar" />;
+
+() => <img src="https://bar.foo?param1=1&param2=2" />;
 
 ================================================================================
 `;
@@ -3424,6 +4204,89 @@ singleQuote: true
 ================================================================================
 `;
 
+exports[`hug.js 5`] = `
+====================================options=====================================
+jsxSelfClosing: true
+jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: false
+                                                                                | printWidth
+=====================================input======================================
+<div>
+  {__DEV__
+    ? this.renderDevApp()
+    : <div>
+      {routes.map(route => (
+        <MatchAsync
+          key={\`\${route.to}-async\`}
+          pattern={route.to}
+          exactly={route.to === "/"}
+          getComponent={routeES6Modules[route.value]}
+        />
+      ))}
+    </div>}
+</div>;
+
+<div>
+  {__DEV__ && <div>
+    {routes.map(route => (
+      <MatchAsync
+        key={\`\${route.to}-async\`}
+        pattern={route.to}
+        exactly={route.to === "/"}
+        getComponent={routeES6Modules[route.value]}
+      />
+    ))}
+    </div>}
+</div>;
+
+<div>
+  {member.memberName.memberSomething +
+    (member.memberDef.memberSomething.signatures ? '()' : '')}
+</div>
+
+=====================================output=====================================
+<div>
+  {__DEV__ ? (
+    this.renderDevApp()
+  ) : (
+    <div>
+      {routes.map(route => (
+        <MatchAsync
+          key={\`\${route.to}-async\`}
+          pattern={route.to}
+          exactly={route.to === "/"}
+          getComponent={routeES6Modules[route.value]}
+        />
+      ))}
+    </div>
+  )}
+</div>;
+
+<div>
+  {__DEV__ && (
+    <div>
+      {routes.map(route => (
+        <MatchAsync
+          key={\`\${route.to}-async\`}
+          pattern={route.to}
+          exactly={route.to === "/"}
+          getComponent={routeES6Modules[route.value]}
+        />
+      ))}
+    </div>
+  )}
+</div>;
+
+<div>
+  {member.memberName.memberSomething +
+    (member.memberDef.memberSomething.signatures ? "()" : "")}
+</div>;
+
+================================================================================
+`;
+
 exports[`logical-expression.js 1`] = `
 ====================================options=====================================
 jsxSingleQuote: false
@@ -3736,6 +4599,85 @@ singleQuote: true
 ================================================================================
 `;
 
+exports[`logical-expression.js 5`] = `
+====================================options=====================================
+jsxSelfClosing: true
+jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: false
+                                                                                | printWidth
+=====================================input======================================
+<div>
+  {a || "b"}
+</div>;
+
+<div>
+  {a && "b"}
+</div>;
+
+<div>
+  {a || <span></span>}
+</div>;
+
+<div>
+  {a && <span></span>}
+</div>;
+
+<div>
+  {a && <span>make this text just so long enough to break this to the next line</span>}
+</div>;
+
+<div>
+  {a && b && <span>make this text just so long enough to break this to the next line</span>}
+</div>;
+
+<div>
+  {a && <span>
+    <div>
+      <div></div>
+    </div>
+  </span>}
+</div>;
+
+=====================================output=====================================
+<div>{a || "b"}</div>;
+
+<div>{a && "b"}</div>;
+
+<div>{a || <span />}</div>;
+
+<div>{a && <span />}</div>;
+
+<div>
+  {a && (
+    <span>
+      make this text just so long enough to break this to the next line
+    </span>
+  )}
+</div>;
+
+<div>
+  {a && b && (
+    <span>
+      make this text just so long enough to break this to the next line
+    </span>
+  )}
+</div>;
+
+<div>
+  {a && (
+    <span>
+      <div>
+        <div />
+      </div>
+    </span>
+  )}
+</div>;
+
+================================================================================
+`;
+
 exports[`object-property.js 1`] = `
 ====================================options=====================================
 jsxSingleQuote: false
@@ -3885,6 +4827,47 @@ const tabs = [
     content: (
       <GeneralForm
         long-attribute='i-need-long-value-here'
+        onSave={onSave}
+        onCancel={onCancel}
+        countries={countries}
+      />
+    )
+  }
+];
+
+================================================================================
+`;
+
+exports[`object-property.js 5`] = `
+====================================options=====================================
+jsxSelfClosing: true
+jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: false
+                                                                                | printWidth
+=====================================input======================================
+const tabs = [
+  {
+    title: "General Info",
+    content: (
+      <GeneralForm
+        long-attribute="i-need-long-value-here"
+        onSave={ onSave }
+        onCancel={ onCancel }
+        countries={ countries }
+      />
+    )
+  }
+];
+
+=====================================output=====================================
+const tabs = [
+  {
+    title: "General Info",
+    content: (
+      <GeneralForm
+        long-attribute="i-need-long-value-here"
         onSave={onSave}
         onCancel={onCancel}
         countries={countries}
@@ -4072,6 +5055,51 @@ onClick={() => {
 ================================================================================
 `;
 
+exports[`open-break.js 5`] = `
+====================================options=====================================
+jsxSelfClosing: true
+jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: false
+                                                                                | printWidth
+=====================================input======================================
+<td
+onClick={() => {
+  a
+}}>{header}{showSort}</td>;
+
+<td
+onClick={() => {
+  a
+}}>{header}<showSort attr="long long long long long long long long long long long"/></td>;
+
+<Foo>{\`    a    very    long    text    that    does    not    break    \`}</Foo>;
+
+=====================================output=====================================
+<td
+  onClick={() => {
+    a;
+  }}
+>
+  {header}
+  {showSort}
+</td>;
+
+<td
+  onClick={() => {
+    a;
+  }}
+>
+  {header}
+  <showSort attr="long long long long long long long long long long long" />
+</td>;
+
+<Foo>{\`    a    very    long    text    that    does    not    break    \`}</Foo>;
+
+================================================================================
+`;
+
 exports[`parens.js 1`] = `
 ====================================options=====================================
 jsxSingleQuote: false
@@ -4216,6 +5244,45 @@ a = [
   <path
     key='1'
     d='M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,'
+  />
+];
+
+<div {...(foo || foo === null ? { foo } : null)} />;
+
+================================================================================
+`;
+
+exports[`parens.js 5`] = `
+====================================options=====================================
+jsxSelfClosing: true
+jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: false
+                                                                                | printWidth
+=====================================input======================================
+a = [
+  <path
+    key='0'
+    d='M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,'
+  />,
+  <path
+    key='1'
+    d='M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,'
+  />,
+];
+
+<div {...((foo || foo === null) ? {foo} : null)} />
+
+=====================================output=====================================
+a = [
+  <path
+    key="0"
+    d="M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,"
+  />,
+  <path
+    key="1"
+    d="M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,"
   />
 ];
 
@@ -4579,6 +5646,97 @@ singleQuote: true
   GitHub Desktop has encountered an unrecoverable error and will need to 1231231
   restart. This has been reported to the team, but if youencounter this121312331
   repeatedly please report this issue to the GitHub 12312312312312313{'  '}{' '}
+</p>;
+
+================================================================================
+`;
+
+exports[`quotes.js 5`] = `
+====================================options=====================================
+jsxSelfClosing: true
+jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: false
+                                                                                | printWidth
+=====================================input======================================
+<div id="&quot;'<>&amp;quot;" />;
+<div id='"&#39;<>&amp;quot;' />;
+<div id={'\\'"&quot;<>&amp;quot;'} />;
+<div id='123' />;
+<div id='&#39;&quot;' />;
+<div id={'\\'\\"\\\\\\''} />;
+<div
+  single='foo'
+  single2={'foo'}
+
+  double="bar"
+  double2={"bar"}
+
+  singleDouble='"'
+  singleDouble2={'"'}
+
+  doubleSingle="'"
+  doubleSingle2={"'"}
+
+  singleEscaped={'\\''}
+  singleEscaped2='&apos;'
+
+  doubleEscaped={"\\""}
+  doubleEscaped2="&quot;"
+
+  singleBothEscaped={'\\'"'}
+  singleBothEscaped2='&apos;"'
+
+  singleBoth='&apos; "'
+  singleBoth2={'\\' "'}
+  singleBoth3='&apos; &apos; "'
+
+  doubleBoth="&quot; '"
+  doubleBoth2={"\\" '"}
+  doubleBoth3="&quot; &apos; '"
+/>;
+
+<p>
+  GitHub Desktop has encountered an unrecoverable error and will need to 1231231
+  restart. This has been reported to the team, but if youencounter this121312331
+  repeatedly please report this issue to the GitHub 12312312312312313{'  '}{' '}
+</p>
+
+=====================================output=====================================
+<div id="&quot;'<>&amp;quot;" />;
+<div id='"&#39;<>&amp;quot;' />;
+<div id={"'\\"&quot;<>&amp;quot;"} />;
+<div id="123" />;
+<div id='&#39;"' />;
+<div id={"'\\"\\\\'"} />;
+<div
+  single="foo"
+  single2={"foo"}
+  double="bar"
+  double2={"bar"}
+  singleDouble='"'
+  singleDouble2={'"'}
+  doubleSingle="'"
+  doubleSingle2={"'"}
+  singleEscaped={"'"}
+  singleEscaped2="'"
+  doubleEscaped={'"'}
+  doubleEscaped2='"'
+  singleBothEscaped={"'\\""}
+  singleBothEscaped2="'&quot;"
+  singleBoth="' &quot;"
+  singleBoth2={"' \\""}
+  singleBoth3="' ' &quot;"
+  doubleBoth="&quot; '"
+  doubleBoth2={"\\" '"}
+  doubleBoth3="&quot; ' '"
+/>;
+
+<p>
+  GitHub Desktop has encountered an unrecoverable error and will need to 1231231
+  restart. This has been reported to the team, but if youencounter this121312331
+  repeatedly please report this issue to the GitHub 12312312312312313{"  "}{" "}
 </p>;
 
 ================================================================================
@@ -5040,6 +6198,121 @@ class BreakingClass extends React.component {
 ================================================================================
 `;
 
+exports[`return-statement.js 5`] = `
+====================================options=====================================
+jsxSelfClosing: true
+jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: false
+                                                                                | printWidth
+=====================================input======================================
+const NonBreakingArrowExpression = () => <div />;
+
+const BreakingArrowExpression = () => <div>
+  <div>
+    bla bla bla
+  </div>
+</div>;
+
+const NonBreakingArrowExpressionWBody = () => {
+  return (
+    <div />
+  );
+};
+
+const BreakingArrowExpressionWBody = () => {
+  return <div>
+    <div>
+      bla bla bla
+    </div>
+  </div>
+};
+
+const NonBreakingFunction = function() {
+  return (
+    <div />
+  );
+};
+
+const BreakingFunction = function() {
+  return <div>
+    <div>
+      bla bla bla
+    </div>
+  </div>
+};
+
+class NonBreakingClass extends React.component {
+  render() {
+    return (
+      <div />
+    );
+  }
+}
+
+class BreakingClass extends React.component {
+  render() {
+    return <div>
+      <div>
+        bla bla bla
+      </div>
+    </div>;
+  }
+}
+
+=====================================output=====================================
+const NonBreakingArrowExpression = () => <div />;
+
+const BreakingArrowExpression = () => (
+  <div>
+    <div>bla bla bla</div>
+  </div>
+);
+
+const NonBreakingArrowExpressionWBody = () => {
+  return <div />;
+};
+
+const BreakingArrowExpressionWBody = () => {
+  return (
+    <div>
+      <div>bla bla bla</div>
+    </div>
+  );
+};
+
+const NonBreakingFunction = function() {
+  return <div />;
+};
+
+const BreakingFunction = function() {
+  return (
+    <div>
+      <div>bla bla bla</div>
+    </div>
+  );
+};
+
+class NonBreakingClass extends React.component {
+  render() {
+    return <div />;
+  }
+}
+
+class BreakingClass extends React.component {
+  render() {
+    return (
+      <div>
+        <div>bla bla bla</div>
+      </div>
+    );
+  }
+}
+
+================================================================================
+`;
+
 exports[`self-closing.js 1`] = `
 ====================================options=====================================
 jsxSingleQuote: false
@@ -5107,6 +6380,25 @@ singleQuote: true
 
 =====================================output=====================================
 <Foo></Foo>;
+<Bar />;
+
+================================================================================
+`;
+
+exports[`self-closing.js 5`] = `
+====================================options=====================================
+jsxSelfClosing: true
+jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: false
+                                                                                | printWidth
+=====================================input======================================
+<Foo></Foo>;
+<Bar />;
+
+=====================================output=====================================
+<Foo />;
 <Bar />;
 
 ================================================================================
@@ -5238,6 +6530,47 @@ jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
 singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+const Labels = {
+  label1: (
+    <fbt>
+      Label 1
+    </fbt>
+  ),
+
+  label2: (
+    <fbt>
+      Label 2
+    </fbt>
+  ),
+
+  label3: (
+    <fbt>
+      Label 3
+    </fbt>
+  ),
+};
+
+=====================================output=====================================
+const Labels = {
+  label1: <fbt>Label 1</fbt>,
+
+  label2: <fbt>Label 2</fbt>,
+
+  label3: <fbt>Label 3</fbt>
+};
+
+================================================================================
+`;
+
+exports[`spacing.js 5`] = `
+====================================options=====================================
+jsxSelfClosing: true
+jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: false
                                                                                 | printWidth
 =====================================input======================================
 const Labels = {

--- a/tests/jsx/jsfmt.spec.js
+++ b/tests/jsx/jsfmt.spec.js
@@ -14,3 +14,8 @@ run_spec(__dirname, ["flow", "babel", "typescript"], {
   singleQuote: true,
   jsxSingleQuote: true
 });
+run_spec(__dirname, ["flow", "babel", "typescript"], {
+  singleQuote: false,
+  jsxSingleQuote: false,
+  jsxSelfClosing: true
+});

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -70,6 +70,8 @@ Format options:
                            Defaults to css.
   --jsx-bracket-same-line  Put > on the last line instead of at a new line.
                            Defaults to false.
+  --jsx-self-closing       Self-close empty JSX elements
+                           Defaults to false.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.
   --parser <flow|babel|babel-flow|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|html|angular|lwc>
@@ -222,6 +224,8 @@ Format options:
                            How to handle whitespaces in HTML.
                            Defaults to css.
   --jsx-bracket-same-line  Put > on the last line instead of at a new line.
+                           Defaults to false.
+  --jsx-self-closing       Self-close empty JSX elements
                            Defaults to false.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.

--- a/tests_integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/help-options.js.snap
@@ -229,6 +229,19 @@ Default: false
 
 exports[`show detailed usage with --help jsx-bracket-same-line (write) 1`] = `Array []`;
 
+exports[`show detailed usage with --help jsx-self-closing (stderr) 1`] = `""`;
+
+exports[`show detailed usage with --help jsx-self-closing (stdout) 1`] = `
+"--jsx-self-closing
+
+  Self-close empty JSX elements
+
+Default: false
+"
+`;
+
+exports[`show detailed usage with --help jsx-self-closing (write) 1`] = `Array []`;
+
 exports[`show detailed usage with --help jsx-single-quote (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help jsx-single-quote (stdout) 1`] = `

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -33,6 +33,7 @@ const ENABLED_OPTIONS = [
   "bracketSpacing",
   "jsxSingleQuote",
   "jsxBracketSameLine",
+  "jsxSelfClosing",
   "quoteProps",
   "arrowParens",
   "trailingComma",


### PR DESCRIPTION
provide a way to put back the behavior removed in [#6127](https://github.com/prettier/prettier/pull/6127)
btw, this project is dope! :rocket: 

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**

nb: pretty huge diff in `tests/jsx/__snapshots__/jsfmt.spec.js.snap` :man_shrugging: is there a way to make snapshots update more "diffable"? seems that lot of code just moved, and I'm not rly used to snapshot testing