### PR TITLE
[Glimmer/Handlebars] Forces multilines print when almost at max length

### DIFF
--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -174,7 +174,7 @@ function print(path, options, print) {
       return group(
         concat([
           n.escaped === false ? "{{{" : "{{",
-          printPathParams(path, print),
+          printPathParams(path, print, { group: false }),
           isConcat ? "" : softline,
           n.escaped === false ? "}}}" : "}}"
         ])
@@ -358,11 +358,16 @@ function getParams(path, print) {
   return parts;
 }
 
-function printPathParams(path, print) {
+function printPathParams(path, print, options) {
   let parts = [];
+  options = Object.assign({ group: true }, options || {});
 
   parts.push(printPath(path, print));
   parts = parts.concat(getParams(path, print));
+
+  if (!options.group) {
+    return indent(join(line, parts));
+  }
 
   return indent(group(join(line, parts)));
 }

--- a/tests/handlebars/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/__snapshots__/jsfmt.spec.js.snap
@@ -53,6 +53,26 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`component.hbs 1`] = `
+====================================options=====================================
+parsers: ["glimmer"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+{{my-component foo="bar" bar="baz" action=(action "almostTheMaximumLengthxxxxxx")}}
+
+{{my-component foo="bar"}}
+
+=====================================output=====================================
+{{my-component
+  foo="bar"
+  bar="baz"
+  action=(action "almostTheMaximumLengthxxxxxx")
+}}
+{{my-component foo="bar"}}
+================================================================================
+`;
+
 exports[`each.hbs 1`] = `
 ====================================options=====================================
 parsers: ["glimmer"]

--- a/tests/handlebars/component.hbs
+++ b/tests/handlebars/component.hbs
@@ -1,0 +1,3 @@
+{{my-component foo="bar" bar="baz" action=(action "almostTheMaximumLengthxxxxxx")}}
+
+{{my-component foo="bar"}}


### PR DESCRIPTION
Hi,

Before:

```
{{my-component  foo="bar"  bar="baz" action=(action "almostTheMaximumLengthxxxx")
}}
```

After:

```
{{my-component
  foo="bar"
  bar="baz"
  action=(action "almostTheMaximumLengthxxxx")
}}
```

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
