### PR TITLE
Remove not publish from plugin pug

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -51,7 +51,7 @@ Providing at least one path to `--plugin-search-dir`/`pluginSearchDirs` turns of
 - [`prettier-plugin-elm`](https://github.com/gicentre/prettier-plugin-elm) by [**@giCentre**](https://github.com/gicentre)
 - [`prettier-plugin-java`](https://github.com/jhipster/prettier-java) by [**@JHipster**](https://github.com/jhipster)
 - [`prettier-plugin-pg`](https://github.com/benjie/prettier-plugin-pg) by [**@benjie**](https://github.com/benjie)
-- [`prettier-plugin-pug`](https://github.com/Shinigami92/prettier-plugin-pug) by [**@Shinigami92**](https://github.com/Shinigami92) (in alpha development / not released)
+- [`prettier-plugin-pug`](https://github.com/Shinigami92/prettier-plugin-pug) by [**@Shinigami92**](https://github.com/Shinigami92) (in alpha development)
 - [`prettier-plugin-solidity`](https://github.com/prettier-solidity/prettier-plugin-solidity) by [**@mattiaerre**](https://github.com/mattiaerre)
 - [`prettier-plugin-svelte`](https://github.com/UnwrittenFun/prettier-plugin-svelte) by [**@UnwrittenFun**](https://github.com/UnwrittenFun)
 - [`prettier-plugin-toml`](https://github.com/bd82/toml-tools/tree/master/packages/prettier-plugin-toml) by [**@bd82**](https://github.com/bd82)


### PR DESCRIPTION
I tried to run `yarn build-docs` but I get some errors :(
I'm on Mac 10.14.5 and using node v12.5.0 and yarn v1.17.0
Can you try to generate the documents? Or better: Is an automation integrated somewhere?