### PR TITLE
Improve spacing around curlies

### DIFF
--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -233,6 +233,9 @@ function print(path, options, print) {
       let leadingSpace = "";
       let trailingSpace = "";
 
+      if (isPreviousNodeOfType(path, "MustacheStatement")) {
+        leadingSpace = " ";
+      }
       if (isNextNodeOfType(path, "MustacheStatement")) {
         trailingSpace = " ";
       }
@@ -399,7 +402,7 @@ function getPreviousNode(path) {
   const node = path.getValue();
   const parentNode = path.getParentNode(0);
 
-  const children = parentNode.children;
+  const children = parentNode.children || parentNode.body;
   if (children) {
     const nodeIndex = children.indexOf(node);
     if (nodeIndex > 0) {
@@ -413,7 +416,7 @@ function getNextNode(path) {
   const node = path.getValue();
   const parentNode = path.getParentNode(0);
 
-  const children = parentNode.children;
+  const children = parentNode.children || parentNode.body;
   if (children) {
     const nodeIndex = children.indexOf(node);
     if (nodeIndex < children.length) {
@@ -430,6 +433,11 @@ function isPreviousNodeOfSomeType(path, types) {
     return types.some(type => previousNode.type === type);
   }
   return false;
+}
+
+function isPreviousNodeOfType(path, type) {
+  const previousNode = getPreviousNode(path);
+  return previousNode && previousNode.type === type;
 }
 
 function isNextNodeOfType(path, type) {

--- a/src/language-handlebars/utils.js
+++ b/src/language-handlebars/utils.js
@@ -1,0 +1,14 @@
+"use strict";
+
+function isWhitespaceNode(node) {
+  return node.type === "TextNode" && !/\S/.test(node.chars);
+}
+
+function beginsWithWhitespace(node) {
+  return node.type === "TextNode" && !/\s+\S/.test(node.chars);
+}
+
+module.exports = {
+  isWhitespaceNode,
+  beginsWithWhitespace,
+};

--- a/tests/glimmer/curly.hbs
+++ b/tests/glimmer/curly.hbs
@@ -1,2 +1,15 @@
 <p>Your username is @{{name}}</p>
 <p>Hi {{firstName}} {{lastName}}</p>
+
+{{alex}} Ben {{sophie}}
+{{alex}}Ben{{sophie}}
+
+<p>{{alex}} Ben {{sophie}}</p>
+<p>{{alex}}Ben{{sophie}}</p>
+
+<p>
+  {{alex}} Ben {{sophie}}
+  <button>click me</button>
+</p>
+
+<p>{{alex}} Ben {{sophie}} <button>click me</button></p>


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**



# Notes
Input
```hbs
<p>Your username is @{{name}}</p>
<p>Hi {{firstName}} {{lastName}}</p>

{{alex}} Ben {{sophie}}
{{alex}}Ben{{sophie}}

<p>{{alex}} Ben {{sophie}}</p>
<p>{{alex}}Ben{{sophie}}</p>

<p>
  {{alex}} Ben {{sophie}}
  <button>click me</button>
</p>

<p>{{alex}} Ben {{sophie}} <button>click me</button></p>

<div>
  {{name}}
  is your name
</div>

 <p>
  {{alex}} Ben {{sophie}}
</p>
```

After PR
```hbs
<p>
  Your username is @{{name}}
</p>
<p>
  Hi {{firstName}} {{lastName}}
</p>
{{alex}}
 Ben
{{sophie}}

{{alex}}
 Ben
{{sophie}}

<p>
  {{alex}} Ben {{sophie}}
</p>
<p>
  {{alex}}Ben{{sophie}}
</p>
<p>
  {{alex}} Ben {{sophie}} <button>
    click me
  </button>
</p>
<p>
  {{alex}} Ben {{sophie}} <button>
    click me
  </button>
</p>
<div>
  {{name}} is your name
</div>
<p>
  {{alex}} Ben {{sophie}}
</p>n 
```
Obviously, the `button` spacing still isn't right, and I don't think the alex/ben/sophie examples are correct either:
```hbs
{{alex}}
Ben
{{sophie}}
```
Also breaks extra tests, need to look into - think it's because `\n` text nodes are also getting trailing/leading spaces


```hbs


```