### PR TITLE
Add ES6 instructions in browser docs

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -32,7 +32,7 @@ import parserGraphql from "prettier/parser-graphql";
 
 prettier.format("query { }", {
   parser: "graphql",
-  plugins: [parserGraphql],
+  plugins: [parserGraphql]
 });
 ```
 

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -24,7 +24,7 @@ prettier.format("query { }", { parser: "graphql", plugins: prettierPlugins });
 </script>
 ```
 
-### ES6
+### ES Modules
 
 ```js
 import prettier from "prettier/standalone";

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -24,6 +24,18 @@ prettier.format("query { }", { parser: "graphql", plugins: prettierPlugins });
 </script>
 ```
 
+### ES6
+
+```js
+import prettier from "prettier/standalone";
+import parserGraphql from "prettier/parser-graphql";
+
+prettier.format("query { }", {
+  parser: "graphql",
+  plugins: [parserGraphql],
+});
+```
+
 ### AMD
 
 ```js


### PR DESCRIPTION
Make it easy for JS developers to know how to use the prettier standalone version in ES6 + applications.