### PR TITLE
HTML, Vue: Don't break the template element included in a line shorter than print-width

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -245,6 +245,7 @@ Previously, Prettier would incorrectly decode HTML entiites.
 </p>
 ```
 
+<<<<<<< HEAD
 #### JavaScript: Stop moving comments inside tagged template literals ([#6236] by [@sosukesuzuki])
 
 Previously, Prettier would move comments after the tag inside the template literal. This version fixes this problem.
@@ -315,7 +316,32 @@ This version updates the TypeScript parser to correctly handle JSX text with dou
 
 Flag used with `--write` to avoid re-checking files that were not changed since they were last written (with the same formatting configuration).
 
+#### HTML, Vue: Don't break the template element included in a line shorter than print-width([#] by [@sosukesuzuki])
+
+Previously, even if the line length is shorter than print-width is Prettier breaks the line with a template element.
+
+<!-- prettier-ignore -->
+```html
+// Input
+<template>
+  <template>foo</template>
+</template>
+
+// Output (Prettier stable)
+<template>
+  <template
+    >foo</template
+  >
+</template>
+
+// Output (Prettier master)
+<template>
+  <template>foo</template>
+</template>
+```
+
 [#5910]: https://github.com/prettier/prettier/pull/5910
+[#6209]: https://github.com/prettier/prettier/pull/6209
 [#6186]: https://github.com/prettier/prettier/pull/6186
 [#6206]: https://github.com/prettier/prettier/pull/6206
 [#6209]: https://github.com/prettier/prettier/pull/6209
@@ -325,6 +351,7 @@ Flag used with `--write` to avoid re-checking files that were not changed since 
 [#6270]: https://github.com/prettier/prettier/pull/6270
 [#6289]: https://github.com/prettier/prettier/pull/6289
 [#6332]: https://github.com/prettier/prettier/pull/6332
+[#]: https://github.com/prettier/prettier/pull/
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
 [@sosukesuzuki]: https://github.com/sosukesuzuki

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -245,7 +245,6 @@ Previously, Prettier would incorrectly decode HTML entiites.
 </p>
 ```
 
-<<<<<<< HEAD
 #### JavaScript: Stop moving comments inside tagged template literals ([#6236] by [@sosukesuzuki])
 
 Previously, Prettier would move comments after the tag inside the template literal. This version fixes this problem.
@@ -316,7 +315,7 @@ This version updates the TypeScript parser to correctly handle JSX text with dou
 
 Flag used with `--write` to avoid re-checking files that were not changed since they were last written (with the same formatting configuration).
 
-#### HTML, Vue: Don't break the template element included in a line shorter than print-width([#] by [@sosukesuzuki])
+#### HTML, Vue: Don't break the template element included in a line shorter than print-width([#6284] by [@sosukesuzuki])
 
 Previously, even if the line length is shorter than print-width is Prettier breaks the line with a template element.
 
@@ -341,7 +340,6 @@ Previously, even if the line length is shorter than print-width is Prettier brea
 ```
 
 [#5910]: https://github.com/prettier/prettier/pull/5910
-[#6209]: https://github.com/prettier/prettier/pull/6209
 [#6186]: https://github.com/prettier/prettier/pull/6186
 [#6206]: https://github.com/prettier/prettier/pull/6206
 [#6209]: https://github.com/prettier/prettier/pull/6209
@@ -351,7 +349,7 @@ Previously, even if the line length is shorter than print-width is Prettier brea
 [#6270]: https://github.com/prettier/prettier/pull/6270
 [#6289]: https://github.com/prettier/prettier/pull/6289
 [#6332]: https://github.com/prettier/prettier/pull/6332
-[#]: https://github.com/prettier/prettier/pull/
+[#6284]: https://github.com/prettier/prettier/pull/6284
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
 [@sosukesuzuki]: https://github.com/sosukesuzuki

--- a/src/language-html/utils.js
+++ b/src/language-html/utils.js
@@ -272,7 +272,7 @@ function forceBreakContent(node) {
     forceBreakChildren(node) ||
     (node.type === "element" &&
       node.children.length !== 0 &&
-      (["body", "template", "script", "style"].indexOf(node.name) !== -1 ||
+      (["body", "script", "style"].indexOf(node.name) !== -1 ||
         node.children.some(child => hasNonTextChild(child)))) ||
     (node.firstChild &&
       node.firstChild === node.lastChild &&

--- a/tests/html_whitespace/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_whitespace/__snapshots__/jsfmt.spec.js.snap
@@ -332,3 +332,31 @@ printWidth: 80
 
 ================================================================================
 `;
+
+exports[`template.html 1`] = `
+====================================options=====================================
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<template>
+  <template>foo</template>
+</template>
+
+<template>
+  <template>foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo</template>
+</template>
+
+=====================================output=====================================
+<template>
+  <template>foo</template>
+</template>
+
+<template>
+  <template
+    >foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo</template
+  >
+</template>
+
+================================================================================
+`;

--- a/tests/html_whitespace/template.html
+++ b/tests/html_whitespace/template.html
@@ -1,0 +1,7 @@
+<template>
+  <template>foo</template>
+</template>
+
+<template>
+  <template>foooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo</template>
+</template>


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fix #6263
Previously, even if the line length is shorter than print-width is Prettier breaks the line with a template element.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
