### PR TITLE
Add JSON script types

### DIFF
--- a/src/language-html/utils.js
+++ b/src/language-html/utils.js
@@ -377,8 +377,8 @@ function inferScriptParser(node) {
     }
 
     if (
-      node.attrMap.type.substr(-4) === "json" ||
-      node.attrMap.type.substr(-9) === "importmap"
+      node.attrMap.type.endsWith("json") ||
+      node.attrMap.type.endsWith("importmap")
     ) {
       return "json";
     }

--- a/src/language-html/utils.js
+++ b/src/language-html/utils.js
@@ -376,7 +376,10 @@ function inferScriptParser(node) {
       return "markdown";
     }
 
-    if (node.attrMap.type === "application/ld+json") {
+    if (
+      node.attrMap.type.substr(-4) === "json" ||
+      node.attrMap.type.substr(-9) === "importmap"
+    ) {
       return "json";
     }
   }

--- a/tests/html_script/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_script/__snapshots__/jsfmt.spec.js.snap
@@ -7,12 +7,36 @@ printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
 <script type="application/ld+json">
+  {   "json": true }
+</script>
+<script type="application/json">
   {   "json":true  }
+</script>
+<script type="importmap">
+  {   "json":true  }
+</script>
+<script type="systemjs-importmap">
+  {   "json":true  }
+</script>
+<script type="invalid">
+  {   "json":false  }
 </script>
 
 =====================================output=====================================
 <script type="application/ld+json">
   { "json": true }
+</script>
+<script type="application/json">
+  { "json": true }
+</script>
+<script type="importmap">
+  { "json": true }
+</script>
+<script type="systemjs-importmap">
+  { "json": true }
+</script>
+<script type="invalid">
+  {   "json":false  }
 </script>
 
 ================================================================================

--- a/tests/html_script/script.html
+++ b/tests/html_script/script.html
@@ -1,3 +1,15 @@
 <script type="application/ld+json">
+  {   "json": true }
+</script>
+<script type="application/json">
   {   "json":true  }
+</script>
+<script type="importmap">
+  {   "json":true  }
+</script>
+<script type="systemjs-importmap">
+  {   "json":true  }
+</script>
+<script type="invalid">
+  {   "json":false  }
 </script>


### PR DESCRIPTION
Prettier currently recognises `<script type="application/ld+json">` as JSON. This PR adds support for other `application/foo+json` types, as well as plain `application/json`. It also adds support for [import maps](https://github.com/WICG/import-maps).

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
