### PR TITLE
TypeScript: Fix specific union type breaks after opening parenthesis, but not before closing

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -368,7 +368,7 @@ foo(
 );
 ```
 
-#### TypeScript: Fix specific union type breaks after opening parenthesis, but not before closing ([#] by [@sosukesuzuki])
+#### TypeScript: Fix specific union type breaks after opening parenthesis, but not before closing ([#6307] by [@sosukesuzuki])
 
 Previously, union type that put with `as` , `keyof`, `[]`, other union(`|`) and intersection(`&`) breaks after opening parenthesis, but not before closing. Please see [#6303](https://github.com/prettier/prettier/issues/6303) for detail.
 
@@ -404,7 +404,7 @@ const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
 [#6332]: https://github.com/prettier/prettier/pull/6332
 [#6284]: https://github.com/prettier/prettier/pull/6284
 [#6301]: https://github.com/prettier/prettier/pull/6301
-[#]: https://github.com/prettier/prettier/pull/
+[#6307]: https://github.com/prettier/prettier/pull/6307
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
 [@sosukesuzuki]: https://github.com/sosukesuzuki

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -368,6 +368,30 @@ foo(
 );
 ```
 
+#### TypeScript: Fix specific union type breaks after opening parenthesis, but not before closing ([#] by [@sosukesuzuki])
+
+Previously, union type that put with `as` , `keyof`, `[]`, other union(`|`) and intersection(`&`) breaks after opening parenthesis, but not before closing. Please see [#6303](https://github.com/prettier/prettier/issues/6303) for detail.
+
+<!-- prettier-ignore-->
+```ts
+// Input
+const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
+  | string
+  | undefined
+)[];
+
+// Prettier (stable)
+const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
+  | string
+  | undefined)[];
+
+// Prettier (master)
+const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
+  | string
+  | undefined
+)[];
+```
+
 [#5910]: https://github.com/prettier/prettier/pull/5910
 [#6186]: https://github.com/prettier/prettier/pull/6186
 [#6206]: https://github.com/prettier/prettier/pull/6206
@@ -380,6 +404,7 @@ foo(
 [#6332]: https://github.com/prettier/prettier/pull/6332
 [#6284]: https://github.com/prettier/prettier/pull/6284
 [#6301]: https://github.com/prettier/prettier/pull/6301
+[#]: https://github.com/prettier/prettier/pull/
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
 [@sosukesuzuki]: https://github.com/sosukesuzuki

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2813,15 +2813,21 @@ function printPathNoParens(path, options, print, args) {
       let hasParens;
 
       if (n.type === "TSUnionType") {
+        const grandParent = path.getNode(2);
         const greatGrandParent = path.getParentNode(2);
         const greatGreatGrandParent = path.getParentNode(3);
 
         hasParens =
-          greatGrandParent &&
-          greatGrandParent.type === "TSParenthesizedType" &&
-          greatGreatGrandParent &&
-          (greatGreatGrandParent.type === "TSUnionType" ||
-            greatGreatGrandParent.type === "TSIntersectionType");
+          (parent.type === "TSParenthesizedType" &&
+            (grandParent.type === "TSAsExpression" ||
+              grandParent.type === "TSUnionType" ||
+              grandParent.type === "TSTypeOperator" ||
+              grandParent.type === "TSArrayType")) ||
+          (greatGrandParent &&
+            greatGrandParent.type === "TSParenthesizedType" &&
+            greatGreatGrandParent &&
+            (greatGreatGrandParent.type === "TSUnionType" ||
+              greatGreatGrandParent.type === "TSIntersectionType"));
       } else {
         hasParens = pathNeedsParens(path, options);
       }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2821,6 +2821,7 @@ function printPathNoParens(path, options, print, args) {
           (parent.type === "TSParenthesizedType" &&
             (grandParent.type === "TSAsExpression" ||
               grandParent.type === "TSUnionType" ||
+              grandParent.type === "TSIntersectionType" ||
               grandParent.type === "TSTypeOperator" ||
               grandParent.type === "TSArrayType")) ||
           (greatGrandParent &&

--- a/tests/typescript_union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_union/__snapshots__/jsfmt.spec.js.snap
@@ -123,6 +123,34 @@ type State = {
   | { discriminant: "BAZ"; baz: any } 
 );
 
+const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
+  | string
+  | undefined
+)[];
+
+const foo: (
+  | AAAAAAAAAAAAAAAAAAAAAA
+  | BBBBBBBBBBBBBBBBBBBBBB
+  | CCCCCCCCCCCCCCCCCCCCCC
+  | DDDDDDDDDDDDDDDDDDDDDD
+)[] = [];
+
+const foo: keyof (
+  | AAAAAAAAAAAAAAAAAAAAAA
+  | BBBBBBBBBBBBBBBBBBBBBB
+  | CCCCCCCCCCCCCCCCCCCCCC
+  | DDDDDDDDDDDDDDDDDDDDDD
+) = bar;
+
+const foo:
+  | foo
+  | (
+      | AAAAAAAAAAAAAAAAAAAAAA
+      | BBBBBBBBBBBBBBBBBBBBBB
+      | CCCCCCCCCCCCCCCCCCCCCC
+      | DDDDDDDDDDDDDDDDDDDDDD
+    ) = bar;
+
 =====================================output=====================================
 export type A =
   | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -160,6 +188,34 @@ type State = {
   | { discriminant: "FOO"; foo: any }
   | { discriminant: "BAR"; bar: any }
   | { discriminant: "BAZ"; baz: any });
+
+const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
+  | string
+  | undefined
+)[];
+
+const foo: (
+  | AAAAAAAAAAAAAAAAAAAAAA
+  | BBBBBBBBBBBBBBBBBBBBBB
+  | CCCCCCCCCCCCCCCCCCCCCC
+  | DDDDDDDDDDDDDDDDDDDDDD
+)[] = [];
+
+const foo: keyof (
+  | AAAAAAAAAAAAAAAAAAAAAA
+  | BBBBBBBBBBBBBBBBBBBBBB
+  | CCCCCCCCCCCCCCCCCCCCCC
+  | DDDDDDDDDDDDDDDDDDDDDD
+) = bar;
+
+const foo:
+  | foo
+  | (
+      | AAAAAAAAAAAAAAAAAAAAAA
+      | BBBBBBBBBBBBBBBBBBBBBB
+      | CCCCCCCCCCCCCCCCCCCCCC
+      | DDDDDDDDDDDDDDDDDDDDDD
+    ) = bar;
 
 ================================================================================
 `;

--- a/tests/typescript_union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_union/__snapshots__/jsfmt.spec.js.snap
@@ -187,7 +187,8 @@ type State = {
 } & (
   | { discriminant: "FOO"; foo: any }
   | { discriminant: "BAR"; bar: any }
-  | { discriminant: "BAZ"; baz: any });
+  | { discriminant: "BAZ"; baz: any }
+);
 
 const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
   | string

--- a/tests/typescript_union/union-parens.ts
+++ b/tests/typescript_union/union-parens.ts
@@ -38,3 +38,31 @@ type State = {
   | { discriminant: "BAR"; bar: any }
   | { discriminant: "BAZ"; baz: any } 
 );
+
+const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
+  | string
+  | undefined
+)[];
+
+const foo: (
+  | AAAAAAAAAAAAAAAAAAAAAA
+  | BBBBBBBBBBBBBBBBBBBBBB
+  | CCCCCCCCCCCCCCCCCCCCCC
+  | DDDDDDDDDDDDDDDDDDDDDD
+)[] = [];
+
+const foo: keyof (
+  | AAAAAAAAAAAAAAAAAAAAAA
+  | BBBBBBBBBBBBBBBBBBBBBB
+  | CCCCCCCCCCCCCCCCCCCCCC
+  | DDDDDDDDDDDDDDDDDDDDDD
+) = bar;
+
+const foo:
+  | foo
+  | (
+      | AAAAAAAAAAAAAAAAAAAAAA
+      | BBBBBBBBBBBBBBBBBBBBBB
+      | CCCCCCCCCCCCCCCCCCCCCC
+      | DDDDDDDDDDDDDDDDDDDDDD
+    ) = bar;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fix #6303

Union types put with `[]`(array), `as`, `keyof`, `|`, `&` breaks after opening parenthesis, but not before closing.

```ts
// Stable
const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
  | string
  | undefined)[];

const foo: (
  | AAAAAAAAAAAAAAAAAAAAAA
  | BBBBBBBBBBBBBBBBBBBBBB
  | CCCCCCCCCCCCCCCCCCCCCC
  | DDDDDDDDDDDDDDDDDDDDDD)[] = [];

const foo: keyof (
  | AAAAAAAAAAAAAAAAAAAAAA
  | BBBBBBBBBBBBBBBBBBBBBB
  | CCCCCCCCCCCCCCCCCCCCCC
  | DDDDDDDDDDDDDDDDDDDDDD) = bar;

const foo:
  | foo
  | (
      | AAAAAAAAAAAAAAAAAAAAAA
      | BBBBBBBBBBBBBBBBBBBBBB
      | CCCCCCCCCCCCCCCCCCCCCC
      | DDDDDDDDDDDDDDDDDDDDDD) = bar;

const foo: foo &
  (
    | AAAAAAAAAAAAAAAAAAAAAA
    | BBBBBBBBBBBBBBBBBBBBBB
    | CCCCCCCCCCCCCCCCCCCCCC
    | DDDDDDDDDDDDDDDDDDDDDD) = bar;

// This pr
const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
  | string
  | undefined
)[];

const foo: (
  | AAAAAAAAAAAAAAAAAAAAAA
  | BBBBBBBBBBBBBBBBBBBBBB
  | CCCCCCCCCCCCCCCCCCCCCC
  | DDDDDDDDDDDDDDDDDDDDDD
)[] = [];

const foo: keyof (
  | AAAAAAAAAAAAAAAAAAAAAA
  | BBBBBBBBBBBBBBBBBBBBBB
  | CCCCCCCCCCCCCCCCCCCCCC
  | DDDDDDDDDDDDDDDDDDDDDD
) = bar;

const foo:
  | foo
  | (
      | AAAAAAAAAAAAAAAAAAAAAA
      | BBBBBBBBBBBBBBBBBBBBBB
      | CCCCCCCCCCCCCCCCCCCCCC
      | DDDDDDDDDDDDDDDDDDDDDD
    ) = bar;

const foo: foo &
  (
    | AAAAAAAAAAAAAAAAAAAAAA
    | BBBBBBBBBBBBBBBBBBBBBB
    | CCCCCCCCCCCCCCCCCCCCCC
    | DDDDDDDDDDDDDDDDDDDDDD
  ) = bar;
```

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
