### PR TITLE
Handle missing cache directory for changedCache

### DIFF
--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -446,13 +446,17 @@ function formatFiles(context) {
   let changedCache = null;
   if (context.argv["only-changed"]) {
     const cacheDir = findCacheDir({ name: "prettier", create: true });
-    changedCache = new ChangedCache({
-      location: path.join(cacheDir, "changed"),
-      readFile: fs.readFileSync,
-      writeFile: thirdParty.writeFileAtomic,
-      context: context,
-      supportInfo: prettier.getSupportInfo()
-    });
+
+    // Abort if cache directory is not found.
+    if (cacheDir !== undefined) {
+      changedCache = new ChangedCache({
+        location: path.join(cacheDir, "changed"),
+        readFile: fs.readFileSync,
+        writeFile: thirdParty.writeFileAtomic,
+        context: context,
+        supportInfo: prettier.getSupportInfo()
+      });
+    }
   }
 
   eachFilename(context, context.filePatterns, filename => {

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -9,6 +9,7 @@ const chalk = require("chalk");
 const readline = require("readline");
 const stringify = require("json-stable-stringify");
 const findCacheDir = require("find-cache-dir");
+const os = require("os");
 
 const minimist = require("./minimist");
 const prettier = require("../../index");
@@ -445,18 +446,16 @@ function formatFiles(context) {
 
   let changedCache = null;
   if (context.argv["only-changed"]) {
-    const cacheDir = findCacheDir({ name: "prettier", create: true });
+    const cacheDir =
+      findCacheDir({ name: "prettier", create: true }) || os.tmpdir();
 
-    // Abort if cache directory is not found.
-    if (cacheDir !== undefined) {
-      changedCache = new ChangedCache({
-        location: path.join(cacheDir, "changed"),
-        readFile: fs.readFileSync,
-        writeFile: thirdParty.writeFileAtomic,
-        context: context,
-        supportInfo: prettier.getSupportInfo()
-      });
-    }
+    changedCache = new ChangedCache({
+      location: path.join(cacheDir, "changed"),
+      readFile: fs.readFileSync,
+      writeFile: thirdParty.writeFileAtomic,
+      context: context,
+      supportInfo: prettier.getSupportInfo()
+    });
   }
 
   eachFilename(context, context.filePatterns, filename => {


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Small patch to check that the cache directory was found before initializing the `changedCache`.

https://github.com/prettier/prettier/pull/5910#discussion_r305870825

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
