### PR TITLE
fix: text with whitespace after JSX trim incorrectly

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -44,6 +44,29 @@ const link = <a href="example.com">http://example.com</a>;
 
 -->
 
+#### MDX: fix text with whitespace after JSX trim incorrectly ([#6340] by [@JounQin])
+
+Previous versions format text with whitespace after JSX incorrectly in mdx, this has been fixed in this version.
+
+<!-- prettier-ignore -->
+```md
+<!-- Input -->
+# Heading
+<Hello>
+    test   <World />   test
+</Hello>       123
+
+<!-- Output (Prettier stable) -->
+<Hello>
+  test <World /> test
+</Hello>123
+
+<!-- Output (Prettier master) -->
+<Hello>
+  test <World /> test
+</Hello> 123
+```
+
 #### MDX: Adjacent JSX elements should be allowed in mdx ([#6332] by [@JounQin])
 
 Previous versions would not format adjacent JSX elements in mdx, this has been fixed in this version.
@@ -65,7 +88,7 @@ SyntaxError: Unexpected token (3:9)
 // Output (Prettier master)
 <Hello>
   test <World /> test
-</Hello>123      ^
+</Hello>123
 
 
 // Input
@@ -405,6 +428,7 @@ const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
 [#6284]: https://github.com/prettier/prettier/pull/6284
 [#6301]: https://github.com/prettier/prettier/pull/6301
 [#6307]: https://github.com/prettier/prettier/pull/6307
+[#6340]: https://github.com/prettier/prettier/pull/6340
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
 [@sosukesuzuki]: https://github.com/sosukesuzuki

--- a/src/language-markdown/parser-markdown.js
+++ b/src/language-markdown/parser-markdown.js
@@ -73,7 +73,7 @@ function htmlToJsx() {
           position.end.offset
         );
 
-        if (value.trim()) {
+        if (value) {
           newNodes.push({
             type: type === "element" ? "jsx" : type,
             value,

--- a/src/language-markdown/parser-markdown.js
+++ b/src/language-markdown/parser-markdown.js
@@ -68,11 +68,12 @@ function htmlToJsx() {
       }
 
       return nodes.reduce((newNodes, { sourceSpan: position, type }) => {
-        const value = node.value
-          .slice(position.start.offset, position.end.offset)
-          .trim();
+        const value = node.value.slice(
+          position.start.offset,
+          position.end.offset
+        );
 
-        if (value) {
+        if (value.trim()) {
           newNodes.push({
             type: type === "element" ? "jsx" : type,
             value,

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -115,7 +115,7 @@ function genericPrint(path, options, print) {
       const index = parentNode.children.indexOf(node);
       const prevNode = parentNode.children[index - 1];
       const nextNode = parentNode.children[index + 1];
-      const hasPrevOrNextWord = // `1*2*3` is considered emphais but `1_2_3` is not
+      const hasPrevOrNextWord = // `1*2*3` is considered emphasis but `1_2_3` is not
         (prevNode &&
           prevNode.type === "sentence" &&
           prevNode.children.length > 0 &&
@@ -770,35 +770,40 @@ function isPrettierIgnore(node) {
   return match === null ? false : match[1] ? match[1] : "next";
 }
 
+function isInlineNode(node) {
+  return node && INLINE_NODE_TYPES.indexOf(node.type) !== -1;
+}
+
 function shouldNotPrePrintHardline(node, data) {
   const isFirstNode = data.parts.length === 0;
-  const isInlineNode = INLINE_NODE_TYPES.indexOf(node.type) !== -1;
 
   const isInlineHTML =
     node.type === "html" &&
     INLINE_NODE_WRAPPER_TYPES.indexOf(data.parentNode.type) !== -1;
 
-  return isFirstNode || isInlineNode || isInlineHTML;
+  return isFirstNode || isInlineNode(node) || isInlineHTML;
 }
 
-function shouldPrePrintDoubleHardline(node, data) {
-  const isSequence = (data.prevNode && data.prevNode.type) === node.type;
+function shouldPrePrintDoubleHardline(node, { parentNode, prevNode }) {
+  const prevNodeType = prevNode && prevNode.type;
+  const nodeType = node.type;
+
+  const isSequence = prevNodeType === nodeType;
   const isSiblingNode =
-    isSequence && SIBLING_NODE_TYPES.indexOf(node.type) !== -1;
+    isSequence && SIBLING_NODE_TYPES.indexOf(nodeType) !== -1;
 
-  const isInTightListItem =
-    data.parentNode.type === "listItem" && !data.parentNode.loose;
-
-  const isPrevNodeLooseListItem =
-    data.prevNode && data.prevNode.type === "listItem" && data.prevNode.loose;
-
-  const isPrevNodePrettierIgnore = isPrettierIgnore(data.prevNode) === "next";
+  const isInTightListItem = parentNode.type === "listItem" && !parentNode.loose;
+  const isPrevNodeLooseListItem = prevNodeType === "listItem" && prevNode.loose;
+  const isPrevNodePrettierIgnore = isPrettierIgnore(prevNode) === "next";
 
   const isBlockHtmlWithoutBlankLineBetweenPrevHtml =
-    node.type === "html" &&
-    data.prevNode &&
-    data.prevNode.type === "html" &&
-    data.prevNode.position.end.line + 1 === node.position.start.line;
+    nodeType === "html" &&
+    prevNodeType === "html" &&
+    prevNode.position.end.line + 1 === node.position.start.line;
+
+  const isJsxInlineSibling =
+    (prevNodeType === "jsx" && isInlineNode(node)) ||
+    (nodeType === "jsx" && isInlineNode(prevNode));
 
   return (
     isPrevNodeLooseListItem ||
@@ -806,7 +811,8 @@ function shouldPrePrintDoubleHardline(node, data) {
       isSiblingNode ||
       isInTightListItem ||
       isPrevNodePrettierIgnore ||
-      isBlockHtmlWithoutBlankLineBetweenPrevHtml
+      isBlockHtmlWithoutBlankLineBetweenPrevHtml ||
+      isJsxInlineSibling
     )
   );
 }

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -774,14 +774,26 @@ function isInlineNode(node) {
   return node && INLINE_NODE_TYPES.indexOf(node.type) !== -1;
 }
 
-function shouldNotPrePrintHardline(node, data) {
-  const isFirstNode = data.parts.length === 0;
+function isEndsWithHardLine(node) {
+  return /\n+$/.test(node.value);
+}
+
+function shouldNotPrePrintHardline(node, { parentNode, parts, prevNode }) {
+  const isFirstNode = parts.length === 0;
 
   const isInlineHTML =
     node.type === "html" &&
-    INLINE_NODE_WRAPPER_TYPES.indexOf(data.parentNode.type) !== -1;
+    INLINE_NODE_WRAPPER_TYPES.indexOf(parentNode.type) !== -1;
 
-  return isFirstNode || isInlineNode(node) || isInlineHTML;
+  const isAfterHardlineNode =
+    prevNode &&
+    (isEndsWithHardLine(prevNode) ||
+      (prevNode.children &&
+        isEndsWithHardLine(prevNode.children[prevNode.children.length - 1])));
+
+  return (
+    isFirstNode || isInlineNode(node) || isInlineHTML || isAfterHardlineNode
+  );
 }
 
 function shouldPrePrintDoubleHardline(node, { parentNode, prevNode }) {

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -775,7 +775,11 @@ function isInlineNode(node) {
 }
 
 function isEndsWithHardLine(node) {
-  return /\n+$/.test(node.value);
+  return node && /\n+$/.test(node.value);
+}
+
+function last(nodes) {
+  return nodes && nodes[nodes.length - 1];
 }
 
 function shouldNotPrePrintHardline(node, { parentNode, parts, prevNode }) {
@@ -788,8 +792,7 @@ function shouldNotPrePrintHardline(node, { parentNode, parts, prevNode }) {
   const isAfterHardlineNode =
     prevNode &&
     (isEndsWithHardLine(prevNode) ||
-      (prevNode.children &&
-        isEndsWithHardLine(prevNode.children[prevNode.children.length - 1])));
+      isEndsWithHardLine(last(prevNode.children)));
 
   return (
     isFirstNode || isInlineNode(node) || isInlineHTML || isAfterHardlineNode

--- a/tests/mdx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/mdx/__snapshots__/jsfmt.spec.js.snap
@@ -256,6 +256,15 @@ printWidth: 80
 
 ---
 
+<Hello>
+    test   <World />   test
+</Hello>       123
+<Hello>
+    test   <World />   test
+</Hello>       234
+
+---
+
 | Column 1 | Column 2 |
 |---|---|
 | Text | <Hello>Text</Hello> |
@@ -277,6 +286,16 @@ printWidth: 80
 <Hello>
   test <World /> test
 </Hello>123
+
+---
+
+<Hello>
+  test <World /> test
+</Hello> 123
+
+<Hello>
+  test <World /> test
+</Hello> 234
 
 ---
 
@@ -314,6 +333,15 @@ semi: false
 
 ---
 
+<Hello>
+    test   <World />   test
+</Hello>       123
+<Hello>
+    test   <World />   test
+</Hello>       234
+
+---
+
 | Column 1 | Column 2 |
 |---|---|
 | Text | <Hello>Text</Hello> |
@@ -335,6 +363,16 @@ semi: false
 <Hello>
   test <World /> test
 </Hello>123
+
+---
+
+<Hello>
+  test <World /> test
+</Hello> 123
+
+<Hello>
+  test <World /> test
+</Hello> 234
 
 ---
 

--- a/tests/mdx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/mdx/__snapshots__/jsfmt.spec.js.snap
@@ -292,7 +292,6 @@ printWidth: 80
 <Hello>
   test <World /> test
 </Hello> 123
-
 <Hello>
   test <World /> test
 </Hello> 234
@@ -369,7 +368,6 @@ semi: false
 <Hello>
   test <World /> test
 </Hello> 123
-
 <Hello>
   test <World /> test
 </Hello> 234

--- a/tests/mdx/jsx.mdx
+++ b/tests/mdx/jsx.mdx
@@ -18,6 +18,15 @@
 
 ---
 
+<Hello>
+    test   <World />   test
+</Hello>       123
+<Hello>
+    test   <World />   test
+</Hello>       234
+
+---
+
 | Column 1 | Column 2 |
 |---|---|
 | Text | <Hello>Text</Hello> |


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
