### PR TITLE
fix: JSX fragment should be allowed in mdx

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -44,6 +44,28 @@ const link = <a href="example.com">http://example.com</a>;
 
 -->
 
+#### MDX: JSX fragment should be allowed in mdx ([#6342] by [@JounQin])
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+<><Hello>
+    test   <World />   test
+</Hello></>
+
+// Output (Prettier stable)
+SyntaxError: Unexpected token (1:2)
+> 1 | </Hello></>
+    |  ^
+
+// Output (Prettier master)
+<>
+  <Hello>
+    test <World /> test
+  </Hello>
+</>
+```
+
 #### MDX: Adjacent JSX elements should be allowed in mdx ([#6332] by [@JounQin])
 
 Previous versions would not format adjacent JSX elements in mdx, this has been fixed in this version.
@@ -65,7 +87,7 @@ SyntaxError: Unexpected token (3:9)
 // Output (Prettier master)
 <Hello>
   test <World /> test
-</Hello>123      ^
+</Hello>123
 
 
 // Input
@@ -325,6 +347,7 @@ Flag used with `--write` to avoid re-checking files that were not changed since 
 [#6270]: https://github.com/prettier/prettier/pull/6270
 [#6289]: https://github.com/prettier/prettier/pull/6289
 [#6332]: https://github.com/prettier/prettier/pull/6332
+[#6342]: https://github.com/prettier/prettier/pull/6342
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
 [@sosukesuzuki]: https://github.com/sosukesuzuki

--- a/src/language-markdown/mdx.js
+++ b/src/language-markdown/mdx.js
@@ -26,7 +26,7 @@
 
 const IMPORT_REGEX = /^import\s/;
 const EXPORT_REGEX = /^export\s/;
-const BLOCKS_REGEX = "[a-z\\.]*(\\.){0,1}[a-z][a-z0-9\\.]*";
+const BLOCKS_REGEX = "[a-z\\.]*(\\.){0,1}[a-z]{0,1}[a-z0-9\\.]*";
 const COMMENT_REGEX = "<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->";
 const EMPTY_NEWLINE = "\n\n";
 

--- a/src/language-markdown/parser-markdown.js
+++ b/src/language-markdown/parser-markdown.js
@@ -60,10 +60,18 @@ function htmlToJsx() {
         return node;
       }
 
-      const nodes = htmlParser.parse(node.value).children;
+      let nodes;
+
+      try {
+        nodes = htmlParser.parse(node.value).children;
+      } catch (e) {
+        // do nothing, it could be JSX fragment here
+        // or, it will be caught by "jsx" parser
+        // FIXME: adjacent JSX fragments could not be parsed, should we care about that?
+      }
 
       // find out if there are adjacent JSX elements which should be allowed in mdx alike in markdown
-      if (nodes.length <= 1) {
+      if (!nodes || nodes.length <= 1) {
         return Object.assign({}, node, { type: "jsx" });
       }
 

--- a/tests/mdx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/mdx/__snapshots__/jsfmt.spec.js.snap
@@ -256,6 +256,12 @@ printWidth: 80
 
 ---
 
+<><Hello>
+    test   <World />   test
+</Hello></>
+
+---
+
 | Column 1 | Column 2 |
 |---|---|
 | Text | <Hello>Text</Hello> |
@@ -277,6 +283,14 @@ printWidth: 80
 <Hello>
   test <World /> test
 </Hello>123
+
+---
+
+<>
+  <Hello>
+    test <World /> test
+  </Hello>
+</>
 
 ---
 
@@ -314,6 +328,12 @@ semi: false
 
 ---
 
+<><Hello>
+    test   <World />   test
+</Hello></>
+
+---
+
 | Column 1 | Column 2 |
 |---|---|
 | Text | <Hello>Text</Hello> |
@@ -335,6 +355,14 @@ semi: false
 <Hello>
   test <World /> test
 </Hello>123
+
+---
+
+<>
+  <Hello>
+    test <World /> test
+  </Hello>
+</>
 
 ---
 

--- a/tests/mdx/jsx.mdx
+++ b/tests/mdx/jsx.mdx
@@ -18,6 +18,12 @@
 
 ---
 
+<><Hello>
+    test   <World />   test
+</Hello></>
+
+---
+
 | Column 1 | Column 2 |
 |---|---|
 | Text | <Hello>Text</Hello> |


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
