### PR TITLE
Add jest-runner-prettier to Related Projects Documention

### DIFF
--- a/docs/related-projects.md
+++ b/docs/related-projects.md
@@ -38,3 +38,4 @@ title: Related Projects
 - [`pretty-quick`](https://github.com/azz/pretty-quick) formats your changed files with Prettier
 - [`prettier-chrome`](https://github.com/u3u/prettier-chrome) an extension that can be formatted using Prettier in Chrome
 - [`prettylint`](https://github.com/ikatyang/prettylint) run Prettier as a linter
+- [`jest-runner-prettier`](https://github.com/keplersj/jest-runner-prettier) run Prettier as a Jest runner


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

A while ago I created a [Jest runner](https://jestjs.io/docs/en/configuration#runner-string) that runs Prettier. I've been using it in several of my projects, have it well tested, and use dependabot to keep it up to date. Since I've found using Jest to run my projects' unit tests and ensure code style to be very convenient, I'd love to have [`jest-runner-prettier`](https://github.com/keplersj/jest-runner-prettier) listed in the documentation to better share this with other Prettier users.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

<!--
- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
-->