### PR TITLE
docs: webstorm info on how to watch partials

### DIFF
--- a/docs/webstorm.md
+++ b/docs/webstorm.md
@@ -30,6 +30,7 @@ In older IDE versions, select Custom and do the following configuration:
 - **Arguments**: `--write [other options] $FilePathRelativeToProjectRoot$`
 - **Output paths to refresh**: `$FilePathRelativeToProjectRoot$`
 - **Working directory**: `$ProjectFileDir$`
+- **Environment variables**: add `COMPILE_PARTIAL=true` if you want to run `prettier` on partials (like `_component.scss`)
 - **Auto-save edited files to trigger the watcher**: Uncheck to reformat on Save only.
 
 ![Example](/docs/assets/webstorm/file-watcher-prettier.png)


### PR DESCRIPTION
Since file watchers ignore partials like `_component.scss` (underscore!) when imported in some `main.scss`, they won’t be prettified. Use the `COMPILE_PARTIAL=true` environment variable to also watch and prettify partials.