### PR TITLE
fix: format JSX Fragment correctly, consider Fragment as block

### DIFF
--- a/changelog_unreleased/mdx/pr-6398.md
+++ b/changelog_unreleased/mdx/pr-6398.md
@@ -1,0 +1,21 @@
+#### MDX: fix JSX Fragment format incorrectly ([#6398](https://github.com/prettier/prettier/pull/6398) by [@JounQin](https://github.com/JounQin))
+
+Previous versions format JSX Fragment incorrectly in mdx, this has been fixed in this version.
+
+<!-- prettier-ignore -->
+```md
+<!-- Input -->
+<>
+    test   <World        />   test
+</>       123
+
+<!-- Output (Prettier stable) -->
+<>
+test <World        /> test
+</> 123
+
+<!-- Output (Prettier master) -->
+<>
+  test <World /> test
+</> 123
+```

--- a/src/language-markdown/mdx.js
+++ b/src/language-markdown/mdx.js
@@ -26,7 +26,7 @@
 
 const IMPORT_REGEX = /^import\s/;
 const EXPORT_REGEX = /^export\s/;
-const BLOCKS_REGEX = "[a-z\\.]*(\\.){0,1}[a-z][a-z0-9\\.]*";
+const BLOCKS_REGEX = "[a-z][a-z0-9]*(\\.[a-z][a-z0-9]*)*|";
 const COMMENT_REGEX = "<!---->|<!--(?:-?[^>-])(?:-?[^-])*-->";
 const EMPTY_NEWLINE = "\n\n";
 

--- a/tests/mdx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/mdx/__snapshots__/jsfmt.spec.js.snap
@@ -265,6 +265,12 @@ printWidth: 80
 
 ---
 
+<>
+    test   <World        />   test
+</>       123
+
+---
+
 | Column 1 | Column 2 |
 |---|---|
 | Text | <Hello>Text</Hello> |
@@ -296,6 +302,12 @@ printWidth: 80
 <Hello>
   test <World /> test
 </Hello> 234
+
+---
+
+<>
+  test <World /> test
+</> 123
 
 ---
 
@@ -342,6 +354,12 @@ semi: false
 
 ---
 
+<>
+    test   <World        />   test
+</>       123
+
+---
+
 | Column 1 | Column 2 |
 |---|---|
 | Text | <Hello>Text</Hello> |
@@ -373,6 +391,12 @@ semi: false
 <Hello>
   test <World /> test
 </Hello> 234
+
+---
+
+<>
+  test <World /> test
+</> 123
 
 ---
 

--- a/tests/mdx/jsx.mdx
+++ b/tests/mdx/jsx.mdx
@@ -27,6 +27,12 @@
 
 ---
 
+<>
+    test   <World        />   test
+</>       123
+
+---
+
 | Column 1 | Column 2 |
 |---|---|
 | Text | <Hello>Text</Hello> |


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
