### PR TITLE
Update ?? precedence to match stage 3 proposal

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -239,7 +239,8 @@ function setLocEnd(node, index) {
 const PRECEDENCE = {};
 [
   ["|>"],
-  ["||", "??"],
+  ["??"],
+  ["||"],
   ["&&"],
   ["|"],
   ["^"],

--- a/tests/nullish_coalescing/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/nullish_coalescing/__snapshots__/jsfmt.spec.js.snap
@@ -14,6 +14,11 @@ foo ? bar ?? foo : baz;
 
 foo ?? (bar ?? baz);
 
+(foo ?? baz) || baz;
+
+// Note: this will trigger a syntax error once the parsers have been
+// updated to the latest specification. If you are doing the upgrade,
+// please remove the following line (and this comment).
 foo ?? baz || baz;
 
 (foo && baz) ?? baz;
@@ -28,7 +33,12 @@ foo ? bar ?? foo : baz;
 
 foo ?? (bar ?? baz);
 
-foo ?? baz || baz;
+(foo ?? baz) || baz;
+
+// Note: this will trigger a syntax error once the parsers have been
+// updated to the latest specification. If you are doing the upgrade,
+// please remove the following line (and this comment).
+(foo ?? baz) || baz;
 
 (foo && baz) ?? baz;
 foo && (baz ?? baz);

--- a/tests/nullish_coalescing/nullish_coalesing_operator.js
+++ b/tests/nullish_coalescing/nullish_coalesing_operator.js
@@ -6,6 +6,11 @@ foo ? bar ?? foo : baz;
 
 foo ?? (bar ?? baz);
 
+(foo ?? baz) || baz;
+
+// Note: this will trigger a syntax error once the parsers have been
+// updated to the latest specification. If you are doing the upgrade,
+// please remove the following line (and this comment).
 foo ?? baz || baz;
 
 (foo && baz) ?? baz;


### PR DESCRIPTION
@mroch told me that the spec was updated ( https://tc39.es/proposal-nullish-coalescing/ ) with the following two changes:
- ?? has lower precedence than ||. (previously equal)
- ?? cannot immediately contain, or be contained within, an && or || operation. (parens are now required)

The safe way to upgrade is to run prettier with just this change so that parenthesis are properly added. Then to upgrade the parser (only flow supports the new precedence in the next release, babel hasn't been updated yet) in prettier so that the new precedence is being used. Failure to do so will result in parse errors because of missing parenthesis so we will not have silent errors.

There was only 44 callsites mixing || and ?? in a confusing way in the Facebook codebase so it shouldn't be a huge deal in practice.

Fixed #6403