### PR TITLE
Remove alpha from plugin pug

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -42,7 +42,7 @@ Providing at least one path to `--plugin-search-dir`/`pluginSearchDirs` turns of
 ## Official Plugins
 
 - [`@prettier/plugin-php`](https://github.com/prettier/plugin-php)
-- [`@prettier/plugin-pug`](https://github.com/prettier/plugin-pug) by [**@Shinigami92**](https://github.com/Shinigami92) (in alpha development)
+- [`@prettier/plugin-pug`](https://github.com/prettier/plugin-pug) by [**@Shinigami92**](https://github.com/Shinigami92)
 - [`@prettier/plugin-ruby`](https://github.com/prettier/plugin-ruby)
 - [`@prettier/plugin-swift`](https://github.com/prettier/plugin-swift)
 

--- a/website/versioned_docs/version-stable/plugins.md
+++ b/website/versioned_docs/version-stable/plugins.md
@@ -43,7 +43,7 @@ Providing at least one path to `--plugin-search-dir`/`pluginSearchDirs` turns of
 ## Official Plugins
 
 - [`@prettier/plugin-php`](https://github.com/prettier/plugin-php)
-- [`@prettier/plugin-pug`](https://github.com/prettier/plugin-pug) by [**@Shinigami92**](https://github.com/Shinigami92) (in alpha development)
+- [`@prettier/plugin-pug`](https://github.com/prettier/plugin-pug) by [**@Shinigami92**](https://github.com/Shinigami92)
 - [`@prettier/plugin-ruby`](https://github.com/prettier/plugin-ruby)
 - [`@prettier/plugin-swift`](https://github.com/prettier/plugin-swift)
 


### PR DESCRIPTION
Remove alpha from plugin pug in docs
I released 1.0.0

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
