### PR TITLE
More readable parentheses for new-call

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -54,14 +54,14 @@ var a = new (x().y.z)();
 var a = new (x().y().z)();
 
 // Output (Prettier stable)
-var a = new (x().y)();
-var a = new (x().y.z)();
-var a = new (x().y().z)();
-
-// Output (Prettier master)
 var a = new (x()).y();
 var a = new (x()).y.z();
 var a = new (x().y()).z();
+
+// Output (Prettier master)
+var a = new (x().y)();
+var a = new (x().y.z)();
+var a = new (x().y().z)();
 ```
 
 #### MDX: fix text with whitespace after JSX trim incorrectly ([#6340] by [@JounQin])

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -44,6 +44,26 @@ const link = <a href="example.com">http://example.com</a>;
 
 -->
 
+#### JavaScript: More readable parentheses for new-call ([#6412] by [@bakkot])
+
+<!-- prettier-ignore -->
+```js
+// Input
+var a = new (x().y)();
+var a = new (x().y.z)();
+var a = new (x().y().z)();
+
+// Output (Prettier stable)
+var a = new (x().y)();
+var a = new (x().y.z)();
+var a = new (x().y().z)();
+
+// Output (Prettier master)
+var a = new (x()).y();
+var a = new (x()).y.z();
+var a = new (x().y()).z();
+```
+
 #### MDX: fix text with whitespace after JSX trim incorrectly ([#6340] by [@JounQin])
 
 Previous versions format text with whitespace after JSX incorrectly in mdx, this has been fixed in this version.
@@ -429,8 +449,10 @@ const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
 [#6301]: https://github.com/prettier/prettier/pull/6301
 [#6307]: https://github.com/prettier/prettier/pull/6307
 [#6340]: https://github.com/prettier/prettier/pull/6340
+[#6412]: https://github.com/prettier/prettier/pull/6412
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
 [@sosukesuzuki]: https://github.com/sosukesuzuki
 [@g-harel]: https://github.com/g-harel
 [@jounqin]: https://github.com/JounQin
+[@bakkot]: https://gibhub.com/bakkot

--- a/tests/new_expression/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/new_expression/__snapshots__/jsfmt.spec.js.snap
@@ -32,14 +32,20 @@ new (createObj()).prop(a());
 new (x()\`\`.y)();
 new e[f().x].y();
 new e[f()].y();
+new (a().b)();
+new (a().b().c)();
+new (a\`\`());
 
 =====================================output=====================================
 new (memoize.Cache || MapCache)();
 new (typeof this == "function" ? this : Dict())();
-new (createObj()).prop(a());
-new (x())\`\`.y();
+new (createObj().prop)(a());
+new (x()\`\`.y)();
 new e[f().x].y();
 new e[f()].y();
+new (a().b)();
+new (a().b().c)();
+new (a\`\`())();
 
 ================================================================================
 `;

--- a/tests/new_expression/new_expression.js
+++ b/tests/new_expression/new_expression.js
@@ -4,3 +4,6 @@ new (createObj()).prop(a());
 new (x()``.y)();
 new e[f().x].y();
 new e[f()].y();
+new (a().b)();
+new (a().b().c)();
+new (a``());

--- a/tests/typescript_non_null/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_non_null/__snapshots__/jsfmt.spec.js.snap
@@ -63,6 +63,10 @@ const b = c!();
 const c = new (d()!)();
 const c = new (d()!);
 const c = new (d()!.e)();
+new (x()\`\`.y!)();
+new (x()\`\`!.y)();
+new (x()!\`\`.y)();
+new (x!()\`\`.y)();
 
 =====================================output=====================================
 (a ? b : c)![tokenKey];
@@ -81,9 +85,13 @@ const a = b()!(); // parens aren't necessary
 const b = c!();
 
 // parens are necessary if the expression result is called as a constructor
-const c = new (d())!();
-const c = new (d())!();
-const c = new (d())!.e();
+const c = new (d()!)();
+const c = new (d()!)();
+const c = new (d()!.e)();
+new (x()\`\`.y!)();
+new (x()\`\`!.y)();
+new (x()!\`\`.y)();
+new (x!()\`\`.y)();
 
 ================================================================================
 `;

--- a/tests/typescript_non_null/parens.ts
+++ b/tests/typescript_non_null/parens.ts
@@ -17,3 +17,7 @@ const b = c!();
 const c = new (d()!)();
 const c = new (d()!);
 const c = new (d()!.e)();
+new (x()``.y!)();
+new (x()``!.y)();
+new (x()!``.y)();
+new (x!()``.y)();


### PR DESCRIPTION
Fixes #6147: leave `new (a().b)()` as-is, rather than changing to `new (a()).b();`.

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
