### PR TITLE
JavaScript: Prefer a trailing comment when there is comment between test and consequent on ternary

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -415,6 +415,29 @@ const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
 )[];
 ```
 
+#### JavaScript: Prefer a trailing comment when there is comment between test and consequent on ternary (by [@sosukesuzuki])
+
+<!-- prettier-ignore -->
+```js
+// Input
+test
+  // comment
+  ? foo
+  : bar;
+
+// Prettier (stable)
+test
+  ? // comment
+    foo
+  : bar;
+
+// Prettier (master)
+test
+  // comment
+  ? foo
+  : bar;
+```
+
 [#5910]: https://github.com/prettier/prettier/pull/5910
 [#6186]: https://github.com/prettier/prettier/pull/6186
 [#6206]: https://github.com/prettier/prettier/pull/6206

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -415,7 +415,7 @@ const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
 )[];
 ```
 
-#### JavaScript: Prefer a trailing comment when there is comment between test and consequent on ternary (by [@sosukesuzuki])
+#### JavaScript: Prefer a trailing comment when there is comment between test and consequent on ternary ([#6418] by [@sosukesuzuki])
 
 <!-- prettier-ignore -->
 ```js
@@ -452,6 +452,7 @@ test
 [#6301]: https://github.com/prettier/prettier/pull/6301
 [#6307]: https://github.com/prettier/prettier/pull/6307
 [#6340]: https://github.com/prettier/prettier/pull/6340
+[#6418]: https://github.com/prettier/prettier/pull/6418
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
 [@sosukesuzuki]: https://github.com/sosukesuzuki

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -237,7 +237,7 @@ function attach(comments, ast, text, options) {
         // But only in this case, prefer a trailing comment.
         //
         // test
-        //   /* comment */
+        //   // comment
         //   ? first
         //   : second
         if (
@@ -471,7 +471,7 @@ function printTrailingComment(commentPath, print, options) {
     parentParentNode.superClass === parentNode;
 
   // test
-  //   /* comment */
+  //   // comment
   //   ? first
   //   : second
   const isParentParentTernary =

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -227,6 +227,9 @@ function attach(comments, ast, text, options) {
       ) {
         // We're good
       } else if (followingNode) {
+        // Always a leading comment.
+        // But only in this case, prefer a trailing comment.
+        //
         // test
         //   /* comment */
         //   ? first
@@ -234,7 +237,6 @@ function attach(comments, ast, text, options) {
         if (isEnclosedByTernary && precedingNode) {
           addTrailingComment(precedingNode, comment);
         } else {
-          // Always a leading comment.
           addLeadingComment(followingNode, comment);
         }
       } else if (precedingNode) {

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -263,6 +263,12 @@ function attach(comments, ast, text, options) {
         //   : second
         if (
           isPrecedingNodeTestForTernary &&
+          // To avoid this case
+          //
+          // test ?
+          //   // comment
+          //   first
+          //   : second
           !hasQuestionInRange(text, locEnd(precedingNode), locStart(comment))
         ) {
           addTrailingComment(precedingNode, comment);

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -224,6 +224,27 @@ function attach(comments, ast, text, options) {
       precedingNode &&
       precedingNode === enclosingNode[testFileld];
 
+    function hasQuestionInRange(text, start, end) {
+      for (let i = start; i < end; ++i) {
+        if (text.charAt(i) === "?") {
+          let hasQuestion = true;
+
+          // Ignore "?" in comments
+          comments.forEach(({ range }) => {
+            const [commentStart, commentEnd] = range;
+            for (let j = commentStart; j < commentEnd; ++j) {
+              if (j === i) {
+                hasQuestion = false;
+              }
+            }
+          });
+
+          return hasQuestion;
+        }
+      }
+      return false;
+    }
+
     if (hasNewline(text, locStart(comment), { backwards: true })) {
       // If a comment exists on its own line, prefer a leading comment.
       // We also need to check if it's the first line of the file.
@@ -239,7 +260,10 @@ function attach(comments, ast, text, options) {
         //   /* comment */
         //   ? first
         //   : second
-        if (isPrecedingNodeTestForTernary) {
+        if (
+          isPrecedingNodeTestForTernary &&
+          !hasQuestionInRange(text, locEnd(precedingNode), locStart(comment))
+        ) {
           addTrailingComment(precedingNode, comment);
         } else {
           addLeadingComment(followingNode, comment);

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -510,6 +510,12 @@ function printTrailingComment(commentPath, print, options) {
     );
 
     if (isParentTestForTernary) {
+      // We want to add indent to a comment in this case
+      //
+      // test
+      //   // comment
+      //   ? first
+      //   : second;
       return indent(content);
     }
 

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -218,7 +218,8 @@ function attach(comments, ast, text, options) {
       enclosingNode &&
       (enclosingNode.type === "ConditionalExpression" ||
         enclosingNode.type === "TSConditionalType");
-    const testFileld = enclosingNode.test ? "test" : "extendsType";
+    const testFileld =
+      enclosingNode && enclosingNode.test ? "test" : "extendsType";
     const isPrecedingNodeTestForTernary =
       isEnclosedByTernary &&
       precedingNode &&

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -218,6 +218,11 @@ function attach(comments, ast, text, options) {
       enclosingNode &&
       (enclosingNode.type === "ConditionalExpression" ||
         enclosingNode.type === "TSConditionalType");
+    const testFileld = enclosingNode.test ? "test" : "extendsType";
+    const isPrecedingNodeTestForTernary =
+      isEnclosedByTernary &&
+      precedingNode &&
+      precedingNode === enclosingNode[testFileld];
 
     if (hasNewline(text, locStart(comment), { backwards: true })) {
       // If a comment exists on its own line, prefer a leading comment.
@@ -234,7 +239,7 @@ function attach(comments, ast, text, options) {
         //   /* comment */
         //   ? first
         //   : second
-        if (isEnclosedByTernary && precedingNode) {
+        if (isPrecedingNodeTestForTernary) {
           addTrailingComment(precedingNode, comment);
         } else {
           addLeadingComment(followingNode, comment);

--- a/tests/conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/conditional/__snapshots__/jsfmt.spec.js.snap
@@ -44,6 +44,34 @@ const { configureStore } = process.env.NODE_ENV === "production"
   ? require("./configureProdStore") // a
   : require("./configureDevStore"); // b
 
+test
+  // ?
+  // comment
+  ? foo
+  : bar;
+
+test
+  /* comment
+     comment
+     comment
+     comment */
+  ? foo
+  : bar;
+
+test ?
+  // ?
+  // comment
+  foo
+  : bar;
+
+test ?
+  /* comment
+     comment
+     comment
+     comment */
+  foo
+  : bar;
+
 =====================================output=====================================
 var inspect =
   4 === util.inspect.length
@@ -68,8 +96,8 @@ var inspect =
       };
 
 const extractTextPluginOptions = shouldUseRelativeAssetPaths
-  ? // Making sure that the publicPath goes back to to build folder.
-    { publicPath: Array(cssFilename.split("/").length).join("../") }
+  // Making sure that the publicPath goes back to to build folder.
+  ? { publicPath: Array(cssFilename.split("/").length).join("../") }
   : {};
 
 const extractTextPluginOptions = shouldUseRelativeAssetPaths
@@ -85,6 +113,34 @@ const { configureStore } =
   process.env.NODE_ENV === "production"
     ? require("./configureProdStore") // a
     : require("./configureDevStore"); // b
+
+test
+  // ?
+  // comment
+  ? foo
+  : bar;
+
+test
+  /* comment
+     comment
+     comment
+     comment */
+  ? foo
+  : bar;
+
+test
+  ? // ?
+    // comment
+    foo
+  : bar;
+
+test
+  ? /* comment
+     comment
+     comment
+     comment */
+    foo
+  : bar;
 
 ================================================================================
 `;

--- a/tests/conditional/comments.js
+++ b/tests/conditional/comments.js
@@ -35,3 +35,31 @@ const extractTextPluginOptions = shouldUseRelativeAssetPaths // Making sure that
 const { configureStore } = process.env.NODE_ENV === "production"
   ? require("./configureProdStore") // a
   : require("./configureDevStore"); // b
+
+test
+  // ?
+  // comment
+  ? foo
+  : bar;
+
+test
+  /* comment
+     comment
+     comment
+     comment */
+  ? foo
+  : bar;
+
+test ?
+  // ?
+  // comment
+  foo
+  : bar;
+
+test ?
+  /* comment
+     comment
+     comment
+     comment */
+  foo
+  : bar;

--- a/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
@@ -90,6 +90,40 @@ let comp = (
 ================================================================================
 `;
 
+exports[`conditional_types.ts 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type Foo = Bar extends Huga
+  // ?
+  // comment
+  ? Bar
+  : Huga;
+
+type Foo = Bar extends Huga ?
+  // ?
+  // comment
+  Bar
+  : Huga;
+
+=====================================output=====================================
+type Foo = Bar extends Huga
+  // ?
+  // comment
+  ? Bar
+  : Huga;
+
+type Foo = Bar extends Huga
+  ? // ?
+    // comment
+    Bar
+  : Huga;
+
+================================================================================
+`;
+
 exports[`jsx.ts 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/typescript_comments/conditional_types.ts
+++ b/tests/typescript_comments/conditional_types.ts
@@ -1,0 +1,11 @@
+type Foo = Bar extends Huga
+  // ?
+  // comment
+  ? Bar
+  : Huga;
+
+type Foo = Bar extends Huga ?
+  // ?
+  // comment
+  Bar
+  : Huga;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fix #2076 

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
