### PR TITLE
TypeScript: Fixed to break line and add a semi in one execution on one line long mapped types

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -437,7 +437,7 @@ const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
 
 #### TypeScript: Fixed to break line and add a semicolon in one execution on one line long mapped types ([#6420] by [@sosukesuzuki])
 
-Previously, when Prettier formats long one line mapped types, breaks line but doesn't add semicolon. This bug also breaks idempotency because it adds a semicolon when run once and then again. This bug also breaks idempotency because it adds a semicolon when run again.
+Previously, when Prettier formatted long, one-line mapped types, it would break the line but didn’t add a semicolon – until you ran Prettier again (which broke Prettier’s idempotency rule). Now, Prettier adds the semicolon in the first run, fixing the issue.
 
 <!-- prettier-ignore -->
 ```ts

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -435,7 +435,7 @@ const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
 )[];
 ```
 
-#### TypeScript: Fixed to break line and add a semicolon in one execution on one line long mapped types ([#] by [@sosukesuzuki])
+#### TypeScript: Fixed to break line and add a semicolon in one execution on one line long mapped types ([#6420] by [@sosukesuzuki])
 
 Previously, when Prettier formats long one line mapped types, breaks line but doesn't add semicolon. This bug also breaks idempotency because it adds a semicolon when run once and then again. This bug also breaks idempotency because it adds a semicolon when run again.
 
@@ -470,7 +470,7 @@ type FooBar<T> = {
 [#6307]: https://github.com/prettier/prettier/pull/6307
 [#6340]: https://github.com/prettier/prettier/pull/6340
 [#6412]: https://github.com/prettier/prettier/pull/6412
-[#]: https://github.com/prettier/prettier/pull/
+[#6420]: https://github.com/prettier/prettier/pull/6420
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
 [@sosukesuzuki]: https://github.com/sosukesuzuki

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -435,6 +435,26 @@ const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
 )[];
 ```
 
+#### TypeScript: Fixed to break line and add a semicolon in one execution on one line long mapped types ([#] by [@sosukesuzuki])
+
+Previously, when Prettier formats long one line mapped types, breaks line but doesn't add semicolon. This bug also breaks idempotency because it adds a semicolon when run once and then again. This bug also breaks idempotency because it adds a semicolon when run again.
+
+<!-- prettier-ignore -->
+```ts
+// Input
+type FooBar<T> = { [P in keyof T]: T[P] extends Something ? Something<T[P]> : T[P] }
+
+// Prettier (stable)
+type FooBar<T> = {
+  [P in keyof T]: T[P] extends Something ? Something<T[P]> : T[P]
+};
+
+// Prettier (master)
+type FooBar<T> = {
+  [P in keyof T]: T[P] extends Something ? Something<T[P]> : T[P];
+};
+```
+
 [#5910]: https://github.com/prettier/prettier/pull/5910
 [#6186]: https://github.com/prettier/prettier/pull/6186
 [#6206]: https://github.com/prettier/prettier/pull/6206
@@ -450,6 +470,7 @@ const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
 [#6307]: https://github.com/prettier/prettier/pull/6307
 [#6340]: https://github.com/prettier/prettier/pull/6340
 [#6412]: https://github.com/prettier/prettier/pull/6412
+[#]: https://github.com/prettier/prettier/pull/
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
 [@sosukesuzuki]: https://github.com/sosukesuzuki

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3260,7 +3260,7 @@ function printPathNoParens(path, options, print, args) {
                 : "",
               ": ",
               path.call(print, "typeAnnotation"),
-              shouldBreak && options.semi ? ";" : ""
+              ifBreak(semi, "")
             ])
           ),
           comments.printDanglingComments(path, options, /* sameIndent */ true),

--- a/tests/typescript_conditional_types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_conditional_types/__snapshots__/jsfmt.spec.js.snap
@@ -32,7 +32,7 @@ export type DeepReadonly<T> = T extends any[]
   : T;
 
 type NonFunctionPropertyNames<T> = {
-  [K in keyof T]: T[K] extends Function ? never : K
+  [K in keyof T]: T[K] extends Function ? never : K;
 }[keyof T];
 
 interface DeepReadonlyArray<T> extends ReadonlyArray<DeepReadonly<T>> {}


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fix #6417 

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
