### PR TITLE
Document behavior of line endins for ranges

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -177,6 +177,8 @@ These two options can be used to format code starting and ending at a given char
 - Backwards to the start of the first line containing the selected statement.
 - Forwards to the end of the selected statement.
 
+On Windows CRLF line endings count as two characters.
+
 These options cannot be used with `cursorOffset`.
 
 | Default    | CLI Override          | API Override        |

--- a/tests/markdown/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown/__snapshots__/jsfmt.spec.js.snap
@@ -646,6 +646,8 @@ These two options can be used to format code starting and ending at a given char
 * Backwards to the start of the first line containing the selected statement.
 * Forwards to the end of the selected statement.
 
+On Windows CRLF line endings count as two characters.
+
 These options cannot be used with \`cursorOffset\`.
 
 Default | CLI Override | API Override
@@ -2625,6 +2627,8 @@ Format only a segment of a file.
 These two options can be used to format code starting and ending at a given character offset (inclusive and exclusive, respectively). The range will extend:
 * Backwards to the start of the first line containing the selected statement.
 * Forwards to the end of the selected statement.
+
+On Windows CRLF line endings count as two characters.
 
 These options cannot be used with \`cursorOffset\`.
 

--- a/tests/markdown/real-world-case.md
+++ b/tests/markdown/real-world-case.md
@@ -637,6 +637,8 @@ These two options can be used to format code starting and ending at a given char
 * Backwards to the start of the first line containing the selected statement.
 * Forwards to the end of the selected statement.
 
+On Windows CRLF line endings count as two characters.
+
 These options cannot be used with `cursorOffset`.
 
 Default | CLI Override | API Override

--- a/website/versioned_docs/version-stable/options.md
+++ b/website/versioned_docs/version-stable/options.md
@@ -178,6 +178,8 @@ These two options can be used to format code starting and ending at a given char
 - Backwards to the start of the first line containing the selected statement.
 - Forwards to the end of the selected statement.
 
+On Windows CRLF line endings count as two characters.
+
 These options cannot be used with `cursorOffset`.
 
 | Default    | CLI Override          | API Override        |


### PR DESCRIPTION
It's not intuitive so I think it should be documented.

Side node: selecting range of lines to format would be much more useful as e.g. git diff output only contains number of lines, not ranges of characters