### PR TITLE
handle empty object patterns with type annotations in function parameters

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -504,6 +504,25 @@ class Class {
 }
 ```
 
+#### JavaScript: Handle empty object patterns with type annotations in function parameters ([#6438] by [@bakkot])
+
+<!-- prettier-ignore -->
+```js
+// Input
+const f = ({}: MyVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongType) => {};
+function g({}: Foo) {}
+
+// Output (Prettier stable)
+const f = ({
+  ,
+}: MyVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongType) => {};
+function g({  }: Foo) {}
+
+// Output (Prettier master)
+const f = ({}: MyVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongType) => {};
+function g({}: Foo) {}
+```
+
 [#5910]: https://github.com/prettier/prettier/pull/5910
 [#6186]: https://github.com/prettier/prettier/pull/6186
 [#6206]: https://github.com/prettier/prettier/pull/6206
@@ -521,6 +540,7 @@ class Class {
 [#6412]: https://github.com/prettier/prettier/pull/6412
 [#6420]: https://github.com/prettier/prettier/pull/6420
 [#6411]: https://github.com/prettier/prettier/pull/6411
+[#6438]: https://github.com/prettier/prettier/pull/6411
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
 [@sosukesuzuki]: https://github.com/sosukesuzuki

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1379,9 +1379,9 @@ function printPathNoParens(path, options, print, args) {
       );
 
       let content;
-      if (props.length === 0 && !n.typeAnnotation) {
+      if (props.length === 0) {
         if (!hasDanglingComments(n)) {
-          return concat([leftBrace, rightBrace]);
+          return concat([leftBrace, rightBrace, printTypeAnnotation(path, options, print)]);
         }
 
         content = group(
@@ -1390,7 +1390,8 @@ function printPathNoParens(path, options, print, args) {
             comments.printDanglingComments(path, options),
             softline,
             rightBrace,
-            printOptionalToken(path)
+            printOptionalToken(path),
+            printTypeAnnotation(path, options, print)
           ])
         );
       } else {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1381,7 +1381,11 @@ function printPathNoParens(path, options, print, args) {
       let content;
       if (props.length === 0) {
         if (!hasDanglingComments(n)) {
-          return concat([leftBrace, rightBrace, printTypeAnnotation(path, options, print)]);
+          return concat([
+            leftBrace,
+            rightBrace,
+            printTypeAnnotation(path, options, print)
+          ]);
         }
 
         content = group(

--- a/tests/flow_parameter_with_type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_parameter_with_type/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`param.js 1`] = `
+====================================options=====================================
+parsers: ["flow", "babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const f = ({}: MyVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongType) => {};
+function g({}: Foo) {}
+
+=====================================output=====================================
+const f = ({}: MyVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongType) => {};
+function g({}: Foo) {}
+
+================================================================================
+`;
+
+exports[`param.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "babel"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+const f = ({}: MyVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongType) => {};
+function g({}: Foo) {}
+
+=====================================output=====================================
+const f = ({}: MyVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongType) => {};
+function g({}: Foo) {}
+
+================================================================================
+`;

--- a/tests/flow_parameter_with_type/jsfmt.spec.js
+++ b/tests/flow_parameter_with_type/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname, ["flow", "babel"]);
+run_spec(__dirname, ["flow", "babel"], { trailingComma: "all" });

--- a/tests/flow_parameter_with_type/param.js
+++ b/tests/flow_parameter_with_type/param.js
@@ -1,0 +1,2 @@
+const f = ({}: MyVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongType) => {};
+function g({}: Foo) {}


### PR DESCRIPTION
Fixes #6435: don't print a trailing comma or extra space when printing an object pattern which is empty but has a type annotation.

This doesn't precisely give the output the OP of that issue asked for, because it doesn't wrap at all - when the parameter is a single array or object pattern, it doesn't allow the parameters to break. But it seems fine, and at least fixes the correctness issue.

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
