### PR TITLE
TypeScript: format TSAsExpression with same logic as BinaryExpression

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -55,8 +55,8 @@ const value = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterfa
 const value = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
 
 // Output (Prettier master)
-const value = thisIsAReallyReallyReallyReallyReallyLongIdentifier as
-  SomeInterface;
+const value =
+  thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
 ```
 
 #### JavaScript: More readable parentheses for new-call ([#6412] by [@bakkot])

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -44,6 +44,21 @@ const link = <a href="example.com">http://example.com</a>;
 
 -->
 
+#### TypeScript: TypeScript: wrap TSAsExpression nodes ([#6450] by [@kaicataldo])
+
+<!-- prettier-ignore -->
+```ts
+// Input
+const value = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
+
+// Output (Prettier stable)
+const value = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
+
+// Output (Prettier master)
+const value = thisIsAReallyReallyReallyReallyReallyLongIdentifier as
+  SomeInterface;
+```
+
 #### JavaScript: More readable parentheses for new-call ([#6412] by [@bakkot])
 
 <!-- prettier-ignore -->

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3099,12 +3099,29 @@ function printPathNoParens(path, options, print, args) {
       return "unknown";
     case "TSVoidKeyword":
       return "void";
-    case "TSAsExpression":
-      return concat([
-        path.call(print, "expression"),
-        " as ",
-        path.call(print, "typeAnnotation")
+    case "TSAsExpression": {
+      const typeText = options.originalText.slice(
+        options.locStart(n.typeAnnotation),
+        options.locEnd(n.typeAnnotation)
+      );
+      // Defer to expansion logic for objects, arrays, and annotations wrapped in parentheses.
+      const mightBeMultiline = /^[({[]/.test(typeText.trim());
+
+      return conditionalGroup([
+        concat([
+          path.call(print, "expression"),
+          " as ",
+          path.call(print, "typeAnnotation")
+        ]),
+        concat([
+          path.call(print, "expression"),
+          " as ",
+          mightBeMultiline
+            ? path.call(print, "typeAnnotation")
+            : indent(concat([softline, path.call(print, "typeAnnotation")]))
+        ])
       ]);
+    }
     case "TSArrayType":
       return concat([path.call(print, "elementType"), "[]"]);
     case "TSPropertySignature": {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -537,7 +537,8 @@ function printPathNoParens(path, options, print, args) {
       );
     case "BinaryExpression":
     case "LogicalExpression":
-    case "NGPipeExpression": {
+    case "NGPipeExpression":
+    case "TSAsExpression": {
       const parent = path.getParentNode();
       const parentParent = path.getParentNode(1);
       const isInsideParenthesis =
@@ -3099,29 +3100,6 @@ function printPathNoParens(path, options, print, args) {
       return "unknown";
     case "TSVoidKeyword":
       return "void";
-    case "TSAsExpression": {
-      const typeText = options.originalText.slice(
-        options.locStart(n.typeAnnotation),
-        options.locEnd(n.typeAnnotation)
-      );
-      // Defer to expansion logic for objects, arrays, and annotations wrapped in parentheses.
-      const mightBeMultiline = /^[({[]/.test(typeText.trim());
-
-      return conditionalGroup([
-        concat([
-          path.call(print, "expression"),
-          " as ",
-          path.call(print, "typeAnnotation")
-        ]),
-        concat([
-          path.call(print, "expression"),
-          " as ",
-          mightBeMultiline
-            ? path.call(print, "typeAnnotation")
-            : indent(concat([softline, path.call(print, "typeAnnotation")]))
-        ])
-      ]);
-    }
     case "TSArrayType":
       return concat([path.call(print, "elementType"), "[]"]);
     case "TSPropertySignature": {
@@ -5828,7 +5806,8 @@ function isBinaryish(node) {
   return (
     node.type === "BinaryExpression" ||
     node.type === "LogicalExpression" ||
-    node.type === "NGPipeExpression"
+    node.type === "NGPipeExpression" ||
+    node.type === "TSAsExpression"
   );
 }
 

--- a/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
@@ -33,6 +33,7 @@ const state = JSON.stringify({
 (foo.bar as any)++;
 
 const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
+const value1 = thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
 const value2 = thisIsAReallyLongIdentifier as (SomeInterface | SomeOtherInterface);
 const value3 = thisIsAReallyLongIdentifier as { prop1: string, prop2: number, prop3: number }[];
 const value4 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [string, number];
@@ -76,6 +77,8 @@ const state = JSON.stringify({
 
 const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as
   SomeInterface;
+const value1 = thisIsAnIdentifier as
+  thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
 const value2 = thisIsAReallyLongIdentifier as (
   | SomeInterface
   | SomeOtherInterface

--- a/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
@@ -9,9 +9,12 @@ printWidth: 80
 const name = (description as DescriptionObject).name || (description as string);
 this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
 (originalError ? wrappedError(errMsg, originalError) : Error(errMsg)) as InjectionError;
-'current' in (props.pagination as Object)
-start + (yearSelectTotal as number)
-scrollTop > (visibilityHeight as number)
+'current' in (props.pagination as Object);
+('current' in props.pagination) as Object;
+start + (yearSelectTotal as number);
+(start + yearSelectTotal) as number;
+scrollTop > (visibilityHeight as number);
+(scrollTop > visibilityHeight) as number;
 export default class Column<T> extends (RcTable.Column as React.ComponentClass<ColumnProps<T>,ColumnProps<T>,ColumnProps<T>,ColumnProps<T>>) {}
 export const MobxTypedForm = class extends (Form as { new (): any }) {}
 export abstract class MobxTypedForm extends (Form as { new (): any }) {}
@@ -33,22 +36,25 @@ const state = JSON.stringify({
 (foo.bar as any)++;
 
 const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
-const value1 = thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
-const value2 = thisIsAReallyLongIdentifier as (SomeInterface | SomeOtherInterface);
-const value3 = thisIsAReallyLongIdentifier as { prop1: string, prop2: number, prop3: number }[];
-const value4 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [string, number];
+const value2 = thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
+const value3 = thisIsAReallyLongIdentifier as (SomeInterface | SomeOtherInterface);
+const value4 = thisIsAReallyLongIdentifier as { prop1: string, prop2: number, prop3: number }[];
+const value5 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [string, number];
 
 (bValue as boolean) ? 0 : -1;
 <boolean>bValue ? 0 : -1;
 
 =====================================output=====================================
-const name = (description as DescriptionObject).name || (description as string);
+const name = (description as DescriptionObject).name || description as string;
 this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
 (originalError ? wrappedError(errMsg, originalError) : Error(errMsg)) as
   InjectionError;
-"current" in (props.pagination as Object);
-start + (yearSelectTotal as number);
-scrollTop > (visibilityHeight as number);
+"current" in props.pagination as Object;
+("current" in props.pagination) as Object;
+start + yearSelectTotal as number;
+(start + yearSelectTotal) as number;
+scrollTop > visibilityHeight as number;
+(scrollTop > visibilityHeight) as number;
 export default class Column<T> extends (RcTable.Column as
   React.ComponentClass<
     ColumnProps<T>,
@@ -75,23 +81,19 @@ const state = JSON.stringify({
 (foo.bar as Baz) = [bar];
 (foo.bar as any)++;
 
-const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as
-  SomeInterface;
-const value1 = thisIsAnIdentifier as
+const value1 =
+  thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
+const value2 =
+  thisIsAnIdentifier as
   thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
-const value2 = thisIsAReallyLongIdentifier as (
-  | SomeInterface
-  | SomeOtherInterface
-);
-const value3 = thisIsAReallyLongIdentifier as {
-  prop1: string;
-  prop2: number;
-  prop3: number;
-}[];
-const value4 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [
-  string,
-  number
-];
+const value3 =
+  thisIsAReallyLongIdentifier as (SomeInterface | SomeOtherInterface);
+const value4 =
+  thisIsAReallyLongIdentifier as
+  { prop1: string; prop2: number; prop3: number }[];
+const value5 =
+  thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as
+  [string, number];
 
 (bValue as boolean) ? 0 : -1;
 <boolean>bValue ? 0 : -1;

--- a/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
@@ -32,25 +32,29 @@ const state = JSON.stringify({
 (foo.bar as Baz) = [bar];
 (foo.bar as any)++;
 
+const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
+const value2 = thisIsAReallyLongIdentifier as (SomeInterface | SomeOtherInterface);
+const value3 = thisIsAReallyLongIdentifier as { prop1: string, prop2: number, prop3: number }[];
+const value4 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [string, number];
+
 (bValue as boolean) ? 0 : -1;
 <boolean>bValue ? 0 : -1;
-
 
 =====================================output=====================================
 const name = (description as DescriptionObject).name || (description as string);
 this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
-(originalError
-  ? wrappedError(errMsg, originalError)
-  : Error(errMsg)) as InjectionError;
+(originalError ? wrappedError(errMsg, originalError) : Error(errMsg)) as
+  InjectionError;
 "current" in (props.pagination as Object);
 start + (yearSelectTotal as number);
 scrollTop > (visibilityHeight as number);
-export default class Column<T> extends (RcTable.Column as React.ComponentClass<
-  ColumnProps<T>,
-  ColumnProps<T>,
-  ColumnProps<T>,
-  ColumnProps<T>
->) {}
+export default class Column<T> extends (RcTable.Column as
+  React.ComponentClass<
+    ColumnProps<T>,
+    ColumnProps<T>,
+    ColumnProps<T>,
+    ColumnProps<T>
+  >) {}
 export const MobxTypedForm = class extends (Form as { new (): any }) {};
 export abstract class MobxTypedForm extends (Form as { new (): any }) {}
 ({} as {});
@@ -69,6 +73,22 @@ const state = JSON.stringify({
 
 (foo.bar as Baz) = [bar];
 (foo.bar as any)++;
+
+const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as
+  SomeInterface;
+const value2 = thisIsAReallyLongIdentifier as (
+  | SomeInterface
+  | SomeOtherInterface
+);
+const value3 = thisIsAReallyLongIdentifier as {
+  prop1: string;
+  prop2: number;
+  prop3: number;
+}[];
+const value4 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [
+  string,
+  number
+];
 
 (bValue as boolean) ? 0 : -1;
 <boolean>bValue ? 0 : -1;

--- a/tests/typescript_as/as.js
+++ b/tests/typescript_as/as.js
@@ -1,9 +1,12 @@
 const name = (description as DescriptionObject).name || (description as string);
 this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
 (originalError ? wrappedError(errMsg, originalError) : Error(errMsg)) as InjectionError;
-'current' in (props.pagination as Object)
-start + (yearSelectTotal as number)
-scrollTop > (visibilityHeight as number)
+'current' in (props.pagination as Object);
+('current' in props.pagination) as Object;
+start + (yearSelectTotal as number);
+(start + yearSelectTotal) as number;
+scrollTop > (visibilityHeight as number);
+(scrollTop > visibilityHeight) as number;
 export default class Column<T> extends (RcTable.Column as React.ComponentClass<ColumnProps<T>,ColumnProps<T>,ColumnProps<T>,ColumnProps<T>>) {}
 export const MobxTypedForm = class extends (Form as { new (): any }) {}
 export abstract class MobxTypedForm extends (Form as { new (): any }) {}
@@ -25,10 +28,10 @@ const state = JSON.stringify({
 (foo.bar as any)++;
 
 const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
-const value1 = thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
-const value2 = thisIsAReallyLongIdentifier as (SomeInterface | SomeOtherInterface);
-const value3 = thisIsAReallyLongIdentifier as { prop1: string, prop2: number, prop3: number }[];
-const value4 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [string, number];
+const value2 = thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
+const value3 = thisIsAReallyLongIdentifier as (SomeInterface | SomeOtherInterface);
+const value4 = thisIsAReallyLongIdentifier as { prop1: string, prop2: number, prop3: number }[];
+const value5 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [string, number];
 
 (bValue as boolean) ? 0 : -1;
 <boolean>bValue ? 0 : -1;

--- a/tests/typescript_as/as.js
+++ b/tests/typescript_as/as.js
@@ -24,6 +24,10 @@ const state = JSON.stringify({
 (foo.bar as Baz) = [bar];
 (foo.bar as any)++;
 
+const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
+const value2 = thisIsAReallyLongIdentifier as (SomeInterface | SomeOtherInterface);
+const value3 = thisIsAReallyLongIdentifier as { prop1: string, prop2: number, prop3: number }[];
+const value4 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [string, number];
+
 (bValue as boolean) ? 0 : -1;
 <boolean>bValue ? 0 : -1;
-

--- a/tests/typescript_as/as.js
+++ b/tests/typescript_as/as.js
@@ -25,6 +25,7 @@ const state = JSON.stringify({
 (foo.bar as any)++;
 
 const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
+const value1 = thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
 const value2 = thisIsAReallyLongIdentifier as (SomeInterface | SomeOtherInterface);
 const value3 = thisIsAReallyLongIdentifier as { prop1: string, prop2: number, prop3: number }[];
 const value4 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [string, number];

--- a/tests/typescript_union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_union/__snapshots__/jsfmt.spec.js.snap
@@ -190,10 +190,8 @@ type State = {
   | { discriminant: "BAZ"; baz: any }
 );
 
-const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
-  | string
-  | undefined
-)[];
+const foo =
+  [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (string | undefined)[];
 
 const foo: (
   | AAAAAAAAAAAAAAAAAAAAAA


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

 fixes https://github.com/prettier/prettier/issues/6443.

I took a stab at working on wrapping `TSAsExpression` nodes! ~~In taking a look at this, it looks like the behavior of moving the initial declaration value up to the same line as the `=` operator happens with other declarations and I think the change might have to happen in that logic (here's an example using the [Prettier playground](https://prettier.io/playground/#N4Igxg9gdgLgprEAuc0DOMAEBDTBeTAHSk1LLQGsATAKwDMALbNAG2vqcqsZuerpqd+ggPw40VCgM5U205i0nyJc3gxV0KvNAyoS6+zEkz79AbmLFIUDJgBG+IiTKkuHBe0Z9uDbcKHc2kqCzLJSIazBMqrY6rKa2roS+qF0Bnrc5iAANCAQAA4wAJboyKDYAE4VEADuAAqVCGjIINgAbhBFVDkgdhXYYBRwMADK+QNFUADmyDAVAK5wuQwwALYsAOoMRfBo42BwI007RW07AJ4tYGjNuZNocBUwdf1Tq9jIdNgsD7k0aAAPABC-UGwxG2FWcAAMpM4J9vr8QP8ASNJlMWHAAIrzCDwBE-JYgcYVB4VFp2bB2c4saA9fIVSYwDZdGAMZAADgADLkGRAHht+vkWgy4GS2vDcgBHXHwF4FZooZgAWigcDgVA1PQqcBlRR1L2wbw+SC+hNyD1WRVmCyJaHRmJxePhpsRRJgVJZVDZyAATLk5tgiix0QBhCCrd4tKDQSUgeYPAAqVMVZoeAF900A)).~~

~~This PR instead focuses on wrapping the `TSAsExpression` node correctly (ensuring that the line break occurs after the `as` operator).~~

This now takes a different approach and converts the `TSAsExpression` node to match the `BinaryExpression` node interface so we can use the same formatting logic for both.

I'm pretty new to the Prettier codebase, and any and all guidance is very welcome!

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
