### PR TITLE
docs: add prettier-plugin-package to community plugins

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -52,6 +52,7 @@ Providing at least one path to `--plugin-search-dir`/`pluginSearchDirs` turns of
 - [`prettier-plugin-elm`](https://github.com/gicentre/prettier-plugin-elm) by [**@giCentre**](https://github.com/gicentre)
 - [`prettier-plugin-java`](https://github.com/jhipster/prettier-java) by [**@JHipster**](https://github.com/jhipster)
 - [`prettier-plugin-kotlin`](https://github.com/Angry-Potato/prettier-plugin-kotlin) by [**@Angry-Potato**](https://github.com/Angry-Potato)
+- [`prettier-plugin-package`](https://github.com/shellscape/prettier-plugin-package) by [**@shellscape**](https://github.com/shellscape)
 - [`prettier-plugin-packagejson`](https://github.com/matzkoh/prettier-plugin-packagejson) by [**@matzkoh**](https://github.com/matzkoh)
 - [`prettier-plugin-pg`](https://github.com/benjie/prettier-plugin-pg) by [**@benjie**](https://github.com/benjie)
 - [`prettier-plugin-solidity`](https://github.com/prettier-solidity/prettier-plugin-solidity) by [**@mattiaerre**](https://github.com/mattiaerre)


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
This is a Documentation PR which proposes to add [`prettier-plugin-package`](https://github.com/shellscape/prettier-plugin-package) to the list of Community Plugins.

Acknowledging that `prettier-plugin-packagejson` already exists, the plugin I am proposing to add is functionally different:

- leverages `parser` rather than `preprocess`. This means that Prettier's parsing and error handling is run before modification, and results in a good user experience. Especially important for `package.json` files containing errors. 
- no extraneous `JSON.stringify` or `JSON.parse` calls
- root sorting based on well-known and prolific package author's preferences

I'm not sure if there is a standard or bar that must be met to have a plugin included in this list, but if it's compelling, the Rollup project will be using the plugin for the organization in the near future. I'm also open to suggestions for how to improve the plugin. There isn't much documentation out there on plugins at the moment, so please do share any thoughts. 

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
