### PR TITLE
Handlebars: fix spaces in dynamic element class name

### DIFF
--- a/changelog_unreleased/handlebars/pr-6464.md
+++ b/changelog_unreleased/handlebars/pr-6464.md
@@ -1,0 +1,31 @@
+#### Fix spaces in dynamic element class name ([#6464](https://github.com/prettier/prettier/pull/6464) by [@FabHof](https://github.com/FabHof))
+
+<!-- prettier-ignore -->
+```hbs
+{{!-- Input --}}
+<div class="  hello {{if goodbye true}}{{if goodbye false}} hello{{if goodbye true}}   hello   {{if goodbye false}}hello {{if goodbye true}} hello  ">
+  hello
+</div>
+
+{{!-- Prettier stable --}}
+<div
+  class="hello {{if goodbye true}}{{if goodbye false}} hello{{
+    if goodbye true
+  }} hello {{if goodbye false}}hello {{if goodbye true}} hello"
+>
+  hello
+</div>
+
+{{!-- Prettier master --}}
+<div
+  class="hello
+    {{if goodbye true}}{{if goodbye false}}
+    hello{{if goodbye true}}
+    hello
+    {{if goodbye false}}hello
+    {{if goodbye true}}
+    hello"
+>
+  hello
+</div>
+```

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -346,7 +346,7 @@ function print(path, options, print) {
         }
       }
 
-      let trimmedChars = n.chars
+      const trimmedChars = n.chars
         .replace(/^[\s ]+/g, leadingSpace)
         .replace(/[\s ]+$/, trailingSpace);
 

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -304,14 +304,14 @@ function print(path, options, print) {
           const isAfterMustache =
             previousNode && previousNode.type === "MustacheStatement";
           const startsWithWhitespace = /^\s/.test(n.chars);
-          if (isAfterMustache && startsWithWhitespace) {
+          if (isAfterMustache && startsWithWhitespace && leadingLineBreaksCount === 0) {
             leadingLine = line;
           }
           const nextNode = getNextNode(path);
           const isBeforeMustache =
             nextNode && nextNode.type === "MustacheStatement";
           const endsWithWhitespace = /\s$/.test(n.chars);
-          if (isBeforeMustache && endsWithWhitespace) {
+          if (isBeforeMustache && endsWithWhitespace && trailingLineBreaksCount === 0) {
             trailingLine = line;
           }
         }
@@ -341,13 +341,15 @@ function print(path, options, print) {
         }
       }
 
+      let chars = n.chars
+      .replace(/^[\s ]+/g, leadingSpace)
+      .replace(/[\s ]+$/, trailingSpace)
+
       return concat(
         [
           ...generateHardlines(leadingLineBreaksCount, maxLineBreaksToPreserve),
           leadingLine,
-          n.chars
-            .replace(/^[\s ]+/g, leadingSpace)
-            .replace(/[\s ]+$/, trailingSpace),
+          chars,
           trailingLine,
           ...generateHardlines(trailingLineBreaksCount, maxLineBreaksToPreserve)
         ].filter(Boolean)

--- a/tests/glimmer/preserved-spaces-and-breaks.hbs
+++ b/tests/glimmer/preserved-spaces-and-breaks.hbs
@@ -1,0 +1,44 @@
+<SomeComponent />
+{{name}}
+
+
+
+Some sentence with  {{dynamic}}  expressions.
+
+sometimes{{nogaps}}areimportant<Hello></Hello>
+
+
+{{name}}  is your name
+
+
+{{#block}}
+{{/block}}
+
+
+{{#block}}
+  some {{text}}
+{{/block}}
+
+{{#block}}
+
+  some {{text}}
+{{/block}}
+
+<HelloWorld>
+</HelloWorld>
+
+<HelloWorld>
+  some {{text}}
+</HelloWorld>
+
+<HelloWorld>
+
+  some {{text}}
+</HelloWorld>
+
+<div class="a list of classes">
+</div>
+
+<div class="a list of classes">
+
+</div>

--- a/tests/handlebars-concat-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars-concat-statement/__snapshots__/jsfmt.spec.js.snap
@@ -10,7 +10,7 @@ printWidth: 80
   Hello
 </div>
 
-<div class="hello {{if goodbye true}} {{if goodbye false}} {{if goodbye true}} {{if goodbye false}} {{if goodbye true}}">
+<div class="  hello {{if goodbye true}}{{if goodbye false}} hello{{if goodbye true}}   hello   {{if goodbye false}}hello {{if goodbye true}} hello  ">
   Hello
 </div>
 
@@ -26,15 +26,20 @@ printWidth: 80
 <div class="class-k {{myClass}}   class-l"></div>
 <div class="  class-m   {{myClass}}     class-n {{myClass}}class-o   "></div>
 <div class="  class-p  class-q"></div>
+<div class="  {{myClass}}  {{myClass}}  "></div>
 =====================================output=====================================
 <div class="hello {{if goodbye true}}">
   Hello
 </div>
 
 <div
-  class="hello {{if goodbye true}} {{if goodbye false}} {{if goodbye true}} {{
-    if goodbye false
-  }} {{if goodbye true}}"
+  class="hello
+    {{if goodbye true}}{{if goodbye false}}
+    hello{{if goodbye true}}
+    hello
+    {{if goodbye false}}hello
+    {{if goodbye true}}
+    hello"
 >
   Hello
 </div>
@@ -51,6 +56,7 @@ printWidth: 80
 <div class="class-k {{myClass}} class-l"></div>
 <div class="class-m {{myClass}} class-n {{myClass}}class-o"></div>
 <div class="class-p  class-q"></div>
+<div class="{{myClass}} {{myClass}}"></div>
 ================================================================================
 `;
 
@@ -65,7 +71,7 @@ singleQuote: true
   Hello
 </div>
 
-<div class="hello {{if goodbye true}} {{if goodbye false}} {{if goodbye true}} {{if goodbye false}} {{if goodbye true}}">
+<div class="  hello {{if goodbye true}}{{if goodbye false}} hello{{if goodbye true}}   hello   {{if goodbye false}}hello {{if goodbye true}} hello  ">
   Hello
 </div>
 
@@ -81,15 +87,20 @@ singleQuote: true
 <div class="class-k {{myClass}}   class-l"></div>
 <div class="  class-m   {{myClass}}     class-n {{myClass}}class-o   "></div>
 <div class="  class-p  class-q"></div>
+<div class="  {{myClass}}  {{myClass}}  "></div>
 =====================================output=====================================
 <div class="hello {{if goodbye true}}">
   Hello
 </div>
 
 <div
-  class="hello {{if goodbye true}} {{if goodbye false}} {{if goodbye true}} {{
-    if goodbye false
-  }} {{if goodbye true}}"
+  class="hello
+    {{if goodbye true}}{{if goodbye false}}
+    hello{{if goodbye true}}
+    hello
+    {{if goodbye false}}hello
+    {{if goodbye true}}
+    hello"
 >
   Hello
 </div>
@@ -106,6 +117,7 @@ singleQuote: true
 <div class="class-k {{myClass}} class-l"></div>
 <div class="class-m {{myClass}} class-n {{myClass}}class-o"></div>
 <div class='class-p  class-q'></div>
+<div class="{{myClass}} {{myClass}}"></div>
 ================================================================================
 `;
 
@@ -125,23 +137,24 @@ printWidth: 80
 
 =====================================output=====================================
 <div
-  class="a very long list of classes that exceeds {{
-    eighty
-  }} chars with emtpy spaces"
+  class="a very long list of classes that exceeds
+    {{eighty}}
+    chars with emtpy spaces"
 >
   hey
 </div>
 <a
   href="a-very-long-href-from-a-third-party-marketing-platform{{
-    id
-  }}longer-than-eighty-chars"
+      id
+    }}longer-than-eighty-chars"
 >
   Link
 </a>
 <button
   class="uk-padding-remove uk-button uk-button-default uk-button-small uk-width-1-{{
-    intl.locales.length
-  }} {{if (contains locale intl.locale) "uk-button-primary"}}"
+      intl.locales.length
+    }}
+    {{if (contains locale intl.locale) "uk-button-primary"}}"
 >
   test
 </button>
@@ -165,23 +178,24 @@ singleQuote: true
 
 =====================================output=====================================
 <div
-  class="a very long list of classes that exceeds {{
-    eighty
-  }} chars with emtpy spaces"
+  class="a very long list of classes that exceeds
+    {{eighty}}
+    chars with emtpy spaces"
 >
   hey
 </div>
 <a
   href="a-very-long-href-from-a-third-party-marketing-platform{{
-    id
-  }}longer-than-eighty-chars"
+      id
+    }}longer-than-eighty-chars"
 >
   Link
 </a>
 <button
   class="uk-padding-remove uk-button uk-button-default uk-button-small uk-width-1-{{
-    intl.locales.length
-  }} {{if (contains locale intl.locale) 'uk-button-primary'}}"
+      intl.locales.length
+    }}
+    {{if (contains locale intl.locale) 'uk-button-primary'}}"
 >
   test
 </button>

--- a/tests/handlebars-concat-statement/concat-statement.hbs
+++ b/tests/handlebars-concat-statement/concat-statement.hbs
@@ -2,7 +2,7 @@
   Hello
 </div>
 
-<div class="hello {{if goodbye true}} {{if goodbye false}} {{if goodbye true}} {{if goodbye false}} {{if goodbye true}}">
+<div class="  hello {{if goodbye true}}{{if goodbye false}} hello{{if goodbye true}}   hello   {{if goodbye false}}hello {{if goodbye true}} hello  ">
   Hello
 </div>
 
@@ -18,3 +18,4 @@
 <div class="class-k {{myClass}}   class-l"></div>
 <div class="  class-m   {{myClass}}     class-n {{myClass}}class-o   "></div>
 <div class="  class-p  class-q"></div>
+<div class="  {{myClass}}  {{myClass}}  "></div>

--- a/tests/handlebars-mustache-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars-mustache-statement/__snapshots__/jsfmt.spec.js.snap
@@ -77,41 +77,39 @@ printWidth: 80
 />
 
 <div
-  class="a long list of classes more than 80 chars with a complex mustache statement {{
-    if (or this.a this.b) this.c this.d
-  }}"
+  class="a long list of classes more than 80 chars with a complex mustache statement
+    {{if (or this.a this.b) this.c this.d}}"
 >
 </div>
 
 <div
   class="a multi line list of classes with a complex mustache statement
-  {{if (or this.a this.b) this.c this.d}}"
+
+    {{if (or this.a this.b) this.c this.d}}"
 >
 </div>
 
 <div
-  class="a-first-class {{if this.optionOne "optionOne"}} {{
-    if this.optionTwo "optionTwo"
-  }} {{if this.optionThree "optionThree"}} {{
-    if this.optionFour "optionFour"
-  }} {{if this.optionFive "optionFive"}} {{this.class}}"
+  class="a-first-class
+    {{if this.optionOne "optionOne"}}
+    {{if this.optionTwo "optionTwo"}}
+    {{if this.optionThree "optionThree"}}
+    {{if this.optionFour "optionFour"}}
+    {{if this.optionFive "optionFive"}}
+    {{this.class}}"
   ...attributes
 >
 </div>
 
 <div
   class="a-first-class
-  {{if this.optionOne "optionOne"}}
 
-   {{if this.optionTwo "optionTwo"}}
-
-   {{if this.optionThree "optionThree"}}
-
-   {{if this.optionFour "optionFour"}}
-
-   {{if this.optionFive "optionFive"}}
-
-   {{this.class}}"
+    {{if this.optionOne "optionOne"}}
+    {{if this.optionTwo "optionTwo"}}
+    {{if this.optionThree "optionThree"}}
+    {{if this.optionFour "optionFour"}}
+    {{if this.optionFive "optionFive"}}
+    {{this.class}}"
   ...attributes
 >
 </div>
@@ -196,41 +194,39 @@ singleQuote: true
 />
 
 <div
-  class="a long list of classes more than 80 chars with a complex mustache statement {{
-    if (or this.a this.b) this.c this.d
-  }}"
+  class="a long list of classes more than 80 chars with a complex mustache statement
+    {{if (or this.a this.b) this.c this.d}}"
 >
 </div>
 
 <div
   class="a multi line list of classes with a complex mustache statement
-  {{if (or this.a this.b) this.c this.d}}"
+
+    {{if (or this.a this.b) this.c this.d}}"
 >
 </div>
 
 <div
-  class="a-first-class {{if this.optionOne 'optionOne'}} {{
-    if this.optionTwo 'optionTwo'
-  }} {{if this.optionThree 'optionThree'}} {{
-    if this.optionFour 'optionFour'
-  }} {{if this.optionFive 'optionFive'}} {{this.class}}"
+  class="a-first-class
+    {{if this.optionOne 'optionOne'}}
+    {{if this.optionTwo 'optionTwo'}}
+    {{if this.optionThree 'optionThree'}}
+    {{if this.optionFour 'optionFour'}}
+    {{if this.optionFive 'optionFive'}}
+    {{this.class}}"
   ...attributes
 >
 </div>
 
 <div
   class="a-first-class
-  {{if this.optionOne 'optionOne'}}
 
-   {{if this.optionTwo 'optionTwo'}}
-
-   {{if this.optionThree 'optionThree'}}
-
-   {{if this.optionFour 'optionFour'}}
-
-   {{if this.optionFive 'optionFive'}}
-
-   {{this.class}}"
+    {{if this.optionOne 'optionOne'}}
+    {{if this.optionTwo 'optionTwo'}}
+    {{if this.optionThree 'optionThree'}}
+    {{if this.optionFour 'optionFour'}}
+    {{if this.optionFive 'optionFive'}}
+    {{this.class}}"
   ...attributes
 >
 </div>

--- a/tests/handlebars-mustache-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars-mustache-statement/__snapshots__/jsfmt.spec.js.snap
@@ -84,7 +84,6 @@ printWidth: 80
 
 <div
   class="a multi line list of classes with a complex mustache statement
-
     {{if (or this.a this.b) this.c this.d}}"
 >
 </div>
@@ -103,7 +102,6 @@ printWidth: 80
 
 <div
   class="a-first-class
-
     {{if this.optionOne "optionOne"}}
     {{if this.optionTwo "optionTwo"}}
     {{if this.optionThree "optionThree"}}
@@ -201,7 +199,6 @@ singleQuote: true
 
 <div
   class="a multi line list of classes with a complex mustache statement
-
     {{if (or this.a this.b) this.c this.d}}"
 >
 </div>
@@ -220,7 +217,6 @@ singleQuote: true
 
 <div
   class="a-first-class
-
     {{if this.optionOne 'optionOne'}}
     {{if this.optionTwo 'optionTwo'}}
     {{if this.optionThree 'optionThree'}}


### PR DESCRIPTION
Should fix #6207 and #6252

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**

