### PR TITLE
TypeScript: Keep type parameters inline for a variable declaration

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -663,6 +663,22 @@ switch (
 }
 ```
 
+#### TypeScript: Keep type parameters inline for a type annotation of variable declaration ([#] by [@sosukesuzuki])
+
+<!-- prettier-ignore -->
+```ts
+// Input
+const fooooooooooooooo: SomeThing<boolean> = looooooooooooooooooooooooooooooongNameFunc();
+
+// Prettier (stable)
+const fooooooooooooooo: SomeThing<
+  boolean
+> = looooooooooooooooooooooooooooooongNameFunc();
+
+// Prettier (master)
+const fooooooooooooooo: SomeThing<boolean> = looooooooooooooooooooooooooooooongNameFunc();
+```
+
 [#5910]: https://github.com/prettier/prettier/pull/5910
 [#6186]: https://github.com/prettier/prettier/pull/6186
 [#6206]: https://github.com/prettier/prettier/pull/6206
@@ -686,6 +702,7 @@ switch (
 [#6446]: https://github.com/prettier/prettier/pull/6446
 [#6506]: https://github.com/prettier/prettier/pull/6506
 [#6514]: https://github.com/prettier/prettier/pull/6514
+[#]: https://github.com/prettier/prettier/pull/
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
 [@sosukesuzuki]: https://github.com/sosukesuzuki

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -663,7 +663,7 @@ switch (
 }
 ```
 
-#### TypeScript: Keep type parameters inline for a type annotation of variable declaration ([#] by [@sosukesuzuki])
+#### TypeScript: Keep type parameters inline for a type annotation of variable declaration ([#6467] by [@sosukesuzuki])
 
 <!-- prettier-ignore -->
 ```ts
@@ -702,7 +702,7 @@ const fooooooooooooooo: SomeThing<boolean> = looooooooooooooooooooooooooooooongN
 [#6446]: https://github.com/prettier/prettier/pull/6446
 [#6506]: https://github.com/prettier/prettier/pull/6506
 [#6514]: https://github.com/prettier/prettier/pull/6514
-[#]: https://github.com/prettier/prettier/pull/
+[#6467]: https://github.com/prettier/prettier/pull/6467
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
 [@sosukesuzuki]: https://github.com/sosukesuzuki

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4711,6 +4711,7 @@ function printTypeParameters(path, options, print, paramsKey) {
   }
 
   const grandparent = path.getNode(2);
+  const greatGreatGrandParent = path.getNode(4);
 
   const isParameterInTestCall = grandparent != null && isTestCall(grandparent);
 
@@ -4723,7 +4724,13 @@ function printTypeParameters(path, options, print, paramsKey) {
           shouldHugType(n[paramsKey][0].id)) ||
         (n[paramsKey][0].type === "TSTypeReference" &&
           shouldHugType(n[paramsKey][0].typeName)) ||
-        n[paramsKey][0].type === "NullableTypeAnnotation"));
+        n[paramsKey][0].type === "NullableTypeAnnotation" ||
+        (greatGreatGrandParent &&
+          greatGreatGrandParent.type === "VariableDeclarator" &&
+          grandparent &&
+          grandparent.type === "TSTypeAnnotation" &&
+          n[paramsKey][0].type !== "TSConditionalType" &&
+          n[paramsKey][0].type !== "TSMappedType")));
 
   if (shouldInline) {
     return concat(["<", join(", ", path.map(print, paramsKey)), ">"]);

--- a/tests/typescript/custom/typeParameters/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/custom/typeParameters/__snapshots__/jsfmt.spec.js.snap
@@ -123,6 +123,12 @@ const fooooooooooooooo: SomeThing<boolean> = looooooooooooooooooooooooooooooongN
 const baaaaaaaaaaaaaaaaaaaaar: SomeThing<boolean, boolean> = looooooooooooooooooooooooooooooongNameFunc();
 const baaaaaaaaaaaaaaar: SomeThing<{ [P in "x" | "y"]: number }> = looooooooooooooooooooooooooooooongNameFunc();
 const baaaaaaaaaaaaaaaar: SomeThing<K extends T ? G : S> = looooooooooooooooooooooooooooooongNameFunc();
+const isAnySuccessfulAttempt$: Observable<boolean> = this._quizService.isAnySuccessfulAttempt$().pipe(
+  tap((isAnySuccessfulAttempt: boolean) => {
+    this.isAnySuccessfulAttempt = isAnySuccessfulAttempt;
+  }),
+);
+const isAnySuccessfulAttempt$: Observable<boolean> = this._someMethodWithLongName();
 
 =====================================output=====================================
 const foo: SomeThing<boolean> = func();
@@ -140,6 +146,14 @@ const baaaaaaaaaaaaaaar: SomeThing<
 const baaaaaaaaaaaaaaaar: SomeThing<
   K extends T ? G : S
 > = looooooooooooooooooooooooooooooongNameFunc();
+const isAnySuccessfulAttempt$: Observable<boolean> = this._quizService
+  .isAnySuccessfulAttempt$()
+  .pipe(
+    tap((isAnySuccessfulAttempt: boolean) => {
+      this.isAnySuccessfulAttempt = isAnySuccessfulAttempt;
+    })
+  );
+const isAnySuccessfulAttempt$: Observable<boolean> = this._someMethodWithLongName();
 
 ================================================================================
 `;

--- a/tests/typescript/custom/typeParameters/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/custom/typeParameters/__snapshots__/jsfmt.spec.js.snap
@@ -115,12 +115,20 @@ parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
+const foo: SomeThing<boolean> = func();
+const bar: SomeThing<boolean, boolean> = func();
+const fooo: SomeThing<{ [P in "x" | "y"]: number }> = func();
+const baar: SomeThing<K extends T ? G : S> = func();
 const fooooooooooooooo: SomeThing<boolean> = looooooooooooooooooooooooooooooongNameFunc();
 const baaaaaaaaaaaaaaaaaaaaar: SomeThing<boolean, boolean> = looooooooooooooooooooooooooooooongNameFunc();
 const baaaaaaaaaaaaaaar: SomeThing<{ [P in "x" | "y"]: number }> = looooooooooooooooooooooooooooooongNameFunc();
 const baaaaaaaaaaaaaaaar: SomeThing<K extends T ? G : S> = looooooooooooooooooooooooooooooongNameFunc();
 
 =====================================output=====================================
+const foo: SomeThing<boolean> = func();
+const bar: SomeThing<boolean, boolean> = func();
+const fooo: SomeThing<{ [P in "x" | "y"]: number }> = func();
+const baar: SomeThing<K extends T ? G : S> = func();
 const fooooooooooooooo: SomeThing<boolean> = looooooooooooooooooooooooooooooongNameFunc();
 const baaaaaaaaaaaaaaaaaaaaar: SomeThing<
   boolean,

--- a/tests/typescript/custom/typeParameters/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/custom/typeParameters/__snapshots__/jsfmt.spec.js.snap
@@ -108,3 +108,30 @@ type ReallyReallyReallyLongName<
 
 ================================================================================
 `;
+
+exports[`variables.ts 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const fooooooooooooooo: SomeThing<boolean> = looooooooooooooooooooooooooooooongNameFunc();
+const baaaaaaaaaaaaaaaaaaaaar: SomeThing<boolean, boolean> = looooooooooooooooooooooooooooooongNameFunc();
+const baaaaaaaaaaaaaaar: SomeThing<{ [P in "x" | "y"]: number }> = looooooooooooooooooooooooooooooongNameFunc();
+const baaaaaaaaaaaaaaaar: SomeThing<K extends T ? G : S> = looooooooooooooooooooooooooooooongNameFunc();
+
+=====================================output=====================================
+const fooooooooooooooo: SomeThing<boolean> = looooooooooooooooooooooooooooooongNameFunc();
+const baaaaaaaaaaaaaaaaaaaaar: SomeThing<
+  boolean,
+  boolean
+> = looooooooooooooooooooooooooooooongNameFunc();
+const baaaaaaaaaaaaaaar: SomeThing<
+  { [P in "x" | "y"]: number }
+> = looooooooooooooooooooooooooooooongNameFunc();
+const baaaaaaaaaaaaaaaar: SomeThing<
+  K extends T ? G : S
+> = looooooooooooooooooooooooooooooongNameFunc();
+
+================================================================================
+`;

--- a/tests/typescript/custom/typeParameters/variables.ts
+++ b/tests/typescript/custom/typeParameters/variables.ts
@@ -6,3 +6,9 @@ const fooooooooooooooo: SomeThing<boolean> = looooooooooooooooooooooooooooooongN
 const baaaaaaaaaaaaaaaaaaaaar: SomeThing<boolean, boolean> = looooooooooooooooooooooooooooooongNameFunc();
 const baaaaaaaaaaaaaaar: SomeThing<{ [P in "x" | "y"]: number }> = looooooooooooooooooooooooooooooongNameFunc();
 const baaaaaaaaaaaaaaaar: SomeThing<K extends T ? G : S> = looooooooooooooooooooooooooooooongNameFunc();
+const isAnySuccessfulAttempt$: Observable<boolean> = this._quizService.isAnySuccessfulAttempt$().pipe(
+  tap((isAnySuccessfulAttempt: boolean) => {
+    this.isAnySuccessfulAttempt = isAnySuccessfulAttempt;
+  }),
+);
+const isAnySuccessfulAttempt$: Observable<boolean> = this._someMethodWithLongName();

--- a/tests/typescript/custom/typeParameters/variables.ts
+++ b/tests/typescript/custom/typeParameters/variables.ts
@@ -1,3 +1,7 @@
+const foo: SomeThing<boolean> = func();
+const bar: SomeThing<boolean, boolean> = func();
+const fooo: SomeThing<{ [P in "x" | "y"]: number }> = func();
+const baar: SomeThing<K extends T ? G : S> = func();
 const fooooooooooooooo: SomeThing<boolean> = looooooooooooooooooooooooooooooongNameFunc();
 const baaaaaaaaaaaaaaaaaaaaar: SomeThing<boolean, boolean> = looooooooooooooooooooooooooooooongNameFunc();
 const baaaaaaaaaaaaaaar: SomeThing<{ [P in "x" | "y"]: number }> = looooooooooooooooooooooooooooooongNameFunc();

--- a/tests/typescript/custom/typeParameters/variables.ts
+++ b/tests/typescript/custom/typeParameters/variables.ts
@@ -1,0 +1,4 @@
+const fooooooooooooooo: SomeThing<boolean> = looooooooooooooooooooooooooooooongNameFunc();
+const baaaaaaaaaaaaaaaaaaaaar: SomeThing<boolean, boolean> = looooooooooooooooooooooooooooooongNameFunc();
+const baaaaaaaaaaaaaaar: SomeThing<{ [P in "x" | "y"]: number }> = looooooooooooooooooooooooooooooongNameFunc();
+const baaaaaaaaaaaaaaaar: SomeThing<K extends T ? G : S> = looooooooooooooooooooooooooooooongNameFunc();


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fix #5684 

I understand that this fix doesn't make much sense in practice. But, since its behavior is a bug, I created pr.

```ts
// Input
const fooooooooooooooo: SomeThing<boolean> = looooooooooooooooooooooooooooooongNameFunc();

// Prettier (stable)
const fooooooooooooooo: SomeThing<
  boolean
> = looooooooooooooooooooooooooooooongNameFunc();

// Prettier (master)
const fooooooooooooooo: SomeThing<boolean> = looooooooooooooooooooooooooooooongNameFunc();
```

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
