### PR TITLE
clarify devDependencies in package.json

### DIFF
--- a/docs/integrating-with-linters.md
+++ b/docs/integrating-with-linters.md
@@ -9,13 +9,13 @@ This allows you to use Prettier for code formatting concerns, while letting your
 Whatever linting tool you wish to integrate with, the steps are broadly similar.
 First disable any existing formatting rules in your linter that may conflict with how Prettier wishes to format your code. Then you can either add an extension to your linting tool to format your file with Prettier - so that you only need a single command for format a file, or run your linter then Prettier as separate steps.
 
-All these instructions assume you have already installed `prettier` in your `devDependencies`.
+All these instructions assume you have already installed `prettier` in your `package.json` section of `devDependencies`.
 
 ## ESLint
 
 ### Disable formatting rules
 
-[`eslint-config-prettier`](https://github.com/prettier/eslint-config-prettier) is a config that disables rules that conflict with Prettier. Add it to your `devDependencies`, then extend from it within your `.eslintrc` configuration. Make sure to put it last in the `extends` array, so it gets the chance to override other configs.
+[`eslint-config-prettier`](https://github.com/prettier/eslint-config-prettier) is a config that disables rules that conflict with Prettier. Add it to your `package.json` section of `devDependencies`, then extend from it within your `.eslintrc` configuration. Make sure to put it last in the `extends` array, so it gets the chance to override other configs.
 
 ```bash
 yarn add --dev eslint-config-prettier
@@ -31,7 +31,7 @@ Then in `.eslintrc.json`:
 
 ### Use ESLint to run Prettier
 
-[`eslint-plugin-prettier`](https://github.com/prettier/eslint-plugin-prettier) is a plugin that adds a rule that formats content using Prettier. Add it to your `devDependencies`, then enable the plugin and rule.
+[`eslint-plugin-prettier`](https://github.com/prettier/eslint-plugin-prettier) is a plugin that adds a rule that formats content using Prettier. Add it to your `package.json` section of `devDependencies`, then enable the plugin and rule.
 
 ```bash
 yarn add --dev eslint-plugin-prettier
@@ -68,7 +68,7 @@ Then in `.eslintrc.json`:
 
 ### Disable formatting rules
 
-[`tslint-config-prettier`](https://github.com/alexjoverm/tslint-config-prettier) is a config that disables rules that conflict with Prettier. Add it to your `devDependencies`, then extend from it within your `tslint.json` configuration. Make sure to put it last in the `extends` array, so it gets the chance to override other configs.
+[`tslint-config-prettier`](https://github.com/alexjoverm/tslint-config-prettier) is a config that disables rules that conflict with Prettier. Add it to your `package.json` section of `devDependencies`, then extend from it within your `tslint.json` configuration. Make sure to put it last in the `extends` array, so it gets the chance to override other configs.
 
 ```bash
 yarn add --dev tslint-config-prettier
@@ -84,7 +84,7 @@ Then in `tslint.json`:
 
 ### Use TSLint to run Prettier
 
-[`tslint-plugin-prettier`](https://github.com/ikatyang/tslint-plugin-prettier) is a plugin that adds a rule that formats content using Prettier. Add it to your `devDependencies`, then enable the plugin and rule.
+[`tslint-plugin-prettier`](https://github.com/ikatyang/tslint-plugin-prettier) is a plugin that adds a rule that formats content using Prettier. Add it to your `package.json` section of `devDependencies`, then enable the plugin and rule.
 
 ```bash
 yarn add --dev tslint-plugin-prettier
@@ -124,7 +124,7 @@ Then in `tslint.json`:
 
 ### Disable formatting rules
 
-[`stylelint-config-prettier`](https://github.com/prettier/stylelint-config-prettier) is a config that disables rules that conflict with Prettier. Add it to your `devDependencies`, then extend from it within your `.stylelintrc` configuration. Make sure to put it last in the `extends` array, so it gets the chance to override other configs.
+[`stylelint-config-prettier`](https://github.com/prettier/stylelint-config-prettier) is a config that disables rules that conflict with Prettier. Add it to your `package.json` section of `devDependencies`, then extend from it within your `.stylelintrc` configuration. Make sure to put it last in the `extends` array, so it gets the chance to override other configs.
 
 ```bash
 yarn add --dev stylelint-config-prettier
@@ -140,7 +140,7 @@ Then in `.stylelintrc`:
 
 ### Use Stylelint to run Prettier
 
-[`stylelint-prettier`](https://github.com/prettier/stylelint-prettier) is a plugin that adds a rule that formats content using Prettier. Add it to your `devDependencies`, then enable the plugin and rule.
+[`stylelint-prettier`](https://github.com/prettier/stylelint-prettier) is a plugin that adds a rule that formats content using Prettier. Add it to your `package.json` section of `devDependencies`, then enable the plugin and rule.
 
 ```bash
 yarn add --dev stylelint-prettier

--- a/docs/integrating-with-linters.md
+++ b/docs/integrating-with-linters.md
@@ -9,13 +9,13 @@ This allows you to use Prettier for code formatting concerns, while letting your
 Whatever linting tool you wish to integrate with, the steps are broadly similar.
 First disable any existing formatting rules in your linter that may conflict with how Prettier wishes to format your code. Then you can either add an extension to your linting tool to format your file with Prettier - so that you only need a single command for format a file, or run your linter then Prettier as separate steps.
 
-All these instructions assume you have already installed `prettier` in your `package.json` section of `devDependencies`.
+All these instructions assume you have already installed `prettier` in your `package.json` file's section named `devDependencies`.
 
 ## ESLint
 
 ### Disable formatting rules
 
-[`eslint-config-prettier`](https://github.com/prettier/eslint-config-prettier) is a config that disables rules that conflict with Prettier. Add it to your `package.json` section of `devDependencies`, then extend from it within your `.eslintrc` configuration. Make sure to put it last in the `extends` array, so it gets the chance to override other configs.
+[`eslint-config-prettier`](https://github.com/prettier/eslint-config-prettier) is a config that disables rules that conflict with Prettier. Add it to your `package.json` file's section named `devDependencies`, then extend from it within your `.eslintrc` configuration. Make sure to put it last in the `extends` array, so it gets the chance to override other configs.
 
 ```bash
 yarn add --dev eslint-config-prettier
@@ -31,7 +31,7 @@ Then in `.eslintrc.json`:
 
 ### Use ESLint to run Prettier
 
-[`eslint-plugin-prettier`](https://github.com/prettier/eslint-plugin-prettier) is a plugin that adds a rule that formats content using Prettier. Add it to your `package.json` section of `devDependencies`, then enable the plugin and rule.
+[`eslint-plugin-prettier`](https://github.com/prettier/eslint-plugin-prettier) is a plugin that adds a rule that formats content using Prettier. Add it to your `package.json` file's section named `devDependencies`, then enable the plugin and rule.
 
 ```bash
 yarn add --dev eslint-plugin-prettier
@@ -68,7 +68,7 @@ Then in `.eslintrc.json`:
 
 ### Disable formatting rules
 
-[`tslint-config-prettier`](https://github.com/alexjoverm/tslint-config-prettier) is a config that disables rules that conflict with Prettier. Add it to your `package.json` section of `devDependencies`, then extend from it within your `tslint.json` configuration. Make sure to put it last in the `extends` array, so it gets the chance to override other configs.
+[`tslint-config-prettier`](https://github.com/alexjoverm/tslint-config-prettier) is a config that disables rules that conflict with Prettier. Add it to your `package.json` file's section named `devDependencies`, then extend from it within your `tslint.json` configuration. Make sure to put it last in the `extends` array, so it gets the chance to override other configs.
 
 ```bash
 yarn add --dev tslint-config-prettier
@@ -84,7 +84,7 @@ Then in `tslint.json`:
 
 ### Use TSLint to run Prettier
 
-[`tslint-plugin-prettier`](https://github.com/ikatyang/tslint-plugin-prettier) is a plugin that adds a rule that formats content using Prettier. Add it to your `package.json` section of `devDependencies`, then enable the plugin and rule.
+[`tslint-plugin-prettier`](https://github.com/ikatyang/tslint-plugin-prettier) is a plugin that adds a rule that formats content using Prettier. Add it to your `package.json` file's section named `devDependencies`, then enable the plugin and rule.
 
 ```bash
 yarn add --dev tslint-plugin-prettier
@@ -124,7 +124,7 @@ Then in `tslint.json`:
 
 ### Disable formatting rules
 
-[`stylelint-config-prettier`](https://github.com/prettier/stylelint-config-prettier) is a config that disables rules that conflict with Prettier. Add it to your `package.json` section of `devDependencies`, then extend from it within your `.stylelintrc` configuration. Make sure to put it last in the `extends` array, so it gets the chance to override other configs.
+[`stylelint-config-prettier`](https://github.com/prettier/stylelint-config-prettier) is a config that disables rules that conflict with Prettier. Add it to your `package.json` file's section named `devDependencies`, then extend from it within your `.stylelintrc` configuration. Make sure to put it last in the `extends` array, so it gets the chance to override other configs.
 
 ```bash
 yarn add --dev stylelint-config-prettier
@@ -140,7 +140,7 @@ Then in `.stylelintrc`:
 
 ### Use Stylelint to run Prettier
 
-[`stylelint-prettier`](https://github.com/prettier/stylelint-prettier) is a plugin that adds a rule that formats content using Prettier. Add it to your `package.json` section of `devDependencies`, then enable the plugin and rule.
+[`stylelint-prettier`](https://github.com/prettier/stylelint-prettier) is a plugin that adds a rule that formats content using Prettier. Add it to your `package.json` file's section named `devDependencies`, then enable the plugin and rule.
 
 ```bash
 yarn add --dev stylelint-prettier

--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -9,7 +9,7 @@ You can use Prettier with a pre-commit tool. This can re-format your files that 
 
 **Use Case:** Useful for when you want to use other code quality tools along with Prettier (e.g. ESLint, Stylelint, etc.) or if you need support for partially staged files (`git add --patch`).
 
-_Make sure Prettier is installed and is in your `package.json` section of `devDependencies` before you proceed._
+_Make sure Prettier is installed and is in your `package.json` file's section named `devDependencies` before you proceed._
 
 ```bash
 npx mrm lint-staged

--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -9,7 +9,7 @@ You can use Prettier with a pre-commit tool. This can re-format your files that 
 
 **Use Case:** Useful for when you want to use other code quality tools along with Prettier (e.g. ESLint, Stylelint, etc.) or if you need support for partially staged files (`git add --patch`).
 
-_Make sure Prettier is installed and is in your `devDependencies` before you proceed._
+_Make sure Prettier is installed and is in your `package.json` section of `devDependencies` before you proceed._
 
 ```bash
 npx mrm lint-staged


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Very minor change that probably isn't worth its own change log entry.  The change is merely to help newbies understand that the references in the documentation to `devDependencies` are to the package.json file's section named `devDependencies`, nothing more, nothing less.  (So, for example, the references aren't to some kind of devDependencies thing within prettier itself.)

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [n/a ] I’ve added tests to confirm my change works.
- [n/a ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [n/a ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
