### PR TITLE
[WIP]Update `remark-math` to v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "postcss-selector-parser": "2.2.3",
     "postcss-values-parser": "1.5.0",
     "regexp-util": "1.2.2",
-    "remark-math": "1.0.4",
+    "remark-math": "2.0.0",
     "remark-parse": "5.0.0",
     "resolve": "1.5.0",
     "semver": "5.4.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5969,11 +5969,10 @@ regjsparser@^0.6.0:
   dependencies:
     jsesc "~0.5.0"
 
-remark-math@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/remark-math/-/remark-math-1.0.4.tgz#ced46473075ff99e4678a154a1a3d0dde403a9f2"
-  dependencies:
-    trim-trailing-lines "^1.1.0"
+remark-math@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/remark-math/-/remark-math-2.0.0.tgz#bc0e981fb7c6c79d6a5f99937709549bebe6bb04"
+  integrity sha512-eQ8LLVIKVJbvNj0HCuuYdaBpHEiv/AX+3nb1ErUSPMNFMzvjKXe+H450vr9bTii9Ih5lRX7Wx/7sDVLLCfXJpg==
 
 remark-parse@5.0.0:
   version "5.0.0"
@@ -6970,7 +6969,7 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
-trim-trailing-lines@^1.0.0, trim-trailing-lines@^1.1.0:
+trim-trailing-lines@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz#e0ec0810fd3c3f1730516b45f49083caaf2774d9"
 


### PR DESCRIPTION
This PR requires changes.

Release note: https://github.com/remarkjs/remark-math/releases/tag/remark-math%402.0.0

close #6556 when this one is fixed