### PR TITLE
Add mapDocInPlace to modify the doc without creating unnecessary copies

### DIFF
--- a/src/doc/doc-utils.js
+++ b/src/doc/doc-utils.js
@@ -72,6 +72,21 @@ function mapDoc(doc, cb) {
   return cb(doc);
 }
 
+function mapDocInPlace(doc, cb) {
+  if (doc.type === "concat" || doc.type === "fill") {
+    for (let partIndex = 0; partIndex < doc.parts.length; ++partIndex) {
+      doc.parts[partIndex] = mapDocInPlace(doc.parts[partIndex], cb);
+    }
+  } else if (doc.type === "if-break") {
+    doc.breakContents =
+      doc.breakContents && mapDocInPlace(doc.breakContents, cb);
+    doc.flatContents = doc.flatContents && mapDocInPlace(doc.flatContents, cb);
+  } else if (doc.contents) {
+    doc.contents = mapDocInPlace(doc.contents, cb);
+  }
+  return cb(doc);
+}
+
 function findInDoc(doc, fn, defaultValue) {
   let result = defaultValue;
   let hasStopped = false;
@@ -212,6 +227,7 @@ module.exports = {
   traverseDoc,
   findInDoc,
   mapDoc,
+  mapDocInPlace,
   propagateBreaks,
   removeLines,
   stripTrailingHardline

--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -13,7 +13,7 @@ const {
     group,
     dedentToRoot
   },
-  utils: { mapDoc, stripTrailingHardline }
+  utils: { mapDoc, mapDocInPlace, stripTrailingHardline }
 } = require("../doc");
 
 function embed(path, print, textToDoc, options) {
@@ -110,7 +110,7 @@ function embed(path, print, textToDoc, options) {
           }
 
           if (doc) {
-            doc = escapeTemplateCharacters(doc, false);
+            doc = escapeTemplateCharacters(doc, false, true);
             if (!isFirst && startsWithBlankLine) {
               parts.push("");
             }
@@ -194,7 +194,7 @@ function embed(path, print, textToDoc, options) {
 
   function printMarkdown(text) {
     const doc = textToDoc(text, { parser: "markdown", __inJsTemplate: true });
-    return stripTrailingHardline(escapeTemplateCharacters(doc, true));
+    return stripTrailingHardline(escapeTemplateCharacters(doc, true, true));
   }
 }
 
@@ -207,8 +207,9 @@ function uncook(cookedValue) {
   return cookedValue.replace(/([\\`]|\$\{)/g, "\\$1");
 }
 
-function escapeTemplateCharacters(doc, raw) {
-  return mapDoc(doc, currentDoc => {
+function escapeTemplateCharacters(doc, raw, mapInPlace) {
+  const mapFunc = mapInPlace ? mapDocInPlace : mapDocInPlace;
+  return mapFunc(doc, currentDoc => {
     if (!currentDoc.parts) {
       return currentDoc;
     }

--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -110,7 +110,7 @@ function embed(path, print, textToDoc, options) {
           }
 
           if (doc) {
-            doc = escapeTemplateCharacters(doc, false, true);
+            doc = escapeTemplateCharacters(doc, false);
             if (!isFirst && startsWithBlankLine) {
               parts.push("");
             }
@@ -194,7 +194,7 @@ function embed(path, print, textToDoc, options) {
 
   function printMarkdown(text) {
     const doc = textToDoc(text, { parser: "markdown", __inJsTemplate: true });
-    return stripTrailingHardline(escapeTemplateCharacters(doc, true, true));
+    return stripTrailingHardline(escapeTemplateCharacters(doc, true));
   }
 }
 
@@ -207,9 +207,10 @@ function uncook(cookedValue) {
   return cookedValue.replace(/([\\`]|\$\{)/g, "\\$1");
 }
 
-function escapeTemplateCharacters(doc, raw, mapInPlace) {
-  const mapFunc = mapInPlace ? mapDocInPlace : mapDocInPlace;
-  return mapFunc(doc, currentDoc => {
+// Note that this uses mapDocInPlace, and so modifies the
+// original doc object.
+function escapeTemplateCharacters(doc, raw) {
+  return mapDocInPlace(doc, currentDoc => {
     if (!currentDoc.parts) {
       return currentDoc;
     }

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -14,7 +14,7 @@ const {
 const rangeUtil = require("./range-util");
 const privateUtil = require("../common/util");
 const {
-  utils: { mapDoc },
+  utils: { mapDocInPlace },
   printer: { printDocToString },
   debug: { printDocToDebug }
 } = require("../doc");
@@ -89,7 +89,7 @@ function coreFormat(text, opts, addAlignmentSize) {
   const result = printDocToString(
     opts.endOfLine === "lf"
       ? doc
-      : mapDoc(doc, currentDoc =>
+      : mapDocInPlace(doc, currentDoc =>
           typeof currentDoc === "string" && currentDoc.indexOf("\n") !== -1
             ? currentDoc.replace(/\n/g, eol)
             : currentDoc


### PR DESCRIPTION
This change aims to reduce memory usage, which was reaching over 8GB when processing one .js file (~2k lines, 104KB size) in our project and giving a `FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory` error. The `mapDoc` function was creating new objects for everything it processed, and is used to convert end of line characters when the line ending is not `lf`. Creating new objects for a lot of the doc is unnecessary when the original `doc` object is not used after the `mapDoc` call, so this function modifies the original object in place instead of creating new copies.

Note that, because this new function modifies the original, it has only been used where we have identified it is safe to do so. Other places could benefit from it, and we've also added another parameter to `escapeTemplateCharacters` so that the caller can be explicit as to whether or not to use the new in place version.

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
