### PR TITLE
feat: Added 'orderedListMarker' option

### DIFF
--- a/src/common/common-options.js
+++ b/src/common/common-options.js
@@ -47,5 +47,29 @@ module.exports = {
       { value: false, deprecated: "1.9.0", redirect: "never" },
       { value: true, deprecated: "1.9.0", redirect: "always" }
     ]
+  },
+  orderedListMarker: {
+    since: "1.19.0",
+    category: CATEGORY_COMMON,
+    type: "choice",
+    default: "auto",
+    description: "Type of markers for oredered list.",
+    choices: [
+      {
+        since: "1.19.0",
+        value: "order",
+        description: "Use oredered numbers as markers for ordered list."
+      },
+      {
+        since: "1.19.0",
+        value: "one",
+        description: "Use 1 as marker for ordered list."
+      },
+      {
+        since: "1.19.0",
+        value: "auto",
+        description: "Auto marker depend on content."
+      }
+    ]
   }
 };

--- a/src/language-markdown/options.js
+++ b/src/language-markdown/options.js
@@ -4,6 +4,7 @@ const commonOptions = require("../common/common-options");
 
 // format based on https://github.com/prettier/prettier/blob/master/src/main/core-options.js
 module.exports = {
+  orderedListMarker: commonOptions.orderedListMarker,
   proseWrap: commonOptions.proseWrap,
   singleQuote: commonOptions.singleQuote
 };

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -269,16 +269,25 @@ function genericPrint(path, options, print) {
           ]);
 
           function getPrefix() {
-            const rawPrefix = node.ordered
-              ? (index === 0
-                  ? node.start
-                  : isGitDiffFriendlyOrderedList
-                  ? 1
-                  : node.start + index) +
-                (nthSiblingIndex % 2 === 0 ? ". " : ") ")
-              : nthSiblingIndex % 2 === 0
-              ? "- "
-              : "* ";
+            let rawPrefix;
+            if (node.ordered) {
+              if (index === 0) {
+                rawPrefix = node.start;
+              } else {
+                if (options.orderedListMarker === "order") {
+                  rawPrefix = node.start + index;
+                } else if (options.orderedListMarker === "one") {
+                  rawPrefix = 1;
+                } else if (options.orderedListMarker === "auto") {
+                  rawPrefix = isGitDiffFriendlyOrderedList
+                    ? 1
+                    : node.start + index;
+                }
+              }
+              rawPrefix += nthSiblingIndex % 2 === 0 ? ". " : ") ";
+            } else {
+              rawPrefix = nthSiblingIndex % 2 === 0 ? "- " : "* ";
+            }
 
             return node.isAligned ||
               /* workaround for https://github.com/remarkjs/remark/issues/315 */ node.hasIndentedCodeblock

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -72,6 +72,9 @@ Format options:
                            Defaults to false.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.
+  --ordered-list-marker <order|one|auto>
+                           Type of markers for oredered list.
+                           Defaults to auto.
   --parser <flow|babel|babel-flow|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|html|angular|lwc>
                            Which parser to use.
   --print-width <int>      The line length where Prettier will try wrap.
@@ -228,6 +231,9 @@ Format options:
                            Defaults to false.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.
+  --ordered-list-marker <order|one|auto>
+                           Type of markers for oredered list.
+                           Defaults to auto.
   --parser <flow|babel|babel-flow|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|html|angular|lwc>
                            Which parser to use.
   --print-width <int>      The line length where Prettier will try wrap.

--- a/tests_integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/help-options.js.snap
@@ -329,6 +329,25 @@ exports[`show detailed usage with --help no-semi (stdout) 1`] = `
 
 exports[`show detailed usage with --help no-semi (write) 1`] = `Array []`;
 
+exports[`show detailed usage with --help ordered-list-marker (stderr) 1`] = `""`;
+
+exports[`show detailed usage with --help ordered-list-marker (stdout) 1`] = `
+"--ordered-list-marker <order|one|auto>
+
+  Type of markers for oredered list.
+
+Valid options:
+
+  order   Use oredered numbers as markers for ordered list.
+  one     Use 1 as marker for ordered list.
+  auto    Auto marker depend on content.
+
+Default: auto
+"
+`;
+
+exports[`show detailed usage with --help ordered-list-marker (write) 1`] = `Array []`;
+
 exports[`show detailed usage with --help parser (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help parser (stdout) 1`] = `

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -37,6 +37,7 @@ const ENABLED_OPTIONS = [
   "arrowParens",
   "trailingComma",
   "proseWrap",
+  "orderedListMarker",
   "htmlWhitespaceSensitivity",
   "insertPragma",
   "requirePragma",


### PR DESCRIPTION
Hey there!

I tried to implement new option for markdown files called `orderedListMarker`. I faced with a problem that I can't force the type of list marks globally and auto detect sometimes make unexpected stuff:

[Example playground](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBBArjCACSUDOMAhrAMQCMAOlOQHTYCW8AttXYy9QEz1NytQAzL05QALCP7VqGLLmiESMUl2lQADJIHs+AnhylCt1CQYEzMOCACcAJnGsU1O0ft3djUN688W5N+0dVKA8zUPcvT29DaOYQABoQCAAHGAYFZFAia2sIAHcABWyEfGQQIgA3CAZbBJAAI2siMABrOBgAZWTmhigAc2QYa3Q4RIALGGYAGwB1Mb58brA4DpKmBgqmAE8ysHxSxN78BxgCpr7mImQAMyIp48SAK3wADwAhJtb2jqJmOAAZXpwG53B4gZ4vDq9PpTOAARXQEHgIPuoxA3Wsx2sZUu1hatnyUDqyWsvRgMxqMDGyAAHOpEiSIMcZk1kmUSXAsRVgYkAI6I+BnFKlFBEfAAWigcDg9lqiWscH5DAVZyIFyuSFuqMSx2YDEGwzR+GhsIRSOBmtBaOI9QptipyC4iSGRAYU2hAGEIMxLmUoNAeSB0McACpEeoirXHAC+0aAA)

Here is one old related issue: https://github.com/prettier/prettier/issues/3463

New option give an ability to set specific type of number mark:

`--ordered-list-marker <order|one|auto>`

Let's discuss this feature! If we agreed with that I can add docs and tests.

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
