### PR TITLE
Add the 'jsCustomTags' option

### DIFF
--- a/scripts/generate-schema.js
+++ b/scripts/generate-schema.js
@@ -106,6 +106,8 @@ function optionTypeToSchemaType(optionType) {
       );
     case "path":
       return "string";
+    case "any":
+      return "object";
     default:
       throw new Error(`Unexpected optionType '${optionType}'`);
   }

--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -28,7 +28,7 @@ function embed(path, print, textToDoc, options) {
         isStyledComponents,
         isCssProp,
         isAngularComponentStyles
-      ].some(isIt => isIt(path));
+      ].some(isIt => isIt(path, options));
 
       if (isCss) {
         // Get full template literal with expressions replaced by placeholders
@@ -431,7 +431,7 @@ function getAngularComponentObjectExpressionPredicates() {
 /**
  * styled-components template literals
  */
-function isStyledComponents(path) {
+function isStyledComponents(path, options) {
   const parent = path.getParentNode();
 
   if (!parent || parent.type !== "TaggedTemplateExpression") {
@@ -440,13 +440,20 @@ function isStyledComponents(path) {
 
   const tag = parent.tag;
 
+  const customTags = options.jsCustomTags["styled-components"] || [];
+
+  function isCustomIdentifier(node) {
+    return node.type === "Identifier" && customTags.includes(node.name);
+  }
+
   switch (tag.type) {
     case "MemberExpression":
       return (
         // styled.foo``
         isStyledIdentifier(tag.object) ||
         // Component.extend``
-        isStyledExtend(tag)
+        isStyledExtend(tag) ||
+        isCustomIdentifier(tag.object)
       );
 
     case "CallExpression":
@@ -466,7 +473,7 @@ function isStyledComponents(path) {
 
     case "Identifier":
       // css``
-      return tag.name === "css";
+      return tag.name === "css" || customTags.includes(tag.name);
 
     default:
       return false;

--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -24,6 +24,14 @@ module.exports = {
     ]
   },
   bracketSpacing: commonOptions.bracketSpacing,
+  jsCustomTags: {
+    since: "1.18.2",
+    category: CATEGORY_JAVASCRIPT,
+    type: "any",
+    default: {},
+    description:
+      "A map of languages and custom template literal tag names. Example: { 'styled-components': ['media'] }"
+  },
   jsxBracketSameLine: {
     since: "0.17.0",
     category: CATEGORY_JAVASCRIPT,

--- a/src/main/options-normalizer.js
+++ b/src/main/options-normalizer.js
@@ -148,6 +148,9 @@ function optionInfoToSchema(optionInfo, { isCLI, optionInfos }) {
     case "path":
       SchemaConstructor = vnopts.StringSchema;
       break;
+    case "any":
+      SchemaConstructor = vnopts.AnySchema;
+      break;
     default:
       throw new Error(`Unexpected type ${optionInfo.type}`);
   }

--- a/tests/template_literals/styled-components-with-custom-tags/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/template_literals/styled-components-with-custom-tags/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,135 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`custom-tags.js 1`] = `
+====================================options=====================================
+jsCustomTags: {"styled-components":["myCustomTag","media"]}
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const Button = styled.a\`
+/* Comment */
+	display: \${props=>props.display};
+\`;
+
+styled.div\`
+	display: \${props=>props.display};
+	border: \${props=>props.border}px;
+	margin: 10px \${props=>props.border}px ;
+\`;
+
+const EqualDivider = styled.div\`
+margin: 0.5rem;
+		padding: 1rem;
+	background: papayawhip    ;
+
+	> * {
+	flex: 1;
+
+	&:not(:first-child) {
+			\${props => props.vertical ? 'margin-top' : 'margin-left'}: 1rem;
+		}
+	}
+\`;
+
+const header = css\`
+.top-bar {background:black;
+margin: 0;
+    position: fixed;
+	top: 0;left:0;
+	width: 100%;
+    text-align: center     ;
+	padding: 15px  0  0  1em;
+		z-index: 9999;
+}
+
+.top-bar .logo {
+  height: 30px;
+  margin: auto; 
+    position: absolute;
+	left: 0;right: 0;
+	
+	\${myCustomTag\`
+background-color:red;
+
+                 :after { color:red;
+                 
+         }
+	\`};
+	
+								\${media.phone\`
+background-color:red;
+
+                 :after { color:red;
+                 
+         }
+	\`};
+}
+\`;
+
+=====================================output=====================================
+const Button = styled.a\`
+  /* Comment */
+  display: \${props => props.display};
+\`;
+
+styled.div\`
+  display: \${props => props.display};
+  border: \${props => props.border}px;
+  margin: 10px \${props => props.border}px;
+\`;
+
+const EqualDivider = styled.div\`
+  margin: 0.5rem;
+  padding: 1rem;
+  background: papayawhip;
+
+  > * {
+    flex: 1;
+
+    &:not(:first-child) {
+      \${props => (props.vertical ? "margin-top" : "margin-left")}: 1rem;
+    }
+  }
+\`;
+
+const header = css\`
+  .top-bar {
+    background: black;
+    margin: 0;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    text-align: center;
+    padding: 15px 0 0 1em;
+    z-index: 9999;
+  }
+
+  .top-bar .logo {
+    height: 30px;
+    margin: auto;
+    position: absolute;
+    left: 0;
+    right: 0;
+
+    \${myCustomTag\`
+      background-color: red;
+
+      :after {
+        color: red;
+      }
+    \`};
+
+    \${media.phone\`
+      background-color: red;
+
+      :after {
+        color: red;
+      }
+    \`};
+  }
+\`;
+
+================================================================================
+`;

--- a/tests/template_literals/styled-components-with-custom-tags/custom-tags.js
+++ b/tests/template_literals/styled-components-with-custom-tags/custom-tags.js
@@ -1,0 +1,59 @@
+const Button = styled.a`
+/* Comment */
+	display: ${props=>props.display};
+`;
+
+styled.div`
+	display: ${props=>props.display};
+	border: ${props=>props.border}px;
+	margin: 10px ${props=>props.border}px ;
+`;
+
+const EqualDivider = styled.div`
+margin: 0.5rem;
+		padding: 1rem;
+	background: papayawhip    ;
+
+	> * {
+	flex: 1;
+
+	&:not(:first-child) {
+			${props => props.vertical ? 'margin-top' : 'margin-left'}: 1rem;
+		}
+	}
+`;
+
+const header = css`
+.top-bar {background:black;
+margin: 0;
+    position: fixed;
+	top: 0;left:0;
+	width: 100%;
+    text-align: center     ;
+	padding: 15px  0  0  1em;
+		z-index: 9999;
+}
+
+.top-bar .logo {
+  height: 30px;
+  margin: auto; 
+    position: absolute;
+	left: 0;right: 0;
+	
+	${myCustomTag`
+background-color:red;
+
+                 :after { color:red;
+                 
+         }
+	`};
+	
+								${media.phone`
+background-color:red;
+
+                 :after { color:red;
+                 
+         }
+	`};
+}
+`;

--- a/tests/template_literals/styled-components-with-custom-tags/jsfmt.spec.js
+++ b/tests/template_literals/styled-components-with-custom-tags/jsfmt.spec.js
@@ -1,0 +1,5 @@
+run_spec(__dirname, ["babel", "flow", "typescript"], {
+  jsCustomTags: {
+    "styled-components": ["myCustomTag", "media"]
+  }
+});


### PR DESCRIPTION
- [X] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**

==========================

Hello!

First of all I want to say that I realize that this PR will be controversial. I have read the [opinion philosophy][1] and #40.

This PR adds a new option `jsCustomTags` with the following form:

```json
{
  "jsCustomTags": {
    "styled-components": ["media"]
  }
}
```

I believe that this option is necesary and must make it into prettier (or any similar option that cover this use case). I understand that we want to keep prettier as opinionated as possible, but in this case this is not a matter of opinion, this is a matter of supporting an use case.

In our code, we use `styled-components`, and we have a custom helper to do media queries:

```ts
const MyComponent = styled.div`
    max-width: 700px;

    ${media.mobile`
        max-width: 90%;
    `};
`;
```

However, in another one of our projects, we do:

```ts
const MyComponent = styled.div`
    max-width: 90%;

    ${from.mobile`
        max-width: 700px;
    `};
`;
```

We use `from` instead of `media` because our queries are mobile-first, and they are more descriptive that way. We are not the only ones to use this pattern: take a look at [this article][2] or [this package][3].

The point here is that we can't just let prettier decide that the only valid tag names for `styled-components` are `styled` and `css`. There's an open issue about supporting `keyframes` too (#5936), but I believe that opening a PR just for `keyframes` is missing the point. What we need to move towards is a customizable list of allowed tags, in which `styled` and `css` are the default, but can also be extended.

There is no standard way to define media queries in styled-components (neither in `styled-components` itself nor there is a well established standard in the community - like [fsa][4] for redux), and while there isn't, we can't have prettier decide which names are acceptable and which aren't.

This not only applies to `styled-components`, but to any potential library that relies on tagged template strings like `graphql`; hence why I named the option `jsCustomTags` and not `styledComponentCustomTags`.

Some final notes:

* I opened this PR knowing that there's a good chance that it won't be merged. I did it instead of opening an issue because I wanted to present a working prototype, and because we can continue to use our own workflow without giving up auto formatting inside media queries.
* I am aware that some tests broke because of this PR, mostly snapshot of configuration help. I didn't want to bother updating them without knowing if this was going to be merged, and if it is, there's a good chance that the API won't be exaclty what I propose, so the tests can be updated later.

Thanks a lot for your time.

[1]: https://prettier.io/docs/en/option-philosophy.html
[2]: https://medium.com/@samuelresua/easy-media-queries-in-styled-components-690b78f50053
[3]: https://github.com/morajabi/styled-media-query
[4]: https://github.com/redux-utilities/flux-standard-action