### PR TITLE
refactoring: unify code for printing methods, remove isNodeStar…

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3662,11 +3662,10 @@ function printMethod(path, options, print) {
       ? node
       : node.value;
 
-  if (value.async) {
-    parts.push("async ");
-  }
-
   if (!kind || kind === "init" || kind === "method" || kind === "constructor") {
+    if (value.async) {
+      parts.push("async ");
+    }
     if (value.generator) {
       parts.push("*");
     }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3704,12 +3704,10 @@ function printMethodInternal(path, options, print) {
     )
   ];
 
-  const body = path.getNode().body;
-
-  if (!body || body.length === 0) {
-    parts.push(options.semi ? ";" : "");
-  } else {
+  if (path.getNode().body) {
     parts.push(" ", path.call(print, "body"));
+  } else {
+    parts.push(options.semi ? ";" : "");
   }
 
   return concat(parts);

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -74,7 +74,6 @@ const {
   isMemberExpressionChain,
   isMemberish,
   isNgForOf,
-  isNodeStartingWithDeclare,
   isNumericLiteral,
   isObjectType,
   isObjectTypePropertyAFunction,
@@ -891,24 +890,6 @@ function printPathNoParens(path, options, print, args) {
         ])
       );
     }
-    case "MethodDefinition":
-    case "TSAbstractMethodDefinition":
-      if (n.decorators && n.decorators.length !== 0) {
-        parts.push(printDecorators(path, options, print));
-      }
-      if (n.accessibility) {
-        parts.push(n.accessibility + " ");
-      }
-      if (n.static) {
-        parts.push("static ");
-      }
-      if (n.type === "TSAbstractMethodDefinition") {
-        parts.push("abstract ");
-      }
-
-      parts.push(printMethod(path, options, print));
-
-      return concat(parts);
     case "YieldExpression":
       parts.push("yield");
 
@@ -1221,7 +1202,7 @@ function printPathNoParens(path, options, print, args) {
       return contents;
     }
     case "TSInterfaceDeclaration":
-      if (isNodeStartingWithDeclare(n, options)) {
+      if (n.declare) {
         parts.push("declare ");
       }
 
@@ -1470,18 +1451,26 @@ function printPathNoParens(path, options, print, args) {
       return concat(parts); // Babel 6
     case "ClassMethod":
     case "ClassPrivateMethod":
+    case "MethodDefinition":
+    case "TSAbstractMethodDefinition":
       if (n.decorators && n.decorators.length !== 0) {
         parts.push(printDecorators(path, options, print));
+      }
+      if (n.accessibility) {
+        parts.push(n.accessibility + " ");
       }
       if (n.static) {
         parts.push("static ");
       }
+      if (n.type === "TSAbstractMethodDefinition") {
+        parts.push("abstract ");
+      }
 
-      parts = parts.concat(printObjectMethod(path, options, print));
+      parts.push(printMethod(path, options, print));
 
-      return concat(parts); // Babel 6
+      return concat(parts);
     case "ObjectMethod":
-      return printObjectMethod(path, options, print);
+      return printMethod(path, options, print);
     case "Decorator":
       return concat([
         "@",
@@ -1699,7 +1688,7 @@ function printPathNoParens(path, options, print, args) {
       }
 
       parts = [
-        isNodeStartingWithDeclare(n, options) ? "declare " : "",
+        n.declare ? "declare " : "",
         n.kind,
         firstVariable ? concat([" ", firstVariable]) : "",
         indent(
@@ -2375,7 +2364,7 @@ function printPathNoParens(path, options, print, args) {
     }
     case "ClassDeclaration":
     case "ClassExpression":
-      if (isNodeStartingWithDeclare(n, options)) {
+      if (n.declare) {
         parts.push("declare ");
       }
       parts.push(concat(printClass(path, options, print)));
@@ -2686,10 +2675,7 @@ function printPathNoParens(path, options, print, args) {
     case "DeclareInterface":
     case "InterfaceDeclaration":
     case "InterfaceTypeAnnotation": {
-      if (
-        n.type === "DeclareInterface" ||
-        isNodeStartingWithDeclare(n, options)
-      ) {
+      if (n.type === "DeclareInterface" || n.declare) {
         parts.push("declare ");
       }
 
@@ -2920,10 +2906,7 @@ function printPathNoParens(path, options, print, args) {
       return "string";
     case "DeclareTypeAlias":
     case "TypeAlias": {
-      if (
-        n.type === "DeclareTypeAlias" ||
-        isNodeStartingWithDeclare(n, options)
-      ) {
+      if (n.type === "DeclareTypeAlias" || n.declare) {
         parts.push("declare ");
       }
 
@@ -3313,7 +3296,7 @@ function printPathNoParens(path, options, print, args) {
 
       return group(concat(parts));
     case "TSEnumDeclaration":
-      if (isNodeStartingWithDeclare(n, options)) {
+      if (n.declare) {
         parts.push("declare ");
       }
 
@@ -3395,7 +3378,7 @@ function printPathNoParens(path, options, print, args) {
       if (parentIsDeclaration) {
         parts.push(".");
       } else {
-        if (n.declare === true) {
+        if (n.declare) {
           parts.push("declare ");
         }
         parts.push(printTypeScriptModifiers(path, options, print));
@@ -3669,24 +3652,22 @@ function printPropertyKey(path, options, print) {
 
 function printMethod(path, options, print) {
   const node = path.getNode();
-  const semi = options.semi ? ";" : "";
   const kind = node.kind;
   const parts = [];
 
-  if (
+  const value =
     node.type === "ObjectMethod" ||
     node.type === "ClassMethod" ||
     node.type === "ClassPrivateMethod"
-  ) {
-    node.value = node;
-  }
+      ? node
+      : node.value;
 
-  if (node.value.async) {
+  if (value.async) {
     parts.push("async ");
   }
 
   if (!kind || kind === "init" || kind === "method" || kind === "constructor") {
-    if (node.value.generator) {
+    if (value.generator) {
       parts.push("*");
     }
   } else {
@@ -3695,34 +3676,40 @@ function printMethod(path, options, print) {
     parts.push(kind, " ");
   }
 
-  let key = printPropertyKey(path, options, print);
+  const key = printPropertyKey(path, options, print);
 
   if (node.computed) {
-    key = concat(["[", key, "]"]);
+    parts.push("[", key, "]");
+  } else {
+    parts.push(key);
   }
 
   parts.push(
-    key,
-    concat(
-      path.call(
-        valuePath => [
-          printFunctionTypeParameters(valuePath, options, print),
-          group(
-            concat([
-              printFunctionParams(valuePath, print, options),
-              printReturnType(valuePath, print, options)
-            ])
-          )
-        ],
-        "value"
-      )
-    )
+    node === value
+      ? printMethodInternal(path, options, print)
+      : path.call(path => printMethodInternal(path, options, print), "value")
   );
 
-  if (!node.value.body || node.value.body.length === 0) {
-    parts.push(semi);
+  return concat(parts);
+}
+
+function printMethodInternal(path, options, print) {
+  const parts = [
+    printFunctionTypeParameters(path, options, print),
+    group(
+      concat([
+        printFunctionParams(path, print, options),
+        printReturnType(path, print, options)
+      ])
+    )
+  ];
+
+  const body = path.getNode().body;
+
+  if (!body || body.length === 0) {
+    parts.push(options.semi ? ";" : "");
   } else {
-    parts.push(" ", path.call(print, "value", "body"));
+    parts.push(" ", path.call(print, "body"));
   }
 
   return concat(parts);
@@ -4311,47 +4298,6 @@ function printFunctionDeclaration(path, print, options) {
       ])
     ),
     n.body ? " " : "",
-    path.call(print, "body")
-  );
-
-  return concat(parts);
-}
-
-function printObjectMethod(path, options, print) {
-  const objMethod = path.getValue();
-  const parts = [];
-
-  if (objMethod.async) {
-    parts.push("async ");
-  }
-  if (objMethod.generator) {
-    parts.push("*");
-  }
-  if (
-    objMethod.method ||
-    objMethod.kind === "get" ||
-    objMethod.kind === "set"
-  ) {
-    return printMethod(path, options, print);
-  }
-
-  const key = printPropertyKey(path, options, print);
-
-  if (objMethod.computed) {
-    parts.push("[", key, "]");
-  } else {
-    parts.push(key);
-  }
-
-  parts.push(
-    printFunctionTypeParameters(path, options, print),
-    group(
-      concat([
-        printFunctionParams(path, print, options),
-        printReturnType(path, print, options)
-      ])
-    ),
-    " ",
     path.call(print, "body")
   );
 

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -281,20 +281,6 @@ function isMemberish(node) {
   );
 }
 
-function isNodeStartingWithDeclare(node, options) {
-  if (!(options.parser === "flow" || options.parser === "typescript")) {
-    return false;
-  }
-  return (
-    options.originalText
-      .slice(0, options.locStart(node))
-      .match(/declare[ \t]*$/) ||
-    options.originalText
-      .slice(node.range[0], node.range[1])
-      .startsWith("declare ")
-  );
-}
-
 function isSimpleFlowType(node) {
   const flowTypeAnnotations = [
     "AnyTypeAnnotation",
@@ -938,7 +924,6 @@ module.exports = {
   isMemberExpressionChain,
   isMemberish,
   isNgForOf,
-  isNodeStartingWithDeclare,
   isNumericLiteral,
   isObjectType,
   isObjectTypePropertyAFunction,


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
These changes should pave the way for #6400.

`isNodeStartingWithDeclare` used to be needed to workaround parser bugs/incompleteness, see #1436. As the passing tests show, the parsers reliably add the `declare` property to nodes now, so we can clean this up.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
