### PR TITLE
docs/configuration: specify order of precedence

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,12 +3,12 @@ id: configuration
 title: Configuration File
 ---
 
-Prettier uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) for configuration file support. This means you can configure prettier via:
+Prettier uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) for configuration file support. This means you can configure prettier via (in order of precedence):
 
-- A `.prettierrc` file, written in YAML or JSON, with optional extensions: `.yaml/.yml/.json`.
-- A `.prettierrc.toml` file, written in TOML (the `.toml` extension is _required_).
-- A `prettier.config.js` or `.prettierrc.js` file that exports an object.
 - A `"prettier"` key in your `package.json` file.
+- A `.prettierrc` file, written in JSON or YAML, with optional extensions: `.json/.yaml/.yml` (without extension takes precedence).
+- A `.prettierrc.js` or `prettier.config.js` file that exports an object.
+- A `.prettierrc.toml` file, written in TOML (the `.toml` extension is _required_).
 
 The configuration file will be resolved starting from the location of the file being formatted, and searching up the file tree until a config file is (or isn't) found.
 


### PR DESCRIPTION
This updates the docs to show the search order of the config files.

Order comes from: https://github.com/prettier/prettier/blob/3805034bdfe45722e31a1abf019d4368dfb8ae11/src/config/resolve-config.js#L35-L44

<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
