### PR TITLE
fix typos

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -244,7 +244,7 @@ skipNewline(text: string, index: number, options: object): number;
 hasNewline(text: string, index: number, options: object): boolean;
 hasNewlineInRange(text: string, start: number, start: number): boolean;
 hasSpaces(text: string, index: number, options: object): number;
-makeString(rawContent: string, enclosingQuote: string, unescapeUnnecessarEscapes: boolean): string;
+makeString(rawContent: string, enclosingQuote: string, unescapeUnnecessaryEscapes: boolean): string;
 getNextNonSpaceNonCommentCharacterIndex(text: string, node: object, options: object): number;
 isNextLineEmptyAfterIndex(text: string, index: number): boolean;
 isNextLineEmpty(text: string, node: object, options: object): boolean;

--- a/docs/webstorm.md
+++ b/docs/webstorm.md
@@ -39,7 +39,7 @@ In older IDE versions, select Custom and do the following configuration:
 
 ### Using Prettier with ESLint
 
-If you are using ESLint with [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier), use the `Fix ESLint Problems` action to reformat the currect file – find it using _Find Action_ (`Cmd/Ctrl-Shift-A`) or [add a keyboard shortcut](https://www.jetbrains.com/help/webstorm/configuring-keyboard-shortcuts.html) to it in _Preferences | Keymap_ and then use it.
+If you are using ESLint with [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier), use the `Fix ESLint Problems` action to reformat the current file – find it using _Find Action_ (`Cmd/Ctrl-Shift-A`) or [add a keyboard shortcut](https://www.jetbrains.com/help/webstorm/configuring-keyboard-shortcuts.html) to it in _Preferences | Keymap_ and then use it.
 
 Make sure that the ESLint integration is enabled in _Preferences | Languages & Frameworks | JavaScript | Code Quality Tools | ESLint_.
 

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -822,7 +822,7 @@ function normalizeDetailedOption(name, option) {
           typeof choice === "object" ? choice : { value: choice }
         );
         if (newChoice.value === true) {
-          newChoice.value = ""; // backward compability for original boolean option
+          newChoice.value = ""; // backward compatibility for original boolean option
         }
         return newChoice;
       })

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -476,16 +476,16 @@ function genericPrint(path, options, print) {
         }
 
         // Ignore spaces before/after string interpolation (i.e. `"#{my-fn("_")}"`)
-        const isStartSCSSinterpolationInString =
+        const isStartSCSSInterpolationInString =
           iNode.type === "value-string" && iNode.value.startsWith("#{");
-        const isEndingSCSSinterpolationInString =
+        const isEndingSCSSInterpolationInString =
           insideSCSSInterpolationInString &&
           iNextNode.type === "value-string" &&
           iNextNode.value.endsWith("}");
 
         if (
-          isStartSCSSinterpolationInString ||
-          isEndingSCSSinterpolationInString
+          isStartSCSSInterpolationInString ||
+          isEndingSCSSInterpolationInString
         ) {
           insideSCSSInterpolationInString = !insideSCSSInterpolationInString;
 

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -123,7 +123,7 @@ function embed(path, print, textToDoc, options) {
         return concat([node.rawName, "=", node.value]);
       }
 
-      // lwc: html`<my-element data-for={value}></my-elememt>`
+      // lwc: html`<my-element data-for={value}></my-element>`
       if (options.parser === "lwc") {
         const interpolationRegex = /^\{[\s\S]*\}$/;
         if (

--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -321,7 +321,7 @@ function printGraphqlComments(lines) {
   lines
     .map(textLine => textLine.trim())
     .forEach((textLine, i, array) => {
-      // Lines are either whitespace only, or a comment (with poential whitespace
+      // Lines are either whitespace only, or a comment (with potential whitespace
       // around it). Drop whitespace-only lines.
       if (textLine === "") {
         return;

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -368,7 +368,7 @@ function needsParens(path, options) {
           }
 
           // Add parenthesis when working with bitwise operators
-          // It's not stricly needed but helps with code understanding
+          // It's not strictly needed but helps with code understanding
           if (util.isBitwiseOperator(po)) {
             return true;
           }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4179,7 +4179,7 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
   const lastParam = getLast(fun[paramsField]);
 
   // If the parent is a call with the first/last argument expansion and this is the
-  // params of the first/last argument, we dont want the arguments to break and instead
+  // params of the first/last argument, we don't want the arguments to break and instead
   // want the whole expression to be on a new line.
   //
   // Good:                 Bad:
@@ -4844,7 +4844,7 @@ function printMemberChain(path, options, print) {
   // The first group is the first node followed by
   //   - as many CallExpression as possible
   //       < fn()()() >.something()
-  //   - as many array acessors as possible
+  //   - as many array accessors as possible
   //       < fn()[0][1][2] >.something()
   //   - then, as many MemberExpression as possible but the last one
   //       < this.items >.something()

--- a/website/blog/2017-06-28-1.5.0.md
+++ b/website/blog/2017-06-28-1.5.0.md
@@ -24,7 +24,7 @@ Prettier is not only a useful tool but it's also a really cool piece of technolo
 
 Thanks to [@stubailo](https://github.com/stubailo), [@jnwng](https://github.com/jnwng), [@tgriesser](https://github.com/tgriesser) and [@azz](https://github.com/azz), prettier now supports printing GraphQL queries!
 
-It works for `.graphql` files and within JavaScipt templates that start with `graphql`, `graphql.experimental` and `gql` in order to work with [Relay](https://facebook.github.io/relay/) and [Apollo](https://www.apollodata.com/).
+It works for `.graphql` files and within JavaScript templates that start with `graphql`, `graphql.experimental` and `gql` in order to work with [Relay](https://facebook.github.io/relay/) and [Apollo](https://www.apollodata.com/).
 
 <!-- prettier-ignore -->
 ```jsx


### PR DESCRIPTION
I use [cSpell](https://github.com/streetsidesoftware/cspell/tree/master/packages/cspell) in VS Code and got tired of its warnings.

I didn't spell-check the whole blog because there is too many meaningless placeholder strings in the code examples there.

If there is interest, I can also commit `cspell.json` (the project-level custom dictionary) or even setup a spelling check on CI.

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
