### PR TITLE
fix(js): Object destructuring in method shorthand #6515

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -911,7 +911,7 @@ function doSmth() {
 // Prettier (master)
 (<a />).toString();
 
-#### JavaScript: Object destructuring in method shorthand. ([#6646] by [@ericsakmar])
+#### JavaScript: Object destructuring in method parameters always broke into multiple lines ([#6646] by [@ericsakmar])
 
 <!-- prettier-ignore -->
 ```js
@@ -926,9 +926,6 @@ class A {
   func(id, { blog: { title } }) {
     return id + title;
   }
-}
-
-class B {
   #func(id, { blog: { title } }) {
     return id + title;
   }
@@ -955,9 +952,6 @@ class A {
   ) {
     return id + title;
   }
-}
-
-class B {
   #func(
     id,
     {
@@ -979,9 +973,6 @@ class A {
   func(id, { blog: { title } }) {
     return id + title;
   }
-}
-
-class B {
   #func(id, { blog: { title } }) {
     return id + title;
   }

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -910,6 +910,82 @@ function doSmth() {
 
 // Prettier (master)
 (<a />).toString();
+
+#### JavaScript: Object destructuring in method shorthand. ([#6646] by [@ericsakmar])
+
+<!-- prettier-ignore -->
+```js
+// Input
+const obj = {
+  func(id, { blog: { title } }) {
+    return id + title;
+  },
+};
+
+class A {
+  func(id, { blog: { title } }) {
+    return id + title;
+  }
+}
+
+class B {
+  #func(id, { blog: { title } }) {
+    return id + title;
+  }
+}
+
+// Prettier (stable)
+const obj = {
+  func(
+    id,
+    {
+      blog: { title }
+    }
+  ) {
+    return id + title;
+  }
+};
+
+class A {
+  func(
+    id,
+    {
+      blog: { title }
+    }
+  ) {
+    return id + title;
+  }
+}
+
+class B {
+  #func(
+    id,
+    {
+      blog: { title }
+    }
+  ) {
+    return id + title;
+  }
+}
+
+// Prettier (master)
+const obj = {
+  func(id, { blog: { title } }) {
+    return id + title;
+  },
+};
+
+class A {
+  func(id, { blog: { title } }) {
+    return id + title;
+  }
+}
+
+class B {
+  #func(id, { blog: { title } }) {
+    return id + title;
+  }
+}
 ```
 
 [#5910]: https://github.com/prettier/prettier/pull/5910
@@ -942,6 +1018,7 @@ function doSmth() {
 [#6496]: https://github.com/prettier/prettier/pull/6496
 [#6605]: https://github.com/prettier/prettier/pull/6605
 [#6640]: https://github.com/prettier/prettier/pull/6640
+[#6646]: https://github.com/prettier/prettier/pull/6646
 [@brainkim]: https://github.com/brainkim
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
@@ -952,3 +1029,4 @@ function doSmth() {
 [@thorn0]: https://github.com/thorn0
 [@dcyriller]: https://github.com/dcyriller
 [@rreverser]: https://github.com/RReverser
+[@ericsakmar]: https://github.com/ericsakmar

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1289,6 +1289,9 @@ function printPathNoParens(path, options, print, args) {
           parent.type !== "FunctionDeclaration" &&
           parent.type !== "FunctionExpression" &&
           parent.type !== "ArrowFunctionExpression" &&
+          parent.type !== "ObjectMethod" &&
+          parent.type !== "ClassMethod" &&
+          parent.type !== "ClassPrivateMethod" &&
           parent.type !== "AssignmentPattern" &&
           parent.type !== "CatchClause" &&
           n.properties.some(

--- a/tests/classes_private_fields/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/classes_private_fields/__snapshots__/jsfmt.spec.js.snap
@@ -50,6 +50,12 @@ class E {
   set #f(taz) {}
 }
 
+class F {
+  #func(id, { blog: { title } }) {
+    return id + title;
+  }
+}
+
 =====================================output=====================================
 class A {
   #x;
@@ -113,6 +119,12 @@ class E {
   set #f(taz) {}
 }
 
+class F {
+  #func(id, { blog: { title } }) {
+    return id + title;
+  }
+}
+
 ================================================================================
 `;
 
@@ -165,6 +177,12 @@ class E {
   async *#e() {}
   get #f() {}
   set #f(taz) {}
+}
+
+class F {
+  #func(id, { blog: { title } }) {
+    return id + title;
+  }
 }
 
 =====================================output=====================================
@@ -228,6 +246,12 @@ class E {
   async *#e() {}
   get #f() {}
   set #f(taz) {}
+}
+
+class F {
+  #func(id, { blog: { title } }) {
+    return id + title
+  }
 }
 
 ================================================================================

--- a/tests/classes_private_fields/private_fields.js
+++ b/tests/classes_private_fields/private_fields.js
@@ -41,3 +41,9 @@ class E {
   get #f() {}
   set #f(taz) {}
 }
+
+class F {
+  #func(id, { blog: { title } }) {
+    return id + title;
+  }
+}

--- a/tests/destructuring/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/destructuring/__snapshots__/jsfmt.spec.js.snap
@@ -40,6 +40,18 @@ try {
   // code
 }
 
+const obj = {
+  func(id, { blog: { title } }) {
+    return id + title;
+  },
+};
+
+class A {
+  func(id, { blog: { title } }) {
+    return id + title;
+  }
+}
+
 =====================================output=====================================
 const [one, two = null, three = null] = arr;
 a = ([s = 1]) => 1;
@@ -88,6 +100,18 @@ try {
   }
 }) {
   // code
+}
+
+const obj = {
+  func(id, { blog: { title } }) {
+    return id + title;
+  }
+};
+
+class A {
+  func(id, { blog: { title } }) {
+    return id + title;
+  }
 }
 
 ================================================================================

--- a/tests/destructuring/destructuring.js
+++ b/tests/destructuring/destructuring.js
@@ -31,3 +31,15 @@ try {
 } catch ({ data: { message: { errors }}}) {
   // code
 }
+
+const obj = {
+  func(id, { blog: { title } }) {
+    return id + title;
+  },
+};
+
+class A {
+  func(id, { blog: { title } }) {
+    return id + title;
+  }
+}


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Adds `ObjectMethod` `ClassMethod`, and `ClassPrivateMethod` to the list of types that should/shouldn't cause line breaks. Now they behave like `ArrowFunctionExpression`.

fixes #6515

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
