### PR TITLE
prettier-emacs is actually prettier-js-mode

### DIFF
--- a/website/data/editors.yml
+++ b/website/data/editors.yml
@@ -7,7 +7,7 @@
 - image: "/images/editors/editor_emacs.svg"
   name: Emacs
   content: |
-    [`prettier-emacs`](https://github.com/prettier/prettier-emacs)
+    [`prettier-js`](https://github.com/prettier/prettier-emacs)
 - image: /images/editors/editor_espresso.svg
   name: Espresso
   content: |


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
The `prettier-emacs` repository actually contains the `prettier-js` package.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
