### PR TITLE
Remove usage of `require.extensions` in `parser-glimmer.js`

### DIFF
--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -99,7 +99,7 @@ async function run(params) {
     await execa("rm", ["-rf", ".cache"]);
   }
 
-  const bundleCache = new Cache(".cache/", "v16");
+  const bundleCache = new Cache(".cache/", "v17");
   await bundleCache.load();
 
   console.log(chalk.inverse(" Building packages "));

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -100,13 +100,13 @@ const parsers = [
         // https://github.com/prettier/prettier/issues/6656
         {
           find: "handlebars",
-          replacement: require.resolve("handlebars/dist/handlebars.js")
+          replacement: require.resolve("handlebars/dist/cjs/handlebars.js")
         }
       ]
     },
     commonjs: {
       namedExports: {
-        "node_modules/handlebars/dist/handlebars.js": ["parse"],
+        "node_modules/handlebars/dist/cjs/handlebars.js": ["parse"],
         "node_modules/@glimmer/syntax/dist/modules/es2017/index.js": "default"
       },
       ignore: ["source-map"]

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -95,8 +95,9 @@ const parsers = [
     target: "universal",
     alias: {
       entries: [
-        // `handlebars` causes webpack warning by using require.extensions
-        // use bundler instead
+        // `handlebars` causes webpack warning by using `require.extensions`
+        // `dist/handlebars.js` also complaint on `window` variable
+        // use cjs build instead
         // https://github.com/prettier/prettier/issues/6656
         {
           find: "handlebars",

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -93,9 +93,20 @@ const parsers = [
   {
     input: "src/language-handlebars/parser-glimmer.js",
     target: "universal",
+    alias: {
+      entries: [
+        // `handlebars` causes webpack warning by using require.extensions
+        // use bundler instead
+        // https://github.com/prettier/prettier/issues/6656
+        {
+          find: "handlebars",
+          replacement: require.resolve("handlebars/dist/handlebars.js")
+        }
+      ]
+    },
     commonjs: {
       namedExports: {
-        "node_modules/handlebars/lib/index.js": ["parse"],
+        "node_modules/handlebars/dist/handlebars.js": ["parse"],
         "node_modules/@glimmer/syntax/dist/modules/es2017/index.js": "default"
       },
       ignore: ["source-map"]


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

fixes: https://github.com/prettier/prettier/issues/6656

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
