### PR TITLE
Use `babel` plugin replace `includes`

### DIFF
--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -39,10 +39,9 @@ const parsers = [
   {
     input: "src/language-js/parser-typescript.js",
     target: "universal",
-    replace: {
-      // node v4 compatibility for @typescript-eslint/typescript-estree
-      "(!unique.includes(raw))": "(unique.indexOf(raw) === -1)"
-    },
+    babelPlugins: [
+      require.resolve("./babel-plugins/replace-array-includes-with-indexof")
+    ],
     commonjs: {
       ignore: [
         // Optional package for TypeScript that logs ETW events (a Windows-only technology).


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

use `includes-with-indexof` instead of hard code replacement

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
