### PR TITLE
enable the allowUndeclaredExports Babel option

### DIFF
--- a/src/language-js/parser-babylon.js
+++ b/src/language-js/parser-babylon.js
@@ -16,6 +16,7 @@ function babelOptions(extraOptions, extraPlugins) {
       allowImportExportEverywhere: true,
       allowReturnOutsideFunction: true,
       allowSuperOutsideMethod: true,
+      allowUndeclaredExports: true,
       plugins: [
         "jsx",
         "doExpressions",

--- a/tests/exports/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/exports/__snapshots__/jsfmt.spec.js.snap
@@ -14,6 +14,8 @@ export * as ns from "mod";
 
 export * as foo,{bar} from "./baz";
 
+export { undefinedExport };
+
 =====================================output=====================================
 export {
   value1,
@@ -28,6 +30,8 @@ export a, { b } from "./baz";
 export * as ns from "mod";
 
 export * as foo, { bar } from "./baz";
+
+export { undefinedExport };
 
 ================================================================================
 `;

--- a/tests/exports/test.js
+++ b/tests/exports/test.js
@@ -5,3 +5,5 @@ export a,{b} from "./baz";
 export * as ns from "mod";
 
 export * as foo,{bar} from "./baz";
+
+export { undefinedExport };


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Babel 7.4.0 introduced a [check for undefined exported bindings](https://github.com/babel/babel/pull/9589). It could break Prettier's range formatting, but luckily, they also added a [way to disable it](https://github.com/babel/babel/pull/9864) in 7.5.0.

No changes in the API or CLI. Not a user-facing change.

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
