### PR TITLE
tests: rename duplicate variable bindings to be ready for #6400

### DIFF
--- a/tests/arrays/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/arrays/__snapshots__/jsfmt.spec.js.snap
@@ -7,12 +7,12 @@ printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
 const a = someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || [];
-const a = someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || {};
+const b = someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || {};
 
 =====================================output=====================================
 const a =
   someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || [];
-const a =
+const b =
   someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || {};
 
 ================================================================================

--- a/tests/arrays/empty.js
+++ b/tests/arrays/empty.js
@@ -1,2 +1,2 @@
 const a = someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || [];
-const a = someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || {};
+const b = someVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeLong.Expression || {};

--- a/tests/assignment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/assignment/__snapshots__/jsfmt.spec.js.snap
@@ -41,7 +41,7 @@ let {
   top: offsetTop,
 } = getPressRectOffset == null ? DEFAULT_PRESS_RECT : getPressRectOffset();
 
-const { accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule,
+const { accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule2, accessibilityModule: FooAccessibilityModule3, accessibilityModule: FooAccessibilityModule4,
       } = foo || {};
 
 ({ prop: toAssign = "default" } = { prop: "propval" });
@@ -56,9 +56,9 @@ let {
 
 const {
   accessibilityModule: FooAccessibilityModule,
-  accessibilityModule: FooAccessibilityModule,
-  accessibilityModule: FooAccessibilityModule,
-  accessibilityModule: FooAccessibilityModule
+  accessibilityModule: FooAccessibilityModule2,
+  accessibilityModule: FooAccessibilityModule3,
+  accessibilityModule: FooAccessibilityModule4
 } = foo || {};
 
 ({ prop: toAssign = "default" } = { prop: "propval" });

--- a/tests/assignment/destructuring.js
+++ b/tests/assignment/destructuring.js
@@ -5,7 +5,7 @@ let {
   top: offsetTop,
 } = getPressRectOffset == null ? DEFAULT_PRESS_RECT : getPressRectOffset();
 
-const { accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule,
+const { accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule2, accessibilityModule: FooAccessibilityModule3, accessibilityModule: FooAccessibilityModule4,
       } = foo || {};
 
 ({ prop: toAssign = "default" } = { prop: "propval" });

--- a/tests/assignment_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/assignment_comments/__snapshots__/jsfmt.spec.js.snap
@@ -45,18 +45,18 @@ var fnString = // Comment
 var fnString = // Comment
   'some' + 'long' + 'string';
 
-let f = (
+let f1 = (
   a =
   //comment
   b
 ) => {};
 
-let f = (
+let f2 = (
   a = //comment
   b
 ) => {};
 
-let f = (
+let f3 = (
   a =
   b //comment
 ) => {};
@@ -110,16 +110,16 @@ var fnString = // Comment
 
 var fnString = "some" + "long" + "string"; // Comment
 
-let f = (
+let f1 = (
   //comment
   a = b
 ) => {};
 
-let f = (
+let f2 = (
   a = b //comment
 ) => {};
 
-let f = (
+let f3 = (
   a = b //comment
 ) => {};
 

--- a/tests/assignment_comments/assignment_comments.js
+++ b/tests/assignment_comments/assignment_comments.js
@@ -37,18 +37,18 @@ var fnString = // Comment
 var fnString = // Comment
   'some' + 'long' + 'string';
 
-let f = (
+let f1 = (
   a =
   //comment
   b
 ) => {};
 
-let f = (
+let f2 = (
   a = //comment
   b
 ) => {};
 
-let f = (
+let f3 = (
   a =
   b //comment
 ) => {};

--- a/tests/async/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/async/__snapshots__/jsfmt.spec.js.snap
@@ -37,16 +37,16 @@ parsers: ["flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-async function f() { (await f()).length }
+async function f1() { (await f()).length }
 async function g() {
   invariant(
     (await driver.navigator.getUrl()).substr(-7)
   );
 }
-function *f(){
+function *f2(){
   !(yield a);
 }
-async function f() {
+async function f3() {
   a = !await f();
 }
 async () => {
@@ -55,16 +55,16 @@ async () => {
 }
 
 =====================================output=====================================
-async function f() {
+async function f1() {
   (await f()).length;
 }
 async function g() {
   invariant((await driver.navigator.getUrl()).substr(-7));
 }
-function* f() {
+function* f2() {
   !(yield a);
 }
-async function f() {
+async function f3() {
   a = !(await f());
 }
 async () => {
@@ -91,7 +91,7 @@ async function f() {
   );
 })()
 
-async function f() {
+async function f2() {
   await (spellcheck && spellcheck.setChecking(false));
   await spellcheck && spellcheck.setChecking(false)
 }
@@ -105,7 +105,7 @@ async function f() {
   console.log(await (true ? Promise.resolve("A") : Promise.resolve("B")));
 })();
 
-async function f() {
+async function f2() {
   await (spellcheck && spellcheck.setChecking(false));
   (await spellcheck) && spellcheck.setChecking(false);
 }
@@ -121,14 +121,14 @@ printWidth: 80
 =====================================input======================================
 async function *f(){ await (yield x); }
 
-async function f(){ await (() => {}); }
+async function f2(){ await (() => {}); }
 
 =====================================output=====================================
 async function* f() {
   await (yield x);
 }
 
-async function f() {
+async function f2() {
   await (() => {});
 }
 

--- a/tests/async/await_parse.js
+++ b/tests/async/await_parse.js
@@ -1,13 +1,13 @@
-async function f() { (await f()).length }
+async function f1() { (await f()).length }
 async function g() {
   invariant(
     (await driver.navigator.getUrl()).substr(-7)
   );
 }
-function *f(){
+function *f2(){
   !(yield a);
 }
-async function f() {
+async function f3() {
   a = !await f();
 }
 async () => {

--- a/tests/async/conditional-expression.js
+++ b/tests/async/conditional-expression.js
@@ -8,7 +8,7 @@ async function f() {
   );
 })()
 
-async function f() {
+async function f2() {
   await (spellcheck && spellcheck.setChecking(false));
   await spellcheck && spellcheck.setChecking(false)
 }

--- a/tests/async/parens.js
+++ b/tests/async/parens.js
@@ -1,3 +1,3 @@
 async function *f(){ await (yield x); }
 
-async function f(){ await (() => {}); }
+async function f2(){ await (() => {}); }

--- a/tests/class_comment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/class_comment/__snapshots__/jsfmt.spec.js.snap
@@ -10,27 +10,27 @@ class A // comment 1
   // comment 2
   extends B {}
 
-class A extends B // comment1
+class A1 extends B // comment1
 // comment2
 // comment3
 {}
 
-class A /* a */ extends B {}
-class A extends B /* a */ {}
-class A extends /* a */ B {}
+class A2 /* a */ extends B {}
+class A3 extends B /* a */ {}
+class A4 extends /* a */ B {}
 
-(class A // comment 1
+(class A5 // comment 1
   // comment 2
   extends B {});
 
-(class A extends B // comment1
+(class A6 extends B // comment1
 // comment2
 // comment3
 {});
 
-(class A /* a */ extends B {});
-(class A extends B /* a */ {});
-(class A extends /* a */ B {});
+(class A7 /* a */ extends B {});
+(class A8 extends B /* a */ {});
+(class A9 extends /* a */ B {});
 
 class x {
   focus() // do nothing
@@ -60,31 +60,31 @@ class A // comment 1
   // comment 2
   extends B {}
 
-class A extends B // comment1
+class A1 extends B // comment1
 // comment2
 // comment3
 {
 }
 
-class A /* a */ extends B {}
-class A extends B /* a */ {
+class A2 /* a */ extends B {}
+class A3 extends B /* a */ {
 }
-class A /* a */ extends B {}
+class A4 /* a */ extends B {}
 
-(class A // comment 1
+(class A5 // comment 1
   // comment 2
   extends B {});
 
-(class A extends B // comment1
+(class A6 extends B // comment1
 // comment2
 // comment3
 {
 });
 
-(class A /* a */ extends B {});
-(class A extends B /* a */ {
+(class A7 /* a */ extends B {});
+(class A8 extends B /* a */ {
 });
-(class A /* a */ extends B {});
+(class A9 /* a */ extends B {});
 
 class x {
   focus() // do nothing

--- a/tests/class_comment/comments.js
+++ b/tests/class_comment/comments.js
@@ -2,27 +2,27 @@ class A // comment 1
   // comment 2
   extends B {}
 
-class A extends B // comment1
+class A1 extends B // comment1
 // comment2
 // comment3
 {}
 
-class A /* a */ extends B {}
-class A extends B /* a */ {}
-class A extends /* a */ B {}
+class A2 /* a */ extends B {}
+class A3 extends B /* a */ {}
+class A4 extends /* a */ B {}
 
-(class A // comment 1
+(class A5 // comment 1
   // comment 2
   extends B {});
 
-(class A extends B // comment1
+(class A6 extends B // comment1
 // comment2
 // comment3
 {});
 
-(class A /* a */ extends B {});
-(class A extends B /* a */ {});
-(class A extends /* a */ B {});
+(class A7 /* a */ extends B {});
+(class A8 extends B /* a */ {});
+(class A9 extends /* a */ B {});
 
 class x {
   focus() // do nothing

--- a/tests/class_extends/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/class_extends/__snapshots__/jsfmt.spec.js.snap
@@ -7,10 +7,10 @@ printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
 // "ArrowFunctionExpression"
-class a extends (() => {}) {}
+class a1 extends (() => {}) {}
 
 // "AssignmentExpression"
-class a extends (b = c) {}
+class a2 extends (b = c) {}
 
 // "AwaitExpression"
 async function f() {
@@ -18,46 +18,46 @@ async function f() {
 }
 
 // "BinaryExpression"
-class a extends (b + c) {}
+class a3 extends (b + c) {}
 
 // "CallExpression"
-class a extends b() {}
+class a4 extends b() {}
 
 // "ClassExpression"
-class a extends class {} {}
+class a5 extends class {} {}
 
 // "ConditionalExpression"
-class a extends (b ? c : d) {}
+class a6 extends (b ? c : d) {}
 
 // "FunctionExpression"
-class a extends (function() {}) {}
+class a7 extends (function() {}) {}
 
 // "LogicalExpression"
-class a extends (b || c) {}
+class a8 extends (b || c) {}
 
 // "MemberExpression"
-class a extends b.c {}
+class a9 extends b.c {}
 
 // "NewExpression"
-class a extends (new B()) {}
+class a10 extends (new B()) {}
 
 // "ObjectExpression"
-class a extends ({}) {}
+class a11 extends ({}) {}
 
 // "SequenceExpression"
-class a extends (b, c) {}
+class a12 extends (b, c) {}
 
 // "TaggedTemplateExpression"
-class a extends \`\` {}
+class a13 extends \`\` {}
 
 // "UnaryExpression"
-class a extends (void b) {}
+class a14 extends (void b) {}
 
 // "UpdateExpression"
-class a extends (++b) {}
+class a15 extends (++b) {}
 
 // "YieldExpression"
-function* f() {
+function* f2() {
   // Flow has a bug parsing it.
   // class a extends (yield 1) {}
 }
@@ -66,10 +66,10 @@ x = class extends (++b) {}
 
 =====================================output=====================================
 // "ArrowFunctionExpression"
-class a extends (() => {}) {}
+class a1 extends (() => {}) {}
 
 // "AssignmentExpression"
-class a extends (b = c) {}
+class a2 extends (b = c) {}
 
 // "AwaitExpression"
 async function f() {
@@ -77,46 +77,46 @@ async function f() {
 }
 
 // "BinaryExpression"
-class a extends (b + c) {}
+class a3 extends (b + c) {}
 
 // "CallExpression"
-class a extends b() {}
+class a4 extends b() {}
 
 // "ClassExpression"
-class a extends class {} {}
+class a5 extends class {} {}
 
 // "ConditionalExpression"
-class a extends (b ? c : d) {}
+class a6 extends (b ? c : d) {}
 
 // "FunctionExpression"
-class a extends function() {} {}
+class a7 extends function() {} {}
 
 // "LogicalExpression"
-class a extends (b || c) {}
+class a8 extends (b || c) {}
 
 // "MemberExpression"
-class a extends b.c {}
+class a9 extends b.c {}
 
 // "NewExpression"
-class a extends (new B()) {}
+class a10 extends (new B()) {}
 
 // "ObjectExpression"
-class a extends ({}) {}
+class a11 extends ({}) {}
 
 // "SequenceExpression"
-class a extends (b, c) {}
+class a12 extends (b, c) {}
 
 // "TaggedTemplateExpression"
-class a extends \`\` {}
+class a13 extends \`\` {}
 
 // "UnaryExpression"
-class a extends (void b) {}
+class a14 extends (void b) {}
 
 // "UpdateExpression"
-class a extends (++b) {}
+class a15 extends (++b) {}
 
 // "YieldExpression"
-function* f() {
+function* f2() {
   // Flow has a bug parsing it.
   // class a extends (yield 1) {}
 }

--- a/tests/class_extends/extends.js
+++ b/tests/class_extends/extends.js
@@ -1,8 +1,8 @@
 // "ArrowFunctionExpression"
-class a extends (() => {}) {}
+class a1 extends (() => {}) {}
 
 // "AssignmentExpression"
-class a extends (b = c) {}
+class a2 extends (b = c) {}
 
 // "AwaitExpression"
 async function f() {
@@ -10,46 +10,46 @@ async function f() {
 }
 
 // "BinaryExpression"
-class a extends (b + c) {}
+class a3 extends (b + c) {}
 
 // "CallExpression"
-class a extends b() {}
+class a4 extends b() {}
 
 // "ClassExpression"
-class a extends class {} {}
+class a5 extends class {} {}
 
 // "ConditionalExpression"
-class a extends (b ? c : d) {}
+class a6 extends (b ? c : d) {}
 
 // "FunctionExpression"
-class a extends (function() {}) {}
+class a7 extends (function() {}) {}
 
 // "LogicalExpression"
-class a extends (b || c) {}
+class a8 extends (b || c) {}
 
 // "MemberExpression"
-class a extends b.c {}
+class a9 extends b.c {}
 
 // "NewExpression"
-class a extends (new B()) {}
+class a10 extends (new B()) {}
 
 // "ObjectExpression"
-class a extends ({}) {}
+class a11 extends ({}) {}
 
 // "SequenceExpression"
-class a extends (b, c) {}
+class a12 extends (b, c) {}
 
 // "TaggedTemplateExpression"
-class a extends `` {}
+class a13 extends `` {}
 
 // "UnaryExpression"
-class a extends (void b) {}
+class a14 extends (void b) {}
 
 // "UpdateExpression"
-class a extends (++b) {}
+class a15 extends (++b) {}
 
 // "YieldExpression"
-function* f() {
+function* f2() {
   // Flow has a bug parsing it.
   // class a extends (yield 1) {}
 }

--- a/tests/conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/conditional/__snapshots__/jsfmt.spec.js.snap
@@ -31,12 +31,12 @@ const extractTextPluginOptions = shouldUseRelativeAssetPaths
   ? { publicPath: Array(cssFilename.split('/').length).join('../') } :
   {};
 
-const extractTextPluginOptions = shouldUseRelativeAssetPaths
+const extractTextPluginOptions2 = shouldUseRelativeAssetPaths
   ? // Making sure that the publicPath goes back to to build folder.
     { publicPath: Array(cssFilename.split("/").length).join("../") }
   : {};
 
-const extractTextPluginOptions = shouldUseRelativeAssetPaths // Making sure that the publicPath goes back to to build folder.
+const extractTextPluginOptions3 = shouldUseRelativeAssetPaths // Making sure that the publicPath goes back to to build folder.
   ? { publicPath: Array(cssFilename.split("/").length).join("../") }
   : {};
 
@@ -72,12 +72,12 @@ const extractTextPluginOptions = shouldUseRelativeAssetPaths
     { publicPath: Array(cssFilename.split("/").length).join("../") }
   : {};
 
-const extractTextPluginOptions = shouldUseRelativeAssetPaths
+const extractTextPluginOptions2 = shouldUseRelativeAssetPaths
   ? // Making sure that the publicPath goes back to to build folder.
     { publicPath: Array(cssFilename.split("/").length).join("../") }
   : {};
 
-const extractTextPluginOptions = shouldUseRelativeAssetPaths // Making sure that the publicPath goes back to to build folder.
+const extractTextPluginOptions3 = shouldUseRelativeAssetPaths // Making sure that the publicPath goes back to to build folder.
   ? { publicPath: Array(cssFilename.split("/").length).join("../") }
   : {};
 

--- a/tests/conditional/comments.js
+++ b/tests/conditional/comments.js
@@ -23,12 +23,12 @@ const extractTextPluginOptions = shouldUseRelativeAssetPaths
   ? { publicPath: Array(cssFilename.split('/').length).join('../') } :
   {};
 
-const extractTextPluginOptions = shouldUseRelativeAssetPaths
+const extractTextPluginOptions2 = shouldUseRelativeAssetPaths
   ? // Making sure that the publicPath goes back to to build folder.
     { publicPath: Array(cssFilename.split("/").length).join("../") }
   : {};
 
-const extractTextPluginOptions = shouldUseRelativeAssetPaths // Making sure that the publicPath goes back to to build folder.
+const extractTextPluginOptions3 = shouldUseRelativeAssetPaths // Making sure that the publicPath goes back to to build folder.
   ? { publicPath: Array(cssFilename.split("/").length).join("../") }
   : {};
 

--- a/tests/if/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/if/__snapshots__/jsfmt.spec.js.snap
@@ -93,7 +93,7 @@ parsers: ["flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-async function f() {
+async function f1() {
   if (untrackedChoice === 0) /* Cancel */ {
     return null;
   } else if (untrackedChoice === 1) /* Add */ {
@@ -104,7 +104,7 @@ async function f() {
   }
 }
 
-async function f() {
+async function f2() {
   if (untrackedChoice === 0) /* Cancel */
     null;
   else if (untrackedChoice === 1) /* Add */
@@ -113,7 +113,7 @@ async function f() {
     allowUntracked = true;
 }
 
-async function f() {
+async function f3() {
   if (untrackedChoice === 0) /* Cancel */ // Cancel
     null;
   else if (untrackedChoice === 1) /* Add */ // Add
@@ -122,7 +122,7 @@ async function f() {
     allowUntracked = true;
 }
 
-async function f() {
+async function f4() {
   if (untrackedChoice === 0)
     /* Cancel */ {
       return null;
@@ -138,7 +138,7 @@ async function f() {
     }
 }
 
-async function f() {
+async function f5() {
   if (untrackedChoice === 0) {
     /* Cancel */ return null;
   } else if (untrackedChoice === 1) {
@@ -150,7 +150,7 @@ async function f() {
 }
 
 =====================================output=====================================
-async function f() {
+async function f1() {
   if (untrackedChoice === 0) {
     /* Cancel */ return null;
   } else if (untrackedChoice === 1) {
@@ -161,7 +161,7 @@ async function f() {
   }
 }
 
-async function f() {
+async function f2() {
   if (untrackedChoice === 0)
     /* Cancel */
     null;
@@ -173,7 +173,7 @@ async function f() {
     allowUntracked = true;
 }
 
-async function f() {
+async function f3() {
   if (untrackedChoice === 0)
     /* Cancel */ // Cancel
     null;
@@ -185,7 +185,7 @@ async function f() {
     allowUntracked = true;
 }
 
-async function f() {
+async function f4() {
   if (untrackedChoice === 0) {
     /* Cancel */ return null;
   } else if (untrackedChoice === 1) {
@@ -196,7 +196,7 @@ async function f() {
   }
 }
 
-async function f() {
+async function f5() {
   if (untrackedChoice === 0) {
     /* Cancel */ return null;
   } else if (untrackedChoice === 1) {

--- a/tests/if/if_comments.js
+++ b/tests/if/if_comments.js
@@ -1,4 +1,4 @@
-async function f() {
+async function f1() {
   if (untrackedChoice === 0) /* Cancel */ {
     return null;
   } else if (untrackedChoice === 1) /* Add */ {
@@ -9,7 +9,7 @@ async function f() {
   }
 }
 
-async function f() {
+async function f2() {
   if (untrackedChoice === 0) /* Cancel */
     null;
   else if (untrackedChoice === 1) /* Add */
@@ -18,7 +18,7 @@ async function f() {
     allowUntracked = true;
 }
 
-async function f() {
+async function f3() {
   if (untrackedChoice === 0) /* Cancel */ // Cancel
     null;
   else if (untrackedChoice === 1) /* Add */ // Add
@@ -27,7 +27,7 @@ async function f() {
     allowUntracked = true;
 }
 
-async function f() {
+async function f4() {
   if (untrackedChoice === 0)
     /* Cancel */ {
       return null;
@@ -43,7 +43,7 @@ async function f() {
     }
 }
 
-async function f() {
+async function f5() {
   if (untrackedChoice === 0) {
     /* Cancel */ return null;
   } else if (untrackedChoice === 1) {

--- a/tests/import/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/import/__snapshots__/jsfmt.spec.js.snap
@@ -84,18 +84,18 @@ import {
   a as //comment1
   //comment2
   //comment3
-  b
+  b1
 } from "";
 
 import {
   a as //comment2 //comment1
   //comment3
-  b
+  b2
 } from "";
 
 import {
   a as //comment3 //comment2 //comment1
-  b
+  b3
 } from "";
 
 import {
@@ -133,18 +133,18 @@ import {
   //comment1
   //comment2
   //comment3
-  a as b
+  a as b1
 } from "";
 
 import {
   //comment2 //comment1
   //comment3
-  a as b
+  a as b2
 } from "";
 
 import {
   //comment3 //comment2 //comment1
-  a as b
+  a as b3
 } from "";
 
 import {
@@ -189,18 +189,18 @@ import {
   a as //comment1
   //comment2
   //comment3
-  b
+  b1
 } from "";
 
 import {
   a as //comment2 //comment1
   //comment3
-  b
+  b2
 } from "";
 
 import {
   a as //comment3 //comment2 //comment1
-  b
+  b3
 } from "";
 
 import {
@@ -238,18 +238,18 @@ import {
   //comment1
   //comment2
   //comment3
-  a as b
+  a as b1
 } from "";
 
 import {
   //comment2 //comment1
   //comment3
-  a as b
+  a as b2
 } from "";
 
 import {
   //comment3 //comment2 //comment1
-  a as b
+  a as b3
 } from "";
 
 import {
@@ -314,19 +314,19 @@ printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
 import somethingSuperLongsomethingSuperLong from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
-import {somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
-import a, {somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
-import {a, somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import {somethingSuperLongsomethingSuperLong1} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import a, {somethingSuperLongsomethingSuperLong2} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import {a2, somethingSuperLongsomethingSuperLong3} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
 
 =====================================output=====================================
 import somethingSuperLongsomethingSuperLong from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
-import { somethingSuperLongsomethingSuperLong } from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
+import { somethingSuperLongsomethingSuperLong1 } from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
 import a, {
-  somethingSuperLongsomethingSuperLong
+  somethingSuperLongsomethingSuperLong2
 } from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
 import {
-  a,
-  somethingSuperLongsomethingSuperLong
+  a2,
+  somethingSuperLongsomethingSuperLong3
 } from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
 
 ================================================================================
@@ -340,19 +340,19 @@ printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
 import somethingSuperLongsomethingSuperLong from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
-import {somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
-import a, {somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
-import {a, somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import {somethingSuperLongsomethingSuperLong1} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import a, {somethingSuperLongsomethingSuperLong2} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import {a2, somethingSuperLongsomethingSuperLong3} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
 
 =====================================output=====================================
 import somethingSuperLongsomethingSuperLong from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
-import {somethingSuperLongsomethingSuperLong} from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
+import {somethingSuperLongsomethingSuperLong1} from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
 import a, {
-  somethingSuperLongsomethingSuperLong
+  somethingSuperLongsomethingSuperLong2
 } from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
 import {
-  a,
-  somethingSuperLongsomethingSuperLong
+  a2,
+  somethingSuperLongsomethingSuperLong3
 } from "somethingSuperLongsomethingSuperLongsomethingSuperLong";
 
 ================================================================================

--- a/tests/import/comments.js
+++ b/tests/import/comments.js
@@ -7,18 +7,18 @@ import {
   a as //comment1
   //comment2
   //comment3
-  b
+  b1
 } from "";
 
 import {
   a as //comment2 //comment1
   //comment3
-  b
+  b2
 } from "";
 
 import {
   a as //comment3 //comment2 //comment1
-  b
+  b3
 } from "";
 
 import {

--- a/tests/import/inline.js
+++ b/tests/import/inline.js
@@ -1,4 +1,4 @@
 import somethingSuperLongsomethingSuperLong from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
-import {somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
-import a, {somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
-import {a, somethingSuperLongsomethingSuperLong} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import {somethingSuperLongsomethingSuperLong1} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import a, {somethingSuperLongsomethingSuperLong2} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'
+import {a2, somethingSuperLongsomethingSuperLong3} from 'somethingSuperLongsomethingSuperLongsomethingSuperLong'

--- a/tests/member/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/member/__snapshots__/jsfmt.spec.js.snap
@@ -38,7 +38,7 @@ const promises = [
   other.fetch(),
 ];
 
-const promises = [
+const promises2 = [
   promise.resolve().veryLongFunctionCall().veryLongFunctionCall().then(console.log).catch(err => {
     console.log(err)
     return null
@@ -79,7 +79,7 @@ const promises = [
   other.fetch()
 ];
 
-const promises = [
+const promises2 = [
   promise
     .resolve()
     .veryLongFunctionCall()

--- a/tests/member/expand.js
+++ b/tests/member/expand.js
@@ -10,7 +10,7 @@ const promises = [
   other.fetch(),
 ];
 
-const promises = [
+const promises2 = [
   promise.resolve().veryLongFunctionCall().veryLongFunctionCall().then(console.log).catch(err => {
     console.log(err)
     return null

--- a/tests/require/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/require/__snapshots__/jsfmt.spec.js.snap
@@ -6,8 +6,8 @@ parsers: ["flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-const { one, two, thee, four, five, six, seven, eight, nine, ten } = require('./my-utils');
-const { one, two, thee, four, five, six, seven, eight, nine, ten, eleven } = require('./my-utils');
+const { one, two, three, four, five, six, seven, eight, nine, ten } = require('./my-utils');
+const { one1, two1, three1, four1, five1, six1, seven1, eight1, nine1, ten1, eleven1 } = require('./my-utils');
 
 const MyReallyExtrememlyLongModuleName = require('MyReallyExtrememlyLongModuleName');
 
@@ -15,7 +15,7 @@ const MyReallyExtrememlyLongModuleName = require('MyReallyExtrememlyLongModuleNa
 const {
   one,
   two,
-  thee,
+  three,
   four,
   five,
   six,
@@ -25,17 +25,17 @@ const {
   ten
 } = require("./my-utils");
 const {
-  one,
-  two,
-  thee,
-  four,
-  five,
-  six,
-  seven,
-  eight,
-  nine,
-  ten,
-  eleven
+  one1,
+  two1,
+  three1,
+  four1,
+  five1,
+  six1,
+  seven1,
+  eight1,
+  nine1,
+  ten1,
+  eleven1
 } = require("./my-utils");
 
 const MyReallyExtrememlyLongModuleName = require("MyReallyExtrememlyLongModuleName");

--- a/tests/require/require.js
+++ b/tests/require/require.js
@@ -1,4 +1,4 @@
-const { one, two, thee, four, five, six, seven, eight, nine, ten } = require('./my-utils');
-const { one, two, thee, four, five, six, seven, eight, nine, ten, eleven } = require('./my-utils');
+const { one, two, three, four, five, six, seven, eight, nine, ten } = require('./my-utils');
+const { one1, two1, three1, four1, five1, six1, seven1, eight1, nine1, ten1, eleven1 } = require('./my-utils');
 
 const MyReallyExtrememlyLongModuleName = require('MyReallyExtrememlyLongModuleName');

--- a/tests/ternaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/ternaries/__snapshots__/jsfmt.spec.js.snap
@@ -1672,7 +1672,7 @@ const paymentMessage = state == 'success'
 
   : 'There was an issue with the payment.  Please contact support.'
 
-const paymentMessage = state == 'success'
+const paymentMessage2 = state == 'success'
   ? 1 //'Payment completed successfully'
 
 : state == 'processing'
@@ -1764,7 +1764,7 @@ const paymentMessage =
     ? "Expiry must be sometime in the past."
     : "There was an issue with the payment.  Please contact support.";
 
-const paymentMessage =
+const paymentMessage2 =
   state == "success"
     ? 1 //'Payment completed successfully'
     : state == "processing"
@@ -1876,7 +1876,7 @@ const paymentMessage = state == 'success'
 
   : 'There was an issue with the payment.  Please contact support.'
 
-const paymentMessage = state == 'success'
+const paymentMessage2 = state == 'success'
   ? 1 //'Payment completed successfully'
 
 : state == 'processing'
@@ -1968,7 +1968,7 @@ const paymentMessage =
         ? "Expiry must be sometime in the past."
         : "There was an issue with the payment.  Please contact support.";
 
-const paymentMessage =
+const paymentMessage2 =
     state == "success"
         ? 1 //'Payment completed successfully'
         : state == "processing"
@@ -2080,7 +2080,7 @@ const paymentMessage = state == 'success'
 
   : 'There was an issue with the payment.  Please contact support.'
 
-const paymentMessage = state == 'success'
+const paymentMessage2 = state == 'success'
   ? 1 //'Payment completed successfully'
 
 : state == 'processing'
@@ -2172,7 +2172,7 @@ const paymentMessage =
 		? "Expiry must be sometime in the past."
 		: "There was an issue with the payment.  Please contact support.";
 
-const paymentMessage =
+const paymentMessage2 =
 	state == "success"
 		? 1 //'Payment completed successfully'
 		: state == "processing"
@@ -2285,7 +2285,7 @@ const paymentMessage = state == 'success'
 
   : 'There was an issue with the payment.  Please contact support.'
 
-const paymentMessage = state == 'success'
+const paymentMessage2 = state == 'success'
   ? 1 //'Payment completed successfully'
 
 : state == 'processing'
@@ -2377,7 +2377,7 @@ const paymentMessage =
 		? "Expiry must be sometime in the past."
 		: "There was an issue with the payment.  Please contact support.";
 
-const paymentMessage =
+const paymentMessage2 =
 	state == "success"
 		? 1 //'Payment completed successfully'
 		: state == "processing"

--- a/tests/ternaries/nested.js
+++ b/tests/ternaries/nested.js
@@ -56,7 +56,7 @@ const paymentMessage = state == 'success'
 
   : 'There was an issue with the payment.  Please contact support.'
 
-const paymentMessage = state == 'success'
+const paymentMessage2 = state == 'success'
   ? 1 //'Payment completed successfully'
 
 : state == 'processing'

--- a/tests/typescript/custom/typeParameters/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/custom/typeParameters/__snapshots__/jsfmt.spec.js.snap
@@ -128,7 +128,7 @@ const isAnySuccessfulAttempt$: Observable<boolean> = this._quizService.isAnySucc
     this.isAnySuccessfulAttempt = isAnySuccessfulAttempt;
   }),
 );
-const isAnySuccessfulAttempt$: Observable<boolean> = this._someMethodWithLongName();
+const isAnySuccessfulAttempt2$: Observable<boolean> = this._someMethodWithLongName();
 
 =====================================output=====================================
 const foo: SomeThing<boolean> = func();
@@ -153,7 +153,7 @@ const isAnySuccessfulAttempt$: Observable<boolean> = this._quizService
       this.isAnySuccessfulAttempt = isAnySuccessfulAttempt;
     })
   );
-const isAnySuccessfulAttempt$: Observable<boolean> = this._someMethodWithLongName();
+const isAnySuccessfulAttempt2$: Observable<boolean> = this._someMethodWithLongName();
 
 ================================================================================
 `;

--- a/tests/typescript/custom/typeParameters/variables.ts
+++ b/tests/typescript/custom/typeParameters/variables.ts
@@ -11,4 +11,4 @@ const isAnySuccessfulAttempt$: Observable<boolean> = this._quizService.isAnySucc
     this.isAnySuccessfulAttempt = isAnySuccessfulAttempt;
   }),
 );
-const isAnySuccessfulAttempt$: Observable<boolean> = this._someMethodWithLongName();
+const isAnySuccessfulAttempt2$: Observable<boolean> = this._someMethodWithLongName();

--- a/tests/typescript_argument_expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_argument_expansion/__snapshots__/jsfmt.spec.js.snap
@@ -6,77 +6,77 @@ parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-const bar = [1,2,3].reduce((carry, value) => {
+const bar1 = [1,2,3].reduce((carry, value) => {
   return [...carry, value];
 }, ([] as unknown) as number[]);
 
-const bar = [1,2,3].reduce((carry, value) => {
+const bar2 = [1,2,3].reduce((carry, value) => {
   return [...carry, value];
 }, <Array<number>>[]);
 
-const bar = [1,2,3].reduce((carry, value) => {
+const bar3 = [1,2,3].reduce((carry, value) => {
   return [...carry, value];
 }, ([1, 2, 3] as unknown) as number[]);
 
-const bar = [1,2,3].reduce((carry, value) => {
+const bar4 = [1,2,3].reduce((carry, value) => {
   return [...carry, value];
 }, <Array<number>>[1, 2, 3]);
 
-const bar = [1,2,3].reduce((carry, value) => {
+const bar5 = [1,2,3].reduce((carry, value) => {
   return {...carry, [value]: true};
 }, ({} as unknown) as {[key: number]: boolean});
 
-const bar = [1,2,3].reduce((carry, value) => {
+const bar6 = [1,2,3].reduce((carry, value) => {
   return {...carry, [value]: true};
 }, <{[key: number]: boolean}>{});
 
-const bar = [1,2,3].reduce((carry, value) => {
+const bar7 = [1,2,3].reduce((carry, value) => {
   return {...carry, [value]: true};
 }, ({1: true} as unknown) as {[key: number]: boolean});
 
-const bar = [1,2,3].reduce((carry, value) => {
+const bar8 = [1,2,3].reduce((carry, value) => {
   return {...carry, [value]: true};
 }, <{[key: number]: boolean}>{1: true});
 
 =====================================output=====================================
-const bar = [1, 2, 3].reduce((carry, value) => {
+const bar1 = [1, 2, 3].reduce((carry, value) => {
   return [...carry, value];
 }, ([] as unknown) as number[]);
 
-const bar = [1, 2, 3].reduce((carry, value) => {
+const bar2 = [1, 2, 3].reduce((carry, value) => {
   return [...carry, value];
 }, <Array<number>>[]);
 
-const bar = [1, 2, 3].reduce(
+const bar3 = [1, 2, 3].reduce(
   (carry, value) => {
     return [...carry, value];
   },
   ([1, 2, 3] as unknown) as number[]
 );
 
-const bar = [1, 2, 3].reduce(
+const bar4 = [1, 2, 3].reduce(
   (carry, value) => {
     return [...carry, value];
   },
   <Array<number>>[1, 2, 3]
 );
 
-const bar = [1, 2, 3].reduce((carry, value) => {
+const bar5 = [1, 2, 3].reduce((carry, value) => {
   return { ...carry, [value]: true };
 }, ({} as unknown) as { [key: number]: boolean });
 
-const bar = [1, 2, 3].reduce((carry, value) => {
+const bar6 = [1, 2, 3].reduce((carry, value) => {
   return { ...carry, [value]: true };
 }, <{ [key: number]: boolean }>{});
 
-const bar = [1, 2, 3].reduce(
+const bar7 = [1, 2, 3].reduce(
   (carry, value) => {
     return { ...carry, [value]: true };
   },
   ({ 1: true } as unknown) as { [key: number]: boolean }
 );
 
-const bar = [1, 2, 3].reduce(
+const bar8 = [1, 2, 3].reduce(
   (carry, value) => {
     return { ...carry, [value]: true };
   },

--- a/tests/typescript_argument_expansion/argument_expansion.js
+++ b/tests/typescript_argument_expansion/argument_expansion.js
@@ -1,31 +1,31 @@
-const bar = [1,2,3].reduce((carry, value) => {
+const bar1 = [1,2,3].reduce((carry, value) => {
   return [...carry, value];
 }, ([] as unknown) as number[]);
 
-const bar = [1,2,3].reduce((carry, value) => {
+const bar2 = [1,2,3].reduce((carry, value) => {
   return [...carry, value];
 }, <Array<number>>[]);
 
-const bar = [1,2,3].reduce((carry, value) => {
+const bar3 = [1,2,3].reduce((carry, value) => {
   return [...carry, value];
 }, ([1, 2, 3] as unknown) as number[]);
 
-const bar = [1,2,3].reduce((carry, value) => {
+const bar4 = [1,2,3].reduce((carry, value) => {
   return [...carry, value];
 }, <Array<number>>[1, 2, 3]);
 
-const bar = [1,2,3].reduce((carry, value) => {
+const bar5 = [1,2,3].reduce((carry, value) => {
   return {...carry, [value]: true};
 }, ({} as unknown) as {[key: number]: boolean});
 
-const bar = [1,2,3].reduce((carry, value) => {
+const bar6 = [1,2,3].reduce((carry, value) => {
   return {...carry, [value]: true};
 }, <{[key: number]: boolean}>{});
 
-const bar = [1,2,3].reduce((carry, value) => {
+const bar7 = [1,2,3].reduce((carry, value) => {
   return {...carry, [value]: true};
 }, ({1: true} as unknown) as {[key: number]: boolean});
 
-const bar = [1,2,3].reduce((carry, value) => {
+const bar8 = [1,2,3].reduce((carry, value) => {
   return {...carry, [value]: true};
 }, <{[key: number]: boolean}>{1: true});

--- a/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_as/__snapshots__/jsfmt.spec.js.snap
@@ -14,12 +14,12 @@ start + (yearSelectTotal as number)
 scrollTop > (visibilityHeight as number)
 export default class Column<T> extends (RcTable.Column as React.ComponentClass<ColumnProps<T>,ColumnProps<T>,ColumnProps<T>,ColumnProps<T>>) {}
 export const MobxTypedForm = class extends (Form as { new (): any }) {}
-export abstract class MobxTypedForm extends (Form as { new (): any }) {}
+export abstract class MobxTypedForm1 extends (Form as { new (): any }) {}
 ({}) as {};
 function*g() {
   const test = (yield 'foo') as number;
 }
-async function g() {
+async function g1() {
   const test = (await 'foo') as number;
 }
 ({}) as X;
@@ -52,12 +52,12 @@ export default class Column<T> extends (RcTable.Column as React.ComponentClass<
   ColumnProps<T>
 >) {}
 export const MobxTypedForm = class extends (Form as { new (): any }) {};
-export abstract class MobxTypedForm extends (Form as { new (): any }) {}
+export abstract class MobxTypedForm1 extends (Form as { new (): any }) {}
 ({} as {});
 function* g() {
   const test = (yield "foo") as number;
 }
-async function g() {
+async function g1() {
   const test = (await "foo") as number;
 }
 ({} as X);

--- a/tests/typescript_as/as.js
+++ b/tests/typescript_as/as.js
@@ -6,12 +6,12 @@ start + (yearSelectTotal as number)
 scrollTop > (visibilityHeight as number)
 export default class Column<T> extends (RcTable.Column as React.ComponentClass<ColumnProps<T>,ColumnProps<T>,ColumnProps<T>,ColumnProps<T>>) {}
 export const MobxTypedForm = class extends (Form as { new (): any }) {}
-export abstract class MobxTypedForm extends (Form as { new (): any }) {}
+export abstract class MobxTypedForm1 extends (Form as { new (): any }) {}
 ({}) as {};
 function*g() {
   const test = (yield 'foo') as number;
 }
-async function g() {
+async function g1() {
   const test = (await 'foo') as number;
 }
 ({}) as X;

--- a/tests/typescript_class/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_class/__snapshots__/jsfmt.spec.js.snap
@@ -48,14 +48,14 @@ printWidth: 80
 =====================================input======================================
 class Class extends AbstractClass implements Interface1, Interface2, Interface3, Interface4 {}
 
-class ExtendsAbstractClassAndImplementsInterfaces extends AbstractClass
+class ExtendsAbstractClassAndImplementsInterfaces1 extends AbstractClass
   implements Interface1, Interface2, Interface3, Interface4 {}
 
-class ExtendsAbstractClassAndImplementsInterfaces
+class ExtendsAbstractClassAndImplementsInterfaces2
   extends AAAAAAAAAAAAAAbstractClass
   implements Interface1, Interface2, Interface3, Interface4 {}
 
-class ExtendsAbstractClassAndImplementsInterfaces
+class ExtendsAbstractClassAndImplementsInterfaces3
   extends AAAAAAAAAAAAAAbstractClass
   implements
     Interface1,
@@ -67,10 +67,10 @@ class ExtendsAbstractClassAndImplementsInterfaces
     Interface7,
     Interface8 {}
 
-class ExtendsAbstractClassAndImplementsInterfaces
-  extends AAAAAAAAAAAAAAbstractClass<Type1, Type2, Type3, Type4, Type5, Type6, Type7> {} 
+class ExtendsAbstractClassAndImplementsInterfaces4
+  extends AAAAAAAAAAAAAAbstractClass<Type1, Type2, Type3, Type4, Type5, Type6, Type7> {}
 
-class ExtendsAbstractClassAndImplementsInterfaces
+class ExtendsAbstractClassAndImplementsInterfaces5
   extends AAAAAAAAAAAAAAbstractClass<Type1, Type2, Type3, Type4, Type5, Type6, Type7>
   implements
     Interface1,
@@ -86,14 +86,14 @@ class ExtendsAbstractClassAndImplementsInterfaces
 class Class extends AbstractClass
   implements Interface1, Interface2, Interface3, Interface4 {}
 
-class ExtendsAbstractClassAndImplementsInterfaces extends AbstractClass
+class ExtendsAbstractClassAndImplementsInterfaces1 extends AbstractClass
   implements Interface1, Interface2, Interface3, Interface4 {}
 
-class ExtendsAbstractClassAndImplementsInterfaces
+class ExtendsAbstractClassAndImplementsInterfaces2
   extends AAAAAAAAAAAAAAbstractClass
   implements Interface1, Interface2, Interface3, Interface4 {}
 
-class ExtendsAbstractClassAndImplementsInterfaces
+class ExtendsAbstractClassAndImplementsInterfaces3
   extends AAAAAAAAAAAAAAbstractClass
   implements
     Interface1,
@@ -105,7 +105,7 @@ class ExtendsAbstractClassAndImplementsInterfaces
     Interface7,
     Interface8 {}
 
-class ExtendsAbstractClassAndImplementsInterfaces extends AAAAAAAAAAAAAAbstractClass<
+class ExtendsAbstractClassAndImplementsInterfaces4 extends AAAAAAAAAAAAAAbstractClass<
   Type1,
   Type2,
   Type3,
@@ -115,7 +115,7 @@ class ExtendsAbstractClassAndImplementsInterfaces extends AAAAAAAAAAAAAAbstractC
   Type7
 > {}
 
-class ExtendsAbstractClassAndImplementsInterfaces
+class ExtendsAbstractClassAndImplementsInterfaces5
   extends AAAAAAAAAAAAAAbstractClass<
     Type1,
     Type2,

--- a/tests/typescript_class/extends_implements.ts
+++ b/tests/typescript_class/extends_implements.ts
@@ -1,13 +1,13 @@
 class Class extends AbstractClass implements Interface1, Interface2, Interface3, Interface4 {}
 
-class ExtendsAbstractClassAndImplementsInterfaces extends AbstractClass
+class ExtendsAbstractClassAndImplementsInterfaces1 extends AbstractClass
   implements Interface1, Interface2, Interface3, Interface4 {}
 
-class ExtendsAbstractClassAndImplementsInterfaces
+class ExtendsAbstractClassAndImplementsInterfaces2
   extends AAAAAAAAAAAAAAbstractClass
   implements Interface1, Interface2, Interface3, Interface4 {}
 
-class ExtendsAbstractClassAndImplementsInterfaces
+class ExtendsAbstractClassAndImplementsInterfaces3
   extends AAAAAAAAAAAAAAbstractClass
   implements
     Interface1,
@@ -19,10 +19,10 @@ class ExtendsAbstractClassAndImplementsInterfaces
     Interface7,
     Interface8 {}
 
-class ExtendsAbstractClassAndImplementsInterfaces
-  extends AAAAAAAAAAAAAAbstractClass<Type1, Type2, Type3, Type4, Type5, Type6, Type7> {} 
+class ExtendsAbstractClassAndImplementsInterfaces4
+  extends AAAAAAAAAAAAAAbstractClass<Type1, Type2, Type3, Type4, Type5, Type6, Type7> {}
 
-class ExtendsAbstractClassAndImplementsInterfaces
+class ExtendsAbstractClassAndImplementsInterfaces5
   extends AAAAAAAAAAAAAAbstractClass<Type1, Type2, Type3, Type4, Type5, Type6, Type7>
   implements
     Interface1,

--- a/tests/typescript_declare/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_declare/__snapshots__/jsfmt.spec.js.snap
@@ -70,14 +70,14 @@ printWidth: 80
 const hello = 5;
 
 // tslint:disable-next-line:no-use-before-declare
-declare const hello = 5;
+declare const hello2 = 5;
 
 =====================================output=====================================
 // tslint:disable-next-line:no-use-before-declare
 const hello = 5;
 
 // tslint:disable-next-line:no-use-before-declare
-declare const hello = 5;
+declare const hello2 = 5;
 
 ================================================================================
 `;

--- a/tests/typescript_declare/declare_var.ts
+++ b/tests/typescript_declare/declare_var.ts
@@ -2,4 +2,4 @@
 const hello = 5;
 
 // tslint:disable-next-line:no-use-before-declare
-declare const hello = 5;
+declare const hello2 = 5;

--- a/tests/typescript_decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_decorators/__snapshots__/jsfmt.spec.js.snap
@@ -96,7 +96,7 @@ class Class {
   }
 }
 
-class Class {
+class Class2 {
   method(
     @Decorator1
     @Decorator2
@@ -106,7 +106,7 @@ class Class {
   }
 }
 
-class Class {
+class Class3 {
   method(
     @Decorator
     { prop1_1, prop1_2 }: Type,
@@ -116,7 +116,7 @@ class Class {
   }
 }
 
-class Class {
+class Class4 {
   method(
     param1,
     @Decorator
@@ -124,7 +124,7 @@ class Class {
   ) {}
 }
 
-class Class {
+class Class5 {
   method(
     @Decorator { prop1 }: Type
   ) {}
@@ -154,7 +154,7 @@ class Class {
   }
 }
 
-class Class {
+class Class2 {
   method(
     @Decorator1
     @Decorator2
@@ -164,7 +164,7 @@ class Class {
   }
 }
 
-class Class {
+class Class3 {
   method(
     @Decorator
     { prop1_1, prop1_2 }: Type,
@@ -174,7 +174,7 @@ class Class {
   }
 }
 
-class Class {
+class Class4 {
   method(
     param1,
     @Decorator
@@ -182,7 +182,7 @@ class Class {
   ) {}
 }
 
-class Class {
+class Class5 {
   method(@Decorator { prop1 }: Type) {}
 }
 
@@ -226,13 +226,13 @@ class Something {
     readonly property: Array<string>
 }
 
-class Something {
+class Something2 {
     @foo()
     // comment
     abstract property: Array<string>
 }
 
-class Something {
+class Something3 {
     @foo()
     // comment
     abstract method(): Array<string>
@@ -269,13 +269,13 @@ class Something {
   readonly property: Array<string>;
 }
 
-class Something {
+class Something2 {
   @foo()
   // comment
   abstract property: Array<string>;
 }
 
-class Something {
+class Something3 {
   @foo()
   // comment
   abstract method(): Array<string>;

--- a/tests/typescript_decorators/decorators-comments.js
+++ b/tests/typescript_decorators/decorators-comments.js
@@ -29,13 +29,13 @@ class Something {
     readonly property: Array<string>
 }
 
-class Something {
+class Something2 {
     @foo()
     // comment
     abstract property: Array<string>
 }
 
-class Something {
+class Something3 {
     @foo()
     // comment
     abstract method(): Array<string>

--- a/tests/typescript_decorators/decorators.js
+++ b/tests/typescript_decorators/decorators.js
@@ -25,7 +25,7 @@ class Class {
   }
 }
 
-class Class {
+class Class2 {
   method(
     @Decorator1
     @Decorator2
@@ -35,7 +35,7 @@ class Class {
   }
 }
 
-class Class {
+class Class3 {
   method(
     @Decorator
     { prop1_1, prop1_2 }: Type,
@@ -45,7 +45,7 @@ class Class {
   }
 }
 
-class Class {
+class Class4 {
   method(
     param1,
     @Decorator
@@ -53,7 +53,7 @@ class Class {
   ) {}
 }
 
-class Class {
+class Class5 {
   method(
     @Decorator { prop1 }: Type
   ) {}

--- a/tests/typescript_non_null/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_non_null/__snapshots__/jsfmt.spec.js.snap
@@ -8,7 +8,7 @@ printWidth: 80
 =====================================input======================================
 const { somePropThatHasAReallyLongName, anotherPropThatHasALongName } = this.props.imReallySureAboutThis!;
 
-const { somePropThatHasAReallyLongName, anotherPropThatHasALongName } = this.props.imReallySureAboutThis!.anotherObject;
+const { somePropThatHasAReallyLongName2, anotherPropThatHasALongName2 } = this.props.imReallySureAboutThis!.anotherObject;
 
 this.foo.get("bar")!.doThings().more();
 
@@ -21,8 +21,8 @@ const {
 } = this.props.imReallySureAboutThis!;
 
 const {
-  somePropThatHasAReallyLongName,
-  anotherPropThatHasALongName
+  somePropThatHasAReallyLongName2,
+  anotherPropThatHasALongName2
 } = this.props.imReallySureAboutThis!.anotherObject;
 
 this.foo
@@ -60,9 +60,9 @@ const a = (b()!)(); // parens aren't necessary
 const b = c!();
 
 // parens are necessary if the expression result is called as a constructor
-const c = new (d()!)();
-const c = new (d()!);
-const c = new (d()!.e)();
+const c1 = new (d()!)();
+const c2 = new (d()!);
+const c3 = new (d()!.e)();
 new (x()\`\`.y!)();
 new (x()\`\`!.y)();
 new (x()!\`\`.y)();
@@ -85,9 +85,9 @@ const a = b()!(); // parens aren't necessary
 const b = c!();
 
 // parens are necessary if the expression result is called as a constructor
-const c = new (d()!)();
-const c = new (d()!)();
-const c = new (d()!.e)();
+const c1 = new (d()!)();
+const c2 = new (d()!)();
+const c3 = new (d()!.e)();
 new (x()\`\`.y!)();
 new (x()\`\`!.y)();
 new (x()!\`\`.y)();

--- a/tests/typescript_non_null/member-chain.js
+++ b/tests/typescript_non_null/member-chain.js
@@ -1,6 +1,6 @@
 const { somePropThatHasAReallyLongName, anotherPropThatHasALongName } = this.props.imReallySureAboutThis!;
 
-const { somePropThatHasAReallyLongName, anotherPropThatHasALongName } = this.props.imReallySureAboutThis!.anotherObject;
+const { somePropThatHasAReallyLongName2, anotherPropThatHasALongName2 } = this.props.imReallySureAboutThis!.anotherObject;
 
 this.foo.get("bar")!.doThings().more();
 

--- a/tests/typescript_non_null/parens.ts
+++ b/tests/typescript_non_null/parens.ts
@@ -14,9 +14,9 @@ const a = (b()!)(); // parens aren't necessary
 const b = c!();
 
 // parens are necessary if the expression result is called as a constructor
-const c = new (d()!)();
-const c = new (d()!);
-const c = new (d()!.e)();
+const c1 = new (d()!)();
+const c2 = new (d()!);
+const c3 = new (d()!.e)();
 new (x()``.y!)();
 new (x()``!.y)();
 new (x()!``.y)();

--- a/tests/typescript_typeparams/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_typeparams/__snapshots__/jsfmt.spec.js.snap
@@ -297,7 +297,7 @@ export const forwardS = R.curry(
   R.assoc(prop, reducer(value, state[prop]), state)
 )
 
-export const forwardS = R.curry(
+export const forwardS1 = R.curry(
   <VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV, TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT>(prop: string, reducer: ReducerFunction<V, T>, value: V, state: {[name: string]: T}) =>
   R.assoc(prop, reducer(value, state[prop]), state)
 )
@@ -313,7 +313,7 @@ export const forwardS = R.curry(
   ) => R.assoc(prop, reducer(value, state[prop]), state)
 );
 
-export const forwardS = R.curry(
+export const forwardS1 = R.curry(
   <
     VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV,
     TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT

--- a/tests/typescript_typeparams/long-function-arg.ts
+++ b/tests/typescript_typeparams/long-function-arg.ts
@@ -3,7 +3,7 @@ export const forwardS = R.curry(
   R.assoc(prop, reducer(value, state[prop]), state)
 )
 
-export const forwardS = R.curry(
+export const forwardS1 = R.curry(
   <VVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVVV, TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT>(prop: string, reducer: ReducerFunction<V, T>, value: V, state: {[name: string]: T}) =>
   R.assoc(prop, reducer(value, state[prop]), state)
 )

--- a/tests/typescript_union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_union/__snapshots__/jsfmt.spec.js.snap
@@ -25,7 +25,7 @@ type UploadState<E, EM, D>
   // Uploading to aws3 and CreatePostMutation succeeded
   | {type: "Success", data: D};
 
-type UploadState<E, EM, D>
+type UploadState2<E, EM, D>
   // The upload hasnt begun yet
   = A
   // The upload timed out
@@ -68,7 +68,7 @@ type UploadState<E, EM, D> =
   // Uploading to aws3 and CreatePostMutation succeeded
   | { type: "Success"; data: D };
 
-type UploadState<E, EM, D> =
+type UploadState2<E, EM, D> =
   // The upload hasnt begun yet
   | A
   // The upload timed out
@@ -141,26 +141,26 @@ type State = {
   | { discriminant: "BAZ"; baz: any }
 );
 
-const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
+const foo1 = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
   | string
   | undefined
 )[];
 
-const foo: (
+const foo2: (
   | AAAAAAAAAAAAAAAAAAAAAA
   | BBBBBBBBBBBBBBBBBBBBBB
   | CCCCCCCCCCCCCCCCCCCCCC
   | DDDDDDDDDDDDDDDDDDDDDD
 )[] = [];
 
-const foo: keyof (
+const foo3: keyof (
   | AAAAAAAAAAAAAAAAAAAAAA
   | BBBBBBBBBBBBBBBBBBBBBB
   | CCCCCCCCCCCCCCCCCCCCCC
   | DDDDDDDDDDDDDDDDDDDDDD
 ) = bar;
 
-const foo:
+const foo4:
   | foo
   | (
       | AAAAAAAAAAAAAAAAAAAAAA
@@ -251,26 +251,26 @@ type State = {
   | { discriminant: "BAZ"; baz: any }
 );
 
-const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
+const foo1 = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
   | string
   | undefined
 )[];
 
-const foo: (
+const foo2: (
   | AAAAAAAAAAAAAAAAAAAAAA
   | BBBBBBBBBBBBBBBBBBBBBB
   | CCCCCCCCCCCCCCCCCCCCCC
   | DDDDDDDDDDDDDDDDDDDDDD
 )[] = [];
 
-const foo: keyof (
+const foo3: keyof (
   | AAAAAAAAAAAAAAAAAAAAAA
   | BBBBBBBBBBBBBBBBBBBBBB
   | CCCCCCCCCCCCCCCCCCCCCC
   | DDDDDDDDDDDDDDDDDDDDDD
 ) = bar;
 
-const foo:
+const foo4:
   | foo
   | (
       | AAAAAAAAAAAAAAAAAAAAAA

--- a/tests/typescript_union/inlining.ts
+++ b/tests/typescript_union/inlining.ts
@@ -17,7 +17,7 @@ type UploadState<E, EM, D>
   // Uploading to aws3 and CreatePostMutation succeeded
   | {type: "Success", data: D};
 
-type UploadState<E, EM, D>
+type UploadState2<E, EM, D>
   // The upload hasnt begun yet
   = A
   // The upload timed out

--- a/tests/typescript_union/union-parens.ts
+++ b/tests/typescript_union/union-parens.ts
@@ -39,26 +39,26 @@ type State = {
   | { discriminant: "BAZ"; baz: any }
 );
 
-const foo = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
+const foo1 = [abc, def, ghi, jkl, mno, pqr, stu, vwx, yz] as (
   | string
   | undefined
 )[];
 
-const foo: (
+const foo2: (
   | AAAAAAAAAAAAAAAAAAAAAA
   | BBBBBBBBBBBBBBBBBBBBBB
   | CCCCCCCCCCCCCCCCCCCCCC
   | DDDDDDDDDDDDDDDDDDDDDD
 )[] = [];
 
-const foo: keyof (
+const foo3: keyof (
   | AAAAAAAAAAAAAAAAAAAAAA
   | BBBBBBBBBBBBBBBBBBBBBB
   | CCCCCCCCCCCCCCCCCCCCCC
   | DDDDDDDDDDDDDDDDDDDDDD
 ) = bar;
 
-const foo:
+const foo4:
   | foo
   | (
       | AAAAAAAAAAAAAAAAAAAAAA

--- a/tests/unary_expression/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/unary_expression/__snapshots__/jsfmt.spec.js.snap
@@ -275,7 +275,7 @@ function* bar() {
   );
 }
 
-async function bar() {
+async function bar2() {
   !(await x);
   !(await x /* foo */);
   !(/* foo */ await x);
@@ -560,7 +560,7 @@ function* bar() {
   );
 }
 
-async function bar() {
+async function bar2() {
   !(await x);
   !((await x) /* foo */);
   !(/* foo */ (await x));

--- a/tests/unary_expression/comments.js
+++ b/tests/unary_expression/comments.js
@@ -267,7 +267,7 @@ function* bar() {
   );
 }
 
-async function bar() {
+async function bar2() {
   !(await x);
   !(await x /* foo */);
   !(/* foo */ await x);


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

I'm extracting these renames from #6400 as they create too much noise and that PR gets too difficult to review. Let's merge them separately. 

They're caused by the fact that since the version 7.4.0, Babel has [scope tracking](https://github.com/babel/babel/pull/9493) and considers duplicate variable bindings a parsing error. Unfortunately, there is no way to disable this check for now.

No changes in the API or CLI. Not a user-facing change.

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
