### PR TITLE
Refactor createLanguage to use function transform

### DIFF
--- a/src/language-css/index.js
+++ b/src/language-css/index.js
@@ -5,37 +5,35 @@ const options = require("./options");
 const createLanguage = require("../utils/create-language");
 
 const languages = [
-  createLanguage(require("linguist-languages/data/CSS"), {
-    override: {
+  createLanguage(require("linguist-languages/data/CSS"), data =>
+    Object.assign(data, {
       since: "1.4.0",
       parsers: ["css"],
       vscodeLanguageIds: ["css"]
-    }
-  }),
-  createLanguage(require("linguist-languages/data/PostCSS"), {
-    override: {
+    })
+  ),
+  createLanguage(require("linguist-languages/data/PostCSS"), data =>
+    Object.assign(data, {
       since: "1.4.0",
       parsers: ["css"],
-      vscodeLanguageIds: ["postcss"]
-    },
-    extend: {
-      extensions: [".postcss"]
-    }
-  }),
-  createLanguage(require("linguist-languages/data/Less"), {
-    override: {
+      vscodeLanguageIds: ["postcss"],
+      extensions: data.extensions.concat(".postcss")
+    })
+  ),
+  createLanguage(require("linguist-languages/data/Less"), data =>
+    Object.assign(data, {
       since: "1.4.0",
       parsers: ["less"],
       vscodeLanguageIds: ["less"]
-    }
-  }),
-  createLanguage(require("linguist-languages/data/SCSS"), {
-    override: {
+    })
+  ),
+  createLanguage(require("linguist-languages/data/SCSS"), data =>
+    Object.assign(data, {
       since: "1.4.0",
       parsers: ["scss"],
       vscodeLanguageIds: ["scss"]
-    }
-  })
+    })
+  )
 ];
 
 const printers = {

--- a/src/language-graphql/index.js
+++ b/src/language-graphql/index.js
@@ -5,13 +5,13 @@ const options = require("./options");
 const createLanguage = require("../utils/create-language");
 
 const languages = [
-  createLanguage(require("linguist-languages/data/GraphQL"), {
-    override: {
+  createLanguage(require("linguist-languages/data/GraphQL"), data =>
+    Object.assign(data, {
       since: "1.5.0",
       parsers: ["graphql"],
       vscodeLanguageIds: ["graphql"]
-    }
-  })
+    })
+  )
 ];
 
 const printers = {

--- a/src/language-handlebars/index.js
+++ b/src/language-handlebars/index.js
@@ -4,13 +4,13 @@ const printer = require("./printer-glimmer");
 const createLanguage = require("../utils/create-language");
 
 const languages = [
-  createLanguage(require("linguist-languages/data/Handlebars"), {
-    override: {
+  createLanguage(require("linguist-languages/data/Handlebars"), data =>
+    Object.assign(data, {
       since: null, // unreleased
       parsers: ["glimmer"],
       vscodeLanguageIds: ["handlebars"]
-    }
-  })
+    })
+  )
 ];
 
 const printers = {

--- a/src/language-html/index.js
+++ b/src/language-html/index.js
@@ -5,47 +5,43 @@ const createLanguage = require("../utils/create-language");
 const options = require("./options");
 
 const languages = [
-  createLanguage(require("linguist-languages/data/HTML"), {
-    override: {
+  createLanguage(require("linguist-languages/data/HTML"), data =>
+    Object.assign(data, {
       name: "Angular",
       since: "1.15.0",
       parsers: ["angular"],
       vscodeLanguageIds: ["html"],
-
       extensions: [".component.html"],
       filenames: []
-    }
-  }),
-  createLanguage(require("linguist-languages/data/HTML"), {
-    override: {
+    })
+  ),
+  createLanguage(require("linguist-languages/data/HTML"), data =>
+    Object.assign(data, {
       since: "1.15.0",
       parsers: ["html"],
-      vscodeLanguageIds: ["html"]
-    },
-    extend: {
-      extensions: [
+      vscodeLanguageIds: ["html"],
+      extensions: data.extensions.concat([
         ".mjml" // MJML is considered XML in Linguist but it should be formatted as HTML
-      ]
-    }
-  }),
-  createLanguage(require("linguist-languages/data/HTML"), {
-    override: {
+      ])
+    })
+  ),
+  createLanguage(require("linguist-languages/data/HTML"), data =>
+    Object.assign(data, {
       name: "Lightning Web Components",
       since: "1.17.0",
       parsers: ["lwc"],
       vscodeLanguageIds: ["html"],
-
       extensions: [],
       filenames: []
-    }
-  }),
-  createLanguage(require("linguist-languages/data/Vue"), {
-    override: {
+    })
+  ),
+  createLanguage(require("linguist-languages/data/Vue"), data =>
+    Object.assign(data, {
       since: "1.10.0",
       parsers: ["vue"],
       vscodeLanguageIds: ["vue"]
-    }
-  })
+    })
+  )
 ];
 
 const printers = {

--- a/src/language-js/index.js
+++ b/src/language-js/index.js
@@ -6,18 +6,16 @@ const options = require("./options");
 const createLanguage = require("../utils/create-language");
 
 const languages = [
-  createLanguage(require("linguist-languages/data/JavaScript"), {
-    override: {
+  createLanguage(require("linguist-languages/data/JavaScript"), data =>
+    Object.assign(data, {
       since: "0.0.0",
       parsers: ["babel", "flow"],
-      vscodeLanguageIds: ["javascript"]
-    },
-    extend: {
-      interpreters: ["nodejs"]
-    }
-  }),
-  createLanguage(require("linguist-languages/data/JavaScript"), {
-    override: {
+      vscodeLanguageIds: ["javascript"],
+      interpreters: data.interpreters.concat(["nodejs"])
+    })
+  ),
+  createLanguage(require("linguist-languages/data/JavaScript"), data =>
+    Object.assign(data, {
       name: "Flow",
       since: "0.0.0",
       parsers: ["babel", "flow"],
@@ -25,66 +23,62 @@ const languages = [
       aliases: [],
       filenames: [],
       extensions: [".js.flow"]
-    }
-  }),
-  createLanguage(require("linguist-languages/data/JSX"), {
-    override: {
+    })
+  ),
+  createLanguage(require("linguist-languages/data/JSX"), data =>
+    Object.assign(data, {
       since: "0.0.0",
       parsers: ["babel", "flow"],
       vscodeLanguageIds: ["javascriptreact"]
-    }
-  }),
-  createLanguage(require("linguist-languages/data/TypeScript"), {
-    override: {
+    })
+  ),
+  createLanguage(require("linguist-languages/data/TypeScript"), data =>
+    Object.assign(data, {
       since: "1.4.0",
       parsers: ["typescript"],
       vscodeLanguageIds: ["typescript"]
-    }
-  }),
-  createLanguage(require("linguist-languages/data/TSX"), {
-    override: {
+    })
+  ),
+  createLanguage(require("linguist-languages/data/TSX"), data =>
+    Object.assign(data, {
       since: "1.4.0",
       parsers: ["typescript"],
       vscodeLanguageIds: ["typescriptreact"]
-    }
-  }),
-  createLanguage(require("linguist-languages/data/JSON"), {
-    override: {
+    })
+  ),
+  createLanguage(require("linguist-languages/data/JSON"), data =>
+    Object.assign(data, {
       name: "JSON.stringify",
       since: "1.13.0",
       parsers: ["json-stringify"],
       vscodeLanguageIds: ["json"],
       extensions: [], // .json file defaults to json instead of json-stringify
       filenames: ["package.json", "package-lock.json", "composer.json"]
-    }
-  }),
-  createLanguage(require("linguist-languages/data/JSON"), {
-    override: {
+    })
+  ),
+  createLanguage(require("linguist-languages/data/JSON"), data =>
+    Object.assign(data, {
       since: "1.5.0",
       parsers: ["json"],
-      vscodeLanguageIds: ["json"]
-    },
-    extend: {
-      filenames: [".prettierrc"]
-    }
-  }),
-  createLanguage(require("linguist-languages/data/JSON with Comments"), {
-    override: {
+      vscodeLanguageIds: ["json"],
+      filenames: data.filenames.concat([".prettierrc"])
+    })
+  ),
+  createLanguage(require("linguist-languages/data/JSON with Comments"), data =>
+    Object.assign(data, {
       since: "1.5.0",
       parsers: ["json"],
-      vscodeLanguageIds: ["jsonc"]
-    },
-    extend: {
-      filenames: [".eslintrc"]
-    }
-  }),
-  createLanguage(require("linguist-languages/data/JSON5"), {
-    override: {
+      vscodeLanguageIds: ["jsonc"],
+      filenames: data.filenames.concat([".eslintrc"])
+    })
+  ),
+  createLanguage(require("linguist-languages/data/JSON5"), data =>
+    Object.assign(data, {
       since: "1.13.0",
       parsers: ["json5"],
       vscodeLanguageIds: ["json5"]
-    }
-  })
+    })
+  )
 ];
 
 const printers = {

--- a/src/language-markdown/index.js
+++ b/src/language-markdown/index.js
@@ -5,29 +5,25 @@ const options = require("./options");
 const createLanguage = require("../utils/create-language");
 
 const languages = [
-  createLanguage(require("linguist-languages/data/Markdown"), {
-    override: {
+  createLanguage(require("linguist-languages/data/Markdown"), data =>
+    Object.assign(data, {
       since: "1.8.0",
       parsers: ["remark"],
-      vscodeLanguageIds: ["markdown"]
-    },
-    extend: {
-      filenames: ["README"]
-    },
-    exclude: {
-      extensions: [".mdx"]
-    }
-  }),
-  createLanguage(require("linguist-languages/data/Markdown"), {
-    override: {
+      vscodeLanguageIds: ["markdown"],
+      filenames: data.filenames.concat(["README"]),
+      extensions: data.extensions.filter(extension => extension !== ".mdx")
+    })
+  ),
+  createLanguage(require("linguist-languages/data/Markdown"), data =>
+    Object.assign(data, {
       name: "MDX",
       since: "1.15.0",
       parsers: ["mdx"],
       vscodeLanguageIds: ["mdx"],
       filenames: [],
       extensions: [".mdx"]
-    }
-  })
+    })
+  )
 ];
 
 const printers = {

--- a/src/language-yaml/index.js
+++ b/src/language-yaml/index.js
@@ -5,13 +5,13 @@ const options = require("./options");
 const createLanguage = require("../utils/create-language");
 
 const languages = [
-  createLanguage(require("linguist-languages/data/YAML"), {
-    override: {
+  createLanguage(require("linguist-languages/data/YAML"), data =>
+    Object.assign(data, {
       since: "1.14.0",
       parsers: ["yaml"],
       vscodeLanguageIds: ["yaml"]
-    }
-  })
+    })
+  )
 ];
 
 module.exports = {

--- a/src/utils/create-language.js
+++ b/src/utils/create-language.js
@@ -1,6 +1,6 @@
 "use strict";
 
-module.exports = function(linguistData, { extend, override, exclude }) {
+module.exports = function(linguistData, transform) {
   const language = {};
 
   for (const key in linguistData) {
@@ -8,23 +8,5 @@ module.exports = function(linguistData, { extend, override, exclude }) {
     language[newKey] = linguistData[key];
   }
 
-  if (extend) {
-    for (const key in extend) {
-      language[key] = (language[key] || []).concat(extend[key]);
-    }
-  }
-
-  if (exclude) {
-    for (const key in exclude) {
-      language[key] = (language[key] || []).filter(
-        value => (exclude[key] || []).indexOf(value) === -1
-      );
-    }
-  }
-
-  for (const key in override) {
-    language[key] = override[key];
-  }
-
-  return language;
+  return transform(language);
 };


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Refactor internal api `createLanguage` to use function transform, this makes it more powerful and easier to use, no need check how `extend` `exclude` `override` works

It will be even easier to use when we support `Spread syntax`

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
