### PR TITLE
fix playground: wrong parser shown in options on first open

### DIFF
--- a/website/playground/util.js
+++ b/website/playground/util.js
@@ -11,9 +11,7 @@ export function getDefaults(availableOptions, optionNames) {
   for (const option of availableOptions) {
     if (optionNames.includes(option.name)) {
       defaults[option.name] =
-        option.name === "parser"
-          ? "babylon" // TODO(1.16): replace with `babel`
-          : option.default;
+        option.name === "parser" ? "babel" : option.default;
     }
   }
   return defaults;


### PR DESCRIPTION
The select shows "flow" while in fact "babel" is used.

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
