### PR TITLE
Fix tooltip being hidden behind browser scrollbars

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -1014,6 +1014,10 @@ class A {
 }
 ```
 
+#### Website: Fix tooltip being hidden behind browser scrollbars ([#6688] by [@mrseanbaines])
+
+Fixes an issue where the tooltip above the buttons in the footer of the playground would be hidden behind the browser's scrollbars.
+
 [#5910]: https://github.com/prettier/prettier/pull/5910
 [#6033]: https://github.com/prettier/prettier/pull/6033
 [#6186]: https://github.com/prettier/prettier/pull/6186
@@ -1049,6 +1053,7 @@ class A {
 [#6640]: https://github.com/prettier/prettier/pull/6640
 [#6646]: https://github.com/prettier/prettier/pull/6646
 [#6673]: https://github.com/prettier/prettier/pull/6673
+[#6688]: https://github.com/prettier/prettier/pull/6688
 [@brainkim]: https://github.com/brainkim
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
@@ -1062,3 +1067,4 @@ class A {
 [@ericsakmar]: https://github.com/ericsakmar
 [@squidfunk]: https://github.com/squidfunk
 [@vjeux]: https://github.com/vjeux
+[@mrseanbaines]: https://github.com/mrseanbaines

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -1014,10 +1014,6 @@ class A {
 }
 ```
 
-#### Website: Fix tooltip being hidden behind browser scrollbars ([#6688] by [@mrseanbaines])
-
-Fixes an issue where the tooltip above the buttons in the footer of the playground would be hidden behind the browser's scrollbars.
-
 [#5910]: https://github.com/prettier/prettier/pull/5910
 [#6033]: https://github.com/prettier/prettier/pull/6033
 [#6186]: https://github.com/prettier/prettier/pull/6186
@@ -1053,7 +1049,6 @@ Fixes an issue where the tooltip above the buttons in the footer of the playgrou
 [#6640]: https://github.com/prettier/prettier/pull/6640
 [#6646]: https://github.com/prettier/prettier/pull/6646
 [#6673]: https://github.com/prettier/prettier/pull/6673
-[#6688]: https://github.com/prettier/prettier/pull/6688
 [@brainkim]: https://github.com/brainkim
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
@@ -1067,4 +1062,3 @@ Fixes an issue where the tooltip above the buttons in the footer of the playgrou
 [@ericsakmar]: https://github.com/ericsakmar
 [@squidfunk]: https://github.com/squidfunk
 [@vjeux]: https://github.com/vjeux
-[@mrseanbaines]: https://github.com/mrseanbaines

--- a/website/static/separate-css/playground.css
+++ b/website/static/separate-css/playground.css
@@ -157,10 +157,6 @@ header h1 {
   float: left;
 }
 
-.bottom-bar-buttons .btn {
-  z-index: 6;
-}
-
 .bottom-bar-buttons-right {
   float: right;
 }

--- a/website/static/separate-css/playground.css
+++ b/website/static/separate-css/playground.css
@@ -157,6 +157,10 @@ header h1 {
   float: left;
 }
 
+.bottom-bar-buttons .btn {
+  z-index: 6;
+}
+
 .bottom-bar-buttons-right {
   float: right;
 }

--- a/website/static/separate-css/playground.css
+++ b/website/static/separate-css/playground.css
@@ -276,7 +276,7 @@ input[type="number"] {
 
 .tooltip {
   position: absolute;
-  z-index: 1;
+  z-index: 6;
   bottom: 100%;
   left: 50%;
   transform: translateX(-50%);


### PR DESCRIPTION
Fixes https://github.com/prettier/prettier/issues/6297

Adds a `z-index` to the button tooltips in the footer in the playground to bring the tooltip above the browser scrollbar.

<img width="190" alt="image" src="https://user-images.githubusercontent.com/24367010/67159663-f4650700-f347-11e9-8f28-51e1b1d86dd6.png">

- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
