### PR TITLE
Avoid switch and chain indents when tab >2 spaces

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -119,6 +119,13 @@ const {
 
 let uid = 0;
 
+// If clients have a large tab setting (usually 4 spaces), then certain
+// indentation points can detract from the reading experience. Use this
+// function to use an indent only if it is small.
+function indentIfSmallTab(options, content) {
+  return options.tabWidth <= 2 ? indent(content) : content;
+}
+
 function shouldPrintComma(options, level) {
   level = level || "es5";
 
@@ -1999,7 +2006,8 @@ function printPathNoParens(path, options, print, args) {
         ),
         " {",
         n.cases.length > 0
-          ? indent(
+          ? indentIfSmallTab(
+              options,
               concat([
                 hardline,
                 join(
@@ -4920,7 +4928,8 @@ function printMemberChain(path, options, print) {
     if (groups.length === 0) {
       return "";
     }
-    return indent(
+    return indentIfSmallTab(
+      options,
       group(concat([hardline, join(hardline, groups.map(printGroup))]))
     );
   }

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -31,6 +31,38 @@ function a() {
 ================================================================================
 `;
 
+exports[`bracket_0.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+function a() {
+  function b() {
+	queryThenMutateDOM(
+      () => {
+        title = SomeThing.call(root, 'someLongStringThatPushesThisTextReallyFar')[0];
+      }
+    );
+  }
+}
+
+=====================================output=====================================
+function a() {
+    function b() {
+        queryThenMutateDOM(() => {
+            title = SomeThing.call(
+                root,
+                "someLongStringThatPushesThisTextReallyFar"
+            )[0];
+        });
+    }
+}
+
+================================================================================
+`;
+
 exports[`break-last-call.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "typescript"]
@@ -157,6 +189,133 @@ it("should group messages with same created time", () => {
 ================================================================================
 `;
 
+exports[`break-last-call.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+export default store => {
+  return callApi(endpoint, schema).then(
+    response => next(actionWith({
+      response,
+      type: successType
+    })),
+    error => next(actionWith({
+      type: failureType,
+      error: error.message || 'Something bad happened'
+    }))
+  )
+}
+
+it('should group messages with same created time', () => {
+  expect(
+    groupMessages(messages).toJS(),
+  ).toEqual({
+    '11/01/2017 13:36': [
+      {message: 'test', messageType: 'SMS', status: 'Unknown', created: '11/01/2017 13:36'},
+      {message: 'test', messageType: 'Email', status: 'Unknown', created: '11/01/2017 13:36'},
+    ],
+    '09/01/2017 17:25': [
+      {message: 'te', messageType: 'SMS', status: 'Unknown', created: '09/01/2017 17:25'},
+      {message: 'te', messageType: 'Email', status: 'Unknown', created: '09/01/2017 17:25'},
+    ],
+    '11/01/2017 13:33': [
+      {message: 'test', messageType: 'SMS', status: 'Unknown', created: '11/01/2017 13:33'},
+      {message: 'test', messageType: 'Email', status: 'Unknown', created: '11/01/2017 13:33'},
+    ],
+    '11/01/2017 13:37': [
+      {message: 'test', messageType: 'SMS', status: 'Unknown', created: '11/01/2017 13:37'},
+      {message: 'test', messageType: 'Email', status: 'Unknown', created: '11/01/2017 13:37'},
+    ],
+  });
+});
+
+=====================================output=====================================
+export default store => {
+    return callApi(endpoint, schema).then(
+        response =>
+            next(
+                actionWith({
+                    response,
+                    type: successType
+                })
+            ),
+        error =>
+            next(
+                actionWith({
+                    type: failureType,
+                    error: error.message || "Something bad happened"
+                })
+            )
+    );
+};
+
+it("should group messages with same created time", () => {
+    expect(groupMessages(messages).toJS()).toEqual({
+        "11/01/2017 13:36": [
+            {
+                message: "test",
+                messageType: "SMS",
+                status: "Unknown",
+                created: "11/01/2017 13:36"
+            },
+            {
+                message: "test",
+                messageType: "Email",
+                status: "Unknown",
+                created: "11/01/2017 13:36"
+            }
+        ],
+        "09/01/2017 17:25": [
+            {
+                message: "te",
+                messageType: "SMS",
+                status: "Unknown",
+                created: "09/01/2017 17:25"
+            },
+            {
+                message: "te",
+                messageType: "Email",
+                status: "Unknown",
+                created: "09/01/2017 17:25"
+            }
+        ],
+        "11/01/2017 13:33": [
+            {
+                message: "test",
+                messageType: "SMS",
+                status: "Unknown",
+                created: "11/01/2017 13:33"
+            },
+            {
+                message: "test",
+                messageType: "Email",
+                status: "Unknown",
+                created: "11/01/2017 13:33"
+            }
+        ],
+        "11/01/2017 13:37": [
+            {
+                message: "test",
+                messageType: "SMS",
+                status: "Unknown",
+                created: "11/01/2017 13:37"
+            },
+            {
+                message: "test",
+                messageType: "Email",
+                status: "Unknown",
+                created: "11/01/2017 13:37"
+            }
+        ]
+    });
+});
+
+================================================================================
+`;
+
 exports[`break-last-member.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "typescript"]
@@ -226,6 +385,76 @@ const {
 ================================================================================
 `;
 
+exports[`break-last-member.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+SomeVeryLongUpperCaseConstant.someVeryLongCallExpression().some_very_long_member_expression
+weNeedToReachTheEightyCharacterLimitXXXXXXXXXXXXXXXXX.someNode
+  .childrenInAnArray[0];
+superSupersuperSupersuperSupersuperSupersuperSuperLong.exampleOfOrderOfGetterAndSetterReordered;
+superSupersuperSupersuperSupersuperSupersuperSuperLong.exampleOfOrderOfGetterAndSetterReordered[0];
+
+expect(
+  findDOMNode(component.instance()).getElementsByClassName(styles.inner)[0].style.paddingRight
+).toBe('1000px');
+
+const { course, conflicts = [], index, scheduleId, studentId, something } = a.this.props;
+
+const { course, conflicts = [], index, scheduleId, studentId, something } = this.props;
+
+const {
+  updated,
+  author: { identifier: ownerId },
+  location,
+  category: categories,
+} = rawAd.entry;
+
+=====================================output=====================================
+SomeVeryLongUpperCaseConstant.someVeryLongCallExpression()
+    .some_very_long_member_expression;
+weNeedToReachTheEightyCharacterLimitXXXXXXXXXXXXXXXXX.someNode
+    .childrenInAnArray[0];
+superSupersuperSupersuperSupersuperSupersuperSuperLong.exampleOfOrderOfGetterAndSetterReordered;
+superSupersuperSupersuperSupersuperSupersuperSuperLong
+    .exampleOfOrderOfGetterAndSetterReordered[0];
+
+expect(
+    findDOMNode(component.instance()).getElementsByClassName(styles.inner)[0]
+        .style.paddingRight
+).toBe("1000px");
+
+const {
+    course,
+    conflicts = [],
+    index,
+    scheduleId,
+    studentId,
+    something
+} = a.this.props;
+
+const {
+    course,
+    conflicts = [],
+    index,
+    scheduleId,
+    studentId,
+    something
+} = this.props;
+
+const {
+    updated,
+    author: { identifier: ownerId },
+    location,
+    category: categories
+} = rawAd.entry;
+
+================================================================================
+`;
+
 exports[`break-multiple.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "typescript"]
@@ -247,6 +476,34 @@ object
 foo()
   .bar()
   .baz();
+
+foo().bar.baz();
+
+================================================================================
+`;
+
+exports[`break-multiple.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+object.foo().bar().baz();
+
+foo().bar().baz();
+
+foo().bar.baz();
+
+=====================================output=====================================
+object
+.foo()
+.bar()
+.baz();
+
+foo()
+.bar()
+.baz();
 
 foo().bar.baz();
 
@@ -405,6 +662,159 @@ angular
 ================================================================================
 `;
 
+exports[`comment.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+function f() {
+  return observableFromSubscribeFunction()
+    // Debounce manually rather than using editor.onDidStopChanging so that the debounce time is
+    // configurable.
+    .debounceTime(debounceInterval);
+}
+
+_.a(a)
+  /* very very very very very very very long such that it is longer than 80 columns */
+  .a()
+
+_.a(
+  a
+)/* very very very very very very very long such that it is longer than 80 columns */
+.a();
+
+_.a(
+  a
+) /* very very very very very very very long such that it is longer than 80 columns */.a();
+
+Something
+  // $FlowFixMe(>=0.41.0)
+  .getInstance(this.props.dao)
+  .getters()
+
+// Warm-up first
+measure()
+  .then(() => {
+    SomethingLong();
+  });
+
+measure() // Warm-up first
+  .then(() => {
+    SomethingLong();
+  });
+
+const configModel = this.baseConfigurationService.getCache().consolidated		// global/default values (do NOT modify)
+  .merge(this.cachedWorkspaceConfig);
+
+this.doWriteConfiguration(target, value, options) // queue up writes to prevent race conditions
+  .then(() => null,
+  error => {
+    return options.donotNotifyError ? TPromise.wrapError(error) : this.onError(error, target, value);
+  });
+
+ret = __DEV__ ?
+  // $FlowFixMe: this type differs according to the env
+vm.runInContext(source, ctx)
+: a
+
+this.firebase.object(\`/shops/\${shopLocation.shop}\`)
+  // keep distance info
+  .first((shop: ShopQueryResult, index: number, source: Observable<ShopQueryResult>): any => {
+      // add distance to result
+      const s = shop;
+      s.distance = shopLocation.distance;
+      return s;
+  });
+
+angular.module('AngularAppModule')
+  // Hello, I am comment.
+  .constant('API_URL', 'http://localhost:8080/api');
+
+=====================================output=====================================
+function f() {
+    return (
+        observableFromSubscribeFunction()
+        // Debounce manually rather than using editor.onDidStopChanging so that the debounce time is
+        // configurable.
+        .debounceTime(debounceInterval)
+    );
+}
+
+_.a(a)
+/* very very very very very very very long such that it is longer than 80 columns */
+.a();
+
+_.a(
+    a
+) /* very very very very very very very long such that it is longer than 80 columns */
+.a();
+
+_.a(
+    a
+) /* very very very very very very very long such that it is longer than 80 columns */
+.a();
+
+Something
+// $FlowFixMe(>=0.41.0)
+.getInstance(this.props.dao)
+.getters();
+
+// Warm-up first
+measure().then(() => {
+    SomethingLong();
+});
+
+measure() // Warm-up first
+.then(() => {
+    SomethingLong();
+});
+
+const configModel = this.baseConfigurationService
+.getCache()
+.consolidated // global/default values (do NOT modify)
+.merge(this.cachedWorkspaceConfig);
+
+this.doWriteConfiguration(target, value, options) // queue up writes to prevent race conditions
+.then(
+    () => null,
+    error => {
+        return options.donotNotifyError
+            ? TPromise.wrapError(error)
+            : this.onError(error, target, value);
+    }
+);
+
+ret = __DEV__
+    ? // $FlowFixMe: this type differs according to the env
+      vm.runInContext(source, ctx)
+    : a;
+
+this.firebase
+.object(\`/shops/\${shopLocation.shop}\`)
+// keep distance info
+.first(
+    (
+        shop: ShopQueryResult,
+        index: number,
+        source: Observable<ShopQueryResult>
+    ): any => {
+        // add distance to result
+        const s = shop;
+        s.distance = shopLocation.distance;
+        return s;
+    }
+);
+
+angular
+.module("AngularAppModule")
+// Hello, I am comment.
+.constant("API_URL", "http://localhost:8080/api");
+
+================================================================================
+`;
+
 exports[`computed.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "typescript"]
@@ -425,6 +835,31 @@ nock(/test/)
   .reply(200, {
     foo: "bar"
   });
+
+================================================================================
+`;
+
+exports[`computed.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+nock(/test/)
+  .matchHeader('Accept', 'application/json')
+  [httpMethodNock(method)]('/foo')
+  .reply(200, {
+    foo: 'bar',
+  });
+
+=====================================output=====================================
+nock(/test/)
+.matchHeader("Accept", "application/json")
+[httpMethodNock(method)]("/foo")
+.reply(200, {
+    foo: "bar"
+});
 
 ================================================================================
 `;
@@ -469,6 +904,51 @@ window.Data[key]("foo")
 window.Data[key]("foo")
   .then(() => a)
   .catch(() => b);
+
+================================================================================
+`;
+
+exports[`computed-merge.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+[].forEach(key => {
+  data[key]('foo')
+    .then(() => console.log('bar'))
+    .catch(() => console.log('baz'));
+});
+
+[].forEach(key => {
+  data('foo')
+    [key]('bar')
+    .then(() => console.log('bar'))
+    .catch(() => console.log('baz'));
+});
+
+window.Data[key]("foo")
+  .then(() => a)
+  .catch(() => b);
+
+=====================================output=====================================
+[].forEach(key => {
+    data[key]("foo")
+    .then(() => console.log("bar"))
+    .catch(() => console.log("baz"));
+});
+
+[].forEach(key => {
+    data("foo")
+    [key]("bar")
+    .then(() => console.log("bar"))
+    .catch(() => console.log("baz"));
+});
+
+window.Data[key]("foo")
+.then(() => a)
+.catch(() => b);
 
 ================================================================================
 `;
@@ -541,6 +1021,75 @@ object[
 ================================================================================
 `;
 
+exports[`conditional.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+(a ? b : c).d();
+
+(a ? b : c).d().e();
+
+(a ? b : c).d().e().f();
+
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(this.defaultUser))
+.map();
+
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(this.defaultUser))
+.map().filter();
+
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(defaultUser))
+.map();
+
+object[valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(defaultUser)]
+.map();
+
+=====================================output=====================================
+(a ? b : c).d();
+
+(a ? b : c).d().e();
+
+(a ? b : c)
+.d()
+.e()
+.f();
+
+(valid
+    ? helper.responseBody(this.currentUser)
+    : helper.responseBody(this.defaultUser)
+).map();
+
+(valid
+    ? helper.responseBody(this.currentUser)
+    : helper.responseBody(this.defaultUser)
+)
+.map()
+.filter();
+
+(valid
+    ? helper.responseBody(this.currentUser)
+    : helper.responseBody(defaultUser)
+).map();
+
+object[
+    valid
+        ? helper.responseBody(this.currentUser)
+        : helper.responseBody(defaultUser)
+].map();
+
+================================================================================
+`;
+
 exports[`d3.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "typescript"]
@@ -585,6 +1134,55 @@ not.d3
   .scaleLinear()
   .domain([1950, 1980])
   .range([0, width]);
+
+================================================================================
+`;
+
+exports[`d3.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+d3.select('body')
+  .append('circle')
+  .at({ width: 30, fill: '#f0f' })
+  .st({ fontWeight: 600 })
+
+d3.scaleLinear()
+  .domain([1950, 1980])
+  .range([0, width])
+
+not.d3.select('body')
+  .append('circle')
+  .at({ width: 30, fill: '#f0f' })
+  .st({ fontWeight: 600 })
+
+not.d3.scaleLinear()
+  .domain([1950, 1980])
+  .range([0, width])
+
+=====================================output=====================================
+d3.select("body")
+.append("circle")
+.at({ width: 30, fill: "#f0f" })
+.st({ fontWeight: 600 });
+
+d3.scaleLinear()
+.domain([1950, 1980])
+.range([0, width]);
+
+not.d3
+.select("body")
+.append("circle")
+.at({ width: 30, fill: "#f0f" })
+.st({ fontWeight: 600 });
+
+not.d3
+.scaleLinear()
+.domain([1950, 1980])
+.range([0, width]);
 
 ================================================================================
 `;
@@ -668,6 +1266,86 @@ function f() {
 ================================================================================
 `;
 
+exports[`first_long.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+export default function theFunction(action$, store) {
+  return action$.ofType(THE_ACTION).switchMap(action => Observable
+    .webSocket({
+      url: THE_URL,
+      more: stuff(),
+      evenMore: stuff({
+        value1: true,
+        value2: false,
+        value3: false
+      })
+    })
+    .filter(data => theFilter(data))
+    .map(({ theType, ...data }) => theMap(theType, data))
+    .retryWhen(errors => errors));
+}
+
+function f() {
+  return this._getWorker(workerOptions)({
+    filePath,
+    hasteImplModulePath: this._options.hasteImplModulePath,
+  }).then(
+    metadata => {
+      // \`1\` for truthy values instead of \`true\` to save cache space.
+      fileMetadata[H.VISITED] = 1;
+      const metadataId = metadata.id;
+      const metadataModule = metadata.module;
+      if (metadataId && metadataModule) {
+        fileMetadata[H.ID] = metadataId;
+        setModule(metadataId, metadataModule);
+      }
+      fileMetadata[H.DEPENDENCIES] = metadata.dependencies || [];
+    }
+  );
+}
+
+=====================================output=====================================
+export default function theFunction(action$, store) {
+    return action$.ofType(THE_ACTION).switchMap(action =>
+        Observable.webSocket({
+            url: THE_URL,
+            more: stuff(),
+            evenMore: stuff({
+                value1: true,
+                value2: false,
+                value3: false
+            })
+        })
+        .filter(data => theFilter(data))
+        .map(({ theType, ...data }) => theMap(theType, data))
+        .retryWhen(errors => errors)
+    );
+}
+
+function f() {
+    return this._getWorker(workerOptions)({
+        filePath,
+        hasteImplModulePath: this._options.hasteImplModulePath
+    }).then(metadata => {
+        // \`1\` for truthy values instead of \`true\` to save cache space.
+        fileMetadata[H.VISITED] = 1;
+        const metadataId = metadata.id;
+        const metadataModule = metadata.module;
+        if (metadataId && metadataModule) {
+            fileMetadata[H.ID] = metadataId;
+            setModule(metadataId, metadataModule);
+        }
+        fileMetadata[H.DEPENDENCIES] = metadata.dependencies || [];
+    });
+}
+
+================================================================================
+`;
+
 exports[`inline_merge.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "typescript"]
@@ -711,6 +1389,54 @@ this.layoutPartsToHide = this.utils.hashset(
 var jqxhr = $.ajax("example.php")
   .done(doneFn)
   .fail(failFn);
+
+================================================================================
+`;
+
+exports[`inline_merge.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+Object.keys(
+  availableLocales({
+    test: true
+  })
+)
+.forEach(locale => {
+  // ...
+});
+
+this.layoutPartsToHide = this.utils.hashset(
+	_.flatMap(this.visibilityHandlers, fn => fn())
+		.concat(this.record.resolved_legacy_visrules)
+		.filter(Boolean)
+);
+
+var jqxhr = $.ajax("example.php")
+  .done(doneFn)
+  .fail(failFn);
+
+=====================================output=====================================
+Object.keys(
+    availableLocales({
+        test: true
+    })
+).forEach(locale => {
+    // ...
+});
+
+this.layoutPartsToHide = this.utils.hashset(
+    _.flatMap(this.visibilityHandlers, fn => fn())
+    .concat(this.record.resolved_legacy_visrules)
+    .filter(Boolean)
+);
+
+var jqxhr = $.ajax("example.php")
+.done(doneFn)
+.fail(failFn);
 
 ================================================================================
 `;
@@ -765,6 +1491,61 @@ const someLongVariableName = (
 )
   .map(tickets => TicketRecord.createFromSomeLongString())
   .filter(obj => !!obj);
+
+================================================================================
+`;
+
+exports[`logical.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+const someLongVariableName = (idx(
+  this.props,
+  props => props.someLongPropertyName
+) || []
+).map(edge => edge.node);
+
+(veryLongVeryLongVeryLong || e).map(tickets =>
+  TicketRecord.createFromSomeLongString());
+
+(veryLongVeryLongVeryLong || e).map(tickets =>
+  TicketRecord.createFromSomeLongString()).filter(obj => !!obj);
+
+(veryLongVeryLongVeryLong || anotherVeryLongVeryLongVeryLong || veryVeryVeryLongError).map(tickets =>
+  TicketRecord.createFromSomeLongString());
+
+(veryLongVeryLongVeryLong || anotherVeryLongVeryLongVeryLong || veryVeryVeryLongError).map(tickets =>
+  TicketRecord.createFromSomeLongString()).filter(obj => !!obj);
+
+=====================================output=====================================
+const someLongVariableName = (
+    idx(this.props, props => props.someLongPropertyName) || []
+).map(edge => edge.node);
+
+(veryLongVeryLongVeryLong || e).map(tickets =>
+    TicketRecord.createFromSomeLongString()
+);
+
+(veryLongVeryLongVeryLong || e)
+.map(tickets => TicketRecord.createFromSomeLongString())
+.filter(obj => !!obj);
+
+(
+    veryLongVeryLongVeryLong ||
+    anotherVeryLongVeryLongVeryLong ||
+    veryVeryVeryLongError
+).map(tickets => TicketRecord.createFromSomeLongString());
+
+(
+    veryLongVeryLongVeryLong ||
+    anotherVeryLongVeryLongVeryLong ||
+    veryVeryVeryLongError
+)
+.map(tickets => TicketRecord.createFromSomeLongString())
+.filter(obj => !!obj);
 
 ================================================================================
 `;
@@ -865,6 +1646,103 @@ wrapper
 ================================================================================
 `;
 
+exports[`multiple-members.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+if (testConfig.ENABLE_ONLINE_TESTS === "true") {
+  describe("POST /users/me/pet", function() {
+    it("saves pet", function() {
+      function assert(pet) {
+        expect(pet).to.have.property("OwnerAddress").that.deep.equals({
+          AddressLine1: "Alexanderstrasse",
+          AddressLine2: "",
+          PostalCode: "10999",
+          Region: "Berlin",
+          City: "Berlin",
+          Country: "DE"
+        });
+      }
+    });
+  });
+}
+
+wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName')().then(function() {
+  doSomething();
+});
+
+wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName')('argument').then(function() {
+  doSomething();
+});
+
+wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName', 'second argument that pushes this group past 80 characters')('argument').then(function() {
+  doSomething();
+});
+
+wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName')('argument', 'second argument that pushes this group past 80 characters').then(function() {
+  doSomething();
+});
+
+=====================================output=====================================
+if (testConfig.ENABLE_ONLINE_TESTS === "true") {
+    describe("POST /users/me/pet", function() {
+        it("saves pet", function() {
+            function assert(pet) {
+                expect(pet)
+                .to.have.property("OwnerAddress")
+                .that.deep.equals({
+                    AddressLine1: "Alexanderstrasse",
+                    AddressLine2: "",
+                    PostalCode: "10999",
+                    Region: "Berlin",
+                    City: "Berlin",
+                    Country: "DE"
+                });
+            }
+        });
+    });
+}
+
+wrapper
+.find("SomewhatLongNodeName")
+.prop("longPropFunctionName")()
+.then(function() {
+    doSomething();
+});
+
+wrapper
+.find("SomewhatLongNodeName")
+.prop("longPropFunctionName")("argument")
+.then(function() {
+    doSomething();
+});
+
+wrapper
+.find("SomewhatLongNodeName")
+.prop(
+    "longPropFunctionName",
+    "second argument that pushes this group past 80 characters"
+)("argument")
+.then(function() {
+    doSomething();
+});
+
+wrapper
+.find("SomewhatLongNodeName")
+.prop("longPropFunctionName")(
+    "argument",
+    "second argument that pushes this group past 80 characters"
+)
+.then(function() {
+    doSomething();
+});
+
+================================================================================
+`;
+
 exports[`short-names.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "typescript"]
@@ -881,6 +1759,27 @@ const svgJsFiles = fs
   .readdirSync(svgDir)
   .filter(f => svgJsFileExtRegex.test(f))
   .map(f => path.join(svgDir, f));
+
+================================================================================
+`;
+
+exports[`short-names.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+const svgJsFiles = fs
+  .readdirSync(svgDir)
+  .filter(f => svgJsFileExtRegex.test(f))
+  .map(f => path.join(svgDir, f));
+
+=====================================output=====================================
+const svgJsFiles = fs
+.readdirSync(svgDir)
+.filter(f => svgJsFileExtRegex.test(f))
+.map(f => path.join(svgDir, f));
 
 ================================================================================
 `;
@@ -915,6 +1814,37 @@ const component = find(".org-lclp-edit-copy-url-banner__link")[0]
 ================================================================================
 `;
 
+exports[`square_0.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+const version = someLongString
+  .split('jest version =')
+  .pop()
+  .split(EOL)[0]
+  .trim();
+
+const component = find('.org-lclp-edit-copy-url-banner__link')[0]
+  .getAttribute('href')
+  .indexOf(this.landingPageLink);
+
+=====================================output=====================================
+const version = someLongString
+.split("jest version =")
+.pop()
+.split(EOL)[0]
+.trim();
+
+const component = find(".org-lclp-edit-copy-url-banner__link")[0]
+.getAttribute("href")
+.indexOf(this.landingPageLink);
+
+================================================================================
+`;
+
 exports[`test.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "typescript"]
@@ -940,6 +1870,32 @@ method()
 ================================================================================
 `;
 
+exports[`test.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+method().then(x => x)
+  ["abc"](x => x)
+  [abc](x => x);
+
+({}.a().b());
+({}).a().b();
+
+=====================================output=====================================
+method()
+.then(x => x)
+["abc"](x => x)
+[abc](x => x);
+
+({}.a().b());
+({}.a().b());
+
+================================================================================
+`;
+
 exports[`this.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "typescript"]
@@ -954,6 +1910,25 @@ const sel = this.connections
 const sel = this.connections
   .concat(this.activities.concat(this.operators))
   .filter(x => x.selected);
+
+================================================================================
+`;
+
+exports[`this.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+const sel = this.connections
+  .concat(this.activities.concat(this.operators))
+  .filter(x => x.selected);
+
+=====================================output=====================================
+const sel = this.connections
+.concat(this.activities.concat(this.operators))
+.filter(x => x.selected);
 
 ================================================================================
 `;

--- a/tests/method-chain/jsfmt.spec.js
+++ b/tests/method-chain/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(__dirname, ["flow", "typescript"]);
+run_spec(__dirname, ["flow", "typescript"], { tabWidth: 4 });

--- a/tests/switch/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/switch/__snapshots__/jsfmt.spec.js.snap
@@ -58,6 +58,65 @@ switch (x) {
 ================================================================================
 `;
 
+exports[`comments.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+switch (true) {
+  case true:
+  // Good luck getting here
+
+  case false:
+}
+
+switch (true) {
+  case true:
+
+  // Good luck getting here
+  case false:
+}
+
+switch(x) {
+  case x: {
+  }
+
+  // other
+
+  case y: {
+  }
+}
+
+=====================================output=====================================
+switch (true) {
+case true:
+// Good luck getting here
+
+case false:
+}
+
+switch (true) {
+case true:
+
+// Good luck getting here
+case false:
+}
+
+switch (x) {
+case x: {
+}
+
+// other
+
+case y: {
+}
+}
+
+================================================================================
+`;
+
 exports[`empty_lines.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "typescript"]
@@ -208,6 +267,157 @@ switch (a) {
 ================================================================================
 `;
 
+exports[`empty_lines.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+switch (foo) {
+  case "bar":
+    doSomething();
+
+  case "baz":
+    doOtherThing();
+}
+
+switch (foo) {
+
+  case "bar":
+    doSomething();
+
+  case "baz":
+    doOtherThing();
+}
+
+switch (foo) {
+  case "bar":
+    doSomething();
+
+  case "baz":
+    doOtherThing();
+
+}
+
+switch (foo) {
+  case "bar":
+    doSomething();
+
+
+
+  case "baz":
+    doOtherThing();
+}
+
+switch (x) {
+  case y:
+    call();
+
+    break;
+
+  case z:
+    call();
+
+    break;
+}
+
+switch (a) {
+  case b:
+    if (1) {};
+    c;
+}
+
+switch (a) {
+  case x:
+  case y:
+    call();
+
+  case z:
+    call();
+}
+
+switch (a) {
+  case x: case y:
+    call();
+
+  case z:
+    call();
+}
+
+=====================================output=====================================
+switch (foo) {
+case "bar":
+    doSomething();
+
+case "baz":
+    doOtherThing();
+}
+
+switch (foo) {
+case "bar":
+    doSomething();
+
+case "baz":
+    doOtherThing();
+}
+
+switch (foo) {
+case "bar":
+    doSomething();
+
+case "baz":
+    doOtherThing();
+}
+
+switch (foo) {
+case "bar":
+    doSomething();
+
+case "baz":
+    doOtherThing();
+}
+
+switch (x) {
+case y:
+    call();
+
+    break;
+
+case z:
+    call();
+
+    break;
+}
+
+switch (a) {
+case b:
+    if (1) {
+    }
+    c;
+}
+
+switch (a) {
+case x:
+case y:
+    call();
+
+case z:
+    call();
+}
+
+switch (a) {
+case x:
+case y:
+    call();
+
+case z:
+    call();
+}
+
+================================================================================
+`;
+
 exports[`empty_statement.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "typescript"]
@@ -233,6 +443,32 @@ switch (error.code) {
 ================================================================================
 `;
 
+exports[`empty_statement.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+switch (error.code) {
+	case ConfigurationEditingErrorCode.ERROR_INVALID_CONFIGURATION: {
+		nls.localize('errorInvalidConfiguration', "Unable to write into settings. Correct errors/warnings in the file and try again.");
+	};
+}
+
+=====================================output=====================================
+switch (error.code) {
+case ConfigurationEditingErrorCode.ERROR_INVALID_CONFIGURATION: {
+    nls.localize(
+        "errorInvalidConfiguration",
+        "Unable to write into settings. Correct errors/warnings in the file and try again."
+    );
+}
+}
+
+================================================================================
+`;
+
 exports[`empty_switch.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "typescript"]
@@ -245,6 +481,26 @@ switch (1) {}
 =====================================output=====================================
 switch (1) {
   default:
+}
+switch (1) {
+}
+
+================================================================================
+`;
+
+exports[`empty_switch.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+switch (1) { default:; }
+switch (1) {}
+
+=====================================output=====================================
+switch (1) {
+default:
 }
 switch (1) {
 }
@@ -339,6 +595,100 @@ switch (
 switch (
   $longButSlightlyShorterVariableName &&
   $anotherSlightlyShorterVariableName
+) {
+}
+
+================================================================================
+`;
+
+exports[`switch.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+tabWidth: 4
+                                                                                | printWidth
+=====================================input======================================
+switch (a) {
+  case 3:
+    alert( '3' );
+    break;
+  case 4:
+    alert( '4' );
+    break;
+  case 5:
+    alert( '5' );
+    break;
+  default:
+    alert( 'default' );
+}
+
+switch (veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong) {
+  case 3:
+    alert( '3' );
+    break;
+  default:
+    alert( 'default' );
+}
+
+switch (veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong > veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong) {
+  case 3:
+    alert( '3' );
+    break;
+  default:
+    alert( 'default' );
+}
+
+switch ($veryLongAndVeryVerboseVariableName && $anotherVeryLongAndVeryVerboseVariableName) {
+}
+
+switch ($longButSlightlyShorterVariableName && $anotherSlightlyShorterVariableName) {
+}
+
+=====================================output=====================================
+switch (a) {
+case 3:
+    alert("3");
+    break;
+case 4:
+    alert("4");
+    break;
+case 5:
+    alert("5");
+    break;
+default:
+    alert("default");
+}
+
+switch (
+    veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong
+) {
+case 3:
+    alert("3");
+    break;
+default:
+    alert("default");
+}
+
+switch (
+    veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong >
+    veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong
+) {
+case 3:
+    alert("3");
+    break;
+default:
+    alert("default");
+}
+
+switch (
+    $veryLongAndVeryVerboseVariableName &&
+    $anotherVeryLongAndVeryVerboseVariableName
+) {
+}
+
+switch (
+    $longButSlightlyShorterVariableName &&
+    $anotherSlightlyShorterVariableName
 ) {
 }
 

--- a/tests/switch/jsfmt.spec.js
+++ b/tests/switch/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(__dirname, ["flow", "typescript"]);
+run_spec(__dirname, ["flow", "typescript"], { tabWidth: 4 });


### PR DESCRIPTION
I work in a codebase that uses 4 spaces for its indent level and 80 spaces for its width, which means every switch statement case-block will indent 10% (8 spaces up) of the visual space. This is visually distracting by itself, but it also causes wrapping nearly everywhere in the statements, which is even more distracting. With a redux codebase like my team uses, it becomes nearly impossible to read anything quickly.

This diff removes the indent in front of the "case" (but not the block), thus changing:
```
// example from the redux example site
function todoApp(state = initialState, action) {
    switch (action.type) {
        case SET_VISIBILITY_FILTER:
            return Object.assign({}, state, {
                visibilityFilter: action.filter
            })
        case ADD_TODO:
            return Object.assign({}, state, {
                todos: [
                    ...state.todos,
                    {
                        text: action.text,
                        completed: false
                    }
                ]
            })
        case TOGGLE_TODO:
            return Object.assign({}, state, {
                todos: state.todos.map((todo, index) => {
                    if (index === action.index) {
                        return Object.assign({}, todo, {
                            completed: !todo.completed
                        })
                    }
                    return todo
                })
            })
        default:
            return state
    }
}
```

to a more readable:
```
function todoApp(state = initialState, action) {
    switch (action.type) {
    case SET_VISIBILITY_FILTER:
        return Object.assign({}, state, {
            visibilityFilter: action.filter
        })
    case ADD_TODO:
        return Object.assign({}, state, {
            todos: [
                ...state.todos,
                {
                    text: action.text,
                    completed: false
                }
            ]
        })
    case TOGGLE_TODO:
        return Object.assign({}, state, {
            todos: state.todos.map((todo, index) => {
                if (index === action.index) {
                    return Object.assign({}, todo, {
                        completed: !todo.completed
                    })
                }
                return todo
            })
        })
    default:
        return state
    }
}
```

In the same vein, this diff removes the tab in front of method chains, which are already visually unambiguous and (with the indent) often make promise chains indent like mad.

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
