### PR TITLE
JSDoc type fixes in `src/main/core-options.js`

### DIFF
--- a/src/main/core-options.js
+++ b/src/main/core-options.js
@@ -12,18 +12,20 @@ const CATEGORY_SPECIAL = "Special";
 
 /**
  * @typedef {Object} OptionInfo
- * @property {string} since - available since version
+ * @property {string} [since] - available since version
  * @property {string} category
  * @property {'int' | 'boolean' | 'choice' | 'path'} type
- * @property {boolean} array - indicate it's an array of the specified type
- * @property {boolean?} deprecated - deprecated since version
- * @property {OptionRedirectInfo?} redirect - redirect deprecated option
+ * @property {boolean} [array] - indicate it's an array of the specified type
+ * @property {OptionValueInfo} [default]
+ * @property {OptionRangeInfo} [range] - for type int
  * @property {string} description
- * @property {string?} oppositeDescription - for `false` option
- * @property {OptionValueInfo} default
- * @property {OptionRangeInfo?} range - for type int
- * @property {OptionChoiceInfo?} choices - for type choice
- * @property {(value: any) => boolean} exception
+ * @property {string} [deprecated] - deprecated since version
+ * @property {OptionRedirectInfo} [redirect] - redirect deprecated option
+ * @property {(value: any) => boolean} [exception]
+ * @property {OptionChoiceInfo[]} [choices] - for type choice
+ * @property {string} [cliName]
+ * @property {string} [cliCategory]
+ * @property {string} [cliDescription]
  *
  * @typedef {number | boolean | string} OptionValue
  * @typedef {OptionValue | [{ value: OptionValue[] }] | Array<{ since: string, value: OptionValue}>} OptionValueInfo
@@ -39,16 +41,13 @@ const CATEGORY_SPECIAL = "Special";
  *
  * @typedef {Object} OptionChoiceInfo
  * @property {boolean | string} value - boolean for the option that is originally boolean type
- * @property {string?} description - undefined if redirect
- * @property {string?} since - undefined if available since the first version of the option
- * @property {string?} deprecated - deprecated since version
- * @property {OptionValueInfo?} redirect - redirect deprecated value
- *
- * @property {string?} cliName
- * @property {string?} cliCategory
- * @property {string?} cliDescription
+ * @property {string} description
+ * @property {string} [since] - undefined if available since the first version of the option
+ * @property {string} [deprecated] - deprecated since version
+ * @property {OptionValueInfo} [redirect] - redirect deprecated value
  */
-/** @type {{ [name: string]: OptionInfo } */
+
+/** @type {{ [name: string]: OptionInfo }} */
 const options = {
   cursorOffset: {
     since: "1.4.0",


### PR DESCRIPTION
with unused `oppositeDescription` parameter removed

and reordering of some other members

to resolve checkJs issues in `src/main/core-options.js`,

as verified by the following command:

```
npx tsc --allowJs --checkJs --noEmit --target es5 src/main/core-options.js
```

I can also enable Check JS in VSCode and see that the type errors go away in `src/main/core-options.js`.

In the future, it should be possible to typecheck the whole project by either:

- using a command like this (99% solution): `npx tsc --allowJs --checkJs --noEmit --resolveJsonModule --target es5 src/index.js`
- add tsconfig.json and just do `npx tsc` or use a script that calls `tsc` to check all sources

for reference:

- https://medium.com/@trukrs/javascript-type-linting-5903e9e3625f
- https://github.com/composi/check-js/blob/master/package.json#L7

see also:

- composi/core#5 - some initial guidance that I got from @rbiggs
- #6313 - proposal to support API type checking, using tsconfig.json

/cc @Shinigami92 @rbiggs

- ~~I’ve added tests to confirm my change works.~~
- ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~~
- ~~(If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.~~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**