### PR TITLE
typescript@3.6.4 update

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "resolve": "1.12.0",
     "semver": "6.3.0",
     "string-width": "3.1.0",
-    "typescript": "3.6.3",
+    "typescript": "3.6.4",
     "unicode-regex": "3.0.0",
     "unified": "6.1.6",
     "vnopts": "1.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7161,10 +7161,10 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@3.6.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
-  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+typescript@3.6.4:
+  version "3.6.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.4.tgz#b18752bb3792bc1a0281335f7f6ebf1bbfc5b91d"
+  integrity sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==
 
 uglify-js@^3.1.4:
   version "3.6.0"


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

### What

see title

### Why

Most recent release of TypeScript is *highly desired* to support JavaScript type linting (type checking using JSDoc comments) as we have been working on in multiple PRs such as  #6313 & #6702.

A timely review would be much appreciated.

Unfortunately I don't think we should include TypeScript 3.7 in the RC stage.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- ~~I’ve added tests to confirm my change works.~~
- ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~~
- ~~(If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.~~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

/cc @Shinigami92 @lydell

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
