### PR TITLE
[RFC DRAFT WIP] automate JavaScript type linting using checkJs, as configured in tsconfig.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
   "devDependencies": {
     "@babel/core": "7.6.3",
     "@babel/preset-env": "7.6.3",
+    "@simple-dom/interface": "1.4.0",
     "babel-loader": "8.0.6",
     "benchmark": "2.1.4",
     "builtin-modules": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
   "devDependencies": {
     "@babel/core": "7.6.3",
     "@babel/preset-env": "7.6.3",
+    "@glimmer/reference": "0.41.4",
+    "@glimmer/runtime": "0.41.4",
     "@simple-dom/interface": "1.4.0",
     "babel-loader": "8.0.6",
     "benchmark": "2.1.4",

--- a/package.json
+++ b/package.json
@@ -125,6 +125,7 @@
     "perf-repeat": "yarn && yarn build && cross-env NODE_ENV=production node ./dist/bin-prettier.js --debug-repeat ${PERF_REPEAT:-1000} --loglevel debug ${PERF_FILE:-./index.js} > /dev/null",
     "perf-repeat-inspect": "yarn && yarn build && cross-env NODE_ENV=production node --inspect-brk ./dist/bin-prettier.js --debug-repeat ${PERF_REPEAT:-1000} --loglevel debug ${PERF_FILE:-./index.js} > /dev/null",
     "perf-benchmark": "yarn && yarn build && cross-env NODE_ENV=production node ./dist/bin-prettier.js --debug-benchmark --loglevel debug ${PERF_FILE:-./index.js} > /dev/null",
+    "checkjs": "tsc",
     "lint": "cross-env EFF_NO_LINK_RULES=true eslint . --format friendly",
     "lint-docs": "prettylint {.,docs,website,website/blog}/*.md",
     "lint-dist": "eslint --no-eslintrc --no-ignore --env=browser \"dist/!(bin-prettier|index|third-party).js\"",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,63 @@
+{
+  "compilerOptions": {
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    // "outDir": "./",                        /* Redirect output structure to the directory. */
+    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,8 @@
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
+    "allowJs": true,                       /* Allow javascript files to be compiled. */
+    "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
@@ -17,13 +17,15 @@
     // "composite": true,                     /* Enable project compilation */
     // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
+    "noEmit": true,                        /* Do not emit outputs. */
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
     // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
+    "resolveJsonModule": true,
+
     /* Strict Type-Checking Options */
-    "strict": true,                           /* Enable all strict type-checking options. */
+    // "strict": true,                           /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,              /* Enable strict null checks. */
     // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
@@ -59,5 +61,16 @@
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
-  }
+  },
+  "exclude": [
+    "bin",
+    "docs",
+    "jest.config.js",
+    "node_modules",
+    "scripts",
+    "tests",
+    "tests_config",
+    "tests_integration",
+    "website"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,26 +1,17 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    // "incremental": true,                   /* Enable incremental compilation */
     "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     "allowJs": true,                       /* Allow javascript files to be compiled. */
     "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
     // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "sourceMap": true,                     /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
     // "outDir": "./",                        /* Redirect output structure to the directory. */
     // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
     // "removeComments": true,                /* Do not emit comments to output. */
     "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
 
     "resolveJsonModule": true,
 
@@ -51,12 +42,6 @@
     // "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
-
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
 
     /* Experimental Options */
     // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,51 +1,51 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
-    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
-    // "lib": [],                             /* Specify library files to be included in the compilation. */
-    "allowJs": true,                       /* Allow javascript files to be compiled. */
-    "checkJs": true,                       /* Report errors in .js files. */
-    // "declaration": true,                   /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    // "outDir": "./",                        /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    "noEmit": true,                        /* Do not emit outputs. */
+    "target": "es5",                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019' or 'ESNEXT'. */
+    "module": "commonjs",           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    //- "lib": [],                  /* Specify library files to be included in the compilation. */
+    "allowJs": true,                /* Allow javascript files to be compiled. */
+    "checkJs": true,                /* Report errors in .js files. */
+    //- "declaration": true,        /* Generates corresponding '.d.ts' file. */
+    //- "declarationMap": true,     /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    //- "outDir": "./",             /* Redirect output structure to the directory. */
+    //- "rootDir": "./",            /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    //- "removeComments": true,     /* Do not emit comments to output. */
+    "noEmit": true,                 /* Do not emit outputs. */
 
     "resolveJsonModule": true,
 
     /* Strict Type-Checking Options */
-    // "strict": true,                           /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+    //- "strict": true,                       /* Enable all strict type-checking options. */
+    //- "noImplicitAny": true,                /* Raise error on expressions and declarations with an implied 'any' type. */
+    //- "strictNullChecks": true,             /* Enable strict null checks. */
+    //- "strictFunctionTypes": true,          /* Enable strict checking of function types. */
+    //- "strictBindCallApply": true,          /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    //- "strictPropertyInitialization": true, /* Enable strict checking of property initialization in classes. */
+    //- "noImplicitThis": true,               /* Raise error on 'this' expressions with an implied 'any' type. */
+    //- "alwaysStrict": true,                 /* Parse in strict mode and emit "use strict" for each source file. */
 
     /* Additional Checks */
-    // "noUnusedLocals": true,                /* Report errors on unused locals. */
-    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
-    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
-    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+    //- "noUnusedLocals": true,             /* Report errors on unused locals. */
+    //- "noUnusedParameters": true,         /* Report errors on unused parameters. */
+    //- "noImplicitReturns": true,          /* Report error when not all code paths in function return a value. */
+    //- "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
 
     /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    // "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+    //- "moduleResolution": "node",           /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    //- "baseUrl": "./",                      /* Base directory to resolve non-absolute module names. */
+    //- "paths": {},                          /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    //- "rootDirs": [],                       /* List of root folders whose combined content represents the structure of the project at runtime. */
+    //- "typeRoots": [],                      /* List of folders to include type definitions from. */
+    //- "types": [],                          /* Type declaration files to be included in compilation. */
+    //- "allowSyntheticDefaultImports": true, /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    //- "esModuleInterop": true               /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    //- "preserveSymlinks": true,             /* Do not resolve the real path of symlinks. */
+    //- "allowUmdGlobalAccess": true,         /* Allow accessing UMD globals from modules. */
 
     /* Experimental Options */
-    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    //- "experimentalDecorators": true, /* Enables experimental support for ES7 decorators. */
+    //- "emitDecoratorMetadata": true,  /* Enables experimental support for emitting type metadata for decorators. */
   },
   "exclude": [
     "bin",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -48,7 +48,7 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
     // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -916,6 +916,11 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
+"@simple-dom/interface@1.4.0":
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/@simple-dom/interface/-/interface-1.4.0.tgz#e8feea579232017f89b0138e2726facda6fbb71f"
+  integrity sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==
+
 "@types/estree@0.0.39":
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"

--- a/yarn.lock
+++ b/yarn.lock
@@ -847,10 +847,57 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
+"@glimmer/encoder@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/encoder/-/encoder-0.41.4.tgz#4ccd292671e3f74d091cf28ff2c43bb9a080eb83"
+  integrity sha512-PNYi8vvyyyGuoZaWRuKc2L5nsuWdjAwo/TnwjfgVcgHh8/lBcPDYro3bPYd/E2Ddmj9QX3M8/UKw/dg3l5VuTw==
+  dependencies:
+    "@glimmer/interfaces" "^0.41.4"
+    "@glimmer/vm" "^0.41.4"
+
 "@glimmer/interfaces@^0.41.0":
   version "0.41.0"
   resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.41.0.tgz#3f571a181025406f29faed9006d0a914afb577b1"
   integrity sha512-d0Ryj8iV3FiyMyT4QpwHNg2QFFEmdzI5cJFcbmC+OmuTe6eOQ52mLDlw1+D+a3ZDv8Jfj3l0QkEcEugCxDY+1Q==
+
+"@glimmer/interfaces@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.41.4.tgz#3f3e26abea8a4e1463130e9a75e94372781d154b"
+  integrity sha512-MzXwMyod3MlwSZezHSaVBsCEIW/giYYfTDYARR46QnYsaFVatMVbydjsI7jkAuBCbnLCyNOIc1TrYIj71i/rpg==
+
+"@glimmer/low-level@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/low-level/-/low-level-0.41.4.tgz#2b48574afb56b8b85578931f25c3880fb6381134"
+  integrity sha512-AvkGDIe2rHPRWeOp17/sMI1RSdBZW7NgzTSl/kPzOweWWuOOYTmzKGn641UeexVUeMMVf4AiMp/jPlXEqZ/pdw==
+
+"@glimmer/program@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/program/-/program-0.41.4.tgz#4903dce34900df75d3610e85b3e7eb6f8cdbacd9"
+  integrity sha512-q7mce9c/cKWEjFuPbB6LP2IuE3NC8eRtn0VKEt9QiGYqWa16cI+R7+ANb7tE+cjdgTIbEneTNY2X+Zx1DZpd0g==
+  dependencies:
+    "@glimmer/encoder" "^0.41.4"
+    "@glimmer/interfaces" "^0.41.4"
+    "@glimmer/util" "^0.41.4"
+
+"@glimmer/reference@0.41.4", "@glimmer/reference@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.41.4.tgz#41bd25183b644138db54ed00379be5e6903e8919"
+  integrity sha512-v8KQdD9RSDoZXCTgyvH8AbEWOMy5W1UUuGr3t6YZC7cecFAjarCeDEvbU+k9EGopTXisf9BVeUgtHj6cTMtiAw==
+  dependencies:
+    "@glimmer/util" "^0.41.4"
+
+"@glimmer/runtime@0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/runtime/-/runtime-0.41.4.tgz#054d05132c40d5dbf2934580b2ab3a62bf32bdb9"
+  integrity sha512-tFiGsZ0ysy6MSIaTIyBnOEJbe3PHik510WqIRN/4Rne32S9k7HzH5tFHTJMkvAV6vmPoGAqK7EDHmwJy5l7/2A==
+  dependencies:
+    "@glimmer/interfaces" "^0.41.4"
+    "@glimmer/low-level" "^0.41.4"
+    "@glimmer/program" "^0.41.4"
+    "@glimmer/reference" "^0.41.4"
+    "@glimmer/util" "^0.41.4"
+    "@glimmer/vm" "^0.41.4"
+    "@glimmer/wire-format" "^0.41.4"
 
 "@glimmer/syntax@0.41.0":
   version "0.41.0"
@@ -866,6 +913,27 @@
   version "0.41.0"
   resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.41.0.tgz#743fa455d1d7fa0ce29688e932c231a99c0752cf"
   integrity sha512-aKmQy62eRFhOZET9XmTB8MOA32G1FmD4d9HWL21OfdcGM4IbguRrWLMQc2DRh1YOE2AaT0PBrFrPmpNwFp5tpQ==
+
+"@glimmer/util@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.41.4.tgz#508fd82ca40305416e130f0da7b537295ded7989"
+  integrity sha512-DwS94K+M0vtG+cymxH0rslJr09qpdjyOLdCjmpKcG/nNiZQfMA1ybAaFEmwk9UaVlUG9STENFeQwyrLevJB+7g==
+
+"@glimmer/vm@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/vm/-/vm-0.41.4.tgz#e6420c03dcaf97cc7cdb5a68bb098ed3ca51319c"
+  integrity sha512-rWFSyosGNi5ph84DKuT1B9u0fvonRZJ3oIk7tLvfAgAVVT87YFl8731kvu87qIB9bMPG8mgcVt4N8jf2r5ibYg==
+  dependencies:
+    "@glimmer/interfaces" "^0.41.4"
+    "@glimmer/util" "^0.41.4"
+
+"@glimmer/wire-format@^0.41.4":
+  version "0.41.4"
+  resolved "https://registry.yarnpkg.com/@glimmer/wire-format/-/wire-format-0.41.4.tgz#edc3279b8216363c925e771b2e2cbe408f2a0812"
+  integrity sha512-vp3Z+PjYkgCCyj5HX3cFB6Mag76GwVkI0cx9vMHKDoqJFJBicxc9JPymNuPuEithsJpUXJj2g7TKwJaliH2+cw==
+  dependencies:
+    "@glimmer/interfaces" "^0.41.4"
+    "@glimmer/util" "^0.41.4"
 
 "@iarna/toml@2.2.3":
   version "2.2.3"


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

## What

- add `tsconfig.json`, as generated by `tsc -init`
- update `tsconfig.json` to support JavaScript type linting
- other `tsconfig.json` updates & cleanup
- additional devDependencies items to resolve some errors
- add `checkjs` package script entry

This is a followup to PR #6313, enables type checking without needing to port to TypeScript (ref: #6286).

Here is a description of JavaScript type linting, with focus on using VSCode: https://medium.com/@trukrs/javascript-type-linting-5903e9e3625f

## Status

Unfortunately there are many type errors that need to be resolved, as I reported in #6703.

I think we should also look into enabling some of the stricter options, once we resolve most of the errors according to #6703.

Any help with resolving the type errors in #6703 would be much appreciated.

/cc @Shinigami92 @rbiggs

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- ~~I’ve added tests to confirm my change works.~~
- ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~~
- ~~(If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.~~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
