### PR TITLE
[WIP] [DRAFT] JSDoc fixes for printer-estree.js

### DIFF
--- a/src/common/fast-path.js
+++ b/src/common/fast-path.js
@@ -2,6 +2,9 @@
 
 const assert = require("assert");
 
+/**
+ * @constructor
+ */
 function FastPath(value) {
   assert.ok(this instanceof FastPath);
   this.stack = [value];

--- a/src/doc/doc-builders.js
+++ b/src/doc/doc-builders.js
@@ -1,5 +1,9 @@
 "use strict";
 
+/**
+ * @typedef {string | Object} Doc
+ */
+
 function assertDoc(val) {
   /* istanbul ignore if */
   if (
@@ -11,6 +15,10 @@ function assertDoc(val) {
   }
 }
 
+/**
+ * @param {Doc[]} parts
+ * @returns Doc
+ */
 function concat(parts) {
   if (process.env.NODE_ENV !== "production") {
     parts.forEach(assertDoc);
@@ -25,6 +33,10 @@ function concat(parts) {
   return { type: "concat", parts };
 }
 
+/**
+ * @param {Doc} contents
+ * @returns Doc
+ */
 function indent(contents) {
   if (process.env.NODE_ENV !== "production") {
     assertDoc(contents);
@@ -41,6 +53,11 @@ function align(n, contents) {
   return { type: "align", contents, n };
 }
 
+/**
+ * @param {Doc} contents
+ * @param {Object} [opts]
+ * @returns Doc
+ */
 function group(contents, opts) {
   opts = opts || {};
 

--- a/src/doc/doc-builders.js
+++ b/src/doc/doc-builders.js
@@ -1,7 +1,10 @@
 "use strict";
 
 /**
- * @typedef {string | Object} Doc
+ * @typedef {Object} DocObject
+ * @property {string} type
+ *
+ * @typedef {string | DocObject} Doc
  */
 
 function assertDoc(val) {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1,5 +1,11 @@
 "use strict";
 
+/**
+ * @typedef {import("../doc/doc-builders").Doc} Doc
+ * @typedef {import("../common/fast-path")} FastPath
+ * @typedef {Object} Options - [TODO: better definition needed]
+ */
+
 const assert = require("assert");
 
 // TODO(azz): anything that imports from main shouldn't be in a `language-*` dir.
@@ -220,7 +226,9 @@ function genericPrint(path, options, printPath, args) {
     needsParens = pathNeedsParens(path, options);
   }
 
+  /** @type Doc[] */
   const parts = [];
+
   if (needsParens) {
     parts.unshift("(");
   }
@@ -437,7 +445,9 @@ function printPathNoParens(path, options, print, args) {
     return htmlBinding;
   }
 
+  /** @type Doc[] */
   let parts = [];
+
   switch (n.type) {
     case "JsExpressionRoot":
       return path.call(print, "node");
@@ -3999,7 +4009,9 @@ function printArgumentsList(path, options, print) {
           shouldGroupFirst
             ? concat([
                 "(",
+                // @ts-ignore [TODO: ensure printedExpanded is defined]
                 group(printedExpanded[0], { shouldBreak: true }),
+                // @ts-ignore [TODO: ensure printedExpanded is defined]
                 concat(printedExpanded.slice(1)),
                 ")"
               ])
@@ -4309,9 +4321,16 @@ function printReturnType(path, print, options) {
   return concat(parts);
 }
 
+/**
+ * @param {Doc} path
+ * @param {Options} options
+ * @param {any} print - [TODO use correct type]
+ * @returns Doc
+ */
 function printExportDeclaration(path, options, print) {
   const decl = path.getValue();
   const semi = options.semi ? ";" : "";
+  /** @type {Doc[]} */
   const parts = ["export "];
 
   const isDefault = decl["default"] || decl.type === "ExportDefaultDeclaration";
@@ -4370,6 +4389,7 @@ function printExportDeclaration(path, options, print) {
         defaultSpecifiers.length > 0 ||
         (decl.specifiers && decl.specifiers.some(node => node.comments));
 
+      /** @type {Doc} */
       let printed = "";
       if (specifiers.length !== 0) {
         if (canBreak) {
@@ -4678,6 +4698,7 @@ function printMemberChain(path, options, print) {
       return isNextLineEmptyAfterIndex(
         originalText,
         nextCharIndex + 1,
+        // @ts-ignore [TODO: support or remove options]
         options
       );
     }
@@ -5655,6 +5676,10 @@ function printRegex(node) {
   return `/${node.pattern}/${flags}`;
 }
 
+/**
+ * @param {Doc} path
+ * @param {Options} options
+ */
 function exprNeedsASIProtection(path, options) {
   const node = path.getValue();
 
@@ -5688,6 +5713,7 @@ function exprNeedsASIProtection(path, options) {
   return path.call.apply(
     path,
     [childPath => exprNeedsASIProtection(childPath, options)].concat(
+      // @ts-ignore [TODO: resolve the checkJs error here]
       getLeftSidePathName(path, node)
     )
   );

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -1,5 +1,10 @@
 "use strict";
 
+/**
+ * @typedef {import("estree").TemplateLiteral} TemplateLiteral
+ * @typedef {import("../doc/doc-builders").Doc} Doc
+ */
+
 const {
   getLast,
   hasNewline,
@@ -90,6 +95,11 @@ function getLeftSide(node) {
   );
 }
 
+/**
+ * @param {Doc} path
+ * @param {Object} node - [TODO better definition needed]
+ * @returns string[]
+ */
 function getLeftSidePathName(path, node) {
   if (node.expressions) {
     return ["expressions", 0];
@@ -406,7 +416,10 @@ function isNgForOf(node, index, parentNode) {
   );
 }
 
-/** @param node {import("estree").TemplateLiteral} */
+/**
+ * @param {TemplateLiteral} node
+ * @returns boolean
+ */
 function isSimpleTemplateLiteral(node) {
   if (node.expressions.length === 0) {
     return false;

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -1,5 +1,9 @@
 "use strict";
 
+/**
+ * @typedef {import("../doc/doc-builders").Doc} Doc
+ */
+
 const assert = require("assert");
 const {
   concat,
@@ -449,6 +453,13 @@ function printTrailingComment(commentPath, print, options) {
   ]);
 }
 
+/**
+ * @param {Doc} path
+ * @param {Object} options
+ * @param {boolean} [sameIndent]
+ * @param {(comment: Doc) => Doc} [filter]
+ * @returns Doc
+ */
 function printDanglingComments(path, options, sameIndent, filter) {
   const parts = [];
   const node = path.getValue();


### PR DESCRIPTION
with some TODO items

ref: #6703

the following command shows no errors in `src/language-js/printer-estree.js`:

```
 npx tsc --allowJs --checkJs --noEmit --resolveJsonModule --target es5 src/index.js
```

/cc @Shinigami92

TODO items:

- [ ] updates to doc-builders.js should be done elsewhere, such as PR #6710, and moved out of this PR
- [ ] automate JSDoc type checking, as already suggested by @thorn0 elsewhere, before moving forward with this proposal
- [ ] resolve TODO items in the code, if possible

<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- ~~I’ve added tests to confirm my change works.~~
- ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~~
- ~~(If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.~~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
