### PR TITLE
fix JSDoc type error in `src/doc/doc-printer.js`

### DIFF
--- a/src/doc/doc-printer.js
+++ b/src/doc/doc-printer.js
@@ -4,7 +4,7 @@ const { getStringWidth } = require("../common/util");
 const { convertEndOfLineToChars } = require("../common/end-of-line");
 const { concat, fill, cursor } = require("./doc-builders");
 
-/** @type {{[groupId: PropertyKey]: MODE}} */
+/** @type {{[groupId: string]: number}} */
 let groupModeMap;
 
 const MODE_BREAK = 1;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Quick fix to resolve the JSDoc type error, to help with resolving #6703.

With this update, the following command will show no JSDoc type errors:

```
npx tsc --allowJs --checkJs --noEmit --resolveJsonModule --target es5 src/doc/doc-printer.js
```

I suspect that `PropertyKey` and `MODE` were used in the JSDoc comment for some historical reasons, as part of PR #4563 (dcf44ffbdc2f403de02f12516b0c6d5d5813b16f). Looking through the commits in PR #4563, I see these were introduced in 0892d1780afc7cebd51565040c2b8bbf2ff3bdf7.

In the future, we may want to use a proper JSDoc enum for the mode. From some quick research, I think this would involve some minor source code updates.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- ~~I’ve added tests to confirm my change works.~~
- ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~~
- ~~(If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.~~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
