### PR TITLE
add & apply doc-builders.js type improvements

### DIFF
--- a/src/doc/doc-builders.js
+++ b/src/doc/doc-builders.js
@@ -1,5 +1,19 @@
 "use strict";
 
+/**
+ * @typedef {Object} DocObject
+ * @property {string} type
+ * @property {boolean} [hard]
+ * @property {boolean} [literal]
+ *
+ * @typedef {string | DocObject} Doc
+ *
+ * @typedef {Object} DocOptions - TBD more specific?
+ */
+
+/**
+ * @param {Doc} val
+ */
 function assertDoc(val) {
   /* istanbul ignore if */
   if (
@@ -11,6 +25,10 @@ function assertDoc(val) {
   }
 }
 
+/**
+ * @param {Doc[]} parts
+ * @returns Doc
+ */
 function concat(parts) {
   if (process.env.NODE_ENV !== "production") {
     parts.forEach(assertDoc);
@@ -25,6 +43,10 @@ function concat(parts) {
   return { type: "concat", parts };
 }
 
+/**
+ * @param {Doc} contents
+ * @returns Doc
+ */
 function indent(contents) {
   if (process.env.NODE_ENV !== "production") {
     assertDoc(contents);
@@ -33,6 +55,10 @@ function indent(contents) {
   return { type: "indent", contents };
 }
 
+/**
+ * @param {number} n
+ * @param {Doc} contents
+ */
 function align(n, contents) {
   if (process.env.NODE_ENV !== "production") {
     assertDoc(contents);
@@ -41,6 +67,11 @@ function align(n, contents) {
   return { type: "align", contents, n };
 }
 
+/**
+ * @param {Doc} contents
+ * @param {Object} [opts]
+ * @returns Doc
+ */
 function group(contents, opts) {
   opts = opts || {};
 
@@ -57,18 +88,36 @@ function group(contents, opts) {
   };
 }
 
+/**
+ * @param {Doc} contents
+ * @returns Doc
+ */
 function dedentToRoot(contents) {
   return align(-Infinity, contents);
 }
 
+/**
+ * @param {Doc} contents
+ * @returns Doc
+ */
 function markAsRoot(contents) {
+  // @ts-ignore - TBD ???:
   return align({ type: "root" }, contents);
 }
 
+/**
+ * @param {Doc} contents
+ * @returns Doc
+ */
 function dedent(contents) {
   return align(-1, contents);
 }
 
+/**
+ * @param {Doc[]} states
+ * @param {DocOptions} opts
+ * @returns Doc
+ */
 function conditionalGroup(states, opts) {
   return group(
     states[0],
@@ -76,6 +125,10 @@ function conditionalGroup(states, opts) {
   );
 }
 
+/**
+ * @param {Doc[]} parts
+ * @returns Doc
+ */
 function fill(parts) {
   if (process.env.NODE_ENV !== "production") {
     parts.forEach(assertDoc);
@@ -84,6 +137,12 @@ function fill(parts) {
   return { type: "fill", parts };
 }
 
+/**
+ * @param {Doc} breakContents
+ * @param {Doc} flatContents
+ * @param {DocOptions} opts
+ * @returns Doc
+ */
 function ifBreak(breakContents, flatContents, opts) {
   opts = opts || {};
 
@@ -104,6 +163,10 @@ function ifBreak(breakContents, flatContents, opts) {
   };
 }
 
+/**
+ * @param {Doc} contents
+ * @returns Doc
+ */
 function lineSuffix(contents) {
   if (process.env.NODE_ENV !== "production") {
     assertDoc(contents);
@@ -123,6 +186,10 @@ const literalline = concat([
 ]);
 const cursor = { type: "cursor", placeholder: Symbol("cursor") };
 
+/**
+ * @param {Doc} sep
+ * @param {Doc[]} arr
+ */
 function join(sep, arr) {
   const res = [];
 
@@ -137,6 +204,11 @@ function join(sep, arr) {
   return concat(res);
 }
 
+/**
+ * @param {Doc} doc
+ * @param {number} size
+ * @param {number} tabWidth
+ */
 function addAlignmentToDoc(doc, size, tabWidth) {
   let aligned = doc;
   if (size > 0) {

--- a/src/doc/index.js
+++ b/src/doc/index.js
@@ -1,5 +1,9 @@
 "use strict";
 
+/**
+ * @typedef {import("../doc/doc-builders").Doc} Doc
+ */
+
 module.exports = {
   builders: require("./doc-builders"),
   printer: require("./doc-printer"),

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1,5 +1,9 @@
 "use strict";
 
+/**
+ * @typedef {import("../doc").Doc} Doc
+ */
+
 const assert = require("assert");
 
 // TODO(azz): anything that imports from main shouldn't be in a `language-*` dir.
@@ -220,7 +224,9 @@ function genericPrint(path, options, printPath, args) {
     needsParens = pathNeedsParens(path, options);
   }
 
+  /** @type Doc[] */
   const parts = [];
+
   if (needsParens) {
     parts.unshift("(");
   }
@@ -437,7 +443,9 @@ function printPathNoParens(path, options, print, args) {
     return htmlBinding;
   }
 
+  /** @type Doc[] */
   let parts = [];
+
   switch (n.type) {
     case "JsExpressionRoot":
       return path.call(print, "node");
@@ -4312,6 +4320,7 @@ function printReturnType(path, print, options) {
 function printExportDeclaration(path, options, print) {
   const decl = path.getValue();
   const semi = options.semi ? ";" : "";
+  /** @type {Doc[]} */
   const parts = ["export "];
 
   const isDefault = decl["default"] || decl.type === "ExportDefaultDeclaration";
@@ -4370,6 +4379,7 @@ function printExportDeclaration(path, options, print) {
         defaultSpecifiers.length > 0 ||
         (decl.specifiers && decl.specifiers.some(node => node.comments));
 
+      /** @type {Doc} */
       let printed = "";
       if (specifiers.length !== 0) {
         if (canBreak) {


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

- add JSDoc type comments to `src/doc/doc-builders.js` & `doc/index.js`
- use the new Doc type in `src/language-js/printer-estree.js`

based on some of the changes in WIP PR #6707

resolves a few of the checkJs errors in `src/language-js/printer-estree.js`, as part of #6703

`src/doc/doc-builders.js` passes checkJs type checking in strict mode with these changes:

```
npx tsc --allowJs --checkJs --noEmit --resolveJsonModule --target es5 --strict src/doc/doc-builders.js
```

There are a couple of TBD comments that I would appreciate some feedback and guidance on.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- ~~I’ve added tests to confirm my change works.~~
- ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~~
- ~~(If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.~~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
