### PR TITLE
Prevent webpack generate `.LICENSE` file when minify

### DIFF
--- a/.azure-pipelines/jobs/prod-build.yml
+++ b/.azure-pipelines/jobs/prod-build.yml
@@ -1,6 +1,6 @@
 steps:
   - template: ../steps/install-nodejs.yml
   - template: ../steps/install-dependencies.yml
-  - script: yarn build && ls -l
+  - script: yarn build && cd dist && ls -l && cd ..
     displayName: "Build dist"
   - template: ../steps/upload-dist.yml

--- a/.azure-pipelines/jobs/prod-build.yml
+++ b/.azure-pipelines/jobs/prod-build.yml
@@ -1,6 +1,6 @@
 steps:
   - template: ../steps/install-nodejs.yml
   - template: ../steps/install-dependencies.yml
-  - script: yarn build
+  - script: yarn build && ls -l
     displayName: "Build dist"
   - template: ../steps/upload-dist.yml

--- a/.azure-pipelines/jobs/prod-build.yml
+++ b/.azure-pipelines/jobs/prod-build.yml
@@ -1,6 +1,6 @@
 steps:
   - template: ../steps/install-nodejs.yml
   - template: ../steps/install-dependencies.yml
-  - script: yarn build && cd dist && ls -l && cd ..
+  - script: yarn build
     displayName: "Build dist"
   - template: ../steps/upload-dist.yml

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -99,7 +99,7 @@ async function run(params) {
     await execa("rm", ["-rf", ".cache"]);
   }
 
-  const bundleCache = new Cache(".cache/", "v17");
+  const bundleCache = new Cache(".cache/", "v18");
   await bundleCache.load();
 
   console.log(chalk.inverse(" Building packages "));

--- a/scripts/build/bundler.js
+++ b/scripts/build/bundler.js
@@ -186,11 +186,7 @@ function getWebpackConfig(bundle) {
     const TerserPlugin = require("terser-webpack-plugin");
 
     config.optimization = {
-      minimizer: [
-        new TerserPlugin({
-          terserOptions: bundle.terserOptions
-        })
-      ]
+      minimizer: [new TerserPlugin(bundle.terserOptions)]
     };
   }
 

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -73,10 +73,14 @@ const parsers = [
     target: "universal",
     // postcss has dependency cycles that don't work with rollup
     bundler: "webpack",
-    // postcss need keep_fnames when minify
     terserOptions: {
-      mangle: {
-        keep_fnames: true
+      // prevent terser generate extra .LICENSE file
+      extractComments: false,
+      terserOptions: {
+        mangle: {
+          // postcss need keep_fnames when minify
+          keep_fnames: true
+        }
       }
     }
   },


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

the new version of `terser-webpack-plugin` v2.1.3 https://github.com/prettier/prettier/pull/6654 generate extra `parser-postcss.js.LICENSE` file, when minify

see this file first line: https://deploy-preview-6654--prettier.netlify.com/lib/parser-postcss.js

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
