### PR TITLE
Fix spellcheck script

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,6 @@
     "build": "node --max-old-space-size=3072 ./scripts/build/build.js",
     "build-docs": "node ./scripts/build-docs.js",
     "check-deps": "node ./scripts/check-deps.js",
-    "spellcheck": "npx cspell -p cspell@4.0.31 {bin,scripts,src}/**/*.js {docs,website/blog}/**/*.md CHANGELOG.unreleased.md"
+    "spellcheck": "npx -p cspell@4.0.31 cspell {bin,scripts,src}/**/*.js {docs,website/blog}/**/*.md CHANGELOG.unreleased.md"
   }
 }


### PR DESCRIPTION
I made a mistake in #6751 `-p` should be a `npx` argument, not `cspell` command argument

to see difference

```bash
$ npx -p cspell@1 cspell --version
npx: installed 117 in 20.66s
1.10.6

$ npx cspell -p cspell@1 --version
4.0.30
```

