### PR TITLE
Update angular-html-parser 1.2.0 -> 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@iarna/toml": "2.2.3",
     "@typescript-eslint/typescript-estree": "2.6.0",
     "angular-estree-parser": "1.1.5",
-    "angular-html-parser": "1.2.0",
+    "angular-html-parser": "1.3.0",
     "camelcase": "5.3.1",
     "chalk": "2.4.2",
     "cjk-regex": "2.0.0",


### PR DESCRIPTION
Update `angular-html-parser` (1.2.0 -> 1.3.0) to fix issue (#6749) with unsupported named entity.

Issue #6749 resolved here: ikatyang/angular-html-parser#8.

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
