### PR TITLE
ci: move `Dev_Test` to the top

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,22 +8,12 @@ variables:
   ENABLE_CODE_COVERAGE: "" # only enable coverage on the fastest job
 
 jobs:
-  - job: Dev_Lint
-    displayName: Dev Lint on Linux Node v12
+  - job: Dev_Test_Linux
+    displayName: Dev Test on Linux Node v12
     pool:
       vmImage: "Ubuntu 16.04"
     variables:
       node_version: 12
-    steps:
-      - template: .azure-pipelines/jobs/dev-lint.yml
-
-  - job: Dev_Test_Windows
-    displayName: Dev Test on Windows Node v12
-    pool:
-      vmImage: vs2017-win2016
-    variables:
-      node_version: 12
-      TEST_CRLF: true
     steps:
       - template: .azure-pipelines/jobs/dev-test.yml
 
@@ -37,14 +27,24 @@ jobs:
     steps:
       - template: .azure-pipelines/jobs/dev-test.yml
 
-  - job: Dev_Test_Linux
-    displayName: Dev Test on Linux Node v12
+  - job: Dev_Test_Windows
+    displayName: Dev Test on Windows Node v12
+    pool:
+      vmImage: vs2017-win2016
+    variables:
+      node_version: 12
+      TEST_CRLF: true
+    steps:
+      - template: .azure-pipelines/jobs/dev-test.yml
+
+  - job: Dev_Lint
+    displayName: Dev Lint on Linux Node v12
     pool:
       vmImage: "Ubuntu 16.04"
     variables:
       node_version: 12
     steps:
-      - template: .azure-pipelines/jobs/dev-test.yml
+      - template: .azure-pipelines/jobs/dev-lint.yml
 
   - job: Prod_Build
     displayName: Prod Build on Linux Node v12


### PR DESCRIPTION
We don't care lint result that much, move `Dev_Test` to the top, so we can see the test result immediately when we click link to azure, no need click the tab on left