### PR TITLE
Fix links to http in website for following #6811

### DIFF
--- a/website/versioned_docs/version-stable/index.md
+++ b/website/versioned_docs/version-stable/index.md
@@ -12,12 +12,12 @@ Prettier is an opinionated code formatter with support for:
 - [Vue](https://vuejs.org/)
 - [Flow](https://flow.org/)
 - [TypeScript](https://www.typescriptlang.org/)
-- CSS, [Less](http://lesscss.org/), and [SCSS](http://sass-lang.com)
+- CSS, [Less](http://lesscss.org/), and [SCSS](https://sass-lang.com)
 - [HTML](https://en.wikipedia.org/wiki/HTML)
 - [JSON](http://json.org/)
-- [GraphQL](http://graphql.org/)
-- [Markdown](http://commonmark.org/), including [GFM](https://github.github.com/gfm/) and [MDX](https://mdxjs.com/)
-- [YAML](http://yaml.org/)
+- [GraphQL](https://graphql.org/)
+- [Markdown](https://commonmark.org/), including [GFM](https://github.github.com/gfm/) and [MDX](https://mdxjs.com/)
+- [YAML](https://yaml.org/)
 
 It removes all original styling[\*](#footnotes) and ensures that all outputted code conforms to a consistent style. (See this [blog post](http://jlongster.com/A-Prettier-Formatter))
 


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

I noticed that links on the website isn't https after #6811 was merged, so I fixed it.
(the link to JSON was also changed to https)

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
