### PR TITLE
test with duplicated class name

### DIFF
--- a/tests_integration/__tests__/__snapshots__/duplicate-class-name.js.snap
+++ b/tests_integration/__tests__/__snapshots__/duplicate-class-name.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`outputs error message & exits with error code in case of a duplicate class name (stderr) 1`] = `
+"[error] stdin: SyntaxError: Identifier 'A' has already been declared (1:18)
+[error] > 1 | class A {} class A {}
+[error]     |                  ^
+"
+`;
+
+exports[`outputs error message & exits with error code in case of a duplicate class name (stdout) 1`] = `""`;
+
+exports[`outputs error message & exits with error code in case of a duplicate class name (write) 1`] = `Array []`;

--- a/tests_integration/__tests__/duplicate-class-name.js
+++ b/tests_integration/__tests__/duplicate-class-name.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const runPrettier = require("../runPrettier");
+
+describe("outputs error message & exits with error code in case of a duplicate class name", () => {
+  runPrettier("cli/with-shebang", ["--stdin", "--parser", "babel"], {
+    input: "class A {} class A {}"
+  }).test({
+    status: 2
+  });
+});


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

@thorn0 pointed out in <https://github.com/prettier/prettier/issues/6469#issuecomment-549821981> that the behavior in case of `class A {} class A {}` had changed since 1.18.2, due to an update of `@babel/parser`.

Here is a test that should confirm the current behavior and hopefully ensure that it does break in the future. The test description and snapshot are based on the new behavior, but it should be straightforward (trivial) to change it for the old behavior if needed.

I did also confirm that rollback to @babel/parser@7.2.0 would give us the old behavior.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- ~~I’ve added tests to confirm my change works.~~
- ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~~
- ~~(If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.~~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
