### PR TITLE
Add mongo as a VS Code supported language

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -1367,7 +1367,7 @@ const bigints = [200_000n, 0x0000_000an, 0b0111_1111n];
 
 #### VS Code: add support for .mongo files ([#6848] by [@aymericbouzy])
 
-When using the Azur Cosmos DB extension for VS Code, you can create .mongo files to write MongoDB queries, which use Javascript syntax. This change allows VS Code to format your file using Prettier.
+When using the Azure Cosmos DB extension for VS Code, you can create .mongo files to write MongoDB queries, which use Javascript syntax. This change allows VS Code to format your file using Prettier.
 
 ```js
 db.users.find({ someField: { $exists: true } });

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -692,7 +692,7 @@ Previously, Prettier only supported the most common HTML entities, such as `&nbs
 [error] stdin: SyntaxError: Unknown entity "excl" - use the "&#<decimal>;" or  "&#x<hex>;" syntax (1:6)
 [error] > 1 | <p>Hi&excl;</p>
 [error]     |      ^
-[error]   2 | 
+[error]   2 |
 -->
 
 <!-- Output (Prettier master) -->
@@ -1365,6 +1365,14 @@ const bigints = [200000n, 0x0000000an, 0b01111111n];
 const bigints = [200_000n, 0x0000_000an, 0b0111_1111n];
 ```
 
+#### VS Code: add support for .mongo files ([#6848] by [@aymericbouzy])
+
+When using the Azur Cosmos DB extension for VS Code, you can create .mongo files to write MongoDB queries, which use Javascript syntax. This change allows VS Code to format your file using Prettier.
+
+```js
+db.users.find({ someField: { $exists: true } });
+```
+
 [#5682]: https://github.com/prettier/prettier/pull/5682
 [#6657]: https://github.com/prettier/prettier/pull/6657
 [#5910]: https://github.com/prettier/prettier/pull/5910
@@ -1413,6 +1421,7 @@ const bigints = [200_000n, 0x0000_000an, 0b0111_1111n];
 [#6708]: https://github.com/prettier/prettier/pull/6708
 [#6687]: https://github.com/prettier/prettier/pull/6687
 [#6796]: https://github.com/prettier/prettier/pull/6796
+[#6848]: https://github.com/prettier/prettier/pull/6848
 [@brainkim]: https://github.com/brainkim
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
@@ -1433,3 +1442,4 @@ const bigints = [200_000n, 0x0000_000an, 0b0111_1111n];
 [@voithos]: https://github.com/voithos
 [@andersk]: https://github.com/andersk
 [@lydell]: https://github.com/lydell
+[@aymericbouzy]: https://github.com/aymericbouzy

--- a/src/language-js/index.js
+++ b/src/language-js/index.js
@@ -10,7 +10,7 @@ const languages = [
     Object.assign(data, {
       since: "0.0.0",
       parsers: ["babel", "flow"],
-      vscodeLanguageIds: ["javascript"],
+      vscodeLanguageIds: ["javascript", "mongo"],
       interpreters: data.interpreters.concat(["nodejs"])
     })
   ),

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -698,7 +698,7 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"since\\": \\"0.0.0\\",
       \\"tmScope\\": \\"source.js\\",
       \\"type\\": \\"programming\\",
-      \\"vscodeLanguageIds\\": [\\"javascript\\"]
+      \\"vscodeLanguageIds\\": [\\"javascript\\", \\"mongo\\"]
     },
     {
       \\"aceMode\\": \\"javascript\\",


### PR DESCRIPTION
Closes https://github.com/prettier/prettier/issues/6769

<!-- Please provide a brief summary of your changes: -->

This PR adds support for the VS Code mongo language (alias of javascript)

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- ~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
