### PR TITLE
Fix nullish coalescing parenthesis with mixed logical operators

### DIFF
--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -483,20 +483,23 @@ Previously, Prettier would sometimes ignore whitespace when formatting comments.
 </div>
 ```
 
-#### JavaScript: Update `??` precedence to match stage 3 proposal ([#6404] by [@vjeux])
+#### JavaScript: Update `??` precedence to match stage 3 proposal ([#6404] by [@vjeux], [#6863] by [@jridgewell])
 
-We've updated Prettier's support for the nullish coalescing operator to match a spec update that no longer allows it to immediately contain, or be contained within an `&&` or `||` operation.
+We've updated Prettier's support for the nullish coalescing operator to match a spec update that no longer allows it to immediately contain, or be contained within, an `&&` or `||` operation.
 
 <!-- prettier-ignore -->
 ```js
 // Input
-(foo ?? baz) || baz;
+(foo ?? bar) || baz;
+(foo || bar) ?? baz;
 
 // Output (Prettier stable)
-foo ?? baz || baz;
+foo ?? bar || baz;
+foo || bar ?? baz;
 
 // Output (Prettier master)
-(foo ?? baz) || baz;
+(foo ?? bar) || baz;
+(foo || bar) ?? baz;
 ```
 
 Please note, as we update our parsers with versions that support this spec update, code without the parenthesis will throw a parse error.
@@ -1402,27 +1405,6 @@ async function f() {
   ).map(({ id, name }) => ({ id, name }));
 }
 ```
-
-#### JavaScript: Fix nullish coalescing parenthesis with mixed logical operators ([#6863] by [@jridgewell])
-
-Ensure parenthesis are kept when the nullish coalescing operator (`??`) is mixed with the other logical operators (`&&` and `||`).
-
-<!-- prettier-ignore -->
-```js
-// Input
-(foo ?? baz) || baz;
-(foo || baz) ?? baz;
-
-// Output (Prettier stable)
-foo ?? baz || baz;
-foo || baz ?? baz;
-
-// Output (Prettier master)
-(foo ?? baz) || baz;
-(foo || baz) ?? baz;
-```
-
-Please note, as we update our parsers with versions that support this spec update, code without the parenthesis will throw a parse error.
 
 [#5682]: https://github.com/prettier/prettier/pull/5682
 [#6657]: https://github.com/prettier/prettier/pull/6657

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -1405,18 +1405,21 @@ async function f() {
 
 #### JavaScript: Fix nullish coalescing parenthesis with mixed logical operators ([#6863] by [@jridgewell])
 
-We've updated Prettier's support for the nullish coalescing operator to match a spec update that no longer allows it to immediately contain, or be contained within an `&&` or `||` operation.
+Ensure parenthesis are kept when the nullish coalescing operator (`??`) is mixed with the other logical operators (`&&` and `||`).
 
 <!-- prettier-ignore -->
 ```js
 // Input
 (foo ?? baz) || baz;
+(foo || baz) ?? baz;
 
 // Output (Prettier stable)
 foo ?? baz || baz;
+foo || baz ?? baz;
 
 // Output (Prettier master)
 (foo ?? baz) || baz;
+(foo || baz) ?? baz;
 ```
 
 Please note, as we update our parsers with versions that support this spec update, code without the parenthesis will throw a parse error.

--- a/CHANGELOG.unreleased.md
+++ b/CHANGELOG.unreleased.md
@@ -1403,6 +1403,24 @@ async function f() {
 }
 ```
 
+#### JavaScript: Fix nullish coalescing parenthesis with mixed logical operators ([#6863] by [@jridgewell])
+
+We've updated Prettier's support for the nullish coalescing operator to match a spec update that no longer allows it to immediately contain, or be contained within an `&&` or `||` operation.
+
+<!-- prettier-ignore -->
+```js
+// Input
+(foo ?? baz) || baz;
+
+// Output (Prettier stable)
+foo ?? baz || baz;
+
+// Output (Prettier master)
+(foo ?? baz) || baz;
+```
+
+Please note, as we update our parsers with versions that support this spec update, code without the parenthesis will throw a parse error.
+
 [#5682]: https://github.com/prettier/prettier/pull/5682
 [#6657]: https://github.com/prettier/prettier/pull/6657
 [#5910]: https://github.com/prettier/prettier/pull/5910
@@ -1453,6 +1471,7 @@ async function f() {
 [#6796]: https://github.com/prettier/prettier/pull/6796
 [#6848]: https://github.com/prettier/prettier/pull/6848
 [#6856]: https://github.com/prettier/prettier/pull/6856
+[#6863]: https://github.com/prettier/prettier/pull/6863
 [@brainkim]: https://github.com/brainkim
 [@duailibe]: https://github.com/duailibe
 [@gavinjoyce]: https://github.com/gavinjoyce
@@ -1474,3 +1493,4 @@ async function f() {
 [@andersk]: https://github.com/andersk
 [@lydell]: https://github.com/lydell
 [@aymericbouzy]: https://github.com/aymericbouzy
+[@jridgewell]: https://github.com/jridgewell

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -356,12 +356,12 @@ function needsParens(path, options) {
 
           if (
             (po === "??" && (no === "||" || no === "&&")) ||
-            ((po === "||" || po === "&&") && po === "??")
+            (no === "??" && (po === "||" || po === "&&"))
           ) {
             return true;
           }
 
-          if ((po === "||" || po === "??") && no === "&&") {
+          if (po === "||" && no === "&&") {
             return true;
           }
 

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -354,6 +354,13 @@ function needsParens(path, options) {
             return true;
           }
 
+          if (
+            (po === "??" && (no === "||" || no === "&&")) ||
+            ((po === "||" || po === "&&") && po === "??")
+          ) {
+            return true;
+          }
+
           if ((po === "||" || po === "??") && no === "&&") {
             return true;
           }

--- a/tests/nullish_coalescing/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/nullish_coalescing/__snapshots__/jsfmt.spec.js.snap
@@ -13,8 +13,18 @@ const x = (foo, bar = foo ?? bar) => {};
 foo ? bar ?? foo : baz;
 
 foo ?? (bar ?? baz);
+(foo ?? bar) ?? baz;
 
+// Mixing ?? and (&& or ||) requires parens
+// It's a syntax error without it.
 (foo ?? baz) || baz;
+foo ?? (baz || baz);
+
+(foo ?? baz) && baz;
+foo ?? (baz && baz);
+
+(foo || baz) ?? baz;
+foo || (baz ?? baz);
 
 (foo && baz) ?? baz;
 foo && (baz ?? baz);
@@ -27,8 +37,18 @@ const x = (foo, bar = foo ?? bar) => {};
 foo ? bar ?? foo : baz;
 
 foo ?? (bar ?? baz);
+foo ?? bar ?? baz;
 
+// Mixing ?? and (&& or ||) requires parens
+// It's a syntax error without it.
 (foo ?? baz) || baz;
+foo ?? (baz || baz);
+
+(foo ?? baz) && baz;
+foo ?? (baz && baz);
+
+(foo || baz) ?? baz;
+foo || (baz ?? baz);
 
 (foo && baz) ?? baz;
 foo && (baz ?? baz);

--- a/tests/nullish_coalescing/nullish_coalesing_operator.js
+++ b/tests/nullish_coalescing/nullish_coalesing_operator.js
@@ -5,8 +5,18 @@ const x = (foo, bar = foo ?? bar) => {};
 foo ? bar ?? foo : baz;
 
 foo ?? (bar ?? baz);
+(foo ?? bar) ?? baz;
 
+// Mixing ?? and (&& or ||) requires parens
+// It's a syntax error without it.
 (foo ?? baz) || baz;
+foo ?? (baz || baz);
+
+(foo ?? baz) && baz;
+foo ?? (baz && baz);
+
+(foo || baz) ?? baz;
+foo || (baz ?? baz);
 
 (foo && baz) ?? baz;
 foo && (baz ?? baz);


### PR DESCRIPTION
Mixing nullish coalescing (`??`) with the other logical operators (`&&` and `||`) requires parenthesis to disambiguate the inteded short circuiting. Without it, it's a `SyntaxError`. Earlier drafts of the spec allowed mixing, but it was disallowed when we reached Stage 3.

See https://v8.dev/features/nullish-coalescing#mixing-and-matching-operators

- [X] I’ve added tests to confirm my change works.
- [ ] ~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
