### PR TITLE
Rudimentary support for the most used directives of AngularJS 1.x

### DIFF
--- a/changelog_unreleased/angular/pr-6869.md
+++ b/changelog_unreleased/angular/pr-6869.md
@@ -1,4 +1,4 @@
-#### Angular: Unofficial rudimentary support for some of the most used directives of AngularJS 1.x ([#6869](https://github.com/prettier/prettier/pull/6869) by [@thorn0](https://github.com/thorn0))
+#### Unofficial rudimentary support for some of the most used directives of AngularJS 1.x ([#6869](https://github.com/prettier/prettier/pull/6869) by [@thorn0](https://github.com/thorn0))
 
 While there are some syntax incompatibilities (one-time bindings and the precedence of `|`) between the expression languages of the old AngularJS and the new Angular, overall the two languages are compatible enough for legacy and hybrid AngularJS-based projects to be able to benefit from using Prettier. Previously, when Prettier formatted AngularJS templates using the Angular parser, it formatted expressions only in interpolations. Now, some of the most used AngularJS directives are formatted too, namely: `ng-if`, `ng-show`, `ng-hide`, `ng-class`, `ng-style`.
 

--- a/changelog_unreleased/angular/pr-6869.md
+++ b/changelog_unreleased/angular/pr-6869.md
@@ -1,0 +1,15 @@
+#### Angular: Unofficial rudimentary support for some of the most used directives of AngularJS 1.x ([#6869](https://github.com/prettier/prettier/pull/6869) by [@thorn0](https://github.com/thorn0))
+
+While there are some syntax incompatibilities (one-time bindings and the precedence of `|`) between the expression languages of the old AngularJS and the new Angular, overall the two languages are compatible enough for legacy and hybrid AngularJS-based projects to be able to benefit from using Prettier. Previously, when Prettier formatted AngularJS templates using the Angular parser, it formatted expressions only in interpolations. Now, some of the most used AngularJS directives are formatted too, namely: `ng-if`, `ng-show`, `ng-hide`, `ng-class`, `ng-style`.
+
+<!-- prettier-ignore -->
+```html
+<!-- Input -->
+<div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading  ">Warning!</div>
+
+<!-- Output (Prettier stable) -->
+<div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading  ">Warning!</div>
+
+<!-- Output (Prettier master) -->
+<div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
+```

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -1036,7 +1036,7 @@ function printEmbeddedAttributeValue(node, originalTextToDoc, options) {
       "^\\[.+\\]$",
       "^bind(on)?-",
       // Unofficial rudimentary support for some of the most used directives of AngularJS 1.x
-      "^ng-(if|show|hide)$"
+      "^ng-(if|show|hide|class|style)$"
     ];
     /**
      *     i18n="longDescription"

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -1032,7 +1032,12 @@ function printEmbeddedAttributeValue(node, originalTextToDoc, options) {
      *     [(target)]="angularExpression"
      *     bindon-target="angularExpression"
      */
-    const ngExpressionBindingPatterns = ["^\\[.+\\]$", "^bind(on)?-"];
+    const ngExpressionBindingPatterns = [
+      "^\\[.+\\]$",
+      "^bind(on)?-",
+      // Unofficial rudimentary support for some of the most used directives of AngularJS 1.x
+      "^ng-(if|show|hide)$"
+    ];
     /**
      *     i18n="longDescription"
      *     i18n-attr="longDescription"

--- a/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
@@ -8,8 +8,34 @@ printWidth: 80
 =====================================input======================================
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
 
+<div
+	class="common--error-message"
+	test-hook="upper-error-message"
+	ng-if="!$ctrl.showsFormBelowPlain() && !!$ctrl.error.message && !($ctrl.error.kind === 'validator' && $ctrl.form.$valid && $ctrl.error.form === $ctrl.form)"
+>
+	<div ng-if="$ctrl.error.html" ng-bind-html="$ctrl.error.message"></div>
+	<div ng-if="!$ctrl.error.html" ng-bind="$ctrl.error.message"></div>
+</div>
+
 =====================================output=====================================
 <div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
+
+<div
+  class="common--error-message"
+  test-hook="upper-error-message"
+  ng-if="
+    !$ctrl.showsFormBelowPlain() &&
+    !!$ctrl.error.message &&
+    !(
+      $ctrl.error.kind === 'validator' &&
+      $ctrl.form.$valid &&
+      $ctrl.error.form === $ctrl.form
+    )
+  "
+>
+  <div ng-if="$ctrl.error.html" ng-bind-html="$ctrl.error.message"></div>
+  <div ng-if="!$ctrl.error.html" ng-bind="$ctrl.error.message"></div>
+</div>
 
 ================================================================================
 `;
@@ -23,8 +49,34 @@ trailingComma: "es5"
 =====================================input======================================
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
 
+<div
+	class="common--error-message"
+	test-hook="upper-error-message"
+	ng-if="!$ctrl.showsFormBelowPlain() && !!$ctrl.error.message && !($ctrl.error.kind === 'validator' && $ctrl.form.$valid && $ctrl.error.form === $ctrl.form)"
+>
+	<div ng-if="$ctrl.error.html" ng-bind-html="$ctrl.error.message"></div>
+	<div ng-if="!$ctrl.error.html" ng-bind="$ctrl.error.message"></div>
+</div>
+
 =====================================output=====================================
 <div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
+
+<div
+  class="common--error-message"
+  test-hook="upper-error-message"
+  ng-if="
+    !$ctrl.showsFormBelowPlain() &&
+    !!$ctrl.error.message &&
+    !(
+      $ctrl.error.kind === 'validator' &&
+      $ctrl.form.$valid &&
+      $ctrl.error.form === $ctrl.form
+    )
+  "
+>
+  <div ng-if="$ctrl.error.html" ng-bind-html="$ctrl.error.message"></div>
+  <div ng-if="!$ctrl.error.html" ng-bind="$ctrl.error.message"></div>
+</div>
 
 ================================================================================
 `;
@@ -37,6 +89,15 @@ printWidth: 1
 =====================================input======================================
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
 
+<div
+	class="common--error-message"
+	test-hook="upper-error-message"
+	ng-if="!$ctrl.showsFormBelowPlain() && !!$ctrl.error.message && !($ctrl.error.kind === 'validator' && $ctrl.form.$valid && $ctrl.error.form === $ctrl.form)"
+>
+	<div ng-if="$ctrl.error.html" ng-bind-html="$ctrl.error.message"></div>
+	<div ng-if="!$ctrl.error.html" ng-bind="$ctrl.error.message"></div>
+</div>
+
 =====================================output=====================================
 <div
   ng-if="
@@ -45,6 +106,47 @@ printWidth: 1
   "
 >
   Warning!
+</div>
+
+<div
+  class="common--error-message"
+  test-hook="upper-error-message"
+  ng-if="
+    !$ctrl.showsFormBelowPlain() &&
+    !!$ctrl
+      .error
+      .message &&
+    !(
+      $ctrl
+        .error
+        .kind ===
+        'validator' &&
+      $ctrl
+        .form
+        .$valid &&
+      $ctrl
+        .error
+        .form ===
+        $ctrl.form
+    )
+  "
+>
+  <div
+    ng-if="
+      $ctrl
+        .error
+        .html
+    "
+    ng-bind-html="$ctrl.error.message"
+  ></div>
+  <div
+    ng-if="
+      !$ctrl
+        .error
+        .html
+    "
+    ng-bind="$ctrl.error.message"
+  ></div>
 </div>
 
 ================================================================================
@@ -59,8 +161,34 @@ printWidth: 80
 =====================================input======================================
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
 
+<div
+	class="common--error-message"
+	test-hook="upper-error-message"
+	ng-if="!$ctrl.showsFormBelowPlain() && !!$ctrl.error.message && !($ctrl.error.kind === 'validator' && $ctrl.form.$valid && $ctrl.error.form === $ctrl.form)"
+>
+	<div ng-if="$ctrl.error.html" ng-bind-html="$ctrl.error.message"></div>
+	<div ng-if="!$ctrl.error.html" ng-bind="$ctrl.error.message"></div>
+</div>
+
 =====================================output=====================================
 <div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
+
+<div
+  class="common--error-message"
+  test-hook="upper-error-message"
+  ng-if="
+    !$ctrl.showsFormBelowPlain() &&
+    !!$ctrl.error.message &&
+    !(
+      $ctrl.error.kind === 'validator' &&
+      $ctrl.form.$valid &&
+      $ctrl.error.form === $ctrl.form
+    )
+  "
+>
+  <div ng-if="$ctrl.error.html" ng-bind-html="$ctrl.error.message"></div>
+  <div ng-if="!$ctrl.error.html" ng-bind="$ctrl.error.message"></div>
+</div>
 
 ================================================================================
 `;
@@ -74,8 +202,34 @@ printWidth: 80
 =====================================input======================================
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
 
+<div
+	class="common--error-message"
+	test-hook="upper-error-message"
+	ng-if="!$ctrl.showsFormBelowPlain() && !!$ctrl.error.message && !($ctrl.error.kind === 'validator' && $ctrl.form.$valid && $ctrl.error.form === $ctrl.form)"
+>
+	<div ng-if="$ctrl.error.html" ng-bind-html="$ctrl.error.message"></div>
+	<div ng-if="!$ctrl.error.html" ng-bind="$ctrl.error.message"></div>
+</div>
+
 =====================================output=====================================
 <div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
+
+<div
+  class="common--error-message"
+  test-hook="upper-error-message"
+  ng-if="
+    !$ctrl.showsFormBelowPlain() &&
+    !!$ctrl.error.message &&
+    !(
+      $ctrl.error.kind === 'validator' &&
+      $ctrl.form.$valid &&
+      $ctrl.error.form === $ctrl.form
+    )
+  "
+>
+  <div ng-if="$ctrl.error.html" ng-bind-html="$ctrl.error.message"></div>
+  <div ng-if="!$ctrl.error.html" ng-bind="$ctrl.error.message"></div>
+</div>
 
 ================================================================================
 `;

--- a/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`angularjs.html 1`] = `
+====================================options=====================================
+parsers: ["angular"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
+
+=====================================output=====================================
+<div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
+
+================================================================================
+`;
+
+exports[`angularjs.html 2`] = `
+====================================options=====================================
+parsers: ["angular"]
+printWidth: 80
+trailingComma: "es5"
+                                                                                | printWidth
+=====================================input======================================
+<div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
+
+=====================================output=====================================
+<div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
+
+================================================================================
+`;
+
+exports[`angularjs.html 3`] = `
+====================================options=====================================
+parsers: ["angular"]
+printWidth: 1
+ | printWidth
+=====================================input======================================
+<div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
+
+=====================================output=====================================
+<div
+  ng-if="
+    $ctrl.shouldShowWarning &&
+    !$ctrl.loading
+  "
+>
+  Warning!
+</div>
+
+================================================================================
+`;
+
+exports[`angularjs.html 4`] = `
+====================================options=====================================
+htmlWhitespaceSensitivity: "ignore"
+parsers: ["angular"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
+
+=====================================output=====================================
+<div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
+
+================================================================================
+`;
+
+exports[`angularjs.html 5`] = `
+====================================options=====================================
+bracketSpacing: false
+parsers: ["angular"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
+
+=====================================output=====================================
+<div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
+
+================================================================================
+`;
+
 exports[`attr-name.component.html 1`] = `
 ====================================options=====================================
 parsers: ["angular"]

--- a/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_angular/__snapshots__/jsfmt.spec.js.snap
@@ -4,6 +4,7 @@ exports[`angularjs.html 1`] = `
 ====================================options=====================================
 parsers: ["angular"]
 printWidth: 80
+trailingComma: "none"
                                                                                 | printWidth
 =====================================input======================================
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
@@ -44,7 +45,6 @@ exports[`angularjs.html 2`] = `
 ====================================options=====================================
 parsers: ["angular"]
 printWidth: 80
-trailingComma: "es5"
                                                                                 | printWidth
 =====================================input======================================
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>

--- a/tests/html_angular/angularjs.html
+++ b/tests/html_angular/angularjs.html
@@ -1,1 +1,10 @@
 <div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
+
+<div
+	class="common--error-message"
+	test-hook="upper-error-message"
+	ng-if="!$ctrl.showsFormBelowPlain() && !!$ctrl.error.message && !($ctrl.error.kind === 'validator' && $ctrl.form.$valid && $ctrl.error.form === $ctrl.form)"
+>
+	<div ng-if="$ctrl.error.html" ng-bind-html="$ctrl.error.message"></div>
+	<div ng-if="!$ctrl.error.html" ng-bind="$ctrl.error.message"></div>
+</div>

--- a/tests/html_angular/angularjs.html
+++ b/tests/html_angular/angularjs.html
@@ -1,0 +1,1 @@
+<div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>


### PR DESCRIPTION
While there are two syntax incompatibilities ([one-time bindings](https://github.com/prettier/prettier/issues/5466) and [the precedence of `|`](https://github.com/prettier/prettier/issues/5586)) between the expression languages of the old AngularJS and the new Angular, overall the two languages are compatible enough for legacy and hybrid AngularJS-based projects to be able to benefit from using Prettier, which I know from my own experience. An ideal solution would be to add a separate parser for AngularJS, but given the [LTS status](https://docs.angularjs.org/misc/version-support-status) of the framework, such an effort would hardly make sense. On the other hand, unofficially impoving the partial support like I'm doing with this PR is very cheap in terms of effort and code complexity, but would significantly improve the experience for those of our fellow programmers who still have to deal with AngularJS.

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to the `CHANGELOG.unreleased.md` file following the template.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
