### PR TITLE
Fix lost adjacent JSX when using Babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@angular/compiler": "8.2.13",
     "@babel/code-frame": "7.5.5",
-    "@babel/parser": "7.7.2",
+    "@babel/parser": "7.7.3",
     "@glimmer/syntax": "0.41.0",
     "@iarna/toml": "2.2.3",
     "@typescript-eslint/typescript-estree": "2.6.1",

--- a/src/language-js/parser-babylon.js
+++ b/src/language-js/parser-babylon.js
@@ -101,7 +101,7 @@ function tryCombinations(fn, combinations) {
   let error;
   for (let i = 0; i < combinations.length; i++) {
     try {
-      return rethrowSomeRecoveredErrors(fn(combinations[i]));
+      return fn(combinations[i]);
     } catch (_error) {
       if (!error) {
         error = _error;
@@ -109,20 +109,6 @@ function tryCombinations(fn, combinations) {
     }
   }
   throw error;
-}
-
-function rethrowSomeRecoveredErrors(ast) {
-  for (const error of ast.errors) {
-    if (
-      typeof error.message === "string" &&
-      error.message.startsWith(
-        "Adjacent JSX elements must be wrapped in an enclosing tag."
-      )
-    ) {
-      throw error;
-    }
-  }
-  return ast;
 }
 
 function parseJson(text, parsers, opts) {

--- a/src/language-js/parser-babylon.js
+++ b/src/language-js/parser-babylon.js
@@ -101,7 +101,7 @@ function tryCombinations(fn, combinations) {
   let error;
   for (let i = 0; i < combinations.length; i++) {
     try {
-      return fn(combinations[i]);
+      return rethrowSomeRecoveredErrors(fn(combinations[i]));
     } catch (_error) {
       if (!error) {
         error = _error;
@@ -109,6 +109,20 @@ function tryCombinations(fn, combinations) {
     }
   }
   throw error;
+}
+
+function rethrowSomeRecoveredErrors(ast) {
+  for (const error of ast.errors) {
+    if (
+      typeof error.message === "string" &&
+      error.message.startsWith(
+        "Adjacent JSX elements must be wrapped in an enclosing tag."
+      )
+    ) {
+      throw error;
+    }
+  }
+  return ast;
 }
 
 function parseJson(text, parsers, opts) {

--- a/tests_integration/__tests__/__snapshots__/format.js.snap
+++ b/tests_integration/__tests__/__snapshots__/format.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`'Adjacent JSX' error should not be swallowed by Babel's error recovery 1`] = `
+"Adjacent JSX elements must be wrapped in an enclosing tag. Did you want a JSX fragment <>...</>? (2:1)
+  1 | <a></a>
+> 2 | <b></b>
+    | ^"
+`;
+
 exports[`html parser should handle CRLF correctly 1`] = `"\\"<!--\\\\r\\\\n  test\\\\r\\\\n  test\\\\r\\\\n-->\\\\r\\\\n\\""`;
 
 exports[`markdown parser should handle CRLF correctly 1`] = `"\\"\`\`\`\\\\r\\\\n\\\\r\\\\n\\\\r\\\\n\`\`\`\\\\r\\\\n\\""`;

--- a/tests_integration/__tests__/format.js
+++ b/tests_integration/__tests__/format.js
@@ -53,3 +53,8 @@ test("should work with foo plugin instance", () => {
     `"\\"{\\\\\\"tabWidth\\\\\\":8,\\\\\\"bracketSpacing\\\\\\":false}\\""`
   );
 });
+
+test("'Adjacent JSX' error should not be swallowed by Babel's error recovery", () => {
+  const input = "<a></a>\n<b></b>";
+  expect(() => prettier.format(input)).toThrowErrorMatchingSnapshot();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -378,15 +378,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.7.3":
+"@babel/parser@7.7.3", "@babel/parser@^7.1.2", "@babel/parser@^7.1.5", "@babel/parser@^7.4.5", "@babel/parser@^7.5.5", "@babel/parser@^7.7.0", "@babel/parser@^7.7.2":
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.3.tgz#5fad457c2529de476a248f75b0f090b3060af043"
   integrity sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==
-
-"@babel/parser@^7.1.2", "@babel/parser@^7.1.5", "@babel/parser@^7.4.5", "@babel/parser@^7.5.5", "@babel/parser@^7.7.0", "@babel/parser@^7.7.2":
-  version "7.7.2"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.2.tgz#ea8334dc77416bfd9473eb470fd00d8245b3943b"
-  integrity sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==
 
 "@babel/plugin-proposal-async-generator-functions@^7.7.0":
   version "7.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -378,7 +378,12 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.7.2", "@babel/parser@^7.1.2", "@babel/parser@^7.1.5", "@babel/parser@^7.4.5", "@babel/parser@^7.5.5", "@babel/parser@^7.7.0", "@babel/parser@^7.7.2":
+"@babel/parser@7.7.3":
+  version "7.7.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.3.tgz#5fad457c2529de476a248f75b0f090b3060af043"
+  integrity sha512-bqv+iCo9i+uLVbI0ILzKkvMorqxouI+GbV13ivcARXn9NNEabi2IEz912IgNpT/60BNXac5dgcfjb94NjsF33A==
+
+"@babel/parser@^7.1.2", "@babel/parser@^7.1.5", "@babel/parser@^7.4.5", "@babel/parser@^7.5.5", "@babel/parser@^7.7.0", "@babel/parser@^7.7.2":
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.7.2.tgz#ea8334dc77416bfd9473eb470fd00d8245b3943b"
   integrity sha512-DDaR5e0g4ZTb9aP7cpSZLkACEBdoLGwJDWgHtBhrGX7Q1RjhdoMOfexICj5cqTAtpowjGQWfcvfnQG7G2kAB5w==


### PR DESCRIPTION
Otherwise Prettier formats `<a/><b/>` to `<a/ >;`.

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
