### PR TITLE
Enable `corejs` option for core bundle `bin-prettier.js` and `third-party.js`

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -61,6 +61,7 @@
         "codemirror",
         "codemod",
         "codemods",
+        "corejs",
         "combinator",
         "commonmark",
         "concating",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "benchmark": "2.1.4",
     "builtin-modules": "3.1.0",
     "codecov": "3.6.1",
+    "core-js": "3.4.0",
     "cross-env": "6.0.3",
     "eslint": "6.6.0",
     "eslint-config-prettier": "6.5.0",

--- a/scripts/build/bundler.js
+++ b/scripts/build/bundler.js
@@ -40,21 +40,40 @@ function getBabelConfig(bundle) {
   const config = {
     babelrc: false,
     plugins: bundle.babelPlugins || [],
+    exclude: [],
     compact: bundle.type === "plugin" ? false : "auto"
+  };
+  const presetEnvConfig = {
+    targets: {
+      node: "4"
+    },
+    modules: false
   };
   if (bundle.type === "core") {
     config.plugins.push(
       require.resolve("./babel-plugins/transform-custom-require")
     );
+
+    if (bundle.corejs) {
+      Object.assign(presetEnvConfig, {
+        useBuiltIns: "usage",
+        corejs: {
+          version: 3,
+          proposals: true
+        }
+      });
+      config.exclude.push(/\/core-js\//);
+    }
   }
-  const targets = { node: 4 };
   if (bundle.target === "universal") {
     // From https://jamie.build/last-2-versions
-    targets.browsers = [">0.25%", "not ie 11", "not op_mini all"];
+    presetEnvConfig.targets.browsers = [
+      ">0.25%",
+      "not ie 11",
+      "not op_mini all"
+    ];
   }
-  config.presets = [
-    [require.resolve("@babel/preset-env"), { targets, modules: false }]
-  ];
+  config.presets = [[require.resolve("@babel/preset-env"), presetEnvConfig]];
   return config;
 }
 
@@ -206,6 +225,10 @@ function runWebpack(config) {
 }
 
 module.exports = async function createBundle(bundle, cache) {
+  if (bundle.corejs && bundle.type !== "core") {
+    throw new Error("Only core bundles can use corejs");
+  }
+
   const inputOptions = getRollupConfig(bundle);
   const outputOptions = getRollupOutputOptions(bundle);
 

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -173,12 +173,14 @@ const coreBundles = [
     input: "bin/prettier.js",
     type: "core",
     output: "bin-prettier.js",
+    corejs: true,
     target: "node",
     externals: [path.resolve("src/common/third-party.js")]
   },
   {
     input: "src/common/third-party.js",
     type: "core",
+    corejs: true,
     target: "node",
     replace: {
       // cosmiconfig@5 -> import-fresh uses `require` to resolve js config, which caused Error:

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -19,6 +19,7 @@ const babelReplaceArrayIncludesWithIndexof = require.resolve(
  * @property {Object.<string, string>} replace - map of strings to replace when processing the bundle
  * @property {string[]} babelPlugins - babel plugins
  * @property {Object?} terserOptions - options for `terser`
+ * @property {boolean?} corejs - use corejs for `@babel/preset-env`
 
  * @typedef {Object} CommonJSConfig
  * @property {Object} namedExports - for cases where rollup can't infer what's exported

--- a/yarn.lock
+++ b/yarn.lock
@@ -1991,6 +1991,11 @@ core-js-pure@3.1.3:
   resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.1.3.tgz#4c90752d5b9471f641514f3728f51c1e0783d0b5"
   integrity sha512-k3JWTrcQBKqjkjI0bkfXS0lbpWPxYuHWfMMjC1VDmzU4Q58IwSbuXSo99YO/hUHlw/EB4AlfA2PVxOGkrIq6dA==
 
+core-js@3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.4.0.tgz#29ea478601789c72f2978e9bb98f43546f89d3aa"
+  integrity sha512-lQxb4HScV71YugF/X28LtePZj9AB7WqOpcB+YztYxusvhrgZiQXPmCYfPC5LHsw/+ScEtDbXU3xbqH3CjBRmYA==
+
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.1.tgz#ae6874dc66937789b80754ff5428df66819ca50b"


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

this PR requires #6866 , fixes #6891 , I tried to make a test for it, but failed. local test

before

```bash
$ cat index.js | node node_modules/prettier/bin-prettier --stdin --parser babel
[error] regeneratorRuntime is not defined
```

after

```bash
$ cat index.js | node dist/bin-prettier --stdin --parser babel
"use strict";

module.exports = require("./src/index");
```

diff

```diff
npm notice
-npm notice package: prettier@1.19.0
+npm notice package: prettier@1.20.0-dev
npm notice === Tarball Contents ===
npm notice 468B    package.json
-npm notice 1.4MB   bin-prettier.js
+npm notice 1.6MB   bin-prettier.js
npm notice 70.6kB  doc.js
npm notice 1.3MB   index.js
npm notice 1.1kB   LICENSE
npm notice 57.4kB  parser-angular.js
npm notice 266.2kB parser-babylon.js
npm notice 1.5MB   parser-flow.js
npm notice 139.6kB parser-glimmer.js
npm notice 51.4kB  parser-graphql.js
npm notice 110.7kB parser-html.js
npm notice 241.1kB parser-markdown.js
npm notice 351.8kB parser-postcss.js
npm notice 2.6MB   parser-typescript.js
npm notice 167.7kB parser-yaml.js
npm notice 3.7kB   README.md
npm notice 1.1MB   standalone.js
-npm notice 146.7kB third-party.js
+npm notice 296.0kB third-party.js
npm notice === Tarball Details ===
npm notice name:          prettier
-npm notice version:       1.19.0
+npm notice version:       1.20.0-dev
-npm notice filename:      prettier-1.19.0.tgz
+npm notice filename:      prettier-1.20.0-dev.tgz
-npm notice package size:  2.2 MB
+npm notice package size:  2.3 MB
-npm notice unpacked size: 9.6 MB
+npm notice unpacked size: 9.9 MB
-npm notice shasum:        0a355225fa968b1a716739508f2689d18a0a513a
+npm notice shasum:        5dc617bfb5759264b838f9d34d238578b220a850
-npm notice integrity:     sha512-p32VAB78i7JQT[...]txg82TWSxTi1A==
+npm notice integrity:     sha512-DLkijM5TPo6uU[...]PoR2Dnm5WbNGw==
npm notice total files:   18
npm notice
-prettier-1.19.0.tgz
+prettier-1.20.0-dev.tgz
```

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
