### PR TITLE
Quick-fix for stdin being broken in 1.19.0

### DIFF
--- a/changelog_unreleased/cli/pr-6894.md
+++ b/changelog_unreleased/cli/pr-6894.md
@@ -1,0 +1,12 @@
+#### Fix `--stdin` regression in 1.19.0 ([#6894](https://github.com/prettier/prettier/pull/6894) by [@lydell](https://github.com/lydell))
+
+<!-- prettier-ignore -->
+```jsx
+// Prettier stable
+$ echo "test" | prettier --stdin --parser babel
+[error] regeneratorRuntime is not defined
+
+// Prettier master
+$ echo "test" | prettier --stdin --parser babel
+test;
+```

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "find-parent-dir": "0.3.0",
     "find-project-root": "1.1.1",
     "flow-parser": "0.111.3",
-    "get-stream": "5.1.0",
+    "get-stream": "4.1.0",
     "globby": "6.1.0",
     "graphql": "14.5.8",
     "html-element-attributes": "2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3033,16 +3033,23 @@ get-stdin@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
   integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
 
-get-stream@5.1.0, get-stream@^5.0.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
-  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
+get-stream@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
+  integrity sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
   dependencies:
     pump "^3.0.0"
 
 get-stream@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-3.0.0.tgz#8e943d1358dc37555054ecbe2edb05aa174ede14"
+
+get-stream@^5.0.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.1.0.tgz#01203cdc92597f9b909067c3e656cc1f4d3c4dc9"
+  integrity sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==
+  dependencies:
+    pump "^3.0.0"
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"


### PR DESCRIPTION
Closes #6891.

This downgrades the get-stream package from 5.x to 4.x, which does not
use `async` functions which works around the problem of
`regeneratorRuntime` not being defined (it shouldn’t be needed).

This is an alternative solution to #6893 because I don’t know yet if we
want to enable `corejs` given that we will most likely drop support for
Node.js 8 and older in the next version.

Just like #6893 this PR comes without tests, but I verified locally that
`--stdin` works after this change.

/cc @fisker @evilebottnawi 