### PR TITLE
Fix stdin with async-to-promises

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "@rollup/plugin-alias": "2.2.0",
     "@rollup/plugin-replace": "2.2.1",
     "babel-loader": "8.0.6",
+    "babel-plugin-transform-async-to-promises": "0.8.15",
     "benchmark": "2.1.4",
     "builtin-modules": "3.1.0",
     "codecov": "3.6.1",

--- a/scripts/build/bundler.js
+++ b/scripts/build/bundler.js
@@ -53,7 +53,14 @@ function getBabelConfig(bundle) {
     targets.browsers = [">0.25%", "not ie 11", "not op_mini all"];
   }
   config.presets = [
-    [require.resolve("@babel/preset-env"), { targets, modules: false }]
+    [
+      require.resolve("@babel/preset-env"),
+      {
+        targets,
+        exclude: ["transform-async-to-generator"],
+        modules: false
+      }
+    ]
   ];
   return config;
 }

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -173,7 +173,8 @@ const coreBundles = [
     type: "core",
     output: "bin-prettier.js",
     target: "node",
-    externals: [path.resolve("src/common/third-party.js")]
+    externals: [path.resolve("src/common/third-party.js")],
+    babelPlugins: ["babel-plugin-transform-async-to-promises"]
   },
   {
     input: "src/common/third-party.js",
@@ -184,7 +185,8 @@ const coreBundles = [
       // Dynamic requires are not currently supported by rollup-plugin-commonjs.
       "require(filePath)": "eval('require')(filePath)",
       "require.cache": "eval('require').cache"
-    }
+    },
+    babelPlugins: ["babel-plugin-transform-async-to-promises"]
   }
 ];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1365,6 +1365,11 @@ babel-plugin-syntax-object-rest-spread@^6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
+babel-plugin-transform-async-to-promises@0.8.15:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-async-to-promises/-/babel-plugin-transform-async-to-promises-0.8.15.tgz#13b6d8ef13676b4e3c576d3600b85344bb1ba346"
+  integrity sha512-fDXP68ZqcinZO2WCiimCL9zhGjGXOnn3D33zvbh+yheZ/qOrNVVDDIBtAaM3Faz8TRvQzHiRKsu3hfrBAhEncQ==
+
 babel-preset-jest@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-23.2.0.tgz#8ec7a03a138f001a1a8fb1e8113652bf1a55da46"


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Another solution for #6891, I'm Ok with any of them

#6894
#6893

also lacal tested

@lydell

----
file size

```text
npm notice package: prettier@1.20.0-dev
npm notice === Tarball Contents ===
npm notice 468B    package.json
npm notice 1.4MB   bin-prettier.js
npm notice 70.6kB  doc.js
npm notice 1.3MB   index.js
npm notice 1.1kB   LICENSE
npm notice 57.4kB  parser-angular.js
npm notice 266.2kB parser-babylon.js
npm notice 1.5MB   parser-flow.js
npm notice 139.6kB parser-glimmer.js
npm notice 51.4kB  parser-graphql.js
npm notice 110.7kB parser-html.js
npm notice 241.1kB parser-markdown.js
npm notice 351.8kB parser-postcss.js
npm notice 2.6MB   parser-typescript.js
npm notice 167.7kB parser-yaml.js
npm notice 3.7kB   README.md
npm notice 1.1MB   standalone.js
npm notice 146.6kB third-party.js
npm notice === Tarball Details ===
npm notice name:          prettier
npm notice version:       1.20.0-dev
npm notice filename:      prettier-1.20.0-dev.tgz
npm notice package size:  2.2 MB
npm notice unpacked size: 9.6 MB
npm notice shasum:        2a9dfc544a44e3026a88d5ba326e378d5a480178
npm notice integrity:     sha512-MEeyf/9UATXuV[...]WXBKi+vKyL93A==
npm notice total files:   18
npm notice
prettier-1.20.0-dev.tgz
```


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
