### PR TITLE
fix formatting of union type as arrow function return type

### DIFF
--- a/changelog_unreleased/typescript/pr-6896.md
+++ b/changelog_unreleased/typescript/pr-6896.md
@@ -1,0 +1,22 @@
+#### Fix formatting of union type as arrow function return type ([#6896](https://github.com/prettier/prettier/pull/6896) by [@thorn0](https://github.com/thorn0))
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+export const getVehicleDescriptor = async (
+  vehicleId: string,
+): Promise<Collections.Parts.PrintedCircuitBoardAssembly['attributes'] | undefined> => {}
+
+// Prettier stable
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<| Collections.Parts.PrintedCircuitBoardAssembly["attributes"]
+| undefined> => {};
+
+// Prettier master
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssembly["attributes"] | undefined
+> => {};
+```

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4587,10 +4587,13 @@ function printTypeParameters(path, options, print, paramsKey) {
         (n[paramsKey][0].type === "TSTypeReference" &&
           shouldHugType(n[paramsKey][0].typeName)) ||
         n[paramsKey][0].type === "NullableTypeAnnotation" ||
+        // See https://github.com/prettier/prettier/pull/6467 for the context.
         (greatGreatGrandParent &&
           greatGreatGrandParent.type === "VariableDeclarator" &&
           grandparent &&
           grandparent.type === "TSTypeAnnotation" &&
+          n[paramsKey][0].type !== "TSUnionType" &&
+          n[paramsKey][0].type !== "UnionTypeAnnotation" &&
           n[paramsKey][0].type !== "TSConditionalType" &&
           n[paramsKey][0].type !== "TSMappedType")));
 

--- a/tests/typescript_generic/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_generic/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`arrow-return-type.ts 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export const getVehicleDescriptor = async (
+  vehicleId: string,
+): Promise<
+  Descriptor | undefined
+> => {}
+
+
+export const getVehicleDescriptor = async (
+  vehicleId: string,
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssembly['attributes'] | undefined
+> => {}
+
+=====================================output=====================================
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<Descriptor | undefined> => {};
+
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssembly["attributes"] | undefined
+> => {};
+
+================================================================================
+`;
+
 exports[`object-method.ts 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/typescript_generic/arrow-return-type.ts
+++ b/tests/typescript_generic/arrow-return-type.ts
@@ -1,0 +1,12 @@
+export const getVehicleDescriptor = async (
+  vehicleId: string,
+): Promise<
+  Descriptor | undefined
+> => {}
+
+
+export const getVehicleDescriptor = async (
+  vehicleId: string,
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssembly['attributes'] | undefined
+> => {}


### PR DESCRIPTION
fixes #6886

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
