### PR TITLE
Fix `since` version for `vueIndentScriptAndStyle`

### DIFF
--- a/src/language-html/options.js
+++ b/src/language-html/options.js
@@ -26,7 +26,7 @@ module.exports = {
     ]
   },
   vueIndentScriptAndStyle: {
-    since: "1.19.0-beta.1",
+    since: "1.19.0",
     category: CATEGORY_HTML,
     type: "boolean",
     default: false,

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -1419,7 +1419,7 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"description\\": \\"Indent script and style tags in Vue files.\\",
       \\"name\\": \\"vueIndentScriptAndStyle\\",
       \\"pluginDefaults\\": {},
-      \\"since\\": \\"1.19.0-beta.1\\",
+      \\"since\\": \\"1.19.0\\",
       \\"type\\": \\"boolean\\"
     }
   ]


### PR DESCRIPTION
See #6887.
