### PR TITLE
TypeScript: Fix formatting of type operators as arrow function…

### DIFF
--- a/changelog_unreleased/typescript/pr-6901.md
+++ b/changelog_unreleased/typescript/pr-6901.md
@@ -1,0 +1,65 @@
+```ts
+// Input
+export const fun1 = async (
+  vehicleId: string,
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssembly['attributes'] & undefined
+> => {}
+
+export const fun2 = async (
+  vehicleId: string,
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssembly['attributes']
+> => {}
+
+export const fun3 = async (
+  vehicleId: string,
+): Promise<
+  keyof Collections.Parts.PrintedCircuitBoardAssembly['attributes']
+> => {}
+
+export const fun4 = async (
+  vehicleId: string,
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssembly[]
+> => {}
+
+// Prettier stable
+export const fun1 = async (
+  vehicleId: string
+): Promise<Collections.Parts.PrintedCircuitBoardAssembly["attributes"] &
+  undefined> => {};
+
+export const fun2 = async (
+  vehicleId: string
+): Promise<Collections.Parts.PrintedCircuitBoardAssembly["attributes"]> => {};
+
+export const fun3 = async (
+  vehicleId: string
+): Promise<keyof Collections.Parts.PrintedCircuitBoardAssembly["attributes"]> => {};
+
+export const fun4 = async (
+  vehicleId: string
+): Promise<Collections.Parts.PrintedCircuitBoardAssembly[]> => {};
+
+// Pretter master
+export const fun1 = async (
+  vehicleId: string
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssembly["attributes"] & undefined
+> => {};
+
+export const fun2 = async (
+  vehicleId: string
+): Promise<Collections.Parts.PrintedCircuitBoardAssembly["attributes"]> => {};
+
+export const fun3 = async (
+  vehicleId: string
+): Promise<
+  keyof Collections.Parts.PrintedCircuitBoardAssembly["attributes"]
+> => {};
+
+export const fun4 = async (
+  vehicleId: string
+): Promise<Collections.Parts.PrintedCircuitBoardAssembly[]> => {};
+```

--- a/changelog_unreleased/typescript/pr-6901.md
+++ b/changelog_unreleased/typescript/pr-6901.md
@@ -8,56 +8,17 @@ export const getVehicleDescriptor = async (
 ): Promise<
   Collections.Parts.PrintedCircuitBoardAssembly["attributes"] & undefined
 > => {};
-export const getVehicleDescriptor = async (
-  vehicleId: string
-): Promise<
-  Collections.Parts.PrintedCircuitBoardAssembly["attributessssssssssssssssssssssss"]
-> => {};
-export const getVehicleDescriptor = async (
-  vehicleId: string
-): Promise<
-  keyof Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
-> => {};
-export const getVehicleDescriptor = async (
-  vehicleId: string
-): Promise<
-  Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy[]
-> => {};
 
 // Prettier stable
 export const getVehicleDescriptor = async (
   vehicleId: string
 ): Promise<Collections.Parts.PrintedCircuitBoardAssembly["attributes"] &
   undefined> => {};
-export const getVehicleDescriptor = async (
-  vehicleId: string
-): Promise<Collections.Parts.PrintedCircuitBoardAssembly["attributessssssssssssssssssssssss"]> => {};
-export const getVehicleDescriptor = async (
-  vehicleId: string
-): Promise<keyof Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy> => {};
-export const getVehicleDescriptor = async (
-  vehicleId: string
-): Promise<Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy[]> => {};
 
-// Prettier
+// Prettier master
 export const getVehicleDescriptor = async (
   vehicleId: string
 ): Promise<
   Collections.Parts.PrintedCircuitBoardAssembly["attributes"] & undefined
-> => {};
-export const getVehicleDescriptor = async (
-  vehicleId: string
-): Promise<
-  Collections.Parts.PrintedCircuitBoardAssembly["attributessssssssssssssssssssssss"]
-> => {};
-export const getVehicleDescriptor = async (
-  vehicleId: string
-): Promise<
-  keyof Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
-> => {};
-export const getVehicleDescriptor = async (
-  vehicleId: string
-): Promise<
-  Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy[]
 > => {};
 ```

--- a/changelog_unreleased/typescript/pr-6901.md
+++ b/changelog_unreleased/typescript/pr-6901.md
@@ -1,65 +1,63 @@
+#### Fix formatting of type operator as arrow function return type ([#6901](https://github.com/prettier/prettier/pull/6901) by [@sosukesuzuki](https://github.com/sosukesuzuki))
+
+<!-- prettier-ignore -->
 ```ts
 // Input
-export const fun1 = async (
-  vehicleId: string,
-): Promise<
-  Collections.Parts.PrintedCircuitBoardAssembly['attributes'] & undefined
-> => {}
-
-export const fun2 = async (
-  vehicleId: string,
-): Promise<
-  Collections.Parts.PrintedCircuitBoardAssembly['attributes']
-> => {}
-
-export const fun3 = async (
-  vehicleId: string,
-): Promise<
-  keyof Collections.Parts.PrintedCircuitBoardAssembly['attributes']
-> => {}
-
-export const fun4 = async (
-  vehicleId: string,
-): Promise<
-  Collections.Parts.PrintedCircuitBoardAssembly[]
-> => {}
-
-// Prettier stable
-export const fun1 = async (
-  vehicleId: string
-): Promise<Collections.Parts.PrintedCircuitBoardAssembly["attributes"] &
-  undefined> => {};
-
-export const fun2 = async (
-  vehicleId: string
-): Promise<Collections.Parts.PrintedCircuitBoardAssembly["attributes"]> => {};
-
-export const fun3 = async (
-  vehicleId: string
-): Promise<keyof Collections.Parts.PrintedCircuitBoardAssembly["attributes"]> => {};
-
-export const fun4 = async (
-  vehicleId: string
-): Promise<Collections.Parts.PrintedCircuitBoardAssembly[]> => {};
-
-// Pretter master
-export const fun1 = async (
+export const getVehicleDescriptor = async (
   vehicleId: string
 ): Promise<
   Collections.Parts.PrintedCircuitBoardAssembly["attributes"] & undefined
 > => {};
-
-export const fun2 = async (
-  vehicleId: string
-): Promise<Collections.Parts.PrintedCircuitBoardAssembly["attributes"]> => {};
-
-export const fun3 = async (
+export const getVehicleDescriptor = async (
   vehicleId: string
 ): Promise<
-  keyof Collections.Parts.PrintedCircuitBoardAssembly["attributes"]
+  Collections.Parts.PrintedCircuitBoardAssembly["attributessssssssssssssssssssssss"]
+> => {};
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<
+  keyof Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+> => {};
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy[]
 > => {};
 
-export const fun4 = async (
+// Prettier stable
+export const getVehicleDescriptor = async (
   vehicleId: string
-): Promise<Collections.Parts.PrintedCircuitBoardAssembly[]> => {};
+): Promise<Collections.Parts.PrintedCircuitBoardAssembly["attributes"] &
+  undefined> => {};
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<Collections.Parts.PrintedCircuitBoardAssembly["attributessssssssssssssssssssssss"]> => {};
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<keyof Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy> => {};
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy[]> => {};
+
+// Prettier
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssembly["attributes"] & undefined
+> => {};
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssembly["attributessssssssssssssssssssssss"]
+> => {};
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<
+  keyof Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+> => {};
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy[]
+> => {};
 ```

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4573,6 +4573,7 @@ function printTypeParameters(path, options, print, paramsKey) {
   }
 
   const grandparent = path.getNode(2);
+  const greatGrandParent = path.getNode(3);
   const greatGreatGrandParent = path.getNode(4);
 
   const isParameterInTestCall = grandparent != null && isTestCall(grandparent);
@@ -4592,6 +4593,8 @@ function printTypeParameters(path, options, print, paramsKey) {
           greatGreatGrandParent.type === "VariableDeclarator" &&
           grandparent &&
           grandparent.type === "TSTypeAnnotation" &&
+          greatGrandParent &&
+          greatGrandParent.type !== "ArrowFunctionExpression" &&
           n[paramsKey][0].type !== "TSUnionType" &&
           n[paramsKey][0].type !== "UnionTypeAnnotation" &&
           n[paramsKey][0].type !== "TSIntersectionType" &&

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4594,8 +4594,13 @@ function printTypeParameters(path, options, print, paramsKey) {
           grandparent.type === "TSTypeAnnotation" &&
           n[paramsKey][0].type !== "TSUnionType" &&
           n[paramsKey][0].type !== "UnionTypeAnnotation" &&
+          n[paramsKey][0].type !== "TSIntersectionType" &&
+          n[paramsKey][0].type !== "IntersectionTypeAnnotation" &&
           n[paramsKey][0].type !== "TSConditionalType" &&
-          n[paramsKey][0].type !== "TSMappedType")));
+          n[paramsKey][0].type !== "TSMappedType" &&
+          n[paramsKey][0].type !== "TSTypeOperator" &&
+          n[paramsKey][0].type !== "TSIndexedAccessType" &&
+          n[paramsKey][0].type !== "TSArrayType")));
 
   if (shouldInline) {
     return concat(["<", join(", ", path.map(print, paramsKey)), ">"]);

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4591,9 +4591,7 @@ function printTypeParameters(path, options, print, paramsKey) {
         // See https://github.com/prettier/prettier/pull/6467 for the context.
         (greatGreatGrandParent &&
           greatGreatGrandParent.type === "VariableDeclarator" &&
-          grandparent &&
           grandparent.type === "TSTypeAnnotation" &&
-          greatGrandParent &&
           greatGrandParent.type !== "ArrowFunctionExpression" &&
           n[paramsKey][0].type !== "TSUnionType" &&
           n[paramsKey][0].type !== "UnionTypeAnnotation" &&

--- a/tests/typescript/custom/typeParameters/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/custom/typeParameters/__snapshots__/jsfmt.spec.js.snap
@@ -129,6 +129,11 @@ const isAnySuccessfulAttempt$: Observable<boolean> = this._quizService.isAnySucc
   }),
 );
 const isAnySuccessfulAttempt2$: Observable<boolean> = this._someMethodWithLongName();
+const fooooooooooooooo: SomeThing<boolean | string> = looooooooooooooooooooooooooooooongNameFunc();
+const fooooooooooooooo: SomeThing<boolean & string> = looooooooooooooooooooooooooooooongNameFunc();
+const fooooooooooooooo: SomeThing<keyof string> = looooooooooooooooooooooooooooooongNameFunc();
+const fooooooooooooooo: SomeThing<string[]> = looooooooooooooooooooooooooooooongNameFunc();
+const fooooooooooooooo: SomeThing<string["anchor"]> = looooooooooooooooooooooooooooooongNameFunc();
 
 =====================================output=====================================
 const foo: SomeThing<boolean> = func();
@@ -154,6 +159,21 @@ const isAnySuccessfulAttempt$: Observable<boolean> = this._quizService
     })
   );
 const isAnySuccessfulAttempt2$: Observable<boolean> = this._someMethodWithLongName();
+const fooooooooooooooo: SomeThing<
+  boolean | string
+> = looooooooooooooooooooooooooooooongNameFunc();
+const fooooooooooooooo: SomeThing<
+  boolean & string
+> = looooooooooooooooooooooooooooooongNameFunc();
+const fooooooooooooooo: SomeThing<
+  keyof string
+> = looooooooooooooooooooooooooooooongNameFunc();
+const fooooooooooooooo: SomeThing<
+  string[]
+> = looooooooooooooooooooooooooooooongNameFunc();
+const fooooooooooooooo: SomeThing<
+  string["anchor"]
+> = looooooooooooooooooooooooooooooongNameFunc();
 
 ================================================================================
 `;

--- a/tests/typescript/custom/typeParameters/variables.ts
+++ b/tests/typescript/custom/typeParameters/variables.ts
@@ -12,3 +12,8 @@ const isAnySuccessfulAttempt$: Observable<boolean> = this._quizService.isAnySucc
   }),
 );
 const isAnySuccessfulAttempt2$: Observable<boolean> = this._someMethodWithLongName();
+const fooooooooooooooo: SomeThing<boolean | string> = looooooooooooooooooooooooooooooongNameFunc();
+const fooooooooooooooo: SomeThing<boolean & string> = looooooooooooooooooooooooooooooongNameFunc();
+const fooooooooooooooo: SomeThing<keyof string> = looooooooooooooooooooooooooooooongNameFunc();
+const fooooooooooooooo: SomeThing<string[]> = looooooooooooooooooooooooooooooongNameFunc();
+const fooooooooooooooo: SomeThing<string["anchor"]> = looooooooooooooooooooooooooooooongNameFunc();

--- a/tests/typescript_generic/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_generic/__snapshots__/jsfmt.spec.js.snap
@@ -7,41 +7,54 @@ printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
 export const getVehicleDescriptor = async (
-  vehicleId: string,
-): Promise<
-  Descriptor | undefined
-> => {}
-
+  vehicleId: string
+): Promise<Descriptor | undefined> => {};
 
 export const getVehicleDescriptor = async (
-  vehicleId: string,
+  vehicleId: string
 ): Promise<
-  Collections.Parts.PrintedCircuitBoardAssembly['attributes'] | undefined
-> => {}
+  Collections.Parts.PrintedCircuitBoardAssembly["attributes"] | undefined
+> => {};
 
-export const fun1 = async (
-  vehicleId: string,
-): Promise<
-  Collections.Parts.PrintedCircuitBoardAssembly['attributes'] & undefined
-> => {}
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<Descriptor & undefined> => {};
 
-export const fun2 = async (
-  vehicleId: string,
+export const getVehicleDescriptor = async (
+  vehicleId: string
 ): Promise<
-  Collections.Parts.PrintedCircuitBoardAssembly['attributes']
-> => {}
+  Collections.Parts.PrintedCircuitBoardAssembly["attributes"] & undefined
+> => {};
 
-export const fun3 = async (
-  vehicleId: string,
-): Promise<
-  keyof Collections.Parts.PrintedCircuitBoardAssembly['attributes']
-> => {}
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<Descriptor["attributes"]> => {};
 
-export const fun4 = async (
-  vehicleId: string,
+export const getVehicleDescriptor = async (
+  vehicleId: string
 ): Promise<
-  Collections.Parts.PrintedCircuitBoardAssembly[]
-> => {}
+  Collections.Parts.PrintedCircuitBoardAssembly["attributessssssssssssssssssssssss"]
+> => {};
+
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<keyof Descriptor> => {};
+
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<
+  keyof Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+> => {};
+
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<Descriptor[]> => {};
+
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy[]
+> => {};
 
 =====================================output=====================================
 export const getVehicleDescriptor = async (
@@ -54,25 +67,45 @@ export const getVehicleDescriptor = async (
   Collections.Parts.PrintedCircuitBoardAssembly["attributes"] | undefined
 > => {};
 
-export const fun1 = async (
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<Descriptor & undefined> => {};
+
+export const getVehicleDescriptor = async (
   vehicleId: string
 ): Promise<
   Collections.Parts.PrintedCircuitBoardAssembly["attributes"] & undefined
 > => {};
 
-export const fun2 = async (
+export const getVehicleDescriptor = async (
   vehicleId: string
-): Promise<Collections.Parts.PrintedCircuitBoardAssembly["attributes"]> => {};
+): Promise<Descriptor["attributes"]> => {};
 
-export const fun3 = async (
+export const getVehicleDescriptor = async (
   vehicleId: string
 ): Promise<
-  keyof Collections.Parts.PrintedCircuitBoardAssembly["attributes"]
+  Collections.Parts.PrintedCircuitBoardAssembly["attributessssssssssssssssssssssss"]
 > => {};
 
-export const fun4 = async (
+export const getVehicleDescriptor = async (
   vehicleId: string
-): Promise<Collections.Parts.PrintedCircuitBoardAssembly[]> => {};
+): Promise<keyof Descriptor> => {};
+
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<
+  keyof Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+> => {};
+
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<Descriptor[]> => {};
+
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy[]
+> => {};
 
 ================================================================================
 `;

--- a/tests/typescript_generic/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_generic/__snapshots__/jsfmt.spec.js.snap
@@ -8,6 +8,16 @@ printWidth: 80
 =====================================input======================================
 export const getVehicleDescriptor = async (
   vehicleId: string
+): Promise<Descriptor> => {};
+
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+> => {};
+
+export const getVehicleDescriptor = async (
+  vehicleId: string
 ): Promise<Descriptor | undefined> => {};
 
 export const getVehicleDescriptor = async (
@@ -57,6 +67,16 @@ export const getVehicleDescriptor = async (
 > => {};
 
 =====================================output=====================================
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<Descriptor> => {};
+
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+> => {};
+
 export const getVehicleDescriptor = async (
   vehicleId: string
 ): Promise<Descriptor | undefined> => {};

--- a/tests/typescript_generic/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_generic/__snapshots__/jsfmt.spec.js.snap
@@ -19,6 +19,30 @@ export const getVehicleDescriptor = async (
   Collections.Parts.PrintedCircuitBoardAssembly['attributes'] | undefined
 > => {}
 
+export const fun1 = async (
+  vehicleId: string,
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssembly['attributes'] & undefined
+> => {}
+
+export const fun2 = async (
+  vehicleId: string,
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssembly['attributes']
+> => {}
+
+export const fun3 = async (
+  vehicleId: string,
+): Promise<
+  keyof Collections.Parts.PrintedCircuitBoardAssembly['attributes']
+> => {}
+
+export const fun4 = async (
+  vehicleId: string,
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssembly[]
+> => {}
+
 =====================================output=====================================
 export const getVehicleDescriptor = async (
   vehicleId: string
@@ -29,6 +53,26 @@ export const getVehicleDescriptor = async (
 ): Promise<
   Collections.Parts.PrintedCircuitBoardAssembly["attributes"] | undefined
 > => {};
+
+export const fun1 = async (
+  vehicleId: string
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssembly["attributes"] & undefined
+> => {};
+
+export const fun2 = async (
+  vehicleId: string
+): Promise<Collections.Parts.PrintedCircuitBoardAssembly["attributes"]> => {};
+
+export const fun3 = async (
+  vehicleId: string
+): Promise<
+  keyof Collections.Parts.PrintedCircuitBoardAssembly["attributes"]
+> => {};
+
+export const fun4 = async (
+  vehicleId: string
+): Promise<Collections.Parts.PrintedCircuitBoardAssembly[]> => {};
 
 ================================================================================
 `;

--- a/tests/typescript_generic/arrow-return-type.ts
+++ b/tests/typescript_generic/arrow-return-type.ts
@@ -10,3 +10,27 @@ export const getVehicleDescriptor = async (
 ): Promise<
   Collections.Parts.PrintedCircuitBoardAssembly['attributes'] | undefined
 > => {}
+
+export const fun1 = async (
+  vehicleId: string,
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssembly['attributes'] & undefined
+> => {}
+
+export const fun2 = async (
+  vehicleId: string,
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssembly['attributes']
+> => {}
+
+export const fun3 = async (
+  vehicleId: string,
+): Promise<
+  keyof Collections.Parts.PrintedCircuitBoardAssembly['attributes']
+> => {}
+
+export const fun4 = async (
+  vehicleId: string,
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssembly[]
+> => {}

--- a/tests/typescript_generic/arrow-return-type.ts
+++ b/tests/typescript_generic/arrow-return-type.ts
@@ -1,36 +1,49 @@
 export const getVehicleDescriptor = async (
-  vehicleId: string,
-): Promise<
-  Descriptor | undefined
-> => {}
-
+  vehicleId: string
+): Promise<Descriptor | undefined> => {};
 
 export const getVehicleDescriptor = async (
-  vehicleId: string,
+  vehicleId: string
 ): Promise<
-  Collections.Parts.PrintedCircuitBoardAssembly['attributes'] | undefined
-> => {}
+  Collections.Parts.PrintedCircuitBoardAssembly["attributes"] | undefined
+> => {};
 
-export const fun1 = async (
-  vehicleId: string,
-): Promise<
-  Collections.Parts.PrintedCircuitBoardAssembly['attributes'] & undefined
-> => {}
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<Descriptor & undefined> => {};
 
-export const fun2 = async (
-  vehicleId: string,
+export const getVehicleDescriptor = async (
+  vehicleId: string
 ): Promise<
-  Collections.Parts.PrintedCircuitBoardAssembly['attributes']
-> => {}
+  Collections.Parts.PrintedCircuitBoardAssembly["attributes"] & undefined
+> => {};
 
-export const fun3 = async (
-  vehicleId: string,
-): Promise<
-  keyof Collections.Parts.PrintedCircuitBoardAssembly['attributes']
-> => {}
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<Descriptor["attributes"]> => {};
 
-export const fun4 = async (
-  vehicleId: string,
+export const getVehicleDescriptor = async (
+  vehicleId: string
 ): Promise<
-  Collections.Parts.PrintedCircuitBoardAssembly[]
-> => {}
+  Collections.Parts.PrintedCircuitBoardAssembly["attributessssssssssssssssssssssss"]
+> => {};
+
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<keyof Descriptor> => {};
+
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<
+  keyof Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+> => {};
+
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<Descriptor[]> => {};
+
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy[]
+> => {};

--- a/tests/typescript_generic/arrow-return-type.ts
+++ b/tests/typescript_generic/arrow-return-type.ts
@@ -1,5 +1,15 @@
 export const getVehicleDescriptor = async (
   vehicleId: string
+): Promise<Descriptor> => {};
+
+export const getVehicleDescriptor = async (
+  vehicleId: string
+): Promise<
+  Collections.Parts.PrintedCircuitBoardAssemblyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy
+> => {};
+
+export const getVehicleDescriptor = async (
+  vehicleId: string
 ): Promise<Descriptor | undefined> => {};
 
 export const getVehicleDescriptor = async (


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
A non-essential workaround for #6899
<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
