### PR TITLE
Drop Node.js 4 test on CI

### DIFF
--- a/.azure-pipelines/jobs/prod-test.yml
+++ b/.azure-pipelines/jobs/prod-test.yml
@@ -2,8 +2,6 @@ steps:
   - template: ../steps/download-dist.yml
   - template: ../steps/install-nodejs.yml
   - template: ../steps/install-dependencies.yml
-    parameters:
-      flags: --ignore-engines # prettier@dev requires node v6+
   - script: yarn test:dist
     displayName: "Run tests on dist"
   - template: ../steps/publish-test-results.yml

--- a/.azure-pipelines/steps/install-dependencies.yml
+++ b/.azure-pipelines/steps/install-dependencies.yml
@@ -2,5 +2,5 @@ parameters:
   flags: ""
 
 steps:
-  - script: yarn install --frozen-lockfile ${{ parameters.flags }}
+  - script: yarn install --frozen-lockfile
     displayName: "Install dependencies"

--- a/.azure-pipelines/steps/install-nodejs.yml
+++ b/.azure-pipelines/steps/install-nodejs.yml
@@ -3,8 +3,3 @@ steps:
     inputs:
       versionSpec: "$(node_version)"
     displayName: "Install Node.js"
-
-  # workaround for https://github.com/yarnpkg/yarn/issues/6900
-  - script: npm install -g yarn@1.12.3
-    displayName: "Install Node v4 compatible Yarn"
-    condition: eq(variables.node_version, 4)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,9 +82,8 @@ jobs:
       vmImage: macos-10.13
     strategy:
       matrix:
-        Node_v4:
-          node_version: 4
-          ENABLE_TEST_RESULTS: "" # jest-junit requires node v6+
+        Node_v10:
+          node_version: 10
         Node_v12:
           node_version: 12
         Node_v12_standalone:


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

As required in https://github.com/prettier/prettier/issues/6888 , drop CI test running on node 4.
It's only two month schedule, the clock is ticking, let's get started

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
