### PR TITLE
Disable trailingComma for Angular internal parser

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -121,7 +121,12 @@ let uid = 0;
 
 function shouldPrintComma(options, level) {
   // angular does not allow trailing comma
-  if (options.parser === "__ng_interpolation") {
+  if (
+    options.parser === "__ng_interpolation" ||
+    options.parser === "__ng_action" ||
+    options.parser === "__ng_binding" ||
+    options.parser === "__ng_directive"
+  ) {
     return false;
   }
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -120,6 +120,11 @@ const {
 let uid = 0;
 
 function shouldPrintComma(options, level) {
+  // angular does not allow trailing comma
+  if (options.parser === "__ng_interpolation") {
+    return false;
+  }
+
   level = level || "es5";
 
   switch (options.trailingComma) {

--- a/tests/angular_interpolation/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/angular_interpolation/__snapshots__/jsfmt.spec.js.snap
@@ -20,10 +20,186 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`logical-expression.ng 2`] = `
+====================================options=====================================
+parsers: ["__ng_interpolation"]
+printWidth: 80
+trailingComma: "es5"
+                                                                                | printWidth
+=====================================input======================================
+[
+    advancedSearchService.patientInformationFieldsRow2 && advancedSearchService.patientInformationFieldsRow2.indexOf(advancedSearchService.formElementData.customFieldList[i].customFieldType) !== -1
+]
+
+=====================================output=====================================
+[
+  advancedSearchService.patientInformationFieldsRow2 &&
+    advancedSearchService.patientInformationFieldsRow2.indexOf(
+      advancedSearchService.formElementData.customFieldList[i].customFieldType
+    ) !== -1
+]
+================================================================================
+`;
+
+exports[`logical-expression.ng 3`] = `
+====================================options=====================================
+parsers: ["__ng_interpolation"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+[
+    advancedSearchService.patientInformationFieldsRow2 && advancedSearchService.patientInformationFieldsRow2.indexOf(advancedSearchService.formElementData.customFieldList[i].customFieldType) !== -1
+]
+
+=====================================output=====================================
+[
+  advancedSearchService.patientInformationFieldsRow2 &&
+    advancedSearchService.patientInformationFieldsRow2.indexOf(
+      advancedSearchService.formElementData.customFieldList[i].customFieldType
+    ) !== -1
+]
+================================================================================
+`;
+
 exports[`pipe-expression.ng 1`] = `
 ====================================options=====================================
 parsers: ["__ng_interpolation"]
 printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+[
+    a ? (b | c : d) : (e | f : g),
+    a | b | c | d,
+    ((a | b) | c) | d,
+    a | b:(c | d),
+    { a: b | c },
+    (a + b) | c,
+    (a | b) + c,
+    fn(a | b),
+    a?.b(c | d),
+    a[b | c],
+    ($students | async).items,
+    ($students | async)(),
+    myData | myPipe:'arg1':'arg2':'arg3',
+    value
+      | pipeA: {
+        keyA: reallySuperLongValue,
+        keyB: shortValue | pipeB | pipeC: valueToPipeC
+      } : {
+        keyA: reallySuperLongValue,
+        keyB: shortValue | pipeB | pipeC: valueToPipeC
+      }
+      | aaa,
+   (hideLinqPanel ? "ReportSelection.HideShowLabel_Show.String" : "ReportSelection.HideShowLabel_Hide.String") | localize:(localizationSection) 
+]
+
+=====================================output=====================================
+[
+  a ? (b | c: d) : (e | f: g),
+  a | b | c | d,
+  a | b | c | d,
+  a | b: (c | d),
+  { a: b | c },
+  a + b | c,
+  (a | b) + c,
+  fn(a | b),
+  a?.b(c | d),
+  a[b | c],
+  ($students | async).items,
+  ($students | async)(),
+  myData | myPipe: "arg1":"arg2":"arg3",
+  value
+    | pipeA
+      : {
+          keyA: reallySuperLongValue,
+          keyB: shortValue | pipeB | pipeC: valueToPipeC
+        }
+      : {
+          keyA: reallySuperLongValue,
+          keyB: shortValue | pipeB | pipeC: valueToPipeC
+        }
+    | aaa,
+  (hideLinqPanel
+    ? "ReportSelection.HideShowLabel_Show.String"
+    : "ReportSelection.HideShowLabel_Hide.String"
+  ) | localize: localizationSection
+]
+================================================================================
+`;
+
+exports[`pipe-expression.ng 2`] = `
+====================================options=====================================
+parsers: ["__ng_interpolation"]
+printWidth: 80
+trailingComma: "es5"
+                                                                                | printWidth
+=====================================input======================================
+[
+    a ? (b | c : d) : (e | f : g),
+    a | b | c | d,
+    ((a | b) | c) | d,
+    a | b:(c | d),
+    { a: b | c },
+    (a + b) | c,
+    (a | b) + c,
+    fn(a | b),
+    a?.b(c | d),
+    a[b | c],
+    ($students | async).items,
+    ($students | async)(),
+    myData | myPipe:'arg1':'arg2':'arg3',
+    value
+      | pipeA: {
+        keyA: reallySuperLongValue,
+        keyB: shortValue | pipeB | pipeC: valueToPipeC
+      } : {
+        keyA: reallySuperLongValue,
+        keyB: shortValue | pipeB | pipeC: valueToPipeC
+      }
+      | aaa,
+   (hideLinqPanel ? "ReportSelection.HideShowLabel_Show.String" : "ReportSelection.HideShowLabel_Hide.String") | localize:(localizationSection) 
+]
+
+=====================================output=====================================
+[
+  a ? (b | c: d) : (e | f: g),
+  a | b | c | d,
+  a | b | c | d,
+  a | b: (c | d),
+  { a: b | c },
+  a + b | c,
+  (a | b) + c,
+  fn(a | b),
+  a?.b(c | d),
+  a[b | c],
+  ($students | async).items,
+  ($students | async)(),
+  myData | myPipe: "arg1":"arg2":"arg3",
+  value
+    | pipeA
+      : {
+          keyA: reallySuperLongValue,
+          keyB: shortValue | pipeB | pipeC: valueToPipeC
+        }
+      : {
+          keyA: reallySuperLongValue,
+          keyB: shortValue | pipeB | pipeC: valueToPipeC
+        }
+    | aaa,
+  (hideLinqPanel
+    ? "ReportSelection.HideShowLabel_Show.String"
+    : "ReportSelection.HideShowLabel_Hide.String"
+  ) | localize: localizationSection
+]
+================================================================================
+`;
+
+exports[`pipe-expression.ng 3`] = `
+====================================options=====================================
+parsers: ["__ng_interpolation"]
+printWidth: 80
+trailingComma: "all"
                                                                                 | printWidth
 =====================================input======================================
 [

--- a/tests/angular_interpolation/jsfmt.spec.js
+++ b/tests/angular_interpolation/jsfmt.spec.js
@@ -1,1 +1,3 @@
 run_spec(__dirname, ["__ng_interpolation"]);
+run_spec(__dirname, ["__ng_interpolation"], { trailingComma: "es5" });
+run_spec(__dirname, ["__ng_interpolation"], { trailingComma: "all" });


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

extra comma, cause parse error, fond in #6910

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
