### PR TITLE
Support string-to-package config in JSON schema:

### DIFF
--- a/scripts/generate-schema.js
+++ b/scripts/generate-schema.js
@@ -18,7 +18,6 @@ function generateSchema(options) {
   return {
     $schema: "http://json-schema.org/draft-04/schema#",
     title: "Schema for .prettierrc",
-    type: "object",
     definitions: {
       optionsDefinition: {
         type: "object",
@@ -65,9 +64,17 @@ function generateSchema(options) {
         }
       }
     },
-    allOf: [
-      { $ref: "#/definitions/optionsDefinition" },
-      { $ref: "#/definitions/overridesDefinition" }
+    oneOf: [
+      {
+        type: "object",
+        allOf: [
+          { $ref: "#/definitions/optionsDefinition" },
+          { $ref: "#/definitions/overridesDefinition" }
+        ]
+      },
+      {
+        type: "string"
+      }
     ]
   };
 }

--- a/tests_integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests_integration/__tests__/__snapshots__/schema.js.snap
@@ -3,14 +3,6 @@
 exports[`schema 1`] = `
 Object {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "allOf": Array [
-    Object {
-      "$ref": "#/definitions/optionsDefinition",
-    },
-    Object {
-      "$ref": "#/definitions/overridesDefinition",
-    },
-  ],
   "definitions": Object {
     "optionsDefinition": Object {
       "properties": Object {
@@ -427,7 +419,22 @@ in order for it to be formatted.",
       "type": "object",
     },
   },
+  "oneOf": Array [
+    Object {
+      "allOf": Array [
+        Object {
+          "$ref": "#/definitions/optionsDefinition",
+        },
+        Object {
+          "$ref": "#/definitions/overridesDefinition",
+        },
+      ],
+      "type": "object",
+    },
+    Object {
+      "type": "string",
+    },
+  ],
   "title": "Schema for .prettierrc",
-  "type": "object",
 }
 `;


### PR DESCRIPTION
Prettier supports having just a string in the config file to use a
shared config from a package. Example:

    "@company/prettier-config"

But the JSON schema generated by running `node
scripts/generate-schema.js` did not include that possibility.

See https://github.com/SchemaStore/schemastore/pull/855 for more
information.
