### PR TITLE
Fix MDX html parsing errors

### DIFF
--- a/changelog_unreleased/mdx/pr-6949.md
+++ b/changelog_unreleased/mdx/pr-6949.md
@@ -1,0 +1,43 @@
+#### Fix MDX html parsing errors ([#6949](https://github.com/prettier/prettier/pull/6949) by [@Tigge](https://github.com/Tigge))
+
+MDX parsing for JSX failed when encountering JSX elements that where not
+parsable as HTML. Such as `<Tag value={{a: 'b'}}>test</Tag>`
+
+<!-- prettier-ignore -->
+````md
+<!-- Input -->
+
+<Tag  value={ {a :  'b'   } }>test</ Tag>
+
+<Foo bg={ 'red' } >
+   <div  style={{   display:   'block'}   }>
+      <Bar    >hi    </Bar>
+       {  hello       }
+         {     /* another comment */}
+            </div>
+</Foo>
+
+<!-- Prettier stable -->
+
+```
+SyntaxError: Unexpected closing tag "Tag". It may happen when the tag has already been closed by another tag. For more info see https://www.w3.org/TR/html5/syntax.html#closing-elements-that-have-implied-end-tags (1:35)
+> 1 | <Tag  value={ {a :  'b'   } }>test</ Tag>
+    |                                   ^
+  2 | 
+  3 | <Foo bg={ 'red' } >
+  4 |    <div  style={{   display:   'block'}   }>
+```
+
+<!-- Prettier master -->
+
+<Tag value={{ a: "b" }}>test</Tag>
+
+<Foo bg={"red"}>
+  <div style={{ display: "block" }}>
+    <Bar>hi </Bar>
+    {hello}
+    {/* another comment */}
+  </div>
+</Foo>
+
+````

--- a/changelog_unreleased/mdx/pr-6949.md
+++ b/changelog_unreleased/mdx/pr-6949.md
@@ -1,4 +1,4 @@
-#### Fix MDX html parsing errors ([#6949](https://github.com/prettier/prettier/pull/6949) by [@Tigge](https://github.com/Tigge))
+#### Fix MDX html parsing errors ([#6949](https://github.com/prettier/prettier/pull/6949) by [@Tigge](https://github.com/Tigge) & [@thorn0](https://github.com/thorn0))
 
 MDX parsing for JSX failed when encountering JSX elements that where not
 parsable as HTML. Such as `<Tag value={{a: 'b'}}>test</Tag>`

--- a/src/language-js/preprocess.js
+++ b/src/language-js/preprocess.js
@@ -10,7 +10,8 @@ function preprocess(ast, options) {
       return Object.assign({}, ast, {
         type: options.parser.startsWith("__") ? "JsExpressionRoot" : "JsonRoot",
         node: ast,
-        comments: []
+        comments: [],
+        rootMarker: options.rootMarker
       });
     default:
       return ast;

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5388,8 +5388,14 @@ function printJSXElement(path, options, print) {
     containsMultipleAttributes ||
     containsMultipleExpressions;
 
+  const isMdxBlock =
+    options.__maybe_mdx_adjacent &&
+    path.getParentNode().type === "JsExpressionRoot";
+
   const rawJsxWhitespace = options.singleQuote ? "{' '}" : '{" "}';
-  const jsxWhitespace = ifBreak(concat([rawJsxWhitespace, softline]), " ");
+  const jsxWhitespace = isMdxBlock
+    ? concat([" "])
+    : ifBreak(concat([rawJsxWhitespace, softline]), " ");
 
   const isFacebookTranslationTag =
     n.openingElement &&
@@ -5509,6 +5515,10 @@ function printJSXElement(path, options, print) {
     ? fill(multilineChildren)
     : group(concat(multilineChildren), { shouldBreak: true });
 
+  if (isMdxBlock) {
+    return content;
+  }
+
   const multiLineElem = group(
     concat([
       openingLines,
@@ -5517,13 +5527,6 @@ function printJSXElement(path, options, print) {
       closingLines
     ])
   );
-
-  if (
-    options.__maybe_mdx_adjacent &&
-    path.getParentNode().type === "JsExpressionRoot"
-  ) {
-    return concat(children);
-  }
 
   if (forcedBreak) {
     return multiLineElem;

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5518,6 +5518,13 @@ function printJSXElement(path, options, print) {
     ])
   );
 
+  if (
+    options.__maybe_mdx_adjacent &&
+    path.getParentNode().type === "JsExpressionRoot"
+  ) {
+    return concat(children);
+  }
+
   if (forcedBreak) {
     return multiLineElem;
   }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5388,9 +5388,7 @@ function printJSXElement(path, options, print) {
     containsMultipleAttributes ||
     containsMultipleExpressions;
 
-  const isMdxBlock =
-    options.__maybe_mdx_adjacent &&
-    path.getParentNode().type === "JsExpressionRoot";
+  const isMdxBlock = path.getParentNode().rootMarker === "mdx";
 
   const rawJsxWhitespace = options.singleQuote ? "{' '}" : '{" "}';
   const jsxWhitespace = isMdxBlock

--- a/src/language-markdown/embed.js
+++ b/src/language-markdown/embed.js
@@ -59,7 +59,7 @@ function embed(path, print, textToDoc, options) {
     case "jsx":
       return textToDoc(`<$>${node.value}</$>`, {
         parser: "__js_expression",
-        __maybe_mdx_adjacent: true
+        rootMarker: "mdx"
       });
   }
 

--- a/src/language-markdown/embed.js
+++ b/src/language-markdown/embed.js
@@ -57,7 +57,10 @@ function embed(path, print, textToDoc, options) {
     case "importExport":
       return textToDoc(node.value, { parser: "babel" });
     case "jsx":
-      return textToDoc(node.value, { parser: "__js_expression" });
+      return textToDoc(`<>${node.value}</>`, {
+        parser: "__js_expression",
+        __maybe_mdx_adjacent: true
+      });
   }
 
   return null;

--- a/src/language-markdown/embed.js
+++ b/src/language-markdown/embed.js
@@ -57,7 +57,7 @@ function embed(path, print, textToDoc, options) {
     case "importExport":
       return textToDoc(node.value, { parser: "babel" });
     case "jsx":
-      return textToDoc(`<>${node.value}</>`, {
+      return textToDoc(`<$>${node.value}</$>`, {
         parser: "__js_expression",
         __maybe_mdx_adjacent: true
       });

--- a/src/language-markdown/parser-markdown.js
+++ b/src/language-markdown/parser-markdown.js
@@ -7,7 +7,6 @@ const parseFrontMatter = require("../utils/front-matter");
 const { mapAst, INLINE_NODE_WRAPPER_TYPES } = require("./utils");
 const mdx = require("./mdx");
 const remarkMath = require("remark-math");
-const htmlParser = require("../language-html/parser-html").parsers.html;
 
 /**
  * based on [MDAST](https://github.com/syntax-tree/mdast) with following modifications:
@@ -60,29 +59,7 @@ function htmlToJsx() {
         return node;
       }
 
-      const nodes = htmlParser.parse(node.value).children;
-
-      // find out if there are adjacent JSX elements which should be allowed in mdx alike in markdown
-      if (nodes.length <= 1) {
-        return Object.assign({}, node, { type: "jsx" });
-      }
-
-      return nodes.reduce((newNodes, { sourceSpan: position, type }) => {
-        const value = node.value.slice(
-          position.start.offset,
-          position.end.offset
-        );
-
-        if (value) {
-          newNodes.push({
-            type: type === "element" ? "jsx" : type,
-            value,
-            position
-          });
-        }
-
-        return newNodes;
-      }, []);
+      return Object.assign({}, node, { type: "jsx" });
     });
 }
 

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -35,12 +35,7 @@ const { replaceEndOfLineWith } = require("../common/util");
 
 const TRAILING_HARDLINE_NODES = ["importExport"];
 const SINGLE_LINE_NODE_TYPES = ["heading", "tableCell", "link"];
-const SIBLING_NODE_TYPES = [
-  "listItem",
-  "definition",
-  "footnoteDefinition",
-  "jsx"
-];
+const SIBLING_NODE_TYPES = ["listItem", "definition", "footnoteDefinition"];
 
 function genericPrint(path, options, print) {
   const node = path.getValue();
@@ -770,55 +765,35 @@ function isPrettierIgnore(node) {
   return match === null ? false : match[1] ? match[1] : "next";
 }
 
-function isInlineNode(node) {
-  return node && INLINE_NODE_TYPES.indexOf(node.type) !== -1;
-}
-
-function isEndsWithHardLine(node) {
-  return node && /\n+$/.test(node.value);
-}
-
-function last(nodes) {
-  return nodes && nodes[nodes.length - 1];
-}
-
-function shouldNotPrePrintHardline(node, { parentNode, parts, prevNode }) {
-  const isFirstNode = parts.length === 0;
+function shouldNotPrePrintHardline(node, data) {
+  const isFirstNode = data.parts.length === 0;
+  const isInlineNode = INLINE_NODE_TYPES.indexOf(node.type) !== -1;
 
   const isInlineHTML =
     node.type === "html" &&
-    INLINE_NODE_WRAPPER_TYPES.indexOf(parentNode.type) !== -1;
+    INLINE_NODE_WRAPPER_TYPES.indexOf(data.parentNode.type) !== -1;
 
-  const isAfterHardlineNode =
-    prevNode &&
-    (isEndsWithHardLine(prevNode) ||
-      isEndsWithHardLine(last(prevNode.children)));
-
-  return (
-    isFirstNode || isInlineNode(node) || isInlineHTML || isAfterHardlineNode
-  );
+  return isFirstNode || isInlineNode || isInlineHTML;
 }
 
-function shouldPrePrintDoubleHardline(node, { parentNode, prevNode }) {
-  const prevNodeType = prevNode && prevNode.type;
-  const nodeType = node.type;
-
-  const isSequence = prevNodeType === nodeType;
+function shouldPrePrintDoubleHardline(node, data) {
+  const isSequence = (data.prevNode && data.prevNode.type) === node.type;
   const isSiblingNode =
-    isSequence && SIBLING_NODE_TYPES.indexOf(nodeType) !== -1;
+    isSequence && SIBLING_NODE_TYPES.indexOf(node.type) !== -1;
 
-  const isInTightListItem = parentNode.type === "listItem" && !parentNode.loose;
-  const isPrevNodeLooseListItem = prevNodeType === "listItem" && prevNode.loose;
-  const isPrevNodePrettierIgnore = isPrettierIgnore(prevNode) === "next";
+  const isInTightListItem =
+    data.parentNode.type === "listItem" && !data.parentNode.loose;
+
+  const isPrevNodeLooseListItem =
+    data.prevNode && data.prevNode.type === "listItem" && data.prevNode.loose;
+
+  const isPrevNodePrettierIgnore = isPrettierIgnore(data.prevNode) === "next";
 
   const isBlockHtmlWithoutBlankLineBetweenPrevHtml =
-    nodeType === "html" &&
-    prevNodeType === "html" &&
-    prevNode.position.end.line + 1 === node.position.start.line;
-
-  const isJsxInlineSibling =
-    (prevNodeType === "jsx" && isInlineNode(node)) ||
-    (nodeType === "jsx" && isInlineNode(prevNode));
+    node.type === "html" &&
+    data.prevNode &&
+    data.prevNode.type === "html" &&
+    data.prevNode.position.end.line + 1 === node.position.start.line;
 
   return (
     isPrevNodeLooseListItem ||
@@ -826,8 +801,7 @@ function shouldPrePrintDoubleHardline(node, { parentNode, prevNode }) {
       isSiblingNode ||
       isInTightListItem ||
       isPrevNodePrettierIgnore ||
-      isBlockHtmlWithoutBlankLineBetweenPrevHtml ||
-      isJsxInlineSibling
+      isBlockHtmlWithoutBlankLineBetweenPrevHtml
     )
   );
 }

--- a/src/language-markdown/utils.js
+++ b/src/language-markdown/utils.js
@@ -202,21 +202,11 @@ function mapAst(ast, handler) {
   return (function preorder(node, index, parentStack) {
     parentStack = parentStack || [];
 
-    let newNode = handler(node, index, parentStack);
-    if (Array.isArray(newNode)) {
-      return newNode;
-    }
-
-    newNode = Object.assign({}, newNode);
+    const newNode = Object.assign({}, handler(node, index, parentStack));
     if (newNode.children) {
-      newNode.children = newNode.children.reduce((nodes, child, index) => {
-        let newNodes = preorder(child, index, [newNode].concat(parentStack));
-        if (!Array.isArray(newNodes)) {
-          newNodes = [newNodes];
-        }
-        nodes.push.apply(nodes, newNodes);
-        return nodes;
-      }, []);
+      newNode.children = newNode.children.map((child, index) => {
+        return preorder(child, index, [newNode].concat(parentStack));
+      });
     }
 
     return newNode;

--- a/tests/mdx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/mdx/__snapshots__/jsfmt.spec.js.snap
@@ -276,7 +276,8 @@ printWidth: 80
 
 <Hello>
   test <World /> test
-</Hello>123
+</Hello>
+123
 
 ---
 
@@ -285,16 +286,19 @@ printWidth: 80
 </Hello>
 <Hello>
   test <World /> test
-</Hello>123
+</Hello>
+123
 
 ---
 
 <Hello>
   test <World /> test
-</Hello> 123
+</Hello>{" "}
+123
 <Hello>
   test <World /> test
-</Hello> 234
+</Hello>{" "}
+234
 
 ---
 
@@ -352,7 +356,8 @@ semi: false
 
 <Hello>
   test <World /> test
-</Hello>123
+</Hello>
+123
 
 ---
 
@@ -361,16 +366,19 @@ semi: false
 </Hello>
 <Hello>
   test <World /> test
-</Hello>123
+</Hello>
+123
 
 ---
 
 <Hello>
   test <World /> test
-</Hello> 123
+</Hello>{" "}
+123
 <Hello>
   test <World /> test
-</Hello> 234
+</Hello>{" "}
+234
 
 ---
 
@@ -434,6 +442,117 @@ const a = 1;
 const a = 1
 ;<div>foo</div>
 \`\`\`
+
+================================================================================
+`;
+
+exports[`levels.mdx 1`] = `
+====================================options=====================================
+parsers: ["mdx"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+import     {     Foo,  Bar } from     './Fixture'
+
+# Hello,    world!
+
+<Foo bg='red'>
+   <div style={{   display:   'block'}   }>
+      <Bar    >hi    </Bar>
+       {  hello       }
+       {     /* another comment */}
+       </div>
+</Foo>
+
+asdfsdf <strong style={{fontWeight: 'bolder'}}>asdfasdf</strong>
+
+<Foo/>
+test
+
+<ul>
+      <li   >item    {' '} </li>
+      <li/>
+        </ul >
+
+
+=====================================output=====================================
+import { Foo, Bar } from "./Fixture";
+
+# Hello, world!
+
+<Foo bg="red">
+  <div style={{ display: "block" }}>
+    <Bar>hi </Bar>
+    {hello}
+    {/* another comment */}
+  </div>
+</Foo>
+
+asdfsdf <strong style={{fontWeight: 'bolder'}}>asdfasdf</strong>
+
+<Foo />
+test
+
+<ul>
+  <li>item </li>
+  <li />
+</ul>
+
+================================================================================
+`;
+
+exports[`levels.mdx 2`] = `
+====================================options=====================================
+parsers: ["mdx"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+import     {     Foo,  Bar } from     './Fixture'
+
+# Hello,    world!
+
+<Foo bg='red'>
+   <div style={{   display:   'block'}   }>
+      <Bar    >hi    </Bar>
+       {  hello       }
+       {     /* another comment */}
+       </div>
+</Foo>
+
+asdfsdf <strong style={{fontWeight: 'bolder'}}>asdfasdf</strong>
+
+<Foo/>
+test
+
+<ul>
+      <li   >item    {' '} </li>
+      <li/>
+        </ul >
+
+
+=====================================output=====================================
+import { Foo, Bar } from "./Fixture"
+
+# Hello, world!
+
+<Foo bg="red">
+  <div style={{ display: "block" }}>
+    <Bar>hi </Bar>
+    {hello}
+    {/* another comment */}
+  </div>
+</Foo>
+
+asdfsdf <strong style={{fontWeight: 'bolder'}}>asdfasdf</strong>
+
+<Foo />
+test
+
+<ul>
+  <li>item </li>
+  <li />
+</ul>
 
 ================================================================================
 `;

--- a/tests/mdx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/mdx/__snapshots__/jsfmt.spec.js.snap
@@ -286,19 +286,16 @@ printWidth: 80
 </Hello>
 <Hello>
   test <World /> test
-</Hello>
-123
+</Hello>123
 
 ---
 
 <Hello>
   test <World /> test
-</Hello>{" "}
-123
+</Hello> 123
 <Hello>
   test <World /> test
-</Hello>{" "}
-234
+</Hello> 234
 
 ---
 
@@ -366,19 +363,16 @@ semi: false
 </Hello>
 <Hello>
   test <World /> test
-</Hello>
-123
+</Hello>123
 
 ---
 
 <Hello>
   test <World /> test
-</Hello>{" "}
-123
+</Hello> 123
 <Hello>
   test <World /> test
-</Hello>{" "}
-234
+</Hello> 234
 
 ---
 

--- a/tests/mdx/levels.mdx
+++ b/tests/mdx/levels.mdx
@@ -1,0 +1,22 @@
+import     {     Foo,  Bar } from     './Fixture'
+
+# Hello,    world!
+
+<Foo bg='red'>
+   <div style={{   display:   'block'}   }>
+      <Bar    >hi    </Bar>
+       {  hello       }
+       {     /* another comment */}
+       </div>
+</Foo>
+
+asdfsdf <strong style={{fontWeight: 'bolder'}}>asdfasdf</strong>
+
+<Foo/>
+test
+
+<ul>
+      <li   >item    {' '} </li>
+      <li/>
+        </ul >
+


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

For MDX wrap JSX parsing in a fragment before sending it of to babel for parsing and formatting. In MDX adjacent JSX tags are permitted in the root.
    
An option sent to the babel parser omits printing the root fragment and instead just prints its children.
    
Fixes #6943

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://deploy-preview-6949--prettier.netlify.com/playground/#N4Igxg9gdgLgprEAuEAeAKgQwOYAIBumANgK5wC8wwumSuAOiAEaO4C+bAfPAM4yoB6LNk64AjACYAzPSioAYhAi4m2SowBOcACaMus3LlTaAlvlx8AnkQpVcpngAcimS3UZMiEMAGtWHTgNDIwAhTA1OAAsTIwEwiKDDYEi4Ii82RNxgAQAqGigIGBSNXEgAWzKEGFwcgQyoQ0FTfEC5AUUIUQAWAFYANhAAGhAIRxgTaB5kUHCNCAB3AAVwhCmUTHwIE20h5g1MXzgYAGVHA5MobGQYDTJhyJgyogB1aN4zsDhj1ZNx-F-LMhwDwpsMLjw4BoYIt9tgyphkAAzYgQ4YAKx4AA8QvtDidMJUADIXOBIlFwdFY44XbA2ACKJEKpKQyKIqJAZw0EI0QLK2kxu0cGguMGe2yKyAAHAAGYZCiAQ577RxAoVwbn4UnDACOjPgMNGaxAmB4AFooHAdDpdlpdSYtDCcPCyWyKSAIWUTNdbm6eDT6Xrmaz2TBMEwxdoJUgJMMbpgTEQaQBhCAVBEoAoW3YkCFYJhrYNu-BkACSUG0VWOYGFYwAguXjjBrEHyRwgA)✨**
