### PR TITLE
Fix loglevel test

### DIFF
--- a/tests_integration/__tests__/loglevel.js
+++ b/tests_integration/__tests__/loglevel.js
@@ -7,15 +7,15 @@ test("do not show logs with --loglevel silent", () => {
 });
 
 test("do not show warnings with --loglevel error", () => {
-  runPrettierWithLogLevel("error", ["[error]"]);
+  runPrettierWithLogLevel("error", [/\[error]/]);
 });
 
 test("show errors and warnings with --loglevel warn", () => {
-  runPrettierWithLogLevel("warn", ["[error]", "[warn]"]);
+  runPrettierWithLogLevel("warn", [/\[error]/, /\[warn]/]);
 });
 
 test("show all logs with --loglevel debug", () => {
-  runPrettierWithLogLevel("debug", ["[error]", "[warn]", "[debug]"]);
+  runPrettierWithLogLevel("debug", [/\[error]/, /\[warn]/, /\[debug]/]);
 });
 
 describe("--write with --loglevel=silent doesn't log filenames", () => {


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

found this problem when upgrading `jest` https://github.com/prettier/prettier/pull/6954

according to [jasmine toMatch source](https://github.com/jasmine/jasmine/blob/15f969bee7066526ba44e562407c728d4a1740df/src/core/matchers/toMatch.js#L22), string are treat as RegExp, original `"[error]"` are not testing against `[error]` string, `[` should be escaped. I changed patterns to RegExp Literals, easier to write.


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
