### PR TITLE
Enable `replace-array-includes-with-indexof` for all bundles

### DIFF
--- a/scripts/build/bundler.js
+++ b/scripts/build/bundler.js
@@ -42,6 +42,9 @@ function getBabelConfig(bundle) {
     plugins: bundle.babelPlugins || [],
     compact: bundle.type === "plugin" ? false : "auto"
   };
+  config.plugins.push(
+    require.resolve("./babel-plugins/replace-array-includes-with-indexof")
+  );
   if (bundle.type === "core") {
     config.plugins.push(
       require.resolve("./babel-plugins/transform-custom-require")

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -2,9 +2,6 @@
 
 const path = require("path");
 const PROJECT_ROOT = path.resolve(__dirname, "../..");
-const babelReplaceArrayIncludesWithIndexof = require.resolve(
-  "./babel-plugins/replace-array-includes-with-indexof"
-);
 
 /**
  * @typedef {Object} Bundle
@@ -29,8 +26,7 @@ const babelReplaceArrayIncludesWithIndexof = require.resolve(
 const parsers = [
   {
     input: "src/language-js/parser-babylon.js",
-    target: "universal",
-    babelPlugins: [babelReplaceArrayIncludesWithIndexof]
+    target: "universal"
   },
   {
     input: "src/language-js/parser-flow.js",
@@ -40,7 +36,6 @@ const parsers = [
   {
     input: "src/language-js/parser-typescript.js",
     target: "universal",
-    babelPlugins: [babelReplaceArrayIncludesWithIndexof],
     replace: {
       'require("@microsoft/typescript-etw")': "undefined"
     }
@@ -130,8 +125,7 @@ const parsers = [
           replacement: require.resolve("lines-and-columns")
         }
       ]
-    },
-    babelPlugins: [babelReplaceArrayIncludesWithIndexof]
+    }
   }
 ].map(parser => {
   const name = getFileOutput(parser)


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

It's really annoying, and hard to locate code, let's enable it for all bundles.

maybe we can also merge #6967 to `master` instead of `next`

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
