### PR TITLE
Fix handling comments in labeled statements

### DIFF
--- a/changelog_unreleased/javascript/pr-6984.md
+++ b/changelog_unreleased/javascript/pr-6984.md
@@ -1,6 +1,6 @@
 #### Fix formatting of labeled statements with comments ([#6994](https://github.com/prettier/prettier/pull/6984) by [@clement26695](https://github.com/clement26695))
 
-Comments in labeled statements should always be printed as leading comments of the labeled statement
+Formatting of comments in labeled statements was not stable
 
 <!-- prettier-ignore -->
 ```jsx
@@ -9,20 +9,15 @@ loop1:
 //test
 const i = 3;
 
+// Prettier stable (first output)
 loop1: //test
 const i = 3;
 
-// Prettier stable
-loop1: //test
-const i = 3;
-
+// Prettier stable (second output)
 //test
 loop1: const i = 3;
 
-// Prettier master
-//test
-loop1: const i = 3;
-
+// Prettier master (first output)
 //test
 loop1: const i = 3;
 ```

--- a/changelog_unreleased/javascript/pr-6984.md
+++ b/changelog_unreleased/javascript/pr-6984.md
@@ -1,0 +1,28 @@
+#### Fix formatting of labeled statements with comments ([#6994](https://github.com/prettier/prettier/pull/6984) by [@clement26695](https://github.com/clement26695))
+
+Comments in labeled statements should always be printed as leading comments of the labeled statement
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+loop1:
+//test
+const i = 3;
+
+loop1: //test
+const i = 3;
+
+// Prettier stable
+loop1: //test
+const i = 3;
+
+//test
+loop1: const i = 3;
+
+// Prettier master
+//test
+loop1: const i = 3;
+
+//test
+loop1: const i = 3;
+```

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -66,7 +66,8 @@ function handleOwnLineComment(comment, text, options, ast, isLastComment) {
       precedingNode,
       comment,
       options
-    )
+    ) ||
+    handleLabeledStatementComments(enclosingNode, comment)
   ) {
     return true;
   }

--- a/tests/label/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/label/__snapshots__/jsfmt.spec.js.snap
@@ -10,8 +10,17 @@ printWidth: 80
   inf_leave: // goto emulation
   for (;;) {}
 }
+{
+  inf_leave:
+  // goto emulation
+  for (; ;) { }
+}
 
 =====================================output=====================================
+{
+  // goto emulation
+  inf_leave: for (;;) {}
+}
 {
   // goto emulation
   inf_leave: for (;;) {}

--- a/tests/label/comment.js
+++ b/tests/label/comment.js
@@ -2,3 +2,8 @@
   inf_leave: // goto emulation
   for (;;) {}
 }
+{
+  inf_leave:
+  // goto emulation
+  for (; ;) { }
+}


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fix #6983 
I added the handleLabeledStatementComments in handleOwnLineComment to deal with comments like:
```js
loop:
// comment
const t = 1;
```

As it is my first PR here, please let me know if I have to do something more (add some tests somewhere, for instance) 😄 

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] N/A: (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
