### PR TITLE
JavaScript: Remove extra parentheses in some expressions in unary expressions with comments

### DIFF
--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -225,6 +225,24 @@ function needsParens(path, options) {
     return true;
   }
 
+  if (
+    (node.type === "BinaryExpression" ||
+      node.type === "LogicalExpression" ||
+      node.type === "ArrowFunctionExpression" ||
+      node.type === "AwaitExpression" ||
+      node.type === "YieldExpression" ||
+      node.type === "SequenceExpression" ||
+      node.type === "ConditionalExpression" ||
+      node.type === "AssignmentExpression" ||
+      node.type === "TSAsExpression" ||
+      node.type === "TSTypeAssertion") &&
+    parent.type === "UnaryExpression" &&
+    node.comments &&
+    node.comments.length > 0
+  ) {
+    return false;
+  }
+
   switch (node.type) {
     case "SpreadElement":
     case "SpreadProperty":
@@ -297,14 +315,6 @@ function needsParens(path, options) {
       };
       if (node.operator === "in" && isLeftOfAForStatement(node)) {
         return true;
-      }
-
-      if (
-        parent.type === "UnaryExpression" &&
-        node.comments &&
-        node.comments.length > 0
-      ) {
-        return false;
       }
     }
     // fallthrough

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -298,6 +298,14 @@ function needsParens(path, options) {
       if (node.operator === "in" && isLeftOfAForStatement(node)) {
         return true;
       }
+
+      if (
+        parent.type === "UnaryExpression" &&
+        node.comments &&
+        node.comments.length > 0
+      ) {
+        return false;
+      }
     }
     // fallthrough
     case "TSTypeAssertion":

--- a/tests/typescript_unary/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_unary/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`comments.ts 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<null>x;
+!(<null>x /* foo */);
+!(/* foo */ <null>x);
+!(
+  /* foo */
+  <null>x
+);
+!(
+  <null>x
+  /* foo */
+);
+!(
+  <null>x // foo
+);
+
+x as string;
+!(x as string /* foo */);
+!(/* foo */ x as string);
+!(
+  /* foo */
+  x as string
+);
+!(
+  x as string
+  /* foo */
+);
+!(
+  x as string // foo
+);
+
+=====================================output=====================================
+<null>x;
+!(<null>x /* foo */);
+!(/* foo */ <null>x);
+!(
+  /* foo */
+  <null>x
+);
+!(
+  <null>x
+  /* foo */
+);
+!(
+  <null>x // foo
+);
+
+x as string;
+!(x as string /* foo */);
+!(/* foo */ x as string);
+!(
+  /* foo */
+  x as string
+);
+!(
+  x as string
+  /* foo */
+);
+!(
+  x as string // foo
+);
+
+================================================================================
+`;

--- a/tests/typescript_unary/comments.ts
+++ b/tests/typescript_unary/comments.ts
@@ -1,0 +1,29 @@
+<null>x;
+!(<null>x /* foo */);
+!(/* foo */ <null>x);
+!(
+  /* foo */
+  <null>x
+);
+!(
+  <null>x
+  /* foo */
+);
+!(
+  <null>x // foo
+);
+
+x as string;
+!(x as string /* foo */);
+!(/* foo */ x as string);
+!(
+  /* foo */
+  x as string
+);
+!(
+  x as string
+  /* foo */
+);
+!(
+  x as string // foo
+);

--- a/tests/typescript_unary/jsfmt.spec.js
+++ b/tests/typescript_unary/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["typescript"]);

--- a/tests/unary_expression/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/unary_expression/__snapshots__/jsfmt.spec.js.snap
@@ -324,18 +324,18 @@ async function bar2() {
 );
 
 !(x || y);
-!(/* foo */ (x || y));
-!((x || y) /* foo */);
+!(/* foo */ x || y);
+!(x || y /* foo */);
 !(
   /* foo */
-  (x || y)
+  x || y
 );
 !(
-  (x || y)
+  x || y
   /* foo */
 );
 !(
-  (x || y) // foo
+  x || y // foo
 );
 
 ![1, 2, 3];
@@ -439,18 +439,18 @@ async function bar2() {
 );
 
 !(x = y);
-!((x = y) /* foo */);
-!(/* foo */ (x = y));
+!(x = y /* foo */);
+!(/* foo */ x = y);
 !(
   /* foo */
-  (x = y)
+  x = y
 );
 !(
-  (x = y)
+  x = y
   /* foo */
 );
 !(
-  (x = y) // foo
+  x = y // foo
 );
 
 !x.y;
@@ -469,18 +469,18 @@ async function bar2() {
 );
 
 !(x ? y : z);
-!((x ? y : z) /* foo */);
-!(/* foo */ (x ? y : z));
+!(x ? y : z /* foo */);
+!(/* foo */ x ? y : z);
 !(
   /* foo */
-  (x ? y : z)
+  x ? y : z
 );
 !(
-  (x ? y : z)
+  x ? y : z
   /* foo */
 );
 !(
-  (x ? y : z) // foo
+  x ? y : z // foo
 );
 
 !x();
@@ -514,14 +514,14 @@ async function bar2() {
 );
 
 !(x, y);
-!((x, y) /* foo */);
-!(/* foo */ (x, y));
+!(x, y /* foo */);
+!(/* foo */ x, y);
 !(
   /* foo */
-  (x, y)
+  x, y
 );
 !(
-  (x, y)
+  x, y
   /* foo */
 );
 !(
@@ -529,51 +529,51 @@ async function bar2() {
 );
 
 !(() => 3);
-!((() => 3) /* foo */);
-!(/* foo */ (() => 3));
+!(() => 3 /* foo */);
+!(/* foo */ () => 3);
 !(
   /* foo */
-  (() => 3)
+  () => 3
 );
 !(
-  (() => 3)
+  () => 3
   /* foo */
 );
 !(
-  (() => 3) // foo
+  () => 3 // foo
 );
 
 function* bar() {
   !(yield x);
-  !((yield x) /* foo */);
-  !(/* foo */ (yield x));
+  !(yield x /* foo */);
+  !(/* foo */ yield x);
   !(
     /* foo */
-    (yield x)
+    yield x
   );
   !(
-    (yield x)
+    yield x
     /* foo */
   );
   !(
-    (yield x) // foo
+    yield x // foo
   );
 }
 
 async function bar2() {
   !(await x);
-  !((await x) /* foo */);
-  !(/* foo */ (await x));
+  !(await x /* foo */);
+  !(/* foo */ await x);
   !(
     /* foo */
-    (await x)
+    await x
   );
   !(
-    (await x)
+    await x
     /* foo */
   );
   !(
-    (await x) // foo
+    await x // foo
   );
 }
 

--- a/tests/unary_expression/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/unary_expression/__snapshots__/jsfmt.spec.js.snap
@@ -309,18 +309,18 @@ async function bar2() {
 );
 
 !(x + y);
-!((x + y) /* foo */);
-!(/* foo */ (x + y));
+!(x + y /* foo */);
+!(/* foo */ x + y);
 !(
   /* foo */
-  (x + y)
+  x + y
 );
 !(
-  (x + y)
+  x + y
   /* foo */
 );
 !(
-  (x + y) // foo
+  x + y // foo
 );
 
 !(x || y);


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fix only the part related to the unary expression in #6945 .

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
