### PR TITLE
TypeScript: print JSDoc-only types

### DIFF
--- a/changelog_unreleased/typescript/pr-7020.md
+++ b/changelog_unreleased/typescript/pr-7020.md
@@ -1,0 +1,15 @@
+#### Print JSDoc-only types as is instead of throwing strange errors ([#7020](https://github.com/prettier/prettier/pull/7020) by [@thorn0](https://github.com/thorn0))
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+function fromFlow(arg: ?Maybe) {}
+
+// Prettier stable
+Error: unknown type: "TSJSDocNullableType"
+    at printPathNoParens (https://prettier.io/lib/standalone.js:26012:13)
+    at Object.genericPrint$3 [as print] (https://prettier.io/lib/standalone.js:23541:28)
+
+// Prettier master
+function fromFlow(arg: ?Maybe) {}
+```

--- a/cspell.json
+++ b/cspell.json
@@ -348,6 +348,7 @@
         "Transloadit",
         "TSAs",
         "tsep",
+        "TSJS",
         "Typeahead",
         "typecasted",
         "typeof",

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -450,6 +450,7 @@ function needsParens(path, options) {
           return false;
       }
 
+    case "TSJSDocFunctionType":
     case "TSConditionalType":
       if (parent.type === "TSConditionalType" && node === parent.extendsType) {
         return true;
@@ -477,7 +478,9 @@ function needsParens(path, options) {
         parent.type === "TSOptionalType" ||
         parent.type === "TSRestType" ||
         (parent.type === "TSIndexedAccessType" && node === parent.objectType) ||
-        parent.type === "TSTypeOperator"
+        parent.type === "TSTypeOperator" ||
+        (parent.type === "TSTypeAnnotation" &&
+          /^TSJSDoc/.test(path.getParentNode(1).type))
       );
 
     case "ArrayTypeAnnotation":

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3637,6 +3637,24 @@ function printPathNoParens(path, options, print, args) {
 
     case "ArgumentPlaceholder":
       return "?";
+
+    // These are not valid TypeScript. Printing them just for the sake of error recovery.
+    case "TSJSDocAllType":
+      return "*";
+    case "TSJSDocUnknownType":
+      return "?";
+    case "TSJSDocNullableType":
+      return concat(["?", path.call(print, "typeAnnotation")]);
+    case "TSJSDocNonNullableType":
+      return concat(["!", path.call(print, "typeAnnotation")]);
+    case "TSJSDocFunctionType":
+      return concat([
+        "function(",
+        // The parameters could be here, but typescript-estree doesn't convert them anyway (throws an error).
+        "): ",
+        path.call(print, "typeAnnotation")
+      ]);
+
     default:
       /* istanbul ignore next */
       throw new Error("unknown type: " + JSON.stringify(n.type));

--- a/tests/typescript_error_recovery/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_error_recovery/__snapshots__/jsfmt.spec.js.snap
@@ -49,3 +49,35 @@ class f7<> {
 
 ================================================================================
 `;
+
+exports[`jsdoc_only_types.ts 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+let a: *;
+function b(x: ?) {}
+let c: ?string;
+let d: string?;
+let e: ?(string | number);
+let f: !string;
+let g: string!;
+let h: !(string | number);
+let i: function(): string;
+let j: (function(): string) | number;
+
+=====================================output=====================================
+let a: *;
+function b(x: ?) {}
+let c: ?string;
+let d: ?string;
+let e: ?(string | number);
+let f: !string;
+let g: !string;
+let h: !(string | number);
+let i: function(): string;
+let j: (function(): string) | number;
+
+================================================================================
+`;

--- a/tests/typescript_error_recovery/jsdoc_only_types.ts
+++ b/tests/typescript_error_recovery/jsdoc_only_types.ts
@@ -1,0 +1,10 @@
+let a: *;
+function b(x: ?) {}
+let c: ?string;
+let d: string?;
+let e: ?(string | number);
+let f: !string;
+let g: string!;
+let h: !(string | number);
+let i: function(): string;
+let j: (function(): string) | number;


### PR DESCRIPTION
fixes #5840 

It would be really easy to replace these types with valid TS, but so far we (with @evilebottnawi) [decided](https://github.com/prettier/prettier/issues/5840#issuecomment-555942944) to print them as is.

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
