### PR TITLE
Add support for @use and @forward rules in Scss

### DIFF
--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -441,7 +441,9 @@ function parseNestedCSS(node, options) {
           "function",
           "return",
           "define-mixin",
-          "add-mixin"
+          "add-mixin",
+          "use",
+          "forward"
         ].indexOf(name) !== -1
       ) {
         // Remove unnecessary spaces in SCSS variable arguments

--- a/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
@@ -1085,6 +1085,42 @@ label {
   @include margin-bottom-1\\/3;
 }
 
+@forward "src/list";
+@forward "src/list" as list-*;
+@forward "src/list"    as    list-*   ;
+@forward "src/list"    hide     list-reset   ,     $horizontal-list-gap   ;
+@forward "src/list"    hide     list-reset   ,     $horizontal-list-gap   , $horizontal-list-gap-foo, $horizontal-list-gap-bar;
+
+
+@use 'src/code';
+@use "src/code" as c;
+@use "src/code"    as    c;
+@use "src/code"    as    *;
+@use 'library'    with (
+$black: #222,
+  $border-radius: 0.1rem
+
+);
+@use 'library'    with (
+$black: #222,
+$border-radius: 0.1rem,
+$left: 10px,
+$right: 400px
+);
+@use 'library'    with (
+$black: #222,
+$border-radius: 0.1rem,
+$left: 10px,
+$right: 400px,
+$box-shadow: 0 0.5rem 1rem rgba($black, 0.15)
+);
+@use       'veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong'       with (
+$black: #222,
+$border-radius: 0.1rem,
+$left: 10px,
+$right: 400px,
+$box-shadow: 0 0.5rem 1rem rgba($black, 0.15), 0 0.5rem 1rem rgba($black, 0.15), 0 0.5rem 1rem rgba($black, 0.15), 0 0.5rem 1rem rgba($black, 0.15)
+);
 =====================================output=====================================
 @media #{$g-breakpoint-tiny} {
 }
@@ -2047,6 +2083,41 @@ $my-map: (
 label {
   @include margin-bottom-1\\/3;
 }
+
+@forward "src/list";
+@forward "src/list" as list- *;
+@forward "src/list" as list- *;
+@forward "src/list" hide list-reset, $horizontal-list-gap;
+@forward "src/list" hide list-reset, $horizontal-list-gap,
+  $horizontal-list-gap-foo, $horizontal-list-gap-bar;
+
+@use "src/code";
+@use "src/code" as c;
+@use "src/code" as c;
+@use "src/code" as *;
+@use "library" with ($black: #222, $border-radius: 0.1rem);
+@use "library" with
+  ($black: #222, $border-radius: 0.1rem, $left: 10px, $right: 400px);
+@use "library" with
+  (
+    $black: #222,
+    $border-radius: 0.1rem,
+    $left: 10px,
+    $right: 400px,
+    $box-shadow: 0 0.5rem 1rem rgba($black, 0.15)
+  );
+@use "veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong"
+  with
+  (
+    $black: #222,
+    $border-radius: 0.1rem,
+    $left: 10px,
+    $right: 400px,
+    $box-shadow: 0 0.5rem 1rem rgba($black, 0.15),
+    0 0.5rem 1rem rgba($black, 0.15),
+    0 0.5rem 1rem rgba($black, 0.15),
+    0 0.5rem 1rem rgba($black, 0.15)
+  );
 
 ================================================================================
 `;
@@ -3108,6 +3179,42 @@ label {
   @include margin-bottom-1\\/3;
 }
 
+@forward "src/list";
+@forward "src/list" as list-*;
+@forward "src/list"    as    list-*   ;
+@forward "src/list"    hide     list-reset   ,     $horizontal-list-gap   ;
+@forward "src/list"    hide     list-reset   ,     $horizontal-list-gap   , $horizontal-list-gap-foo, $horizontal-list-gap-bar;
+
+
+@use 'src/code';
+@use "src/code" as c;
+@use "src/code"    as    c;
+@use "src/code"    as    *;
+@use 'library'    with (
+$black: #222,
+  $border-radius: 0.1rem
+
+);
+@use 'library'    with (
+$black: #222,
+$border-radius: 0.1rem,
+$left: 10px,
+$right: 400px
+);
+@use 'library'    with (
+$black: #222,
+$border-radius: 0.1rem,
+$left: 10px,
+$right: 400px,
+$box-shadow: 0 0.5rem 1rem rgba($black, 0.15)
+);
+@use       'veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong'       with (
+$black: #222,
+$border-radius: 0.1rem,
+$left: 10px,
+$right: 400px,
+$box-shadow: 0 0.5rem 1rem rgba($black, 0.15), 0 0.5rem 1rem rgba($black, 0.15), 0 0.5rem 1rem rgba($black, 0.15), 0 0.5rem 1rem rgba($black, 0.15)
+);
 =====================================output=====================================
 @media #{$g-breakpoint-tiny} {
 }
@@ -4070,6 +4177,41 @@ $my-map: (
 label {
   @include margin-bottom-1\\/3;
 }
+
+@forward "src/list";
+@forward "src/list" as list- *;
+@forward "src/list" as list- *;
+@forward "src/list" hide list-reset, $horizontal-list-gap;
+@forward "src/list" hide list-reset, $horizontal-list-gap,
+  $horizontal-list-gap-foo, $horizontal-list-gap-bar;
+
+@use "src/code";
+@use "src/code" as c;
+@use "src/code" as c;
+@use "src/code" as *;
+@use "library" with ($black: #222, $border-radius: 0.1rem);
+@use "library" with
+  ($black: #222, $border-radius: 0.1rem, $left: 10px, $right: 400px);
+@use "library" with
+  (
+    $black: #222,
+    $border-radius: 0.1rem,
+    $left: 10px,
+    $right: 400px,
+    $box-shadow: 0 0.5rem 1rem rgba($black, 0.15)
+  );
+@use "veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong"
+  with
+  (
+    $black: #222,
+    $border-radius: 0.1rem,
+    $left: 10px,
+    $right: 400px,
+    $box-shadow: 0 0.5rem 1rem rgba($black, 0.15),
+    0 0.5rem 1rem rgba($black, 0.15),
+    0 0.5rem 1rem rgba($black, 0.15),
+    0 0.5rem 1rem rgba($black, 0.15)
+  );
 
 ================================================================================
 `;

--- a/tests/css_scss/scss.scss
+++ b/tests/css_scss/scss.scss
@@ -1047,3 +1047,40 @@ $my-map: (
 label {
   @include margin-bottom-1\/3;
 }
+
+@forward "src/list";
+@forward "src/list" as list-*;
+@forward "src/list"    as    list-*   ;
+@forward "src/list"    hide     list-reset   ,     $horizontal-list-gap   ;
+@forward "src/list"    hide     list-reset   ,     $horizontal-list-gap   , $horizontal-list-gap-foo, $horizontal-list-gap-bar;
+
+
+@use 'src/code';
+@use "src/code" as c;
+@use "src/code"    as    c;
+@use "src/code"    as    *;
+@use 'library'    with (
+$black: #222,
+  $border-radius: 0.1rem
+
+);
+@use 'library'    with (
+$black: #222,
+$border-radius: 0.1rem,
+$left: 10px,
+$right: 400px
+);
+@use 'library'    with (
+$black: #222,
+$border-radius: 0.1rem,
+$left: 10px,
+$right: 400px,
+$box-shadow: 0 0.5rem 1rem rgba($black, 0.15)
+);
+@use       'veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong'       with (
+$black: #222,
+$border-radius: 0.1rem,
+$left: 10px,
+$right: 400px,
+$box-shadow: 0 0.5rem 1rem rgba($black, 0.15), 0 0.5rem 1rem rgba($black, 0.15), 0 0.5rem 1rem rgba($black, 0.15), 0 0.5rem 1rem rgba($black, 0.15)
+);


### PR DESCRIPTION
Add detection for new `@use` and `@forward` rules included in Sass 1.23. Addresses #7019.

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
