### PR TITLE
JavaScript: Format ThrowStatement like ReturnStatement

### DIFF
--- a/changelog_unreleased/javascript/pr-7070.md
+++ b/changelog_unreleased/javascript/pr-7070.md
@@ -1,0 +1,24 @@
+# JavaScript: Format ThrowStatement like ReturnStatement([#7070](https://github.com/prettier/prettier/pull/7070) by [@sosukesuzuki](https://github.com/sosukesuzuki))
+
+<!-- prettier-ignore -->
+```js
+// Input
+function foo() {
+  throw this.hasPlugin("dynamicImports") && this.lookahead().type === tt.parenLeft.right;
+}
+
+// Prettier stable
+function foo() {
+  throw this.hasPlugin("dynamicImports") &&
+    this.lookahead().type === tt.parenLeft.right;
+}
+
+
+// Prettier master
+function foo() {
+  throw (
+    this.hasPlugin("dynamicImports") &&
+    this.lookahead().type === tt.parenLeft.right
+  );
+}
+``` 

--- a/changelog_unreleased/javascript/pr-7070.md
+++ b/changelog_unreleased/javascript/pr-7070.md
@@ -1,4 +1,4 @@
-# JavaScript: Format ThrowStatement like ReturnStatement([#7070](https://github.com/prettier/prettier/pull/7070) by [@sosukesuzuki](https://github.com/sosukesuzuki))
+# Format `throw` like `return` ([#7070](https://github.com/prettier/prettier/pull/7070) by [@sosukesuzuki](https://github.com/sosukesuzuki))
 
 <!-- prettier-ignore -->
 ```js

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -759,6 +759,7 @@ function needsParens(path, options) {
           parent.type !== "OptionalCallExpression" &&
           parent.type !== "Property" &&
           parent.type !== "ReturnStatement" &&
+          parent.type !== "ThrowStatement" &&
           parent.type !== "TypeCastExpression" &&
           parent.type !== "VariableDeclarator")
       );

--- a/tests/throw_statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/throw_statement/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,173 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`binaryish.js 1`] = `
+====================================options=====================================
+parsers: ["flow", "typescript", "babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function f() {
+  throw (
+    property.isIdentifier() &&
+     FUNCTIONS[property.node.name] &&
+     (object.isIdentifier(JEST_GLOBAL) ||
+       (callee.isMemberExpression() && shouldHoistExpression(object))) &&
+    FUNCTIONS[property.node.name](expr.get('arguments'))
+  );
+
+  throw (
+    chalk.bold(
+      'No tests found related to files changed since last commit.\\n',
+    ) +
+    chalk.dim(
+      patternInfo.watch ?
+        'Press \`a\` to run all tests, or run Jest with \`--watchAll\`.' :
+        'Run Jest without \`-o\` to run all tests.',
+    )
+  );
+
+  throw !filePath.includes(coverageDirectory) &&
+    !filePath.endsWith(\`.\${SNAPSHOT_EXTENSION}\`);
+}
+
+=====================================output=====================================
+function f() {
+  throw (
+    property.isIdentifier() &&
+    FUNCTIONS[property.node.name] &&
+    (object.isIdentifier(JEST_GLOBAL) ||
+      (callee.isMemberExpression() && shouldHoistExpression(object))) &&
+    FUNCTIONS[property.node.name](expr.get("arguments"))
+  );
+
+  throw (
+    chalk.bold("No tests found related to files changed since last commit.\\n") +
+    chalk.dim(
+      patternInfo.watch
+        ? "Press \`a\` to run all tests, or run Jest with \`--watchAll\`."
+        : "Run Jest without \`-o\` to run all tests."
+    )
+  );
+
+  throw (
+    !filePath.includes(coverageDirectory) &&
+    !filePath.endsWith(\`.\${SNAPSHOT_EXTENSION}\`)
+  );
+}
+
+================================================================================
+`;
+
+exports[`comment.js 1`] = `
+====================================options=====================================
+parsers: ["flow", "typescript", "babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function x() {
+  throw func2
+      //comment
+      .bar();
+}
+ 
+function f() {
+  throw (
+    foo
+      // comment
+      .bar()
+  );
+}
+ 
+fn(function f() {
+  throw (
+    foo
+      // comment
+      .bar()
+  );
+});
+
+=====================================output=====================================
+function x() {
+  throw (
+    func2
+      //comment
+      .bar()
+  );
+}
+
+function f() {
+  throw (
+    foo
+      // comment
+      .bar()
+  );
+}
+
+fn(function f() {
+  throw (
+    foo
+      // comment
+      .bar()
+  );
+});
+
+================================================================================
+`;
+
+exports[`jsx.js 1`] = `
+====================================options=====================================
+parsers: ["flow", "typescript", "babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function foo() {
+  throw <Bar />;
+}
+
+function foo() {
+  throw <Bar>baz</Bar>;
+}
+
+function foo() {
+  throw <Bar baz={baz} />;
+}
+
+function foo() {
+  throw <Bar baz={baz}>foo</Bar>;
+}
+
+function foo() {
+  throw <></>;
+}
+
+function foo() {
+  throw <>foo</>;
+}
+
+=====================================output=====================================
+function foo() {
+  throw <Bar />;
+}
+
+function foo() {
+  throw <Bar>baz</Bar>;
+}
+
+function foo() {
+  throw <Bar baz={baz} />;
+}
+
+function foo() {
+  throw <Bar baz={baz}>foo</Bar>;
+}
+
+function foo() {
+  throw <></>;
+}
+
+function foo() {
+  throw <>foo</>;
+}
+
+================================================================================
+`;

--- a/tests/throw_statement/binaryish.js
+++ b/tests/throw_statement/binaryish.js
@@ -1,0 +1,23 @@
+function f() {
+  throw (
+    property.isIdentifier() &&
+     FUNCTIONS[property.node.name] &&
+     (object.isIdentifier(JEST_GLOBAL) ||
+       (callee.isMemberExpression() && shouldHoistExpression(object))) &&
+    FUNCTIONS[property.node.name](expr.get('arguments'))
+  );
+
+  throw (
+    chalk.bold(
+      'No tests found related to files changed since last commit.\n',
+    ) +
+    chalk.dim(
+      patternInfo.watch ?
+        'Press `a` to run all tests, or run Jest with `--watchAll`.' :
+        'Run Jest without `-o` to run all tests.',
+    )
+  );
+
+  throw !filePath.includes(coverageDirectory) &&
+    !filePath.endsWith(`.${SNAPSHOT_EXTENSION}`);
+}

--- a/tests/throw_statement/comment.js
+++ b/tests/throw_statement/comment.js
@@ -1,0 +1,21 @@
+function x() {
+  throw func2
+      //comment
+      .bar();
+}
+ 
+function f() {
+  throw (
+    foo
+      // comment
+      .bar()
+  );
+}
+ 
+fn(function f() {
+  throw (
+    foo
+      // comment
+      .bar()
+  );
+});

--- a/tests/throw_statement/jsfmt.spec.js
+++ b/tests/throw_statement/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["flow", "typescript", "babel"]);

--- a/tests/throw_statement/jsx.js
+++ b/tests/throw_statement/jsx.js
@@ -1,0 +1,23 @@
+function foo() {
+  throw <Bar />;
+}
+
+function foo() {
+  throw <Bar>baz</Bar>;
+}
+
+function foo() {
+  throw <Bar baz={baz} />;
+}
+
+function foo() {
+  throw <Bar baz={baz}>foo</Bar>;
+}
+
+function foo() {
+  throw <></>;
+}
+
+function foo() {
+  throw <>foo</>;
+}


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

https://github.com/prettier/prettier/pull/7042#discussion_r349902896

```js
// Input
function foo() {
  throw this.hasPlugin("dynamicImports") && this.lookahead().type === tt.parenLeft.right;
}
function foo() {
  return this.hasPlugin("dynamicImports") && this.lookahead().type === tt.parenLeft.right;
}

// Prettier stable
function foo() {
  throw this.hasPlugin("dynamicImports") &&
    this.lookahead().type === tt.parenLeft.right;
}
function foo() {
  return (
    this.hasPlugin("dynamicImports") &&
    this.lookahead().type === tt.parenLeft.right
  );
}

// Prettier master
function foo() {
  throw (
    this.hasPlugin("dynamicImports") &&
    this.lookahead().type === tt.parenLeft.right
  );
}
function foo() {
  return (
    this.hasPlugin("dynamicImports") &&
    this.lookahead().type === tt.parenLeft.right
  );
}

``` 

@prettier/core How do you think about this?

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
