### PR TITLE
Don't print trailing commas after rest elements in tuples

### DIFF
--- a/changelog_unreleased/typescript/pr-7075.md
+++ b/changelog_unreleased/typescript/pr-7075.md
@@ -1,0 +1,35 @@
+#### Don't print trailing commas after rest elements in tuples ([#7075](https://github.com/prettier/prettier/pull/7075) by [@thorn](https://github.com/thorn0))
+
+* A rest element is always the last element of a tuple type. Nothing can be added after it.
+* While TS is okay with this comma, [Babel doesn't parse it](https://github.com/babel/babel/issues/10769)
+* In function parameters and array destructuring, such a comma is a syntax error. Keeping it in tuples is inconsistent.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+type ValidateArgs = [
+	{
+		[key: string]: any;
+	},
+	string,
+	...string[],
+];
+
+// Prettier stable
+type ValidateArgs = [
+  {
+    [key: string]: any;
+  },
+  string,
+  ...string[],
+];
+
+// Prettier master
+type ValidateArgs = [
+  {
+    [key: string]: any;
+  },
+  string,
+  ...string[]
+];
+```

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2509,6 +2509,9 @@ function printPathNoParens(path, options, print, args) {
     case "TSTupleType":
     case "TupleTypeAnnotation": {
       const typesField = n.type === "TSTupleType" ? "elementTypes" : "types";
+      const hasRest =
+        n[typesField].length > 0 &&
+        getLast(n[typesField]).type === "TSRestType";
       return group(
         concat([
           "[",
@@ -2518,7 +2521,7 @@ function printPathNoParens(path, options, print, args) {
               printArrayItems(path, options, typesField, print)
             ])
           ),
-          ifBreak(shouldPrintComma(options, "all") ? "," : ""),
+          ifBreak(shouldPrintComma(options, "all") && !hasRest ? "," : ""),
           comments.printDanglingComments(path, options, /* sameIndent */ true),
           softline,
           "]"

--- a/tests/typescript_tuple/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_tuple/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,91 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`no-trailing-comma-after-rest.ts 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type ValidateArgs = [
+	{
+		[key: string]: any;
+	},
+	string,
+	string,
+	...string[],
+];
+
+=====================================output=====================================
+type ValidateArgs = [
+  {
+    [key: string]: any;
+  },
+  string,
+  string,
+  ...string[]
+];
+
+================================================================================
+`;
+
+exports[`no-trailing-comma-after-rest.ts 2`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+trailingComma: "es5"
+                                                                                | printWidth
+=====================================input======================================
+type ValidateArgs = [
+	{
+		[key: string]: any;
+	},
+	string,
+	string,
+	...string[],
+];
+
+=====================================output=====================================
+type ValidateArgs = [
+  {
+    [key: string]: any;
+  },
+  string,
+  string,
+  ...string[]
+];
+
+================================================================================
+`;
+
+exports[`no-trailing-comma-after-rest.ts 3`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+type ValidateArgs = [
+	{
+		[key: string]: any;
+	},
+	string,
+	string,
+	...string[],
+];
+
+=====================================output=====================================
+type ValidateArgs = [
+  {
+    [key: string]: any;
+  },
+  string,
+  string,
+  ...string[]
+];
+
+================================================================================
+`;
+
 exports[`trailing-comma.ts 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/typescript_tuple/no-trailing-comma-after-rest.ts
+++ b/tests/typescript_tuple/no-trailing-comma-after-rest.ts
@@ -1,0 +1,8 @@
+type ValidateArgs = [
+	{
+		[key: string]: any;
+	},
+	string,
+	string,
+	...string[],
+];


### PR DESCRIPTION
* A rest element is always the last element of a tuple type. Nothing can be added after it.
* While TS is okay with this comma, Babel doesn't parse it. https://github.com/babel/babel/issues/10769
* In function parameters and array destructuring, such a comma is a syntax error. Keeping it in tuples is inconsistent.

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
