### PR TITLE
tests: "Expected" and "Received" are mixed up in parser verification tests

### DIFF
--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -94,7 +94,7 @@ global.run_spec = (dirname, parsers, options) => {
       const verifyOptions = Object.assign({}, baseOptions, { parser });
       test(`${basename} - ${parser}-verify`, () => {
         const verifyOutput = format(input, filename, verifyOptions);
-        expect(visualizedOutput).toEqual(visualizeEndOfLine(verifyOutput));
+        expect(visualizeEndOfLine(verifyOutput)).toEqual(visualizedOutput);
       });
     }
 


### PR DESCRIPTION
E.g. a test called "flow-verify" verifies that the output with `--parser flow` is identical to the the reference output. However, when such a test fails, the reference output is called "Received" and the output of the current parser "Expected", which is really confusing and misleading.

![image](https://user-images.githubusercontent.com/94334/70525711-a05cee80-1b50-11ea-88b8-216e78028c5c.png)
