### PR TITLE
fix: configure pre-commit hook to only output changed files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
 - id: prettier
   name: prettier
-  entry: prettier --write
+  entry: prettier --write --list-different
   language: node
   files: "\\.(\
     css|less|scss\


### PR DESCRIPTION
Currently, the pre-commit hook will output all files that prettier analyzes.

The changed lines are highlighted in the terminal, but this highlighting is not always successful (e.g. we have seen the highlighting disappear when running inside Jenkins)

This sets prettier (when running within pre-commit) to only output changed files

<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
