### PR TITLE
revert function composition logic for decorators

### DIFF
--- a/changelog_unreleased/javascript/pr-7138.md
+++ b/changelog_unreleased/javascript/pr-7138.md
@@ -1,0 +1,31 @@
+#### Tweak function composition logic for decorators ([#7138](https://github.com/prettier/prettier/pull/7138) by [@brainkim](https://github.com/brainkim))
+
+Because decorators modify the line following, splitting a decorator call’s
+arguments onto multiple lines can obscure the relationship between the
+decorator and its intended target, producing less-readable code. Therefore, the
+function composition logic introduced in #6033 has been changed to exclude
+decorator calls.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+export class Item {
+  @OneToOne(() => Thing, x => x.item)
+  thing!: Thing;
+}
+
+// Output (Prettier stable)
+export class Item {
+  @OneToOne(
+    () => Thing,
+    x => x.item,
+  )
+  thing!: Thing;
+}
+
+// Output (Prettier master)
+export class Item {
+  @OneToOne(() => Thing, x => x.item)
+  thing!: Thing;
+}
+```

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4069,7 +4069,10 @@ function printArgumentsList(path, options, print) {
     );
   }
 
-  if (isFunctionCompositionArgs(args)) {
+  if (
+    path.getParentNode().type !== "Decorator" &&
+    isFunctionCompositionArgs(args)
+  ) {
     return allArgsBrokenOut();
   }
 

--- a/tests/decorators-ts/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators-ts/__snapshots__/jsfmt.spec.js.snap
@@ -321,10 +321,7 @@ export class Board {
   @Column()
   description: string;
 
-  @OneToMany(
-    type => Topic,
-    topic => topic.board
-  )
+  @OneToMany(type => Topic, topic => topic.board)
   topics: Topic[];
 }
 


### PR DESCRIPTION
fixes #6953

Decorators are most readable when they’re on a single line, because they modify the declaration/parameter which follows them. Therefore, we revert the new function literal behavior introduced in https://github.com/prettier/prettier/pull/6033 for decorator calls.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
