### PR TITLE
JavaScript: Fix moving semi for `return` to end of line-comment

### DIFF
--- a/changelog_unreleased/javascript/pr-7140.md
+++ b/changelog_unreleased/javascript/pr-7140.md
@@ -1,0 +1,13 @@
+#### Fix moving semi for `return` to end of line-comment([#7140](https://github.com/prettier/prettier/pull/7140) by [@sosukesuzuki](https://github.com/sosukesuzuki))
+
+```js
+// Input
+return // comment
+;
+
+// Prettier stable
+return // comment;
+
+// Prettier master
+return; // comment
+```

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5959,6 +5959,15 @@ function printReturnAndThrowArgument(path, options, print) {
     }
   }
 
+  const lastComment =
+    Array.isArray(node.comments) && node.comments[node.comments.length - 1];
+  const isLastCommentLine =
+    lastComment.type === "CommentLine" || lastComment.type === "Line";
+
+  if (isLastCommentLine) {
+    parts.push(semi);
+  }
+
   if (hasDanglingComments(node)) {
     parts.push(
       " ",
@@ -5966,7 +5975,9 @@ function printReturnAndThrowArgument(path, options, print) {
     );
   }
 
-  parts.push(semi);
+  if (!isLastCommentLine) {
+    parts.push(semi);
+  }
 
   return concat(parts);
 }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5962,7 +5962,8 @@ function printReturnAndThrowArgument(path, options, print) {
   const lastComment =
     Array.isArray(node.comments) && node.comments[node.comments.length - 1];
   const isLastCommentLine =
-    lastComment.type === "CommentLine" || lastComment.type === "Line";
+    lastComment &&
+    (lastComment.type === "CommentLine" || lastComment.type === "Line");
 
   if (isLastCommentLine) {
     parts.push(semi);

--- a/tests/return/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/return/__snapshots__/jsfmt.spec.js.snap
@@ -73,6 +73,17 @@ function f() {
   ;
 }
 
+function f() {
+  return // a
+  /* b */;
+}
+
+function f() {
+  return /* a */
+  // b
+  ;
+}
+
 function x() {
   return func2
       //comment
@@ -102,6 +113,16 @@ function f() {
 
 function f() {
   return; // a
+}
+
+function f() {
+  return // a
+  /* b */;
+}
+
+function f() {
+  return; /* a */
+  // b
 }
 
 function x() {

--- a/tests/return/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/return/__snapshots__/jsfmt.spec.js.snap
@@ -68,6 +68,11 @@ function f() {
   return /* a */;
 }
 
+function f() {
+  return // a
+  ;
+}
+
 function x() {
   return func2
       //comment
@@ -93,6 +98,10 @@ fn(function f() {
 =====================================output=====================================
 function f() {
   return /* a */;
+}
+
+function f() {
+  return; // a
 }
 
 function x() {

--- a/tests/return/comment.js
+++ b/tests/return/comment.js
@@ -7,6 +7,17 @@ function f() {
   ;
 }
 
+function f() {
+  return // a
+  /* b */;
+}
+
+function f() {
+  return /* a */
+  // b
+  ;
+}
+
 function x() {
   return func2
       //comment

--- a/tests/return/comment.js
+++ b/tests/return/comment.js
@@ -2,6 +2,11 @@ function f() {
   return /* a */;
 }
 
+function f() {
+  return // a
+  ;
+}
+
 function x() {
   return func2
       //comment


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fix #7139

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
