### PR TITLE
fix: comments for typescript function like nodes

### DIFF
--- a/changelog_unreleased/typescript/pr-7144.md
+++ b/changelog_unreleased/typescript/pr-7144.md
@@ -39,6 +39,41 @@ let foo10: new /* foo */ (a: /* bar */ string) /* baz */ => string;
 
 // Prettier stable
 interface foo1 {
+  bar3/* foo */ (/* baz */) // bat
+  bar/* foo */ ? /* bar */ (/* baz */) /* bat */;
+  bar2/* foo */ (/* baz */) /* bat */
+}
+
+interface foo2 {
+  bar/* foo */ ? /* bar */ (bar: /* baz */ string): /* bat */ string;
+}
+
+interface foo3 {
+  /* foo */ (/* bar */): /* baz */ string;
+}
+
+interface foo4 {
+  /* foo */ (bar: /* bar */ string): /* baz */ string;
+}
+
+interface foo5 {
+  /* foo */ new /* bar */  (a: /* baz */ string): /* bat */ string
+}
+
+interface foo6 {
+  /* foo */ new /* bar */ (/* baz */): /* bat */ string
+}
+
+type foo7 = /* foo */ (/* bar */) /* baz */ => void
+
+type foo8 = /* foo */ (a: /* bar */ string) /* baz */ => void
+
+let foo9: new /* foo */ (/* bar */) /* baz */ => string;
+
+let foo10: new /* foo */ (a: /* bar */ string) /* baz */ => string;
+
+// Prettier master
+interface foo1 {
   bar3 /* foo */(/* baz */); // bat
   bar /* foo */ /* bar */?(/* baz */) /* bat */;
   bar2 /* foo */(/* baz */) /* bat */;
@@ -72,41 +107,6 @@ let foo9: new (/* bar */) => /* foo */ /* baz */ string;
 
 let foo10: new (/* foo */ a: /* bar */ string) => /* baz */ string;
 
-
-// Prettier master
-interface foo1 {
-  bar3 /* foo */ /* baz */(); // bat
-  bar /* foo */ /* bar */ /* baz */ /* bat */?();
-  bar2 /* foo */ /* baz */() /* bat */;
-}
-
-interface foo2 {
-  bar /* foo */?(/* bar */ bar: /* baz */ string): /* bat */ string;
-}
-
-interface foo3 {
-  /* foo */ (): /* bar */ /* baz */ string;
-}
-
-interface foo4 {
-  /* foo */ (bar: /* bar */ string): /* baz */ string;
-}
-
-interface foo5 {
-  /* foo */ new (/* bar */ a: /* baz */ string): /* bat */ string;
-}
-
-interface foo6 {
-  /* foo */ new (): /* bar */ /* baz */ /* bat */ string;
-}
-
-type foo7 = /* foo */ () => /* bar */ /* baz */ void;
-
-type foo8 = /* foo */ (a: /* bar */ string) => /* baz */ void;
-
-let foo9: new () => /* foo */ /* bar */ /* baz */ string;
-
-let foo10: new (/* foo */ a: /* bar */ string) => /* baz */ string;
 ```
 
 ```ts
@@ -118,13 +118,6 @@ abstract class Test {
 }
 
 // Prettier stable
-abstract class Test {
-  abstract foo12 /* foo */(a: /* bar */ string): /* baz */ void;
-
-  abstract foo13 /* foo */(/* bar */); /* baz */
-}
-
-// Prettier master
 Error: Comment "foo" was not printed. Please report this error!
     at https://prettier.io/lib/standalone.js:15543:15
     at Array.forEach (<anonymous>)
@@ -136,4 +129,11 @@ Error: Comment "foo" was not printed. Please report this error!
     at Object.format (https://prettier.io/lib/standalone.js:31802:14)
     at formatCode (https://prettier.io/worker.js:234:21)
     at handleMessage (https://prettier.io/worker.js:185:18)
+
+// Prettier master
+abstract class Test {
+  abstract foo12 /* foo */(a: /* bar */ string): /* baz */ void;
+
+  abstract foo13 /* foo */(/* bar */); /* baz */
+}
 ```

--- a/changelog_unreleased/typescript/pr-7144.md
+++ b/changelog_unreleased/typescript/pr-7144.md
@@ -1,0 +1,139 @@
+#### Fix formatting comments for typescript function like nodes ([#6901](https://github.com/prettier/prettier/pull/7144) by [@armano2](https://github.com/armano2))
+
+<!-- prettier-ignore -->
+```ts
+// Input
+interface foo1 {
+  bar3/* foo */ (/* baz */) // bat
+  bar/* foo */ ? /* bar */ (/* baz */) /* bat */;
+  bar2/* foo */ (/* baz */) /* bat */
+}
+
+interface foo2 {
+  bar/* foo */ ? /* bar */ (bar: /* baz */ string): /* bat */ string;
+}
+
+interface foo3 {
+  /* foo */ (/* bar */): /* baz */ string;
+}
+
+interface foo4 {
+  /* foo */ (bar: /* bar */ string): /* baz */ string;
+}
+
+interface foo5 {
+  /* foo */ new /* bar */  (a: /* baz */ string): /* bat */ string
+}
+
+interface foo6 {
+  /* foo */ new /* bar */ (/* baz */): /* bat */ string
+}
+
+type foo7 = /* foo */ (/* bar */) /* baz */ => void
+
+type foo8 = /* foo */ (a: /* bar */ string) /* baz */ => void
+
+let foo9: new /* foo */ (/* bar */) /* baz */ => string;
+
+let foo10: new /* foo */ (a: /* bar */ string) /* baz */ => string;
+
+// Prettier stable
+interface foo1 {
+  bar3 /* foo */(/* baz */); // bat
+  bar /* foo */ /* bar */?(/* baz */) /* bat */;
+  bar2 /* foo */(/* baz */) /* bat */;
+}
+
+interface foo2 {
+  bar /* foo */?(/* bar */ bar: /* baz */ string): /* bat */ string;
+}
+
+interface foo3 {
+  /* foo */ (/* bar */): /* baz */ string;
+}
+
+interface foo4 {
+  /* foo */ (bar: /* bar */ string): /* baz */ string;
+}
+
+interface foo5 {
+  /* foo */ new (/* bar */ a: /* baz */ string): /* bat */ string;
+}
+
+interface foo6 {
+  /* foo */ new (/* baz */): /* bar */ /* bat */ string;
+}
+
+type foo7 = /* foo */ (/* bar */) => /* baz */ void;
+
+type foo8 = /* foo */ (a: /* bar */ string) => /* baz */ void;
+
+let foo9: new (/* bar */) => /* foo */ /* baz */ string;
+
+let foo10: new (/* foo */ a: /* bar */ string) => /* baz */ string;
+
+
+// Prettier master
+interface foo1 {
+  bar3 /* foo */ /* baz */(); // bat
+  bar /* foo */ /* bar */ /* baz */ /* bat */?();
+  bar2 /* foo */ /* baz */() /* bat */;
+}
+
+interface foo2 {
+  bar /* foo */?(/* bar */ bar: /* baz */ string): /* bat */ string;
+}
+
+interface foo3 {
+  /* foo */ (): /* bar */ /* baz */ string;
+}
+
+interface foo4 {
+  /* foo */ (bar: /* bar */ string): /* baz */ string;
+}
+
+interface foo5 {
+  /* foo */ new (/* bar */ a: /* baz */ string): /* bat */ string;
+}
+
+interface foo6 {
+  /* foo */ new (): /* bar */ /* baz */ /* bat */ string;
+}
+
+type foo7 = /* foo */ () => /* bar */ /* baz */ void;
+
+type foo8 = /* foo */ (a: /* bar */ string) => /* baz */ void;
+
+let foo9: new () => /* foo */ /* bar */ /* baz */ string;
+
+let foo10: new (/* foo */ a: /* bar */ string) => /* baz */ string;
+```
+
+```ts
+// Input
+abstract class Test {
+  abstract foo12 /* foo */ (a: /* bar */ string): /* baz */ void
+
+  abstract foo13 /* foo */ (/* bar */) /* baz */
+}
+
+// Prettier stable
+abstract class Test {
+  abstract foo12 /* foo */(a: /* bar */ string): /* baz */ void;
+
+  abstract foo13 /* foo */(/* bar */); /* baz */
+}
+
+// Prettier master
+Error: Comment "foo" was not printed. Please report this error!
+    at https://prettier.io/lib/standalone.js:15543:15
+    at Array.forEach (<anonymous>)
+    at ensureAllCommentsPrinted (https://prettier.io/lib/standalone.js:15541:17)
+    at coreFormat (https://prettier.io/lib/standalone.js:15592:5)
+    at format (https://prettier.io/lib/standalone.js:15832:75)
+    at formatWithCursor (https://prettier.io/lib/standalone.js:15848:14)
+    at https://prettier.io/lib/standalone.js:31794:17
+    at Object.format (https://prettier.io/lib/standalone.js:31802:14)
+    at formatCode (https://prettier.io/worker.js:234:21)
+    at handleMessage (https://prettier.io/worker.js:185:18)
+```

--- a/changelog_unreleased/typescript/pr-7144.md
+++ b/changelog_unreleased/typescript/pr-7144.md
@@ -1,110 +1,56 @@
-#### Fix formatting comments for typescript function like nodes ([#6901](https://github.com/prettier/prettier/pull/7144) by [@armano2](https://github.com/armano2))
+#### Fix formatting comments for function-like nodes ([#6901](https://github.com/prettier/prettier/pull/7144) by [@armano2](https://github.com/armano2))
 
 <!-- prettier-ignore -->
 ```ts
 // Input
 interface foo1 {
-  bar3/* foo */ (/* baz */) // bat
-  bar/* foo */ ? /* bar */ (/* baz */) /* bat */;
-  bar2/* foo */ (/* baz */) /* bat */
-}
-
-interface foo2 {
-  bar/* foo */ ? /* bar */ (bar: /* baz */ string): /* bat */ string;
-}
-
-interface foo3 {
+  bar1/* foo */ (/* baz */) // bat
+  bar2/* foo */ ? /* bar */ (/* baz */) /* bat */;
+  bar3/* foo */ (/* baz */) /* bat */
+  bar4/* foo */ ? /* bar */ (bar: /* baz */ string): /* bat */ string;
   /* foo */ (/* bar */): /* baz */ string;
-}
-
-interface foo4 {
   /* foo */ (bar: /* bar */ string): /* baz */ string;
-}
-
-interface foo5 {
   /* foo */ new /* bar */  (a: /* baz */ string): /* bat */ string
-}
-
-interface foo6 {
   /* foo */ new /* bar */ (/* baz */): /* bat */ string
 }
 
 type foo7 = /* foo */ (/* bar */) /* baz */ => void
-
 type foo8 = /* foo */ (a: /* bar */ string) /* baz */ => void
-
 let foo9: new /* foo */ (/* bar */) /* baz */ => string;
-
 let foo10: new /* foo */ (a: /* bar */ string) /* baz */ => string;
 
 // Prettier stable
 interface foo1 {
-  bar3 /* foo */ /* baz */(); // bat
-  bar /* foo */ /* bar */ /* baz */ /* bat */?();
-  bar2 /* foo */ /* baz */() /* bat */;
-}
-
-interface foo2 {
-  bar /* foo */?(/* bar */ bar: /* baz */ string): /* bat */ string;
-}
-
-interface foo3 {
+  bar1 /* foo */ /* baz */(); // bat
+  bar2 /* foo */ /* bar */ /* baz */ /* bat */?();
+  bar3 /* foo */ /* baz */() /* bat */;
+  bar4 /* foo */?(/* bar */ bar: /* baz */ string): /* bat */ string;
   /* foo */ (): /* bar */ /* baz */ string;
-}
-
-interface foo4 {
   /* foo */ (bar: /* bar */ string): /* baz */ string;
-}
-
-interface foo5 {
   /* foo */ new (/* bar */ a: /* baz */ string): /* bat */ string;
-}
-
-interface foo6 {
   /* foo */ new (): /* bar */ /* baz */ /* bat */ string;
 }
 
 type foo7 = /* foo */ () => /* bar */ /* baz */ void;
-
 type foo8 = /* foo */ (a: /* bar */ string) => /* baz */ void;
-
 let foo9: new () => /* foo */ /* bar */ /* baz */ string;
-
 let foo10: new (/* foo */ a: /* bar */ string) => /* baz */ string;
 
 // Prettier master
 interface foo1 {
-  bar3 /* foo */(/* baz */); // bat
-  bar /* foo */ /* bar */?(/* baz */) /* bat */;
-  bar2 /* foo */(/* baz */) /* bat */;
-}
-
-interface foo2 {
-  bar /* foo */?(/* bar */ bar: /* baz */ string): /* bat */ string;
-}
-
-interface foo3 {
+  bar1 /* foo */(/* baz */); // bat
+  bar2 /* foo */ /* bar */?(/* baz */) /* bat */;
+  bar3 /* foo */(/* baz */) /* bat */;
+  bar4 /* foo */?(/* bar */ bar: /* baz */ string): /* bat */ string;
   /* foo */ (/* bar */): /* baz */ string;
-}
-
-interface foo4 {
   /* foo */ (bar: /* bar */ string): /* baz */ string;
-}
-
-interface foo5 {
   /* foo */ new (/* bar */ a: /* baz */ string): /* bat */ string;
-}
-
-interface foo6 {
   /* foo */ new (/* baz */): /* bar */ /* bat */ string;
 }
 
 type foo7 = /* foo */ (/* bar */) => /* baz */ void;
-
 type foo8 = /* foo */ (a: /* bar */ string) => /* baz */ void;
-
 let foo9: new (/* bar */) => /* foo */ /* baz */ string;
-
 let foo10: new (/* foo */ a: /* bar */ string) => /* baz */ string;
 ```
 
@@ -112,7 +58,6 @@ let foo10: new (/* foo */ a: /* bar */ string) => /* baz */ string;
 // Input
 abstract class Test {
   abstract foo12 /* foo */ (a: /* bar */ string): /* baz */ void
-
   abstract foo13 /* foo */ (/* bar */) /* baz */
 }
 
@@ -132,7 +77,6 @@ Error: Comment "foo" was not printed. Please report this error!
 // Prettier master
 abstract class Test {
   abstract foo12 /* foo */(a: /* bar */ string): /* baz */ void;
-
   abstract foo13 /* foo */(/* bar */); /* baz */
 }
 ```

--- a/changelog_unreleased/typescript/pr-7144.md
+++ b/changelog_unreleased/typescript/pr-7144.md
@@ -39,17 +39,17 @@ let foo10: new /* foo */ (a: /* bar */ string) /* baz */ => string;
 
 // Prettier stable
 interface foo1 {
-  bar3/* foo */ (/* baz */) // bat
-  bar/* foo */ ? /* bar */ (/* baz */) /* bat */;
-  bar2/* foo */ (/* baz */) /* bat */
+  bar3 /* foo */ /* baz */(); // bat
+  bar /* foo */ /* bar */ /* baz */ /* bat */?();
+  bar2 /* foo */ /* baz */() /* bat */;
 }
 
 interface foo2 {
-  bar/* foo */ ? /* bar */ (bar: /* baz */ string): /* bat */ string;
+  bar /* foo */?(/* bar */ bar: /* baz */ string): /* bat */ string;
 }
 
 interface foo3 {
-  /* foo */ (/* bar */): /* baz */ string;
+  /* foo */ (): /* bar */ /* baz */ string;
 }
 
 interface foo4 {
@@ -57,20 +57,20 @@ interface foo4 {
 }
 
 interface foo5 {
-  /* foo */ new /* bar */  (a: /* baz */ string): /* bat */ string
+  /* foo */ new (/* bar */ a: /* baz */ string): /* bat */ string;
 }
 
 interface foo6 {
-  /* foo */ new /* bar */ (/* baz */): /* bat */ string
+  /* foo */ new (): /* bar */ /* baz */ /* bat */ string;
 }
 
-type foo7 = /* foo */ (/* bar */) /* baz */ => void
+type foo7 = /* foo */ () => /* bar */ /* baz */ void;
 
-type foo8 = /* foo */ (a: /* bar */ string) /* baz */ => void
+type foo8 = /* foo */ (a: /* bar */ string) => /* baz */ void;
 
-let foo9: new /* foo */ (/* bar */) /* baz */ => string;
+let foo9: new () => /* foo */ /* bar */ /* baz */ string;
 
-let foo10: new /* foo */ (a: /* bar */ string) /* baz */ => string;
+let foo10: new (/* foo */ a: /* bar */ string) => /* baz */ string;
 
 // Prettier master
 interface foo1 {
@@ -106,7 +106,6 @@ type foo8 = /* foo */ (a: /* bar */ string) => /* baz */ void;
 let foo9: new (/* bar */) => /* foo */ /* baz */ string;
 
 let foo10: new (/* foo */ a: /* bar */ string) => /* baz */ string;
-
 ```
 
 ```ts

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -850,21 +850,21 @@ function handleTSFunctionTrailingComments(
   options
 ) {
   if (
-    followingNode ||
-    !enclosingNode ||
-    (enclosingNode.type !== "TSMethodSignature" &&
-      enclosingNode.type !== "TSDeclareFunction" &&
-      enclosingNode.type !== "TSAbstractMethodDefinition") ||
+    !followingNode &&
+    enclosingNode &&
+    (enclosingNode.type === "TSMethodSignature" ||
+      enclosingNode.type === "TSDeclareFunction" ||
+      enclosingNode.type === "TSAbstractMethodDefinition") &&
     privateUtil.getNextNonSpaceNonCommentCharacter(
       text,
       comment,
       options.locEnd
-    ) !== ";"
+    ) === ";"
   ) {
-    return false;
+    addTrailingComment(enclosingNode, comment);
+    return true;
   }
-  addTrailingComment(enclosingNode, comment);
-  return true;
+  return false;
 }
 
 function handleTSMappedTypeComments(

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -467,7 +467,8 @@ function handleMethodNameComments(
     enclosingNode &&
     precedingNode &&
     (enclosingNode.type === "Property" ||
-      enclosingNode.type === "MethodDefinition") &&
+      enclosingNode.type === "MethodDefinition" ||
+      enclosingNode.type === "TSAbstractMethodDefinition") &&
     precedingNode.type === "Identifier" &&
     enclosingNode.key === precedingNode &&
     // special Property case: { key: /*comment*/(value) };
@@ -854,7 +855,9 @@ function handleTSFunctionTrailingComments(
   if (
     followingNode ||
     !enclosingNode ||
-    enclosingNode.type !== "TSMethodSignature" ||
+    (enclosingNode.type !== "TSMethodSignature" &&
+      enclosingNode.type !== "TSDeclareFunction" &&
+      enclosingNode.type !== "TSAbstractMethodDefinition") ||
     privateUtil.getNextNonSpaceNonCommentCharacter(
       text,
       comment,

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -8,23 +8,6 @@ const {
   addDanglingComment
 } = sharedUtil;
 
-function isRealFunctionLikeNode(node) {
-  return (
-    node.type === "ArrowFunctionExpression" ||
-    node.type === "FunctionExpression" ||
-    node.type === "FunctionDeclaration" ||
-    node.type === "ObjectMethod" ||
-    node.type === "ClassMethod" ||
-    node.type === "TSDeclareFunction" ||
-    node.type === "TSCallSignatureDeclaration" ||
-    node.type === "TSConstructSignatureDeclaration" ||
-    node.type === "TSConstructSignatureDeclaration" ||
-    node.type === "TSMethodSignature" ||
-    node.type === "TSConstructorType" ||
-    node.type === "TSFunctionType"
-  );
-}
-
 function handleOwnLineComment(comment, text, options, ast, isLastComment) {
   const { precedingNode, enclosingNode, followingNode } = comment;
   if (
@@ -911,6 +894,23 @@ function hasLeadingComment(node, fn = () => true) {
     return node.comments.some(comment => comment.leading && fn(comment));
   }
   return false;
+}
+
+function isRealFunctionLikeNode(node) {
+  return (
+    node.type === "ArrowFunctionExpression" ||
+    node.type === "FunctionExpression" ||
+    node.type === "FunctionDeclaration" ||
+    node.type === "ObjectMethod" ||
+    node.type === "ClassMethod" ||
+    node.type === "TSDeclareFunction" ||
+    node.type === "TSCallSignatureDeclaration" ||
+    node.type === "TSConstructSignatureDeclaration" ||
+    node.type === "TSConstructSignatureDeclaration" ||
+    node.type === "TSMethodSignature" ||
+    node.type === "TSConstructorType" ||
+    node.type === "TSFunctionType"
+  );
 }
 
 module.exports = {

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -174,7 +174,14 @@ function handleRemainingComment(comment, text, options, ast, isLastComment) {
       followingNode,
       comment
     ) ||
-    handleBreakAndContinueStatementComments(enclosingNode, comment)
+    handleBreakAndContinueStatementComments(enclosingNode, comment) ||
+    handleTSFunctionTrailingComments(
+      text,
+      enclosingNode,
+      followingNode,
+      comment,
+      options
+    )
   ) {
     return true;
   }
@@ -835,6 +842,29 @@ function handleVariableDeclaratorComments(
     return true;
   }
   return false;
+}
+
+function handleTSFunctionTrailingComments(
+  text,
+  enclosingNode,
+  followingNode,
+  comment,
+  options
+) {
+  if (
+    followingNode ||
+    !enclosingNode ||
+    enclosingNode.type !== "TSMethodSignature" ||
+    privateUtil.getNextNonSpaceNonCommentCharacter(
+      text,
+      comment,
+      options.locEnd
+    ) !== ";"
+  ) {
+    return false;
+  }
+  addTrailingComment(enclosingNode, comment);
+  return true;
 }
 
 function handleTSMappedTypeComments(

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -8,6 +8,23 @@ const {
   addDanglingComment
 } = sharedUtil;
 
+function isRealFunctionLikeNode(node) {
+  return (
+    node.type === "ArrowFunctionExpression" ||
+    node.type === "FunctionExpression" ||
+    node.type === "FunctionDeclaration" ||
+    node.type === "ObjectMethod" ||
+    node.type === "ClassMethod" ||
+    node.type === "TSDeclareFunction" ||
+    node.type === "TSCallSignatureDeclaration" ||
+    node.type === "TSConstructSignatureDeclaration" ||
+    node.type === "TSConstructSignatureDeclaration" ||
+    node.type === "TSMethodSignature" ||
+    node.type === "TSConstructorType" ||
+    node.type === "TSFunctionType"
+  );
+}
+
 function handleOwnLineComment(comment, text, options, ast, isLastComment) {
   const { precedingNode, enclosingNode, followingNode } = comment;
   if (
@@ -567,17 +584,7 @@ function handleCommentInEmptyParens(text, enclosingNode, comment, options) {
   // i.e. a function without any argument.
   if (
     enclosingNode &&
-    (((enclosingNode.type === "FunctionDeclaration" ||
-      enclosingNode.type === "FunctionExpression" ||
-      enclosingNode.type === "ArrowFunctionExpression" ||
-      enclosingNode.type === "ClassMethod" ||
-      enclosingNode.type === "ObjectMethod" ||
-      enclosingNode.type === "TSDeclareFunction" ||
-      enclosingNode.type === "TSCallSignatureDeclaration" ||
-      enclosingNode.type === "TSConstructSignatureDeclaration" ||
-      enclosingNode.type === "TSMethodSignature" ||
-      enclosingNode.type === "TSConstructorType" ||
-      enclosingNode.type === "TSFunctionType") &&
+    ((isRealFunctionLikeNode(enclosingNode) &&
       enclosingNode.params.length === 0) ||
       ((enclosingNode.type === "CallExpression" ||
         enclosingNode.type === "OptionalCallExpression" ||
@@ -625,17 +632,7 @@ function handleLastFunctionArgComments(
     (precedingNode.type === "Identifier" ||
       precedingNode.type === "AssignmentPattern") &&
     enclosingNode &&
-    (enclosingNode.type === "ArrowFunctionExpression" ||
-      enclosingNode.type === "FunctionExpression" ||
-      enclosingNode.type === "FunctionDeclaration" ||
-      enclosingNode.type === "ObjectMethod" ||
-      enclosingNode.type === "ClassMethod" ||
-      enclosingNode.type === "TSDeclareFunction" ||
-      enclosingNode.type === "TSCallSignatureDeclaration" ||
-      enclosingNode.type === "TSConstructSignatureDeclaration" ||
-      enclosingNode.type === "TSMethodSignature" ||
-      enclosingNode.type === "TSConstructorType" ||
-      enclosingNode.type === "TSFunctionType") &&
+    isRealFunctionLikeNode(enclosingNode) &&
     privateUtil.getNextNonSpaceNonCommentCharacter(
       text,
       comment,

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -563,7 +563,13 @@ function handleCommentInEmptyParens(text, enclosingNode, comment, options) {
       enclosingNode.type === "FunctionExpression" ||
       enclosingNode.type === "ArrowFunctionExpression" ||
       enclosingNode.type === "ClassMethod" ||
-      enclosingNode.type === "ObjectMethod") &&
+      enclosingNode.type === "ObjectMethod" ||
+      enclosingNode.type === "TSDeclareFunction" ||
+      enclosingNode.type === "TSCallSignatureDeclaration" ||
+      enclosingNode.type === "TSConstructSignatureDeclaration" ||
+      enclosingNode.type === "TSMethodSignature" ||
+      enclosingNode.type === "TSConstructorType" ||
+      enclosingNode.type === "TSFunctionType") &&
       enclosingNode.params.length === 0) ||
       ((enclosingNode.type === "CallExpression" ||
         enclosingNode.type === "OptionalCallExpression" ||

--- a/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
@@ -500,7 +500,7 @@ let foo10: new /* foo */ (a: /* bar */ string) /* baz */ => string;
 
 =====================================output=====================================
 interface foo1 {
-  bar /* foo */ /* bar */ /* baz */ /* bat */?();
+  bar /* foo */ /* bar */ /* bat */?(/* baz */);
 }
 
 interface foo2 {
@@ -508,7 +508,7 @@ interface foo2 {
 }
 
 interface foo3 {
-  /* foo */ (): /* bar */ /* baz */ string;
+  /* foo */ (/* bar */): /* baz */ string;
 }
 
 interface foo4 {
@@ -520,14 +520,14 @@ interface foo5 {
 }
 
 interface foo6 {
-  /* foo */ new (): /* bar */ /* baz */ /* bat */ string;
+  /* foo */ new (/* baz */): /* bar */ /* bat */ string;
 }
 
-type foo7 = /* foo */ () => /* bar */ /* baz */ void;
+type foo7 = /* foo */ (/* bar */) => /* baz */ void;
 
 type foo8 = /* foo */ (a: /* bar */ string) => /* baz */ void;
 
-let foo9: new () => /* foo */ /* bar */ /* baz */ string;
+let foo9: new (/* bar */) => /* foo */ /* baz */ string;
 
 let foo10: new (/* foo */ a: /* bar */ string) => /* baz */ string;
 

--- a/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
@@ -108,7 +108,7 @@ declare function fn(
   // TODO this is a very very very very long comment that makes it go > 80 columns
 ): number;
 
-declare function /* foo */ f(/* baz */ a /* taz */ /* bar */);
+declare function /* foo */ f(/* baz */ a /* taz */); /* bar */
 
 ================================================================================
 `;
@@ -500,6 +500,12 @@ let foo9: new /* foo */ (/* bar */) /* baz */ => string;
 
 let foo10: new /* foo */ (a: /* bar */ string) /* baz */ => string;
 
+abstract class Test {
+  abstract foo12 /* foo */ (a: /* bar */ string): /* baz */ void
+
+  abstract foo13 /* foo */ (/* bar */) /* baz */
+}
+
 =====================================output=====================================
 interface foo1 {
   bar3 /* foo */(/* baz */); // bat
@@ -534,6 +540,12 @@ type foo8 = /* foo */ (a: /* bar */ string) => /* baz */ void;
 let foo9: new (/* bar */) => /* foo */ /* baz */ string;
 
 let foo10: new (/* foo */ a: /* bar */ string) => /* baz */ string;
+
+abstract class Test {
+  abstract foo12 /* foo */(a: /* bar */ string): /* baz */ void;
+
+  abstract foo13 /* foo */(/* bar */); /* baz */
+}
 
 ================================================================================
 `;

--- a/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
@@ -101,11 +101,14 @@ declare function fn(
   // TODO this is a very very very very long comment that makes it go > 80 columns
 ): number;
 
+declare function /* foo */ f( /* baz */ a /* taz */) /* bar */;
 =====================================output=====================================
 declare function fn(
   currentRequest: { a: number }
   // TODO this is a very very very very long comment that makes it go > 80 columns
 ): number;
+
+declare function /* foo */ f(/* baz */ a /* taz */ /* bar */);
 
 ================================================================================
 `;
@@ -457,6 +460,80 @@ type M = { [m in M /* commentG */]: string };
 ================================================================================
 `;
 
+exports[`method_types.ts 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+interface foo1 {
+  bar/* foo */ ? /* bar */ (/* baz */) /* bat */;
+}
+
+interface foo2 {
+  bar/* foo */ ? /* bar */ (bar: /* baz */ string): /* bat */ string;
+}
+
+interface foo3 {
+  /* foo */ (/* bar */): /* baz */ string;
+}
+
+interface foo4 {
+  /* foo */ (bar: /* bar */ string): /* baz */ string;
+}
+
+interface foo5 {
+  /* foo */ new /* bar */  (a: /* baz */ string): /* bat */ string
+}
+
+interface foo6 {
+  /* foo */ new /* bar */ (/* baz */): /* bat */ string
+}
+
+type foo7 = /* foo */ (/* bar */) /* baz */ => void
+
+type foo8 = /* foo */ (a: /* bar */ string) /* baz */ => void
+
+let foo9: new /* foo */ (/* bar */) /* baz */ => string;
+
+let foo10: new /* foo */ (a: /* bar */ string) /* baz */ => string;
+
+=====================================output=====================================
+interface foo1 {
+  bar /* foo */ /* bar */ /* baz */ /* bat */?();
+}
+
+interface foo2 {
+  bar /* foo */?(/* bar */ bar: /* baz */ string): /* bat */ string;
+}
+
+interface foo3 {
+  /* foo */ (): /* bar */ /* baz */ string;
+}
+
+interface foo4 {
+  /* foo */ (bar: /* bar */ string): /* baz */ string;
+}
+
+interface foo5 {
+  /* foo */ new (/* bar */ a: /* baz */ string): /* bat */ string;
+}
+
+interface foo6 {
+  /* foo */ new (): /* bar */ /* baz */ /* bat */ string;
+}
+
+type foo7 = /* foo */ () => /* bar */ /* baz */ void;
+
+type foo8 = /* foo */ (a: /* bar */ string) => /* baz */ void;
+
+let foo9: new () => /* foo */ /* bar */ /* baz */ string;
+
+let foo10: new (/* foo */ a: /* bar */ string) => /* baz */ string;
+
+================================================================================
+`;
+
 exports[`methods.ts 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -508,6 +585,7 @@ export class Point {
    */
   mismatchedIndentation() {}
 
+  inline /* foo*/ (/* bar */) /* baz */ {}
 }
 
 =====================================output=====================================
@@ -555,6 +633,8 @@ export class Point {
    * Four
    */
   mismatchedIndentation() {}
+
+  inline /* foo*/(/* bar */) /* baz */ {}
 }
 
 ================================================================================

--- a/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
@@ -467,7 +467,9 @@ printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
 interface foo1 {
+  bar3/* foo */ (/* baz */) // bat
   bar/* foo */ ? /* bar */ (/* baz */) /* bat */;
+  bar2/* foo */ (/* baz */) /* bat */
 }
 
 interface foo2 {
@@ -500,7 +502,9 @@ let foo10: new /* foo */ (a: /* bar */ string) /* baz */ => string;
 
 =====================================output=====================================
 interface foo1 {
-  bar /* foo */ /* bar */ /* bat */?(/* baz */);
+  bar3 /* foo */(/* baz */); // bat
+  bar /* foo */ /* bar */?(/* baz */) /* bat */;
+  bar2 /* foo */(/* baz */) /* bat */;
 }
 
 interface foo2 {

--- a/tests/typescript_comments/declare_function.ts
+++ b/tests/typescript_comments/declare_function.ts
@@ -2,3 +2,5 @@ declare function fn(
   currentRequest: {a: number},
   // TODO this is a very very very very long comment that makes it go > 80 columns
 ): number;
+
+declare function /* foo */ f( /* baz */ a /* taz */) /* bar */;

--- a/tests/typescript_comments/method_types.ts
+++ b/tests/typescript_comments/method_types.ts
@@ -31,3 +31,9 @@ type foo8 = /* foo */ (a: /* bar */ string) /* baz */ => void
 let foo9: new /* foo */ (/* bar */) /* baz */ => string;
 
 let foo10: new /* foo */ (a: /* bar */ string) /* baz */ => string;
+
+abstract class Test {
+  abstract foo12 /* foo */ (a: /* bar */ string): /* baz */ void
+
+  abstract foo13 /* foo */ (/* bar */) /* baz */
+}

--- a/tests/typescript_comments/method_types.ts
+++ b/tests/typescript_comments/method_types.ts
@@ -1,5 +1,7 @@
 interface foo1 {
+  bar3/* foo */ (/* baz */) // bat
   bar/* foo */ ? /* bar */ (/* baz */) /* bat */;
+  bar2/* foo */ (/* baz */) /* bat */
 }
 
 interface foo2 {

--- a/tests/typescript_comments/method_types.ts
+++ b/tests/typescript_comments/method_types.ts
@@ -1,0 +1,31 @@
+interface foo1 {
+  bar/* foo */ ? /* bar */ (/* baz */) /* bat */;
+}
+
+interface foo2 {
+  bar/* foo */ ? /* bar */ (bar: /* baz */ string): /* bat */ string;
+}
+
+interface foo3 {
+  /* foo */ (/* bar */): /* baz */ string;
+}
+
+interface foo4 {
+  /* foo */ (bar: /* bar */ string): /* baz */ string;
+}
+
+interface foo5 {
+  /* foo */ new /* bar */  (a: /* baz */ string): /* bat */ string
+}
+
+interface foo6 {
+  /* foo */ new /* bar */ (/* baz */): /* bat */ string
+}
+
+type foo7 = /* foo */ (/* bar */) /* baz */ => void
+
+type foo8 = /* foo */ (a: /* bar */ string) /* baz */ => void
+
+let foo9: new /* foo */ (/* bar */) /* baz */ => string;
+
+let foo10: new /* foo */ (a: /* bar */ string) /* baz */ => string;

--- a/tests/typescript_comments/methods.ts
+++ b/tests/typescript_comments/methods.ts
@@ -43,4 +43,5 @@ export class Point {
    */
   mismatchedIndentation() {}
 
+  inline /* foo*/ (/* bar */) /* baz */ {}
 }


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
This PR fixes some of position issues with comment and fixes  #4078

Affected comments are only one from within function like nodes when there is no params provided.
Tests shows other issues that was not affected by this change.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
 