### PR TITLE
handlebars: Improve MustacheStatement printing

### DIFF
--- a/changelog_unreleased/handlebars/pr-7157.md
+++ b/changelog_unreleased/handlebars/pr-7157.md
@@ -1,0 +1,23 @@
+#### handlebars: Improve MustacheStatement printing ([#7157](https://github.com/prettier/prettier/pull/7157) by [@dcyriller](https://github.com/dcyriller))
+
+<!-- prettier-ignore -->
+```hbs
+{{!-- Options --}}
+--print-width=40
+
+{{!-- input --}}
+<p>Hi  {{firstName}}  {{lastName}}   , welcome!</p>
+
+{{!-- stable --}}
+<p>
+  Hi {{firstName}} {{lastName
+  }} , welcome!
+</p>
+
+{{!-- master --}}
+<p>
+  Hi {{firstName}} {{
+    lastName
+  }} , welcome!
+</p>
+```

--- a/changelog_unreleased/handlebars/pr-7157.md
+++ b/changelog_unreleased/handlebars/pr-7157.md
@@ -2,21 +2,18 @@
 
 <!-- prettier-ignore -->
 ```hbs
-{{!-- Options --}}
---print-width=40
-
 {{!-- input --}}
-<p>Hi  {{firstName}}  {{lastName}}   , welcome!</p>
+<p>Hi here is your name, as it will be displayed  {{firstName}}  {{lastName}}   , welcome!</p>
 
 {{!-- stable --}}
 <p>
-  Hi {{firstName}} {{lastName
+  Hi here is your name, as it will be displayed {{firstName}} {{lastName
   }} , welcome!
 </p>
 
 {{!-- master --}}
 <p>
-  Hi {{firstName}} {{
+  Hi here is your name, as it will be displayed {{firstName}} {{
     lastName
   }} , welcome!
 </p>

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -157,21 +157,26 @@ function print(path, options, print) {
       );
     }
     case "MustacheStatement": {
-      const p = path.getParentNode(0);
-      const isParentConcat = p && p.type === "ConcatStatement";
-      const isParentAttr = p && p.type === "AttrNode";
       const isEscaped = n.escaped === false;
 
       const opening = isEscaped ? "{{{" : "{{";
       const closing = isEscaped ? "}}}" : "}}";
 
-      const inner = [printPathParams(path, print)];
-      if (!isParentConcat && !isParentAttr) {
-        inner.push(softline);
-      }
+      const p = path.getParentNode(0);
+      const isParentAttr = p && p.type === "AttrNode";
+      const isParentConcat = p && p.type === "ConcatStatement";
+      const isParentElement = p && p.type === "ElementNode";
 
-      return group(concat([opening, ...inner, closing]));
+      const leading =
+        isParentAttr || isParentConcat || isParentElement
+          ? [opening, indent(softline)]
+          : [opening];
+
+      return group(
+        concat([...leading, printPathParams(path, print), softline, closing])
+      );
     }
+
     case "SubExpression": {
       const params = printParams(path, print);
       const printedParams =

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -477,7 +477,8 @@ function isWhitespaceNode(node) {
 }
 
 function isParentOfType(path, nodeType) {
-  return path && path.getParentNode(0) === nodeType;
+  const p = path.getParentNode(0);
+  return p && p.type === nodeType;
 }
 
 function getPreviousNode(path) {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -162,13 +162,10 @@ function print(path, options, print) {
       const opening = isEscaped ? "{{{" : "{{";
       const closing = isEscaped ? "}}}" : "}}";
 
-      const p = path.getParentNode(0);
-      const isParentAttr = p && p.type === "AttrNode";
-      const isParentConcat = p && p.type === "ConcatStatement";
-      const isParentElement = p && p.type === "ElementNode";
-
       const leading =
-        isParentAttr || isParentConcat || isParentElement
+        isParentOfType(path, "AttrNode") ||
+        isParentOfType(path, "ConcatStatement") ||
+        isParentOfType(path, "ElementNode")
           ? [opening, indent(softline)]
           : [opening];
 
@@ -477,6 +474,10 @@ function printCloseBlock(path, print) {
 
 function isWhitespaceNode(node) {
   return node.type === "TextNode" && !/\S/.test(node.chars);
+}
+
+function isParentOfType(path, nodeType) {
+  return path && path.getParentNode(0) === nodeType;
 }
 
 function getPreviousNode(path) {

--- a/tests/handlebars-mustache-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars-mustache-statement/__snapshots__/jsfmt.spec.js.snap
@@ -9,11 +9,45 @@ printWidth: 80
 <GlimmerComponent @progress={{aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue}}
 />
 
+<GlimmerComponent
+  class="medium"
+  @autocomplete="off"
+  @errors={{or this.aLongProperty (and this.aProperty (v-get bike "number" "message"))}}
+  data-test-beneficiary-account-number
+/>
+
+<GlimmerComponent
+  class="medium"
+  @autocomplete="off"
+  @errors={{or this.aVeryLongProperty (and this.aProperty (v-get bike "number" "message"))}}
+  data-test-beneficiary-account-number
+/>
+
 =====================================output=====================================
 <GlimmerComponent
   @progress={{
     aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue
   }}
+/>
+
+<GlimmerComponent
+  class="medium"
+  @autocomplete="off"
+  @errors={{
+    or this.aLongProperty (and this.aProperty (v-get bike "number" "message"))
+  }}
+  data-test-beneficiary-account-number
+/>
+
+<GlimmerComponent
+  class="medium"
+  @autocomplete="off"
+  @errors={{
+    or
+    this.aVeryLongProperty
+    (and this.aProperty (v-get bike "number" "message"))
+  }}
+  data-test-beneficiary-account-number
 />
 ================================================================================
 `;
@@ -28,11 +62,45 @@ singleQuote: true
 <GlimmerComponent @progress={{aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue}}
 />
 
+<GlimmerComponent
+  class="medium"
+  @autocomplete="off"
+  @errors={{or this.aLongProperty (and this.aProperty (v-get bike "number" "message"))}}
+  data-test-beneficiary-account-number
+/>
+
+<GlimmerComponent
+  class="medium"
+  @autocomplete="off"
+  @errors={{or this.aVeryLongProperty (and this.aProperty (v-get bike "number" "message"))}}
+  data-test-beneficiary-account-number
+/>
+
 =====================================output=====================================
 <GlimmerComponent
   @progress={{
     aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue
   }}
+/>
+
+<GlimmerComponent
+  class='medium'
+  @autocomplete='off'
+  @errors={{
+    or this.aLongProperty (and this.aProperty (v-get bike 'number' 'message'))
+  }}
+  data-test-beneficiary-account-number
+/>
+
+<GlimmerComponent
+  class='medium'
+  @autocomplete='off'
+  @errors={{
+    or
+    this.aVeryLongProperty
+    (and this.aProperty (v-get bike 'number' 'message'))
+  }}
+  data-test-beneficiary-account-number
 />
 ================================================================================
 `;

--- a/tests/handlebars-mustache-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars-mustache-statement/__snapshots__/jsfmt.spec.js.snap
@@ -11,7 +11,9 @@ printWidth: 80
 
 =====================================output=====================================
 <GlimmerComponent
-  @progress={{aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue}}
+  @progress={{
+    aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue
+  }}
 />
 ================================================================================
 `;
@@ -28,7 +30,9 @@ singleQuote: true
 
 =====================================output=====================================
 <GlimmerComponent
-  @progress={{aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue}}
+  @progress={{
+    aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue
+  }}
 />
 ================================================================================
 `;

--- a/tests/handlebars-mustache-statement/basics.hbs
+++ b/tests/handlebars-mustache-statement/basics.hbs
@@ -1,2 +1,16 @@
 <GlimmerComponent @progress={{aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue}}
 />
+
+<GlimmerComponent
+  class="medium"
+  @autocomplete="off"
+  @errors={{or this.aLongProperty (and this.aProperty (v-get bike "number" "message"))}}
+  data-test-beneficiary-account-number
+/>
+
+<GlimmerComponent
+  class="medium"
+  @autocomplete="off"
+  @errors={{or this.aVeryLongProperty (and this.aProperty (v-get bike "number" "message"))}}
+  data-test-beneficiary-account-number
+/>

--- a/tests/handlebars-text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars-text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -231,7 +231,8 @@ printWidth: 80
 </div>
 
 <div>
-  before {{stuff}} after {{stuff}} after {{stuff}} after {{stuff}} after {{stuff
+  before {{stuff}} after {{stuff}} after {{stuff}} after {{stuff}} after {{
+    stuff
   }} after {{stuff}} {{stuff}} {{stuff}} after {{stuff}} after
 </div>
 
@@ -320,9 +321,11 @@ printWidth: 80
 
 {{! this really should split across lines }}
 <div>
-  before{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after{{stuff
-  }}after{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after{{stuff
-  }}after{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after
+  before{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after{{
+    stuff
+  }}after{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after{{
+    stuff
+  }}after{{stuff}}after{{stuff}}after{{stuff}}after
 </div>
 
 {{! solitary whitespace }}
@@ -406,7 +409,8 @@ printWidth: 80
 
 {{! expression does not break }}
 <div>
-  texty text text text text text text text text text text text {{this.props.type
+  texty text text text text text text text text text text text {{
+    this.props.type
   }}
 </div>
 

--- a/tests/handlebars-whitespace/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars-whitespace/__snapshots__/jsfmt.spec.js.snap
@@ -118,7 +118,8 @@ hey
 
 =====================================output=====================================
 <p>
-  Hi {{firstName}} {{lastName
+  Hi {{firstName}} {{
+    lastName
   }} , welcome!
 </p>
 {{#component propA}}


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Here is the issue addressed by this PR:
```
{{!-- input --}}
<p>Hi here is your name, as it will be displayed  {{firstName}}  {{lastName}}   , welcome!</p>

{{!-- stable --}}
<p>
  Hi here is your name, as it will be displayed {{firstName}} {{lastName
  }} , welcome!
</p>

{{!-- master --}}
<p>
  Hi here is your name, as it will be displayed {{firstName}} {{
    lastName
  }} , welcome!
</p>
```

As a result, it will implement https://github.com/prettier/prettier/pull/7051#discussion_r351894842 and https://github.com/prettier/prettier/pull/7051#discussion_r351877770

It depends on [this first](https://github.com/prettier/prettier/pull/7072) and [second](https://github.com/prettier/prettier/pull/7072) PRs (they should be settled first).

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
