### PR TITLE
handlebars: Do not add line breaks in AttrNode

### DIFF
--- a/changelog_unreleased/handlebars/pr-7173.md
+++ b/changelog_unreleased/handlebars/pr-7173.md
@@ -1,0 +1,70 @@
+
+#### Do not add line breaks in AttrNode ([#7173](https://github.com/prettier/prettier/pull/7173) by [@dcyriller](https://github.com/dcyriller))
+
+<!-- prettier-ignore -->
+```hbs
+{{!-- input --}}
+<div
+  class="a-first-class
+  {{if this.optionOne 'optionOne'}}
+
+   {{if this.optionTwo 'optionTwo'}}
+
+   {{if this.optionThree 'optionThree'}}
+
+   {{if this.optionFour 'optionFour'}}
+
+   {{if this.optionFive 'optionFive'}}
+
+   {{this.class}}"
+  ...attributes
+>
+</div>
+
+{{!-- stable --}}
+<div
+  class="a-first-class
+
+    {{if this.optionOne "optionOne"}}
+
+
+
+    {{if this.optionTwo "optionTwo"}}
+
+
+
+    {{if this.optionThree "optionThree"}}
+
+
+
+    {{if this.optionFour "optionFour"}}
+
+
+
+    {{if this.optionFive "optionFive"}}
+
+
+
+    {{this.class}}"
+  ...attributes
+>
+</div>
+
+{{!-- master --}}
+<div
+  class="a-first-class
+  {{if this.optionOne 'optionOne'}}
+
+  {{if this.optionTwo 'optionTwo'}}
+
+  {{if this.optionThree 'optionThree'}}
+
+  {{if this.optionFour 'optionFour'}}
+
+  {{if this.optionFive 'optionFive'}}
+
+  {{this.class}}"
+  ...attributes
+>
+</div>
+```

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -260,6 +260,12 @@ function print(path, options, print) {
       // when next to mustache statement.
       const inAttrNode = path.stack.indexOf("attributes") >= 0;
       if (inAttrNode) {
+        // trim  leading and trailing newlines inside AttrNode
+        // these line breaks would be interpreted
+        // as a single whitespace by browsers
+        leadingLineBreaksCount = 0;
+        trailingLineBreaksCount = 0;
+
         const parentNode = path.getParentNode(0);
         const isConcat = parentNode.type === "ConcatStatement";
         if (isConcat) {

--- a/tests/flow_enums/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_enums/__snapshots__/jsfmt.spec.js.snap
@@ -85,32 +85,33 @@ enum /*Q*/ E6 of string {}
 
 =====================================output=====================================
 enum E1 {
-// B = 1,
   A = 0,
+  // B = 1,
   C = 2,
 }
 
 enum E2 of number {
-// AA = -1,
-// B = 1,
-// D = 100
+  // AA = -1,
   A = 0,
+  // B = 1,
   C = 2,
+  // D = 100
 }
 
-enum E3 /*Q*/ {}
-
-enum E4 /*Q*/ of string {
-  Foo = "foo",
+enum E3 {
+  /*Q*/
 }
 
-enum E5 of string { // Q
+enum E4 of string {
+  /*Q*/ Foo = "foo",
+}
+
+enum E5 of string {
+  // Q
   Bar = "bar",
 }
 
-enum E6 of string {
-  /*Q*/
-}
+enum /*Q*/ E6 of string {}
 
 ================================================================================
 `;

--- a/tests/flow_enums/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_enums/__snapshots__/jsfmt.spec.js.snap
@@ -85,33 +85,32 @@ enum /*Q*/ E6 of string {}
 
 =====================================output=====================================
 enum E1 {
+// B = 1,
   A = 0,
-  // B = 1,
   C = 2,
 }
 
 enum E2 of number {
-  // AA = -1,
+// AA = -1,
+// B = 1,
+// D = 100
   A = 0,
-  // B = 1,
   C = 2,
-  // D = 100
 }
 
-enum E3 {
-  /*Q*/
+enum E3 /*Q*/ {}
+
+enum E4 /*Q*/ of string {
+  Foo = "foo",
 }
 
-enum E4 of string {
-  /*Q*/ Foo = "foo",
-}
-
-enum E5 of string {
-  // Q
+enum E5 of string { // Q
   Bar = "bar",
 }
 
-enum /*Q*/ E6 of string {}
+enum E6 of string {
+  /*Q*/
+}
 
 ================================================================================
 `;

--- a/tests/handlebars-attr-node/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars-attr-node/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,86 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`basics.hbs 1`] = `
+====================================options=====================================
+parsers: ["glimmer"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<input name=address maxlength=200>
+<input name='address' maxlength='200'>
+<input name="address" maxlength="200">
+<div class="foo"></div>
+<div   class="foo"   ></div>
+<div class="foo bar"></div>
+<div class="foo bar" id="header"></div>
+<div   class="foo bar"   id="header"   ></div>
+<div data-prettier></div>
+<div data-prettier="true"></div>
+<meta property="og:description" content="The Mozilla Developer Network (MDN) provides
+information about Open Web technologies including HTML, CSS, and APIs for both Web sites
+and HTML5 Apps. It also documents Mozilla products, like Firefox OS.">
+
+=====================================output=====================================
+<input name="address" maxlength="200" />
+<input name="address" maxlength="200" />
+<input name="address" maxlength="200" />
+<div class="foo"></div>
+<div class="foo"></div>
+<div class="foo bar"></div>
+<div class="foo bar" id="header"></div>
+<div class="foo bar" id="header"></div>
+<div data-prettier></div>
+<div data-prettier="true"></div>
+<meta
+  property="og:description"
+  content="The Mozilla Developer Network (MDN) provides
+information about Open Web technologies including HTML, CSS, and APIs for both Web sites
+and HTML5 Apps. It also documents Mozilla products, like Firefox OS."
+/>
+================================================================================
+`;
+
+exports[`basics.hbs 2`] = `
+====================================options=====================================
+parsers: ["glimmer"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+<input name=address maxlength=200>
+<input name='address' maxlength='200'>
+<input name="address" maxlength="200">
+<div class="foo"></div>
+<div   class="foo"   ></div>
+<div class="foo bar"></div>
+<div class="foo bar" id="header"></div>
+<div   class="foo bar"   id="header"   ></div>
+<div data-prettier></div>
+<div data-prettier="true"></div>
+<meta property="og:description" content="The Mozilla Developer Network (MDN) provides
+information about Open Web technologies including HTML, CSS, and APIs for both Web sites
+and HTML5 Apps. It also documents Mozilla products, like Firefox OS.">
+
+=====================================output=====================================
+<input name='address' maxlength='200' />
+<input name='address' maxlength='200' />
+<input name='address' maxlength='200' />
+<div class='foo'></div>
+<div class='foo'></div>
+<div class='foo bar'></div>
+<div class='foo bar' id='header'></div>
+<div class='foo bar' id='header'></div>
+<div data-prettier></div>
+<div data-prettier='true'></div>
+<meta
+  property='og:description'
+  content='The Mozilla Developer Network (MDN) provides
+information about Open Web technologies including HTML, CSS, and APIs for both Web sites
+and HTML5 Apps. It also documents Mozilla products, like Firefox OS.'
+/>
+================================================================================
+`;
+
 exports[`brackets.hbs 1`] = `
 ====================================options=====================================
 parsers: ["glimmer"]

--- a/tests/handlebars-attr-node/basics.hbs
+++ b/tests/handlebars-attr-node/basics.hbs
@@ -1,0 +1,13 @@
+<input name=address maxlength=200>
+<input name='address' maxlength='200'>
+<input name="address" maxlength="200">
+<div class="foo"></div>
+<div   class="foo"   ></div>
+<div class="foo bar"></div>
+<div class="foo bar" id="header"></div>
+<div   class="foo bar"   id="header"   ></div>
+<div data-prettier></div>
+<div data-prettier="true"></div>
+<meta property="og:description" content="The Mozilla Developer Network (MDN) provides
+information about Open Web technologies including HTML, CSS, and APIs for both Web sites
+and HTML5 Apps. It also documents Mozilla products, like Firefox OS.">

--- a/tests/handlebars-mustache-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars-mustache-statement/__snapshots__/jsfmt.spec.js.snap
@@ -35,18 +35,19 @@ printWidth: 80
 
 <div
   class="a-first-class
-    {{if this.optionOne "optionOne"}}
-    
-    {{if this.optionTwo "optionTwo"}}
-    
-    {{if this.optionThree "optionThree"}}
-    
-    {{if this.optionFour "optionFour"}}
-    
-    {{if this.optionFive "optionFive"}}
-    
-    {{this.class}}"
-  ...attributes >
+  {{if this.optionOne 'optionOne'}}
+
+   {{if this.optionTwo 'optionTwo'}}
+
+   {{if this.optionThree 'optionThree'}}
+
+   {{if this.optionFour 'optionFour'}}
+
+   {{if this.optionFive 'optionFive'}}
+
+   {{this.class}}"
+  ...attributes
+>
 </div>
 
 =====================================output=====================================
@@ -154,18 +155,19 @@ singleQuote: true
 
 <div
   class="a-first-class
-    {{if this.optionOne "optionOne"}}
-    
-    {{if this.optionTwo "optionTwo"}}
-    
-    {{if this.optionThree "optionThree"}}
-    
-    {{if this.optionFour "optionFour"}}
-    
-    {{if this.optionFive "optionFive"}}
-    
-    {{this.class}}"
-  ...attributes >
+  {{if this.optionOne 'optionOne'}}
+
+   {{if this.optionTwo 'optionTwo'}}
+
+   {{if this.optionThree 'optionThree'}}
+
+   {{if this.optionFour 'optionFour'}}
+
+   {{if this.optionFive 'optionFive'}}
+
+   {{this.class}}"
+  ...attributes
+>
 </div>
 
 =====================================output=====================================

--- a/tests/handlebars-mustache-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars-mustache-statement/__snapshots__/jsfmt.spec.js.snap
@@ -85,8 +85,9 @@ printWidth: 80
 </div>
 
 <div
-  class="a multi line list of classes with a complex mustache statement
-  {{if (or this.a this.b) this.c this.d}}"
+  class="a multi line list of classes with a complex mustache statement {{
+    if (or this.a this.b) this.c this.d
+  }}"
 >
 </div>
 
@@ -101,18 +102,11 @@ printWidth: 80
 </div>
 
 <div
-  class="a-first-class
-  {{if this.optionOne "optionOne"}}
-
-   {{if this.optionTwo "optionTwo"}}
-
-   {{if this.optionThree "optionThree"}}
-
-   {{if this.optionFour "optionFour"}}
-
-   {{if this.optionFive "optionFive"}}
-
-   {{this.class}}"
+  class="a-first-class {{if this.optionOne "optionOne"}} {{
+    if this.optionTwo "optionTwo"
+  }} {{if this.optionThree "optionThree"}} {{
+    if this.optionFour "optionFour"
+  }} {{if this.optionFive "optionFive"}} {{this.class}}"
   ...attributes
 >
 </div>
@@ -205,8 +199,9 @@ singleQuote: true
 </div>
 
 <div
-  class="a multi line list of classes with a complex mustache statement
-  {{if (or this.a this.b) this.c this.d}}"
+  class="a multi line list of classes with a complex mustache statement {{
+    if (or this.a this.b) this.c this.d
+  }}"
 >
 </div>
 
@@ -221,18 +216,11 @@ singleQuote: true
 </div>
 
 <div
-  class="a-first-class
-  {{if this.optionOne 'optionOne'}}
-
-   {{if this.optionTwo 'optionTwo'}}
-
-   {{if this.optionThree 'optionThree'}}
-
-   {{if this.optionFour 'optionFour'}}
-
-   {{if this.optionFive 'optionFive'}}
-
-   {{this.class}}"
+  class="a-first-class {{if this.optionOne 'optionOne'}} {{
+    if this.optionTwo 'optionTwo'
+  }} {{if this.optionThree 'optionThree'}} {{
+    if this.optionFour 'optionFour'
+  }} {{if this.optionFive 'optionFive'}} {{this.class}}"
   ...attributes
 >
 </div>

--- a/tests/handlebars-mustache-statement/basics.hbs
+++ b/tests/handlebars-mustache-statement/basics.hbs
@@ -27,16 +27,17 @@
 
 <div
   class="a-first-class
-    {{if this.optionOne "optionOne"}}
-    
-    {{if this.optionTwo "optionTwo"}}
-    
-    {{if this.optionThree "optionThree"}}
-    
-    {{if this.optionFour "optionFour"}}
-    
-    {{if this.optionFive "optionFive"}}
-    
-    {{this.class}}"
-  ...attributes >
+  {{if this.optionOne 'optionOne'}}
+
+   {{if this.optionTwo 'optionTwo'}}
+
+   {{if this.optionThree 'optionThree'}}
+
+   {{if this.optionFour 'optionFour'}}
+
+   {{if this.optionFive 'optionFive'}}
+
+   {{this.class}}"
+  ...attributes
+>
 </div>


### PR DESCRIPTION
### description
On master, glimmer printer inserts additional line breaks in AttrNodes when there is existing line breaks. This PRs fixes this bug.

The PR also takes tests from HTML printer to increase AttrNode test coverage.

As usual, the review will be easier commit by commit.

Will close https://github.com/prettier/prettier/issues/6207

### summary
<!-- Please provide a brief summary of your changes: -->
```hbs
{{!-- input --}}
<div
  class="a-first-class
  {{if this.optionOne 'optionOne'}}

   {{if this.optionTwo 'optionTwo'}}

   {{if this.optionThree 'optionThree'}}

   {{if this.optionFour 'optionFour'}}

   {{if this.optionFive 'optionFive'}}

   {{this.class}}"
  ...attributes
>
</div>

{{!-- stable --}}
<div
  class="a-first-class

    {{if this.optionOne "optionOne"}}



    {{if this.optionTwo "optionTwo"}}



    {{if this.optionThree "optionThree"}}



    {{if this.optionFour "optionFour"}}



    {{if this.optionFive "optionFive"}}



    {{this.class}}"
  ...attributes
>
</div>

{{!-- master --}}
<div
  class="a-first-class
  {{if this.optionOne 'optionOne'}}

  {{if this.optionTwo 'optionTwo'}}

  {{if this.optionThree 'optionThree'}}

  {{if this.optionFour 'optionFour'}}

  {{if this.optionFive 'optionFive'}}

  {{this.class}}"
  ...attributes
>
</div>
```

### checklist
<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
