### PR TITLE
Markdown: fix HTML formatting broken if the beginning tag starts after a list item

### DIFF
--- a/changelog_unreleased/markdown/pr-7181.md
+++ b/changelog_unreleased/markdown/pr-7181.md
@@ -1,5 +1,7 @@
 #### fix HTML formatting broken if the beginning tag starts after a list item ([#7181](https://github.com/prettier/prettier/pull/7181) by [@sasurau4](https://github.com/sasurau4))
 
+Previously, when Prettier format the html tag that starts after a list item, it would insert indent and break the relationship of open and close tag. Now, Prettier no longer change anything.
+
 <!-- prettier-ignore -->
 ```md
 <!-- Input -->

--- a/changelog_unreleased/markdown/pr-7181.md
+++ b/changelog_unreleased/markdown/pr-7181.md
@@ -1,0 +1,36 @@
+#### (Markdown: fix HTML formatting broken if the beginning tag starts after a list item [#7181](https://github.com/prettier/prettier/pull/7181) by [@sasurau4](https://github.com/sasurau4))
+
+<!-- prettier-ignore -->
+```md
+<!-- Input -->
+- A list item.
+<details><summary>Summary</summary>
+<p>
+
+- A list item.
+
+</p>
+</details>
+
+<!-- Prettier stable -->
+- A list item.
+
+  <details><summary>Summary</summary>
+  <p>
+
+- A list item.
+
+</p>
+</details>
+
+<!-- Prettier master -->
+- A list item.
+
+<details><summary>Summary</summary>
+<p>
+
+- A list item.
+
+</p>
+</details>
+```

--- a/changelog_unreleased/markdown/pr-7181.md
+++ b/changelog_unreleased/markdown/pr-7181.md
@@ -25,7 +25,6 @@
 
 <!-- Prettier master -->
 - A list item.
-
 <details><summary>Summary</summary>
 <p>
 

--- a/changelog_unreleased/markdown/pr-7181.md
+++ b/changelog_unreleased/markdown/pr-7181.md
@@ -1,4 +1,4 @@
-#### (Markdown: fix HTML formatting broken if the beginning tag starts after a list item [#7181](https://github.com/prettier/prettier/pull/7181) by [@sasurau4](https://github.com/sasurau4))
+#### fix HTML formatting broken if the beginning tag starts after a list item ([#7181](https://github.com/prettier/prettier/pull/7181) by [@sasurau4](https://github.com/sasurau4))
 
 <!-- prettier-ignore -->
 ```md

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -254,12 +254,27 @@ function genericPrint(path, options, print) {
       return printChildren(path, options, print, {
         processor: (childPath, index) => {
           const prefix = getPrefix();
+          const childNode = childPath.getValue();
+
+          if (
+            childNode.children.length === 1 ||
+            childNode.children.every(
+              child =>
+                child.type !== "html" ||
+                child.position.indent.every(indent => indent !== 1)
+            )
+          ) {
+            return concat([
+              prefix,
+              align(
+                " ".repeat(prefix.length),
+                printListItem(childPath, options, print, prefix)
+              )
+            ]);
+          }
           return concat([
             prefix,
-            align(
-              " ".repeat(prefix.length),
-              printListItem(childPath, options, print, prefix)
-            )
+            printListItem(childPath, options, print, prefix)
           ]);
 
           function getPrefix() {

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -257,24 +257,22 @@ function genericPrint(path, options, print) {
           const childNode = childPath.getValue();
 
           if (
-            childNode.children.length === 1 ||
-            childNode.children.every(
-              child =>
-                child.type !== "html" ||
-                child.position.indent.every(indent => indent !== 1)
-            )
+            childNode.children.length === 2 &&
+            childNode.children[1].type === "html" &&
+            childNode.children[1].position.indent.every(indent => indent === 1)
           ) {
             return concat([
               prefix,
-              align(
-                " ".repeat(prefix.length),
-                printListItem(childPath, options, print, prefix)
-              )
+              printListItem(childPath, options, print, prefix)
             ]);
           }
+
           return concat([
             prefix,
-            printListItem(childPath, options, print, prefix)
+            align(
+              " ".repeat(prefix.length),
+              printListItem(childPath, options, print, prefix)
+            )
           ]);
 
           function getPrefix() {

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -809,13 +809,21 @@ function shouldPrePrintDoubleHardline(node, data) {
     data.prevNode.type === "html" &&
     data.prevNode.position.end.line + 1 === node.position.start.line;
 
+  const isHtmlDirectAfterListItem =
+    node.type === "html" &&
+    data.parentNode.type === "listItem" &&
+    data.prevNode &&
+    data.prevNode.type === "paragraph" &&
+    data.prevNode.position.end.line + 1 === node.position.start.line;
+
   return (
     isPrevNodeLooseListItem ||
     !(
       isSiblingNode ||
       isInTightListItem ||
       isPrevNodePrettierIgnore ||
-      isBlockHtmlWithoutBlankLineBetweenPrevHtml
+      isBlockHtmlWithoutBlankLineBetweenPrevHtml ||
+      isHtmlDirectAfterListItem
     )
   );
 }

--- a/tests/markdown_html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_html/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`beginning-tag-after-a-list-item.md 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+printWidth: 80
+proseWrap: "always"
+                                                                                | printWidth
+=====================================input======================================
+- A list item.
+<details><summary>Summary</summary>
+<p>
+
+- A list item.
+
+</p>
+</details>
+
+=====================================output=====================================
+- A list item.
+
+<details><summary>Summary</summary>
+<p>
+
+- A list item.
+
+</p>
+</details>
+
+================================================================================
+`;
+
 exports[`blank-line-between-htmls.md 1`] = `
 ====================================options=====================================
 parsers: ["markdown"]

--- a/tests/markdown_html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_html/__snapshots__/jsfmt.spec.js.snap
@@ -16,6 +16,13 @@ proseWrap: "always"
 </p>
 </details>
 
+- A list item.
+<blockquote>
+
+<p>quoted sentence1<br>
+quoted sentence2</p>
+</blockquote>
+
 =====================================output=====================================
 - A list item.
 <details><summary>Summary</summary>
@@ -25,6 +32,13 @@ proseWrap: "always"
 
 </p>
 </details>
+
+- A list item.
+<blockquote>
+
+<p>quoted sentence1<br>
+quoted sentence2</p>
+</blockquote>
 
 ================================================================================
 `;

--- a/tests/markdown_html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_html/__snapshots__/jsfmt.spec.js.snap
@@ -18,7 +18,6 @@ proseWrap: "always"
 
 =====================================output=====================================
 - A list item.
-
 <details><summary>Summary</summary>
 <p>
 

--- a/tests/markdown_html/beginning-tag-after-a-list-item.md
+++ b/tests/markdown_html/beginning-tag-after-a-list-item.md
@@ -1,0 +1,8 @@
+- A list item.
+<details><summary>Summary</summary>
+<p>
+
+- A list item.
+
+</p>
+</details>

--- a/tests/markdown_html/beginning-tag-after-a-list-item.md
+++ b/tests/markdown_html/beginning-tag-after-a-list-item.md
@@ -6,3 +6,10 @@
 
 </p>
 </details>
+
+- A list item.
+<blockquote>
+
+<p>quoted sentence1<br>
+quoted sentence2</p>
+</blockquote>


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

fix #5907

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**


## Note

I apologize for making mistakes creating a lot of troublesome PRs (#7182 - #7201) and sending unnecessary notifications to repository watchers and maintainers :bowing_man: 
 