### PR TITLE
Markdown: fix incorrect prettification of multi-line markdown footnote

### DIFF
--- a/changelog_unreleased/markdown/pr-7203.md
+++ b/changelog_unreleased/markdown/pr-7203.md
@@ -1,4 +1,4 @@
-#### Markdown: fix incorrect prettification of multi-line markdown footnote ([#7203](https://github.com/prettier/prettier/pull/7203) by [@sasurau4](https://github.com/sasurau4))
+#### Fix incorrect prettification of multi-line markdown footnote ([#7203](https://github.com/prettier/prettier/pull/7203) by [@sasurau4](https://github.com/sasurau4))
 
 <!-- prettier-ignore -->
 ```md

--- a/changelog_unreleased/markdown/pr-7203.md
+++ b/changelog_unreleased/markdown/pr-7203.md
@@ -1,0 +1,26 @@
+#### Markdown: fix incorrect prettification of multi-line markdown footnote ([#7203](https://github.com/prettier/prettier/pull/7203) by [@sasurau4](https://github.com/sasurau4))
+
+<!-- prettier-ignore -->
+```md
+<!-- Input -->
+Here's a statement[^footnote].
+
+[^footnote]:
+    Here's a multi-line footnote walking back the above statement, and showing
+    how it's all totally bollocks.
+
+<!-- Prettier stable -->
+Here's a statement[^footnote].
+
+[^footnote]:
+
+  Here's a multi-line footnote walking back the above statement, and showing
+  how it's all totally bollocks.
+
+<!-- Prettier master -->
+Here's a statement[^footnote].
+
+[^footnote]:
+  Here's a multi-line footnote walking back the above statement, and showing
+  how it's all totally bollocks.
+```

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -358,24 +358,8 @@ function genericPrint(path, options, print) {
                   " ".repeat(options.tabWidth),
                   printChildren(path, options, print, {
                     processor: (childPath, index) => {
-                      const node = path.getValue();
-                      const isMultilineFootnote =
-                        node.children &&
-                        node.children[0].children &&
-                        node.children[0].children.some(
-                          child => child.value === "\n"
-                        );
-
                       return index === 0
-                        ? isMultilineFootnote
-                          ? group(concat([softline, childPath.call(print)]))
-                          : group(
-                              concat([
-                                softline,
-                                softline,
-                                childPath.call(print)
-                              ])
-                            )
+                        ? group(concat([softline, childPath.call(print)]))
                         : childPath.call(print);
                     }
                   })

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -357,12 +357,27 @@ function genericPrint(path, options, print) {
                 align(
                   " ".repeat(options.tabWidth),
                   printChildren(path, options, print, {
-                    processor: (childPath, index) =>
-                      index === 0
-                        ? group(
-                            concat([softline, softline, childPath.call(print)])
-                          )
-                        : childPath.call(print)
+                    processor: (childPath, index) => {
+                      const node = path.getValue();
+                      const isMultilineFootnote =
+                        node.children &&
+                        node.children[0].children &&
+                        node.children[0].children.some(
+                          child => child.value === "\n"
+                        );
+
+                      return index === 0
+                        ? isMultilineFootnote
+                          ? group(concat([softline, childPath.call(print)]))
+                          : group(
+                              concat([
+                                softline,
+                                softline,
+                                childPath.call(print)
+                              ])
+                            )
+                        : childPath.call(print);
+                    }
                   })
                 ),
                 nextNode && nextNode.type === "footnoteDefinition"

--- a/tests/markdown_footnoteDefinition/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_footnoteDefinition/__snapshots__/jsfmt.spec.js.snap
@@ -13,7 +13,6 @@ proseWrap: "always"
 
 =====================================output=====================================
 [^hello]:
-
   this is a long long long long long long long long long long long long long
   paragraph.
 
@@ -96,7 +95,6 @@ proseWrap: "always"
 
 =====================================output=====================================
 [^fn1]:
-
   > \`\`\`rs
   > fn main() {
   >     println!("this is some Rust!");
@@ -112,7 +110,6 @@ proseWrap: "always"
   \`\`\`
 
 [^fn2]:
-
   Here is a footnote which includes code. Here is a footnote which includes
   code. Here is a footnote which includes code.
 
@@ -158,7 +155,6 @@ proseWrap: "never"
 
 =====================================output=====================================
 [^fn1]:
-
   > \`\`\`rs
   > fn main() {
   >     println!("this is some Rust!");
@@ -174,7 +170,6 @@ proseWrap: "never"
   \`\`\`
 
 [^fn2]:
-
   Here is a footnote which includes code. Here is a footnote which includes code. Here is a footnote which includes code.
 
   \`\`\`rs
@@ -219,7 +214,6 @@ proseWrap: "preserve"
 
 =====================================output=====================================
 [^fn1]:
-
   > \`\`\`rs
   > fn main() {
   >     println!("this is some Rust!");
@@ -235,7 +229,6 @@ proseWrap: "preserve"
   \`\`\`
 
 [^fn2]:
-
   Here is a footnote which includes code. Here is a footnote which includes code. Here is a footnote which includes code.
 
   \`\`\`rs
@@ -295,13 +288,11 @@ proseWrap: "always"
 [^a]: a
 [^a]: a
 [^a]:
-
   > 123\\
   > 456
 
 [^a]: a
 [^a]:
-
   > 123\\
   > 456
 
@@ -360,13 +351,11 @@ proseWrap: "never"
 [^a]: a
 [^a]: a
 [^a]:
-
   > 123\\
   > 456
 
 [^a]: a
 [^a]:
-
   > 123\\
   > 456
 
@@ -425,13 +414,11 @@ proseWrap: "preserve"
 [^a]: a
 [^a]: a
 [^a]:
-
   > 123\\
   > 456
 
 [^a]: a
 [^a]:
-
   > 123\\
   > 456
 

--- a/tests/markdown_footnoteDefinition/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown_footnoteDefinition/__snapshots__/jsfmt.spec.js.snap
@@ -18,7 +18,6 @@ proseWrap: "always"
   paragraph.
 
 [^world]:
-
   this is a long long long long long long long long long long long long long
   paragraph. this is a long long long long long long long long long long long
   long long paragraph.
@@ -58,7 +57,6 @@ proseWrap: "preserve"
 =====================================output=====================================
 [^hello]: this is a long long long long long long long long long long long long long paragraph.
 [^world]:
-
   this is a long long long long long long long long long long long long long paragraph.
   this is a long long long long long long long long long long long long long paragraph.
 


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

fix #5958

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
