### PR TITLE
javascript: fix Template strings aren't moved to new line, where '' or "" strings are

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5740,7 +5740,8 @@ function printAssignmentRight(leftNode, rightNode, printedRight, options) {
       // do not put values on a separate line from the key in json
       options.parser !== "json" &&
       options.parser !== "json5") ||
-    rightNode.type === "SequenceExpression";
+    rightNode.type === "SequenceExpression" ||
+    (leftNode.type === "Identifier" && rightNode.type === "TemplateLiteral");
 
   if (canBreak) {
     return group(indent(concat([line, printedRight])));

--- a/tests/angular_component_examples/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/angular_component_examples/__snapshots__/jsfmt.spec.js.snap
@@ -27,11 +27,12 @@ class     TestComponent {}
 =====================================output=====================================
 @Component({
   selector: "app-test",
-  template: \`
-    <ul>
-      <li>test</li>
-    </ul>
-  \`,
+  template:
+    \`
+      <ul>
+        <li>test</li>
+      </ul>
+    \`,
   styles: [
     \`
       :host {
@@ -76,11 +77,12 @@ class     TestComponent {}
 =====================================output=====================================
 @Component({
   selector: "app-test",
-  template: \`
-    <ul>
-      <li>test</li>
-    </ul>
-  \`,
+  template:
+    \`
+      <ul>
+        <li>test</li>
+      </ul>
+    \`,
   styles: [
     \`
       :host {

--- a/tests/decorators-ts/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/decorators-ts/__snapshots__/jsfmt.spec.js.snap
@@ -66,9 +66,10 @@ export class HeroButtonComponent {
 =====================================output=====================================
 @Component({
   selector: "toh-hero-button",
-  template: \`
-    <button>{{ label }}</button>
-  \`
+  template:
+    \`
+      <button>{{ label }}</button>
+    \`
 })
 export class HeroButtonComponent {
   @Output() change = new EventEmitter<any>();

--- a/tests/multiparser_js_graphql/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_graphql/__snapshots__/jsfmt.spec.js.snap
@@ -17,15 +17,16 @@ const query = /* GraphQL */\`
 \`;
 
 =====================================output=====================================
-const query = /* GraphQL */ \`
-  {
-    user(id: 5) {
-      firstName
+const query =
+  /* GraphQL */ \`
+    {
+      user(id: 5) {
+        firstName
 
-      lastName
+        lastName
+      }
     }
-  }
-\`;
+  \`;
 
 ================================================================================
 `;

--- a/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_html/__snapshots__/jsfmt.spec.js.snap
@@ -112,9 +112,10 @@ customElements.define("my-element", MyElement);
 const someHtml1 = html\`
   <div>hello \${world}</div>
 \`;
-const someHtml2 = /* HTML */ \`
-  <div>hello \${world}</div>
-\`;
+const someHtml2 =
+  /* HTML */ \`
+    <div>hello \${world}</div>
+  \`;
 
 html\`\`;
 
@@ -146,28 +147,32 @@ const trickyParens = html\`
     f((\${expr}) / 2);
   </script>
 \`;
-const nestedFun = /* HTML */ \`
-  \${outerExpr(1)}
-  <script>
-    const tpl = html\\\`
-      <div>\\\${innerExpr(1)} \${outerExpr(2)}</div>
-    \\\`;
-  </script>
-\`;
+const nestedFun =
+  /* HTML */ \`
+    \${outerExpr(1)}
+    <script>
+      const tpl = html\\\`
+        <div>\\\${innerExpr(1)} \${outerExpr(2)}</div>
+      \\\`;
+    </script>
+  \`;
 
-const closingScriptTagShouldBeEscapedProperly = /* HTML */ \`
-  <script>
-    const html = /* HTML */ \\\`
-      <script><\\\\/script>
-    \\\`;
-  </script>
-\`;
+const closingScriptTagShouldBeEscapedProperly =
+  /* HTML */ \`
+    <script>
+      const html =
+        /* HTML */ \\\`
+          <script><\\\\/script>
+        \\\`;
+    </script>
+  \`;
 
-const closingScriptTag2 = /* HTML */ \`
-  <script>
-    const scriptTag = "<\\\\/script>";
-  </script>
-\`;
+const closingScriptTag2 =
+  /* HTML */ \`
+    <script>
+      const scriptTag = "<\\\\/script>";
+    </script>
+  \`;
 
 ================================================================================
 `;

--- a/tests/object-prop-break-in/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/object-prop-break-in/__snapshots__/jsfmt.spec.js.snap
@@ -113,7 +113,8 @@ const g = classnames({
 
 const h = {
   foo: "bar",
-  baz: \`Lorem
+  baz:
+    \`Lorem
 ipsum\`
 };
 

--- a/tests/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/strings/__snapshots__/jsfmt.spec.js.snap
@@ -196,28 +196,29 @@ foo(
   } with expr\`
 );
 
-const x = \`a long string \${
-  1 +
-  2 +
-  3 +
-  2 +
-  3 +
-  2 +
-  3 +
-  2 +
-  3 +
-  2 +
-  3 +
-  2 +
-  (function() {
-    return 3;
-  })() +
-  3 +
-  2 +
-  3 +
-  2 +
-  3
-} with expr\`;
+const x =
+  \`a long string \${
+    1 +
+    2 +
+    3 +
+    2 +
+    3 +
+    2 +
+    3 +
+    2 +
+    3 +
+    2 +
+    3 +
+    2 +
+    (function() {
+      return 3;
+    })() +
+    3 +
+    2 +
+    3 +
+    2 +
+    3
+  } with expr\`;
 
 foo(
   \`a long string \${
@@ -253,19 +254,20 @@ pipe.write(
 );
 
 // https://github.com/prettier/prettier/issues/1662#issue-230406820
-const content = \`
+const content =
+  \`
 const env = \${JSON.stringify(
-  {
-    assetsRootUrl: env.assetsRootUrl,
-    env: env.env,
-    role: "client",
-    adsfafa: "sdfsdff",
-    asdfasff: "wefwefw",
-    fefef: "sf sdfs fdsfdsf s dfsfds"
-  },
-  null,
-  "\\t"
-)});
+    {
+      assetsRootUrl: env.assetsRootUrl,
+      env: env.env,
+      role: "client",
+      adsfafa: "sdfsdff",
+      asdfasff: "wefwefw",
+      fefef: "sf sdfs fdsfdsf s dfsfds"
+    },
+    null,
+    "\\t"
+  )});
 \`;
 
 // https://github.com/prettier/prettier/issues/821#issue-210557749
@@ -380,28 +382,29 @@ foo(
   } with expr\`,
 );
 
-const x = \`a long string \${
-  1 +
-  2 +
-  3 +
-  2 +
-  3 +
-  2 +
-  3 +
-  2 +
-  3 +
-  2 +
-  3 +
-  2 +
-  (function() {
-    return 3;
-  })() +
-  3 +
-  2 +
-  3 +
-  2 +
-  3
-} with expr\`;
+const x =
+  \`a long string \${
+    1 +
+    2 +
+    3 +
+    2 +
+    3 +
+    2 +
+    3 +
+    2 +
+    3 +
+    2 +
+    3 +
+    2 +
+    (function() {
+      return 3;
+    })() +
+    3 +
+    2 +
+    3 +
+    2 +
+    3
+  } with expr\`;
 
 foo(
   \`a long string \${
@@ -437,19 +440,20 @@ pipe.write(
 );
 
 // https://github.com/prettier/prettier/issues/1662#issue-230406820
-const content = \`
+const content =
+  \`
 const env = \${JSON.stringify(
-  {
-    assetsRootUrl: env.assetsRootUrl,
-    env: env.env,
-    role: "client",
-    adsfafa: "sdfsdff",
-    asdfasff: "wefwefw",
-    fefef: "sf sdfs fdsfdsf s dfsfds",
-  },
-  null,
-  "\\t",
-)});
+    {
+      assetsRootUrl: env.assetsRootUrl,
+      env: env.env,
+      role: "client",
+      adsfafa: "sdfsdff",
+      asdfasff: "wefwefw",
+      fefef: "sf sdfs fdsfdsf s dfsfds",
+    },
+    null,
+    "\\t",
+  )});
 \`;
 
 // https://github.com/prettier/prettier/issues/821#issue-210557749

--- a/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/template_literals/__snapshots__/jsfmt.spec.js.snap
@@ -165,24 +165,31 @@ descirbe('something', () => {
 throw new Error(\`pretty-format: Option "theme" has a key "\${key}" whose value "\${value}" is undefined in ansi-styles.\`,)
 
 =====================================output=====================================
-const long1 = \`long \${
-  a.b //comment
-} long longlong \${a.b.c.d.e} long longlong \${a.b.c.d.e} long longlong \${
-  a.b.c.d.e
-} long long\`;
-const long2 = \`long \${a.b.c.d.e} long longlong \${loooooooooooooooooong} long longlong \${loooooooooooooooooong} long longlong \${loooooooooooooooooong} long long\`;
+const long1 =
+  \`long \${
+    a.b //comment
+  } long longlong \${a.b.c.d.e} long longlong \${a.b.c.d.e} long longlong \${
+    a.b.c.d.e
+  } long long\`;
+const long2 =
+  \`long \${a.b.c.d.e} long longlong \${loooooooooooooooooong} long longlong \${loooooooooooooooooong} long longlong \${loooooooooooooooooong} long long\`;
 
-const long3 = \`long long long long long long long long long long long \${a.b.c.d.e} long long long long long long long long long long long long long\`;
+const long3 =
+  \`long long long long long long long long long long long \${a.b.c.d.e} long long long long long long long long long long long long long\`;
 
-const description = \`The value of the \${cssName} css of the \${this._name} element\`;
+const description =
+  \`The value of the \${cssName} css of the \${this._name} element\`;
 
-const foo = \`such a long template string \${foo.bar.baz} that prettier will want to wrap it\`;
+const foo =
+  \`such a long template string \${foo.bar.baz} that prettier will want to wrap it\`;
 
-const shouldWrapForNow = \`such a long template string \${
-  foo().bar.baz
-} that prettier will want to wrap it\`;
+const shouldWrapForNow =
+  \`such a long template string \${
+    foo().bar.baz
+  } that prettier will want to wrap it\`;
 
-const shouldNotWrap = \`simple expressions should not break \${this} \${variable} \${a.b.c} \${this.b.c} \${a[b].c} \${a.b[c]} \${a.b["c"]} \${a?.b?.c}\`;
+const shouldNotWrap =
+  \`simple expressions should not break \${this} \${variable} \${a.b.c} \${this.b.c} \${a[b].c} \${a.b[c]} \${a.b["c"]} \${a?.b?.c}\`;
 
 console.log(
   chalk.white(
@@ -190,9 +197,10 @@ console.log(
   )
 );
 
-x = \`mdl-textfield mdl-js-textfield \${className} \${
-  content.length > 0 ? "is-dirty" : ""
-} combo-box__input\`;
+x =
+  \`mdl-textfield mdl-js-textfield \${className} \${
+    content.length > 0 ? "is-dirty" : ""
+  } combo-box__input\`;
 
 function testing() {
   const p = {};

--- a/tests/typescript_template_literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_template_literals/__snapshots__/jsfmt.spec.js.snap
@@ -14,19 +14,17 @@ const b = \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVe
 
 =====================================output=====================================
 const a = \`\${(foo + bar) as baz}\`;
-const b = \`\${
-  (veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + bar) as baz
-}\`;
-const b = \`\${
-  (foo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) as baz
-}\`;
-const b = \`\${
-  (foo + bar) as veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz
-}\`;
-const b = \`\${
-  (veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo +
-    veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) as veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz
-}\`;
+const b =
+  \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + bar) as baz}\`;
+const b =
+  \`\${(foo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) as baz}\`;
+const b =
+  \`\${(foo + bar) as veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}\`;
+const b =
+  \`\${
+    (veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo +
+      veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) as veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz
+  }\`;
 
 ================================================================================
 `;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

fix #4719

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
