### PR TITLE
Update linguist-languages to support file extensions `.cjs` and `.yaml.sed`

### DIFF
--- a/changelog_unreleased/cli/pr-7210.md
+++ b/changelog_unreleased/cli/pr-7210.md
@@ -1,0 +1,12 @@
+#### Support file extensions `.cjs` and `.yaml.sed`([#7210](https://github.com/prettier/prettier/pull/7210) by [@sosukesuzuki](https://github.com/sosukesuzuki))
+
+```sh
+# Prettier stable
+$ prettier test.cjs
+test.cjs[error] No parser could be inferred for file: test.cjs
+
+# Prettier master
+$ prettier test.cjs
+"use strict";
+console.log("Hello, World!");
+```

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "json-stable-stringify": "1.0.1",
     "leven": "3.1.0",
     "lines-and-columns": "1.1.6",
-    "linguist-languages": "7.6.0",
+    "linguist-languages": "7.7.0",
     "lodash.uniqby": "4.7.0",
     "mem": "5.1.1",
     "minimatch": "3.0.4",

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -675,6 +675,7 @@ exports[`CLI --support-info (stdout) 1`] = `
         \\".js\\",
         \\"._js\\",
         \\".bones\\",
+        \\".cjs\\",
         \\".es\\",
         \\".es6\\",
         \\".frag\\",
@@ -1071,6 +1072,7 @@ exports[`CLI --support-info (stdout) 1`] = `
         \\".syntax\\",
         \\".yaml\\",
         \\".yaml-tmlanguage\\",
+        \\".yaml.sed\\",
         \\".yml.mysql\\"
       ],
       \\"filenames\\": [\\".clang-format\\", \\".clang-tidy\\", \\".gemrc\\", \\"glide.lock\\"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -4491,10 +4491,10 @@ lines-and-columns@1.1.6, lines-and-columns@^1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
 
-linguist-languages@7.6.0:
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/linguist-languages/-/linguist-languages-7.6.0.tgz#6e3d9aa7a98ddf5299f8115788dce8deb8a97c9d"
-  integrity sha512-DBZPIWjrQmb/52UlSEN8MTiwwugrAh4NBX9/DyIG8IuO8rDLYDRM+KVPbuiPVKd3ResxYtZB5AiSuc8dTzOSog==
+linguist-languages@7.7.0:
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/linguist-languages/-/linguist-languages-7.7.0.tgz#c069731f8b307ce301980a4bac4b81bf06a2c351"
+  integrity sha512-6vR1OgfD/YK1xgqVBT3aUx9zurSVeHUsXpVyTilT1o7LW6MNAcGmWy5wwmQAAhvEXxG2PZmktHbQiGtJ5hpGkg==
 
 load-json-file@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Update [linguist-languages](https://github.com/ikatyang/linguist-languages) to 7.7 for `.cjs` and `.yaml.sed`
```sh
# Prettier stable
$ prettier test.cjs
test.cjs[error] No parser could be inferred for file: test.cjs

# Prettier master
$ prettier test.cjs
"use strict";
console.log("Hello, World!");
```

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
