### PR TITLE
Scss: fix scss variable string concatenation removing spaces

### DIFF
--- a/changelog_unreleased/scss/pr-7211.md
+++ b/changelog_unreleased/scss/pr-7211.md
@@ -1,0 +1,22 @@
+#### Fix scss variable string concatenation removing spaces ([#7211](https://github.com/prettier/prettier/pull/7211) by [@sasurau4](https://github.com/sasurau4))
+
+Previously, when Prettier format the scss variable string concatenation, it would remove spaces. Now, Prettier insert spaces around plus operator.
+
+<!-- prettier-ignore -->
+```scss
+// Input
+a {
+  background-image: url($test-path + 'static/test.jpg');
+}
+
+// Prettier stable
+a {
+  background-image: url($test-path+"static/test.jpg");
+}
+
+// Prettier master
+a {
+  background-image: url($test-path + "static/test.jpg");
+}
+```
+

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -458,15 +458,22 @@ function genericPrint(path, options, print) {
       for (let i = 0; i < node.groups.length; ++i) {
         parts.push(printed[i]);
 
-        // Ignore value inside `url()`
-        if (insideURLFunction) {
-          continue;
-        }
-
         const iPrevNode = node.groups[i - 1];
         const iNode = node.groups[i];
         const iNextNode = node.groups[i + 1];
         const iNextNextNode = node.groups[i + 2];
+
+        if (insideURLFunction) {
+          if (
+            (iNextNode &&
+              iNextNode.type === "value-operator" &&
+              iNextNode.value === "+") ||
+            (iNode.type === "value-operator" && iNode.value === "+")
+          ) {
+            parts.push(" ");
+          }
+          continue;
+        }
 
         // Ignore after latest node (i.e. before semicolon)
         if (!iNextNode) {

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -465,10 +465,8 @@ function genericPrint(path, options, print) {
 
         if (insideURLFunction) {
           if (
-            (iNextNode &&
-              iNextNode.type === "value-operator" &&
-              iNextNode.value === "+") ||
-            (iNode.type === "value-operator" && iNode.value === "+")
+            (iNextNode && isAdditionNode(iNextNode)) ||
+            isAdditionNode(iNode)
           ) {
             parts.push(" ");
           }

--- a/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
@@ -4073,3 +4073,52 @@ label {
 
 ================================================================================
 `;
+
+exports[`string-concatanation.scss 1`] = `
+====================================options=====================================
+parsers: ["scss"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+a {
+  background-image: url($test-path + $test-path);
+  background-image: url($test-path + 'static/test.jpg');
+  background-image: url('../test/' + $test-path);
+  background-image: url('../test/' + 'static/test.jpg');
+}
+
+=====================================output=====================================
+a {
+  background-image: url($test-path + $test-path);
+  background-image: url($test-path + "static/test.jpg");
+  background-image: url("../test/" + $test-path);
+  background-image: url("../test/" + "static/test.jpg");
+}
+
+================================================================================
+`;
+
+exports[`string-concatanation.scss 2`] = `
+====================================options=====================================
+parsers: ["scss"]
+printWidth: 80
+trailingComma: "es5"
+                                                                                | printWidth
+=====================================input======================================
+a {
+  background-image: url($test-path + $test-path);
+  background-image: url($test-path + 'static/test.jpg');
+  background-image: url('../test/' + $test-path);
+  background-image: url('../test/' + 'static/test.jpg');
+}
+
+=====================================output=====================================
+a {
+  background-image: url($test-path + $test-path);
+  background-image: url($test-path + "static/test.jpg");
+  background-image: url("../test/" + $test-path);
+  background-image: url("../test/" + "static/test.jpg");
+}
+
+================================================================================
+`;

--- a/tests/css_scss/string-concatanation.scss
+++ b/tests/css_scss/string-concatanation.scss
@@ -1,0 +1,6 @@
+a {
+  background-image: url($test-path + $test-path);
+  background-image: url($test-path + 'static/test.jpg');
+  background-image: url('../test/' + $test-path);
+  background-image: url('../test/' + 'static/test.jpg');
+}


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

fix #4691

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
