### PR TITLE
TypeScript: fix ugly TS output for type alias of a function type with generics

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4334,6 +4334,26 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
   const canHaveTrailingComma =
     !(lastParam && lastParam.type === "RestElement") && !fun.rest;
 
+  if (
+    typeParams !== "" &&
+    parent.type === "TSTypeAliasDeclaration" &&
+    fun.typeParameters &&
+    fun.typeParameters.params.length === 1
+  ) {
+    return indent(
+      concat([
+        hardline,
+        typeParams,
+        "(",
+        concat(printed),
+        ifBreak(
+          canHaveTrailingComma && shouldPrintComma(options, "all") ? "," : ""
+        ),
+        ")"
+      ])
+    );
+  }
+
   return concat([
     typeParams,
     "(",

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4342,7 +4342,7 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
   ) {
     return indent(
       concat([
-        hardline,
+        softline,
         typeParams,
         "(",
         concat(printed),

--- a/tests/typescript/custom/typeParameters/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/custom/typeParameters/__snapshots__/jsfmt.spec.js.snap
@@ -90,6 +90,61 @@ interface ReallyReallyLongName<
 ================================================================================
 `;
 
+exports[`typeAlias.ts 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type FooBarBuzz<T1 extends string> = (
+  <T2 extends string>(bar: T1) => Output<T1, T2>
+);
+
+type FooBarBuzz<T1 extends string> = (
+  <T2 extends string, T3 extends string>(bar: T1) => Output<T1, T2, T3>
+);
+
+type FooBarBuzz<T1 extends string, T2 extends string> = (
+  <T3 extends string>(bar: T1) => Output<T1, T2, T3>
+);
+
+type FooBarBuzz<T1 extends string, T2 extends string> = (
+  <T3 extends string, T4 extends string>(bar: T1) => Output<T1, T2, T3, T4>
+);
+
+type FooBarBuzz<T1> = (
+  <T2>(bar: T1) => Output<T1, T2>
+);
+
+type FooBarBuzz<T1> = (
+  <T2, T3>(bar: T1) => Output<T1, T2, T3>
+);
+
+=====================================output=====================================
+type FooBarBuzz<T1 extends string> =
+  <T2 extends string>(bar: T1) => Output<T1, T2>;
+
+type FooBarBuzz<T1 extends string> = <T2 extends string, T3 extends string>(
+  bar: T1
+) => Output<T1, T2, T3>;
+
+type FooBarBuzz<T1 extends string, T2 extends string> =
+  <T3 extends string>(bar: T1) => Output<T1, T2, T3>;
+
+type FooBarBuzz<T1 extends string, T2 extends string> = <
+  T3 extends string,
+  T4 extends string
+>(
+  bar: T1
+) => Output<T1, T2, T3, T4>;
+
+type FooBarBuzz<T1> = <T2>(bar: T1) => Output<T1, T2>;
+
+type FooBarBuzz<T1> = <T2, T3>(bar: T1) => Output<T1, T2, T3>;
+
+================================================================================
+`;
+
 exports[`typeParametersLong.ts 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/typescript/custom/typeParameters/typeAlias.ts
+++ b/tests/typescript/custom/typeParameters/typeAlias.ts
@@ -1,0 +1,23 @@
+type FooBarBuzz<T1 extends string> = (
+  <T2 extends string>(bar: T1) => Output<T1, T2>
+);
+
+type FooBarBuzz<T1 extends string> = (
+  <T2 extends string, T3 extends string>(bar: T1) => Output<T1, T2, T3>
+);
+
+type FooBarBuzz<T1 extends string, T2 extends string> = (
+  <T3 extends string>(bar: T1) => Output<T1, T2, T3>
+);
+
+type FooBarBuzz<T1 extends string, T2 extends string> = (
+  <T3 extends string, T4 extends string>(bar: T1) => Output<T1, T2, T3, T4>
+);
+
+type FooBarBuzz<T1> = (
+  <T2>(bar: T1) => Output<T1, T2>
+);
+
+type FooBarBuzz<T1> = (
+  <T2, T3>(bar: T1) => Output<T1, T2, T3>
+);


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

#4238 

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
