### PR TITLE
docs: Fix broken links

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -51,7 +51,7 @@ Human-friendly status messages help project contributors react on possible probl
 To minimise the number of times `prettier --check` finds unformatted files, you may be interested in configuring a [pre-commit hook](precommit.md) in your repo.
 Applying this practice will minimise the number of times the CI fails because of code formatting problems.
 
-If you need to pipe the list of unformatted files to another command, you can use [`--list-different`](cli.md#list-different) flag instead of `--check`.
+If you need to pipe the list of unformatted files to another command, you can use [`--list-different`](cli.md#--list-different) flag instead of `--check`.
 
 ### Exit codes
 
@@ -112,7 +112,7 @@ Another useful flag is `--list-different` (or `-l`) which prints the filenames o
 prettier --single-quote --list-different "src/**/*.js"
 ```
 
-You can also use [`--check`](cli.md#check) flag, which works the same way as `--list-different`, but also prints a human-friendly summary message to stdout.
+You can also use [`--check`](cli.md#--check) flag, which works the same way as `--list-different`, but also prints a human-friendly summary message to stdout.
 
 ## `--no-config`
 


### PR DESCRIPTION
I noticed that two links on https://prettier.io/docs/en/cli.html are broken. They are both missing the `--`.