### PR TITLE
GraphQL: Support repeatable directive definition printing (closes #7226)

### DIFF
--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -380,6 +380,7 @@ function genericPrint(path, options, print) {
               ])
             )
           : "",
+        n.repeatable ? " repeatable" : "",
         concat([" on ", join(" | ", path.map(print, "locations"))])
       ]);
     }

--- a/tests/graphql_directive_decl/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_directive_decl/__snapshots__/jsfmt.spec.js.snap
@@ -12,8 +12,10 @@ directive @a(as: String = 1) on QUERY
 directive @a(as: String, b: Int!) on QUERY
 directive @a(as: String! = 1 @deprecated) on QUERY
 directive @a(as: String! = 1 @deprecated) on QUERY | MUTATION
+directive @a(as: String! = 1 @deprecated) repeatable on QUERY | MUTATION
 
 directive @a on QUERY
+directive @a repeatable on QUERY
 
 
 directive @a(as: String) on QUERY
@@ -21,7 +23,7 @@ directive @a(as: String) on QUERY
 
 
 
-directive @a(as: String = 1) repeatable on QUERY
+directive @a(as: String = 1) on QUERY
 
 =====================================output=====================================
 directive @a on QUERY
@@ -30,12 +32,14 @@ directive @a(as: String = 1) on QUERY
 directive @a(as: String, b: Int!) on QUERY
 directive @a(as: String! = 1 @deprecated) on QUERY
 directive @a(as: String! = 1 @deprecated) on QUERY | MUTATION
+directive @a(as: String! = 1 @deprecated) repeatable on QUERY | MUTATION
 
 directive @a on QUERY
+directive @a repeatable on QUERY
 
 directive @a(as: String) on QUERY
 
-directive @a(as: String = 1) repeatable on QUERY
+directive @a(as: String = 1) on QUERY
 
 ================================================================================
 `;

--- a/tests/graphql_directive_decl/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_directive_decl/__snapshots__/jsfmt.spec.js.snap
@@ -21,7 +21,7 @@ directive @a(as: String) on QUERY
 
 
 
-directive @a(as: String = 1) on QUERY
+directive @a(as: String = 1) repeatable on QUERY
 
 =====================================output=====================================
 directive @a on QUERY
@@ -35,7 +35,7 @@ directive @a on QUERY
 
 directive @a(as: String) on QUERY
 
-directive @a(as: String = 1) on QUERY
+directive @a(as: String = 1) repeatable on QUERY
 
 ================================================================================
 `;

--- a/tests/graphql_directive_decl/directive_decl.graphql
+++ b/tests/graphql_directive_decl/directive_decl.graphql
@@ -13,4 +13,4 @@ directive @a(as: String) on QUERY
 
 
 
-directive @a(as: String = 1) on QUERY
+directive @a(as: String = 1) repeatable on QUERY

--- a/tests/graphql_directive_decl/directive_decl.graphql
+++ b/tests/graphql_directive_decl/directive_decl.graphql
@@ -4,8 +4,10 @@ directive @a(as: String = 1) on QUERY
 directive @a(as: String, b: Int!) on QUERY
 directive @a(as: String! = 1 @deprecated) on QUERY
 directive @a(as: String! = 1 @deprecated) on QUERY | MUTATION
+directive @a(as: String! = 1 @deprecated) repeatable on QUERY | MUTATION
 
 directive @a on QUERY
+directive @a repeatable on QUERY
 
 
 directive @a(as: String) on QUERY
@@ -13,4 +15,4 @@ directive @a(as: String) on QUERY
 
 
 
-directive @a(as: String = 1) repeatable on QUERY
+directive @a(as: String = 1) on QUERY


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
This PR fixes a bug where (or really adds a feature) `repeatable` (new in `graphql@14.4.0`) GraphQL `DirectiveDefinitionNode`'s were not being printed correctly.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
