### PR TITLE
use lodash/* instead of lodash.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "leven": "3.1.0",
     "lines-and-columns": "1.1.6",
     "linguist-languages": "7.7.0",
-    "lodash.uniqby": "4.7.0",
+    "lodash": "4.17.15",
     "mem": "5.1.1",
     "minimatch": "3.0.4",
     "minimist": "1.2.0",

--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const uniqBy = require("lodash.uniqby");
+const uniqBy = require("lodash/uniqBy");
 const fs = require("fs");
 const globby = require("globby");
 const path = require("path");

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,7 @@
     "clipboard": "2.0.4",
     "codemirror": "5.50.2",
     "codemirror-graphql": "0.11.2",
-    "lodash.groupby": "4.6.0",
+    "lodash": "4.17.15",
     "lz-string": "1.4.4",
     "prop-types": "15.7.2",
     "react": "16.12.0",

--- a/website/playground/sidebar/SidebarOptions.js
+++ b/website/playground/sidebar/SidebarOptions.js
@@ -1,5 +1,5 @@
 import React from "react";
-import groupBy from "lodash.groupby";
+import groupBy from "lodash/groupBy";
 
 import { SidebarCategory } from "./components";
 import Option from "./options";

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -4643,10 +4643,6 @@ lodash.foreach@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
   integrity sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=
 
-lodash.groupby@4.6.0:
-  version "4.6.0"
-  resolved "https://registry.yarnpkg.com/lodash.groupby/-/lodash.groupby-4.6.0.tgz#0b08a1dcf68397c397855c3239783832df7403d1"
-
 lodash.map@^4.4.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
@@ -4710,7 +4706,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@~4.17.10:
+lodash@4.17.15, lodash@^4.17.10, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@~4.17.10:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4559,11 +4559,7 @@ lodash.unescape@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
 
-lodash.uniqby@4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
-
-lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
+lodash@4.17.15, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
The `lodash.*` packages are deprecated and abandoned. The recommended thing is to use `lodash/*` instead. See https://github.com/lodash/lodash/issues/3838

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
