### PR TITLE
Let's start using the object spread syntax in the code base

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -7,7 +7,7 @@ extends:
   - plugin:react/recommended
   - plugin:prettier/recommended
 parserOptions:
-  ecmaVersion: 2017
+  ecmaVersion: 2018
 plugins:
   - import
   - unicorn

--- a/scripts/build/bundler.js
+++ b/scripts/build/bundler.js
@@ -55,6 +55,10 @@ function getBabelConfig(bundle) {
   config.presets = [
     [require.resolve("@babel/preset-env"), { targets, modules: false }]
   ];
+  config.plugins.push([
+    require.resolve("@babel/plugin-proposal-object-rest-spread"),
+    { loose: true, useBuiltIns: true }
+  ]);
   return config;
 }
 


### PR DESCRIPTION
I think it's time to start using it. It's still transpiled by Babel because that's how `@babel/preset-env` is configured (`targets.browsers = [">0.25%", "not ie 11", "not op_mini all"]`), but I switched this transpilation to the [loose mode](https://babeljs.io/docs/en/babel-plugin-proposal-object-rest-spread#loose) to minimize the overhead.