### PR TITLE
Use shorthand `bin` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,9 +2,7 @@
   "name": "prettier",
   "version": "1.20.0-dev",
   "description": "Prettier is an opinionated code formatter",
-  "bin": {
-    "prettier": "./bin/prettier.js"
-  },
+  "bin": "./bin/prettier.js",
   "repository": "prettier/prettier",
   "homepage": "https://prettier.io",
   "author": "James Long",

--- a/tests_integration/runPrettier.js
+++ b/tests_integration/runPrettier.js
@@ -8,7 +8,11 @@ const SynchronousPromise = require("synchronous-promise").SynchronousPromise;
 const isProduction = process.env.NODE_ENV === "production";
 const prettierRootDir = isProduction ? process.env.PRETTIER_DIR : "../";
 const prettierPkg = require(path.join(prettierRootDir, "package.json"));
-const prettierCli = path.join(prettierRootDir, prettierPkg.bin.prettier);
+const bin = prettierPkg.bin;
+const prettierCli = path.join(
+  prettierRootDir,
+  typeof bin === "object" ? bin.prettier : bin
+);
 
 const thirdParty = isProduction
   ? path.join(prettierRootDir, "./third-party")


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

> If you have a single executable, and its name should be the name of the package, then you can just supply it as a string. 

Ref: https://docs.npmjs.com/files/package.json#bin

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
