### PR TITLE
Style: enable `prefer-spread`

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -7,7 +7,7 @@ extends:
   - plugin:react/recommended
   - plugin:prettier/recommended
 parserOptions:
-  ecmaVersion: 2017
+  ecmaVersion: 2018
 plugins:
   - import
   - unicorn
@@ -26,6 +26,7 @@ rules:
     - never
   prefer-arrow-callback: error
   prefer-const: error
+  prefer-spread: error
   react/display-name: off
   react/no-deprecated: off
   react/prop-types: off

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -667,7 +667,7 @@ function createOptionUsageType(option) {
 }
 
 function flattenArray(array) {
-  return [].concat.apply([], array);
+  return [].concat(...array);
 }
 
 function createChoiceUsages(choices, margin, indentation) {

--- a/src/index.js
+++ b/src/index.js
@@ -14,13 +14,14 @@ const doc = require("./doc");
 
 // Luckily `opts` is always the 2nd argument
 function _withPlugins(fn) {
-  return function() {
-    const args = Array.from(arguments);
-    const opts = args[1] || {};
-    args[1] = Object.assign({}, opts, {
+  return function(first, opts, ...rest) {
+    opts = opts || {};
+    opts = {
+      ...opts,
       plugins: loadPlugins(opts.plugins, opts.pluginSearchDirs)
-    });
-    return fn.apply(null, args);
+    };
+
+    return fn(first, opts, ...rest);
   };
 }
 

--- a/src/language-html/syntax-attribute.js
+++ b/src/language-html/syntax-attribute.js
@@ -25,7 +25,7 @@ function printImgSrcset(value) {
   const key = hasW ? "w" : hasH ? "h" : "d";
   const unit = hasW ? "w" : hasH ? "h" : "x";
 
-  const getMax = values => Math.max.apply(Math, values);
+  const getMax = values => Math.max(...values);
 
   const urls = srcset.map(src => src.url);
   const maxUrlLength = getMax(urls.map(url => url.length));

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -908,11 +908,9 @@ function shouldWrapFunctionForExportDefault(path, options) {
     return false;
   }
 
-  return path.call.apply(
-    path,
-    [
-      childPath => shouldWrapFunctionForExportDefault(childPath, options)
-    ].concat(getLeftSidePathName(path, node))
+  return path.call(
+    childPath => shouldWrapFunctionForExportDefault(childPath, options),
+    ...getLeftSidePathName(path, node)
   );
 }
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5842,11 +5842,9 @@ function exprNeedsASIProtection(path, options) {
     return false;
   }
 
-  return path.call.apply(
-    path,
-    [childPath => exprNeedsASIProtection(childPath, options)].concat(
-      getLeftSidePathName(path, node)
-    )
+  return path.call(
+    childPath => exprNeedsASIProtection(childPath, options),
+    ...getLeftSidePathName(path, node)
   );
 }
 

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -867,19 +867,19 @@ function normalizeDoc(doc) {
       return currentDoc.parts[0];
     }
 
-    const parts = [];
-
-    currentDoc.parts.forEach(part => {
+    const parts = currentDoc.parts.reduce((parts, part) => {
       if (part.type === "concat") {
-        parts.push.apply(parts, part.parts);
+        parts.push(...part.parts);
       } else if (part !== "") {
         parts.push(part);
       }
-    });
+      return parts;
+    }, []);
 
-    return Object.assign({}, currentDoc, {
+    return {
+      ...currentDoc,
       parts: normalizeParts(parts)
-    });
+    };
   });
 }
 

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -18,24 +18,20 @@ const internalPlugins = [
   require("./language-yaml")
 ];
 
-const isArray =
-  Array.isArray ||
-  function(arr) {
-    return Object.prototype.toString.call(arr) === "[object Array]";
-  };
-
 // Luckily `opts` is always the 2nd argument
 function withPlugins(fn) {
-  return function() {
-    const args = Array.from(arguments);
-    let plugins = (args[1] && args[1].plugins) || [];
-    if (!isArray(plugins)) {
-      plugins = Object.values(plugins);
-    }
-    args[1] = Object.assign({}, args[1], {
-      plugins: internalPlugins.concat(plugins)
-    });
-    return fn.apply(null, args);
+  return function(first, opts, ...rest) {
+    const { plugins = [] } = opts || {};
+
+    opts = {
+      ...opts,
+      plugins: [
+        ...internalPlugins,
+        ...(Array.isArray(plugins) ? plugins : Object.values(plugins))
+      ]
+    };
+
+    return fn(first, opts, ...rest);
   };
 }
 


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Use `fn(...args)` insteadof `fn.apply(this, args)`, enable [`prefer-spread`](https://eslint.org/docs/rules/prefer-spread)

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
