### PR TITLE
handlebars: Add prettier-ignore

### DIFF
--- a/changelog_unreleased/handlebars/pr-7275.md
+++ b/changelog_unreleased/handlebars/pr-7275.md
@@ -1,0 +1,49 @@
+#### Glimmer: Add prettier-ignore ([#7275](https://github.com/prettier/prettier/pull/7275) by [@chadian](https://github.com/chadian))
+
+<!-- prettier-ignore -->
+```hbs
+{{! Input}}
+{{! prettier-ignore }}
+<div>
+  "hello! my parent was ignored"
+  {{#my-crazy-component     "shall"     be="preserved"}}
+    <This
+
+      is="preserved"
+    />
+  {{/my-crazy-component}}
+</div>
+
+{{#a-normal-component    isRestoredTo   = "order"    }}
+  <ThisWillBeNormal backTo    =   "normal" />
+{{/a-normal-component}}
+
+{{! Prettier stable}}
+{{! prettier-ignore }}
+<div>
+  "hello! my parent was ignored"
+  {{#my-crazy-component "shall" be="preserved"}}
+    <This is="preserved" />
+  {{/my-crazy-component}}
+</div>
+
+{{#a-normal-component isRestoredTo="order"}}
+  <ThisWillBeNormal backTo="normal" />
+{{/a-normal-component}}
+
+{{! Prettier master}}
+{{! prettier-ignore }}
+<div>
+  "hello! my parent was ignored"
+  {{#my-crazy-component     "shall"     be="preserved"}}
+    <This
+
+      is="preserved"
+    />
+  {{/my-crazy-component}}
+</div>
+
+{{#a-normal-component isRestoredTo='order'}}
+  <ThisWillBeNormal backTo='normal' />
+{{/a-normal-component}}
+```

--- a/docs/ignore.md
+++ b/docs/ignore.md
@@ -117,3 +117,17 @@ This type of ignore is only allowed to be used in top-level and aimed to disable
   }
 }
 ```
+
+## Handlebars
+
+```hbs
+{{! prettier-ignore }}
+<div>
+  "hello! my parent was ignored"
+  {{#my-crazy-component     "shall"     be="preserved"}}
+    <This
+      is  =  "also preserved as is"
+    />
+  {{/my-crazy-component}}
+</div>
+```

--- a/docs/ignore.md
+++ b/docs/ignore.md
@@ -120,6 +120,7 @@ This type of ignore is only allowed to be used in top-level and aimed to disable
 
 ## Handlebars
 
+<!-- prettier-ignore -->
 ```hbs
 {{! prettier-ignore }}
 <div>

--- a/src/language-handlebars/parser-glimmer.js
+++ b/src/language-handlebars/parser-glimmer.js
@@ -29,6 +29,10 @@ module.exports = {
     glimmer: {
       parse,
       astFormat: "glimmer",
+      // TODO: `locStart` and `locEnd` should return a number offset
+      // https://prettier.io/docs/en/plugins.html#parsers
+      // but we need access to the original text to use
+      // `loc.start` and `loc.end` objects to calculate the offset
       locStart(node) {
         return node.loc && node.loc.start;
       },

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -578,6 +578,9 @@ function hasPrettierIgnore(path) {
   return isIgnoreNode || isCoveredByIgnoreNode;
 }
 
+/* istanbul ignore next
+   https://github.com/glimmerjs/glimmer-vm/blob/master/packages/%40glimmer/compiler/lib/location.ts#L5-L29
+*/
 function locationToOffset(source, line, column) {
   let seenLines = 0;
   let seenChars = 0;

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -624,5 +624,4 @@ function isPrettierIgnoreNode(node) {
 module.exports = {
   print,
   massageAstNode: clean
-  // hasPrettierIgnore
 };

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -40,6 +40,22 @@ function print(path, options, print) {
     return "";
   }
 
+  if (hasPrettierIgnore(path)) {
+    const startOffset = locationToOffset(
+      options.originalText,
+      n.loc.start.line - 1,
+      n.loc.start.column
+    );
+    const endOffset = locationToOffset(
+      options.originalText,
+      n.loc.end.line - 1,
+      n.loc.end.column
+    );
+
+    const ignoredText = options.originalText.slice(startOffset, endOffset);
+    return ignoredText;
+  }
+
   switch (n.type) {
     case "Block":
     case "Program":
@@ -474,15 +490,15 @@ function isParentOfType(path, nodeType) {
   return p && p.type === nodeType;
 }
 
-function getPreviousNode(path) {
+function getPreviousNode(path, lookBack = 1) {
   const node = path.getValue();
   const parentNode = path.getParentNode(0);
 
-  const children = parentNode.children || parentNode.body;
+  const children = parentNode && (parentNode.children || parentNode.body);
   if (children) {
     const nodeIndex = children.indexOf(node);
     if (nodeIndex > 0) {
-      const previousNode = children[nodeIndex - 1];
+      const previousNode = children[nodeIndex - lookBack];
       return previousNode;
     }
   }
@@ -553,7 +569,57 @@ function generateHardlines(number = 0, max = 0) {
   return new Array(Math.min(number, max)).fill(hardline);
 }
 
+function hasPrettierIgnore(path) {
+  const n = path.getValue();
+  const previousPreviousNode = getPreviousNode(path, 2);
+  const isIgnoreNode = isPrettierIgnoreNode(n);
+  const isCoveredByIgnoreNode = isPrettierIgnoreNode(previousPreviousNode);
+
+  return isIgnoreNode || isCoveredByIgnoreNode;
+}
+
+function locationToOffset(source, line, column) {
+  let seenLines = 0;
+  let seenChars = 0;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    if (seenChars === source.length) {
+      return null;
+    }
+
+    let nextLine = source.indexOf("\n", seenChars);
+    if (nextLine === -1) {
+      nextLine = source.length;
+    }
+
+    if (seenLines === line) {
+      if (seenChars + column > nextLine) {
+        return null;
+      }
+      return seenChars + column;
+    } else if (nextLine === -1) {
+      return null;
+    }
+    seenLines += 1;
+    seenChars = nextLine + 1;
+  }
+}
+
+function isPrettierIgnoreNode(node) {
+  if (!node) {
+    return false;
+  }
+
+  const isMustacheComment = node.type === "MustacheCommentStatement";
+  const containsPrettierIgnore =
+    typeof node.value === "string" && node.value.trim() === "prettier-ignore";
+
+  return isMustacheComment && containsPrettierIgnore;
+}
+
 module.exports = {
   print,
   massageAstNode: clean
+  // hasPrettierIgnore
 };

--- a/tests/handlebars-prettier-ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars-prettier-ignore/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,154 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`prettier-ignore.hbs 1`] = `
+====================================options=====================================
+parsers: ["glimmer"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+{{! prettier-ignore }}
+<div>
+  "hello! my parent was ignored"
+  {{#my-crazy-component     "shall"     be="preserved"}}
+    <This
+
+      is="preserved"
+    />
+  {{/my-crazy-component}}
+</div>
+
+{{#a-normal-component    isRestoredTo   = "order"    }}
+  <ThisWillBeNormal backTo    =   "normal" />
+{{/a-normal-component}}
+
+<div     class="this should be fixed"          >
+  <Sibling isFixed   =  {{true}}      />
+  {{! prettier-ignore }}
+  <div  class = " left in chaos as well as children   "     >
+
+      <SomeComponent @broken =   {{    true    }}></SomeComponent>
+
+
+  </div>
+  {{#another-sibling    as     |isFixed|}}
+
+    <div class =    "fixed"   >{{   isFixed   }}
+
+        All of this should be fixed
+
+    </div>
+
+  {{/another-sibling}}
+</div>
+=====================================output=====================================
+{{! prettier-ignore }}
+<div>
+  "hello! my parent was ignored"
+  {{#my-crazy-component     "shall"     be="preserved"}}
+    <This
+
+      is="preserved"
+    />
+  {{/my-crazy-component}}
+</div>
+
+{{#a-normal-component isRestoredTo="order"}}
+  <ThisWillBeNormal backTo="normal" />
+{{/a-normal-component}}
+
+<div class="this should be fixed">
+  <Sibling isFixed={{true}} />
+  {{! prettier-ignore }}
+  <div  class = " left in chaos as well as children   "     >
+
+      <SomeComponent @broken =   {{    true    }}></SomeComponent>
+
+
+  </div>
+  {{#another-sibling as |isFixed|}}
+    <div class="fixed">
+      {{isFixed}}
+
+      All of this should be fixed
+    </div>
+  {{/another-sibling}}
+</div>
+================================================================================
+`;
+
+exports[`prettier-ignore.hbs 2`] = `
+====================================options=====================================
+parsers: ["glimmer"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+{{! prettier-ignore }}
+<div>
+  "hello! my parent was ignored"
+  {{#my-crazy-component     "shall"     be="preserved"}}
+    <This
+
+      is="preserved"
+    />
+  {{/my-crazy-component}}
+</div>
+
+{{#a-normal-component    isRestoredTo   = "order"    }}
+  <ThisWillBeNormal backTo    =   "normal" />
+{{/a-normal-component}}
+
+<div     class="this should be fixed"          >
+  <Sibling isFixed   =  {{true}}      />
+  {{! prettier-ignore }}
+  <div  class = " left in chaos as well as children   "     >
+
+      <SomeComponent @broken =   {{    true    }}></SomeComponent>
+
+
+  </div>
+  {{#another-sibling    as     |isFixed|}}
+
+    <div class =    "fixed"   >{{   isFixed   }}
+
+        All of this should be fixed
+
+    </div>
+
+  {{/another-sibling}}
+</div>
+=====================================output=====================================
+{{! prettier-ignore }}
+<div>
+  "hello! my parent was ignored"
+  {{#my-crazy-component     "shall"     be="preserved"}}
+    <This
+
+      is="preserved"
+    />
+  {{/my-crazy-component}}
+</div>
+
+{{#a-normal-component isRestoredTo='order'}}
+  <ThisWillBeNormal backTo='normal' />
+{{/a-normal-component}}
+
+<div class='this should be fixed'>
+  <Sibling isFixed={{true}} />
+  {{! prettier-ignore }}
+  <div  class = " left in chaos as well as children   "     >
+
+      <SomeComponent @broken =   {{    true    }}></SomeComponent>
+
+
+  </div>
+  {{#another-sibling as |isFixed|}}
+    <div class='fixed'>
+      {{isFixed}}
+
+      All of this should be fixed
+    </div>
+  {{/another-sibling}}
+</div>
+================================================================================
+`;

--- a/tests/handlebars-prettier-ignore/jsfmt.spec.js
+++ b/tests/handlebars-prettier-ignore/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname, ["glimmer"]);
+run_spec(__dirname, ["glimmer"], { singleQuote: true });

--- a/tests/handlebars-prettier-ignore/prettier-ignore.hbs
+++ b/tests/handlebars-prettier-ignore/prettier-ignore.hbs
@@ -1,0 +1,34 @@
+{{! prettier-ignore }}
+<div>
+  "hello! my parent was ignored"
+  {{#my-crazy-component     "shall"     be="preserved"}}
+    <This
+
+      is="preserved"
+    />
+  {{/my-crazy-component}}
+</div>
+
+{{#a-normal-component    isRestoredTo   = "order"    }}
+  <ThisWillBeNormal backTo    =   "normal" />
+{{/a-normal-component}}
+
+<div     class="this should be fixed"          >
+  <Sibling isFixed   =  {{true}}      />
+  {{! prettier-ignore }}
+  <div  class = " left in chaos as well as children   "     >
+
+      <SomeComponent @broken =   {{    true    }}></SomeComponent>
+
+
+  </div>
+  {{#another-sibling    as     |isFixed|}}
+
+    <div class =    "fixed"   >{{   isFixed   }}
+
+        All of this should be fixed
+
+    </div>
+
+  {{/another-sibling}}
+</div>


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
This pull request adds the ability to use `{{! prettier-ignore }}` in  glimmer/handlebars

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
