### PR TITLE
Fix: don't throw on broken html

### DIFF
--- a/changelog_unreleased/html/pr-7293.md
+++ b/changelog_unreleased/html/pr-7293.md
@@ -1,0 +1,24 @@
+#### Do not throw on broken html ([#7293](https://github.com/prettier/prettier/pull/7293) by [@fisker](https://github.com/fisker))
+
+<!-- prettier-ignore -->
+```html
+<!-- Input -->
+<div><span>
+< 
+
+<!-- Prettier stable -->
+TypeError: Cannot read property 'start' of null
+    at hasTrailingLineBreak (https://prettier.io/lib/standalone.js:19694:169)
+    at forceBreakContent (https://prettier.io/lib/standalone.js:19668:154)
+    at Object.genericPrint$2 [as print] (https://prettier.io/lib/standalone.js:21068:126)
+    at callPluginPrintFunction (https://prettier.io/lib/standalone.js:15302:20)
+    at https://prettier.io/lib/standalone.js:15253:18
+    at Object.printComments (https://prettier.io/lib/standalone.js:14974:19)
+    at printGenerically (https://prettier.io/lib/standalone.js:15252:24)
+    at printChild (https://prettier.io/lib/standalone.js:21227:14)
+    at https://prettier.io/lib/standalone.js:21211:104
+    at FastPath.map (https://prettier.io/lib/standalone.js:15155:23)
+
+<!-- Prettier master -->
+<div><span> < </span></div>
+```

--- a/src/language-html/utils.js
+++ b/src/language-html/utils.js
@@ -330,7 +330,8 @@ function hasTrailingLineBreak(node) {
     (node.next
       ? node.next.sourceSpan.start.line > node.sourceSpan.end.line
       : node.parent.type === "root" ||
-        node.parent.endSourceSpan.start.line > node.sourceSpan.end.line)
+        (node.parent.endSourceSpan &&
+          node.parent.endSourceSpan.start.line > node.sourceSpan.end.line))
   );
 }
 

--- a/tests/html_basics/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_basics/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`broken-html.html 1`] = `
+====================================options=====================================
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<!-- 
+#7241, 
+reproduction:
+two different element,
+linebreak
+\`<\`
+extra space(s)
+-->
+<div><span>
+
+
+
+<                                           
+
+=====================================output=====================================
+<!-- 
+#7241, 
+reproduction:
+two different element,
+linebreak
+\`<\`
+extra space(s)
+-->
+<div><span> < </span></div>
+
+================================================================================
+`;
+
 exports[`comment.html 1`] = `
 ====================================options=====================================
 parsers: ["html"]

--- a/tests/html_basics/broken-html.html
+++ b/tests/html_basics/broken-html.html
@@ -1,0 +1,13 @@
+<!-- 
+#7241, 
+reproduction:
+two different element,
+linebreak
+`<`
+extra space(s)
+-->
+<div><span>
+
+
+
+<                                           


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

fixes: #7241

- [stable playground](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAeAJgSwG4D5UDOADgIZS4A6UqABFSADQgREybQHKgkBOPEAdwAKvBJxQlsETOkYgARjxJgA1nBgBlUmExQA5shg8ArnCYALGAFsANgHVzmeMWVwNYpzicBPZOAKcTLoEcDwwQkp6ViTIAGYkNiFMAFYEAB4AQkqq6hokVnAAMrpwcQlJIKlpGrp6NnAAisYQ8GWJZiCkPCE8fpa2ckQ8ujB2MjDmyAAcAAxMQxAhdkpEfkNwPdilTACOzfARLOIgJAQAtFBwcOjXcjxwe5j3ESRRMUjx7UwhVpiGJh0CLV6k0WqUPuUOjASPIxugJsgAExMIwkTA2WoAYQgVmifig0G2IGMIQAKjDxJ8KthTABJKA3WAaMDDVgAQQZGhg3nqbRCAF9+UA)
- [PR playground](https://deploy-preview-7293--prettier.netlify.com/playground/#N4Igxg9gdgLgprEAuEAeAJgSwG4D5UDOADgIZS4A6UqABFSADQgREybQHKgkBOPEAdwAKvBJxQlsETOkYgARjxJgA1nBgBlUmExQA5shg8ArnCYALGAFsANgHVzmeMWVwNYpzicBPZOAKcTLoEcDwwQkp6ViTIAGYkNiFMAFYEAB4AQkqq6hokVnAAMrpwcQlJIKlpGrp6NnAAisYQ8GWJZiCkPCE8fpa2ckQ8ujB2MjDmyAAcAAxMQxAhdkpEfkNwPdilTACOzfARLOIgJAQAtFBwcOjXcjxwe5j3ESRRMUjx7UwhVpiGJh0CLV6k0WqUPuUOjASPIxugJsgAExMIwkTA2WoAYQgVmifig0G2IGMIQAKjDxJ8KthTABJKA3WAaMDDVgAQQZGhg3nqbRCAF9+UA)

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
