### PR TITLE
Upgrade Node.js version and drop mkdirp

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "main": "./index.js",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.13.0"
   },
   "dependencies": {
     "@angular/compiler": "8.2.14",
@@ -97,7 +97,6 @@
     "jest-snapshot-serializer-ansi": "1.0.0",
     "jest-snapshot-serializer-raw": "1.1.0",
     "jest-watch-typeahead": "0.4.2",
-    "mkdirp": "0.5.1",
     "prettier": "1.19.1",
     "rimraf": "3.0.0",
     "rollup": "1.29.0",

--- a/scripts/sync-flow-tests.js
+++ b/scripts/sync-flow-tests.js
@@ -3,7 +3,6 @@
 const fs = require("fs");
 const flowParser = require("flow-parser");
 const globby = require("globby");
-const mkdirp = require("mkdirp");
 const path = require("path");
 const rimraf = require("rimraf");
 
@@ -65,7 +64,7 @@ function syncTests(syncDir) {
     const specFile = path.join(dirname, SPEC_FILE_NAME);
     const specContent = specContents[specFile] || DEFAULT_SPEC_CONTENT;
 
-    mkdirp.sync(dirname);
+    fs.mkdirSync(dirname, { recursive: true });
     fs.writeFileSync(newFile, content);
     fs.writeFileSync(specFile, specContent);
   });

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -20,12 +20,13 @@ global.run_spec = (dirname, parsers, options) => {
     throw new Error(`No parsers were specified for ${dirname}`);
   }
 
-  fs.readdirSync(dirname).forEach(basename => {
+  fs.readdirSync(dirname, { withFileTypes: true }).forEach(dirent => {
+    const basename = dirent.name;
     const filename = path.join(dirname, basename);
 
     if (
       path.extname(basename) === ".snap" ||
-      !fs.lstatSync(filename).isFile() ||
+      !dirent.isFile() ||
       basename[0] === "." ||
       basename === "jsfmt.spec.js"
     ) {

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -20,14 +20,14 @@ global.run_spec = (dirname, parsers, options) => {
     throw new Error(`No parsers were specified for ${dirname}`);
   }
 
-  const dir = fs.readdirSync(dirname, { withFileTypes: true });
-  for (const dirent of dir) {
-    const basename = dirent.name;
+  const files = fs.readdirSync(dirname, { withFileTypes: true });
+  for (const file of files) {
+    const basename = file.name;
     const filename = path.join(dirname, basename);
 
     if (
       path.extname(basename) === ".snap" ||
-      !dirent.isFile() ||
+      !file.isFile() ||
       basename[0] === "." ||
       basename === "jsfmt.spec.js"
     ) {

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -20,7 +20,8 @@ global.run_spec = (dirname, parsers, options) => {
     throw new Error(`No parsers were specified for ${dirname}`);
   }
 
-  fs.readdirSync(dirname, { withFileTypes: true }).forEach(dirent => {
+  const dir = fs.readdirSync(dirname, { withFileTypes: true });
+  for (const dirent of dir) {
     const basename = dirent.name;
     const filename = path.join(dirname, basename);
 
@@ -30,7 +31,7 @@ global.run_spec = (dirname, parsers, options) => {
       basename[0] === "." ||
       basename === "jsfmt.spec.js"
     ) {
-      return;
+      continue;
     }
 
     let rangeStart;
@@ -114,7 +115,7 @@ global.run_spec = (dirname, parsers, options) => {
         expect(originalAst).toEqual(formattedAst);
       });
     }
-  });
+  }
 };
 
 function parse(source, options) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5208,7 +5208,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.0, mkdirp@^0.5.1:
+mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=

--- a/yarn.lock
+++ b/yarn.lock
@@ -5208,7 +5208,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@0.5.1, mkdirp@^0.5.1:
+mkdirp@^0.5.0, mkdirp@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Node.js v8 moved to End-of-Life on Dec 31, 2019. ( Please see https://github.com/nodejs/Release)
Node.js v10.13.0 is minimum LTS version now.
Moreover, new API's options in Node.js Core are added in Node.js v10.13.0. 
- [withFileTypes](https://nodejs.org/api/fs.html#fs_fs_readdirsync_path_options) option for `fs.readdirSync` can make code faster than using `fs.stat`.
- [recursive](https://nodejs.org/api/fs.html#fs_fs_mkdirsync_path_options) option for `fs.mkdirSync` can recursively make directories so that `mkdirp` package is no longer need.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
