### PR TITLE
Move React ESLint rules to `/website`

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -4,7 +4,6 @@ env:
   node: true
 extends:
   - eslint:recommended
-  - plugin:react/recommended
   - plugin:prettier/recommended
 parserOptions:
   ecmaVersion: 2018
@@ -14,7 +13,7 @@ plugins:
 rules:
   curly: error
   dot-notation: error
-  eqeqeq: 
+  eqeqeq:
     - error
     - always
     - null: ignore
@@ -46,9 +45,6 @@ rules:
     - error
     - double
     - avoidEscape: true
-  react/display-name: off
-  react/no-deprecated: off
-  react/prop-types: off
   strict: error
   symbol-description: error
   yoda:

--- a/website/.eslintrc.yml
+++ b/website/.eslintrc.yml
@@ -1,2 +1,7 @@
+extends:
+  - plugin:react/recommended
 rules:
   import/no-extraneous-dependencies: off
+  react/display-name: off
+  react/no-deprecated: off
+  react/prop-types: off


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Local tested, root rules works as expected in `/website`.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
