### PR TITLE
Fix `prefer-object-spread` in `/website`

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -14,7 +14,7 @@ plugins:
 rules:
   curly: error
   dot-notation: error
-  eqeqeq: 
+  eqeqeq:
     - error
     - always
     - null: ignore
@@ -25,6 +25,9 @@ rules:
   no-inner-declarations: error
   no-unneeded-ternary: error
   no-useless-return: error
+  no-unused-vars:
+    - error
+    - ignoreRestSiblings: true
   no-var: error
   object-shorthand: error
   one-var:

--- a/website/playground/EditorState.js
+++ b/website/playground/EditorState.js
@@ -6,20 +6,17 @@ import * as storage from "./storage";
 export default class extends React.Component {
   constructor() {
     super();
-    this.state = Object.assign(
-      {
-        showSidebar: false,
-        showAst: false,
-        showDoc: false,
-        showSecondFormat: false,
-        toggleSidebar: () => this.setState(stateToggler("showSidebar")),
-        toggleAst: () => this.setState(stateToggler("showAst")),
-        toggleDoc: () => this.setState(stateToggler("showDoc")),
-        toggleSecondFormat: () =>
-          this.setState(stateToggler("showSecondFormat"))
-      },
-      storage.get("editor_state")
-    );
+    this.state = {
+      showSidebar: false,
+      showAst: false,
+      showDoc: false,
+      showSecondFormat: false,
+      toggleSidebar: () => this.setState(stateToggler("showSidebar")),
+      toggleAst: () => this.setState(stateToggler("showAst")),
+      toggleDoc: () => this.setState(stateToggler("showDoc")),
+      toggleSecondFormat: () => this.setState(stateToggler("showSecondFormat")),
+      ...storage.get("editor_state")
+    };
   }
 
   componentDidUpdate(_, prevState) {

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -90,7 +90,7 @@ class Playground extends React.Component {
 
   handleOptionValueChange(option, value) {
     this.setState(state => {
-      const options = Object.assign({}, state.options);
+      const options = { ...state.options };
 
       if (option.type === "int" && isNaN(value)) {
         delete options[option.name];
@@ -240,7 +240,7 @@ class Playground extends React.Component {
                           // parser there is an anti-pattern. Note:
                           // `JSON.stringify` omits keys whose values are
                           // `undefined`.
-                          Object.assign({}, options, { parser: undefined }),
+                          { ...options, parser: undefined },
                           null,
                           2
                         )}

--- a/website/playground/buttons.js
+++ b/website/playground/buttons.js
@@ -37,11 +37,8 @@ export class ClipboardButton extends React.Component {
   }
 
   render() {
-    const { children } = this.props;
+    const { children, copy, ...rest } = this.props;
     const { showTooltip, tooltipText } = this.state;
-    const rest = { ...this.props };
-    delete rest.children;
-    delete rest.copy;
 
     return (
       <Button ref={this.ref} {...rest}>

--- a/website/playground/buttons.js
+++ b/website/playground/buttons.js
@@ -39,7 +39,7 @@ export class ClipboardButton extends React.Component {
   render() {
     const { children } = this.props;
     const { showTooltip, tooltipText } = this.state;
-    const rest = Object.assign({}, this.props);
+    const rest = { ...this.props };
     delete rest.children;
     delete rest.copy;
 

--- a/website/playground/panels.js
+++ b/website/playground/panels.js
@@ -13,7 +13,7 @@ class CodeMirrorPanel extends React.Component {
   }
 
   componentDidMount() {
-    const options = Object.assign({}, this.props);
+    const options = { ...this.props };
     delete options.ruler;
     delete options.rulerColor;
     delete options.value;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
