### PR TITLE
Expose create logger for plugins

### DIFF
--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -20,6 +20,7 @@ const optionsNormalizer = require("../main/options-normalizer");
 const thirdParty = require("../common/third-party");
 const arrayify = require("../utils/arrayify");
 const isTTY = require("../utils/is-tty");
+const logger = require("../utils/logger");
 
 const OPTION_USAGE_THRESHOLD = 25;
 const CHOICE_USAGE_MARGIN = 3;
@@ -764,54 +765,6 @@ function pick(object, keys) {
       );
 }
 
-function createLogger(logLevel) {
-  return {
-    warn: createLogFunc("warn", "yellow"),
-    error: createLogFunc("error", "red"),
-    debug: createLogFunc("debug", "blue"),
-    log: createLogFunc("log")
-  };
-
-  function createLogFunc(loggerName, color) {
-    if (!shouldLog(loggerName)) {
-      return () => {};
-    }
-
-    const prefix = color ? `[${chalk[color](loggerName)}] ` : "";
-    return function(message, opts) {
-      opts = Object.assign({ newline: true }, opts);
-      const stream = process[loggerName === "log" ? "stdout" : "stderr"];
-      stream.write(message.replace(/^/gm, prefix) + (opts.newline ? "\n" : ""));
-    };
-  }
-
-  function shouldLog(loggerName) {
-    switch (logLevel) {
-      case "silent":
-        return false;
-      default:
-        return true;
-      case "debug":
-        if (loggerName === "debug") {
-          return true;
-        }
-      // fall through
-      case "log":
-        if (loggerName === "log") {
-          return true;
-        }
-      // fall through
-      case "warn":
-        if (loggerName === "warn") {
-          return true;
-        }
-      // fall through
-      case "error":
-        return loggerName === "error";
-    }
-  }
-}
-
 function normalizeDetailedOption(name, option) {
   return Object.assign({ category: coreOptions.CATEGORY_OTHER }, option, {
     choices:
@@ -917,7 +870,7 @@ function createContext(args) {
   updateContextArgv(context);
   normalizeContextArgv(context, ["loglevel", "plugin", "plugin-search-dir"]);
 
-  context.logger = createLogger(context.argv["loglevel"]);
+  context.logger = logger.createLogger(context.argv["loglevel"]);
 
   updateContextArgv(
     context,

--- a/src/common/util-shared.js
+++ b/src/common/util-shared.js
@@ -20,6 +20,7 @@ function getNextNonSpaceNonCommentCharacterIndex(text, node, options) {
 }
 
 module.exports = {
+  createLogger: util.createLogger,
   getMaxContinuousCount: util.getMaxContinuousCount,
   getStringWidth: util.getStringWidth,
   getAlignmentSize: util.getAlignmentSize,

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -3,6 +3,7 @@
 const stringWidth = require("string-width");
 const escapeStringRegexp = require("escape-string-regexp");
 const getLast = require("../utils/get-last");
+const logger = require("../utils/logger");
 
 // eslint-disable-next-line no-control-regex
 const notAsciiRegex = /[^\x20-\x7F]/;
@@ -880,5 +881,6 @@ module.exports = {
   addLeadingComment,
   addDanglingComment,
   addTrailingComment,
-  isWithinParentArrayProperty
+  isWithinParentArrayProperty,
+  createLogger: logger.createLogger
 };

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -2,6 +2,13 @@
 
 const chalk = require("chalk");
 
+/**
+ * @typedef {'silent' | 'debug' | 'log' | 'warn' | 'error'} LogLevel
+ */
+
+/**
+ * @param {LogLevel} logLevel
+ */
 function createLogger(logLevel) {
   return {
     warn: createLogFunc("warn", "yellow"),
@@ -10,6 +17,11 @@ function createLogger(logLevel) {
     log: createLogFunc("log")
   };
 
+  /**
+   * @param {string} loggerName
+   * @param {string=} color
+   * @returns {(message: string, opts?: { newline?: boolean }) => void}
+   */
   function createLogFunc(loggerName, color) {
     if (!shouldLog(loggerName)) {
       return () => {};
@@ -23,6 +35,9 @@ function createLogger(logLevel) {
     };
   }
 
+  /**
+   * @param {string} loggerName
+   */
   function shouldLog(loggerName) {
     switch (logLevel) {
       case "silent":

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -1,0 +1,55 @@
+"use strict";
+
+const chalk = require("chalk");
+
+function createLogger(logLevel) {
+  return {
+    warn: createLogFunc("warn", "yellow"),
+    error: createLogFunc("error", "red"),
+    debug: createLogFunc("debug", "blue"),
+    log: createLogFunc("log")
+  };
+
+  function createLogFunc(loggerName, color) {
+    if (!shouldLog(loggerName)) {
+      return () => {};
+    }
+
+    const prefix = color ? `[${chalk[color](loggerName)}] ` : "";
+    return function(message, opts) {
+      opts = Object.assign({ newline: true }, opts);
+      const stream = process[loggerName === "log" ? "stdout" : "stderr"];
+      stream.write(message.replace(/^/gm, prefix) + (opts.newline ? "\n" : ""));
+    };
+  }
+
+  function shouldLog(loggerName) {
+    switch (logLevel) {
+      case "silent":
+        return false;
+      default:
+        return true;
+      case "debug":
+        if (loggerName === "debug") {
+          return true;
+        }
+      // fall through
+      case "log":
+        if (loggerName === "log") {
+          return true;
+        }
+      // fall through
+      case "warn":
+        if (loggerName === "warn") {
+          return true;
+        }
+      // fall through
+      case "error":
+        return loggerName === "error";
+    }
+  }
+}
+
+module.exports = {
+  createLogger
+};


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Exposes the `createLogger` function, that was used by the CLI so it can be used via util-shared
In addition I added some JSDocs

closes #7370 

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**

![Bildschirmfoto 2020-01-17 um 17 46 11](https://user-images.githubusercontent.com/7195563/72630096-e8421300-3951-11ea-8384-429665345bf1.png)
