### PR TITLE
Enable ESLint `prefer-rest-params` rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -43,6 +43,7 @@ rules:
         array: false
         object: false
     - enforceForRenamedProperties: false
+  prefer-rest-params: error
   prefer-spread: error
   quotes:
     - error

--- a/src/common/fast-path.js
+++ b/src/common/fast-path.js
@@ -56,10 +56,7 @@ FastPath.prototype.getParentNode = function getParentNode(count) {
 // reference to this (modified) FastPath object. Note that the stack will
 // be restored to its original state after the callback is finished, so it
 // is probably a mistake to retain a reference to the path.
-FastPath.prototype.call = function call(
-  callback,
-  /* name1, name2, ... */ ...names
-) {
+FastPath.prototype.call = function call(callback, ...names) {
   const s = this.stack;
   const origLen = s.length;
   let value = s[origLen - 1];
@@ -86,10 +83,7 @@ FastPath.prototype.callParent = function callParent(callback, count) {
 // accessing this.getValue()[name1][name2]... should be array-like. The
 // callback will be called with a reference to this path object for each
 // element of the array.
-FastPath.prototype.each = function each(
-  callback,
-  /* name1, name2, ... */ ...names
-) {
+FastPath.prototype.each = function each(callback, ...names) {
   const s = this.stack;
   const origLen = s.length;
   let value = s[origLen - 1];
@@ -117,10 +111,7 @@ FastPath.prototype.each = function each(
 // Similar to FastPath.prototype.each, except that the results of the
 // callback function invocations are stored in an array and returned at
 // the end of the iteration.
-FastPath.prototype.map = function map(
-  callback,
-  /* name1, name2, ... */ ...names
-) {
+FastPath.prototype.map = function map(callback, ...names) {
   const s = this.stack;
   const origLen = s.length;
   let value = s[origLen - 1];
@@ -153,7 +144,7 @@ FastPath.prototype.map = function map(
  *   | undefined
  * )} predicates
  */
-FastPath.prototype.match = function match(/* predicates */ ...predicates) {
+FastPath.prototype.match = function match(...predicates) {
   let stackPointer = this.stack.length - 1;
 
   let name = null;

--- a/src/common/fast-path.js
+++ b/src/common/fast-path.js
@@ -56,13 +56,16 @@ FastPath.prototype.getParentNode = function getParentNode(count) {
 // reference to this (modified) FastPath object. Note that the stack will
 // be restored to its original state after the callback is finished, so it
 // is probably a mistake to retain a reference to the path.
-FastPath.prototype.call = function call(callback /*, name1, name2, ... */) {
+FastPath.prototype.call = function call(
+  callback,
+  /* name1, name2, ... */ ...names
+) {
   const s = this.stack;
   const origLen = s.length;
   let value = s[origLen - 1];
-  const argc = arguments.length;
-  for (let i = 1; i < argc; ++i) {
-    const name = arguments[i];
+  const argc = names.length;
+  for (let i = 0; i < argc; ++i) {
+    const name = names[i];
     value = value[name];
     s.push(name, value);
   }
@@ -83,14 +86,17 @@ FastPath.prototype.callParent = function callParent(callback, count) {
 // accessing this.getValue()[name1][name2]... should be array-like. The
 // callback will be called with a reference to this path object for each
 // element of the array.
-FastPath.prototype.each = function each(callback /*, name1, name2, ... */) {
+FastPath.prototype.each = function each(
+  callback,
+  /* name1, name2, ... */ ...names
+) {
   const s = this.stack;
   const origLen = s.length;
   let value = s[origLen - 1];
-  const argc = arguments.length;
+  const argc = names.length;
 
-  for (let i = 1; i < argc; ++i) {
-    const name = arguments[i];
+  for (let i = 0; i < argc; ++i) {
+    const name = names[i];
     value = value[name];
     s.push(name, value);
   }
@@ -111,14 +117,17 @@ FastPath.prototype.each = function each(callback /*, name1, name2, ... */) {
 // Similar to FastPath.prototype.each, except that the results of the
 // callback function invocations are stored in an array and returned at
 // the end of the iteration.
-FastPath.prototype.map = function map(callback /*, name1, name2, ... */) {
+FastPath.prototype.map = function map(
+  callback,
+  /* name1, name2, ... */ ...names
+) {
   const s = this.stack;
   const origLen = s.length;
   let value = s[origLen - 1];
-  const argc = arguments.length;
+  const argc = names.length;
 
-  for (let i = 1; i < argc; ++i) {
-    const name = arguments[i];
+  for (let i = 0; i < argc; ++i) {
+    const name = names[i];
     value = value[name];
     s.push(name, value);
   }
@@ -144,13 +153,13 @@ FastPath.prototype.map = function map(callback /*, name1, name2, ... */) {
  *   | undefined
  * )} predicates
  */
-FastPath.prototype.match = function match(/* predicates */) {
+FastPath.prototype.match = function match(/* predicates */ ...predicates) {
   let stackPointer = this.stack.length - 1;
 
   let name = null;
   let node = this.stack[stackPointer--];
 
-  for (let i = 0; i < arguments.length; ++i) {
+  for (let i = 0; i < predicates.length; ++i) {
     if (node === undefined) {
       return false;
     }
@@ -163,7 +172,7 @@ FastPath.prototype.match = function match(/* predicates */) {
       node = this.stack[stackPointer--];
     }
 
-    if (arguments[i] && !arguments[i](node, name, number)) {
+    if (predicates[i] && !predicates[i](node, name, number)) {
       return false;
     }
 

--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -516,11 +516,8 @@ function requireParser(isSCSSParser) {
   // TODO: Remove this hack when this issue is fixed:
   // https://github.com/shellscape/postcss-less/issues/88
   const LessParser = require("postcss-less/dist/less-parser");
-  LessParser.prototype.atrule = function() {
-    return Object.getPrototypeOf(LessParser.prototype).atrule.apply(
-      this,
-      arguments
-    );
+  LessParser.prototype.atrule = function(...args) {
+    return Object.getPrototypeOf(LessParser.prototype).atrule.apply(this, args);
   };
 
   return require("postcss-less");


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Notice: Similar changes inside `fast-path.js` was merged and reverted.  ( #6225 and #6226 )

But I see no reason not use rest params (node 10 supports this), we already used it a lot.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
