### PR TITLE
Clarify API docs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -9,7 +9,7 @@ const prettier = require("prettier");
 
 ## `prettier.format(source [, options])`
 
-`format` is used to format text using Prettier. Set `options.parser` to the language you are formatting. [Options](options.md) may be provided to override the defaults. 
+`format` is used to format text using Prettier. [Options](options.md) may be provided to override the defaults. Set `options.parser` according to the language you are formatting (see the [list of available parsers](options.md#parser)).
 
 ```js
 prettier.format("foo ( );", { semi: false, parser: "babel" });

--- a/docs/api.md
+++ b/docs/api.md
@@ -9,7 +9,7 @@ const prettier = require("prettier");
 
 ## `prettier.format(source [, options])`
 
-`format` is used to format text using Prettier. [Options](options.md) may be provided to override the defaults.
+`format` is used to format text using Prettier. Set `options.parser` to the language you are formatting. [Options](options.md) may be provided to override the defaults. 
 
 ```js
 prettier.format("foo ( );", { semi: false, parser: "babel" });


### PR DESCRIPTION
It is not immediately obvious how to set the language (`options.parser`), hopefully this will save others time.

<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
