### PR TITLE
Fix object literal checks in isSimpleCallArgument

### DIFF
--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -926,9 +926,7 @@ function isSimpleCallArgument(node, depth) {
   }
   if (node.type === "ObjectExpression") {
     return node.properties.every(
-      p =>
-        p.shorthand ||
-        (isSimpleCallArgument(p.key, depth) && isChildSimple(p.value))
+      p => !p.computed && (p.shorthand || (p.value && isChildSimple(p.value)))
     );
   }
   if (node.type === "ArrayExpression") {

--- a/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -1176,6 +1176,48 @@ wrapper
 ================================================================================
 `;
 
+exports[`object-literal.js 1`] = `
+====================================options=====================================
+parsers: ["flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+of("test")
+  .pipe(throwIfEmpty())
+  .subscribe({
+    error(err) {
+      thrown = err;
+    }
+  });
+
+of("test")
+  .pipe(throwIfEmpty())
+  .subscribe({
+    get foo() {
+      bar();
+    }
+  });
+
+=====================================output=====================================
+of("test")
+  .pipe(throwIfEmpty())
+  .subscribe({
+    error(err) {
+      thrown = err;
+    },
+  });
+
+of("test")
+  .pipe(throwIfEmpty())
+  .subscribe({
+    get foo() {
+      bar();
+    },
+  });
+
+================================================================================
+`;
+
 exports[`short-names.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "typescript"]

--- a/tests/method-chain/object-literal.js
+++ b/tests/method-chain/object-literal.js
@@ -1,0 +1,15 @@
+of("test")
+  .pipe(throwIfEmpty())
+  .subscribe({
+    error(err) {
+      thrown = err;
+    }
+  });
+
+of("test")
+  .pipe(throwIfEmpty())
+  .subscribe({
+    get foo() {
+      bar();
+    }
+  });


### PR DESCRIPTION
Fix for #6685.

With the `babel` parser this code couldn't be formatted, an error was thrown (`TypeError: Cannot read property 'type' of undefined` as `ObjectMethod` nodes don't have `value` in Babel):
```js
of("test")
  .pipe(throwIfEmpty())
  .subscribe({
    error(err) {
      thrown = err;
    }
  });
```

Also I simplified the check for `key`. Instead of checking whether the `key` expression is 'simple', now it just checks whether the property is computed.

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
