### PR TITLE
fix tests on Windows: drive letter case issue

### DIFF
--- a/tests_integration/path-serializer.js
+++ b/tests_integration/path-serializer.js
@@ -2,8 +2,18 @@
 
 const replaceCWD = text => {
   const cwd = process.cwd();
-  while (text.includes(cwd)) {
-    text = text.replace(cwd, "<cwd>");
+
+  const variants = /^[a-z]:\\/i.test(cwd)
+    ? [
+        cwd.charAt(0).toLowerCase() + cwd.slice(1),
+        cwd.charAt(0).toUpperCase() + cwd.slice(1)
+      ]
+    : [cwd];
+
+  for (const variant of variants) {
+    while (text.includes(variant)) {
+      text = text.replace(variant, "<cwd>");
+    }
   }
 
   return text;


### PR DESCRIPTION
The drive letter case returned by `process.cwd()` and other functions can be inconsistent.

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
