### PR TITLE
Use BOM string instead of BOM charCode

### DIFF
--- a/src/main/core.js
+++ b/src/main/core.js
@@ -19,7 +19,7 @@ const {
   debug: { printDocToDebug }
 } = require("../document");
 
-const UTF8BOM = 0xfeff;
+const BOM = "\uFEFF";
 
 const CURSOR = Symbol("cursor");
 const PLACEHOLDERS = {
@@ -319,7 +319,7 @@ function format(text, opts) {
     }
   }
 
-  const hasUnicodeBOM = text.charCodeAt(0) === UTF8BOM;
+  const hasUnicodeBOM = text.charAt(0) === BOM;
   if (hasUnicodeBOM) {
     text = text.substring(1);
     if (hasCursor) {
@@ -354,7 +354,7 @@ function format(text, opts) {
         );
 
   if (hasUnicodeBOM) {
-    result.formatted = String.fromCharCode(UTF8BOM) + result.formatted;
+    result.formatted = BOM + result.formatted;
 
     if (hasCursor) {
       result.cursorOffset++;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Use BOM string, so we don't have to use `String.fromCharCode` after format.
And renamed it, I believe it's called `unicode BOM` or [`BOM`](https://en.wikipedia.org/wiki/Byte_order_mark)

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
