### PR TITLE
Remove useless argument in `editorconfig` load function

### DIFF
--- a/src/config/resolve-config-editorconfig.js
+++ b/src/config/resolve-config-editorconfig.js
@@ -10,7 +10,7 @@ const findProjectRoot = require("find-project-root");
 
 const jsonStringifyMem = fn => mem(fn, { cacheKey: JSON.stringify });
 
-const maybeParse = (filePath, config, parse) => {
+const maybeParse = (filePath, parse) => {
   // findProjectRoot will throw an error if we pass a nonexistent directory to
   // it, which is possible, for example, when the path is given via
   // --stdin-filepath. So, first, traverse up until we find an existing
@@ -24,16 +24,14 @@ const maybeParse = (filePath, config, parse) => {
   return filePath && parse(filePath, { root });
 };
 
-const editorconfigAsyncNoCache = async (filePath, config) => {
-  const editorConfig = await maybeParse(filePath, config, editorconfig.parse);
+const editorconfigAsyncNoCache = async filePath => {
+  const editorConfig = await maybeParse(filePath, editorconfig.parse);
   return editorConfigToPrettier(editorConfig);
 };
 const editorconfigAsyncWithCache = jsonStringifyMem(editorconfigAsyncNoCache);
 
-const editorconfigSyncNoCache = (filePath, config) => {
-  return editorConfigToPrettier(
-    maybeParse(filePath, config, editorconfig.parseSync)
-  );
+const editorconfigSyncNoCache = filePath => {
+  return editorConfigToPrettier(maybeParse(filePath, editorconfig.parseSync));
 };
 const editorconfigSyncWithCache = jsonStringifyMem(editorconfigSyncNoCache);
 


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

This `config` never used.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
