### PR TITLE
Vue: don't print long single expression of `TemplateLiteral` and `StringLiteral` on new line

### DIFF
--- a/changelog_unreleased/vue/pr-7479.md
+++ b/changelog_unreleased/vue/pr-7479.md
@@ -1,0 +1,42 @@
+#### Don't print single `TemplateLiteral` and `StringLiteral` expression on new line ([#7479](https://github.com/prettier/prettier/pull/7479) by [@fisker](https://github.com/fisker))
+
+Previously, we print long `TemplateLiteral` and `StringLiteral` on new line in attribute, now we print them on the same line with attribute name.
+
+<!-- prettier-ignore -->
+```vue
+<!-- Input -->
+<template>
+<MyComponent :attr="`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog ${template} literal value`"/>
+</template>
+<template>
+<MyComponent :attr="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog string literal value'"/>
+</template>
+
+<!-- Prettier stable -->
+<template>
+  <MyComponent
+    :attr="
+      `loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog ${template} literal value`
+    "
+  />
+</template>
+<template>
+  <MyComponent
+    :attr="
+      'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog string literal value'
+    "
+  />
+</template>
+
+<!-- Prettier master -->
+<template>
+  <MyComponent
+    :attr="`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog ${template} literal value`"
+  />
+</template>
+<template>
+  <MyComponent
+    :attr="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog string literal value'"
+  />
+</template>
+```

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -922,7 +922,7 @@ function printEmbeddedAttributeValue(node, originalTextToDoc, options) {
 
   let shouldHug = false;
 
-  const __onHtmlBindingRoot = root => {
+  const __onHtmlBindingRoot = (root, options) => {
     const rootNode =
       root.type === "NGRoot"
         ? root.node.type === "NGMicrosyntax" &&
@@ -934,9 +934,12 @@ function printEmbeddedAttributeValue(node, originalTextToDoc, options) {
         ? root.node
         : root;
     if (
-      rootNode &&
-      (rootNode.type === "ObjectExpression" ||
-        rootNode.type === "ArrayExpression")
+      (rootNode &&
+        (rootNode.type === "ObjectExpression" ||
+          rootNode.type === "ArrayExpression")) ||
+      (options.parser === "__vue_expression" &&
+        (rootNode.type === "TemplateLiteral" ||
+          rootNode.type === "StringLiteral"))
     ) {
       shouldHug = true;
     }

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -934,12 +934,12 @@ function printEmbeddedAttributeValue(node, originalTextToDoc, options) {
         ? root.node
         : root;
     if (
-      (rootNode &&
-        (rootNode.type === "ObjectExpression" ||
-          rootNode.type === "ArrayExpression")) ||
-      (options.parser === "__vue_expression" &&
-        (rootNode.type === "TemplateLiteral" ||
-          rootNode.type === "StringLiteral"))
+      rootNode &&
+      (rootNode.type === "ObjectExpression" ||
+        rootNode.type === "ArrayExpression" ||
+        (options.parser === "__vue_expression" &&
+          (rootNode.type === "TemplateLiteral" ||
+            rootNode.type === "StringLiteral")))
     ) {
       shouldHug = true;
     }

--- a/src/language-js/html-binding.js
+++ b/src/language-js/html-binding.js
@@ -8,7 +8,7 @@ function printHtmlBinding(path, options, print) {
   const node = path.getValue();
 
   if (options.__onHtmlBindingRoot && path.getName() === null) {
-    options.__onHtmlBindingRoot(node);
+    options.__onHtmlBindingRoot(node, options);
   }
 
   if (node.type !== "File") {

--- a/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
@@ -968,6 +968,158 @@ semi: false
 ================================================================================
 `;
 
+exports[`expression-binding.vue 1`] = `
+====================================options=====================================
+parsers: ["vue"]
+printWidth: 80
+trailingComma: "none"
+                                                                                | printWidth
+=====================================input======================================
+<!-- #7396 -->
+<template>
+	<Element :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"/>
+</template>
+<template>
+	<Element :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo +               bar} template literal value\`"/>
+</template>
+<template>
+	<img :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"/>
+</template>
+<template>
+	<img :src="100000000000000000000000000000000000000000000000000000000000000000000000000000"/>
+</template>
+
+=====================================output=====================================
+<!-- #7396 -->
+<template>
+  <Element
+    :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"
+  />
+</template>
+<template>
+  <Element
+    :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${
+      foo + bar
+    } template literal value\`"
+  />
+</template>
+<template>
+  <img
+    :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"
+  />
+</template>
+<template>
+  <img
+    :src="
+      100000000000000000000000000000000000000000000000000000000000000000000000000000
+    "
+  />
+</template>
+
+================================================================================
+`;
+
+exports[`expression-binding.vue 2`] = `
+====================================options=====================================
+parsers: ["vue"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<!-- #7396 -->
+<template>
+	<Element :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"/>
+</template>
+<template>
+	<Element :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo +               bar} template literal value\`"/>
+</template>
+<template>
+	<img :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"/>
+</template>
+<template>
+	<img :src="100000000000000000000000000000000000000000000000000000000000000000000000000000"/>
+</template>
+
+=====================================output=====================================
+<!-- #7396 -->
+<template>
+  <Element
+    :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"
+  />
+</template>
+<template>
+  <Element
+    :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${
+      foo + bar
+    } template literal value\`"
+  />
+</template>
+<template>
+  <img
+    :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"
+  />
+</template>
+<template>
+  <img
+    :src="
+      100000000000000000000000000000000000000000000000000000000000000000000000000000
+    "
+  />
+</template>
+
+================================================================================
+`;
+
+exports[`expression-binding.vue 3`] = `
+====================================options=====================================
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<!-- #7396 -->
+<template>
+	<Element :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"/>
+</template>
+<template>
+	<Element :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo +               bar} template literal value\`"/>
+</template>
+<template>
+	<img :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"/>
+</template>
+<template>
+	<img :src="100000000000000000000000000000000000000000000000000000000000000000000000000000"/>
+</template>
+
+=====================================output=====================================
+<!-- #7396 -->
+<template>
+  <Element
+    :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"
+  />
+</template>
+<template>
+  <Element
+    :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${
+      foo + bar
+    } template literal value\`"
+  />
+</template>
+<template>
+  <img
+    :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"
+  />
+</template>
+<template>
+  <img
+    :src="
+      100000000000000000000000000000000000000000000000000000000000000000000000000000
+    "
+  />
+</template>
+
+================================================================================
+`;
+
 exports[`filter.vue 1`] = `
 ====================================options=====================================
 parsers: ["vue"]

--- a/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
@@ -977,39 +977,39 @@ trailingComma: "none"
 =====================================input======================================
 <!-- #7396 -->
 <template>
-	<Element :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"/>
+	<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"/>
 </template>
 <template>
-	<Element :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo +               bar} template literal value\`"/>
+	<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo +               bar} template literal value\`"/>
 </template>
 <template>
-	<img :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"/>
+	<MyComponent :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"/>
 </template>
 <template>
-	<img :src="100000000000000000000000000000000000000000000000000000000000000000000000000000"/>
+	<MyComponent :src="100000000000000000000000000000000000000000000000000000000000000000000000000000"/>
 </template>
 
 =====================================output=====================================
 <!-- #7396 -->
 <template>
-  <Element
-    :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"
+  <MyComponent
+    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"
   />
 </template>
 <template>
-  <Element
-    :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${
+  <MyComponent
+    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${
       foo + bar
     } template literal value\`"
   />
 </template>
 <template>
-  <img
+  <MyComponent
     :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"
   />
 </template>
 <template>
-  <img
+  <MyComponent
     :src="
       100000000000000000000000000000000000000000000000000000000000000000000000000000
     "
@@ -1027,39 +1027,39 @@ printWidth: 80
 =====================================input======================================
 <!-- #7396 -->
 <template>
-	<Element :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"/>
+	<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"/>
 </template>
 <template>
-	<Element :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo +               bar} template literal value\`"/>
+	<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo +               bar} template literal value\`"/>
 </template>
 <template>
-	<img :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"/>
+	<MyComponent :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"/>
 </template>
 <template>
-	<img :src="100000000000000000000000000000000000000000000000000000000000000000000000000000"/>
+	<MyComponent :src="100000000000000000000000000000000000000000000000000000000000000000000000000000"/>
 </template>
 
 =====================================output=====================================
 <!-- #7396 -->
 <template>
-  <Element
-    :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"
+  <MyComponent
+    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"
   />
 </template>
 <template>
-  <Element
-    :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${
+  <MyComponent
+    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${
       foo + bar
     } template literal value\`"
   />
 </template>
 <template>
-  <img
+  <MyComponent
     :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"
   />
 </template>
 <template>
-  <img
+  <MyComponent
     :src="
       100000000000000000000000000000000000000000000000000000000000000000000000000000
     "
@@ -1078,39 +1078,39 @@ semi: false
 =====================================input======================================
 <!-- #7396 -->
 <template>
-	<Element :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"/>
+	<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"/>
 </template>
 <template>
-	<Element :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo +               bar} template literal value\`"/>
+	<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo +               bar} template literal value\`"/>
 </template>
 <template>
-	<img :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"/>
+	<MyComponent :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"/>
 </template>
 <template>
-	<img :src="100000000000000000000000000000000000000000000000000000000000000000000000000000"/>
+	<MyComponent :src="100000000000000000000000000000000000000000000000000000000000000000000000000000"/>
 </template>
 
 =====================================output=====================================
 <!-- #7396 -->
 <template>
-  <Element
-    :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"
+  <MyComponent
+    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"
   />
 </template>
 <template>
-  <Element
-    :src="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${
+  <MyComponent
+    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${
       foo + bar
     } template literal value\`"
   />
 </template>
 <template>
-  <img
+  <MyComponent
     :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"
   />
 </template>
 <template>
-  <img
+  <MyComponent
     :src="
       100000000000000000000000000000000000000000000000000000000000000000000000000000
     "

--- a/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html_vue/__snapshots__/jsfmt.spec.js.snap
@@ -977,41 +977,64 @@ trailingComma: "none"
 =====================================input======================================
 <!-- #7396 -->
 <template>
-	<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"/>
+<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`"/>
 </template>
 <template>
-	<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo +               bar} template literal value\`"/>
+<MyComponent :attr="\`\${first} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`
++\`\${second} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`"/>
 </template>
 <template>
-	<MyComponent :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"/>
+<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo +               bar} template literal value\`"/>
 </template>
 <template>
-	<MyComponent :src="100000000000000000000000000000000000000000000000000000000000000000000000000000"/>
+<MyComponent :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value'"/>
+</template>
+<template>
+<MyComponent :src="'first loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog' + 'second loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog'"/>
+</template>
+<template>
+<MyComponent :src="100000000000000000000000000000000000000000000000000000000000000000000000000"/>
 </template>
 
 =====================================output=====================================
 <!-- #7396 -->
 <template>
   <MyComponent
-    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"
+    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`"
   />
 </template>
 <template>
   <MyComponent
-    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${
+    :attr="
+      \`\${first} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\` +
+        \`\${second} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`
+    "
+  />
+</template>
+<template>
+  <MyComponent
+    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${
       foo + bar
     } template literal value\`"
   />
 </template>
 <template>
   <MyComponent
-    :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"
+    :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value'"
   />
 </template>
 <template>
   <MyComponent
     :src="
-      100000000000000000000000000000000000000000000000000000000000000000000000000000
+      'first loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog' +
+        'second loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog'
+    "
+  />
+</template>
+<template>
+  <MyComponent
+    :src="
+      100000000000000000000000000000000000000000000000000000000000000000000000000
     "
   />
 </template>
@@ -1027,41 +1050,64 @@ printWidth: 80
 =====================================input======================================
 <!-- #7396 -->
 <template>
-	<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"/>
+<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`"/>
 </template>
 <template>
-	<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo +               bar} template literal value\`"/>
+<MyComponent :attr="\`\${first} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`
++\`\${second} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`"/>
 </template>
 <template>
-	<MyComponent :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"/>
+<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo +               bar} template literal value\`"/>
 </template>
 <template>
-	<MyComponent :src="100000000000000000000000000000000000000000000000000000000000000000000000000000"/>
+<MyComponent :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value'"/>
+</template>
+<template>
+<MyComponent :src="'first loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog' + 'second loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog'"/>
+</template>
+<template>
+<MyComponent :src="100000000000000000000000000000000000000000000000000000000000000000000000000"/>
 </template>
 
 =====================================output=====================================
 <!-- #7396 -->
 <template>
   <MyComponent
-    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"
+    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`"
   />
 </template>
 <template>
   <MyComponent
-    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${
+    :attr="
+      \`\${first} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\` +
+        \`\${second} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`
+    "
+  />
+</template>
+<template>
+  <MyComponent
+    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${
       foo + bar
     } template literal value\`"
   />
 </template>
 <template>
   <MyComponent
-    :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"
+    :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value'"
   />
 </template>
 <template>
   <MyComponent
     :src="
-      100000000000000000000000000000000000000000000000000000000000000000000000000000
+      'first loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog' +
+        'second loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog'
+    "
+  />
+</template>
+<template>
+  <MyComponent
+    :src="
+      100000000000000000000000000000000000000000000000000000000000000000000000000
     "
   />
 </template>
@@ -1078,41 +1124,64 @@ semi: false
 =====================================input======================================
 <!-- #7396 -->
 <template>
-	<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"/>
+<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`"/>
 </template>
 <template>
-	<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo +               bar} template literal value\`"/>
+<MyComponent :attr="\`\${first} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`
++\`\${second} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`"/>
 </template>
 <template>
-	<MyComponent :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"/>
+<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo +               bar} template literal value\`"/>
 </template>
 <template>
-	<MyComponent :src="100000000000000000000000000000000000000000000000000000000000000000000000000000"/>
+<MyComponent :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value'"/>
+</template>
+<template>
+<MyComponent :src="'first loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog' + 'second loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog'"/>
+</template>
+<template>
+<MyComponent :src="100000000000000000000000000000000000000000000000000000000000000000000000000"/>
 </template>
 
 =====================================output=====================================
 <!-- #7396 -->
 <template>
   <MyComponent
-    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${foo} template literal value\`"
+    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`"
   />
 </template>
 <template>
   <MyComponent
-    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong\${
+    :attr="
+      \`\${first} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\` +
+        \`\${second} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`
+    "
+  />
+</template>
+<template>
+  <MyComponent
+    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${
       foo + bar
     } template literal value\`"
   />
 </template>
 <template>
   <MyComponent
-    :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"
+    :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value'"
   />
 </template>
 <template>
   <MyComponent
     :src="
-      100000000000000000000000000000000000000000000000000000000000000000000000000000
+      'first loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog' +
+        'second loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog'
+    "
+  />
+</template>
+<template>
+  <MyComponent
+    :src="
+      100000000000000000000000000000000000000000000000000000000000000000000000000
     "
   />
 </template>

--- a/tests/html_vue/expression-binding.vue
+++ b/tests/html_vue/expression-binding.vue
@@ -1,0 +1,13 @@
+<!-- #7396 -->
+<template>
+	<Element :src="`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong${foo} template literal value`"/>
+</template>
+<template>
+	<Element :src="`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong${foo +               bar} template literal value`"/>
+</template>
+<template>
+	<img :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"/>
+</template>
+<template>
+	<img :src="100000000000000000000000000000000000000000000000000000000000000000000000000000"/>
+</template>

--- a/tests/html_vue/expression-binding.vue
+++ b/tests/html_vue/expression-binding.vue
@@ -1,13 +1,20 @@
 <!-- #7396 -->
 <template>
-	<MyComponent :attr="`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong${foo} template literal value`"/>
+<MyComponent :attr="`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog ${foo} template literal value`"/>
 </template>
 <template>
-	<MyComponent :attr="`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong${foo +               bar} template literal value`"/>
+<MyComponent :attr="`${first} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog ${template} ${literal}`
++`${second} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog ${template} ${literal}`"/>
 </template>
 <template>
-	<MyComponent :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"/>
+<MyComponent :attr="`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog ${foo +               bar} template literal value`"/>
 </template>
 <template>
-	<MyComponent :src="100000000000000000000000000000000000000000000000000000000000000000000000000000"/>
+<MyComponent :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value'"/>
+</template>
+<template>
+<MyComponent :src="'first loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog' + 'second loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog'"/>
+</template>
+<template>
+<MyComponent :src="100000000000000000000000000000000000000000000000000000000000000000000000000"/>
 </template>

--- a/tests/html_vue/expression-binding.vue
+++ b/tests/html_vue/expression-binding.vue
@@ -1,13 +1,13 @@
 <!-- #7396 -->
 <template>
-	<Element :src="`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong${foo} template literal value`"/>
+	<MyComponent :attr="`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong${foo} template literal value`"/>
 </template>
 <template>
-	<Element :src="`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong${foo +               bar} template literal value`"/>
+	<MyComponent :attr="`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong${foo +               bar} template literal value`"/>
 </template>
 <template>
-	<img :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"/>
+	<MyComponent :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong literal string value'"/>
 </template>
 <template>
-	<img :src="100000000000000000000000000000000000000000000000000000000000000000000000000000"/>
+	<MyComponent :src="100000000000000000000000000000000000000000000000000000000000000000000000000000"/>
 </template>


### PR DESCRIPTION
Fixes https://github.com/prettier/prettier/issues/7396

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
