### PR TITLE
Fix a failed test on `flow` parser

### DIFF
--- a/src/common/parser-include-shebang.js
+++ b/src/common/parser-include-shebang.js
@@ -12,7 +12,6 @@ function includeShebang(text, ast) {
     value: shebang,
     range: [0, index],
     loc: {
-      source: null,
       start: {
         line: 1,
         column: 0

--- a/src/language-js/clean.js
+++ b/src/language-js/clean.js
@@ -17,6 +17,10 @@ function clean(ast, newObj, parent) {
     delete newObj[name];
   });
 
+  if (ast.loc && ast.loc.source === null) {
+    delete newObj.loc.source;
+  }
+
   if (ast.type === "BigIntLiteral") {
     newObj.value = newObj.value.toLowerCase();
   }

--- a/tests/flow/sketchy_null_default/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/sketchy_null_default/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,193 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test.js 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+/* @flow */
+
+/* EXAMPLES NOT IN A CONDITIONAL */
+
+//"Sketchy" checks excused by the default pattern (Not errors)
+
+var x1: ?boolean = null;
+x1 = x1 || false;
+
+var y1: ?number = null;
+y1 = y1 || 0;
+
+var z1: ?string = null;
+z1 = z1 || '';
+
+//These checks aren't excused because they aren't the same as a null check
+//(Errors: one per line)
+
+var x2: ?boolean = null;
+x2 = x2 || true;
+
+var y2: ?number = null;
+y2 = y2 || 1;
+
+var z2: ?string = null;
+z2 = z2 || 'foo';
+
+//The default pattern doesn't excuse all sketchy null checks, just
+//sound ones. (Errors: two per line)
+
+var a1: boolean | number | string | null = null;
+a1 = a1 || false;
+
+var b1: boolean | number | string | null = null;
+b1 = b1 || 0;
+
+var c1: boolean | number | string | null = null;
+c1 = c1 || '';
+
+
+/* EXAMPLES IN A CONDITIONAL */
+
+//"Sketchy" checks excused by the default pattern (Not errors)
+
+var x3: ?boolean = null;
+if (x3 || false) {}
+
+var y3: ?number = null;
+if (y3 || 0) {}
+
+var z3: ?string = null;
+if (z3 || '') {}
+
+//These checks aren't excused because they aren't the same as a null check
+//(Errors: one per line)
+
+var x4: ?boolean = null;
+if (x4 || true) {}
+
+var y4: ?number = null;
+if (y4 || false) {}
+
+var z4: ?string = null;
+if (z4 || 'foo') {}
+
+//The default pattern doesn't excuse all sketchy null checks, just
+//sound ones. (Errors: two per line)
+
+var a2: boolean | number | string | null = null;
+if (a2 || false) {}
+
+var b2: boolean | number | string | null = null;
+if (b2 || 0) {}
+
+var c2: boolean | number | string | null = null;
+if (c2 || '') {}
+
+//Compound sketchy null checks
+
+var d1: ?boolean = null;
+var e1: ?boolean = true;
+d1 = (d1 || e1) || false; //Both checks are sketchy. (This is how it gets parsed without the parentheses)
+
+var d2: ?boolean = null;
+var e2: ?boolean = true;
+d2 = d2 || (e2 || false); //Only d2 is sketchy; e2 matches the default pattern.
+
+=====================================output=====================================
+/* @flow */
+
+/* EXAMPLES NOT IN A CONDITIONAL */
+
+//"Sketchy" checks excused by the default pattern (Not errors)
+
+var x1: ?boolean = null;
+x1 = x1 || false;
+
+var y1: ?number = null;
+y1 = y1 || 0;
+
+var z1: ?string = null;
+z1 = z1 || "";
+
+//These checks aren't excused because they aren't the same as a null check
+//(Errors: one per line)
+
+var x2: ?boolean = null;
+x2 = x2 || true;
+
+var y2: ?number = null;
+y2 = y2 || 1;
+
+var z2: ?string = null;
+z2 = z2 || "foo";
+
+//The default pattern doesn't excuse all sketchy null checks, just
+//sound ones. (Errors: two per line)
+
+var a1: boolean | number | string | null = null;
+a1 = a1 || false;
+
+var b1: boolean | number | string | null = null;
+b1 = b1 || 0;
+
+var c1: boolean | number | string | null = null;
+c1 = c1 || "";
+
+/* EXAMPLES IN A CONDITIONAL */
+
+//"Sketchy" checks excused by the default pattern (Not errors)
+
+var x3: ?boolean = null;
+if (x3 || false) {
+}
+
+var y3: ?number = null;
+if (y3 || 0) {
+}
+
+var z3: ?string = null;
+if (z3 || "") {
+}
+
+//These checks aren't excused because they aren't the same as a null check
+//(Errors: one per line)
+
+var x4: ?boolean = null;
+if (x4 || true) {
+}
+
+var y4: ?number = null;
+if (y4 || false) {
+}
+
+var z4: ?string = null;
+if (z4 || "foo") {
+}
+
+//The default pattern doesn't excuse all sketchy null checks, just
+//sound ones. (Errors: two per line)
+
+var a2: boolean | number | string | null = null;
+if (a2 || false) {
+}
+
+var b2: boolean | number | string | null = null;
+if (b2 || 0) {
+}
+
+var c2: boolean | number | string | null = null;
+if (c2 || "") {
+}
+
+//Compound sketchy null checks
+
+var d1: ?boolean = null;
+var e1: ?boolean = true;
+d1 = d1 || e1 || false; //Both checks are sketchy. (This is how it gets parsed without the parentheses)
+
+var d2: ?boolean = null;
+var e2: ?boolean = true;
+d2 = d2 || e2 || false; //Only d2 is sketchy; e2 matches the default pattern.
+
+================================================================================
+`;

--- a/tests/flow/sketchy_null_default/jsfmt.spec.js
+++ b/tests/flow/sketchy_null_default/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["flow"]);

--- a/tests/flow/sketchy_null_default/test.js
+++ b/tests/flow/sketchy_null_default/test.js
@@ -1,0 +1,86 @@
+/* @flow */
+
+/* EXAMPLES NOT IN A CONDITIONAL */
+
+//"Sketchy" checks excused by the default pattern (Not errors)
+
+var x1: ?boolean = null;
+x1 = x1 || false;
+
+var y1: ?number = null;
+y1 = y1 || 0;
+
+var z1: ?string = null;
+z1 = z1 || '';
+
+//These checks aren't excused because they aren't the same as a null check
+//(Errors: one per line)
+
+var x2: ?boolean = null;
+x2 = x2 || true;
+
+var y2: ?number = null;
+y2 = y2 || 1;
+
+var z2: ?string = null;
+z2 = z2 || 'foo';
+
+//The default pattern doesn't excuse all sketchy null checks, just
+//sound ones. (Errors: two per line)
+
+var a1: boolean | number | string | null = null;
+a1 = a1 || false;
+
+var b1: boolean | number | string | null = null;
+b1 = b1 || 0;
+
+var c1: boolean | number | string | null = null;
+c1 = c1 || '';
+
+
+/* EXAMPLES IN A CONDITIONAL */
+
+//"Sketchy" checks excused by the default pattern (Not errors)
+
+var x3: ?boolean = null;
+if (x3 || false) {}
+
+var y3: ?number = null;
+if (y3 || 0) {}
+
+var z3: ?string = null;
+if (z3 || '') {}
+
+//These checks aren't excused because they aren't the same as a null check
+//(Errors: one per line)
+
+var x4: ?boolean = null;
+if (x4 || true) {}
+
+var y4: ?number = null;
+if (y4 || false) {}
+
+var z4: ?string = null;
+if (z4 || 'foo') {}
+
+//The default pattern doesn't excuse all sketchy null checks, just
+//sound ones. (Errors: two per line)
+
+var a2: boolean | number | string | null = null;
+if (a2 || false) {}
+
+var b2: boolean | number | string | null = null;
+if (b2 || 0) {}
+
+var c2: boolean | number | string | null = null;
+if (c2 || '') {}
+
+//Compound sketchy null checks
+
+var d1: ?boolean = null;
+var e1: ?boolean = true;
+d1 = (d1 || e1) || false; //Both checks are sketchy. (This is how it gets parsed without the parentheses)
+
+var d2: ?boolean = null;
+var e2: ?boolean = true;
+d2 = d2 || (e2 || false); //Only d2 is sketchy; e2 matches the default pattern.


### PR DESCRIPTION
I found a failed test

```js
const foo: ?boolean = true;
const bar = true || (foo || false);
```

This will format to 

```js
const foo: ?boolean = true;
const bar = true || foo || false;
```

AST_COMPARE shows diff

```diff
@@ -67,13 +67,11 @@
                    "source": null,
                  },
                  "type": "Literal",
                  "value": true,
                },
-               "loc": Object {
-                 "source": null,
-               },
+               "loc": Object {},
                "operator": "||",
                "right": Object {
                  "loc": Object {
                    "source": null,
                  },
@@ -81,14 +79,12 @@
                  "optional": false,
                  "type": "Identifier",
                  "typeAnnotation": null,
                },
                "type": "LogicalExpression",
-             },
-             "loc": Object {
-               "source": null,
              },
+             "loc": Object {},
              "operator": "||",
              "right": Object {
                "loc": Object {
                  "source": null,
                },
```

I'm not sure I'm doing this right.