### PR TITLE
refactoring(glimmer): Extract utils from printer

### DIFF
--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -11,7 +11,15 @@ const {
   ifBreak
 } = require("../document").builders;
 
-const { isGlimmerComponent, isWhitespaceNode } = require("./utils");
+const {
+  getPreviousNode,
+  getNextNode,
+  isParentOfSomeType,
+  isPreviousNodeOfSomeType,
+  isNextNodeOfSomeType,
+  isWhitespaceNode,
+  isGlimmerComponent
+} = require("./utils");
 
 // http://w3c.github.io/html/single-page.html#void-elements
 const voidTags = [
@@ -476,56 +484,6 @@ function printOpenBlock(path, print) {
 
 function printCloseBlock(path, print) {
   return concat(["{{/", path.call(print, "path"), "}}"]);
-}
-
-function getPreviousNode(path, lookBack = 1) {
-  const node = path.getValue();
-  const parentNode = path.getParentNode(0);
-
-  const children = parentNode && (parentNode.children || parentNode.body);
-  if (children) {
-    const nodeIndex = children.indexOf(node);
-    if (nodeIndex > 0) {
-      const previousNode = children[nodeIndex - lookBack];
-      return previousNode;
-    }
-  }
-}
-
-function getNextNode(path) {
-  const node = path.getValue();
-  const parentNode = path.getParentNode(0);
-
-  const children = parentNode.children || parentNode.body;
-  if (children) {
-    const nodeIndex = children.indexOf(node);
-    if (nodeIndex < children.length) {
-      const nextNode = children[nodeIndex + 1];
-      return nextNode;
-    }
-  }
-}
-
-function isNodeOfSomeType(node, types) {
-  if (node) {
-    return types.some(type => node.type === type);
-  }
-  return false;
-}
-
-function isParentOfSomeType(path, types) {
-  const parentNode = path.getParentNode(0);
-  return isNodeOfSomeType(parentNode, types);
-}
-
-function isPreviousNodeOfSomeType(path, types) {
-  const previousNode = getPreviousNode(path);
-  return isNodeOfSomeType(previousNode, types);
-}
-
-function isNextNodeOfSomeType(path, types) {
-  const nextNode = getNextNode(path);
-  return isNodeOfSomeType(nextNode, types);
 }
 
 function clean(ast, newObj) {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -565,15 +565,13 @@ function locationToOffset(source, line, column) {
 }
 
 function isPrettierIgnoreNode(node) {
-  if (!node) {
+  if (!isNodeOfSomeType(node, ["MustacheCommentStatement"])) {
     return false;
   }
 
-  const isMustacheComment = node.type === "MustacheCommentStatement";
-  const containsPrettierIgnore =
-    typeof node.value === "string" && node.value.trim() === "prettier-ignore";
-
-  return isMustacheComment && containsPrettierIgnore;
+  return (
+    typeof node.value === "string" && node.value.trim() === "prettier-ignore"
+  );
 }
 
 module.exports = {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -509,22 +509,21 @@ function getNextNode(path) {
   }
 }
 
-function isParentOfSomeType(path, types) {
-  const parentNode = path.getParentNode(0);
-
-  if (parentNode) {
-    return types.some(type => parentNode.type === type);
+function isNodeOfSomeType(node, types) {
+  if (node) {
+    return types.some(type => node.type === type);
   }
   return false;
 }
 
+function isParentOfSomeType(path, types) {
+  const parentNode = path.getParentNode(0);
+  return isNodeOfSomeType(parentNode, types);
+}
+
 function isPreviousNodeOfSomeType(path, types) {
   const previousNode = getPreviousNode(path);
-
-  if (previousNode) {
-    return types.some(type => previousNode.type === type);
-  }
-  return false;
+  return isNodeOfSomeType(previousNode, types);
 }
 
 function isNextNodeOfType(path, type) {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -12,13 +12,14 @@ const {
 } = require("../document").builders;
 
 const {
-  getPreviousNode,
   getNextNode,
+  getPreviousNode,
+  isGlimmerComponent,
+  isNextNodeOfSomeType,
+  isNodeOfSomeType,
   isParentOfSomeType,
   isPreviousNodeOfSomeType,
-  isNextNodeOfSomeType,
-  isWhitespaceNode,
-  isGlimmerComponent
+  isWhitespaceNode
 } = require("./utils");
 
 // http://w3c.github.io/html/single-page.html#void-elements

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -11,7 +11,7 @@ const {
   ifBreak
 } = require("../document").builders;
 
-const { isGlimmerComponent } = require("./utils");
+const { isGlimmerComponent, isWhitespaceNode } = require("./utils");
 
 // http://w3c.github.io/html/single-page.html#void-elements
 const voidTags = [
@@ -478,10 +478,6 @@ function printOpenBlock(path, print) {
 
 function printCloseBlock(path, print) {
   return concat(["{{/", path.call(print, "path"), "}}"]);
-}
-
-function isWhitespaceNode(node) {
-  return node.type === "TextNode" && !/\S/.test(node.chars);
 }
 
 function isParentOfType(path, nodeType) {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -254,10 +254,7 @@ function print(path, options, print) {
         );
         trailingLineBreaksCount = 0;
       } else {
-        if (
-          isNextNodeOfType(path, "ElementNode") ||
-          isNextNodeOfType(path, "BlockStatement")
-        ) {
+        if (isNextNodeOfSomeType(path, ["BlockStatement", "ElementNode"])) {
           trailingLineBreaksCount = Math.max(trailingLineBreaksCount, 1);
         }
 
@@ -299,7 +296,7 @@ function print(path, options, print) {
       } else {
         if (
           trailingLineBreaksCount === 0 &&
-          isNextNodeOfType(path, "MustacheStatement")
+          isNextNodeOfSomeType(path, ["MustacheStatement"])
         ) {
           trailingSpace = " ";
         }
@@ -526,9 +523,9 @@ function isPreviousNodeOfSomeType(path, types) {
   return isNodeOfSomeType(previousNode, types);
 }
 
-function isNextNodeOfType(path, type) {
+function isNextNodeOfSomeType(path, types) {
   const nextNode = getNextNode(path);
-  return nextNode && nextNode.type === type;
+  return isNodeOfSomeType(nextNode, types);
 }
 
 function clean(ast, newObj) {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -177,12 +177,13 @@ function print(path, options, print) {
       const opening = isEscaped ? "{{{" : "{{";
       const closing = isEscaped ? "}}}" : "}}";
 
-      const leading =
-        isParentOfType(path, "AttrNode") ||
-        isParentOfType(path, "ConcatStatement") ||
-        isParentOfType(path, "ElementNode")
-          ? [opening, indent(softline)]
-          : [opening];
+      const leading = isParentOfSomeType(path, [
+        "AttrNode",
+        "ConcatStatement",
+        "ElementNode"
+      ])
+        ? [opening, indent(softline)]
+        : [opening];
 
       return group(
         concat([...leading, printPathParams(path, print), softline, closing])
@@ -480,11 +481,6 @@ function printCloseBlock(path, print) {
   return concat(["{{/", path.call(print, "path"), "}}"]);
 }
 
-function isParentOfType(path, nodeType) {
-  const p = path.getParentNode(0);
-  return p && p.type === nodeType;
-}
-
 function getPreviousNode(path, lookBack = 1) {
   const node = path.getValue();
   const parentNode = path.getParentNode(0);
@@ -511,6 +507,15 @@ function getNextNode(path) {
       return nextNode;
     }
   }
+}
+
+function isParentOfSomeType(path, types) {
+  const parentNode = path.getParentNode(0);
+
+  if (parentNode) {
+    return types.some(type => parentNode.type === type);
+  }
+  return false;
 }
 
 function isPreviousNodeOfSomeType(path, types) {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -14,9 +14,9 @@ const {
 const {
   getNextNode,
   getPreviousNode,
+  hasPrettierIgnore,
   isGlimmerComponent,
   isNextNodeOfSomeType,
-  isNodeOfSomeType,
   isParentOfSomeType,
   isPreviousNodeOfSomeType,
   isWhitespaceNode
@@ -524,15 +524,6 @@ function generateHardlines(number = 0, max = 0) {
   return new Array(Math.min(number, max)).fill(hardline);
 }
 
-function hasPrettierIgnore(path) {
-  const n = path.getValue();
-  const previousPreviousNode = getPreviousNode(path, 2);
-  const isIgnoreNode = isPrettierIgnoreNode(n);
-  const isCoveredByIgnoreNode = isPrettierIgnoreNode(previousPreviousNode);
-
-  return isIgnoreNode || isCoveredByIgnoreNode;
-}
-
 /* istanbul ignore next
    https://github.com/glimmerjs/glimmer-vm/blob/master/packages/%40glimmer/compiler/lib/location.ts#L5-L29
 */
@@ -562,16 +553,6 @@ function locationToOffset(source, line, column) {
     seenLines += 1;
     seenChars = nextLine + 1;
   }
-}
-
-function isPrettierIgnoreNode(node) {
-  if (!isNodeOfSomeType(node, ["MustacheCommentStatement"])) {
-    return false;
-  }
-
-  return (
-    typeof node.value === "string" && node.value.trim() === "prettier-ignore"
-  );
 }
 
 module.exports = {

--- a/src/language-handlebars/utils.js
+++ b/src/language-handlebars/utils.js
@@ -65,9 +65,29 @@ function getNextNode(path) {
   }
 }
 
+function isPrettierIgnoreNode(node) {
+  if (!isNodeOfSomeType(node, ["MustacheCommentStatement"])) {
+    return false;
+  }
+
+  return (
+    typeof node.value === "string" && node.value.trim() === "prettier-ignore"
+  );
+}
+
+function hasPrettierIgnore(path) {
+  const n = path.getValue();
+  const previousPreviousNode = getPreviousNode(path, 2);
+  const isIgnoreNode = isPrettierIgnoreNode(n);
+  const isCoveredByIgnoreNode = isPrettierIgnoreNode(previousPreviousNode);
+
+  return isIgnoreNode || isCoveredByIgnoreNode;
+}
+
 module.exports = {
   getNextNode,
   getPreviousNode,
+  hasPrettierIgnore,
   isGlimmerComponent,
   isNextNodeOfSomeType,
   isNodeOfSomeType,

--- a/src/language-handlebars/utils.js
+++ b/src/language-handlebars/utils.js
@@ -16,10 +16,7 @@ function isWhitespaceNode(node) {
 }
 
 function isNodeOfSomeType(node, types) {
-  if (node) {
-    return types.some(type => node.type === type);
-  }
-  return false;
+  return node && types.some(type => node.type === type);
 }
 
 function isParentOfSomeType(path, types) {

--- a/src/language-handlebars/utils.js
+++ b/src/language-handlebars/utils.js
@@ -66,12 +66,12 @@ function getNextNode(path) {
 }
 
 module.exports = {
-  getPreviousNode,
   getNextNode,
+  getPreviousNode,
+  isGlimmerComponent,
+  isNextNodeOfSomeType,
   isNodeOfSomeType,
   isParentOfSomeType,
   isPreviousNodeOfSomeType,
-  isNextNodeOfSomeType,
-  isWhitespaceNode,
-  isGlimmerComponent
+  isWhitespaceNode
 };

--- a/src/language-handlebars/utils.js
+++ b/src/language-handlebars/utils.js
@@ -35,20 +35,20 @@ function isNextNodeOfSomeType(path, types) {
   return isNodeOfSomeType(nextNode, types);
 }
 
-function getPreviousNode(path, lookBack = 1) {
+function getSiblingNode(path, offset) {
   const node = path.getValue();
   const parentNode = path.getParentNode(0) || {};
   const children = parentNode.children || parentNode.body || [];
   const index = children.indexOf(node);
-  return index !== -1 && children[index - lookBack];
+  return index !== -1 && children[index + offset];
+}
+
+function getPreviousNode(path, lookBack = 1) {
+  return getSiblingNode(path, -lookBack);
 }
 
 function getNextNode(path) {
-  const node = path.getValue();
-  const parentNode = path.getParentNode(0);
-  const children = parentNode.children || parentNode.body || [];
-  const index = children.indexOf(node);
-  return index !== -1 && children[index + 1];
+  return getSiblingNode(path, 1);
 }
 
 function isPrettierIgnoreNode(node) {

--- a/src/language-handlebars/utils.js
+++ b/src/language-handlebars/utils.js
@@ -11,6 +11,11 @@ function isGlimmerComponent(node) {
   return tagFirstChar.toUpperCase() === tagFirstChar || isLocal;
 }
 
+function isWhitespaceNode(node) {
+  return node.type === "TextNode" && !/\S/.test(node.chars);
+}
+
 module.exports = {
+  isWhitespaceNode,
   isGlimmerComponent
 };

--- a/src/language-handlebars/utils.js
+++ b/src/language-handlebars/utils.js
@@ -15,7 +15,63 @@ function isWhitespaceNode(node) {
   return node.type === "TextNode" && !/\S/.test(node.chars);
 }
 
+function isNodeOfSomeType(node, types) {
+  if (node) {
+    return types.some(type => node.type === type);
+  }
+  return false;
+}
+
+function isParentOfSomeType(path, types) {
+  const parentNode = path.getParentNode(0);
+  return isNodeOfSomeType(parentNode, types);
+}
+
+function isPreviousNodeOfSomeType(path, types) {
+  const previousNode = getPreviousNode(path);
+  return isNodeOfSomeType(previousNode, types);
+}
+
+function isNextNodeOfSomeType(path, types) {
+  const nextNode = getNextNode(path);
+  return isNodeOfSomeType(nextNode, types);
+}
+
+function getPreviousNode(path, lookBack = 1) {
+  const node = path.getValue();
+  const parentNode = path.getParentNode(0);
+
+  const children = parentNode && (parentNode.children || parentNode.body);
+  if (children) {
+    const nodeIndex = children.indexOf(node);
+    if (nodeIndex > 0) {
+      const previousNode = children[nodeIndex - lookBack];
+      return previousNode;
+    }
+  }
+}
+
+function getNextNode(path) {
+  const node = path.getValue();
+  const parentNode = path.getParentNode(0);
+
+  const children = parentNode.children || parentNode.body;
+  if (children) {
+    const nodeIndex = children.indexOf(node);
+    if (nodeIndex < children.length) {
+      const nextNode = children[nodeIndex + 1];
+      return nextNode;
+    }
+  }
+}
+
 module.exports = {
+  getPreviousNode,
+  getNextNode,
+  isNodeOfSomeType,
+  isParentOfSomeType,
+  isPreviousNodeOfSomeType,
+  isNextNodeOfSomeType,
   isWhitespaceNode,
   isGlimmerComponent
 };


### PR DESCRIPTION
#### Description
<!-- Please provide a brief summary of your changes: -->
Extract a few glimmer printer utils into a file, similar to what is done for others languages.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

#### Checklist
- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
