### PR TITLE
Add Apex to list of supported languages on home page

### DIFF
--- a/website/data/languages.yml
+++ b/website/data/languages.yml
@@ -42,6 +42,7 @@
   showName: true
   image: /images/languages/tools_wip.svg
   variants:
+  - "[Apex](https://github.com/dangmai/prettier-plugin-apex)"
   - "[Elm](https://github.com/gicentre/prettier-plugin-elm) (via [`elm-format`](https://github.com/avh4/elm-format))"
   - "[Java](https://github.com/jhipster/prettier-java)"
   - "[PHP](https://github.com/prettier/plugin-php)"


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Simple addition to Prettier home page for Apex as a supported language.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
