### PR TITLE
A little DRY on `TypeCastExpression` print

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3048,31 +3048,10 @@ function printPathNoParens(path, options, print, args) {
       return group(concat(parts));
     }
     case "TypeCastExpression": {
-      const value = path.getValue();
-      // Flow supports a comment syntax for specifying type annotations: https://flow.org/en/docs/types/comments/.
-      // Unfortunately, its parser doesn't differentiate between comment annotations and regular
-      // annotations when producing an AST. So to preserve parentheses around type casts that use
-      // the comment syntax, we need to hackily read the source itself to see if the code contains
-      // a type annotation comment.
-      //
-      // Note that we're able to use the normal whitespace regex here because the Flow parser has
-      // already deemed this AST node to be a type cast. Only the Babel parser needs the
-      // non-line-break whitespace regex, which is why hasFlowShorthandAnnotationComment() is
-      // implemented differently.
-      const commentSyntax =
-        value &&
-        value.typeAnnotation &&
-        value.typeAnnotation.range &&
-        options.originalText
-          .slice(value.typeAnnotation.range[0])
-          .match(/^\/\*\s*:/);
       return concat([
         "(",
         path.call(print, "expression"),
-        commentSyntax ? " /*" : "",
-        ": ",
-        path.call(print, "typeAnnotation"),
-        commentSyntax ? " */" : "",
+        printTypeAnnotation(path, options, print),
         ")"
       ]);
     }


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Found this can DRY a little bit here, when I was trying to do something else.
Those codes are from #5280 , but `printTypeAnnotation` function already exists #3449 , I guess `printTypeAnnotation` hasn't cover this case yet back then, or just missed that function.

Wow, `utils.js` was first introduced in that PR  :).

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
