### PR TITLE
fix(glimmer): Do not strip AttrNode value when it is not blank

### DIFF
--- a/changelog_unreleased/handlebars/pr-7552.md
+++ b/changelog_unreleased/handlebars/pr-7552.md
@@ -1,0 +1,16 @@
+#### Fix stripped value from AttrNode ([#7552](https://github.com/prettier/prettier/pull/7552) by [@bantic](https://github.com/bantic))
+
+<!-- prettier-ignore -->
+```hbs
+{{!-- input --}}
+<ul class="abc
+       def">
+</ul>
+
+{{!-- Prettier stable --}}
+<ul class></ul>
+
+{{!-- Prettier master --}}
+<ul class="abc
+       def">
+</ul>

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -202,7 +202,14 @@ function print(path, options, print) {
     }
     case "AttrNode": {
       const isText = n.value.type === "TextNode";
-      if (isText && n.value.loc.start.column === n.value.loc.end.column) {
+      const isEmptyText = isText && n.value.chars === "";
+
+      // If the text is empty and the value's loc start and end columns are the
+      // same, there is no value for this AttrNode and it should be printed
+      // without the `=""`. Example: `<img data-test>` -> `<img data-test>`
+      const isEmptyValue =
+        isEmptyText && n.value.loc.start.column === n.value.loc.end.column;
+      if (isEmptyValue) {
         return concat([n.name]);
       }
       const value = path.call(print, "value");

--- a/tests/handlebars-basics/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars-basics/__snapshots__/jsfmt.spec.js.snap
@@ -32,6 +32,9 @@ printWidth: 80
 
 <div ...attributes>Hello</div>
 
+<ul class="list-unstyled
+  one-tab">
+</ul>
 =====================================output=====================================
 <UserGreeting @name="Ricardo" @greeting="Olá" />
 {{@greeting}}, {{@name}}!
@@ -64,6 +67,10 @@ printWidth: 80
 <div ...attributes>
   Hello
 </div>
+
+<ul class="list-unstyled
+  one-tab">
+</ul>
 ================================================================================
 `;
 
@@ -100,6 +107,9 @@ singleQuote: true
 
 <div ...attributes>Hello</div>
 
+<ul class="list-unstyled
+  one-tab">
+</ul>
 =====================================output=====================================
 <UserGreeting @name='Ricardo' @greeting='Olá' />
 {{@greeting}}, {{@name}}!
@@ -132,6 +142,10 @@ singleQuote: true
 <div ...attributes>
   Hello
 </div>
+
+<ul class='list-unstyled
+  one-tab'>
+</ul>
 ================================================================================
 `;
 

--- a/tests/handlebars-basics/component.hbs
+++ b/tests/handlebars-basics/component.hbs
@@ -23,3 +23,7 @@
 <img alt="" />
 
 <div ...attributes>Hello</div>
+
+<ul class="list-unstyled
+  one-tab">
+</ul>


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fixes #7550. The code in `printer-glimmer.js` that checks if an `AttrNode` has blank text appears to have a logical error; it checks if the node value's location's start and end columns are the same as a heuristic to determine if there should be no value in the output. But this will be incorrect when the start/end columns are the same but the start/end *lines* are not.

The code was added in #4897 to ensure that empty-value attributes, like the `alt` in `<img alt=""` are preserved (i.e., it prints `<img alt=""` rather than `<img alt`).
But the logical error mentioned above makes it so that if the attribute value has a linebreak and the start/end columns line up, it is stripped, like so:

```hbs
<ul class="abc
      def"></ul> <!-- this ending quote is on the same column as the starting quote -->
```

In that ^ example, the AttrNode's value's location has a start column of 10 (on line 1) and an end column of line 10 (but on line 2).
Prior to the change introduced in this PR, that case would be printed with the stripped value, e.g. `<ul class>...`.

- [x] I’ve added tests to confirm my change works.
- [x] (n/a) (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
