### PR TITLE
Fix a warning on test

### DIFF
--- a/tests_integration/__tests__/format.js
+++ b/tests_integration/__tests__/format.js
@@ -62,5 +62,7 @@ test("should work with foo plugin instance", () => {
 
 test("'Adjacent JSX' error should not be swallowed by Babel's error recovery", () => {
   const input = "<a></a>\n<b></b>";
-  expect(() => prettier.format(input)).toThrowErrorMatchingSnapshot();
+  expect(() =>
+    prettier.format(input, { parser: "babel" })
+  ).toThrowErrorMatchingSnapshot();
 });


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

[Before:](https://dev.azure.com/prettier/prettier/_build/results?buildId=5096&view=logs&j=feaed275-2517-5ad3-d429-3dc96013ea33&t=e2f326fe-3fae-5235-1e33-c604ad7f1ff7&l=32)

```text
PASS tests_integration/__tests__/format.js
  ● Console

    console.warn src/main/options.js:42
      No parser and no filepath given, using 'babel' the parser now but this will throw an error in the future. Please specify a parser or a filepath so one can be inferred.
```

[After:](https://dev.azure.com/prettier/prettier/_build/results?buildId=5126&view=logs&j=feaed275-2517-5ad3-d429-3dc96013ea33&t=e2f326fe-3fae-5235-1e33-c604ad7f1ff7&l=31)

```text
PASS tests_integration/__tests__/format.js
```


- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
