### PR TITLE
Respect prettierignore when executed in subdirectories

### DIFF
--- a/changelog_unreleased/cli/pr-7588.md
+++ b/changelog_unreleased/cli/pr-7588.md
@@ -1,0 +1,4 @@
+#### Respect `--ignore-path` when prettier executes from a subdirectory ([#7588](https://github.com/prettier/prettier/pull/7588) by [@heylookltsme](https://github.com/heylookltsme))
+
+Changes the filename used when filtering ignored files to be relative to the
+`--ignore-path`, if present, rather than the current working directory.

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -366,7 +366,11 @@ function formatStdin(context) {
     : process.cwd();
 
   const ignorer = createIgnorerFromContextOrDie(context);
-  const relativeFilepath = path.relative(process.cwd(), filepath);
+  // If there's an ignore-path set, the filename must be relative to the
+  // ignore path, not the current working directory.
+  const relativeFilepath = context.argv["ignore-path"]
+    ? path.relative(path.dirname(context.argv["ignore-path"]), filepath)
+    : path.relative(process.cwd(), filepath);
 
   thirdParty
     .getStream(process.stdin)
@@ -443,7 +447,12 @@ function formatFiles(context) {
   }
 
   eachFilename(context, context.filePatterns, filename => {
-    const fileIgnored = ignorer.filter([filename]).length === 0;
+    // If there's an ignore-path set, the filename must be relative to the
+    // ignore path, not the current working directory.
+    const ignoreFilename = context.argv["ignore-path"]
+      ? path.relative(path.dirname(context.argv["ignore-path"]), filename)
+      : filename;
+    const fileIgnored = ignorer.filter([ignoreFilename]).length === 0;
     if (
       fileIgnored &&
       (context.argv["debug-check"] ||

--- a/tests_integration/__tests__/__snapshots__/ignore-in-subdirectories.js.snap
+++ b/tests_integration/__tests__/__snapshots__/ignore-in-subdirectories.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`formats files when executing in a subdirectory (stderr) 1`] = `""`;
+
+exports[`formats files when executing in a subdirectory (stderr) 2`] = `""`;
+
+exports[`formats files when executing in a subdirectory (stdout) 1`] = `
+"should-not-ignore.js
+"
+`;
+
+exports[`formats files when executing in a subdirectory (stdout) 2`] = `
+"should-not-ignore.js
+"
+`;
+
+exports[`formats files when executing in a subdirectory (write) 1`] = `Array []`;
+
+exports[`formats files when executing in a subdirectory (write) 2`] = `Array []`;
+
+exports[`formats files when executing in a subdirectory and using stdin (stderr) 1`] = `""`;
+
+exports[`formats files when executing in a subdirectory and using stdin (write) 1`] = `Array []`;
+
+exports[`ignore files when executing in a subdirectory and using stdin (stderr) 1`] = `""`;
+
+exports[`ignore files when executing in a subdirectory and using stdin (write) 1`] = `Array []`;
+
+exports[`ignores files when executing in a subdirectory (stderr) 1`] = `""`;
+
+exports[`ignores files when executing in a subdirectory (stderr) 2`] = `""`;
+
+exports[`ignores files when executing in a subdirectory (stdout) 1`] = `""`;
+
+exports[`ignores files when executing in a subdirectory (stdout) 2`] = `""`;
+
+exports[`ignores files when executing in a subdirectory (write) 1`] = `Array []`;
+
+exports[`ignores files when executing in a subdirectory (write) 2`] = `Array []`;

--- a/tests_integration/__tests__/ignore-in-subdirectories.js
+++ b/tests_integration/__tests__/ignore-in-subdirectories.js
@@ -1,0 +1,77 @@
+"use strict";
+
+const runPrettier = require("../runPrettier");
+
+expect.addSnapshotSerializer(require("../path-serializer"));
+
+describe("ignores files when executing in a subdirectory", () => {
+  runPrettier("cli/ignore-in-subdirectories/web1", [
+    "ignore-me/should-ignore.js",
+    "--ignore-path",
+    "../.prettierignore",
+    "-l"
+  ]).test({
+    status: 0
+  });
+
+  runPrettier("cli/ignore-in-subdirectories/web1", [
+    "ignore-me/subdirectory/should-ignore.js",
+    "--ignore-path",
+    "../.prettierignore",
+    "-l"
+  ]).test({
+    status: 0
+  });
+});
+
+describe("formats files when executing in a subdirectory", () => {
+  runPrettier("cli/ignore-in-subdirectories/web1", [
+    "should-not-ignore.js",
+    "--ignore-path",
+    "../.prettierignore",
+    "-l"
+  ]).test({
+    status: 1
+  });
+
+  runPrettier("cli/ignore-in-subdirectories/web2", [
+    "should-not-ignore.js",
+    "--ignore-path",
+    "../.prettierignore",
+    "-l"
+  ]).test({
+    status: 1
+  });
+});
+
+describe("ignore files when executing in a subdirectory and using stdin", () => {
+  runPrettier(
+    "cli/ignore-in-subdirectories/web1",
+    [
+      "--ignore-path",
+      "../.prettierignore",
+      "--stdin-filepath",
+      "ignore-me/example.js"
+    ],
+    {
+      input: "hello_world( );"
+    }
+  ).test({
+    stdout: "hello_world( );",
+    status: 0
+  });
+});
+
+describe("formats files when executing in a subdirectory and using stdin", () => {
+  runPrettier(
+    "cli/ignore-in-subdirectories/web1",
+    ["--ignore-path", "../.prettierignore", "--stdin-filepath", "example.js"],
+    {
+      input: "hello_world( );"
+    }
+  ).test({
+    stdout: `hello_world();
+`,
+    status: 0
+  });
+});

--- a/tests_integration/cli/ignore-in-subdirectories/.prettierignore
+++ b/tests_integration/cli/ignore-in-subdirectories/.prettierignore
@@ -1,0 +1,1 @@
+web1/ignore-me

--- a/tests_integration/cli/ignore-in-subdirectories/web1/ignore-me/should-ignore.js
+++ b/tests_integration/cli/ignore-in-subdirectories/web1/ignore-me/should-ignore.js
@@ -1,0 +1,1 @@
+var x = 'this should not be formatted';

--- a/tests_integration/cli/ignore-in-subdirectories/web1/ignore-me/subdirectory/should-ignore.js
+++ b/tests_integration/cli/ignore-in-subdirectories/web1/ignore-me/subdirectory/should-ignore.js
@@ -1,0 +1,1 @@
+var x = 'this should not be formatted';

--- a/tests_integration/cli/ignore-in-subdirectories/web1/should-not-ignore.js
+++ b/tests_integration/cli/ignore-in-subdirectories/web1/should-not-ignore.js
@@ -1,0 +1,1 @@
+var x = 'this should be formatted';

--- a/tests_integration/cli/ignore-in-subdirectories/web2/should-not-ignore.js
+++ b/tests_integration/cli/ignore-in-subdirectories/web2/should-not-ignore.js
@@ -1,0 +1,1 @@
+var x = 'this should be formatted';


### PR DESCRIPTION
This fixes https://github.com/prettier/prettier/issues/7586. It changes the filename we use in `ignore.filter` to be relative to the location of the `ignore-path` and not the current working directory. 

This is my first exposure to the prettier source code, so please school me! This fixes the issue I have locally, but I have no idea if other changes might be needed or if there are other scenarios I'm not considering here. Thanks!

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works. 
- [ ] **N/A** (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
