### PR TITLE
Declared arrow fn

### DIFF
--- a/tests/flow_function_parentheses/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_function_parentheses/__snapshots__/jsfmt.spec.js.snap
@@ -15,11 +15,12 @@ const selectorByPath:
 > = memoizeWithArgs(/* ... */)
 
 =====================================output=====================================
-const selectorByPath: Path => SomethingSelector<
-  SomethingUEditorContextType,
-  SomethingUEditorContextType,
-  SomethingBulkValue<string>
-> = memoizeWithArgs(/* ... */);
+const selectorByPath: Path =>
+  SomethingSelector<
+    SomethingUEditorContextType,
+    SomethingUEditorContextType,
+    SomethingBulkValue<string>
+  > = memoizeWithArgs(/* ... */);
 
 ================================================================================
 `;
@@ -40,11 +41,12 @@ const selectorByPath:
 > = memoizeWithArgs(/* ... */)
 
 =====================================output=====================================
-const selectorByPath: Path => SomethingSelector<
-  SomethingUEditorContextType,
-  SomethingUEditorContextType,
-  SomethingBulkValue<string>,
-> = memoizeWithArgs(/* ... */);
+const selectorByPath: Path =>
+  SomethingSelector<
+    SomethingUEditorContextType,
+    SomethingUEditorContextType,
+    SomethingBulkValue<string>,
+  > = memoizeWithArgs(/* ... */);
 
 ================================================================================
 `;
@@ -65,11 +67,12 @@ const selectorByPath:
 > = memoizeWithArgs(/* ... */)
 
 =====================================output=====================================
-const selectorByPath: (Path) => SomethingSelector<
-  SomethingUEditorContextType,
-  SomethingUEditorContextType,
-  SomethingBulkValue<string>
-> = memoizeWithArgs(/* ... */);
+const selectorByPath: (Path) =>
+  SomethingSelector<
+    SomethingUEditorContextType,
+    SomethingUEditorContextType,
+    SomethingBulkValue<string>
+  > = memoizeWithArgs(/* ... */);
 
 ================================================================================
 `;
@@ -182,12 +185,14 @@ type f6 = (?arg) => void;
 
 class Y {
   constructor(
-    ideConnectionFactory: child_process$ChildProcess => FlowIDEConnection = defaultIDEConnectionFactory
+    ideConnectionFactory: child_process$ChildProcess =>
+      FlowIDEConnection = defaultIDEConnectionFactory
   ) {}
 }
 
 interface F {
-  ideConnectionFactoryLongLongLong: child_process$ChildProcess => FlowIDEConnection;
+  ideConnectionFactoryLongLongLong: child_process$ChildProcess =>
+    FlowIDEConnection;
 }
 
 type ExtractType = <A>(B<C>) => D;
@@ -319,12 +324,14 @@ type f6 = (?arg) => void;
 
 class Y {
   constructor(
-    ideConnectionFactory: child_process$ChildProcess => FlowIDEConnection = defaultIDEConnectionFactory,
+    ideConnectionFactory: child_process$ChildProcess =>
+      FlowIDEConnection = defaultIDEConnectionFactory,
   ) {}
 }
 
 interface F {
-  ideConnectionFactoryLongLongLong: child_process$ChildProcess => FlowIDEConnection;
+  ideConnectionFactoryLongLongLong: child_process$ChildProcess =>
+    FlowIDEConnection;
 }
 
 type ExtractType = <A>(B<C>) => D;
@@ -456,12 +463,14 @@ type f6 = (?arg) => void;
 
 class Y {
   constructor(
-    ideConnectionFactory: (child_process$ChildProcess) => FlowIDEConnection = defaultIDEConnectionFactory
+    ideConnectionFactory: (child_process$ChildProcess) =>
+      FlowIDEConnection = defaultIDEConnectionFactory
   ) {}
 }
 
 interface F {
-  ideConnectionFactoryLongLongLong: (child_process$ChildProcess) => FlowIDEConnection;
+  ideConnectionFactoryLongLongLong: (child_process$ChildProcess) =>
+    FlowIDEConnection;
 }
 
 type ExtractType = <A>(B<C>) => D;

--- a/tests/typescript/conformance/types/functions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conformance/types/functions/__snapshots__/jsfmt.spec.js.snap
@@ -494,40 +494,52 @@ class AnotherClass {
 // if f is a contextually typed function expression, the inferred return type is the union type
 // of the types of the return statement expressions in the function body,
 // ignoring return statements with no expressions.
-var f7: (x: number) => string | number = x => {
-  // should be (x: number) => number | string
-  if (x < 0) {
-    return x;
-  }
-  return x.toString();
-};
-var f8: (x: number) => any = x => {
-  // should be (x: number) => Base
-  return new Base();
-  return new Derived2();
-};
-var f9: (x: number) => any = x => {
-  // should be (x: number) => Base
-  return new Base();
-  return new Derived();
-  return new Derived2();
-};
-var f10: (x: number) => any = x => {
-  // should be (x: number) => Derived | Derived1
-  return new Derived();
-  return new Derived2();
-};
-var f11: (x: number) => any = x => {
-  // should be (x: number) => Base | AnotherClass
-  return new Base();
-  return new AnotherClass();
-};
-var f12: (x: number) => any = x => {
-  // should be (x: number) => Base | AnotherClass
-  return new Base();
-  return; // should be ignored
-  return new AnotherClass();
-};
+var f7
+  : (x: number) => string | number
+  = x => {
+    // should be (x: number) => number | string
+    if (x < 0) {
+      return x;
+    }
+    return x.toString();
+  };
+var f8
+  : (x: number) => any
+  = x => {
+    // should be (x: number) => Base
+    return new Base();
+    return new Derived2();
+  };
+var f9
+  : (x: number) => any
+  = x => {
+    // should be (x: number) => Base
+    return new Base();
+    return new Derived();
+    return new Derived2();
+  };
+var f10
+  : (x: number) => any
+  = x => {
+    // should be (x: number) => Derived | Derived1
+    return new Derived();
+    return new Derived2();
+  };
+var f11
+  : (x: number) => any
+  = x => {
+    // should be (x: number) => Base | AnotherClass
+    return new Base();
+    return new AnotherClass();
+  };
+var f12
+  : (x: number) => any
+  = x => {
+    // should be (x: number) => Base | AnotherClass
+    return new Base();
+    return; // should be ignored
+    return new AnotherClass();
+  };
 
 ================================================================================
 `;

--- a/tests/typescript_typed_arrow_fn_declr/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_typed_arrow_fn_declr/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,131 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`declared-arrow-fn.ts 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const arrFn: (x: string) => (y: number) => (z: boolean) => [string, number, boolean]
+  = (x) => y => z => [x, y, z]
+
+=====================================output=====================================
+const arrFn
+  : (x: string) => (y: number) => (z: boolean) => [string, number, boolean]
+  = x => y => z => [x, y, z];
+
+================================================================================
+`;
+
+exports[`declared-arrow-fn.ts 2`] = `
+====================================options=====================================
+arrowParens: "always"
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const arrFn: (x: string) => (y: number) => (z: boolean) => [string, number, boolean]
+  = (x) => y => z => [x, y, z]
+
+=====================================output=====================================
+const arrFn
+  : (x: string) => (y: number) => (z: boolean) => [string, number, boolean]
+  = (x) => (y) => (z) => [x, y, z];
+
+================================================================================
+`;
+
+exports[`long-type-defn.ts 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const arrFn: (x: SuperLongTypeNameDefinedElseWhere) => (y: AnotherReallyLongTypeName) => (z: ThirdVeryLongAndBoringInterfaceName) => VeryLongReturnTypeValue;
+
+const arrFnWithImpl: (x: SuperLongTypeNameDefinedElseWhere) => (y: AnotherReallyLongTypeName) => (z: ThirdVeryLongAndBoringInterfaceName) => VeryLongReturnTypeValue
+  = (argumentNumberOne) => (argumentNumberTwo) => (argumentNumberThree) =>
+    someVeryVeryVeryLoooooooooongFunctionInvocation(argumentNumberOne, argumentNumberTwo, argumentNumberThree);
+
+const arrFnWithLongerImpl: (x: SuperLongTypeNameDefinedElseWhere) => (y: AnotherReallyLongTypeName) => (z: ThirdVeryLongAndBoringInterfaceName) => VeryLongReturnTypeValue
+  = (argumentNumberOne) => (argumentNumberTwo) => (argumentNumberThreeIsLoooooooooooooooooooooooooooooong) =>
+    someVeryVeryVeryLoooooooooongFunctionInvocation(argumentNumberOne, argumentNumberTwo, argumentNumberThreeIsLoooooooooooooooooooooooooooooong);
+
+=====================================output=====================================
+const arrFn: (x: SuperLongTypeNameDefinedElseWhere) =>
+  (y: AnotherReallyLongTypeName) =>
+    (z: ThirdVeryLongAndBoringInterfaceName) => VeryLongReturnTypeValue;
+
+const arrFnWithImpl
+  : (x: SuperLongTypeNameDefinedElseWhere) =>
+      (y: AnotherReallyLongTypeName) =>
+        (z: ThirdVeryLongAndBoringInterfaceName) => VeryLongReturnTypeValue
+  = argumentNumberOne => argumentNumberTwo => argumentNumberThree =>
+    someVeryVeryVeryLoooooooooongFunctionInvocation(
+      argumentNumberOne,
+      argumentNumberTwo,
+      argumentNumberThree
+    );
+
+const arrFnWithLongerImpl
+  : (x: SuperLongTypeNameDefinedElseWhere) =>
+      (y: AnotherReallyLongTypeName) =>
+        (z: ThirdVeryLongAndBoringInterfaceName) => VeryLongReturnTypeValue
+  = argumentNumberOne => argumentNumberTwo => argumentNumberThreeIsLoooooooooooooooooooooooooooooong =>
+    someVeryVeryVeryLoooooooooongFunctionInvocation(
+      argumentNumberOne,
+      argumentNumberTwo,
+      argumentNumberThreeIsLoooooooooooooooooooooooooooooong
+    );
+
+================================================================================
+`;
+
+exports[`long-type-defn.ts 2`] = `
+====================================options=====================================
+arrowParens: "always"
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const arrFn: (x: SuperLongTypeNameDefinedElseWhere) => (y: AnotherReallyLongTypeName) => (z: ThirdVeryLongAndBoringInterfaceName) => VeryLongReturnTypeValue;
+
+const arrFnWithImpl: (x: SuperLongTypeNameDefinedElseWhere) => (y: AnotherReallyLongTypeName) => (z: ThirdVeryLongAndBoringInterfaceName) => VeryLongReturnTypeValue
+  = (argumentNumberOne) => (argumentNumberTwo) => (argumentNumberThree) =>
+    someVeryVeryVeryLoooooooooongFunctionInvocation(argumentNumberOne, argumentNumberTwo, argumentNumberThree);
+
+const arrFnWithLongerImpl: (x: SuperLongTypeNameDefinedElseWhere) => (y: AnotherReallyLongTypeName) => (z: ThirdVeryLongAndBoringInterfaceName) => VeryLongReturnTypeValue
+  = (argumentNumberOne) => (argumentNumberTwo) => (argumentNumberThreeIsLoooooooooooooooooooooooooooooong) =>
+    someVeryVeryVeryLoooooooooongFunctionInvocation(argumentNumberOne, argumentNumberTwo, argumentNumberThreeIsLoooooooooooooooooooooooooooooong);
+
+=====================================output=====================================
+const arrFn: (x: SuperLongTypeNameDefinedElseWhere) =>
+  (y: AnotherReallyLongTypeName) =>
+    (z: ThirdVeryLongAndBoringInterfaceName) => VeryLongReturnTypeValue;
+
+const arrFnWithImpl
+  : (x: SuperLongTypeNameDefinedElseWhere) =>
+      (y: AnotherReallyLongTypeName) =>
+        (z: ThirdVeryLongAndBoringInterfaceName) => VeryLongReturnTypeValue
+  = (argumentNumberOne) => (argumentNumberTwo) => (argumentNumberThree) =>
+    someVeryVeryVeryLoooooooooongFunctionInvocation(
+      argumentNumberOne,
+      argumentNumberTwo,
+      argumentNumberThree
+    );
+
+const arrFnWithLongerImpl
+  : (x: SuperLongTypeNameDefinedElseWhere) =>
+      (y: AnotherReallyLongTypeName) =>
+        (z: ThirdVeryLongAndBoringInterfaceName) => VeryLongReturnTypeValue
+  = (argumentNumberOne) => (argumentNumberTwo) => (
+    argumentNumberThreeIsLoooooooooooooooooooooooooooooong
+  ) =>
+    someVeryVeryVeryLoooooooooongFunctionInvocation(
+      argumentNumberOne,
+      argumentNumberTwo,
+      argumentNumberThreeIsLoooooooooooooooooooooooooooooong
+    );
+
+================================================================================
+`;

--- a/tests/typescript_typed_arrow_fn_declr/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_typed_arrow_fn_declr/__snapshots__/jsfmt.spec.js.snap
@@ -171,26 +171,23 @@ const myCurriedFn
 const myCurriedFn2
   : (longNameFirstArgument: LongFirstType) =>
       (longNameSecondArgument: LongSecondType) =>
-        (longNameThirdArgument: LongThirdType) =>
-          LongReturnType
+        (longNameThirdArgument: LongThirdType) => LongReturnType
   = a => b => c => a + b + c;
 
 const myCurriedFn3
   : (longNameFirstArgument: LongFirstType) =>
       (longNameSecondArgument: LongSecondType) =>
-        (longNameThirdArgument: LongThirdType) =>
-          LongReturnType
+        (longNameThirdArgument: LongThirdType) => LongReturnType
   = longFirstParameter => longSecondParameter => longThirdParameter =>
     longFirstParameter + longSecondParameter + longThirdParameter;
 
 const myCurriedFn4
   : (longNameFirstArgument: LongFirstType) =>
       (longNameSecondArgument: LongSecondType) =>
-        (longNameThirdArgument: LongThirdType) =>
-          LongReturnType
-  = (longFirstParameter: LongFirstType) =>
-    (longSecondParameter: LongSecondType) =>
-    (longThirdParameter: LongThirdType): LongReturnType =>
+        (longNameThirdArgument: LongThirdType) => LongReturnType
+  = (longFirstParameter: LongFirstType) => (
+    longSecondParameter: LongSecondType
+  ) => (longThirdParameter: LongThirdType): LongReturnType =>
     longFirstParameter + longSecondParameter + longThirdParameter;
 
 ================================================================================
@@ -238,26 +235,23 @@ const myCurriedFn
 const myCurriedFn2
   : (longNameFirstArgument: LongFirstType) =>
       (longNameSecondArgument: LongSecondType) =>
-        (longNameThirdArgument: LongThirdType) =>
-          LongReturnType
+        (longNameThirdArgument: LongThirdType) => LongReturnType
   = (a) => (b) => (c) => a + b + c;
 
 const myCurriedFn3
   : (longNameFirstArgument: LongFirstType) =>
       (longNameSecondArgument: LongSecondType) =>
-        (longNameThirdArgument: LongThirdType) =>
-          LongReturnType
+        (longNameThirdArgument: LongThirdType) => LongReturnType
   = (longFirstParameter) => (longSecondParameter) => (longThirdParameter) =>
     longFirstParameter + longSecondParameter + longThirdParameter;
 
 const myCurriedFn4
   : (longNameFirstArgument: LongFirstType) =>
       (longNameSecondArgument: LongSecondType) =>
-        (longNameThirdArgument: LongThirdType) =>
-          LongReturnType
-  = (longFirstParameter: LongFirstType) =>
-    (longSecondParameter: LongSecondType) =>
-    (longThirdParameter: LongThirdType): LongReturnType =>
+        (longNameThirdArgument: LongThirdType) => LongReturnType
+  = (longFirstParameter: LongFirstType) => (
+    longSecondParameter: LongSecondType
+  ) => (longThirdParameter: LongThirdType): LongReturnType =>
     longFirstParameter + longSecondParameter + longThirdParameter;
 
 ================================================================================

--- a/tests/typescript_typed_arrow_fn_declr/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_typed_arrow_fn_declr/__snapshots__/jsfmt.spec.js.snap
@@ -129,3 +129,136 @@ const arrFnWithLongerImpl
 
 ================================================================================
 `;
+
+exports[`samples-from-issue-4166.ts 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const myCurriedFn: (arg1: number) => (arg2: number) => (arg3: number) => number = arg1 => arg2 => arg3 => arg1 + arg2 + arg3;
+
+const myCurriedFn2
+  : (longNameFirstArgument: LongFirstType) =>
+      (longNameSecondArgument: LongSecondType) =>
+        (longNameThirdArgument: LongThirdType) =>
+          LongReturnType
+  = a => b => c => a + b + c;
+
+const myCurriedFn3
+  : (longNameFirstArgument: LongFirstType) =>
+      (longNameSecondArgument: LongSecondType) =>
+        (longNameThirdArgument: LongThirdType) =>
+          LongReturnType
+  = longFirstParameter => longSecondParameter => longThirdParameter =>
+      longFirstParameter + longSecondParameter + longThirdParameter;
+
+const myCurriedFn4
+  : (longNameFirstArgument: LongFirstType) =>
+      (longNameSecondArgument: LongSecondType) =>
+        (longNameThirdArgument: LongThirdType) =>
+          LongReturnType
+  = (longFirstParameter: LongFirstType) =>
+      (longSecondParameter: LongSecondType) =>
+        (longThirdParameter: LongThirdType): LongReturnType =>
+          longFirstParameter + longSecondParameter + longThirdParameter;
+
+=====================================output=====================================
+const myCurriedFn
+  : (arg1: number) => (arg2: number) => (arg3: number) => number
+  = arg1 => arg2 => arg3 => arg1 + arg2 + arg3;
+
+const myCurriedFn2
+  : (longNameFirstArgument: LongFirstType) =>
+      (longNameSecondArgument: LongSecondType) =>
+        (longNameThirdArgument: LongThirdType) =>
+          LongReturnType
+  = a => b => c => a + b + c;
+
+const myCurriedFn3
+  : (longNameFirstArgument: LongFirstType) =>
+      (longNameSecondArgument: LongSecondType) =>
+        (longNameThirdArgument: LongThirdType) =>
+          LongReturnType
+  = longFirstParameter => longSecondParameter => longThirdParameter =>
+    longFirstParameter + longSecondParameter + longThirdParameter;
+
+const myCurriedFn4
+  : (longNameFirstArgument: LongFirstType) =>
+      (longNameSecondArgument: LongSecondType) =>
+        (longNameThirdArgument: LongThirdType) =>
+          LongReturnType
+  = (longFirstParameter: LongFirstType) =>
+    (longSecondParameter: LongSecondType) =>
+    (longThirdParameter: LongThirdType): LongReturnType =>
+    longFirstParameter + longSecondParameter + longThirdParameter;
+
+================================================================================
+`;
+
+exports[`samples-from-issue-4166.ts 2`] = `
+====================================options=====================================
+arrowParens: "always"
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const myCurriedFn: (arg1: number) => (arg2: number) => (arg3: number) => number = arg1 => arg2 => arg3 => arg1 + arg2 + arg3;
+
+const myCurriedFn2
+  : (longNameFirstArgument: LongFirstType) =>
+      (longNameSecondArgument: LongSecondType) =>
+        (longNameThirdArgument: LongThirdType) =>
+          LongReturnType
+  = a => b => c => a + b + c;
+
+const myCurriedFn3
+  : (longNameFirstArgument: LongFirstType) =>
+      (longNameSecondArgument: LongSecondType) =>
+        (longNameThirdArgument: LongThirdType) =>
+          LongReturnType
+  = longFirstParameter => longSecondParameter => longThirdParameter =>
+      longFirstParameter + longSecondParameter + longThirdParameter;
+
+const myCurriedFn4
+  : (longNameFirstArgument: LongFirstType) =>
+      (longNameSecondArgument: LongSecondType) =>
+        (longNameThirdArgument: LongThirdType) =>
+          LongReturnType
+  = (longFirstParameter: LongFirstType) =>
+      (longSecondParameter: LongSecondType) =>
+        (longThirdParameter: LongThirdType): LongReturnType =>
+          longFirstParameter + longSecondParameter + longThirdParameter;
+
+=====================================output=====================================
+const myCurriedFn
+  : (arg1: number) => (arg2: number) => (arg3: number) => number
+  = (arg1) => (arg2) => (arg3) => arg1 + arg2 + arg3;
+
+const myCurriedFn2
+  : (longNameFirstArgument: LongFirstType) =>
+      (longNameSecondArgument: LongSecondType) =>
+        (longNameThirdArgument: LongThirdType) =>
+          LongReturnType
+  = (a) => (b) => (c) => a + b + c;
+
+const myCurriedFn3
+  : (longNameFirstArgument: LongFirstType) =>
+      (longNameSecondArgument: LongSecondType) =>
+        (longNameThirdArgument: LongThirdType) =>
+          LongReturnType
+  = (longFirstParameter) => (longSecondParameter) => (longThirdParameter) =>
+    longFirstParameter + longSecondParameter + longThirdParameter;
+
+const myCurriedFn4
+  : (longNameFirstArgument: LongFirstType) =>
+      (longNameSecondArgument: LongSecondType) =>
+        (longNameThirdArgument: LongThirdType) =>
+          LongReturnType
+  = (longFirstParameter: LongFirstType) =>
+    (longSecondParameter: LongSecondType) =>
+    (longThirdParameter: LongThirdType): LongReturnType =>
+    longFirstParameter + longSecondParameter + longThirdParameter;
+
+================================================================================
+`;

--- a/tests/typescript_typed_arrow_fn_declr/declared-arrow-fn.ts
+++ b/tests/typescript_typed_arrow_fn_declr/declared-arrow-fn.ts
@@ -1,0 +1,2 @@
+const arrFn: (x: string) => (y: number) => (z: boolean) => [string, number, boolean]
+  = (x) => y => z => [x, y, z]

--- a/tests/typescript_typed_arrow_fn_declr/jsfmt.spec.js
+++ b/tests/typescript_typed_arrow_fn_declr/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname, ["typescript"]);
+run_spec(__dirname, ["typescript"], { arrowParens: "always" });

--- a/tests/typescript_typed_arrow_fn_declr/long-type-defn.ts
+++ b/tests/typescript_typed_arrow_fn_declr/long-type-defn.ts
@@ -1,0 +1,9 @@
+const arrFn: (x: SuperLongTypeNameDefinedElseWhere) => (y: AnotherReallyLongTypeName) => (z: ThirdVeryLongAndBoringInterfaceName) => VeryLongReturnTypeValue;
+
+const arrFnWithImpl: (x: SuperLongTypeNameDefinedElseWhere) => (y: AnotherReallyLongTypeName) => (z: ThirdVeryLongAndBoringInterfaceName) => VeryLongReturnTypeValue
+  = (argumentNumberOne) => (argumentNumberTwo) => (argumentNumberThree) =>
+    someVeryVeryVeryLoooooooooongFunctionInvocation(argumentNumberOne, argumentNumberTwo, argumentNumberThree);
+
+const arrFnWithLongerImpl: (x: SuperLongTypeNameDefinedElseWhere) => (y: AnotherReallyLongTypeName) => (z: ThirdVeryLongAndBoringInterfaceName) => VeryLongReturnTypeValue
+  = (argumentNumberOne) => (argumentNumberTwo) => (argumentNumberThreeIsLoooooooooooooooooooooooooooooong) =>
+    someVeryVeryVeryLoooooooooongFunctionInvocation(argumentNumberOne, argumentNumberTwo, argumentNumberThreeIsLoooooooooooooooooooooooooooooong);

--- a/tests/typescript_typed_arrow_fn_declr/samples-from-issue-4166.ts
+++ b/tests/typescript_typed_arrow_fn_declr/samples-from-issue-4166.ts
@@ -1,0 +1,26 @@
+const myCurriedFn: (arg1: number) => (arg2: number) => (arg3: number) => number = arg1 => arg2 => arg3 => arg1 + arg2 + arg3;
+
+const myCurriedFn2
+  : (longNameFirstArgument: LongFirstType) =>
+      (longNameSecondArgument: LongSecondType) =>
+        (longNameThirdArgument: LongThirdType) =>
+          LongReturnType
+  = a => b => c => a + b + c;
+
+const myCurriedFn3
+  : (longNameFirstArgument: LongFirstType) =>
+      (longNameSecondArgument: LongSecondType) =>
+        (longNameThirdArgument: LongThirdType) =>
+          LongReturnType
+  = longFirstParameter => longSecondParameter => longThirdParameter =>
+      longFirstParameter + longSecondParameter + longThirdParameter;
+
+const myCurriedFn4
+  : (longNameFirstArgument: LongFirstType) =>
+      (longNameSecondArgument: LongSecondType) =>
+        (longNameThirdArgument: LongThirdType) =>
+          LongReturnType
+  = (longFirstParameter: LongFirstType) =>
+      (longSecondParameter: LongSecondType) =>
+        (longThirdParameter: LongThirdType): LongReturnType =>
+          longFirstParameter + longSecondParameter + longThirdParameter;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Initial work on issues #6107 and #4166. Format is not finalized in issues, so the pull request is not final either. 

The last commit of this pr, shows changes between how prettier prints functions with these changes, instead of one possible desired printing style.

Things that are not done, which would be nice to do:
 - [ ] each level of curried function should be aligned, instead of indented at each level
 - [ ] return type of the very last function should go to the new line too
 - [ ] function implementation does not break on `=>` right now

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
