### PR TITLE
api: remove the version parameter of getSupportInfo

### DIFF
--- a/changelog_unreleased/api/pr-7620.md
+++ b/changelog_unreleased/api/pr-7620.md
@@ -1,0 +1,3 @@
+#### Remove the `version` parameter of `prettier.getSupportInfo()` ([#7620](https://github.com/prettier/prettier/pull/7620) by [@thorn0](https://github.com/thorn0))
+
+In Prettier 1.x (since 1.8.0), it was possible to pass a version number to `prettier.getSupportInfo()` to get information on the languages, options, etc. supported by previous versions. This feature has been virtually unused while the maintenance burden it caused was significant. In Prettier 2.0.0, this parameter has been removed.

--- a/changelog_unreleased/api/pr-7620.md
+++ b/changelog_unreleased/api/pr-7620.md
@@ -1,3 +1,3 @@
-#### Remove the `version` parameter of `prettier.getSupportInfo()` ([#7620](https://github.com/prettier/prettier/pull/7620) by [@thorn0](https://github.com/thorn0))
+#### [BREAKING] Remove the `version` parameter of `prettier.getSupportInfo()` ([#7620](https://github.com/prettier/prettier/pull/7620) by [@thorn0](https://github.com/thorn0))
 
-In Prettier 1.x (since 1.8.0), it was possible to pass a version number to `prettier.getSupportInfo()` to get information on the languages, options, etc. supported by previous versions. This feature has been virtually unused while the maintenance burden it caused was significant. In Prettier 2.0.0, this parameter has been removed.
+In Prettier 1.x (since 1.8.0), it was possible to pass a version number to `prettier.getSupportInfo()` to get information on the languages, options, etc. supported by previous versions. This interesting but apparently not very useful API kept causing maintenance problems and has been removed in Prettier 2.0.0.

--- a/docs/api.md
+++ b/docs/api.md
@@ -104,11 +104,9 @@ When setting `options.resolveConfig` (`boolean`, default `false`), Prettier will
 
 Use `prettier.getFileInfo.sync(filePath [, options])` if you'd like to use sync version.
 
-## `prettier.getSupportInfo([version])`
+## `prettier.getSupportInfo()`
 
-Returns an object representing the parsers, languages and file types Prettier supports.
-
-If `version` is provided (e.g. `"1.5.0"`), information for that version will be returned, otherwise information for the current version will be returned.
+Returns an object representing the parsers, languages and file types the current version of Prettier supports.
 
 The support information looks like this:
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -106,7 +106,7 @@ Use `prettier.getFileInfo.sync(filePath [, options])` if you'd like to use sync 
 
 ## `prettier.getSupportInfo()`
 
-Returns an object representing the parsers, languages and file types the current version of Prettier supports.
+Returns an object representing the options, parsers, languages and file types Prettier supports.
 
 The support information looks like this:
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -68,7 +68,7 @@ Prettier plugins are regular JavaScript modules with five exports:
 
 ### `languages`
 
-Languages is an array of language definitions that your plugin will contribute to Prettier. It can include all of the fields specified in [`prettier.getSupportInfo()`](api.md#prettiergetsupportinfo-version).
+Languages is an array of language definitions that your plugin will contribute to Prettier. It can include all of the fields specified in [`prettier.getSupportInfo()`](api.md#prettiergetsupportinfo).
 
 It **must** include `name` and `parsers`.
 

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -938,7 +938,7 @@ function initContext(context) {
 }
 
 function updateContextOptions(context, plugins, pluginSearchDirs) {
-  const supportOptions = prettier.getSupportInfo(null, {
+  const supportOptions = prettier.getSupportInfo({
     showDeprecated: true,
     showUnreleased: true,
     showInternal: true,

--- a/src/index.js
+++ b/src/index.js
@@ -12,23 +12,24 @@ const config = require("./config/resolve-config");
 
 const doc = require("./document");
 
-// Luckily `opts` is always the 2nd argument
-function _withPlugins(fn) {
-  return function(first, opts, ...rest) {
-    opts = opts || {};
-    opts = {
+function _withPlugins(
+  fn,
+  optsArgIdx = 1 // Usually `opts` is the 2nd argument
+) {
+  return (...args) => {
+    const opts = args[optsArgIdx] || {};
+    args[optsArgIdx] = {
       ...opts,
       plugins: loadPlugins(opts.plugins, opts.pluginSearchDirs)
     };
-
-    return fn(first, opts, ...rest);
+    return fn(...args);
   };
 }
 
-function withPlugins(fn) {
-  const resultingFn = _withPlugins(fn);
+function withPlugins(fn, optsArgIdx) {
+  const resultingFn = _withPlugins(fn, optsArgIdx);
   if (fn.sync) {
-    resultingFn.sync = _withPlugins(fn.sync);
+    resultingFn.sync = _withPlugins(fn.sync, optsArgIdx);
   }
   return resultingFn;
 }
@@ -54,7 +55,7 @@ module.exports = {
   clearConfigCache: config.clearCache,
 
   getFileInfo: withPlugins(getFileInfo),
-  getSupportInfo: withPlugins(getSupportInfo),
+  getSupportInfo: withPlugins(getSupportInfo, 0),
 
   version,
 

--- a/src/language-markdown/embed.js
+++ b/src/language-markdown/embed.js
@@ -66,9 +66,7 @@ function embed(path, print, textToDoc, options) {
   return null;
 
   function getParserName(lang) {
-    const supportInfo = support.getSupportInfo(null, {
-      plugins: options.plugins
-    });
+    const supportInfo = support.getSupportInfo({ plugins: options.plugins });
     const language = supportInfo.languages.find(
       language =>
         language.name.toLowerCase() === lang ||

--- a/src/language-markdown/index.js
+++ b/src/language-markdown/index.js
@@ -7,7 +7,7 @@ const createLanguage = require("../utils/create-language");
 const languages = [
   createLanguage(require("linguist-languages/data/Markdown"), data => ({
     since: "1.8.0",
-    parsers: ["remark"],
+    parsers: ["markdown"],
     vscodeLanguageIds: ["markdown"],
     filenames: data.filenames.concat(["README"]),
     extensions: data.extensions.filter(extension => extension !== ".mdx")

--- a/src/main/options.js
+++ b/src/main/options.js
@@ -23,11 +23,12 @@ function normalize(options, opts) {
 
   const rawOptions = { ...options };
 
-  const supportOptions = getSupportInfo(null, {
+  const supportOptions = getSupportInfo({
     plugins: options.plugins,
     showUnreleased: true,
     showDeprecated: true
   }).options;
+
   const defaults = {
     ...hiddenDefaults,
     ...fromPairs(
@@ -166,9 +167,7 @@ function inferParser(filepath, plugins) {
   // If the file has no extension, we can try to infer the language from the
   // interpreter in the shebang line, if any; but since this requires FS access,
   // do it last.
-  const language = getSupportInfo(null, {
-    plugins
-  }).languages.find(
+  const language = getSupportInfo({ plugins }).languages.find(
     language =>
       language.since !== null &&
       ((language.extensions &&

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -14,7 +14,7 @@ function getSupportInfo({
   showUnreleased = false,
   showDeprecated = false,
   showInternal = false
-}) {
+} = {}) {
   // pre-release version is smaller than the normal version in semver,
   // we need to treat it as the normal one so as to test new features.
   const version = currentVersion.split("-", 1)[0];

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -9,16 +9,12 @@ const arrayify = require("../utils/arrayify");
 const currentVersion = require("../../package.json").version;
 const coreOptions = require("./core-options").options;
 
-function getSupportInfo(
-  _,
-  // This has to be the second parameter. See _withPlugins in src/index.js.
-  {
-    plugins = [],
-    showUnreleased = false,
-    showDeprecated = false,
-    showInternal = false
-  }
-) {
+function getSupportInfo({
+  plugins = [],
+  showUnreleased = false,
+  showDeprecated = false,
+  showInternal = false
+}) {
   // pre-release version is smaller than the normal version in semver,
   // we need to treat it as the normal one so as to test new features.
   const version = currentVersion.split("-", 1)[0];

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -9,22 +9,19 @@ const arrayify = require("../utils/arrayify");
 const currentVersion = require("../../package.json").version;
 const coreOptions = require("./core-options").options;
 
-function getSupportInfo(version, opts) {
-  opts = {
-    plugins: [],
-    showUnreleased: false,
-    showDeprecated: false,
-    showInternal: false,
-    ...opts
-  };
-
-  if (!version) {
-    // pre-release version is smaller than the normal version in semver,
-    // we need to treat it as the normal one so as to test new features.
-    version = currentVersion.split("-", 1)[0];
+function getSupportInfo(
+  _,
+  // This has to be the second parameter. See _withPlugins in src/index.js.
+  {
+    plugins = [],
+    showUnreleased = false,
+    showDeprecated = false,
+    showInternal = false
   }
-
-  const { plugins } = opts;
+) {
+  // pre-release version is smaller than the normal version in semver,
+  // we need to treat it as the normal one so as to test new features.
+  const version = currentVersion.split("-", 1)[0];
 
   const options = arrayify(
     Object.assign({}, ...plugins.map(({ options }) => options), coreOptions),
@@ -59,64 +56,48 @@ function getSupportInfo(version, opts) {
           plugin.defaultOptions &&
           plugin.defaultOptions[option.name] !== undefined
       );
+
       const pluginDefaults = filteredPlugins.reduce((reduced, plugin) => {
         reduced[plugin.name] = plugin.defaultOptions[option.name];
         return reduced;
       }, {});
+
       return { ...option, pluginDefaults };
     });
 
-  const usePostCssParser = semver.lt(version, "1.7.1");
-  const useBabylonParser = semver.lt(version, "1.16.0");
-
   const languages = plugins
     .reduce((all, plugin) => all.concat(plugin.languages || []), [])
-    .filter(filterSince)
-    .map(language => {
-      let parsers;
-      // Prevent breaking changes
-      if (language.name === "Markdown") {
-        parsers = ["markdown"];
-        // "babylon" was renamed to "babel" in 1.16.0
-      } else if (useBabylonParser && language.parsers.includes("babel")) {
-        parsers = language.parsers.map(parser =>
-          parser === "babel" ? "babylon" : parser
-        );
-      } else if (
-        usePostCssParser &&
-        (language.name === "CSS" || language.group === "CSS")
-      ) {
-        parsers = ["postcss"];
-      }
-      return parsers ? { ...language, parsers } : language;
-    });
+    .filter(filterSince);
 
   return { languages, options };
 
   function filterSince(object) {
     return (
-      opts.showUnreleased ||
+      showUnreleased ||
       !("since" in object) ||
       (object.since && semver.gte(version, object.since))
     );
   }
+
   function filterDeprecated(object) {
     return (
-      opts.showDeprecated ||
+      showDeprecated ||
       !("deprecated" in object) ||
       (object.deprecated && semver.lt(version, object.deprecated))
     );
   }
+
   function mapDeprecated(object) {
-    if (!object.deprecated || opts.showDeprecated) {
+    if (!object.deprecated || showDeprecated) {
       return object;
     }
 
     const { deprecated, redirect, ...newObject } = object;
     return newObject;
   }
+
   function mapInternal(object) {
-    if (opts.showInternal) {
+    if (showInternal) {
       return object;
     }
     const { cliName, cliCategory, cliDescription, ...newObject } = object;

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -29,7 +29,6 @@ function getSupportInfo(
   )
     .filter(option => filterSince(option) && filterDeprecated(option))
     .sort((a, b) => (a.name === b.name ? 0 : a.name < b.name ? -1 : 1))
-    .map(mapDeprecated)
     .map(mapInternal)
     .map(option => {
       option = { ...option };
@@ -46,9 +45,9 @@ function getSupportInfo(
       }
 
       if (Array.isArray(option.choices)) {
-        option.choices = option.choices
-          .filter(option => filterSince(option) && filterDeprecated(option))
-          .map(mapDeprecated);
+        option.choices = option.choices.filter(
+          option => filterSince(option) && filterDeprecated(option)
+        );
       }
 
       const filteredPlugins = plugins.filter(
@@ -85,15 +84,6 @@ function getSupportInfo(
       !("deprecated" in object) ||
       (object.deprecated && semver.lt(version, object.deprecated))
     );
-  }
-
-  function mapDeprecated(object) {
-    if (!object.deprecated || showDeprecated) {
-      return object;
-    }
-
-    const { deprecated, redirect, ...newObject } = object;
-    return newObject;
   }
 
   function mapInternal(object) {

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -18,12 +18,15 @@ const internalPlugins = [
   require("./language-yaml")
 ];
 
-// Luckily `opts` is always the 2nd argument
-function withPlugins(fn) {
-  return function(first, opts, ...rest) {
-    const { plugins = [] } = opts || {};
+function withPlugins(
+  fn,
+  optsArgIdx = 1 // Usually `opts` is the 2nd argument
+) {
+  return (...args) => {
+    const opts = args[optsArgIdx] || {};
+    const plugins = opts.plugins || [];
 
-    opts = {
+    args[optsArgIdx] = {
       ...opts,
       plugins: [
         ...internalPlugins,
@@ -31,7 +34,7 @@ function withPlugins(fn) {
       ]
     };
 
-    return fn(first, opts, ...rest);
+    return fn(...args);
   };
 }
 
@@ -51,7 +54,7 @@ module.exports = {
 
   doc,
 
-  getSupportInfo: withPlugins(getSupportInfo),
+  getSupportInfo: withPlugins(getSupportInfo, 0),
 
   version,
 

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -1,88 +1,166 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`API getSupportInfo() with version 0.0.0 -> 1.0.0 1`] = `
-"Snapshot Diff:
-- First value
-+ Second value
-
-@@ -16,19 +16,35 @@
-    \\"options\\": Object {
-      \\"bracketSpacing\\": Object {
-        \\"default\\": true,
-        \\"type\\": \\"boolean\\",
-      },
-+     \\"jsxBracketSameLine\\": Object {
-+       \\"default\\": false,
-+       \\"type\\": \\"boolean\\",
-+     },
-+     \\"parser\\": Object {
-+       \\"choices\\": Array [
-+         \\"flow\\",
-+         \\"babylon\\",
-+       ],
-+       \\"default\\": \\"babylon\\",
-+       \\"type\\": \\"choice\\",
-+     },
-      \\"printWidth\\": Object {
-        \\"default\\": 80,
-        \\"range\\": Object {
-          \\"end\\": Infinity,
-          \\"start\\": 0,
-          \\"step\\": 1,
-        },
-        \\"type\\": \\"int\\",
-      },
-+     \\"semi\\": Object {
-+       \\"default\\": true,
-+       \\"type\\": \\"boolean\\",
-+     },
-      \\"singleQuote\\": Object {
-        \\"default\\": false,
-        \\"type\\": \\"boolean\\",
-      },
-      \\"tabWidth\\": Object {
-@@ -43,17 +59,15 @@
-      \\"trailingComma\\": Object {
-        \\"choices\\": Array [
-          \\"es5\\",
-          \\"none\\",
-          \\"all\\",
--         true,
--         false,
-        ],
--       \\"default\\": false,
-+       \\"default\\": \\"none\\",
-        \\"type\\": \\"choice\\",
-      },
--     \\"useFlowParser\\": Object {
-+     \\"useTabs\\": Object {
-        \\"default\\": false,
-        \\"type\\": \\"boolean\\",
-      },
-    },
-  }"
-`;
-
-exports[`API getSupportInfo() with version 0.0.0 1`] = `
+exports[`API getSupportInfo() 1`] = `
 Object {
   "languages": Object {
+    "Angular": Array [
+      "angular",
+    ],
+    "CSS": Array [
+      "css",
+    ],
     "Flow": Array [
-      "babylon",
+      "babel",
       "flow",
     ],
+    "GraphQL": Array [
+      "graphql",
+    ],
+    "HTML": Array [
+      "html",
+    ],
+    "JSON": Array [
+      "json",
+    ],
+    "JSON with Comments": Array [
+      "json",
+    ],
+    "JSON.stringify": Array [
+      "json-stringify",
+    ],
+    "JSON5": Array [
+      "json5",
+    ],
     "JSX": Array [
-      "babylon",
+      "babel",
       "flow",
     ],
     "JavaScript": Array [
-      "babylon",
+      "babel",
       "flow",
+    ],
+    "Less": Array [
+      "less",
+    ],
+    "Lightning Web Components": Array [
+      "lwc",
+    ],
+    "MDX": Array [
+      "mdx",
+    ],
+    "Markdown": Array [
+      "markdown",
+    ],
+    "PostCSS": Array [
+      "css",
+    ],
+    "SCSS": Array [
+      "scss",
+    ],
+    "TSX": Array [
+      "typescript",
+      "babel-ts",
+    ],
+    "TypeScript": Array [
+      "typescript",
+      "babel-ts",
+    ],
+    "Vue": Array [
+      "vue",
+    ],
+    "YAML": Array [
+      "yaml",
     ],
   },
   "options": Object {
+    "arrowParens": Object {
+      "choices": Array [
+        "always",
+        "avoid",
+      ],
+      "default": "always",
+      "type": "choice",
+    },
     "bracketSpacing": Object {
       "default": true,
       "type": "boolean",
+    },
+    "cursorOffset": Object {
+      "default": -1,
+      "range": Object {
+        "end": Infinity,
+        "start": -1,
+        "step": 1,
+      },
+      "type": "int",
+    },
+    "endOfLine": Object {
+      "choices": Array [
+        "lf",
+        "crlf",
+        "cr",
+        "auto",
+      ],
+      "default": "lf",
+      "type": "choice",
+    },
+    "filepath": Object {
+      "default": undefined,
+      "type": "path",
+    },
+    "htmlWhitespaceSensitivity": Object {
+      "choices": Array [
+        "css",
+        "strict",
+        "ignore",
+      ],
+      "default": "css",
+      "type": "choice",
+    },
+    "insertPragma": Object {
+      "default": false,
+      "type": "boolean",
+    },
+    "jsxBracketSameLine": Object {
+      "default": false,
+      "type": "boolean",
+    },
+    "jsxSingleQuote": Object {
+      "default": false,
+      "type": "boolean",
+    },
+    "parser": Object {
+      "choices": Array [
+        "flow",
+        "babel",
+        "babel-flow",
+        "babel-ts",
+        "typescript",
+        "css",
+        "less",
+        "scss",
+        "json",
+        "json5",
+        "json-stringify",
+        "graphql",
+        "markdown",
+        "mdx",
+        "vue",
+        "yaml",
+        "html",
+        "angular",
+        "lwc",
+      ],
+      "default": undefined,
+      "type": "choice",
+    },
+    "pluginSearchDirs": Object {
+      "default": Array [],
+      "type": "path",
+    },
+    "plugins": Object {
+      "default": Array [],
+      "type": "path",
     },
     "printWidth": Object {
       "default": 80,
@@ -92,6 +170,50 @@ Object {
         "step": 1,
       },
       "type": "int",
+    },
+    "proseWrap": Object {
+      "choices": Array [
+        "always",
+        "never",
+        "preserve",
+      ],
+      "default": "preserve",
+      "type": "choice",
+    },
+    "quoteProps": Object {
+      "choices": Array [
+        "as-needed",
+        "consistent",
+        "preserve",
+      ],
+      "default": "as-needed",
+      "type": "choice",
+    },
+    "rangeEnd": Object {
+      "default": Infinity,
+      "range": Object {
+        "end": Infinity,
+        "start": 0,
+        "step": 1,
+      },
+      "type": "int",
+    },
+    "rangeStart": Object {
+      "default": 0,
+      "range": Object {
+        "end": Infinity,
+        "start": 0,
+        "step": 1,
+      },
+      "type": "int",
+    },
+    "requirePragma": Object {
+      "default": false,
+      "type": "boolean",
+    },
+    "semi": Object {
+      "default": true,
+      "type": "boolean",
     },
     "singleQuote": Object {
       "default": false,
@@ -111,596 +233,20 @@ Object {
         "es5",
         "none",
         "all",
-        true,
-        false,
       ],
-      "default": false,
+      "default": "es5",
       "type": "choice",
     },
-    "useFlowParser": Object {
+    "useTabs": Object {
+      "default": false,
+      "type": "boolean",
+    },
+    "vueIndentScriptAndStyle": Object {
       "default": false,
       "type": "boolean",
     },
   },
 }
-`;
-
-exports[`API getSupportInfo() with version 1.0.0 -> 1.4.0 1`] = `
-"Snapshot Diff:
-- First value
-+ Second value
-
-@@ -1,7 +1,10 @@
-  Object {
-    \\"languages\\": Object {
-+     \\"CSS\\": Array [
-+       \\"postcss\\",
-+     ],
-      \\"Flow\\": Array [
-        \\"babylon\\",
-        \\"flow\\",
-      ],
-      \\"JSX\\": Array [
-@@ -9,31 +12,81 @@
-        \\"flow\\",
-      ],
-      \\"JavaScript\\": Array [
-        \\"babylon\\",
-        \\"flow\\",
-+     ],
-+     \\"Less\\": Array [
-+       \\"postcss\\",
-+     ],
-+     \\"PostCSS\\": Array [
-+       \\"postcss\\",
-+     ],
-+     \\"SCSS\\": Array [
-+       \\"postcss\\",
-+     ],
-+     \\"TSX\\": Array [
-+       \\"typescript\\",
-+       \\"babel-ts\\",
-+     ],
-+     \\"TypeScript\\": Array [
-+       \\"typescript\\",
-+       \\"babel-ts\\",
-      ],
-    },
-    \\"options\\": Object {
-      \\"bracketSpacing\\": Object {
-        \\"default\\": true,
-        \\"type\\": \\"boolean\\",
-      },
-+     \\"cursorOffset\\": Object {
-+       \\"default\\": -1,
-+       \\"range\\": Object {
-+         \\"end\\": Infinity,
-+         \\"start\\": -1,
-+         \\"step\\": 1,
-+       },
-+       \\"type\\": \\"int\\",
-+     },
-+     \\"filepath\\": Object {
-+       \\"default\\": undefined,
-+       \\"type\\": \\"path\\",
-+     },
-      \\"jsxBracketSameLine\\": Object {
-        \\"default\\": false,
-        \\"type\\": \\"boolean\\",
-      },
-      \\"parser\\": Object {
-        \\"choices\\": Array [
-          \\"flow\\",
-          \\"babylon\\",
-+         \\"typescript\\",
-+         \\"postcss\\",
-        ],
-        \\"default\\": \\"babylon\\",
-        \\"type\\": \\"choice\\",
-      },
-      \\"printWidth\\": Object {
-        \\"default\\": 80,
-+       \\"range\\": Object {
-+         \\"end\\": Infinity,
-+         \\"start\\": 0,
-+         \\"step\\": 1,
-+       },
-+       \\"type\\": \\"int\\",
-+     },
-+     \\"rangeEnd\\": Object {
-+       \\"default\\": Infinity,
-+       \\"range\\": Object {
-+         \\"end\\": Infinity,
-+         \\"start\\": 0,
-+         \\"step\\": 1,
-+       },
-+       \\"type\\": \\"int\\",
-+     },
-+     \\"rangeStart\\": Object {
-+       \\"default\\": 0,
-        \\"range\\": Object {
-          \\"end\\": Infinity,
-          \\"start\\": 0,
-          \\"step\\": 1,
-        },"
-`;
-
-exports[`API getSupportInfo() with version 1.4.0 -> 1.5.0 1`] = `
-"Snapshot Diff:
-- First value
-+ Second value
-
-@@ -5,10 +5,19 @@
-      ],
-      \\"Flow\\": Array [
-        \\"babylon\\",
-        \\"flow\\",
-      ],
-+     \\"GraphQL\\": Array [
-+       \\"graphql\\",
-+     ],
-+     \\"JSON\\": Array [
-+       \\"json\\",
-+     ],
-+     \\"JSON with Comments\\": Array [
-+       \\"json\\",
-+     ],
-      \\"JSX\\": Array [
-        \\"babylon\\",
-        \\"flow\\",
-      ],
-      \\"JavaScript\\": Array [
-@@ -59,10 +68,12 @@
-        \\"choices\\": Array [
-          \\"flow\\",
-          \\"babylon\\",
-          \\"typescript\\",
-          \\"postcss\\",
-+         \\"json\\",
-+         \\"graphql\\",
-        ],
-        \\"default\\": \\"babylon\\",
-        \\"type\\": \\"choice\\",
-      },
-      \\"printWidth\\": Object {"
-`;
-
-exports[`API getSupportInfo() with version 1.5.0 -> 1.7.1 1`] = `
-"Snapshot Diff:
-- First value
-+ Second value
-
-@@ -1,9 +1,9 @@
-  Object {
-    \\"languages\\": Object {
-      \\"CSS\\": Array [
--       \\"postcss\\",
-+       \\"css\\",
-      ],
-      \\"Flow\\": Array [
-        \\"babylon\\",
-        \\"flow\\",
-      ],
-@@ -23,17 +23,17 @@
-      \\"JavaScript\\": Array [
-        \\"babylon\\",
-        \\"flow\\",
-      ],
-      \\"Less\\": Array [
--       \\"postcss\\",
-+       \\"less\\",
-      ],
-      \\"PostCSS\\": Array [
--       \\"postcss\\",
-+       \\"css\\",
-      ],
-      \\"SCSS\\": Array [
--       \\"postcss\\",
-+       \\"scss\\",
-      ],
-      \\"TSX\\": Array [
-        \\"typescript\\",
-        \\"babel-ts\\",
-      ],
-@@ -67,11 +67,13 @@
-      \\"parser\\": Object {
-        \\"choices\\": Array [
-          \\"flow\\",
-          \\"babylon\\",
-          \\"typescript\\",
--         \\"postcss\\",
-+         \\"css\\",
-+         \\"less\\",
-+         \\"scss\\",
-          \\"json\\",
-          \\"graphql\\",
-        ],
-        \\"default\\": \\"babylon\\",
-        \\"type\\": \\"choice\\",
-@@ -100,10 +102,14 @@
-          \\"end\\": Infinity,
-          \\"start\\": 0,
-          \\"step\\": 1,
-        },
-        \\"type\\": \\"int\\",
-+     },
-+     \\"requirePragma\\": Object {
-+       \\"default\\": false,
-+       \\"type\\": \\"boolean\\",
-      },
-      \\"semi\\": Object {
-        \\"default\\": true,
-        \\"type\\": \\"boolean\\",
-      },"
-`;
-
-exports[`API getSupportInfo() with version 1.7.1 -> 1.8.0 1`] = `
-"Snapshot Diff:
-- First value
-+ Second value
-
-@@ -25,10 +25,13 @@
-        \\"flow\\",
-      ],
-      \\"Less\\": Array [
-        \\"less\\",
-      ],
-+     \\"Markdown\\": Array [
-+       \\"markdown\\",
-+     ],
-      \\"PostCSS\\": Array [
-        \\"css\\",
-      ],
-      \\"SCSS\\": Array [
-        \\"scss\\",
-@@ -57,10 +60,14 @@
-        \\"type\\": \\"int\\",
-      },
-      \\"filepath\\": Object {
-        \\"default\\": undefined,
-        \\"type\\": \\"path\\",
-+     },
-+     \\"insertPragma\\": Object {
-+       \\"default\\": false,
-+       \\"type\\": \\"boolean\\",
-      },
-      \\"jsxBracketSameLine\\": Object {
-        \\"default\\": false,
-        \\"type\\": \\"boolean\\",
-      },
-@@ -72,10 +79,11 @@
-          \\"css\\",
-          \\"less\\",
-          \\"scss\\",
-          \\"json\\",
-          \\"graphql\\",
-+         \\"markdown\\",
-        ],
-        \\"default\\": \\"babylon\\",
-        \\"type\\": \\"choice\\",
-      },
-      \\"printWidth\\": Object {"
-`;
-
-exports[`API getSupportInfo() with version 1.8.0 -> 1.8.2 1`] = `
-"Snapshot Diff:
-- First value
-+ Second value
-
-@@ -93,10 +93,18 @@
-          \\"start\\": 0,
-          \\"step\\": 1,
-        },
-        \\"type\\": \\"int\\",
-      },
-+     \\"proseWrap\\": Object {
-+       \\"choices\\": Array [
-+         false,
-+         true,
-+       ],
-+       \\"default\\": true,
-+       \\"type\\": \\"choice\\",
-+     },
-      \\"rangeEnd\\": Object {
-        \\"default\\": Infinity,
-        \\"range\\": Object {
-          \\"end\\": Infinity,
-          \\"start\\": 0,"
-`;
-
-exports[`API getSupportInfo() with version 1.8.2 -> 1.16.0 1`] = `
-"Snapshot Diff:
-- First value
-+ Second value
-
-@@ -1,33 +1,48 @@
-  Object {
-    \\"languages\\": Object {
-+     \\"Angular\\": Array [
-+       \\"angular\\",
-+     ],
-      \\"CSS\\": Array [
-        \\"css\\",
-      ],
-      \\"Flow\\": Array [
--       \\"babylon\\",
-+       \\"babel\\",
-        \\"flow\\",
-      ],
-      \\"GraphQL\\": Array [
-        \\"graphql\\",
-+     ],
-+     \\"HTML\\": Array [
-+       \\"html\\",
-      ],
-      \\"JSON\\": Array [
-        \\"json\\",
-      ],
-      \\"JSON with Comments\\": Array [
-        \\"json\\",
-      ],
-+     \\"JSON.stringify\\": Array [
-+       \\"json-stringify\\",
-+     ],
-+     \\"JSON5\\": Array [
-+       \\"json5\\",
-+     ],
-      \\"JSX\\": Array [
--       \\"babylon\\",
-+       \\"babel\\",
-        \\"flow\\",
-      ],
-      \\"JavaScript\\": Array [
--       \\"babylon\\",
-+       \\"babel\\",
-        \\"flow\\",
-      ],
-      \\"Less\\": Array [
-        \\"less\\",
-+     ],
-+     \\"MDX\\": Array [
-+       \\"mdx\\",
-      ],
-      \\"Markdown\\": Array [
-        \\"markdown\\",
-      ],
-      \\"PostCSS\\": Array [
-@@ -41,13 +56,27 @@
-        \\"babel-ts\\",
-      ],
-      \\"TypeScript\\": Array [
-        \\"typescript\\",
-        \\"babel-ts\\",
-+     ],
-+     \\"Vue\\": Array [
-+       \\"vue\\",
-+     ],
-+     \\"YAML\\": Array [
-+       \\"yaml\\",
-      ],
-    },
-    \\"options\\": Object {
-+     \\"arrowParens\\": Object {
-+       \\"choices\\": Array [
-+         \\"always\\",
-+         \\"avoid\\",
-+       ],
-+       \\"default\\": \\"avoid\\",
-+       \\"type\\": \\"choice\\",
-+     },
-      \\"bracketSpacing\\": Object {
-        \\"default\\": true,
-        \\"type\\": \\"boolean\\",
-      },
-      \\"cursorOffset\\": Object {
-@@ -57,36 +86,75 @@
-          \\"start\\": -1,
-          \\"step\\": 1,
-        },
-        \\"type\\": \\"int\\",
-      },
-+     \\"endOfLine\\": Object {
-+       \\"choices\\": Array [
-+         \\"lf\\",
-+         \\"crlf\\",
-+         \\"cr\\",
-+         \\"auto\\",
-+       ],
-+       \\"default\\": \\"auto\\",
-+       \\"type\\": \\"choice\\",
-+     },
-      \\"filepath\\": Object {
-        \\"default\\": undefined,
-        \\"type\\": \\"path\\",
-      },
-+     \\"htmlWhitespaceSensitivity\\": Object {
-+       \\"choices\\": Array [
-+         \\"css\\",
-+         \\"strict\\",
-+         \\"ignore\\",
-+       ],
-+       \\"default\\": \\"css\\",
-+       \\"type\\": \\"choice\\",
-+     },
-      \\"insertPragma\\": Object {
-        \\"default\\": false,
-        \\"type\\": \\"boolean\\",
-      },
-      \\"jsxBracketSameLine\\": Object {
-        \\"default\\": false,
-        \\"type\\": \\"boolean\\",
-      },
-+     \\"jsxSingleQuote\\": Object {
-+       \\"default\\": false,
-+       \\"type\\": \\"boolean\\",
-+     },
-      \\"parser\\": Object {
-        \\"choices\\": Array [
-          \\"flow\\",
--         \\"babylon\\",
-+         \\"babel\\",
-+         \\"babel-flow\\",
-          \\"typescript\\",
-          \\"css\\",
-          \\"less\\",
-          \\"scss\\",
-          \\"json\\",
-+         \\"json5\\",
-+         \\"json-stringify\\",
-          \\"graphql\\",
-          \\"markdown\\",
-+         \\"mdx\\",
-+         \\"vue\\",
-+         \\"yaml\\",
-+         \\"html\\",
-+         \\"angular\\",
-        ],
--       \\"default\\": \\"babylon\\",
-+       \\"default\\": undefined,
-        \\"type\\": \\"choice\\",
-+     },
-+     \\"pluginSearchDirs\\": Object {
-+       \\"default\\": Array [],
-+       \\"type\\": \\"path\\",
-+     },
-+     \\"plugins\\": Object {
-+       \\"default\\": Array [],
-+       \\"type\\": \\"path\\",
-      },
-      \\"printWidth\\": Object {
-        \\"default\\": 80,
-        \\"range\\": Object {
-          \\"end\\": Infinity,
-@@ -95,14 +163,15 @@
-        },
-        \\"type\\": \\"int\\",
-      },
-      \\"proseWrap\\": Object {
-        \\"choices\\": Array [
--         false,
--         true,
-+         \\"always\\",
-+         \\"never\\",
-+         \\"preserve\\",
-        ],
--       \\"default\\": true,
-+       \\"default\\": \\"preserve\\",
-        \\"type\\": \\"choice\\",
-      },
-      \\"rangeEnd\\": Object {
-        \\"default\\": Infinity,
-        \\"range\\": Object {"
-`;
-
-exports[`API getSupportInfo() with version 1.16.0 -> undefined 1`] = `
-"Snapshot Diff:
-- First value
-+ Second value
-
-@@ -37,10 +37,13 @@
-        \\"flow\\",
-      ],
-      \\"Less\\": Array [
-        \\"less\\",
-      ],
-+     \\"Lightning Web Components\\": Array [
-+       \\"lwc\\",
-+     ],
-      \\"MDX\\": Array [
-        \\"mdx\\",
-      ],
-      \\"Markdown\\": Array [
-        \\"markdown\\",
-@@ -70,11 +73,11 @@
-      \\"arrowParens\\": Object {
-        \\"choices\\": Array [
-          \\"always\\",
-          \\"avoid\\",
-        ],
--       \\"default\\": \\"avoid\\",
-+       \\"default\\": \\"always\\",
-        \\"type\\": \\"choice\\",
-      },
-      \\"bracketSpacing\\": Object {
-        \\"default\\": true,
-        \\"type\\": \\"boolean\\",
-@@ -93,11 +96,11 @@
-          \\"lf\\",
-          \\"crlf\\",
-          \\"cr\\",
-          \\"auto\\",
-        ],
--       \\"default\\": \\"auto\\",
-+       \\"default\\": \\"lf\\",
-        \\"type\\": \\"choice\\",
-      },
-      \\"filepath\\": Object {
-        \\"default\\": undefined,
-        \\"type\\": \\"path\\",
-@@ -126,10 +129,11 @@
-      \\"parser\\": Object {
-        \\"choices\\": Array [
-          \\"flow\\",
-          \\"babel\\",
-          \\"babel-flow\\",
-+         \\"babel-ts\\",
-          \\"typescript\\",
-          \\"css\\",
-          \\"less\\",
-          \\"scss\\",
-          \\"json\\",
-@@ -140,10 +144,11 @@
-          \\"mdx\\",
-          \\"vue\\",
-          \\"yaml\\",
-          \\"html\\",
-          \\"angular\\",
-+         \\"lwc\\",
-        ],
-        \\"default\\": undefined,
-        \\"type\\": \\"choice\\",
-      },
-      \\"pluginSearchDirs\\": Object {
-@@ -168,10 +173,19 @@
-          \\"always\\",
-          \\"never\\",
-          \\"preserve\\",
-        ],
-        \\"default\\": \\"preserve\\",
-+       \\"type\\": \\"choice\\",
-+     },
-+     \\"quoteProps\\": Object {
-+       \\"choices\\": Array [
-+         \\"as-needed\\",
-+         \\"consistent\\",
-+         \\"preserve\\",
-+       ],
-+       \\"default\\": \\"as-needed\\",
-        \\"type\\": \\"choice\\",
-      },
-      \\"rangeEnd\\": Object {
-        \\"default\\": Infinity,
-        \\"range\\": Object {
-@@ -215,14 +229,18 @@
-        \\"choices\\": Array [
-          \\"es5\\",
-          \\"none\\",
-          \\"all\\",
-        ],
--       \\"default\\": \\"none\\",
-+       \\"default\\": \\"es5\\",
-        \\"type\\": \\"choice\\",
-      },
-      \\"useTabs\\": Object {
-+       \\"default\\": false,
-+       \\"type\\": \\"boolean\\",
-+     },
-+     \\"vueIndentScriptAndStyle\\": Object {
-        \\"default\\": false,
-        \\"type\\": \\"boolean\\",
-      },
-    },
-  }"
 `;
 
 exports[`CLI --support-info (stderr) 1`] = `""`;

--- a/tests_integration/__tests__/help-options.js
+++ b/tests_integration/__tests__/help-options.js
@@ -9,7 +9,7 @@ const arrayify = require("../../src/utils/arrayify");
 arrayify(
   {
     ...util.createDetailedOptionMap(
-      prettier.getSupportInfo(null, {
+      prettier.getSupportInfo({
         showDeprecated: true,
         showUnreleased: true,
         showInternal: true

--- a/tests_integration/__tests__/support-info.js
+++ b/tests_integration/__tests__/support-info.js
@@ -2,43 +2,17 @@
 
 const prettier = require("prettier/local");
 const runPrettier = require("../runPrettier");
-const snapshotDiff = require("snapshot-diff");
 
-describe("API getSupportInfo()", () => {
-  const testVersions = [
-    "0.0.0",
-    "1.0.0",
-    "1.4.0",
-    "1.5.0",
-    "1.7.1",
-    "1.8.0",
-    "1.8.2",
-    "1.16.0",
-    undefined
-  ];
-
-  testVersions.forEach((version, index) => {
-    const info = getCoreInfo(version);
-    if (index === 0) {
-      test(`with version ${version}`, () => {
-        expect(info).toMatchSnapshot();
-      });
-    } else {
-      const previousVersion = testVersions[index - 1];
-      const previousInfo = getCoreInfo(previousVersion);
-      test(`with version ${previousVersion} -> ${version}`, () => {
-        expect(snapshotDiff(previousInfo, info)).toMatchSnapshot();
-      });
-    }
-  });
+test("API getSupportInfo()", () => {
+  expect(getCoreInfo()).toMatchSnapshot();
 });
 
 describe("CLI --support-info", () => {
   runPrettier("cli", "--support-info").test({ status: 0 });
 });
 
-function getCoreInfo(version) {
-  const supportInfo = prettier.getSupportInfo(version);
+function getCoreInfo() {
+  const supportInfo = prettier.getSupportInfo();
   const languages = supportInfo.languages.reduce(
     (obj, language) => ({ [language.name]: language.parsers, ...obj }),
     {}

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -166,7 +166,7 @@ function handleMessage(message) {
       type: "meta",
       supportInfo: JSON.parse(
         JSON.stringify(
-          prettier.getSupportInfo(null, {
+          prettier.getSupportInfo({
             showUnreleased: /-pr\./.test(prettier.version)
           })
         )


### PR DESCRIPTION
closes https://github.com/prettier/prettier/issues/7615

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
