### PR TITLE
Remove unnecessary expression

### DIFF
--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -937,9 +937,7 @@ function adjustNumbers(value) {
     ADJUST_NUMBERS_REGEX,
     (match, quote, wordPart, number, unit) =>
       !wordPart && number
-        ? (wordPart || "") +
-          printCssNumber(number) +
-          maybeToLowerCase(unit || "")
+        ? printCssNumber(number) + maybeToLowerCase(unit || "")
         : match
   );
 }


### PR DESCRIPTION
Since wordPart is checked for falsiness on the previous line, it will always evaluate to an empty string. The expression in the parentheses will then evaluate to `"" || ""`, which I assume is not desired.

Ref: https://lgtm.com/projects/g/prettier/prettier/snapshot/ecfc5e9b8320d79ed8a801d811e0a63892b040d0/files/src/printer-postcss.js?sort=name&dir=ASC&mode=heatmap#L468

cc @lydell 

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
