### PR TITLE
TypeScript: force newline and indentation before type annotation with leading comment

### DIFF
--- a/changelog_unreleased/typescript/pr-7728.md
+++ b/changelog_unreleased/typescript/pr-7728.md
@@ -1,0 +1,39 @@
+#### Fix formatting of type annotation with leading comment ([#7728](https://github.com/prettier/prettier/pull/7728) by [@uhyo](https://github.com/uhyo))
+
+If a type used as a type annotation has a leading comment, Prettier now always inserts a newline before the comment and handles indentation properly.
+
+<!-- prettier-ignore -->
+```ts
+// Input
+type T = {
+  prop:
+    // comment
+    | T1
+    // comment
+    | T2
+  prop2: // comment
+    T3
+}
+
+// Prettier stable
+type T = {
+  prop: // comment
+  | T1
+    // comment
+    | T2;
+  prop2: // comment
+  T3;
+};
+
+// Prettier master
+type T = {
+  prop:
+    // comment
+    | T1
+    // comment
+    | T2;
+  prop2:
+    // comment
+    T3;
+};
+```

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2919,6 +2919,12 @@ function printPathNoParens(path, options, print, args) {
         shouldIndent &&
         !hasLeadingOwnLineComment(options.originalText, n, options);
 
+      // console.log(
+      //   "s",
+      //   shouldIndent,
+      //   hasLeadingOwnLineComment(options.originalText, n, options)
+      // );
+
       const code = concat([
         ifBreak(concat([shouldAddStartLine ? line : "", "| "])),
         join(concat([line, "| "]), printed)
@@ -4221,10 +4227,23 @@ function printTypeAnnotation(path, options, print) {
     return concat([" /*: ", path.call(print, "typeAnnotation"), " */"]);
   }
 
-  return concat([
-    isFunctionDeclarationIdentifier ? "" : isDefinite ? "!: " : ": ",
-    path.call(print, "typeAnnotation")
-  ]);
+  const parts = [
+    isFunctionDeclarationIdentifier ? "" : isDefinite ? "!: " : ": "
+  ];
+  const printed = path.call(print, "typeAnnotation");
+  if (
+    hasLeadingOwnLineComment(
+      options.originalText,
+      node.typeAnnotation.typeAnnotation,
+      options
+    )
+  ) {
+    parts.push(indent(concat([hardline, printed])));
+  } else {
+    parts.push(printed);
+  }
+
+  return concat(parts);
 }
 
 function printFunctionTypeParameters(path, options, print) {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2888,7 +2888,8 @@ function printPathNoParens(path, options, print, args) {
         !(
           (parent.type === "TypeAlias" ||
             parent.type === "VariableDeclarator" ||
-            parent.type === "TSTypeAliasDeclaration") &&
+            parent.type === "TSTypeAliasDeclaration" ||
+            parent.type === "TSTypeAnnotation") &&
           hasLeadingOwnLineComment(options.originalText, n, options)
         );
 
@@ -3202,7 +3203,18 @@ function printPathNoParens(path, options, print, args) {
 
       if (n.typeAnnotation) {
         parts.push(": ");
-        parts.push(path.call(print, "typeAnnotation"));
+        const typeAnnotation = path.call(print, "typeAnnotation");
+        if (
+          hasLeadingOwnLineComment(
+            options.originalText,
+            n.typeAnnotation.typeAnnotation,
+            options
+          )
+        ) {
+          parts.push(indent(concat([hardline, typeAnnotation])));
+        } else {
+          parts.push(typeAnnotation);
+        }
       }
 
       // This isn't valid semantically, but it's in the AST so we can print it.

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2919,12 +2919,6 @@ function printPathNoParens(path, options, print, args) {
         shouldIndent &&
         !hasLeadingOwnLineComment(options.originalText, n, options);
 
-      // console.log(
-      //   "s",
-      //   shouldIndent,
-      //   hasLeadingOwnLineComment(options.originalText, n, options)
-      // );
-
       const code = concat([
         ifBreak(concat([shouldAddStartLine ? line : "", "| "])),
         join(concat([line, "| "]), printed)

--- a/tests/flow_union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_union/__snapshots__/jsfmt.spec.js.snap
@@ -13,11 +13,12 @@ const myValue = (callcallcallcallcallcall(87689769876876897698768768976987687689
 =====================================output=====================================
 const myValue = (callcallcallcallcallcall(
   87689769876876897698768768976987687689769876
-): // Comment
-| one
-  | two
-  | thre
-  | jdkxhflksjdhfglkjsdhfglkjhsdkfljghskdjhfgkljshdfgkjhsdkljfhgkljshdfgjdfklgjhklj);
+):
+  // Comment
+  | one
+    | two
+    | thre
+    | jdkxhflksjdhfglkjsdhfglkjhsdkfljghskdjhfgkljshdfgkjhsdkljfhgkljshdfgjdfklgjhklj);
 
 ================================================================================
 `;

--- a/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
@@ -113,6 +113,42 @@ declare function /* foo */ f(/* baz */ a /* taz */); /* bar */
 ================================================================================
 `;
 
+exports[`identifier-leading-comments.ts 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// https://github.com/prettier/prettier/issues/7725
+type T = (arg:
+  // comment 1
+  | T1
+  // comment 2
+  | T2
+  // comment 3
+) => void
+
+const a: // comment 4
+  T = v;
+
+=====================================output=====================================
+// https://github.com/prettier/prettier/issues/7725
+type T = (
+  arg:
+    // comment 1
+    | T1
+    // comment 2
+    | T2
+  // comment 3
+) => void;
+
+const a:
+  // comment 4
+  T = v;
+
+================================================================================
+`;
+
 exports[`interface.ts 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -652,6 +688,44 @@ export class Point {
 
   inline /* foo*/(/* bar */) /* baz */ {}
 }
+
+================================================================================
+`;
+
+exports[`property-signature.ts 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// https://github.com/prettier/prettier/issues/7725
+type T = {
+  // comment 1
+  prop:
+    // comment 2
+    | T1
+    // comment 3
+    | T2;
+  // comment 4
+  prop2: // comment 5
+    T3 | T4;
+};
+
+
+=====================================output=====================================
+// https://github.com/prettier/prettier/issues/7725
+type T = {
+  // comment 1
+  prop:
+    // comment 2
+    | T1
+    // comment 3
+    | T2;
+  // comment 4
+  prop2:
+    // comment 5
+    T3 | T4;
+};
 
 ================================================================================
 `;

--- a/tests/typescript_comments/identifier-leading-comments.ts
+++ b/tests/typescript_comments/identifier-leading-comments.ts
@@ -1,0 +1,11 @@
+// https://github.com/prettier/prettier/issues/7725
+type T = (arg:
+  // comment 1
+  | T1
+  // comment 2
+  | T2
+  // comment 3
+) => void
+
+const a: // comment 4
+  T = v;

--- a/tests/typescript_comments/property-signature.ts
+++ b/tests/typescript_comments/property-signature.ts
@@ -1,0 +1,13 @@
+// https://github.com/prettier/prettier/issues/7725
+type T = {
+  // comment 1
+  prop:
+    // comment 2
+    | T1
+    // comment 3
+    | T2;
+  // comment 4
+  prop2: // comment 5
+    T3 | T4;
+};
+


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
fixes #7725 

With this PR, a leading comment of a type used as a type annotation forces a newline before it.
This is similar to what `printAssignmentRight` already does.
As I modified `printTypeAnnotation`, in addition to fixing #7725, it introduces a change like this:

```ts
// Input
const a: // comment
string = "";

// Current (pretter 1.19.1)
const a: // comment
string = "";

// This PR
const a:
  //comment
  string = "";
```

If this is not acceptable, I think I can limit the change to the particular function argument case.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
