### PR TITLE
TypeScript: Print dangling comment in empty type parameters

### DIFF
--- a/changelog_unreleased/typescript/pr-7729.md
+++ b/changelog_unreleased/typescript/pr-7729.md
@@ -1,0 +1,23 @@
+# Fix printing of comments in empty type parameters ([#7729](https://github.com/prettier/prettier/pull/7729) by [@sosukesuzuki](https://github.com/sosukesuzuki))
+
+<!-- prettier-ignore -->
+```ts
+// Input
+const a: T</* comment */> = 1;
+
+// Prettier stable
+Error: Comment "comment" was not printed. Please report this error!
+    at https://prettier.io/lib/standalone.js:15543:15
+    at Array.forEach (<anonymous>)
+    at ensureAllCommentsPrinted (https://prettier.io/lib/standalone.js:15541:17)
+    at coreFormat (https://prettier.io/lib/standalone.js:15592:5)
+    at format (https://prettier.io/lib/standalone.js:15832:75)
+    at formatWithCursor (https://prettier.io/lib/standalone.js:15848:14)
+    at https://prettier.io/lib/standalone.js:31794:17
+    at Object.format (https://prettier.io/lib/standalone.js:31802:14)
+    at formatCode (https://prettier.io/worker.js:234:21)
+    at handleMessage (https://prettier.io/worker.js:185:18)
+
+// Prettier master
+const a: T</* comment */> = 1;
+```

--- a/changelog_unreleased/typescript/pr-7729.md
+++ b/changelog_unreleased/typescript/pr-7729.md
@@ -1,4 +1,4 @@
-# Fix printing of comments in empty type parameters ([#7729](https://github.com/prettier/prettier/pull/7729) by [@sosukesuzuki](https://github.com/sosukesuzuki))
+#### Fix printing of comments in empty type parameters ([#7729](https://github.com/prettier/prettier/pull/7729) by [@sosukesuzuki](https://github.com/sosukesuzuki))
 
 <!-- prettier-ignore -->
 ```ts

--- a/changelog_unreleased/typescript/pr-7729.md
+++ b/changelog_unreleased/typescript/pr-7729.md
@@ -7,16 +7,6 @@ const a: T</* comment */> = 1;
 
 // Prettier stable
 Error: Comment "comment" was not printed. Please report this error!
-    at https://prettier.io/lib/standalone.js:15543:15
-    at Array.forEach (<anonymous>)
-    at ensureAllCommentsPrinted (https://prettier.io/lib/standalone.js:15541:17)
-    at coreFormat (https://prettier.io/lib/standalone.js:15592:5)
-    at format (https://prettier.io/lib/standalone.js:15832:75)
-    at formatWithCursor (https://prettier.io/lib/standalone.js:15848:14)
-    at https://prettier.io/lib/standalone.js:31794:17
-    at Object.format (https://prettier.io/lib/standalone.js:31802:14)
-    at formatCode (https://prettier.io/worker.js:234:21)
-    at handleMessage (https://prettier.io/worker.js:185:18)
 
 // Prettier master
 const a: T</* comment */> = 1;

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4639,7 +4639,14 @@ function printTypeParameters(path, options, print, paramsKey) {
           n[paramsKey][0].type !== "TSArrayType")));
 
   if (shouldInline) {
-    return concat(["<", join(", ", path.map(print, paramsKey)), ">"]);
+    return concat([
+      "<",
+      join(", ", path.map(print, paramsKey)),
+      hasDanglingComments(n)
+        ? comments.printDanglingComments(path, options, /* sameIndent */ true)
+        : "",
+      ">"
+    ]);
   }
 
   return group(

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4653,7 +4653,7 @@ function printTypeParameters(path, options, print, paramsKey) {
     if (hasOnlyBlockComments) {
       return printed;
     }
-    return concat([printed, line]);
+    return concat([printed, hardline]);
   }
 
   if (shouldInline) {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4638,13 +4638,29 @@ function printTypeParameters(path, options, print, paramsKey) {
           n[paramsKey][0].type !== "TSIndexedAccessType" &&
           n[paramsKey][0].type !== "TSArrayType")));
 
+  function printDanglingCommentsForInline(n) {
+    if (!hasDanglingComments(n)) {
+      return "";
+    }
+    const hasOnlyBlockComments = n.comments.every(
+      handleComments.isBlockComment
+    );
+    const printed = comments.printDanglingComments(
+      path,
+      options,
+      /* sameIndent */ hasOnlyBlockComments
+    );
+    if (hasOnlyBlockComments) {
+      return printed;
+    }
+    return concat([printed, line]);
+  }
+
   if (shouldInline) {
     return concat([
       "<",
       join(", ", path.map(print, paramsKey)),
-      hasDanglingComments(n)
-        ? comments.printDanglingComments(path, options, /* sameIndent */ true)
-        : "",
+      printDanglingCommentsForInline(n),
       ">"
     ]);
   }

--- a/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
@@ -671,6 +671,27 @@ interface Foo {
 }
 type T = </* comment */>(arg) => any;
 
+functionName<
+  A // comment
+>();
+const a: T<
+  // comment
+> = 1;
+functionName<
+  // comment
+>();
+function foo<
+  // comment
+>() {}
+interface Foo {
+ <
+  A// comment
+ >(arg): any;
+}
+type T = <
+  // comment
+>(arg) => any;
+
 =====================================output=====================================
 functionName<A /* A comment */>();
 const a: T</* comment */> = 1;
@@ -680,6 +701,31 @@ interface Foo {
   </* comment */>(arg): any;
 }
 type T = </* comment */>(arg) => any;
+
+functionName<
+  A // comment
+>();
+const a: T<
+  // comment
+> = 1;
+functionName<
+  // comment
+>();
+function foo<
+  // comment
+>() {}
+interface Foo {
+  <
+    A // comment
+  >(
+    arg
+  ): any;
+}
+type T = <
+  // comment
+>(
+  arg
+) => any;
 
 ================================================================================
 `;

--- a/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_comments/__snapshots__/jsfmt.spec.js.snap
@@ -663,9 +663,23 @@ printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
 functionName<A /* A comment */>();
+const a: T</* comment */> = 1;
+functionName</* comment */>();
+function foo</* comment */>() {}
+interface Foo {
+ </* comment */>(arg): any;
+}
+type T = </* comment */>(arg) => any;
 
 =====================================output=====================================
 functionName<A /* A comment */>();
+const a: T</* comment */> = 1;
+functionName</* comment */>();
+function foo</* comment */>() {}
+interface Foo {
+  </* comment */>(arg): any;
+}
+type T = </* comment */>(arg) => any;
 
 ================================================================================
 `;

--- a/tests/typescript_comments/type-parameters.ts
+++ b/tests/typescript_comments/type-parameters.ts
@@ -6,3 +6,24 @@ interface Foo {
  </* comment */>(arg): any;
 }
 type T = </* comment */>(arg) => any;
+
+functionName<
+  A // comment
+>();
+const a: T<
+  // comment
+> = 1;
+functionName<
+  // comment
+>();
+function foo<
+  // comment
+>() {}
+interface Foo {
+ <
+  A// comment
+ >(arg): any;
+}
+type T = <
+  // comment
+>(arg) => any;

--- a/tests/typescript_comments/type-parameters.ts
+++ b/tests/typescript_comments/type-parameters.ts
@@ -1,1 +1,8 @@
 functionName<A /* A comment */>();
+const a: T</* comment */> = 1;
+functionName</* comment */>();
+function foo</* comment */>() {}
+interface Foo {
+ </* comment */>(arg): any;
+}
+type T = </* comment */>(arg) => any;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fixes #7574

```ts
// Input
const a: T</* comment */> = 1;

// Prettier stable
Error: Comment "comment" was not printed. Please report this error!
    at https://prettier.io/lib/standalone.js:15543:15
    at Array.forEach (<anonymous>)
    at ensureAllCommentsPrinted (https://prettier.io/lib/standalone.js:15541:17)
    at coreFormat (https://prettier.io/lib/standalone.js:15592:5)
    at format (https://prettier.io/lib/standalone.js:15832:75)
    at formatWithCursor (https://prettier.io/lib/standalone.js:15848:14)
    at https://prettier.io/lib/standalone.js:31794:17
    at Object.format (https://prettier.io/lib/standalone.js:31802:14)
    at formatCode (https://prettier.io/worker.js:234:21)
    at handleMessage (https://prettier.io/worker.js:185:18)

// Prettier master
const a: T</* comment */> = 1;
```


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
