### PR TITLE
azure pipelines: switch to macOS 10.14

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ jobs:
   - job: Dev_Test_macOS
     displayName: Dev Test on macOS Node v12
     pool:
-      vmImage: macos-10.13
+      vmImage: macos-10.14
     variables:
       node_version: 12
       ENABLE_CODE_COVERAGE: true
@@ -78,7 +78,7 @@ jobs:
     dependsOn: Prod_Build
     displayName: Prod Test on macOS
     pool:
-      vmImage: macos-10.13
+      vmImage: macos-10.14
     strategy:
       matrix:
         Node_v10:


### PR DESCRIPTION
see https://devblogs.microsoft.com/devops/removing-older-images-in-azure-pipelines-hosted-pools/
