### PR TITLE
docs: add prettier-plugin-organize-imports to list of community plugins

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -316,6 +316,7 @@
         "Shigeaki",
         "Shinigami",
         "Simen",
+        "simonhaenisch",
         "singleline",
         "skratchdot",
         "smirea",

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -55,6 +55,7 @@ Providing at least one path to `--plugin-search-dir`/`pluginSearchDirs` turns of
 - [`prettier-plugin-solidity`](https://github.com/prettier-solidity/prettier-plugin-solidity) by [**@mattiaerre**](https://github.com/mattiaerre)
 - [`prettier-plugin-svelte`](https://github.com/UnwrittenFun/prettier-plugin-svelte) by [**@UnwrittenFun**](https://github.com/UnwrittenFun)
 - [`prettier-plugin-toml`](https://github.com/bd82/toml-tools/tree/master/packages/prettier-plugin-toml) by [**@bd82**](https://github.com/bd82)
+- [`prettier-plugin-organize-imports`](https://github.com/simonhaenisch/prettier-plugin-organize-imports) by [**@simonhaenisch**](https://github.com/simonhaenisch)
 
 ## Developing Plugins
 


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] ~I’ve added tests to confirm my change works.~
- [ ] ~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~
- [ ] ~(If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

Just adding a plugin I wrote to organize tyepscript imports to the list of community plugins cause I find it quite handy and want other people to be able to discover it and benefit from it as well. Not sure whether this list is open to additions but I hope so!