### PR TITLE
Fix printing of nested closure typecasts

### DIFF
--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -950,6 +950,31 @@ function getCommentChildNodes(node, options) {
   }
 }
 
+function makeComment() {
+  return {
+    type: "CommentBlock",
+    value: "",
+    start: 0,
+    end: 0,
+    leading: false,
+    trailing: false
+  };
+}
+
+function makeOpenParenComment() {
+  const comment = makeComment();
+  comment.value = "__PRETTIER_OPEN_PAREN__";
+  comment.leading = true;
+  return comment;
+}
+
+function makeCloseParenComment() {
+  const comment = makeComment();
+  comment.value = "__PRETTIER_CLOSE_PAREN__";
+  comment.trailing = true;
+  return comment;
+}
+
 module.exports = {
   handleOwnLineComment,
   handleEndOfLineComment,
@@ -957,5 +982,7 @@ module.exports = {
   hasLeadingComment,
   isBlockComment,
   getGapRegex,
-  getCommentChildNodes
+  getCommentChildNodes,
+  makeCloseParenComment,
+  makeOpenParenComment
 };

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -42,9 +42,10 @@ function hasClosureCompilerTypeCastComment(text, path) {
 
   function hasTypeCastComment(node, parenStart, ancestorParenStart) {
     return (
-      node.leadingComments &&
-      node.leadingComments.some(
+      node.comments &&
+      node.comments.some(
         comment =>
+          comment.leading &&
           comment.end <= parenStart &&
           comment.start >= ancestorParenStart &&
           comments.isBlockComment(comment) &&

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -50,8 +50,8 @@ function hasClosureCompilerTypeCastComment(text, path) {
 
     // There's an annoying issue if both our node contains a typecast, and this
     // ancestor contains a typecast. Unfortunately, both comments are applied
-    // to ancestor. So we need to detect this situation, and insert hacky paren
-    // comments to simulate the correct warpping.
+    // to ancestor. So we need to detect this situation, and insert hack paren
+    // comments to simulate the correct wrapping.
     if (
       ancestorParenStart !== -1 &&
       getTypeCastIndex(ancestor, ancestorParenStart, -1) !== -1

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -510,9 +510,13 @@ function printComments(path, print, options, needsSemi) {
 
   path.each(commentPath => {
     const comment = commentPath.getValue();
-    const { leading, trailing } = comment;
+    const { leading, trailing, value } = comment;
 
-    if (leading) {
+    if (value === "__PRETTIER_OPEN_PAREN__") {
+      leadingParts.push(concat(["("]));
+    } else if (value === "__PRETTIER_CLOSE_PAREN__") {
+      trailingParts.push(concat([")"]));
+    } else if (leading) {
       const contents = printLeadingComment(commentPath, print, options);
       if (!contents) {
         return;

--- a/tests/comments_closure_typecast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments_closure_typecast/__snapshots__/jsfmt.spec.js.snap
@@ -84,10 +84,6 @@ const v9 = /** @type {string} */
 var foo = (/** @type {!Baz} */ (baz)).bar;
 var foo = (/** @type {!Baz} */ (baz).bar);
 var foo = /** @type {!Bar} */ ((/** @type {!Baz} */ (baz)).bar);
-
-// TODO: This next one will not print correct. The paren location is important
-// to the typecast parse, and printing both comments before the opening paren
-// makes it inavlid.
 var foo = /** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar);
 
 =====================================output=====================================
@@ -171,11 +167,7 @@ const v9 = /** @type {string} */ (value);
 var foo = /** @type {!Baz} */ (baz).bar;
 var foo = /** @type {!Baz} */ (baz).bar;
 var foo = /** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar);
-
-// TODO: This next one will not print correct. The paren location is important
-// to the typecast parse, and printing both comments before the opening paren
-// makes it inavlid.
-var foo = /** @type {!Bar} */ /** @type {!Baz} */ ((baz).bar);
+var foo = /** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar);
 
 ================================================================================
 `;

--- a/tests/comments_closure_typecast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments_closure_typecast/__snapshots__/jsfmt.spec.js.snap
@@ -86,6 +86,17 @@ var foo = (/** @type {!Baz} */ (baz).bar);
 var foo = /** @type {!Bar} */ ((/** @type {!Baz} */ (baz)).bar);
 var foo = /** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar);
 
+var foo = /** @type {!Foo} */ ((/** @type {!Bar} */ ((/** @type {!Baz} */ (baz)).bar)).foo);
+var foo = /** @type {!Foo} */ ((/** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar)).foo);
+var foo = /** @type {!Foo} */ (/** @type {!Bar} */ ((/** @type {!Baz} */ (baz)).bar).foo);
+var foo = /** @type {!Foo} */ (/** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar).foo);
+
+var foo = /** @type {!Foo} */ ((((/** @type {!Baz} */ (baz)).bar)).foo);
+var foo = /** @type {!Foo} */ (((/** @type {!Baz} */ (baz).bar)).foo);
+var foo = /** @type {!Foo} */ (((/** @type {!Baz} */ (baz)).bar).foo);
+var foo = /** @type {!Foo} */ ((/** @type {!Baz} */ (baz).bar).foo);
+var foo = /** @type {!Foo} */ (/** @type {!Baz} */ (baz).bar.foo);
+
 =====================================output=====================================
 // test to make sure comments are attached correctly
 let inlineComment = /* some comment */ someReallyLongFunctionCall(
@@ -168,6 +179,21 @@ var foo = /** @type {!Baz} */ (baz).bar;
 var foo = /** @type {!Baz} */ (baz).bar;
 var foo = /** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar);
 var foo = /** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar);
+
+var foo =
+  /** @type {!Foo} */ (/** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar).foo);
+var foo =
+  /** @type {!Foo} */ (/** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar).foo);
+var foo =
+  /** @type {!Foo} */ (/** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar).foo);
+var foo =
+  /** @type {!Foo} */ (/** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar).foo);
+
+var foo = /** @type {!Foo} */ (/** @type {!Baz} */ (baz).bar.foo);
+var foo = /** @type {!Foo} */ (/** @type {!Baz} */ (baz).bar.foo);
+var foo = /** @type {!Foo} */ (/** @type {!Baz} */ (baz).bar.foo);
+var foo = /** @type {!Foo} */ (/** @type {!Baz} */ (baz).bar.foo);
+var foo = /** @type {!Foo} */ (/** @type {!Baz} */ (baz).bar.foo);
 
 ================================================================================
 `;

--- a/tests/comments_closure_typecast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments_closure_typecast/__snapshots__/jsfmt.spec.js.snap
@@ -97,6 +97,11 @@ var foo = /** @type {!Foo} */ (((/** @type {!Baz} */ (baz)).bar).foo);
 var foo = /** @type {!Foo} */ ((/** @type {!Baz} */ (baz).bar).foo);
 var foo = /** @type {!Foo} */ (/** @type {!Baz} */ (baz).bar.foo);
 
+var foo = /** @type {!Foo} */ ((((/** @type {!Qux} */ (qux)).baz).bar).foo);
+var foo = /** @type {!Foo} */ (((/** @type {!Qux} */ (qux).baz).bar).foo);
+var foo = /** @type {!Foo} */ ((/** @type {!Qux} */ (qux).baz.bar).foo);
+var foo = /** @type {!Foo} */ (/** @type {!Qux} */ (qux).baz.bar.foo);
+
 =====================================output=====================================
 // test to make sure comments are attached correctly
 let inlineComment = /* some comment */ someReallyLongFunctionCall(
@@ -194,6 +199,11 @@ var foo = /** @type {!Foo} */ (/** @type {!Baz} */ (baz).bar.foo);
 var foo = /** @type {!Foo} */ (/** @type {!Baz} */ (baz).bar.foo);
 var foo = /** @type {!Foo} */ (/** @type {!Baz} */ (baz).bar.foo);
 var foo = /** @type {!Foo} */ (/** @type {!Baz} */ (baz).bar.foo);
+
+var foo = /** @type {!Foo} */ (/** @type {!Qux} */ (qux).baz.bar.foo);
+var foo = /** @type {!Foo} */ (/** @type {!Qux} */ (qux).baz.bar.foo);
+var foo = /** @type {!Foo} */ (/** @type {!Qux} */ (qux).baz.bar.foo);
+var foo = /** @type {!Foo} */ (/** @type {!Qux} */ (qux).baz.bar.foo);
 
 ================================================================================
 `;

--- a/tests/comments_closure_typecast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments_closure_typecast/__snapshots__/jsfmt.spec.js.snap
@@ -81,6 +81,15 @@ const v8 = /**@type{string} */(value);
 const v9 = /** @type {string} */
   (value);
 
+var foo = (/** @type {!Baz} */ (baz)).bar;
+var foo = (/** @type {!Baz} */ (baz).bar);
+var foo = /** @type {!Bar} */ ((/** @type {!Baz} */ (baz)).bar);
+
+// TODO: This next one will not print correct. The paren location is important
+// to the typecast parse, and printing both comments before the opening paren
+// makes it inavlid.
+var foo = /** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar);
+
 =====================================output=====================================
 // test to make sure comments are attached correctly
 let inlineComment = /* some comment */ someReallyLongFunctionCall(
@@ -158,6 +167,15 @@ const v7 = /** @type{string} */ (value);
 const v8 = /**@type{string} */ (value);
 
 const v9 = /** @type {string} */ (value);
+
+var foo = /** @type {!Baz} */ (baz).bar;
+var foo = /** @type {!Baz} */ (baz).bar;
+var foo = /** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar);
+
+// TODO: This next one will not print correct. The paren location is important
+// to the typecast parse, and printing both comments before the opening paren
+// makes it inavlid.
+var foo = /** @type {!Bar} */ /** @type {!Baz} */ ((baz).bar);
 
 ================================================================================
 `;

--- a/tests/comments_closure_typecast/closure-compiler-type-cast.js
+++ b/tests/comments_closure_typecast/closure-compiler-type-cast.js
@@ -72,3 +72,12 @@ const v8 = /**@type{string} */(value);
 
 const v9 = /** @type {string} */
   (value);
+
+var foo = (/** @type {!Baz} */ (baz)).bar;
+var foo = (/** @type {!Baz} */ (baz).bar);
+var foo = /** @type {!Bar} */ ((/** @type {!Baz} */ (baz)).bar);
+
+// TODO: This next one will not print correct. The paren location is important
+// to the typecast parse, and printing both comments before the opening paren
+// makes it inavlid.
+var foo = /** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar);

--- a/tests/comments_closure_typecast/closure-compiler-type-cast.js
+++ b/tests/comments_closure_typecast/closure-compiler-type-cast.js
@@ -76,8 +76,4 @@ const v9 = /** @type {string} */
 var foo = (/** @type {!Baz} */ (baz)).bar;
 var foo = (/** @type {!Baz} */ (baz).bar);
 var foo = /** @type {!Bar} */ ((/** @type {!Baz} */ (baz)).bar);
-
-// TODO: This next one will not print correct. The paren location is important
-// to the typecast parse, and printing both comments before the opening paren
-// makes it inavlid.
 var foo = /** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar);

--- a/tests/comments_closure_typecast/closure-compiler-type-cast.js
+++ b/tests/comments_closure_typecast/closure-compiler-type-cast.js
@@ -77,3 +77,14 @@ var foo = (/** @type {!Baz} */ (baz)).bar;
 var foo = (/** @type {!Baz} */ (baz).bar);
 var foo = /** @type {!Bar} */ ((/** @type {!Baz} */ (baz)).bar);
 var foo = /** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar);
+
+var foo = /** @type {!Foo} */ ((/** @type {!Bar} */ ((/** @type {!Baz} */ (baz)).bar)).foo);
+var foo = /** @type {!Foo} */ ((/** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar)).foo);
+var foo = /** @type {!Foo} */ (/** @type {!Bar} */ ((/** @type {!Baz} */ (baz)).bar).foo);
+var foo = /** @type {!Foo} */ (/** @type {!Bar} */ (/** @type {!Baz} */ (baz).bar).foo);
+
+var foo = /** @type {!Foo} */ ((((/** @type {!Baz} */ (baz)).bar)).foo);
+var foo = /** @type {!Foo} */ (((/** @type {!Baz} */ (baz).bar)).foo);
+var foo = /** @type {!Foo} */ (((/** @type {!Baz} */ (baz)).bar).foo);
+var foo = /** @type {!Foo} */ ((/** @type {!Baz} */ (baz).bar).foo);
+var foo = /** @type {!Foo} */ (/** @type {!Baz} */ (baz).bar.foo);

--- a/tests/comments_closure_typecast/closure-compiler-type-cast.js
+++ b/tests/comments_closure_typecast/closure-compiler-type-cast.js
@@ -88,3 +88,8 @@ var foo = /** @type {!Foo} */ (((/** @type {!Baz} */ (baz).bar)).foo);
 var foo = /** @type {!Foo} */ (((/** @type {!Baz} */ (baz)).bar).foo);
 var foo = /** @type {!Foo} */ ((/** @type {!Baz} */ (baz).bar).foo);
 var foo = /** @type {!Foo} */ (/** @type {!Baz} */ (baz).bar.foo);
+
+var foo = /** @type {!Foo} */ ((((/** @type {!Qux} */ (qux)).baz).bar).foo);
+var foo = /** @type {!Foo} */ (((/** @type {!Qux} */ (qux).baz).bar).foo);
+var foo = /** @type {!Foo} */ ((/** @type {!Qux} */ (qux).baz.bar).foo);
+var foo = /** @type {!Foo} */ (/** @type {!Qux} */ (qux).baz.bar.foo);


### PR DESCRIPTION
Fixes https://github.com/prettier/prettier/issues/6122.

This goes through the rather complicated steps to determine when parens surround a typecast comment, including when both the node and the ancestor have typecasts.

I had to add _really_ hacky comment nodes in order to insert the parens in the correct locations. This is because using the normal `needsParens` would insert multiple typecasts comments before the first `(`. It order to get it right, we need to print the first typecast, then the first `(`, then the next typecast, so on. I was only able to get it right by splicing the comments in.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
