### PR TITLE
Fix broken HTML anchor in the Rationale documentation

### DIFF
--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -187,7 +187,7 @@ This practice is also common in [standard] which uses a semicolon-free style.
 
 The [`--print-width`](options.md#print-width) is more of a guideline to Prettier than a hard rule. It generally means “try to make lines this long, go shorter if needed and longer in special cases.”
 
-There are some edge cases, such as really long string literals, regexps, comments and variable names, which cannot be broken across lines (without using code transforms which [Prettier doesn’t do](#what-prettier-is-not-concerned-about)). Or if you nest your code 50 levels deep your lines are of course going to be mostly indentation :)
+There are some edge cases, such as really long string literals, regexps, comments and variable names, which cannot be broken across lines (without using code transforms which [Prettier doesn’t do](#what-prettier-is-_not_-concerned-about)). Or if you nest your code 50 levels deep your lines are of course going to be mostly indentation :)
 
 Apart from that, there are a few cases where Prettier intentionally exceeds the print width.
 

--- a/website/versioned_docs/version-stable/rationale.md
+++ b/website/versioned_docs/version-stable/rationale.md
@@ -188,7 +188,7 @@ This practice is also common in [standard] which uses a semicolon-free style.
 
 The [`--print-width`](options.md#print-width) is more of a guideline to Prettier than a hard rule. It generally means “try to make lines this long, go shorter if needed and longer in special cases.”
 
-There are some edge cases, such as really long string literals, regexps, comments and variable names, which cannot be broken across lines (without using code transforms which [Prettier doesn’t do](#what-prettier-is-not-concerned-about)). Or if you nest your code 50 levels deep your lines are of course going to be mostly indentation :)
+There are some edge cases, such as really long string literals, regexps, comments and variable names, which cannot be broken across lines (without using code transforms which [Prettier doesn’t do](#what-prettier-is-_not_-concerned-about)). Or if you nest your code 50 levels deep your lines are of course going to be mostly indentation :)
 
 Apart from that, there are a few cases where Prettier intentionally exceeds the print width.
 


### PR DESCRIPTION
The italic Markdown formatting is included in the [automatically generated ID](https://prettier.io/docs/en/rationale.html#what-prettier-is-_not_-concerned-about), so it must be present in the references as well.

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**