### PR TITLE
Run verify test on  disabled `babel-ts` tests

### DIFF
--- a/tests/typescript/custom/abstract/jsfmt.spec.js
+++ b/tests/typescript/custom/abstract/jsfmt.spec.js
@@ -1,1 +1,3 @@
-run_spec(__dirname, ["typescript"], { disableBabelTS: true });
+run_spec(__dirname, ["typescript"], {
+  disableBabelTS: ["abstractProperties.ts", "abstractPropertiesWithBreaks.js"]
+});

--- a/tests/typescript/custom/abstract/jsfmt.spec.js
+++ b/tests/typescript/custom/abstract/jsfmt.spec.js
@@ -1,3 +1,3 @@
 run_spec(__dirname, ["typescript"], {
-  disableBabelTS: ["abstractProperties.ts", "abstractPropertiesWithBreaks.js"]
+  disableBabelTS: ["abstractProperties.ts", "abstractPropertiesWithBreaks.ts"]
 });

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -101,24 +101,28 @@ global.run_spec = (dirname, parsers, options) => {
     });
 
     const parsersToVerify = parsers.slice(1);
-    if (
-      parsers.includes("typescript") &&
-      !parsers.includes("babel-ts") &&
-      !(
-        options &&
-        (options.disableBabelTS === true ||
-          (Array.isArray(options.disableBabelTS) &&
-            options.disableBabelTS.includes(basename)))
-      )
-    ) {
+    if (parsers.includes("typescript") && !parsers.includes("babel-ts")) {
       parsersToVerify.push("babel-ts");
     }
 
     for (const parser of parsersToVerify) {
       const verifyOptions = { ...baseOptions, parser };
+
       test(`${basename} - ${parser}-verify`, () => {
-        const verifyOutput = format(input, filename, verifyOptions);
-        expect(visualizeEndOfLine(verifyOutput)).toEqual(visualizedOutput);
+        if (
+          parser === "babel-ts" &&
+          options &&
+          (options.disableBabelTS === true ||
+            (Array.isArray(options.disableBabelTS) &&
+              options.disableBabelTS.includes(basename)))
+        ) {
+          expect(() => {
+            format(input, filename, verifyOptions);
+          }).toThrow(TEST_STANDALONE ? undefined : SyntaxError);
+        } else {
+          const verifyOutput = format(input, filename, verifyOptions);
+          expect(visualizeEndOfLine(verifyOutput)).toEqual(visualizedOutput);
+        }
       });
     }
 


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

~Refactor disabled `babel-ts` tests to a better way to manage.~

~Seems there is already a fixture fixed see https://github.com/prettier/prettier/commit/95edf2ee7b7b7d8193070a9fce8d845d20858a0d~

Run verify test on disabled `babel-ts` tests, make sure they throws `SyntaxError`

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
