### PR TITLE
Support type only import/export via `babel-ts`

### DIFF
--- a/changelog_unreleased/typescript/pr-7631.md
+++ b/changelog_unreleased/typescript/pr-7631.md
@@ -1,7 +1,7 @@
-#### TypeScript 3.8 ([#7631](https://github.com/prettier/prettier/pull/7631) by [@thorn0](https://github.com/thorn0), [#7764](https://github.com/prettier/prettier/pull/7764) by [@sosukesuzuki](https://github.com/sosukesuzuki))
+#### TypeScript 3.8 ([#7631](https://github.com/prettier/prettier/pull/7631) by [@thorn0](https://github.com/thorn0), [#7764](https://github.com/prettier/prettier/pull/7764) by [@sosukesuzuki](https://github.com/sosukesuzuki), [#7804](https://github.com/prettier/prettier/pull/7804) by [@sosukesuzuki](https://github.com/sosukesuzuki))
 
 Prettier now supports the new syntax added in TypeScript 3.8:
 
-- [Type-Only Imports and Exports](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8/#type-only-imports-exports) (not supported by the `babel-ts` parser yet)
+- [Type-Only Imports and Exports](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8/#type-only-imports-exports)
 - [ECMAScript Private Fields](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8/#ecmascript-private-fields)
 - [`export * as ns`](https://devblogs.microsoft.com/typescript/announcing-typescript-3-8/#export-star-as-namespace-syntax)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@angular/compiler": "9.0.5",
     "@babel/code-frame": "7.8.0",
-    "@babel/parser": "7.9.0",
+    "@babel/parser": "7.9.2",
     "@glimmer/syntax": "0.48.0",
     "@iarna/toml": "2.2.3",
     "@typescript-eslint/typescript-estree": "2.24.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@angular/compiler": "9.0.5",
     "@babel/code-frame": "7.8.0",
-    "@babel/parser": "7.8.8",
+    "@babel/parser": "7.9.0",
     "@glimmer/syntax": "0.48.0",
     "@iarna/toml": "2.2.3",
     "@typescript-eslint/typescript-estree": "2.24.0",

--- a/tests/typescript_import_export/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_import_export/__snapshots__/jsfmt.spec.js.snap
@@ -10,7 +10,6 @@ export type { SomeThing };
 export type { A as B };
 export type { B as C } from './a';
 export type { foo } from 'bar';
-export type * from 'bar';
 export type { foo };
 
 // this should be treated as a normal import statement
@@ -28,7 +27,6 @@ export type { SomeThing };
 export type { A as B };
 export type { B as C } from "./a";
 export type { foo } from "bar";
-export type * from "bar";
 export type { foo };
 
 // this should be treated as a normal import statement

--- a/tests/typescript_import_export/jsfmt.spec.js
+++ b/tests/typescript_import_export/jsfmt.spec.js
@@ -1,2 +1,1 @@
-// TODO: remove disableBabelTS when Babel's TS plugin gets support for import/export `type` modifier
-run_spec(__dirname, ["typescript"], { disableBabelTS: true });
+run_spec(__dirname, ["typescript"]);

--- a/tests/typescript_import_export/type-modifier.ts
+++ b/tests/typescript_import_export/type-modifier.ts
@@ -2,7 +2,6 @@ export type { SomeThing };
 export type { A as B };
 export type { B as C } from './a';
 export type { foo } from 'bar';
-export type * from 'bar';
 export type { foo };
 
 // this should be treated as a normal import statement

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,10 +270,10 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.0.tgz#f821b32313f07ee570976d3f6238e8d2d66e0a8e"
-  integrity sha512-Iwyp00CZsypoNJcpXCbq3G4tcDgphtlMwMVrMhhZ//XBkqjXF7LW6V511yk0+pBX3ZwwGnPea+pTKNJiqA7pUg==
+"@babel/parser@7.9.2":
+  version "7.9.2"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.2.tgz#4e767f424b479c514077544484d1f9bdba7f1158"
+  integrity sha512-2jyvKdoOS1aWAFL2rjJZmamyDDkPCx/AAz4/Wh1Dfxvw8qqnOvek/ZlHQ2noO/o8JpnXa/WiUUFOv48meBKkpA==
 
 "@babel/parser@^7.1.0", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.8.7":
   version "7.8.8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,7 +270,12 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.8.8", "@babel/parser@^7.1.0", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.8.7":
+"@babel/parser@7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.0.tgz#f821b32313f07ee570976d3f6238e8d2d66e0a8e"
+  integrity sha512-Iwyp00CZsypoNJcpXCbq3G4tcDgphtlMwMVrMhhZ//XBkqjXF7LW6V511yk0+pBX3ZwwGnPea+pTKNJiqA7pUg==
+
+"@babel/parser@^7.1.0", "@babel/parser@^7.7.5", "@babel/parser@^7.8.6", "@babel/parser@^7.8.7":
   version "7.8.8"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.8.8.tgz#4c3b7ce36db37e0629be1f0d50a571d2f86f6cd4"
   integrity sha512-mO5GWzBPsPf6865iIbzNE0AvkKF3NE+2S3eRUpE+FE07BOAkXh6G+GW/Pj01hhXjve1WScbaIO4UlY1JKeqCcA==


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

[Babel 7.9.0](https://babeljs.io/blog/2020/03/16/7.9.0) has been released! It supports TypeScript 3.8 type only import/export.

~~But, we cannot update snapshots now, because there is https://github.com/babel/babel/issues/11291. We need to wait the issue is fixed.~~

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
