### PR TITLE
Fix indentation of logical expressions for styled components

### DIFF
--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -17,6 +17,8 @@ const {
   utils: { mapDoc, stripTrailingHardline },
 } = require("../document");
 
+const { isStyledComponents } = require("./utils");
+
 function embed(path, print, textToDoc, options) {
   const node = path.getValue();
   const parent = path.getParentNode();
@@ -421,51 +423,6 @@ const angularComponentObjectExpressionPredicates = [
 ];
 
 /**
- * styled-components template literals
- */
-function isStyledComponents(path) {
-  const parent = path.getParentNode();
-
-  if (!parent || parent.type !== "TaggedTemplateExpression") {
-    return false;
-  }
-
-  const { tag } = parent;
-
-  switch (tag.type) {
-    case "MemberExpression":
-      return (
-        // styled.foo``
-        isStyledIdentifier(tag.object) ||
-        // Component.extend``
-        isStyledExtend(tag)
-      );
-
-    case "CallExpression":
-      return (
-        // styled(Component)``
-        isStyledIdentifier(tag.callee) ||
-        (tag.callee.type === "MemberExpression" &&
-          ((tag.callee.object.type === "MemberExpression" &&
-            // styled.foo.attrs({})``
-            (isStyledIdentifier(tag.callee.object.object) ||
-              // Component.extend.attrs({})``
-              isStyledExtend(tag.callee.object))) ||
-            // styled(Component).attrs({})``
-            (tag.callee.object.type === "CallExpression" &&
-              isStyledIdentifier(tag.callee.object.callee))))
-      );
-
-    case "Identifier":
-      // css``
-      return tag.name === "css";
-
-    default:
-      return false;
-  }
-}
-
-/**
  * JSX element with CSS prop
  */
 function isCssProp(path) {
@@ -478,14 +435,6 @@ function isCssProp(path) {
     parentParent.name.type === "JSXIdentifier" &&
     parentParent.name.name === "css"
   );
-}
-
-function isStyledIdentifier(node) {
-  return node.type === "Identifier" && node.name === "styled";
-}
-
-function isStyledExtend(node) {
-  return /^[A-Z]/.test(node.object.name) && node.property.name === "extend";
 }
 
 /*

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -66,6 +66,7 @@ const {
   isJestEachTemplateLiteral,
   isJSXNode,
   isJSXWhitespaceExpression,
+  isStyledComponents,
   isLastStatement,
   isLiteral,
   isLongCurriedCallExpression,
@@ -860,6 +861,17 @@ function printPathNoParens(path, options, print, args) {
 
       const body = path.call((bodyPath) => print(bodyPath, args), "body");
 
+      let isStyledComponentsExpression;
+      if (
+        isStyledComponents(path) &&
+        n.body.left &&
+        (n.body.right.type === "TaggedTemplateExpression" ||
+          n.body.right.type === "TemplateLiteral") &&
+        !shouldFlatten(n.body.operator, n.body.left.operator)
+      ) {
+        isStyledComponentsExpression = true;
+      }
+
       // We want to always keep these types of nodes on the same line
       // as the arrow.
       if (
@@ -868,6 +880,7 @@ function printPathNoParens(path, options, print, args) {
           n.body.type === "ObjectExpression" ||
           n.body.type === "BlockStatement" ||
           isJSXNode(n.body) ||
+          isStyledComponentsExpression ||
           isTemplateOnItsOwnLine(n.body, options.originalText, options) ||
           n.body.type === "ArrowFunctionExpression" ||
           n.body.type === "DoExpression")
@@ -5737,7 +5750,17 @@ function printBinaryishExpressions(
       parts.push(path.call(print, "left"));
     }
 
-    const shouldInline = shouldInlineLogicalExpression(node);
+    let shouldInline = shouldInlineLogicalExpression(node);
+
+    if (
+      isStyledComponents(path) &&
+      !shouldFlatten(node.operator, node.left.operator) &&
+      (node.right.type === "TaggedTemplateExpression" ||
+        node.right.type === "TemplateLiteral")
+    ) {
+      shouldInline = true;
+    }
+
     const lineBeforeOperator =
       (node.operator === "|>" ||
         node.type === "NGPipeExpression" ||

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -8,6 +8,7 @@ const {
   hasNodeIgnoreComment,
   skipWhitespace,
 } = require("../common/util");
+const { getAncestorNode } = require("../language-css/utils");
 const isIdentifierName = require("esutils").keyword.isIdentifierNameES5;
 const handleComments = require("./comments");
 
@@ -221,6 +222,59 @@ function isTheOnlyJSXElementInMarkdown(options, path) {
   const parent = path.getParentNode();
 
   return parent.type === "Program" && parent.body.length === 1;
+}
+
+function isStyledComponents(path) {
+  const node = getAncestorNode(path, "TaggedTemplateExpression");
+  return isStyledComponentsNode(node);
+}
+
+function isStyledComponentsNode(node) {
+  if (!node || node.type !== "TaggedTemplateExpression") {
+    return false;
+  }
+
+  const { tag } = node;
+
+  switch (tag.type) {
+    case "MemberExpression":
+      return (
+        // styled.foo``
+        isStyledIdentifier(tag.object) ||
+        // Component.extend``
+        isStyledExtend(tag)
+      );
+
+    case "CallExpression":
+      return (
+        // styled(Component)``
+        isStyledIdentifier(tag.callee) ||
+        (tag.callee.type === "MemberExpression" &&
+          ((tag.callee.object.type === "MemberExpression" &&
+            // styled.foo.attrs({})``
+            (isStyledIdentifier(tag.callee.object.object) ||
+              // Component.extend.attrs({})``
+              isStyledExtend(tag.callee.object))) ||
+            // styled(Component).attrs({})``
+            (tag.callee.object.type === "CallExpression" &&
+              isStyledIdentifier(tag.callee.object.callee))))
+      );
+
+    case "Identifier":
+      // css``
+      return tag.name === "css";
+
+    default:
+      return false;
+  }
+}
+
+function isStyledIdentifier(node) {
+  return node.type === "Identifier" && node.name === "styled";
+}
+
+function isStyledExtend(node) {
+  return /^[A-Z]/.test(node.object.name) && node.property.name === "extend";
 }
 
 // Detect an expression node representing `{" "}`
@@ -1034,6 +1088,8 @@ module.exports = {
   isJestEachTemplateLiteral,
   isJSXNode,
   isJSXWhitespaceExpression,
+  isStyledComponentsNode,
+  isStyledComponents,
   isLastStatement,
   isLiteral,
   isLongCurriedCallExpression,

--- a/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
@@ -255,6 +255,31 @@ const Foo = styled.p\`
   }
 \`;
 
+styled.div\`
+  \${props => props.firstProp && css\`
+    color: red;
+  \`}
+\`
+
+styled.div\`
+  \${props => props.firstProp && props.secondProp && props.thirdProp && css\`
+    color: red;
+  \`}
+\`
+
+const foo = css\`
+  color: red;
+  background: yellow;
+
+  \${bool && css\`
+    border: 1px solid blue;
+
+    \${bool2 && css\`
+      padding: 20px;
+    \`}
+  \`}
+\`;
+
 =====================================output=====================================
 const ListItem1 = styled.li\`\`;
 
@@ -417,13 +442,21 @@ const StyledComponent2 = styled.div\`
 \`;
 
 const Direction = styled.span\`
-  \${({ up }) => up && \`color: \${color.positive};\`}
-  \${({ down }) => down && \`color: \${color.negative};\`}
+  \${({ up }) => up && \`
+    color: \${color.positive};
+  \`}
+  \${({ down }) => down && \`
+    color: \${color.negative};
+  \`}
 \`;
 
 const Direction2 = styled.span\`
-  \${({ up }) => up && \`color: \${color.positive}\`};
-  \${({ down }) => down && \`color: \${color.negative}\`};
+  \${({ up }) => up && \`
+    color: \${color.positive};
+  \`};
+  \${({ down }) => down && \`
+    color: \${color.negative};
+  \`};
 \`;
 
 const mixin = css\`
@@ -456,11 +489,9 @@ const bar = styled.div\`
   height: 40px;
   width: 40px;
 
-  \${(props) =>
-    (props.complete || props.inProgress) &&
-    css\`
-      border-color: rgba(var(--green-rgb), 0.15);
-    \`}
+  \${(props) => (props.complete || props.inProgress) && css\`
+    border-color: rgba(var(--green-rgb), 0.15);
+  \`}
 
   div {
     background-color: var(--purpleTT);
@@ -469,29 +500,23 @@ const bar = styled.div\`
     color: var(--purpleTT);
     display: inline-flex;
 
-    \${(props) =>
-      props.complete &&
-      css\`
-        background-color: var(--green);
-        border-width: 7px;
-      \`}
+    \${(props) => props.complete && css\`
+      background-color: var(--green);
+      border-width: 7px;
+    \`}
 
-    \${(props) =>
-      (props.complete || props.inProgress) &&
-      css\`
-        border-color: var(--green);
-      \`}
+    \${(props) => (props.complete || props.inProgress) && css\`
+      border-color: var(--green);
+    \`}
   }
 \`;
 
 const A = styled.a\`
   display: inline-block;
   color: #fff;
-  \${(props) =>
-    props.a &&
-    css\`
-      display: none;
-    \`}
+  \${(props) => props.a && css\`
+    display: none;
+  \`}
   height: 30px;
 \`;
 
@@ -506,6 +531,35 @@ const Foo = styled.p\`
   &.bottom {
     margin-top: 3rem;
   }
+\`;
+
+styled.div\`
+  \${(props) => props.firstProp && css\`
+    color: red;
+  \`}
+\`;
+
+styled.div\`
+  \${(props) =>
+    props.firstProp &&
+    props.secondProp &&
+    props.thirdProp &&
+    css\`
+      color: red;
+    \`}
+\`;
+
+const foo = css\`
+  color: red;
+  background: yellow;
+
+  \${bool && css\`
+    border: 1px solid blue;
+
+    \${bool2 && css\`
+      padding: 20px;
+    \`}
+  \`}
 \`;
 
 ================================================================================

--- a/tests/multiparser_js_css/styled-components.js
+++ b/tests/multiparser_js_css/styled-components.js
@@ -246,3 +246,28 @@ const Foo = styled.p`
     margin-top: 3rem;
   }
 `;
+
+styled.div`
+  ${props => props.firstProp && css`
+    color: red;
+  `}
+`
+
+styled.div`
+  ${props => props.firstProp && props.secondProp && props.thirdProp && css`
+    color: red;
+  `}
+`
+
+const foo = css`
+  color: red;
+  background: yellow;
+
+  ${bool && css`
+    border: 1px solid blue;
+
+    ${bool2 && css`
+      padding: 20px;
+    `}
+  `}
+`;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
There is an attempt to fix #1872

I used a https://github.com/prettier/prettier/issues/1872#issuecomment-458476888 as a starting point.

Despite the fact that the fix is quite simple, I'm not sure that I've chosen an optimal approach.

Before:
```javascript
const Container = styled.span`
  ${props => 
    props.isError &&
    css`
      color: red;
    `};
`;
```

After:
```javascript
const Container = styled.span`
  ${props => props.isError && css`
    color: red;
  `};
`;
```

Any feedback is appreciated. 😄

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
