### PR TITLE
Remove codemirror from website/package.json as Playground loads it from CDN

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "clipboard": "2.0.6",
-    "codemirror": "5.52.0",
     "codemirror-graphql": "0.11.6",
     "lodash": "4.17.15",
     "lz-string": "1.4.4",

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1888,11 +1888,6 @@ codemirror-graphql@0.11.6:
     graphql-language-service-interface "^2.3.3"
     graphql-language-service-parser "^1.5.2"
 
-codemirror@5.52.0:
-  version "5.52.0"
-  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.52.0.tgz#4dbd6aef7f0e63db826b9a23922f0c03ac75c0a7"
-  integrity sha512-K2UB6zjscrfME03HeRe/IuOmCeqNpw7PLKGHThYpLbZEuKf+ZoujJPhxZN4hHJS1O7QyzEsV7JJZGxuQWVaFCg==
-
 coffee-script@^1.12.4:
   version "1.12.7"
   resolved "https://registry.yarnpkg.com/coffee-script/-/coffee-script-1.12.7.tgz#c05dae0cb79591d05b3070a8433a98c9a89ccc53"


### PR DESCRIPTION
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
