### PR TITLE
Refactor inferParser to extract interpreter only once

### DIFF
--- a/src/main/options.js
+++ b/src/main/options.js
@@ -127,6 +127,7 @@ function getInterpreter(filepath) {
   try {
     fd = fs.openSync(filepath, "r");
   } catch (err) {
+    // istanbul ignore next
     return "";
   }
 


### PR DESCRIPTION
Just microrefactoring.

- I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
