### PR TITLE
TypeScript: avoid trailing commas on index signatures with only one parameter

### DIFF
--- a/changelog_unreleased/typescript/pr-7836.md
+++ b/changelog_unreleased/typescript/pr-7836.md
@@ -1,0 +1,33 @@
+#### Avoid trailing commas on index signatures with only one parameter ([#7836](https://github.com/prettier/prettier/pull/7836) by [@bakkot](https://github.com/bakkot))
+
+TypeScript index signatures technically allow multiple parameters and trailing commas, but it's an error to have multiple parameters there, and Babel's TypeScript parser does not accept them. So Prettier now avoids putting a trailing comma there when you have only one parameter.
+
+<!-- prettier-ignore -->
+```ts
+// Input
+export type A = {
+  a?: {
+    [
+      x: string
+    ]: typeof SomeLongLongLongTypeName[keyof typeof SomeLongLongLongTypeName];
+  } | null;
+};
+
+// Prettier stable
+export type A = {
+  a?: {
+    [
+      x: string,
+    ]: typeof SomeLongLongLongTypeName[keyof typeof SomeLongLongLongTypeName];
+  } | null;
+};
+
+// Prettier master
+export type A = {
+  a?: {
+    [
+      x: string
+    ]: typeof SomeLongLongLongTypeName[keyof typeof SomeLongLongLongTypeName];
+  } | null;
+};
+```

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3259,6 +3259,14 @@ function printPathNoParens(path, options, print, args) {
     case "TSIndexSignature": {
       const parent = path.getParentNode();
 
+      // The typescript parser accepts multiple parameters here. If you're
+      // using them, it makes sense to have a trailing comma. But if you
+      // aren't, this is more like a computed property name than an array.
+      // So we leave off the trailing comma when there's just one parameter.
+      const trailingComma = n.parameters.length > 1
+        ? ifBreak(shouldPrintComma(options) ? "," : "")
+        : "";
+
       const parametersGroup = group(
         concat([
           indent(
@@ -3267,7 +3275,7 @@ function printPathNoParens(path, options, print, args) {
               join(concat([", ", softline]), path.map(print, "parameters")),
             ])
           ),
-          ifBreak(shouldPrintComma(options) ? "," : ""),
+          trailingComma,
           softline,
         ])
       );

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3263,9 +3263,10 @@ function printPathNoParens(path, options, print, args) {
       // using them, it makes sense to have a trailing comma. But if you
       // aren't, this is more like a computed property name than an array.
       // So we leave off the trailing comma when there's just one parameter.
-      const trailingComma = n.parameters.length > 1
-        ? ifBreak(shouldPrintComma(options) ? "," : "")
-        : "";
+      const trailingComma =
+        n.parameters.length > 1
+          ? ifBreak(shouldPrintComma(options) ? "," : "")
+          : "";
 
       const parametersGroup = group(
         concat([

--- a/tests/typescript_error_recovery/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_error_recovery/__snapshots__/jsfmt.spec.js.snap
@@ -173,6 +173,11 @@ type TooLong = {
 type TooLong81 = { [loooooooooooooooooooooooooong: string, loooooooooooooooooong: string]: string; }
 type TooLong80 = { [loooooooooooooooooooooooooong: string, looooooooooooooooong: string]: string; }
 
+// note lack of trailing comma in the index signature
+type TooLongSingleParam = {
+  [looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong: string]: string;
+}
+
 =====================================output=====================================
 type A = { [key: string] };
 
@@ -197,6 +202,13 @@ type TooLong81 = {
 };
 type TooLong80 = {
   [loooooooooooooooooooooooooong: string, looooooooooooooooong: string]: string;
+};
+
+// note lack of trailing comma in the index signature
+type TooLongSingleParam = {
+  [
+    looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong: string
+  ]: string;
 };
 
 ================================================================================
@@ -224,6 +236,11 @@ type TooLong = {
 type TooLong81 = { [loooooooooooooooooooooooooong: string, loooooooooooooooooong: string]: string; }
 type TooLong80 = { [loooooooooooooooooooooooooong: string, looooooooooooooooong: string]: string; }
 
+// note lack of trailing comma in the index signature
+type TooLongSingleParam = {
+  [looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong: string]: string;
+}
+
 =====================================output=====================================
 type A = { [key: string] };
 
@@ -248,6 +265,13 @@ type TooLong81 = {
 };
 type TooLong80 = {
   [loooooooooooooooooooooooooong: string, looooooooooooooooong: string]: string;
+};
+
+// note lack of trailing comma in the index signature
+type TooLongSingleParam = {
+  [
+    looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong: string
+  ]: string;
 };
 
 ================================================================================
@@ -275,6 +299,11 @@ type TooLong = {
 type TooLong81 = { [loooooooooooooooooooooooooong: string, loooooooooooooooooong: string]: string; }
 type TooLong80 = { [loooooooooooooooooooooooooong: string, looooooooooooooooong: string]: string; }
 
+// note lack of trailing comma in the index signature
+type TooLongSingleParam = {
+  [looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong: string]: string;
+}
+
 =====================================output=====================================
 type A = { [key: string] };
 
@@ -299,6 +328,13 @@ type TooLong81 = {
 };
 type TooLong80 = {
   [loooooooooooooooooooooooooong: string, looooooooooooooooong: string]: string;
+};
+
+// note lack of trailing comma in the index signature
+type TooLongSingleParam = {
+  [
+    looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong: string
+  ]: string;
 };
 
 ================================================================================

--- a/tests/typescript_error_recovery/index-signature.ts
+++ b/tests/typescript_error_recovery/index-signature.ts
@@ -12,3 +12,8 @@ type TooLong = {
 }
 type TooLong81 = { [loooooooooooooooooooooooooong: string, loooooooooooooooooong: string]: string; }
 type TooLong80 = { [loooooooooooooooooooooooooong: string, looooooooooooooooong: string]: string; }
+
+// note lack of trailing comma in the index signature
+type TooLongSingleParam = {
+  [looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong: string]: string;
+}


### PR DESCRIPTION
Fixes https://github.com/prettier/prettier/issues/7834. Specifically, it now outputs the trailing comma only when there's multiple parameters. In the usual (non-error) case, it treats it like a computed property name and therefore omits the trailing comma.

See https://github.com/prettier/prettier/issues/7224 and https://github.com/prettier/prettier/pull/7228 for some context.

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
