### PR TITLE
fix formatting of pseudo-elements and pseudo-classes in styled-component

### DIFF
--- a/changelog_unreleased/javascript/pr-7842.md
+++ b/changelog_unreleased/javascript/pr-7842.md
@@ -1,0 +1,21 @@
+#### Fix formatting of pseudo-elements and pseudo-classes in styled-components template literals ([#7842](https://github.com/prettier/prettier/pull/7842) by [@thorn0](https://github.com/thorn0))
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+const Foo = styled.div`
+  ${media.smallDown}::before {}
+`;
+
+// Prettier stable
+const Foo = styled.div`
+  ${media.smallDown}: : before{
+  }
+`;
+
+// Prettier master
+const Foo = styled.div`
+  ${media.smallDown}::before {
+  }
+`;
+```

--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -36,14 +36,35 @@ function embed(path, print, textToDoc, options) {
         const rawQuasis = node.quasis.map((q) => q.value.raw);
         let placeholderID = 0;
         const text = rawQuasis.reduce((prevVal, currVal, idx) => {
-          return idx === 0
-            ? currVal
-            : prevVal +
-                "@prettier-placeholder-" +
-                placeholderID++ +
-                "-id" +
-                currVal;
+          if (idx === 0) {
+            return currVal;
+          }
+
+          let specialSuffix = ""; // colons and whitespaces
+
+          const trailingColons = currVal.match(/^(\s*)(:+)(\s*)/);
+          if (trailingColons) {
+            const whitespaceBeforeColons = !!trailingColons[1];
+            const numberOfColons = trailingColons[2].length;
+            const whitespaceAfterColons = !!trailingColons[3];
+
+            if (whitespaceAfterColons) {
+              // do nothing, it's not a pseudo-element or pseudo-class
+            } else {
+              if (whitespaceBeforeColons) {
+                specialSuffix += "-whitespace";
+              }
+              specialSuffix += "-colon".repeat(numberOfColons);
+
+              currVal = "\uffff" + currVal.slice(trailingColons[0].length);
+            }
+          }
+
+          const placeholder = `@prettier-placeholder${specialSuffix}-${placeholderID++}-id`;
+
+          return prevVal + placeholder + currVal;
         }, "");
+
         const doc = textToDoc(text, { parser: "css" });
         return transformCssDoc(doc, path, print);
       }
@@ -292,13 +313,20 @@ function replacePlaceholders(quasisDoc, expressionDocs) {
       const placeholder = parts[atPlaceholderIndex];
       const rest = parts.slice(atPlaceholderIndex + 1);
       const placeholderMatch = placeholder.match(
-        /@prettier-placeholder-(.+)-id([\s\S]*)/
+        /@prettier-placeholder((?:-whitespace|-colon)*)-(.+)-id([\s\S]*)/
       );
-      const placeholderID = placeholderMatch[1];
+      const specialSuffix = placeholderMatch[1]; // colons and whitespaces
+      const placeholderID = placeholderMatch[2];
       // When the expression has a suffix appended, like:
       // animation: linear ${time}s ease-out;
-      const suffix = placeholderMatch[2];
+      let suffix = placeholderMatch[3];
       const expression = expressions[placeholderID];
+
+      if (specialSuffix) {
+        suffix =
+          specialSuffix.replace(/-whitespace/g, " ").replace(/-colon/g, ":") +
+          suffix.replace(/^\uffff/g, "");
+      }
 
       replaceCounter++;
       parts = parts

--- a/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/multiparser_js_css/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`colons-after-substitutions.js 1`] = `
+====================================options=====================================
+parsers: ["babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const Icon = styled.div\`
+  flex: none;
+  transition:    fill 0.25s;
+  width: 48px;
+  height: 48px;
+
+  \${Link}:hover {
+    fill:   rebeccapurple;
+  }
+
+  \${Link} :hover {
+    fill: yellow;
+  }
+
+  \${media.smallDown}::before {}
+\`
+
+=====================================output=====================================
+const Icon = styled.div\`
+  flex: none;
+  transition: fill 0.25s;
+  width: 48px;
+  height: 48px;
+
+  \${Link}:hover {
+    fill: rebeccapurple;
+  }
+
+  \${Link} :hover {
+    fill: yellow;
+  }
+
+  \${media.smallDown}::before {
+  }
+\`;
+
+================================================================================
+`;
+
 exports[`styled-components.js 1`] = `
 ====================================options=====================================
 parsers: ["babel"]

--- a/tests/multiparser_js_css/colons-after-substitutions.js
+++ b/tests/multiparser_js_css/colons-after-substitutions.js
@@ -1,0 +1,16 @@
+const Icon = styled.div`
+  flex: none;
+  transition:    fill 0.25s;
+  width: 48px;
+  height: 48px;
+
+  ${Link}:hover {
+    fill:   rebeccapurple;
+  }
+
+  ${Link} :hover {
+    fill: yellow;
+  }
+
+  ${media.smallDown}::before {}
+`


### PR DESCRIPTION
fixes https://github.com/prettier/prettier/issues/7826

The solution is pretty dirty, but hopefully it will do for now.

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
