### PR TITLE
Tweak test and CI configs

### DIFF
--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -24,6 +24,9 @@ jobs:
           - os: "ubuntu-latest"
             node: "12"
             ENABLE_CODE_COVERAGE: true
+        exclude:
+          - os: "macos-latest"
+            node: "13"
     env:
       ENABLE_CODE_COVERAGE: ${{ matrix.ENABLE_CODE_COVERAGE }}
     name: Node.js ${{ matrix.node }} on ${{ matrix.os }}

--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -72,6 +72,9 @@ jobs:
           - "13"
           - "12"
           - "10"
+        exclude:
+          - os: "macos-latest"
+            node: "13"
     name: Node.js ${{ matrix.node }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     needs: [build]
@@ -110,6 +113,9 @@ jobs:
           - "13"
           - "12"
           - "10"
+        exclude:
+          - os: "macos-latest"
+            node: "13"
     env:
       STANDALONE: true
     name: Node.js ${{ matrix.node }} on ${{ matrix.os }} (standalone)

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,6 @@ module.exports = {
     "jest-snapshot-serializer-ansi",
   ],
   testRegex: "jsfmt\\.spec\\.js$|__tests__/.*\\.js$",
-  testPathIgnorePatterns: ["tests/new_react", "tests/more_react"],
   collectCoverage: ENABLE_CODE_COVERAGE,
   collectCoverageFrom: ["src/**/*.js", "index.js", "!<rootDir>/node_modules/"],
   coveragePathIgnorePatterns: [

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 "use strict";
+const { isCI } = require("ci-info");
 const ENABLE_CODE_COVERAGE = !!process.env.ENABLE_CODE_COVERAGE;
 
 module.exports = {
@@ -33,5 +34,5 @@ module.exports = {
     "jest-watch-typeahead/filename",
     "jest-watch-typeahead/testname",
   ],
-  verbose: true,
+  verbose: isCI,
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -14,7 +14,7 @@ module.exports = {
   collectCoverageFrom: ["src/**/*.js", "index.js", "!<rootDir>/node_modules/"],
   coveragePathIgnorePatterns: [
     "<rootDir>/standalone.js",
-    "<rootDir>/src/doc/doc-debug.js",
+    "<rootDir>/src/document/doc-debug.js",
     "<rootDir>/src/main/massage-ast.js",
   ],
   coverageReporters: ["text", "lcov"],


### PR DESCRIPTION
- Set `jest` verbose to false by default
- Correct `doc-debug.js` path
- Remove outdated ignore patterns
- Exclude Node.js 13 on macos

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
