### PR TITLE
Flow: Print dangling comments for empty inexact object type

### DIFF
--- a/changelog_unreleased/flow/pr-7892.md
+++ b/changelog_unreleased/flow/pr-7892.md
@@ -1,4 +1,4 @@
-#### Print dangling comments for inexact object type([#7892](https://github.com/prettier/prettier/pull/7892) by [@sosukesuzuki](https://github.com/sosukesuzuki))
+#### Print dangling comments for inexact object type ([#7892](https://github.com/prettier/prettier/pull/7892) by [@sosukesuzuki](https://github.com/sosukesuzuki))
 
 <!-- prettier-ignore -->
 ```js

--- a/changelog_unreleased/flow/pr-7892.md
+++ b/changelog_unreleased/flow/pr-7892.md
@@ -1,0 +1,19 @@
+#### Print dangling comments for inexact object type([#7892](https://github.com/prettier/prettier/pull/7892) by [@sosukesuzuki](https://github.com/sosukesuzuki))
+
+<!-- prettier-ignore -->
+```js
+// Input
+type Foo = {
+  // comment
+  ...,
+};
+
+// Prettier stable
+Error: Comment "comment" was not printed. Please report this error!
+
+// Prettier master
+type Foo = {
+  // comment
+  ...,
+};
+```

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1382,7 +1382,7 @@ function printPathNoParens(path, options, print, args) {
         });
 
       if (n.inexact) {
-        props.push(concat(separatorParts.concat(group("..."))));
+        props.push(concat(separatorParts.concat("...")));
       }
 
       const lastElem = getLast(n[propertiesField]);

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1382,7 +1382,31 @@ function printPathNoParens(path, options, print, args) {
         });
 
       if (n.inexact) {
-        props.push(concat(separatorParts.concat("...")));
+        let printed;
+        if (hasDanglingComments(n)) {
+          const hasLineComments = !n.comments.every(
+            handleComments.isBlockComment
+          );
+          const printedDanglingComments = comments.printDanglingComments(
+            path,
+            options,
+            /* sameIndent */ true
+          );
+          printed = concat([
+            printedDanglingComments,
+            hasLineComments ||
+            hasNewline(
+              options.originalText,
+              options.locEnd(n.comments[n.comments.length - 1])
+            )
+              ? hardline
+              : line,
+            "...",
+          ]);
+        } else {
+          printed = "...";
+        }
+        props.push(concat(separatorParts.concat(printed)));
       }
 
       const lastElem = getLast(n[propertiesField]);

--- a/tests/flow_object_inexact/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_object_inexact/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,128 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`comments.js 1`] = `
+====================================options=====================================
+parsers: ["flow", "babel"]
+printWidth: 80
+trailingComma: "none"
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+type Foo = {
+  // comment
+  ...,
+};
+
+type Foo = {
+  /* comment */
+  ...,
+};
+
+type Foo = { /* comment */ ... };
+
+type Foo = { /* comment */
+  ...};
+
+type Foo = {
+  // comment0
+  // comment1
+  ...,
+};
+
+type Foo = {
+  /* comment0 */
+  /* comment1 */
+  ...,
+};
+
+type Foo = {
+  // comment
+  foo: string,
+  ...
+};
+
+type Foo = {
+  // comment0
+  // comment1
+  foo: string,
+  ...
+};
+
+type Foo = {
+  /* comment */
+  foo: string,
+  ...
+};
+
+type Foo = {
+  /* comment0 */
+  /* comment1 */
+  foo: string,
+  ...
+};
+
+=====================================output=====================================
+// @flow
+
+type Foo = {
+  // comment
+  ...
+};
+
+type Foo = {
+  /* comment */
+  ...
+};
+
+type Foo = { /* comment */ ... };
+
+type Foo = {
+  /* comment */
+  ...
+};
+
+type Foo = {
+  // comment0
+  // comment1
+  ...
+};
+
+type Foo = {
+  /* comment0 */
+  /* comment1 */
+  ...
+};
+
+type Foo = {
+  // comment
+  foo: string,
+  ...
+};
+
+type Foo = {
+  // comment0
+  // comment1
+  foo: string,
+  ...
+};
+
+type Foo = {
+  /* comment */
+  foo: string,
+  ...
+};
+
+type Foo = {
+  /* comment0 */
+  /* comment1 */
+  foo: string,
+  ...
+};
+
+================================================================================
+`;
+
 exports[`test.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "babel"]

--- a/tests/flow_object_inexact/comments.js
+++ b/tests/flow_object_inexact/comments.js
@@ -1,0 +1,54 @@
+// @flow
+
+type Foo = {
+  // comment
+  ...,
+};
+
+type Foo = {
+  /* comment */
+  ...,
+};
+
+type Foo = { /* comment */ ... };
+
+type Foo = { /* comment */
+  ...};
+
+type Foo = {
+  // comment0
+  // comment1
+  ...,
+};
+
+type Foo = {
+  /* comment0 */
+  /* comment1 */
+  ...,
+};
+
+type Foo = {
+  // comment
+  foo: string,
+  ...
+};
+
+type Foo = {
+  // comment0
+  // comment1
+  foo: string,
+  ...
+};
+
+type Foo = {
+  /* comment */
+  foo: string,
+  ...
+};
+
+type Foo = {
+  /* comment0 */
+  /* comment1 */
+  foo: string,
+  ...
+};


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fixes #7718

The following comments cannot be formatted in this PR:
**Input:**
```js
type Foo = {
  // comment0
  ...,
  // comment1
};
```

**Output:**
```js
type Foo = {
  // comment0
  // comment1
  ...,
};
```

**Expected:**
```js
type Foo = {
  // comment0
  ...,
  // comment1
};
```
It is hard to format this because there was not much information about inexact in the AST. But, since this is an edge case, I don't think this is a problem.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
