### PR TITLE
An attempt to fix coverage after updating Jest to 25.2.0

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -28,7 +28,6 @@ module.exports = {
     "prettier/standalone": "<rootDir>/tests_config/require_standalone.js",
   },
   testEnvironment: "node",
-  transform: {},
   watchPlugins: [
     "jest-watch-typeahead/filename",
     "jest-watch-typeahead/testname",


### PR DESCRIPTION
Seems like the coverage wasn't collected because of `transform:{}` in `jest.config.js`.
Any idea why we needed this line there? Apparently, it disables the Babel transform, so we probably should disable it conditionally or use `coverageProvider: "v8"`: https://github.com/prettier/prettier/pull/7897

closes https://github.com/prettier/prettier/issues/7893