### PR TITLE
Revert "Add please-upgrade-node"

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "minimatch": "3.0.4",
     "minimist": "1.2.5",
     "n-readlines": "1.0.0",
-    "please-upgrade-node": "3.2.0",
     "postcss-less": "3.1.4",
     "postcss-media-query-parser": "0.2.3",
     "postcss-scss": "2.0.0",

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,7 +1,5 @@
 "use strict";
 
-require("please-upgrade-node")(require("../../package.json"));
-
 const prettier = require("../../index");
 const stringify = require("json-stable-stringify");
 const util = require("./util");

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -1,14 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`node version error (stderr) 1`] = `
-"prettier requires at least version 10.13.0 of Node, please upgrade
-"
-`;
-
-exports[`node version error (stdout) 1`] = `""`;
-
-exports[`node version error (write) 1`] = `Array []`;
-
 exports[`show detailed usage with --help l (alias) (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help l (alias) (stdout) 1`] = `

--- a/tests_integration/__tests__/early-exit.js
+++ b/tests_integration/__tests__/early-exit.js
@@ -85,19 +85,3 @@ describe("throw error and show usage with something unexpected", () => {
     status: "non-zero",
   });
 });
-
-describe("node version error", () => {
-  const originalProcessVersion = process.version;
-  try {
-    Object.defineProperty(process, "version", {
-      value: "v8.0.0",
-      writable: false,
-    });
-    runPrettier("cli", ["--help"]).test({ status: 1 });
-  } finally {
-    Object.defineProperty(process, "version", {
-      value: originalProcessVersion,
-      writable: false,
-    });
-  }
-});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6243,13 +6243,6 @@ platform@^1.3.3:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.5.tgz#fb6958c696e07e2918d2eeda0f0bc9448d733444"
   integrity sha512-TuvHS8AOIZNAlE77WUDiR4rySV/VMptyMfcfeoMgs4P8apaZM3JrnbzBiixKUv+XR6i+BXrQh8WAnjaSPFO65Q==
 
-please-upgrade-node@3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz#aeddd3f994c933e4ad98b99d9a556efa0e2fe942"
-  integrity sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
-  dependencies:
-    semver-compare "^1.0.0"
-
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"
@@ -7006,11 +6999,6 @@ schema-utils@^2.6.4, schema-utils@^2.6.5:
   dependencies:
     ajv "^6.12.0"
     ajv-keywords "^3.4.1"
-
-semver-compare@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
-  integrity sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
 
 "semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"


### PR DESCRIPTION
This is causing false positives when prettier is packed with https://github.com/zeit/pkg. I'm unable to use prettier with node 12.16.1 after this change. Reverts prettier/prettier#7837.