### PR TITLE
[CSS] Fix incorrectly adding spaces around plus sign in css urls

### DIFF
--- a/changelog_unreleased/css/pr-7908.md
+++ b/changelog_unreleased/css/pr-7908.md
@@ -1,0 +1,13 @@
+#### Fix incorrectly adding spaces around plus sign in css urls  ([#7908](https://github.com/prettier/prettier/pull/7908) by [@sosukesuzuki](https://github.com/sosukesuzuki))
+
+<!-- prettier-ignore -->
+```css
+/* Input */
+@import url(foo+bar);
+
+/* Prettier stable */
+@import url(foo + bar);
+
+/* Prettier master */
+@import url(foo+bar);
+```

--- a/changelog_unreleased/css/pr-7908.md
+++ b/changelog_unreleased/css/pr-7908.md
@@ -1,4 +1,4 @@
-#### Fix incorrectly adding spaces around plus sign in css urls  ([#7908](https://github.com/prettier/prettier/pull/7908) by [@sosukesuzuki](https://github.com/sosukesuzuki))
+#### Fix incorrectly adding spaces around plus sign in css urls ([#7908](https://github.com/prettier/prettier/pull/7908) by [@sosukesuzuki](https://github.com/sosukesuzuki))
 
 <!-- prettier-ignore -->
 ```css

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -72,6 +72,7 @@ const {
   isMediaAndSupportsKeywords,
   isColorAdjusterFuncNode,
   lastLineHasInlineComment,
+  isAdditionOperandNodeInsideURLFunction,
 } = require("./utils");
 
 function shouldPrintComma(options) {
@@ -517,8 +518,11 @@ function genericPrint(path, options, print) {
 
         if (insideURLFunction) {
           if (
-            (iNextNode && isAdditionNode(iNextNode)) ||
-            isAdditionNode(iNode)
+            (iNextNode &&
+              isAdditionNode(iNextNode) &&
+              isAdditionOperandNodeInsideURLFunction(iNode)) ||
+            (isAdditionNode(iNode) &&
+              isAdditionOperandNodeInsideURLFunction(iNextNode))
           ) {
             parts.push(" ");
           }

--- a/src/language-css/utils.js
+++ b/src/language-css/utils.js
@@ -388,6 +388,13 @@ function lastLineHasInlineComment(text) {
   return /\/\//.test(text.split(/[\r\n]/).pop());
 }
 
+function isAdditionOperandNodeInsideURLFunction(node) {
+  return (
+    node.type === "value-string" ||
+    (node.type === "value-word" && node.value.startsWith("$"))
+  );
+}
+
 module.exports = {
   getAncestorCounter,
   getAncestorNode,
@@ -436,4 +443,5 @@ module.exports = {
   isMediaAndSupportsKeywords,
   isColorAdjusterFuncNode,
   lastLineHasInlineComment,
+  isAdditionOperandNodeInsideURLFunction,
 };

--- a/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css_scss/__snapshots__/jsfmt.spec.js.snap
@@ -4171,6 +4171,9 @@ a {
   background-image: url($test-path + 'static/test.jpg');
   background-image: url('../test/' + $test-path);
   background-image: url('../test/' + 'static/test.jpg');
+  background-image: url(foo+bar);
+  background-image: url(foo+bar+baz);
+  background-image: url(foo++bar);
 }
 
 =====================================output=====================================
@@ -4179,6 +4182,9 @@ a {
   background-image: url($test-path + "static/test.jpg");
   background-image: url("../test/" + $test-path);
   background-image: url("../test/" + "static/test.jpg");
+  background-image: url(foo+bar);
+  background-image: url(foo+bar+baz);
+  background-image: url(foo++bar);
 }
 
 ================================================================================
@@ -4195,6 +4201,9 @@ a {
   background-image: url($test-path + 'static/test.jpg');
   background-image: url('../test/' + $test-path);
   background-image: url('../test/' + 'static/test.jpg');
+  background-image: url(foo+bar);
+  background-image: url(foo+bar+baz);
+  background-image: url(foo++bar);
 }
 
 =====================================output=====================================
@@ -4203,6 +4212,9 @@ a {
   background-image: url($test-path + "static/test.jpg");
   background-image: url("../test/" + $test-path);
   background-image: url("../test/" + "static/test.jpg");
+  background-image: url(foo+bar);
+  background-image: url(foo+bar+baz);
+  background-image: url(foo++bar);
 }
 
 ================================================================================

--- a/tests/css_scss/string-concatanation.scss
+++ b/tests/css_scss/string-concatanation.scss
@@ -3,4 +3,7 @@ a {
   background-image: url($test-path + 'static/test.jpg');
   background-image: url('../test/' + $test-path);
   background-image: url('../test/' + 'static/test.jpg');
+  background-image: url(foo+bar);
+  background-image: url(foo+bar+baz);
+  background-image: url(foo++bar);
 }


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fixes #7906 

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
