### PR TITLE
Update `isSCSS` test regex

### DIFF
--- a/src/language-css/utils.js
+++ b/src/language-css/utils.js
@@ -60,7 +60,7 @@ function getPropOfDeclNode(path) {
 
 function isSCSS(parser, text) {
   const hasExplicitParserChoice = parser === "less" || parser === "scss";
-  const IS_POSSIBLY_SCSS = /(\w\s*: ?[^}:]+|#){|@import[^\n]+(url|,)/;
+  const IS_POSSIBLY_SCSS = /(\w\s*:\s*[^}:]+|#){|@import[^\n]+(?:url|,)/;
   return hasExplicitParserChoice
     ? parser === "scss"
     : IS_POSSIBLY_SCSS.test(text);

--- a/src/language-css/utils.js
+++ b/src/language-css/utils.js
@@ -60,7 +60,7 @@ function getPropOfDeclNode(path) {
 
 function isSCSS(parser, text) {
   const hasExplicitParserChoice = parser === "less" || parser === "scss";
-  const IS_POSSIBLY_SCSS = /(\w\s*: [^}:]+|#){|@import[^\n]+(url|,)/;
+  const IS_POSSIBLY_SCSS = /(\w\s*: ?[^}:]+|#){|@import[^\n]+(url|,)/;
   return hasExplicitParserChoice
     ? parser === "scss"
     : IS_POSSIBLY_SCSS.test(text);

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -28,7 +28,6 @@ const unstableTests = new Map(
     "comments/return-statement.js",
     "comments/tagged-template-literal.js",
     "comments_closure_typecast/iife.js",
-    "css_atrule/include.css",
     "graphql_interface/separator-detection.graphql",
     [
       "html_angular/attributes.component.html",


### PR DESCRIPTION
Fix `css_atrule/include.css` second format.

I don't really understand this regex, but space after `:` should be optional.

It's added in https://github.com/prettier/prettier/pull/4317/files#diff-29bcb0b461c4ae51930e975e53edfdd9L481


- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
