### PR TITLE
Fix #7920 - do not add comma for explicit inexact object with indexer property

### DIFF
--- a/changelog_unreleased/flow/pr-7923.md
+++ b/changelog_unreleased/flow/pr-7923.md
@@ -1,0 +1,52 @@
+#### Do not add comma for explicit inexact object with indexer property or no properties ([#7923](https://github.com/prettier/prettier/pull/7923) by [@DmitryGonchar](https://github.com/DmitryGonchar))
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+type T = {
+  a: number,
+  ...,
+}
+
+type T = {
+   [string]: number,
+  ...,
+}
+
+type T = {
+  // comment
+  ...,
+}
+
+// Prettier stable
+type T = {
+  a: number,
+  ...
+}
+
+type T = {
+   [string]: number,
+  ...,
+}
+
+type T = {
+  // comment
+  ...,
+}
+
+// Prettier master
+type T = {
+  a: number,
+  ...
+}
+
+type T = {
+   [string]: number,
+  ...
+}
+
+type T = {
+  // comment
+  ...
+}
+```

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1416,11 +1416,11 @@ function printPathNoParens(path, options, print, args) {
       const lastElem = getLast(n[propertiesField]);
 
       const canHaveTrailingSeparator = !(
-        lastElem &&
-        (lastElem.type === "RestProperty" ||
-          lastElem.type === "RestElement" ||
-          hasNodeIgnoreComment(lastElem) ||
-          n.inexact)
+        n.inexact ||
+        (lastElem &&
+          (lastElem.type === "RestProperty" ||
+            lastElem.type === "RestElement" ||
+            hasNodeIgnoreComment(lastElem)))
       );
 
       let content;

--- a/tests/flow_object_inexact/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_object_inexact/__snapshots__/jsfmt.spec.js.snap
@@ -73,31 +73,31 @@ type Foo = {
 
 type Foo = {
   // comment
-  ...,
+  ...
 };
 
 type Foo = {
   /* comment */
-  ...,
+  ...
 };
 
 type Foo = { /* comment */ ... };
 
 type Foo = {
   /* comment */
-  ...,
+  ...
 };
 
 type Foo = {
   // comment0
   // comment1
-  ...,
+  ...
 };
 
 type Foo = {
   /* comment0 */
   /* comment1 */
-  ...,
+  ...
 };
 
 type Foo = {
@@ -122,7 +122,7 @@ type Foo = {
 type Foo = {
   /* comment */
   [string]: string,
-  ...,
+  ...
 };
 
 type Foo = {
@@ -343,31 +343,31 @@ type Foo = {
 
 type Foo = {
   // comment
-  ...,
+  ...
 };
 
 type Foo = {
   /* comment */
-  ...,
+  ...
 };
 
 type Foo = { /* comment */ ... };
 
 type Foo = {
   /* comment */
-  ...,
+  ...
 };
 
 type Foo = {
   // comment0
   // comment1
-  ...,
+  ...
 };
 
 type Foo = {
   /* comment0 */
   /* comment1 */
-  ...,
+  ...
 };
 
 type Foo = {
@@ -392,7 +392,7 @@ type Foo = {
 type Foo = {
   /* comment */
   [string]: string,
-  ...,
+  ...
 };
 
 type Foo = {
@@ -444,7 +444,7 @@ type T = {
 
 type I = {
   [string]: number,
-  ...,
+  ...
 };
 
 type U = {
@@ -670,7 +670,7 @@ type T = {
 
 type I = {
   [string]: number,
-  ...,
+  ...
 };
 
 type U = {

--- a/tests/flow_object_inexact/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_object_inexact/__snapshots__/jsfmt.spec.js.snap
@@ -270,6 +270,141 @@ type Foo = {
 ================================================================================
 `;
 
+exports[`comments.js 3`] = `
+====================================options=====================================
+parsers: ["flow", "babel"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+type Foo = {
+  // comment
+  ...,
+};
+
+type Foo = {
+  /* comment */
+  ...,
+};
+
+type Foo = { /* comment */ ... };
+
+type Foo = { /* comment */
+  ...};
+
+type Foo = {
+  // comment0
+  // comment1
+  ...,
+};
+
+type Foo = {
+  /* comment0 */
+  /* comment1 */
+  ...,
+};
+
+type Foo = {
+  // comment
+  foo: string,
+  ...
+};
+
+type Foo = {
+  // comment0
+  // comment1
+  foo: string,
+  ...
+};
+
+type Foo = {
+  /* comment */
+  foo: string,
+  ...
+};
+
+type Foo = {
+  /* comment */
+  [string]: string,
+  ...
+};
+
+type Foo = {
+  /* comment0 */
+  /* comment1 */
+  foo: string,
+  ...
+};
+
+=====================================output=====================================
+// @flow
+
+type Foo = {
+  // comment
+  ...,
+};
+
+type Foo = {
+  /* comment */
+  ...,
+};
+
+type Foo = { /* comment */ ... };
+
+type Foo = {
+  /* comment */
+  ...,
+};
+
+type Foo = {
+  // comment0
+  // comment1
+  ...,
+};
+
+type Foo = {
+  /* comment0 */
+  /* comment1 */
+  ...,
+};
+
+type Foo = {
+  // comment
+  foo: string,
+  ...
+};
+
+type Foo = {
+  // comment0
+  // comment1
+  foo: string,
+  ...
+};
+
+type Foo = {
+  /* comment */
+  foo: string,
+  ...
+};
+
+type Foo = {
+  /* comment */
+  [string]: string,
+  ...,
+};
+
+type Foo = {
+  /* comment0 */
+  /* comment1 */
+  foo: string,
+  ...
+};
+
+================================================================================
+`;
+
 exports[`test.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "babel"]
@@ -423,6 +558,119 @@ type T = {
 type I = {
   [string]: number,
   ...
+};
+
+type U = {
+  a: number,
+  b: number,
+  c: number,
+  d: number,
+  e: number,
+  f: number,
+  g: number,
+  ...
+};
+
+type V = {
+  x: { ... },
+  y: {
+    x: { ... },
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    e: number,
+    f: number,
+    ...
+  },
+  z: { ... },
+  foo: number,
+  bar: { foo: number, ... },
+  ...
+};
+
+function test(x: {
+  foo: number,
+  bar: number,
+  baz: number,
+  qux: nunber,
+  a: number,
+  b: number,
+  c: { a: number, ... },
+  ...
+}) {
+  return x;
+}
+function test(x: {
+  foo: number,
+  bar: number,
+  baz: number,
+  qux: nunber,
+  a: number,
+  b: number,
+  c: {
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    e: number,
+    f: number,
+    g: number,
+    h: number,
+    i: number,
+    ...
+  },
+  ...
+}) {
+  return x;
+}
+
+type W = { ... };
+type X = { ... };
+
+================================================================================
+`;
+
+exports[`test.js 3`] = `
+====================================options=====================================
+parsers: ["flow", "babel"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+//@flow
+type T = {
+  a: number,
+  ...,
+}
+
+type I = {
+  [string]: number,
+  ...,
+}
+
+type U = { a: number, b: number, c: number, d: number, e: number, f: number, g: number, ...};
+
+type V = {x: {...}, y: {x: {...}, a: number, b: number, c: number, d: number, e: number, f: number, ...}, z: {...}, foo: number, bar: {foo: number, ...}, ...};
+
+function test(x: {foo: number, bar: number, baz: number, qux: nunber, a: number, b: number, c: {a: number, ...}, ...}) { return x; }
+function test(x: {foo: number, bar: number, baz: number, qux: nunber, a: number, b: number, c: {a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, ...}, ...}) { return x; }
+
+type W = {...};
+type X = {
+  ...,
+};
+
+=====================================output=====================================
+//@flow
+type T = {
+  a: number,
+  ...
+};
+
+type I = {
+  [string]: number,
+  ...,
 };
 
 type U = {

--- a/tests/flow_object_inexact/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_object_inexact/__snapshots__/jsfmt.spec.js.snap
@@ -4,6 +4,129 @@ exports[`comments.js 1`] = `
 ====================================options=====================================
 parsers: ["flow", "babel"]
 printWidth: 80
+trailingComma: "es5"
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+type Foo = {
+  // comment
+  ...,
+};
+
+type Foo = {
+  /* comment */
+  ...,
+};
+
+type Foo = { /* comment */ ... };
+
+type Foo = { /* comment */
+  ...};
+
+type Foo = {
+  // comment0
+  // comment1
+  ...,
+};
+
+type Foo = {
+  /* comment0 */
+  /* comment1 */
+  ...,
+};
+
+type Foo = {
+  // comment
+  foo: string,
+  ...
+};
+
+type Foo = {
+  // comment0
+  // comment1
+  foo: string,
+  ...
+};
+
+type Foo = {
+  /* comment */
+  foo: string,
+  ...
+};
+
+type Foo = {
+  /* comment0 */
+  /* comment1 */
+  foo: string,
+  ...
+};
+
+=====================================output=====================================
+// @flow
+
+type Foo = {
+  // comment
+  ...,
+};
+
+type Foo = {
+  /* comment */
+  ...,
+};
+
+type Foo = { /* comment */ ... };
+
+type Foo = {
+  /* comment */
+  ...,
+};
+
+type Foo = {
+  // comment0
+  // comment1
+  ...,
+};
+
+type Foo = {
+  /* comment0 */
+  /* comment1 */
+  ...,
+};
+
+type Foo = {
+  // comment
+  foo: string,
+  ...
+};
+
+type Foo = {
+  // comment0
+  // comment1
+  foo: string,
+  ...
+};
+
+type Foo = {
+  /* comment */
+  foo: string,
+  ...
+};
+
+type Foo = {
+  /* comment0 */
+  /* comment1 */
+  foo: string,
+  ...
+};
+
+================================================================================
+`;
+
+exports[`comments.js 2`] = `
+====================================options=====================================
+parsers: ["flow", "babel"]
+printWidth: 80
 trailingComma: "none"
                                                                                 | printWidth
 =====================================input======================================
@@ -124,6 +247,109 @@ type Foo = {
 `;
 
 exports[`test.js 1`] = `
+====================================options=====================================
+parsers: ["flow", "babel"]
+printWidth: 80
+trailingComma: "es5"
+                                                                                | printWidth
+=====================================input======================================
+//@flow
+type T = {
+  a: number,
+  ...,
+}
+
+type U = { a: number, b: number, c: number, d: number, e: number, f: number, g: number, ...};
+
+type V = {x: {...}, y: {x: {...}, a: number, b: number, c: number, d: number, e: number, f: number, ...}, z: {...}, foo: number, bar: {foo: number, ...}, ...};
+
+function test(x: {foo: number, bar: number, baz: number, qux: nunber, a: number, b: number, c: {a: number, ...}, ...}) { return x; }
+function test(x: {foo: number, bar: number, baz: number, qux: nunber, a: number, b: number, c: {a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number, i: number, ...}, ...}) { return x; }
+
+type W = {...};
+type X = {
+  ...,
+};
+
+=====================================output=====================================
+//@flow
+type T = {
+  a: number,
+  ...
+};
+
+type U = {
+  a: number,
+  b: number,
+  c: number,
+  d: number,
+  e: number,
+  f: number,
+  g: number,
+  ...
+};
+
+type V = {
+  x: { ... },
+  y: {
+    x: { ... },
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    e: number,
+    f: number,
+    ...
+  },
+  z: { ... },
+  foo: number,
+  bar: { foo: number, ... },
+  ...
+};
+
+function test(x: {
+  foo: number,
+  bar: number,
+  baz: number,
+  qux: nunber,
+  a: number,
+  b: number,
+  c: { a: number, ... },
+  ...
+}) {
+  return x;
+}
+function test(x: {
+  foo: number,
+  bar: number,
+  baz: number,
+  qux: nunber,
+  a: number,
+  b: number,
+  c: {
+    a: number,
+    b: number,
+    c: number,
+    d: number,
+    e: number,
+    f: number,
+    g: number,
+    h: number,
+    i: number,
+    ...
+  },
+  ...
+}) {
+  return x;
+}
+
+type W = { ... };
+type X = { ... };
+
+================================================================================
+`;
+
+exports[`test.js 2`] = `
 ====================================options=====================================
 parsers: ["flow", "babel"]
 printWidth: 80

--- a/tests/flow_object_inexact/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow_object_inexact/__snapshots__/jsfmt.spec.js.snap
@@ -56,6 +56,12 @@ type Foo = {
 };
 
 type Foo = {
+  /* comment */
+  [string]: string,
+  ...
+};
+
+type Foo = {
   /* comment0 */
   /* comment1 */
   foo: string,
@@ -111,6 +117,12 @@ type Foo = {
   /* comment */
   foo: string,
   ...
+};
+
+type Foo = {
+  /* comment */
+  [string]: string,
+  ...,
 };
 
 type Foo = {
@@ -179,6 +191,12 @@ type Foo = {
 };
 
 type Foo = {
+  /* comment */
+  [string]: string,
+  ...
+};
+
+type Foo = {
   /* comment0 */
   /* comment1 */
   foo: string,
@@ -237,6 +255,12 @@ type Foo = {
 };
 
 type Foo = {
+  /* comment */
+  [string]: string,
+  ...
+};
+
+type Foo = {
   /* comment0 */
   /* comment1 */
   foo: string,
@@ -259,6 +283,11 @@ type T = {
   ...,
 }
 
+type I = {
+  [string]: number,
+  ...,
+}
+
 type U = { a: number, b: number, c: number, d: number, e: number, f: number, g: number, ...};
 
 type V = {x: {...}, y: {x: {...}, a: number, b: number, c: number, d: number, e: number, f: number, ...}, z: {...}, foo: number, bar: {foo: number, ...}, ...};
@@ -276,6 +305,11 @@ type X = {
 type T = {
   a: number,
   ...
+};
+
+type I = {
+  [string]: number,
+  ...,
 };
 
 type U = {
@@ -362,6 +396,11 @@ type T = {
   ...,
 }
 
+type I = {
+  [string]: number,
+  ...,
+}
+
 type U = { a: number, b: number, c: number, d: number, e: number, f: number, g: number, ...};
 
 type V = {x: {...}, y: {x: {...}, a: number, b: number, c: number, d: number, e: number, f: number, ...}, z: {...}, foo: number, bar: {foo: number, ...}, ...};
@@ -378,6 +417,11 @@ type X = {
 //@flow
 type T = {
   a: number,
+  ...
+};
+
+type I = {
+  [string]: number,
   ...
 };
 

--- a/tests/flow_object_inexact/comments.js
+++ b/tests/flow_object_inexact/comments.js
@@ -47,6 +47,12 @@ type Foo = {
 };
 
 type Foo = {
+  /* comment */
+  [string]: string,
+  ...
+};
+
+type Foo = {
   /* comment0 */
   /* comment1 */
   foo: string,

--- a/tests/flow_object_inexact/jsfmt.spec.js
+++ b/tests/flow_object_inexact/jsfmt.spec.js
@@ -1,1 +1,2 @@
+run_spec(__dirname, ["flow", "babel"], { trailingComma: "es5" });
 run_spec(__dirname, ["flow", "babel"], { trailingComma: "none" });

--- a/tests/flow_object_inexact/jsfmt.spec.js
+++ b/tests/flow_object_inexact/jsfmt.spec.js
@@ -1,2 +1,3 @@
 run_spec(__dirname, ["flow", "babel"], { trailingComma: "es5" });
 run_spec(__dirname, ["flow", "babel"], { trailingComma: "none" });
+run_spec(__dirname, ["flow", "babel"], { trailingComma: "all" });

--- a/tests/flow_object_inexact/test.js
+++ b/tests/flow_object_inexact/test.js
@@ -4,6 +4,11 @@ type T = {
   ...,
 }
 
+type I = {
+  [string]: number,
+  ...,
+}
+
 type U = { a: number, b: number, c: number, d: number, e: number, f: number, g: number, ...};
 
 type V = {x: {...}, y: {x: {...}, a: number, b: number, c: number, d: number, e: number, f: number, ...}, z: {...}, foo: number, bar: {foo: number, ...}, ...};


### PR DESCRIPTION
Fixes #7920  - do not add comma for explicit inexact object with indexer property - for all cases. Previously it was removed only when type had some simple "properties" field defined.

In tests, the main factor that it works is that comma being shown or hidden behaves the same for both the simple/main case
```
type T = {
  a: number,
  ...,
}
```
and for object with indexer property or without properties.

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
