### PR TITLE
Ugly formatting of nested conditional types [TypeScript]

### DIFF
--- a/changelog_unreleased/typescript/pr-7948.md
+++ b/changelog_unreleased/typescript/pr-7948.md
@@ -1,7 +1,5 @@
 #### Make nested conditional types nicer ([#7948](https://github.com/prettier/prettier/pull/7948) by [@mmiszy](https://github.com/mmiszy))
 
-Optional description if it makes sense.
-
 <!-- prettier-ignore -->
 ```typescript
 // Input

--- a/changelog_unreleased/typescript/pr-7948.md
+++ b/changelog_unreleased/typescript/pr-7948.md
@@ -3,7 +3,7 @@
 Optional description if it makes sense.
 
 <!-- prettier-ignore -->
-```jsx
+```typescript
 // Input
 type TypeName<T> =
   T extends string ? "string" :

--- a/changelog_unreleased/typescript/pr-7948.md
+++ b/changelog_unreleased/typescript/pr-7948.md
@@ -1,0 +1,49 @@
+#### Make nested conditional types nicer ([#7948](https://github.com/prettier/prettier/pull/7948) by [@mmiszy](https://github.com/mmiszy))
+
+Optional description if it makes sense.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+type TypeName<T> =
+  T extends string ? "string" :
+  T extends number ? "number" :
+  T extends boolean ? "boolean" :
+  T extends undefined ? "undefined" :
+  T extends Function ? "function" :
+  T extends Array<any> ? "array" :
+  T extends null ? "null" :
+  T extends symbol ? "symbol" :
+  "object";
+
+// Prettier stable
+type TypeName<T> = T extends string
+  ? "string"
+  : T extends number
+  ? "number"
+  : T extends boolean
+  ? "boolean"
+  : T extends undefined
+  ? "undefined"
+  : T extends Function
+  ? "function"
+  : T extends Array<any>
+  ? "array"
+  : T extends null
+  ? "null"
+  : T extends symbol
+  ? "symbol"
+  : "object";
+
+// Prettier master
+type TypeName<T> =
+  T extends string ? "string" :
+  T extends number ? "number" :
+  T extends boolean ? "boolean" :
+  T extends undefined ? "undefined" :
+  T extends Function ? "function" :
+  T extends Array<any> ? "array" :
+  T extends null ? "null" :
+  T extends symbol ? "symbol" :
+  "object";
+```

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -288,7 +288,7 @@ function printTernaryOperator(path, options, print, operatorOptions) {
     parent.type === operatorOptions.conditionalNodeType &&
     operatorOptions.testNodePropertyNames.some((prop) => parent[prop] === node);
   let forceNoIndent =
-  operatorOptions.conditionalNodeType === 'TSConditionalType' ||
+    operatorOptions.conditionalNodeType === "TSConditionalType" ||
     (parent.type === operatorOptions.conditionalNodeType && !isParentTest);
 
   // Find the outermost non-ConditionalExpression parent, and the outermost
@@ -354,28 +354,31 @@ function printTernaryOperator(path, options, print, operatorOptions) {
     );
   } else {
     // normal mode
-    const part = concat([
-      operatorOptions.conditionalNodeType === 'TSConditionalType' ? " " : softline,
-      "?",
-      operatorOptions.conditionalNodeType === 'TSConditionalType' ? " " : "",
+    const firstPartOfCondition = concat([
+      operatorOptions.conditionalNodeType === "TSConditionalType"
+        ? softline
+        : ifBreak(" ", ""),
+      align(2, path.call(print, operatorOptions.consequentNodePropertyName)),
       consequentNode.type === operatorOptions.conditionalNodeType
-        ? ifBreak("", "(")
+        ? ifBreak("", ")")
         : "",
-      group(
-        concat([
-          operatorOptions.conditionalNodeType === 'TSConditionalType' ? softline : " ",
-          align(
-            2,
-            path.call(print, operatorOptions.consequentNodePropertyName)
-          ),
-          consequentNode.type === operatorOptions.conditionalNodeType
-            ? ifBreak("", ")")
-            : "",
-          operatorOptions.conditionalNodeType === 'TSConditionalType' ? " " : line,
-          ":",
-        ])
-      ),
-      operatorOptions.conditionalNodeType === 'TSConditionalType' ? line : " ",
+      operatorOptions.conditionalNodeType === "TSConditionalType" ? " " : line,
+      ":",
+    ]);
+
+    const part = concat([
+      operatorOptions.conditionalNodeType === "TSConditionalType" ? " " : line,
+      "?",
+      operatorOptions.conditionalNodeType === "TSConditionalType" ? " " : "",
+      consequentNode.type === operatorOptions.conditionalNodeType
+        ? ifBreak("", " (")
+        : operatorOptions.conditionalNodeType === "TSConditionalType"
+        ? ""
+        : ifBreak("", " "),
+      operatorOptions.conditionalNodeType === "TSConditionalType"
+        ? group(firstPartOfCondition)
+        : firstPartOfCondition,
+      operatorOptions.conditionalNodeType === "TSConditionalType" ? line : " ",
       alternateNode.type === operatorOptions.conditionalNodeType
         ? path.call(print, operatorOptions.alternateNodePropertyName)
         : align(2, path.call(print, operatorOptions.alternateNodePropertyName)),
@@ -412,7 +415,10 @@ function printTernaryOperator(path, options, print, operatorOptions) {
   const result = maybeGroup(
     concat(
       [].concat(
-        operatorOptions.conditionalNodeType === 'TSConditionalType' && parent.type !== operatorOptions.conditionalNodeType ? [softline] : [],
+        operatorOptions.conditionalNodeType === "TSConditionalType" &&
+          parent.type !== operatorOptions.conditionalNodeType
+          ? [softline]
+          : [],
         ((testDoc) => {
           /**
            *     a
@@ -437,7 +443,8 @@ function printTernaryOperator(path, options, print, operatorOptions) {
 
   return isParentTest
     ? group(concat([indent(concat([softline, result])), softline]))
-    : parent.type !== operatorOptions.conditionalNodeType && operatorOptions.conditionalNodeType === 'TSConditionalType'
+    : parent.type !== operatorOptions.conditionalNodeType &&
+      operatorOptions.conditionalNodeType === "TSConditionalType"
     ? indent(result)
     : result;
 }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -354,17 +354,24 @@ function printTernaryOperator(path, options, print, operatorOptions) {
   } else {
     // normal mode
     const part = concat([
-      line,
-      "? ",
+      " ? ",
       consequentNode.type === operatorOptions.conditionalNodeType
         ? ifBreak("", "(")
         : "",
-      align(2, path.call(print, operatorOptions.consequentNodePropertyName)),
-      consequentNode.type === operatorOptions.conditionalNodeType
-        ? ifBreak("", ")")
-        : "",
+      group(
+        concat([
+          softline,
+          align(
+            2,
+            path.call(print, operatorOptions.consequentNodePropertyName)
+          ),
+          consequentNode.type === operatorOptions.conditionalNodeType
+            ? ifBreak("", ")")
+            : "",
+          " :",
+        ])
+      ),
       line,
-      ": ",
       alternateNode.type === operatorOptions.conditionalNodeType
         ? path.call(print, operatorOptions.alternateNodePropertyName)
         : align(2, path.call(print, operatorOptions.alternateNodePropertyName)),
@@ -401,22 +408,24 @@ function printTernaryOperator(path, options, print, operatorOptions) {
   const result = maybeGroup(
     concat(
       [].concat(
-        ((testDoc) =>
+        parent.type !== operatorOptions.conditionalNodeType ? [softline] : [],
+        ((testDoc) => {
           /**
            *     a
-           *       ? b
-           *       : multiline
+           *       ? b :
+           *         multiline
            *         test
            *         node
            *       ^^ align(2)
-           *       ? d
-           *       : e
+           *       ? d :
+           *       e
            */
-          parent.type === operatorOptions.conditionalNodeType &&
-          parent[operatorOptions.alternateNodePropertyName] === node
+          return parent.type === operatorOptions.conditionalNodeType &&
+            parent[operatorOptions.alternateNodePropertyName] === node
             ? align(2, testDoc)
-            : testDoc)(concat(operatorOptions.beforeParts())),
-        forceNoIndent ? concat(parts) : indent(concat(parts)),
+            : testDoc;
+        })(concat(operatorOptions.beforeParts())),
+        forceNoIndent ? concat(parts) : concat(parts),
         operatorOptions.afterParts(breakClosingParen)
       )
     )
@@ -424,6 +433,8 @@ function printTernaryOperator(path, options, print, operatorOptions) {
 
   return isParentTest
     ? group(concat([indent(concat([softline, result])), softline]))
+    : parent.type !== operatorOptions.conditionalNodeType
+    ? indent(result)
     : result;
 }
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -288,7 +288,8 @@ function printTernaryOperator(path, options, print, operatorOptions) {
     parent.type === operatorOptions.conditionalNodeType &&
     operatorOptions.testNodePropertyNames.some((prop) => parent[prop] === node);
   let forceNoIndent =
-    parent.type === operatorOptions.conditionalNodeType && !isParentTest;
+  operatorOptions.conditionalNodeType === 'TSConditionalType' ||
+    (parent.type === operatorOptions.conditionalNodeType && !isParentTest);
 
   // Find the outermost non-ConditionalExpression parent, and the outermost
   // ConditionalExpression parent. We'll use these to determine if we should
@@ -354,13 +355,15 @@ function printTernaryOperator(path, options, print, operatorOptions) {
   } else {
     // normal mode
     const part = concat([
-      " ? ",
+      operatorOptions.conditionalNodeType === 'TSConditionalType' ? " " : softline,
+      "?",
+      operatorOptions.conditionalNodeType === 'TSConditionalType' ? " " : "",
       consequentNode.type === operatorOptions.conditionalNodeType
         ? ifBreak("", "(")
         : "",
       group(
         concat([
-          softline,
+          operatorOptions.conditionalNodeType === 'TSConditionalType' ? softline : " ",
           align(
             2,
             path.call(print, operatorOptions.consequentNodePropertyName)
@@ -368,10 +371,11 @@ function printTernaryOperator(path, options, print, operatorOptions) {
           consequentNode.type === operatorOptions.conditionalNodeType
             ? ifBreak("", ")")
             : "",
-          " :",
+          operatorOptions.conditionalNodeType === 'TSConditionalType' ? " " : line,
+          ":",
         ])
       ),
-      line,
+      operatorOptions.conditionalNodeType === 'TSConditionalType' ? line : " ",
       alternateNode.type === operatorOptions.conditionalNodeType
         ? path.call(print, operatorOptions.alternateNodePropertyName)
         : align(2, path.call(print, operatorOptions.alternateNodePropertyName)),
@@ -408,7 +412,7 @@ function printTernaryOperator(path, options, print, operatorOptions) {
   const result = maybeGroup(
     concat(
       [].concat(
-        parent.type !== operatorOptions.conditionalNodeType ? [softline] : [],
+        operatorOptions.conditionalNodeType === 'TSConditionalType' && parent.type !== operatorOptions.conditionalNodeType ? [softline] : [],
         ((testDoc) => {
           /**
            *     a
@@ -425,7 +429,7 @@ function printTernaryOperator(path, options, print, operatorOptions) {
             ? align(2, testDoc)
             : testDoc;
         })(concat(operatorOptions.beforeParts())),
-        forceNoIndent ? concat(parts) : concat(parts),
+        forceNoIndent ? concat(parts) : indent(concat(parts)),
         operatorOptions.afterParts(breakClosingParen)
       )
     )
@@ -433,7 +437,7 @@ function printTernaryOperator(path, options, print, operatorOptions) {
 
   return isParentTest
     ? group(concat([indent(concat([softline, result])), softline]))
-    : parent.type !== operatorOptions.conditionalNodeType
+    : parent.type !== operatorOptions.conditionalNodeType && operatorOptions.conditionalNodeType === 'TSConditionalType'
     ? indent(result)
     : result;
 }

--- a/tests/typescript_conditional_types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript_conditional_types/__snapshots__/jsfmt.spec.js.snap
@@ -44,11 +44,10 @@ type U1b = new () => (X) extends T ? U : V;
 type U2 = (new () => X) extends T ? U : V;
 
 =====================================output=====================================
-export type DeepReadonly<T> = T extends any[]
-  ? DeepReadonlyArray<T[number]>
-  : T extends object
-  ? DeepReadonlyObject<T>
-  : T;
+export type DeepReadonly<T> =
+  T extends any[] ? DeepReadonlyArray<T[number]> :
+  T extends object ? DeepReadonlyObject<T> :
+  T;
 
 type NonFunctionPropertyNames<T> = {
   [K in keyof T]: T[K] extends Function ? never : K;
@@ -60,17 +59,13 @@ type DeepReadonlyObject<T> = {
   readonly [P in NonFunctionPropertyNames<T>]: DeepReadonly<T[P]>;
 };
 
-type TypeName<T> = T extends string
-  ? "string"
-  : T extends number
-  ? "number"
-  : T extends boolean
-  ? "boolean"
-  : T extends undefined
-  ? "undefined"
-  : T extends Function
-  ? "function"
-  : "object";
+type TypeName<T> =
+  T extends string ? "string" :
+  T extends number ? "number" :
+  T extends boolean ? "boolean" :
+  T extends undefined ? "undefined" :
+  T extends Function ? "function" :
+  "object";
 
 type Type01 = 0 extends (1 extends 2 ? 3 : 4) ? 5 : 6;
 type Type02 = 0 extends (1 extends 2 ? 3 : 4) ? 5 : 6;
@@ -109,19 +104,15 @@ type Unpacked<T> =
   T;
 
 =====================================output=====================================
-type TestReturnType<T extends (...args: any[]) => any> = T extends (
-  ...args: any[]
-) => infer R
-  ? R
-  : any;
+type TestReturnType<T extends (...args: any[]) => any> =
+  T extends (...args: any[]) => infer R ? R :
+  any;
 
-type Unpacked<T> = T extends (infer U)[]
-  ? U
-  : T extends (...args: any[]) => infer U
-  ? U
-  : T extends Promise<infer U>
-  ? U
-  : T;
+type Unpacked<T> =
+  T extends (infer U)[] ? U :
+  T extends (...args: any[]) => infer U ? U :
+  T extends Promise<infer U> ? U :
+  T;
 
 ================================================================================
 `;
@@ -151,33 +142,33 @@ type Foo3 =
     : CompositeZamazingoResolver;
 
 =====================================output=====================================
-type Foo = (
-  ThingamabobberFactory extends AbstractThingamabobberFactory
-    ? GobbledygookProvider
-    : CompositeGobbledygookProvider
-) extends DoubleGobbledygookProvider
-  ? UniqueDalgametreService
-  : CompositeZamazingoResolver;
+type Foo =
+  (
+    ThingamabobberFactory extends AbstractThingamabobberFactory ?
+    GobbledygookProvider :
+    CompositeGobbledygookProvider
+  ) extends DoubleGobbledygookProvider ? UniqueDalgametreService :
+  CompositeZamazingoResolver;
 
-type Foo2 = DoubleGobbledygookProvider extends (
-  ThingamabobberFactory extends AbstractThingamabobberFactory
-    ? GobbledygookProvider
-    : CompositeGobbledygookProvider
-)
-  ? UniqueDalgametreService
-  : CompositeZamazingoResolver;
+type Foo2 =
+  DoubleGobbledygookProvider extends (
+    ThingamabobberFactory extends AbstractThingamabobberFactory ?
+    GobbledygookProvider :
+    CompositeGobbledygookProvider
+  ) ? UniqueDalgametreService :
+  CompositeZamazingoResolver;
 
-type Foo3 = (
-  ThingamabobberFactory extends AbstractThingamabobberFactory
-    ? GobbledygookProvider
-    : CompositeGobbledygookProvider
-) extends (
-  DoubleGobbledygookProvider extends MockGobbledygookProvider
-    ? MockThingamabobberFactory
-    : ThingamabobberFactory
-)
-  ? UniqueDalgametreService
-  : CompositeZamazingoResolver;
+type Foo3 =
+  (
+    ThingamabobberFactory extends AbstractThingamabobberFactory ?
+    GobbledygookProvider :
+    CompositeGobbledygookProvider
+  ) extends (
+    DoubleGobbledygookProvider extends MockGobbledygookProvider ?
+    MockThingamabobberFactory :
+    ThingamabobberFactory
+  ) ? UniqueDalgametreService :
+  CompositeZamazingoResolver;
 
 ================================================================================
 `;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fixes https://github.com/prettier/prettier/issues/7940

My intention was to only affect nested conditional types in TypeScript and not to introduce any changes to how ternary expressions are formatted. This allows for a smoother transition, however, it might yield seemingly inconsistent results (see [this example](https://deploy-preview-7948--prettier.netlify.com/playground/#N4Igxg9gdgLgprEAuEMCeAHOACAKpuAOQEMBbOAHlwD5sBeAHSmz2zgA94oATAZ214wATgEsoAc2wB+bAxCDREudiRMWuNpwR9sUAK6kARnCHTZIfUZPLVzVhy47DECABs4xZjLnO3HqDZq9lo8-Ho8cABmYnDcZnLh3FEx3IF2Gg7a-ABi4WAwItDxIJF5BdBp6pqO-ACCQkLEaBSeaLTeIMQNTZXBNbp6rq7F+kO9GSE6vGhGbsXTs669chCGAFZw+XIA3ExMkFCC2AAa9EEadHQCwmKSHQq34-RXlsamHa-WICrnz9i+7k8xQB-iel2wiWSUFixUh0WhqW+tiq4NyUHyhS85lK6PKASRv3B9UaaGKXRJYJeg2GH2plIEM2cNPMCyZyxAqw2WxA2xAABoORg8bxkKByRAAO4ABS6CBFKGIrglTRFAsMjTAAGs4DAAMoYYhgW7IYR6OACgAWMFIrgA6haRPBeAawHBdXLHSIAG6OtDIcC8VUgMS8EwwKWNcSkYjISKK0MCta8dgAIQ12r1ZDgABkYrH4+aQEn2Lrbu4AIp6CDwfOuBMgA1CUNCf3oLC8MCiIX8huKGC2kTcGAW5AADgADAKMEIIKHbY0MP7p3Bm164D2AI5V+ARiAYeWdXgAWmhsViPaEcC3IkvEeIUZjSDjdcLodIIhNQjNAt4ZbglerdcnwLAUYGIQwByHEckAAJlAxoRFcW4AGEIFIaN-RXABWHs9FDXBwPlZ96y9M0AEkIlgXVOxEIVah4XV0HcWtQwAX1YoA)).

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
