### PR TITLE
workaround for require.resolve in prettier-vscode

### DIFF
--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -8,6 +8,7 @@ const path = require("path");
 const thirdParty = require("./third-party");
 const internalPlugins = require("./internal-plugins");
 const mem = require("mem");
+const resolve = require("./resolve");
 
 const memoizedLoad = mem(load, { cacheKey: JSON.stringify });
 const memoizedSearch = mem(findPluginsInNodeModules);
@@ -42,14 +43,10 @@ function load(plugins, pluginSearchDirs) {
       let requirePath;
       try {
         // try local files
-        requirePath = eval("require").resolve(
-          path.resolve(process.cwd(), pluginName)
-        );
+        requirePath = resolve(path.resolve(process.cwd(), pluginName));
       } catch (_) {
         // try node modules
-        requirePath = eval("require").resolve(pluginName, {
-          paths: [process.cwd()],
-        });
+        requirePath = resolve(pluginName, { paths: [process.cwd()] });
       }
 
       return {
@@ -85,9 +82,7 @@ function load(plugins, pluginSearchDirs) {
 
       return memoizedSearch(nodeModulesDir).map((pluginName) => ({
         name: pluginName,
-        requirePath: eval("require").resolve(pluginName, {
-          paths: [resolvedPluginSearchDir],
-        }),
+        requirePath: resolve(pluginName, { paths: [resolvedPluginSearchDir] }),
       }));
     })
     .reduce((a, b) => a.concat(b), []);

--- a/src/common/resolve.js
+++ b/src/common/resolve.js
@@ -1,0 +1,12 @@
+"use strict";
+
+let { resolve } = eval("require");
+
+// In the VS Code extension `require` is overridden and `require.resolve` doesn't support the 2nd argument.
+if (resolve.length === 1) {
+  const Module = eval("require")("module");
+  const createRequire = Module.createRequire || Module.createRequireFromPath;
+  resolve = createRequire(__dirname).resolve;
+}
+
+module.exports = resolve;

--- a/src/config/resolve-config.js
+++ b/src/config/resolve-config.js
@@ -7,6 +7,7 @@ const mem = require("mem");
 
 const resolveEditorConfig = require("./resolve-config-editorconfig");
 const loadToml = require("../utils/load-toml");
+const resolve = require("../common/resolve");
 
 const getExplorerMemoized = mem(
   (opts) => {
@@ -18,9 +19,7 @@ const getExplorerMemoized = mem(
           if (typeof result.config === "string") {
             const dir = path.dirname(result.filepath);
             try {
-              const modulePath = eval("require").resolve(result.config, {
-                paths: [dir],
-              });
+              const modulePath = resolve(result.config, { paths: [dir] });
               result.config = eval("require")(modulePath);
             } catch (error) {
               // Original message contains `__filename`, can't pass tests


### PR DESCRIPTION
fixes #7949

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
