### PR TITLE
change playground redirect to use *.netlify.app domains

### DIFF
--- a/website/pages/playground-redirect.html
+++ b/website/pages/playground-redirect.html
@@ -22,7 +22,7 @@
       if (match != null) {
         const [, /* url */ pr] = match;
         location.replace(
-          `https://deploy-preview-${pr}--prettier.netlify.com/playground`
+          `https://deploy-preview-${pr}--prettier.netlify.app/playground`
         );
       } else {
         const el = document.createElement("p");


### PR DESCRIPTION
https://community.netlify.com/t/changes-coming-to-netlify-site-urls/8918

> Starting April 14, 2020, sites without a custom domain are being moved from site-name.netlify.com to site-name.netlify.app . New websites will also have URLs ending with netlify.app by default. Custom domains set on old, or new, sites will behave in the same way as before!

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
