### PR TITLE
An attempt to fix unexpected GitHub Actions failures

### DIFF
--- a/tests_integration/__tests__/check.js
+++ b/tests_integration/__tests__/check.js
@@ -27,10 +27,8 @@ describe("--checks works in CI just as in a non-TTY mode", () => {
     "cli/write",
     ["--check", "formatted.js", "unformatted.js"],
     {
-      env: {
-        CI: "true",
-      },
       stdoutIsTTY: true,
+      ci: true,
     }
   ).test({
     status: 1,

--- a/tests_integration/__tests__/list-different.js
+++ b/tests_integration/__tests__/list-different.js
@@ -27,10 +27,8 @@ describe("--list-different works in CI just as in a non-TTY mode", () => {
     "cli/write",
     ["--list-different", "formatted.js", "unformatted.js"],
     {
-      env: {
-        CI: "true",
-      },
       stdoutIsTTY: true,
+      ci: true,
     }
   ).test({
     status: 1,

--- a/tests_integration/runPrettier.js
+++ b/tests_integration/runPrettier.js
@@ -62,13 +62,11 @@ function runPrettier(dir, args, options) {
   const originalExitCode = process.exitCode;
   const originalStdinIsTTY = process.stdin.isTTY;
   const originalStdoutIsTTY = process.stdout.isTTY;
-  const originalEnv = process.env;
 
   process.chdir(normalizeDir(dir));
   process.stdin.isTTY = !!options.isTTY;
   process.stdout.isTTY = !!options.stdoutIsTTY;
   process.argv = ["path/to/node", "path/to/prettier/bin"].concat(args);
-  process.env = { ...process.env, ...options.env };
 
   jest.resetModules();
 
@@ -113,7 +111,6 @@ function runPrettier(dir, args, options) {
     process.exitCode = originalExitCode;
     process.stdin.isTTY = originalStdinIsTTY;
     process.stdout.isTTY = originalStdoutIsTTY;
-    process.env = originalEnv;
     jest.restoreAllMocks();
   }
 

--- a/tests_integration/runPrettier.js
+++ b/tests_integration/runPrettier.js
@@ -80,7 +80,7 @@ function runPrettier(dir, args, options) {
     .mockImplementation(() => SynchronousPromise.resolve(options.input || ""));
   jest
     .spyOn(require(thirdParty), "isCI")
-    .mockImplementation(() => process.env.CI);
+    .mockImplementation(() => !!options.ci);
   jest
     .spyOn(require(thirdParty), "cosmiconfig")
     .mockImplementation((moduleName, options) =>


### PR DESCRIPTION
Seems like GitHub Actions have the `CI` environment variable set now whereas some tests (added in #5804) depended on this variable.

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
