### PR TITLE
Adjust `maxWorkers` for `jest`

### DIFF
--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -46,7 +46,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Run Tests
-        run: yarn test --maxWorkers=4
+        run: yarn test --maxWorkers=2
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v1

--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -45,7 +45,12 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
 
-      - name: Run Tests
+      - name: Run Tests (macOS)
+        if: matrix.os == 'macos-latest'
+        run: yarn test --maxWorkers=4
+
+      - name: Run Tests (Linux and Windows)
+        if: matrix.os != 'macos-latest'
         run: yarn test --maxWorkers=2
 
       - name: Upload Coverage

--- a/scripts/test-dist.js
+++ b/scripts/test-dist.js
@@ -21,9 +21,9 @@ shell.exec("npm init -y", { cwd: tmpDir });
 shell.exec(`npm install "${tarPath}"`, { cwd: tmpDir });
 shell.config.silent = false;
 
-const runInBand = isCI ? "--runInBand" : "";
+const maxWorkers = isCI ? "--maxWorkers=2" : "";
 const testPath = process.env.TEST_STANDALONE ? "tests/" : "";
-const cmd = `yarn test --color ${runInBand} ${testPath}`;
+const cmd = `yarn test --color ${maxWorkers} ${testPath}`;
 
 const { code } = shell.exec(cmd, {
   cwd: rootDir,

--- a/scripts/test-dist.js
+++ b/scripts/test-dist.js
@@ -2,6 +2,7 @@
 
 "use strict";
 
+const os = require("os");
 const path = require("path");
 const shell = require("shelljs");
 const tempy = require("tempy");
@@ -21,7 +22,10 @@ shell.exec("npm init -y", { cwd: tmpDir });
 shell.exec(`npm install "${tarPath}"`, { cwd: tmpDir });
 shell.config.silent = false;
 
-const maxWorkers = isCI ? "--maxWorkers=2" : "";
+// This `maxWorkers` number is hard code for github actions
+const maxWorkers = isCI
+  ? `--maxWorkers=${os.platform() === "darwin" ? 4 : 2}`
+  : "";
 const testPath = process.env.TEST_STANDALONE ? "tests/" : "";
 const cmd = `yarn test --color ${maxWorkers} ${testPath}`;
 


### PR DESCRIPTION
I ran several tests (only the slowest job and a normal windows job) with different `maxWorkers` on my fork

job | duration
:--|--:
[max-workers-1](https://github.com/fisker/prettier/actions/runs/73379503) | 22m 50s 
[max-workers-2](https://github.com/fisker/prettier/actions/runs/73381299) | 14m 10s
[max-workers-3](https://github.com/fisker/prettier/actions/runs/73379954) | 16m 4s
[max-workers-4(current)](https://github.com/fisker/prettier/actions/runs/73388980) | 17m 30s
[max-workers-5](https://github.com/fisker/prettier/actions/runs/73380194) |  22m 56s
[max-workers-6](https://github.com/fisker/prettier/actions/runs/73380357) | 17m 0s
[max-workers-7](https://github.com/fisker/prettier/actions/runs/73393607) | 17m 5s

I also tried increase memory, seems not helping

job | duration
:--|--:
[max-workers-2, --max-old-space-size=6144](https://github.com/fisker/prettier/actions/runs/73400692) | 16m 18s
[max-workers-3, --max-old-space-size=6144](https://github.com/fisker/prettier/actions/runs/73401716) | 17m 38s
[max-workers-4, --max-old-space-size=6144](https://github.com/fisker/prettier/actions/runs/73401171) | 19m 6s 
[max-workers-5, --max-old-space-size=6144](https://github.com/fisker/prettier/actions/runs/73403025) | 15m 28s
[max-workers-6, --max-old-space-size=6144](https://github.com/fisker/prettier/actions/runs/73419518) | 15m 50s

Set `maxWorkers` to `2` seems a little faster, maybe save us about 2 mins :smile: , I ran tests again

job | duration
:--|--:
[max-workers-2(second run)](https://github.com/fisker/prettier/actions/runs/73419069) | 13m 57s 
[max-workers-4(second run)](https://github.com/fisker/prettier/actions/runs/73426505) | 16m 52s

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
