### PR TITLE
Use yaml formatter to format ansible files

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -6,6 +6,7 @@
         "Amjad",
         "Andrey",
         "animationend",
+        "ansible",
         "apos",
         "aquibm",
         "arduner",

--- a/src/language-yaml/index.js
+++ b/src/language-yaml/index.js
@@ -8,7 +8,7 @@ const languages = [
   createLanguage(require("linguist-languages/data/YAML"), (data) => ({
     since: "1.14.0",
     parsers: ["yaml"],
-    vscodeLanguageIds: ["yaml"],
+    vscodeLanguageIds: ["yaml", "ansible"],
     // yarn.lock is not YAML: https://github.com/yarnpkg/yarn/issues/5629
     filenames: data.filenames.filter((filename) => filename !== "yarn.lock"),
   })),

--- a/tests/yaml_ansible/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/yaml_ansible/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`playbook.yml format 1`] = `
+====================================options=====================================
+parsers: ["yaml"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+---
+- hosts: webservers
+  vars:
+    http_port: 80
+    max_clients: 200
+  remote_user: root
+  tasks:
+  - name: ensure apache is at the latest version
+    yum:
+      name: httpd
+      state: latest
+  - name: write the apache config file
+    template:
+      src: /srv/httpd.j2
+      dest: /etc/httpd.conf
+    notify:
+    - restart apache
+  - name: ensure apache is running
+    service:
+      name: httpd
+      state: started
+  handlers:
+    - name: restart apache
+      service:
+        name: httpd
+        state: restarted
+
+=====================================output=====================================
+---
+- hosts: webservers
+  vars:
+    http_port: 80
+    max_clients: 200
+  remote_user: root
+  tasks:
+    - name: ensure apache is at the latest version
+      yum:
+        name: httpd
+        state: latest
+    - name: write the apache config file
+      template:
+        src: /srv/httpd.j2
+        dest: /etc/httpd.conf
+      notify:
+        - restart apache
+    - name: ensure apache is running
+      service:
+        name: httpd
+        state: started
+  handlers:
+    - name: restart apache
+      service:
+        name: httpd
+        state: restarted
+
+================================================================================
+`;

--- a/tests/yaml_ansible/jsfmt.spec.js
+++ b/tests/yaml_ansible/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["yaml"]);

--- a/tests/yaml_ansible/playbook.yml
+++ b/tests/yaml_ansible/playbook.yml
@@ -1,0 +1,26 @@
+---
+- hosts: webservers
+  vars:
+    http_port: 80
+    max_clients: 200
+  remote_user: root
+  tasks:
+  - name: ensure apache is at the latest version
+    yum:
+      name: httpd
+      state: latest
+  - name: write the apache config file
+    template:
+      src: /srv/httpd.j2
+      dest: /etc/httpd.conf
+    notify:
+    - restart apache
+  - name: ensure apache is running
+    service:
+      name: httpd
+      state: started
+  handlers:
+    - name: restart apache
+      service:
+        name: httpd
+        state: restarted

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -684,7 +684,7 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"since\\": \\"1.14.0\\",
       \\"tmScope\\": \\"source.yaml\\",
       \\"type\\": \\"data\\",
-      \\"vscodeLanguageIds\\": [\\"yaml\\"]
+      \\"vscodeLanguageIds\\": [\\"yaml\\", \\"ansible\\"]
     }
   ],
   \\"options\\": [


### PR DESCRIPTION
The Ansible[1] extension define a new language for yaml files that describe
ansible playbooks and because of that is not possible use the prettier
extension with ansible files.

1 - https://marketplace.visualstudio.com/items?itemName=vscoss.vscode-ansible

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
