### PR TITLE
Enable GitHub Actions for a patch-release branch

### DIFF
--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - patch-release
   pull_request:
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - patch-release
   pull_request:
 
 jobs:

--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - patch-release
   pull_request:
 
 jobs:


### PR DESCRIPTION
This weekend I want to release 2.0.5 from a branch. It will be based on 2.0.4 and include only https://github.com/prettier/prettier/pull/7984 (a 2.0 regression).