### PR TITLE
add information about how to run Prettier on save

### DIFF
--- a/docs/webstorm.md
+++ b/docs/webstorm.md
@@ -18,6 +18,7 @@ To use Prettier in IntelliJ IDEA, PhpStorm, PyCharm, and other JetBrains IDEs, p
 To run Prettier on save in older IDE versions, you can set up a file watcher following the instructions below.
 
 ## Running Prettier on save using File Watcher
+To automatically format your files using Prettier on save in WebStorm 2020.1 onwards, you can use the built-in _Run on save for files_ option located in _Preferences/Settings | Languages & Frameworks | JavaScript | Prettier_.
 
 To automatically format your files using Prettier on save in WebStorm 2019.\* or earlier, you can use a [File Watcher](https://plugins.jetbrains.com/plugin/7177-file-watchers).
 


### PR DESCRIPTION
WebStorm 2020.1 comes with an option for running Prettier on save, so file watchers are no longer required. More info is available here: https://blog.jetbrains.com/webstorm/2020/04/webstorm-2020-1/#tools, it might be worth adding a link to this blog post as well.

<!-- Please provide a brief summary of your changes: -->
<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
