### PR TITLE
Use `jest@24` to collect coverage

### DIFF
--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -46,6 +46,12 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
 
+      # TODO: remove this task when/if this fixed
+      # https://github.com/facebook/jest/issues/9457
+      - name: Install jest@24
+        if: matrix.ENABLE_CODE_COVERAGE
+        run: yarn upgrade jest@24
+
       - name: Run Tests (macOS)
         if: matrix.os == 'macos-latest'
         run: yarn test --maxWorkers=4


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Possible regression  https://github.com/facebook/jest/issues/9457#issuecomment-612497425

Switch `jest` back to `v24` for coverage collect job, ~8 mins vs ~15 mins.
Finally get everything back normal.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
