### PR TITLE
Cache CI build result

### DIFF
--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -24,6 +24,23 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
 
+      - name: Cache Build Results
+        # Prevent error on re-run
+        # https://github.com/actions/cache/issues/107#issuecomment-556037278
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        id: build-cache
+        uses: actions/cache@v1
+        with:
+          path: .cache
+          key: v1-build-cache-${{ hashFiles('yarn.lock') }}-${{ github.ref }}-
+          restore-keys: |
+            v1-build-cache-${{ hashFiles('yarn.lock') }}-${{ github.ref }}-
+            v1-build-cache-${{ hashFiles('yarn.lock') }}-${{ github.base_ref }}-
+            v1-build-cache-${{ hashFiles('yarn.lock') }}-master-
+
+      # Unknown reason `scripts/build/build.js` created dir can't work
+      - run: mkdir -p .cache/files
+
       - name: Build Package
         run: yarn build
 

--- a/cspell.json
+++ b/cspell.json
@@ -206,6 +206,7 @@
         "mitermayer",
         "mixins",
         "mjml",
+        "mkdir",
         "Moeller",
         "Monteiro",
         "Morrell",


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

The build cache system seems [designed to speed up CI build](https://github.com/prettier/prettier/pull/4693), but lost in last CI setup.


With cache, ~12s https://github.com/prettier/prettier/pull/8027/checks?check_run_id=580817579#step:7:22

For reference: this caching was implemented in https://github.com/prettier/prettier/pull/4693

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
