### PR TITLE
Add `prettier/standard` to list of eslintrc extends. 

### DIFF
--- a/docs/integrating-with-linters.md
+++ b/docs/integrating-with-linters.md
@@ -25,7 +25,7 @@ Then in `.eslintrc.json`:
 
 ```json
 {
-  "extends": ["prettier"]
+  "extends": ["prettier", "prettier/standard"]
 }
 ```
 


### PR DESCRIPTION
This will disable additional rules like "standard/computed-property-even-spacing" which may conflict with prettier for some long lines (especially with arrays)

This is a simple documentation change. No tests.
