### PR TITLE
playground: fix how ranges are rendered

### DIFF
--- a/website/playground/panels.js
+++ b/website/playground/panels.js
@@ -116,7 +116,7 @@ function getIndexPosition(text, indexes) {
     while (count < index && count < text.length) {
       if (text[count] === "\n") {
         line++;
-        lineStart = count;
+        lineStart = count + 1;
       }
       count++;
     }


### PR DESCRIPTION
[An example of the current wrong rendering](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEBGAOlATCANCCABxgEtoBnZUAQwCdaIB3ABToUpWoBtHqBPSvgBGtamADWcGAGVCYklADmyGLQCucfAAsYAWy4B1LSXjk5YONPYmSANxN9k4coJALycWjGajFu6sgAZtwe+ABW5AAeAEKiElLS1LpwADIKcEEhmiARkdIKilxwAIpqEPCZXKEgcrQetE5C1EJwXHg1tAowBiQAJjBayAAcAAz4hAweBqKEThNw9bYZ+ACOZfA+RBwg1OQAtFBwcL3H7bRwayTnPtR+AUjBVdkeuiQq6s8FRaXlGQ9Z+BgzR6-UGSCwgNEJC4BQAwhBdP4nAsAKztNQeAAqzQ4j2qtg0AEkoCdYNIwJ1iABBEnSGB8IqVaqiJSWIFeZBjEAsxRwACiJOQWAAvsKgA).

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
