### PR TITLE
Fix ignore bug on windows

### DIFF
--- a/changelog_unreleased/cli/pr-8098.md
+++ b/changelog_unreleased/cli/pr-8098.md
@@ -1,0 +1,15 @@
+#### Fix filenames contains CJK or emoji not correctly ignored ([#8098](https://github.com/prettier/prettier/pull/8098) by [@fisker](https://github.com/fisker))
+
+```console
+// Prettier stable
+$ echo "dir" > .prettierignore
+$ prettier **/*.js -l
+dir/😁.js
+dir/中文.js
+not-ignored.js
+
+// Prettier master
+$ echo "dir" > .prettierignore
+$ prettier **/*.js -l
+not-ignored.js
+```

--- a/src/cli/expand-patterns.js
+++ b/src/cli/expand-patterns.js
@@ -212,4 +212,7 @@ function fixWindowsSlashes(pattern) {
   return isWindows ? pattern.replace(/\\/g, "/") : pattern;
 }
 
-module.exports = expandPatterns;
+module.exports = {
+  expandPatterns,
+  fixWindowsSlashes,
+};

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -430,8 +430,7 @@ function formatFiles(context) {
       ? path.relative(path.dirname(context.argv["ignore-path"]), filename)
       : filename;
 
-    const fileIgnored =
-      ignorer.filter([fixWindowsSlashes(ignoreFilename)]).length === 0;
+    const fileIgnored = ignorer.ignores(fixWindowsSlashes(ignoreFilename));
     if (
       fileIgnored &&
       (context.argv["debug-check"] ||

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -374,7 +374,10 @@ function formatStdin(context) {
   thirdParty
     .getStream(process.stdin)
     .then((input) => {
-      if (relativeFilepath && ignorer.filter([relativeFilepath]).length === 0) {
+      if (
+        relativeFilepath &&
+        ignorer.ignores(fixWindowsSlashes(relativeFilepath))
+      ) {
         writeOutput(context, { formatted: input });
         return;
       }

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -16,7 +16,7 @@ const flat = require("lodash/flatten");
 const minimist = require("./minimist");
 const prettier = require("../../index");
 const createIgnorer = require("../common/create-ignorer");
-const expandPatterns = require("./expand-patterns");
+const { expandPatterns, fixWindowsSlashes } = require("./expand-patterns");
 const errors = require("../common/errors");
 const constant = require("./constant");
 const coreOptions = require("../main/core-options");
@@ -429,7 +429,9 @@ function formatFiles(context) {
     const ignoreFilename = context.argv["ignore-path"]
       ? path.relative(path.dirname(context.argv["ignore-path"]), filename)
       : filename;
-    const fileIgnored = ignorer.filter([ignoreFilename]).length === 0;
+
+    const fileIgnored =
+      ignorer.filter([fixWindowsSlashes(ignoreFilename)]).length === 0;
     if (
       fileIgnored &&
       (context.argv["debug-check"] ||

--- a/tests_integration/__tests__/__snapshots__/ignore-emoji.js.snap
+++ b/tests_integration/__tests__/__snapshots__/ignore-emoji.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ignores file name contains emoji (stderr) 1`] = `""`;
+
+exports[`ignores file name contains emoji (stdout) 1`] = `
+"not-ignored.js
+"
+`;
+
+exports[`ignores file name contains emoji (write) 1`] = `Array []`;

--- a/tests_integration/__tests__/__snapshots__/ignore-emoji.js.snap
+++ b/tests_integration/__tests__/__snapshots__/ignore-emoji.js.snap
@@ -8,3 +8,9 @@ exports[`ignores file name contains emoji (stdout) 1`] = `
 `;
 
 exports[`ignores file name contains emoji (write) 1`] = `Array []`;
+
+exports[`stdin (stderr) 1`] = `""`;
+
+exports[`stdin (stdout) 1`] = `".name {                         display: none; }"`;
+
+exports[`stdin (write) 1`] = `Array []`;

--- a/tests_integration/__tests__/ignore-emoji.js
+++ b/tests_integration/__tests__/ignore-emoji.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const runPrettier = require("../runPrettier");
+
+expect.addSnapshotSerializer(require("../path-serializer"));
+
+describe("ignores file name contains emoji", () => {
+  runPrettier("cli/ignore-emoji", ["**/*.js", "-l"]).test({
+    status: 1,
+  });
+});

--- a/tests_integration/__tests__/ignore-emoji.js
+++ b/tests_integration/__tests__/ignore-emoji.js
@@ -9,3 +9,13 @@ describe("ignores file name contains emoji", () => {
     status: 1,
   });
 });
+
+describe("stdin", () => {
+  runPrettier(
+    "cli/ignore-emoji",
+    ["--stdin-filepath", "ignored/我的样式.css"],
+    { input: ".name {                         display: none; }" }
+  ).test({
+    status: 0,
+  });
+});

--- a/tests_integration/cli/ignore-emoji/.prettierignore
+++ b/tests_integration/cli/ignore-emoji/.prettierignore
@@ -1,0 +1,1 @@
+ignored

--- a/tests_integration/cli/ignore-emoji/ignored/1.js
+++ b/tests_integration/cli/ignore-emoji/ignored/1.js
@@ -1,0 +1,3 @@
+const foo
+=         'bar'
+;

--- a/tests_integration/cli/ignore-emoji/ignored/中文.js
+++ b/tests_integration/cli/ignore-emoji/ignored/中文.js
@@ -1,0 +1,3 @@
+const foo
+=         'bar'
+;

--- a/tests_integration/cli/ignore-emoji/ignored/😁.js
+++ b/tests_integration/cli/ignore-emoji/ignored/😁.js
@@ -1,0 +1,3 @@
+const foo
+=         'bar'
+;

--- a/tests_integration/cli/ignore-emoji/not-ignored.js
+++ b/tests_integration/cli/ignore-emoji/not-ignored.js
@@ -1,0 +1,3 @@
+const foo
+=         'bar'
+;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fixes #7899

Not only filename contains emoji, but also CJK characters are not ignored.

We are passing `a\中文.js` to ignore, and here 
https://github.com/kaelzhang/node-ignore/blob/56976cef6d5ec0e5651910801669f9aa3daa8120/index.js#L452-L453
 passed, so `\` won't replace to `a/中文.js`, this file will not ignored.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
