### PR TITLE
fix :: in call expr comment causing crash

### DIFF
--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -38,8 +38,16 @@ function hasFlowShorthandAnnotationComment(node) {
   );
 }
 
+function isEmptyFlowAnnotationComment(comment) {
+  return comment.trim() === "::";
+}
+
 function hasFlowAnnotationComment(comments) {
-  return comments && comments[0].value.match(FLOW_ANNOTATION);
+  return (
+    comments &&
+    !isEmptyFlowAnnotationComment(comments[0].value) &&
+    FLOW_ANNOTATION.test(comments[0].value)
+  );
 }
 
 function hasNode(node, fn) {

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -646,6 +646,7 @@ render?.( // Warm any cache
   container
 );
 
+x(/* :: */[])
 =====================================output=====================================
 render(
   // Warm any cache
@@ -664,6 +665,8 @@ render?.(
   <ChildUpdates renderAnchor={true} anchorClassOn={true} />,
   container
 )
+
+x([])
 
 ================================================================================
 `;
@@ -689,6 +692,7 @@ render?.( // Warm any cache
   container
 );
 
+x(/* :: */[])
 =====================================output=====================================
 render(
   // Warm any cache
@@ -707,6 +711,8 @@ render?.(
   <ChildUpdates renderAnchor={true} anchorClassOn={true} />,
   container
 );
+
+x([]);
 
 ================================================================================
 `;

--- a/tests/comments/call_comment.js
+++ b/tests/comments/call_comment.js
@@ -12,3 +12,5 @@ render?.( // Warm any cache
   <ChildUpdates renderAnchor={true} anchorClassOn={true} />,
   container
 );
+
+x(/* :: */[])


### PR DESCRIPTION
Fixes #7748 

Prettier crashed when `::` appeared in a call expression. This PR is supposed to fix that. The error is due to Prettier (wrongly) assuming that the comment is a Flow annotation. I have added a check against empty flow annotations which fixes it.

However, I can't seem to get the tests to pass. I have manually tested with both the CLI & the API (with all parsers) and it works. **The playground works too** _but_ when I run the test suite with `x(/* :: */[]);` input, prettier automatically erases the comment. Don't know why. This happens even without my changes. @thorn0 would appreciate any help :smile:  

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**