### PR TITLE
better handling of comments before else

### DIFF
--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -256,17 +256,12 @@ function handleIfStatementComments(
   }
 
   // Comments before `else`:
-  // - treat as trailing comments of the consequent, if it's a BlockStatement
-  // - treat as a dangling comment otherwise
+  // always treat as a dangling comment
   if (
     precedingNode === enclosingNode.consequent &&
     followingNode === enclosingNode.alternate
   ) {
-    if (precedingNode.type === "BlockStatement") {
-      addTrailingComment(precedingNode, comment);
-    } else {
-      addDanglingComment(enclosingNode, comment);
-    }
+    addDanglingComment(enclosingNode, comment);
     return true;
   }
 

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1510,6 +1510,23 @@ else if (15) // comment
 /* comment */ // comment
 true
 
+if (cond) 
+  console.log("db");
+/* comment */ 
+else {
+}
+
+if (cond) {}
+/* comment */ 
+else {
+}
+
+if (cond) {
+  console.log("db");
+}
+/* comment */ 
+else {
+}
 =====================================output=====================================
 if (1) {
   // comment
@@ -1585,6 +1602,19 @@ if (14) {
   /* comment */ // comment
   true
 
+if (cond) console.log("db")
+/* comment */ else {
+}
+
+if (cond) {
+} /* comment */ else {
+}
+
+if (cond) {
+  console.log("db")
+} /* comment */ else {
+}
+
 ================================================================================
 `;
 
@@ -1656,6 +1686,23 @@ else if (15) // comment
 /* comment */ // comment
 true
 
+if (cond) 
+  console.log("db");
+/* comment */ 
+else {
+}
+
+if (cond) {}
+/* comment */ 
+else {
+}
+
+if (cond) {
+  console.log("db");
+}
+/* comment */ 
+else {
+}
 =====================================output=====================================
 if (1) {
   // comment
@@ -1730,6 +1777,19 @@ if (14) {
   /* comment */
   /* comment */ // comment
   true;
+
+if (cond) console.log("db");
+/* comment */ else {
+}
+
+if (cond) {
+} /* comment */ else {
+}
+
+if (cond) {
+  console.log("db");
+} /* comment */ else {
+}
 
 ================================================================================
 `;

--- a/tests/comments/if.js
+++ b/tests/comments/if.js
@@ -59,3 +59,21 @@ else if (15) // comment
 /* comment */
 /* comment */ // comment
 true
+
+if (cond) 
+  console.log("db");
+/* comment */ 
+else {
+}
+
+if (cond) {}
+/* comment */ 
+else {
+}
+
+if (cond) {
+  console.log("db");
+}
+/* comment */ 
+else {
+}


### PR DESCRIPTION
Fixes #7487 

This PR addresses the issue where the block comment was moved inside the else statement.

**Input:**
```js
if (cond) {}
/* comment */
else {
  return;
}
````

**Before:**
```js
if (cond) {
} else {
  /* comment */
  return;
}
```

**Now:**
```js
if (cond) {
} /* comment*/ else {
  return;
}
```

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
