### PR TITLE
fix comment duplicating when the comment starts with : in JSX

### DIFF
--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -29,11 +29,14 @@ const FLOW_ANNOTATION = new RegExp(`^${NON_LINE_TERMINATING_WHITE_SPACE}*::`);
 function hasFlowShorthandAnnotationComment(node) {
   // https://flow.org/en/docs/types/comments/
   // Syntax example: const r = new (window.Request /*: Class<Request> */)("");
-
   return (
     node.extra &&
     node.extra.parenthesized &&
     node.trailingComments &&
+    // To avoid reprinting the same comment
+    !node.trailingComments[0].printed &&
+    // Flow annotations are always block comments
+    node.trailingComments[0].type === "CommentBlock" &&
     node.trailingComments[0].value.match(FLOW_SHORTHAND_ANNOTATION)
   );
 }

--- a/tests/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1241,6 +1241,10 @@ function foo4() {
   return 42;
 }
 
+btnActions[1] = () => (
+  <button> test </button>
+  // :testC
+)
 =====================================output=====================================
 function a(/* comment */) {} // comment
 function b() {} // comment
@@ -1303,6 +1307,11 @@ function foo4() {
   // this is a function
   return 42
 }
+
+btnActions[1] = () => (
+  <button> test </button>
+  // :testC
+)
 
 ================================================================================
 `;
@@ -1375,6 +1384,10 @@ function foo4() {
   return 42;
 }
 
+btnActions[1] = () => (
+  <button> test </button>
+  // :testC
+)
 =====================================output=====================================
 function a(/* comment */) {} // comment
 function b() {} // comment
@@ -1437,6 +1450,11 @@ function foo4() {
   // this is a function
   return 42;
 }
+
+btnActions[1] = () => (
+  <button> test </button>
+  // :testC
+);
 
 ================================================================================
 `;

--- a/tests/comments/function-declaration.js
+++ b/tests/comments/function-declaration.js
@@ -59,3 +59,8 @@ function foo4() {
   // this is a function
   return 42;
 }
+
+btnActions[1] = () => (
+  <button> test </button>
+  // :testC
+)


### PR DESCRIPTION
Fixes #6995

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
