### PR TITLE
Build: Fix cache logic

### DIFF
--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -33,11 +33,9 @@ jobs:
         uses: actions/cache@v1
         with:
           path: .cache
-          key: v1-build-cache-${{ hashFiles('yarn.lock') }}-${{ github.ref }}-
+          key: -2020-04-23-
           restore-keys: |
-            v1-build-cache-${{ hashFiles('yarn.lock') }}-${{ github.ref }}-
-            v1-build-cache-${{ hashFiles('yarn.lock') }}-refs/heads/${{ github.base_ref }}-
-            v1-build-cache-${{ hashFiles('yarn.lock') }}-refs/heads/master-
+            -2020-04-23-
 
       - name: Build Package
         run: yarn build

--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -33,9 +33,11 @@ jobs:
         uses: actions/cache@v1
         with:
           path: .cache
-          key: -2020-04-23-
+          key: v1-build-cache-${{ hashFiles('yarn.lock') }}-${{ github.ref }}-
           restore-keys: |
-            -2020-04-23-
+            v1-build-cache-${{ hashFiles('yarn.lock') }}-${{ github.ref }}-
+            v1-build-cache-${{ hashFiles('yarn.lock') }}-refs/heads/${{ github.base_ref }}-
+            v1-build-cache-${{ hashFiles('yarn.lock') }}-refs/heads/master-
 
       - name: Build Package
         run: yarn build

--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -39,9 +39,6 @@ jobs:
             v1-build-cache-${{ hashFiles('yarn.lock') }}-refs/heads/${{ github.base_ref }}-
             v1-build-cache-${{ hashFiles('yarn.lock') }}-refs/heads/master-
 
-      # Unknown reason `scripts/build/build.js` created dir can't work
-      - run: mkdir -p .cache/files
-
       - name: Build Package
         run: yarn build
 

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -106,8 +106,8 @@ async function run(params) {
     await createBundle(bundleConfig, bundleCache);
   }
 
-  await bundleCache.save();
   await cacheFiles();
+  await bundleCache.save();
 
   await preparePackage();
 }


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Finally found the reason, 

We write `.cache/manifest.json` first, then copy files to `.cache/files/`

If `.cache` is missing, we try to write `.cache/manifest.json`, it will fail and continue, then we copy js files to `.cache/files/`, this will success, so we missed the `manifest.json` in cache.

With new logic, we copy js files to `.cache/files/` first, in this step, the `.cache` dir will be created, then write `.cache/manifest.json` won't fail.

Test steps:

- [x] 1. Test build with missing cache key, [commit](https://github.com/prettier/prettier/pull/8128/commits/2f08361cd67307c9dc43b78ebec29ee4d0fa64d4) ,  expect 1) [missing cache](https://github.com/prettier/prettier/runs/610879495?check_suite_focus=true#step:5:7) 2) [upload new cache](https://github.com/prettier/prettier/runs/610879495?check_suite_focus=true#step:13:3);
- [x] 2. Test build with the cache created in step 1, [commit](https://github.com/prettier/prettier/pull/8128/commits/348ed95e9e77c717458823f5117235c58ca08c1d), expect 1) [hit cache](https://github.com/prettier/prettier/runs/610892850?check_suite_focus=true#step:5:9) 2) [skip build](https://github.com/prettier/prettier/runs/610892850?check_suite_focus=true#step:6:7);
- [x] 3. restore cache key settings

Test result: 

As expected.

---- 
<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
