### PR TITLE
Build: remove `doc.js`

### DIFF
--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -142,13 +142,6 @@ const coreBundles = [
     },
   },
   {
-    input: "src/document/index.js",
-    name: "doc",
-    type: "core",
-    output: "doc.js",
-    target: "universal",
-  },
-  {
     input: "standalone.js",
     name: "prettier",
     type: "core",


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Why are we building this file? It's not used anywhere.

Should use `const {doc} = require("prettier")` instead of `const doc = require("prettier/doc")`

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
