### PR TITLE
Update CI  cache  key

### DIFF
--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -33,11 +33,11 @@ jobs:
         uses: actions/cache@v1
         with:
           path: .cache
-          key: v1-build-cache-${{ hashFiles('yarn.lock') }}-${{ github.ref }}-
+          key: v1-build-cache-${{ hashFiles('yarn.lock') }}-${{ hashFiles('scripts/build/**/*') }}-${{ github.ref }}-
           restore-keys: |
-            v1-build-cache-${{ hashFiles('yarn.lock') }}-${{ github.ref }}-
-            v1-build-cache-${{ hashFiles('yarn.lock') }}-refs/heads/${{ github.base_ref }}-
-            v1-build-cache-${{ hashFiles('yarn.lock') }}-refs/heads/master-
+            v1-build-cache-${{ hashFiles('yarn.lock') }}-${{ hashFiles('scripts/build/**/*') }}-${{ github.ref }}-
+            v1-build-cache-${{ hashFiles('yarn.lock') }}-${{ hashFiles('scripts/build/**/*') }}-refs/heads/${{ github.base_ref }}-
+            v1-build-cache-${{ hashFiles('yarn.lock') }}-${{ hashFiles('scripts/build/**/*') }}-refs/heads/master-
 
       - name: Build Package
         run: yarn build

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -21,7 +21,7 @@ process.on("unhandledRejection", (err) => {
   process.exit(1);
 });
 
-const CACHE_VERSION = "v22"; // This need update when updating build scripts
+const CACHE_VERSION = "v23"; // This need update when updating build scripts
 const CACHED = chalk.bgYellow.black(" CACHED ");
 const OK = chalk.bgGreen.black("  DONE  ");
 const FAIL = chalk.bgRed.black("  FAIL  ");


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

I  updated  [cache version](https://github.com/prettier/prettier/blob/736db9b0db4d5698f8ad8260a35f115aac2045ae/scripts/build/build.js#L24) in https://github.com/prettier/prettier/pull/8119 , like  I  said https://github.com/prettier/prettier/pull/8027#discussion_r407215287 , we  are  not able to  update cache  unless `yarn.lock` changes, now  `scripts/build/` changes updates the cache too.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
