### PR TITLE
Fix extra space after minus in CSS-in-JS

### DIFF
--- a/changelog_unreleased/javascript/pr-8255.md
+++ b/changelog_unreleased/javascript/pr-8255.md
@@ -1,0 +1,19 @@
+#### Fix extra space after minus in CSS-in-JS ([#8255](https://github.com/prettier/prettier/pull/8255) by [@thorn0](https://github.com/thorn0))
+
+<!-- prettier-ignore -->
+```js
+// Input
+css`
+color: var(--global--color--${props.color});
+`
+
+// Prettier stable
+css`
+  color: var(--global--color-- ${props.color});
+`;
+
+// Prettier master
+css`
+  color: var(--global--color--${props.color});
+`;
+```

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -542,9 +542,10 @@ function genericPrint(path, options, print) {
 
         // styled.div` background: var(--${one}); `
         if (
-          !iPrevNode &&
-          iNode.value === "--" &&
-          iNextNode.type === "value-atword"
+          iNode.type === "value-word" &&
+          iNode.value.endsWith("-") &&
+          iNextNode.type === "value-atword" &&
+          iNextNode.value.startsWith("prettier-placeholder-")
         ) {
           continue;
         }

--- a/tests/js/multiparser-css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/multiparser-css/__snapshots__/jsfmt.spec.js.snap
@@ -884,6 +884,22 @@ const StyledPurchaseCard = styled(Card)\`
   color: #fff;
 \`;
 
+const v1 =  css\`
+prop: var(--global--color--\${props.variant});
+\`;
+
+const v2 = css\`
+        background-color: var(--global--color--\${props.variant});
+
+        &:hover {
+          background-color: var(--global--color--\${props.variant}__one);
+        }
+      \`
+
+export const StyledComponent = styled.div\`
+  grid-area:  area-\${props => props.propName};
+\`
+
 =====================================output=====================================
 const Something = styled.div\`
   background: var(--\${one}); /* ... */
@@ -894,6 +910,22 @@ const StyledPurchaseCard = styled(Card)\`
   min-width: 200px;
   background-color: var(--\${(props) => props.color});
   color: #fff;
+\`;
+
+const v1 = css\`
+  prop: var(--global--color--\${props.variant});
+\`;
+
+const v2 = css\`
+  background-color: var(--global--color--\${props.variant});
+
+  &:hover {
+    background-color: var(--global--color--\${props.variant}__one);
+  }
+\`;
+
+export const StyledComponent = styled.div\`
+  grid-area: area-\${(props) => props.propName};
 \`;
 
 ================================================================================

--- a/tests/js/multiparser-css/var.js
+++ b/tests/js/multiparser-css/var.js
@@ -8,3 +8,19 @@ const StyledPurchaseCard = styled(Card)`
   background-color: var(--${props => props.color});
   color: #fff;
 `;
+
+const v1 =  css`
+prop: var(--global--color--${props.variant});
+`;
+
+const v2 = css`
+        background-color: var(--global--color--${props.variant});
+
+        &:hover {
+          background-color: var(--global--color--${props.variant}__one);
+        }
+      `
+
+export const StyledComponent = styled.div`
+  grid-area:  area-${props => props.propName};
+`


### PR DESCRIPTION
fixes #5465 
fixes #8250

I feel like this fix might break some other cases where whitespace is actually needed. Please help me find them.

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
