### PR TITLE
refactor(css): calculate correct location data for value-* nodes

### DIFF
--- a/src/language-css/clean.js
+++ b/src/language-css/clean.js
@@ -40,6 +40,10 @@ function clean(ast, newObj, parent) {
     }
   }
 
+  if (ast.type === "value-root") {
+    delete newObj.text;
+  }
+
   if (
     ast.type === "media-query" ||
     ast.type === "media-query-list" ||

--- a/src/language-css/loc.js
+++ b/src/language-css/loc.js
@@ -5,6 +5,9 @@ const { getLast, skipEverythingButNewLine } = require("../common/util");
 
 function calculateLocStart(node, text) {
   if (node.source) {
+    if (typeof node.source.sourceIndex === "number") {
+      return node.source.sourceIndex; // value-* nodes have this
+    }
     return lineColumnToIndex(node.source.start, text) - 1;
   }
   return null;
@@ -25,26 +28,68 @@ function calculateLocEnd(node, text) {
 }
 
 function calculateLoc(node, text) {
-  if (node && typeof node === "object") {
-    if (node.source) {
-      node.source.startOffset = calculateLocStart(node, text);
-      node.source.endOffset = calculateLocEnd(node, text);
+  if (node.source) {
+    node.source.startOffset = calculateLocStart(node, text);
+    node.source.endOffset = calculateLocEnd(node, text);
+  }
+
+  for (const key in node) {
+    const child = node[key];
+
+    if (key === "source" || !child || typeof child !== "object") {
+      continue;
     }
 
-    for (const key in node) {
-      calculateLoc(node[key], text);
+    if (child.type === "value-root" || child.type === "value-unknown") {
+      calculateValueNodeLoc(
+        child,
+        getValueRootOffset(node),
+        child.text || child.value
+      );
+    } else {
+      calculateLoc(child, text);
     }
   }
 }
 
+function calculateValueNodeLoc(node, rootOffset, text) {
+  if (node.source) {
+    node.source.startOffset = calculateLocStart(node, text) + rootOffset;
+    node.source.endOffset = calculateLocEnd(node, text) + rootOffset;
+  }
+
+  for (const key in node) {
+    const child = node[key];
+
+    if (key === "source" || !child || typeof child !== "object") {
+      continue;
+    }
+
+    calculateValueNodeLoc(child, rootOffset, text);
+  }
+}
+
+function getValueRootOffset(node) {
+  return (
+    node.source.startOffset +
+    (typeof node.prop === "string" ? node.prop.length : 0) +
+    (node.type === "css-atrule" && typeof node.name === "string"
+      ? 1 + node.name.length + getLeadingWhitespaceLength(node.raws.afterName)
+      : 0) +
+    (node.type !== "css-atrule" &&
+    node.raws &&
+    typeof node.raws.between === "string"
+      ? node.raws.between.length
+      : 0)
+  );
+}
+
 /**
  * Workaround for a bug: quotes in inline comments corrupt loc data of subsequent nodes.
- * This function replaces the quotes with U+FFFE and U+FFFF. Later, when the comments are printed,
- * their content is extracted from the original text or restored by replacing the placeholder
- * characters back with quotes.
+ * This function replaces the quotes with spaces. Later, when the comments are printed,
+ * their content is extracted from the original text.
  * - https://github.com/prettier/prettier/issues/7780
  * - https://github.com/shellscape/postcss-less/issues/145
- * - About noncharacters (U+FFFE and U+FFFF): http://www.unicode.org/faq/private_use.html#nonchar1
  * @param text {string}
  */
 function replaceQuotesInInlineComments(text) {
@@ -157,19 +202,19 @@ function replaceQuotesInInlineComments(text) {
   for (const [start, end] of inlineCommentsToReplace) {
     text =
       text.slice(0, start) +
-      text.slice(start, end).replace(/'/g, "\ufffe").replace(/"/g, "\uffff") +
+      text.slice(start, end).replace(/["']/g, " ") +
       text.slice(end);
   }
 
   return text;
 }
 
-function restoreQuotesInInlineComments(text) {
-  return text.replace(/\ufffe/g, "'").replace(/\uffff/g, '"');
+function getLeadingWhitespaceLength(string) {
+  const m = string.match(/^\s*/);
+  return m ? m[0].length : 0;
 }
 
 module.exports = {
   calculateLoc,
   replaceQuotesInInlineComments,
-  restoreQuotesInInlineComments,
 };

--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -189,6 +189,8 @@ function parseValue(value) {
     };
   }
 
+  result.text = value;
+
   const parsedResult = parseNestedValue(result);
 
   return addTypePrefix(parsedResult, "value-");

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -10,7 +10,6 @@ const {
   hasNewline,
 } = require("../common/util");
 const { isNextLineEmpty } = require("../common/util-shared");
-const { restoreQuotesInInlineComments } = require("./loc");
 
 const {
   builders: {
@@ -500,13 +499,10 @@ function genericPrint(path, options, print) {
       return path.call(print, "group");
     }
     case "value-comment": {
-      return concat([
-        node.inline ? "//" : "/*",
-        // see replaceQuotesInInlineComments in loc.js
-        // value-* nodes don't have correct location data, so we have to rely on placeholder characters.
-        restoreQuotesInInlineComments(node.value),
-        node.inline ? "" : "*/",
-      ]);
+      return options.originalText.slice(
+        options.locStart(node),
+        options.locEnd(node)
+      );
     }
     case "value-comma_group": {
       const parentNode = path.getParentNode();


### PR DESCRIPTION
Once all the nodes have the correct location data (`selector-*` and `media-*` are TBD), it'll be possible to use Prettier's comment attachment logic for CSS like discussed in #3905. Here's the plan:

- Have correct location data in the AST.
- Preparse the input with a simple parser (similar to what we already have in `language-css/loc.js`, see `replaceQuotesInInlineComments` there) and collect comments.
- Remove the comments from the input, so that the `postcss-*` parsers don't have to deal with them.
- Use the comment attachment logic like it's done for JS.

A big problem here is that it's not always possible to remove a comment safely (e.g. [`div/**/span`](https://mobile.twitter.com/thorn0/status/1257251001448398854)), so some of them will have to stay and be handled the way they're handled now. But at least all SCSS and LESS single line comments are safe to remove.

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
