### PR TITLE
Add arm-template to vscodeLanguageIds of JSON and JSONC

### DIFF
--- a/src/language-js/index.js
+++ b/src/language-js/index.js
@@ -47,7 +47,7 @@ const languages = [
   createLanguage(require("linguist-languages/data/JSON"), (data) => ({
     since: "1.5.0",
     parsers: ["json"],
-    vscodeLanguageIds: ["json"],
+    vscodeLanguageIds: ["json", "arm-template"],
     filenames: data.filenames.concat([".prettierrc"]),
   })),
   createLanguage(
@@ -55,7 +55,7 @@ const languages = [
     (data) => ({
       since: "1.5.0",
       parsers: ["json"],
-      vscodeLanguageIds: ["jsonc"],
+      vscodeLanguageIds: ["jsonc", "arm-template"],
       filenames: data.filenames.concat([".eslintrc"]),
     })
   ),


### PR DESCRIPTION
Related: https://github.com/microsoft/vscode-azurearmtools/issues/465
Second attempt after https://github.com/prettier/prettier-vscode/pull/1335

cc @ntotten 

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
