### PR TITLE
Treat <select> and <optgroup> as inline-block for whitespace sensitivity

### DIFF
--- a/changelog_unreleased/html/pr-8275.md
+++ b/changelog_unreleased/html/pr-8275.md
@@ -1,0 +1,28 @@
+#### Treat `<select>` and `<optgroup>` as inline-block ([#8275](https://github.com/prettier/prettier/pull/8275) by [@thorn0](https://github.com/thorn0))
+
+Now Prettier knows that it's safe to add whitespace inside `select` and `optgroup` tags.
+
+<!-- prettier-ignore -->
+```html
+<!-- Input -->
+<select><option>Blue</option><option>Green</option><optgroup label="Darker"><option>Dark Blue</option><option>Dark Green</option></optgroup></select>
+
+<!-- Prettier stable -->
+<select
+  ><option>Blue</option
+  ><option>Green</option
+  ><optgroup label="Darker"
+    ><option>Dark Blue</option><option>Dark Green</option></optgroup
+  ></select
+>
+
+<!-- Prettier master -->
+<select>
+  <option>Blue</option>
+  <option>Green</option>
+  <optgroup label="Darker">
+    <option>Dark Blue</option>
+    <option>Dark Green</option>
+  </optgroup>
+</select>
+```

--- a/src/language-html/constants.evaluate.js
+++ b/src/language-html/constants.evaluate.js
@@ -35,6 +35,8 @@ const CSS_DISPLAY_TAGS = {
   // there's no css display for these elements but they behave these ways
   video: "inline-block",
   audio: "inline-block",
+  select: "inline-block",
+  optgroup: "inline-block",
 };
 const CSS_DISPLAY_DEFAULT = "inline";
 const CSS_WHITE_SPACE_TAGS = getCssStyleTags("white-space");

--- a/tests/html/tags/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html/tags/__snapshots__/jsfmt.spec.js.snap
@@ -719,6 +719,156 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`option.html - {"htmlWhitespaceSensitivity":"ignore"} format 1`] = `
+====================================options=====================================
+htmlWhitespaceSensitivity: "ignore"
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<select><option>Blue</option><option>Green</option><optgroup label="Darker"><option>Dark Blue</option><option>Dark Green</option></optgroup></select>
+<input list=colors>
+<datalist id=colors><option>Blue</option><option>Green</option></datalist>
+
+=====================================output=====================================
+<select>
+  <option>Blue</option>
+  <option>Green</option>
+  <optgroup label="Darker">
+    <option>Dark Blue</option>
+    <option>Dark Green</option>
+  </optgroup>
+</select>
+<input list="colors" />
+<datalist id="colors">
+  <option>Blue</option>
+  <option>Green</option>
+</datalist>
+
+================================================================================
+`;
+
+exports[`option.html - {"htmlWhitespaceSensitivity":"strict"} format 1`] = `
+====================================options=====================================
+htmlWhitespaceSensitivity: "strict"
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<select><option>Blue</option><option>Green</option><optgroup label="Darker"><option>Dark Blue</option><option>Dark Green</option></optgroup></select>
+<input list=colors>
+<datalist id=colors><option>Blue</option><option>Green</option></datalist>
+
+=====================================output=====================================
+<select
+  ><option>Blue</option
+  ><option>Green</option
+  ><optgroup label="Darker"
+    ><option>Dark Blue</option><option>Dark Green</option></optgroup
+  ></select
+>
+<input list="colors" />
+<datalist id="colors"><option>Blue</option><option>Green</option></datalist>
+
+================================================================================
+`;
+
+exports[`option.html - {"printWidth":"Infinity"} format 1`] = `
+====================================options=====================================
+parsers: ["html"]
+printWidth: Infinity
+=====================================input======================================
+<select><option>Blue</option><option>Green</option><optgroup label="Darker"><option>Dark Blue</option><option>Dark Green</option></optgroup></select>
+<input list=colors>
+<datalist id=colors><option>Blue</option><option>Green</option></datalist>
+
+=====================================output=====================================
+<select>
+  <option>Blue</option
+  ><option>Green</option
+  ><optgroup label="Darker"><option>Dark Blue</option><option>Dark Green</option></optgroup>
+</select>
+<input list="colors" />
+<datalist id="colors">
+  <option>Blue</option>
+  <option>Green</option>
+</datalist>
+
+================================================================================
+`;
+
+exports[`option.html - {"printWidth":1} format 1`] = `
+====================================options=====================================
+parsers: ["html"]
+printWidth: 1
+ | printWidth
+=====================================input======================================
+<select><option>Blue</option><option>Green</option><optgroup label="Darker"><option>Dark Blue</option><option>Dark Green</option></optgroup></select>
+<input list=colors>
+<datalist id=colors><option>Blue</option><option>Green</option></datalist>
+
+=====================================output=====================================
+<select>
+  <option
+    >Blue</option
+  ><option
+    >Green</option
+  ><optgroup
+    label="Darker"
+  >
+    <option
+      >Dark
+      Blue</option
+    ><option
+      >Dark
+      Green</option
+    >
+  </optgroup>
+</select>
+<input
+  list="colors"
+/>
+<datalist
+  id="colors"
+>
+  <option
+    >Blue</option
+  >
+  <option
+    >Green</option
+  >
+</datalist>
+
+================================================================================
+`;
+
+exports[`option.html format 1`] = `
+====================================options=====================================
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<select><option>Blue</option><option>Green</option><optgroup label="Darker"><option>Dark Blue</option><option>Dark Green</option></optgroup></select>
+<input list=colors>
+<datalist id=colors><option>Blue</option><option>Green</option></datalist>
+
+=====================================output=====================================
+<select>
+  <option>Blue</option
+  ><option>Green</option
+  ><optgroup label="Darker">
+    <option>Dark Blue</option><option>Dark Green</option>
+  </optgroup>
+</select>
+<input list="colors" />
+<datalist id="colors">
+  <option>Blue</option>
+  <option>Green</option>
+</datalist>
+
+================================================================================
+`;
+
 exports[`pre.html - {"htmlWhitespaceSensitivity":"ignore"} format 1`] = `
 ====================================options=====================================
 htmlWhitespaceSensitivity: "ignore"

--- a/tests/html/tags/option.html
+++ b/tests/html/tags/option.html
@@ -1,0 +1,3 @@
+<select><option>Blue</option><option>Green</option><optgroup label="Darker"><option>Dark Blue</option><option>Dark Green</option></optgroup></select>
+<input list=colors>
+<datalist id=colors><option>Blue</option><option>Green</option></datalist>


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
