### PR TITLE
Remove duplicated `outdent` in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,6 @@
     "jest-snapshot-serializer-ansi": "1.0.0",
     "jest-snapshot-serializer-raw": "1.1.0",
     "jest-watch-typeahead": "0.6.0",
-    "outdent": "0.7.1",
     "prettier": "2.0.5",
     "rimraf": "3.0.2",
     "rollup": "2.9.1",


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

I remember I did move it from `devDependencies` to `dependencies`, somehow added back when rebasing.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
