### PR TITLE
Test: "Expected" and "Received" are mixed up in ast compare tests

### DIFF
--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -239,7 +239,7 @@ global.run_spec = (fixtures, parsers, options) => {
           const { cursorOffset, ...parseOptions } = mainOptions;
           const originalAst = parse(input, parseOptions);
           const formattedAst = parse(formatted, parseOptions);
-          expect(originalAst).toEqual(formattedAst);
+          expect(formattedAst).toEqual(originalAst);
         });
       }
     });


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Same as #7125

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
