### PR TITLE
Playground: add Prettier version to document title

### DIFF
--- a/website/playground/VersionLink.js
+++ b/website/playground/VersionLink.js
@@ -13,13 +13,20 @@ export default function ({ version }) {
   } else {
     href = `blob/master/CHANGELOG.md#${version.replace(/\./g, "")}`;
   }
+
+  const formattedVersion = match ? `PR #${match[1]}` : `v${version}`;
+
+  React.useEffect(() => {
+    document.title = `Prettier ${formattedVersion}`;
+  }, [formattedVersion]);
+
   return ReactDOM.createPortal(
     <a
       href={`https://github.com/prettier/prettier/${href}`}
       target="_blank"
       rel="noreferrer noopener"
     >
-      {match ? `PR #${match[1]}` : `v${version}`}
+      {formattedVersion}
     </a>,
     root
   );


### PR DESCRIPTION
This way it should be a bit easier not to get lost comparing the output of pull requests with the release.

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
