### PR TITLE
Fix: don't wrap arrays in `test.each` template strings

### DIFF
--- a/changelog_unreleased/javascript/pr-8354.md
+++ b/changelog_unreleased/javascript/pr-8354.md
@@ -1,0 +1,25 @@
+#### Don't wrap arrays in Jest `test.each` template strings ([#8354](https://github.com/prettier/prettier/pull/8354) by [@yogmel](https://github.com/yogmel))
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+test.each`
+a | b | c
+${1} | ${[{ start: 1, end: 3 },{ start: 15, end: 20 },]} | ${[]}
+`("example test", ({a, b, c}) => {})
+
+// Prettier stable
+test.each`
+  a | b | c
+  ${1} | ${[
+  { start: 1, end: 3 },
+  { start: 15, end: 20 }
+]} | ${[]}
+`("example test", ({ a, b, c }) => {});
+
+// Prettier master
+test.each`
+  a    | b                                                 | c
+  ${1} | ${[{ start: 1, end: 3 }, { start: 15, end: 20 }]} | ${[]}
+`("example test", ({ a, b, c }) => {});
+```

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1558,7 +1558,6 @@ function printPathNoParens(path, options, print, args) {
           n.elements.length > 1 &&
           n.elements.every((element, i, elements) => {
             const elementType = element && element.type;
-
             if (
               elementType !== "ArrayExpression" &&
               elementType !== "ObjectExpression"
@@ -1579,7 +1578,7 @@ function printPathNoParens(path, options, print, args) {
 
         if (n.type === "ArrayExpression") {
           let i = 0;
-          let node = path.getNode(i);
+          let node = n;
           while (node && shouldBreak) {
             const parent = path.getParentNode(i++);
             if (parent && isJestEachTemplateLiteral(node, parent)) {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2439,7 +2439,7 @@ function printPathNoParens(path, options, print, args) {
       const parentNode = path.getParentNode();
 
       if (isJestEachTemplateLiteral(n, parentNode)) {
-        const printed = printJestEachTemplateLiteral(options, path, print);
+        const printed = printJestEachTemplateLiteral(path, options, print);
         if (printed) {
           return printed;
         }
@@ -3875,7 +3875,7 @@ function printMethodInternal(path, options, print) {
   return concat(parts);
 }
 
-function printJestEachTemplateLiteral(options, path, print) {
+function printJestEachTemplateLiteral(path, options, print) {
   /**
    * a    | b    | expected
    * ${1} | ${1} | ${2}

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1555,7 +1555,7 @@ function printPathNoParens(path, options, print, args) {
           canHaveTrailingComma && lastElem === null;
 
         const shouldBreak =
-          !options.isJestEachTemplateLiteral &&
+          !options.__inJestEach &&
           n.elements.length > 1 &&
           n.elements.every((element, i, elements) => {
             const elementType = element && element.type;
@@ -3888,9 +3888,9 @@ function printJestEachTemplateLiteral(path, options, print) {
     headerNames.length > 1 ||
     headerNames.some((headerName) => headerName.length !== 0)
   ) {
-    options.isJestEachTemplateLiteral = true;
+    options.__inJestEach = true;
     const expressions = path.map(print, "expressions");
-    options.isJestEachTemplateLiteral = false;
+    options.__inJestEach = false;
     const parts = [];
     const stringifiedExpressions = expressions.map(
       (doc) =>

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1554,7 +1554,7 @@ function printPathNoParens(path, options, print, args) {
         const needsForcedTrailingComma =
           canHaveTrailingComma && lastElem === null;
 
-        const shouldBreak =
+        let shouldBreak =
           n.elements.length > 1 &&
           n.elements.every((element, i, elements) => {
             const elementType = element && element.type;
@@ -1575,6 +1575,19 @@ function printPathNoParens(path, options, print, args) {
 
             return element[itemsKey] && element[itemsKey].length > 1;
           });
+
+        for (let i = 0; i < path.stack.length; i++) {
+          if (path.getParentNode(i) !== null) {
+            if (
+              isJestEachTemplateLiteral(path.getNode(i), path.getParentNode(i))
+            ) {
+              shouldBreak = false;
+              break;
+            }
+          } else {
+            break;
+          }
+        }
 
         parts.push(
           group(

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1554,22 +1554,10 @@ function printPathNoParens(path, options, print, args) {
         const needsForcedTrailingComma =
           canHaveTrailingComma && lastElem === null;
 
-        const shouldBreak =
+        let shouldBreak =
           n.elements.length > 1 &&
           n.elements.every((element, i, elements) => {
             const elementType = element && element.type;
-
-            if (n.type === "ArrayExpression") {
-              let i = 0;
-              let node = path.getNode(i);
-              while (node) {
-                const parent = path.getParentNode(i++);
-                if (parent && isJestEachTemplateLiteral(node, parent)) {
-                  return false;
-                }
-                node = parent;
-              }
-            }
 
             if (
               elementType !== "ArrayExpression" &&
@@ -1588,6 +1576,18 @@ function printPathNoParens(path, options, print, args) {
 
             return element[itemsKey] && element[itemsKey].length > 1;
           });
+
+        if (n.type === "ArrayExpression") {
+          let i = 0;
+          let node = path.getNode(i);
+          while (node && shouldBreak) {
+            const parent = path.getParentNode(i++);
+            if (parent && isJestEachTemplateLiteral(node, parent)) {
+              shouldBreak = false;
+            }
+            node = parent;
+          }
+        }
 
         parts.push(
           group(

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1554,10 +1554,23 @@ function printPathNoParens(path, options, print, args) {
         const needsForcedTrailingComma =
           canHaveTrailingComma && lastElem === null;
 
-        let shouldBreak =
+        const shouldBreak =
           n.elements.length > 1 &&
           n.elements.every((element, i, elements) => {
             const elementType = element && element.type;
+
+            if (n.type === "ArrayExpression") {
+              let i = 0;
+              let node = path.getNode(i);
+              while (node) {
+                const parent = path.getParentNode(i++);
+                if (parent && isJestEachTemplateLiteral(node, parent)) {
+                  return false;
+                }
+                node = parent;
+              }
+            }
+
             if (
               elementType !== "ArrayExpression" &&
               elementType !== "ObjectExpression"
@@ -1575,19 +1588,6 @@ function printPathNoParens(path, options, print, args) {
 
             return element[itemsKey] && element[itemsKey].length > 1;
           });
-
-        for (let i = 0; i < path.stack.length; i++) {
-          if (path.getParentNode(i) !== null) {
-            if (
-              isJestEachTemplateLiteral(path.getNode(i), path.getParentNode(i))
-            ) {
-              shouldBreak = false;
-              break;
-            }
-          } else {
-            break;
-          }
-        }
 
         parts.push(
           group(

--- a/tests/js/test-declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/test-declarations/__snapshots__/jsfmt.spec.js.snap
@@ -485,6 +485,21 @@ test.each([
   }
 );
 
+test.each\`
+a | b         | c
+\${1}      | \${[{ start: 5, end: 15 }]} | \${[1,2,3,4,5,6,7,8]}
+\${1}| \${[{ start: 5, end: 15 }]} | \${["test", "string", "for", "prettier"]}
+\${3}      | \${[{ start: 5, end: 15 }]} | \${[]}
+\${4} | \${[{ start: 1, end: 3 },{ start: 15, end: 20 },]} | \${[]}
+\`("test", ({givenInteger, givenObjectArray, givenSimpleArray}) => {})
+
+
+test.each\`
+a | 
+\${[{ a: 1, b: 3 },{ c: 15, d: 20 }]}| 
+\${[{ start: 1, end: 3 },{ start: 15, end: 20 }, { start: 15, end: 20 },]}| 
+\`("test", ({givenInteger, givenObjectArray, givenSimpleArray}) => {})
+
 =====================================output=====================================
 describe.each\`
   a            | b        | expected
@@ -556,6 +571,20 @@ test.each([
 ])("test", ({ a, b }) => {
   expect(Number(a)).toBe(b);
 });
+
+test.each\`
+  a    | b                                                 | c
+  \${1} | \${[{ start: 5, end: 15 }]}                        | \${[1, 2, 3, 4, 5, 6, 7, 8]}
+  \${1} | \${[{ start: 5, end: 15 }]}                        | \${["test", "string", "for", "prettier"]}
+  \${3} | \${[{ start: 5, end: 15 }]}                        | \${[]}
+  \${4} | \${[{ start: 1, end: 3 }, { start: 15, end: 20 }]} | \${[]}
+\`("test", ({ givenInteger, givenObjectArray, givenSimpleArray }) => {});
+
+test.each\`
+  a                                                                         |
+  \${[{ a: 1, b: 3 }, { c: 15, d: 20 }]}
+  \${[{ start: 1, end: 3 }, { start: 15, end: 20 }, { start: 15, end: 20 }]}
+\`("test", ({ givenInteger, givenObjectArray, givenSimpleArray }) => {});
 
 ================================================================================
 `;
@@ -629,6 +658,21 @@ test.each([
   }
 );
 
+test.each\`
+a | b         | c
+\${1}      | \${[{ start: 5, end: 15 }]} | \${[1,2,3,4,5,6,7,8]}
+\${1}| \${[{ start: 5, end: 15 }]} | \${["test", "string", "for", "prettier"]}
+\${3}      | \${[{ start: 5, end: 15 }]} | \${[]}
+\${4} | \${[{ start: 1, end: 3 },{ start: 15, end: 20 },]} | \${[]}
+\`("test", ({givenInteger, givenObjectArray, givenSimpleArray}) => {})
+
+
+test.each\`
+a | 
+\${[{ a: 1, b: 3 },{ c: 15, d: 20 }]}| 
+\${[{ start: 1, end: 3 },{ start: 15, end: 20 }, { start: 15, end: 20 },]}| 
+\`("test", ({givenInteger, givenObjectArray, givenSimpleArray}) => {})
+
 =====================================output=====================================
 describe.each\`
   a            | b        | expected
@@ -700,6 +744,20 @@ test.each([
 ])("test", ({ a, b }) => {
   expect(Number(a)).toBe(b);
 });
+
+test.each\`
+  a    | b                                                 | c
+  \${1} | \${[{ start: 5, end: 15 }]}                        | \${[1, 2, 3, 4, 5, 6, 7, 8]}
+  \${1} | \${[{ start: 5, end: 15 }]}                        | \${["test", "string", "for", "prettier"]}
+  \${3} | \${[{ start: 5, end: 15 }]}                        | \${[]}
+  \${4} | \${[{ start: 1, end: 3 }, { start: 15, end: 20 }]} | \${[]}
+\`("test", ({ givenInteger, givenObjectArray, givenSimpleArray }) => {});
+
+test.each\`
+  a                                                                         |
+  \${[{ a: 1, b: 3 }, { c: 15, d: 20 }]}
+  \${[{ start: 1, end: 3 }, { start: 15, end: 20 }, { start: 15, end: 20 }]}
+\`("test", ({ givenInteger, givenObjectArray, givenSimpleArray }) => {});
 
 ================================================================================
 `;

--- a/tests/js/test-declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/test-declarations/__snapshots__/jsfmt.spec.js.snap
@@ -485,21 +485,6 @@ test.each([
   }
 );
 
-test.each\`
-a | b         | c
-\${1}      | \${[{ start: 5, end: 15 }]} | \${[1,2,3,4,5,6,7,8]}
-\${1}| \${[{ start: 5, end: 15 }]} | \${["test", "string", "for", "prettier"]}
-\${3}      | \${[{ start: 5, end: 15 }]} | \${[]}
-\${4} | \${[{ start: 1, end: 3 },{ start: 15, end: 20 },]} | \${[]}
-\`("test", ({givenInteger, givenObjectArray, givenSimpleArray}) => {})
-
-
-test.each\`
-a | 
-\${[{ a: 1, b: 3 },{ c: 15, d: 20 }]}| 
-\${[{ start: 1, end: 3 },{ start: 15, end: 20 }, { start: 15, end: 20 },]}| 
-\`("test", ({givenInteger, givenObjectArray, givenSimpleArray}) => {})
-
 =====================================output=====================================
 describe.each\`
   a            | b        | expected
@@ -571,20 +556,6 @@ test.each([
 ])("test", ({ a, b }) => {
   expect(Number(a)).toBe(b);
 });
-
-test.each\`
-  a    | b                                                 | c
-  \${1} | \${[{ start: 5, end: 15 }]}                        | \${[1, 2, 3, 4, 5, 6, 7, 8]}
-  \${1} | \${[{ start: 5, end: 15 }]}                        | \${["test", "string", "for", "prettier"]}
-  \${3} | \${[{ start: 5, end: 15 }]}                        | \${[]}
-  \${4} | \${[{ start: 1, end: 3 }, { start: 15, end: 20 }]} | \${[]}
-\`("test", ({ givenInteger, givenObjectArray, givenSimpleArray }) => {});
-
-test.each\`
-  a                                                                         |
-  \${[{ a: 1, b: 3 }, { c: 15, d: 20 }]}
-  \${[{ start: 1, end: 3 }, { start: 15, end: 20 }, { start: 15, end: 20 }]}
-\`("test", ({ givenInteger, givenObjectArray, givenSimpleArray }) => {});
 
 ================================================================================
 `;
@@ -658,21 +629,6 @@ test.each([
   }
 );
 
-test.each\`
-a | b         | c
-\${1}      | \${[{ start: 5, end: 15 }]} | \${[1,2,3,4,5,6,7,8]}
-\${1}| \${[{ start: 5, end: 15 }]} | \${["test", "string", "for", "prettier"]}
-\${3}      | \${[{ start: 5, end: 15 }]} | \${[]}
-\${4} | \${[{ start: 1, end: 3 },{ start: 15, end: 20 },]} | \${[]}
-\`("test", ({givenInteger, givenObjectArray, givenSimpleArray}) => {})
-
-
-test.each\`
-a | 
-\${[{ a: 1, b: 3 },{ c: 15, d: 20 }]}| 
-\${[{ start: 1, end: 3 },{ start: 15, end: 20 }, { start: 15, end: 20 },]}| 
-\`("test", ({givenInteger, givenObjectArray, givenSimpleArray}) => {})
-
 =====================================output=====================================
 describe.each\`
   a            | b        | expected
@@ -745,19 +701,84 @@ test.each([
   expect(Number(a)).toBe(b);
 });
 
+================================================================================
+`;
+
+exports[`jest-each-template-string.js - {"arrowParens":"avoid"} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+test.each\`
+a | b         | c
+\${1}      | \${[{ start: 5, end: 15 }]} | \${[1,2,3,4,5,6,7,8]}
+\${1}| \${[{ start: 5, end: 15 }]} | \${["test", "string", "for", "prettier"]}
+\${3}      | \${[{ start: 5, end: 15 }]} | \${[]}
+\${4} | \${[{ start: 1, end: 3 },{ start: 15, end: 20 },]} | \${[]}
+\`("example test", ({a, b, c}) => {})
+
+
+test.each\`
+a | 
+\${[{ a: 1, b: 3 },{ c: 15, d: 20 }]}| 
+\${[{ start: 1, end: 3 },{ start: 15, end: 20 }, { start: 15, end: 20 },]}| 
+\`("example test", ({a, b, c}) => {})
+
+=====================================output=====================================
 test.each\`
   a    | b                                                 | c
   \${1} | \${[{ start: 5, end: 15 }]}                        | \${[1, 2, 3, 4, 5, 6, 7, 8]}
   \${1} | \${[{ start: 5, end: 15 }]}                        | \${["test", "string", "for", "prettier"]}
   \${3} | \${[{ start: 5, end: 15 }]}                        | \${[]}
   \${4} | \${[{ start: 1, end: 3 }, { start: 15, end: 20 }]} | \${[]}
-\`("test", ({ givenInteger, givenObjectArray, givenSimpleArray }) => {});
+\`("example test", ({ a, b, c }) => {});
 
 test.each\`
   a                                                                         |
   \${[{ a: 1, b: 3 }, { c: 15, d: 20 }]}
   \${[{ start: 1, end: 3 }, { start: 15, end: 20 }, { start: 15, end: 20 }]}
-\`("test", ({ givenInteger, givenObjectArray, givenSimpleArray }) => {});
+\`("example test", ({ a, b, c }) => {});
+
+================================================================================
+`;
+
+exports[`jest-each-template-string.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+test.each\`
+a | b         | c
+\${1}      | \${[{ start: 5, end: 15 }]} | \${[1,2,3,4,5,6,7,8]}
+\${1}| \${[{ start: 5, end: 15 }]} | \${["test", "string", "for", "prettier"]}
+\${3}      | \${[{ start: 5, end: 15 }]} | \${[]}
+\${4} | \${[{ start: 1, end: 3 },{ start: 15, end: 20 },]} | \${[]}
+\`("example test", ({a, b, c}) => {})
+
+
+test.each\`
+a | 
+\${[{ a: 1, b: 3 },{ c: 15, d: 20 }]}| 
+\${[{ start: 1, end: 3 },{ start: 15, end: 20 }, { start: 15, end: 20 },]}| 
+\`("example test", ({a, b, c}) => {})
+
+=====================================output=====================================
+test.each\`
+  a    | b                                                 | c
+  \${1} | \${[{ start: 5, end: 15 }]}                        | \${[1, 2, 3, 4, 5, 6, 7, 8]}
+  \${1} | \${[{ start: 5, end: 15 }]}                        | \${["test", "string", "for", "prettier"]}
+  \${3} | \${[{ start: 5, end: 15 }]}                        | \${[]}
+  \${4} | \${[{ start: 1, end: 3 }, { start: 15, end: 20 }]} | \${[]}
+\`("example test", ({ a, b, c }) => {});
+
+test.each\`
+  a                                                                         |
+  \${[{ a: 1, b: 3 }, { c: 15, d: 20 }]}
+  \${[{ start: 1, end: 3 }, { start: 15, end: 20 }, { start: 15, end: 20 }]}
+\`("example test", ({ a, b, c }) => {});
 
 ================================================================================
 `;

--- a/tests/js/test-declarations/jest-each-template-string.js
+++ b/tests/js/test-declarations/jest-each-template-string.js
@@ -1,0 +1,14 @@
+test.each`
+a | b         | c
+${1}      | ${[{ start: 5, end: 15 }]} | ${[1,2,3,4,5,6,7,8]}
+${1}| ${[{ start: 5, end: 15 }]} | ${["test", "string", "for", "prettier"]}
+${3}      | ${[{ start: 5, end: 15 }]} | ${[]}
+${4} | ${[{ start: 1, end: 3 },{ start: 15, end: 20 },]} | ${[]}
+`("example test", ({a, b, c}) => {})
+
+
+test.each`
+a | 
+${[{ a: 1, b: 3 },{ c: 15, d: 20 }]}| 
+${[{ start: 1, end: 3 },{ start: 15, end: 20 }, { start: 15, end: 20 },]}| 
+`("example test", ({a, b, c}) => {})

--- a/tests/js/test-declarations/jest-each.js
+++ b/tests/js/test-declarations/jest-each.js
@@ -60,3 +60,18 @@ test.each([
     expect(Number(a)).toBe(b);
   }
 );
+
+test.each`
+a | b         | c
+${1}      | ${[{ start: 5, end: 15 }]} | ${[1,2,3,4,5,6,7,8]}
+${1}| ${[{ start: 5, end: 15 }]} | ${["test", "string", "for", "prettier"]}
+${3}      | ${[{ start: 5, end: 15 }]} | ${[]}
+${4} | ${[{ start: 1, end: 3 },{ start: 15, end: 20 },]} | ${[]}
+`("test", ({givenInteger, givenObjectArray, givenSimpleArray}) => {})
+
+
+test.each`
+a | 
+${[{ a: 1, b: 3 },{ c: 15, d: 20 }]}| 
+${[{ start: 1, end: 3 },{ start: 15, end: 20 }, { start: 15, end: 20 },]}| 
+`("test", ({givenInteger, givenObjectArray, givenSimpleArray}) => {})

--- a/tests/js/test-declarations/jest-each.js
+++ b/tests/js/test-declarations/jest-each.js
@@ -60,18 +60,3 @@ test.each([
     expect(Number(a)).toBe(b);
   }
 );
-
-test.each`
-a | b         | c
-${1}      | ${[{ start: 5, end: 15 }]} | ${[1,2,3,4,5,6,7,8]}
-${1}| ${[{ start: 5, end: 15 }]} | ${["test", "string", "for", "prettier"]}
-${3}      | ${[{ start: 5, end: 15 }]} | ${[]}
-${4} | ${[{ start: 1, end: 3 },{ start: 15, end: 20 },]} | ${[]}
-`("test", ({givenInteger, givenObjectArray, givenSimpleArray}) => {})
-
-
-test.each`
-a | 
-${[{ a: 1, b: 3 },{ c: 15, d: 20 }]}| 
-${[{ start: 1, end: 3 },{ start: 15, end: 20 }, { start: 15, end: 20 },]}| 
-`("test", ({givenInteger, givenObjectArray, givenSimpleArray}) => {})


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fixes #7653

This adds a verification in the "ArrayPattern" in `printer-estree.js` and updates `shouldBreak` variable if a Jest Each Template Literal is identified.

-----------

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
