### PR TITLE
Enable glimmer printer in the playground

### DIFF
--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -162,7 +162,7 @@ function handleMessage(message) {
       supportInfo: JSON.parse(
         JSON.stringify(
           prettier.getSupportInfo({
-            showUnreleased: /-pr\./.test(prettier.version),
+            showUnreleased: true,
           })
         )
       ),


### PR DESCRIPTION
## Description

https://prettier.io/playground doesn't let select `glimmer` parser (for handlebars) because it is still experimental. With this PR, I propose to enable glimmer parser on the playground. It would simplify the bug reporting on that parser.

AFAICT glimmer is the only parser to be experimental.

<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

## Checklist
- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
