### PR TITLE
Playground: Redirect `babylon` parser to `babel`

### DIFF
--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -60,6 +60,12 @@ class Playground extends React.Component {
     );
 
     const options = Object.assign(defaultOptions, original.options);
+
+    // backwards support for old parser `babylon`
+    if (options.parser === "babylon") {
+      options.parser = "babel";
+    }
+
     const content = original.content || getCodeSample(options.parser);
     const selection = {};
 


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Old issues has `parser=babylon` in url, every time people click it, has to change the parser to `babel` manually.

https://prettier.io/playground/#N4Igxg9gdgLgprEAuEACVkoGcaoB6oC8qADANwA6U6V6A9AFSoCWOAhlAEYCuANiwHMoEAE5wWAM1QM6qOrIAmcHgIxss4sNxFjYvAJ6phuGCOYCBcMQtqTUAClPc4ASlTBb6PJWqoAviAANCAQAA4wzNBYyKDqMMgSbLwawZwibGAA1nAwAMqhGcxQAshOcMEKEGAJSSkgAFZYeABC6Vk5uWwAtnAAMkVwNcnlIdwwoWMATEN1BSIaIsggnGyc+rzQQSChZrAA6swKMAAWyAAcJMEaXcylIs5XRQK8cACK3BDwMyMwqwdHpyQk2CpjYzF4TwAwhAul02EthFBBsFuBoACqraJIRLDPx+IA

https://deploy-preview-8382--prettier.netlify.app/playground/#N4Igxg9gdgLgprEAuEACVkoGcaoB6oC8qADANwA6U6V6A9AFSoCWOAhlAEYCuANiwHMoEAE5wWAM1QM6qOrIAmcHgIxss4sNxFjYvAJ6phuGCOYCBcMQtqTUAClPc4ASlTBb6PJWqoAviAANCAQAA4wzNBYyKDqMMgSbLwawZwibGAA1nAwAMqhGcxQAshOcMEKEGAJSSkgAFZYeABC6Vk5uWwAtnAAMkVwNcnlIdwwoWMATEN1BSIaIsggnGyc+rzQQSChZrAA6swKMAAWyAAcJMEaXcylIs5XRQK8cACK3BDwMyMwqwdHpyQk2CpjYzF4TwAwhAul02EthFBBsFuBoACqraJIRLDPx+IA



<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
