### PR TITLE
Add the browser and unpkg field to package.json

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -28,6 +28,8 @@ See [Usage](#usage) below for examples.
 </script>
 ```
 
+Note that the [`unpkg` field](https://unpkg.com/#examples) in Prettier's `package.json` points to `standalone.js`, that's why `https://unpkg.com/prettier` can also be used instead of `https://unpkg.com/prettier/standalone.js`.
+
 ### ES Modules
 
 ```js

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -5,6 +5,8 @@ title: Browser
 
 Run Prettier in the browser with the `standalone.js` UMD bundle shipped in the NPM package (starting in version 1.13). The UMD bundle only formats the code and has no support for config files, ignore files, CLI usage, or automatic loading of plugins.
 
+The [`browser` field](https://github.com/defunctzombie/package-browser-field-spec) in Prettier's `package.json` points to `standalone.js`. That's why you can just `import` or `require` the `prettier` module to access Prettier's API, and your code can stay compatible with both Node and the browser as long as webpack or another bundler that supports the `browser` field is used. This is especially convenient for [plugins](plugins.md).
+
 ### `prettier.format(code, options)`
 
 Unlike the `format` function from the [main API](api.md#prettierformatsource--options), this function does not load plugins automatically, so a `plugins` property is required if you want to load plugins. Additionally, the parsers included in the Prettier package won't be loaded automatically, so you need to load them before using them.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "license": "MIT",
   "main": "./index.js",
   "browser": "./standalone.js",
+  "unpkg": "./standalone.js",
   "engines": {
     "node": ">=10.13.0"
   },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "author": "James Long",
   "license": "MIT",
   "main": "./index.js",
+  "browser": "./standalone.js",
   "engines": {
     "node": ">=10.13.0"
   },


### PR DESCRIPTION
Closes #7557

When this [field](https://docs.npmjs.com/files/package.json#browser) is specified, `import prettier from "prettier";` and `require("prettier")` ["just works" with webpack](https://webpack.js.org/configuration/resolve/#resolvealiasfields), [Parcel](https://parceljs.org/module_resolution.html#package.json-%60browser%60-field) and probably with other bundlers. It's important for plugins because otherwise it's not clear what they should import to access Prettier's API. E.g. this simple change would make `prettier-plugin-csharp` web-compatible.

Theoretically, this might break someone's setup if they use webpack to bundle Prettier as part of non-web code, but as it's described in #7557 and https://github.com/warrenseine/prettier-plugin-csharp/issues/39, Prettier's Node bundle is very difficult for webpack to digest, so I don't think anybody actually does that. And if someone does, they should use `target: "node"` in their webpack config anyway.

- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
