### PR TITLE
Clarified usage of `embed`

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -184,7 +184,7 @@ function embed(
 ): Doc | null;
 ```
 
-If an `embed` function is included, it will be called _first_ on every node. If the `embed` function returns `null` or `undefiend`, the current plugin's `print` function is called. Otherwise, the `Doc` returned by the `embed` function is used. The `embed` function is passed `textToDoc` which can be called with a suitable `options` argument to obtain the `Doc` produced by a different plugin (which can then be directly returned or used inside a larger `Doc` construction). For example, to print embedded Javascript, a plugin might return `textToDoc(javascriptText, {parser: "babel"})` from the `embed` function.
+If an `embed` function is included, it will be called _first_ on every node. If the `embed` function returns `null` or `undefined`, the current plugin's `print` function is called. Otherwise, the `Doc` returned by the `embed` function is used. The `embed` function is passed `textToDoc` which can be called with a suitable `options` argument to obtain the `Doc` produced by a different plugin (which can then be directly returned or used inside a larger `Doc` construction). For example, to print embedded Javascript, a plugin might return `textToDoc(javascriptText, {parser: "babel"})` from the `embed` function.
 
 A plugin can implement how a pragma comment is inserted in the resulting code when the `--insert-pragma` option is used, in the `insertPragma` function. Its signature is:
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -184,7 +184,7 @@ function embed(
 ): Doc | null;
 ```
 
-If you don't want to switch to a different parser, simply return `null` or `undefined`.
+If an `embed` function is included, it will be called *first* on every node. If the `embed` function returns `null` or `undefiend`, the current plugin's `print` function is called. Otherwise, the `Doc` returned by the `embed` function is used. The `embed` function is passed `textToDoc` which can be called with a suitable `options` argument to obtain the `Doc` produced by a different plugin (which can then be directly returned or used inside a larger `Doc` construction). For example, to print embedded Javascript, a plugin might return `textToDoc(javascriptText, {parser: "babel"})` from the `embed` function.
 
 A plugin can implement how a pragma comment is inserted in the resulting code when the `--insert-pragma` option is used, in the `insertPragma` function. Its signature is:
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -184,7 +184,7 @@ function embed(
 ): Doc | null;
 ```
 
-If an `embed` function is included, it will be called *first* on every node. If the `embed` function returns `null` or `undefiend`, the current plugin's `print` function is called. Otherwise, the `Doc` returned by the `embed` function is used. The `embed` function is passed `textToDoc` which can be called with a suitable `options` argument to obtain the `Doc` produced by a different plugin (which can then be directly returned or used inside a larger `Doc` construction). For example, to print embedded Javascript, a plugin might return `textToDoc(javascriptText, {parser: "babel"})` from the `embed` function.
+If an `embed` function is included, it will be called _first_ on every node. If the `embed` function returns `null` or `undefiend`, the current plugin's `print` function is called. Otherwise, the `Doc` returned by the `embed` function is used. The `embed` function is passed `textToDoc` which can be called with a suitable `options` argument to obtain the `Doc` produced by a different plugin (which can then be directly returned or used inside a larger `Doc` construction). For example, to print embedded Javascript, a plugin might return `textToDoc(javascriptText, {parser: "babel"})` from the `embed` function.
 
 A plugin can implement how a pragma comment is inserted in the resulting code when the `--insert-pragma` option is used, in the `insertPragma` function. Its signature is:
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -184,7 +184,7 @@ function embed(
 ): Doc | null;
 ```
 
-If an `embed` function is included, it will be called _first_ on every node. If the `embed` function returns `null` or `undefined`, the current plugin's `print` function is called. Otherwise, the `Doc` returned by the `embed` function is used. The `embed` function is passed `textToDoc` which can be called with a suitable `options` argument to obtain the `Doc` produced by a different plugin (which can then be directly returned or used inside a larger `Doc` construction). For example, to print embedded Javascript, a plugin might return `textToDoc(javascriptText, {parser: "babel"})` from the `embed` function.
+If an `embed` function is included, it will be called _first_ on every node. If the `embed` function returns a falsy value, the current plugin's `print` function is called. Otherwise, the `Doc` returned by the `embed` function is used. The `embed` function is passed `textToDoc` which can be called with a suitable `options` argument to obtain the `Doc` produced by a different plugin (which can then be directly returned or used inside a larger `Doc` construction). For example, to print embedded JavaScript, a plugin might return `textToDoc(javaScriptText, { parser: "babel" })` from the `embed` function.
 
 A plugin can implement how a pragma comment is inserted in the resulting code when the `--insert-pragma` option is used, in the `insertPragma` function. Its signature is:
 


### PR DESCRIPTION
The current documentation doesn't give good guidance about how to use the `embed` function or what the call chain is. This PR explains in more detail.

- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.