### PR TITLE
Add plugins' parsers to the `parser` option

### DIFF
--- a/changelog_unreleased/api/pr-8390.md
+++ b/changelog_unreleased/api/pr-8390.md
@@ -1,0 +1,16 @@
+#### Add plugins' parsers to the `parser` option ([#8390](https://github.com/prettier/prettier/pull/8390) by [@thorn0](https://github.com/thorn0))
+
+When a plugin defines a language, the parsers specified for this language are now automatically added to the list of valid values of the `parser` option.
+This might be useful for editor integrations or other applications that need a list of available parsers.
+
+```console
+> yarn add prettier @prettier/plugin-php
+```
+
+```js
+const hasPhpParser = prettier
+  .getSupportInfo()
+  .options.find((option) => option.name === "parser")
+  .choices.map((choice) => choice.value)
+  .includes("php"); // false in Prettier stable, true in Prettier master
+```

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -60,20 +60,20 @@ function getSupportInfo({
         );
 
         if (option.name === "parser") {
-          collectParsersFromLanguages(option, languages);
+          collectParsersFromLanguages(option, languages, plugins);
         }
       }
 
-      const filteredPlugins = plugins.filter(
-        (plugin) =>
-          plugin.defaultOptions &&
-          plugin.defaultOptions[option.name] !== undefined
-      );
-
-      const pluginDefaults = filteredPlugins.reduce((reduced, plugin) => {
-        reduced[plugin.name] = plugin.defaultOptions[option.name];
-        return reduced;
-      }, {});
+      const pluginDefaults = plugins
+        .filter(
+          (plugin) =>
+            plugin.defaultOptions &&
+            plugin.defaultOptions[option.name] !== undefined
+        )
+        .reduce((reduced, plugin) => {
+          reduced[plugin.name] = plugin.defaultOptions[option.name];
+          return reduced;
+        }, {});
 
       return { ...option, pluginDefaults };
     });
@@ -105,14 +105,21 @@ function getSupportInfo({
   }
 }
 
-function collectParsersFromLanguages(option, languages) {
+function collectParsersFromLanguages(option, languages, plugins) {
   const existingValues = new Set(option.choices.map((choice) => choice.value));
   for (const language of languages) {
     if (language.parsers) {
-      for (const parser of language.parsers) {
-        if (!existingValues.has(parser)) {
-          existingValues.add(parser);
-          option.choices.push({ value: parser, description: language.name });
+      for (const value of language.parsers) {
+        if (!existingValues.has(value)) {
+          existingValues.add(value);
+          const plugin = plugins.find(
+            (plugin) => plugin.parsers && plugin.parsers[value]
+          );
+          let description = language.name;
+          if (plugin && plugin.name) {
+            description += ` (plugin: ${plugin.name})`;
+          }
+          option.choices.push({ value, description });
         }
       }
     }

--- a/tests_integration/__tests__/__snapshots__/plugin-options-string.js.snap
+++ b/tests_integration/__tests__/__snapshots__/plugin-options-string.js.snap
@@ -5,7 +5,7 @@ exports[` 1`] = `
 - First value
 + Second value
 
-@@ -20,10 +20,12 @@
+@@ -20,18 +20,20 @@
                              Control how Prettier formats quoted code embedded in the file.
                              Defaults to auto.
     --end-of-line <lf|crlf|cr|auto>
@@ -17,7 +17,16 @@ exports[` 1`] = `
                              How to handle whitespaces in HTML.
                              Defaults to css.
     --jsx-bracket-same-line  Put > on the last line instead of at a new line.
-                             Defaults to false."
+                             Defaults to false.
+    --jsx-single-quote       Use single quotes in JSX.
+                             Defaults to false.
+-   --parser <flow|babel|babel-flow|babel-ts|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|html|angular|lwc>
++   --parser <flow|babel|babel-flow|babel-ts|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|html|angular|lwc|foo-parser>
+                             Which parser to use.
+    --print-width <int>      The line length where Prettier will try wrap.
+                             Defaults to 80.
+    --prose-wrap <always|never|preserve>
+                             How to wrap prose."
 `;
 
 exports[`show detailed external option with \`--help foo-string\` (stderr) 1`] = `""`;

--- a/tests_integration/__tests__/__snapshots__/plugin-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/plugin-options.js.snap
@@ -57,7 +57,7 @@ Valid options:
   html             HTML
   angular          Angular
   lwc              Lightning Web Components
-  foo-parser       foo
+  foo-parser       foo (plugin: ./plugin)
 "
 `;
 

--- a/tests_integration/__tests__/__snapshots__/plugin-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/plugin-options.js.snap
@@ -5,7 +5,7 @@ exports[` 1`] = `
 - First value
 + Second value
 
-@@ -20,10 +20,12 @@
+@@ -20,18 +20,20 @@
                              Control how Prettier formats quoted code embedded in the file.
                              Defaults to auto.
     --end-of-line <lf|crlf|cr|auto>
@@ -17,8 +17,51 @@ exports[` 1`] = `
                              How to handle whitespaces in HTML.
                              Defaults to css.
     --jsx-bracket-same-line  Put > on the last line instead of at a new line.
-                             Defaults to false."
+                             Defaults to false.
+    --jsx-single-quote       Use single quotes in JSX.
+                             Defaults to false.
+-   --parser <flow|babel|babel-flow|babel-ts|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|html|angular|lwc>
++   --parser <flow|babel|babel-flow|babel-ts|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|html|angular|lwc|foo-parser>
+                             Which parser to use.
+    --print-width <int>      The line length where Prettier will try wrap.
+                             Defaults to 80.
+    --prose-wrap <always|never|preserve>
+                             How to wrap prose."
 `;
+
+exports[`include plugin's parsers to the values of the \`parser\` option\` (stderr) 1`] = `""`;
+
+exports[`include plugin's parsers to the values of the \`parser\` option\` (stdout) 1`] = `
+"--parser <flow|babel|babel-flow|babel-ts|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|html|angular|lwc|foo-parser>
+
+  Which parser to use.
+
+Valid options:
+
+  flow             Flow
+  babel            JavaScript
+  babel-flow       Flow
+  babel-ts         TypeScript
+  typescript       TypeScript
+  css              CSS
+  less             Less
+  scss             SCSS
+  json             JSON
+  json5            JSON5
+  json-stringify   JSON.stringify
+  graphql          GraphQL
+  markdown         Markdown
+  mdx              MDX
+  vue              Vue
+  yaml             YAML
+  html             HTML
+  angular          Angular
+  lwc              Lightning Web Components
+  foo-parser       foo
+"
+`;
+
+exports[`include plugin's parsers to the values of the \`parser\` option\` (write) 1`] = `Array []`;
 
 exports[`show detailed external option with \`--help foo-option\` (stderr) 1`] = `""`;
 

--- a/tests_integration/__tests__/plugin-options.js
+++ b/tests_integration/__tests__/plugin-options.js
@@ -22,6 +22,16 @@ describe("show detailed external option with `--help foo-option`", () => {
   });
 });
 
+describe("include plugin's parsers to the values of the `parser` option`", () => {
+  runPrettier("plugins/options", [
+    "--plugin=./plugin",
+    "--help",
+    "parser",
+  ]).test({
+    status: 0,
+  });
+});
+
 describe("external options from CLI should work", () => {
   runPrettier(
     "plugins/options",


### PR DESCRIPTION
Fixes #8389

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
