### PR TITLE
Fixes #5014 by avoiding adding whitespace and line breaks to urls

### DIFF
--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -536,7 +536,14 @@ function genericPrint(path, options, print) {
             (iNextNode && isAdditionNode(iNextNode)) ||
             isAdditionNode(iNode)
           ) {
-            parts.push(" ");
+            const isString =
+              iNode.type !== "value-word" && iNextNode.type !== "value-word";
+            const hasVars =
+              iNode.value.startsWith("$") || iNextNode.value.startsWith("$");
+
+            if (isString || hasVars) {
+              parts.push(" ");
+            }
           }
           continue;
         }
@@ -824,6 +831,8 @@ function genericPrint(path, options, print) {
       const lastItem = node.groups[node.groups.length - 1];
       const isLastItemComment = lastItem && lastItem.type === "value-comment";
 
+      const isInsideUrl = isURLFunctionNode(parentNode);
+
       return group(
         concat([
           node.open ? path.call(print, "open") : "",
@@ -831,7 +840,7 @@ function genericPrint(path, options, print) {
             concat([
               softline,
               join(
-                concat([",", line]),
+                isInsideUrl ? "," : concat([",", line]),
                 path.map((childPath) => {
                   const node = childPath.getValue();
                   const printed = print(childPath);

--- a/tests/css/inline-url/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css/inline-url/__snapshots__/jsfmt.spec.js.snap
@@ -32,18 +32,24 @@ printWidth: 80
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=");
   background-image: url(data:application/font-woff;charset=utf-8;base64,ThisIsNormalBut/+0ThisIsLowerCased);
   background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=) center center no-repeat;
+  background-image: url("hello"+"world");
+  background-image: url(https://prettier-fonts.com/css?family=Prettier+Sans&size=500,400,300,1000,600);
 }
 
 =====================================output=====================================
 .breadItem {
   background-image: url("/images/product/simple_product_manager/breadcrumb/chevron_right.png");
   background-image: url(/images/product/simple_product_manager/breadcrumb/chevron_right.png);
-  -fb-sprite: url(fbglyph:cross-outline, fig-white);
+  -fb-sprite: url(fbglyph:cross-outline,fig-white);
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=);
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=");
   background-image: url(data:application/font-woff;charset=utf-8;base64,ThisIsNormalBut/+0ThisIsLowerCased);
   background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=)
     center center no-repeat;
+  background-image: url("hello" + "world");
+  background-image: url(
+    https://prettier-fonts.com/css?family=Prettier+Sans&size=500,400,300,1000,600
+  );
 }
 
 ================================================================================

--- a/tests/css/inline-url/inline_url.css
+++ b/tests/css/inline-url/inline_url.css
@@ -6,4 +6,6 @@
   background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=");
   background-image: url(data:application/font-woff;charset=utf-8;base64,ThisIsNormalBut/+0ThisIsLowerCased);
   background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mO4/B8AAqgB0yr7dJgAAAAASUVORK5CYII=) center center no-repeat;
+  background-image: url("hello"+"world");
+  background-image: url(https://prettier-fonts.com/css?family=Prettier+Sans&size=500,400,300,1000,600);
 }


### PR DESCRIPTION
Spent the whole day on this. Really nasty problem. Happy to make any changes to it.

Unfortunately: I can't distinguish between: `url(fbglyph:cross-outline , fig-white);` and `url(url.com/Prettier+Sans&size=500,400,300,1000,600);`

However the fbglygh: syntax isn't really supported by CSS, and this change means that prettier won't break stylesheets.

<!-- Please provide a brief summary of your changes: -->

Fixed an issue where prettier mangled CSS urls that were unqoted and had commas or addition signs in them.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
