### PR TITLE
Build: Fix `@rollup/plugin-commonjs` warning

### DIFF
--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -66,15 +66,6 @@ const parsers = [
   {
     input: "src/language-handlebars/parser-glimmer.js",
     commonjs: {
-      namedExports: {
-        [require.resolve("handlebars/dist/cjs/handlebars.js")]: [
-          "parse",
-          "parseWithoutProcessing",
-        ],
-        [require.resolve(
-          "@glimmer/syntax/dist/modules/es2017/index.js"
-        )]: "default",
-      },
       ignore: ["source-map"],
     },
   },

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -18,7 +18,6 @@ const path = require("path");
  * @property {boolean?} minify - minify
 
  * @typedef {Object} CommonJSConfig
- * @property {Object} namedExports - for cases where rollup can't infer what's exported
  * @property {string[]} ignore - paths of CJS modules to ignore
  */
 


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Ref: https://github.com/prettier/prettier/pull/8367#issuecomment-633497645

Local build and compared, nothing changes.

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
