### PR TITLE
JavaScript: Support Babel 7.10 private field in `in`

### DIFF
--- a/changelog_unreleased/javascript/pr-8431.md
+++ b/changelog_unreleased/javascript/pr-8431.md
@@ -2,6 +2,7 @@
 
 Support Stage-1 proposal [Private Fields in `in`](https://github.com/tc39/proposal-private-fields-in-in/blob/master/README.md).
 
+<!-- prettier-ignore -->
 ```js
 // Input
 #prop in obj;

--- a/changelog_unreleased/javascript/pr-8431.md
+++ b/changelog_unreleased/javascript/pr-8431.md
@@ -1,0 +1,17 @@
+#### Support Private Fields in `in` ([#8431](https://github.com/prettier/prettier/pull/8431) by [@sosukesuzuki](https://github.com/sosukesuzuki))
+
+Support Stage-1 proposal [Private Fields in `in`](https://github.com/tc39/proposal-private-fields-in-in/blob/master/README.md).
+
+```js
+// Input
+#prop in obj;
+
+// Prettier stable
+SyntaxError: Unexpected token (1:1)
+> 1 | #prop in obj;
+    | ^
+  2 | 
+
+// Prettier master
+#prop in obj;
+```

--- a/src/language-js/parser-babel.js
+++ b/src/language-js/parser-babel.js
@@ -37,6 +37,7 @@ function babelOptions({ sourceType, extraPlugins = [] }) {
       "classPrivateMethods",
       "v8intrinsic",
       "partialApplication",
+      "privateIn",
       ["decorators", { decoratorsBeforeExport: false }],
       ...extraPlugins,
     ],

--- a/tests/js/private-in/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/private-in/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`private-in.js format 1`] = `
+====================================options=====================================
+parsers: ["babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+if (#prop in obj) {
+}
+
+#prop in     obj;
+
+#prop      in obj;
+
+#prop in
+obj;
+
+#prop
+in
+obj;
+
+#prop
+in obj;
+
+=====================================output=====================================
+if (#prop in obj) {
+}
+
+#prop in obj;
+
+#prop in obj;
+
+#prop in obj;
+
+#prop in obj;
+
+#prop in obj;
+
+================================================================================
+`;

--- a/tests/js/private-in/jsfmt.spec.js
+++ b/tests/js/private-in/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["babel"]);

--- a/tests/js/private-in/private-in.js
+++ b/tests/js/private-in/private-in.js
@@ -1,0 +1,16 @@
+if (#prop in obj) {
+}
+
+#prop in     obj;
+
+#prop      in obj;
+
+#prop in
+obj;
+
+#prop
+in
+obj;
+
+#prop
+in obj;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
- https://babeljs.io/blog/2020/05/25/7.10.0#private-fields-in-in-11372-https-githubcom-babel-babel-pull-11372
- https://github.com/tc39/proposal-private-fields-in-in/blob/master/README.md
<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
