### PR TITLE
Test: extract code to utils

### DIFF
--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -6,6 +6,11 @@ const raw = require("jest-snapshot-serializer-raw").wrap;
 const { isCI } = require("ci-info");
 const checkParsers = require("./utils/check-parsers");
 const visualizeRange = require("./utils/visualize-range");
+const createSnapshot = require("./utils/create-snapshot");
+const composeOptionsForSnapshot = require("./utils/compose-options-for-snapshot");
+const visualizeEndOfLine = require("./utils/visualize-end-of-line");
+const consistentEndOfLine = require("./utils/consistent-end-of-line");
+const stringifyOptionsForTitle = require("./utils/stringify-options-for-title");
 
 const { TEST_STANDALONE } = process.env;
 const AST_COMPARE = isCI || process.env.AST_COMPARE;
@@ -110,7 +115,7 @@ global.run_spec = (fixtures, parsers, options) => {
     checkParsers({ dirname, files }, parsers);
   }
 
-  const stringifiedOptions = stringifyOptions(options);
+  const stringifiedOptions = stringifyOptionsForTitle(options);
 
   for (const { name, filename, code, output } of [...files, ...snippets]) {
     describe(`${name}${
@@ -195,7 +200,7 @@ global.run_spec = (fixtures, parsers, options) => {
               createSnapshot(
                 codeForSnapshot,
                 hasEndOfLine ? visualizedOutput : formattedWithCursor,
-                { ...baseOptions, parsers },
+                composeOptionsForSnapshot(baseOptions, parsers),
                 { codeOffset }
               )
             )
@@ -278,101 +283,4 @@ function format(source, filename, options) {
         CURSOR_PLACEHOLDER +
         result.formatted.slice(result.cursorOffset)
     : result.formatted;
-}
-
-function consistentEndOfLine(text) {
-  let firstEndOfLine;
-  return text.replace(/\r\n?|\n/g, (endOfLine) => {
-    if (!firstEndOfLine) {
-      firstEndOfLine = endOfLine;
-    }
-    return firstEndOfLine;
-  });
-}
-
-function visualizeEndOfLine(text) {
-  return text.replace(/\r\n?|\n/g, (endOfLine) => {
-    switch (endOfLine) {
-      case "\n":
-        return "<LF>\n";
-      case "\r\n":
-        return "<CRLF>\n";
-      case "\r":
-        return "<CR>\n";
-      default:
-        throw new Error(`Unexpected end of line ${JSON.stringify(endOfLine)}`);
-    }
-  });
-}
-
-function createSnapshot(input, output, options, { codeOffset }) {
-  const separatorWidth = 80;
-  const printWidthIndicator =
-    options.printWidth > 0 && Number.isFinite(options.printWidth)
-      ? (codeOffset ? " ".repeat(codeOffset - 1) + "|" : "") +
-        " ".repeat(options.printWidth) +
-        "| printWidth"
-      : [];
-  return []
-    .concat(
-      printSeparator(separatorWidth, "options"),
-      printOptions(
-        omit(
-          options,
-          (k) =>
-            k === "rangeStart" ||
-            k === "rangeEnd" ||
-            k === "cursorOffset" ||
-            k === "disableBabelTS"
-        )
-      ),
-      printWidthIndicator,
-      printSeparator(separatorWidth, "input"),
-      input,
-      printSeparator(separatorWidth, "output"),
-      output,
-      printSeparator(separatorWidth)
-    )
-    .join("\n");
-}
-
-function printSeparator(width, description) {
-  description = description || "";
-  const leftLength = Math.floor((width - description.length) / 2);
-  const rightLength = width - leftLength - description.length;
-  return "=".repeat(leftLength) + description + "=".repeat(rightLength);
-}
-
-function printOptions(options) {
-  const keys = Object.keys(options).sort();
-  return keys.map((key) => `${key}: ${stringify(options[key])}`).join("\n");
-  function stringify(value) {
-    return value === Infinity
-      ? "Infinity"
-      : Array.isArray(value)
-      ? `[${value.map((v) => JSON.stringify(v)).join(", ")}]`
-      : JSON.stringify(value);
-  }
-}
-
-function omit(obj, fn) {
-  return Object.keys(obj).reduce((reduced, key) => {
-    const value = obj[key];
-    if (!fn(key, value)) {
-      reduced[key] = value;
-    }
-    return reduced;
-  }, {});
-}
-
-function stringifyOptions(options) {
-  const string = JSON.stringify(options || {}, (key, value) =>
-    key === "disableBabelTS"
-      ? undefined
-      : value === Infinity
-      ? "Infinity"
-      : value
-  );
-
-  return string === "{}" ? "" : string;
 }

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -2,7 +2,6 @@
 
 const fs = require("fs");
 const path = require("path");
-const raw = require("jest-snapshot-serializer-raw").wrap;
 const { isCI } = require("ci-info");
 const checkParsers = require("./utils/check-parsers");
 const visualizeRange = require("./utils/visualize-range");
@@ -196,13 +195,11 @@ global.run_spec = (fixtures, parsers, options) => {
           }
 
           expect(
-            raw(
-              createSnapshot(
-                codeForSnapshot,
-                hasEndOfLine ? visualizedOutput : formattedWithCursor,
-                composeOptionsForSnapshot(baseOptions, parsers),
-                { codeOffset }
-              )
+            createSnapshot(
+              codeForSnapshot,
+              hasEndOfLine ? visualizedOutput : formattedWithCursor,
+              composeOptionsForSnapshot(baseOptions, parsers),
+              { codeOffset }
             )
           ).toMatchSnapshot();
         }

--- a/tests_config/utils/compose-options-for-snapshot.js
+++ b/tests_config/utils/compose-options-for-snapshot.js
@@ -1,0 +1,17 @@
+"use strict";
+
+function composeOptionsForSnapshot(baseOptions, parsers) {
+  const snapshotOptions = { ...baseOptions, parsers };
+  const keepRange =
+    typeof baseOptions.rangeStart === "number" &&
+    typeof baseOptions.rangeEnd === "number";
+  if (!keepRange) {
+    delete snapshotOptions.rangeStart;
+    delete snapshotOptions.rangeEnd;
+  }
+  delete snapshotOptions.cursorOffset;
+  delete snapshotOptions.disableBabelTS;
+  return snapshotOptions;
+}
+
+module.exports = composeOptionsForSnapshot;

--- a/tests_config/utils/compose-options-for-snapshot.js
+++ b/tests_config/utils/compose-options-for-snapshot.js
@@ -1,17 +1,19 @@
 "use strict";
 
 function composeOptionsForSnapshot(baseOptions, parsers) {
-  const snapshotOptions = { ...baseOptions, parsers };
-  const keepRange =
-    typeof baseOptions.rangeStart === "number" &&
-    typeof baseOptions.rangeEnd === "number";
-  if (!keepRange) {
-    delete snapshotOptions.rangeStart;
-    delete snapshotOptions.rangeEnd;
-  }
-  delete snapshotOptions.cursorOffset;
-  delete snapshotOptions.disableBabelTS;
-  return snapshotOptions;
+  const {
+    rangeStart,
+    rangeEnd,
+    cursorOffset,
+    disableBabelTS,
+
+    ...snapshotOptions
+  } = baseOptions;
+
+  return {
+    ...snapshotOptions,
+    parsers,
+  };
 }
 
 module.exports = composeOptionsForSnapshot;

--- a/tests_config/utils/consistent-end-of-line.js
+++ b/tests_config/utils/consistent-end-of-line.js
@@ -1,0 +1,13 @@
+"use strict";
+
+function consistentEndOfLine(text) {
+  let firstEndOfLine;
+  return text.replace(/\r\n?|\n/g, (endOfLine) => {
+    if (!firstEndOfLine) {
+      firstEndOfLine = endOfLine;
+    }
+    return firstEndOfLine;
+  });
+}
+
+module.exports = consistentEndOfLine;

--- a/tests_config/utils/create-snapshot.js
+++ b/tests_config/utils/create-snapshot.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const raw = require("jest-snapshot-serializer-raw").wrap;
+
 function printSeparator(width, description) {
   description = description || "";
   const leftLength = Math.floor((width - description.length) / 2);
@@ -27,18 +29,20 @@ function createSnapshot(input, output, options, { codeOffset }) {
         " ".repeat(options.printWidth) +
         "| printWidth"
       : [];
-  return []
-    .concat(
-      printSeparator(separatorWidth, "options"),
-      printOptions(options),
-      printWidthIndicator,
-      printSeparator(separatorWidth, "input"),
-      input,
-      printSeparator(separatorWidth, "output"),
-      output,
-      printSeparator(separatorWidth)
-    )
-    .join("\n");
+  return raw(
+    []
+      .concat(
+        printSeparator(separatorWidth, "options"),
+        printOptions(options),
+        printWidthIndicator,
+        printSeparator(separatorWidth, "input"),
+        input,
+        printSeparator(separatorWidth, "output"),
+        output,
+        printSeparator(separatorWidth)
+      )
+      .join("\n")
+  );
 }
 
 module.exports = createSnapshot;

--- a/tests_config/utils/create-snapshot.js
+++ b/tests_config/utils/create-snapshot.js
@@ -1,0 +1,44 @@
+"use strict";
+
+function printSeparator(width, description) {
+  description = description || "";
+  const leftLength = Math.floor((width - description.length) / 2);
+  const rightLength = width - leftLength - description.length;
+  return "=".repeat(leftLength) + description + "=".repeat(rightLength);
+}
+
+function stringify(value) {
+  return value === Infinity
+    ? "Infinity"
+    : Array.isArray(value)
+    ? `[${value.map((v) => JSON.stringify(v)).join(", ")}]`
+    : JSON.stringify(value);
+}
+function printOptions(options) {
+  const keys = Object.keys(options).sort();
+  return keys.map((key) => `${key}: ${stringify(options[key])}`).join("\n");
+}
+
+function createSnapshot(input, output, options, { codeOffset }) {
+  const separatorWidth = 80;
+  const printWidthIndicator =
+    options.printWidth > 0 && Number.isFinite(options.printWidth)
+      ? (codeOffset ? " ".repeat(codeOffset - 1) + "|" : "") +
+        " ".repeat(options.printWidth) +
+        "| printWidth"
+      : [];
+  return []
+    .concat(
+      printSeparator(separatorWidth, "options"),
+      printOptions(options),
+      printWidthIndicator,
+      printSeparator(separatorWidth, "input"),
+      input,
+      printSeparator(separatorWidth, "output"),
+      output,
+      printSeparator(separatorWidth)
+    )
+    .join("\n");
+}
+
+module.exports = createSnapshot;

--- a/tests_config/utils/stringify-options-for-title.js
+++ b/tests_config/utils/stringify-options-for-title.js
@@ -1,0 +1,15 @@
+"use strict";
+
+function stringifyOptions(options) {
+  const string = JSON.stringify(options || {}, (key, value) =>
+    key === "disableBabelTS"
+      ? undefined
+      : value === Infinity
+      ? "Infinity"
+      : value
+  );
+
+  return string === "{}" ? "" : string;
+}
+
+module.exports = stringifyOptions;

--- a/tests_config/utils/visualize-end-of-line.js
+++ b/tests_config/utils/visualize-end-of-line.js
@@ -1,0 +1,18 @@
+"use strict";
+
+function visualizeEndOfLine(text) {
+  return text.replace(/\r\n?|\n/g, (endOfLine) => {
+    switch (endOfLine) {
+      case "\n":
+        return "<LF>\n";
+      case "\r\n":
+        return "<CRLF>\n";
+      case "\r":
+        return "<CR>\n";
+      default:
+        throw new Error(`Unexpected end of line ${JSON.stringify(endOfLine)}`);
+    }
+  });
+}
+
+module.exports = visualizeEndOfLine;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

~`composeOptionsForSnapshot` function is from #8408~ Didn't notice it keeps ranges.

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
