### PR TITLE
Refactor: simplify import/export print

### DIFF
--- a/src/language-js/print/misc.js
+++ b/src/language-js/print/misc.js
@@ -58,9 +58,15 @@ function printBindExpressionCallee(path, options, print) {
   return concat(["::", path.call(print, "callee")]);
 }
 
+function printModuleSource(path, options, print) {
+  const node = path.getValue();
+  return node.source ? concat([" from ", path.call(print, "source")]) : "";
+}
+
 module.exports = {
   printOptionalToken,
   printFunctionTypeParameters,
   printMemberLookup,
   printBindExpressionCallee,
+  printModuleSource,
 };

--- a/src/language-js/print/misc.js
+++ b/src/language-js/print/misc.js
@@ -58,15 +58,9 @@ function printBindExpressionCallee(path, options, print) {
   return concat(["::", path.call(print, "callee")]);
 }
 
-function printModuleSource(path, options, print) {
-  const node = path.getValue();
-  return node.source ? concat([" from ", path.call(print, "source")]) : "";
-}
-
 module.exports = {
   printOptionalToken,
   printFunctionTypeParameters,
   printMemberLookup,
   printBindExpressionCallee,
-  printModuleSource,
 };

--- a/src/language-js/print/module.js
+++ b/src/language-js/print/module.js
@@ -1,0 +1,95 @@
+"use strict";
+
+const {
+  builders: { concat, softline, group, indent, join, line, ifBreak },
+} = require("../../document");
+const { shouldPrintComma } = require("../utils");
+
+function printModuleSource(path, options, print) {
+  const node = path.getValue();
+  return node.source ? concat([" from ", path.call(print, "source")]) : "";
+}
+
+function printModuleSpecifiers(path, options, print) {
+  const node = path.getValue();
+  const parts = [
+    node.type === "ImportDeclaration" ? " " : "",
+    node.exportKind === "type" ? "type " : "",
+  ];
+
+  const standalonesSpecifiers = [];
+  const groupedSpecifiers = [];
+
+  if (node.specifiers && node.specifiers.length > 0) {
+    path.each((specifierPath) => {
+      const specifierType = path.getValue().type;
+      if (
+        specifierType === "ExportNamespaceSpecifier" ||
+        specifierType === "ExportDefaultSpecifier" ||
+        specifierType === "ImportNamespaceSpecifier" ||
+        specifierType === "ImportDefaultSpecifier"
+      ) {
+        standalonesSpecifiers.push(print(specifierPath));
+      } else if (
+        specifierType === "ExportSpecifier" ||
+        specifierType === "ImportSpecifier"
+      ) {
+        groupedSpecifiers.push(print(specifierPath));
+      } else {
+        throw new Error(
+          `Unknown specifier type ${JSON.stringify(specifierType)}`
+        );
+      }
+    }, "specifiers");
+
+    parts.push(join(", ", standalonesSpecifiers));
+
+    const canBreak =
+      groupedSpecifiers.length > 1 ||
+      standalonesSpecifiers.length > 0 ||
+      (node.specifiers && node.specifiers.some((node) => node.comments));
+
+    if (groupedSpecifiers.length !== 0) {
+      if (standalonesSpecifiers.length !== 0) {
+        parts.push(", ");
+      }
+
+      if (canBreak) {
+        parts.push(
+          group(
+            concat([
+              "{",
+              indent(
+                concat([
+                  options.bracketSpacing ? line : softline,
+                  join(concat([",", line]), groupedSpecifiers),
+                ])
+              ),
+              ifBreak(shouldPrintComma(options) ? "," : ""),
+              options.bracketSpacing ? line : softline,
+              "}",
+            ])
+          )
+        );
+      } else {
+        parts.push(
+          concat([
+            "{",
+            options.bracketSpacing ? " " : "",
+            concat(groupedSpecifiers),
+            options.bracketSpacing ? " " : "",
+            "}",
+          ])
+        );
+      }
+    }
+  } else {
+    parts.push("{}");
+  }
+  return concat(parts);
+}
+
+module.exports = {
+  printModuleSource,
+  printModuleSpecifiers,
+};

--- a/src/language-js/print/module.js
+++ b/src/language-js/print/module.js
@@ -42,15 +42,15 @@ function printModuleSpecifiers(path, options, print) {
 
     parts.push(join(", ", standalonesSpecifiers));
 
-    const canBreak =
-      groupedSpecifiers.length > 1 ||
-      standalonesSpecifiers.length > 0 ||
-      node.specifiers.some((node) => node.comments);
-
     if (groupedSpecifiers.length !== 0) {
       if (standalonesSpecifiers.length !== 0) {
         parts.push(", ");
       }
+
+      const canBreak =
+        groupedSpecifiers.length > 1 ||
+        standalonesSpecifiers.length > 0 ||
+        node.specifiers.some((node) => node.comments);
 
       if (canBreak) {
         parts.push(

--- a/src/language-js/print/module.js
+++ b/src/language-js/print/module.js
@@ -12,10 +12,7 @@ function printModuleSource(path, options, print) {
 
 function printModuleSpecifiers(path, options, print) {
   const node = path.getValue();
-  const parts = [
-    node.type === "ImportDeclaration" ? " " : "",
-    node.exportKind === "type" ? "type " : "",
-  ];
+  const parts = [node.type === "ImportDeclaration" ? " " : ""];
 
   const standalonesSpecifiers = [];
   const groupedSpecifiers = [];

--- a/src/language-js/print/module.js
+++ b/src/language-js/print/module.js
@@ -36,6 +36,7 @@ function printModuleSpecifiers(path, options, print) {
       ) {
         groupedSpecifiers.push(print(specifierPath));
       } else {
+        /* istanbul ignore next */
         throw new Error(
           `Unknown specifier type ${JSON.stringify(specifierType)}`
         );

--- a/src/language-js/print/module.js
+++ b/src/language-js/print/module.js
@@ -14,10 +14,10 @@ function printModuleSpecifiers(path, options, print) {
   const node = path.getValue();
   const parts = [node.type === "ImportDeclaration" ? " " : ""];
 
-  const standalonesSpecifiers = [];
-  const groupedSpecifiers = [];
-
   if (node.specifiers && node.specifiers.length > 0) {
+    const standalonesSpecifiers = [];
+    const groupedSpecifiers = [];
+
     path.each((specifierPath) => {
       const specifierType = path.getValue().type;
       if (
@@ -45,7 +45,7 @@ function printModuleSpecifiers(path, options, print) {
     const canBreak =
       groupedSpecifiers.length > 1 ||
       standalonesSpecifiers.length > 0 ||
-      (node.specifiers && node.specifiers.some((node) => node.comments));
+      node.specifiers.some((node) => node.comments);
 
     if (groupedSpecifiers.length !== 0) {
       if (standalonesSpecifiers.length !== 0) {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4182,6 +4182,7 @@ function printExportDeclaration(path, options, print) {
       parts.push(semi);
     }
   } else {
+    parts.push(decl.exportKind === "type" ? "type " : "");
     parts.push(printModuleSpecifiers(path, options, print));
     parts.push(printModuleSource(path, options, print));
     parts.push(semi);

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -974,6 +974,8 @@ function printPathNoParens(path, options, print, args) {
     case "ExportDefaultDeclaration":
     case "ExportNamedDeclaration":
       return printExportDeclaration(path, options, print);
+    case "DeclareExportDeclaration":
+      return concat(["declare ", printExportDeclaration(path, options, print)]);
     case "ExportAllDeclaration":
       parts.push("export");
 
@@ -2526,8 +2528,6 @@ function printPathNoParens(path, options, print, args) {
         "declare export *",
         printModuleSource(path, options, print),
       ]);
-    case "DeclareExportDeclaration":
-      return concat(["declare ", printExportDeclaration(path, options, print)]);
     case "DeclareOpaqueType":
     case "OpaqueType": {
       parts.push(


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Add `printModuleSpecifiers` to print import/export 'specifiers'
Add `printModuleSource` to print import/export 'source'

There still some differences between import and export 'specifiers'

- `printModuleSpecifiers` handles empty `specifiers` for `export`, but not for `import`, a little difference between current implementation.
- leading space handled differently, this effect comment print.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
