### PR TITLE
Changelog: Fix Stage-1 => Stage-2

### DIFF
--- a/changelog_unreleased/javascript/pr-8431.md
+++ b/changelog_unreleased/javascript/pr-8431.md
@@ -1,6 +1,6 @@
 #### Support Private Fields in `in` ([#8431](https://github.com/prettier/prettier/pull/8431) by [@sosukesuzuki](https://github.com/sosukesuzuki))
 
-Support Stage-1 proposal [Private Fields in `in`](https://github.com/tc39/proposal-private-fields-in-in/blob/master/README.md).
+Support Stage-2 proposal [Private Fields in `in`](https://github.com/tc39/proposal-private-fields-in-in/blob/master/README.md).
 
 <!-- prettier-ignore -->
 ```js


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
This is a tiny fix for a changelog. `proposal-private-fields-in-in` is Stage-2 in now. See https://github.com/tc39/proposal-private-fields-in-in/commit/4d9da6aa3c5ee617d0d7f6d16a4a4965b8048c28
<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
