### PR TITLE
Refactor: Use `normalizeParts` from `document/utils` in `printer-markdown`

### DIFF
--- a/src/document/doc-utils.js
+++ b/src/document/doc-utils.js
@@ -250,6 +250,18 @@ function normalizeParts(parts) {
   return newParts;
 }
 
+function normalizeDoc(doc) {
+  return mapDoc(doc, (currentDoc) => {
+    if (!currentDoc.parts) {
+      return currentDoc;
+    }
+    return {
+      ...currentDoc,
+      parts: normalizeParts(currentDoc.parts),
+    };
+  });
+}
+
 module.exports = {
   isEmpty,
   willBreak,
@@ -261,4 +273,5 @@ module.exports = {
   removeLines,
   stripTrailingHardline,
   normalizeParts,
+  normalizeDoc,
 };

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -856,20 +856,6 @@ function normalizeDoc(doc) {
     if (!currentDoc.parts) {
       return currentDoc;
     }
-
-    if (currentDoc.type === "concat" && currentDoc.parts.length === 1) {
-      return currentDoc.parts[0];
-    }
-
-    const parts = currentDoc.parts.reduce((parts, part) => {
-      if (part.type === "concat") {
-        parts.push(...part.parts);
-      } else if (part !== "") {
-        parts.push(part);
-      }
-      return parts;
-    }, []);
-
     return {
       ...currentDoc,
       parts: normalizeParts(parts),

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -20,7 +20,7 @@ const {
     indent,
     group,
   },
-  utils: { mapDoc },
+  utils: { mapDoc, normalizeParts },
   printer: { printDocToString },
 } = require("../document");
 const {
@@ -911,20 +911,6 @@ function printTitle(title, options, printSpace) {
       : '"';
   title = title.replace(new RegExp(`(${quote})`, "g"), "\\$1");
   return `${quote}${title}${quote}`;
-}
-
-function normalizeParts(parts) {
-  return parts.reduce((current, part) => {
-    const lastPart = privateUtil.getLast(current);
-
-    if (typeof lastPart === "string" && typeof part === "string") {
-      current.splice(-1, 1, lastPart + part);
-    } else {
-      current.push(part);
-    }
-
-    return current;
-  }, []);
 }
 
 function clamp(value, min, max) {

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -858,7 +858,7 @@ function normalizeDoc(doc) {
     }
     return {
       ...currentDoc,
-      parts: normalizeParts(parts),
+      parts: normalizeParts(currentDoc.parts),
     };
   });
 }

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -20,7 +20,7 @@ const {
     indent,
     group,
   },
-  utils: { mapDoc, normalizeParts },
+  utils: { normalizeDoc },
   printer: { printDocToString },
 } = require("../document");
 const {
@@ -849,18 +849,6 @@ function shouldRemainTheSameContent(path) {
     (ancestorNode.type !== "linkReference" ||
       ancestorNode.referenceType !== "full")
   );
-}
-
-function normalizeDoc(doc) {
-  return mapDoc(doc, (currentDoc) => {
-    if (!currentDoc.parts) {
-      return currentDoc;
-    }
-    return {
-      ...currentDoc,
-      parts: normalizeParts(currentDoc.parts),
-    };
-  });
 }
 
 function printUrl(url, dangerousCharOrChars) {

--- a/tests_integration/__tests__/normalize-doc.js
+++ b/tests_integration/__tests__/normalize-doc.js
@@ -1,0 +1,42 @@
+"use strict";
+
+const prettier = require("prettier/local");
+const docBuilders = prettier.doc.builders;
+const docUtils = prettier.doc.utils;
+
+const { normalizeDoc } = docUtils;
+const { group, concat, fill } = docBuilders;
+
+describe("normalizeDoc", () => {
+  test.each([
+    [
+      "removes empty strings",
+      concat(["", "foo", fill(["", "bar", ""]), ""]),
+      concat(["foo", fill(["bar"])]),
+    ],
+    [
+      "flattens nested concats",
+      concat(["foo", "", concat(["bar", "", concat(["baz", ""])])]),
+      concat(["foobarbaz"]),
+    ],
+    [
+      "flattens nested concats in other docs",
+      group(concat(["foo", concat(["bar", "", concat(["baz", ""])])])),
+      group(concat(["foobarbaz"])),
+    ],
+    [
+      "keeps groups",
+      concat([group("foo"), group("bar"), group("baz")]),
+      concat([group("foo"), group("bar"), group("baz")]),
+    ],
+    [
+      "keeps fills",
+      fill(["foo", fill(["bar", fill(["baz"])])]),
+      fill(["foo", fill(["bar", fill(["baz"])])]),
+    ],
+  ])("%s", (_, doc, expected) => {
+    const result = normalizeDoc(doc);
+
+    expect(result).toEqual(expected);
+  });
+});

--- a/tests_integration/__tests__/normalize-doc.js
+++ b/tests_integration/__tests__/normalize-doc.js
@@ -15,14 +15,14 @@ describe("normalizeDoc", () => {
       concat(["foo", fill(["bar"])]),
     ],
     [
-      "flattens nested concats",
-      concat(["foo", "", concat(["bar", "", concat(["baz", ""])])]),
-      concat(["foobarbaz"]),
+      "flattens nested concat",
+      concat(["foo ", "", concat(["bar ", "", concat(["baz", ""])])]),
+      concat(["foo bar baz"]),
     ],
     [
-      "flattens nested concats in other docs",
-      group(concat(["foo", concat(["bar", "", concat(["baz", ""])])])),
-      group(concat(["foobarbaz"])),
+      "flattens nested concat in other docs",
+      group(concat(["foo ", concat(["bar ", "", concat(["baz", ""])])])),
+      group(concat(["foo bar baz"])),
     ],
     [
       "keeps groups",


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Using `normalizeParts` from utils in `printer-markdown` seems to work fine.
<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
