### PR TITLE
Fix crash on `tabWidth: 0`

### DIFF
--- a/src/document/doc-builders.js
+++ b/src/document/doc-builders.js
@@ -209,6 +209,7 @@ function join(sep, arr) {
  * @param {number} tabWidth
  */
 function addAlignmentToDoc(doc, size, tabWidth) {
+  tabWidth = Math.max(tabWidth, 1);
   let aligned = doc;
   if (size > 0) {
     // Use indent to add tabs for all the levels of tabs we need

--- a/src/main/core-options.js
+++ b/src/main/core-options.js
@@ -237,7 +237,7 @@ const options = {
     category: CATEGORY_GLOBAL,
     default: 2,
     description: "Number of spaces per indentation level.",
-    range: { start: 0, end: Infinity, step: 1 },
+    range: { start: 1, end: Infinity, step: 1 },
   },
   useTabs: {
     since: "1.0.0",

--- a/tests/misc/tab-width/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/misc/tab-width/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,157 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test.js - {"useTabs":true,"tabWidth":"Infinity"} format 1`] = `
+====================================options=====================================
+parsers: ["babel"]
+printWidth: 80
+tabWidth: Infinity
+useTabs: true
+                                                                                | printWidth
+=====================================input======================================
+foo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne(),
+
+// This template literal triggers \`addAlignmentToDoc\` in \`src/language-js/printer-estree.js\`
+\`
+  \${foo}
+    bar
+    \${
+            foo
+                  }
+    \${
+              bar
+      \`
+                      \${foo}
+            \${
+                  foo
+}
+      \`
+    }
+    foo
+\`);
+
+=====================================output=====================================
+foo(
+	reallyLongArg(),
+	omgSoManyParameters(),
+	IShouldRefactorThis(),
+	isThereSeriouslyAnotherOne(),
+
+	// This template literal triggers \`addAlignmentToDoc\` in \`src/language-js/printer-estree.js\`
+	\`
+  \${foo}
+    bar
+    \${foo}
+    \${bar\`
+                      \${foo}
+            \${foo}
+      \`}
+    foo
+\`
+);
+
+================================================================================
+`;
+
+exports[`test.js - {"useTabs":true,"tabWidth":-2} format 1`] = `
+====================================options=====================================
+parsers: ["babel"]
+printWidth: 80
+tabWidth: -2
+useTabs: true
+                                                                                | printWidth
+=====================================input======================================
+foo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne(),
+
+// This template literal triggers \`addAlignmentToDoc\` in \`src/language-js/printer-estree.js\`
+\`
+  \${foo}
+    bar
+    \${
+            foo
+                  }
+    \${
+              bar
+      \`
+                      \${foo}
+            \${
+                  foo
+}
+      \`
+    }
+    foo
+\`);
+
+=====================================output=====================================
+foo(
+	reallyLongArg(),
+	omgSoManyParameters(),
+	IShouldRefactorThis(),
+	isThereSeriouslyAnotherOne(),
+
+	// This template literal triggers \`addAlignmentToDoc\` in \`src/language-js/printer-estree.js\`
+	\`
+  \${foo}
+    bar
+    \${foo}
+    \${bar\`
+                      \${foo}
+            \${foo}
+      \`}
+    foo
+\`
+);
+
+================================================================================
+`;
+
+exports[`test.js - {"useTabs":true,"tabWidth":0} format 1`] = `
+====================================options=====================================
+parsers: ["babel"]
+printWidth: 80
+tabWidth: 0
+useTabs: true
+                                                                                | printWidth
+=====================================input======================================
+foo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne(),
+
+// This template literal triggers \`addAlignmentToDoc\` in \`src/language-js/printer-estree.js\`
+\`
+  \${foo}
+    bar
+    \${
+            foo
+                  }
+    \${
+              bar
+      \`
+                      \${foo}
+            \${
+                  foo
+}
+      \`
+    }
+    foo
+\`);
+
+=====================================output=====================================
+foo(
+	reallyLongArg(),
+	omgSoManyParameters(),
+	IShouldRefactorThis(),
+	isThereSeriouslyAnotherOne(),
+
+	// This template literal triggers \`addAlignmentToDoc\` in \`src/language-js/printer-estree.js\`
+	\`
+  \${foo}
+    bar
+    \${foo}
+    \${bar\`
+                      \${foo}
+            \${foo}
+      \`}
+    foo
+\`
+);
+
+================================================================================
+`;

--- a/tests/misc/tab-width/jsfmt.spec.js
+++ b/tests/misc/tab-width/jsfmt.spec.js
@@ -1,0 +1,3 @@
+run_spec(__dirname, ["babel"], { useTabs: true, tabWidth: 0 });
+run_spec(__dirname, ["babel"], { useTabs: true, tabWidth: Infinity });
+run_spec(__dirname, ["babel"], { useTabs: true, tabWidth: -2 });

--- a/tests/misc/tab-width/test.js
+++ b/tests/misc/tab-width/test.js
@@ -1,0 +1,20 @@
+foo(reallyLongArg(), omgSoManyParameters(), IShouldRefactorThis(), isThereSeriouslyAnotherOne(),
+
+// This template literal triggers `addAlignmentToDoc` in `src/language-js/printer-estree.js`
+`
+  ${foo}
+    bar
+    ${
+            foo
+                  }
+    ${
+              bar
+      `
+                      ${foo}
+            ${
+                  foo
+}
+      `
+    }
+    foo
+`);

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -231,7 +231,7 @@ Object {
       "default": 2,
       "range": Object {
         "end": Infinity,
-        "start": 0,
+        "start": 1,
         "step": 1,
       },
       "type": "int",
@@ -1013,7 +1013,7 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"description\\": \\"Number of spaces per indentation level.\\",
       \\"name\\": \\"tabWidth\\",
       \\"pluginDefaults\\": {},
-      \\"range\\": { \\"end\\": null, \\"start\\": 0, \\"step\\": 1 },
+      \\"range\\": { \\"end\\": null, \\"start\\": 1, \\"step\\": 1 },
       \\"type\\": \\"int\\"
     },
     {


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fixes #7388

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
