### PR TITLE
[WIP] Add option to prevent mutating the AST during printing

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -764,8 +764,14 @@ function isNodeIgnoreComment(comment) {
 }
 
 function addCommentHelper(node, comment) {
-  const comments = node.comments || (node.comments = []);
-  comments.push(comment);
+  if (comment._cache) {
+    // If the comment has a `_cache` property, we should not mutate the AST.
+    // Use the cache instead.
+    comment._cache.attachCommentToNode(node, comment);
+  } else {
+    const comments = node.comments || (node.comments = []);
+    comments.push(comment);
+  }
   comment.printed = false;
 
   // For some reason, TypeScript parses `// x` inside of JSXText as a comment

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -74,7 +74,7 @@ function printAstToDoc(ast, options, alignmentSize = 0) {
     return res;
   }
 
-  let doc = printGenerically(new FastPath(ast));
+  let doc = printGenerically(new FastPath(ast, comments.getAugmenter(options)));
   if (alignmentSize > 0) {
     // Add a hardline to make the indents take effect
     // It should be removed in index.js format()

--- a/src/main/core-options.js
+++ b/src/main/core-options.js
@@ -246,6 +246,14 @@ const options = {
     default: false,
     description: "Indent with tabs instead of spaces.",
   },
+  preserveAst: {
+    since: "2.1.0",
+    category: CATEGORY_OTHER,
+    type: "boolean",
+    default: false,
+    description:
+      "Whether Prettier will (potentially) modify the AST to attach comments.",
+  },
   embeddedLanguageFormatting: {
     since: "2.1.0",
     category: CATEGORY_GLOBAL,

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -53,9 +53,21 @@ function ensureAllCommentsPrinted(astComments) {
 }
 
 function attachComments(text, ast, opts) {
-  const astComments = ast.comments;
+  let astComments = ast.comments;
   if (astComments) {
-    delete ast.comments;
+    if (opts.preserveAst) {
+      opts._commentCache = { astComments, cache: new comments.CommentMap() };
+      if (Array.isArray(astComments)) {
+        // Make a 2-level shallow copy of the comments so they
+        // can be safely mutated
+        astComments = astComments.map((comment) => ({
+          ...comment,
+          _cache: opts._commentCache.cache,
+        }));
+      }
+    } else {
+      delete ast.comments;
+    }
     comments.attach(astComments, ast, text, opts);
   }
   ast.tokens = [];

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -86,6 +86,8 @@ Format options:
                            Defaults to false.
   --parser <flow|babel|babel-flow|babel-ts|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|html|angular|lwc>
                            Which parser to use.
+  --preserve-ast           Whether Prettier will (potentially) modify the AST to attach comments.
+                           Defaults to false.
   --print-width <int>      The line length where Prettier will try wrap.
                            Defaults to 80.
   --prose-wrap <always|never|preserve>
@@ -245,6 +247,8 @@ Format options:
                            Defaults to false.
   --parser <flow|babel|babel-flow|babel-ts|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|html|angular|lwc>
                            Which parser to use.
+  --preserve-ast           Whether Prettier will (potentially) modify the AST to attach comments.
+                           Defaults to false.
   --print-width <int>      The line length where Prettier will try wrap.
                            Defaults to 80.
   --prose-wrap <always|never|preserve>

--- a/tests_integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/help-options.js.snap
@@ -408,6 +408,19 @@ Default: []
 
 exports[`show detailed usage with --help plugin-search-dir (write) 1`] = `Array []`;
 
+exports[`show detailed usage with --help preserve-ast (stderr) 1`] = `""`;
+
+exports[`show detailed usage with --help preserve-ast (stdout) 1`] = `
+"--preserve-ast
+
+  Whether Prettier will (potentially) modify the AST to attach comments.
+
+Default: false
+"
+`;
+
+exports[`show detailed usage with --help preserve-ast (write) 1`] = `Array []`;
+
 exports[`show detailed usage with --help print-width (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help print-width (stdout) 1`] = `

--- a/tests_integration/__tests__/__snapshots__/plugin-options-string.js.snap
+++ b/tests_integration/__tests__/__snapshots__/plugin-options-string.js.snap
@@ -23,10 +23,10 @@ exports[` 1`] = `
 -   --parser <flow|babel|babel-flow|babel-ts|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|html|angular|lwc>
 +   --parser <flow|babel|babel-flow|babel-ts|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|html|angular|lwc|foo-parser>
                              Which parser to use.
+    --preserve-ast           Whether Prettier will (potentially) modify the AST to attach comments.
+                             Defaults to false.
     --print-width <int>      The line length where Prettier will try wrap.
-                             Defaults to 80.
-    --prose-wrap <always|never|preserve>
-                             How to wrap prose."
+                             Defaults to 80."
 `;
 
 exports[`show detailed external option with \`--help foo-string\` (stderr) 1`] = `""`;

--- a/tests_integration/__tests__/__snapshots__/plugin-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/plugin-options.js.snap
@@ -23,10 +23,10 @@ exports[` 1`] = `
 -   --parser <flow|babel|babel-flow|babel-ts|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|html|angular|lwc>
 +   --parser <flow|babel|babel-flow|babel-ts|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|html|angular|lwc|foo-parser>
                              Which parser to use.
+    --preserve-ast           Whether Prettier will (potentially) modify the AST to attach comments.
+                             Defaults to false.
     --print-width <int>      The line length where Prettier will try wrap.
-                             Defaults to 80.
-    --prose-wrap <always|never|preserve>
-                             How to wrap prose."
+                             Defaults to 80."
 `;
 
 exports[`include plugin's parsers to the values of the \`parser\` option\` (stderr) 1`] = `""`;

--- a/tests_integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests_integration/__tests__/__snapshots__/schema.js.snap
@@ -266,6 +266,11 @@ Multiple values are accepted.",
           },
           "type": "array",
         },
+        "preserveAst": Object {
+          "default": false,
+          "description": "Whether Prettier will (potentially) modify the AST to attach comments.",
+          "type": "boolean",
+        },
         "printWidth": Object {
           "default": 80,
           "description": "The line length where Prettier will try wrap.",

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -170,6 +170,10 @@ Object {
       "default": Array [],
       "type": "path",
     },
+    "preserveAst": Object {
+      "default": false,
+      "type": "boolean",
+    },
     "printWidth": Object {
       "default": 80,
       "range": Object {
@@ -899,6 +903,15 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"pluginDefaults\\": {},
       \\"since\\": \\"1.10.0\\",
       \\"type\\": \\"path\\"
+    },
+    {
+      \\"category\\": \\"Other\\",
+      \\"default\\": false,
+      \\"description\\": \\"Whether Prettier will (potentially) modify the AST to attach comments.\\",
+      \\"name\\": \\"preserveAst\\",
+      \\"pluginDefaults\\": {},
+      \\"since\\": \\"2.1.0\\",
+      \\"type\\": \\"boolean\\"
     },
     {
       \\"category\\": \\"Global\\",


### PR DESCRIPTION
Attempts to address #8122 an allow for printing of an AST without mutating it. Mutation seems to only happen when dealing with comments (the `.comments` property of the root AST is deleted, and
comments are attached to nodes; `.comments` properties are created on nodes if they don't exist).

This PR, instead of mutating the AST, keeps a parallel cache of modifications via a Javascript `Map()` object. When an AST node is requested via `FastPath`, the cache is consulted. If there are cached comments, a new object is constructed containing the contents of the original node and the cached contents. In this way, the original node is never touched.

A new option `preserveAst` is added, which defaults to `false`, to enable the new behavior. This is in case third party plugins rely on Prettier mutating the AST.

This is a WIP because I wanted to see if the community likes this approach before investing more time. It *mostly* works, however, there are some issues I am not sure how to track down.

For example, the code
```
import { //comment
x } from "";
```
will format as itself when `preserveAst === true` but should format as
```
import {
   //comment
   x
} from "";
```
I cannot figure out why/where this is happening. The output from `comments.printComments` is identical with and without `preserveAst`.




- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
