### PR TITLE
Fix encoding in postcss-parser build

### DIFF
--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -47,7 +47,7 @@ async function createBundle(bundleConfig, cache) {
     // `prettier-chrome-extension` https://github.com/prettier/prettier-chrome-extension
     // details https://github.com/prettier/prettier/pull/8534
     if (target === "universal") {
-      const file = path.join("dist", bundleConfig.output);
+      const file = path.join("dist", output);
       const content = fs.readFileSync(file, "utf8");
       if (content.includes("\ufffe")) {
         throw new Error("Bundled umd file should not has U+FFFE character.");

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -41,7 +41,12 @@ async function createBundle(bundleConfig, cache) {
   process.stdout.write(fitTerminal(output));
 
   try {
-    const result = await bundler(bundleConfig, cache);
+    const { cached } = await bundler(bundleConfig, cache);
+
+    if (cached) {
+      console.log(CACHED);
+      return;
+    }
 
     // Files include U+FFEE can't load in Chrome Extension
     // `prettier-chrome-extension` https://github.com/prettier/prettier-chrome-extension
@@ -54,11 +59,7 @@ async function createBundle(bundleConfig, cache) {
       }
     }
 
-    if (result.cached) {
-      console.log(CACHED);
-    } else {
-      console.log(OK);
-    }
+    console.log(OK);
   } catch (error) {
     console.log(FAIL + "\n");
     handleError(error);

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -48,14 +48,14 @@ async function createBundle(bundleConfig, cache) {
       return;
     }
 
-    // Files include U+FFEE can't load in Chrome Extension
+    // Files including U+FFEE can't load in Chrome Extension
     // `prettier-chrome-extension` https://github.com/prettier/prettier-chrome-extension
     // details https://github.com/prettier/prettier/pull/8534
     if (target === "universal") {
       const file = path.join("dist", output);
       const content = fs.readFileSync(file, "utf8");
       if (content.includes("\ufffe")) {
-        throw new Error("Bundled umd file should not has U+FFFE character.");
+        throw new Error("Bundled umd file should not have U+FFFE character.");
       }
     }
 

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -47,10 +47,10 @@ const parsers = [
       // prevent terser generate extra .LICENSE file
       extractComments: false,
       terserOptions: {
-        // prevent U+FFFE in the output
-        output: {
-          ascii_only: true,
-        },
+        // // prevent U+FFFE in the output
+        // output: {
+        //   ascii_only: true,
+        // },
         mangle: {
           // postcss need keep_fnames when minify
           keep_fnames: true,

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -47,6 +47,10 @@ const parsers = [
       // prevent terser generate extra .LICENSE file
       extractComments: false,
       terserOptions: {
+        // https://github.com/webpack-contrib/terser-webpack-plugin/issues/107
+        output: {
+          ascii_only: true,
+        },
         mangle: {
           // postcss need keep_fnames when minify
           keep_fnames: true,

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -47,10 +47,10 @@ const parsers = [
       // prevent terser generate extra .LICENSE file
       extractComments: false,
       terserOptions: {
-        // // prevent U+FFFE in the output
-        // output: {
-        //   ascii_only: true,
-        // },
+        // prevent U+FFFE in the output
+        output: {
+          ascii_only: true,
+        },
         mangle: {
           // postcss need keep_fnames when minify
           keep_fnames: true,

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -47,7 +47,7 @@ const parsers = [
       // prevent terser generate extra .LICENSE file
       extractComments: false,
       terserOptions: {
-        // https://github.com/webpack-contrib/terser-webpack-plugin/issues/107
+        // prevent U+FFFE in the output
         output: {
           ascii_only: true,
         },


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**

Fix encoding in postcss-parser build
The encoding in parser-postcss build makes it not possible to load it inside a chrome extension. 

Related issues:

- Fixes: https://github.com/prettier/prettier-chrome-extension/issues/203
- https://github.com/webpack-contrib/terser-webpack-plugin/issues/107