### PR TITLE
Fix: Incorrect whitespace added after escaped colon in css line name

### DIFF
--- a/changelog_unreleased/css/pr-8535.md
+++ b/changelog_unreleased/css/pr-8535.md
@@ -1,0 +1,20 @@
+#### Incorrect whitespace added after escaped colon in css grid line name ([#8535](https://github.com/prettier/prettier/pull/8535) by [@boyenn](https://github.com/boyenn))
+
+<!-- prettier-ignore -->
+```css
+/* Input */
+.grid {
+  grid-template-rows:
+    [row-1-00\:00] auto;
+}
+
+/* Prettier stable */
+.grid {
+  grid-template-rows: [row-1-00\: 00] auto;
+}
+
+/* Prettier master */
+.grid {
+  grid-template-rows: [row-1-00\:00] auto;
+}
+```

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -902,10 +902,17 @@ function genericPrint(path, options, print) {
       return node.value;
     }
     case "value-colon": {
+      const parentNode = path.getParentNode();
+      const index = parentNode && parentNode.groups.indexOf(node);
+      const prevNode = index && parentNode.groups[index - 1];
       return concat([
         node.value,
+        // Don't add spaces on escaped colon `:`, e.g: grid-template-rows: [row-1-00\:00] auto;
+        prevNode.value[prevNode.value.length - 1] === "\\" ||
         // Don't add spaces on `:` in `url` function (i.e. `url(fbglyph: cross-outline, fig-white)`)
-        insideValueFunctionNode(path, "url") ? "" : line,
+        insideValueFunctionNode(path, "url")
+          ? ""
+          : line,
       ]);
     }
     case "value-comma": {

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -908,7 +908,7 @@ function genericPrint(path, options, print) {
       return concat([
         node.value,
         // Don't add spaces on escaped colon `:`, e.g: grid-template-rows: [row-1-00\:00] auto;
-        prevNode.value[prevNode.value.length - 1] === "\\" ||
+        (prevNode && prevNode.value[prevNode.value.length - 1] === "\\") ||
         // Don't add spaces on `:` in `url` function (i.e. `url(fbglyph: cross-outline, fig-white)`)
         insideValueFunctionNode(path, "url")
           ? ""

--- a/tests/css/character-escaping/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css/character-escaping/__snapshots__/jsfmt.spec.js.snap
@@ -60,6 +60,11 @@ printWidth: 80
     content: "\\21D3";
 }
 
+.grid {
+  grid-template-rows:
+    [row-1-00\\:00] auto;
+}
+
 =====================================output=====================================
 #♥ {
 }
@@ -154,6 +159,10 @@ printWidth: 80
 .bar\\/baz {
   animation-name: \\@mymove;
   content: "\\21D3";
+}
+
+.grid {
+  grid-template-rows: [row-1-00\\:00] auto;
 }
 
 ================================================================================

--- a/tests/css/character-escaping/character_escaping.css
+++ b/tests/css/character-escaping/character_escaping.css
@@ -51,3 +51,8 @@
     animation-name: \@mymove;
     content: "\21D3";
 }
+
+.grid {
+  grid-template-rows:
+    [row-1-00\:00] auto;
+}


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Potentially fixes https://github.com/prettier/prettier/issues/8512. I'm guessing however that this is at its core an issue in the ast parser, see https://github.com/prettier/prettier/issues/8512#issuecomment-641322576
<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
**Prettier pr-8535**
[Playground link](https://deploy-preview-8535--prettier.netlify.app/playground/#N4Igxg9gdgLgprEAuEA6A5gJwJYBMAEwAOlPvlngLTwC2ADgDYCG8lmEA7gM5IllkBtdh0oBGSgAYJRIkikBdfEwCuMCAG4SAXxAAaEBDoxs0LslBNMwgAqWEZlEwYcmATzP6ARpiZgA1nAwAMp0vthQ6MgwmMpw+nA0nnC4uMkAMkwRykzocABiEJg0LMYRyCAqanogABYwNAwA6jXY8FyhYHBB9q3YAG6truVgXB4g4VxwmDDWPujFyABmTpP6AFZcAB4AQj7+gUFMNHBp4XBLK3EgG5tB4egMcACKyhDwFwyrIKGYk5jDo2qdBwsEaeBgNWQAA4JPpgRBJo0fHRysC4H8+ud9ABHV7wWaGBwVLiUKBwZLJaqYOC47DU2Y5BZIZafK6TGjYKIxNn3R4vN7nZmXfQwJieMG4CHIABMIp82AY9wAwhAaEyQOiAKzVZSTAAqYocLK+fViAEkoKlYEEwDgjABBS1BGCuR4fSZaLRAA)
```sh
--parser css
```

**Input:**
```css
.grid {
  grid-template-rows:
    [row-1-00\:00] auto;
}
```

**Output:**
```css
.grid {
  grid-template-rows: [row-1-00\:00] auto;
}

```