### PR TITLE
Fix: at rule supports selector

### DIFF
--- a/changelog_unreleased/css/pr-8545.md
+++ b/changelog_unreleased/css/pr-8545.md
@@ -1,0 +1,37 @@
+#### Add support for @supports selector(<custom-selector>) ([#8545](https://github.com/prettier/prettier/pull/8545) by [@boyenn](https://github.com/boyenn))
+
+<!-- prettier-ignore -->
+```css
+/* Input */
+@supports selector(:focus-visible) {
+  button:focus {
+    outline: none;
+  }
+
+  button:focus-visible {
+    outline: 2px solid orange;
+  }
+}
+
+/* Prettier stable */
+@supports selector(: focus-visible) {
+  button:focus {
+    outline: none;
+  }
+
+  button:focus-visible {
+    outline: 2px solid orange;
+  }
+}
+
+/* Prettier master */
+@supports selector(:focus-visible) {
+  button:focus {
+    outline: none;
+  }
+
+  button:focus-visible {
+    outline: 2px solid orange;
+  }
+}
+```

--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -14,12 +14,12 @@ const {
 } = require("./utils");
 const { calculateLoc, replaceQuotesInInlineComments } = require("./loc");
 
-function getHighestAncestor(node) {
-  if (!node.parent) {
-    return node;
+const getHighestAncestor = node => {
+  while (node.parent) {
+    node = node.parent;
   }
-  return getHighestAncestor(node.parent);
-}
+  return node;
+};
 
 function parseValueNode(valueNode, options) {
   const { nodes } = valueNode;

--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -14,7 +14,15 @@ const {
 } = require("./utils");
 const { calculateLoc, replaceQuotesInInlineComments } = require("./loc");
 
-function parseValueNodes(nodes, options) {
+function getHighestAncestor(node) {
+  if (!node.parent) {
+    return node;
+  }
+  return getHighestAncestor(node.parent);
+}
+
+function parseValueNode(valueNode, options) {
+  const { nodes } = valueNode;
   let parenGroup = {
     open: null,
     close: null,
@@ -43,6 +51,17 @@ function parseValueNodes(nodes, options) {
       // For example, 50px... is parsed as `50` with unit `px...` already by postcss-values-parser.
       node.value = node.value.slice(0, -1);
       node.unit = "...";
+    }
+
+    if (node.type === "func" && node.value === "selector") {
+      node.group.groups = [
+        parseSelector(
+          getHighestAncestor(valueNode).text.slice(
+            node.group.open.sourceIndex + 1,
+            node.group.close.sourceIndex
+          )
+        ),
+      ];
     }
 
     if (node.type === "func" && node.value === "url") {
@@ -138,13 +157,16 @@ function flattenGroups(node) {
   return node;
 }
 
-function addTypePrefix(node, prefix) {
+function addTypePrefix(node, prefix, skipPrefix) {
   if (node && typeof node === "object") {
     delete node.parent;
     for (const key in node) {
-      addTypePrefix(node[key], prefix);
+      addTypePrefix(node[key], prefix, skipPrefix);
       if (key === "type" && typeof node[key] === "string") {
-        if (!node[key].startsWith(prefix)) {
+        if (
+          !node[key].startsWith(prefix) &&
+          (!skipPrefix || !skipPrefix.test(node[key]))
+        ) {
           node[key] = prefix + node[key];
         }
       }
@@ -168,14 +190,16 @@ function addMissingType(node) {
 
 function parseNestedValue(node, options) {
   if (node && typeof node === "object") {
-    delete node.parent;
     for (const key in node) {
-      parseNestedValue(node[key], options);
-      if (key === "nodes") {
-        node.group = flattenGroups(parseValueNodes(node[key], options));
-        delete node[key];
+      if (key !== "parent") {
+        parseNestedValue(node[key]), options;
+        if (key === "nodes") {
+          node.group = flattenGroups(parseValueNode(node, options));
+          delete node[key];
+        }
       }
     }
+    delete node.parent;
   }
   return node;
 }
@@ -198,7 +222,7 @@ function parseValue(value, options) {
 
   const parsedResult = parseNestedValue(result, options);
 
-  return addTypePrefix(parsedResult, "value-");
+  return addTypePrefix(parsedResult, "value-", /^selector-/);
 }
 
 function parseSelector(selector) {

--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -192,7 +192,7 @@ function parseNestedValue(node, options) {
   if (node && typeof node === "object") {
     for (const key in node) {
       if (key !== "parent") {
-        parseNestedValue(node[key]), options;
+        parseNestedValue(node[key], options);
         if (key === "nodes") {
           node.group = flattenGroups(parseValueNode(node, options));
           delete node[key];

--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -14,7 +14,7 @@ const {
 } = require("./utils");
 const { calculateLoc, replaceQuotesInInlineComments } = require("./loc");
 
-const getHighestAncestor = node => {
+const getHighestAncestor = (node) => {
   while (node.parent) {
     node = node.parent;
   }

--- a/tests/css/atrule/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css/atrule/__snapshots__/jsfmt.spec.js.snap
@@ -4283,6 +4283,17 @@ B
 @supports selector(selector(:focus-visible)) {}
 @supports selector(:::selector(:focus-visible)) {}
 @supports selector(--selector(:focus-visible)) {}
+@supports not (transform-origin: 10em 10em 10em) {}
+@supports not (not (transform-origin: 2px)) {}
+@supports (display: grid) and (not (display: inline-grid)) {}
+@supports (display: table-cell) and (display: list-item) and (display:run-in) {}
+@supports (display: table-cell) and ((display: list-item) and (display:run-in)) {}
+@supports (transform-style: preserve) or (-moz-transform-style: preserve) {}
+@supports (transform-style: preserve) or (-moz-transform-style: preserve) or
+          (-o-transform-style: preserve) or (-webkit-transform-style: preserve) {}
+
+@supports (transform-style: preserve-3d) or ((-moz-transform-style: preserve-3d) or
+          ((-o-transform-style: preserve-3d) or (-webkit-transform-style: preserve-3d))) {}
 
 =====================================output=====================================
 @supports (transform-origin: 5% 5%) {
@@ -4534,6 +4545,31 @@ B
 @supports selector(:::selector(:focus-visible)) {
 }
 @supports selector(--selector(:focus-visible)) {
+}
+@supports not (transform-origin: 10em 10em 10em) {
+}
+@supports not (not (transform-origin: 2px)) {
+}
+@supports (display: grid) and (not (display: inline-grid)) {
+}
+@supports (display: table-cell) and (display: list-item) and (display: run-in) {
+}
+@supports (display: table-cell) and ((display: list-item) and (display: run-in)) {
+}
+@supports (transform-style: preserve) or (-moz-transform-style: preserve) {
+}
+@supports (transform-style: preserve) or (-moz-transform-style: preserve) or
+  (-o-transform-style: preserve) or (-webkit-transform-style: preserve) {
+}
+
+@supports (transform-style: preserve-3d) or
+  (
+    (-moz-transform-style: preserve-3d) or
+      (
+        (-o-transform-style: preserve-3d) or
+          (-webkit-transform-style: preserve-3d)
+      )
+  ) {
 }
 
 ================================================================================

--- a/tests/css/atrule/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css/atrule/__snapshots__/jsfmt.spec.js.snap
@@ -4195,6 +4195,92 @@ run-in
 @supports not((text-align-last:justify)and(-moz-text-align-last:justify)){ }
 @supports (--foo:green) {}
 
+@supports selector(:after) {}
+@supports selector(:focus) {}
+@supports selector(:focus-visible) {}
+@supports selector(A>B) {}
+@supports selector(A       >      B) {}
+@supports selector(A       >
+     B) {}
+@supports selector(A
+>
+B
+) {}
+@supports selector(
+A
+<
+B
+) {}
+@supports selector(.a:not(.b)){}
+@supports selector(:not(.b)){}
+@supports not selector(:after){
+}
+@supports (--foo:green) and selector(:after){
+}
+@supports selector(:before) and selector(:focus-visible){
+}
+@supports selector(:not(.a,.b)) and selector(:focus-visible){
+}
+@supports selector(.a,.b){
+
+}
+@supports selector(){
+
+}
+
+@supports selector(:focus-visible) {
+  button:focus {
+    outline: none;
+  }
+
+  button:focus-visible {
+    outline: 2px solid orange;
+  }
+}
+
+@supports selector(:not(.a,.b)) {
+}
+
+@supports selector(:not(.a,.b), :not(.b,.c)) {
+}
+@supports selector(:not(.a,.b), .b, .c) {
+}
+
+@supports selector(
+  :not(
+  .a,.b)
+  ) {
+}
+@supports selector(
+  :not(
+  .a,.b
+  )
+  ) {
+}
+@supports selector(.asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas .asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas,
+.asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas .asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas){
+}
+@supports selector(.parent>.child ){
+}
+@supports selector(> .child-one){
+}
+@supports selector(.parent  ~  .child){
+}
+@supports selector(ns|* ){
+}
+@supports selector(svg|a ){
+}
+@supports selector(|B ){
+}
+@supports selector(*|*){
+}
+@supports selector(|*){
+}
+@supports selector(.a,.b,:not(asdasldaskdhjkashdahsdkjahskdjhakj,asdasldaskdhjkashdahsdkjahskdjhakj)){
+}
+@supports not (selector(:before) or not (not (selector(:before)))) {
+}
+
 =====================================output=====================================
 @supports (transform-origin: 5% 5%) {
 }
@@ -4342,6 +4428,103 @@ run-in
 @supports not ((text-align-last: justify) and (-moz-text-align-last: justify)) {
 }
 @supports (--foo: green) {
+}
+
+@supports selector(:after) {
+}
+@supports selector(:focus) {
+}
+@supports selector(:focus-visible) {
+}
+@supports selector(A > B) {
+}
+@supports selector(A > B) {
+}
+@supports selector(A > B) {
+}
+@supports selector(A > B) {
+}
+@supports selector(A < B) {
+}
+@supports selector(.a:not(.b)) {
+}
+@supports selector(:not(.b)) {
+}
+@supports not selector(:after) {
+}
+@supports (--foo: green) and selector(:after) {
+}
+@supports selector(:before) and selector(:focus-visible) {
+}
+@supports selector(:not(.a, .b)) and selector(:focus-visible) {
+}
+@supports selector(
+  .a,
+  .b
+) {
+}
+@supports selector() {
+}
+
+@supports selector(:focus-visible) {
+  button:focus {
+    outline: none;
+  }
+
+  button:focus-visible {
+    outline: 2px solid orange;
+  }
+}
+
+@supports selector(:not(.a, .b)) {
+}
+
+@supports selector(
+  :not(.a, .b),
+  :not(.b, .c)
+) {
+}
+@supports selector(
+  :not(.a, .b),
+  .b,
+  .c
+) {
+}
+
+@supports selector(:not(.a, .b)) {
+}
+@supports selector(:not(.a, .b)) {
+}
+@supports selector(
+  .asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas
+    .asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas,
+  .asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas
+    .asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas
+) {
+}
+@supports selector(.parent > .child) {
+}
+@supports selector(> .child-one) {
+}
+@supports selector(.parent ~ .child) {
+}
+@supports selector(ns|*) {
+}
+@supports selector(svg|a) {
+}
+@supports selector(|B) {
+}
+@supports selector(*|*) {
+}
+@supports selector(|*) {
+}
+@supports selector(
+  .a,
+  .b,
+  :not(asdasldaskdhjkashdahsdkjahskdjhakj, asdasldaskdhjkashdahsdkjahskdjhakj)
+) {
+}
+@supports not (selector(:before) or not (not (selector(:before)))) {
 }
 
 ================================================================================

--- a/tests/css/atrule/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css/atrule/__snapshots__/jsfmt.spec.js.snap
@@ -4280,6 +4280,9 @@ B
 }
 @supports not (selector(:before) or not (not (selector(:before)))) {
 }
+@supports selector(selector(:focus-visible)) {}
+@supports selector(:::selector(:focus-visible)) {}
+@supports selector(--selector(:focus-visible)) {}
 
 =====================================output=====================================
 @supports (transform-origin: 5% 5%) {
@@ -4525,6 +4528,12 @@ B
 ) {
 }
 @supports not (selector(:before) or not (not (selector(:before)))) {
+}
+@supports selector(selector(:focus-visible)) {
+}
+@supports selector(:::selector(:focus-visible)) {
+}
+@supports selector(--selector(:focus-visible)) {
 }
 
 ================================================================================

--- a/tests/css/atrule/supports.css
+++ b/tests/css/atrule/supports.css
@@ -370,3 +370,14 @@ B
 @supports selector(selector(:focus-visible)) {}
 @supports selector(:::selector(:focus-visible)) {}
 @supports selector(--selector(:focus-visible)) {}
+@supports not (transform-origin: 10em 10em 10em) {}
+@supports not (not (transform-origin: 2px)) {}
+@supports (display: grid) and (not (display: inline-grid)) {}
+@supports (display: table-cell) and (display: list-item) and (display:run-in) {}
+@supports (display: table-cell) and ((display: list-item) and (display:run-in)) {}
+@supports (transform-style: preserve) or (-moz-transform-style: preserve) {}
+@supports (transform-style: preserve) or (-moz-transform-style: preserve) or
+          (-o-transform-style: preserve) or (-webkit-transform-style: preserve) {}
+
+@supports (transform-style: preserve-3d) or ((-moz-transform-style: preserve-3d) or
+          ((-o-transform-style: preserve-3d) or (-webkit-transform-style: preserve-3d))) {}

--- a/tests/css/atrule/supports.css
+++ b/tests/css/atrule/supports.css
@@ -281,3 +281,89 @@ run-in
 @supports not((text-align-last:justify)or(-moz-text-align-last:justify)){ }
 @supports not((text-align-last:justify)and(-moz-text-align-last:justify)){ }
 @supports (--foo:green) {}
+
+@supports selector(:after) {}
+@supports selector(:focus) {}
+@supports selector(:focus-visible) {}
+@supports selector(A>B) {}
+@supports selector(A       >      B) {}
+@supports selector(A       >
+     B) {}
+@supports selector(A
+>
+B
+) {}
+@supports selector(
+A
+<
+B
+) {}
+@supports selector(.a:not(.b)){}
+@supports selector(:not(.b)){}
+@supports not selector(:after){
+}
+@supports (--foo:green) and selector(:after){
+}
+@supports selector(:before) and selector(:focus-visible){
+}
+@supports selector(:not(.a,.b)) and selector(:focus-visible){
+}
+@supports selector(.a,.b){
+
+}
+@supports selector(){
+
+}
+
+@supports selector(:focus-visible) {
+  button:focus {
+    outline: none;
+  }
+
+  button:focus-visible {
+    outline: 2px solid orange;
+  }
+}
+
+@supports selector(:not(.a,.b)) {
+}
+
+@supports selector(:not(.a,.b), :not(.b,.c)) {
+}
+@supports selector(:not(.a,.b), .b, .c) {
+}
+
+@supports selector(
+  :not(
+  .a,.b)
+  ) {
+}
+@supports selector(
+  :not(
+  .a,.b
+  )
+  ) {
+}
+@supports selector(.asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas .asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas,
+.asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas .asdasldaskdhjkashdahsdkjahskdjhakjsdkjahsdhkas){
+}
+@supports selector(.parent>.child ){
+}
+@supports selector(> .child-one){
+}
+@supports selector(.parent  ~  .child){
+}
+@supports selector(ns|* ){
+}
+@supports selector(svg|a ){
+}
+@supports selector(|B ){
+}
+@supports selector(*|*){
+}
+@supports selector(|*){
+}
+@supports selector(.a,.b,:not(asdasldaskdhjkashdahsdkjahskdjhakj,asdasldaskdhjkashdahsdkjahskdjhakj)){
+}
+@supports not (selector(:before) or not (not (selector(:before)))) {
+}

--- a/tests/css/atrule/supports.css
+++ b/tests/css/atrule/supports.css
@@ -367,3 +367,6 @@ B
 }
 @supports not (selector(:before) or not (not (selector(:before)))) {
 }
+@supports selector(selector(:focus-visible)) {}
+@supports selector(:::selector(:focus-visible)) {}
+@supports selector(--selector(:focus-visible)) {}


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fixes https://github.com/prettier/prettier/issues/8409.

Parses `<complex-selector>` in `@supports selector(<complex-selector>)` as a selector.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**