### PR TITLE
Do not inferParser for ignored files

### DIFF
--- a/src/common/get-file-info.js
+++ b/src/common/get-file-info.js
@@ -67,27 +67,38 @@ function _getFileInfo({
 }) {
   const fileInfo = {
     ignored: ignorer.ignores(filePath),
-    inferredParser: options.inferParser(filePath, plugins) || null,
+    inferredParser: null,
   };
 
-  if (!fileInfo.inferredParser && resolveConfig) {
-    if (!sync) {
-      return config.resolveConfig(filePath).then((resolvedConfig) => {
-        if (resolvedConfig && resolvedConfig.parser) {
-          fileInfo.inferredParser = resolvedConfig.parser;
-        }
+  if (fileInfo.ignored) {
+    return fileInfo;
+  }
 
-        return fileInfo;
-      });
-    }
+  const inferredParser = options.inferParser(filePath, plugins);
 
+  if (inferredParser) {
+    fileInfo.inferredParser = inferredParser;
+    return fileInfo;
+  }
+
+  if (!resolveConfig) {
+    return fileInfo;
+  }
+
+  if (sync) {
     const resolvedConfig = config.resolveConfig.sync(filePath);
     if (resolvedConfig && resolvedConfig.parser) {
       fileInfo.inferredParser = resolvedConfig.parser;
     }
+    return fileInfo;
   }
 
-  return fileInfo;
+  return config.resolveConfig(filePath).then((resolvedConfig) => {
+    if (resolvedConfig && resolvedConfig.parser) {
+      fileInfo.inferredParser = resolvedConfig.parser;
+    }
+    return fileInfo;
+  });
 }
 
 function normalizeFilePath(filePath, ignorePath) {

--- a/tests_integration/__tests__/__snapshots__/file-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/file-info.js.snap
@@ -53,7 +53,7 @@ exports[`extracts file-info with ignored=false for a file in node_modules when -
 exports[`extracts file-info with ignored=true for a file in .prettierignore (stderr) 1`] = `""`;
 
 exports[`extracts file-info with ignored=true for a file in .prettierignore (stdout) 1`] = `
-"{ \\"ignored\\": true, \\"inferredParser\\": \\"babel\\" }
+"{ \\"ignored\\": true, \\"inferredParser\\": null }
 
 "
 `;
@@ -63,7 +63,7 @@ exports[`extracts file-info with ignored=true for a file in .prettierignore (wri
 exports[`extracts file-info with ignored=true for a file in a hand-picked .prettierignore (stderr) 1`] = `""`;
 
 exports[`extracts file-info with ignored=true for a file in a hand-picked .prettierignore (stdout) 1`] = `
-"{ \\"ignored\\": true, \\"inferredParser\\": \\"babel\\" }
+"{ \\"ignored\\": true, \\"inferredParser\\": null }
 
 "
 `;
@@ -113,7 +113,7 @@ exports[`extracts file-info with inferredParser=null for file.foo (write) 1`] = 
 exports[`extracts file-info with with ignored=true for a file in node_modules (stderr) 1`] = `""`;
 
 exports[`extracts file-info with with ignored=true for a file in node_modules (stdout) 1`] = `
-"{ \\"ignored\\": true, \\"inferredParser\\": \\"babel\\" }
+"{ \\"ignored\\": true, \\"inferredParser\\": null }
 
 "
 `;

--- a/tests_integration/__tests__/file-info.js
+++ b/tests_integration/__tests__/file-info.js
@@ -286,7 +286,7 @@ test("API getFileInfo with ignorePath", () => {
     })
   ).resolves.toMatchObject({
     ignored: true,
-    inferredParser: "babel",
+    inferredParser: null,
   });
 });
 
@@ -309,7 +309,7 @@ test("API getFileInfo.sync with ignorePath", () => {
     })
   ).toMatchObject({
     ignored: true,
-    inferredParser: "babel",
+    inferredParser: null,
   });
 });
 
@@ -353,7 +353,7 @@ test("API getFileInfo with withNodeModules", () => {
   );
   expect(prettier.getFileInfo(file)).resolves.toMatchObject({
     ignored: true,
-    inferredParser: "babel",
+    inferredParser: null,
   });
   expect(
     prettier.getFileInfo(file, {

--- a/tests_integration/__tests__/file-info.js
+++ b/tests_integration/__tests__/file-info.js
@@ -138,6 +138,9 @@ test("API getFileInfo with resolveConfig", () => {
   const file2 = path.resolve(
     path.join(__dirname, "../cli/with-resolve-config/file.bar")
   );
+  const file3 = path.resolve(
+    path.join(__dirname, "../cli/with-resolve-config/file.js")
+  );
 
   expect(prettier.getFileInfo(file1)).resolves.toMatchObject({
     ignored: false,
@@ -146,6 +149,10 @@ test("API getFileInfo with resolveConfig", () => {
   expect(prettier.getFileInfo(file2)).resolves.toMatchObject({
     ignored: false,
     inferredParser: null,
+  });
+  expect(prettier.getFileInfo(file3)).resolves.toMatchObject({
+    ignored: false,
+    inferredParser: 'babel',
   });
   expect(
     prettier.getFileInfo(file1, {
@@ -161,6 +168,15 @@ test("API getFileInfo with resolveConfig", () => {
     })
   ).resolves.toMatchObject({
     ignored: false,
+    inferredParser: "babel",
+  });
+  expect(
+    prettier.getFileInfo(file2, {
+      resolveConfig: true,
+    })
+  ).resolves.toMatchObject({
+    ignored: false,
+    // Bug: should be `not-babel`
     inferredParser: "babel",
   });
 });

--- a/tests_integration/__tests__/file-info.js
+++ b/tests_integration/__tests__/file-info.js
@@ -152,7 +152,7 @@ test("API getFileInfo with resolveConfig", () => {
   });
   expect(prettier.getFileInfo(file3)).resolves.toMatchObject({
     ignored: false,
-    inferredParser: 'babel',
+    inferredParser: "babel",
   });
   expect(
     prettier.getFileInfo(file1, {
@@ -171,7 +171,7 @@ test("API getFileInfo with resolveConfig", () => {
     inferredParser: "babel",
   });
   expect(
-    prettier.getFileInfo(file2, {
+    prettier.getFileInfo(file3, {
       resolveConfig: true,
     })
   ).resolves.toMatchObject({

--- a/tests_integration/cli/with-resolve-config/.prettierrc
+++ b/tests_integration/cli/with-resolve-config/.prettierrc
@@ -7,6 +7,10 @@
     {
       "files": "*.bar",
       "options": { "parser": "babel" }
+    },
+    {
+      "files": "*.js",
+      "options": { "parser": "not-babel" }
     }
   ]
 }


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

`inferredParser` is useless for ignored files.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
