### PR TITLE
JavaScript: Prefer a trailing comment when comment on between test and consequent on ternary

### DIFF
--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -67,7 +67,8 @@ function handleOwnLineComment(comment, text, options, ast, isLastComment) {
       comment,
       options
     ) ||
-    handleLabeledStatementComments(enclosingNode, comment)
+    handleLabeledStatementComments(enclosingNode, comment) ||
+    handleTernaryComment(enclosingNode, precedingNode, comment)
   );
 }
 
@@ -938,6 +939,24 @@ function handleTSMappedTypeComments(
     return true;
   }
 
+  return false;
+}
+
+function handleTernaryComment(enclosingNode, precedingNode, comment) {
+  const isTernaryTest = (node, ternary) => {
+    if (!node || !ternary) {
+      return false;
+    }
+    const isTernary =
+      ternary.type === "ConditionalExpression" ||
+      ternary.type === "TSConditionalType";
+    const testField = ternary.test ? "test" : "extendsType";
+    return isTernary && node === ternary[testField];
+  }
+  if (isTernaryTest(precedingNode, enclosingNode)) {
+    addTrailingComment(precedingNode, comment);
+    return true;
+  }
   return false;
 }
 

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -943,16 +943,6 @@ function handleTSMappedTypeComments(
 }
 
 function handleTernaryComment(enclosingNode, precedingNode, comment) {
-  const isTernaryTest = (node, ternary) => {
-    if (!node || !ternary) {
-      return false;
-    }
-    const isTernary =
-      ternary.type === "ConditionalExpression" ||
-      ternary.type === "TSConditionalType";
-    const testField = ternary.test ? "test" : "extendsType";
-    return isTernary && node === ternary[testField];
-  }
   if (isTernaryTest(precedingNode, enclosingNode)) {
     addTrailingComment(precedingNode, comment);
     return true;
@@ -1037,6 +1027,23 @@ function isTypeCastComment(comment) {
   );
 }
 
+function isTernaryTest(node, ternary) {
+  if (!node || !ternary) {
+    return false;
+  }
+  const isTernary =
+    ternary.type === "ConditionalExpression" ||
+    ternary.type === "TSConditionalType";
+  const testField = ternary.test ? "test" : "extendsType";
+  return isTernary && node === ternary[testField];
+}
+
+function shouldIndentComment(path) {
+  const parent = path.getParentNode();
+  const parentParent = path.getParentNode(1);
+  return parent && parentParent && isTernaryTest(parent, parentParent);
+}
+
 module.exports = {
   handleOwnLineComment,
   handleEndOfLineComment,
@@ -1046,4 +1053,5 @@ module.exports = {
   isTypeCastComment,
   getGapRegex,
   getCommentChildNodes,
+  shouldIndentComment,
 };

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -943,6 +943,10 @@ function handleTSMappedTypeComments(
 }
 
 function handleTernaryComment(enclosingNode, precedingNode, comment) {
+  // test
+  //   // comment
+  //   ? first
+  //   : second
   if (isTernaryTest(precedingNode, enclosingNode)) {
     addTrailingComment(precedingNode, comment);
     return true;

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -1061,14 +1061,14 @@ function isCommentParentTernaryTest(commentPath) {
 function shouldIndentComment(path) {
   return (
     isCommentParentTernaryTest(path) &&
-    isTernaryExpression(path.getParentNode(2))
+    !isTernaryExpression(path.getParentNode(2))
   );
 }
 
 function shouldDedentComment(path) {
   return (
     isCommentParentTernaryTest(path) &&
-    !isTernaryExpression(path.getParentNode(2))
+    isTernaryExpression(path.getParentNode(2))
   );
 }
 

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -964,10 +964,8 @@ function hasQuestionInRange(text, start, end, comments, options) {
       for (const comment of comments) {
         const commentStart = options.locStart(comment);
         const commentEnd = options.locEnd(comment);
-        for (let j = commentStart; j < commentEnd; ++j) {
-          if (j === i) {
-            hasQuestion = false;
-          }
+        if (commentStart < i && i < commentEnd) {
+          hasQuestion = false;
         }
       }
       return hasQuestion;

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -1084,11 +1084,9 @@ function isTypeCastComment(comment) {
 }
 
 function isTernaryExpression(node) {
-  if (!node) {
-    return false;
-  }
   return (
-    node.type === "ConditionalExpression" || node.type === "TSConditionalType"
+    node &&
+    (node.type === "ConditionalExpression" || node.type === "TSConditionalType")
   );
 }
 
@@ -1096,11 +1094,11 @@ function isTernaryExpression(node) {
  * Check if node matches the ternary test node
  */
 function isTernaryTest(node, ternary) {
-  if (!node || !ternary) {
+  if (!node || !isTernaryExpression(ternary)) {
     return false;
   }
   const testField = ternary.test ? "test" : "extendsType";
-  return isTernaryExpression(ternary) && node === ternary[testField];
+  return node === ternary[testField];
 }
 
 function isCommentParentTernaryTest(commentPath) {

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -1045,7 +1045,33 @@ function isTernaryTest(node, ternary) {
 function shouldIndentComment(path) {
   const parent = path.getParentNode();
   const parentParent = path.getParentNode(1);
-  return parent && parentParent && isTernaryTest(parent, parentParent);
+  const parentParentParent = path.getParentNode(2);
+  const isNestedTernary =
+    parentParentParent &&
+    (parentParentParent.type === "ConditionalExpression" ||
+    parentParentParent.type === "TSConditionalType")
+  return (
+    parent &&
+    parentParent &&
+    isTernaryTest(parent, parentParent) &&
+    !isNestedTernary
+  );
+}
+
+function shouldDedentComment(path) {
+  const parent = path.getParentNode();
+  const parentParent = path.getParentNode(1);
+  const parentParentParent = path.getParentNode(2);
+  const isNestedTernary =
+    parentParentParent &&
+    (parentParentParent.type === "ConditionalExpression" ||
+    parentParentParent.type === "TSConditionalType")
+  return (
+    parent &&
+    parentParent &&
+    isTernaryTest(parent, parentParent) &&
+    isNestedTernary
+  );
 }
 
 module.exports = {
@@ -1058,4 +1084,5 @@ module.exports = {
   getGapRegex,
   getCommentChildNodes,
   shouldIndentComment,
+  shouldDedentComment,
 };

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -1031,46 +1031,44 @@ function isTypeCastComment(comment) {
   );
 }
 
+function isTernaryExpression(node) {
+  if (!node) {
+    return false;
+  }
+  return (
+    node.type === "ConditionalExpression" || node.type === "TSConditionalType"
+  );
+}
+
+/**
+ * Check if node matches the ternary test node
+ */
 function isTernaryTest(node, ternary) {
   if (!node || !ternary) {
     return false;
   }
-  const isTernary =
-    ternary.type === "ConditionalExpression" ||
-    ternary.type === "TSConditionalType";
   const testField = ternary.test ? "test" : "extendsType";
-  return isTernary && node === ternary[testField];
+  return isTernaryExpression(ternary) && node === ternary[testField];
+}
+
+function isCommentParentTernaryTest(commentPath) {
+  return isTernaryTest(
+    commentPath.getParentNode(),
+    commentPath.getParentNode(1)
+  );
 }
 
 function shouldIndentComment(path) {
-  const parent = path.getParentNode();
-  const parentParent = path.getParentNode(1);
-  const parentParentParent = path.getParentNode(2);
-  const isNestedTernary =
-    parentParentParent &&
-    (parentParentParent.type === "ConditionalExpression" ||
-    parentParentParent.type === "TSConditionalType")
   return (
-    parent &&
-    parentParent &&
-    isTernaryTest(parent, parentParent) &&
-    !isNestedTernary
+    isCommentParentTernaryTest(path) &&
+    isTernaryExpression(path.getParentNode(2))
   );
 }
 
 function shouldDedentComment(path) {
-  const parent = path.getParentNode();
-  const parentParent = path.getParentNode(1);
-  const parentParentParent = path.getParentNode(2);
-  const isNestedTernary =
-    parentParentParent &&
-    (parentParentParent.type === "ConditionalExpression" ||
-    parentParentParent.type === "TSConditionalType")
   return (
-    parent &&
-    parentParent &&
-    isTernaryTest(parent, parentParent) &&
-    isNestedTernary
+    isCommentParentTernaryTest(path) &&
+    !isTernaryExpression(path.getParentNode(2))
   );
 }
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5397,4 +5397,5 @@ module.exports = {
   getGapRegex: handleComments.getGapRegex,
   getCommentChildNodes: handleComments.getCommentChildNodes,
   shouldIndentComment: handleComments.shouldIndentComment,
+  shouldDedentComment: handleComments.shouldDedentComment,
 };

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5396,4 +5396,5 @@ module.exports = {
   },
   getGapRegex: handleComments.getGapRegex,
   getCommentChildNodes: handleComments.getCommentChildNodes,
+  shouldIndentComment: handleComments.shouldIndentComment,
 };

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -219,7 +219,14 @@ function attach(comments, ast, text, options) {
       // If a comment exists on its own line, prefer a leading comment.
       // We also need to check if it's the first line of the file.
       if (
-        pluginHandleOwnLineComment(comment, text, options, ast, isLastComment)
+        pluginHandleOwnLineComment(
+          comment,
+          text,
+          options,
+          ast,
+          isLastComment,
+          comments
+        )
       ) {
         // We're good
       } else if (followingNode) {

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -431,9 +431,18 @@ function printTrailingComment(commentPath, options) {
       locStart
     );
 
-    return lineSuffix(
+    const printed = lineSuffix(
       concat([hardline, isLineBeforeEmpty ? hardline : "", contents])
     );
+
+    if (
+      options.printer.shouldIndentComment &&
+      options.printer.shouldIndentComment(commentPath)
+    ) {
+     return indent(printed);
+    }
+
+    return printed;
   }
 
   let printed = concat([" ", contents]);

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -9,6 +9,7 @@ const {
   indent,
   lineSuffix,
   join,
+  dedent,
   cursor,
 } = require("../document").builders;
 const {
@@ -439,7 +440,14 @@ function printTrailingComment(commentPath, options) {
       options.printer.shouldIndentComment &&
       options.printer.shouldIndentComment(commentPath)
     ) {
-     return indent(printed);
+      return indent(printed);
+    }
+
+    if (
+      options.printer.shouldDedentComment &&
+      options.printer.shouldDedentComment(commentPath)
+    ) {
+      return dedent(printed);
     }
 
     return printed;

--- a/tests/js/conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/conditional/__snapshots__/jsfmt.spec.js.snap
@@ -50,12 +50,33 @@ test
   ? foo
   : bar;
 
+test ?
+  // comment
+  foo
+  : bar;
+
+test ?
+  // comment
+  first
+  : test
+  // comment
+  ? first
+  : second;
+
 test
   /* comment
      comment
      comment
      comment */
   ? foo
+  : bar;
+
+test ?
+  /* comment
+     comment
+     comment
+     comment */
+  foo
   : bar;
 
 test
@@ -130,11 +151,32 @@ test
   : bar;
 
 test
+  ? // comment
+    foo
+  : bar;
+
+test
+  ? // comment
+    first
+  : test
+  // comment
+  ? first
+  : second;
+
+test
   /* comment
      comment
      comment
      comment */
   ? foo
+  : bar;
+
+test
+  ? /* comment
+     comment
+     comment
+     comment */
+    foo
   : bar;
 
 test

--- a/tests/js/conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/conditional/__snapshots__/jsfmt.spec.js.snap
@@ -58,6 +58,29 @@ test
   ? foo
   : bar;
 
+test
+  // ?
+  // comment
+  ? foo
+  : test2
+  // comment
+  // comment
+  ? foo
+  : bar;
+
+test
+  /* comment
+     comment
+     comment
+     comment */
+  ? foo
+  : test
+  /* comment
+     comment
+     comment */
+  ? foo
+  : bar;
+
 =====================================output=====================================
 var inspect =
   4 === util.inspect.length
@@ -109,6 +132,29 @@ test
 test
   /* comment
      comment
+     comment
+     comment */
+  ? foo
+  : bar;
+
+test
+  // ?
+  // comment
+  ? foo
+  : test2
+  // comment
+  // comment
+  ? foo
+  : bar;
+
+test
+  /* comment
+     comment
+     comment
+     comment */
+  ? foo
+  : test
+  /* comment
      comment
      comment */
   ? foo

--- a/tests/js/conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/conditional/__snapshots__/jsfmt.spec.js.snap
@@ -44,6 +44,20 @@ const { configureStore } = process.env.NODE_ENV === "production"
   ? require("./configureProdStore") // a
   : require("./configureDevStore"); // b
 
+test
+  // ?
+  // comment
+  ? foo
+  : bar;
+
+test
+  /* comment
+     comment
+     comment
+     comment */
+  ? foo
+  : bar;
+
 =====================================output=====================================
 var inspect =
   4 === util.inspect.length
@@ -68,8 +82,8 @@ var inspect =
       };
 
 const extractTextPluginOptions = shouldUseRelativeAssetPaths
-  ? // Making sure that the publicPath goes back to to build folder.
-    { publicPath: Array(cssFilename.split("/").length).join("../") }
+  // Making sure that the publicPath goes back to to build folder.
+  ? { publicPath: Array(cssFilename.split("/").length).join("../") }
   : {};
 
 const extractTextPluginOptions2 = shouldUseRelativeAssetPaths
@@ -85,6 +99,20 @@ const { configureStore } =
   process.env.NODE_ENV === "production"
     ? require("./configureProdStore") // a
     : require("./configureDevStore"); // b
+
+test
+  // ?
+  // comment
+  ? foo
+  : bar;
+
+test
+  /* comment
+     comment
+     comment
+     comment */
+  ? foo
+  : bar;
 
 ================================================================================
 `;

--- a/tests/js/conditional/comments.js
+++ b/tests/js/conditional/comments.js
@@ -42,12 +42,33 @@ test
   ? foo
   : bar;
 
+test ?
+  // comment
+  foo
+  : bar;
+
+test ?
+  // comment
+  first
+  : test
+  // comment
+  ? first
+  : second;
+
 test
   /* comment
      comment
      comment
      comment */
   ? foo
+  : bar;
+
+test ?
+  /* comment
+     comment
+     comment
+     comment */
+  foo
   : bar;
 
 test

--- a/tests/js/conditional/comments.js
+++ b/tests/js/conditional/comments.js
@@ -49,3 +49,26 @@ test
      comment */
   ? foo
   : bar;
+
+test
+  // ?
+  // comment
+  ? foo
+  : test2
+  // comment
+  // comment
+  ? foo
+  : bar;
+
+test
+  /* comment
+     comment
+     comment
+     comment */
+  ? foo
+  : test
+  /* comment
+     comment
+     comment */
+  ? foo
+  : bar;

--- a/tests/js/conditional/comments.js
+++ b/tests/js/conditional/comments.js
@@ -35,3 +35,17 @@ const extractTextPluginOptions3 = shouldUseRelativeAssetPaths // Making sure tha
 const { configureStore } = process.env.NODE_ENV === "production"
   ? require("./configureProdStore") // a
   : require("./configureDevStore"); // b
+
+test
+  // ?
+  // comment
+  ? foo
+  : bar;
+
+test
+  /* comment
+     comment
+     comment
+     comment */
+  ? foo
+  : bar;

--- a/tests/js/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -372,8 +372,8 @@ this.doWriteConfiguration(target, value, options) // queue up writes to prevent 
   );
 
 ret = __DEV__
-  // $FlowFixMe: this type differs according to the env
-  ? vm.runInContext(source, ctx)
+  ? // $FlowFixMe: this type differs according to the env
+    vm.runInContext(source, ctx)
   : a;
 
 this.firebase

--- a/tests/js/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -372,8 +372,8 @@ this.doWriteConfiguration(target, value, options) // queue up writes to prevent 
   );
 
 ret = __DEV__
-  ? // $FlowFixMe: this type differs according to the env
-    vm.runInContext(source, ctx)
+  // $FlowFixMe: this type differs according to the env
+  ? vm.runInContext(source, ctx)
   : a;
 
 this.firebase

--- a/tests/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
@@ -20,6 +20,29 @@ type A = test extends B
   ? foo
   : bar;
 
+type A = test extends B
+  // ?
+  // comment
+  ? foo
+  : test2 extends C
+  // comment
+  // comment
+  ? foo
+  : bar;
+
+type B  = test extends B
+  /* comment
+     comment
+     comment
+     comment */
+  ? foo
+  : test2 extends C
+  /* comment
+     comment
+     comment */
+  ? foo
+  : bar;
+
 =====================================output=====================================
 type A = test extends B
   // ?
@@ -30,6 +53,29 @@ type A = test extends B
 type A = test extends B
   /* comment
      comment
+     comment
+     comment */
+  ? foo
+  : bar;
+
+type A = test extends B
+  // ?
+  // comment
+  ? foo
+  : test2 extends C
+  // comment
+  // comment
+  ? foo
+  : bar;
+
+type B = test extends B
+  /* comment
+     comment
+     comment
+     comment */
+  ? foo
+  : test2 extends C
+  /* comment
      comment
      comment */
   ? foo

--- a/tests/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`comments.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type A = test extends B
+  // ?
+  // comment
+  ? foo
+  : bar;
+
+type A = test extends B
+  /* comment
+     comment
+     comment
+     comment */
+  ? foo
+  : bar;
+
+=====================================output=====================================
+type A = test extends B
+  // ?
+  // comment
+  ? foo
+  : bar;
+
+type A = test extends B
+  /* comment
+     comment
+     comment
+     comment */
+  ? foo
+  : bar;
+
+================================================================================
+`;
+
 exports[`conditonal-types.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
@@ -43,6 +43,19 @@ type B  = test extends B
   ? foo
   : bar;
 
+type A = B extends test ?
+  // comment
+  foo
+  : bar;
+
+type A = B extends test ?
+  // comment
+  first
+  : B extends test
+  // comment
+  ? first
+  : second;
+
 =====================================output=====================================
 type A = test extends B
   // ?
@@ -80,6 +93,19 @@ type B = test extends B
      comment */
   ? foo
   : bar;
+
+type A = B extends test
+  ? // comment
+    foo
+  : bar;
+
+type A = B extends test
+  ? // comment
+    first
+  : B extends test
+  // comment
+  ? first
+  : second;
 
 ================================================================================
 `;

--- a/tests/typescript/conditional-types/comments.ts
+++ b/tests/typescript/conditional-types/comments.ts
@@ -11,3 +11,26 @@ type A = test extends B
      comment */
   ? foo
   : bar;
+
+type A = test extends B
+  // ?
+  // comment
+  ? foo
+  : test2 extends C
+  // comment
+  // comment
+  ? foo
+  : bar;
+
+type B  = test extends B
+  /* comment
+     comment
+     comment
+     comment */
+  ? foo
+  : test2 extends C
+  /* comment
+     comment
+     comment */
+  ? foo
+  : bar;

--- a/tests/typescript/conditional-types/comments.ts
+++ b/tests/typescript/conditional-types/comments.ts
@@ -1,0 +1,13 @@
+type A = test extends B
+  // ?
+  // comment
+  ? foo
+  : bar;
+
+type A = test extends B
+  /* comment
+     comment
+     comment
+     comment */
+  ? foo
+  : bar;

--- a/tests/typescript/conditional-types/comments.ts
+++ b/tests/typescript/conditional-types/comments.ts
@@ -34,3 +34,16 @@ type B  = test extends B
      comment */
   ? foo
   : bar;
+
+type A = B extends test ?
+  // comment
+  foo
+  : bar;
+
+type A = B extends test ?
+  // comment
+  first
+  : B extends test
+  // comment
+  ? first
+  : second;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fixes #2076. this is re-implementation of #6418.

The below case is out of this PR scope, I'll work on it after this PR is merged:
**Prettier 2.0.5**
[Playground link](https://prettier.io/playground/#N4Igxg9gdgLgprEAuE8DOMA6UAEOD8OAZgJYBOG2eA9NTpALYMJa45I5pyRQAmIAGhAQADjBLQ0yUAEMyZCAHcACnIRSUMgDaKZATylCARmRlgA1nBgBlEWZJQA5shhkArnCEALGAy0B1LxJ0OzA4a3VgkgA3YL1kcDRDEAcuMhhlU0cGGWQibS4hACs0AA8AIVMLK2sZZgAZBzg8gs8QEtLrB0ctOABFNwh4Fq1CkDsKODIEoxkjOC1BcbIHGH8SXhgvZAAOAAYhEQUuf1MRBKO4NOjmoQBHQfhM0Q0QGTQAWig4OF5fpbIcAe5DgmRk2VySHyozaXAYJBc7lh3V6AyGzShrSEMDm6022yQACZsaYSFpugBhCBMSEgK4AViWbi4ABU5hpoWNoh4AJJ8FjWMArMQAQT41hgel6Iy4AF9ZUA)
```sh
--parser babel
```

**Input:**
```jsx
test
  ? first
  // comment
  : second
```

**Output:**
```jsx
test
  ? first
  : // comment
    second;

```
<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
