### PR TITLE
feat: use different font stack for website

### DIFF
--- a/website/static/overrides.css
+++ b/website/static/overrides.css
@@ -1,6 +1,6 @@
 html body {
-  font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, Helvetica,
-    Arial, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto, Oxygen,
+    Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
 
   overflow-x: hidden;
 }

--- a/website/static/overrides.css
+++ b/website/static/overrides.css
@@ -1,6 +1,6 @@
 html body {
-  font-family: "Apple SD Gothic Neo", "AppleSDGothicNeo", -apple-system,
-    BlinkMacSystemFont, Helvetica, Arial, sans-serif;
+  font-family: "Source Sans Pro", -apple-system, BlinkMacSystemFont, Helvetica,
+    Arial, sans-serif;
 
   overflow-x: hidden;
 }


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

https://github.com/prettier/prettier/issues/8509

Using different font stack for website. `Apple SD Gothic Neo` and `AppleSDGothicNeo` are for the Korean language. It's often a bad idea to use such fonts for English.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
