### PR TITLE
Fix: Prettier breaks code when inline number lists are used as arbitrary arguments [SCSS]

### DIFF
--- a/changelog_unreleased/css/pr-8567.md
+++ b/changelog_unreleased/css/pr-8567.md
@@ -1,6 +1,7 @@
 #### Improve Prettier handling of arbitrary arguments ([#8567](https://github.com/prettier/prettier/pull/8567), ([#8566](https://github.com/prettier/prettier/pull/8566) by [@boyenn](https://github.com/boyenn))
 
 Prettier no longer unexpectedly add extra space after function when passing arbitrary arguments.
+
 <!-- prettier-ignore -->
 ```css
 /* Input */
@@ -23,6 +24,7 @@ body {
 ```
 
 Prettier no longer breaks code when inline number lists are used as arbitrary arguments.
+
 <!-- prettier-ignore -->
 ```css
 /* Input */

--- a/changelog_unreleased/css/pr-8567.md
+++ b/changelog_unreleased/css/pr-8567.md
@@ -30,7 +30,6 @@ Prettier no longer breaks code when inline number lists are used as arbitrary ar
 /* Input */
 body {
   background-color: rgba(50 50 50 50...);
-  test: function(return-list($list)...);
 }
 
 /* Prettier stable */

--- a/changelog_unreleased/css/pr-8567.md
+++ b/changelog_unreleased/css/pr-8567.md
@@ -1,44 +1,28 @@
 #### Improve Prettier handling of arbitrary arguments ([#8567](https://github.com/prettier/prettier/pull/8567), [#8566](https://github.com/prettier/prettier/pull/8566) by [@boyenn](https://github.com/boyenn))
 
 Prettier no longer unexpectedly add extra space after function when passing arbitrary arguments.
-
-<!-- prettier-ignore -->
-```css
-/* Input */
-body {
-  test: function($list...);
-  test: function(return-list($list)...);
-}
-
-/* Prettier stable */
-body {
-  test: function($list...);
-  test: function(return-list($list) ...);
-}
-
-/* Prettier master */
-body {
-  test: function($list...);
-  test: function(return-list($list)...);
-}
-```
-
 Prettier no longer breaks code when inline number lists are used as arbitrary arguments.
 
 <!-- prettier-ignore -->
 ```css
 /* Input */
 body {
+  test: function($list...);
+  foo: bar(returns-list($list)...);
   background-color: rgba(50 50 50 50...);
 }
 
 /* Prettier stable */
 body {
+  test: function($list...);
+  foo: bar(returns-list($list) ...); 
   background-color: rgba(50 50 50 50..);
 }
 
 /* Prettier master */
 body {
+  test: function($list...);
+  foo: bar(returns-list($list)...);
   background-color: rgba(50 50 50 50...);
 }
 ```

--- a/changelog_unreleased/css/pr-8567.md
+++ b/changelog_unreleased/css/pr-8567.md
@@ -1,5 +1,6 @@
-#### Fix: [Sass] Unexpectedly add extra space after function when passing arbitrary arguments ([#8567](https://github.com/prettier/prettier/pull/8567) by [@boyenn](https://github.com/boyenn))
+#### Improve Prettier handling of arbitrary arguments. ([#8567](https://github.com/prettier/prettier/pull/8567) and ([#8566](https://github.com/prettier/prettier/pull/8566) by [@boyenn](https://github.com/boyenn))
 
+##### Fix: [SCSS] Unexpectedly add extra space after function when passing arbitrary arguments
 <!-- prettier-ignore -->
 ```css
 /* Input */
@@ -18,5 +19,25 @@ body {
 body {
   test: function($list...);
   test: function(return-list($list)...);
+}
+```
+
+##### Fix: [SCSS] Prettier breaks code when inline number lists are used as arbitrary arguments
+<!-- prettier-ignore -->
+```css
+/* Input */
+body {
+  background-color: rgba(50 50 50 50...);
+  test: function(return-list($list)...);
+}
+
+/* Prettier stable */
+body {
+  background-color: rgba(50 50 50 50..);
+}
+
+/* Prettier master */
+body {
+  background-color: rgba(50 50 50 50...);
 }
 ```

--- a/changelog_unreleased/css/pr-8567.md
+++ b/changelog_unreleased/css/pr-8567.md
@@ -1,6 +1,6 @@
 #### Improve Prettier handling of arbitrary arguments. ([#8567](https://github.com/prettier/prettier/pull/8567) and ([#8566](https://github.com/prettier/prettier/pull/8566) by [@boyenn](https://github.com/boyenn))
 
-##### Fix: [SCSS] Unexpectedly add extra space after function when passing arbitrary arguments
+##### Fix: [SCSS] Unexpectedly add extra space after function when passing arbitrary arguments ([#8567](https://github.com/prettier/prettier/pull/8567)
 <!-- prettier-ignore -->
 ```css
 /* Input */
@@ -22,7 +22,7 @@ body {
 }
 ```
 
-##### Fix: [SCSS] Prettier breaks code when inline number lists are used as arbitrary arguments
+##### Fix: [SCSS] Prettier breaks code when inline number lists are used as arbitrary arguments ([#8566](https://github.com/prettier/prettier/pull/8566)
 <!-- prettier-ignore -->
 ```css
 /* Input */

--- a/changelog_unreleased/css/pr-8567.md
+++ b/changelog_unreleased/css/pr-8567.md
@@ -1,4 +1,4 @@
-#### Improve Prettier handling of arbitrary arguments ([#8567](https://github.com/prettier/prettier/pull/8567), ([#8566](https://github.com/prettier/prettier/pull/8566) by [@boyenn](https://github.com/boyenn))
+#### Improve Prettier handling of arbitrary arguments ([#8567](https://github.com/prettier/prettier/pull/8567), [#8566](https://github.com/prettier/prettier/pull/8566) by [@boyenn](https://github.com/boyenn))
 
 Prettier no longer unexpectedly add extra space after function when passing arbitrary arguments.
 

--- a/changelog_unreleased/css/pr-8567.md
+++ b/changelog_unreleased/css/pr-8567.md
@@ -1,6 +1,6 @@
-#### Improve Prettier handling of arbitrary arguments. ([#8567](https://github.com/prettier/prettier/pull/8567) and ([#8566](https://github.com/prettier/prettier/pull/8566) by [@boyenn](https://github.com/boyenn))
+#### Improve Prettier handling of arbitrary arguments ([#8567](https://github.com/prettier/prettier/pull/8567), ([#8566](https://github.com/prettier/prettier/pull/8566) by [@boyenn](https://github.com/boyenn))
 
-##### Fix: [SCSS] Unexpectedly add extra space after function when passing arbitrary arguments ([#8567](https://github.com/prettier/prettier/pull/8567)
+Prettier no longer unexpectedly add extra space after function when passing arbitrary arguments.
 <!-- prettier-ignore -->
 ```css
 /* Input */
@@ -22,7 +22,7 @@ body {
 }
 ```
 
-##### Fix: [SCSS] Prettier breaks code when inline number lists are used as arbitrary arguments ([#8566](https://github.com/prettier/prettier/pull/8566)
+Prettier no longer breaks code when inline number lists are used as arbitrary arguments.
 <!-- prettier-ignore -->
 ```css
 /* Input */

--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -32,6 +32,20 @@ function parseValueNodes(nodes) {
   for (let i = 0; i < nodes.length; ++i) {
     const node = nodes[i];
 
+
+    if (
+      node.type === "number" &&
+      node.unit === ".." &&
+      node.value[node.value.length - 1] === "."
+    ) {
+      // Work around postcss bug parsing `50...` as `50.` with unit `..`
+      // Set the unit to `...` to "accidentally" work in the same way that cases where the node already had a unit work.
+      // For example, 50px... is parsed as `50` with unit `px...` already by postcss-values-parser.
+      node.value = node.value.slice(0, -1);
+
+      node.unit = "...";
+    }
+
     if (node.type === "func" && node.value === "url") {
       const groups = (node.group && node.group.groups) || [];
 

--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -39,10 +39,9 @@ function parseValueNodes(nodes) {
       node.value[node.value.length - 1] === "."
     ) {
       // Work around postcss bug parsing `50...` as `50.` with unit `..`
-      // Set the unit to `...` to "accidentally" work in the same way that cases where the node already had a unit work.
+      // Set the unit to `...` to "accidentally" have arbitrary arguments work in the same way that cases where the node already had a unit work.
       // For example, 50px... is parsed as `50` with unit `px...` already by postcss-values-parser.
       node.value = node.value.slice(0, -1);
-
       node.unit = "...";
     }
 

--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -32,7 +32,6 @@ function parseValueNodes(nodes) {
   for (let i = 0; i < nodes.length; ++i) {
     const node = nodes[i];
 
-
     if (
       node.type === "number" &&
       node.unit === ".." &&

--- a/tests/scss/scss/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/scss/scss/__snapshots__/jsfmt.spec.js.snap
@@ -39,6 +39,16 @@ $parameters: (
 );
 $value: dummy($parameters...);
 
+body {
+  background-color: rgba(50, 50, 50, 50);
+  background-color: rgba(50 50 50 50...);
+  background-color: rgba(50 50 .50 50...);
+  background-color: rgba(50 50 50. .50...);
+  // Input is not technically valid ( output is ), but still nice to know that the \`.\` gets dropped as it would for \`50.\`
+  background-color: rgba(50 50 50 50....);
+  width: min(50px 20px 30px...);
+}
+
 =====================================output=====================================
 body {
   test: foo(return-list($list)...);
@@ -71,6 +81,16 @@ $parameters: (
   "b": 42
 );
 $value: dummy($parameters...);
+
+body {
+  background-color: rgba(50, 50, 50, 50);
+  background-color: rgba(50 50 50 50...);
+  background-color: rgba(50 50 0.5 50...);
+  background-color: rgba(50 50 50 0.5...);
+  // Input is not technically valid ( output is ), but still nice to know that the \`.\` gets dropped as it would for \`50.\`
+  background-color: rgba(50 50 50 50...);
+  width: min(50px 20px 30px...);
+}
 
 ================================================================================
 `;
@@ -113,6 +133,16 @@ $parameters: (
 );
 $value: dummy($parameters...);
 
+body {
+  background-color: rgba(50, 50, 50, 50);
+  background-color: rgba(50 50 50 50...);
+  background-color: rgba(50 50 .50 50...);
+  background-color: rgba(50 50 50. .50...);
+  // Input is not technically valid ( output is ), but still nice to know that the \`.\` gets dropped as it would for \`50.\`
+  background-color: rgba(50 50 50 50....);
+  width: min(50px 20px 30px...);
+}
+
 =====================================output=====================================
 body {
   test: foo(return-list($list)...);
@@ -145,6 +175,16 @@ $parameters: (
   "b": 42,
 );
 $value: dummy($parameters...);
+
+body {
+  background-color: rgba(50, 50, 50, 50);
+  background-color: rgba(50 50 50 50...);
+  background-color: rgba(50 50 0.5 50...);
+  background-color: rgba(50 50 50 0.5...);
+  // Input is not technically valid ( output is ), but still nice to know that the \`.\` gets dropped as it would for \`50.\`
+  background-color: rgba(50 50 50 50...);
+  width: min(50px 20px 30px...);
+}
 
 ================================================================================
 `;
@@ -357,67 +397,6 @@ printWidth: 80
 
 =====================================output=====================================
 @import "rounded-corners", "text-shadow";
-
-================================================================================
-`;
-
-exports[`inline_arbitrary_arguments.scss - {"trailingComma":"none"} format 1`] = `
-====================================options=====================================
-parsers: ["scss"]
-printWidth: 80
-trailingComma: "none"
-                                                                                | printWidth
-=====================================input======================================
-body {
-  background-color: rgba(50, 50, 50, 50);
-  background-color: rgba(50 50 50 50...);
-  background-color: rgba(50 50 .50 50...);
-  background-color: rgba(50 50 50. .50...);
-  // Input is not technically valid ( output is ), but still nice to know that the \`.\` gets dropped as it would for \`50.\`
-  background-color: rgba(50 50 50 50....);
-  width: min(50px 20px 30px...);
-}
-
-=====================================output=====================================
-body {
-  background-color: rgba(50, 50, 50, 50);
-  background-color: rgba(50 50 50 50...);
-  background-color: rgba(50 50 0.5 50...);
-  background-color: rgba(50 50 50 0.5...);
-  // Input is not technically valid ( output is ), but still nice to know that the \`.\` gets dropped as it would for \`50.\`
-  background-color: rgba(50 50 50 50...);
-  width: min(50px 20px 30px...);
-}
-
-================================================================================
-`;
-
-exports[`inline_arbitrary_arguments.scss format 1`] = `
-====================================options=====================================
-parsers: ["scss"]
-printWidth: 80
-                                                                                | printWidth
-=====================================input======================================
-body {
-  background-color: rgba(50, 50, 50, 50);
-  background-color: rgba(50 50 50 50...);
-  background-color: rgba(50 50 .50 50...);
-  background-color: rgba(50 50 50. .50...);
-  // Input is not technically valid ( output is ), but still nice to know that the \`.\` gets dropped as it would for \`50.\`
-  background-color: rgba(50 50 50 50....);
-  width: min(50px 20px 30px...);
-}
-
-=====================================output=====================================
-body {
-  background-color: rgba(50, 50, 50, 50);
-  background-color: rgba(50 50 50 50...);
-  background-color: rgba(50 50 0.5 50...);
-  background-color: rgba(50 50 50 0.5...);
-  // Input is not technically valid ( output is ), but still nice to know that the \`.\` gets dropped as it would for \`50.\`
-  background-color: rgba(50 50 50 50...);
-  width: min(50px 20px 30px...);
-}
 
 ================================================================================
 `;

--- a/tests/scss/scss/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/scss/scss/__snapshots__/jsfmt.spec.js.snap
@@ -361,6 +361,67 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`inline_arbitrary_arguments.scss - {"trailingComma":"none"} format 1`] = `
+====================================options=====================================
+parsers: ["scss"]
+printWidth: 80
+trailingComma: "none"
+                                                                                | printWidth
+=====================================input======================================
+body {
+  background-color: rgba(50, 50, 50, 50);
+  background-color: rgba(50 50 50 50...);
+  background-color: rgba(50 50 .50 50...);
+  background-color: rgba(50 50 50. .50...);
+  // Input is not technically valid ( output is ), but still nice to know that the \`.\` gets dropped as it would for \`50.\`
+  background-color: rgba(50 50 50 50....);
+  width: min(50px 20px 30px...);
+}
+
+=====================================output=====================================
+body {
+  background-color: rgba(50, 50, 50, 50);
+  background-color: rgba(50 50 50 50...);
+  background-color: rgba(50 50 0.5 50...);
+  background-color: rgba(50 50 50 0.5...);
+  // Input is not technically valid ( output is ), but still nice to know that the \`.\` gets dropped as it would for \`50.\`
+  background-color: rgba(50 50 50 50...);
+  width: min(50px 20px 30px...);
+}
+
+================================================================================
+`;
+
+exports[`inline_arbitrary_arguments.scss format 1`] = `
+====================================options=====================================
+parsers: ["scss"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+body {
+  background-color: rgba(50, 50, 50, 50);
+  background-color: rgba(50 50 50 50...);
+  background-color: rgba(50 50 .50 50...);
+  background-color: rgba(50 50 50. .50...);
+  // Input is not technically valid ( output is ), but still nice to know that the \`.\` gets dropped as it would for \`50.\`
+  background-color: rgba(50 50 50 50....);
+  width: min(50px 20px 30px...);
+}
+
+=====================================output=====================================
+body {
+  background-color: rgba(50, 50, 50, 50);
+  background-color: rgba(50 50 50 50...);
+  background-color: rgba(50 50 0.5 50...);
+  background-color: rgba(50 50 50 0.5...);
+  // Input is not technically valid ( output is ), but still nice to know that the \`.\` gets dropped as it would for \`50.\`
+  background-color: rgba(50 50 50 50...);
+  width: min(50px 20px 30px...);
+}
+
+================================================================================
+`;
+
 exports[`scss.scss - {"trailingComma":"none"} format 1`] = `
 ====================================options=====================================
 parsers: ["scss"]

--- a/tests/scss/scss/arbitrary-arguments.scss
+++ b/tests/scss/scss/arbitrary-arguments.scss
@@ -29,3 +29,13 @@ $parameters: (
   'b': 42
 );
 $value: dummy($parameters...);
+
+body {
+  background-color: rgba(50, 50, 50, 50);
+  background-color: rgba(50 50 50 50...);
+  background-color: rgba(50 50 .50 50...);
+  background-color: rgba(50 50 50. .50...);
+  // Input is not technically valid ( output is ), but still nice to know that the `.` gets dropped as it would for `50.`
+  background-color: rgba(50 50 50 50....);
+  width: min(50px 20px 30px...);
+}

--- a/tests/scss/scss/inline_arbitrary_arguments.scss
+++ b/tests/scss/scss/inline_arbitrary_arguments.scss
@@ -1,0 +1,9 @@
+body {
+  background-color: rgba(50, 50, 50, 50);
+  background-color: rgba(50 50 50 50...);
+  background-color: rgba(50 50 .50 50...);
+  background-color: rgba(50 50 50. .50...);
+  // Input is not technically valid ( output is ), but still nice to know that the `.` gets dropped as it would for `50.`
+  background-color: rgba(50 50 50 50....);
+  width: min(50px 20px 30px...);
+}

--- a/tests/scss/scss/inline_arbitrary_arguments.scss
+++ b/tests/scss/scss/inline_arbitrary_arguments.scss
@@ -1,9 +1,0 @@
-body {
-  background-color: rgba(50, 50, 50, 50);
-  background-color: rgba(50 50 50 50...);
-  background-color: rgba(50 50 .50 50...);
-  background-color: rgba(50 50 50. .50...);
-  // Input is not technically valid ( output is ), but still nice to know that the `.` gets dropped as it would for `50.`
-  background-color: rgba(50 50 50 50....);
-  width: min(50px 20px 30px...);
-}


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fixes: https://github.com/prettier/prettier/issues/8565

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.

Not sure if this warrants a changelog ? Might just clutter it ?
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
