### PR TITLE
Fix: resolving to incorrect config in `getFileInfo()`

### DIFF
--- a/changelog_unreleased/api/pr-8551.md
+++ b/changelog_unreleased/api/pr-8551.md
@@ -1,6 +1,8 @@
-#### Fix `prettier.getFileInfo()` ([#8548](https://github.com/prettier/prettier/pull/8548), [#8551](https://github.com/prettier/prettier/pull/8551) by [@fisker](https://github.com/fisker))
+#### Fix `prettier.getFileInfo()` ([#8548](https://github.com/prettier/prettier/pull/8548), [#8551](https://github.com/prettier/prettier/pull/8551), [#8585](https://github.com/prettier/prettier/pull/8585) by [@fisker](https://github.com/fisker))
 
-When passing `{resolveConfig: true}`, the parsers in config file is preferred.
+- When passing `{resolveConfig: true}`, the `inferredParser` should be the parser resolved from config file, previous version might returns wrong result for files supported by builtin parsers.
+- When passing `{resolveConfig: true}` and `{ignorePath: "a/file/in/different/dir"}`, the `inferredParser` result might incorrect.
+- If given `filePath` is ignored, the `inferredParser` is always `null` now.
 
 <!-- prettier-ignore -->
 ```console
@@ -13,8 +15,6 @@ $ node -p "require('prettier').getFileInfo.sync('./foo.js', {resolveConfig: true
 # Prettier master
 # { ignored: false, inferredParser: 'flow' }
 ```
-
-If given `filePath` is ignored, the `inferredParser` is always `null`.
 
 <!-- prettier-ignore -->
 ```console

--- a/src/common/get-file-info.js
+++ b/src/common/get-file-info.js
@@ -29,9 +29,10 @@ async function getFileInfo(filePath, opts) {
   const ignorer = await createIgnorer(opts.ignorePath, opts.withNodeModules);
   return _getFileInfo({
     ignorer,
-    filePath: normalizeFilePath(filePath, opts.ignorePath),
+    filePath,
     plugins: opts.plugins,
     resolveConfig: opts.resolveConfig,
+    ignorePath: opts.ignorePath,
     sync: false,
   });
 }
@@ -51,9 +52,10 @@ getFileInfo.sync = function (filePath, opts) {
   const ignorer = createIgnorer.sync(opts.ignorePath, opts.withNodeModules);
   return _getFileInfo({
     ignorer,
-    filePath: normalizeFilePath(filePath, opts.ignorePath),
+    filePath,
     plugins: opts.plugins,
     resolveConfig: opts.resolveConfig,
+    ignorePath: opts.ignorePath,
     sync: true,
   });
 };
@@ -77,10 +79,13 @@ function _getFileInfo({
   filePath,
   plugins,
   resolveConfig = false,
+  ignorePath,
   sync = false,
 }) {
+  const normalizedFilePath = normalizeFilePath(filePath, ignorePath);
+
   const fileInfo = {
-    ignored: ignorer.ignores(filePath),
+    ignored: ignorer.ignores(normalizedFilePath),
     inferredParser: null,
   };
 

--- a/tests_integration/__tests__/file-info.js
+++ b/tests_integration/__tests__/file-info.js
@@ -461,3 +461,23 @@ test("API getFileInfo with hand-picked plugins", () => {
     inferredParser: "foo",
   });
 });
+
+test("API getFileInfo with ignorePath and resolveConfig should infer parser with correct filepath", () => {
+  const dir = path.join(__dirname, "../cli/ignore-and-config/");
+  const filePath = path.join(dir, "config-dir/foo");
+  const ignorePath = path.join(dir, "ignore-path-dir/.prettierignore");
+  const options = {
+    resolveConfig: true,
+    ignorePath,
+  };
+
+  expect(prettier.getFileInfo(filePath, options)).resolves.toMatchObject({
+    ignored: false,
+    inferredParser: "parser-for-config-dir",
+  });
+
+  expect(prettier.getFileInfo.sync(filePath, options)).toMatchObject({
+    ignored: false,
+    inferredParser: "parser-for-config-dir",
+  });
+});

--- a/tests_integration/cli/ignore-and-config/config-dir/.prettierrc
+++ b/tests_integration/cli/ignore-and-config/config-dir/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "parser": "parser-for-config-dir"
+}


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Ref https://github.com/prettier/prettier/pull/8546#discussion_r439279587

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
