### PR TITLE
Fix cli `--file-info` bug

### DIFF
--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -116,6 +116,7 @@ function logFileInfoOrDie(context) {
     withNodeModules: context.argv["with-node-modules"],
     plugins: context.argv.plugin,
     pluginSearchDirs: context.argv["plugin-search-dir"],
+    resolveConfig: true,
   };
   context.logger.log(
     prettier.format(

--- a/tests_integration/__tests__/__snapshots__/file-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/file-info.js.snap
@@ -119,3 +119,13 @@ exports[`extracts file-info with with ignored=true for a file in node_modules (s
 `;
 
 exports[`extracts file-info with with ignored=true for a file in node_modules (write) 1`] = `Array []`;
+
+exports[`file-info should try resolve config (stderr) 1`] = `""`;
+
+exports[`file-info should try resolve config (stdout) 1`] = `
+"{ \\"ignored\\": false, \\"inferredParser\\": \\"override-js-parser\\" }
+
+"
+`;
+
+exports[`file-info should try resolve config (write) 1`] = `Array []`;

--- a/tests_integration/__tests__/file-info.js
+++ b/tests_integration/__tests__/file-info.js
@@ -34,6 +34,12 @@ describe("extracts file-info with ignored=true for a file in .prettierignore", (
   });
 });
 
+describe("file-info should try resolve config", () => {
+  runPrettier("cli/with-resolve-config/", ["--file-info", "file.js"]).test({
+    status: 0,
+  });
+});
+
 describe("extracts file-info with ignored=true for a file in a hand-picked .prettierignore", () => {
   runPrettier("cli/", [
     "--file-info",


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

```bash
prettier --file-info
```

Don't respect the `.prettierrc`.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
