### PR TITLE
Fix resolve EditorConfig for files in deep directory

### DIFF
--- a/changelog_unreleased/api/pr-8591.md
+++ b/changelog_unreleased/api/pr-8591.md
@@ -1,0 +1,3 @@
+#### Fix resolve editorConfig for files in deep directory ([#8591](https://github.com/prettier/prettier/pull/8591) by [@fisker](https://github.com/fisker))
+
+Previous version can't find `.editorconfig` for files in deep directory (depth great than 9 to project root, see #5705).

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "esutils": "2.0.3",
     "fast-glob": "3.2.4",
     "find-parent-dir": "0.3.0",
-    "find-project-root": "1.1.1",
     "flow-parser": "0.127.0",
     "get-stream": "5.1.0",
     "globby": "11.0.1",

--- a/src/config/find-project-root.js
+++ b/src/config/find-project-root.js
@@ -1,0 +1,32 @@
+"use strict";
+
+// Simple version of `find-project-root`
+// https://github.com/kirstein/find-project-root/blob/master/index.js
+
+const fs = require("fs");
+const path = require("path");
+
+const MARKERS = new Set([".git", ".hg"]);
+
+const markerExists = (directory) =>
+  fs.existsSync(directory) &&
+  fs.readdirSync(directory).some((file) => MARKERS.has(file));
+
+function findProjectRoot(directory) {
+  while (directory) {
+    if (markerExists(directory)) {
+      return directory;
+    }
+
+    const parentDirectory = path.resolve(directory, "..");
+    if (parentDirectory !== directory) {
+      directory = parentDirectory;
+    } else {
+      break;
+    }
+  }
+
+  return directory;
+}
+
+module.exports = findProjectRoot;

--- a/src/config/find-project-root.js
+++ b/src/config/find-project-root.js
@@ -6,11 +6,10 @@
 const fs = require("fs");
 const path = require("path");
 
-const MARKERS = new Set([".git", ".hg"]);
+const MARKERS = [".git", ".hg"];
 
 const markerExists = (directory) =>
-  fs.existsSync(directory) &&
-  fs.readdirSync(directory).some((file) => MARKERS.has(file));
+  MARKERS.some((mark) => fs.existsSync(path.join(directory, mark)));
 
 function findProjectRoot(directory) {
   while (!markerExists(directory)) {

--- a/src/config/find-project-root.js
+++ b/src/config/find-project-root.js
@@ -13,17 +13,12 @@ const markerExists = (directory) =>
   fs.readdirSync(directory).some((file) => MARKERS.has(file));
 
 function findProjectRoot(directory) {
-  while (directory) {
-    if (markerExists(directory)) {
-      return directory;
-    }
-
+  while (!markerExists(directory)) {
     const parentDirectory = path.resolve(directory, "..");
-    if (parentDirectory !== directory) {
-      directory = parentDirectory;
-    } else {
+    if (parentDirectory === directory) {
       break;
     }
+    directory = parentDirectory;
   }
 
   return directory;

--- a/src/config/resolve-config-editorconfig.js
+++ b/src/config/resolve-config-editorconfig.js
@@ -1,38 +1,26 @@
 "use strict";
 
-const fs = require("fs");
 const path = require("path");
 
 const editorconfig = require("editorconfig");
 const mem = require("mem");
 const editorConfigToPrettier = require("editorconfig-to-prettier");
-const findProjectRoot = require("find-project-root");
+const findProjectRoot = require("./find-project-root");
 
 const jsonStringifyMem = (fn) => mem(fn, { cacheKey: JSON.stringify });
 
-const maybeParse = (filePath, parse) => {
-  // findProjectRoot will throw an error if we pass a nonexistent directory to
-  // it, which is possible, for example, when the path is given via
-  // --stdin-filepath. So, first, traverse up until we find an existing
-  // directory.
-  let dirPath = path.dirname(path.resolve(filePath));
-  const fsRoot = path.parse(dirPath).root;
-  while (dirPath !== fsRoot && !fs.existsSync(dirPath)) {
-    dirPath = path.dirname(dirPath);
-  }
-  const root = findProjectRoot(dirPath);
-  return filePath && parse(filePath, { root });
-};
+const maybeParse = (filePath, parse) =>
+  filePath &&
+  parse(filePath, {
+    root: findProjectRoot(path.dirname(path.resolve(filePath))),
+  });
 
-const editorconfigAsyncNoCache = async (filePath) => {
-  const editorConfig = await maybeParse(filePath, editorconfig.parse);
-  return editorConfigToPrettier(editorConfig);
-};
+const editorconfigAsyncNoCache = async (filePath) =>
+  editorConfigToPrettier(await maybeParse(filePath, editorconfig.parse));
 const editorconfigAsyncWithCache = jsonStringifyMem(editorconfigAsyncNoCache);
 
-const editorconfigSyncNoCache = (filePath) => {
-  return editorConfigToPrettier(maybeParse(filePath, editorconfig.parseSync));
-};
+const editorconfigSyncNoCache = (filePath) =>
+  editorConfigToPrettier(maybeParse(filePath, editorconfig.parseSync));
 const editorconfigSyncWithCache = jsonStringifyMem(editorconfigSyncNoCache);
 
 function getLoadFunction(opts) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3629,11 +3629,6 @@ find-parent-dir@0.3.0:
   resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
   integrity sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=
 
-find-project-root@1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/find-project-root/-/find-project-root-1.1.1.tgz#d242727a2d904725df5714f23dfdcdedda0b6ef8"
-  integrity sha1-0kJyei2QRyXfVxTyPf3N7doLbvg=
-
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fixes #5705

`find-project-root` package can't use `Infinity` as `maxDepth`, so I wrote a simple one.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
