### PR TITLE
Handlebars: Fix incorrect classic component syntax formatting

### DIFF
--- a/changelog_unreleased/handlebars/pr-8593.md
+++ b/changelog_unreleased/handlebars/pr-8593.md
@@ -1,0 +1,35 @@
+#### Fix formatting of classic components inside element ([#8593](https://github.com/prettier/prettier/pull/8593) by [@mikoscz](https://github.com/mikoscz)
+
+<!-- prettier-ignore -->
+```hbs
+{{!-- Input --}}
+<div>
+  {{classic-component-with-many-properties
+    class="hello"
+    param=this.someValue
+    secondParam=this.someValue
+    thirdParam=this.someValue
+  }}
+</div>
+
+{{!-- Prettier stable --}}
+<div>
+  {{
+    classic-component-with-many-properties
+    class="hello"
+    param=this.someValue
+    secondParam=this.someValue
+    thirdParam=this.someValue
+  }}
+</div>
+
+{{!-- Prettier master --}}
+<div>
+  {{classic-component-with-many-properties
+    class="hello"
+    param=this.someValue
+    secondParam=this.someValue
+    thirdParam=this.someValue
+  }}
+</div>
+```

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -118,10 +118,15 @@ function print(path, options, print) {
       const isParentOfSpecifiedTypes = isParentOfSomeType(path, [
         "AttrNode",
         "ConcatStatement",
-        "ElementNode",
       ]);
+
+      const isChildOfElementNodeAndDoesNotHaveParams =
+        isParentOfSomeType(path, ["ElementNode"]) &&
+        doesNotHaveHashParams(n) &&
+        doesNotHavePositionalParams(n);
+
       const shouldBreakOpeningMustache =
-        isParentOfSpecifiedTypes && doesNotHaveHashParams(n) && isNotYield(n);
+        isParentOfSpecifiedTypes || isChildOfElementNodeAndDoesNotHaveParams;
 
       return group(
         concat([
@@ -655,10 +660,8 @@ function doesNotHaveHashParams(node) {
   return node.hash.pairs.length === 0;
 }
 
-function isNotYield(node) {
-  const isYield =
-    node.path.type === "PathExpression" && node.path.original === "yield";
-  return !isYield;
+function doesNotHavePositionalParams(node) {
+  return node.params.length === 0;
 }
 
 module.exports = {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -121,7 +121,7 @@ function print(path, options, print) {
         "ElementNode",
       ]);
       const shouldBreakOpeningMustache =
-        isParentOfSpecifiedTypes && doesNotHaveHashParams(n);
+        isParentOfSpecifiedTypes && doesNotHaveHashParams(n) && isNotYield(n);
 
       return group(
         concat([
@@ -653,6 +653,12 @@ function locationToOffset(source, line, column) {
 
 function doesNotHaveHashParams(node) {
   return node.hash.pairs.length === 0;
+}
+
+function isNotYield(node) {
+  const isYield =
+    node.path.type === "PathExpression" && node.path.original === "yield";
+  return !isYield;
 }
 
 module.exports = {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -115,11 +115,13 @@ function print(path, options, print) {
       );
     }
     case "MustacheStatement": {
-      const shouldBreakOpeningMustache = isParentOfSomeType(path, [
+      const isParentOfSpecifiedTypes = isParentOfSomeType(path, [
         "AttrNode",
         "ConcatStatement",
         "ElementNode",
       ]);
+      const shouldBreakOpeningMustache =
+        isParentOfSpecifiedTypes && doesNotHaveHashParams(n);
 
       return group(
         concat([
@@ -647,6 +649,10 @@ function locationToOffset(source, line, column) {
     seenLines += 1;
     seenChars = nextLine + 1;
   }
+}
+
+function doesNotHaveHashParams(node) {
+  return node.hash.pairs.length === 0;
 }
 
 module.exports = {

--- a/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
@@ -37,18 +37,29 @@ singleQuote: true
 <div
   class="a-first-class
     {{if this.optionOne "optionOne"}}
-    
+
     {{if this.optionTwo "optionTwo"}}
-    
+
     {{if this.optionThree "optionThree"}}
-    
+
     {{if this.optionFour "optionFour"}}
-    
+
     {{if this.optionFive "optionFive"}}
-    
+
     {{this.class}}"
   ...attributes >
 </div>
+
+<div>
+  {{classic-component-with-many-properties
+    class="hello"
+    param=this.someValue
+    secondParam=this.someValue
+    thirdParam=this.someValue
+  }}
+</div>
+
+
 
 =====================================output=====================================
 <GlimmerComponent
@@ -116,6 +127,15 @@ singleQuote: true
   ...attributes
 >
 </div>
+
+<div>
+  {{classic-component-with-many-properties
+    class='hello'
+    param=this.someValue
+    secondParam=this.someValue
+    thirdParam=this.someValue
+  }}
+</div>
 ================================================================================
 `;
 
@@ -155,18 +175,29 @@ printWidth: 80
 <div
   class="a-first-class
     {{if this.optionOne "optionOne"}}
-    
+
     {{if this.optionTwo "optionTwo"}}
-    
+
     {{if this.optionThree "optionThree"}}
-    
+
     {{if this.optionFour "optionFour"}}
-    
+
     {{if this.optionFive "optionFive"}}
-    
+
     {{this.class}}"
   ...attributes >
 </div>
+
+<div>
+  {{classic-component-with-many-properties
+    class="hello"
+    param=this.someValue
+    secondParam=this.someValue
+    thirdParam=this.someValue
+  }}
+</div>
+
+
 
 =====================================output=====================================
 <GlimmerComponent
@@ -233,6 +264,15 @@ printWidth: 80
    {{this.class}}"
   ...attributes
 >
+</div>
+
+<div>
+  {{classic-component-with-many-properties
+    class="hello"
+    param=this.someValue
+    secondParam=this.someValue
+    thirdParam=this.someValue
+  }}
 </div>
 ================================================================================
 `;

--- a/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
@@ -67,6 +67,10 @@ singleQuote: true
   )}}
 </div>
 
+<div>
+  {{a-helper "that takes some arguments" this.anotherOne "why not" @aLastOneLongEnoughToBreak}}
+</div>
+
 =====================================output=====================================
 <GlimmerComponent
   @progress={{
@@ -152,6 +156,15 @@ singleQuote: true
     )
   }}
 </div>
+
+<div>
+  {{a-helper
+    'that takes some arguments'
+    this.anotherOne
+    'why not'
+    @aLastOneLongEnoughToBreak
+  }}
+</div>
 ================================================================================
 `;
 
@@ -219,6 +232,10 @@ printWidth: 80
     header=(component header)
     language=(component language)
   )}}
+</div>
+
+<div>
+  {{a-helper "that takes some arguments" this.anotherOne "why not" @aLastOneLongEnoughToBreak}}
 </div>
 
 =====================================output=====================================
@@ -304,6 +321,15 @@ printWidth: 80
       header=(component header)
       language=(component language)
     )
+  }}
+</div>
+
+<div>
+  {{a-helper
+    "that takes some arguments"
+    this.anotherOne
+    "why not"
+    @aLastOneLongEnoughToBreak
   }}
 </div>
 ================================================================================

--- a/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
@@ -59,7 +59,13 @@ singleQuote: true
   }}
 </div>
 
-
+<div>
+  {{yield (hash
+    title=(component title)
+    header=(component header)
+    language=(component language)
+  )}}
+</div>
 
 =====================================output=====================================
 <GlimmerComponent
@@ -136,6 +142,16 @@ singleQuote: true
     thirdParam=this.someValue
   }}
 </div>
+
+<div>
+  {{yield
+    (hash
+      title=(component title)
+      header=(component header)
+      language=(component language)
+    )
+  }}
+</div>
 ================================================================================
 `;
 
@@ -197,7 +213,13 @@ printWidth: 80
   }}
 </div>
 
-
+<div>
+  {{yield (hash
+    title=(component title)
+    header=(component header)
+    language=(component language)
+  )}}
+</div>
 
 =====================================output=====================================
 <GlimmerComponent
@@ -272,6 +294,16 @@ printWidth: 80
     param=this.someValue
     secondParam=this.someValue
     thirdParam=this.someValue
+  }}
+</div>
+
+<div>
+  {{yield
+    (hash
+      title=(component title)
+      header=(component header)
+      language=(component language)
+    )
   }}
 </div>
 ================================================================================

--- a/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
@@ -37,15 +37,15 @@ singleQuote: true
 <div
   class="a-first-class
     {{if this.optionOne "optionOne"}}
-
+    
     {{if this.optionTwo "optionTwo"}}
-
+    
     {{if this.optionThree "optionThree"}}
-
+    
     {{if this.optionFour "optionFour"}}
-
+    
     {{if this.optionFive "optionFive"}}
-
+    
     {{this.class}}"
   ...attributes >
 </div>
@@ -204,15 +204,15 @@ printWidth: 80
 <div
   class="a-first-class
     {{if this.optionOne "optionOne"}}
-
+    
     {{if this.optionTwo "optionTwo"}}
-
+    
     {{if this.optionThree "optionThree"}}
-
+    
     {{if this.optionFour "optionFour"}}
-
+    
     {{if this.optionFive "optionFive"}}
-
+    
     {{this.class}}"
   ...attributes >
 </div>

--- a/tests/handlebars/mustache-statement/basics.hbs
+++ b/tests/handlebars/mustache-statement/basics.hbs
@@ -28,15 +28,26 @@
 <div
   class="a-first-class
     {{if this.optionOne "optionOne"}}
-    
+
     {{if this.optionTwo "optionTwo"}}
-    
+
     {{if this.optionThree "optionThree"}}
-    
+
     {{if this.optionFour "optionFour"}}
-    
+
     {{if this.optionFive "optionFive"}}
-    
+
     {{this.class}}"
   ...attributes >
 </div>
+
+<div>
+  {{classic-component-with-many-properties
+    class="hello"
+    param=this.someValue
+    secondParam=this.someValue
+    thirdParam=this.someValue
+  }}
+</div>
+
+

--- a/tests/handlebars/mustache-statement/basics.hbs
+++ b/tests/handlebars/mustache-statement/basics.hbs
@@ -50,4 +50,10 @@
   }}
 </div>
 
-
+<div>
+  {{yield (hash
+    title=(component title)
+    header=(component header)
+    language=(component language)
+  )}}
+</div>

--- a/tests/handlebars/mustache-statement/basics.hbs
+++ b/tests/handlebars/mustache-statement/basics.hbs
@@ -57,3 +57,7 @@
     language=(component language)
   )}}
 </div>
+
+<div>
+  {{a-helper "that takes some arguments" this.anotherOne "why not" @aLastOneLongEnoughToBreak}}
+</div>

--- a/tests/handlebars/mustache-statement/basics.hbs
+++ b/tests/handlebars/mustache-statement/basics.hbs
@@ -28,15 +28,15 @@
 <div
   class="a-first-class
     {{if this.optionOne "optionOne"}}
-
+    
     {{if this.optionTwo "optionTwo"}}
-
+    
     {{if this.optionThree "optionThree"}}
-
+    
     {{if this.optionFour "optionFour"}}
-
+    
     {{if this.optionFive "optionFive"}}
-
+    
     {{this.class}}"
   ...attributes >
 </div>


### PR DESCRIPTION
Resolves:
#8584 
https://github.com/jgwhite/prettier/issues/1#issuecomment-607273019
https://github.com/jgwhite/prettier/issues/1#issuecomment-630412651

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/handlebars/pr-8593.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).
