### PR TITLE
Treat <option> and <optgroup> as block

### DIFF
--- a/changelog_unreleased/html/pr-8275.md
+++ b/changelog_unreleased/html/pr-8275.md
@@ -1,6 +1,6 @@
 #### Treat `<select>` as inline-block and `<optgroup>`/`<option>` as block ([#8275](https://github.com/prettier/prettier/pull/8275) by [@thorn0](https://github.com/thorn0), [#8620](https://github.com/prettier/prettier/pull/8620) by [@fisker](https://github.com/fisker))
 
-Now Prettier knows that it's safe to add whitespace inside `select`, `<option>` and `optgroup` tags.
+Now Prettier knows that it's safe to add whitespace inside `select`, `option` and `optgroup` tags.
 
 <!-- prettier-ignore -->
 ```html

--- a/changelog_unreleased/html/pr-8275.md
+++ b/changelog_unreleased/html/pr-8275.md
@@ -1,6 +1,6 @@
-#### Treat `<select>` and `<optgroup>` as inline-block ([#8275](https://github.com/prettier/prettier/pull/8275) by [@thorn0](https://github.com/thorn0))
+#### Treat `<select>` as inline-block and `<optgroup>`/`<option>` as block ([#8275](https://github.com/prettier/prettier/pull/8275) by [@thorn0](https://github.com/thorn0), [#8620](https://github.com/prettier/prettier/pull/8620) by [@fisker](https://github.com/fisker))
 
-Now Prettier knows that it's safe to add whitespace inside `select` and `optgroup` tags.
+Now Prettier knows that it's safe to add whitespace inside `select`, `<option>` and `optgroup` tags.
 
 <!-- prettier-ignore -->
 ```html

--- a/src/language-html/constants.evaluate.js
+++ b/src/language-html/constants.evaluate.js
@@ -36,7 +36,8 @@ const CSS_DISPLAY_TAGS = {
   video: "inline-block",
   audio: "inline-block",
   select: "inline-block",
-  optgroup: "inline-block",
+  option: "block",
+  optgroup: "block",
 };
 const CSS_DISPLAY_DEFAULT = "inline";
 const CSS_WHITE_SPACE_TAGS = getCssStyleTags("white-space");

--- a/tests/html/tags/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html/tags/__snapshots__/jsfmt.spec.js.snap
@@ -784,9 +784,12 @@ printWidth: Infinity
 
 =====================================output=====================================
 <select>
-  <option>Blue</option
-  ><option>Green</option
-  ><optgroup label="Darker"><option>Dark Blue</option><option>Dark Green</option></optgroup>
+  <option>Blue</option>
+  <option>Green</option>
+  <optgroup label="Darker">
+    <option>Dark Blue</option>
+    <option>Dark Green</option>
+  </optgroup>
 </select>
 <input list="colors" />
 <datalist id="colors">
@@ -809,20 +812,23 @@ printWidth: 1
 
 =====================================output=====================================
 <select>
-  <option
-    >Blue</option
-  ><option
-    >Green</option
-  ><optgroup
+  <option>
+    Blue
+  </option>
+  <option>
+    Green
+  </option>
+  <optgroup
     label="Darker"
   >
-    <option
-      >Dark
-      Blue</option
-    ><option
-      >Dark
-      Green</option
-    >
+    <option>
+      Dark
+      Blue
+    </option>
+    <option>
+      Dark
+      Green
+    </option>
   </optgroup>
 </select>
 <input
@@ -831,12 +837,12 @@ printWidth: 1
 <datalist
   id="colors"
 >
-  <option
-    >Blue</option
-  >
-  <option
-    >Green</option
-  >
+  <option>
+    Blue
+  </option>
+  <option>
+    Green
+  </option>
 </datalist>
 
 ================================================================================
@@ -854,10 +860,11 @@ printWidth: 80
 
 =====================================output=====================================
 <select>
-  <option>Blue</option
-  ><option>Green</option
-  ><optgroup label="Darker">
-    <option>Dark Blue</option><option>Dark Green</option>
+  <option>Blue</option>
+  <option>Green</option>
+  <optgroup label="Darker">
+    <option>Dark Blue</option>
+    <option>Dark Green</option>
   </optgroup>
 </select>
 <input list="colors" />


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Related: [`Treat <select> and <optgroup> as inline-block for whitespace sensitivity`](https://github.com/prettier/prettier/pull/8275)

I think it's safe to treat `option` and `optgroup` as `block`.
This is how `chrome` do https://chromium.googlesource.com/chromium/blink/+/refs/heads/master/Source/core/css/html.css

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
