### PR TITLE
Use `html-void-elements` for more completed list

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "html-element-attributes": "2.2.1",
     "html-styles": "1.0.0",
     "html-tag-names": "1.1.5",
+    "html-void-elements": "1.0.5",
     "ignore": "4.0.6",
     "jest-docblock": "26.0.0",
     "leven": "3.1.0",

--- a/src/language-handlebars/utils.js
+++ b/src/language-handlebars/utils.js
@@ -1,22 +1,6 @@
 "use strict";
 
-// http://w3c.github.io/html/single-page.html#void-elements
-const voidTags = new Set([
-  "area",
-  "base",
-  "br",
-  "col",
-  "embed",
-  "hr",
-  "img",
-  "input",
-  "link",
-  "meta",
-  "param",
-  "source",
-  "track",
-  "wbr",
-]);
+const htmlVoidElements = require("html-void-elements");
 
 function isUppercase(string) {
   return string.toUpperCase() === string;
@@ -30,6 +14,7 @@ function isGlimmerComponent(node) {
   );
 }
 
+const voidTags = new Set(htmlVoidElements);
 function isVoid(node) {
   return (
     (isGlimmerComponent(node) &&

--- a/yarn.lock
+++ b/yarn.lock
@@ -4059,6 +4059,11 @@ html-tag-names@1.1.5:
   resolved "https://registry.yarnpkg.com/html-tag-names/-/html-tag-names-1.1.5.tgz#f537420c16769511283f8ae1681785fbc89ee0a9"
   integrity sha512-aI5tKwNTBzOZApHIynaAwecLBv8TlZTEy/P4Sj2SzzAhBrGuI8yGZ0UIXVPQzOHGS+to2mjb04iy6VWt/8+d8A==
 
+html-void-elements@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/html-void-elements/-/html-void-elements-1.0.5.tgz#ce9159494e86d95e45795b166c2021c2cfca4483"
+  integrity sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==
+
 http-signature@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Missing elements `basefont`, `bgsound`, `command`, `frame`, `image`, `isindex`, `keygen`, `menuitem`, `nextid`

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
