### PR TITLE
handlebars: Support escaping a mustache with a backslash

### DIFF
--- a/changelog_unreleased/handlebars/pr-8634.md
+++ b/changelog_unreleased/handlebars/pr-8634.md
@@ -1,0 +1,19 @@
+#### Support escaping a mustache with a backslash ([#8634](https://github.com/prettier/prettier/pull/8634) by [@dcyriller](https://github.com/dcyriller)
+
+<!-- prettier-ignore -->
+```hbs
+{{!-- Input --}}
+\{{mustache}}
+\\{{mustache}}
+\\\{{mustache}}
+
+{{!-- Prettier stable --}}
+{{mustache}}
+\{{mustache}}
+\\{{mustache}}
+
+{{!-- Prettier master --}}
+\{{mustache}}
+\\{{mustache}}
+\\\{{mustache}}
+```

--- a/src/language-handlebars/preprocess.js
+++ b/src/language-handlebars/preprocess.js
@@ -1,0 +1,34 @@
+"use strict";
+
+const transform = require("@glimmer/syntax").traverse;
+
+const PREPROCESS_PIPELINE = [addBackslash];
+
+/* VISITORS */
+
+/*
+ */
+function addBackslash(/* options*/) {
+  return {
+    TextNode(node) {
+      /* from the following template: `non-escaped mustache \\{{helper}}`
+       * glimmer parser will produce an AST missing a backslash
+       * so here we add it back
+       * */
+      if (node.chars.includes("\\")) {
+        node.chars = node.chars.replace(/\\/, "\\\\");
+      }
+    },
+  };
+}
+
+function preprocess(ast, options) {
+  for (const fn of PREPROCESS_PIPELINE) {
+    const visitor = fn(options);
+    transform(ast, visitor);
+  }
+
+  return ast;
+}
+
+module.exports = preprocess;

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -251,9 +251,18 @@ function print(path, options, print) {
         }
       }
 
+      let text = n.chars;
+      /* if `{{my-component}}` (or any text starting with a mustache)
+       * makes it to the TextNode,
+       * it means it was escaped,
+       * so let's print it escaped, ie.; `\{{my-component}}` */
+      if (text.startsWith("{{") && text.includes("}}")) {
+        text = "\\" + text;
+      }
+
       return concat([
         ...generateHardlines(leadingLineBreaksCount, maxLineBreaksToPreserve),
-        n.chars.replace(/^\s+/g, leadingSpace).replace(/\s+$/, trailingSpace),
+        text.replace(/^\s+/g, leadingSpace).replace(/\s+$/, trailingSpace),
         ...generateHardlines(trailingLineBreaksCount, maxLineBreaksToPreserve),
       ]);
     }

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const clean = require("./clean");
+const preprocess = require("./preprocess");
 
 const {
   concat,
@@ -661,4 +662,5 @@ function locationToOffset(source, line, column) {
 module.exports = {
   print,
   massageAstNode: clean,
+  preprocess,
 };

--- a/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
@@ -389,3 +389,50 @@ printWidth: 80
 </div>
 ================================================================================
 `;
+
+exports[`escaped.hbs - {"singleQuote":true} format 1`] = `
+====================================options=====================================
+parsers: ["glimmer"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+an escaped mustache:
+\\{{my-component}}
+a non-escaped mustache:
+\\\\{{my-component}}
+another non-escaped mustache:
+\\\\\\{{my-component}}
+
+=====================================output=====================================
+an escaped mustache:
+\\{{my-component}}
+a non-escaped mustache:
+\\\\{{my-component}}
+another non-escaped mustache:
+\\\\\\{{my-component}}
+================================================================================
+`;
+
+exports[`escaped.hbs format 1`] = `
+====================================options=====================================
+parsers: ["glimmer"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+an escaped mustache:
+\\{{my-component}}
+a non-escaped mustache:
+\\\\{{my-component}}
+another non-escaped mustache:
+\\\\\\{{my-component}}
+
+=====================================output=====================================
+an escaped mustache:
+\\{{my-component}}
+a non-escaped mustache:
+\\\\{{my-component}}
+another non-escaped mustache:
+\\\\\\{{my-component}}
+================================================================================
+`;

--- a/tests/handlebars/mustache-statement/escaped.hbs
+++ b/tests/handlebars/mustache-statement/escaped.hbs
@@ -1,0 +1,6 @@
+an escaped mustache:
+\{{my-component}}
+a non-escaped mustache:
+\\{{my-component}}
+another non-escaped mustache:
+\\\{{my-component}}


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
## Description

In handlebars, it is possible to escape a mustache with a backslash. [See handelbars documentation here.](https://handlebarsjs.com/guide/expressions.html#escaping-handlebars-expressions)

This PR propose to add the support for this feature.

This would close https://github.com/prettier/prettier/issues/8633

Initial report: https://github.com/jgwhite/prettier/issues/1#issuecomment-646227623

## Details

This PR would introduce a new file: `src/language-handlebars/preprocess.js`. It is present to make an adjustement to the AST produced by Glimmer parser.

Indeed, given that template:
```hbs
a non-escaped mustache: \\\{{helper}}
```
Glimmer parser will produce two nodes for the template body:
- a TextNode where `node.chars === "a non-escaped mustache: \\\\"` (note the backslash escaping here, so it is actually`"a non-escaped mustache: \\"`, which means that a backslash has been swallowed)
- a MustacheStatement for `{{helper}}`

In order to correctly print the input, we need to adjust the TextNode to `node.chars === "a non-escaped mustache: \\\\\\"` (or `"a non-escaped mustache: \\\"` without the backslash escaping), namely we have to add a backslash that is removed by Glimmer parser. This is the third commit purpose. If you'd like you could checkout [the second commit's CI report](https://github.com/prettier/prettier/runs/800743079). It highlights the need for the third commit (the preprocess file).

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
