### PR TITLE
Support printing handlebars in javascript files though `hbs`

### DIFF
--- a/changelog_unreleased/handlebars/pr-8642.md
+++ b/changelog_unreleased/handlebars/pr-8642.md
@@ -1,0 +1,26 @@
+#### Support printing handlebars in javascript files ([#8642](https://github.com/prettier/prettier/pull/8642) by [@dcyriller](https://github.com/dcyriller)
+
+<!-- prettier-ignore -->
+```js
+/* Input */
+hbs`<MyElement prop={{@prop}} anotherProp={{@anotherProp}}
+yetAnotherProp={{@yetAnotherProp}}
+       {{modifier}}
+    />`;
+
+/* Prettier stable */
+hbs`<MyElement prop={{@prop}} anotherProp={{@anotherProp}}
+yetAnotherProp={{@yetAnotherProp}}
+       {{modifier}}
+    />`;
+
+/* Prettier master */
+hbs`
+  <MyElement
+    prop={{@prop}}
+    anotherProp={{@anotherProp}}
+    yetAnotherProp={{@yetAnotherProp}}
+    {{modifier}}
+  />
+`;
+```

--- a/cspell.json
+++ b/cspell.json
@@ -146,6 +146,7 @@
         "Horky",
         "hotpink",
         "hsla",
+        "htmlbars",
         "htmlblock",
         "htmlhint",
         "hugomrdias",

--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -136,6 +136,10 @@ function embed(path, print, textToDoc, options) {
         ]);
       }
 
+      if (isHandlebars(path)) {
+        return printHandlebarsTemplateLiteral(path, print, textToDoc, options);
+      }
+
       const htmlParser = isHtml(path)
         ? "html"
         : isAngularComponentTemplate(path)
@@ -646,6 +650,63 @@ function printHtmlTemplateLiteral(path, print, textToDoc, parser, options) {
       trailingWhitespace,
       "`",
     ])
+  );
+}
+
+/*
+ * ember-cli-htmlbars
+ * hbs`...`
+ * Handlebars comment block
+ */
+function isHandlebars(path) {
+  const node = path.getValue();
+  const parent = path.getParentNode();
+
+  return (
+    hasLanguageComment(node, "hbs") ||
+    (parent &&
+      parent.type === "TaggedTemplateExpression" &&
+      parent.tag.type === "Identifier" &&
+      parent.tag.name === "hbs")
+  );
+}
+
+function printHandlebarsTemplateLiteral(path, print, textToDoc, options) {
+  const node = path.getValue();
+
+  const text = node.quasis.map((quasi) => quasi.value.cooked).join("");
+
+  const expressionDocs = path.map(print, "expressions");
+
+  if (expressionDocs.length === 0 && text.trim().length === 0) {
+    return "``";
+  }
+
+  const contentDoc = textToDoc(text, { parser: "glimmer" });
+
+  const leadingWhitespace = /^\s/.test(text) ? " " : "";
+  const trailingWhitespace = /\s$/.test(text) ? " " : "";
+
+  const linebreak =
+    options.htmlWhitespaceSensitivity === "ignore"
+      ? hardline
+      : leadingWhitespace && trailingWhitespace
+      ? line
+      : null;
+
+  if (linebreak) {
+    return group(
+      concat([
+        "`",
+        indent(concat([linebreak, group(contentDoc)])),
+        linebreak,
+        "`",
+      ])
+    );
+  }
+
+  return group(
+    concat(["`", leadingWhitespace, group(contentDoc), trailingWhitespace, "`"])
   );
 }
 

--- a/tests/js/multiparser-handlebars/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/multiparser-handlebars/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,440 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`hbs.js - {"htmlWhitespaceSensitivity":"ignore"} format 1`] = `
+====================================options=====================================
+htmlWhitespaceSensitivity: "ignore"
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+import { hbs } from 'ember-cli-htmlbars';
+
+class MyComponent extends Component {
+  constructor() {
+    super();
+    this.mood = 'happy';
+  }
+
+  async rerender() {
+    await render(hbs\`<MyComponent class=this.classes/>\`);
+  }
+
+  template() {
+    return hbs\`
+         Glimmer            Components         are     <span
+
+
+      class="mood"      >
+      </span
+
+           >!
+           {{hello-mustache}}
+    \`;
+  }
+}
+
+const someHbs1 = hbs\`<div       > hello {{world}} </div     >\`;
+const someHbs2 = /* Handlebars */ \`<div      > hello {{world}} </div     >\`;
+
+hbs\`\`
+
+hbs\`<MyElement prop={{@prop}} anotherProp={{@anotherProp}} yetAnotherProp={{@yetAnotherProp}} {{modifier}}></MyElement>\`;
+
+hbs\`  <div />  \`
+
+hbs\`
+  <div />
+\`
+
+hbs\`<span>one</span><span>two</span><span>three</span>\`;
+
+hbs\`
+ <div style=
+{{this.styles}}
+></div>
+\`
+
+hbs\`<div style="   color : red;
+            display    :inline ">
+  </div>\`
+
+const nestedFun = /* Handlebars */ html\`\${outerExpr}
+  <script>
+    const tpl = hbs\\\`<div>    {{innerExpr  }}</div>\\\`;
+  </script>\`;
+
+const nestedFun2 = /* Handlebars */ html\`\${outerExpr}
+  <script>
+    const tpl = hbs\\\`\\\\n    <div>{{    innerExpr}}</div>\\\\n\\\`;
+  </script>\`;
+
+setFoo(
+  hbs\`<div>one</div>
+  {{a-mustache}}
+    <div>two</div>
+    <div>three</div>\`,
+  secondArgument
+);
+
+setFoo(
+  hbs\`<div>
+      <div>nested</div>
+    </div>
+  {{a-mustache}}
+    <div>two</div>
+    <div>three</div>\`,
+  secondArgument
+);
+
+hbs\`<MyElement prop={{@prop}} anotherProp={{@anotherProp}}
+yetAnotherProp={{@yetAnotherProp}}
+       {{modifier}}
+    />\`;
+
+=====================================output=====================================
+import { hbs } from "ember-cli-htmlbars";
+
+class MyComponent extends Component {
+  constructor() {
+    super();
+    this.mood = "happy";
+  }
+
+  async rerender() {
+    await render(
+      hbs\`
+        <MyComponent class="this.classes" />
+      \`
+    );
+  }
+
+  template() {
+    return hbs\`
+      Glimmer            Components         are
+      <span class="mood">
+      </span>
+      !
+      {{hello-mustache}}
+    \`;
+  }
+}
+
+const someHbs1 = hbs\`
+  <div>
+    hello {{world}}
+  </div>
+\`;
+const someHbs2 = /* Handlebars */ \`<div      > hello {{world}} </div     >\`;
+
+hbs\`\`;
+
+hbs\`
+  <MyElement
+    prop={{@prop}}
+    anotherProp={{@anotherProp}}
+    yetAnotherProp={{@yetAnotherProp}}
+    {{modifier}}
+  />
+\`;
+
+hbs\`
+  <div></div>
+\`;
+
+hbs\`
+  <div></div>
+\`;
+
+hbs\`
+  <span>
+    one
+  </span>
+  <span>
+    two
+  </span>
+  <span>
+    three
+  </span>
+\`;
+
+hbs\`
+  <div style={{this.styles}}></div>
+\`;
+
+hbs\`
+  <div style="color : red;
+            display    :inline">
+  </div>
+\`;
+
+const nestedFun = /* Handlebars */ html\`
+  \${outerExpr}
+  <script>
+    const tpl = hbs\\\`
+      <div>
+        {{innerExpr}}
+      </div>
+    \\\`;
+  </script>
+\`;
+
+const nestedFun2 = /* Handlebars */ html\`
+  \${outerExpr}
+  <script>
+    const tpl = hbs\\\`
+      <div>
+        {{innerExpr}}
+      </div>
+    \\\`;
+  </script>
+\`;
+
+setFoo(
+  hbs\`
+    <div>
+      one
+    </div>
+    {{a-mustache}}
+    <div>
+      two
+    </div>
+    <div>
+      three
+    </div>
+  \`,
+  secondArgument
+);
+
+setFoo(
+  hbs\`
+    <div>
+      <div>
+        nested
+      </div>
+    </div>
+    {{a-mustache}}
+    <div>
+      two
+    </div>
+    <div>
+      three
+    </div>
+  \`,
+  secondArgument
+);
+
+hbs\`
+  <MyElement
+    prop={{@prop}}
+    anotherProp={{@anotherProp}}
+    yetAnotherProp={{@yetAnotherProp}}
+    {{modifier}}
+  />
+\`;
+
+================================================================================
+`;
+
+exports[`hbs.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+import { hbs } from 'ember-cli-htmlbars';
+
+class MyComponent extends Component {
+  constructor() {
+    super();
+    this.mood = 'happy';
+  }
+
+  async rerender() {
+    await render(hbs\`<MyComponent class=this.classes/>\`);
+  }
+
+  template() {
+    return hbs\`
+         Glimmer            Components         are     <span
+
+
+      class="mood"      >
+      </span
+
+           >!
+           {{hello-mustache}}
+    \`;
+  }
+}
+
+const someHbs1 = hbs\`<div       > hello {{world}} </div     >\`;
+const someHbs2 = /* Handlebars */ \`<div      > hello {{world}} </div     >\`;
+
+hbs\`\`
+
+hbs\`<MyElement prop={{@prop}} anotherProp={{@anotherProp}} yetAnotherProp={{@yetAnotherProp}} {{modifier}}></MyElement>\`;
+
+hbs\`  <div />  \`
+
+hbs\`
+  <div />
+\`
+
+hbs\`<span>one</span><span>two</span><span>three</span>\`;
+
+hbs\`
+ <div style=
+{{this.styles}}
+></div>
+\`
+
+hbs\`<div style="   color : red;
+            display    :inline ">
+  </div>\`
+
+const nestedFun = /* Handlebars */ html\`\${outerExpr}
+  <script>
+    const tpl = hbs\\\`<div>    {{innerExpr  }}</div>\\\`;
+  </script>\`;
+
+const nestedFun2 = /* Handlebars */ html\`\${outerExpr}
+  <script>
+    const tpl = hbs\\\`\\\\n    <div>{{    innerExpr}}</div>\\\\n\\\`;
+  </script>\`;
+
+setFoo(
+  hbs\`<div>one</div>
+  {{a-mustache}}
+    <div>two</div>
+    <div>three</div>\`,
+  secondArgument
+);
+
+setFoo(
+  hbs\`<div>
+      <div>nested</div>
+    </div>
+  {{a-mustache}}
+    <div>two</div>
+    <div>three</div>\`,
+  secondArgument
+);
+
+hbs\`<MyElement prop={{@prop}} anotherProp={{@anotherProp}}
+yetAnotherProp={{@yetAnotherProp}}
+       {{modifier}}
+    />\`;
+
+=====================================output=====================================
+import { hbs } from "ember-cli-htmlbars";
+
+class MyComponent extends Component {
+  constructor() {
+    super();
+    this.mood = "happy";
+  }
+
+  async rerender() {
+    await render(hbs\`<MyComponent class="this.classes" />\`);
+  }
+
+  template() {
+    return hbs\`
+      Glimmer            Components         are
+      <span class="mood">
+      </span>
+      !
+      {{hello-mustache}}
+    \`;
+  }
+}
+
+const someHbs1 = hbs\`<div>
+  hello {{world}}
+</div>\`;
+const someHbs2 = /* Handlebars */ \`<div      > hello {{world}} </div     >\`;
+
+hbs\`\`;
+
+hbs\`<MyElement
+  prop={{@prop}}
+  anotherProp={{@anotherProp}}
+  yetAnotherProp={{@yetAnotherProp}}
+  {{modifier}}
+/>\`;
+
+hbs\` <div></div> \`;
+
+hbs\` <div></div> \`;
+
+hbs\`<span>
+  one
+</span>
+<span>
+  two
+</span>
+<span>
+  three
+</span>\`;
+
+hbs\` <div style={{this.styles}}></div> \`;
+
+hbs\`<div style="color : red;
+            display    :inline">
+</div>\`;
+
+const nestedFun = /* Handlebars */ html\`\${outerExpr}
+  <script>
+    const tpl = hbs\\\`<div>
+      {{innerExpr}}
+    </div>\\\`;
+  </script>\`;
+
+const nestedFun2 = /* Handlebars */ html\`\${outerExpr}
+  <script>
+    const tpl = hbs\\\`
+      <div>
+        {{innerExpr}}
+      </div>
+    \\\`;
+  </script>\`;
+
+setFoo(
+  hbs\`<div>
+    one
+  </div>
+  {{a-mustache}}
+  <div>
+    two
+  </div>
+  <div>
+    three
+  </div>\`,
+  secondArgument
+);
+
+setFoo(
+  hbs\`<div>
+    <div>
+      nested
+    </div>
+  </div>
+  {{a-mustache}}
+  <div>
+    two
+  </div>
+  <div>
+    three
+  </div>\`,
+  secondArgument
+);
+
+hbs\`<MyElement
+  prop={{@prop}}
+  anotherProp={{@anotherProp}}
+  yetAnotherProp={{@yetAnotherProp}}
+  {{modifier}}
+/>\`;
+
+================================================================================
+`;

--- a/tests/js/multiparser-handlebars/hbs.js
+++ b/tests/js/multiparser-handlebars/hbs.js
@@ -1,0 +1,83 @@
+import { hbs } from 'ember-cli-htmlbars';
+
+class MyComponent extends Component {
+  constructor() {
+    super();
+    this.mood = 'happy';
+  }
+
+  async rerender() {
+    await render(hbs`<MyComponent class=this.classes/>`);
+  }
+
+  template() {
+    return hbs`
+         Glimmer            Components         are     <span
+
+
+      class="mood"      >
+      </span
+
+           >!
+           {{hello-mustache}}
+    `;
+  }
+}
+
+const someHbs1 = hbs`<div       > hello {{world}} </div     >`;
+const someHbs2 = /* Handlebars */ `<div      > hello {{world}} </div     >`;
+
+hbs``
+
+hbs`<MyElement prop={{@prop}} anotherProp={{@anotherProp}} yetAnotherProp={{@yetAnotherProp}} {{modifier}}></MyElement>`;
+
+hbs`  <div />  `
+
+hbs`
+  <div />
+`
+
+hbs`<span>one</span><span>two</span><span>three</span>`;
+
+hbs`
+ <div style=
+{{this.styles}}
+></div>
+`
+
+hbs`<div style="   color : red;
+            display    :inline ">
+  </div>`
+
+const nestedFun = /* Handlebars */ html`${outerExpr}
+  <script>
+    const tpl = hbs\`<div>    {{innerExpr  }}</div>\`;
+  </script>`;
+
+const nestedFun2 = /* Handlebars */ html`${outerExpr}
+  <script>
+    const tpl = hbs\`\\n    <div>{{    innerExpr}}</div>\\n\`;
+  </script>`;
+
+setFoo(
+  hbs`<div>one</div>
+  {{a-mustache}}
+    <div>two</div>
+    <div>three</div>`,
+  secondArgument
+);
+
+setFoo(
+  hbs`<div>
+      <div>nested</div>
+    </div>
+  {{a-mustache}}
+    <div>two</div>
+    <div>three</div>`,
+  secondArgument
+);
+
+hbs`<MyElement prop={{@prop}} anotherProp={{@anotherProp}}
+yetAnotherProp={{@yetAnotherProp}}
+       {{modifier}}
+    />`;

--- a/tests/js/multiparser-handlebars/jsfmt.spec.js
+++ b/tests/js/multiparser-handlebars/jsfmt.spec.js
@@ -1,0 +1,4 @@
+run_spec(__dirname, ["babel", "flow", "typescript"]);
+run_spec(__dirname, ["babel", "flow", "typescript"], {
+  htmlWhitespaceSensitivity: "ignore",
+});


### PR DESCRIPTION
## Description

### `hbs` usages
`hbs` is provided by the [ember-cli-htmlbars library](https://github.com/ember-cli/ember-cli-htmlbars).

The first usage is in tests, where components are rendered:
```js
import { hbs } from 'ember-cli-htmlbars';

await render(hbs`
  <MyComponent />
`);
```

A second usage can be with Storybook:
```js
import { text } from '@storybook/addon-knobs';

import hbs from 'htmlbars-inline-precompile';

export default {
  title: 'Components/Checkbox',
};

export const checkbox = () => {
  return {
    template: hbs`<Checkbox @label={{this.label}} {{on "click" this.toggleCheckbox}} />`,
    context: {
      label: text('title', 'Welcome to storybook'),
      toggleCheckbox() {},
    },
  };
};

checkbox.story = {
  name: '...',
};
```

### technical details
javascript's `TaggedTemplateExpression`s with the tag `hbs` will be printed using glimmer printer.

### credit
This implementation mimicks html's.

It is adapted in two ways:
- `hbs` doesn't support printing <script> tags
- `hbs` doesn't support interpolation with ${}

## Links / Related
- [Support printing inline handlebars in html](https://github.com/prettier/prettier/pull/7306)

## Checklist

<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
