### PR TITLE
Drop Node.js v11 and v13 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "browser": "./standalone.js",
   "unpkg": "./standalone.js",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=10.13.0 < 11 || >=12 <13 || >=14"
   },
   "files": [
     "index.js",

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`node version error (stderr) 1`] = `
-"prettier requires at least version 10.13.0 of Node, please upgrade
+"prettier requires at least version 10.13.0 < 11 || >=12 <13 || >=14 of Node, please upgrade
 "
 `;
 


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Node.js v13 is end of life on 01 Jun 2020

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
