### PR TITLE
Refactor: Extract long function `printTernaryOperator` and related utils to the other file

### DIFF
--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -1,0 +1,213 @@
+"use strict";
+
+const flat = require("lodash/flatten");
+
+const { conditionalExpressionChainContainsJSX, isJSXNode } = require("../utils");
+const { hasNewlineInRange } = require("../../common/util");
+const handleComments = require("../comments");
+const {
+  builders: {
+    concat,
+    line,
+    softline,
+    group,
+    indent,
+    align,
+    ifBreak,
+    dedent,
+    breakParent,
+  },
+} = require("../../document");
+
+/**
+ * The following is the shared logic for
+ * ternary operators, namely ConditionalExpression
+ * and TSConditionalType
+ * @typedef {Object} OperatorOptions
+ * @property {() => Array<string | Doc>} beforeParts - Parts to print before the `?`.
+ * @property {(breakClosingParen: boolean) => Array<string | Doc>} afterParts - Parts to print after the conditional expression.
+ * @property {boolean} shouldCheckJsx - Whether to check for and print in JSX mode.
+ * @property {string} conditionalNodeType - The type of the conditional expression node, ie "ConditionalExpression" or "TSConditionalType".
+ * @property {string} consequentNodePropertyName - The property at which the consequent node can be found on the main node, eg "consequent".
+ * @property {string} alternateNodePropertyName - The property at which the alternate node can be found on the main node, eg "alternate".
+ * @property {string[]} testNodePropertyNames - The properties at which the test nodes can be found on the main node, eg "test".
+ * @param {FastPath} path - The path to the ConditionalExpression/TSConditionalType node.
+ * @param {Options} options - Prettier options
+ * @param {Function} print - Print function to call recursively
+ * @param {OperatorOptions} operatorOptions
+ * @returns Doc
+ */
+function printTernaryOperator(path, options, print, operatorOptions) {
+  const node = path.getValue();
+  const consequentNode = node[operatorOptions.consequentNodePropertyName];
+  const alternateNode = node[operatorOptions.alternateNodePropertyName];
+  const parts = [];
+
+  // We print a ConditionalExpression in either "JSX mode" or "normal mode".
+  // See tests/jsx/conditional-expression.js for more info.
+  let jsxMode = false;
+  const parent = path.getParentNode();
+  const isParentTest =
+    parent.type === operatorOptions.conditionalNodeType &&
+    operatorOptions.testNodePropertyNames.some((prop) => parent[prop] === node);
+  let forceNoIndent =
+    parent.type === operatorOptions.conditionalNodeType && !isParentTest;
+
+  // Find the outermost non-ConditionalExpression parent, and the outermost
+  // ConditionalExpression parent. We'll use these to determine if we should
+  // print in JSX mode.
+  let currentParent;
+  let previousParent;
+  let i = 0;
+  do {
+    previousParent = currentParent || node;
+    currentParent = path.getParentNode(i);
+    i++;
+  } while (
+    currentParent &&
+    currentParent.type === operatorOptions.conditionalNodeType &&
+    operatorOptions.testNodePropertyNames.every(
+      (prop) => currentParent[prop] !== previousParent
+    )
+  );
+  const firstNonConditionalParent = currentParent || parent;
+  const lastConditionalParent = previousParent;
+
+  if (
+    operatorOptions.shouldCheckJsx &&
+    (isJSXNode(node[operatorOptions.testNodePropertyNames[0]]) ||
+      isJSXNode(consequentNode) ||
+      isJSXNode(alternateNode) ||
+      conditionalExpressionChainContainsJSX(lastConditionalParent))
+  ) {
+    jsxMode = true;
+    forceNoIndent = true;
+
+    // Even though they don't need parens, we wrap (almost) everything in
+    // parens when using ?: within JSX, because the parens are analogous to
+    // curly braces in an if statement.
+    const wrap = (doc) =>
+      concat([
+        ifBreak("(", ""),
+        indent(concat([softline, doc])),
+        softline,
+        ifBreak(")", ""),
+      ]);
+
+    // The only things we don't wrap are:
+    // * Nested conditional expressions in alternates
+    // * null
+    // * undefined
+    const isNil = (node) =>
+      node.type === "NullLiteral" ||
+      (node.type === "Literal" && node.value === null) ||
+      (node.type === "Identifier" && node.name === "undefined");
+
+    parts.push(
+      " ? ",
+      isNil(consequentNode)
+        ? path.call(print, operatorOptions.consequentNodePropertyName)
+        : wrap(path.call(print, operatorOptions.consequentNodePropertyName)),
+      " : ",
+      alternateNode.type === operatorOptions.conditionalNodeType ||
+        isNil(alternateNode)
+        ? path.call(print, operatorOptions.alternateNodePropertyName)
+        : wrap(path.call(print, operatorOptions.alternateNodePropertyName))
+    );
+  } else {
+    // normal mode
+    const part = concat([
+      line,
+      "? ",
+      consequentNode.type === operatorOptions.conditionalNodeType
+        ? ifBreak("", "(")
+        : "",
+      align(2, path.call(print, operatorOptions.consequentNodePropertyName)),
+      consequentNode.type === operatorOptions.conditionalNodeType
+        ? ifBreak("", ")")
+        : "",
+      line,
+      ": ",
+      alternateNode.type === operatorOptions.conditionalNodeType
+        ? path.call(print, operatorOptions.alternateNodePropertyName)
+        : align(2, path.call(print, operatorOptions.alternateNodePropertyName)),
+    ]);
+    parts.push(
+      parent.type !== operatorOptions.conditionalNodeType ||
+        parent[operatorOptions.alternateNodePropertyName] === node ||
+        isParentTest
+        ? part
+        : options.useTabs
+        ? dedent(indent(part))
+        : align(Math.max(0, options.tabWidth - 2), part)
+    );
+  }
+
+  // We want a whole chain of ConditionalExpressions to all
+  // break if any of them break. That means we should only group around the
+  // outer-most ConditionalExpression.
+  const comments = flat([
+    ...operatorOptions.testNodePropertyNames.map(
+      (propertyName) => node[propertyName].comments
+    ),
+    consequentNode.comments,
+    alternateNode.comments,
+  ]).filter(Boolean);
+  const shouldBreak = comments.some(
+    (comment) =>
+      handleComments.isBlockComment(comment) &&
+      hasNewlineInRange(
+        options.originalText,
+        options.locStart(comment),
+        options.locEnd(comment)
+      )
+  );
+  const maybeGroup = (doc) =>
+    parent === firstNonConditionalParent
+      ? group(doc, { shouldBreak })
+      : shouldBreak
+      ? concat([doc, breakParent])
+      : doc;
+
+  // Break the closing paren to keep the chain right after it:
+  // (a
+  //   ? b
+  //   : c
+  // ).call()
+  const breakClosingParen =
+    !jsxMode &&
+    (parent.type === "MemberExpression" ||
+      parent.type === "OptionalMemberExpression" ||
+      (parent.type === "NGPipeExpression" && parent.left === node)) &&
+    !parent.computed;
+
+  const result = maybeGroup(
+    concat(
+      [].concat(
+        ((testDoc) =>
+          /**
+           *     a
+           *       ? b
+           *       : multiline
+           *         test
+           *         node
+           *       ^^ align(2)
+           *       ? d
+           *       : e
+           */
+          parent.type === operatorOptions.conditionalNodeType &&
+          parent[operatorOptions.alternateNodePropertyName] === node
+            ? align(2, testDoc)
+            : testDoc)(concat(operatorOptions.beforeParts())),
+        forceNoIndent ? concat(parts) : indent(concat(parts)),
+        operatorOptions.afterParts(breakClosingParen)
+      )
+    )
+  );
+
+  return isParentTest
+    ? group(concat([indent(concat([softline, result])), softline]))
+    : result;
+}
+
+module.exports = printTernaryOperator;

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1,7 +1,6 @@
 "use strict";
 
 const assert = require("assert");
-const flat = require("lodash/flatten");
 
 // TODO(azz): anything that imports from main shouldn't be in a `language-*` dir.
 const comments = require("../main/comments");
@@ -40,8 +39,6 @@ const {
     ifBreak,
     lineSuffixBoundary,
     addAlignmentToDoc,
-    dedent,
-    breakParent,
   },
   utils: { willBreak, isLineNext, isEmpty, removeLines, normalizeParts },
   printer: { printDocToString },
@@ -59,7 +56,6 @@ const preprocess = require("./preprocess");
 const {
   classChildNeedsASIProtection,
   classPropMayCauseASIProblems,
-  conditionalExpressionChainContainsJSX,
   getFlowVariance,
   getLeftSidePathName,
   getParentExportDeclaration,
@@ -120,6 +116,7 @@ const {
   printBindExpressionCallee,
 } = require("./print/misc");
 const { printModuleSource, printModuleSpecifiers } = require("./print/module");
+const printTernaryOperator = require("./print/ternary");
 
 const needsQuoteProps = new WeakMap();
 
@@ -240,197 +237,6 @@ function printDecorators(path, options, print) {
       hasNewlineBetweenOrAfterDecorators(node, options) ? hardline : line,
     ])
   );
-}
-
-/**
- * The following is the shared logic for
- * ternary operators, namely ConditionalExpression
- * and TSConditionalType
- * @typedef {Object} OperatorOptions
- * @property {() => Array<string | Doc>} beforeParts - Parts to print before the `?`.
- * @property {(breakClosingParen: boolean) => Array<string | Doc>} afterParts - Parts to print after the conditional expression.
- * @property {boolean} shouldCheckJsx - Whether to check for and print in JSX mode.
- * @property {string} conditionalNodeType - The type of the conditional expression node, ie "ConditionalExpression" or "TSConditionalType".
- * @property {string} consequentNodePropertyName - The property at which the consequent node can be found on the main node, eg "consequent".
- * @property {string} alternateNodePropertyName - The property at which the alternate node can be found on the main node, eg "alternate".
- * @property {string[]} testNodePropertyNames - The properties at which the test nodes can be found on the main node, eg "test".
- * @param {FastPath} path - The path to the ConditionalExpression/TSConditionalType node.
- * @param {Options} options - Prettier options
- * @param {Function} print - Print function to call recursively
- * @param {OperatorOptions} operatorOptions
- * @returns Doc
- */
-function printTernaryOperator(path, options, print, operatorOptions) {
-  const node = path.getValue();
-  const consequentNode = node[operatorOptions.consequentNodePropertyName];
-  const alternateNode = node[operatorOptions.alternateNodePropertyName];
-  const parts = [];
-
-  // We print a ConditionalExpression in either "JSX mode" or "normal mode".
-  // See tests/jsx/conditional-expression.js for more info.
-  let jsxMode = false;
-  const parent = path.getParentNode();
-  const isParentTest =
-    parent.type === operatorOptions.conditionalNodeType &&
-    operatorOptions.testNodePropertyNames.some((prop) => parent[prop] === node);
-  let forceNoIndent =
-    parent.type === operatorOptions.conditionalNodeType && !isParentTest;
-
-  // Find the outermost non-ConditionalExpression parent, and the outermost
-  // ConditionalExpression parent. We'll use these to determine if we should
-  // print in JSX mode.
-  let currentParent;
-  let previousParent;
-  let i = 0;
-  do {
-    previousParent = currentParent || node;
-    currentParent = path.getParentNode(i);
-    i++;
-  } while (
-    currentParent &&
-    currentParent.type === operatorOptions.conditionalNodeType &&
-    operatorOptions.testNodePropertyNames.every(
-      (prop) => currentParent[prop] !== previousParent
-    )
-  );
-  const firstNonConditionalParent = currentParent || parent;
-  const lastConditionalParent = previousParent;
-
-  if (
-    operatorOptions.shouldCheckJsx &&
-    (isJSXNode(node[operatorOptions.testNodePropertyNames[0]]) ||
-      isJSXNode(consequentNode) ||
-      isJSXNode(alternateNode) ||
-      conditionalExpressionChainContainsJSX(lastConditionalParent))
-  ) {
-    jsxMode = true;
-    forceNoIndent = true;
-
-    // Even though they don't need parens, we wrap (almost) everything in
-    // parens when using ?: within JSX, because the parens are analogous to
-    // curly braces in an if statement.
-    const wrap = (doc) =>
-      concat([
-        ifBreak("(", ""),
-        indent(concat([softline, doc])),
-        softline,
-        ifBreak(")", ""),
-      ]);
-
-    // The only things we don't wrap are:
-    // * Nested conditional expressions in alternates
-    // * null
-    // * undefined
-    const isNil = (node) =>
-      node.type === "NullLiteral" ||
-      (node.type === "Literal" && node.value === null) ||
-      (node.type === "Identifier" && node.name === "undefined");
-
-    parts.push(
-      " ? ",
-      isNil(consequentNode)
-        ? path.call(print, operatorOptions.consequentNodePropertyName)
-        : wrap(path.call(print, operatorOptions.consequentNodePropertyName)),
-      " : ",
-      alternateNode.type === operatorOptions.conditionalNodeType ||
-        isNil(alternateNode)
-        ? path.call(print, operatorOptions.alternateNodePropertyName)
-        : wrap(path.call(print, operatorOptions.alternateNodePropertyName))
-    );
-  } else {
-    // normal mode
-    const part = concat([
-      line,
-      "? ",
-      consequentNode.type === operatorOptions.conditionalNodeType
-        ? ifBreak("", "(")
-        : "",
-      align(2, path.call(print, operatorOptions.consequentNodePropertyName)),
-      consequentNode.type === operatorOptions.conditionalNodeType
-        ? ifBreak("", ")")
-        : "",
-      line,
-      ": ",
-      alternateNode.type === operatorOptions.conditionalNodeType
-        ? path.call(print, operatorOptions.alternateNodePropertyName)
-        : align(2, path.call(print, operatorOptions.alternateNodePropertyName)),
-    ]);
-    parts.push(
-      parent.type !== operatorOptions.conditionalNodeType ||
-        parent[operatorOptions.alternateNodePropertyName] === node ||
-        isParentTest
-        ? part
-        : options.useTabs
-        ? dedent(indent(part))
-        : align(Math.max(0, options.tabWidth - 2), part)
-    );
-  }
-
-  // We want a whole chain of ConditionalExpressions to all
-  // break if any of them break. That means we should only group around the
-  // outer-most ConditionalExpression.
-  const comments = flat([
-    ...operatorOptions.testNodePropertyNames.map(
-      (propertyName) => node[propertyName].comments
-    ),
-    consequentNode.comments,
-    alternateNode.comments,
-  ]).filter(Boolean);
-  const shouldBreak = comments.some(
-    (comment) =>
-      handleComments.isBlockComment(comment) &&
-      hasNewlineInRange(
-        options.originalText,
-        options.locStart(comment),
-        options.locEnd(comment)
-      )
-  );
-  const maybeGroup = (doc) =>
-    parent === firstNonConditionalParent
-      ? group(doc, { shouldBreak })
-      : shouldBreak
-      ? concat([doc, breakParent])
-      : doc;
-
-  // Break the closing paren to keep the chain right after it:
-  // (a
-  //   ? b
-  //   : c
-  // ).call()
-  const breakClosingParen =
-    !jsxMode &&
-    (parent.type === "MemberExpression" ||
-      parent.type === "OptionalMemberExpression" ||
-      (parent.type === "NGPipeExpression" && parent.left === node)) &&
-    !parent.computed;
-
-  const result = maybeGroup(
-    concat(
-      [].concat(
-        ((testDoc) =>
-          /**
-           *     a
-           *       ? b
-           *       : multiline
-           *         test
-           *         node
-           *       ^^ align(2)
-           *       ? d
-           *       : e
-           */
-          parent.type === operatorOptions.conditionalNodeType &&
-          parent[operatorOptions.alternateNodePropertyName] === node
-            ? align(2, testDoc)
-            : testDoc)(concat(operatorOptions.beforeParts())),
-        forceNoIndent ? concat(parts) : indent(concat(parts)),
-        operatorOptions.afterParts(breakClosingParen)
-      )
-    )
-  );
-
-  return isParentTest
-    ? group(concat([indent(concat([softline, result])), softline]))
-    : result;
 }
 
 function printPathNoParens(path, options, print, args) {

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -837,101 +837,6 @@ function needsHardlineAfterDanglingComment(node) {
   );
 }
 
-// If we have nested conditional expressions, we want to print them in JSX mode
-// if there's at least one JSXElement somewhere in the tree.
-//
-// A conditional expression chain like this should be printed in normal mode,
-// because there aren't JSXElements anywhere in it:
-//
-// isA ? "A" : isB ? "B" : isC ? "C" : "Unknown";
-//
-// But a conditional expression chain like this should be printed in JSX mode,
-// because there is a JSXElement in the last ConditionalExpression:
-//
-// isA ? "A" : isB ? "B" : isC ? "C" : <span className="warning">Unknown</span>;
-//
-// This type of ConditionalExpression chain is structured like this in the AST:
-//
-// ConditionalExpression {
-//   test: ...,
-//   consequent: ...,
-//   alternate: ConditionalExpression {
-//     test: ...,
-//     consequent: ...,
-//     alternate: ConditionalExpression {
-//       test: ...,
-//       consequent: ...,
-//       alternate: ...,
-//     }
-//   }
-// }
-//
-// We want to traverse over that shape and convert it into a flat structure so
-// that we can find if there's a JSXElement somewhere inside.
-function getConditionalChainContents(node) {
-  // Given this code:
-  //
-  // // Using a ConditionalExpression as the consequent is uncommon, but should
-  // // be handled.
-  // A ? B : C ? D : E ? F ? G : H : I
-  //
-  // which has this AST:
-  //
-  // ConditionalExpression {
-  //   test: Identifier(A),
-  //   consequent: Identifier(B),
-  //   alternate: ConditionalExpression {
-  //     test: Identifier(C),
-  //     consequent: Identifier(D),
-  //     alternate: ConditionalExpression {
-  //       test: Identifier(E),
-  //       consequent: ConditionalExpression {
-  //         test: Identifier(F),
-  //         consequent: Identifier(G),
-  //         alternate: Identifier(H),
-  //       },
-  //       alternate: Identifier(I),
-  //     }
-  //   }
-  // }
-  //
-  // we should return this Array:
-  //
-  // [
-  //   Identifier(A),
-  //   Identifier(B),
-  //   Identifier(C),
-  //   Identifier(D),
-  //   Identifier(E),
-  //   Identifier(F),
-  //   Identifier(G),
-  //   Identifier(H),
-  //   Identifier(I)
-  // ];
-  //
-  // This loses the information about whether each node was the test,
-  // consequent, or alternate, but we don't care about that here- we are only
-  // flattening this structure to find if there's any JSXElements inside.
-  const nonConditionalExpressions = [];
-
-  function recurse(node) {
-    if (node.type === "ConditionalExpression") {
-      recurse(node.test);
-      recurse(node.consequent);
-      recurse(node.alternate);
-    } else {
-      nonConditionalExpressions.push(node);
-    }
-  }
-  recurse(node);
-
-  return nonConditionalExpressions;
-}
-
-function conditionalExpressionChainContainsJSX(node) {
-  return Boolean(getConditionalChainContents(node).find(isJSXNode));
-}
-
 // Logic to check for args with multiple anonymous functions. For instance,
 // the following call should be split on multiple lines for readability:
 // source.pipe(map((x) => x + x), filter((x) => x % 2 === 0))
@@ -1096,7 +1001,6 @@ function shouldPrintComma(options, level) {
 module.exports = {
   classChildNeedsASIProtection,
   classPropMayCauseASIProblems,
-  conditionalExpressionChainContainsJSX,
   getFlowVariance,
   getLeftSidePathName,
   getParentExportDeclaration,


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
