### PR TITLE
Fix broken JSDoc type comments for `printTernaryOperator`

### DIFF
--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -118,6 +118,7 @@ function conditionalExpressionChainContainsJSX(node) {
  * The following is the shared logic for
  * ternary operators, namely ConditionalExpression
  * and TSConditionalType
+ * @typedef {import("../../document/doc-builders").Doc} Doc
  * @typedef {Object} OperatorOptions
  * @property {() => Array<string | Doc>} beforeParts - Parts to print before the `?`.
  * @property {(breakClosingParen: boolean) => Array<string | Doc>} afterParts - Parts to print after the conditional expression.
@@ -130,7 +131,7 @@ function conditionalExpressionChainContainsJSX(node) {
  * @param {Options} options - Prettier options
  * @param {Function} print - Print function to call recursively
  * @param {OperatorOptions} operatorOptions
- * @returns Doc
+ * @returns {Doc}
  */
 function printTernaryOperator(path, options, print, operatorOptions) {
   const node = path.getValue();


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
