### PR TITLE
Suppress “Checking formatting...” message on non-TTY

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -56,7 +56,7 @@ This will output a human-friendly message and a list of unformatted files, if an
 prettier --check "src/**/*.js"
 ```
 
-Console output if all files are formatted:
+Console output if all files are formatted (these messages will be suppressed when redirecting output to a file or program):
 
 ```console
 Checking formatting...

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -418,7 +418,7 @@ function formatFiles(context) {
 
   let numberOfUnformattedFilesFound = 0;
 
-  if (context.argv.check) {
+  if (context.argv.check && isTTY()) {
     context.logger.log("Checking formatting...");
   }
 
@@ -536,13 +536,17 @@ function formatFiles(context) {
 
   // Print check summary based on expected exit code
   if (context.argv.check) {
-    context.logger.log(
-      numberOfUnformattedFilesFound === 0
-        ? "All matched files use Prettier code style!"
-        : context.argv.write
-        ? "Code style issues fixed in the above file(s)."
-        : "Code style issues found in the above file(s). Forgot to run Prettier?"
-    );
+    if (numberOfUnformattedFilesFound === 0) {
+      if (isTTY()) {
+        context.logger.log("All matched files use Prettier code style!");
+      }
+    } else {
+      context.logger.log(
+        context.argv.write
+          ? "Code style issues fixed in the above file(s)."
+          : "Code style issues found in the above file(s). Forgot to run Prettier?"
+      );
+    }
   }
 
   // Ensure non-zero exitCode when using --check/list-different is not combined with --write

--- a/tests_integration/__tests__/__snapshots__/check.js.snap
+++ b/tests_integration/__tests__/__snapshots__/check.js.snap
@@ -5,15 +5,13 @@ exports[`--checks works in CI just as in a non-TTY mode (stderr) 1`] = `""`;
 exports[`--checks works in CI just as in a non-TTY mode (stderr) 2`] = `""`;
 
 exports[`--checks works in CI just as in a non-TTY mode (stdout) 1`] = `
-"Checking formatting...
-unformatted.js
+"unformatted.js
 Code style issues found in the above file(s). Forgot to run Prettier?
 "
 `;
 
 exports[`--checks works in CI just as in a non-TTY mode (stdout) 2`] = `
-"Checking formatting...
-unformatted.js
+"unformatted.js
 Code style issues found in the above file(s). Forgot to run Prettier?
 "
 `;

--- a/tests_integration/__tests__/__snapshots__/debug-check.js.snap
+++ b/tests_integration/__tests__/__snapshots__/debug-check.js.snap
@@ -7,9 +7,7 @@ exports[`doesn't crash when --debug-check is passed (write) 1`] = `Array []`;
 exports[`should not exit non-zero for already prettified code with --debug-check + --check (stderr) 1`] = `""`;
 
 exports[`should not exit non-zero for already prettified code with --debug-check + --check (stdout) 1`] = `
-"Checking formatting...
-issue-4599.js
-All matched files use Prettier code style!
+"issue-4599.js
 "
 `;
 

--- a/tests_integration/__tests__/__snapshots__/infer-parser.js.snap
+++ b/tests_integration/__tests__/__snapshots__/infer-parser.js.snap
@@ -6,8 +6,7 @@ exports[`--check with unknown path and no parser multiple files (stderr) 1`] = `
 `;
 
 exports[`--check with unknown path and no parser multiple files (stdout) 1`] = `
-"Checking formatting...
-foo.js
+"foo.js
 Code style issues found in the above file(s). Forgot to run Prettier?
 "
 `;
@@ -17,11 +16,7 @@ exports[`--check with unknown path and no parser specific file (stderr) 1`] = `
 "
 `;
 
-exports[`--check with unknown path and no parser specific file (stdout) 1`] = `
-"Checking formatting...
-All matched files use Prettier code style!
-"
-`;
+exports[`--check with unknown path and no parser specific file (stdout) 1`] = `""`;
 
 exports[`--list-different with unknown path and no parser multiple files (stderr) 1`] = `
 "[error] No parser could be inferred for file: FOO
@@ -39,8 +34,7 @@ exports[`--write and --check with unknown path and no parser multiple files (std
 `;
 
 exports[`--write and --check with unknown path and no parser multiple files (stdout) 1`] = `
-"Checking formatting...
-foo.js
+"foo.js
 Code style issues fixed in the above file(s).
 "
 `;
@@ -60,11 +54,7 @@ exports[`--write and --check with unknown path and no parser specific file (stde
 "
 `;
 
-exports[`--write and --check with unknown path and no parser specific file (stdout) 1`] = `
-"Checking formatting...
-All matched files use Prettier code style!
-"
-`;
+exports[`--write and --check with unknown path and no parser specific file (stdout) 1`] = `""`;
 
 exports[`--write and --list-different with unknown path and no parser multiple files (stderr) 1`] = `
 "[error] No parser could be inferred for file: FOO

--- a/tests_integration/__tests__/__snapshots__/piped-output.js.snap
+++ b/tests_integration/__tests__/__snapshots__/piped-output.js.snap
@@ -10,11 +10,7 @@ formatted.jsAll matched files use Prettier code style!
 "
 `;
 
-exports[`no file diffs with --check + formatted file (stdout) 2`] = `
-"Checking formatting...
-All matched files use Prettier code style!
-"
-`;
+exports[`no file diffs with --check + formatted file (stdout) 2`] = `""`;
 
 exports[`no file diffs with --check + formatted file (write) 1`] = `Array []`;
 
@@ -44,8 +40,7 @@ Code style issues fixed in the above file(s).
 `;
 
 exports[`output with --check + unformatted differs when piped (stdout) 2`] = `
-"Checking formatting...
-unformatted.js
+"unformatted.js
 Code style issues fixed in the above file(s).
 "
 `;

--- a/tests_integration/__tests__/__snapshots__/with-parser-inference.js.snap
+++ b/tests_integration/__tests__/__snapshots__/with-parser-inference.js.snap
@@ -16,11 +16,7 @@ exports[`infers postcss parser (write) 1`] = `Array []`;
 
 exports[`infers postcss parser with --check (stderr) 1`] = `""`;
 
-exports[`infers postcss parser with --check (stdout) 1`] = `
-"Checking formatting...
-All matched files use Prettier code style!
-"
-`;
+exports[`infers postcss parser with --check (stdout) 1`] = `""`;
 
 exports[`infers postcss parser with --check (write) 1`] = `Array []`;
 


### PR DESCRIPTION
When Prettier is run by a script that combines the output from dozens of separate linters, any progress output is just noise that makes it harder to see whether there are real errors.  Similarly to how we already suppress printing each filename as it’s checked when outputting to a non-TTY, also suppress the “Checking formatting...” and “All matched files use Prettier code style!” messages in this case.

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
