### PR TITLE
Bump loglevel of issues reported by --check to warn

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -67,9 +67,9 @@ Console output if some of the files require re-formatting:
 
 ```console
 Checking formatting...
-src/fileA.js
-src/fileB.js
-Code style issues found in the above file(s). Forgot to run Prettier?
+[warn] src/fileA.js
+[warn] src/fileB.js
+[warn] Code style issues found in the above file(s). Forgot to run Prettier?
 ```
 
 The command will return exit code 1 in the second case, which is helpful inside the CI pipelines.

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -528,21 +528,27 @@ function formatFiles(context) {
       writeOutput(context, result, options);
     }
 
-    if ((context.argv.check || context.argv["list-different"]) && isDifferent) {
-      context.logger.log(filename);
+    if (isDifferent) {
+      if (context.argv.check) {
+        context.logger.warn(filename);
+      } else if (context.argv["list-different"]) {
+        context.logger.log(filename);
+      }
       numberOfUnformattedFilesFound += 1;
     }
   }
 
   // Print check summary based on expected exit code
   if (context.argv.check) {
-    context.logger.log(
-      numberOfUnformattedFilesFound === 0
-        ? "All matched files use Prettier code style!"
-        : context.argv.write
-        ? "Code style issues fixed in the above file(s)."
-        : "Code style issues found in the above file(s). Forgot to run Prettier?"
-    );
+    if (numberOfUnformattedFilesFound === 0) {
+      context.logger.log("All matched files use Prettier code style!");
+    } else {
+      context.logger.warn(
+        context.argv.write
+          ? "Code style issues fixed in the above file(s)."
+          : "Code style issues found in the above file(s). Forgot to run Prettier?"
+      );
+    }
   }
 
   // Ensure non-zero exitCode when using --check/list-different is not combined with --write

--- a/tests_integration/__tests__/__snapshots__/check.js.snap
+++ b/tests_integration/__tests__/__snapshots__/check.js.snap
@@ -1,20 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`--checks works in CI just as in a non-TTY mode (stderr) 1`] = `""`;
+exports[`--checks works in CI just as in a non-TTY mode (stderr) 1`] = `
+"[warn] unformatted.js
+[warn] Code style issues found in the above file(s). Forgot to run Prettier?
+"
+`;
 
-exports[`--checks works in CI just as in a non-TTY mode (stderr) 2`] = `""`;
+exports[`--checks works in CI just as in a non-TTY mode (stderr) 2`] = `
+"[warn] unformatted.js
+[warn] Code style issues found in the above file(s). Forgot to run Prettier?
+"
+`;
 
 exports[`--checks works in CI just as in a non-TTY mode (stdout) 1`] = `
 "Checking formatting...
-unformatted.js
-Code style issues found in the above file(s). Forgot to run Prettier?
 "
 `;
 
 exports[`--checks works in CI just as in a non-TTY mode (stdout) 2`] = `
 "Checking formatting...
-unformatted.js
-Code style issues found in the above file(s). Forgot to run Prettier?
 "
 `;
 

--- a/tests_integration/__tests__/__snapshots__/infer-parser.js.snap
+++ b/tests_integration/__tests__/__snapshots__/infer-parser.js.snap
@@ -2,13 +2,13 @@
 
 exports[`--check with unknown path and no parser multiple files (stderr) 1`] = `
 "[error] No parser could be inferred for file: FOO
+[warn] foo.js
+[warn] Code style issues found in the above file(s). Forgot to run Prettier?
 "
 `;
 
 exports[`--check with unknown path and no parser multiple files (stdout) 1`] = `
 "Checking formatting...
-foo.js
-Code style issues found in the above file(s). Forgot to run Prettier?
 "
 `;
 
@@ -35,13 +35,13 @@ exports[`--list-different with unknown path and no parser specific file (stderr)
 
 exports[`--write and --check with unknown path and no parser multiple files (stderr) 1`] = `
 "[error] No parser could be inferred for file: FOO
+[warn] foo.js
+[warn] Code style issues fixed in the above file(s).
 "
 `;
 
 exports[`--write and --check with unknown path and no parser multiple files (stdout) 1`] = `
 "Checking formatting...
-foo.js
-Code style issues fixed in the above file(s).
 "
 `;
 

--- a/tests_integration/__tests__/__snapshots__/piped-output.js.snap
+++ b/tests_integration/__tests__/__snapshots__/piped-output.js.snap
@@ -32,21 +32,25 @@ exports[`no file diffs with --list-different + formatted file (write) 1`] = `Arr
 
 exports[`no file diffs with --list-different + formatted file (write) 2`] = `Array []`;
 
-exports[`output with --check + unformatted differs when piped (stderr) 1`] = `""`;
+exports[`output with --check + unformatted differs when piped (stderr) 1`] = `
+"[warn] unformatted.js
+[warn] Code style issues fixed in the above file(s).
+"
+`;
 
-exports[`output with --check + unformatted differs when piped (stderr) 2`] = `""`;
+exports[`output with --check + unformatted differs when piped (stderr) 2`] = `
+"[warn] unformatted.js
+[warn] Code style issues fixed in the above file(s).
+"
+`;
 
 exports[`output with --check + unformatted differs when piped (stdout) 1`] = `
 "Checking formatting...
-unformatted.jsunformatted.js
-Code style issues fixed in the above file(s).
-"
+unformatted.js"
 `;
 
 exports[`output with --check + unformatted differs when piped (stdout) 2`] = `
 "Checking formatting...
-unformatted.js
-Code style issues fixed in the above file(s).
 "
 `;
 


### PR DESCRIPTION
When `prettier --check` is run by a script that combines the output from dozens of separate linters, any progress output like “Checking formatting...” and “All matched files use Prettier code style!” is just noise that makes it harder to see whether there are real errors.  Bump the loglevel of issues reported by `--check` from `log` to `warn` so that the noise can be selectively silenced with `--loglevel=warn`.

Alternative to #8694 suggested by @thorn0.

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
