### PR TITLE
Remove the precise-commits section

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -69,42 +69,7 @@ Copy the following config into your `.pre-commit-config.yaml` file:
 
 Read more at the [pre-commit](https://pre-commit.com) website.
 
-## Option 4. [precise-commits](https://github.com/JamesHenry/precise-commits)
-
-**Use Case:** Great for when you want partial file formatting on your changed/staged files.
-
-Install it along with [husky](https://github.com/typicode/husky):
-
-<!--DOCUSAURUS_CODE_TABS-->
-<!--npm-->
-
-```bash
-npm install --save-dev precise-commits husky
-```
-
-<!--yarn-->
-
-```bash
-yarn add --dev precise-commits husky
-```
-
-<!--END_DOCUSAURUS_CODE_TABS-->
-
-and add this config to your `package.json`:
-
-```json
-{
-  "husky": {
-    "hooks": {
-      "pre-commit": "precise-commits"
-    }
-  }
-}
-```
-
-Read more at the [precise-commits](https://github.com/JamesHenry/precise-commits#2-precommit-hook) repo.
-
-## Option 5. [git-format-staged](https://github.com/hallettj/git-format-staged)
+## Option 4. [git-format-staged](https://github.com/hallettj/git-format-staged)
 
 **Use Case:** Great for when you want to format partially-staged files, and other options do not provide a good fit for your project.
 
@@ -148,7 +113,7 @@ Add or remove file extensions to suit your project. Note that regardless of whic
 
 To read about how git-format-staged works see [Automatic Code Formatting for Partially-Staged Files](https://www.olioapps.com/blog/automatic-code-formatting/).
 
-## Option 6. Shell script
+## Option 5. Shell script
 
 Alternately you can save this script as `.git/hooks/pre-commit` and give it execute permission:
 


### PR DESCRIPTION
Unfortunately, the precise-commits repo does not seem to have been maintained for the past two years:
- [most recent commit](https://github.com/nrwl/precise-commits/commit/803871289f59e2c326b4d20c08e6b1b862c0408e) to master was on Mar 27, 2018
- [most recent release](https://github.com/nrwl/precise-commits/releases/tag/v1.0.2) was on Feb 16, 2018
- [most recently closed issue](https://github.com/nrwl/precise-commits/issues/19) was closed on Jul 29, 2018

I have [requested](https://github.com/nrwl/precise-commits/issues/58) archiving.

This is sad. I could think of several use-cases where a tool like `precise-commits` could be very useful, especially for already matured projects that are trying to onboard linting and prettifying.

<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works. - N/A
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory) - N/A
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`. - N/A
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
