### PR TITLE
Remove dead code

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -296,30 +296,6 @@ function hasSpaces(text, index, opts) {
 }
 
 /**
- * @param {{range?: [number, number], start?: number}} node
- * @param {number} index
- */
-function setLocStart(node, index) {
-  if (node.range) {
-    node.range[0] = index;
-  } else {
-    node.start = index;
-  }
-}
-
-/**
- * @param {{range?: [number, number], end?: number}} node
- * @param {number} index
- */
-function setLocEnd(node, index) {
-  if (node.range) {
-    node.range[1] = index;
-  } else {
-    node.end = index;
-  }
-}
-
-/**
  * @param {string} value
  * @param {number} tabWidth
  * @param {number=} startIndex
@@ -716,8 +692,6 @@ module.exports = {
   hasNewline,
   hasNewlineInRange,
   hasSpaces,
-  setLocStart,
-  setLocEnd,
   getAlignmentSize,
   getIndentSize,
   getPreferredQuote,


### PR DESCRIPTION
[`isWithinParentArrayProperty` function](https://github.com/prettier/prettier/blob/b0fbd726888de44c9e5e2157a4032ea5bd1272e2/src/common/util.js#L636) is also not used, not sure if we want remove it.


- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
