### PR TITLE
Add an option to enable empty/self-closing tags conversion in JSX

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -97,6 +97,14 @@ Use single quotes instead of double quotes in JSX.
 | ------- | -------------------- | ------------------------ |
 | `false` | `--jsx-single-quote` | `jsxSingleQuote: <bool>` |
 
+## JSX Self Closing Tags
+
+Convert empty tags to self closing tags.
+
+| Default | CLI Override              | API Override                 |
+| ------- | ------------------------- | ---------------------------- |
+| `false` | `--jsx-self-closing-tags` | `jsxSelfClosingTags: <bool>` |
+
 ## Trailing Commas
 
 _Default value changed from `none` to `es5` in v2.0.0_

--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -97,4 +97,11 @@ module.exports = {
       },
     ],
   },
+  jsxSelfClosingTags: {
+    since: "2.1.0",
+    category: CATEGORY_JAVASCRIPT,
+    type: "boolean",
+    default: false,
+    description: "Prefer self closing tags in JSX.",
+  },
 };

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4473,6 +4473,10 @@ function printJSXElement(path, options, print) {
   const n = path.getValue();
 
   if (n.type === "JSXElement" && isEmptyJSXElement(n)) {
+    if (options.jsxSelfClosingTags) {
+      n.openingElement.selfClosing = true;
+      return path.call(print, "openingElement");
+    }
     return concat([
       path.call(print, "openingElement"),
       path.call(print, "closingElement"),

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -82,6 +82,8 @@ Format options:
                            Defaults to css.
   --jsx-bracket-same-line  Put > on the last line instead of at a new line.
                            Defaults to false.
+  --jsx-self-closing-tags  Prefer self closing tags in JSX.
+                           Defaults to false.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.
   --parser <flow|babel|babel-flow|babel-ts|typescript|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|html|angular|lwc>
@@ -240,6 +242,8 @@ Format options:
                            How to handle whitespaces in HTML.
                            Defaults to css.
   --jsx-bracket-same-line  Put > on the last line instead of at a new line.
+                           Defaults to false.
+  --jsx-self-closing-tags  Prefer self closing tags in JSX.
                            Defaults to false.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.

--- a/tests_integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/help-options.js.snap
@@ -247,6 +247,19 @@ Default: false
 
 exports[`show detailed usage with --help jsx-bracket-same-line (write) 1`] = `Array []`;
 
+exports[`show detailed usage with --help jsx-self-closing-tags (stderr) 1`] = `""`;
+
+exports[`show detailed usage with --help jsx-self-closing-tags (stdout) 1`] = `
+"--jsx-self-closing-tags
+
+  Prefer self closing tags in JSX.
+
+Default: false
+"
+`;
+
+exports[`show detailed usage with --help jsx-self-closing-tags (write) 1`] = `Array []`;
+
 exports[`show detailed usage with --help jsx-single-quote (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help jsx-single-quote (stdout) 1`] = `

--- a/tests_integration/__tests__/__snapshots__/plugin-options-string.js.snap
+++ b/tests_integration/__tests__/__snapshots__/plugin-options-string.js.snap
@@ -5,7 +5,7 @@ exports[` 1`] = `
 - First value
 + Second value
 
-@@ -20,18 +20,20 @@
+@@ -20,20 +20,22 @@
                              Control how Prettier formats quoted code embedded in the file.
                              Defaults to auto.
     --end-of-line <lf|crlf|cr|auto>
@@ -17,6 +17,8 @@ exports[` 1`] = `
                              How to handle whitespaces in HTML.
                              Defaults to css.
     --jsx-bracket-same-line  Put > on the last line instead of at a new line.
+                             Defaults to false.
+    --jsx-self-closing-tags  Prefer self closing tags in JSX.
                              Defaults to false.
     --jsx-single-quote       Use single quotes in JSX.
                              Defaults to false.

--- a/tests_integration/__tests__/__snapshots__/plugin-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/plugin-options.js.snap
@@ -5,7 +5,7 @@ exports[` 1`] = `
 - First value
 + Second value
 
-@@ -20,18 +20,20 @@
+@@ -20,20 +20,22 @@
                              Control how Prettier formats quoted code embedded in the file.
                              Defaults to auto.
     --end-of-line <lf|crlf|cr|auto>
@@ -17,6 +17,8 @@ exports[` 1`] = `
                              How to handle whitespaces in HTML.
                              Defaults to css.
     --jsx-bracket-same-line  Put > on the last line instead of at a new line.
+                             Defaults to false.
+    --jsx-self-closing-tags  Prefer self closing tags in JSX.
                              Defaults to false.
     --jsx-single-quote       Use single quotes in JSX.
                              Defaults to false.

--- a/tests_integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests_integration/__tests__/__snapshots__/schema.js.snap
@@ -123,6 +123,11 @@ This option cannot be used with --range-start and --range-end.",
           "description": "Put > on the last line instead of at a new line.",
           "type": "boolean",
         },
+        "jsxSelfClosingTags": Object {
+          "default": false,
+          "description": "Prefer self closing tags in JSX.",
+          "type": "boolean",
+        },
         "jsxSingleQuote": Object {
           "default": false,
           "description": "Use single quotes in JSX.",

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -133,6 +133,10 @@ Object {
       "default": false,
       "type": "boolean",
     },
+    "jsxSelfClosingTags": Object {
+      "default": false,
+      "type": "boolean",
+    },
     "jsxSingleQuote": Object {
       "default": false,
       "type": "boolean",
@@ -828,6 +832,15 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"name\\": \\"jsxBracketSameLine\\",
       \\"pluginDefaults\\": {},
       \\"since\\": \\"0.17.0\\",
+      \\"type\\": \\"boolean\\"
+    },
+    {
+      \\"category\\": \\"JavaScript\\",
+      \\"default\\": false,
+      \\"description\\": \\"Prefer self closing tags in JSX.\\",
+      \\"name\\": \\"jsxSelfClosingTags\\",
+      \\"pluginDefaults\\": {},
+      \\"since\\": \\"2.1.0\\",
       \\"type\\": \\"boolean\\"
     },
     {

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -32,6 +32,7 @@ const ENABLED_OPTIONS = [
   "singleQuote",
   "bracketSpacing",
   "jsxSingleQuote",
+  "jsxSelfClosingTags",
   "jsxBracketSameLine",
   "quoteProps",
   "arrowParens",


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
