### PR TITLE
Simplify `escapeTemplateCharacters`

### DIFF
--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -212,14 +212,12 @@ function escapeTemplateCharacters(doc, raw) {
       return currentDoc;
     }
 
-    const parts = [];
-
-    currentDoc.parts.forEach((part) => {
+    const parts = currentDoc.parts.map((part) => {
       if (typeof part === "string") {
-        parts.push(raw ? part.replace(/(\\*)`/g, "$1$1\\`") : uncook(part));
-      } else {
-        parts.push(part);
+        return raw ? part.replace(/(\\*)`/g, "$1$1\\`") : uncook(part);
       }
+
+      return part;
     });
 
     return { ...currentDoc, parts };


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Use `.map` instead of `.forEach + .push`


- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
