### PR TITLE
Add Home Assistant vscode language ID as YAML

### DIFF
--- a/src/language-yaml/index.js
+++ b/src/language-yaml/index.js
@@ -8,7 +8,7 @@ const languages = [
   createLanguage(require("linguist-languages/data/YAML"), (data) => ({
     since: "1.14.0",
     parsers: ["yaml"],
-    vscodeLanguageIds: ["yaml", "ansible"],
+    vscodeLanguageIds: ["yaml", "ansible", "home-assistant"],
     // yarn.lock is not YAML: https://github.com/yarnpkg/yarn/issues/5629
     filenames: data.filenames.filter((filename) => filename !== "yarn.lock"),
   })),

--- a/tests/yaml/home-assistant/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/yaml/home-assistant/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,191 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`configuration.yml format 1`] = `
+====================================options=====================================
+parsers: ["yaml"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+---
+default_config:
+tts:
+  - platform: google_translate
+
+homeassistant:
+  time_zone: Europe/Amsterdam
+  latitude: 80.1
+  longitude: -160
+
+automation:
+
+- description: Send notification on Home Assistant start
+  alias: system_start_notification
+  id: 104463f6-7524-48d9-bbe5-2bb09017e946
+  mode: single
+  trigger:
+    platform: homeassistant
+    event: start
+  action:
+  - service: notify.frenck_telegram
+    data:
+      message: Home Assistant is starting up again 🎉
+
+- description: Open the hall curtain based on time and type of day
+  alias: hall_curtain_open
+  id: 43178d7d-b1b5-45cc-a557-a918c397708b
+  mode: single
+  trigger:
+    - platform: homeassistant
+      event: start
+    - platform: event
+      event_type: automation_reloaded
+    - platform: state
+      entity_id:
+        - alarm_control_panel.home_alarm
+    - platform: time
+      at: "08:10:00"
+    - platform: time
+      at: "10:00:00"
+  condition:
+
+  - condition: state
+    entity_id:
+      - alarm_control_panel.home_alarm
+    state:
+      - disarmed
+  - condition: time
+    before: "19:00:00"
+  - condition: or
+    conditions:
+      - condition: and
+        conditions:
+          - condition: time
+            after: "08:10:00"
+          - condition: state
+            entity_id:
+              - binary_sensor.workday
+            state: "on"
+      - condition: and
+        conditions:
+          - condition: time
+            after: "10:00:00"
+            weekday:
+              - sat
+          - condition: state
+            entity_id:
+              - binary_sensor.holiday
+            state: "off"
+    action:
+      - service: cover.open_cover
+        data:
+          entity_id:
+            - cover.hall_curtain
+
+
+logger:
+
+  default: info
+  logs:
+    homeassistant.core: warning
+
+switch:
+- platform: wake_on_lan
+  entity_id:
+    - sensor.attic_boiler_bssid
+
+
+
+hue:
+    bridges:
+        - host: 192.168.1.1
+
+=====================================output=====================================
+---
+default_config:
+tts:
+  - platform: google_translate
+
+homeassistant:
+  time_zone: Europe/Amsterdam
+  latitude: 80.1
+  longitude: -160
+
+automation:
+  - description: Send notification on Home Assistant start
+    alias: system_start_notification
+    id: 104463f6-7524-48d9-bbe5-2bb09017e946
+    mode: single
+    trigger:
+      platform: homeassistant
+      event: start
+    action:
+      - service: notify.frenck_telegram
+        data:
+          message: Home Assistant is starting up again 🎉
+
+  - description: Open the hall curtain based on time and type of day
+    alias: hall_curtain_open
+    id: 43178d7d-b1b5-45cc-a557-a918c397708b
+    mode: single
+    trigger:
+      - platform: homeassistant
+        event: start
+      - platform: event
+        event_type: automation_reloaded
+      - platform: state
+        entity_id:
+          - alarm_control_panel.home_alarm
+      - platform: time
+        at: "08:10:00"
+      - platform: time
+        at: "10:00:00"
+    condition:
+      - condition: state
+        entity_id:
+          - alarm_control_panel.home_alarm
+        state:
+          - disarmed
+      - condition: time
+        before: "19:00:00"
+      - condition: or
+        conditions:
+          - condition: and
+            conditions:
+              - condition: time
+                after: "08:10:00"
+              - condition: state
+                entity_id:
+                  - binary_sensor.workday
+                state: "on"
+          - condition: and
+            conditions:
+              - condition: time
+                after: "10:00:00"
+                weekday:
+                  - sat
+              - condition: state
+                entity_id:
+                  - binary_sensor.holiday
+                state: "off"
+        action:
+          - service: cover.open_cover
+            data:
+              entity_id:
+                - cover.hall_curtain
+
+logger:
+  default: info
+  logs:
+    homeassistant.core: warning
+
+switch:
+  - platform: wake_on_lan
+    entity_id:
+      - sensor.attic_boiler_bssid
+
+hue:
+  bridges:
+    - host: 192.168.1.1
+
+================================================================================
+`;

--- a/tests/yaml/home-assistant/configuration.yml
+++ b/tests/yaml/home-assistant/configuration.yml
@@ -1,0 +1,92 @@
+---
+default_config:
+tts:
+  - platform: google_translate
+
+homeassistant:
+  time_zone: Europe/Amsterdam
+  latitude: 80.1
+  longitude: -160
+
+automation:
+
+- description: Send notification on Home Assistant start
+  alias: system_start_notification
+  id: 104463f6-7524-48d9-bbe5-2bb09017e946
+  mode: single
+  trigger:
+    platform: homeassistant
+    event: start
+  action:
+  - service: notify.frenck_telegram
+    data:
+      message: Home Assistant is starting up again 🎉
+
+- description: Open the hall curtain based on time and type of day
+  alias: hall_curtain_open
+  id: 43178d7d-b1b5-45cc-a557-a918c397708b
+  mode: single
+  trigger:
+    - platform: homeassistant
+      event: start
+    - platform: event
+      event_type: automation_reloaded
+    - platform: state
+      entity_id:
+        - alarm_control_panel.home_alarm
+    - platform: time
+      at: "08:10:00"
+    - platform: time
+      at: "10:00:00"
+  condition:
+
+  - condition: state
+    entity_id:
+      - alarm_control_panel.home_alarm
+    state:
+      - disarmed
+  - condition: time
+    before: "19:00:00"
+  - condition: or
+    conditions:
+      - condition: and
+        conditions:
+          - condition: time
+            after: "08:10:00"
+          - condition: state
+            entity_id:
+              - binary_sensor.workday
+            state: "on"
+      - condition: and
+        conditions:
+          - condition: time
+            after: "10:00:00"
+            weekday:
+              - sat
+          - condition: state
+            entity_id:
+              - binary_sensor.holiday
+            state: "off"
+    action:
+      - service: cover.open_cover
+        data:
+          entity_id:
+            - cover.hall_curtain
+
+
+logger:
+
+  default: info
+  logs:
+    homeassistant.core: warning
+
+switch:
+- platform: wake_on_lan
+  entity_id:
+    - sensor.attic_boiler_bssid
+
+
+
+hue:
+    bridges:
+        - host: 192.168.1.1

--- a/tests/yaml/home-assistant/jsfmt.spec.js
+++ b/tests/yaml/home-assistant/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["yaml"]);

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -692,7 +692,7 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"since\\": \\"1.14.0\\",
       \\"tmScope\\": \\"source.yaml\\",
       \\"type\\": \\"data\\",
-      \\"vscodeLanguageIds\\": [\\"yaml\\", \\"ansible\\"]
+      \\"vscodeLanguageIds\\": [\\"yaml\\", \\"ansible\\", \\"home-assistant\\"]
     }
   ],
   \\"options\\": [


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

This PR adds a custom language identifier for the Home Assistant language/vscode extension, as documented in:
<https://github.com/prettier/prettier-vscode/wiki/Custom-File-Extension-Configuration#custom-language-identifier>

The Home Assistant extension can be found here: https://marketplace.visualstudio.com/items?itemName=keesschollaart.vscode-home-assistant

Registers `home-assistant` in its language ID, however, it is YAML.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
