### PR TITLE
Check comment `printed` before printComment

### DIFF
--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -347,6 +347,15 @@ function breakTies(tiesToBreak, text, options) {
 
 function printComment(commentPath, options) {
   const comment = commentPath.getValue();
+
+  if (comment.printed) {
+    throw new Error(
+      'Comment "' +
+        comment.value.trim() +
+        '" already printed. Please report this error!'
+    );
+  }
+
   comment.printed = true;
   return options.printer.printComment(commentPath, options);
 }


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

We check not printed comments,

https://github.com/prettier/prettier/blob/350f641fca83d40aadfc7df8302b861c2f60efbf/src/main/core.js#L43-L52

I think make sense to prevent comments print multiple times too.

This can prevent #8736 happens.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
