### PR TITLE
refactor typedefs in src/language-js/print/ternary.js

### DIFF
--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -19,6 +19,22 @@ const {
   },
 } = require("../../document");
 
+/**
+ * @typedef {import("../../document/doc-builders").Doc} Doc
+ * @typedef {import("../../common/fast-path")} FastPath
+ */
+
+/**
+ * @typedef {Object} OperatorOptions
+ * @property {() => Array<string | Doc>} beforeParts - Parts to print before the `?`.
+ * @property {(breakClosingParen: boolean) => Array<string | Doc>} afterParts - Parts to print after the conditional expression.
+ * @property {boolean} shouldCheckJsx - Whether to check for and print in JSX mode.
+ * @property {string} conditionalNodeType - The type of the conditional expression node, ie "ConditionalExpression" or "TSConditionalType".
+ * @property {string} consequentNodePropertyName - The property at which the consequent node can be found on the main node, eg "consequent".
+ * @property {string} alternateNodePropertyName - The property at which the alternate node can be found on the main node, eg "alternate".
+ * @property {string[]} testNodePropertyNames - The properties at which the test nodes can be found on the main node, eg "test".
+ */
+
 // If we have nested conditional expressions, we want to print them in JSX mode
 // if there's at least one JSXElement somewhere in the tree.
 //
@@ -118,16 +134,7 @@ function conditionalExpressionChainContainsJSX(node) {
  * The following is the shared logic for
  * ternary operators, namely ConditionalExpression
  * and TSConditionalType
- * @typedef {import("../../document/doc-builders").Doc} Doc
- * @typedef {Object} OperatorOptions
- * @property {() => Array<string | Doc>} beforeParts - Parts to print before the `?`.
- * @property {(breakClosingParen: boolean) => Array<string | Doc>} afterParts - Parts to print after the conditional expression.
- * @property {boolean} shouldCheckJsx - Whether to check for and print in JSX mode.
- * @property {string} conditionalNodeType - The type of the conditional expression node, ie "ConditionalExpression" or "TSConditionalType".
- * @property {string} consequentNodePropertyName - The property at which the consequent node can be found on the main node, eg "consequent".
- * @property {string} alternateNodePropertyName - The property at which the alternate node can be found on the main node, eg "alternate".
- * @property {string[]} testNodePropertyNames - The properties at which the test nodes can be found on the main node, eg "test".
- * @param {import("../../common/fast-path")} path - The path to the ConditionalExpression/TSConditionalType node.
+ * @param {FastPath} path - The path to the ConditionalExpression/TSConditionalType node.
  * @param {Options} options - Prettier options
  * @param {Function} print - Print function to call recursively
  * @param {OperatorOptions} operatorOptions


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

- move the JSDoc typedefs to the beginning of `src/language-js/print/ternary.js`
- add & use JSDoc typedef for `@param {FastPath} path`, which effectively reverts the change in PR #8740
- keep JSDoc typedef for `@typedef {Object} OperatorOptions` in its own comment block

I think these changes should improve the readability.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- ~~I’ve added tests to confirm my change works.~~
- ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~~
- ~~(If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.~~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
