### PR TITLE
Do not expose `composeLoc`

### DIFF
--- a/src/language-js/parser-angular.js
+++ b/src/language-js/parser-angular.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const locFns = require("./loc");
+const { locStart, locEnd } = require("./loc");
 
 function createParser(_parse) {
   const parse = (text, parsers, options) => {
@@ -14,7 +14,7 @@ function createParser(_parse) {
           : node,
     };
   };
-  return { astFormat: "estree", parse, ...locFns };
+  return { astFormat: "estree", parse, locStart, locEnd };
 }
 
 module.exports = {

--- a/src/language-js/parser-babel.js
+++ b/src/language-js/parser-babel.js
@@ -2,7 +2,7 @@
 
 const createError = require("../common/parser-create-error");
 const { hasPragma } = require("./pragma");
-const locFns = require("./loc");
+const { locStart, locEnd } = require("./loc");
 const postprocess = require("./postprocess");
 
 function babelOptions({ sourceType, extraPlugins = [] }) {
@@ -225,7 +225,7 @@ function assertJsonNode(node, parent) {
   }
 }
 
-const babel = { parse, astFormat: "estree", hasPragma, ...locFns };
+const babel = { parse, astFormat: "estree", hasPragma, locStart, locEnd };
 const babelFlow = { ...babel, parse: parseFlow };
 const babelTypeScript = { ...babel, parse: parseTypeScript };
 const babelExpression = { ...babel, parse: parseExpression };
@@ -246,7 +246,8 @@ module.exports = {
     "json-stringify": {
       parse: parseJson,
       astFormat: "estree-json",
-      ...locFns,
+      locStart,
+      locEnd,
     },
     /** @internal */
     __js_expression: babelExpression,

--- a/src/language-js/parser-flow.js
+++ b/src/language-js/parser-flow.js
@@ -2,7 +2,7 @@
 
 const createError = require("../common/parser-create-error");
 const { hasPragma } = require("./pragma");
-const locFns = require("./loc");
+const { locStart, locEnd } = require("./loc");
 const postprocess = require("./postprocess");
 
 function parse(text, parsers, opts) {
@@ -33,6 +33,6 @@ function parse(text, parsers, opts) {
 // Export as a plugin so we can reuse the same bundle for UMD loading
 module.exports = {
   parsers: {
-    flow: { parse, astFormat: "estree", hasPragma, ...locFns },
+    flow: { parse, astFormat: "estree", hasPragma, locStart, locEnd },
   },
 };

--- a/src/language-js/parser-typescript.js
+++ b/src/language-js/parser-typescript.js
@@ -2,7 +2,7 @@
 
 const createError = require("../common/parser-create-error");
 const { hasPragma } = require("./pragma");
-const locFns = require("./loc");
+const { locStart, locEnd } = require("./loc");
 const postprocess = require("./postprocess");
 
 function parse(text, parsers, opts) {
@@ -56,7 +56,7 @@ function isProbablyJsx(text) {
   ).test(text);
 }
 
-const parser = { parse, astFormat: "estree", hasPragma, ...locFns };
+const parser = { parse, astFormat: "estree", hasPragma, locStart, locEnd };
 
 // Export as a plugin so we can reuse the same bundle for UMD loading
 module.exports = {


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

`loc.js` has extra function `composeLoc`, this not public api, should not add to parser.


- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
