### PR TITLE
use strict number JSDoc type in src/common/util.js

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -21,7 +21,7 @@ function getPenultimate(arr) {
 
 /**
  * @param {string | RegExp} chars
- * @returns {(text: string, index: number | false, opts?: SkipOptions) => number | false}
+ * @returns {(text: string, index: number, opts?: SkipOptions) => number}
  */
 function skip(chars) {
   return (text, index, opts) => {
@@ -29,8 +29,8 @@ function skip(chars) {
 
     // Allow `skip` functions to be threaded together without having
     // to check for failures (did someone say monads?).
-    if (index === false) {
-      return false;
+    if (index < 0) {
+      return -Infinity;
     }
 
     const { length } = text;
@@ -55,35 +55,35 @@ function skip(chars) {
       // actually skipped valid characters.
       return cursor;
     }
-    return false;
+    return -Infinity;
   };
 }
 
 /**
- * @type {(text: string, index: number | false, opts?: SkipOptions) => number | false}
+ * @type {(text: string, index: number, opts?: SkipOptions) => number}
  */
 const skipWhitespace = skip(/\s/);
 /**
- * @type {(text: string, index: number | false, opts?: SkipOptions) => number | false}
+ * @type {(text: string, index: number, opts?: SkipOptions) => number}
  */
 const skipSpaces = skip(" \t");
 /**
- * @type {(text: string, index: number | false, opts?: SkipOptions) => number | false}
+ * @type {(text: string, index: number, opts?: SkipOptions) => number}
  */
 const skipToLineEnd = skip(",; \t");
 /**
- * @type {(text: string, index: number | false, opts?: SkipOptions) => number | false}
+ * @type {(text: string, index: number, opts?: SkipOptions) => number}
  */
 const skipEverythingButNewLine = skip(/[^\n\r]/);
 
 /**
  * @param {string} text
- * @param {number | false} index
- * @returns {number | false}
+ * @param {number} index
+ * @returns {number}
  */
 function skipInlineComment(text, index) {
-  if (index === false) {
-    return false;
+  if (index < 0) {
+    return -Infinity;
   }
 
   if (text.charAt(index) === "/" && text.charAt(index + 1) === "*") {
@@ -98,12 +98,12 @@ function skipInlineComment(text, index) {
 
 /**
  * @param {string} text
- * @param {number | false} index
- * @returns {number | false}
+ * @param {number} index
+ * @returns {number}
  */
 function skipTrailingComment(text, index) {
-  if (index === false) {
-    return false;
+  if (index < 0) {
+    return -Infinity;
   }
 
   if (text.charAt(index) === "/" && text.charAt(index + 1) === "/") {
@@ -117,14 +117,14 @@ function skipTrailingComment(text, index) {
 // want to skip one newline. It's simple to implement.
 /**
  * @param {string} text
- * @param {number | false} index
+ * @param {number} index
  * @param {SkipOptions=} opts
- * @returns {number | false}
+ * @returns {number}
  */
 function skipNewline(text, index, opts) {
   const backwards = opts && opts.backwards;
-  if (index === false) {
-    return false;
+  if (index < 0) {
+    return -Infinity;
   }
 
   const atIndex = text.charAt(index);
@@ -193,7 +193,6 @@ function hasNewlineInRange(text, start, end) {
  * @param {(node: N) => number} locStart
  */
 function isPreviousLineEmpty(text, node, locStart) {
-  /** @type {number | false} */
   let idx = locStart(node) - 1;
   idx = skipSpaces(text, idx, { backwards: true });
   idx = skipNewline(text, idx, { backwards: true });
@@ -208,9 +207,7 @@ function isPreviousLineEmpty(text, node, locStart) {
  * @returns {boolean}
  */
 function isNextLineEmptyAfterIndex(text, index) {
-  /** @type {number | false} */
-  let oldIdx = null;
-  /** @type {number | false} */
+  let oldIdx = -Infinity;
   let idx = index;
   while (idx !== oldIdx) {
     // We need to skip all the potential trailing inline comments
@@ -221,7 +218,7 @@ function isNextLineEmptyAfterIndex(text, index) {
   }
   idx = skipTrailingComment(text, idx);
   idx = skipNewline(text, idx);
-  return idx !== false && hasNewline(text, idx);
+  return idx >= 0 && hasNewline(text, idx);
 }
 
 /**
@@ -238,12 +235,10 @@ function isNextLineEmpty(text, node, locEnd) {
 /**
  * @param {string} text
  * @param {number} idx
- * @returns {number | false}
+ * @returns {number}
  */
 function getNextNonSpaceNonCommentCharacterIndexWithStartIndex(text, idx) {
-  /** @type {number | false} */
-  let oldIdx = null;
-  /** @type {number | false} */
+  let oldIdx = -Infinity;
   let nextIdx = idx;
   while (nextIdx !== oldIdx) {
     oldIdx = nextIdx;
@@ -260,7 +255,7 @@ function getNextNonSpaceNonCommentCharacterIndexWithStartIndex(text, idx) {
  * @param {string} text
  * @param {N} node
  * @param {(node: N) => number} locEnd
- * @returns {number | false}
+ * @returns {number}
  */
 function getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd) {
   return getNextNonSpaceNonCommentCharacterIndexWithStartIndex(

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -506,7 +506,7 @@ function printComments(path, print, options, needsSemi) {
         text,
         skipSpaces(text, options.locEnd(comment))
       );
-      if (index !== false && hasNewline(text, index)) {
+      if (index >= 0 && hasNewline(text, index)) {
         leadingParts.push(hardline);
       }
     } else if (trailing) {


### PR DESCRIPTION
by using `-Infinity` instead of `false`

<!-- Please provide a brief summary of your changes: -->

expected benefits:

- avoid some of the type issues encountered in PR #8759
- may be faster on engines like V8
- may be less likely for weird, unexpected behavior to show up

I would actually like to wait for PR #8759 to be reviewed first. In case PR #8759 is accepted and merged, it should be possible to remove some of the `@ts-ignore` TODO items as well.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- ~~I’ve added tests to confirm my change works.~~
- ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~~
- ~~(If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.~~
- ~~I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).~~

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
