### PR TITLE
When default exporting a Flow Enum, do not append semicolon

### DIFF
--- a/changelog_unreleased/flow/pr-8768.md
+++ b/changelog_unreleased/flow/pr-8768.md
@@ -1,0 +1,15 @@
+#### Fix export default of Flow Enum ([#8768](https://github.com/prettier/prettier/pull/8768) by [@gkz](https://github.com/gkz))
+
+Do not add a trailing semicolon if default exporting a Flow Enum.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+export default enum B {}
+
+// Prettier stable
+export default enum B {};
+
+// Prettier master
+export default enum B {}
+```

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4064,7 +4064,8 @@ function printExportDeclaration(path, options, print) {
       decl.declaration.type !== "TSInterfaceDeclaration" &&
       decl.declaration.type !== "DeclareClass" &&
       decl.declaration.type !== "DeclareFunction" &&
-      decl.declaration.type !== "TSDeclareFunction"
+      decl.declaration.type !== "TSDeclareFunction" &&
+      decl.declaration.type !== "EnumDeclaration"
     ) {
       parts.push(semi);
     }

--- a/tests/flow/enums/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/enums/__snapshots__/jsfmt.spec.js.snap
@@ -153,7 +153,7 @@ export default enum B {}
 
 export enum A {}
 
-export default enum B {};
+export default enum B {}
 
 ================================================================================
 `;


### PR DESCRIPTION
This is a bug fix (missed this during initial support). Like function declarations and class declarations, Flow Enum declarations should not be trailed by a semicolon.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
