### PR TITLE
typecheck fixes in src/language-handlebars

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
   "devDependencies": {
     "@babel/core": "7.11.0",
     "@babel/preset-env": "7.11.0",
+    "@glimmer/reference": "0.55.3",
     "@rollup/plugin-alias": "3.1.1",
     "@rollup/plugin-babel": "5.1.0",
     "@rollup/plugin-commonjs": "14.0.0",

--- a/src/common/parser-create-error.js
+++ b/src/common/parser-create-error.js
@@ -5,6 +5,7 @@ function createError(message, loc) {
   const error = new SyntaxError(
     message + " (" + loc.start.line + ":" + loc.start.column + ")"
   );
+  // @ts-ignore - TBD (...)
   error.loc = loc;
   return error;
 }

--- a/src/language-handlebars/postprocess.js
+++ b/src/language-handlebars/postprocess.js
@@ -1,5 +1,6 @@
 "use strict";
 
+/** @type {Array<(any) => any>} */
 const PIPELINE = [addBackslash];
 
 /* VISITORS */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,7 +25,6 @@
     // [TBD] src/language-* source directory trees with known JSDoc type issues:
     "src/language-css",
     "src/language-graphql",
-    "src/language-handlebars",
     "src/language-html",
     "src/language-js",
     "src/language-markdown",

--- a/yarn.lock
+++ b/yarn.lock
@@ -879,7 +879,7 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@glimmer/env@0.1.7":
+"@glimmer/env@0.1.7", "@glimmer/env@^0.1.7":
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
   integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
@@ -890,6 +890,16 @@
   integrity sha512-EbnLv4CDKVBdW4+uv4OG50UTSoyuDYeXQ6hQ8HJrlkmgy5qpY6m/lIrvbMbR1tBcJsULQD37qdmSoDb9zOQycg==
   dependencies:
     "@simple-dom/interface" "^1.4.0"
+
+"@glimmer/reference@0.55.3":
+  version "0.55.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/reference/-/reference-0.55.3.tgz#da716add87a6c0ba4e91510c52aef1e6af60644a"
+  integrity sha512-9nRG3aqApqmVnscbCBFeS8CvnixPDYSRBlj6t2SBCe6YLiqDl7Zu3GuoS0QLZeTov32+kf3anRWQGbZFw+XyEQ==
+  dependencies:
+    "@glimmer/env" "^0.1.7"
+    "@glimmer/interfaces" "^0.55.3"
+    "@glimmer/util" "^0.55.3"
+    "@glimmer/validator" "^0.55.3"
 
 "@glimmer/syntax@0.55.3":
   version "0.55.3"
@@ -909,6 +919,13 @@
     "@glimmer/env" "0.1.7"
     "@glimmer/interfaces" "^0.55.3"
     "@simple-dom/interface" "^1.4.0"
+
+"@glimmer/validator@^0.55.3":
+  version "0.55.3"
+  resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.55.3.tgz#f57a6267819d2f29241a2ea04e2ee677973b47d7"
+  integrity sha512-DeXn8/jCtpwSEmFEwrWgLbighPVqT5IinmLrDUf9+OwBJ4LflN23fD4ZlCAO8mXy/FVDCRjVfgB9rRvJzUnpJw==
+  dependencies:
+    "@glimmer/env" "^0.1.7"
 
 "@iarna/toml@2.2.5":
   version "2.2.5"


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

- add `@glimmer/reference` to devDependencies, as needed to avoid some "cannot find module" typecheck errors
- quick JSDoc type workaround in `src/language-handlebars/postprocess.js`
- `@ts-ignore` comments, including a comment in `src/common/parser-create-error.js` which is duplicated from PR #8759
- remove `src/language-handlebars` from `exclude` list in `tsconfig.json`

TODO items:

- [x] ~~This update is blocked by a type error in `@glimmer/validator` due to <https://github.com/glimmerjs/glimmer-vm/issues/1116>. I have not found a way to ignore this kind of an error coming from a package dependency, and I would appreciate any ideas or suggestions.~~
- ~~I think PR #8759 should be merged first, if accepted, and remove `src/common/parser-create-error.js` update from this PR~~

I am also not so happy that I had to add an extra Glimmer dependency to resolve some "cannot find module" typecheck errors, hope they can improve the situation between `@glimmer/syntax` and `tsc` (TypeScript compiler).

~~I am raising this PR as a draft PR now to give Glimmer some more context for <https://github.com/glimmerjs/glimmer-vm/issues/1116>.~~

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- ~~I’ve added tests to confirm my change works.~~
- ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~~
- ~~(If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.~~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
