### PR TITLE
Mention Apheleia in list of Emacs plugins

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -7,6 +7,7 @@
         "Andrey",
         "animationend",
         "ansible",
+        "Apheleia",
         "apos",
         "arduner",
         "arrayify",

--- a/docs/editors.md
+++ b/docs/editors.md
@@ -17,7 +17,7 @@ If you’d like to toggle the formatter on and off, install [`vscode-status-bar-
 
 ## Emacs
 
-Check out the [prettier-emacs](https://github.com/prettier/prettier-emacs) repo, or [prettier.el](https://github.com/jscheid/prettier.el).
+Check out the [prettier-emacs](https://github.com/prettier/prettier-emacs) repo, or [prettier.el](https://github.com/jscheid/prettier.el). The package [Apheleia](https://github.com/raxod502/apheleia) supports multiple code formatters, including Prettier.
 
 ## Vim
 

--- a/website/data/editors.yml
+++ b/website/data/editors.yml
@@ -9,7 +9,7 @@
   content: |
     [`prettier-js`](https://github.com/prettier/prettier-emacs)
     [`prettier.el`](https://github.com/jscheid/prettier.el)
-    [Apheleia](https://github.com/raxod502/apheleia)
+    [`Apheleia`](https://github.com/raxod502/apheleia)
 - image: /images/editors/editor_espresso.svg
   name: Espresso
   content: |

--- a/website/data/editors.yml
+++ b/website/data/editors.yml
@@ -9,6 +9,7 @@
   content: |
     [`prettier-js`](https://github.com/prettier/prettier-emacs)
     [`prettier.el`](https://github.com/jscheid/prettier.el)
+    [Apheleia](https://github.com/raxod502/apheleia)
 - image: /images/editors/editor_espresso.svg
   name: Espresso
   content: |


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

I am the maintainer of the Emacs package [Apheleia](https://github.com/raxod502/apheleia) which allows users to apply code formatters asychronously on save without (for the most part) moving the cursor when code is reformatted. Prettier is supported out of the box. This pull request adds Apheleia to the list of suggested Emacs plugins that have support for Prettier.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
