### PR TITLE
Update `test:dist-standalone` script

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ const ENABLE_CODE_COVERAGE = !!process.env.ENABLE_CODE_COVERAGE;
 if (process.env.NODE_ENV === "production" || process.env.INSTALL_PACKAGE) {
   process.env.PRETTIER_DIR = installPrettier();
 }
+const { TEST_STANDALONE } = process.env;
 
 module.exports = {
   setupFiles: ["<rootDir>/tests_config/run_spec.js"],
@@ -14,6 +15,9 @@ module.exports = {
     "jest-snapshot-serializer-ansi",
   ],
   testRegex: "jsfmt\\.spec\\.js$|__tests__/.*\\.js$",
+  testPathIgnorePatterns: TEST_STANDALONE
+    ? ["<rootDir>/tests_integration/"]
+    : [],
   collectCoverage: ENABLE_CODE_COVERAGE,
   collectCoverageFrom: ["src/**/*.js", "index.js", "!<rootDir>/node_modules/"],
   coveragePathIgnorePatterns: [

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "test": "jest",
     "test:dev-package": "cross-env INSTALL_PACKAGE=1 jest",
     "test:dist": "cross-env NODE_ENV=production jest",
-    "test:dist-standalone": "cross-env NODE_ENV=production TEST_STANDALONE=1 jest tests/",
+    "test:dist-standalone": "cross-env NODE_ENV=production TEST_STANDALONE=1 jest",
     "test:integration": "jest tests_integration",
     "perf:repeat": "yarn && yarn build && cross-env NODE_ENV=production node ./dist/bin-prettier.js --debug-repeat ${PERF_REPEAT:-1000} --loglevel debug ${PERF_FILE:-./index.js} > /dev/null",
     "perf:repeat-inspect": "yarn && yarn build && cross-env NODE_ENV=production node --inspect-brk ./dist/bin-prettier.js --debug-repeat ${PERF_REPEAT:-1000} --loglevel debug ${PERF_FILE:-./index.js} > /dev/null",


### PR DESCRIPTION
Make `test:dist-standalone` easier to test subset of tests.

Before, if I want run test only on vue files `yarn test:dist-standalone tests/vue/` won't work, it will be `cross-env NODE_ENV=production TEST_STANDALONE=1 jest tests/ tests/vue/`



- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
