### PR TITLE
Build: Avoid `PREFER_NAMED_EXPORTS` warning

### DIFF
--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -22,7 +22,7 @@ process.on("unhandledRejection", (err) => {
   process.exit(1);
 });
 
-const CACHE_VERSION = "v25"; // This need update when updating build scripts
+const CACHE_VERSION = "v26"; // This need update when updating build scripts
 const CACHED = chalk.bgYellow.black(" CACHED ");
 const OK = chalk.bgGreen.black("  DONE  ");
 const FAIL = chalk.bgRed.black("  FAIL  ");

--- a/scripts/build/bundler.js
+++ b/scripts/build/bundler.js
@@ -197,6 +197,8 @@ function getRollupConfig(bundle) {
 
 function getRollupOutputOptions(bundle) {
   const options = {
+    // Avoid warning form #8797
+    exports: "auto",
     file: `dist/${bundle.output}`,
     strict: typeof bundle.strict === "undefined" ? true : bundle.strict,
   };


### PR DESCRIPTION
There is a warning info during build, introduced in #8797

https://github.com/prettier/prettier/runs/888536756#step:6:7


- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
