### PR TITLE
Fix cli `--file-info` bug (part 2)

### DIFF
--- a/changelog_unreleased/cli/pr-8586.md
+++ b/changelog_unreleased/cli/pr-8586.md
@@ -1,12 +1,17 @@
-#### `--file-info` respect the `.prettierrc` ([#8586](https://github.com/prettier/prettier/pull/8586) by [@fisker](https://github.com/fisker))
+#### `--file-info` respect the `.prettierrc` and `--no-config` ([#8586](https://github.com/prettier/prettier/pull/8586), [#8830](https://github.com/prettier/prettier/pull/8830) by [@fisker](https://github.com/fisker))
 
 ```console
 $ echo {"parser":"ninja"}>.prettierrc
-$ prettier --file-info file.js
 
 # Prettier stable
+$ prettier --file-info file.js
+# { "ignored": false, "inferredParser": "babel" }
+$ prettier --file-info file.js --no-config
 # { "ignored": false, "inferredParser": "babel" }
 
 # Prettier master
+$ prettier --file-info file.js
 # { "ignored": false, "inferredParser": "ninja" }
+$ prettier --file-info file.js --no-config
+# { "ignored": false, "inferredParser": "babel" }
 ```

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -116,8 +116,9 @@ function logFileInfoOrDie(context) {
     withNodeModules: context.argv["with-node-modules"],
     plugins: context.argv.plugin,
     pluginSearchDirs: context.argv["plugin-search-dir"],
-    resolveConfig: true,
+    resolveConfig: context.argv.config !== false,
   };
+
   context.logger.log(
     prettier.format(
       stringify(prettier.getFileInfo.sync(context.argv["file-info"], options)),

--- a/tests_integration/__tests__/__snapshots__/file-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/file-info.js.snap
@@ -120,6 +120,12 @@ exports[`extracts file-info with with ignored=true for a file in node_modules (s
 
 exports[`extracts file-info with with ignored=true for a file in node_modules (write) 1`] = `Array []`;
 
+exports[`file-info should not try resolve config with --no-config (stdout) 1`] = `
+"{ \\"ignored\\": false, \\"inferredParser\\": \\"babel\\" }
+
+"
+`;
+
 exports[`file-info should try resolve config (stderr) 1`] = `""`;
 
 exports[`file-info should try resolve config (stdout) 1`] = `

--- a/tests_integration/__tests__/file-info.js
+++ b/tests_integration/__tests__/file-info.js
@@ -40,6 +40,18 @@ describe("file-info should try resolve config", () => {
   });
 });
 
+describe("file-info should not try resolve config with --no-config", () => {
+  runPrettier("cli/with-resolve-config/", [
+    "--file-info",
+    "file.js",
+    "--no-config",
+  ]).test({
+    status: 0,
+    stderr: "",
+    write: [],
+  });
+});
+
 describe("extracts file-info with ignored=true for a file in a hand-picked .prettierignore", () => {
   runPrettier("cli/", [
     "--file-info",


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fix for #8586, I don't know we have `--no-config`

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
