### PR TITLE
CLI: Add `-w` alias for `--write` option

### DIFF
--- a/changelog_unreleased/cli/pr-8833.md
+++ b/changelog_unreleased/cli/pr-8833.md
@@ -1,0 +1,14 @@
+#### Add `-w` alias for `--write` option ([#8833](https://github.com/prettier/prettier/pull/8833) by [@fisker](https://github.com/fisker))
+
+```console
+# Prettier stable
+$ prettier index.js -w
+[warn] Ignored unknown option -w. Did you mean -_?
+"use strict";
+
+module.exports = require("./src/index");
+
+# Prettier master
+$ prettier index.js -w
+index.js 30ms
+```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -172,7 +172,7 @@ Prettier CLI will ignore files located in `node_modules` directory. To opt-out f
 
 ## `--write`
 
-This rewrites all processed files in place. This is comparable to the `eslint --fix` workflow.
+This rewrites all processed files in place. This is comparable to the `eslint --fix` workflow. You can also use `-w` alias.
 
 ## `--loglevel`
 

--- a/src/cli/constant.js
+++ b/src/cli/constant.js
@@ -203,6 +203,7 @@ const options = {
   },
   write: {
     type: "boolean",
+    alias: "w",
     category: coreOptions.CATEGORY_OUTPUT,
     description: "Edit files in-place. (Beware!)",
   },

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -63,7 +63,7 @@ Output options:
   -c, --check              Check if the given files are formatted, print a human-friendly summary
                            message and paths to unformatted files (see also --list-different).
   -l, --list-different     Print the names of files that are different from Prettier's formatting (see also --check).
-  --write                  Edit files in-place. (Beware!)
+  -w, --write              Edit files in-place. (Beware!)
 
 Format options:
 
@@ -222,7 +222,7 @@ Output options:
   -c, --check              Check if the given files are formatted, print a human-friendly summary
                            message and paths to unformatted files (see also --list-different).
   -l, --list-different     Print the names of files that are different from Prettier's formatting (see also --check).
-  --write                  Edit files in-place. (Beware!)
+  -w, --write              Edit files in-place. (Beware!)
 
 Format options:
 

--- a/tests_integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/help-options.js.snap
@@ -634,7 +634,7 @@ exports[`show detailed usage with --help with-node-modules (write) 1`] = `Array 
 exports[`show detailed usage with --help write (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help write (stdout) 1`] = `
-"--write
+"-w, --write
 
   Edit files in-place. (Beware!)
 "

--- a/tests_integration/__tests__/__snapshots__/write.js.snap
+++ b/tests_integration/__tests__/__snapshots__/write.js.snap
@@ -35,3 +35,20 @@ Array [
   },
 ]
 `;
+
+exports[`write file with -w + unformatted file (stderr) 1`] = `""`;
+
+exports[`write file with -w + unformatted file (stdout) 1`] = `
+"unformatted.js 0ms
+"
+`;
+
+exports[`write file with -w + unformatted file (write) 1`] = `
+Array [
+  Object {
+    "content": "var x = 1;
+",
+    "filename": "unformatted.js",
+  },
+]
+`;

--- a/tests_integration/__tests__/write.js
+++ b/tests_integration/__tests__/write.js
@@ -8,6 +8,12 @@ describe("write file with --write + unformatted file", () => {
   });
 });
 
+describe("write file with -w + unformatted file", () => {
+  runPrettier("cli/write", ["-w", "unformatted.js"]).test({
+    status: 0,
+  });
+});
+
 describe("do not write file with --write + formatted file", () => {
   runPrettier("cli/write", ["--write", "formatted.js"]).test({
     write: [],


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
