### PR TITLE
fix(vue): named slots shorthand value is not formatted

### DIFF
--- a/changelog_unreleased/vue/pr-8839.md
+++ b/changelog_unreleased/vue/pr-8839.md
@@ -1,0 +1,19 @@
+#### Fix named slots shorthand value is not formatted ([#8839](https://github.com/prettier/prettier/pull/8839) by [@wenfangdu](https://github.com/wenfangdu))
+
+<!-- prettier-ignore -->
+```vue
+<!-- Input -->
+<template>
+  <div #default="{foo:{bar:{baz}}}"></div>
+</template>
+
+<!-- Prettier stable -->
+<template>
+  <div #default="{foo:{bar:{baz}}}"></div>
+</template>
+
+<!-- Prettier master -->
+<template>
+  <div #default="{ foo: { bar: { baz } } }"></div>
+</template>
+```

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -1086,7 +1086,7 @@ function printEmbeddedAttributeValue(node, originalTextToDoc, options) {
     /**
      *     v-if="jsExpression"
      */
-    const jsExpressionBindingPatterns = ["^v-"];
+    const jsExpressionBindingPatterns = ["^v-", "^#"];
 
     if (isKeyMatched(vueEventBindingPatterns)) {
       const value = getValue();

--- a/tests/vue/vue/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/vue/vue/__snapshots__/jsfmt.spec.js.snap
@@ -41,6 +41,7 @@ semi: false
   "
   @click="doSomething()"
   @click="doSomething;"
+  #default="{foo:{bar:{baz}}}"
 ></div>
 </template>
 
@@ -103,6 +104,7 @@ semi: false
     "
     @click="doSomething()"
     @click="doSomething;"
+    #default="{ foo: { bar: { baz } } }"
   ></div>
 </template>
 
@@ -150,6 +152,7 @@ trailingComma: "none"
   "
   @click="doSomething()"
   @click="doSomething;"
+  #default="{foo:{bar:{baz}}}"
 ></div>
 </template>
 
@@ -212,6 +215,7 @@ trailingComma: "none"
     "
     @click="doSomething()"
     @click="doSomething;"
+    #default="{ foo: { bar: { baz } } }"
   ></div>
 </template>
 
@@ -258,6 +262,7 @@ printWidth: 80
   "
   @click="doSomething()"
   @click="doSomething;"
+  #default="{foo:{bar:{baz}}}"
 ></div>
 </template>
 
@@ -320,6 +325,7 @@ printWidth: 80
     "
     @click="doSomething()"
     @click="doSomething;"
+    #default="{ foo: { bar: { baz } } }"
   ></div>
 </template>
 

--- a/tests/vue/vue/attributes.vue
+++ b/tests/vue/vue/attributes.vue
@@ -32,5 +32,6 @@
   "
   @click="doSomething()"
   @click="doSomething;"
+  #default="{foo:{bar:{baz}}}"
 ></div>
 </template>


### PR DESCRIPTION
Fixes #6800
<!-- Please ensure you’ve done all of these things (if applicable). -->
- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
