### PR TITLE
`graphql`: Allow interfaces to implement other interfaces (#8007)

### DIFF
--- a/changelog_unreleased/graphql/pr-8007.md
+++ b/changelog_unreleased/graphql/pr-8007.md
@@ -1,0 +1,24 @@
+#### Allow interfaces to implement other interfaces ([#8007](https://github.com/prettier/prettier/pull/8007) by [@fisker](https://github.com/fisker))
+
+See ["RFC: Allow interfaces to implement other interfaces"](https://github.com/graphql/graphql-spec/pull/373)
+
+<!-- prettier-ignore -->
+```graphql
+# Input
+interface Resource implements Node {
+  id: ID!
+  url: String
+}
+
+# Prettier stable
+interface Resource {
+  id: ID!
+  url: String
+}
+
+# Prettier master
+interface Resource implements Node {
+  id: ID!
+  url: String
+}
+```

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -506,8 +506,13 @@ function genericPrint(path, options, print) {
         n.kind === "InterfaceTypeExtension" ? "extend " : "",
         "interface ",
         path.call(print, "name"),
+        n.interfaces.length > 0
+          ? concat([
+              " implements ",
+              concat(printInterfaces(path, options, print)),
+            ])
+          : "",
         printDirectives(path, print, n),
-
         n.fields.length > 0
           ? concat([
               " {",

--- a/tests/graphql_interface/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql_interface/__snapshots__/jsfmt.spec.js.snap
@@ -6,15 +6,87 @@ parsers: ["graphql"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
+# https://github.com/graphql/graphql-spec/blob/master/spec/Section%203%20--%20Type%20System.md#interfaces
+
 interface Actor {
   id: ID
   name: String
 }
 
+interface Resource implements Node
+{
+  id: ID!
+  url: String
+}
+
+interface Resource implements
+Node {
+  id: ID!
+  url: String
+}
+
+interface Image implements Resource
+& Node {
+  id: ID!
+  url: String
+  thumbnail: String
+}
+
+interface Node implements Named &
+Node {
+  id: ID!
+  name: String
+}
+
+interface Named implements
+Node & Named {
+  id: ID!
+  name: String
+}
+
+# \`InterfaceTypeExtension\`
+extend interface Bar implements
+A, B & C {
+  two(argument: InputType!): Type
+}
+
 =====================================output=====================================
+# https://github.com/graphql/graphql-spec/blob/master/spec/Section%203%20--%20Type%20System.md#interfaces
+
 interface Actor {
   id: ID
   name: String
+}
+
+interface Resource implements Node {
+  id: ID!
+  url: String
+}
+
+interface Resource implements Node {
+  id: ID!
+  url: String
+}
+
+interface Image implements Resource & Node {
+  id: ID!
+  url: String
+  thumbnail: String
+}
+
+interface Node implements Named & Node {
+  id: ID!
+  name: String
+}
+
+interface Named implements Node & Named {
+  id: ID!
+  name: String
+}
+
+# \`InterfaceTypeExtension\`
+extend interface Bar implements A, B & C {
+  two(argument: InputType!): Type
 }
 
 ================================================================================

--- a/tests/graphql_interface/interface.graphql
+++ b/tests/graphql_interface/interface.graphql
@@ -1,4 +1,43 @@
+# https://github.com/graphql/graphql-spec/blob/master/spec/Section%203%20--%20Type%20System.md#interfaces
+
 interface Actor {
   id: ID
   name: String
+}
+
+interface Resource implements Node
+{
+  id: ID!
+  url: String
+}
+
+interface Resource implements
+Node {
+  id: ID!
+  url: String
+}
+
+interface Image implements Resource
+& Node {
+  id: ID!
+  url: String
+  thumbnail: String
+}
+
+interface Node implements Named &
+Node {
+  id: ID!
+  name: String
+}
+
+interface Named implements
+Node & Named {
+  id: ID!
+  name: String
+}
+
+# `InterfaceTypeExtension`
+extend interface Bar implements
+A, B & C {
+  two(argument: InputType!): Type
 }


### PR DESCRIPTION
* `graphql`: Allow interfaces to implement other interfaces

* Add changelog

(cherry picked from commit cf6f251b3cdede3631b8e771f88f3c0c74a8619d)

<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
