### PR TITLE
feat: condense graphql docstring into a single line if possible

### DIFF
--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -160,9 +160,9 @@ function genericPrint(path, options, print) {
       if (n.block) {
         return concat([
           '"""',
-          hardline,
+          n.value.includes("\n") ? softline : "",
           join(hardline, n.value.replace(/"""/g, "\\$&").split("\n")),
-          hardline,
+          n.value.includes("\n") ? softline : "",
           '"""',
         ]);
       }

--- a/tests/graphql/kitchen-sink/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql/kitchen-sink/__snapshots__/jsfmt.spec.js.snap
@@ -116,12 +116,7 @@ fragment frag on Friend {
   foo(
     size: $size
     bar: $b
-    obj: {
-      key: "value"
-      block: """
-      block string uses \\"""
-      """
-    }
+    obj: { key: "value", block: """block string uses \\"""""" }
   )
 }
 
@@ -163,6 +158,10 @@ type Foo implements Bar {
   seven(argument: Int = null): Type
 }
 
+"""
+This is a very very very very very very very very very very very very very very very very long description
+of the \`AnnotatedObject\` type.
+"""
 type AnnotatedObject @onObject(arg: "value") {
   annotatedField(arg: Type = "default" @onArg): Type @onField
 }
@@ -170,6 +169,7 @@ type AnnotatedObject @onObject(arg: "value") {
 type UndefinedType
 
 extend type Foo {
+  """This should be on a single line"""
   seven(argument: [String]): Type
 }
 
@@ -285,6 +285,10 @@ type Foo implements Bar {
   seven(argument: Int = null): Type
 }
 
+"""
+This is a very very very very very very very very very very very very very very very very long description
+of the \`AnnotatedObject\` type.
+"""
 type AnnotatedObject @onObject(arg: "value") {
   annotatedField(arg: Type = "default" @onArg): Type @onField
 }
@@ -292,14 +296,13 @@ type AnnotatedObject @onObject(arg: "value") {
 type UndefinedType
 
 extend type Foo {
+  """This should be on a single line"""
   seven(argument: [String]): Type
 }
 
 extend type Foo @onType
 
-"""
-This is a description
-"""
+"""This is a description"""
 interface Bar {
   one: Type
   four(argument: String = "string"): String

--- a/tests/graphql/kitchen-sink/schema_kitchen_sink.graphql
+++ b/tests/graphql/kitchen-sink/schema_kitchen_sink.graphql
@@ -22,6 +22,10 @@ type Foo implements Bar {
   seven(argument: Int = null): Type
 }
 
+"""
+This is a very very very very very very very very very very very very very very very very long description
+of the `AnnotatedObject` type.
+"""
 type AnnotatedObject @onObject(arg: "value") {
   annotatedField(arg: Type = "default" @onArg): Type @onField
 }
@@ -29,6 +33,7 @@ type AnnotatedObject @onObject(arg: "value") {
 type UndefinedType
 
 extend type Foo {
+  """This should be on a single line"""
   seven(argument: [String]): Type
 }
 

--- a/tests/graphql/string/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql/string/__snapshots__/jsfmt.spec.js.snap
@@ -64,16 +64,12 @@ query X($a: Int) @relay(meta: "{\\"lowPri\\": true}") {
   a
 }
 
-"""
-abc
-"""
+"""abc"""
 type T {
   a: Int
 }
 
-"""
-abc
-"""
+"""abc"""
 type T {
   a: Int
 }
@@ -102,24 +98,18 @@ type Foo {
     field: String
   ): Type
   q(
-    """
-    docs
-    """
+    """docs"""
     field: String
   ): Type
 }
 
 enum Enum {
-  """
-  Description of \`one\`
-  """
+  """Description of \`one\`"""
   one
 }
 
 input Input {
-  """
-  Description of \`one\`
-  """
+  """Description of \`one\`"""
   one: string
 }
 

--- a/tests/js/multiparser-graphql/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/multiparser-graphql/__snapshots__/jsfmt.spec.js.snap
@@ -120,9 +120,7 @@ gql\`
   type Project {
     "Pattern: \\\`\\\${project}\\\`"
     pattern: String
-    """
-    Pattern: \\\`\\\${project}\\\`
-    """
+    """Pattern: \\\`\\\${project}\\\`"""
     pattern: String
 
     # Also: Escaping the first parentheses...


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
This work allows for GraphQL docstrings to be contained into a single line if there were no linebreaks (and if the line is < than printWidth). 

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
