### PR TITLE
start typecheck on language-markdown

### DIFF
--- a/src/language-markdown/index.js
+++ b/src/language-markdown/index.js
@@ -5,14 +5,14 @@ const printer = require("./printer-markdown");
 const options = require("./options");
 
 const languages = [
-  createLanguage(require("linguist-languages/data/Markdown"), (data) => ({
+  createLanguage(require("linguist-languages/data/Markdown.json"), (data) => ({
     since: "1.8.0",
     parsers: ["markdown"],
     vscodeLanguageIds: ["markdown"],
     filenames: data.filenames.concat(["README"]),
     extensions: data.extensions.filter((extension) => extension !== ".mdx"),
   })),
-  createLanguage(require("linguist-languages/data/Markdown"), () => ({
+  createLanguage(require("linguist-languages/data/Markdown.json"), () => ({
     name: "MDX",
     since: "1.15.0",
     parsers: ["mdx"],

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -219,6 +219,7 @@ function genericPrint(path, options, print) {
         ")",
       ]);
     case "blockquote":
+      // @ts-ignore
       return concat(["> ", align("> ", printChildren(path, options, print))]);
     case "heading":
       return concat([
@@ -230,6 +231,7 @@ function genericPrint(path, options, print) {
         // indented code block
         const alignment = " ".repeat(4);
         return align(
+          // @ts-ignore
           alignment,
           concat([
             alignment,
@@ -309,6 +311,7 @@ function genericPrint(path, options, print) {
           return concat([
             prefix,
             align(
+              // @ts-ignore
               " ".repeat(prefix.length),
               printListItem(childPath, options, print, prefix)
             ),
@@ -407,6 +410,7 @@ function genericPrint(path, options, print) {
           : group(
               concat([
                 align(
+                  // @ts-ignore
                   " ".repeat(4),
                   printChildren(path, options, print, {
                     processor: (childPath, index) => {
@@ -475,12 +479,14 @@ function printListItem(path, options, print, listPrefix) {
     printChildren(path, options, print, {
       processor: (childPath, index) => {
         if (index === 0 && childPath.getValue().type !== "list") {
+          // @ts-ignore
           return align(" ".repeat(prefix.length), childPath.call(print));
         }
 
         const alignment = " ".repeat(
           clamp(options.tabWidth - listPrefix.length, 0, 3) // 4+ will cause indented code block
         );
+        // @ts-ignore
         return concat([alignment, align(alignment, childPath.call(print))]);
       },
     }),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,6 @@
     "src/language-handlebars",
     "src/language-html",
     "src/language-js",
-    "src/language-markdown",
     "src/language-yaml",
     // [TBD] JavaScript sources affected by JSDoc issues in src/language-*:
     "src/common/load-plugins.js",


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

- remove src/language-markdown from tsconfig.json
- require `linguist-languages` JSON data with `.json` extension, as suggested by @fisker in #8759
- ignore align type errors in src/language-markdown/printer-markdown.js

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- ~~I’ve added tests to confirm my change works.~~
- ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)~~
- ~~(If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.~~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
