### PR TITLE
Enforce `.json` extensions

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,9 +9,11 @@ extends:
 plugins:
   - import
   - unicorn
+  - prettier-internal-rules
 settings:
   import/internal-regex: ^linguist-languages/
 rules:
+  prettier-internal-rules/require-json-extensions: error
   curly: error
   dot-notation: error
   eqeqeq:

--- a/cspell.json
+++ b/cspell.json
@@ -117,6 +117,7 @@
         "Filipe",
         "finalizer",
         "Fiorini",
+        "fisker",
         "fnames",
         "foldgutter",
         "formatprg",

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "eslint-config-prettier": "6.11.0",
     "eslint-formatter-friendly": "7.0.0",
     "eslint-plugin-import": "2.22.0",
+    "eslint-plugin-prettier-internal-rules": "file:scripts/tools/eslint-plugin-prettier-internal-rules",
     "eslint-plugin-jest": "23.20.0",
     "eslint-plugin-react": "7.20.5",
     "eslint-plugin-unicorn": "21.0.0",

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/index.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/index.js
@@ -1,0 +1,7 @@
+"use strict";
+
+module.exports = {
+  rules: {
+    "require-json-extensions": require("./require-json-extensions"),
+  },
+};

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/package.json
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/package.json
@@ -2,6 +2,8 @@
   "name": "eslint-plugin-prettier-internal-rules",
   "version": "1.0.0",
   "description": "Prettier internal eslint rules",
-  "license": "MIT",
-  "main": "./index.js"
+  "private": true,
+  "author": "fisker",
+  "main": "./index.js",
+  "license": "MIT"
 }

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/package.json
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "eslint-plugin-prettier-internal-rules",
+  "version": "1.0.0",
+  "description": "Prettier internal eslint rules",
+  "license": "MIT",
+  "main": "./index.js"
+}

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/require-json-extensions.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/require-json-extensions.js
@@ -27,7 +27,7 @@ module.exports = {
     type: "suggestion",
     docs: {
       url:
-        "https://github.com/prettier/prettier/scripts/eslint-plugin-prettier-internal-rules/require-json-extensions.js",
+        "https://github.com/prettier/prettier/blob/master/scripts/eslint-plugin-prettier-internal-rules/require-json-extensions.js",
     },
     messages: {
       [MESSAGE_ID]: 'Missing file extension ".json" for "{{id}}".',

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/require-json-extensions.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/require-json-extensions.js
@@ -1,0 +1,78 @@
+"use strict";
+
+const path = require("path");
+
+const SELECTOR = [
+  "CallExpression",
+  '[callee.type="Identifier"]',
+  '[callee.name="require"]',
+  "[arguments.length=1]",
+  '[arguments.0.type="Literal"]',
+  ">",
+  "Literal.arguments",
+].join("");
+
+const MESSAGE_ID = "require-json-extensions";
+
+const resolveModuleInDirectory = (directory, id) => {
+  try {
+    return require.resolve(id, { paths: [directory] });
+  } catch {
+    // noop
+  }
+};
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      url:
+        "https://github.com/prettier/prettier/scripts/eslint-plugin-prettier-internal-rules/require-json-extensions.js",
+    },
+    messages: {
+      [MESSAGE_ID]: 'Missing file extension ".json" for "{{id}}".',
+    },
+    fixable: "code",
+  },
+  create(context) {
+    const filename = context.getFilename();
+    const directory = path.dirname(filename);
+    const resolve = (id) => resolveModuleInDirectory(directory, id);
+
+    return {
+      [SELECTOR](node) {
+        const id = node.value;
+
+        if (id.endsWith(".json") || !id.includes("/")) {
+          return;
+        }
+
+        const file = resolve(id);
+
+        if (!file) {
+          return;
+        }
+
+        const extension = path.extname(file);
+        if (extension !== ".json") {
+          return;
+        }
+
+        let fix;
+        if (resolve(`${id}.json`) === file) {
+          fix = (fixer) => {
+            const [start, end] = node.range;
+            return fixer.replaceTextRange([start + 1, end - 1], `${id}.json`);
+          };
+        }
+
+        context.report({
+          node,
+          messageId: MESSAGE_ID,
+          data: { id },
+          fix,
+        });
+      },
+    };
+  },
+};

--- a/src/language-css/index.js
+++ b/src/language-css/index.js
@@ -5,22 +5,22 @@ const printer = require("./printer-postcss");
 const options = require("./options");
 
 const languages = [
-  createLanguage(require("linguist-languages/data/CSS"), () => ({
+  createLanguage(require("linguist-languages/data/CSS.json"), () => ({
     since: "1.4.0",
     parsers: ["css"],
     vscodeLanguageIds: ["css"],
   })),
-  createLanguage(require("linguist-languages/data/PostCSS"), () => ({
+  createLanguage(require("linguist-languages/data/PostCSS.json"), () => ({
     since: "1.4.0",
     parsers: ["css"],
     vscodeLanguageIds: ["postcss"],
   })),
-  createLanguage(require("linguist-languages/data/Less"), () => ({
+  createLanguage(require("linguist-languages/data/Less.json"), () => ({
     since: "1.4.0",
     parsers: ["less"],
     vscodeLanguageIds: ["less"],
   })),
-  createLanguage(require("linguist-languages/data/SCSS"), () => ({
+  createLanguage(require("linguist-languages/data/SCSS.json"), () => ({
     since: "1.4.0",
     parsers: ["scss"],
     vscodeLanguageIds: ["scss"],

--- a/src/language-graphql/index.js
+++ b/src/language-graphql/index.js
@@ -5,7 +5,7 @@ const printer = require("./printer-graphql");
 const options = require("./options");
 
 const languages = [
-  createLanguage(require("linguist-languages/data/GraphQL"), () => ({
+  createLanguage(require("linguist-languages/data/GraphQL.json"), () => ({
     since: "1.5.0",
     parsers: ["graphql"],
     vscodeLanguageIds: ["graphql"],

--- a/src/language-handlebars/index.js
+++ b/src/language-handlebars/index.js
@@ -4,7 +4,7 @@ const createLanguage = require("../utils/create-language");
 const printer = require("./printer-glimmer");
 
 const languages = [
-  createLanguage(require("linguist-languages/data/Handlebars"), () => ({
+  createLanguage(require("linguist-languages/data/Handlebars.json"), () => ({
     since: null, // unreleased
     parsers: ["glimmer"],
     vscodeLanguageIds: ["handlebars"],

--- a/src/language-html/index.js
+++ b/src/language-html/index.js
@@ -5,7 +5,7 @@ const printer = require("./printer-html");
 const options = require("./options");
 
 const languages = [
-  createLanguage(require("linguist-languages/data/HTML"), () => ({
+  createLanguage(require("linguist-languages/data/HTML.json"), () => ({
     name: "Angular",
     since: "1.15.0",
     parsers: ["angular"],
@@ -13,7 +13,7 @@ const languages = [
     extensions: [".component.html"],
     filenames: [],
   })),
-  createLanguage(require("linguist-languages/data/HTML"), (data) => ({
+  createLanguage(require("linguist-languages/data/HTML.json"), (data) => ({
     since: "1.15.0",
     parsers: ["html"],
     vscodeLanguageIds: ["html"],
@@ -21,7 +21,7 @@ const languages = [
       ".mjml", // MJML is considered XML in Linguist but it should be formatted as HTML
     ]),
   })),
-  createLanguage(require("linguist-languages/data/HTML"), () => ({
+  createLanguage(require("linguist-languages/data/HTML.json"), () => ({
     name: "Lightning Web Components",
     since: "1.17.0",
     parsers: ["lwc"],
@@ -29,7 +29,7 @@ const languages = [
     extensions: [],
     filenames: [],
   })),
-  createLanguage(require("linguist-languages/data/Vue"), () => ({
+  createLanguage(require("linguist-languages/data/Vue.json"), () => ({
     since: "1.10.0",
     parsers: ["vue"],
     vscodeLanguageIds: ["vue"],

--- a/src/language-js/index.js
+++ b/src/language-js/index.js
@@ -6,13 +6,13 @@ const estreeJsonPrinter = require("./printer-estree-json");
 const options = require("./options");
 
 const languages = [
-  createLanguage(require("linguist-languages/data/JavaScript"), (data) => ({
+  createLanguage(require("linguist-languages/data/JavaScript.json"), (data) => ({
     since: "0.0.0",
     parsers: ["babel", "flow"],
     vscodeLanguageIds: ["javascript", "mongo"],
     interpreters: data.interpreters.concat(["nodejs"]),
   })),
-  createLanguage(require("linguist-languages/data/JavaScript"), () => ({
+  createLanguage(require("linguist-languages/data/JavaScript.json"), () => ({
     name: "Flow",
     since: "0.0.0",
     parsers: ["babel", "flow"],
@@ -21,22 +21,22 @@ const languages = [
     filenames: [],
     extensions: [".js.flow"],
   })),
-  createLanguage(require("linguist-languages/data/JSX"), () => ({
+  createLanguage(require("linguist-languages/data/JSX.json"), () => ({
     since: "0.0.0",
     parsers: ["babel", "flow"],
     vscodeLanguageIds: ["javascriptreact"],
   })),
-  createLanguage(require("linguist-languages/data/TypeScript"), () => ({
+  createLanguage(require("linguist-languages/data/TypeScript.json"), () => ({
     since: "1.4.0",
     parsers: ["typescript", "babel-ts"],
     vscodeLanguageIds: ["typescript"],
   })),
-  createLanguage(require("linguist-languages/data/TSX"), () => ({
+  createLanguage(require("linguist-languages/data/TSX.json"), () => ({
     since: "1.4.0",
     parsers: ["typescript", "babel-ts"],
     vscodeLanguageIds: ["typescriptreact"],
   })),
-  createLanguage(require("linguist-languages/data/JSON"), () => ({
+  createLanguage(require("linguist-languages/data/JSON.json"), () => ({
     name: "JSON.stringify",
     since: "1.13.0",
     parsers: ["json-stringify"],
@@ -44,14 +44,14 @@ const languages = [
     extensions: [], // .json file defaults to json instead of json-stringify
     filenames: ["package.json", "package-lock.json", "composer.json"],
   })),
-  createLanguage(require("linguist-languages/data/JSON"), (data) => ({
+  createLanguage(require("linguist-languages/data/JSON.json"), (data) => ({
     since: "1.5.0",
     parsers: ["json"],
     vscodeLanguageIds: ["json"],
     filenames: data.filenames.concat([".prettierrc"]),
   })),
   createLanguage(
-    require("linguist-languages/data/JSON with Comments"),
+    require("linguist-languages/data/JSON with Comments.json"),
     (data) => ({
       since: "1.5.0",
       parsers: ["json"],
@@ -59,7 +59,7 @@ const languages = [
       filenames: data.filenames.concat([".eslintrc"]),
     })
   ),
-  createLanguage(require("linguist-languages/data/JSON5"), () => ({
+  createLanguage(require("linguist-languages/data/JSON5.json"), () => ({
     since: "1.13.0",
     parsers: ["json5"],
     vscodeLanguageIds: ["json5"],

--- a/src/language-js/index.js
+++ b/src/language-js/index.js
@@ -6,12 +6,15 @@ const estreeJsonPrinter = require("./printer-estree-json");
 const options = require("./options");
 
 const languages = [
-  createLanguage(require("linguist-languages/data/JavaScript.json"), (data) => ({
-    since: "0.0.0",
-    parsers: ["babel", "flow"],
-    vscodeLanguageIds: ["javascript", "mongo"],
-    interpreters: data.interpreters.concat(["nodejs"]),
-  })),
+  createLanguage(
+    require("linguist-languages/data/JavaScript.json"),
+    (data) => ({
+      since: "0.0.0",
+      parsers: ["babel", "flow"],
+      vscodeLanguageIds: ["javascript", "mongo"],
+      interpreters: data.interpreters.concat(["nodejs"]),
+    })
+  ),
   createLanguage(require("linguist-languages/data/JavaScript.json"), () => ({
     name: "Flow",
     since: "0.0.0",

--- a/src/language-markdown/index.js
+++ b/src/language-markdown/index.js
@@ -5,14 +5,14 @@ const printer = require("./printer-markdown");
 const options = require("./options");
 
 const languages = [
-  createLanguage(require("linguist-languages/data/Markdown"), (data) => ({
+  createLanguage(require("linguist-languages/data/Markdown.json"), (data) => ({
     since: "1.8.0",
     parsers: ["markdown"],
     vscodeLanguageIds: ["markdown"],
     filenames: data.filenames.concat(["README"]),
     extensions: data.extensions.filter((extension) => extension !== ".mdx"),
   })),
-  createLanguage(require("linguist-languages/data/Markdown"), () => ({
+  createLanguage(require("linguist-languages/data/Markdown.json"), () => ({
     name: "MDX",
     since: "1.15.0",
     parsers: ["mdx"],

--- a/src/language-yaml/index.js
+++ b/src/language-yaml/index.js
@@ -5,7 +5,7 @@ const printer = require("./printer-yaml");
 const options = require("./options");
 
 const languages = [
-  createLanguage(require("linguist-languages/data/YAML"), (data) => ({
+  createLanguage(require("linguist-languages/data/YAML.json"), (data) => ({
     since: "1.14.0",
     parsers: ["yaml"],
     vscodeLanguageIds: ["yaml", "ansible", "home-assistant"],

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -6,7 +6,7 @@ const path = require("path");
 const fs = require("fs");
 const parseYaml = require("js-yaml").safeLoad;
 
-const PACKAGE = require("../package");
+const PACKAGE = require("../package.json");
 const GITHUB_URL = `https://github.com/${PACKAGE.repository}`;
 
 function loadYaml(fsPath) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3358,6 +3358,9 @@ eslint-plugin-jest@23.20.0:
   dependencies:
     "@typescript-eslint/experimental-utils" "^2.5.0"
 
+"eslint-plugin-prettier-internal-rules@file:scripts/tools/eslint-plugin-prettier-internal-rules":
+  version "1.0.0"
+
 eslint-plugin-react@7.20.5:
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/eslint-plugin-react/-/eslint-plugin-react-7.20.5.tgz#29480f3071f64a04b2c3d99d9b460ce0f76fb857"


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

The JSDoc throws when require JSON files without `.json` extension. 

ESLint rule `import/extensions` don't work with `require`, so I made a eslint plugin for it.

Context https://github.com/prettier/prettier/pull/8759#discussion_r465129685

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
