### PR TITLE
Ignore `test*` file in `lint:prettier` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "lint:typecheck": "tsc",
     "lint:eslint": "cross-env EFF_NO_LINK_RULES=true eslint . --format friendly",
     "lint:changelog": "node ./scripts/lint-changelog.js",
-    "lint:prettier": "prettier \"**/*.{md,json,yml,html,css,js}\" --check",
+    "lint:prettier": "prettier \"**/*.{md,json,yml,html,css,js}\" \"!test*\" --check",
     "lint:dist": "eslint --no-eslintrc --no-ignore --env=es6,browser --parser-options=ecmaVersion:2016 \"dist/!(bin-prettier|index|third-party).js\"",
     "lint:spellcheck": "cspell \"**/*\" \".github/**/*\"",
     "lint:deps": "node ./scripts/check-deps.js",


### PR DESCRIPTION
These files can't add to `.prettierignore`, otherwise `node bin/prettier test.js` for debug won't work.
But `yarn lint:prettier` won't pass (and `yarn format:pretter` #8909 will format them) , if we have some `test*` file not formatted.


- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
