### PR TITLE
JS: Implement range ignore (Fixes #5287)

### DIFF
--- a/changelog_unreleased/javascript/pr-8926.md
+++ b/changelog_unreleased/javascript/pr-8926.md
@@ -1,4 +1,4 @@
-#### Support range ignore for javascript code
+#### Implement range ignore (javascript) ([#8926](https://github.com/prettier/prettier/pull/8926) by [@chaitan94](https://github.com/chaitan94))
 
 <!-- prettier-ignore -->
 ```js

--- a/changelog_unreleased/javascript/pr-8926.md
+++ b/changelog_unreleased/javascript/pr-8926.md
@@ -1,0 +1,39 @@
+#### Support range ignore for javascript code
+
+<!-- prettier-ignore -->
+```js
+// Input
+
+// prettier-ignore-start
+let i_like         = 1;
+let my_assignments = 2;
+let sorted         = 3;
+// prettier-ignore-end
+let but_not    = 4;
+let after      = 5;
+let ignore_end = 6;
+
+
+// Prettier stable
+
+// prettier-ignore-start
+let i_like = 1;
+let my_assignments = 2;
+let sorted = 3;
+// prettier-ignore-end
+let but_not = 4;
+let after = 5;
+let ignore_end = 6;
+
+
+// Prettier master
+
+// prettier-ignore-start
+let i_like         = 1;
+let my_assignments = 2;
+let sorted         = 3;
+// prettier-ignore-end
+let but_not = 4;
+let after = 5;
+let ignore_end = 6;
+```

--- a/changelog_unreleased/javascript/pr-8926.md
+++ b/changelog_unreleased/javascript/pr-8926.md
@@ -1,4 +1,4 @@
-#### Implement range ignore (javascript) ([#8926](https://github.com/prettier/prettier/pull/8926) by [@chaitan94](https://github.com/chaitan94))
+#### Implement range ignore ([#8926](https://github.com/prettier/prettier/pull/8926) by [@chaitan94](https://github.com/chaitan94))
 
 <!-- prettier-ignore -->
 ```js

--- a/docs/ignore.md
+++ b/docs/ignore.md
@@ -83,6 +83,7 @@ let ignore_end = 6;
 
 will be transformed to:
 
+<!-- prettier-ignore -->
 ```js
 // prettier-ignore-start
 let i_like         = 1;

--- a/docs/ignore.md
+++ b/docs/ignore.md
@@ -61,6 +61,39 @@ matrix(
 )
 ```
 
+### Range Ignore
+
+_available in v2.1.0+_
+
+JavaScript code within `// prettier-ignore-start` and `// prettier-ignore-end` will be excluded in the abstract syntax tree from formatting.
+
+For example:
+
+<!-- prettier-ignore -->
+```js
+// prettier-ignore-start
+let i_like         = 1;
+let my_assignments = 2;
+let sorted         = 3;
+// prettier-ignore-end
+let but_not    = 4;
+let after      = 5;
+let ignore_end = 6;
+```
+
+will be transformed to:
+
+```js
+// prettier-ignore-start
+let i_like         = 1;
+let my_assignments = 2;
+let sorted         = 3;
+// prettier-ignore-end
+let but_not = 4;
+let after = 5;
+let ignore_end = 6;
+```
+
 ## JSX
 
 ```jsx

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -582,7 +582,7 @@ function hasNodeIgnoreComment(node) {
 /** @return {false | "next" | "start" | "end"} */
 function isNodeIgnoreComment(comment) {
   const match = comment.value.match(/\s*prettier-ignore(?:-(start|end))?\s*/);
-  return match === null ? false : match[1] ? match[1] : "next";
+  return match === null ? false : (match[1] && comment.leading) ? match[1] : "next";
 }
 
 function addCommentHelper(node, comment) {

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -582,7 +582,11 @@ function hasNodeIgnoreComment(node) {
 /** @return {false | "next" | "start" | "end"} */
 function isNodeIgnoreComment(comment) {
   const match = comment.value.match(/\s*prettier-ignore(?:-(start|end))?\s*/);
-  return match === null ? false : (match[1] && comment.leading) ? match[1] : "next";
+  return match === null
+    ? false
+    : match[1] && comment.leading
+    ? match[1]
+    : "next";
 }
 
 function addCommentHelper(node, comment) {

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -554,25 +554,35 @@ function getStringWidth(text) {
   return stringWidth(text);
 }
 
+/** @return {false | "next" | "start" | "end"} */
 function hasIgnoreComment(path) {
   const node = path.getValue();
   return hasNodeIgnoreComment(node);
 }
 
+/** @return {false | "next" | "start" | "end"} */
 function hasNodeIgnoreComment(node) {
-  return (
-    node &&
-    ((node.comments &&
-      node.comments.length > 0 &&
-      node.comments.some(
-        (comment) => isNodeIgnoreComment(comment) && !comment.unignore
-      )) ||
-      node.prettierIgnore)
-  );
+  if (node) {
+    if (node.prettierIgnore) {
+      return "next";
+    }
+    if (node.comments && node.comments.length > 0) {
+      for (let index = 0; index < node.comments.length; index++) {
+        const comment = node.comments[index];
+        const ignore = isNodeIgnoreComment(comment);
+        if (ignore && !comment.unignore) {
+          return ignore;
+        }
+      }
+    }
+  }
+  return false;
 }
 
+/** @return {false | "next" | "start" | "end"} */
 function isNodeIgnoreComment(comment) {
-  return comment.value.trim() === "prettier-ignore";
+  const match = comment.value.match(/\s*prettier-ignore(?:-(start|end))?\s*/);
+  return match === null ? false : match[1] ? match[1] : "next";
 }
 
 function addCommentHelper(node, comment) {

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -741,7 +741,7 @@ function handleUnionTypeComments(
     (enclosingNode.type === "UnionTypeAnnotation" ||
       enclosingNode.type === "TSUnionType")
   ) {
-    if (isNodeIgnoreComment(comment)) {
+    if (isNodeIgnoreComment(comment) === "next") {
       followingNode.prettierIgnore = true;
       comment.unignore = true;
     }
@@ -756,7 +756,7 @@ function handleUnionTypeComments(
     followingNode &&
     (followingNode.type === "UnionTypeAnnotation" ||
       followingNode.type === "TSUnionType") &&
-    isNodeIgnoreComment(comment)
+    isNodeIgnoreComment(comment) === "next"
   ) {
     followingNode.types[0].prettierIgnore = true;
     comment.unignore = true;

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1128,7 +1128,7 @@ function printPathNoParens(path, options, print, args) {
             (prop.node.type === "TSPropertySignature" ||
               prop.node.type === "TSMethodSignature" ||
               prop.node.type === "TSConstructSignatureDeclaration") &&
-            hasNodeIgnoreComment(prop.node)
+            hasNodeIgnoreComment(prop.node) === "next"
           ) {
             separatorParts.shift();
           }

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -657,7 +657,8 @@ function hasJsxIgnoreComment(path) {
     prevSibling.expression.comments &&
     prevSibling.expression.comments.some(
       (comment) => comment.value.trim() === "prettier-ignore"
-    ) && "next"
+    ) &&
+    "next"
   );
 }
 

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -657,7 +657,7 @@ function hasJsxIgnoreComment(path) {
     prevSibling.expression.comments &&
     prevSibling.expression.comments.some(
       (comment) => comment.value.trim() === "prettier-ignore"
-    )
+    ) && "next"
   );
 }
 
@@ -675,6 +675,7 @@ function isEmptyJSXElement(node) {
   return isLiteral(child) && !isMeaningfulJSXText(child);
 }
 
+/** @return {false | "next" | "start" | "end"} */
 function hasPrettierIgnore(path) {
   return hasIgnoreComment(path) || hasJsxIgnoreComment(path);
 }
@@ -701,7 +702,7 @@ function isFlowAnnotationComment(text, typeAnnotation, options) {
 
 function hasLeadingOwnLineComment(text, node, options) {
   if (isJSXNode(node)) {
-    return hasNodeIgnoreComment(node);
+    return hasNodeIgnoreComment(node) === "next";
   }
 
   const res =

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -650,16 +650,19 @@ function hasJsxIgnoreComment(path) {
     break;
   }
 
-  return (
+  if (
     prevSibling &&
     prevSibling.type === "JSXExpressionContainer" &&
     prevSibling.expression.type === "JSXEmptyExpression" &&
     prevSibling.expression.comments &&
     prevSibling.expression.comments.some(
       (comment) => comment.value.trim() === "prettier-ignore"
-    ) &&
-    "next"
-  );
+    )
+  ) {
+    return "next";
+  }
+
+  return false;
 }
 
 function isEmptyJSXElement(node) {

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -999,7 +999,7 @@ function hasPrettierIgnore(path) {
   }
 
   const prevNode = path.getParentNode().children[index - 1];
-  return isPrettierIgnore(prevNode) === "next";
+  return isPrettierIgnore(prevNode) === "next" ? "next" : false;
 }
 
 module.exports = {

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -126,7 +126,7 @@ function callPluginPrintFunction(path, options, printPath, args) {
   }
 
   // Escape hatch
-  if (options.ignoring || ignore === "next") {
+  if ((node && options.ignoring) || ignore === "next") {
     return printPrettierIgnoredNode(node, options);
   }
 

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -115,8 +115,18 @@ function callPluginPrintFunction(path, options, printPath, args) {
   const node = path.getValue();
   const { printer } = options;
 
+  const ignore = printer.hasPrettierIgnore && printer.hasPrettierIgnore(path);
+  switch (ignore) {
+    case "start":
+      options.ignoring = true;
+      break;
+    case "end":
+      options.ignoring = false;
+      break;
+  }
+
   // Escape hatch
-  if (printer.hasPrettierIgnore && printer.hasPrettierIgnore(path)) {
+  if (options.ignoring || ignore === "next") {
     return printPrettierIgnoredNode(node, options);
   }
 

--- a/tests/js/ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/ignore/__snapshots__/jsfmt.spec.js.snap
@@ -68,15 +68,6 @@ function a() {
           // prettier-ignore
         )
       }
-
-  // prettier-ignore-start
-  let i_like         = 1;
-  let my_assignments = 2;
-  let sorted         = 3;
-  // prettier-ignore-end
-  let but_not    = 4;
-  let after      = 5;
-  let ignore_end = 6;
 }
 
 const response = {
@@ -147,15 +138,6 @@ function a() {
       // prettier-ignore
     );
   }
-
-  // prettier-ignore-start
-  let i_like         = 1;
-  let my_assignments = 2;
-  let sorted         = 3;
-  // prettier-ignore-end
-  let but_not = 4;
-  let after = 5;
-  let ignore_end = 6;
 }
 
 const response = {
@@ -213,6 +195,86 @@ a = <div {...b /* prettier-ignore */} />;
 a = <div {.../* prettier-ignore */ {}} />;
 a = <div {...{/* prettier-ignore */}} />;
 a = <div {...{} /* prettier-ignore */} />;
+
+================================================================================
+`;
+
+exports[`range-ignore.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// prettier-ignore-start
+let i_like         = 1;
+let my_assignments = 2;
+let sorted         = 3;
+// prettier-ignore-end
+let but_not    = 4;
+let after      = 5;
+let ignore_end = 6;
+
+/* prettier-ignore-start */
+route('my-designs', '/my-designs/', require('./pages/my-designs/my-designs'));
+route('order', '/:project/:thank/order/', require('./pages/order/order'));
+route('order-success', '/:project/order-success/', require('./pages/order-success/order-success'));
+route('page-not-found', '/page-not-found/', require('./pages/page-not-found/page-not-found'));
+route('password-forgot', '/password-forgot/', require('./pages/password-forgot/password-forgot'));
+route('restore-password', '/restore-password/:token', require('./pages/restore-password/restore-password'));
+/* prettier-ignore-end */
+
+let  this_shall_not_be_ignored   =  2;
+
+// prettier-ignore-start
+appApplication.post(
+  \`\${APIRouteDefinitions.pathForRoute( APIDefinitions.routes.getPendingChangesForThreshold)}\`,
+  (req, res) => {
+    validateRequest(req, res, APIDefinitions.routes.getPendingChangesForThreshold, req.body);
+  }
+);
+appApplication.post(
+  \`\${APIRouteDefinitions.pathForRoute( APIDefinitions.routes.getPendingChangesForThreshold)}\`,
+  (req, res) => {
+    validateRequest(req, res, APIDefinitions.routes.getPendingChangesForThreshold, req.body);
+  }
+);
+// prettier-ignore-end
+
+=====================================output=====================================
+// prettier-ignore-start
+let i_like         = 1;
+let my_assignments = 2;
+let sorted         = 3;
+// prettier-ignore-end
+let but_not = 4;
+let after = 5;
+let ignore_end = 6;
+
+/* prettier-ignore-start */
+route('my-designs', '/my-designs/', require('./pages/my-designs/my-designs'));
+route('order', '/:project/:thank/order/', require('./pages/order/order'));
+route('order-success', '/:project/order-success/', require('./pages/order-success/order-success'));
+route('page-not-found', '/page-not-found/', require('./pages/page-not-found/page-not-found'));
+route('password-forgot', '/password-forgot/', require('./pages/password-forgot/password-forgot'));
+route('restore-password', '/restore-password/:token', require('./pages/restore-password/restore-password'));
+/* prettier-ignore-end */
+
+let this_shall_not_be_ignored = 2;
+
+// prettier-ignore-start
+appApplication.post(
+  \`\${APIRouteDefinitions.pathForRoute( APIDefinitions.routes.getPendingChangesForThreshold)}\`,
+  (req, res) => {
+    validateRequest(req, res, APIDefinitions.routes.getPendingChangesForThreshold, req.body);
+  }
+);
+appApplication.post(
+  \`\${APIRouteDefinitions.pathForRoute( APIDefinitions.routes.getPendingChangesForThreshold)}\`,
+  (req, res) => {
+    validateRequest(req, res, APIDefinitions.routes.getPendingChangesForThreshold, req.body);
+  }
+);
+// prettier-ignore-end
 
 ================================================================================
 `;

--- a/tests/js/ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/ignore/__snapshots__/jsfmt.spec.js.snap
@@ -223,7 +223,7 @@ route('password-forgot', '/password-forgot/', require('./pages/password-forgot/p
 route('restore-password', '/restore-password/:token', require('./pages/restore-password/restore-password'));
 /* prettier-ignore-end */
 
-let  this_shall_not_be_ignored   =  2;
+let  this_shall_not_be_ignored   =  21;
 
 // prettier-ignore-start
 appApplication.post(
@@ -239,6 +239,19 @@ appApplication.post(
   }
 );
 // prettier-ignore-end
+
+function foo({
+  a   =   0,
+  // prettier-ignore-start
+  b          = 1,
+  // prettier-ignore-end
+    c = 1
+               }) {
+                 console.log(a)
+                 console.log(b)
+  }
+
+  this_shall_not_be_ignored   =  22;
 
 =====================================output=====================================
 // prettier-ignore-start
@@ -259,7 +272,7 @@ route('password-forgot', '/password-forgot/', require('./pages/password-forgot/p
 route('restore-password', '/restore-password/:token', require('./pages/restore-password/restore-password'));
 /* prettier-ignore-end */
 
-let this_shall_not_be_ignored = 2;
+let this_shall_not_be_ignored = 21;
 
 // prettier-ignore-start
 appApplication.post(
@@ -275,6 +288,19 @@ appApplication.post(
   }
 );
 // prettier-ignore-end
+
+function foo({
+  a = 0,
+  // prettier-ignore-start
+  b          = 1,
+  // prettier-ignore-end
+  c = 1,
+}) {
+  console.log(a);
+  console.log(b);
+}
+
+this_shall_not_be_ignored = 22;
 
 ================================================================================
 `;

--- a/tests/js/ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/ignore/__snapshots__/jsfmt.spec.js.snap
@@ -68,6 +68,15 @@ function a() {
           // prettier-ignore
         )
       }
+
+  // prettier-ignore-start
+  let i_like         = 1;
+  let my_assignments = 2;
+  let sorted         = 3;
+  // prettier-ignore-end
+  let but_not    = 4;
+  let after      = 5;
+  let ignore_end = 6;
 }
 
 const response = {
@@ -138,6 +147,15 @@ function a() {
       // prettier-ignore
     );
   }
+
+  // prettier-ignore-start
+  let i_like         = 1;
+  let my_assignments = 2;
+  let sorted         = 3;
+  // prettier-ignore-end
+  let but_not = 4;
+  let after = 5;
+  let ignore_end = 6;
 }
 
 const response = {

--- a/tests/js/ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/ignore/__snapshots__/jsfmt.spec.js.snap
@@ -253,6 +253,48 @@ function foo({
 
   this_shall_not_be_ignored   =  22;
 
+// If else statements
+// prettier-ignore-start
+if(after == 10) {}
+else if  ((after == 20)||after==1) {
+  after  = 11;
+} else {after =    12;}
+// prettier-ignore-end
+
+function isNodeIgnoreComment(comment){
+  const match = comment.value.match(/\\s*prettier-ignore(?:-(start|end))?\\s*/);
+  
+  // Ternary statements, in a local scope
+  // prettier-ignore-start
+  const ignore = match === null ? false : match[1] && comment.leading ? match[1] : "next";
+  // prettier-ignore-end
+
+  return ignore;
+}
+this_shall_not_be_ignored   =  24;
+
+// Template literals and function chaining
+// prettier-ignore-start
+const content = \`
+const env = \${ JSON.stringify({
+  assetsRootUrl: env.assetsRootUrl,
+	env: env.env,
+	role: "client",
+	adsfafa: "sdfsdff",
+	asdfasff: "wefwefw",
+  fefef: "sf sdfs fdsfdsf s dfsfds"
+}, null, "\\t") });
+\`;
+
+function foo() {
+  return a
+  .b()
+  .c()
+  // Comment
+  ?.d()
+}
+// prettier-ignore-end
+
 =====================================output=====================================
 // prettier-ignore-start
 let i_like         = 1;
@@ -301,6 +343,48 @@ function foo({
 }
 
 this_shall_not_be_ignored = 22;
+
+// If else statements
+// prettier-ignore-start
+if(after == 10) {}
+else if  ((after == 20)||after==1) {
+  after  = 11;
+} else {after =    12;}
+// prettier-ignore-end
+
+function isNodeIgnoreComment(comment) {
+  const match = comment.value.match(/\\s*prettier-ignore(?:-(start|end))?\\s*/);
+
+  // Ternary statements, in a local scope
+  // prettier-ignore-start
+  const ignore = match === null ? false : match[1] && comment.leading ? match[1] : "next";
+  // prettier-ignore-end
+
+  return ignore;
+}
+this_shall_not_be_ignored = 24;
+
+// Template literals and function chaining
+// prettier-ignore-start
+const content = \`
+const env = \${ JSON.stringify({
+  assetsRootUrl: env.assetsRootUrl,
+	env: env.env,
+	role: "client",
+	adsfafa: "sdfsdff",
+	asdfasff: "wefwefw",
+  fefef: "sf sdfs fdsfdsf s dfsfds"
+}, null, "\\t") });
+\`;
+
+function foo() {
+  return a
+  .b()
+  .c()
+  // Comment
+  ?.d()
+}
+// prettier-ignore-end
 
 ================================================================================
 `;

--- a/tests/js/ignore/ignore.js
+++ b/tests/js/ignore/ignore.js
@@ -60,6 +60,15 @@ function a() {
           // prettier-ignore
         )
       }
+
+  // prettier-ignore-start
+  let i_like         = 1;
+  let my_assignments = 2;
+  let sorted         = 3;
+  // prettier-ignore-end
+  let but_not    = 4;
+  let after      = 5;
+  let ignore_end = 6;
 }
 
 const response = {

--- a/tests/js/ignore/ignore.js
+++ b/tests/js/ignore/ignore.js
@@ -60,15 +60,6 @@ function a() {
           // prettier-ignore
         )
       }
-
-  // prettier-ignore-start
-  let i_like         = 1;
-  let my_assignments = 2;
-  let sorted         = 3;
-  // prettier-ignore-end
-  let but_not    = 4;
-  let after      = 5;
-  let ignore_end = 6;
 }
 
 const response = {

--- a/tests/js/ignore/range-ignore.js
+++ b/tests/js/ignore/range-ignore.js
@@ -1,0 +1,34 @@
+// prettier-ignore-start
+let i_like         = 1;
+let my_assignments = 2;
+let sorted         = 3;
+// prettier-ignore-end
+let but_not    = 4;
+let after      = 5;
+let ignore_end = 6;
+
+/* prettier-ignore-start */
+route('my-designs', '/my-designs/', require('./pages/my-designs/my-designs'));
+route('order', '/:project/:thank/order/', require('./pages/order/order'));
+route('order-success', '/:project/order-success/', require('./pages/order-success/order-success'));
+route('page-not-found', '/page-not-found/', require('./pages/page-not-found/page-not-found'));
+route('password-forgot', '/password-forgot/', require('./pages/password-forgot/password-forgot'));
+route('restore-password', '/restore-password/:token', require('./pages/restore-password/restore-password'));
+/* prettier-ignore-end */
+
+let  this_shall_not_be_ignored   =  2;
+
+// prettier-ignore-start
+appApplication.post(
+  `${APIRouteDefinitions.pathForRoute( APIDefinitions.routes.getPendingChangesForThreshold)}`,
+  (req, res) => {
+    validateRequest(req, res, APIDefinitions.routes.getPendingChangesForThreshold, req.body);
+  }
+);
+appApplication.post(
+  `${APIRouteDefinitions.pathForRoute( APIDefinitions.routes.getPendingChangesForThreshold)}`,
+  (req, res) => {
+    validateRequest(req, res, APIDefinitions.routes.getPendingChangesForThreshold, req.body);
+  }
+);
+// prettier-ignore-end

--- a/tests/js/ignore/range-ignore.js
+++ b/tests/js/ignore/range-ignore.js
@@ -16,7 +16,7 @@ route('password-forgot', '/password-forgot/', require('./pages/password-forgot/p
 route('restore-password', '/restore-password/:token', require('./pages/restore-password/restore-password'));
 /* prettier-ignore-end */
 
-let  this_shall_not_be_ignored   =  2;
+let  this_shall_not_be_ignored   =  21;
 
 // prettier-ignore-start
 appApplication.post(
@@ -32,3 +32,16 @@ appApplication.post(
   }
 );
 // prettier-ignore-end
+
+function foo({
+  a   =   0,
+  // prettier-ignore-start
+  b          = 1,
+  // prettier-ignore-end
+    c = 1
+               }) {
+                 console.log(a)
+                 console.log(b)
+  }
+
+  this_shall_not_be_ignored   =  22;

--- a/tests/js/ignore/range-ignore.js
+++ b/tests/js/ignore/range-ignore.js
@@ -45,3 +45,45 @@ function foo({
   }
 
   this_shall_not_be_ignored   =  22;
+
+// If else statements
+// prettier-ignore-start
+if(after == 10) {}
+else if  ((after == 20)||after==1) {
+  after  = 11;
+} else {after =    12;}
+// prettier-ignore-end
+
+function isNodeIgnoreComment(comment){
+  const match = comment.value.match(/\s*prettier-ignore(?:-(start|end))?\s*/);
+  
+  // Ternary statements, in a local scope
+  // prettier-ignore-start
+  const ignore = match === null ? false : match[1] && comment.leading ? match[1] : "next";
+  // prettier-ignore-end
+
+  return ignore;
+}
+this_shall_not_be_ignored   =  24;
+
+// Template literals and function chaining
+// prettier-ignore-start
+const content = `
+const env = ${ JSON.stringify({
+  assetsRootUrl: env.assetsRootUrl,
+	env: env.env,
+	role: "client",
+	adsfafa: "sdfsdff",
+	asdfasff: "wefwefw",
+  fefef: "sf sdfs fdsfdsf s dfsfds"
+}, null, "\t") });
+`;
+
+function foo() {
+  return a
+  .b()
+  .c()
+  // Comment
+  ?.d()
+}
+// prettier-ignore-end

--- a/tests/typescript/union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/union/__snapshots__/jsfmt.spec.js.snap
@@ -126,6 +126,16 @@ export type a =
   // qux
   | qux1&qux2;
 
+// prettier-ignore-start
+export type a =
+  // foo
+  | foo1&foo2
+  // bar
+  | bar1&bar2
+  // qux
+  | qux1&qux2;
+// prettier-ignore-end
+
 =====================================output=====================================
 export type a =
   // foo
@@ -152,6 +162,16 @@ export type a =
   | (bar1 & bar2)
   // qux
   | (qux1 & qux2);
+
+// prettier-ignore-start
+export type a =
+  // foo
+  | foo1&foo2
+  // bar
+  | bar1&bar2
+  // qux
+  | qux1&qux2;
+// prettier-ignore-end
 
 ================================================================================
 `;

--- a/tests/typescript/union/prettier-ignore.ts
+++ b/tests/typescript/union/prettier-ignore.ts
@@ -23,3 +23,13 @@ export type a =
   | bar1&bar2
   // qux
   | qux1&qux2;
+
+// prettier-ignore-start
+export type a =
+  // foo
+  | foo1&foo2
+  // bar
+  | bar1&bar2
+  // qux
+  | qux1&qux2;
+// prettier-ignore-end


### PR DESCRIPTION
## Summary

JavaScript code within `// prettier-ignore-start` and `// prettier-ignore-end` will be excluded in the abstract syntax tree from formatting.

For example:

<!-- prettier-ignore -->
```js
// prettier-ignore-start
let i_like         = 1;
let my_assignments = 2;
let sorted         = 3;
// prettier-ignore-end
let but_not    = 4;
let after      = 5;
let ignore_end = 6;
```

will be transformed to:

```js
// prettier-ignore-start
let i_like         = 1;
let my_assignments = 2;
let sorted         = 3;
// prettier-ignore-end
let but_not = 4;
let after = 5;
let ignore_end = 6;
```

## About the PR

- This PR fixes #5287
- The approach is slightly based on https://github.com/prettier/prettier/pull/4202
- This is my first time looking into prettier internals, so any feedback over the approach is welcome. Specifically, I am not sure if the way I am using `options` to store some state information is appropriate. Nevertheless it did simplify the implementation significantly for me.

---------

- [x] I’ve added tests to confirm my change works.
- [x] I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
