### PR TITLE
Build: remove extra global objects exposed by UMD bundles

### DIFF
--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -22,7 +22,7 @@ process.on("unhandledRejection", (err) => {
   process.exit(1);
 });
 
-const CACHE_VERSION = "v26"; // This need update when updating build scripts
+const CACHE_VERSION = "v27"; // This need update when updating build scripts
 const CACHED = chalk.bgYellow.black(" CACHED ");
 const OK = chalk.bgGreen.black("  DONE  ");
 const FAIL = chalk.bgRed.black("  FAIL  ");

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -34,8 +34,9 @@ const parsers = [
     input: "src/language-js/parser-typescript.js",
     replace: {
       // `typescript/lib/typescript.js` expose extra global objects
-      // `TypeScript` and `toolsVersion`
+      // `TypeScript`, `toolsVersion`, `globalThis`
       'typeof process === "undefined" || process.browser': "false",
+      'typeof globalThis === "object"': "true",
     },
   },
   {

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -32,6 +32,11 @@ const parsers = [
   },
   {
     input: "src/language-js/parser-typescript.js",
+    replace: {
+      // `typescript/lib/typescript.js` expose extra global objects
+      // `TypeScript` and `toolsVersion`
+      'typeof process === "undefined" || process.browser': "false",
+    },
   },
   {
     input: "src/language-js/parser-angular.js",

--- a/tests_config/require_standalone.js
+++ b/tests_config/require_standalone.js
@@ -16,6 +16,13 @@ const source = globby
 
 vm.runInContext(source, sandbox);
 
+const allowedGlobalObjects = new Set(["prettier", "prettierPlugins"])
+for (const property of Object.keys(sandbox)) {
+  if (!allowedGlobalObjects.has(property)) {
+    throw new Error(`Global "${property}" object should not be exposed.`)
+  }
+}
+
 // TODO: maybe expose (and write tests) for `format`, `utils`, and
 // `__debug` methods
 module.exports = {

--- a/tests_config/require_standalone.js
+++ b/tests_config/require_standalone.js
@@ -16,10 +16,10 @@ const source = globby
 
 vm.runInContext(source, sandbox);
 
-const allowedGlobalObjects = new Set(["prettier", "prettierPlugins"])
+const allowedGlobalObjects = new Set(["prettier", "prettierPlugins"]);
 for (const property of Object.keys(sandbox)) {
   if (!allowedGlobalObjects.has(property)) {
-    throw new Error(`Global "${property}" object should not be exposed.`)
+    throw new Error(`Global "${property}" object should not be exposed.`);
   }
 }
 


### PR DESCRIPTION
The bundled `parser-typescript.js` exposes global objects `TypeScript`, `toolsVersion`, and `globalThis`.


- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
