### PR TITLE
Revert #7367 "Fix: remove unnecessary parens when yielding jsx"

### DIFF
--- a/changelog_unreleased/javascript/pr-9011.md
+++ b/changelog_unreleased/javascript/pr-9011.md
@@ -1,0 +1,21 @@
+#### Add parens when yielding jsx ([#9011](https://github.com/prettier/prettier/pull/9011) by [@fisker](https://github.com/fisker))
+
+In `v2.0.0` we [removed the parens when yielding jsx](https://prettier.io/blog/2020/03/21/2.0.0.html#remove-unnecessary-parens-when-yielding-jsx-7367httpsgithubcomprettierprettierpull7367-by-cola119httpsgithubcomcola119), this works for most parsers, but ESLint throws when parsing it, [related issue](https://github.com/acornjs/acorn-jsx/issues/82).
+
+<!-- prettier-ignore -->
+```js
+// Input
+function* f() {
+  yield <div>generator</div>
+}
+
+// Prettier stable
+function* f() {
+  yield <div>generator</div>
+}
+
+// Prettier master
+function* f() {
+  yield (<div>generator</div>);
+}
+```

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -729,8 +729,7 @@ function needsParens(path, options) {
           parent.type !== "ReturnStatement" &&
           parent.type !== "ThrowStatement" &&
           parent.type !== "TypeCastExpression" &&
-          parent.type !== "VariableDeclarator" &&
-          parent.type !== "YieldExpression")
+          parent.type !== "VariableDeclarator")
       );
     case "TypeAnnotation":
       return (

--- a/tests/js/yield/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/yield/__snapshots__/jsfmt.spec.js.snap
@@ -87,8 +87,8 @@ function* f() {
 
 =====================================output=====================================
 function* f() {
-  yield <div>generator</div>;
-  yield <div>generator</div>;
+  yield (<div>generator</div>);
+  yield (<div>generator</div>);
   yield (
     <div>
       <p>generator</p>


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Without parens, eslint default parser `espree` can't parse it

Fixes #8999

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
