### PR TITLE
Improve internal `cursorOffset` calculate

### DIFF
--- a/src/main/core.js
+++ b/src/main/core.js
@@ -199,8 +199,8 @@ function formatRange(text, opts) {
 
   let formatted =
     text.slice(0, rangeStart) + rangeTrimmed + text.slice(rangeEnd);
-  const eol = convertEndOfLineToChars(opts.endOfLine);
-  if (eol !== "\n") {
+  if (opts.endOfLine !== "lf") {
+    const eol = convertEndOfLineToChars(opts.endOfLine);
     if (cursorOffset >= 0 && eol === "\r\n") {
       const before = formatted.slice(0, cursorOffset);
       const match = before.match(/\n/g);

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -171,11 +171,13 @@ function formatRange(text, opts) {
       ...opts,
       rangeStart: 0,
       rangeEnd: Infinity,
-      // track the cursor offset only if it's within our range
+      // Track the cursor offset only if it's within our range
       cursorOffset:
-        opts.cursorOffset >= rangeStart && opts.cursorOffset < rangeEnd
+        opts.cursorOffset > rangeStart && opts.cursorOffset < rangeEnd
           ? opts.cursorOffset - rangeStart
           : -1,
+      // Always use `lf` to format, we'll replace it later
+      endOfLine: "lf",
     },
     alignmentSize
   );
@@ -183,56 +185,31 @@ function formatRange(text, opts) {
   // Since the range contracts to avoid trailing whitespace,
   // we need to remove the newline that was inserted by the `format` call.
   const rangeTrimmed = rangeResult.formatted.trimEnd();
-  const rangeLeft = text.slice(0, rangeStart);
-  const rangeRight = text.slice(rangeEnd);
 
   let { cursorOffset } = opts;
-  if (opts.cursorOffset >= rangeEnd) {
+  if (cursorOffset >= rangeEnd) {
     // handle the case where the cursor was past the end of the range
     cursorOffset =
-      opts.cursorOffset - rangeEnd + (rangeStart + rangeTrimmed.length);
+      opts.cursorOffset + (rangeTrimmed.length - rangeString.length);
   } else if (rangeResult.cursorOffset !== undefined) {
     // handle the case where the cursor was in the range
     cursorOffset = rangeResult.cursorOffset + rangeStart;
   }
   // keep the cursor as it was if it was before the start of the range
 
-  let formatted;
-  if (opts.endOfLine === "lf") {
-    formatted = rangeLeft + rangeTrimmed + rangeRight;
-  } else {
-    const eol = convertEndOfLineToChars(opts.endOfLine);
-    if (cursorOffset >= 0) {
-      const parts = [rangeLeft, rangeTrimmed, rangeRight];
-      let partIndex = 0;
-      let partOffset = cursorOffset;
-      while (partIndex < parts.length) {
-        const part = parts[partIndex];
-        if (partOffset < part.length) {
-          parts[partIndex] =
-            parts[partIndex].slice(0, partOffset) +
-            PLACEHOLDERS.cursorOffset +
-            parts[partIndex].slice(partOffset);
-          break;
-        }
-        partIndex++;
-        partOffset -= part.length;
+  let formatted =
+    text.slice(0, rangeStart) + rangeTrimmed + text.slice(rangeEnd);
+  const eol = convertEndOfLineToChars(opts.endOfLine);
+  if (eol !== "\n") {
+    if (cursorOffset >= 0 && eol === "\r\n") {
+      const before = formatted.slice(0, cursorOffset);
+      const match = before.match(/\n/g);
+      if (match) {
+        cursorOffset += match.length;
       }
-      const [newRangeLeft, newRangeTrimmed, newRangeRight] = parts;
-      formatted = (
-        newRangeLeft.replace(/\n/g, eol) +
-        newRangeTrimmed +
-        newRangeRight.replace(/\n/g, eol)
-      ).replace(PLACEHOLDERS.cursorOffset, (_, index) => {
-        cursorOffset = index;
-        return "";
-      });
-    } else {
-      formatted =
-        rangeLeft.replace(/\n/g, eol) +
-        rangeTrimmed +
-        rangeRight.replace(/\n/g, eol);
     }
+
+    formatted = formatted.replace(/\n/g, eol);
   }
 
   return { formatted, cursorOffset };

--- a/tests/js/cursor/jsfmt.spec.js
+++ b/tests/js/cursor/jsfmt.spec.js
@@ -58,7 +58,7 @@ test("cursorOffset === rangeStart", () => {
       rangeEnd: 8,
     })
   ).toEqual({
-    formatted: `1.0000\n2.0;\n3.0000`,
+    formatted: "1.0000\n2.0;\n3.0000",
     cursorOffset: 7,
   });
 });

--- a/tests/js/cursor/jsfmt.spec.js
+++ b/tests/js/cursor/jsfmt.spec.js
@@ -46,3 +46,19 @@ foo('bar', cb => {
     cursorOffset: 25,
   });
 });
+
+test("cursorOffset === rangeStart", () => {
+  const code = "1.0000\n2.0000\n3.0000";
+
+  expect(
+    prettier.formatWithCursor(code, {
+      parser: "babel",
+      cursorOffset: 7,
+      rangeStart: 7,
+      rangeEnd: 8,
+    })
+  ).toEqual({
+    formatted: `1.0000\n2.0;\n3.0000`,
+    cursorOffset: 7,
+  });
+});


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Similar to #9012, this one is more tricky.


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
