### PR TITLE
Prevent jest warning on production tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -30,6 +30,7 @@ module.exports = {
     "prettier/local": "<rootDir>/tests_config/require_prettier.js",
     "prettier/standalone": "<rootDir>/tests_config/require_standalone.js",
   },
+  modulePathIgnorePatterns: ["<rootDir>/dist"],
   testEnvironment: "node",
   transform: {},
   watchPlugins: [


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Kill this warning on production tests https://github.com/prettier/prettier/runs/1011304179#step:7:49


```text
jest-haste-map: Haste module naming collision: prettier
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/dist/package.json
    * <rootDir>/package.json
```

It's gone https://github.com/prettier/prettier/runs/1013238728?check_suite_focus=true#step:7:48

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
