### PR TITLE
Build: Quick fix for #8639

### DIFF
--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -22,7 +22,7 @@ process.on("unhandledRejection", (err) => {
   process.exit(1);
 });
 
-const CACHE_VERSION = "v27"; // This need update when updating build scripts
+const CACHE_VERSION = "v28"; // This need update when updating build scripts
 const CACHED = chalk.bgYellow.black(" CACHED ");
 const OK = chalk.bgGreen.black("  DONE  ");
 const FAIL = chalk.bgRed.black("  FAIL  ");

--- a/scripts/build/bundler.js
+++ b/scripts/build/bundler.js
@@ -19,9 +19,6 @@ const externals = require("./rollup-plugins/externals");
 const bundles = require("./config");
 
 const PROJECT_ROOT = path.resolve(__dirname, "../..");
-const plugins = bundles
-  .filter(({ type }) => type === "plugin")
-  .map(({ input }) => path.join(PROJECT_ROOT, input));
 
 const EXTERNALS = [
   "assert",
@@ -178,11 +175,9 @@ function getRollupConfig(bundle) {
     commonjs({
       ignoreGlobal: bundle.target === "node",
       ...bundle.commonjs,
+      ignore: bundle.type === "plugin" ? undefined: (id) =>/\.\/parser-.*?/.test(id)
     }),
-    externals([
-      ...(bundle.externals || []),
-      ...(bundle.type !== "plugin" ? plugins : []),
-    ]),
+    externals(bundle.externals),
     bundle.target === "universal" && nodeGlobals(),
     babel(babelConfig),
     bundle.minify !== false && bundle.target === "universal" && terser(),

--- a/scripts/build/bundler.js
+++ b/scripts/build/bundler.js
@@ -16,7 +16,6 @@ const nativeShims = require("./rollup-plugins/native-shims");
 const executable = require("./rollup-plugins/executable");
 const evaluate = require("./rollup-plugins/evaluate");
 const externals = require("./rollup-plugins/externals");
-const bundles = require("./config");
 
 const PROJECT_ROOT = path.resolve(__dirname, "../..");
 

--- a/scripts/build/bundler.js
+++ b/scripts/build/bundler.js
@@ -174,7 +174,10 @@ function getRollupConfig(bundle) {
     commonjs({
       ignoreGlobal: bundle.target === "node",
       ...bundle.commonjs,
-      ignore: bundle.type === "plugin" ? undefined: (id) =>/\.\/parser-.*?/.test(id)
+      ignore:
+        bundle.type === "plugin"
+          ? undefined
+          : (id) => /\.\/parser-.*?/.test(id),
     }),
     externals(bundle.externals),
     bundle.target === "universal" && nodeGlobals(),


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->


Local checked, seems working

![image](https://user-images.githubusercontent.com/172584/91022716-2ca03a80-e628-11ea-8a04-10b1d72555f0.png)




> Regression on build script cause by #8639
>
> Before, require('parse-*') is "Dynamic Require", now it's not, this will slow down prettier, I'll try to find a way or revert that PR.

posted in https://github.com/prettier/prettier/issues/8882#issuecomment-678979437

---

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
