### PR TITLE
[blog] fix proposal stages

### DIFF
--- a/website/blog/2020-08-24-2.1.0.md
+++ b/website/blog/2020-08-24-2.1.0.md
@@ -435,7 +435,7 @@ SyntaxError: Unexpected token (1:1)
 
 #### Support ES Module Attributes and JSON modules ([#8436](https://github.com/prettier/prettier/pull/8436) by [@fisker](https://github.com/fisker))
 
-Support Stage-1 proposal [ES Module Attributes and JSON modules](https://github.com/tc39/proposal-module-attributes).
+Support Stage-2 proposal [ES Module Attributes and JSON modules](https://github.com/tc39/proposal-module-attributes).
 
 <!-- prettier-ignore -->
 ```js
@@ -453,7 +453,7 @@ import foo from "foo.json" with type: "json";
 
 #### Support record and tuple syntax ([#8453](https://github.com/prettier/prettier/pull/8453) by [@fisker](https://github.com/fisker))
 
-Support Stage-1 proposal [JavaScript Records & Tuples Proposal](https://github.com/tc39/proposal-record-tuple/blob/master/README.md).
+Support Stage-2 proposal [JavaScript Records & Tuples Proposal](https://github.com/tc39/proposal-record-tuple/blob/master/README.md).
 
 _Only support `#[]`/`#{}` syntax, not `{| |}` / `[| |]`._
 

--- a/website/blog/2020-08-24-2.1.0.md
+++ b/website/blog/2020-08-24-2.1.0.md
@@ -416,7 +416,7 @@ for (const element of list) {
 
 #### Support Private Fields in `in` ([#8431](https://github.com/prettier/prettier/pull/8431) by [@sosukesuzuki](https://github.com/sosukesuzuki))
 
-Support Stage-2 proposal [Private Fields in `in`](https://github.com/tc39/proposal-private-fields-in-in/blob/master/README.md).
+Support Stage-2 proposal [Private Fields in `in`](https://github.com/tc39/proposal-private-fields-in-in).
 
 <!-- prettier-ignore -->
 ```js
@@ -435,7 +435,7 @@ SyntaxError: Unexpected token (1:1)
 
 #### Support ES Module Attributes and JSON modules ([#8436](https://github.com/prettier/prettier/pull/8436) by [@fisker](https://github.com/fisker))
 
-Support Stage-2 proposal [ES Module Attributes and JSON modules](https://github.com/tc39/proposal-module-attributes).
+Support Stage-2 proposal [ES Module Attributes and JSON modules](https://github.com/tc39/proposal-import-assertions).
 
 <!-- prettier-ignore -->
 ```js
@@ -453,7 +453,7 @@ import foo from "foo.json" with type: "json";
 
 #### Support record and tuple syntax ([#8453](https://github.com/prettier/prettier/pull/8453) by [@fisker](https://github.com/fisker))
 
-Support Stage-2 proposal [JavaScript Records & Tuples Proposal](https://github.com/tc39/proposal-record-tuple/blob/master/README.md).
+Support Stage-2 proposal [JavaScript Records & Tuples Proposal](https://github.com/tc39/proposal-record-tuple).
 
 _Only support `#[]`/`#{}` syntax, not `{| |}` / `[| |]`._
 

--- a/website/blog/2020-08-24-2.1.0.md
+++ b/website/blog/2020-08-24-2.1.0.md
@@ -1255,7 +1255,7 @@ Non-ASCII whitespace characters like `U+00A0` `U+2005` etc. are not considered w
 Previously we parse html `<script>` blocks as "module"([ECMAScript Module grammar](https://babeljs.io/docs/en/options#sourcetype)), this is why we can't parse comments starts with `<!--`(aka [HTML-like comments](https://tc39.es/ecma262/#sec-html-like-comments)), now we parse `<script>` blocks as "script", unless this `<script>`
 
 1. `type="module"`
-2. `type="text/babel"` and `data-type="module"`, [will be introduced in babel@v7.10.0](https://github.com/babel/babel/pull/11466)
+2. `type="text/babel"` and `data-type="module"`, [introduced in babel@v7.10.0](https://github.com/babel/babel/pull/11466)
 
 <!-- prettier-ignore -->
 ```html


### PR DESCRIPTION
In the [release notes for v2.1.0](https://prettier.io/blog/2020/08/24/2.1.0.html), [ES Module Attributes and JSON modules](https://github.com/tc39/proposal-import-assertions) and [Records & Tuples Proposal](https://github.com/tc39/proposal-record-tuple) are described as Stage-1, when in fact they appear to be Stage-2.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
