### PR TITLE
Vue: fix format on blocks with `src` attribute

### DIFF
--- a/changelog_unreleased/vue/pr-9052.md
+++ b/changelog_unreleased/vue/pr-9052.md
@@ -1,0 +1,20 @@
+#### Fix format blocks with `src` attribute ([#9052](https://github.com/prettier/prettier/pull/9052) by [@fisker](https://github.com/fisker))
+
+<!-- prettier-ignore -->
+```vue
+<!-- Input -->
+<custom lang="markdown" src="./foo.md"></custom>
+<custom lang="markdown" src="./foo.md" />
+
+<!-- Prettier stable -->
+<custom lang="markdown" src="./foo.md">
+
+</custom>
+<custom lang="markdown" src="./foo.md"
+
+/>
+
+<!-- Prettier master -->
+<custom lang="markdown" src="./foo.md"></custom>
+<custom lang="markdown" src="./foo.md" />
+```

--- a/src/language-html/utils.js
+++ b/src/language-html/utils.js
@@ -428,7 +428,7 @@ function inferScriptParser(node, options) {
     return (
       _inferScriptParser(node) ||
       inferStyleParser(node) ||
-      (!node.attrMap.src && getParserName(node.attrMap.lang, options))
+      (!("src" in node.attrMap) && getParserName(node.attrMap.lang, options))
     );
   }
 }

--- a/src/language-html/utils.js
+++ b/src/language-html/utils.js
@@ -428,7 +428,7 @@ function inferScriptParser(node, options) {
     return (
       _inferScriptParser(node) ||
       inferStyleParser(node) ||
-      getParserName(node.attrMap.lang, options)
+      (!node.attrMap.src && getParserName(node.attrMap.lang, options))
     );
   }
 }

--- a/tests/vue/with-plugins/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/vue/with-plugins/__snapshots__/jsfmt.spec.js.snap
@@ -247,22 +247,61 @@ printWidth: 80
 <style lang="uppercase-rocks" src="foo.uppercase-rocks"></style>
 <script lang="uppercase-rocks" src="foo.uppercase-rocks"></script>
 <custom lang="uppercase-rocks" src="foo.uppercase-rocks"></custom>
+<template lang="uppercase-rocks" src></template>
+<template lang="uppercase-rocks" src=""></template>
+<template lang="uppercase-rocks" src>PrEtTiEr</template>
+<template lang="uppercase-rocks" src="">PrEtTiEr</template>
+<template lang="uppercase-rocks" src>
+
+     </template>
+<template lang="uppercase-rocks" src="">
+
+     </template>
+
+<template lang="uppercase-rocks" src="foo.uppercase-rocks">
+PrEtTiEr
+</template>
+
+
+<template lang="uppercase-rocks" :src="">PrEtTiEr</template>
+<template lang="uppercase-rocks" @src="">PrEtTiEr</template>
 
 <template lang="uppercase-rocks" src="foo.uppercase-rocks"/>
 <style lang="uppercase-rocks" src="foo.uppercase-rocks"/>
 <script lang="uppercase-rocks" src="foo.uppercase-rocks"/>
 <custom lang="uppercase-rocks" src="foo.uppercase-rocks"/>
+<custom lang="uppercase-rocks" src/>
+<template lang="uppercase-rocks" src=""/>
 
 =====================================output=====================================
 <template lang="uppercase-rocks" src="foo.uppercase-rocks"></template>
 <style lang="uppercase-rocks" src="foo.uppercase-rocks"></style>
 <script lang="uppercase-rocks" src="foo.uppercase-rocks"></script>
 <custom lang="uppercase-rocks" src="foo.uppercase-rocks"></custom>
+<template lang="uppercase-rocks" src></template>
+<template lang="uppercase-rocks" src=""></template>
+<template lang="uppercase-rocks" src>PrEtTiEr</template>
+<template lang="uppercase-rocks" src="">PrEtTiEr</template>
+<template lang="uppercase-rocks" src>
+
+     </template>
+<template lang="uppercase-rocks" src="">
+
+     </template>
+
+<template lang="uppercase-rocks" src="foo.uppercase-rocks">
+PrEtTiEr
+</template>
+
+<template lang="uppercase-rocks" :src="">PrEtTiEr</template>
+<template lang="uppercase-rocks" @src="">PrEtTiEr</template>
 
 <template lang="uppercase-rocks" src="foo.uppercase-rocks" />
 <style lang="uppercase-rocks" src="foo.uppercase-rocks" />
 <script lang="uppercase-rocks" src="foo.uppercase-rocks" />
 <custom lang="uppercase-rocks" src="foo.uppercase-rocks" />
+<custom lang="uppercase-rocks" src />
+<template lang="uppercase-rocks" src="" />
 
 ================================================================================
 `;
@@ -277,28 +316,75 @@ printWidth: 80
 <style lang="uppercase-rocks" src="foo.uppercase-rocks"></style>
 <script lang="uppercase-rocks" src="foo.uppercase-rocks"></script>
 <custom lang="uppercase-rocks" src="foo.uppercase-rocks"></custom>
+<template lang="uppercase-rocks" src></template>
+<template lang="uppercase-rocks" src=""></template>
+<template lang="uppercase-rocks" src>PrEtTiEr</template>
+<template lang="uppercase-rocks" src="">PrEtTiEr</template>
+<template lang="uppercase-rocks" src>
+
+     </template>
+<template lang="uppercase-rocks" src="">
+
+     </template>
+
+<template lang="uppercase-rocks" src="foo.uppercase-rocks">
+PrEtTiEr
+</template>
+
+
+<template lang="uppercase-rocks" :src="">PrEtTiEr</template>
+<template lang="uppercase-rocks" @src="">PrEtTiEr</template>
 
 <template lang="uppercase-rocks" src="foo.uppercase-rocks"/>
 <style lang="uppercase-rocks" src="foo.uppercase-rocks"/>
 <script lang="uppercase-rocks" src="foo.uppercase-rocks"/>
 <custom lang="uppercase-rocks" src="foo.uppercase-rocks"/>
+<custom lang="uppercase-rocks" src/>
+<template lang="uppercase-rocks" src=""/>
 
 =====================================output=====================================
-<template lang="uppercase-rocks" src="foo.uppercase-rocks">
-
-</template>
+<template lang="uppercase-rocks" src="foo.uppercase-rocks"></template>
 <style lang="uppercase-rocks" src="foo.uppercase-rocks"></style>
 <script lang="uppercase-rocks" src="foo.uppercase-rocks"></script>
-<custom lang="uppercase-rocks" src="foo.uppercase-rocks">
+<custom lang="uppercase-rocks" src="foo.uppercase-rocks"></custom>
+<template lang="uppercase-rocks" src>
 
-</custom>
+</template>
+<template lang="uppercase-rocks" src="">
 
-<template lang="uppercase-rocks" src="foo.uppercase-rocks"
+</template>
+<template lang="uppercase-rocks" src>
+PRETTIER
+</template>
+<template lang="uppercase-rocks" src="">
+PRETTIER
+</template>
+<template lang="uppercase-rocks" src>
 
-/>
+</template>
+<template lang="uppercase-rocks" src="">
+
+</template>
+
+<template lang="uppercase-rocks" src="foo.uppercase-rocks">
+PrEtTiEr
+</template>
+
+<template lang="uppercase-rocks" :src="">
+PRETTIER
+</template>
+<template lang="uppercase-rocks" @src="">
+PRETTIER
+</template>
+
+<template lang="uppercase-rocks" src="foo.uppercase-rocks" />
 <style lang="uppercase-rocks" src="foo.uppercase-rocks" />
 <script lang="uppercase-rocks" src="foo.uppercase-rocks" />
-<custom lang="uppercase-rocks" src="foo.uppercase-rocks"
+<custom lang="uppercase-rocks" src="foo.uppercase-rocks" />
+<custom lang="uppercase-rocks" src
+
+/>
+<template lang="uppercase-rocks" src=""
 
 />
 

--- a/tests/vue/with-plugins/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/vue/with-plugins/__snapshots__/jsfmt.spec.js.snap
@@ -347,24 +347,16 @@ PrEtTiEr
 <style lang="uppercase-rocks" src="foo.uppercase-rocks"></style>
 <script lang="uppercase-rocks" src="foo.uppercase-rocks"></script>
 <custom lang="uppercase-rocks" src="foo.uppercase-rocks"></custom>
+<template lang="uppercase-rocks" src></template>
+<template lang="uppercase-rocks" src=""></template>
+<template lang="uppercase-rocks" src>PrEtTiEr</template>
+<template lang="uppercase-rocks" src="">PrEtTiEr</template>
 <template lang="uppercase-rocks" src>
 
-</template>
+     </template>
 <template lang="uppercase-rocks" src="">
 
-</template>
-<template lang="uppercase-rocks" src>
-PRETTIER
-</template>
-<template lang="uppercase-rocks" src="">
-PRETTIER
-</template>
-<template lang="uppercase-rocks" src>
-
-</template>
-<template lang="uppercase-rocks" src="">
-
-</template>
+     </template>
 
 <template lang="uppercase-rocks" src="foo.uppercase-rocks">
 PrEtTiEr
@@ -381,12 +373,8 @@ PRETTIER
 <style lang="uppercase-rocks" src="foo.uppercase-rocks" />
 <script lang="uppercase-rocks" src="foo.uppercase-rocks" />
 <custom lang="uppercase-rocks" src="foo.uppercase-rocks" />
-<custom lang="uppercase-rocks" src
-
-/>
-<template lang="uppercase-rocks" src=""
-
-/>
+<custom lang="uppercase-rocks" src />
+<template lang="uppercase-rocks" src="" />
 
 ================================================================================
 `;

--- a/tests/vue/with-plugins/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/vue/with-plugins/__snapshots__/jsfmt.spec.js.snap
@@ -235,3 +235,72 @@ printWidth: 80
 
 ================================================================================
 `;
+
+exports[`with-src.vue - {"embeddedLanguageFormatting":"off"} format 1`] = `
+====================================options=====================================
+embeddedLanguageFormatting: "off"
+parsers: ["vue"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<template lang="uppercase-rocks" src="foo.uppercase-rocks"></template>
+<style lang="uppercase-rocks" src="foo.uppercase-rocks"></style>
+<script lang="uppercase-rocks" src="foo.uppercase-rocks"></script>
+<custom lang="uppercase-rocks" src="foo.uppercase-rocks"></custom>
+
+<template lang="uppercase-rocks" src="foo.uppercase-rocks"/>
+<style lang="uppercase-rocks" src="foo.uppercase-rocks"/>
+<script lang="uppercase-rocks" src="foo.uppercase-rocks"/>
+<custom lang="uppercase-rocks" src="foo.uppercase-rocks"/>
+
+=====================================output=====================================
+<template lang="uppercase-rocks" src="foo.uppercase-rocks"></template>
+<style lang="uppercase-rocks" src="foo.uppercase-rocks"></style>
+<script lang="uppercase-rocks" src="foo.uppercase-rocks"></script>
+<custom lang="uppercase-rocks" src="foo.uppercase-rocks"></custom>
+
+<template lang="uppercase-rocks" src="foo.uppercase-rocks" />
+<style lang="uppercase-rocks" src="foo.uppercase-rocks" />
+<script lang="uppercase-rocks" src="foo.uppercase-rocks" />
+<custom lang="uppercase-rocks" src="foo.uppercase-rocks" />
+
+================================================================================
+`;
+
+exports[`with-src.vue format 1`] = `
+====================================options=====================================
+parsers: ["vue"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<template lang="uppercase-rocks" src="foo.uppercase-rocks"></template>
+<style lang="uppercase-rocks" src="foo.uppercase-rocks"></style>
+<script lang="uppercase-rocks" src="foo.uppercase-rocks"></script>
+<custom lang="uppercase-rocks" src="foo.uppercase-rocks"></custom>
+
+<template lang="uppercase-rocks" src="foo.uppercase-rocks"/>
+<style lang="uppercase-rocks" src="foo.uppercase-rocks"/>
+<script lang="uppercase-rocks" src="foo.uppercase-rocks"/>
+<custom lang="uppercase-rocks" src="foo.uppercase-rocks"/>
+
+=====================================output=====================================
+<template lang="uppercase-rocks" src="foo.uppercase-rocks">
+
+</template>
+<style lang="uppercase-rocks" src="foo.uppercase-rocks"></style>
+<script lang="uppercase-rocks" src="foo.uppercase-rocks"></script>
+<custom lang="uppercase-rocks" src="foo.uppercase-rocks">
+
+</custom>
+
+<template lang="uppercase-rocks" src="foo.uppercase-rocks"
+
+/>
+<style lang="uppercase-rocks" src="foo.uppercase-rocks" />
+<script lang="uppercase-rocks" src="foo.uppercase-rocks" />
+<custom lang="uppercase-rocks" src="foo.uppercase-rocks"
+
+/>
+
+================================================================================
+`;

--- a/tests/vue/with-plugins/with-src.vue
+++ b/tests/vue/with-plugins/with-src.vue
@@ -1,0 +1,9 @@
+<template lang="uppercase-rocks" src="foo.uppercase-rocks"></template>
+<style lang="uppercase-rocks" src="foo.uppercase-rocks"></style>
+<script lang="uppercase-rocks" src="foo.uppercase-rocks"></script>
+<custom lang="uppercase-rocks" src="foo.uppercase-rocks"></custom>
+
+<template lang="uppercase-rocks" src="foo.uppercase-rocks"/>
+<style lang="uppercase-rocks" src="foo.uppercase-rocks"/>
+<script lang="uppercase-rocks" src="foo.uppercase-rocks"/>
+<custom lang="uppercase-rocks" src="foo.uppercase-rocks"/>

--- a/tests/vue/with-plugins/with-src.vue
+++ b/tests/vue/with-plugins/with-src.vue
@@ -2,8 +2,28 @@
 <style lang="uppercase-rocks" src="foo.uppercase-rocks"></style>
 <script lang="uppercase-rocks" src="foo.uppercase-rocks"></script>
 <custom lang="uppercase-rocks" src="foo.uppercase-rocks"></custom>
+<template lang="uppercase-rocks" src></template>
+<template lang="uppercase-rocks" src=""></template>
+<template lang="uppercase-rocks" src>PrEtTiEr</template>
+<template lang="uppercase-rocks" src="">PrEtTiEr</template>
+<template lang="uppercase-rocks" src>
+
+     </template>
+<template lang="uppercase-rocks" src="">
+
+     </template>
+
+<template lang="uppercase-rocks" src="foo.uppercase-rocks">
+PrEtTiEr
+</template>
+
+
+<template lang="uppercase-rocks" :src="">PrEtTiEr</template>
+<template lang="uppercase-rocks" @src="">PrEtTiEr</template>
 
 <template lang="uppercase-rocks" src="foo.uppercase-rocks"/>
 <style lang="uppercase-rocks" src="foo.uppercase-rocks"/>
 <script lang="uppercase-rocks" src="foo.uppercase-rocks"/>
 <custom lang="uppercase-rocks" src="foo.uppercase-rocks"/>
+<custom lang="uppercase-rocks" src/>
+<template lang="uppercase-rocks" src=""/>


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fixes #9049

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
