### PR TITLE
Add `loc` back for `typescript` parser

### DIFF
--- a/src/language-js/parser-typescript.js
+++ b/src/language-js/parser-typescript.js
@@ -36,6 +36,9 @@ function parse(text, parsers, opts) {
 function tryParseTypeScript(text, jsx) {
   const parser = require("@typescript-eslint/typescript-estree");
   return parser.parse(text, {
+    // `jest@<=26.4.2` rely on `loc`
+    // https://github.com/facebook/jest/issues/10444
+    loc: true,
     range: true,
     comment: true,
     useJSXTextNode: true,


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Jest `inline snapshot` rely on AST `loc` property, add it back to avoid breaking jest.

I also checked other parsers, we have `loc` in `babel`, because `comment`s in `babel` don't have range info. `flow` parser seems don't have an option for it.

Context https://github.com/facebook/jest/issues/10444

/cc @SimenB @evilebottnawi @thorn0


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
