### PR TITLE
test(TypeScript): test ...infer type with parens

### DIFF
--- a/tests/typescript/rest-type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/rest-type/__snapshots__/jsfmt.spec.js.snap
@@ -22,12 +22,24 @@ printWidth: 80
 =====================================input======================================
 type Tail<T extends any[]> = T extends [infer U, ...infer R] ? R : never;
 
+// should remove parens from this, to avoid a type issue with TypeScript 4.0:
+type Tail2<T extends any[]> = T extends [infer U, ...(infer R)] ? R : never;
+
+// but not remove parens from this:
+type Tail3<T extends any[]> = T extends [infer U, ...(infer R)[]] ? R : never;
+
 type ReduceNextElement<
   T extends readonly unknown[]
 > = T extends readonly [infer V, ...infer R] ? [V, R] : never
 
 =====================================output=====================================
 type Tail<T extends any[]> = T extends [infer U, ...infer R] ? R : never;
+
+// should remove parens from this, to avoid a type issue with TypeScript 4.0:
+type Tail2<T extends any[]> = T extends [infer U, ...infer R] ? R : never;
+
+// but not remove parens from this:
+type Tail3<T extends any[]> = T extends [infer U, ...(infer R)[]] ? R : never;
 
 type ReduceNextElement<T extends readonly unknown[]> = T extends readonly [
   infer V,

--- a/tests/typescript/rest-type/infer-type.ts
+++ b/tests/typescript/rest-type/infer-type.ts
@@ -1,5 +1,11 @@
 type Tail<T extends any[]> = T extends [infer U, ...infer R] ? R : never;
 
+// should remove parens from this, to avoid a type issue with TypeScript 4.0:
+type Tail2<T extends any[]> = T extends [infer U, ...(infer R)] ? R : never;
+
+// but not remove parens from this:
+type Tail3<T extends any[]> = T extends [infer U, ...(infer R)[]] ? R : never;
+
 type ReduceNextElement<
   T extends readonly unknown[]
 > = T extends readonly [infer V, ...infer R] ? [V, R] : never


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

In followup to PR #9044, I was thinking it may be good to test that these cases continue to be handled correctly:

```ts
// should remove parens from this, to avoid a type issue with TypeScript 4.0:
type Tail2<T extends any[]> = T extends [infer U, ...(infer R)] ? R : never;

// but not remove parens from this:
type Tail3<T extends any[]> = T extends [infer U, ...(infer R)[]] ? R : never;
```

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
