### PR TITLE
Refactor `RecoveredErrors` rethrow

### DIFF
--- a/src/language-js/parser-babel.js
+++ b/src/language-js/parser-babel.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const errorMessages = require("@babel/parser/lib/parser/error-message");
+const { ErrorMessages } = require("@babel/parser/lib/parser/error-message");
 const createError = require("../common/parser-create-error");
 const { hasPragma } = require("./pragma");
 const { locStart, locEnd } = require("./loc");
@@ -133,7 +133,7 @@ function tryCombinations(fn, combinations) {
 const messagesShouldThrow = new Set([
   // `UnexpectedTypeAnnotation` not exported
   "Did not expect a type annotation here.",
-  errorMessages.ModuleAttributeDifferentFromType,
+  ErrorMessages.ModuleAttributeDifferentFromType,
 ]);
 
 function shouldRethrow(error) {

--- a/src/language-js/parser-babel.js
+++ b/src/language-js/parser-babel.js
@@ -131,7 +131,8 @@ function tryCombinations(fn, combinations) {
 }
 
 const messagesShouldThrow = new Set([
-  // `UnexpectedTypeAnnotation` not exported
+  // `TSErrors.UnexpectedTypeAnnotation` not exported
+  // https://github.com/babel/babel/blob/008fe25ae22e78288fbc637d41069bb4a1040987/packages/babel-parser/src/plugins/typescript/index.js#L95
   "Did not expect a type annotation here.",
   ErrorMessages.ModuleAttributeDifferentFromType,
 ]);


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

We can access the babel error messages now. 

~I'm thinking instead of listing the errors need rethrow, we may want list the errors we want ignore.
@thorn0~ Sorry, not a good idea

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
