### PR TITLE
CI: remove `fetch-depth`

### DIFF
--- a/.github/workflows/dev-package-test.yml
+++ b/.github/workflows/dev-package-test.yml
@@ -31,8 +31,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.2
-        with:
-          fetch-depth: 1
 
       - name: Setup Node.js
         uses: actions/setup-node@v2.1.1

--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -38,8 +38,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.2
-        with:
-          fetch-depth: 1
 
       - name: Setup Node.js
         uses: actions/setup-node@v2.1.1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.2
-        with:
-          fetch-depth: 1
 
       - name: Setup Node.js
         uses: actions/setup-node@v2.1.1

--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.2
-        with:
-          fetch-depth: 1
 
       - name: Setup Node.js
         uses: actions/setup-node@v2.1.1
@@ -60,8 +58,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.2
-        with:
-          fetch-depth: 1
 
       - name: Setup Node.js
         uses: actions/setup-node@v2.1.1
@@ -102,8 +98,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.2
-        with:
-          fetch-depth: 1
 
       - name: Setup Node.js
         uses: actions/setup-node@v2.1.1


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Remove `fetch-depth:1` for checkout action, it default to `1`

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
