### PR TITLE
Remove `css` parser from `isLessParser` check

### DIFF
--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -6,7 +6,6 @@ const { hasPragma } = require("./pragma");
 const {
   hasSCSSInterpolation,
   hasStringOrFunction,
-  isLessParser,
   isSCSS,
   isSCSSNestedPropertyNode,
   isSCSSVariable,
@@ -414,7 +413,7 @@ function parseNestedCSS(node, options) {
     }
 
     if (
-      isLessParser(options) &&
+      options.parser === "less" &&
       node.type === "css-decl" &&
       value.startsWith("extend(")
     ) {
@@ -431,7 +430,7 @@ function parseNestedCSS(node, options) {
     }
 
     if (node.type === "css-atrule") {
-      if (isLessParser(options)) {
+      if (options.parser === "less") {
         // mixin
         if (node.mixin) {
           const source =
@@ -461,7 +460,7 @@ function parseNestedCSS(node, options) {
         return node;
       }
 
-      if (isLessParser(options)) {
+      if (options.parser === "less") {
         // Whitespace between variable and colon
         if (node.name.includes(":") && !node.params) {
           node.variable = true;

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -40,7 +40,6 @@ const {
   isWideKeywords,
   isSCSS,
   isLastNode,
-  isLessParser,
   isSCSSControlDirectiveNode,
   isDetachedRulesetDeclarationNode,
   isRelationalOperatorNode,
@@ -158,7 +157,7 @@ function genericPrint(path, options, print) {
         trimmedBetween.startsWith("//") ? " " : "",
         trimmedBetween,
         node.extend ? "" : " ",
-        isLessParser(options) && node.extend && node.selector
+        options.parser === "less" && node.extend && node.selector
           ? concat(["extend(", path.call(print, "selector"), ")"])
           : "",
         value,
@@ -202,7 +201,7 @@ function genericPrint(path, options, print) {
         !parentNode.raws.semicolon &&
         options.originalText[options.locEnd(node) - 1] !== ";";
 
-      if (isLessParser(options)) {
+      if (options.parser === "less") {
         if (node.mixin) {
           return concat([
             path.call(print, "selector"),

--- a/src/language-css/utils.js
+++ b/src/language-css/utils.js
@@ -415,11 +415,6 @@ function isColorAdjusterFuncNode(node) {
   return colorAdjusterFunctions.has(node.value.toLowerCase());
 }
 
-// TODO: only check `less` when we don't use `less` to parse `css`
-function isLessParser(options) {
-  return options.parser === "css" || options.parser === "less";
-}
-
 function lastLineHasInlineComment(text) {
   return /\/\//.test(text.split(/[\n\r]/).pop());
 }
@@ -477,7 +472,6 @@ module.exports = {
   isSCSS,
   isSCSSVariable,
   isLastNode,
-  isLessParser,
   isSCSSControlDirectiveNode,
   isDetachedRulesetDeclarationNode,
   isRelationalOperatorNode,


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Followup #7933, these parts should only work for less now.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
