### PR TITLE
markdown: remove unnecessary blockquote `>`

### DIFF
--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -128,6 +128,14 @@ function genericPrint(path, options, print) {
           prefix.replace(/\\/g, "")
         );
       }
+      if (escapedValue === ">") {
+        const parentNode = path.getParentNode();
+        const index = parentNode.children.indexOf(node);
+        const prevNode = parentNode.children[index - 1];
+        if (prevNode && prevNode.type === "whitespace" && prevNode.value === "\n") {
+          return ""
+        }
+      }
 
       return escapedValue;
     }
@@ -141,8 +149,11 @@ function genericPrint(path, options, print) {
         nextNode && /^>|^([*+-]|#{1,6}|\d+[).])$/.test(nextNode.value)
           ? "never"
           : options.proseWrap;
-
-      return printLine(path, node.value, { proseWrap });
+      let {value} = node;
+      if (node.value === "\n" && nextNode && nextNode.type === "word" && nextNode.value === ">") {
+        value = "";
+      }
+      return printLine(path, value, { proseWrap });
     }
     case "emphasis": {
       let style;

--- a/tests/markdown/blockquote/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown/blockquote/__snapshots__/jsfmt.spec.js.snap
@@ -183,10 +183,29 @@ proseWrap: "always"
 > This is a long long long long long long long long long long long long long long long paragraph.
 > This is a long long long long long long long long long long long long long long long paragraph.
 
+> \`x\`
+> \`y\`
+
+> _x_
+> _y_
+
+> [foo](http://foo)
+> [bar](http://bar)
+
+> \`this\` behaves
+> \`correctly\`
 =====================================output=====================================
 > This is a long long long long long long long long long long long long long
 > long long paragraph. This is a long long long long long long long long long
 > long long long long long long paragraph.
+
+> \`x\` \`y\`
+
+> _x_ _y_
+
+> [foo](http://foo) [bar](http://bar)
+
+> \`this\` behaves \`correctly\`
 
 ================================================================================
 `;

--- a/tests/markdown/blockquote/paragraph.md
+++ b/tests/markdown/blockquote/paragraph.md
@@ -1,2 +1,14 @@
 > This is a long long long long long long long long long long long long long long long paragraph.
 > This is a long long long long long long long long long long long long long long long paragraph.
+
+> `x`
+> `y`
+
+> _x_
+> _y_
+
+> [foo](http://foo)
+> [bar](http://bar)
+
+> `this` behaves
+> `correctly`


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fix #9099

This removes unnecessary blockquote `>` when the paragraph is made a single line.
I am not confident my implementation is good. Please tell me if you know a better way to fix this.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
