### PR TITLE
Do not try to format media queries containing SCSS single-line comments

### DIFF
--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -266,6 +266,14 @@ function parseMediaQuery(params) {
 
   let result = null;
 
+  // bail on SCSS comments inside the query
+  if (/\/\//.test(params)) {
+    return {
+      type: "selector-unknown",
+      value: params.trim(),
+    };
+  }
+
   try {
     result = mediaParser(params);
   } catch (e) {

--- a/tests/scss/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/scss/comments/__snapshots__/jsfmt.spec.js.snap
@@ -562,6 +562,11 @@ printWidth: 80
 // comment 29
 {}
 
+@media screen, // comment 30
+  print { 
+  // comment 31
+}
+
 =====================================output=====================================
 .powerPathNavigator .helm button.pressedButton, // comment 1
 .powerPathNavigator .helm button:active:not(.disabledButton),
@@ -627,6 +632,11 @@ printWidth: 80
 .bar
 // comment 29
 {
+}
+
+@media screen, // comment 30
+  print {
+  // comment 31
 }
 
 ================================================================================

--- a/tests/scss/comments/selectors.scss
+++ b/tests/scss/comments/selectors.scss
@@ -60,3 +60,8 @@
 .bar
 // comment 29
 {}
+
+@media screen, // comment 30
+  print { 
+  // comment 31
+}


### PR DESCRIPTION
As reported in #8915: In SCSS, if media queries contain single-line comments, they would be reformatted. Any continuation of the query that was previously on the next line would be commented out. 

The CSS plugin [already bails on comments inside selectors](https://github.com/prettier/prettier/blob/master/src/language-css/parser-postcss.js#L233); do the same thing for single-line comments in media queries.

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**

Fixes #8915