### PR TITLE
Added `undefined` to the list of keywords used in deciding whether to line break union types

### DIFF
--- a/changelog_unreleased/typescript/pr-9145.md
+++ b/changelog_unreleased/typescript/pr-9145.md
@@ -1,0 +1,21 @@
+#### Do not line break union types where all but one option are keywords and contain `undefined` (#9145 by @ehrencrona)
+
+<!-- prettier-ignore -->
+```typescript
+// Input
+type T = {
+  foo: string,
+} | undefined;
+
+// Prettier stable
+type T =
+  | {
+      foo: string;
+    }
+  | undefined;
+
+// Prettier master
+type T = {
+  foo: string;
+} | undefined;
+```

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5080,6 +5080,7 @@ function shouldHugType(node) {
       (n) =>
         n.type === "VoidTypeAnnotation" ||
         n.type === "TSVoidKeyword" ||
+        n.type === "TSUndefinedKeyword" ||
         n.type === "NullLiteralTypeAnnotation" ||
         n.type === "TSNullKeyword"
     ).length;

--- a/tests/typescript/cast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/cast/__snapshots__/jsfmt.spec.js.snap
@@ -109,18 +109,17 @@ function y() {
   >someExistingConfigMap.mergeDeep(fallbackOptions);
 
   const stillTooLong2 = <
-    | Immutable.Map<
-        string,
-        boolean,
-        number,
-        object,
-        null,
-        undefined,
-        any,
-        void,
-        never
-      >
-    | undefined
+    Immutable.Map<
+      string,
+      boolean,
+      number,
+      object,
+      null,
+      undefined,
+      any,
+      void,
+      never
+    > | undefined
   >someExistingConfigMap.mergeDeep(fallbackOptions);
 
   const stillTooLong3 = <Immutable.Map<string>>(
@@ -130,18 +129,17 @@ function y() {
   );
 
   const stillTooLong4 = <
-    | Immutable.Map<
-        string,
-        boolean,
-        number,
-        object,
-        null,
-        undefined,
-        any,
-        void,
-        never
-      >
-    | undefined
+    Immutable.Map<
+      string,
+      boolean,
+      number,
+      object,
+      null,
+      undefined,
+      any,
+      void,
+      never
+    > | undefined
   >someExistingConfigMap.mergeDeep(
     fallbackOptions.someMethodWithLongName(param1, param2)
   );

--- a/tests/typescript/union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/union/__snapshots__/jsfmt.spec.js.snap
@@ -48,6 +48,10 @@ type T6 = number | (((arg: any) => void));
 type T7 = number | ((((arg: any) => void)));
 type T8 = number | (((((arg: any) => void))));
 
+type T9 = {
+  __id: string,
+} | undefined;
+
 =====================================output=====================================
 interface RelayProps {
   articles: a | null;
@@ -90,6 +94,10 @@ type T5 = number | ((arg: any) => void);
 type T6 = number | ((arg: any) => void);
 type T7 = number | ((arg: any) => void);
 type T8 = number | ((arg: any) => void);
+
+type T9 = {
+  __id: string;
+} | undefined;
 
 ================================================================================
 `;

--- a/tests/typescript/union/inlining.ts
+++ b/tests/typescript/union/inlining.ts
@@ -39,3 +39,7 @@ type T5 = number | ((arg: any) => void);
 type T6 = number | (((arg: any) => void));
 type T7 = number | ((((arg: any) => void)));
 type T8 = number | (((((arg: any) => void))));
+
+type T9 = {
+  __id: string,
+} | undefined;


### PR DESCRIPTION
To decide if union types should be single or multi-lines, it looks at whether all the options in except for one are single keywords, i.e. `null` or `void`. Added `undefined` to this list of keywords to fix #8877.

Fixes #8877 

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
