### PR TITLE
Enable `CR` test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -20,7 +20,10 @@ module.exports = {
     : [],
   collectCoverage: ENABLE_CODE_COVERAGE,
   collectCoverageFrom: ["<rootDir>/src/**/*.js", "<rootDir>/bin/**/*.js"],
-  coveragePathIgnorePatterns: ["<rootDir>/src/document/doc-debug.js"],
+  coveragePathIgnorePatterns: [
+    "<rootDir>/src/standalone.js",
+    "<rootDir>/src/document/doc-debug.js",
+  ],
   coverageReporters: ["text", "lcov"],
   moduleNameMapper: {
     "prettier/local": "<rootDir>/tests_config/require_prettier.js",

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -299,11 +299,7 @@ function runTest({
   }
 
   if (!code.includes("\r") && !formatOptions.requirePragma) {
-    for (const eol of [
-      "\r\n",
-      // There are some edge cases failed on `\r` test, disable for now
-      // "\r"
-    ]) {
+    for (const eol of ["\r\n", "\r"]) {
       test(`[${parser}] EOL ${JSON.stringify(eol)}`, () => {
         const output = format(code.replace(/\n/g, eol), formatOptions)
           .eolVisualizedOutput;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

As we can see on first commit, there are several tests failed.

1. [1](https://github.com/prettier/prettier/runs/1072793119?check_suite_focus=true#step:7:53943), [2](https://github.com/prettier/prettier/runs/1072793119?check_suite_focus=true#step:7:53974), [3](https://github.com/prettier/prettier/runs/1072793119?check_suite_focus=true#step:7:54005), [4](https://github.com/prettier/prettier/runs/1072793119?check_suite_focus=true#step:7:54036), [5](https://github.com/prettier/prettier/runs/1072793119?check_suite_focus=true#step:7:54067), [6](https://github.com/prettier/prettier/runs/1072793119?check_suite_focus=true#step:7:54096), [7](https://github.com/prettier/prettier/runs/1072793119?check_suite_focus=true#step:7:54125), [8](https://github.com/prettier/prettier/runs/1072793119?check_suite_focus=true#step:7:54154) fails, because `jest-docblock` can't work with EOL `CR`, fixed by replacing EOL before pass to `jest-docblock`

2. [1](https://github.com/prettier/prettier/runs/1072793119?check_suite_focus=true#step:7:54184) [2](https://github.com/prettier/prettier/runs/1072793119?check_suite_focus=true#step:7:54211), similar to the first one, `pragma` check for `graphql`/`yaml`, only works for `LF` as EOL




<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
