### PR TITLE
Switch `get-stream` to `get-stdin`

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fast-json-stable-stringify": "2.1.0",
     "find-parent-dir": "0.3.0",
     "flow-parser": "0.133.0",
-    "get-stream": "6.0.0",
+    "get-stdin": "8.0.0",
     "globby": "11.0.1",
     "graphql": "15.3.0",
     "html-element-attributes": "2.2.1",

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -16,7 +16,7 @@ const partition = require("lodash/partition");
 // eslint-disable-next-line no-restricted-modules
 const prettier = require("../index");
 // eslint-disable-next-line no-restricted-modules
-const { getStream } = require("../common/third-party");
+const { getStdin } = require("../common/third-party");
 const {
   createIgnorer,
   errors,
@@ -387,7 +387,7 @@ function formatStdin(context) {
     ? path.relative(path.dirname(context.argv["ignore-path"]), filepath)
     : path.relative(process.cwd(), filepath);
 
-  getStream(process.stdin)
+  getStdin()
     .then((input) => {
       if (
         relativeFilepath &&

--- a/src/common/third-party.js
+++ b/src/common/third-party.js
@@ -4,6 +4,6 @@ module.exports = {
   cosmiconfig: require("cosmiconfig").cosmiconfig,
   cosmiconfigSync: require("cosmiconfig").cosmiconfigSync,
   findParentDir: require("find-parent-dir").sync,
-  getStream: require("get-stream"),
+  getStdin: require("get-stdin"),
   isCI: () => require("ci-info").isCI,
 };

--- a/tests_integration/runPrettier.js
+++ b/tests_integration/runPrettier.js
@@ -74,7 +74,7 @@ function runPrettier(dir, args, options) {
   // production build everything is bundled into one file so there is no
   // "get-stream" module to mock.
   jest
-    .spyOn(require(thirdParty), "getStream")
+    .spyOn(require(thirdParty), "getStdin")
     .mockImplementation(() => SynchronousPromise.resolve(options.input || ""));
   jest
     .spyOn(require(thirdParty), "isCI")

--- a/yarn.lock
+++ b/yarn.lock
@@ -3986,6 +3986,11 @@ get-package-type@^0.1.0:
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
   integrity sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
 
+get-stdin@8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-8.0.0.tgz#cbad6a73feb75f6eeb22ba9e01f89aa28aa97a53"
+  integrity sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==
+
 get-stdin@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
@@ -3995,11 +4000,6 @@ get-stdin@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-7.0.0.tgz#8d5de98f15171a125c5e516643c7a6d0ea8a96f6"
   integrity sha512-zRKcywvrXlXsA0v0i9Io4KDRaAw7+a1ZpjRwl9Wox8PFlVCCHra7E9c4kqXCoCM9nR5tBkaTTZRBoCm60bFqTQ==
-
-get-stream@6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.0.tgz#3e0012cb6827319da2706e601a1583e8629a6718"
-  integrity sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==
 
 get-stream@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

`get-stdin` is simpler

- <https://unpkg.com/browse/get-stdin@8.0.0/>
- <https://unpkg.com/browse/get-stream@6.0.0/>

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
