### PR TITLE
Variable declarations with union types should allow for a line break after the equals sign

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -4966,7 +4966,14 @@ function printAssignmentRight(leftNode, rightNode, printedRight, options) {
       // do not put values on a separate line from the key in json
       options.parser !== "json" &&
       options.parser !== "json5") ||
-    rightNode.type === "SequenceExpression";
+    rightNode.type === "SequenceExpression" ||
+    // variable definitions with union types can get very long;
+    // allow breaks after them
+    (leftNode.type === "Identifier" &&
+      leftNode.typeAnnotation &&
+      leftNode.typeAnnotation.type === "TSTypeAnnotation" &&
+      leftNode.typeAnnotation.typeAnnotation &&
+      leftNode.typeAnnotation.typeAnnotation.type === "TSUnionType");
 
   if (canBreak) {
     return group(indent(concat([line, printedRight])));

--- a/tests/typescript/union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/union/__snapshots__/jsfmt.spec.js.snap
@@ -48,6 +48,24 @@ type T6 = number | (((arg: any) => void));
 type T7 = number | ((((arg: any) => void)));
 type T8 = number | (((((arg: any) => void))));
 
+const existingAdWordsMasterAccount: AdWordsMasterMccAccountModel | undefined = this.allAdWordsMasterMccAccounts.find((item) => item.isTheOne());
+
+const existingAdWordsMasterAccount: (AdWordsMasterMccAccountModel | undefined) = this.allAdWordsMasterMccAccounts.find((item) => item.isTheOne());
+
+const a: Short | undefined = shortFunctionName();
+
+const a: Short | undefined = morePlaces(forPotentialLineBreaks());
+
+let a: LoooooooooooooooongTypeNames | ThatMakeTheLineGrowOverEightyChars = a.shortFn();
+
+let a: LoooooooooooooooongTypeNames | ThatEvenTakenByThemselves | AreLongerThanEightyChars = a.shortFn();
+
+const x: Short | ThisToo = thisFunctionNameIsSoLongThatItMakesTheLineExceedEightyChars();
+
+const x: Short | ThisToo = thisFunctionNameIsABitShorter(butTheLineInTotalStillExceedsEightyChars());
+
+const x: Short | ThisToo = thisFunctionNameIsABitShorter(butTheFunctionCallsByThemselvesExceedEightyChars());
+
 =====================================output=====================================
 interface RelayProps {
   articles: a | null;
@@ -90,6 +108,35 @@ type T5 = number | ((arg: any) => void);
 type T6 = number | ((arg: any) => void);
 type T7 = number | ((arg: any) => void);
 type T8 = number | ((arg: any) => void);
+
+const existingAdWordsMasterAccount: AdWordsMasterMccAccountModel | undefined =
+  this.allAdWordsMasterMccAccounts.find((item) => item.isTheOne());
+
+const existingAdWordsMasterAccount: AdWordsMasterMccAccountModel | undefined =
+  this.allAdWordsMasterMccAccounts.find((item) => item.isTheOne());
+
+const a: Short | undefined = shortFunctionName();
+
+const a: Short | undefined = morePlaces(forPotentialLineBreaks());
+
+let a: LoooooooooooooooongTypeNames | ThatMakeTheLineGrowOverEightyChars =
+  a.shortFn();
+
+let a:
+  | LoooooooooooooooongTypeNames
+  | ThatEvenTakenByThemselves
+  | AreLongerThanEightyChars = a.shortFn();
+
+const x: Short | ThisToo =
+  thisFunctionNameIsSoLongThatItMakesTheLineExceedEightyChars();
+
+const x: Short | ThisToo =
+  thisFunctionNameIsABitShorter(butTheLineInTotalStillExceedsEightyChars());
+
+const x: Short | ThisToo =
+  thisFunctionNameIsABitShorter(
+    butTheFunctionCallsByThemselvesExceedEightyChars()
+  );
 
 ================================================================================
 `;

--- a/tests/typescript/union/inlining.ts
+++ b/tests/typescript/union/inlining.ts
@@ -39,3 +39,21 @@ type T5 = number | ((arg: any) => void);
 type T6 = number | (((arg: any) => void));
 type T7 = number | ((((arg: any) => void)));
 type T8 = number | (((((arg: any) => void))));
+
+const existingAdWordsMasterAccount: AdWordsMasterMccAccountModel | undefined = this.allAdWordsMasterMccAccounts.find((item) => item.isTheOne());
+
+const existingAdWordsMasterAccount: (AdWordsMasterMccAccountModel | undefined) = this.allAdWordsMasterMccAccounts.find((item) => item.isTheOne());
+
+const a: Short | undefined = shortFunctionName();
+
+const a: Short | undefined = morePlaces(forPotentialLineBreaks());
+
+let a: LoooooooooooooooongTypeNames | ThatMakeTheLineGrowOverEightyChars = a.shortFn();
+
+let a: LoooooooooooooooongTypeNames | ThatEvenTakenByThemselves | AreLongerThanEightyChars = a.shortFn();
+
+const x: Short | ThisToo = thisFunctionNameIsSoLongThatItMakesTheLineExceedEightyChars();
+
+const x: Short | ThisToo = thisFunctionNameIsABitShorter(butTheLineInTotalStillExceedsEightyChars());
+
+const x: Short | ThisToo = thisFunctionNameIsABitShorter(butTheFunctionCallsByThemselvesExceedEightyChars());


### PR DESCRIPTION
When declaring a union type variable in TypeScript the declaration itself can be pretty long, so allow a line break after the equals sign.

i.e. rather than 

```
let a:
  | LoooooooooooooooongTypeNames
  | ThatMakeTheLineGrowOverEightyChars = a.shortFn();
```

produce

```
let a: LoooooooooooooooongTypeNames | ThatMakeTheLineGrowOverEightyChars =
  a.shortFn();
```

This fixes #8877.

- [x] I’ve added tests to confirm my change works.
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
