### PR TITLE
Fix plugin search on `pnpm`

### DIFF
--- a/changelog_unreleased/api/pr-9167.md
+++ b/changelog_unreleased/api/pr-9167.md
@@ -1,0 +1,3 @@
+#### Fix plugins search with `pnpm` (#9167 by @fisker)
+
+Previously, when install `prettier` and plugins with `pnpm`, the installed plugins can't load automaticlly.

--- a/changelog_unreleased/api/pr-9167.md
+++ b/changelog_unreleased/api/pr-9167.md
@@ -1,3 +1,3 @@
 #### Fix plugins search with `pnpm` (#9167 by @fisker)
 
-Previously, when install `prettier` and plugins with `pnpm`, the installed plugins can't load automaticlly.
+Previously, when install `prettier` and plugins with `pnpm`, the installed plugins can't load automatically.

--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -7,7 +7,7 @@ const partition = require("lodash/partition");
 const globby = require("globby");
 const mem = require("mem");
 const internalPlugins = require("../languages");
-const thirdParty = require("./third-party");
+const {findParentDir} = require("./third-party");
 const resolve = require("./resolve");
 
 const memoizedLoad = mem(load, { cacheKey: JSON.stringify });
@@ -27,9 +27,17 @@ function load(plugins, pluginSearchDirs) {
   }
   // unless pluginSearchDirs are provided, auto-load plugins from node_modules that are parent to Prettier
   if (!pluginSearchDirs.length) {
-    const autoLoadDir = thirdParty.findParentDir(__dirname, "node_modules");
-    if (autoLoadDir) {
-      pluginSearchDirs = [autoLoadDir];
+    const nodeModulesDir = findParentDir(__dirname, "node_modules");
+    if (nodeModulesDir) {
+      const dotPnpmDir = findParentDir(nodeModulesDir, ".pnpm");
+      if (dotPnpmDir) {
+        const nodeModulesDir = findParentDir(dotPnpmDir, "node_modules");
+        if (nodeModulesDir) {
+          pluginSearchDirs = [nodeModulesDir];
+        }
+      } else {
+        pluginSearchDirs = [nodeModulesDir];
+      }
     }
   }
 

--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -7,7 +7,7 @@ const partition = require("lodash/partition");
 const globby = require("globby");
 const mem = require("mem");
 const internalPlugins = require("../languages");
-const {findParentDir} = require("./third-party");
+const { findParentDir } = require("./third-party");
 const resolve = require("./resolve");
 
 const memoizedLoad = mem(load, { cacheKey: JSON.stringify });
@@ -27,17 +27,11 @@ function load(plugins, pluginSearchDirs) {
   }
   // unless pluginSearchDirs are provided, auto-load plugins from node_modules that are parent to Prettier
   if (!pluginSearchDirs.length) {
-    const nodeModulesDir = findParentDir(__dirname, "node_modules");
-    if (nodeModulesDir) {
-      const dotPnpmDir = findParentDir(nodeModulesDir, ".pnpm");
-      if (dotPnpmDir) {
-        const nodeModulesDir = findParentDir(dotPnpmDir, "node_modules");
-        if (nodeModulesDir) {
-          pluginSearchDirs = [nodeModulesDir];
-        }
-      } else {
-        pluginSearchDirs = [nodeModulesDir];
-      }
+    const autoLoadDir =
+      findParentDir(__dirname, "node_modules/.pnpm") ||
+      findParentDir(__dirname, "node_modules");
+    if (autoLoadDir) {
+      pluginSearchDirs = [autoLoadDir];
     }
   }
 


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Local tested, it not easy to test, because this logic need plugin installed in same location with `prettier`.

Fixes #8056

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
