### PR TITLE
CSS: format camelCase props to kebab-case

### DIFF
--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -32,6 +32,7 @@ const {
   getAncestorNode,
   getPropOfDeclNode,
   maybeToLowerCase,
+  maybeToKebabOrLowerCase,
   insideValueFunctionNode,
   insideICSSRuleNode,
   insideAtRuleNode,
@@ -152,7 +153,9 @@ function genericPrint(path, options, print) {
 
       return concat([
         node.raws.before.replace(/[\s;]/g, ""),
-        insideICSSRuleNode(path) ? node.prop : maybeToLowerCase(node.prop),
+        insideICSSRuleNode(path)
+          ? node.prop
+          : maybeToKebabOrLowerCase(node.prop),
         trimmedBetween.startsWith("//") ? " " : "",
         trimmedBetween,
         node.extend ? "" : " ",

--- a/src/language-css/utils.js
+++ b/src/language-css/utils.js
@@ -123,6 +123,21 @@ function maybeToLowerCase(value) {
     : value.toLowerCase();
 }
 
+function maybeToKebabOrLowerCase(value) {
+  return value.includes("$") ||
+    value.includes("@") ||
+    value.includes("#") ||
+    value.startsWith("%") ||
+    value.startsWith("--") ||
+    value.startsWith(":--") ||
+    (value.includes("(") && value.includes(")"))
+    ? value
+    : // Check if value is exactlyCamelCase
+    /^[a-z]+[A-Z]+[A-Za-z]*$/.test(value)
+    ? value.replace(/([a-z]|(?=[A-Z]))([A-Z])/g, "$1-$2").toLowerCase()
+    : value.toLowerCase();
+}
+
 function insideValueFunctionNode(path, functionName) {
   const funcAncestorNode = getAncestorNode(path, "value-func");
   return (
@@ -469,6 +484,7 @@ module.exports = {
   hasSCSSInterpolation,
   hasStringOrFunction,
   maybeToLowerCase,
+  maybeToKebabOrLowerCase,
   insideValueFunctionNode,
   insideICSSRuleNode,
   insideAtRuleNode,

--- a/tests/css/case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/css/case/__snapshots__/jsfmt.spec.js.snap
@@ -158,3 +158,49 @@ printWidth: 80
 
 ================================================================================
 `;
+
+exports[`kebab-case.css format 1`] = `
+====================================options=====================================
+parsers: ["css"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+.fromCssInJsToCss {
+  backgroundAttachment: fixed;
+}
+
+.another-css-in-js-to-css {
+  marginBottom: 2px;
+  maxWidth: 42;
+}
+
+.yet-another-css-in-js-to-css {
+  borderBottomRightRadius: 0%;
+  borderTopRightRadius: 12;
+}
+
+.not-css-in-js {
+  border-top-right-radius: 0%;
+}
+
+=====================================output=====================================
+.fromCssInJsToCss {
+  background-attachment: fixed;
+}
+
+.another-css-in-js-to-css {
+  margin-bottom: 2px;
+  max-width: 42;
+}
+
+.yet-another-css-in-js-to-css {
+  border-bottom-right-radius: 0%;
+  border-top-right-radius: 12;
+}
+
+.not-css-in-js {
+  border-top-right-radius: 0%;
+}
+
+================================================================================
+`;

--- a/tests/css/case/kebab-case.css
+++ b/tests/css/case/kebab-case.css
@@ -1,0 +1,17 @@
+.fromCssInJsToCss {
+  backgroundAttachment: fixed;
+}
+
+.another-css-in-js-to-css {
+  marginBottom: 2px;
+  maxWidth: 42;
+}
+
+.yet-another-css-in-js-to-css {
+  borderBottomRightRadius: 0%;
+  borderTopRightRadius: 12;
+}
+
+.not-css-in-js {
+  border-top-right-radius: 0%;
+}


### PR DESCRIPTION
First, I want to thank you for your works on Prettier.

I add a little tweak for the CSS printer that will transform camelCase to kebab-case, pretty useful when I copy CSS-in-JS rules:
```css
.fromCssInJsToCss {
  backgroundAttachment: fixed;
}
```
and Prettier can transform that to:
```css
.fromCssInJsToCss {
  background-attachment: fixed;
}
```

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
