### PR TITLE
Use better fonts in Playground

### DIFF
--- a/website/static/separate-css/playground.css
+++ b/website/static/separate-css/playground.css
@@ -144,6 +144,7 @@ header h1 {
   right: 0;
   bottom: 0;
   line-height: 1.6;
+  font-family: "Lucida Console", Monaco, monospace;
 }
 
 .bottom-bar {

--- a/website/static/separate-css/playground.css
+++ b/website/static/separate-css/playground.css
@@ -144,7 +144,7 @@ header h1 {
   right: 0;
   bottom: 0;
   line-height: 1.6;
-  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
 }
 
 .bottom-bar {

--- a/website/static/separate-css/playground.css
+++ b/website/static/separate-css/playground.css
@@ -144,7 +144,7 @@ header h1 {
   right: 0;
   bottom: 0;
   line-height: 1.6;
-  font-family: "Lucida Console", Monaco, monospace;
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
 }
 
 .bottom-bar {


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
I've always found fonts used in Playground's CodeMirror hard to read. If you know any other good fonts, please let me know.

What do you think?
***
Screen shots were taken on Google Chrome on MacOS.
**Before(current):**
<img width="2047" alt="スクリーンショット 2020-09-12 22 47 56" src="https://user-images.githubusercontent.com/14838850/92996895-0ba57800-f54a-11ea-9fff-0b667ef21e20.png">
**After:**
<img width="2048" alt="スクリーンショット 2020-09-12 22 47 12" src="https://user-images.githubusercontent.com/14838850/92996898-13fdb300-f54a-11ea-8ca8-d524949891aa.png">

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
