### PR TITLE
Typescript tagged template literal test

### DIFF
--- a/tests/typescript/template-literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/template-literals/__snapshots__/jsfmt.spec.js.snap
@@ -30,3 +30,18 @@ const b = \`\${
 
 ================================================================================
 `;
+
+exports[`expressions.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const bar = tag<number>\`but where will prettier wrap such a long tagged template literal? \${foo.bar.baz} long long long long long long long long long long long long long long\`;
+=====================================output=====================================
+const bar = tag<
+  number
+>\`but where will prettier wrap such a long tagged template literal? \${foo.bar.baz} long long long long long long long long long long long long long long\`;
+
+================================================================================
+`;

--- a/tests/typescript/template-literals/expressions.ts
+++ b/tests/typescript/template-literals/expressions.ts
@@ -1,0 +1,1 @@
+const bar = tag<number>`but where will prettier wrap such a long tagged template literal? ${foo.bar.baz} long long long long long long long long long long long long long long`;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

I've added a new test that demonstrates how prettier behaves with typed literals in Typescript that have generic parameters.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground/#N4Igxg9gdgLgprEAuc0DOMAEAjAhgJ0wF5MZcBzAHigFcBbbOfAPgANsasB3ACybkxcAlgBsRmAA744MGEKaD8uCZjQ0wPTLkwjo5UhXJwAJqTh0JI3PB1D4SkQH5MAEmAAzCBAB0efL9wALwBfHT0wqH1dSIio8Oi4mITYlOS0+L1WAG4QABoQCAk5dGRQAnwILgAFAgQ0ZBBcES5cAE96-OwlMABrGQBlCVwwIUjkGHwaOHzzRmNjEwAZXEiaCjgAMQh8Oms5MZRcTgg8kB4YOhEAdR47ODQhsDh+urshADc7VoawNA6QUZoJgwKpKci7ZDuJpA-IAKzQAA8AELdPowfq4OhwRajOCQ6HTEDwhH9UbkERwACKNAg8HxIhhICG+CB+AaMFaEnuYHwQiKpykoxgVyExhgPGQAA4AAz5KQQIFXJQSBpSe5Md54-IARxp8FBhXqhzQAFooHATCZTtJdUJpKCKBCkFCGYSgXQhONJm6yRTqbS8c6CfkyNgRWKJUgAEwhpSiMkAYQgdCdIHuAFZTjQgQAVXDYI0uxnvKYASSgC1g-R5fJgAEEK-0ORT6UDgsEgA)✨**
