### PR TITLE
CI: Move `Check Sizes` to a separate job

### DIFF
--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -41,16 +41,6 @@ jobs:
           name: dist
           path: dist
 
-      # This step calls `git reset`
-      # It should be the last step
-      # The cache step might saving the result of master branch, need investigate
-      - name: Check Sizes
-        if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'dependabot/npm_and_yarn/')
-        uses: preactjs/compressed-size-action@v2.0.1
-        with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
-          compression: none
-
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -73,6 +63,30 @@ jobs:
 
       - name: Lint Code
         run: yarn lint:dist
+
+  size:
+    name: Check Sizes
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'dependabot/npm_and_yarn/')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v2.1.1
+
+      - name: Download Artifact
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+
+      - name: Check Sizes
+        uses: preactjs/compressed-size-action@v2.0.1
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          compression: none
 
   test:
     timeout-minutes: 60


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

This should speed up build step

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
