### PR TITLE
Remove `.flowconfig`

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -1,4 +1,0 @@
-[ignore]
-.*/tests/.*
-.*/node_modules/.*
-.*/dist/.*


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

`.flowconfig` file is added in #1711, for [Nuclide](https://github.com/facebookarchive/nuclide), and [Nuclide is retired](https://github.com/facebookarchive/nuclide/blob/master/docs/index.md#retiring-the-nuclide-open-source-project)

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
