### PR TITLE
CLI: Fix error on dir or file that name is a number

### DIFF
--- a/changelog_unreleased/cli/pr-9298.md
+++ b/changelog_unreleased/cli/pr-9298.md
@@ -1,0 +1,15 @@
+#### Fix error on dir or file that name is a number (#9298 by @fisker)
+
+<!-- prettier-ignore -->
+```console
+$ cat 1/index.js
+hello('world')
+
+// Prettier stable
+$ prettier 1
+[error] The "path" argument must be of type string. Received type number (1)
+
+// Prettier master
+$ prettier 1
+hello("world");
+```

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -1010,7 +1010,7 @@ function updateContextArgv(context, plugins, pluginSearchDirs) {
   const argv = minimist(context.args, minimistOptions);
 
   context.argv = argv;
-  context.filePatterns = argv._.map(file => String(file));
+  context.filePatterns = argv._.map((file) => String(file));
 }
 
 function normalizeContextArgv(context, keys) {

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -1010,7 +1010,7 @@ function updateContextArgv(context, plugins, pluginSearchDirs) {
   const argv = minimist(context.args, minimistOptions);
 
   context.argv = argv;
-  context.filePatterns = argv._;
+  context.filePatterns = argv._.map(file => String(file));
 }
 
 function normalizeContextArgv(context, keys) {

--- a/tests_integration/__tests__/__snapshots__/arg-parsing.js.snap
+++ b/tests_integration/__tests__/__snapshots__/arg-parsing.js.snap
@@ -23,12 +23,12 @@ exports[`negated options work (stdout) 1`] = `
 exports[`negated options work (write) 1`] = `Array []`;
 
 exports[`number file/dir (stdout) 1`] = `
-"1\\\\file-in-dir-named-1.js
+"1/file-in-dir-named-1.js
 "
 `;
 
 exports[`number file/dir (stdout) 2`] = `
-"2.2\\\\file-in-dir-named-2.2.js
+"2.2/file-in-dir-named-2.2.js
 "
 `;
 
@@ -43,8 +43,8 @@ exports[`number file/dir (stdout) 4`] = `
 `;
 
 exports[`number file/dir (stdout) 5`] = `
-"1\\\\file-in-dir-named-1.js
-2.2\\\\file-in-dir-named-2.2.js
+"1/file-in-dir-named-1.js
+2.2/file-in-dir-named-2.2.js
 3
 4.44
 "

--- a/tests_integration/__tests__/__snapshots__/arg-parsing.js.snap
+++ b/tests_integration/__tests__/__snapshots__/arg-parsing.js.snap
@@ -22,6 +22,34 @@ exports[`negated options work (stdout) 1`] = `
 
 exports[`negated options work (write) 1`] = `Array []`;
 
+exports[`number file/dir (stdout) 1`] = `
+"1\\\\file-in-dir-named-1.js
+"
+`;
+
+exports[`number file/dir (stdout) 2`] = `
+"2.2\\\\file-in-dir-named-2.2.js
+"
+`;
+
+exports[`number file/dir (stdout) 3`] = `
+"3
+"
+`;
+
+exports[`number file/dir (stdout) 4`] = `
+"4.44
+"
+`;
+
+exports[`number file/dir (stdout) 5`] = `
+"1\\\\file-in-dir-named-1.js
+2.2\\\\file-in-dir-named-2.2.js
+3
+4.44
+"
+`;
+
 exports[`unknown negated options are warned (stderr) 1`] = `
 "[warn] Ignored unknown option --no-unknown.
 "

--- a/tests_integration/__tests__/arg-parsing.js
+++ b/tests_integration/__tests__/arg-parsing.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const runPrettier = require("../runPrettier");
+expect.addSnapshotSerializer(require("../path-serializer"));
 
 describe("boolean flags do not swallow the next argument", () => {
   runPrettier("cli/arg-parsing", [

--- a/tests_integration/__tests__/arg-parsing.js
+++ b/tests_integration/__tests__/arg-parsing.js
@@ -63,3 +63,27 @@ describe("allow overriding flags", () => {
     status: 0,
   });
 });
+
+describe("number file/dir", () => {
+  const patterns = ["1", "2.2", "3", "4.44"];
+  for (const pattern of patterns) {
+    runPrettier("cli/arg-parsing/number", [
+      "--parser=babel",
+      "--list-different",
+      pattern,
+    ]).test({
+      stderr: "",
+      status: 1,
+      write: [],
+    });
+  }
+  runPrettier("cli/arg-parsing/number", [
+    "--parser=babel",
+    "--list-different",
+    ...patterns,
+  ]).test({
+    stderr: "",
+    status: 1,
+    write: [],
+  });
+});

--- a/tests_integration/cli/arg-parsing/number/1/file-in-dir-named-1.js
+++ b/tests_integration/cli/arg-parsing/number/1/file-in-dir-named-1.js
@@ -1,0 +1,2 @@
+hello(
+     'prettier')

--- a/tests_integration/cli/arg-parsing/number/2.2/file-in-dir-named-2.2.js
+++ b/tests_integration/cli/arg-parsing/number/2.2/file-in-dir-named-2.2.js
@@ -1,0 +1,2 @@
+hello(
+     'prettier')

--- a/tests_integration/cli/arg-parsing/number/3
+++ b/tests_integration/cli/arg-parsing/number/3
@@ -1,0 +1,2 @@
+hello(
+     'prettier')

--- a/tests_integration/cli/arg-parsing/number/4.44
+++ b/tests_integration/cli/arg-parsing/number/4.44
@@ -1,0 +1,2 @@
+hello(
+     'prettier')


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Prettier can't work if a dir/file named `1` passed to CLI

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
