### PR TITLE
Style: no function reference in iterator methods

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -64,7 +64,6 @@ rules:
     - exceptRange: true
   unicorn/better-regex: error
   unicorn/new-for-builtins: error
-  unicorn/no-fn-reference-in-iterator: error
   unicorn/no-useless-undefined: error
   unicorn/prefer-includes: error
   unicorn/prefer-string-slice: error

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -64,6 +64,7 @@ rules:
     - exceptRange: true
   unicorn/better-regex: error
   unicorn/new-for-builtins: error
+  unicorn/no-fn-reference-in-iterator: error
   unicorn/no-useless-undefined: error
   unicorn/prefer-includes: error
   unicorn/prefer-string-slice: error

--- a/scripts/draft-blog-post.js
+++ b/scripts/draft-blog-post.js
@@ -112,7 +112,7 @@ function printEntries({ title, filter }) {
   const result = [];
 
   for (const { entries = [], title } of categories) {
-    const filteredEntries = entries.filter(filter);
+    const filteredEntries = entries.filter((entry) => filter(entry));
     if (filteredEntries.length) {
       result.push("### " + title);
       result.push(...filteredEntries.map((entry) => entry.content));

--- a/scripts/generate-schema.js
+++ b/scripts/generate-schema.js
@@ -84,7 +84,7 @@ function optionToSchema(option) {
     default: option.default,
     ...(option.array ? wrapWithArraySchema : identity)(
       option.type === "choice"
-        ? { oneOf: option.choices.map(choiceToSchema) }
+        ? { oneOf: option.choices.map((choice) => choiceToSchema(choice)) }
         : { type: optionTypeToSchemaType(option.type) }
     ),
   };

--- a/src/cli/util.js
+++ b/src/cli/util.js
@@ -651,7 +651,9 @@ function createOptionUsage(context, option, threshold) {
 
 function createDefaultValueDisplay(value) {
   return Array.isArray(value)
-    ? `[${value.map(createDefaultValueDisplay).join(", ")}]`
+    ? `[${value
+        .map((valueItem) => createDefaultValueDisplay(valueItem))
+        .join(", ")}]`
     : value;
 }
 

--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -112,7 +112,9 @@ function findPluginsInNodeModules(nodeModulesDir) {
       expandDirectories: false,
     }
   );
-  return pluginPackageJsonPaths.map(path.dirname);
+  return pluginPackageJsonPaths.map((packageJsonFile) =>
+    path.dirname(packageJsonFile)
+  );
 }
 
 function isDirectory(dir) {

--- a/src/document/doc-builders.js
+++ b/src/document/doc-builders.js
@@ -31,7 +31,9 @@ function assertDoc(val) {
  */
 function concat(parts) {
   if (process.env.NODE_ENV !== "production") {
-    parts.forEach(assertDoc);
+    for (const part of parts) {
+      assertDoc(part);
+    }
   }
 
   // We cannot do this until we change `printJSXElement` to not
@@ -129,7 +131,9 @@ function conditionalGroup(states, opts) {
  */
 function fill(parts) {
   if (process.env.NODE_ENV !== "production") {
-    parts.forEach(assertDoc);
+    for (const part of parts) {
+      assertDoc(part);
+    }
   }
 
   return { type: "fill", parts };

--- a/src/document/doc-debug.js
+++ b/src/document/doc-debug.js
@@ -30,7 +30,7 @@ function flattenDoc(doc) {
       ...doc,
       contents: flattenDoc(doc.contents),
       expandedStates: doc.expandedStates
-        ? doc.expandedStates.map(flattenDoc)
+        ? doc.expandedStates.map((doc) => flattenDoc(doc))
         : doc.expandedStates,
     };
   } else if (doc.contents) {
@@ -66,7 +66,7 @@ function printDoc(doc) {
   }
 
   if (doc.type === "concat") {
-    return "[" + doc.parts.map(printDoc).join(", ") + "]";
+    return "[" + doc.parts.map((doc) => printDoc(doc)).join(", ") + "]";
   }
 
   if (doc.type === "indent") {
@@ -97,7 +97,7 @@ function printDoc(doc) {
       return (
         "conditionalGroup(" +
         "[" +
-        doc.expandedStates.map(printDoc).join(",") +
+        doc.expandedStates.map((doc) => printDoc(doc)).join(",") +
         "])"
       );
     }
@@ -111,7 +111,9 @@ function printDoc(doc) {
   }
 
   if (doc.type === "fill") {
-    return "fill" + "(" + doc.parts.map(printDoc).join(", ") + ")";
+    return (
+      "fill" + "(" + doc.parts.map((doc) => printDoc(doc)).join(", ") + ")"
+    );
   }
 
   if (doc.type === "line-suffix") {

--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -151,7 +151,7 @@ function flattenGroups(node) {
   }
 
   if (node.type === "paren_group" || node.type === "comma_group") {
-    return { ...node, groups: node.groups.map(flattenGroups) };
+    return { ...node, groups: node.groups.map((doc) => flattenGroups(doc)) };
   }
 
   return node;

--- a/src/language-html/ast.js
+++ b/src/language-html/ast.js
@@ -37,7 +37,9 @@ class Node {
     for (const NODES_KEY in NODES_KEYS) {
       const nodes = this[NODES_KEY];
       if (nodes) {
-        const mappedNodes = mapNodesIfChanged(nodes, (node) => node.map(fn));
+        const mappedNodes = mapNodesIfChanged(nodes, (node) =>
+          node.map((node) => fn(node))
+        );
         if (newNode !== nodes) {
           if (!newNode) {
             newNode = new Node();
@@ -92,7 +94,7 @@ class Node {
 }
 
 function mapNodesIfChanged(nodes, fn) {
-  const newNodes = nodes.map(fn);
+  const newNodes = nodes.map((node) => fn(node));
   return newNodes.some((newNode, index) => newNode !== nodes[index])
     ? newNodes
     : nodes;

--- a/src/language-html/parser-html.js
+++ b/src/language-html/parser-html.js
@@ -70,7 +70,7 @@ function ngHtmlParser(
       const langValue = langAttr && langAttr.value;
       return langValue == null || getParserName(langValue, options) === "html";
     };
-    if (rootNodes.some(shouldParseAsHTML)) {
+    if (rootNodes.some((node) => shouldParseAsHTML(node))) {
       let secondParseResult;
       const doSecondParse = () =>
         parser.parse(input, {

--- a/src/language-html/preprocess.js
+++ b/src/language-html/preprocess.js
@@ -70,7 +70,7 @@ function mergeIeConditonalStartEndCommentIntoElementOpeningTag(
     node.firstChild.sourceSpan.start.offset === node.startSourceSpan.end.offset;
   return ast.map((node) => {
     if (node.children) {
-      const isTargetResults = node.children.map(isTarget);
+      const isTargetResults = node.children.map((child) => isTarget(child));
       if (isTargetResults.some(Boolean)) {
         const newChildren = [];
 
@@ -121,7 +121,9 @@ function mergeIeConditonalStartEndCommentIntoElementOpeningTag(
 function mergeNodeIntoText(ast, shouldMerge, getValue) {
   return ast.map((node) => {
     if (node.children) {
-      const shouldMergeResults = node.children.map(shouldMerge);
+      const shouldMergeResults = node.children.map((child) =>
+        shouldMerge(child)
+      );
       if (shouldMergeResults.some(Boolean)) {
         const newChildren = [];
         for (let i = 0; i < node.children.length; i++) {
@@ -192,7 +194,9 @@ function mergeSimpleElementIntoText(ast /*, options */) {
     node.next.type === "text";
   return ast.map((node) => {
     if (node.children) {
-      const isSimpleElementResults = node.children.map(isSimpleElement);
+      const isSimpleElementResults = node.children.map((child) =>
+        isSimpleElement(child)
+      );
       if (isSimpleElementResults.some(Boolean)) {
         const newChildren = [];
         for (let i = 0; i < node.children.length; i++) {

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -940,7 +940,7 @@ function isBlockComment(comment) {
  */
 function hasLeadingComment(node, fn = () => true) {
   if (node.leadingComments) {
-    return node.leadingComments.some(fn);
+    return node.leadingComments.some((comment) => fn(comment));
   }
   if (node.comments) {
     return node.comments.some((comment) => comment.leading && fn(comment));

--- a/src/language-js/parser-babel.js
+++ b/src/language-js/parser-babel.js
@@ -193,7 +193,9 @@ function rethrowSomeRecoveredErrors(ast) {
 function parseJson(text, parsers, opts) {
   const ast = parseExpression(text, parsers, opts);
 
-  ast.comments.forEach(assertJsonNode);
+  for (const comment of ast.comments) {
+    assertJsonNode(comment);
+  }
   assertJsonNode(ast);
 
   return ast;
@@ -202,9 +204,15 @@ function parseJson(text, parsers, opts) {
 function assertJsonNode(node, parent) {
   switch (node.type) {
     case "ArrayExpression":
-      return node.elements.forEach(assertJsonChildNode);
+      for (const node of node.elements) {
+        assertJsonNode(assertJsonChildNode);
+      }
+      return;
     case "ObjectExpression":
-      return node.properties.forEach(assertJsonChildNode);
+      for (const node of node.properties) {
+        assertJsonNode(assertJsonChildNode);
+      }
+      return;
     case "ObjectProperty":
       if (node.computed) {
         throw createJsonError("computed");
@@ -213,7 +221,9 @@ function assertJsonNode(node, parent) {
       if (node.shorthand) {
         throw createJsonError("shorthand");
       }
-      return [node.key, node.value].forEach(assertJsonChildNode);
+      assertJsonChildNode(node.key);
+      assertJsonChildNode(node.value);
+      return;
     case "UnaryExpression":
       switch (node.operator) {
         case "+":

--- a/src/language-js/postprocess.js
+++ b/src/language-js/postprocess.js
@@ -24,7 +24,7 @@ function postprocess(ast, options) {
     ast = visitNode(ast, (node) => {
       if (
         node.leadingComments &&
-        node.leadingComments.some(isTypeCastComment)
+        node.leadingComments.some((comment) => isTypeCastComment(comment))
       ) {
         startOffsetsOfTypeCastedNodes.add(locStart(node));
       }

--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -153,8 +153,9 @@ function printCallArguments(path, options, print) {
   if (shouldGroupFirst || shouldGroupLast) {
     const shouldBreak =
       (shouldGroupFirst
-        ? printedArguments.slice(1).some(willBreak)
-        : printedArguments.slice(0, -1).some(willBreak)) ||
+        ? printedArguments.slice(1)
+        : printedArguments.slice(0, -1)
+      ).some((doc) => willBreak(doc)) ||
       anyArgEmptyLine ||
       shouldBreakForArrowFunction;
 
@@ -186,7 +187,9 @@ function printCallArguments(path, options, print) {
       path.each(printArgument, "arguments");
     }
 
-    const somePrintedArgumentsWillBreak = printedArguments.some(willBreak);
+    const somePrintedArgumentsWillBreak = printedArguments.some((doc) =>
+      willBreak(doc)
+    );
 
     const simpleConcat = concat(["(", concat(printedExpanded), ")"]);
 
@@ -235,7 +238,8 @@ function printCallArguments(path, options, print) {
   }
 
   return group(contents, {
-    shouldBreak: printedArguments.some(willBreak) || anyArgEmptyLine,
+    shouldBreak:
+      printedArguments.some((doc) => willBreak(doc)) || anyArgEmptyLine,
   });
 }
 

--- a/src/language-js/print/member-chain.js
+++ b/src/language-js/print/member-chain.js
@@ -328,11 +328,19 @@ function printMemberChain(path, options, print) {
       return "";
     }
     return indent(
-      group(concat([hardline, join(hardline, groups.map(printGroup))]))
+      group(
+        concat([
+          hardline,
+          join(
+            hardline,
+            groups.map((group) => printGroup(group))
+          ),
+        ])
+      )
     );
   }
 
-  const printedGroups = groups.map(printGroup);
+  const printedGroups = groups.map((group) => printGroup(group));
   const oneLine = concat(printedGroups);
 
   const cutoff = shouldMerge ? 3 : 2;
@@ -361,14 +369,16 @@ function printMemberChain(path, options, print) {
 
   const expanded = concat([
     printGroup(groups[0]),
-    shouldMerge ? concat(groups.slice(1, 2).map(printGroup)) : "",
+    shouldMerge
+      ? concat(groups.slice(1, 2).map((group) => printGroup(group)))
+      : "",
     shouldHaveEmptyLineBeforeIndent ? hardline : "",
     printIndentedGroup(groups.slice(shouldMerge ? 2 : 1)),
   ]);
 
   const callExpressions = printedNodes
     .map(({ node }) => node)
-    .filter(isCallOrOptionalCallExpression);
+    .filter((node) => isCallOrOptionalCallExpression(node));
 
   function lastGroupWillBreakAndOtherCallsHaveFunctionArguments() {
     const lastGroupNode = getLast(getLast(groups)).node;
@@ -378,7 +388,9 @@ function printMemberChain(path, options, print) {
       willBreak(lastGroupDoc) &&
       callExpressions
         .slice(0, -1)
-        .some((n) => n.arguments.some(isFunctionOrArrowExpression))
+        .some((n) =>
+          n.arguments.some((node) => isFunctionOrArrowExpression(node))
+        )
     );
   }
 
@@ -394,7 +406,7 @@ function printMemberChain(path, options, print) {
       callExpressions.some(
         (expr) => !expr.arguments.every((arg) => isSimpleCallArgument(arg, 0))
       )) ||
-    printedGroups.slice(0, -1).some(willBreak) ||
+    printedGroups.slice(0, -1).some((group) => willBreak(group)) ||
     lastGroupWillBreakAndOtherCallsHaveFunctionArguments()
   ) {
     return group(expanded);

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -127,7 +127,7 @@ function getConditionalChainContents(node) {
 }
 
 function conditionalExpressionChainContainsJSX(node) {
-  return getConditionalChainContents(node).some(isJSXNode);
+  return getConditionalChainContents(node).some((node) => isJSXNode(node));
 }
 
 /**

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1155,8 +1155,8 @@ function printPathNoParens(path, options, print, args) {
       if (n.inexact) {
         let printed;
         if (hasDanglingComments(n)) {
-          const hasLineComments = !n.comments.every(
-            handleComments.isBlockComment
+          const hasLineComments = !n.comments.every((comment) =>
+            handleComments.isBlockComment(comment)
           );
           const printedDanglingComments = comments.printDanglingComments(
             path,
@@ -2101,7 +2101,8 @@ function printPathNoParens(path, options, print, args) {
     case "JSXClosingFragment": {
       const hasComment = n.comments && n.comments.length;
       const hasOwnLineComment =
-        hasComment && !n.comments.every(handleComments.isBlockComment);
+        hasComment &&
+        !n.comments.every((comment) => handleComments.isBlockComment(comment));
       const isOpeningFragment = n.type === "JSXOpeningFragment";
       return concat([
         isOpeningFragment ? "<" : "</",
@@ -2124,7 +2125,8 @@ function printPathNoParens(path, options, print, args) {
       throw new Error("JSXTest should be handled by JSXElement");
     case "JSXEmptyExpression": {
       const requiresHardline =
-        n.comments && !n.comments.every(handleComments.isBlockComment);
+        n.comments &&
+        !n.comments.every((comment) => handleComments.isBlockComment(comment));
 
       return concat([
         comments.printDanglingComments(
@@ -3927,7 +3929,7 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
       concat([
         removeLines(typeParams),
         "(",
-        concat(printed.map(removeLines)),
+        concat(printed.map((doc) => removeLines(doc))),
         ")",
       ])
     );
@@ -4205,8 +4207,8 @@ function printTypeParameters(path, options, print, paramsKey) {
     if (!hasDanglingComments(n)) {
       return "";
     }
-    const hasOnlyBlockComments = n.comments.every(
-      handleComments.isBlockComment
+    const hasOnlyBlockComments = n.comments.every((comment) =>
+      handleComments.isBlockComment(comment)
     );
     const printed = comments.printDanglingComments(
       path,
@@ -4597,7 +4599,7 @@ function printJSXElement(path, options, print) {
     return child;
   });
 
-  const containsTag = n.children.filter(isJSXNode).length > 0;
+  const containsTag = n.children.filter((child) => isJSXNode(child)).length > 0;
   const containsMultipleExpressions =
     n.children.filter((child) => child.type === "JSXExpressionContainer")
       .length > 1;

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -1113,7 +1113,7 @@ function isSimpleCallArgument(node, depth) {
   }
 
   if (node.type === "TemplateLiteral") {
-    return node.expressions.every(isChildSimple);
+    return node.expressions.every((node) => isChildSimple(node));
   }
 
   if (node.type === "ObjectExpression") {
@@ -1137,7 +1137,7 @@ function isSimpleCallArgument(node, depth) {
   ) {
     return (
       isSimpleCallArgument(node.callee, depth) &&
-      node.arguments.every(isChildSimple)
+      node.arguments.every((node) => isChildSimple(node))
     );
   }
 

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -31,7 +31,7 @@ function getSupportInfo({
 
   const languages = plugins
     .reduce((all, plugin) => all.concat(plugin.languages || []), [])
-    .filter(filterSince);
+    .filter((plugin) => filterSince(plugin));
 
   const options = arrayify(
     Object.assign({}, ...plugins.map(({ options }) => options), coreOptions),
@@ -39,7 +39,7 @@ function getSupportInfo({
   )
     .filter((option) => filterSince(option) && filterDeprecated(option))
     .sort((a, b) => (a.name === b.name ? 0 : a.name < b.name ? -1 : 1))
-    .map(mapInternal)
+    .map((option) => mapInternal(option))
     .map((option) => {
       option = { ...option };
 
@@ -48,7 +48,7 @@ function getSupportInfo({
           option.default.length === 1
             ? option.default[0].value
             : option.default
-                .filter(filterSince)
+                .filter((option) => filterSince(option))
                 .sort((info1, info2) =>
                   semver.compare(info2.since, info1.since)
                 )[0].value;

--- a/src/utils/front-matter.js
+++ b/src/utils/front-matter.js
@@ -11,7 +11,9 @@ const DELIMITER_MAP = {
 };
 
 function parse(text) {
-  const delimiterRegex = Object.keys(DELIMITER_MAP).map(escape).join("|");
+  const delimiterRegex = Object.keys(DELIMITER_MAP)
+    .map((delimiter) => escape(delimiter))
+    .join("|");
 
   const match = text.match(
     // trailing spaces after delimiters are allowed

--- a/website/playground/index.js
+++ b/website/playground/index.js
@@ -19,7 +19,9 @@ class App extends React.Component {
     this.worker.getMetadata().then(({ supportInfo, version }) => {
       this.setState({
         loaded: true,
-        availableOptions: supportInfo.options.map(augmentOption),
+        availableOptions: supportInfo.options.map((option) =>
+          augmentOption(option)
+        ),
         version: fixPrettierVersion(version),
       });
     });


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fix errors caught by [`unicorn/no-fn-reference-in-iterator`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/master/docs/rules/no-fn-reference-in-iterator.md), unfortunately it can't distinguish `FastPath#map` and `Array#map`, so we can't enable this rule.



- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
