### PR TITLE
Fix placing leading comments for a body of while statement

### DIFF
--- a/changelog_unreleased/javascript/pr-9345.md
+++ b/changelog_unreleased/javascript/pr-9345.md
@@ -1,0 +1,20 @@
+#### Fix placing leading comments for a body of while statement (#9345 by @sosukesuzuki)
+
+<!-- prettier-ignore -->
+```js
+// Input
+while(1) // Comment
+  foo();
+
+// Prettier stable
+while (
+  1 // Comment
+)
+  foo();
+
+// Prettier master
+while (1)
+  // Comment
+  foo();
+
+```

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -336,6 +336,11 @@ function handleWhileComments(
     return true;
   }
 
+  if (enclosingNode.body === followingNode) {
+    addLeadingComment(followingNode, comment);
+    return true;
+  }
+
   return false;
 }
 

--- a/tests/js/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/comments/__snapshots__/jsfmt.spec.js.snap
@@ -5097,6 +5097,9 @@ while(true) {} // comment
 
 while(true) /* comment */ ++x; 
 
+while(1) // Comment
+  foo();
+
 =====================================output=====================================
 while (
   true
@@ -5121,6 +5124,10 @@ while (
 while (true) {} // comment
 
 while (true) /* comment */ ++x
+
+while (1)
+  // Comment
+  foo()
 
 ================================================================================
 `;
@@ -5152,6 +5159,9 @@ while(true) {} // comment
 
 while(true) /* comment */ ++x; 
 
+while(1) // Comment
+  foo();
+
 =====================================output=====================================
 while (
   true
@@ -5176,6 +5186,10 @@ while (
 while (true) {} // comment
 
 while (true) /* comment */ ++x;
+
+while (1)
+  // Comment
+  foo();
 
 ================================================================================
 `;

--- a/tests/js/comments/while.js
+++ b/tests/js/comments/while.js
@@ -18,3 +18,6 @@ while(
 while(true) {} // comment
 
 while(true) /* comment */ ++x; 
+
+while(1) // Comment
+  foo();


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fixes #9316
<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
