### PR TITLE
Fix ugly formatting for assignment with closure style type casting

### DIFF
--- a/changelog_unreleased/javascript/pr-9361.md
+++ b/changelog_unreleased/javascript/pr-9361.md
@@ -1,0 +1,16 @@
+#### Fix ugly formatting for assignment with closure style type casting (#9361 by @sosukesuzuki)
+
+<!-- prettier-ignore -->
+```js
+// Input
+const foooobar = /** @type {Array.<fooo.barr.baaaaaaz>} */ (fooobaarbazzItems || foo);
+
+// Prettier Stable
+const foooobar = /** @type {Array.<fooo.barr.baaaaaaz>} */ (fooobaarbazzItems ||
+  foo);
+
+// Prettier master
+const foooobar =
+  /** @type {Array.<fooo.barr.baaaaaaz>} */ (fooobaarbazzItems || foo);
+
+```

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -108,6 +108,7 @@ const {
   shouldPrintComma,
   shouldFlatten,
   startsWithNoLookaheadToken,
+  getParenthesizedExpression,
 } = require("./utils");
 
 const printMemberChain = require("./print/member-chain");
@@ -4968,11 +4969,11 @@ function printAssignmentRight(leftNode, rightNode, printedRight, options) {
   if (hasLeadingOwnLineComment(options.originalText, rightNode, options)) {
     return indent(concat([line, printedRight]));
   }
-
+  rightNode = getParenthesizedExpression(rightNode);
   const canBreak =
     (isBinaryish(rightNode) && !shouldInlineLogicalExpression(rightNode)) ||
     (rightNode.type === "ConditionalExpression" &&
-      isBinaryish(rightNode.test) &&
+      isBinaryish(getParenthesizedExpression(rightNode.test)) &&
       !shouldInlineLogicalExpression(rightNode.test)) ||
     rightNode.type === "StringLiteralTypeAnnotation" ||
     (rightNode.type === "ClassExpression" &&

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -1359,6 +1359,13 @@ function isBitwiseOperator(operator) {
   );
 }
 
+function getParenthesizedExpression(node) {
+  if (node.type === "ParenthesizedExpression") {
+    return node.expression;
+  }
+  return node;
+}
+
 module.exports = {
   classChildNeedsASIProtection,
   classPropMayCauseASIProblems,
@@ -1421,4 +1428,5 @@ module.exports = {
   shouldFlatten,
   startsWithNoLookaheadToken,
   getPrecedence,
+  getParenthesizedExpression,
 };

--- a/tests/js/comments-closure-typecast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/comments-closure-typecast/__snapshots__/jsfmt.spec.js.snap
@@ -81,6 +81,10 @@ const style2 =/**
   width,
 });
 
+const foooobar = /** @type {Array.<fooo.barr.baaaaaaz>} */ (fooobaarbazzItems || foo);
+const foooobar = /** @type {Array.<fooo.barr.baaaaaaz>} */ (fooobaarbazzItems + foo);
+const foooobar = /** @type {Array.<fooo.barr.baaaaaaz>} */ (fooobaarbazzItems || foo) ? foo : bar;
+const foooobar = /** @type {Array.<fooo.barr.baaaaaaz>} */ (fooobaarbazzItems.fooooo.fooo);
 
 =====================================output=====================================
 // test to make sure comments are attached correctly
@@ -145,6 +149,17 @@ const style2 = /**
  */ ({
   width,
 });
+
+const foooobar =
+  /** @type {Array.<fooo.barr.baaaaaaz>} */ (fooobaarbazzItems || foo);
+const foooobar =
+  /** @type {Array.<fooo.barr.baaaaaaz>} */ (fooobaarbazzItems + foo);
+const foooobar =
+  /** @type {Array.<fooo.barr.baaaaaaz>} */ (fooobaarbazzItems || foo)
+    ? foo
+    : bar;
+const foooobar =
+  /** @type {Array.<fooo.barr.baaaaaaz>} */ (fooobaarbazzItems.fooooo.fooo);
 
 ================================================================================
 `;

--- a/tests/js/comments-closure-typecast/closure-compiler-type-cast.js
+++ b/tests/js/comments-closure-typecast/closure-compiler-type-cast.js
@@ -58,3 +58,7 @@ const style2 =/**
   width,
 });
 
+const foooobar = /** @type {Array.<fooo.barr.baaaaaaz>} */ (fooobaarbazzItems || foo);
+const foooobar = /** @type {Array.<fooo.barr.baaaaaaz>} */ (fooobaarbazzItems + foo);
+const foooobar = /** @type {Array.<fooo.barr.baaaaaaz>} */ (fooobaarbazzItems || foo) ? foo : bar;
+const foooobar = /** @type {Array.<fooo.barr.baaaaaaz>} */ (fooobaarbazzItems.fooooo.fooo);


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fixes #9358
<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
