### PR TITLE
Consistent format on invalid template literals

### DIFF
--- a/changelog_unreleased/javascript/pr-9431.md
+++ b/changelog_unreleased/javascript/pr-9431.md
@@ -3,16 +3,19 @@
 <!-- prettier-ignore -->
 ```js
 // Input
+foo = html`<div>\u{prettier}</div>`;
 foo = html`\u{prettier}${foo}pr\u{0065}ttier`;
-foo = markdown`\u{prettier}\u{0065}`;
+foo = markdown`# \u{prettier}\u{0065}`;
 
 // Prettier stable
+foo = html``;
 foo = html`null${foo}prettier`;
 foo = markdown`
-\u{prettier}\u{0065}
+# \u{prettier}\u{0065}
 `;
 
 // Prettier master
+foo = html`<div>\u{prettier}</div>`;
 foo = html`\u{prettier}${foo}pr\u{0065}ttier`;
-foo = markdown`\u{prettier}\u{0065}`;
+foo = markdown`# \u{prettier}\u{0065}`;
 ```

--- a/changelog_unreleased/javascript/pr-9431.md
+++ b/changelog_unreleased/javascript/pr-9431.md
@@ -1,0 +1,18 @@
+#### Keep html and markdown invalid template literals as it is (#9345 by @sosukesuzuki)
+
+<!-- prettier-ignore -->
+```js
+// Input
+foo = html`\u{prettier}${foo}pr\u{0065}ttier`;
+foo = markdown`\u{prettier}\u{0065}`;
+
+// Prettier stable
+foo = html`null${foo}prettier`;
+foo = markdown`
+\u{prettier}\u{0065}
+`;
+
+// Prettier master
+foo = html`\u{prettier}${foo}pr\u{0065}ttier`;
+foo = markdown`\u{prettier}\u{0065}`;
+```

--- a/changelog_unreleased/javascript/pr-9431.md
+++ b/changelog_unreleased/javascript/pr-9431.md
@@ -1,4 +1,4 @@
-#### Keep html and markdown invalid template literals as it is (#9345 by @sosukesuzuki)
+#### Keep html and markdown invalid template literals as it is (#9429 by @fisker)
 
 <!-- prettier-ignore -->
 ```js

--- a/changelog_unreleased/javascript/pr-9431.md
+++ b/changelog_unreleased/javascript/pr-9431.md
@@ -1,4 +1,4 @@
-#### Keep html and markdown invalid template literals as it is (#9429 by @fisker)
+#### Keep html and markdown invalid template literals as it is (#9431 by @fisker)
 
 <!-- prettier-ignore -->
 ```js

--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -570,10 +570,6 @@ function printHtmlTemplateLiteral(
   parser,
   options
 ) {
-  if (hasInvalidCookedValue(node)) {
-    return;
-  }
-
   const counter = htmlTemplateLiteralCounter;
   htmlTemplateLiteralCounter = (htmlTemplateLiteralCounter + 1) >>> 0;
 
@@ -668,8 +664,8 @@ function printHtmlTemplateLiteral(
   );
 }
 
-function hasInvalidCookedValue({ quasi }) {
-  return quasi.some(({ value: { cooked } }) => cooked === null);
+function hasInvalidCookedValue({ quasis }) {
+  return quasis.some(({ value: { cooked } }) => cooked === null);
 }
 
 module.exports = embed;

--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -165,6 +165,9 @@ function embed(path, print, textToDoc, options) {
     }
 
     case "TemplateElement": {
+      if (hasInvalidCookedValue(parent)) {
+        return;
+      }
       /**
        * md`...`
        * markdown`...`
@@ -176,9 +179,6 @@ function embed(path, print, textToDoc, options) {
         parentParent.tag.type === "Identifier" &&
         (parentParent.tag.name === "md" || parentParent.tag.name === "markdown")
       ) {
-        if (hasInvalidCookedValue(parent)) {
-          return;
-        }
         const text = parent.quasis[0].value.raw.replace(
           /((?:\\\\)*)\\`/g,
           (_, backslashes) => "\\".repeat(backslashes.length / 2) + "`"

--- a/tests/js/multiparser-invalid/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/multiparser-invalid/__snapshots__/jsfmt.spec.js.snap
@@ -30,6 +30,14 @@ foo = css\`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
 foo = /* HTML */\`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
 foo = /* GraphQL */\`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
 
+foo = foo\`pr\\u{0065}ttier\${foo}\\u{prettier}\${bar}pr\\u{0065}ttier\`;
+foo = html\`pr\\u{0065}ttier\${foo}\\u{prettier}\${bar}pr\\u{0065}ttier\`;
+foo = graphql\`pr\\u{0065}ttier\${foo}\\u{prettier}\${bar}pr\\u{0065}ttier\`;
+foo = markdown\`pr\\u{0065}ttier\${foo}\\u{prettier}\${bar}pr\\u{0065}ttier\`;
+foo = css\`pr\\u{0065}ttier\${foo}\\u{prettier}\${bar}pr\\u{0065}ttier\`;
+foo = /* HTML */\`pr\\u{0065}ttier\${foo}\\u{prettier}\${bar}pr\\u{0065}ttier\`;
+foo = /* GraphQL */\`pr\\u{0065}ttier\${foo}\\u{prettier}\${bar}pr\\u{0065}ttier\`;
+
 =====================================output=====================================
 foo = foo\`\\u{prettier}\\u{0065}\`;
 foo = html\`\\u{prettier}\\u{0065}\`;
@@ -54,6 +62,14 @@ foo = markdown\`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
 foo = css\`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
 foo = /* HTML */ \`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
 foo = /* GraphQL */ \`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
+
+foo = foo\`pr\\u{0065}ttier\${foo}\\u{prettier}\${bar}pr\\u{0065}ttier\`;
+foo = html\`pr\\u{0065}ttier\${foo}\\u{prettier}\${bar}pr\\u{0065}ttier\`;
+foo = graphql\`pr\\u{0065}ttier\${foo}\\u{prettier}\${bar}pr\\u{0065}ttier\`;
+foo = markdown\`pr\\u{0065}ttier\${foo}\\u{prettier}\${bar}pr\\u{0065}ttier\`;
+foo = css\`pr\\u{0065}ttier\${foo}\\u{prettier}\${bar}pr\\u{0065}ttier\`;
+foo = /* HTML */ \`pr\\u{0065}ttier\${foo}\\u{prettier}\${bar}pr\\u{0065}ttier\`;
+foo = /* GraphQL */ \`pr\\u{0065}ttier\${foo}\\u{prettier}\${bar}pr\\u{0065}ttier\`;
 
 ================================================================================
 `;

--- a/tests/js/multiparser-invalid/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/multiparser-invalid/__snapshots__/jsfmt.spec.js.snap
@@ -22,13 +22,13 @@ foo = css\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
 foo = /* HTML */\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
 foo = /* GraphQL */\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
 
-foo = foo\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
-foo = html\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
-foo = graphql\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
-foo = markdown\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
-foo = css\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
-foo = /* HTML */\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
-foo = /* GraphQL */\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = foo\`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
+foo = html\`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
+foo = graphql\`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
+foo = markdown\`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
+foo = css\`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
+foo = /* HTML */\`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
+foo = /* GraphQL */\`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
 
 =====================================output=====================================
 foo = foo\`\\u{prettier}\\u{0065}\`;
@@ -47,13 +47,13 @@ foo = css\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
 foo = /* HTML */ \`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
 foo = /* GraphQL */ \`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
 
-foo = foo\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
-foo = html\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
-foo = graphql\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
-foo = markdown\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
-foo = css\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
-foo = /* HTML */ \`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
-foo = /* GraphQL */ \`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = foo\`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
+foo = html\`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
+foo = graphql\`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
+foo = markdown\`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
+foo = css\`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
+foo = /* HTML */ \`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
+foo = /* GraphQL */ \`pr\\u{0065}ttier\${foo}\\u{prettier}\`;
 
 ================================================================================
 `;

--- a/tests/js/multiparser-invalid/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/multiparser-invalid/__snapshots__/jsfmt.spec.js.snap
@@ -6,52 +6,52 @@ parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-foo\`\\u{prettier}\\u{0065}\`;
-html\`\\u{prettier}\\u{0065}\`;
-graphql\`\\u{prettier}\\u{0065}\`;
-markdown\`\\u{prettier}\\u{0065}\`;
-css\`\\u{prettier}\\u{0065}\`;
+foo = foo\`\\u{prettier}\\u{0065}\`;
+foo = html\`\\u{prettier}\\u{0065}\`;
+foo = graphql\`\\u{prettier}\\u{0065}\`;
+foo = markdown\`\\u{prettier}\\u{0065}\`;
+foo = css\`\\u{prettier}\\u{0065}\`;
 foo = /* HTML */\`\\u{prettier}\\u{0065}\`;
 foo = /* GraphQL */\`\\u{prettier}\\u{0065}\`;
 
-foo\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
-html\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
-graphql\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
-markdown\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
-css\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = foo\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = html\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = graphql\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = markdown\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = css\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
 foo = /* HTML */\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
 foo = /* GraphQL */\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
 
-foo\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
-html\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
-graphql\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
-markdown\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
-css\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = foo\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
+foo = html\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
+foo = graphql\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
+foo = markdown\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
+foo = css\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
 foo = /* HTML */\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
 foo = /* GraphQL */\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
 
 =====================================output=====================================
-foo\`\\u{prettier}\\u{0065}\`;
-html\`\\u{prettier}\\u{0065}\`;
-graphql\`\\u{prettier}\\u{0065}\`;
-markdown\`\\u{prettier}\\u{0065}\`;
-css\`\\u{prettier}\\u{0065}\`;
+foo = foo\`\\u{prettier}\\u{0065}\`;
+foo = html\`\\u{prettier}\\u{0065}\`;
+foo = graphql\`\\u{prettier}\\u{0065}\`;
+foo = markdown\`\\u{prettier}\\u{0065}\`;
+foo = css\`\\u{prettier}\\u{0065}\`;
 foo = /* HTML */ \`\\u{prettier}\\u{0065}\`;
 foo = /* GraphQL */ \`\\u{prettier}\\u{0065}\`;
 
-foo\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
-html\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
-graphql\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
-markdown\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
-css\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = foo\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = html\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = graphql\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = markdown\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = css\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
 foo = /* HTML */ \`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
 foo = /* GraphQL */ \`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
 
-foo\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
-html\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
-graphql\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
-markdown\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
-css\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = foo\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
+foo = html\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
+foo = graphql\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
+foo = markdown\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
+foo = css\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
 foo = /* HTML */ \`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
 foo = /* GraphQL */ \`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
 

--- a/tests/js/multiparser-invalid/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/multiparser-invalid/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,59 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`text.js format 1`] = `
+====================================options=====================================
+parsers: ["babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+foo\`\\u{prettier}\\u{0065}\`;
+html\`\\u{prettier}\\u{0065}\`;
+graphql\`\\u{prettier}\\u{0065}\`;
+markdown\`\\u{prettier}\\u{0065}\`;
+css\`\\u{prettier}\\u{0065}\`;
+foo = /* HTML */\`\\u{prettier}\\u{0065}\`;
+foo = /* GraphQL */\`\\u{prettier}\\u{0065}\`;
+
+foo\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+html\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+graphql\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+markdown\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+css\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = /* HTML */\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = /* GraphQL */\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+
+foo\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
+html\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
+graphql\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
+markdown\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
+css\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = /* HTML */\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = /* GraphQL */\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+
+=====================================output=====================================
+foo\`\\u{prettier}\\u{0065}\`;
+html\`\\u{prettier}\\u{0065}\`;
+graphql\`\\u{prettier}\\u{0065}\`;
+markdown\`\\u{prettier}\\u{0065}\`;
+css\`\\u{prettier}\\u{0065}\`;
+foo = /* HTML */ \`\\u{prettier}\\u{0065}\`;
+foo = /* GraphQL */ \`\\u{prettier}\\u{0065}\`;
+
+foo\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+html\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+graphql\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+markdown\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+css\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = /* HTML */ \`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = /* GraphQL */ \`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+
+foo\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
+html\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
+graphql\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
+markdown\`\\u{0065}\${foo}pr\\u{0065}ttier\`;
+css\`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = /* HTML */ \`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+foo = /* GraphQL */ \`\\u{prettier}\${foo}pr\\u{0065}ttier\`;
+
+================================================================================
+`;

--- a/tests/js/multiparser-invalid/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/multiparser-invalid/__snapshots__/jsfmt.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`text.js format 1`] = `
 ====================================options=====================================
-parsers: ["babel"]
+parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/js/multiparser-invalid/jsfmt.spec.js
+++ b/tests/js/multiparser-invalid/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["babel"], { errors: { espree: true } });

--- a/tests/js/multiparser-invalid/jsfmt.spec.js
+++ b/tests/js/multiparser-invalid/jsfmt.spec.js
@@ -1,1 +1,3 @@
-run_spec(__dirname, ["babel"], { errors: { espree: true } });
+run_spec(__dirname, ["babel", "flow", "typescript"], {
+  errors: { espree: true, flow: true, typescript: true },
+});

--- a/tests/js/multiparser-invalid/text.js
+++ b/tests/js/multiparser-invalid/text.js
@@ -1,23 +1,23 @@
-foo`\u{prettier}\u{0065}`;
-html`\u{prettier}\u{0065}`;
-graphql`\u{prettier}\u{0065}`;
-markdown`\u{prettier}\u{0065}`;
-css`\u{prettier}\u{0065}`;
+foo = foo`\u{prettier}\u{0065}`;
+foo = html`\u{prettier}\u{0065}`;
+foo = graphql`\u{prettier}\u{0065}`;
+foo = markdown`\u{prettier}\u{0065}`;
+foo = css`\u{prettier}\u{0065}`;
 foo = /* HTML */`\u{prettier}\u{0065}`;
 foo = /* GraphQL */`\u{prettier}\u{0065}`;
 
-foo`\u{prettier}${foo}pr\u{0065}ttier`;
-html`\u{prettier}${foo}pr\u{0065}ttier`;
-graphql`\u{prettier}${foo}pr\u{0065}ttier`;
-markdown`\u{prettier}${foo}pr\u{0065}ttier`;
-css`\u{prettier}${foo}pr\u{0065}ttier`;
+foo = foo`\u{prettier}${foo}pr\u{0065}ttier`;
+foo = html`\u{prettier}${foo}pr\u{0065}ttier`;
+foo = graphql`\u{prettier}${foo}pr\u{0065}ttier`;
+foo = markdown`\u{prettier}${foo}pr\u{0065}ttier`;
+foo = css`\u{prettier}${foo}pr\u{0065}ttier`;
 foo = /* HTML */`\u{prettier}${foo}pr\u{0065}ttier`;
 foo = /* GraphQL */`\u{prettier}${foo}pr\u{0065}ttier`;
 
-foo`\u{0065}${foo}pr\u{0065}ttier`;
-html`\u{0065}${foo}pr\u{0065}ttier`;
-graphql`\u{0065}${foo}pr\u{0065}ttier`;
-markdown`\u{0065}${foo}pr\u{0065}ttier`;
-css`\u{prettier}${foo}pr\u{0065}ttier`;
+foo = foo`\u{0065}${foo}pr\u{0065}ttier`;
+foo = html`\u{0065}${foo}pr\u{0065}ttier`;
+foo = graphql`\u{0065}${foo}pr\u{0065}ttier`;
+foo = markdown`\u{0065}${foo}pr\u{0065}ttier`;
+foo = css`\u{prettier}${foo}pr\u{0065}ttier`;
 foo = /* HTML */`\u{prettier}${foo}pr\u{0065}ttier`;
 foo = /* GraphQL */`\u{prettier}${foo}pr\u{0065}ttier`;

--- a/tests/js/multiparser-invalid/text.js
+++ b/tests/js/multiparser-invalid/text.js
@@ -21,3 +21,11 @@ foo = markdown`pr\u{0065}ttier${foo}\u{prettier}`;
 foo = css`pr\u{0065}ttier${foo}\u{prettier}`;
 foo = /* HTML */`pr\u{0065}ttier${foo}\u{prettier}`;
 foo = /* GraphQL */`pr\u{0065}ttier${foo}\u{prettier}`;
+
+foo = foo`pr\u{0065}ttier${foo}\u{prettier}${bar}pr\u{0065}ttier`;
+foo = html`pr\u{0065}ttier${foo}\u{prettier}${bar}pr\u{0065}ttier`;
+foo = graphql`pr\u{0065}ttier${foo}\u{prettier}${bar}pr\u{0065}ttier`;
+foo = markdown`pr\u{0065}ttier${foo}\u{prettier}${bar}pr\u{0065}ttier`;
+foo = css`pr\u{0065}ttier${foo}\u{prettier}${bar}pr\u{0065}ttier`;
+foo = /* HTML */`pr\u{0065}ttier${foo}\u{prettier}${bar}pr\u{0065}ttier`;
+foo = /* GraphQL */`pr\u{0065}ttier${foo}\u{prettier}${bar}pr\u{0065}ttier`;

--- a/tests/js/multiparser-invalid/text.js
+++ b/tests/js/multiparser-invalid/text.js
@@ -1,0 +1,23 @@
+foo`\u{prettier}\u{0065}`;
+html`\u{prettier}\u{0065}`;
+graphql`\u{prettier}\u{0065}`;
+markdown`\u{prettier}\u{0065}`;
+css`\u{prettier}\u{0065}`;
+foo = /* HTML */`\u{prettier}\u{0065}`;
+foo = /* GraphQL */`\u{prettier}\u{0065}`;
+
+foo`\u{prettier}${foo}pr\u{0065}ttier`;
+html`\u{prettier}${foo}pr\u{0065}ttier`;
+graphql`\u{prettier}${foo}pr\u{0065}ttier`;
+markdown`\u{prettier}${foo}pr\u{0065}ttier`;
+css`\u{prettier}${foo}pr\u{0065}ttier`;
+foo = /* HTML */`\u{prettier}${foo}pr\u{0065}ttier`;
+foo = /* GraphQL */`\u{prettier}${foo}pr\u{0065}ttier`;
+
+foo`\u{0065}${foo}pr\u{0065}ttier`;
+html`\u{0065}${foo}pr\u{0065}ttier`;
+graphql`\u{0065}${foo}pr\u{0065}ttier`;
+markdown`\u{0065}${foo}pr\u{0065}ttier`;
+css`\u{prettier}${foo}pr\u{0065}ttier`;
+foo = /* HTML */`\u{prettier}${foo}pr\u{0065}ttier`;
+foo = /* GraphQL */`\u{prettier}${foo}pr\u{0065}ttier`;

--- a/tests/js/multiparser-invalid/text.js
+++ b/tests/js/multiparser-invalid/text.js
@@ -14,10 +14,10 @@ foo = css`\u{prettier}${foo}pr\u{0065}ttier`;
 foo = /* HTML */`\u{prettier}${foo}pr\u{0065}ttier`;
 foo = /* GraphQL */`\u{prettier}${foo}pr\u{0065}ttier`;
 
-foo = foo`\u{0065}${foo}pr\u{0065}ttier`;
-foo = html`\u{0065}${foo}pr\u{0065}ttier`;
-foo = graphql`\u{0065}${foo}pr\u{0065}ttier`;
-foo = markdown`\u{0065}${foo}pr\u{0065}ttier`;
-foo = css`\u{prettier}${foo}pr\u{0065}ttier`;
-foo = /* HTML */`\u{prettier}${foo}pr\u{0065}ttier`;
-foo = /* GraphQL */`\u{prettier}${foo}pr\u{0065}ttier`;
+foo = foo`pr\u{0065}ttier${foo}\u{prettier}`;
+foo = html`pr\u{0065}ttier${foo}\u{prettier}`;
+foo = graphql`pr\u{0065}ttier${foo}\u{prettier}`;
+foo = markdown`pr\u{0065}ttier${foo}\u{prettier}`;
+foo = css`pr\u{0065}ttier${foo}\u{prettier}`;
+foo = /* HTML */`pr\u{0065}ttier${foo}\u{prettier}`;
+foo = /* GraphQL */`pr\u{0065}ttier${foo}\u{prettier}`;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fixes #9429

---

I'll do more improvements on js embed after this merge.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
