### PR TITLE
JS: Fix `import {a as a}` and `export {a as a}` format

### DIFF
--- a/changelog_unreleased/javascript/pr-9435.md
+++ b/changelog_unreleased/javascript/pr-9435.md
@@ -1,0 +1,16 @@
+#### Fix `import {a as a}` and `export {a as a}` format (#9435 by @fisker)
+
+<!-- prettier-ignore -->
+```js
+// Input
+import { a as a } from "a";
+export { b as b } from "b";
+
+// Prettier stable
+import { a } from "a";
+export { b } from "b";
+
+// Prettier master
+import { a as a } from "a";
+export { b as b } from "b";
+```

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -69,6 +69,7 @@ const {
   hasNewlineBetweenOrAfterDecorators,
   hasNgSideEffect,
   hasPrettierIgnore,
+  hasSameLoc,
   hasTrailingComment,
   hasTrailingLineComment,
   identity,
@@ -91,7 +92,6 @@ const {
   isNumericLiteral,
   isObjectType,
   isObjectTypePropertyAFunction,
-  isSameNode,
   isSimpleFlowType,
   isSimpleNumber,
   isSimpleTemplateLiteral,
@@ -804,7 +804,7 @@ function printPathNoParens(path, options, print, args) {
 
       parts.push(path.call(print, "imported"));
 
-      if (n.local && !isSameNode(n.local, n.imported, options)) {
+      if (n.local && !hasSameLoc(n.local, n.imported, options)) {
         parts.push(" as ", path.call(print, "local"));
       }
 
@@ -812,7 +812,7 @@ function printPathNoParens(path, options, print, args) {
     case "ExportSpecifier":
       parts.push(path.call(print, "local"));
 
-      if (n.exported && !isSameNode(n.local, n.exported, options)) {
+      if (n.exported && !hasSameLoc(n.local, n.exported, options)) {
         parts.push(" as ", path.call(print, "exported"));
       }
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -91,7 +91,7 @@ const {
   isNumericLiteral,
   isObjectType,
   isObjectTypePropertyAFunction,
-  isSameLoc,
+  isSameNode,
   isSimpleFlowType,
   isSimpleNumber,
   isSimpleTemplateLiteral,
@@ -804,7 +804,7 @@ function printPathNoParens(path, options, print, args) {
 
       parts.push(path.call(print, "imported"));
 
-      if (n.local && !isSameLoc(n.local, n.imported, options)) {
+      if (n.local && !isSameNode(n.local, n.imported, options)) {
         parts.push(" as ", path.call(print, "local"));
       }
 
@@ -812,7 +812,7 @@ function printPathNoParens(path, options, print, args) {
     case "ExportSpecifier":
       parts.push(path.call(print, "local"));
 
-      if (n.exported && !isSameLoc(n.local, n.exported, options)) {
+      if (n.exported && !isSameNode(n.local, n.exported, options)) {
         parts.push(" as ", path.call(print, "exported"));
       }
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -91,6 +91,7 @@ const {
   isNumericLiteral,
   isObjectType,
   isObjectTypePropertyAFunction,
+  isSameLoc,
   isSimpleFlowType,
   isSimpleNumber,
   isSimpleTemplateLiteral,
@@ -803,7 +804,7 @@ function printPathNoParens(path, options, print, args) {
 
       parts.push(path.call(print, "imported"));
 
-      if (n.local && n.local.name !== n.imported.name) {
+      if (n.local && !isSameLoc(n.local, n.imported, options)) {
         parts.push(" as ", path.call(print, "local"));
       }
 
@@ -811,7 +812,7 @@ function printPathNoParens(path, options, print, args) {
     case "ExportSpecifier":
       parts.push(path.call(print, "local"));
 
-      if (n.exported && n.exported.name !== n.local.name) {
+      if (n.exported && !isSameLoc(n.local, n.exported, options)) {
         parts.push(" as ", path.call(print, "exported"));
       }
 

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -342,7 +342,7 @@ function isGetterOrSetter(node) {
  * @param {Node} nodeB
  * @returns {boolean}
  */
-function sameLocStart(nodeA, nodeB, {locStart}) {
+function sameLocStart(nodeA, nodeB, { locStart }) {
   return locStart(nodeA) === locStart(nodeB);
 }
 
@@ -351,7 +351,7 @@ function sameLocStart(nodeA, nodeB, {locStart}) {
  * @param {Node} nodeB
  * @returns {boolean}
  */
-function sameLocEnd(nodeA, nodeB, {locEnd}) {
+function sameLocEnd(nodeA, nodeB, { locEnd }) {
   return locEnd(nodeA) === locEnd(nodeB);
 }
 
@@ -360,8 +360,10 @@ function sameLocEnd(nodeA, nodeB, {locEnd}) {
  * @param {Node} nodeB
  * @returns {boolean}
  */
-function isSameLoc(nodeA, nodeB, options) {
-  return sameLocStart(nodeA, nodeB, options) && sameLocEnd(nodeA, nodeB, options);
+function isSameNode(nodeA, nodeB, options) {
+  return (
+    sameLocStart(nodeA, nodeB, options) && sameLocEnd(nodeA, nodeB, options)
+  );
 }
 
 // TODO: This is a bad hack and we need a better way to distinguish between
@@ -1420,7 +1422,7 @@ module.exports = {
   isNumericLiteral,
   isObjectType,
   isObjectTypePropertyAFunction,
-  isSameLoc,
+  isSameNode,
   isSimpleFlowType,
   isSimpleNumber,
   isSimpleTemplateLiteral,

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -360,7 +360,7 @@ function sameLocEnd(nodeA, nodeB, { locEnd }) {
  * @param {Node} nodeB
  * @returns {boolean}
  */
-function isSameNode(nodeA, nodeB, options) {
+function hasSameLoc(nodeA, nodeB, options) {
   return (
     sameLocStart(nodeA, nodeB, options) && sameLocEnd(nodeA, nodeB, options)
   );
@@ -1396,6 +1396,7 @@ module.exports = {
   hasNgSideEffect,
   hasNode,
   hasPrettierIgnore,
+  hasSameLoc,
   hasTrailingComment,
   hasTrailingLineComment,
   identity,
@@ -1422,7 +1423,6 @@ module.exports = {
   isNumericLiteral,
   isObjectType,
   isObjectTypePropertyAFunction,
-  isSameNode,
   isSimpleFlowType,
   isSimpleNumber,
   isSimpleTemplateLiteral,

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -351,8 +351,17 @@ function sameLocStart(nodeA, nodeB, {locStart}) {
  * @param {Node} nodeB
  * @returns {boolean}
  */
+function sameLocEnd(nodeA, nodeB, {locEnd}) {
+  return locEnd(nodeA) === locEnd(nodeB);
+}
+
+/**
+ * @param {Node} nodeA
+ * @param {Node} nodeB
+ * @returns {boolean}
+ */
 function isSameLoc(nodeA, nodeB, options) {
-  return sameLocStart(nodeA, nodeB, options) && options.locEnd(nodeA) === options.locEnd(nodeB);
+  return sameLocStart(nodeA, nodeB, options) && sameLocEnd(nodeA, nodeB, options);
 }
 
 // TODO: This is a bad hack and we need a better way to distinguish between

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -342,8 +342,17 @@ function isGetterOrSetter(node) {
  * @param {Node} nodeB
  * @returns {boolean}
  */
-function sameLocStart(nodeA, nodeB, options) {
-  return options.locStart(nodeA) === options.locStart(nodeB);
+function sameLocStart(nodeA, nodeB, {locStart}) {
+  return locStart(nodeA) === locStart(nodeB);
+}
+
+/**
+ * @param {Node} nodeA
+ * @param {Node} nodeB
+ * @returns {boolean}
+ */
+function isSameLoc(nodeA, nodeB, options) {
+  return sameLocStart(nodeA, nodeB, options) && options.locEnd(nodeA) === options.locEnd(nodeB);
 }
 
 // TODO: This is a bad hack and we need a better way to distinguish between
@@ -1402,6 +1411,7 @@ module.exports = {
   isNumericLiteral,
   isObjectType,
   isObjectTypePropertyAFunction,
+  isSameLoc,
   isSimpleFlowType,
   isSimpleNumber,
   isSimpleTemplateLiteral,

--- a/tests/js/export/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/export/__snapshots__/jsfmt.spec.js.snap
@@ -141,3 +141,40 @@ export {} from ".";
 
 ================================================================================
 `;
+
+exports[`same-local-and-exported.js - {"bracketSpacing":false} format 1`] = `
+====================================options=====================================
+bracketSpacing: false
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export {a} from 'a';
+export {b as b} from 'b';
+export {c as /* comment */c} from 'c';
+
+=====================================output=====================================
+export {a} from "a";
+export {b as b} from "b";
+export {c as /* comment */ c} from "c";
+
+================================================================================
+`;
+
+exports[`same-local-and-exported.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export {a} from 'a';
+export {b as b} from 'b';
+export {c as /* comment */c} from 'c';
+
+=====================================output=====================================
+export { a } from "a";
+export { b as b } from "b";
+export { c as /* comment */ c } from "c";
+
+================================================================================
+`;

--- a/tests/js/export/same-local-and-exported.js
+++ b/tests/js/export/same-local-and-exported.js
@@ -1,0 +1,3 @@
+export {a} from 'a';
+export {b as b} from 'b';
+export {c as /* comment */c} from 'c';

--- a/tests/js/import/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/import/__snapshots__/jsfmt.spec.js.snap
@@ -415,3 +415,40 @@ import a, * as b from "a";
 
 ================================================================================
 `;
+
+exports[`same-local-and-imported.js - {"bracketSpacing":false} format 1`] = `
+====================================options=====================================
+bracketSpacing: false
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+import {a} from 'a';
+import {b as b} from 'b';
+import {c as /* comment */c} from 'c';
+
+=====================================output=====================================
+import {a} from "a";
+import {b as b} from "b";
+import {c as /* comment */ c} from "c";
+
+================================================================================
+`;
+
+exports[`same-local-and-imported.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+import {a} from 'a';
+import {b as b} from 'b';
+import {c as /* comment */c} from 'c';
+
+=====================================output=====================================
+import { a } from "a";
+import { b as b } from "b";
+import { c as /* comment */ c } from "c";
+
+================================================================================
+`;

--- a/tests/js/import/same-local-and-imported.js
+++ b/tests/js/import/same-local-and-imported.js
@@ -1,0 +1,3 @@
+import {a} from 'a';
+import {b as b} from 'b';
+import {c as /* comment */c} from 'c';


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fixes #9434

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
