### PR TITLE
Support Flow this parameter annotations

### DIFF
--- a/changelog_unreleased/flow/pr-9457.md
+++ b/changelog_unreleased/flow/pr-9457.md
@@ -1,0 +1,47 @@
+<!--
+
+1. Choose a folder based on which language your PR is for.
+
+   - For JavaScript, choose `javascript/` etc.
+   - For TypeScript specific syntax, choose `typescript/`.
+   - If your PR applies to multiple languages, such as TypeScript/Flow, choose one folder and mention which languages it applies to.
+
+2. In your chosen folder, create a file with your PR number: `pr-XXXX.md`. For example: `typescript/pr-6728.md`.
+
+3. Copy the content below and paste it in your new file.
+
+4. Fill in a title, the PR number and your user name.
+
+5. Optionally write a description. Many times it’s enough with just sample code.
+
+6. Change ```jsx to your language. For example, ```yaml.
+
+7. Change the `// Input` and `// Prettier` comments to the comment syntax of your language. For example, `# Input`.
+
+8. Choose some nice input example code. Paste it along with the output before and after your PR.
+
+-->
+
+#### Flow `this` annotations (#9457 by @dsainati1)
+
+Add support for `this` parameter annotations in Flow.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+function f(this: string, a: number) {
+}
+
+type T = (this: boolean, a: number) => boolean;
+
+// Prettier stable
+function f(this: string, a: number) {}
+
+type T = (a: number) => boolean;
+
+// Prettier master
+function f(this: string, a: number) {
+}
+
+type T = (this: boolean, a: number) => boolean;
+```

--- a/changelog_unreleased/flow/pr-9457.md
+++ b/changelog_unreleased/flow/pr-9457.md
@@ -1,27 +1,3 @@
-<!--
-
-1. Choose a folder based on which language your PR is for.
-
-   - For JavaScript, choose `javascript/` etc.
-   - For TypeScript specific syntax, choose `typescript/`.
-   - If your PR applies to multiple languages, such as TypeScript/Flow, choose one folder and mention which languages it applies to.
-
-2. In your chosen folder, create a file with your PR number: `pr-XXXX.md`. For example: `typescript/pr-6728.md`.
-
-3. Copy the content below and paste it in your new file.
-
-4. Fill in a title, the PR number and your user name.
-
-5. Optionally write a description. Many times it’s enough with just sample code.
-
-6. Change ```jsx to your language. For example, ```yaml.
-
-7. Change the `// Input` and `// Prettier` comments to the comment syntax of your language. For example, `# Input`.
-
-8. Choose some nice input example code. Paste it along with the output before and after your PR.
-
--->
-
 #### Flow `this` annotations (#9457 by @dsainati1)
 
 Add support for `this` parameter annotations in Flow.

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -604,7 +604,8 @@ function handleCommentInEmptyParens(text, enclosingNode, comment, options) {
     enclosingNode &&
     ((isRealFunctionLikeNode(enclosingNode) &&
       // `params` vs `parameters` - see https://github.com/babel/babel/issues/9231
-      (enclosingNode.params || enclosingNode.parameters).length === 0) ||
+      (enclosingNode.params || enclosingNode.parameters).length === 0 &&
+      !enclosingNode.this) ||
       ((enclosingNode.type === "CallExpression" ||
         enclosingNode.type === "OptionalCallExpression" ||
         enclosingNode.type === "NewExpression") &&
@@ -665,12 +666,14 @@ function handleLastFunctionArgComments(
     followingNode.type === "BlockStatement"
   ) {
     const functionParamRightParenIndex = (() => {
-      if ((enclosingNode.params || enclosingNode.parameters).length !== 0) {
+      let parameters = enclosingNode.params || enclosingNode.parameters;
+      if (enclosingNode.this) {
+        parameters = [enclosingNode.this, ...parameters];
+      }
+      if (parameters.length !== 0) {
         return getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
           text,
-          options.locEnd(
-            getLast(enclosingNode.params || enclosingNode.parameters)
-          )
+          options.locEnd(getLast(parameters))
         );
       }
       const functionParamLeftParenIndex = getNextNonSpaceNonCommentCharacterIndexWithStartIndex(

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2606,7 +2606,7 @@ function printPathNoParens(path, options, print, args) {
       return concat(["...", path.call(print, "typeAnnotation")]);
     case "TSOptionalType":
       return concat([path.call(print, "typeAnnotation"), "?"]);
-    case "FunctionTypeParam":
+    case "FunctionTypeParam": {
       const parent = path.getParentNode(0);
       return concat([
         n.name ? path.call(print, "name") : parent.this === n ? "this: " : "",
@@ -2614,6 +2614,7 @@ function printPathNoParens(path, options, print, args) {
         n.name ? ": " : "",
         path.call(print, "typeAnnotation"),
       ]);
+    }
     case "GenericTypeAnnotation":
       return concat([
         path.call(print, "id"),

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3879,16 +3879,16 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
     : "";
 
   let parts = [];
-  if (fun[paramsField]) {
-    parts = path.map((childPath) => {
-      return { value: childPath.getValue(), param: print(childPath) };
-    }, paramsField);
-  }
-
   if (fun.this) {
     fun.this.name = "this";
-    parts = [{ value: fun.this, param: path.call(print, "this") }].concat(
-      parts
+    parts = [{ value: fun.this, param: path.call(print, "this") }];
+  }
+
+  if (fun[paramsField]) {
+    parts = parts.concat(
+      path.map((childPath) => {
+        return { value: childPath.getValue(), param: print(childPath) };
+      }, paramsField)
     );
   }
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2607,8 +2607,9 @@ function printPathNoParens(path, options, print, args) {
     case "TSOptionalType":
       return concat([path.call(print, "typeAnnotation"), "?"]);
     case "FunctionTypeParam":
+      const parent = path.getParentNode(0);
       return concat([
-        path.call(print, "name"),
+        n.name ? path.call(print, "name") : parent.this === n ? "this: " : "",
         printOptionalToken(path),
         n.name ? ": " : "",
         path.call(print, "typeAnnotation"),
@@ -2738,6 +2739,7 @@ function printPathNoParens(path, options, print, args) {
       // | C
 
       const parent = path.getParentNode();
+      const parentParent = path.getParentNode(1);
 
       // If there's a leading comment, the parent is doing the indentation
       const shouldIndent =
@@ -2748,7 +2750,11 @@ function printPathNoParens(path, options, print, args) {
         parent.type !== "TSTypeAssertion" &&
         parent.type !== "TupleTypeAnnotation" &&
         parent.type !== "TSTupleType" &&
-        !(parent.type === "FunctionTypeParam" && !parent.name) &&
+        !(
+          parent.type === "FunctionTypeParam" &&
+          !parent.name &&
+          parentParent.this !== parent
+        ) &&
         !(
           (parent.type === "TypeAlias" ||
             parent.type === "VariableDeclarator" ||
@@ -3880,7 +3886,6 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
 
   let parts = [];
   if (fun.this) {
-    fun.this.name = "this";
     parts = [{ value: fun.this, param: path.call(print, "this") }];
   }
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3885,23 +3885,26 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
     ? printFunctionTypeParameters(path, options, print)
     : "";
 
-  const parameters = [];
+  const printedParameters = [];
   if (fun.this) {
-    parameters.push({ node: fun.this, doc: path.call(print, "this") });
+    printedParameters.push({ node: fun.this, doc: path.call(print, "this") });
   }
 
   if (fun[paramsField]) {
     path.each((childPath) => {
-      parameters.push({ node: childPath.getValue(), doc: print(childPath) });
+      printedParameters.push({
+        node: childPath.getValue(),
+        doc: print(childPath),
+      });
     }, paramsField);
   }
 
   const shouldExpandParameters =
-    expandArg && !parameters.some(({ node }) => node.comments);
+    expandArg && !printedParameters.some(({ node }) => node.comments);
 
   const printed = [];
-  const lastArgIndex = parameters.length - 1;
-  for (const [index, { node, doc }] of parameters.entries()) {
+  const lastArgIndex = printedParameters.length - 1;
+  for (const [index, { node, doc }] of printedParameters.entries()) {
     printed.push(doc);
     if (index === lastArgIndex) {
       if (fun.rest) {
@@ -3971,7 +3974,7 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
   //   b,
   //   c
   // }) {}
-  const hasNotParameterDecorator = parameters.every(
+  const hasNotParameterDecorator = printedParameters.every(
     ({ node }) => !node.decorators
   );
   if (shouldHugParameters && hasNotParameterDecorator) {
@@ -3992,11 +3995,11 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
       parent.type === "IntersectionTypeAnnotation" ||
       (parent.type === "FunctionTypeAnnotation" &&
         parent.returnType === fun)) &&
-    parameters.length === 1 &&
-    parameters[0].node.name === null &&
-    parameters[0].node.typeAnnotation &&
+    printedParameters.length === 1 &&
+    printedParameters[0].node.name === null &&
+    printedParameters[0].node.typeAnnotation &&
     fun.typeParameters === null &&
-    isSimpleFlowType(parameters[0].node.typeAnnotation) &&
+    isSimpleFlowType(printedParameters[0].node.typeAnnotation) &&
     !fun.rest;
 
   if (isFlowShorthandWithOneArg) {
@@ -4006,7 +4009,7 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
     return concat(printed);
   }
 
-  const lastParam = getLast(parameters);
+  const lastParam = getLast(printedParameters);
   const canHaveTrailingComma =
     !(lastParam && lastParam.node.type === "RestElement") && !fun.rest;
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3880,7 +3880,7 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
 
   let parts = [];
   if (fun[paramsField]) {
-    parts = path.map((childPath, _) => {
+    parts = path.map(childPath => {
       return { value: childPath.getValue(), param: print(childPath) };
     }, paramsField);
   }
@@ -3892,7 +3892,7 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
     );
   }
 
-  let printed = [];
+  const printed = [];
   const lastArgIndex = parts.length - 1;
   parts.forEach(({ value, param }, index) => {
     printed.push(param);

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3908,6 +3908,16 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
     }, paramsField);
   }
 
+  if (fun.this) {
+    const parts = [];
+    parts.push("this:", line);
+    parts.push(path.call(print, "this"));
+    if (printed.length > 0 || fun.rest) {
+      parts.push(",", line);
+    }
+    printed = parts.concat(printed);
+  }
+
   if (fun.rest) {
     printed.push(concat(["...", path.call(print, "rest")]));
   }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3880,7 +3880,7 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
 
   let parts = [];
   if (fun[paramsField]) {
-    parts = path.map(childPath => {
+    parts = path.map((childPath) => {
       return { value: childPath.getValue(), param: print(childPath) };
     }, paramsField);
   }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3910,7 +3910,7 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
 
   if (fun.this) {
     const parts = [];
-    parts.push("this:", line);
+    parts.push("this: ");
     parts.push(path.call(print, "this"));
     if (printed.length > 0 || fun.rest) {
       parts.push(",", line);

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -5150,7 +5150,7 @@ function shouldHugArguments(fun) {
   if (!fun || fun.rest) {
     return false;
   }
-  let params = fun.params || fun.parameters;
+  let params = fun.params || fun.parameters || [];
   if (fun.this) {
     params = [fun.this, ...params];
   }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -3913,7 +3913,11 @@ function printFunctionParams(path, print, options, expandArg, printTypeParams) {
     parts.push("this: ");
     parts.push(path.call(print, "this"));
     if (printed.length > 0 || fun.rest) {
-      parts.push(",", line);
+      if (isNextLineEmpty(options.originalText, fun.this, options.locEnd)) {
+        parts.push(",", hardline, hardline);
+      } else {
+        parts.push(",", line);
+      }
     }
     printed = parts.concat(printed);
   }

--- a/tests/flow/this-annotation/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/this-annotation/__snapshots__/jsfmt.spec.js.snap
@@ -96,12 +96,36 @@ type T = (this: boolean,
           b: number,
          ) => boolean;
 
+type A = (
+  this: SupperLongLongLongLongLongLongLongLongLongLongLongType,
+
+  b: number,
+) => boolean;
+
+type B = (
+  _this: SupperLongLongLongLongLongLongLongLongLongLongLongType,
+
+  b: number,
+) => boolean
+
 =====================================output=====================================
 // @flow
 
 type T = (
   this: boolean,
   a: number,
+
+  b: number,
+) => boolean;
+
+type A = (
+  this: SupperLongLongLongLongLongLongLongLongLongLongLongType,
+
+  b: number,
+) => boolean;
+
+type B = (
+  _this: SupperLongLongLongLongLongLongLongLongLongLongLongType,
 
   b: number,
 ) => boolean;

--- a/tests/flow/this-annotation/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/this-annotation/__snapshots__/jsfmt.spec.js.snap
@@ -81,6 +81,34 @@ type V = (this: number) => void;
 ================================================================================
 `;
 
+exports[`line_break.js - {"trailingComma":"all"} format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+type T = (this: boolean,
+          a: number,
+
+          b: number,
+         ) => boolean;
+
+=====================================output=====================================
+// @flow
+
+type T = (
+  this: boolean,
+  a: number,
+
+  b: number,
+) => boolean;
+
+================================================================================
+`;
+
 exports[`method.js - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
 parsers: ["flow"]

--- a/tests/flow/this-annotation/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/this-annotation/__snapshots__/jsfmt.spec.js.snap
@@ -96,6 +96,12 @@ type T = (this: boolean,
           b: number,
          ) => boolean;
 
+type T2 = (_this: boolean,
+          a: number,
+
+          b: number,
+         ) => boolean;
+
 type A = (
   this: SupperLongLongLongLongLongLongLongLongLongLongLongType,
 
@@ -113,6 +119,13 @@ type B = (
 
 type T = (
   this: boolean,
+  a: number,
+
+  b: number,
+) => boolean;
+
+type T2 = (
+  _this: boolean,
   a: number,
 
   b: number,
@@ -156,6 +169,45 @@ class A {
   n(this: number, ...c) {}
   o(this: number) {}
 }
+
+================================================================================
+`;
+
+exports[`union_type.js - {"trailingComma":"all"} format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+type A = (
+  this: | SupperLongLongLongLongLongLongLongLongLongLongLongType | FooBarBazLorem12345,
+  b: number,
+) => boolean;
+
+type B = (
+  _this: | SupperLongLongLongLongLongLongLongLongLongLongLongType | FooBarBazLorem12345,
+  b: number,
+) => boolean
+
+=====================================output=====================================
+// @flow
+
+type A = (
+  this:
+    | SupperLongLongLongLongLongLongLongLongLongLongLongType
+    | FooBarBazLorem12345,
+  b: number,
+) => boolean;
+
+type B = (
+  _this:
+    | SupperLongLongLongLongLongLongLongLongLongLongLongType
+    | FooBarBazLorem12345,
+  b: number,
+) => boolean;
 
 ================================================================================
 `;

--- a/tests/flow/this-annotation/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/this-annotation/__snapshots__/jsfmt.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`declare_function.js - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
-parsers: ["flow"]
+parsers: ["flow", "babel-flow"]
 printWidth: 80
 trailingComma: "all"
                                                                                 | printWidth
@@ -29,7 +29,7 @@ declare function baz(this: number, ...a: any): void;
 
 exports[`function_declaration.js - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
-parsers: ["flow"]
+parsers: ["flow", "babel-flow"]
 printWidth: 80
 trailingComma: "all"
                                                                                 | printWidth
@@ -56,7 +56,7 @@ function baz(this: number, ...a) {}
 
 exports[`function_type.js - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
-parsers: ["flow"]
+parsers: ["flow", "babel-flow"]
 printWidth: 80
 trailingComma: "all"
                                                                                 | printWidth
@@ -83,7 +83,7 @@ type V = (this: number) => void;
 
 exports[`line_break.js - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
-parsers: ["flow"]
+parsers: ["flow", "babel-flow"]
 printWidth: 80
 trailingComma: "all"
                                                                                 | printWidth
@@ -148,7 +148,7 @@ type B = (
 
 exports[`method.js - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
-parsers: ["flow"]
+parsers: ["flow", "babel-flow"]
 printWidth: 80
 trailingComma: "all"
                                                                                 | printWidth
@@ -175,7 +175,7 @@ class A {
 
 exports[`union_type.js - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
-parsers: ["flow"]
+parsers: ["flow", "babel-flow"]
 printWidth: 80
 trailingComma: "all"
                                                                                 | printWidth

--- a/tests/flow/this-annotation/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/this-annotation/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,109 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`declare_function.js - {"trailingComma":"all"} format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+declare function foo (this : number, a : string, b) : void
+
+declare function bar (this : number): void
+
+declare function baz (this : number, ...a : any): void
+
+=====================================output=====================================
+// @flow
+
+declare function foo(this: number, a: string, b): void;
+
+declare function bar(this: number): void;
+
+declare function baz(this: number, ...a: any): void;
+
+================================================================================
+`;
+
+exports[`function_declaration.js - {"trailingComma":"all"} format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+function foo (this : number, a : string, b) {}
+
+function bar (this : number) {}
+
+function baz (this : number, ...a) {}
+
+=====================================output=====================================
+// @flow
+
+function foo(this: number, a: string, b) {}
+
+function bar(this: number) {}
+
+function baz(this: number, ...a) {}
+
+================================================================================
+`;
+
+exports[`function_type.js - {"trailingComma":"all"} format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+type T = (this : number, a : string, b : number) => void
+
+type U = (this : number, ...c : any) => void
+
+type V = (this : number) => void
+
+=====================================output=====================================
+// @flow
+
+type T = (this: number, a: string, b: number) => void;
+
+type U = (this: number, ...c: any) => void;
+
+type V = (this: number) => void;
+
+================================================================================
+`;
+
+exports[`method.js - {"trailingComma":"all"} format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+class A {
+    m(this : number, a : number, b : string) {}
+    n(this : number, ...c) {}
+    o(this : number) {}
+}
+
+=====================================output=====================================
+// @flow
+
+class A {
+  m(this: number, a: number, b: string) {}
+  n(this: number, ...c) {}
+  o(this: number) {}
+}
+
+================================================================================
+`;

--- a/tests/flow/this-annotation/declare_function.js
+++ b/tests/flow/this-annotation/declare_function.js
@@ -1,0 +1,7 @@
+// @flow
+
+declare function foo (this : number, a : string, b) : void
+
+declare function bar (this : number): void
+
+declare function baz (this : number, ...a : any): void

--- a/tests/flow/this-annotation/function_declaration.js
+++ b/tests/flow/this-annotation/function_declaration.js
@@ -1,0 +1,7 @@
+// @flow
+
+function foo (this : number, a : string, b) {}
+
+function bar (this : number) {}
+
+function baz (this : number, ...a) {}

--- a/tests/flow/this-annotation/function_type.js
+++ b/tests/flow/this-annotation/function_type.js
@@ -1,0 +1,7 @@
+// @flow
+
+type T = (this : number, a : string, b : number) => void
+
+type U = (this : number, ...c : any) => void
+
+type V = (this : number) => void

--- a/tests/flow/this-annotation/jsfmt.spec.js
+++ b/tests/flow/this-annotation/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["flow"], { trailingComma: "all" });

--- a/tests/flow/this-annotation/jsfmt.spec.js
+++ b/tests/flow/this-annotation/jsfmt.spec.js
@@ -1,1 +1,6 @@
-run_spec(__dirname, ["flow"], { trailingComma: "all" });
+run_spec(__dirname, ["flow", "babel-flow"], {
+  trailingComma: "all",
+  errors: {
+    "babel-flow": ["function_type.js", "line_break.js", "union_type.js"],
+  },
+});

--- a/tests/flow/this-annotation/line_break.js
+++ b/tests/flow/this-annotation/line_break.js
@@ -6,6 +6,12 @@ type T = (this: boolean,
           b: number,
          ) => boolean;
 
+type T2 = (_this: boolean,
+          a: number,
+
+          b: number,
+         ) => boolean;
+
 type A = (
   this: SupperLongLongLongLongLongLongLongLongLongLongLongType,
 

--- a/tests/flow/this-annotation/line_break.js
+++ b/tests/flow/this-annotation/line_break.js
@@ -5,3 +5,15 @@ type T = (this: boolean,
 
           b: number,
          ) => boolean;
+
+type A = (
+  this: SupperLongLongLongLongLongLongLongLongLongLongLongType,
+
+  b: number,
+) => boolean;
+
+type B = (
+  _this: SupperLongLongLongLongLongLongLongLongLongLongLongType,
+
+  b: number,
+) => boolean

--- a/tests/flow/this-annotation/line_break.js
+++ b/tests/flow/this-annotation/line_break.js
@@ -1,0 +1,7 @@
+// @flow
+
+type T = (this: boolean,
+          a: number,
+
+          b: number,
+         ) => boolean;

--- a/tests/flow/this-annotation/method.js
+++ b/tests/flow/this-annotation/method.js
@@ -1,0 +1,7 @@
+// @flow
+
+class A {
+    m(this : number, a : number, b : string) {}
+    n(this : number, ...c) {}
+    o(this : number) {}
+}

--- a/tests/flow/this-annotation/union_type.js
+++ b/tests/flow/this-annotation/union_type.js
@@ -1,0 +1,11 @@
+// @flow
+
+type A = (
+  this: | SupperLongLongLongLongLongLongLongLongLongLongLongType | FooBarBazLorem12345,
+  b: number,
+) => boolean;
+
+type B = (
+  _this: | SupperLongLongLongLongLongLongLongLongLongLongLongType | FooBarBazLorem12345,
+  b: number,
+) => boolean


### PR DESCRIPTION
This PR adds support for Flow `this` parameter annotations. 

E.g.

```
function foo (this : number) {}
``` 

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [X] I’ve added tests to confirm my change works.
- [X] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
