### PR TITLE
Test "import assertions" on other parsers

### DIFF
--- a/tests/js/dynamic-import/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/dynamic-import/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`assertions.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+import("./foo.json", { assert: { type: "json" } });
+
+=====================================output=====================================
+import("./foo.json", { assert: { type: "json" } });
+
+================================================================================
+`;
+
 exports[`test.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/js/dynamic-import/assertions.js
+++ b/tests/js/dynamic-import/assertions.js
@@ -1,0 +1,1 @@
+import("./foo.json", { assert: { type: "json" } });

--- a/tests/js/dynamic-import/jsfmt.spec.js
+++ b/tests/js/dynamic-import/jsfmt.spec.js
@@ -1,1 +1,7 @@
-run_spec(__dirname, ["babel", "flow", "typescript"]);
+run_spec(__dirname, ["babel", "flow", "typescript"], {
+  errors: {
+    flow: ["assertions.js"],
+    typescript: ["assertions.js"],
+    espree: ["assertions.js"],
+  },
+});


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

The second argument in `import()` is not handled, https://github.com/prettier/prettier/blob/56e9602a28d10b05a7205692786356f5d1e8308d/src/language-js/print/call-arguments.js#L121, when parser support this syntax, the test should fail.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
