### PR TITLE
Improve `massageAST`

### DIFF
--- a/src/language-js/clean.js
+++ b/src/language-js/clean.js
@@ -1,24 +1,22 @@
 "use strict";
 
-function clean(ast, newObj, parent) {
-  [
-    "range",
-    "raw",
-    "comments",
-    "leadingComments",
-    "trailingComments",
-    "innerComments",
-    "extra",
-    "start",
-    "end",
-    "loc",
-    "flags",
-    "errors",
-    "tokens",
-  ].forEach((name) => {
-    delete newObj[name];
-  });
+const ignoredProperties = new Set([
+  "range",
+  "raw",
+  "comments",
+  "leadingComments",
+  "trailingComments",
+  "innerComments",
+  "extra",
+  "start",
+  "end",
+  "loc",
+  "flags",
+  "errors",
+  "tokens",
+]);
 
+function clean(ast, newObj, parent) {
   if (ast.type === "Program") {
     delete newObj.sourceType;
   }
@@ -209,5 +207,7 @@ function clean(ast, newObj, parent) {
     newObj.value = newObj.value.trimEnd();
   }
 }
+
+clean.ignoredProperties = ignoredProperties;
 
 module.exports = clean;

--- a/src/main/massage-ast.js
+++ b/src/main/massage-ast.js
@@ -9,15 +9,23 @@ function massageAST(ast, options, parent) {
     return ast;
   }
 
+  const cleanFunction = options.printer.massageAstNode;
+  let ignoredProperties;
+  if (cleanFunction && cleanFunction.ignoredProperties) {
+    ignoredProperties = cleanFunction.ignoredProperties;
+  } else {
+    ignoredProperties = new Set();
+  }
+
   const newObj = {};
   for (const key of Object.keys(ast)) {
-    if (typeof ast[key] !== "function") {
+    if (!ignoredProperties.has(key) && typeof ast[key] !== "function") {
       newObj[key] = massageAST(ast[key], options, ast);
     }
   }
 
-  if (options.printer.massageAstNode) {
-    const result = options.printer.massageAstNode(ast, newObj, parent);
+  if (cleanFunction) {
+    const result = cleanFunction(ast, newObj, parent);
     if (result === null) {
       return;
     }


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

We deleted `ast.tokens` in clean, but the `massageAST` will still run `clean` over objects inside `tokens` and `comments`, because `Object.keys()` is called before `clean()`.
Found this during https://github.com/prettier/prettier/pull/9514, [there is a token `{type: 'TemplateLiteral'}`](https://github.com/prettier/prettier/pull/9514/files#diff-6bb1daf26b0ff781b5a96f32e9b3faf9bf0375deac42f3e7235430bf9ad92eeaR207)

Current implementation not looks good, but I can figure a better way. Any better idea?

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
