### PR TITLE
Playground: serialize ast contains BigInt

### DIFF
--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -37,6 +37,15 @@ self.onmessage = function (event) {
   });
 };
 
+function serializeAst(ast) {
+  return JSON.stringify(
+    ast,
+    (_, value) =>
+      typeof value === "bigint" ? `BigInt('${String(value)}')` : value,
+    2
+  );
+}
+
 function handleMessage(message) {
   if (message.type === "meta") {
     return {
@@ -75,7 +84,7 @@ function handleMessage(message) {
       let ast;
       let errored = false;
       try {
-        ast = JSON.stringify(prettier.__debug.parse(message.code, options).ast);
+        ast = serializeAst(prettier.__debug.parse(message.code, options).ast);
       } catch (e) {
         errored = true;
         ast = String(e);
@@ -85,7 +94,7 @@ function handleMessage(message) {
         try {
           ast = formatCode(ast, { parser: "json", plugins });
         } catch (e) {
-          ast = JSON.stringify(ast, null, 2);
+          ast = serializeAst(ast);
         }
       }
       response.debug.ast = ast;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

[`serialize-javascript` serialize BigInt like 'BigInt("9999")'](https://github.com/yahoo/serialize-javascript/blob/ac79a5aa9578131cd199f45c5e449eca84f9e35e/test/unit/serialize.js#L439-L440), I replaced `"` with `'` to avoid escape in JSON values.

Fixes #9524

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
