### PR TITLE
Use `-1` instead of `false` when index out of bounds

### DIFF
--- a/src/common/util-shared.js
+++ b/src/common/util-shared.js
@@ -26,28 +26,48 @@ const {
   addTrailingComment,
 } = require("./util");
 
+const returnFalseIfNegativeOne = (fn) => (...args) => {
+  const result = fn(...args);
+  return result === -1 ? false : result;
+};
+
 module.exports = {
   getMaxContinuousCount,
   getStringWidth,
   getAlignmentSize,
   getIndentSize,
-  skip,
-  skipWhitespace,
-  skipSpaces,
-  skipNewline,
-  skipToLineEnd,
-  skipEverythingButNewLine,
-  skipInlineComment,
-  skipTrailingComment,
   hasNewline,
   hasNewlineInRange,
   hasSpaces,
   isNextLineEmpty,
   isNextLineEmptyAfterIndex,
   isPreviousLineEmpty,
-  getNextNonSpaceNonCommentCharacterIndex,
   makeString,
   addLeadingComment,
   addDanglingComment,
   addTrailingComment,
+  // TODO: Change these functions to use `-1` instead of `false` in v3.0.0
+  skip(chars) {
+    return (text, index, opts) => {
+      return index === false
+        ? false
+        : returnFalseIfNegativeOne(skip(chars))(text, index, opts);
+    };
+  },
+  skipNewline(text, index, opts) {
+    return index === false ? false : skipNewline(text, index, opts);
+  },
+  skipInlineComment(text, index) {
+    return index === false ? false : skipInlineComment(text, index);
+  },
+  skipTrailingComment(text, index) {
+    return index === false ? false : skipTrailingComment(text, index);
+  },
+  skipWhitespace: returnFalseIfNegativeOne(skipWhitespace),
+  skipSpaces: returnFalseIfNegativeOne(skipSpaces),
+  skipToLineEnd: returnFalseIfNegativeOne(skipToLineEnd),
+  skipEverythingButNewLine: returnFalseIfNegativeOne(skipEverythingButNewLine),
+  getNextNonSpaceNonCommentCharacterIndex: returnFalseIfNegativeOne(
+    getNextNonSpaceNonCommentCharacterIndex
+  ),
 };

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -584,7 +584,7 @@ function handleCommentAfterArrowParams(text, enclosingNode, comment, options) {
     comment,
     options.locEnd
   );
-  if (index !== false && text.slice(index, index + 2) === "=>") {
+  if (index !== -1 && text.slice(index, index + 2) === "=>") {
     addDanglingComment(enclosingNode, comment);
     return true;
   }
@@ -677,7 +677,7 @@ function handleLastFunctionArgComments(
         options.locEnd(enclosingNode.id)
       );
       return (
-        functionParamLeftParenIndex !== false &&
+        functionParamLeftParenIndex !== -1 &&
         getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
           text,
           functionParamLeftParenIndex + 1

--- a/src/language-js/parser-babel.js
+++ b/src/language-js/parser-babel.js
@@ -82,7 +82,7 @@ function isFlowFile(text, options) {
     0
   );
 
-  if (firstNonSpaceNonCommentCharacterIndex !== false) {
+  if (firstNonSpaceNonCommentCharacterIndex !== -1) {
     text = text.slice(0, firstNonSpaceNonCommentCharacterIndex);
   }
 

--- a/src/language-js/print/member-chain.js
+++ b/src/language-js/print/member-chain.js
@@ -81,7 +81,7 @@ function printMemberChain(path, options, print) {
     // line after that parenthesis
     if (nextChar === ")") {
       return (
-        nextCharIndex !== false &&
+        nextCharIndex !== -1 &&
         isNextLineEmptyAfterIndex(originalText, nextCharIndex + 1)
       );
     }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -19,11 +19,9 @@ const {
   hasNodeIgnoreComment,
   getIndentSize,
   getPreferredQuote,
-} = require("../common/util");
-const {
   isNextLineEmpty,
   getNextNonSpaceNonCommentCharacterIndex,
-} = require("../common/util-shared");
+} = require("../common/util");
 const {
   builders: {
     concat,
@@ -687,7 +685,7 @@ function printPathNoParens(path, options, print, args) {
             options.locEnd
           );
           return (
-            nextCharacter !== false &&
+            nextCharacter !== -1 &&
             options.originalText.slice(nextCharacter, nextCharacter + 2) ===
               "=>"
           );

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -881,7 +881,7 @@ function isFlowAnnotationComment(text, typeAnnotation, options) {
   const start = options.locStart(typeAnnotation);
   const end = skipWhitespace(text, options.locEnd(typeAnnotation));
   return (
-    end !== false &&
+    end !== -1 &&
     text.slice(start, start + 2) === "/*" &&
     text.slice(end, end + 2) === "*/"
   );

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -515,7 +515,7 @@ function printComments(path, print, options, needsSemi) {
         text,
         skipSpaces(text, options.locEnd(comment))
       );
-      if (index !== false && hasNewline(text, index)) {
+      if (index !== -1 && hasNewline(text, index)) {
         leadingParts.push(hardline);
       }
     } else if (trailing) {


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Idea from https://github.com/prettier/prettier/pull/8759/files#r465118376

Align this with built-in methods like `String#indexOf()` `Array#findIndex()` etc.
To prevent breaking changes, I add several simple wrapper to make public api behave the old way.

cc @brodybits

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
