### PR TITLE
Use JSX style for all nested ternaries

### DIFF
--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -231,9 +231,7 @@ function printTernaryOperator(path, options, print, operatorOptions) {
         : "",
       line,
       ": ",
-      alternateNode.type === operatorOptions.conditionalNodeType
-        ? path.call(print, operatorOptions.alternateNodePropertyName)
-        : align(2, path.call(print, operatorOptions.alternateNodePropertyName)),
+      align(2, path.call(print, operatorOptions.alternateNodePropertyName)),
     ]);
     parts.push(
       parent.type !== operatorOptions.conditionalNodeType ||

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -182,13 +182,13 @@ function printTernaryOperator(path, options, print, operatorOptions) {
     lastConditionalParent !== node;
 
   if (
-    // We now print nested ternaries the same way we print JSX ternaries.
-    isTernaryChain ||
-    (operatorOptions.shouldCheckJsx &&
-      (isJSXNode(node[operatorOptions.testNodePropertyNames[0]]) ||
-        isJSXNode(consequentNode) ||
-        isJSXNode(alternateNode) ||
-        conditionalExpressionChainContainsJSX(lastConditionalParent)))
+    operatorOptions.shouldCheckJsx &&
+    // We now print nested ternaries the same way we print JSX ternaries, except for TS Conditional types.
+    (isTernaryChain ||
+      isJSXNode(node[operatorOptions.testNodePropertyNames[0]]) ||
+      isJSXNode(consequentNode) ||
+      isJSXNode(alternateNode) ||
+      conditionalExpressionChainContainsJSX(lastConditionalParent))
   ) {
     jsxMode = true;
     forceNoIndent = true;

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -176,12 +176,19 @@ function printTernaryOperator(path, options, print, operatorOptions) {
   const firstNonConditionalParent = currentParent || parent;
   const lastConditionalParent = previousParent;
 
+  const isTernaryChain =
+    alternateNode.type === operatorOptions.conditionalNodeType ||
+    consequentNode.type === operatorOptions.conditionalNodeType ||
+    lastConditionalParent !== node;
+
   if (
-    operatorOptions.shouldCheckJsx &&
-    (isJSXNode(node[operatorOptions.testNodePropertyNames[0]]) ||
-      isJSXNode(consequentNode) ||
-      isJSXNode(alternateNode) ||
-      conditionalExpressionChainContainsJSX(lastConditionalParent))
+    // We now print nested ternaries the same way we print JSX ternaries.
+    isTernaryChain ||
+    (operatorOptions.shouldCheckJsx &&
+      (isJSXNode(node[operatorOptions.testNodePropertyNames[0]]) ||
+        isJSXNode(consequentNode) ||
+        isJSXNode(alternateNode) ||
+        conditionalExpressionChainContainsJSX(lastConditionalParent)))
   ) {
     jsxMode = true;
     forceNoIndent = true;

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -215,9 +215,15 @@ function printTernaryOperator(path, options, print, operatorOptions) {
 
     parts.push(
       " ? ",
+      consequentNode.type === operatorOptions.conditionalNodeType
+        ? ifBreak("", "(")
+        : "",
       isNil(consequentNode)
         ? path.call(print, operatorOptions.consequentNodePropertyName)
         : wrap(path.call(print, operatorOptions.consequentNodePropertyName)),
+      consequentNode.type === operatorOptions.conditionalNodeType
+        ? ifBreak("", ")")
+        : "",
       " : ",
       alternateNode.type === operatorOptions.conditionalNodeType ||
         isNil(alternateNode)

--- a/tests/js/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/comments/__snapshots__/jsfmt.spec.js.snap
@@ -3680,7 +3680,7 @@ function memberInAndOutWithCalls() {
 function excessiveEverything() {
   return (
     // Reason for stuff
-    a.b() * 3 + 4 ? (a\`hi\`, 1) ? 1 : 1 : 1
+    a.b() * 3 + 4 ? ((a\`hi\`, 1) ? 1 : 1) : 1
   )
 }
 
@@ -3942,7 +3942,7 @@ function memberInAndOutWithCalls() {
 function excessiveEverything() {
   return (
     // Reason for stuff
-    a.b() * 3 + 4 ? (a\`hi\`, 1) ? 1 : 1 : 1
+    a.b() * 3 + 4 ? ((a\`hi\`, 1) ? 1 : 1) : 1
   );
 }
 

--- a/tests/js/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/comments/__snapshots__/jsfmt.spec.js.snap
@@ -3680,7 +3680,7 @@ function memberInAndOutWithCalls() {
 function excessiveEverything() {
   return (
     // Reason for stuff
-    a.b() * 3 + 4 ? ((a\`hi\`, 1) ? 1 : 1) : 1
+    a.b() * 3 + 4 ? (a\`hi\`, 1) ? 1 : 1 : 1
   )
 }
 
@@ -3942,7 +3942,7 @@ function memberInAndOutWithCalls() {
 function excessiveEverything() {
   return (
     // Reason for stuff
-    a.b() * 3 + 4 ? ((a\`hi\`, 1) ? 1 : 1) : 1
+    a.b() * 3 + 4 ? (a\`hi\`, 1) ? 1 : 1 : 1
   );
 }
 

--- a/tests/js/conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/conditional/__snapshots__/jsfmt.spec.js.snap
@@ -177,11 +177,11 @@ test
     */
     foo
   : test
-  ? /* comment
+    ? /* comment
   comment
     comment */
-    foo
-  : bar;
+      foo
+    : bar;
 
 test ? /* comment */ foo : bar;
 
@@ -201,13 +201,13 @@ test
      comment
            comment
     */
-  test
-  ? foo
-  : /* comment
+    test
+    ? foo
+    : /* comment
   comment
     comment
    */
-    bar;
+      bar;
 
 test ? foo : /* comment */ bar;
 

--- a/tests/js/conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/conditional/__snapshots__/jsfmt.spec.js.snap
@@ -169,19 +169,21 @@ test
     foo
   : bar;
 
-test
-  ? /* comment
+test ? (
+  /* comment
        comment
        comment
        comment
     */
-    foo
-  : test
-    ? /* comment
+  foo
+) : test ? (
+  /* comment
   comment
     comment */
-      foo
-    : bar;
+  foo
+) : (
+  bar
+);
 
 test ? /* comment */ foo : bar;
 
@@ -194,29 +196,35 @@ test
     */
     bar;
 
-test
-  ? foo
-  : /* comment
+test ? (
+  foo
+) : /* comment
          comment
      comment
            comment
     */
-    test
-    ? foo
-    : /* comment
+test ? (
+  foo
+) : (
+  /* comment
   comment
     comment
    */
-      bar;
+  bar
+);
 
 test ? foo : /* comment */ bar;
 
-test
-  ? test /* c
-c */
-    ? foo
-    : bar
-  : bar;
+test ? (
+  test /* c
+c */ ? (
+    foo
+  ) : (
+    bar
+  )
+) : (
+  bar
+);
 
 ================================================================================
 `;

--- a/tests/js/ternaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/ternaries/__snapshots__/jsfmt.spec.js.snap
@@ -463,10 +463,10 @@ a
 aaaaaaaaaaaaaaa
     ? bbbbbbbbbbbbbbbbbb
     : ccccccccccccccc
-    ? ddddddddddddddd
-    : eeeeeeeeeeeeeee
-    ? fffffffffffffff
-    : gggggggggggggggg;
+      ? ddddddddddddddd
+      : eeeeeeeeeeeeeee
+        ? fffffffffffffff
+        : gggggggggggggggg;
 
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
     ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -794,10 +794,10 @@ a
 aaaaaaaaaaaaaaa
 	? bbbbbbbbbbbbbbbbbb
 	: ccccccccccccccc
-	? ddddddddddddddd
-	: eeeeeeeeeeeeeee
-	? fffffffffffffff
-	: gggggggggggggggg;
+	  ? ddddddddddddddd
+	  : eeeeeeeeeeeeeee
+	    ? fffffffffffffff
+	    : gggggggggggggggg;
 
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 	? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -1128,10 +1128,10 @@ a
 aaaaaaaaaaaaaaa
 	? bbbbbbbbbbbbbbbbbb
 	: ccccccccccccccc
-	? ddddddddddddddd
-	: eeeeeeeeeeeeeee
-	? fffffffffffffff
-	: gggggggggggggggg;
+	  ? ddddddddddddddd
+	  : eeeeeeeeeeeeeee
+	    ? fffffffffffffff
+	    : gggggggggggggggg;
 
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 	? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -1457,10 +1457,10 @@ a
 aaaaaaaaaaaaaaa
   ? bbbbbbbbbbbbbbbbbb
   : ccccccccccccccc
-  ? ddddddddddddddd
-  : eeeeeeeeeeeeeee
-  ? fffffffffffffff
-  : gggggggggggggggg;
+    ? ddddddddddddddd
+    : eeeeeeeeeeeeeee
+      ? fffffffffffffff
+      : gggggggggggggggg;
 
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
   ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -1720,10 +1720,10 @@ let icecream =
 const value = condition1
     ? value1
     : condition2
-    ? value2
-    : condition3
-    ? value3
-    : value4;
+      ? value2
+      : condition3
+        ? value3
+        : value4;
 
 const StorybookLoader = ({ match }) =>
     match.params.storyId === "button" ? (
@@ -1749,32 +1749,32 @@ const message =
     i % 3 === 0 && i % 5 === 0
         ? "fizzbuzz"
         : i % 3 === 0
-        ? "fizz"
-        : i % 5 === 0
-        ? "buzz"
-        : String(i);
+          ? "fizz"
+          : i % 5 === 0
+            ? "buzz"
+            : String(i);
 
 const paymentMessage =
     state == "success"
         ? "Payment completed successfully"
         : state == "processing"
-        ? "Payment processing"
-        : state == "invalid_cvc"
-        ? "There was an issue with your CVC number"
-        : state == "invalid_expiry"
-        ? "Expiry must be sometime in the past."
-        : "There was an issue with the payment.  Please contact support.";
+          ? "Payment processing"
+          : state == "invalid_cvc"
+            ? "There was an issue with your CVC number"
+            : state == "invalid_expiry"
+              ? "Expiry must be sometime in the past."
+              : "There was an issue with the payment.  Please contact support.";
 
 const paymentMessage2 =
     state == "success"
         ? 1 //'Payment completed successfully'
         : state == "processing"
-        ? 2 //'Payment processing'
-        : state == "invalid_cvc"
-        ? 3 //'There was an issue with your CVC number'
-        : true //state == 'invalid_expiry'
-        ? 4 //'Expiry must be sometime in the past.'
-        : 5; // 'There was an issue with the payment.  Please contact support.'
+          ? 2 //'Payment processing'
+          : state == "invalid_cvc"
+            ? 3 //'There was an issue with your CVC number'
+            : true //state == 'invalid_expiry'
+              ? 4 //'Expiry must be sometime in the past.'
+              : 5; // 'There was an issue with the payment.  Please contact support.'
 
 const foo = (
     <div
@@ -1783,31 +1783,31 @@ const foo = (
             (medals[0].record
                 ? "-record"
                 : medals[0].unique
-                ? "-unique"
-                : medals[0].type)
+                  ? "-unique"
+                  : medals[0].type)
         }
     >
         {medals[0].record
             ? i18n("Record")
             : medals[0].unique
-            ? i18n("Unique")
-            : medals[0].type === 0
-            ? i18n("Silver")
-            : medals[0].type === 1
-            ? i18n("Gold")
-            : medals[0].type === 2
-            ? i18n("Platinum")
-            : i18n("Theme")}
+              ? i18n("Unique")
+              : medals[0].type === 0
+                ? i18n("Silver")
+                : medals[0].type === 1
+                  ? i18n("Gold")
+                  : medals[0].type === 2
+                    ? i18n("Platinum")
+                    : i18n("Theme")}
     </div>
 );
 
 a
     ? literalline
     : {
-          123: 12,
-      }
-    ? line
-    : softline;
+            123: 12,
+        }
+      ? line
+      : softline;
 
 ================================================================================
 `;
@@ -1925,10 +1925,10 @@ let icecream =
 const value = condition1
 	? value1
 	: condition2
-	? value2
-	: condition3
-	? value3
-	: value4;
+	  ? value2
+	  : condition3
+	    ? value3
+	    : value4;
 
 const StorybookLoader = ({ match }) =>
 	match.params.storyId === "button" ? (
@@ -1954,32 +1954,32 @@ const message =
 	i % 3 === 0 && i % 5 === 0
 		? "fizzbuzz"
 		: i % 3 === 0
-		? "fizz"
-		: i % 5 === 0
-		? "buzz"
-		: String(i);
+		  ? "fizz"
+		  : i % 5 === 0
+		    ? "buzz"
+		    : String(i);
 
 const paymentMessage =
 	state == "success"
 		? "Payment completed successfully"
 		: state == "processing"
-		? "Payment processing"
-		: state == "invalid_cvc"
-		? "There was an issue with your CVC number"
-		: state == "invalid_expiry"
-		? "Expiry must be sometime in the past."
-		: "There was an issue with the payment.  Please contact support.";
+		  ? "Payment processing"
+		  : state == "invalid_cvc"
+		    ? "There was an issue with your CVC number"
+		    : state == "invalid_expiry"
+		      ? "Expiry must be sometime in the past."
+		      : "There was an issue with the payment.  Please contact support.";
 
 const paymentMessage2 =
 	state == "success"
 		? 1 //'Payment completed successfully'
 		: state == "processing"
-		? 2 //'Payment processing'
-		: state == "invalid_cvc"
-		? 3 //'There was an issue with your CVC number'
-		: true //state == 'invalid_expiry'
-		? 4 //'Expiry must be sometime in the past.'
-		: 5; // 'There was an issue with the payment.  Please contact support.'
+		  ? 2 //'Payment processing'
+		  : state == "invalid_cvc"
+		    ? 3 //'There was an issue with your CVC number'
+		    : true //state == 'invalid_expiry'
+		      ? 4 //'Expiry must be sometime in the past.'
+		      : 5; // 'There was an issue with the payment.  Please contact support.'
 
 const foo = (
 	<div
@@ -1988,31 +1988,31 @@ const foo = (
 			(medals[0].record
 				? "-record"
 				: medals[0].unique
-				? "-unique"
-				: medals[0].type)
+				  ? "-unique"
+				  : medals[0].type)
 		}
 	>
 		{medals[0].record
 			? i18n("Record")
 			: medals[0].unique
-			? i18n("Unique")
-			: medals[0].type === 0
-			? i18n("Silver")
-			: medals[0].type === 1
-			? i18n("Gold")
-			: medals[0].type === 2
-			? i18n("Platinum")
-			: i18n("Theme")}
+			  ? i18n("Unique")
+			  : medals[0].type === 0
+			    ? i18n("Silver")
+			    : medals[0].type === 1
+			      ? i18n("Gold")
+			      : medals[0].type === 2
+			        ? i18n("Platinum")
+			        : i18n("Theme")}
 	</div>
 );
 
 a
 	? literalline
 	: {
-			123: 12,
-	  }
-	? line
-	: softline;
+				123: 12,
+	    }
+	  ? line
+	  : softline;
 
 ================================================================================
 `;
@@ -2129,10 +2129,10 @@ let icecream =
 const value = condition1
 	? value1
 	: condition2
-	? value2
-	: condition3
-	? value3
-	: value4;
+	  ? value2
+	  : condition3
+	    ? value3
+	    : value4;
 
 const StorybookLoader = ({ match }) =>
 	match.params.storyId === "button" ? (
@@ -2158,32 +2158,32 @@ const message =
 	i % 3 === 0 && i % 5 === 0
 		? "fizzbuzz"
 		: i % 3 === 0
-		? "fizz"
-		: i % 5 === 0
-		? "buzz"
-		: String(i);
+		  ? "fizz"
+		  : i % 5 === 0
+		    ? "buzz"
+		    : String(i);
 
 const paymentMessage =
 	state == "success"
 		? "Payment completed successfully"
 		: state == "processing"
-		? "Payment processing"
-		: state == "invalid_cvc"
-		? "There was an issue with your CVC number"
-		: state == "invalid_expiry"
-		? "Expiry must be sometime in the past."
-		: "There was an issue with the payment.  Please contact support.";
+		  ? "Payment processing"
+		  : state == "invalid_cvc"
+		    ? "There was an issue with your CVC number"
+		    : state == "invalid_expiry"
+		      ? "Expiry must be sometime in the past."
+		      : "There was an issue with the payment.  Please contact support.";
 
 const paymentMessage2 =
 	state == "success"
 		? 1 //'Payment completed successfully'
 		: state == "processing"
-		? 2 //'Payment processing'
-		: state == "invalid_cvc"
-		? 3 //'There was an issue with your CVC number'
-		: true //state == 'invalid_expiry'
-		? 4 //'Expiry must be sometime in the past.'
-		: 5; // 'There was an issue with the payment.  Please contact support.'
+		  ? 2 //'Payment processing'
+		  : state == "invalid_cvc"
+		    ? 3 //'There was an issue with your CVC number'
+		    : true //state == 'invalid_expiry'
+		      ? 4 //'Expiry must be sometime in the past.'
+		      : 5; // 'There was an issue with the payment.  Please contact support.'
 
 const foo = (
 	<div
@@ -2192,31 +2192,31 @@ const foo = (
 			(medals[0].record
 				? "-record"
 				: medals[0].unique
-				? "-unique"
-				: medals[0].type)
+				  ? "-unique"
+				  : medals[0].type)
 		}
 	>
 		{medals[0].record
 			? i18n("Record")
 			: medals[0].unique
-			? i18n("Unique")
-			: medals[0].type === 0
-			? i18n("Silver")
-			: medals[0].type === 1
-			? i18n("Gold")
-			: medals[0].type === 2
-			? i18n("Platinum")
-			: i18n("Theme")}
+			  ? i18n("Unique")
+			  : medals[0].type === 0
+			    ? i18n("Silver")
+			    : medals[0].type === 1
+			      ? i18n("Gold")
+			      : medals[0].type === 2
+			        ? i18n("Platinum")
+			        : i18n("Theme")}
 	</div>
 );
 
 a
 	? literalline
 	: {
-			123: 12,
-	  }
-	? line
-	: softline;
+				123: 12,
+	    }
+	  ? line
+	  : softline;
 
 ================================================================================
 `;
@@ -2332,10 +2332,10 @@ let icecream =
 const value = condition1
   ? value1
   : condition2
-  ? value2
-  : condition3
-  ? value3
-  : value4;
+    ? value2
+    : condition3
+      ? value3
+      : value4;
 
 const StorybookLoader = ({ match }) =>
   match.params.storyId === "button" ? (
@@ -2361,32 +2361,32 @@ const message =
   i % 3 === 0 && i % 5 === 0
     ? "fizzbuzz"
     : i % 3 === 0
-    ? "fizz"
-    : i % 5 === 0
-    ? "buzz"
-    : String(i);
+      ? "fizz"
+      : i % 5 === 0
+        ? "buzz"
+        : String(i);
 
 const paymentMessage =
   state == "success"
     ? "Payment completed successfully"
     : state == "processing"
-    ? "Payment processing"
-    : state == "invalid_cvc"
-    ? "There was an issue with your CVC number"
-    : state == "invalid_expiry"
-    ? "Expiry must be sometime in the past."
-    : "There was an issue with the payment.  Please contact support.";
+      ? "Payment processing"
+      : state == "invalid_cvc"
+        ? "There was an issue with your CVC number"
+        : state == "invalid_expiry"
+          ? "Expiry must be sometime in the past."
+          : "There was an issue with the payment.  Please contact support.";
 
 const paymentMessage2 =
   state == "success"
     ? 1 //'Payment completed successfully'
     : state == "processing"
-    ? 2 //'Payment processing'
-    : state == "invalid_cvc"
-    ? 3 //'There was an issue with your CVC number'
-    : true //state == 'invalid_expiry'
-    ? 4 //'Expiry must be sometime in the past.'
-    : 5; // 'There was an issue with the payment.  Please contact support.'
+      ? 2 //'Payment processing'
+      : state == "invalid_cvc"
+        ? 3 //'There was an issue with your CVC number'
+        : true //state == 'invalid_expiry'
+          ? 4 //'Expiry must be sometime in the past.'
+          : 5; // 'There was an issue with the payment.  Please contact support.'
 
 const foo = (
   <div
@@ -2395,31 +2395,31 @@ const foo = (
       (medals[0].record
         ? "-record"
         : medals[0].unique
-        ? "-unique"
-        : medals[0].type)
+          ? "-unique"
+          : medals[0].type)
     }
   >
     {medals[0].record
       ? i18n("Record")
       : medals[0].unique
-      ? i18n("Unique")
-      : medals[0].type === 0
-      ? i18n("Silver")
-      : medals[0].type === 1
-      ? i18n("Gold")
-      : medals[0].type === 2
-      ? i18n("Platinum")
-      : i18n("Theme")}
+        ? i18n("Unique")
+        : medals[0].type === 0
+          ? i18n("Silver")
+          : medals[0].type === 1
+            ? i18n("Gold")
+            : medals[0].type === 2
+              ? i18n("Platinum")
+              : i18n("Theme")}
   </div>
 );
 
 a
   ? literalline
   : {
-      123: 12,
-    }
-  ? line
-  : softline;
+        123: 12,
+      }
+    ? line
+    : softline;
 
 ================================================================================
 `;
@@ -2486,8 +2486,8 @@ const value = (
         ? true
         : false
     : true
-    ? true
-    : false;
+      ? true
+      : false;
 
 (
     bifornCringerMoshedPerplexSawder
@@ -2576,8 +2576,8 @@ const value = (
 		? true
 		: false
 	: true
-	? true
-	: false;
+	  ? true
+	  : false;
 
 (
 	bifornCringerMoshedPerplexSawder
@@ -2665,8 +2665,8 @@ const value = (
 		? true
 		: false
 	: true
-	? true
-	: false;
+	  ? true
+	  : false;
 
 (
 	bifornCringerMoshedPerplexSawder
@@ -2753,8 +2753,8 @@ const value = (
     ? true
     : false
   : true
-  ? true
-  : false;
+    ? true
+    : false;
 
 (
   bifornCringerMoshedPerplexSawder

--- a/tests/js/ternaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/ternaries/__snapshots__/jsfmt.spec.js.snap
@@ -179,9 +179,9 @@ fn(
   bifornCringerMoshedPerplexSawder,
   askTrovenaBeenaDependsRowans,
   glimseGlyphsHazardNoopsTieTie === averredBathersBoxroomBuggyNurl &&
-    anodyneCondosMalateOverateRetinol 
-      ? annularCooeedSplicesWalksWayWay 
-      : kochabCooieGameOnOboleUnweave 
+    anodyneCondosMalateOverateRetinol
+      ? annularCooeedSplicesWalksWayWay
+      : kochabCooieGameOnOboleUnweave
 );
 
 =====================================output=====================================
@@ -209,9 +209,9 @@ fn(
   bifornCringerMoshedPerplexSawder,
   askTrovenaBeenaDependsRowans,
   glimseGlyphsHazardNoopsTieTie === averredBathersBoxroomBuggyNurl &&
-    anodyneCondosMalateOverateRetinol 
-      ? annularCooeedSplicesWalksWayWay 
-      : kochabCooieGameOnOboleUnweave 
+    anodyneCondosMalateOverateRetinol
+      ? annularCooeedSplicesWalksWayWay
+      : kochabCooieGameOnOboleUnweave
 );
 
 =====================================output=====================================
@@ -238,9 +238,9 @@ fn(
   bifornCringerMoshedPerplexSawder,
   askTrovenaBeenaDependsRowans,
   glimseGlyphsHazardNoopsTieTie === averredBathersBoxroomBuggyNurl &&
-    anodyneCondosMalateOverateRetinol 
-      ? annularCooeedSplicesWalksWayWay 
-      : kochabCooieGameOnOboleUnweave 
+    anodyneCondosMalateOverateRetinol
+      ? annularCooeedSplicesWalksWayWay
+      : kochabCooieGameOnOboleUnweave
 );
 
 =====================================output=====================================
@@ -266,9 +266,9 @@ fn(
   bifornCringerMoshedPerplexSawder,
   askTrovenaBeenaDependsRowans,
   glimseGlyphsHazardNoopsTieTie === averredBathersBoxroomBuggyNurl &&
-    anodyneCondosMalateOverateRetinol 
-      ? annularCooeedSplicesWalksWayWay 
-      : kochabCooieGameOnOboleUnweave 
+    anodyneCondosMalateOverateRetinol
+      ? annularCooeedSplicesWalksWayWay
+      : kochabCooieGameOnOboleUnweave
 );
 
 =====================================output=====================================

--- a/tests/js/ternaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/ternaries/__snapshots__/jsfmt.spec.js.snap
@@ -460,21 +460,29 @@ a
     : a;
 
 =====================================output=====================================
-aaaaaaaaaaaaaaa
-    ? bbbbbbbbbbbbbbbbbb
-    : ccccccccccccccc
-      ? ddddddddddddddd
-      : eeeeeeeeeeeeeee
-        ? fffffffffffffff
-        : gggggggggggggggg;
+aaaaaaaaaaaaaaa ? (
+    bbbbbbbbbbbbbbbbbb
+) : ccccccccccccccc ? (
+    ddddddddddddddd
+) : eeeeeeeeeeeeeee ? (
+    fffffffffffffff
+) : (
+    gggggggggggggggg
+);
 
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-        ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-            ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-            : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-        : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ? (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ? (
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ? (
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        ) : (
+            aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        )
+    ) : (
+        aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    )
+) : (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+);
 
 a
     ? {
@@ -791,21 +799,29 @@ a
     : a;
 
 =====================================output=====================================
-aaaaaaaaaaaaaaa
-	? bbbbbbbbbbbbbbbbbb
-	: ccccccccccccccc
-	  ? ddddddddddddddd
-	  : eeeeeeeeeeeeeee
-	    ? fffffffffffffff
-	    : gggggggggggggggg;
+aaaaaaaaaaaaaaa ? (
+	bbbbbbbbbbbbbbbbbb
+) : ccccccccccccccc ? (
+	ddddddddddddddd
+) : eeeeeeeeeeeeeee ? (
+	fffffffffffffff
+) : (
+	gggggggggggggggg
+);
 
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-	? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-		? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-			? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-			: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-		: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-	: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ? (
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ? (
+		aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ? (
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+		) : (
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+		)
+	) : (
+		aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+	)
+) : (
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+);
 
 a
 	? {
@@ -1125,21 +1141,29 @@ a
     : a;
 
 =====================================output=====================================
-aaaaaaaaaaaaaaa
-	? bbbbbbbbbbbbbbbbbb
-	: ccccccccccccccc
-	  ? ddddddddddddddd
-	  : eeeeeeeeeeeeeee
-	    ? fffffffffffffff
-	    : gggggggggggggggg;
+aaaaaaaaaaaaaaa ? (
+	bbbbbbbbbbbbbbbbbb
+) : ccccccccccccccc ? (
+	ddddddddddddddd
+) : eeeeeeeeeeeeeee ? (
+	fffffffffffffff
+) : (
+	gggggggggggggggg
+);
 
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-	? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-		? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-			? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-			: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-		: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-	: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ? (
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ? (
+		aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ? (
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+		) : (
+			aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+		)
+	) : (
+		aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+	)
+) : (
+	aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+);
 
 a
 	? {
@@ -1454,21 +1478,29 @@ a
     : a;
 
 =====================================output=====================================
-aaaaaaaaaaaaaaa
-  ? bbbbbbbbbbbbbbbbbb
-  : ccccccccccccccc
-    ? ddddddddddddddd
-    : eeeeeeeeeeeeeee
-      ? fffffffffffffff
-      : gggggggggggggggg;
+aaaaaaaaaaaaaaa ? (
+  bbbbbbbbbbbbbbbbbb
+) : ccccccccccccccc ? (
+  ddddddddddddddd
+) : eeeeeeeeeeeeeee ? (
+  fffffffffffffff
+) : (
+  gggggggggggggggg
+);
 
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-  ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-      ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-      : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-    : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-  : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ? (
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ? (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ? (
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    ) : (
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    )
+  ) : (
+    aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  )
+) : (
+  aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+);
 
 a
   ? {
@@ -1717,13 +1749,15 @@ let icecream =
         ? (p) => (!!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`)
         : (p) => \`here's your \${p} \${what}\`;
 
-const value = condition1
-    ? value1
-    : condition2
-      ? value2
-      : condition3
-        ? value3
-        : value4;
+const value = condition1 ? (
+    value1
+) : condition2 ? (
+    value2
+) : condition3 ? (
+    value3
+) : (
+    value4
+);
 
 const StorybookLoader = ({ match }) =>
     match.params.storyId === "button" ? (
@@ -1746,68 +1780,80 @@ const StorybookLoader = ({ match }) =>
     );
 
 const message =
-    i % 3 === 0 && i % 5 === 0
-        ? "fizzbuzz"
-        : i % 3 === 0
-          ? "fizz"
-          : i % 5 === 0
-            ? "buzz"
-            : String(i);
+    i % 3 === 0 && i % 5 === 0 ? (
+        "fizzbuzz"
+    ) : i % 3 === 0 ? (
+        "fizz"
+    ) : i % 5 === 0 ? (
+        "buzz"
+    ) : (
+        String(i)
+    );
 
 const paymentMessage =
-    state == "success"
-        ? "Payment completed successfully"
-        : state == "processing"
-          ? "Payment processing"
-          : state == "invalid_cvc"
-            ? "There was an issue with your CVC number"
-            : state == "invalid_expiry"
-              ? "Expiry must be sometime in the past."
-              : "There was an issue with the payment.  Please contact support.";
+    state == "success" ? (
+        "Payment completed successfully"
+    ) : state == "processing" ? (
+        "Payment processing"
+    ) : state == "invalid_cvc" ? (
+        "There was an issue with your CVC number"
+    ) : state == "invalid_expiry" ? (
+        "Expiry must be sometime in the past."
+    ) : (
+        "There was an issue with the payment.  Please contact support."
+    );
 
 const paymentMessage2 =
-    state == "success"
-        ? 1 //'Payment completed successfully'
-        : state == "processing"
-          ? 2 //'Payment processing'
-          : state == "invalid_cvc"
-            ? 3 //'There was an issue with your CVC number'
-            : true //state == 'invalid_expiry'
-              ? 4 //'Expiry must be sometime in the past.'
-              : 5; // 'There was an issue with the payment.  Please contact support.'
+    state == "success" ? (
+        1 //'Payment completed successfully'
+    ) : state == "processing" ? (
+        2 //'Payment processing'
+    ) : state == "invalid_cvc" ? (
+        3 //'There was an issue with your CVC number'
+    ) : true ? ( //state == 'invalid_expiry'
+        4 //'Expiry must be sometime in the past.'
+    ) : (
+        5
+    ); // 'There was an issue with the payment.  Please contact support.'
 
 const foo = (
     <div
         className={
             "match-achievement-medal-type type" +
-            (medals[0].record
-                ? "-record"
-                : medals[0].unique
-                  ? "-unique"
-                  : medals[0].type)
+            (medals[0].record ? (
+                "-record"
+            ) : medals[0].unique ? (
+                "-unique"
+            ) : (
+                medals[0].type
+            ))
         }
     >
-        {medals[0].record
-            ? i18n("Record")
-            : medals[0].unique
-              ? i18n("Unique")
-              : medals[0].type === 0
-                ? i18n("Silver")
-                : medals[0].type === 1
-                  ? i18n("Gold")
-                  : medals[0].type === 2
-                    ? i18n("Platinum")
-                    : i18n("Theme")}
+        {medals[0].record ? (
+            i18n("Record")
+        ) : medals[0].unique ? (
+            i18n("Unique")
+        ) : medals[0].type === 0 ? (
+            i18n("Silver")
+        ) : medals[0].type === 1 ? (
+            i18n("Gold")
+        ) : medals[0].type === 2 ? (
+            i18n("Platinum")
+        ) : (
+            i18n("Theme")
+        )}
     </div>
 );
 
-a
-    ? literalline
-    : {
-            123: 12,
-        }
-      ? line
-      : softline;
+a ? (
+    literalline
+) : {
+      123: 12,
+  } ? (
+    line
+) : (
+    softline
+);
 
 ================================================================================
 `;
@@ -1922,13 +1968,15 @@ let icecream =
 		? (p) => (!!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`)
 		: (p) => \`here's your \${p} \${what}\`;
 
-const value = condition1
-	? value1
-	: condition2
-	  ? value2
-	  : condition3
-	    ? value3
-	    : value4;
+const value = condition1 ? (
+	value1
+) : condition2 ? (
+	value2
+) : condition3 ? (
+	value3
+) : (
+	value4
+);
 
 const StorybookLoader = ({ match }) =>
 	match.params.storyId === "button" ? (
@@ -1951,68 +1999,80 @@ const StorybookLoader = ({ match }) =>
 	);
 
 const message =
-	i % 3 === 0 && i % 5 === 0
-		? "fizzbuzz"
-		: i % 3 === 0
-		  ? "fizz"
-		  : i % 5 === 0
-		    ? "buzz"
-		    : String(i);
+	i % 3 === 0 && i % 5 === 0 ? (
+		"fizzbuzz"
+	) : i % 3 === 0 ? (
+		"fizz"
+	) : i % 5 === 0 ? (
+		"buzz"
+	) : (
+		String(i)
+	);
 
 const paymentMessage =
-	state == "success"
-		? "Payment completed successfully"
-		: state == "processing"
-		  ? "Payment processing"
-		  : state == "invalid_cvc"
-		    ? "There was an issue with your CVC number"
-		    : state == "invalid_expiry"
-		      ? "Expiry must be sometime in the past."
-		      : "There was an issue with the payment.  Please contact support.";
+	state == "success" ? (
+		"Payment completed successfully"
+	) : state == "processing" ? (
+		"Payment processing"
+	) : state == "invalid_cvc" ? (
+		"There was an issue with your CVC number"
+	) : state == "invalid_expiry" ? (
+		"Expiry must be sometime in the past."
+	) : (
+		"There was an issue with the payment.  Please contact support."
+	);
 
 const paymentMessage2 =
-	state == "success"
-		? 1 //'Payment completed successfully'
-		: state == "processing"
-		  ? 2 //'Payment processing'
-		  : state == "invalid_cvc"
-		    ? 3 //'There was an issue with your CVC number'
-		    : true //state == 'invalid_expiry'
-		      ? 4 //'Expiry must be sometime in the past.'
-		      : 5; // 'There was an issue with the payment.  Please contact support.'
+	state == "success" ? (
+		1 //'Payment completed successfully'
+	) : state == "processing" ? (
+		2 //'Payment processing'
+	) : state == "invalid_cvc" ? (
+		3 //'There was an issue with your CVC number'
+	) : true ? ( //state == 'invalid_expiry'
+		4 //'Expiry must be sometime in the past.'
+	) : (
+		5
+	); // 'There was an issue with the payment.  Please contact support.'
 
 const foo = (
 	<div
 		className={
 			"match-achievement-medal-type type" +
-			(medals[0].record
-				? "-record"
-				: medals[0].unique
-				  ? "-unique"
-				  : medals[0].type)
+			(medals[0].record ? (
+				"-record"
+			) : medals[0].unique ? (
+				"-unique"
+			) : (
+				medals[0].type
+			))
 		}
 	>
-		{medals[0].record
-			? i18n("Record")
-			: medals[0].unique
-			  ? i18n("Unique")
-			  : medals[0].type === 0
-			    ? i18n("Silver")
-			    : medals[0].type === 1
-			      ? i18n("Gold")
-			      : medals[0].type === 2
-			        ? i18n("Platinum")
-			        : i18n("Theme")}
+		{medals[0].record ? (
+			i18n("Record")
+		) : medals[0].unique ? (
+			i18n("Unique")
+		) : medals[0].type === 0 ? (
+			i18n("Silver")
+		) : medals[0].type === 1 ? (
+			i18n("Gold")
+		) : medals[0].type === 2 ? (
+			i18n("Platinum")
+		) : (
+			i18n("Theme")
+		)}
 	</div>
 );
 
-a
-	? literalline
-	: {
-				123: 12,
-	    }
-	  ? line
-	  : softline;
+a ? (
+	literalline
+) : {
+		123: 12,
+  } ? (
+	line
+) : (
+	softline
+);
 
 ================================================================================
 `;
@@ -2126,13 +2186,15 @@ let icecream =
 		? (p) => (!!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`)
 		: (p) => \`here's your \${p} \${what}\`;
 
-const value = condition1
-	? value1
-	: condition2
-	  ? value2
-	  : condition3
-	    ? value3
-	    : value4;
+const value = condition1 ? (
+	value1
+) : condition2 ? (
+	value2
+) : condition3 ? (
+	value3
+) : (
+	value4
+);
 
 const StorybookLoader = ({ match }) =>
 	match.params.storyId === "button" ? (
@@ -2155,68 +2217,80 @@ const StorybookLoader = ({ match }) =>
 	);
 
 const message =
-	i % 3 === 0 && i % 5 === 0
-		? "fizzbuzz"
-		: i % 3 === 0
-		  ? "fizz"
-		  : i % 5 === 0
-		    ? "buzz"
-		    : String(i);
+	i % 3 === 0 && i % 5 === 0 ? (
+		"fizzbuzz"
+	) : i % 3 === 0 ? (
+		"fizz"
+	) : i % 5 === 0 ? (
+		"buzz"
+	) : (
+		String(i)
+	);
 
 const paymentMessage =
-	state == "success"
-		? "Payment completed successfully"
-		: state == "processing"
-		  ? "Payment processing"
-		  : state == "invalid_cvc"
-		    ? "There was an issue with your CVC number"
-		    : state == "invalid_expiry"
-		      ? "Expiry must be sometime in the past."
-		      : "There was an issue with the payment.  Please contact support.";
+	state == "success" ? (
+		"Payment completed successfully"
+	) : state == "processing" ? (
+		"Payment processing"
+	) : state == "invalid_cvc" ? (
+		"There was an issue with your CVC number"
+	) : state == "invalid_expiry" ? (
+		"Expiry must be sometime in the past."
+	) : (
+		"There was an issue with the payment.  Please contact support."
+	);
 
 const paymentMessage2 =
-	state == "success"
-		? 1 //'Payment completed successfully'
-		: state == "processing"
-		  ? 2 //'Payment processing'
-		  : state == "invalid_cvc"
-		    ? 3 //'There was an issue with your CVC number'
-		    : true //state == 'invalid_expiry'
-		      ? 4 //'Expiry must be sometime in the past.'
-		      : 5; // 'There was an issue with the payment.  Please contact support.'
+	state == "success" ? (
+		1 //'Payment completed successfully'
+	) : state == "processing" ? (
+		2 //'Payment processing'
+	) : state == "invalid_cvc" ? (
+		3 //'There was an issue with your CVC number'
+	) : true ? ( //state == 'invalid_expiry'
+		4 //'Expiry must be sometime in the past.'
+	) : (
+		5
+	); // 'There was an issue with the payment.  Please contact support.'
 
 const foo = (
 	<div
 		className={
 			"match-achievement-medal-type type" +
-			(medals[0].record
-				? "-record"
-				: medals[0].unique
-				  ? "-unique"
-				  : medals[0].type)
+			(medals[0].record ? (
+				"-record"
+			) : medals[0].unique ? (
+				"-unique"
+			) : (
+				medals[0].type
+			))
 		}
 	>
-		{medals[0].record
-			? i18n("Record")
-			: medals[0].unique
-			  ? i18n("Unique")
-			  : medals[0].type === 0
-			    ? i18n("Silver")
-			    : medals[0].type === 1
-			      ? i18n("Gold")
-			      : medals[0].type === 2
-			        ? i18n("Platinum")
-			        : i18n("Theme")}
+		{medals[0].record ? (
+			i18n("Record")
+		) : medals[0].unique ? (
+			i18n("Unique")
+		) : medals[0].type === 0 ? (
+			i18n("Silver")
+		) : medals[0].type === 1 ? (
+			i18n("Gold")
+		) : medals[0].type === 2 ? (
+			i18n("Platinum")
+		) : (
+			i18n("Theme")
+		)}
 	</div>
 );
 
-a
-	? literalline
-	: {
-				123: 12,
-	    }
-	  ? line
-	  : softline;
+a ? (
+	literalline
+) : {
+		123: 12,
+  } ? (
+	line
+) : (
+	softline
+);
 
 ================================================================================
 `;
@@ -2329,13 +2403,15 @@ let icecream =
     ? (p) => (!!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`)
     : (p) => \`here's your \${p} \${what}\`;
 
-const value = condition1
-  ? value1
-  : condition2
-    ? value2
-    : condition3
-      ? value3
-      : value4;
+const value = condition1 ? (
+  value1
+) : condition2 ? (
+  value2
+) : condition3 ? (
+  value3
+) : (
+  value4
+);
 
 const StorybookLoader = ({ match }) =>
   match.params.storyId === "button" ? (
@@ -2358,68 +2434,80 @@ const StorybookLoader = ({ match }) =>
   );
 
 const message =
-  i % 3 === 0 && i % 5 === 0
-    ? "fizzbuzz"
-    : i % 3 === 0
-      ? "fizz"
-      : i % 5 === 0
-        ? "buzz"
-        : String(i);
+  i % 3 === 0 && i % 5 === 0 ? (
+    "fizzbuzz"
+  ) : i % 3 === 0 ? (
+    "fizz"
+  ) : i % 5 === 0 ? (
+    "buzz"
+  ) : (
+    String(i)
+  );
 
 const paymentMessage =
-  state == "success"
-    ? "Payment completed successfully"
-    : state == "processing"
-      ? "Payment processing"
-      : state == "invalid_cvc"
-        ? "There was an issue with your CVC number"
-        : state == "invalid_expiry"
-          ? "Expiry must be sometime in the past."
-          : "There was an issue with the payment.  Please contact support.";
+  state == "success" ? (
+    "Payment completed successfully"
+  ) : state == "processing" ? (
+    "Payment processing"
+  ) : state == "invalid_cvc" ? (
+    "There was an issue with your CVC number"
+  ) : state == "invalid_expiry" ? (
+    "Expiry must be sometime in the past."
+  ) : (
+    "There was an issue with the payment.  Please contact support."
+  );
 
 const paymentMessage2 =
-  state == "success"
-    ? 1 //'Payment completed successfully'
-    : state == "processing"
-      ? 2 //'Payment processing'
-      : state == "invalid_cvc"
-        ? 3 //'There was an issue with your CVC number'
-        : true //state == 'invalid_expiry'
-          ? 4 //'Expiry must be sometime in the past.'
-          : 5; // 'There was an issue with the payment.  Please contact support.'
+  state == "success" ? (
+    1 //'Payment completed successfully'
+  ) : state == "processing" ? (
+    2 //'Payment processing'
+  ) : state == "invalid_cvc" ? (
+    3 //'There was an issue with your CVC number'
+  ) : true ? ( //state == 'invalid_expiry'
+    4 //'Expiry must be sometime in the past.'
+  ) : (
+    5
+  ); // 'There was an issue with the payment.  Please contact support.'
 
 const foo = (
   <div
     className={
       "match-achievement-medal-type type" +
-      (medals[0].record
-        ? "-record"
-        : medals[0].unique
-          ? "-unique"
-          : medals[0].type)
+      (medals[0].record ? (
+        "-record"
+      ) : medals[0].unique ? (
+        "-unique"
+      ) : (
+        medals[0].type
+      ))
     }
   >
-    {medals[0].record
-      ? i18n("Record")
-      : medals[0].unique
-        ? i18n("Unique")
-        : medals[0].type === 0
-          ? i18n("Silver")
-          : medals[0].type === 1
-            ? i18n("Gold")
-            : medals[0].type === 2
-              ? i18n("Platinum")
-              : i18n("Theme")}
+    {medals[0].record ? (
+      i18n("Record")
+    ) : medals[0].unique ? (
+      i18n("Unique")
+    ) : medals[0].type === 0 ? (
+      i18n("Silver")
+    ) : medals[0].type === 1 ? (
+      i18n("Gold")
+    ) : medals[0].type === 2 ? (
+      i18n("Platinum")
+    ) : (
+      i18n("Theme")
+    )}
   </div>
 );
 
-a
-  ? literalline
-  : {
-        123: 12,
-      }
-    ? line
-    : softline;
+a ? (
+  literalline
+) : {
+    123: 12,
+  } ? (
+  line
+) : (
+  softline
+);
 
 ================================================================================
 `;
@@ -2481,13 +2569,17 @@ const value = (
     bifornCringerMoshedPerplexSawder
         ? askTrovenaBeenaDependsRowans
         : glimseGlyphsHazardNoopsTieTie
-)
-    ? true
-        ? true
-        : false
-    : true
-      ? true
-      : false;
+) ? (
+    true ? (
+        true
+    ) : (
+        false
+    )
+) : true ? (
+    true
+) : (
+    false
+);
 
 (
     bifornCringerMoshedPerplexSawder
@@ -2571,13 +2663,17 @@ const value = (
 	bifornCringerMoshedPerplexSawder
 		? askTrovenaBeenaDependsRowans
 		: glimseGlyphsHazardNoopsTieTie
-)
-	? true
-		? true
-		: false
-	: true
-	  ? true
-	  : false;
+) ? (
+	true ? (
+		true
+	) : (
+		false
+	)
+) : true ? (
+	true
+) : (
+	false
+);
 
 (
 	bifornCringerMoshedPerplexSawder
@@ -2660,13 +2756,17 @@ const value = (
 	bifornCringerMoshedPerplexSawder
 		? askTrovenaBeenaDependsRowans
 		: glimseGlyphsHazardNoopsTieTie
-)
-	? true
-		? true
-		: false
-	: true
-	  ? true
-	  : false;
+) ? (
+	true ? (
+		true
+	) : (
+		false
+	)
+) : true ? (
+	true
+) : (
+	false
+);
 
 (
 	bifornCringerMoshedPerplexSawder
@@ -2748,13 +2848,17 @@ const value = (
   bifornCringerMoshedPerplexSawder
     ? askTrovenaBeenaDependsRowans
     : glimseGlyphsHazardNoopsTieTie
-)
-  ? true
-    ? true
-    : false
-  : true
-    ? true
-    : false;
+) ? (
+  true ? (
+    true
+  ) : (
+    false
+  )
+) : true ? (
+  true
+) : (
+  false
+);
 
 (
   bifornCringerMoshedPerplexSawder
@@ -2795,12 +2899,14 @@ a => a ? a : a
 a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
 
 =====================================output=====================================
-debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
-debug
-    ? this.state.isVisible && somethingComplex
-        ? "partially visible"
-        : "hidden"
-    : null;
+debug ? this.state.isVisible ? "partially visible" : "hidden" : null;
+debug ? (
+    this.state.isVisible && somethingComplex ? (
+        "partially visible"
+    ) : (
+        "hidden"
+    )
+) : null;
 
 (a) =>
     a
@@ -2833,12 +2939,14 @@ a => a ? a : a
 a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
 
 =====================================output=====================================
-debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
-debug
-	? this.state.isVisible && somethingComplex
-		? "partially visible"
-		: "hidden"
-	: null;
+debug ? this.state.isVisible ? "partially visible" : "hidden" : null;
+debug ? (
+	this.state.isVisible && somethingComplex ? (
+		"partially visible"
+	) : (
+		"hidden"
+	)
+) : null;
 
 (a) =>
 	a
@@ -2870,12 +2978,14 @@ a => a ? a : a
 a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
 
 =====================================output=====================================
-debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
-debug
-	? this.state.isVisible && somethingComplex
-		? "partially visible"
-		: "hidden"
-	: null;
+debug ? this.state.isVisible ? "partially visible" : "hidden" : null;
+debug ? (
+	this.state.isVisible && somethingComplex ? (
+		"partially visible"
+	) : (
+		"hidden"
+	)
+) : null;
 
 (a) =>
 	a
@@ -2906,12 +3016,14 @@ a => a ? a : a
 a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
 
 =====================================output=====================================
-debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
-debug
-  ? this.state.isVisible && somethingComplex
-    ? "partially visible"
-    : "hidden"
-  : null;
+debug ? this.state.isVisible ? "partially visible" : "hidden" : null;
+debug ? (
+  this.state.isVisible && somethingComplex ? (
+    "partially visible"
+  ) : (
+    "hidden"
+  )
+) : null;
 
 (a) =>
   a

--- a/tests/js/ternaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/ternaries/__snapshots__/jsfmt.spec.js.snap
@@ -2899,7 +2899,7 @@ a => a ? a : a
 a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
 
 =====================================output=====================================
-debug ? this.state.isVisible ? "partially visible" : "hidden" : null;
+debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
 debug ? (
     this.state.isVisible && somethingComplex ? (
         "partially visible"
@@ -2939,7 +2939,7 @@ a => a ? a : a
 a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
 
 =====================================output=====================================
-debug ? this.state.isVisible ? "partially visible" : "hidden" : null;
+debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
 debug ? (
 	this.state.isVisible && somethingComplex ? (
 		"partially visible"
@@ -2978,7 +2978,7 @@ a => a ? a : a
 a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
 
 =====================================output=====================================
-debug ? this.state.isVisible ? "partially visible" : "hidden" : null;
+debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
 debug ? (
 	this.state.isVisible && somethingComplex ? (
 		"partially visible"
@@ -3016,7 +3016,7 @@ a => a ? a : a
 a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
 
 =====================================output=====================================
-debug ? this.state.isVisible ? "partially visible" : "hidden" : null;
+debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
 debug ? (
   this.state.isVisible && somethingComplex ? (
     "partially visible"

--- a/tests/js/ternaries/func-call.js
+++ b/tests/js/ternaries/func-call.js
@@ -2,7 +2,7 @@ fn(
   bifornCringerMoshedPerplexSawder,
   askTrovenaBeenaDependsRowans,
   glimseGlyphsHazardNoopsTieTie === averredBathersBoxroomBuggyNurl &&
-    anodyneCondosMalateOverateRetinol 
-      ? annularCooeedSplicesWalksWayWay 
-      : kochabCooieGameOnOboleUnweave 
+    anodyneCondosMalateOverateRetinol
+      ? annularCooeedSplicesWalksWayWay
+      : kochabCooieGameOnOboleUnweave
 );

--- a/tests/js/throw_expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/throw_expressions/__snapshots__/jsfmt.spec.js.snap
@@ -33,13 +33,15 @@ lint(ast, {
 
 function getEncoder(encoding) {
   const encoder =
-    encoding === "utf8"
-      ? new UTF8Encoder()
-      : encoding === "utf16le"
-        ? new UTF16Encoder(false)
-        : encoding === "utf16be"
-          ? new UTF16Encoder(true)
-          : throw new Error("Unsupported encoding");
+    encoding === "utf8" ? (
+      new UTF8Encoder()
+    ) : encoding === "utf16le" ? (
+      new UTF16Encoder(false)
+    ) : encoding === "utf16be" ? (
+      new UTF16Encoder(true)
+    ) : (
+      throw new Error("Unsupported encoding")
+    );
 }
 
 class Product {

--- a/tests/js/throw_expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/throw_expressions/__snapshots__/jsfmt.spec.js.snap
@@ -36,10 +36,10 @@ function getEncoder(encoding) {
     encoding === "utf8"
       ? new UTF8Encoder()
       : encoding === "utf16le"
-      ? new UTF16Encoder(false)
-      : encoding === "utf16be"
-      ? new UTF16Encoder(true)
-      : throw new Error("Unsupported encoding");
+        ? new UTF16Encoder(false)
+        : encoding === "utf16be"
+          ? new UTF16Encoder(true)
+          : throw new Error("Unsupported encoding");
 }
 
 class Product {

--- a/tests/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
@@ -108,11 +108,11 @@ type T = test extends B
     */
     foo
   : test extends B
-  ? /* comment
+    ? /* comment
   comment
     comment */
-    foo
-  : bar;
+      foo
+    : bar;
 
 type T = test extends B ? /* comment */ foo : bar;
 
@@ -132,13 +132,13 @@ type T = test extends B
      comment
            comment
     */
-  test extends B
-  ? foo
-  : /* comment
+    test extends B
+    ? foo
+    : /* comment
   comment
     comment
    */
-    bar;
+      bar;
 
 type T = test extends B ? foo : /* comment */ bar;
 
@@ -199,8 +199,8 @@ type U2 = (new () => X) extends T ? U : V;
 export type DeepReadonly<T> = T extends any[]
   ? DeepReadonlyArray<T[number]>
   : T extends object
-  ? DeepReadonlyObject<T>
-  : T;
+    ? DeepReadonlyObject<T>
+    : T;
 
 type NonFunctionPropertyNames<T> = {
   [K in keyof T]: T[K] extends Function ? never : K;
@@ -215,14 +215,14 @@ type DeepReadonlyObject<T> = {
 type TypeName<T> = T extends string
   ? "string"
   : T extends number
-  ? "number"
-  : T extends boolean
-  ? "boolean"
-  : T extends undefined
-  ? "undefined"
-  : T extends Function
-  ? "function"
-  : "object";
+    ? "number"
+    : T extends boolean
+      ? "boolean"
+      : T extends undefined
+        ? "undefined"
+        : T extends Function
+          ? "function"
+          : "object";
 
 type Type01 = 0 extends (1 extends 2 ? 3 : 4) ? 5 : 6;
 type Type02 = 0 extends (1 extends 2 ? 3 : 4) ? 5 : 6;
@@ -270,10 +270,10 @@ type TestReturnType<T extends (...args: any[]) => any> = T extends (
 type Unpacked<T> = T extends (infer U)[]
   ? U
   : T extends (...args: any[]) => infer U
-  ? U
-  : T extends Promise<infer U>
-  ? U
-  : T;
+    ? U
+    : T extends Promise<infer U>
+      ? U
+      : T;
 
 ================================================================================
 `;

--- a/tests/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
@@ -100,21 +100,19 @@ type T = test extends B
     foo
   : bar;
 
-type T = test extends B ? (
-  /* comment
+type T = test extends B
+  ? /* comment
        comment
        comment
        comment
     */
-  foo
-) : test extends B ? (
-  /* comment
+    foo
+  : test extends B
+    ? /* comment
   comment
     comment */
-  foo
-) : (
-  bar
-);
+      foo
+    : bar;
 
 type T = test extends B ? /* comment */ foo : bar;
 
@@ -127,35 +125,29 @@ type T = test extends B
     */
     bar;
 
-type T = test extends B ? (
-  foo
-) : /* comment
+type T = test extends B
+  ? foo
+  : /* comment
          comment
      comment
            comment
     */
-test extends B ? (
-  foo
-) : (
-  /* comment
+    test extends B
+    ? foo
+    : /* comment
   comment
     comment
    */
-  bar
-);
+      bar;
 
 type T = test extends B ? foo : /* comment */ bar;
 
-type T = test extends B ? (
-  test extends B /* c
-c */ ? (
-    foo
-  ) : (
-    bar
-  )
-) : (
-  bar
-);
+type T = test extends B
+  ? test extends B /* c
+c */
+    ? foo
+    : bar
+  : bar;
 
 ================================================================================
 `;
@@ -204,13 +196,11 @@ type U1b = new () => (X) extends T ? U : V;
 type U2 = (new () => X) extends T ? U : V;
 
 =====================================output=====================================
-export type DeepReadonly<T> = T extends any[] ? (
-  DeepReadonlyArray<T[number]>
-) : T extends object ? (
-  DeepReadonlyObject<T>
-) : (
-  T
-);
+export type DeepReadonly<T> = T extends any[]
+  ? DeepReadonlyArray<T[number]>
+  : T extends object
+    ? DeepReadonlyObject<T>
+    : T;
 
 type NonFunctionPropertyNames<T> = {
   [K in keyof T]: T[K] extends Function ? never : K;
@@ -222,19 +212,17 @@ type DeepReadonlyObject<T> = {
   readonly [P in NonFunctionPropertyNames<T>]: DeepReadonly<T[P]>;
 };
 
-type TypeName<T> = T extends string ? (
-  "string"
-) : T extends number ? (
-  "number"
-) : T extends boolean ? (
-  "boolean"
-) : T extends undefined ? (
-  "undefined"
-) : T extends Function ? (
-  "function"
-) : (
-  "object"
-);
+type TypeName<T> = T extends string
+  ? "string"
+  : T extends number
+    ? "number"
+    : T extends boolean
+      ? "boolean"
+      : T extends undefined
+        ? "undefined"
+        : T extends Function
+          ? "function"
+          : "object";
 
 type Type01 = 0 extends (1 extends 2 ? 3 : 4) ? 5 : 6;
 type Type02 = 0 extends (1 extends 2 ? 3 : 4) ? 5 : 6;
@@ -279,15 +267,13 @@ type TestReturnType<T extends (...args: any[]) => any> = T extends (
   ? R
   : any;
 
-type Unpacked<T> = T extends (infer U)[] ? (
-  U
-) : T extends (...args: any[]) => infer U ? (
-  U
-) : T extends Promise<infer U> ? (
-  U
-) : (
-  T
-);
+type Unpacked<T> = T extends (infer U)[]
+  ? U
+  : T extends (...args: any[]) => infer U
+    ? U
+    : T extends Promise<infer U>
+      ? U
+      : T;
 
 ================================================================================
 `;

--- a/tests/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
@@ -100,19 +100,21 @@ type T = test extends B
     foo
   : bar;
 
-type T = test extends B
-  ? /* comment
+type T = test extends B ? (
+  /* comment
        comment
        comment
        comment
     */
-    foo
-  : test extends B
-    ? /* comment
+  foo
+) : test extends B ? (
+  /* comment
   comment
     comment */
-      foo
-    : bar;
+  foo
+) : (
+  bar
+);
 
 type T = test extends B ? /* comment */ foo : bar;
 
@@ -125,29 +127,35 @@ type T = test extends B
     */
     bar;
 
-type T = test extends B
-  ? foo
-  : /* comment
+type T = test extends B ? (
+  foo
+) : /* comment
          comment
      comment
            comment
     */
-    test extends B
-    ? foo
-    : /* comment
+test extends B ? (
+  foo
+) : (
+  /* comment
   comment
     comment
    */
-      bar;
+  bar
+);
 
 type T = test extends B ? foo : /* comment */ bar;
 
-type T = test extends B
-  ? test extends B /* c
-c */
-    ? foo
-    : bar
-  : bar;
+type T = test extends B ? (
+  test extends B /* c
+c */ ? (
+    foo
+  ) : (
+    bar
+  )
+) : (
+  bar
+);
 
 ================================================================================
 `;
@@ -196,11 +204,13 @@ type U1b = new () => (X) extends T ? U : V;
 type U2 = (new () => X) extends T ? U : V;
 
 =====================================output=====================================
-export type DeepReadonly<T> = T extends any[]
-  ? DeepReadonlyArray<T[number]>
-  : T extends object
-    ? DeepReadonlyObject<T>
-    : T;
+export type DeepReadonly<T> = T extends any[] ? (
+  DeepReadonlyArray<T[number]>
+) : T extends object ? (
+  DeepReadonlyObject<T>
+) : (
+  T
+);
 
 type NonFunctionPropertyNames<T> = {
   [K in keyof T]: T[K] extends Function ? never : K;
@@ -212,17 +222,19 @@ type DeepReadonlyObject<T> = {
   readonly [P in NonFunctionPropertyNames<T>]: DeepReadonly<T[P]>;
 };
 
-type TypeName<T> = T extends string
-  ? "string"
-  : T extends number
-    ? "number"
-    : T extends boolean
-      ? "boolean"
-      : T extends undefined
-        ? "undefined"
-        : T extends Function
-          ? "function"
-          : "object";
+type TypeName<T> = T extends string ? (
+  "string"
+) : T extends number ? (
+  "number"
+) : T extends boolean ? (
+  "boolean"
+) : T extends undefined ? (
+  "undefined"
+) : T extends Function ? (
+  "function"
+) : (
+  "object"
+);
 
 type Type01 = 0 extends (1 extends 2 ? 3 : 4) ? 5 : 6;
 type Type02 = 0 extends (1 extends 2 ? 3 : 4) ? 5 : 6;
@@ -267,13 +279,15 @@ type TestReturnType<T extends (...args: any[]) => any> = T extends (
   ? R
   : any;
 
-type Unpacked<T> = T extends (infer U)[]
-  ? U
-  : T extends (...args: any[]) => infer U
-    ? U
-    : T extends Promise<infer U>
-      ? U
-      : T;
+type Unpacked<T> = T extends (infer U)[] ? (
+  U
+) : T extends (...args: any[]) => infer U ? (
+  U
+) : T extends Promise<infer U> ? (
+  U
+) : (
+  T
+);
 
 ================================================================================
 `;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fixes #5814

This is an alternative to https://github.com/prettier/prettier/pull/9559; **please upvote this PR or https://github.com/prettier/prettier/pull/9559, or a proposal in https://github.com/prettier/prettier/pull/9561**

I think this PR has better behavior since it scales better to long ternary formats, has an extremely clear visual difference between conditionals and consequents, and is easy to refactor. I've also had good experiences and heard good feedback on the JSX style when it is used in JSX.

Headline examples from the tests:

```jsx
const message =
  i % 3 === 0 && i % 5 === 0 ? (
    "fizzbuzz"
  ) : i % 3 === 0 ? (
    "fizz"
  ) : i % 5 === 0 ? (
    "buzz"
  ) : (
    String(i)
  );

const paymentMessage =
  state == "success" ? (
    "Payment completed successfully"
  ) : state == "processing" ? (
    "Payment processing"
  ) : state == "invalid_cvc" ? (
    "There was an issue with your CVC number"
  ) : state == "invalid_expiry" ? (
    "Expiry must be sometime in the past."
  ) : (
    "There was an issue with the payment.  Please contact support."
  );

const StorybookLoader = ({ match }) =>
  match.params.storyId === "button" ? (
    <ButtonStorybook />
  ) : match.params.storyId === "color" ? (
    <ColorBook />
  ) : match.params.storyId === "typography" ? (
    <TypographyBook />
  ) : match.params.storyId === "loading" ? (
    <LoaderStorybook />
  ) : match.params.storyId === "deal-list" ? (
    <DealListStory />
  ) : (
    <Message>
      <Title>{"Missing story book"}</Title>
      <Content>
        <BackButton />
      </Content>
    </Message>
  );
```

and a case I hope to add to the tests:

```jsx
children && !isEmptyChildren(children) ? (
  children
) : props.match ? (
  component ? (
    React.createElement(component, props)
  ) : render ? (
    render(props)
  ) : null
) : null;
```

Note that this PR uses indents for TS Conditional Types, eg:

```ts
type TypeName<T> = T extends string
  ? "string"
  : T extends number
    ? "number"
    : T extends boolean
      ? "boolean"
      : T extends undefined
        ? "undefined"
        : T extends Function
          ? "function"
          : "object";
```
but we could easily back that change out.

I may seek to change TS Conditional Type formatting in a follow-on PR, and am considering this **case-style** format:

```ts
type Animal<T> =
  T extends Quacker ? Duck :
  T extends SuperTall ? Giraffe :
  T extends SingleCelled ? (
    T extends Eukaryotic ? Amoeba :
    Bacteria
  ) :
  T extends Barker ? Dog :
  GenericAnimal;
```

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
