### PR TITLE
Flow: Fix missing parentheses around prettier-ignored arguments

### DIFF
--- a/changelog_unreleased/flow/pr-9553.md
+++ b/changelog_unreleased/flow/pr-9553.md
@@ -1,4 +1,4 @@
-#### Fix missing parentheses around prettier-ignored arguments (#9553 by @fisker)
+#### Fix missing parentheses around `prettier-ignore`d type assertions (#9553 by @fisker)
 
 <!-- prettier-ignore -->
 ```jsx

--- a/changelog_unreleased/flow/pr-9553.md
+++ b/changelog_unreleased/flow/pr-9553.md
@@ -1,0 +1,22 @@
+#### Fix missing parentheses around prettier-ignored arguments (#9553 by @fisker)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+transform(
+  // prettier-ignore
+  (pointTransformer: (Point => Point))
+);
+
+// Prettier stable
+transform(
+  // prettier-ignore
+  pointTransformer: (Point => Point)
+);
+
+// Prettier master
+transform(
+  // prettier-ignore
+  (pointTransformer: (Point => Point))
+);
+```

--- a/src/language-js/postprocess.js
+++ b/src/language-js/postprocess.js
@@ -40,9 +40,16 @@ function postprocess(ast, options) {
 
     ast = visitNode(ast, (node) => {
       if (node.type === "ParenthesizedExpression") {
+        const { expression } = node;
+
+        // Align range with `flow`
+        if (expression.type === "TypeCastExpression") {
+          expression.range = node.range;
+          return expression;
+        }
+
         const start = locStart(node);
         if (!startOffsetsOfTypeCastedNodes.has(start)) {
-          const { expression } = node;
           if (!expression.extra) {
             expression.extra = {};
           }

--- a/tests/flow/ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/ignore/__snapshots__/jsfmt.spec.js.snap
@@ -34,3 +34,41 @@ function a() {
 
 ================================================================================
 `;
+
+exports[`type-cast-expression.js format 1`] = `
+====================================options=====================================
+parsers: ["flow", "babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+transform(
+  // prettier-ignore
+  (pointTransformer: T)
+);
+
+transform(
+  // prettier-ignore
+  (/* comment */pointTransformer: T /* comment */)
+);
+
+transform(
+  /* prettier-ignore */(/* prettier-ignore */pointTransformer: (Point => Point))
+);
+
+=====================================output=====================================
+transform(
+  // prettier-ignore
+  (pointTransformer: T)
+);
+
+transform(
+  // prettier-ignore
+  (/* comment */pointTransformer: T /* comment */)
+);
+
+transform(
+  /* prettier-ignore */ (/* prettier-ignore */pointTransformer: (Point => Point))
+);
+
+================================================================================
+`;

--- a/tests/flow/ignore/type-cast-expression.js
+++ b/tests/flow/ignore/type-cast-expression.js
@@ -1,0 +1,13 @@
+transform(
+  // prettier-ignore
+  (pointTransformer: T)
+);
+
+transform(
+  // prettier-ignore
+  (/* comment */pointTransformer: T /* comment */)
+);
+
+transform(
+  /* prettier-ignore */(/* prettier-ignore */pointTransformer: (Point => Point))
+);


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Fixes #4608

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
