### PR TITLE
Refactor: Use `locStart` and `locEnd` directly from `language-js/loc.js`

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -105,3 +105,6 @@ overrides:
   - files: src/**/*.js
     rules:
       prettier-internal-rules/prefer-fast-path-each: error
+  - files: src/language-js/**/*.js
+    rules:
+      prettier-internal-rules/directly-loc-start-end: error

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/directly-loc-start-end.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/directly-loc-start-end.js
@@ -7,14 +7,14 @@ const selector = [
   ':matches([property.name="locStart"], [property.name="locEnd"])',
 ].join("");
 
-const MESSAGE_ID = "direct-loc-start-end";
+const MESSAGE_ID = "directly-loc-start-end";
 
 module.exports = {
   meta: {
     type: "suggestion",
     docs: {
       url:
-        "https://github.com/prettier/prettier/blob/master/scripts/eslint-plugin-prettier-internal-rules/direct-loc-start-end.js",
+        "https://github.com/prettier/prettier/blob/master/scripts/eslint-plugin-prettier-internal-rules/directly-loc-start-end.js",
     },
     messages: {
       [MESSAGE_ID]:

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/directly-loc-start-end.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/directly-loc-start-end.js
@@ -1,0 +1,38 @@
+"use strict";
+
+const selector = [
+  "MemberExpression",
+  "[computed=false]",
+  '[property.type="Identifier"]',
+  ':matches([property.name="locStart"], [property.name="locEnd"])',
+].join("");
+
+const MESSAGE_ID = "direct-loc-start-end";
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      url:
+        "https://github.com/prettier/prettier/blob/master/scripts/eslint-plugin-prettier-internal-rules/direct-loc-start-end.js",
+    },
+    messages: {
+      [MESSAGE_ID]:
+        "Call `{{function}}` directly from `src/language-js/loc.js`.",
+    },
+    fixable: "code",
+  },
+  create(context) {
+    return {
+      [selector](node) {
+        context.report({
+          node,
+          messageId: MESSAGE_ID,
+          data: { function: node.property.name },
+          fix: (fixer) =>
+            fixer.replaceTextRange([node.range[0], node.property.range[0]], ""),
+        });
+      },
+    };
+  },
+};

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/index.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/index.js
@@ -3,6 +3,7 @@
 module.exports = {
   rules: {
     "better-parent-property-check-in-needs-parens": require("./better-parent-property-check-in-needs-parens"),
+    "directly-loc-start-end": require("./directly-loc-start-end"),
     "prefer-fast-path-each": require("./prefer-fast-path-each"),
     "require-json-extensions": require("./require-json-extensions"),
   },

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/package.json
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-prettier-internal-rules",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Prettier internal eslint rules",
   "private": true,
   "author": "fisker",

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/package.json
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-prettier-internal-rules",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "description": "Prettier internal eslint rules",
   "private": true,
   "author": "fisker",

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -13,6 +13,7 @@ const {
   getNextNonSpaceNonCommentCharacterIndex,
 } = require("../common/util");
 const { isBlockComment, getFunctionParameters } = require("./utils");
+const { locStart, locEnd } = require("./loc");
 
 function handleOwnLineComment(comment, text, options, ast, isLastComment) {
   const { precedingNode, enclosingNode, followingNode } = comment;
@@ -22,8 +23,7 @@ function handleOwnLineComment(comment, text, options, ast, isLastComment) {
       precedingNode,
       enclosingNode,
       followingNode,
-      comment,
-      options
+      comment
     ) ||
     handleMemberExpressionComments(enclosingNode, followingNode, comment) ||
     handleIfStatementComments(
@@ -31,16 +31,14 @@ function handleOwnLineComment(comment, text, options, ast, isLastComment) {
       precedingNode,
       enclosingNode,
       followingNode,
-      comment,
-      options
+      comment
     ) ||
     handleWhileComments(
       text,
       precedingNode,
       enclosingNode,
       followingNode,
-      comment,
-      options
+      comment
     ) ||
     handleTryStatementComments(
       enclosingNode,
@@ -62,17 +60,10 @@ function handleOwnLineComment(comment, text, options, ast, isLastComment) {
       text,
       enclosingNode,
       precedingNode,
-      comment,
-      options
+      comment
     ) ||
     handleAssignmentPatternComments(enclosingNode, comment) ||
-    handleMethodNameComments(
-      text,
-      enclosingNode,
-      precedingNode,
-      comment,
-      options
-    ) ||
+    handleMethodNameComments(text, enclosingNode, precedingNode, comment) ||
     handleLabeledStatementComments(enclosingNode, comment)
   );
 }
@@ -86,16 +77,14 @@ function handleEndOfLineComment(comment, text, options, ast, isLastComment) {
       precedingNode,
       enclosingNode,
       followingNode,
-      comment,
-      options
+      comment
     ) ||
     handleConditionalExpressionComments(
       enclosingNode,
       precedingNode,
       followingNode,
       comment,
-      text,
-      options
+      text
     ) ||
     handleImportSpecifierComments(enclosingNode, comment) ||
     handleIfStatementComments(
@@ -103,16 +92,14 @@ function handleEndOfLineComment(comment, text, options, ast, isLastComment) {
       precedingNode,
       enclosingNode,
       followingNode,
-      comment,
-      options
+      comment
     ) ||
     handleWhileComments(
       text,
       precedingNode,
       enclosingNode,
       followingNode,
-      comment,
-      options
+      comment
     ) ||
     handleTryStatementComments(
       enclosingNode,
@@ -139,35 +126,21 @@ function handleRemainingComment(comment, text, options, ast, isLastComment) {
       precedingNode,
       enclosingNode,
       followingNode,
-      comment,
-      options
+      comment
     ) ||
     handleWhileComments(
       text,
       precedingNode,
       enclosingNode,
       followingNode,
-      comment,
-      options
+      comment
     ) ||
     handleObjectPropertyAssignment(enclosingNode, precedingNode, comment) ||
-    handleCommentInEmptyParens(text, enclosingNode, comment, options) ||
-    handleMethodNameComments(
-      text,
-      enclosingNode,
-      precedingNode,
-      comment,
-      options
-    ) ||
+    handleCommentInEmptyParens(text, enclosingNode, comment) ||
+    handleMethodNameComments(text, enclosingNode, precedingNode, comment) ||
     handleOnlyComments(enclosingNode, ast, comment, isLastComment) ||
-    handleCommentAfterArrowParams(text, enclosingNode, comment, options) ||
-    handleFunctionNameComments(
-      text,
-      enclosingNode,
-      precedingNode,
-      comment,
-      options
-    ) ||
+    handleCommentAfterArrowParams(text, enclosingNode, comment) ||
+    handleFunctionNameComments(text, enclosingNode, precedingNode, comment) ||
     handleTSMappedTypeComments(
       text,
       enclosingNode,
@@ -180,8 +153,7 @@ function handleRemainingComment(comment, text, options, ast, isLastComment) {
       text,
       enclosingNode,
       followingNode,
-      comment,
-      options
+      comment
     )
   ) {
     return true;
@@ -237,8 +209,7 @@ function handleIfStatementComments(
   precedingNode,
   enclosingNode,
   followingNode,
-  comment,
-  options
+  comment
 ) {
   if (
     !enclosingNode ||
@@ -256,7 +227,7 @@ function handleIfStatementComments(
   const nextCharacter = getNextNonSpaceNonCommentCharacter(
     text,
     comment,
-    options.locEnd
+    locEnd
   );
   if (nextCharacter === ")") {
     addTrailingComment(precedingNode, comment);
@@ -306,8 +277,7 @@ function handleWhileComments(
   precedingNode,
   enclosingNode,
   followingNode,
-  comment,
-  options
+  comment
 ) {
   if (
     !enclosingNode ||
@@ -325,7 +295,7 @@ function handleWhileComments(
   const nextCharacter = getNextNonSpaceNonCommentCharacter(
     text,
     comment,
-    options.locEnd
+    locEnd
   );
   if (nextCharacter === ")") {
     addTrailingComment(precedingNode, comment);
@@ -404,16 +374,11 @@ function handleConditionalExpressionComments(
   precedingNode,
   followingNode,
   comment,
-  text,
-  options
+  text
 ) {
   const isSameLineAsPrecedingNode =
     precedingNode &&
-    !hasNewlineInRange(
-      text,
-      options.locEnd(precedingNode),
-      options.locStart(comment)
-    );
+    !hasNewlineInRange(text, locEnd(precedingNode), locStart(comment));
 
   if (
     (!precedingNode || !isSameLineAsPrecedingNode) &&
@@ -498,13 +463,7 @@ function handleClassComments(
   return false;
 }
 
-function handleMethodNameComments(
-  text,
-  enclosingNode,
-  precedingNode,
-  comment,
-  options
-) {
+function handleMethodNameComments(text, enclosingNode, precedingNode, comment) {
   // This is only needed for estree parsers (flow, typescript) to attach
   // after a method name:
   // obj = { fn /*comment*/() {} };
@@ -519,8 +478,7 @@ function handleMethodNameComments(
     enclosingNode.key === precedingNode &&
     // special Property case: { key: /*comment*/(value) };
     // comment should be attached to value instead of key
-    getNextNonSpaceNonCommentCharacter(text, precedingNode, options.locEnd) !==
-      ":"
+    getNextNonSpaceNonCommentCharacter(text, precedingNode, locEnd) !== ":"
   ) {
     addTrailingComment(precedingNode, comment);
     return true;
@@ -550,12 +508,9 @@ function handleFunctionNameComments(
   text,
   enclosingNode,
   precedingNode,
-  comment,
-  options
+  comment
 ) {
-  if (
-    getNextNonSpaceNonCommentCharacter(text, comment, options.locEnd) !== "("
-  ) {
+  if (getNextNonSpaceNonCommentCharacter(text, comment, locEnd) !== "(") {
     return false;
   }
 
@@ -574,16 +529,12 @@ function handleFunctionNameComments(
   return false;
 }
 
-function handleCommentAfterArrowParams(text, enclosingNode, comment, options) {
+function handleCommentAfterArrowParams(text, enclosingNode, comment) {
   if (!(enclosingNode && enclosingNode.type === "ArrowFunctionExpression")) {
     return false;
   }
 
-  const index = getNextNonSpaceNonCommentCharacterIndex(
-    text,
-    comment,
-    options.locEnd
-  );
+  const index = getNextNonSpaceNonCommentCharacterIndex(text, comment, locEnd);
   if (index !== false && text.slice(index, index + 2) === "=>") {
     addDanglingComment(enclosingNode, comment);
     return true;
@@ -592,10 +543,8 @@ function handleCommentAfterArrowParams(text, enclosingNode, comment, options) {
   return false;
 }
 
-function handleCommentInEmptyParens(text, enclosingNode, comment, options) {
-  if (
-    getNextNonSpaceNonCommentCharacter(text, comment, options.locEnd) !== ")"
-  ) {
+function handleCommentInEmptyParens(text, enclosingNode, comment) {
+  if (getNextNonSpaceNonCommentCharacter(text, comment, locEnd) !== ")") {
     return false;
   }
 
@@ -629,8 +578,7 @@ function handleLastFunctionArgComments(
   precedingNode,
   enclosingNode,
   followingNode,
-  comment,
-  options
+  comment
 ) {
   // Flow function type definitions
   if (
@@ -652,7 +600,7 @@ function handleLastFunctionArgComments(
       precedingNode.type === "AssignmentPattern") &&
     enclosingNode &&
     isRealFunctionLikeNode(enclosingNode) &&
-    getNextNonSpaceNonCommentCharacter(text, comment, options.locEnd) === ")"
+    getNextNonSpaceNonCommentCharacter(text, comment, locEnd) === ")"
   ) {
     addTrailingComment(precedingNode, comment);
     return true;
@@ -669,12 +617,12 @@ function handleLastFunctionArgComments(
       if (parameters.length !== 0) {
         return getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
           text,
-          options.locEnd(getLast(parameters))
+          locEnd(getLast(parameters))
         );
       }
       const functionParamLeftParenIndex = getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
         text,
-        options.locEnd(enclosingNode.id)
+        locEnd(enclosingNode.id)
       );
       return (
         functionParamLeftParenIndex !== false &&
@@ -684,7 +632,7 @@ function handleLastFunctionArgComments(
         )
       );
     })();
-    if (options.locStart(comment) > functionParamRightParenIndex) {
+    if (locStart(comment) > functionParamRightParenIndex) {
       addBlockStatementFirstComment(followingNode, comment);
       return true;
     }
@@ -826,15 +774,14 @@ function handleImportDeclarationComments(
   text,
   enclosingNode,
   precedingNode,
-  comment,
-  options
+  comment
 ) {
   if (
     precedingNode &&
     precedingNode.type === "ImportSpecifier" &&
     enclosingNode &&
     enclosingNode.type === "ImportDeclaration" &&
-    hasNewline(text, options.locEnd(comment))
+    hasNewline(text, locEnd(comment))
   ) {
     addTrailingComment(precedingNode, comment);
     return true;
@@ -884,8 +831,7 @@ function handleTSFunctionTrailingComments(
   text,
   enclosingNode,
   followingNode,
-  comment,
-  options
+  comment
 ) {
   if (
     !followingNode &&
@@ -893,7 +839,7 @@ function handleTSFunctionTrailingComments(
     (enclosingNode.type === "TSMethodSignature" ||
       enclosingNode.type === "TSDeclareFunction" ||
       enclosingNode.type === "TSAbstractMethodDefinition") &&
-    getNextNonSpaceNonCommentCharacter(text, comment, options.locEnd) === ";"
+    getNextNonSpaceNonCommentCharacter(text, comment, locEnd) === ";"
   ) {
     addTrailingComment(enclosingNode, comment);
     return true;

--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -16,6 +16,7 @@ const {
   isLongCurriedCallExpression,
   shouldPrintComma,
 } = require("../utils");
+const { locEnd } = require("../loc");
 
 const {
   builders: {
@@ -99,7 +100,7 @@ function printCallArguments(path, options, print) {
 
     if (index === lastArgIndex) {
       // do nothing
-    } else if (isNextLineEmpty(options.originalText, arg, options.locEnd)) {
+    } else if (isNextLineEmpty(options.originalText, arg, locEnd)) {
       if (index === 0) {
         hasEmptyLineFollowingFirstArg = true;
       }

--- a/src/language-js/print/member-chain.js
+++ b/src/language-js/print/member-chain.js
@@ -20,6 +20,7 @@ const {
   isNumericLiteral,
   isSimpleCallArgument,
 } = require("../utils");
+const { locEnd } = require("../loc");
 
 const {
   builders: {
@@ -73,7 +74,7 @@ function printMemberChain(path, options, print) {
     const nextCharIndex = getNextNonSpaceNonCommentCharacterIndex(
       originalText,
       node,
-      options.locEnd
+      locEnd
     );
     const nextChar = originalText.charAt(nextCharIndex);
 
@@ -86,7 +87,7 @@ function printMemberChain(path, options, print) {
       );
     }
 
-    return isNextLineEmpty(originalText, node, options.locEnd);
+    return isNextLineEmpty(originalText, node, locEnd);
   }
 
   function rec(path) {

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -3,6 +3,7 @@
 const flat = require("lodash/flatten");
 
 const { isJSXNode } = require("../utils");
+const { locStart, locEnd } = require("../loc");
 const { hasNewlineInRange } = require("../../common/util");
 const handleComments = require("../comments");
 const {
@@ -261,8 +262,8 @@ function printTernaryOperator(path, options, print, operatorOptions) {
       handleComments.isBlockComment(comment) &&
       hasNewlineInRange(
         options.originalText,
-        options.locStart(comment),
-        options.locEnd(comment)
+        locStart(comment),
+        locEnd(comment)
       )
   );
   const maybeGroup = (doc) =>

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -113,6 +113,7 @@ const {
   shouldFlatten,
   startsWithNoLookaheadToken,
 } = require("./utils");
+const { locStart, locEnd } = require("./loc");
 
 const printMemberChain = require("./print/member-chain");
 const printCallArguments = require("./print/call-arguments");
@@ -159,8 +160,8 @@ function genericPrint(path, options, printPath, args) {
     // for printing the decorators.
     !(
       parentExportDecl &&
-      options.locStart(parentExportDecl, { ignoreDecorators: true }) >
-        options.locStart(node.decorators[0])
+      locStart(parentExportDecl, { ignoreDecorators: true }) >
+        locStart(node.decorators[0])
     )
   ) {
     const shouldBreak =
@@ -191,8 +192,8 @@ function genericPrint(path, options, printPath, args) {
     node.declaration.decorators.length > 0 &&
     // Only print decorators here if they were written before the export,
     // otherwise they are printed by the node.declaration
-    options.locStart(node, { ignoreDecorators: true }) >
-      options.locStart(node.declaration.decorators[0])
+    locStart(node, { ignoreDecorators: true }) >
+      locStart(node.declaration.decorators[0])
   ) {
     // Export declarations are responsible for printing any decorators
     // that logically apply to node.declaration.
@@ -298,11 +299,7 @@ function printPathNoParens(path, options, print, args) {
           parts.push(print(childPath), semi, hardline);
           if (
             (index < directivesCount - 1 || hasContents) &&
-            isNextLineEmpty(
-              options.originalText,
-              childPath.getValue(),
-              options.locEnd
-            )
+            isNextLineEmpty(options.originalText, childPath.getValue(), locEnd)
           ) {
             parts.push(hardline);
           }
@@ -684,7 +681,7 @@ function printPathNoParens(path, options, print, args) {
           const nextCharacter = getNextNonSpaceNonCommentCharacterIndex(
             options.originalText,
             comment,
-            options.locEnd
+            locEnd
           );
           return (
             nextCharacter !== false &&
@@ -704,12 +701,12 @@ function printPathNoParens(path, options, print, args) {
       // We want to always keep these types of nodes on the same line
       // as the arrow.
       if (
-        !hasLeadingOwnLineComment(options.originalText, n.body, options) &&
+        !hasLeadingOwnLineComment(options.originalText, n.body) &&
         (n.body.type === "ArrayExpression" ||
           n.body.type === "ObjectExpression" ||
           n.body.type === "BlockStatement" ||
           isJSXNode(n.body) ||
-          isTemplateOnItsOwnLine(n.body, options.originalText, options) ||
+          isTemplateOnItsOwnLine(n.body, options.originalText) ||
           n.body.type === "ArrowFunctionExpression" ||
           n.body.type === "DoExpression")
       ) {
@@ -869,10 +866,7 @@ function printPathNoParens(path, options, print, args) {
         (n.importKind && n.importKind === "type") ||
         // import {} from 'x'
         /{\s*}/.test(
-          options.originalText.slice(
-            options.locStart(n),
-            options.locStart(n.source)
-          )
+          options.originalText.slice(locStart(n), locStart(n.source))
         )
       ) {
         parts.push(" {}", printModuleSource(path, options, print));
@@ -941,11 +935,7 @@ function printPathNoParens(path, options, print, args) {
         path.each((childPath) => {
           parts.push(indent(concat([hardline, print(childPath), semi])));
           if (
-            isNextLineEmpty(
-              options.originalText,
-              childPath.getValue(),
-              options.locEnd
-            )
+            isNextLineEmpty(options.originalText, childPath.getValue(), locEnd)
           ) {
             parts.push(hardline);
           }
@@ -985,7 +975,7 @@ function printPathNoParens(path, options, print, args) {
           (n.callee.name === "require" || n.callee.name === "define")) ||
         // Template literals as single arguments
         (args.length === 1 &&
-          isTemplateOnItsOwnLine(args[0], options.originalText, options)) ||
+          isTemplateOnItsOwnLine(args[0], options.originalText)) ||
         // Keep test declarations on a single line
         // e.g. `it('long name', () => {`
         (!isNew && isTestCall(n, path.getParentNode()))
@@ -1086,7 +1076,7 @@ function printPathNoParens(path, options, print, args) {
 
       const firstProperty = fields
         .map((field) => n[field][0])
-        .sort((a, b) => options.locStart(a) - options.locStart(b))[0];
+        .sort((a, b) => locStart(a) - locStart(b))[0];
 
       const parent = path.getParentNode(0);
       const isFlowInterfaceLikeBody =
@@ -1118,8 +1108,8 @@ function printPathNoParens(path, options, print, args) {
           firstProperty &&
           hasNewlineInRange(
             options.originalText,
-            options.locStart(n),
-            options.locStart(firstProperty)
+            locStart(n),
+            locStart(firstProperty)
           ));
 
       const separator = isFlowInterfaceLikeBody
@@ -1141,7 +1131,7 @@ function printPathNoParens(path, options, print, args) {
           propsAndLoc.push({
             node,
             printed: print(childPath),
-            loc: options.locStart(node),
+            loc: locStart(node),
           });
         }, field);
       });
@@ -1160,9 +1150,7 @@ function printPathNoParens(path, options, print, args) {
           ) {
             separatorParts.shift();
           }
-          if (
-            isNextLineEmpty(options.originalText, prop.node, options.locEnd)
-          ) {
+          if (isNextLineEmpty(options.originalText, prop.node, locEnd)) {
             separatorParts.push(hardline);
           }
           return result;
@@ -1184,7 +1172,7 @@ function printPathNoParens(path, options, print, args) {
             hasLineComments ||
             hasNewline(
               options.originalText,
-              options.locEnd(n.comments[n.comments.length - 1])
+              locEnd(n.comments[n.comments.length - 1])
             )
               ? hardline
               : line,
@@ -1826,9 +1814,9 @@ function printPathNoParens(path, options, print, args) {
             (comment) =>
               !handleComments.isBlockComment(comment) ||
               (comment.leading &&
-                hasNewline(options.originalText, options.locEnd(comment))) ||
+                hasNewline(options.originalText, locEnd(comment))) ||
               (comment.trailing &&
-                hasNewline(options.originalText, options.locStart(comment), {
+                hasNewline(options.originalText, locStart(comment), {
                   backwards: true,
                 }))
           );
@@ -1872,11 +1860,7 @@ function printPathNoParens(path, options, print, args) {
                     return concat([
                       casePath.call(print),
                       n.cases.indexOf(caseNode) !== n.cases.length - 1 &&
-                      isNextLineEmpty(
-                        options.originalText,
-                        caseNode,
-                        options.locEnd
-                      )
+                      isNextLineEmpty(options.originalText, caseNode, locEnd)
                         ? hardline
                         : "",
                     ]);
@@ -2558,7 +2542,7 @@ function printPathNoParens(path, options, print, args) {
             parent.type === "ObjectTypeInternalSlot") &&
             !getFlowVariance(parent) &&
             !parent.optional &&
-            options.locStart(parent) === options.locStart(n)) ||
+            locStart(parent) === locStart(n)) ||
           parent.type === "ObjectTypeCallProperty" ||
           (parentParentParent && parentParentParent.type === "DeclareFunction")
         );
@@ -2769,7 +2753,7 @@ function printPathNoParens(path, options, print, args) {
           (parent.type === "TypeAlias" ||
             parent.type === "VariableDeclarator" ||
             parent.type === "TSTypeAliasDeclaration") &&
-          hasLeadingOwnLineComment(options.originalText, n, options)
+          hasLeadingOwnLineComment(options.originalText, n)
         );
 
       // {
@@ -2795,8 +2779,7 @@ function printPathNoParens(path, options, print, args) {
       }
 
       const shouldAddStartLine =
-        shouldIndent &&
-        !hasLeadingOwnLineComment(options.originalText, n, options);
+        shouldIndent && !hasLeadingOwnLineComment(options.originalText, n);
 
       const code = concat([
         ifBreak(concat([shouldAddStartLine ? line : "", "| "])),
@@ -2919,7 +2902,7 @@ function printPathNoParens(path, options, print, args) {
     case "TypeParameterInstantiation": {
       const value = path.getValue();
       const commentStart = options.originalText
-        .slice(0, options.locStart(value))
+        .slice(0, locStart(value))
         .lastIndexOf("/*");
       // As noted in the TypeCastExpression comments above, we're able to use a normal whitespace regex here
       // because we know for sure that this is a type definition.
@@ -3225,8 +3208,8 @@ function printPathNoParens(path, options, print, args) {
     case "TSMappedType": {
       const shouldBreak = hasNewlineInRange(
         options.originalText,
-        options.locStart(n),
-        options.locEnd(n)
+        locStart(n),
+        locEnd(n)
       );
       return group(
         concat([
@@ -3381,8 +3364,8 @@ function printPathNoParens(path, options, print, args) {
         parts.push(printTypeScriptModifiers(path, options, print));
 
         const textBetweenNodeAndItsId = options.originalText.slice(
-          options.locStart(n),
-          options.locStart(n.id)
+          locStart(n),
+          locStart(n.id)
         );
 
         // Global declaration looks like this:
@@ -3445,7 +3428,7 @@ function printPathNoParens(path, options, print, args) {
     case "InterpreterDirective":
       parts.push("#!", n.value, hardline);
 
-      if (isNextLineEmpty(options.originalText, n, options.locEnd)) {
+      if (isNextLineEmpty(options.originalText, n, locEnd)) {
         parts.push(hardline);
       }
 
@@ -3621,10 +3604,7 @@ function printStatementSequence(path, options, print) {
       }
     }
 
-    if (
-      isNextLineEmpty(text, stmt, options.locEnd) &&
-      !isLastStatement(stmtPath)
-    ) {
+    if (isNextLineEmpty(text, stmt, locEnd) && !isLastStatement(stmtPath)) {
       parts.push(hardline);
     }
 
@@ -3875,9 +3855,7 @@ function printTypeAnnotation(path, options, print) {
   const isFunctionDeclarationIdentifier =
     parentNode.type === "DeclareFunction" && parentNode.id === node;
 
-  if (
-    isFlowAnnotationComment(options.originalText, node.typeAnnotation, options)
-  ) {
+  if (isFlowAnnotationComment(options.originalText, node.typeAnnotation)) {
     return concat([" /*: ", path.call(print, "typeAnnotation"), " */"]);
   }
 
@@ -3912,7 +3890,7 @@ function printFunctionParameters(
           getNextNonSpaceNonCommentCharacter(
             options.originalText,
             comment,
-            options.locEnd
+            locEnd
           ) === ")"
       ),
       ")",
@@ -3942,7 +3920,7 @@ function printFunctionParameters(
     ) {
       printed.push(" ");
     } else if (
-      isNextLineEmpty(options.originalText, parameters[index], options.locEnd)
+      isNextLineEmpty(options.originalText, parameters[index], locEnd)
     ) {
       printed.push(hardline, hardline);
     } else {
@@ -4096,7 +4074,7 @@ function printReturnType(path, print, options) {
 
   if (
     n.returnType &&
-    isFlowAnnotationComment(options.originalText, n.returnType, options)
+    isFlowAnnotationComment(options.originalText, n.returnType)
   ) {
     return concat([" /*: ", returnType, " */"]);
   }
@@ -4914,7 +4892,7 @@ function printBinaryishExpressions(
       (node.operator === "|>" ||
         node.type === "NGPipeExpression" ||
         (node.operator === "|" && options.parser === "__vue_expression")) &&
-      !hasLeadingOwnLineComment(options.originalText, node.right, options);
+      !hasLeadingOwnLineComment(options.originalText, node.right);
 
     const operator = node.type === "NGPipeExpression" ? "|" : node.operator;
     const rightSuffix =
@@ -4978,7 +4956,7 @@ function printBinaryishExpressions(
 }
 
 function printAssignmentRight(leftNode, rightNode, printedRight, options) {
-  if (hasLeadingOwnLineComment(options.originalText, rightNode, options)) {
+  if (hasLeadingOwnLineComment(options.originalText, rightNode)) {
     return indent(concat([line, printedRight]));
   }
 
@@ -5175,11 +5153,7 @@ function printArrayItems(path, options, printPath, print) {
     separatorParts = [",", line];
     if (
       childPath.getValue() &&
-      isNextLineEmpty(
-        options.originalText,
-        childPath.getValue(),
-        options.locEnd
-      )
+      isNextLineEmpty(options.originalText, childPath.getValue(), locEnd)
     ) {
       separatorParts.push(softline);
     }
@@ -5299,7 +5273,7 @@ function printComment(commentPath, options) {
         // interleaved. See https://github.com/prettier/prettier/issues/4412
         if (
           comment.trailing &&
-          !hasNewline(options.originalText, options.locStart(comment), {
+          !hasNewline(options.originalText, locStart(comment), {
             backwards: true,
           })
         ) {
@@ -5308,7 +5282,7 @@ function printComment(commentPath, options) {
         return printed;
       }
 
-      const commentEnd = options.locEnd(comment);
+      const commentEnd = locEnd(comment);
       const isInsideFlowComment =
         options.originalText.slice(commentEnd - 3, commentEnd) === "*-/";
 
@@ -5318,7 +5292,7 @@ function printComment(commentPath, options) {
     case "Line":
       // Supports `//`, `#!`, `<!--`, and `-->`
       return options.originalText
-        .slice(options.locStart(comment), options.locEnd(comment))
+        .slice(locStart(comment), locEnd(comment))
         .trimEnd();
     default:
       /* istanbul ignore next */

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -9,6 +9,7 @@ const {
   hasNodeIgnoreComment,
   skipWhitespace,
 } = require("../common/util");
+const { locStart, locEnd } = require("./loc");
 
 /**
  * @typedef {import("./types/estree").Node} Node
@@ -808,10 +809,9 @@ function hasNewlineBetweenOrAfterDecorators(node, options) {
   return (
     hasNewlineInRange(
       options.originalText,
-      options.locStart(node.decorators[0]),
-      options.locEnd(getLast(node.decorators))
-    ) ||
-    hasNewline(options.originalText, options.locEnd(getLast(node.decorators)))
+      locStart(node.decorators[0]),
+      locEnd(getLast(node.decorators))
+    ) || hasNewline(options.originalText, locEnd(getLast(node.decorators)))
   );
 }
 
@@ -918,9 +918,9 @@ function isLastStatement(path) {
  * @param {Node} typeAnnotation
  * @returns {boolean}
  */
-function isFlowAnnotationComment(text, typeAnnotation, options) {
-  const start = options.locStart(typeAnnotation);
-  const end = skipWhitespace(text, options.locEnd(typeAnnotation));
+function isFlowAnnotationComment(text, typeAnnotation) {
+  const start = locStart(typeAnnotation);
+  const end = skipWhitespace(text, locEnd(typeAnnotation));
   return (
     end !== false &&
     text.slice(start, start + 2) === "/*" &&
@@ -933,7 +933,7 @@ function isFlowAnnotationComment(text, typeAnnotation, options) {
  * @param {Node} node
  * @returns {boolean}
  */
-function hasLeadingOwnLineComment(text, node, options) {
+function hasLeadingOwnLineComment(text, node) {
   if (isJSXNode(node)) {
     return hasNodeIgnoreComment(node);
   }
@@ -941,7 +941,7 @@ function hasLeadingOwnLineComment(text, node, options) {
   const res =
     node.comments &&
     node.comments.some(
-      (comment) => comment.leading && hasNewline(text, options.locEnd(comment))
+      (comment) => comment.leading && hasNewline(text, locEnd(comment))
     );
   return res;
 }
@@ -950,7 +950,7 @@ function hasLeadingOwnLineComment(text, node, options) {
 // (the leftmost leaf node) and, if it (or its parents) has any
 // leadingComments, returns true (so it can be wrapped in parens).
 function returnArgumentHasLeadingComment(options, argument) {
-  if (hasLeadingOwnLineComment(options.originalText, argument, options)) {
+  if (hasLeadingOwnLineComment(options.originalText, argument)) {
     return true;
   }
 
@@ -960,7 +960,7 @@ function returnArgumentHasLeadingComment(options, argument) {
     while ((newLeftMost = getLeftSide(leftMost))) {
       leftMost = newLeftMost;
 
-      if (hasLeadingOwnLineComment(options.originalText, leftMost, options)) {
+      if (hasLeadingOwnLineComment(options.originalText, leftMost)) {
         return true;
       }
     }
@@ -1065,12 +1065,12 @@ function templateLiteralHasNewLines(template) {
  * @param {string} text
  * @returns {boolean}
  */
-function isTemplateOnItsOwnLine(n, text, options) {
+function isTemplateOnItsOwnLine(n, text) {
   return (
     ((n.type === "TemplateLiteral" && templateLiteralHasNewLines(n)) ||
       (n.type === "TaggedTemplateExpression" &&
         templateLiteralHasNewLines(n.quasi))) &&
-    !hasNewline(text, options.locStart(n), { backwards: true })
+    !hasNewline(text, locStart(n), { backwards: true })
   );
 }
 


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
