### PR TITLE
Remove `for-each-in` syntax

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1728,10 +1728,9 @@ function printPathNoParens(path, options, print, args) {
         ])
       );
     case "ForInStatement":
-      // Note: esprima can't actually parse "for each (".
       return group(
         concat([
-          n.each ? "for each (" : "for (",
+          "for (",
           path.call(print, "left"),
           " in ",
           path.call(print, "right"),

--- a/tests/misc/errors/invalid/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/misc/errors/invalid/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snippet: #0 error test 1`] = `
+"Unexpected token, expected \\"(\\" (1:5)
+> 1 | for each (a in b) {}
+    |     ^"
+`;
+
+exports[`snippet: #0 error test 2`] = `
+"Unexpected identifier, expected the token \`(\` (1:5)
+> 1 | for each (a in b) {}
+    |     ^^^^"
+`;
+
+exports[`snippet: #0 error test 3`] = `
+"'(' expected. (1:5)
+> 1 | for each (a in b) {}
+    |     ^"
+`;
+
+exports[`snippet: #0 error test 4`] = `
+"Unexpected token, expected \\"(\\" (1:5)
+> 1 | for each (a in b) {}
+    |     ^"
+`;
+
+exports[`snippet: #0 error test 5`] = `
+"Unexpected token, expected \\"(\\" (1:5)
+> 1 | for each (a in b) {}
+    |     ^"
+`;
+
+exports[`snippet: #0 error test 6`] = `
+"Unexpected token each (1:5)
+> 1 | for each (a in b) {}
+    |     ^"
+`;

--- a/tests/misc/errors/invalid/jsfmt.spec.js
+++ b/tests/misc/errors/invalid/jsfmt.spec.js
@@ -1,0 +1,16 @@
+for (const parser of [
+  "babel",
+  "flow",
+  "typescript",
+  "babel-flow",
+  "babel-ts",
+  "espree",
+]) {
+  run_spec(
+    {
+      dirname: __dirname,
+      snippets: ["for each (a in b) {}"],
+    },
+    [parser]
+  );
+}


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

This was [added long time ago](https://github.com/josephfrazier/prettier/commit/9b4535e9f8a7040f2fbc65b22c9713632f3731be#diff-2d346b55d05d4171a948f6cb1573717ecd3adfb47cd9647448728c024cfec86bR891), maybe some parser support this syntax back then, but as I checked, no parser support it now.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
