### PR TITLE
Fix more `locStart`/`locEnd` from `options`

### DIFF
--- a/src/language-js/loc.js
+++ b/src/language-js/loc.js
@@ -4,10 +4,6 @@
  * @typedef {import("./types/estree").Node} Node
  */
 
-/**
- * @param {Node} node
- * @returns {number}
- */
 function locStart(node, opts) {
   const { ignoreDecorators } = opts || {};
 
@@ -24,10 +20,6 @@ function locStart(node, opts) {
   return node.range ? node.range[0] : node.start;
 }
 
-/**
- * @param {Node} node
- * @returns {number}
- */
 function locEnd(node) {
   const end = node.range ? node.range[1] : node.end;
   return node.typeAnnotation ? Math.max(end, locEnd(node.typeAnnotation)) : end;

--- a/src/language-js/loc.js
+++ b/src/language-js/loc.js
@@ -1,5 +1,13 @@
 "use strict";
 
+/**
+ * @typedef {import("./types/estree").Node} Node
+ */
+
+/**
+ * @param {Node} node
+ * @returns {number}
+ */
 function locStart(node, opts) {
   const { ignoreDecorators } = opts || {};
 
@@ -16,11 +24,20 @@ function locStart(node, opts) {
   return node.range ? node.range[0] : node.start;
 }
 
+/**
+ * @param {Node} node
+ * @returns {number}
+ */
 function locEnd(node) {
   const end = node.range ? node.range[1] : node.end;
   return node.typeAnnotation ? Math.max(end, locEnd(node.typeAnnotation)) : end;
 }
 
+/**
+ * @param {Node} startNode
+ * @param {Node | number} endNodeOrLength
+ * @returns {number[]}
+ */
 function composeLoc(startNode, endNodeOrLength = startNode) {
   const start = locStart(startNode);
   const end =
@@ -31,8 +48,37 @@ function composeLoc(startNode, endNodeOrLength = startNode) {
   return [start, end];
 }
 
+/**
+ * @param {Node} nodeA
+ * @param {Node} nodeB
+ * @returns {boolean}
+ */
+function hasSameLocStart(nodeA, nodeB) {
+  return locStart(nodeA) === locStart(nodeB);
+}
+
+/**
+ * @param {Node} nodeA
+ * @param {Node} nodeB
+ * @returns {boolean}
+ */
+function hasSameLocEnd(nodeA, nodeB) {
+  return locEnd(nodeA) === locEnd(nodeB);
+}
+
+/**
+ * @param {Node} nodeA
+ * @param {Node} nodeB
+ * @returns {boolean}
+ */
+function hasSameLoc(nodeA, nodeB) {
+  return hasSameLocStart(nodeA, nodeB) && hasSameLocEnd(nodeA, nodeB);
+}
+
 module.exports = {
   locStart,
   locEnd,
   composeLoc,
+  hasSameLocStart,
+  hasSameLoc,
 };

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -72,7 +72,6 @@ const {
   hasNewlineBetweenOrAfterDecorators,
   hasNgSideEffect,
   hasPrettierIgnore,
-  hasSameLoc,
   hasTrailingComment,
   hasTrailingLineComment,
   identity,
@@ -113,7 +112,7 @@ const {
   shouldFlatten,
   startsWithNoLookaheadToken,
 } = require("./utils");
-const { locStart, locEnd } = require("./loc");
+const { locStart, locEnd, hasSameLoc } = require("./loc");
 
 const printMemberChain = require("./print/member-chain");
 const printCallArguments = require("./print/call-arguments");

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -804,7 +804,7 @@ function printPathNoParens(path, options, print, args) {
 
       parts.push(path.call(print, "imported"));
 
-      if (n.local && !hasSameLoc(n.local, n.imported, options)) {
+      if (n.local && !hasSameLoc(n.local, n.imported)) {
         parts.push(" as ", path.call(print, "local"));
       }
 
@@ -812,7 +812,7 @@ function printPathNoParens(path, options, print, args) {
     case "ExportSpecifier": {
       parts.push(path.call(print, "local"));
 
-      if (n.exported && !hasSameLoc(n.local, n.exported, options)) {
+      if (n.exported && !hasSameLoc(n.local, n.exported)) {
         parts.push(" as ", path.call(print, "exported"));
       }
 
@@ -2561,7 +2561,7 @@ function printPathNoParens(path, options, print, args) {
           parent.type === "TSTypeAnnotation") &&
         parentParent.type === "ArrowFunctionExpression";
 
-      if (isObjectTypePropertyAFunction(parent, options)) {
+      if (isObjectTypePropertyAFunction(parent)) {
         isArrowFunctionTypeAnnotation = true;
         needsColon = true;
       }
@@ -2843,7 +2843,7 @@ function printPathNoParens(path, options, print, args) {
         variance || "",
         printPropertyKey(path, options, print),
         printOptionalToken(path),
-        isFunctionNotation(n, options) ? "" : ": ",
+        isFunctionNotation(n) ? "" : ": ",
         path.call(print, "value"),
       ]);
     }
@@ -3966,8 +3966,8 @@ function printFunctionParameters(
   }
 
   const isFlowShorthandWithOneArg =
-    (isObjectTypePropertyAFunction(parent, options) ||
-      isTypeAnnotationAFunction(parent, options) ||
+    (isObjectTypePropertyAFunction(parent) ||
+      isTypeAnnotationAFunction(parent) ||
       parent.type === "TypeAlias" ||
       parent.type === "UnionTypeAnnotation" ||
       parent.type === "TSUnionType" ||

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -346,7 +346,7 @@ function isGetterOrSetter(node) {
  * @param {Node} nodeB
  * @returns {boolean}
  */
-function sameLocStart(nodeA, nodeB, { locStart }) {
+function sameLocStart(nodeA, nodeB) {
   return locStart(nodeA) === locStart(nodeB);
 }
 
@@ -355,7 +355,7 @@ function sameLocStart(nodeA, nodeB, { locStart }) {
  * @param {Node} nodeB
  * @returns {boolean}
  */
-function sameLocEnd(nodeA, nodeB, { locEnd }) {
+function sameLocEnd(nodeA, nodeB) {
   return locEnd(nodeA) === locEnd(nodeB);
 }
 
@@ -364,16 +364,14 @@ function sameLocEnd(nodeA, nodeB, { locEnd }) {
  * @param {Node} nodeB
  * @returns {boolean}
  */
-function hasSameLoc(nodeA, nodeB, options) {
-  return (
-    sameLocStart(nodeA, nodeB, options) && sameLocEnd(nodeA, nodeB, options)
-  );
+function hasSameLoc(nodeA, nodeB) {
+  return sameLocStart(nodeA, nodeB) && sameLocEnd(nodeA, nodeB);
 }
 
 // TODO: This is a bad hack and we need a better way to distinguish between
 // arrow functions and otherwise
-function isFunctionNotation(node, options) {
-  return isGetterOrSetter(node) || sameLocStart(node, node.value, options);
+function isFunctionNotation(node) {
+  return isGetterOrSetter(node) || sameLocStart(node, node.value);
 }
 
 // Hack to differentiate between the following two which have the same ast
@@ -383,25 +381,25 @@ function isFunctionNotation(node, options) {
  * @param {Node} node
  * @returns {boolean}
  */
-function isObjectTypePropertyAFunction(node, options) {
+function isObjectTypePropertyAFunction(node) {
   return (
     (node.type === "ObjectTypeProperty" ||
       node.type === "ObjectTypeInternalSlot") &&
     node.value.type === "FunctionTypeAnnotation" &&
     !node.static &&
-    !isFunctionNotation(node, options)
+    !isFunctionNotation(node)
   );
 }
 
 // Hack to differentiate between the following two which have the same ast
 // declare function f(a): void;
 // var f: (a) => void;
-function isTypeAnnotationAFunction(node, options) {
+function isTypeAnnotationAFunction(node) {
   return (
     (node.type === "TypeAnnotation" || node.type === "TSTypeAnnotation") &&
     node.typeAnnotation.type === "FunctionTypeAnnotation" &&
     !node.static &&
-    !sameLocStart(node, node.typeAnnotation, options)
+    !sameLocStart(node, node.typeAnnotation)
   );
 }
 

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -9,7 +9,7 @@ const {
   hasNodeIgnoreComment,
   skipWhitespace,
 } = require("../common/util");
-const { locStart, locEnd } = require("./loc");
+const { locStart, locEnd, hasSameLocStart } = require("./loc");
 
 /**
  * @typedef {import("./types/estree").Node} Node
@@ -339,33 +339,6 @@ function isMemberExpressionChain(node) {
 
 function isGetterOrSetter(node) {
   return node.kind === "get" || node.kind === "set";
-}
-
-/**
- * @param {Node} nodeA
- * @param {Node} nodeB
- * @returns {boolean}
- */
-function hasSameLocStart(nodeA, nodeB) {
-  return locStart(nodeA) === locStart(nodeB);
-}
-
-/**
- * @param {Node} nodeA
- * @param {Node} nodeB
- * @returns {boolean}
- */
-function hasSameLocEnd(nodeA, nodeB) {
-  return locEnd(nodeA) === locEnd(nodeB);
-}
-
-/**
- * @param {Node} nodeA
- * @param {Node} nodeB
- * @returns {boolean}
- */
-function hasSameLoc(nodeA, nodeB) {
-  return hasSameLocStart(nodeA, nodeB) && hasSameLocEnd(nodeA, nodeB);
 }
 
 // TODO: This is a bad hack and we need a better way to distinguish between
@@ -1486,7 +1459,6 @@ module.exports = {
   hasNgSideEffect,
   hasNode,
   hasPrettierIgnore,
-  hasSameLoc,
   hasTrailingComment,
   hasTrailingLineComment,
   identity,

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -346,7 +346,7 @@ function isGetterOrSetter(node) {
  * @param {Node} nodeB
  * @returns {boolean}
  */
-function sameLocStart(nodeA, nodeB) {
+function hasSameLocStart(nodeA, nodeB) {
   return locStart(nodeA) === locStart(nodeB);
 }
 
@@ -355,7 +355,7 @@ function sameLocStart(nodeA, nodeB) {
  * @param {Node} nodeB
  * @returns {boolean}
  */
-function sameLocEnd(nodeA, nodeB) {
+function hasSameLocEnd(nodeA, nodeB) {
   return locEnd(nodeA) === locEnd(nodeB);
 }
 
@@ -365,13 +365,13 @@ function sameLocEnd(nodeA, nodeB) {
  * @returns {boolean}
  */
 function hasSameLoc(nodeA, nodeB) {
-  return sameLocStart(nodeA, nodeB) && sameLocEnd(nodeA, nodeB);
+  return hasSameLocStart(nodeA, nodeB) && hasSameLocEnd(nodeA, nodeB);
 }
 
 // TODO: This is a bad hack and we need a better way to distinguish between
 // arrow functions and otherwise
 function isFunctionNotation(node) {
-  return isGetterOrSetter(node) || sameLocStart(node, node.value);
+  return isGetterOrSetter(node) || hasSameLocStart(node, node.value);
 }
 
 // Hack to differentiate between the following two which have the same ast
@@ -399,7 +399,7 @@ function isTypeAnnotationAFunction(node) {
     (node.type === "TypeAnnotation" || node.type === "TSTypeAnnotation") &&
     node.typeAnnotation.type === "FunctionTypeAnnotation" &&
     !node.static &&
-    !sameLocStart(node, node.typeAnnotation)
+    !hasSameLocStart(node, node.typeAnnotation)
   );
 }
 


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

Missed in #9576

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
