### PR TITLE
Revert #9011, don’t add parens when yielding simple JSX expressions

### DIFF
--- a/changelog_unreleased/javascript/pr-9650.md
+++ b/changelog_unreleased/javascript/pr-9650.md
@@ -1,0 +1,17 @@
+#### Fix formatting of yielded JSX expressions (#9650 by @brainkim)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+function* f() {
+  yield <div>generator</div>
+}
+// Prettier stable
+function* f() {
+  yield (<div>generator</div>);
+}
+// Prettier master
+function* f() {
+  yield <div>generator</div>;
+}
+```

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -725,7 +725,8 @@ function needsParens(path, options) {
           parent.type !== "ReturnStatement" &&
           parent.type !== "ThrowStatement" &&
           parent.type !== "TypeCastExpression" &&
-          parent.type !== "VariableDeclarator")
+          parent.type !== "VariableDeclarator" &&
+          parent.type !== "YieldExpression")
       );
     case "TypeAnnotation":
       return (

--- a/tests/js/yield/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/yield/__snapshots__/jsfmt.spec.js.snap
@@ -96,7 +96,7 @@ function* f() {
 
 =====================================output=====================================
 function* f() {
-  yield (<div>generator</div>);
+  yield <div>generator</div>;
   yield (
     <div>
       <p>generator</p>
@@ -120,7 +120,7 @@ function* f() {
 
 =====================================output=====================================
 function* f() {
-  yield (<div>generator</div>);
+  yield <div>generator</div>;
   yield (
     <div>
       <p>generator</p>


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->
Fixes #9173

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
