### PR TITLE
Flatten function expression parameters in hugged last argument

### DIFF
--- a/changelog_unreleased/javascript/pr-9662.md
+++ b/changelog_unreleased/javascript/pr-9662.md
@@ -1,0 +1,29 @@
+#### Flatten function expression parameters in hugged last argument (#9662 by @thorn0)
+
+<!-- prettier-ignore -->
+```jsx
+// Prettier stable
+function* mySagas() {
+  yield effects.takeEvery(rexpress.actionTypes.REQUEST_START, function* ({
+    id
+  }) {
+    console.log(id);
+    yield rexpress.actions(store).writeHead(id, 400);
+    yield rexpress.actions(store).end(id, "pong");
+    console.log("pong");
+  });
+}
+
+// Prettier master
+function* mySagas() {
+  yield effects.takeEvery(
+    rexpress.actionTypes.REQUEST_START,
+    function* ({ id }) {
+      console.log(id);
+      yield rexpress.actions(store).writeHead(id, 400);
+      yield rexpress.actions(store).end(id, "pong");
+      console.log("pong");
+    }
+  );
+}
+```

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -644,7 +644,16 @@ function printPathNoParens(path, options, print, args) {
       ]);
     case "FunctionDeclaration":
     case "FunctionExpression":
-      parts.push(printFunctionDeclaration(path, print, options));
+      parts.push(
+        printFunctionDeclaration(
+          path,
+          print,
+          options,
+          args &&
+            args.expandLastArg &&
+            getCallArguments(path.getParentNode()).length > 1
+        )
+      );
       if (!n.body) {
         parts.push(semi);
       }
@@ -3736,7 +3745,7 @@ function canPrintParamsWithoutParens(node) {
   );
 }
 
-function printFunctionDeclaration(path, print, options) {
+function printFunctionDeclaration(path, print, options, expandArg) {
   const n = path.getValue();
   const parts = [];
 
@@ -3758,7 +3767,7 @@ function printFunctionDeclaration(path, print, options) {
     printFunctionTypeParameters(path, options, print),
     group(
       concat([
-        printFunctionParameters(path, print, options),
+        printFunctionParameters(path, print, options, expandArg),
         printReturnType(path, print, options),
       ])
     ),

--- a/tests/js/last-argument-expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/last-argument-expansion/__snapshots__/jsfmt.spec.js.snap
@@ -186,26 +186,26 @@ a(
 
 exports.examples = [
   {
-    render: withGraphQLQuery("node(1234567890){image{uri}}", function (
-      container,
-      data
-    ) {
-      return (
-        <div>
-          <InlineBlock>
-            <img
-              src={data[1234567890].image.uri}
-              style={{
-                position: "absolute",
-                top: "0",
-                left: "0",
-                zIndex: "-1",
-              }}
-            />
-          </InlineBlock>
-        </div>
-      );
-    }),
+    render: withGraphQLQuery(
+      "node(1234567890){image{uri}}",
+      function (container, data) {
+        return (
+          <div>
+            <InlineBlock>
+              <img
+                src={data[1234567890].image.uri}
+                style={{
+                  position: "absolute",
+                  top: "0",
+                  left: "0",
+                  zIndex: "-1",
+                }}
+              />
+            </InlineBlock>
+          </div>
+        );
+      }
+    ),
   },
 ];
 
@@ -217,32 +217,32 @@ someReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReal
   ]
 );
 
-(function webpackUniversalModuleDefinition() {})(this, function (
-  __WEBPACK_EXTERNAL_MODULE_85__,
-  __WEBPACK_EXTERNAL_MODULE_115__
-) {
-  return /******/ (function (modules) {
-    // webpackBootstrap
-    /******/
-  })(
-    /************************************************************************/
-    /******/ [
-      /* 0 */
-      /***/ function (module, exports, __webpack_require__) {
-        /***/
-      },
-      /* 1 */
-      /***/ function (module, exports, __webpack_require__) {
-        /***/
-      },
-      /* 2 */
-      /***/ function (module, exports, __webpack_require__) {
-        /***/
-      },
+(function webpackUniversalModuleDefinition() {})(
+  this,
+  function (__WEBPACK_EXTERNAL_MODULE_85__, __WEBPACK_EXTERNAL_MODULE_115__) {
+    return /******/ (function (modules) {
+      // webpackBootstrap
       /******/
-    ]
-  );
-});
+    })(
+      /************************************************************************/
+      /******/ [
+        /* 0 */
+        /***/ function (module, exports, __webpack_require__) {
+          /***/
+        },
+        /* 1 */
+        /***/ function (module, exports, __webpack_require__) {
+          /***/
+        },
+        /* 2 */
+        /***/ function (module, exports, __webpack_require__) {
+          /***/
+        },
+        /******/
+      ]
+    );
+  }
+);
 
 ================================================================================
 `;
@@ -305,6 +305,58 @@ func(
   // comment
   {}
 );
+
+================================================================================
+`;
+
+exports[`function-expression.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function* mySagas() {
+  yield effects.takeEvery(
+    rexpress.actionTypes.REQUEST_START,
+    function*({ id }) {
+      console.log(id);
+      yield rexpress.actions(store).writeHead(id, 400);
+      yield rexpress.actions(store).end(id, 'pong');
+      console.log('pong');
+    }
+  );
+}
+
+function mySagas2() {
+  return effects.takeEvery(
+    rexpress.actionTypes.REQUEST_START,
+    function({ id }) {
+      console.log(id);
+    }
+  );
+}
+
+=====================================output=====================================
+function* mySagas() {
+  yield effects.takeEvery(
+    rexpress.actionTypes.REQUEST_START,
+    function* ({ id }) {
+      console.log(id);
+      yield rexpress.actions(store).writeHead(id, 400);
+      yield rexpress.actions(store).end(id, "pong");
+      console.log("pong");
+    }
+  );
+}
+
+function mySagas2() {
+  return effects.takeEvery(
+    rexpress.actionTypes.REQUEST_START,
+    function ({ id }) {
+      console.log(id);
+    }
+  );
+}
 
 ================================================================================
 `;

--- a/tests/js/last-argument-expansion/function-expression.js
+++ b/tests/js/last-argument-expansion/function-expression.js
@@ -1,0 +1,20 @@
+function* mySagas() {
+  yield effects.takeEvery(
+    rexpress.actionTypes.REQUEST_START,
+    function*({ id }) {
+      console.log(id);
+      yield rexpress.actions(store).writeHead(id, 400);
+      yield rexpress.actions(store).end(id, 'pong');
+      console.log('pong');
+    }
+  );
+}
+
+function mySagas2() {
+  return effects.takeEvery(
+    rexpress.actionTypes.REQUEST_START,
+    function({ id }) {
+      console.log(id);
+    }
+  );
+}


### PR DESCRIPTION
Fixes #3376
This was done for arrow functions in #1305 ("Avoid breaking arguments for last arg expansion").
This PR enables the same for function expressions unless the function expression is the only argument.

**Before:**
```js
function* mySagas() {
  yield effects.takeEvery(rexpress.actionTypes.REQUEST_START, function*({
    id
  }) {
    console.log(id);
    yield rexpress.actions(store).writeHead(id, 400);
    yield rexpress.actions(store).end(id, "pong");
    console.log("pong");
  });
}
```

**After:**
```js
function* mySagas() {
  yield effects.takeEvery(
    rexpress.actionTypes.REQUEST_START,
    function* ({ id }) {
      console.log(id);
      yield rexpress.actions(store).writeHead(id, 400);
      yield rexpress.actions(store).end(id, "pong");
      console.log("pong");
    }
  );
}
```

Where did "unless the function expression is the only argument" come from? From code I found in the tests:
```ts
export class Thing12 implements OtherThing {
  do: (type: Type) => Provider<Prop> = memoize(function (
    type: ObjectType
  ): Provider<Opts> {
    return type;
  });
}
```
Apparently we want to keep it hugged.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
