### PR TITLE
Refactor: Move `isSourceElement` to languages

### DIFF
--- a/src/language-graphql/parser-graphql.js
+++ b/src/language-graphql/parser-graphql.js
@@ -3,6 +3,7 @@
 const createError = require("../common/parser-create-error");
 const { hasPragma } = require("./pragma");
 const { locStart, locEnd } = require("./loc");
+const isSourceElement = require("./source-elements");
 
 function parseComments(ast) {
   const comments = [];
@@ -80,6 +81,7 @@ module.exports = {
       hasPragma,
       locStart,
       locEnd,
+      isSourceElement,
     },
   },
 };

--- a/src/language-graphql/source-elements.js
+++ b/src/language-graphql/source-elements.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const graphqlSourceElements = new Set([
+  "OperationDefinition",
+  "FragmentDefinition",
+  "VariableDefinition",
+  "TypeExtensionDefinition",
+  "ObjectTypeDefinition",
+  "FieldDefinition",
+  "DirectiveDefinition",
+  "EnumTypeDefinition",
+  "EnumValueDefinition",
+  "InputValueDefinition",
+  "InputObjectTypeDefinition",
+  "SchemaDefinition",
+  "OperationTypeDefinition",
+  "InterfaceTypeDefinition",
+  "UnionTypeDefinition",
+  "ScalarTypeDefinition",
+]);
+function isSourceElement(node) {
+  return graphqlSourceElements.has(node.kind);
+}
+
+module.exports = isSourceElement;

--- a/src/language-html/parser-html.js
+++ b/src/language-html/parser-html.js
@@ -17,6 +17,7 @@ const { hasPragma } = require("./pragma");
 const { Node } = require("./ast");
 const { parseIeConditionalComment } = require("./conditional-comment");
 const { locStart, locEnd } = require("./loc");
+const { isVueSourceElement } = require("./source-elements");
 
 function ngHtmlParser(
   input,
@@ -382,22 +383,25 @@ module.exports = {
       allowHtmComponentClosingTags: true,
     }),
     angular: createParser(),
-    vue: createParser({
-      recognizeSelfClosing: true,
-      isTagNameCaseSensitive: true,
-      getTagContentType: (tagName, prefix, hasParent, attrs) => {
-        if (
-          tagName.toLowerCase() !== "html" &&
-          !hasParent &&
-          (tagName !== "template" ||
-            attrs.some(
-              ({ name, value }) => name === "lang" && value !== "html"
-            ))
-        ) {
-          return require("angular-html-parser").TagContentType.RAW_TEXT;
-        }
-      },
-    }),
+    vue: {
+      ...createParser({
+        recognizeSelfClosing: true,
+        isTagNameCaseSensitive: true,
+        getTagContentType: (tagName, prefix, hasParent, attrs) => {
+          if (
+            tagName.toLowerCase() !== "html" &&
+            !hasParent &&
+            (tagName !== "template" ||
+              attrs.some(
+                ({ name, value }) => name === "lang" && value !== "html"
+              ))
+          ) {
+            return require("angular-html-parser").TagContentType.RAW_TEXT;
+          }
+        },
+      }),
+      isSourceElement: isVueSourceElement,
+    },
     lwc: createParser(),
   },
 };

--- a/src/language-html/source-elements.js
+++ b/src/language-html/source-elements.js
@@ -1,0 +1,7 @@
+"use strict";
+
+function isVueSourceElement(node) {
+  return node.tag !== "root";
+}
+
+module.exports = { isVueSourceElement };

--- a/src/language-js/parser-babel.js
+++ b/src/language-js/parser-babel.js
@@ -8,6 +8,7 @@ const {
 const { hasPragma } = require("./pragma");
 const { locStart, locEnd } = require("./loc");
 const postprocess = require("./parse-postprocess");
+const { isSourceElement, isJsonSourceElement } = require("./source-elements");
 
 function babelOptions({ sourceType, extraPlugins = [] }) {
   return {
@@ -252,10 +253,27 @@ function assertJsonNode(node, parent) {
   }
 }
 
-const babel = { parse, astFormat: "estree", hasPragma, locStart, locEnd };
-const babelFlow = { ...babel, parse: parseFlow };
-const babelTypeScript = { ...babel, parse: parseTypeScript };
-const babelExpression = { ...babel, parse: parseExpression };
+const babel = {
+  parse,
+  astFormat: "estree",
+  hasPragma,
+  locStart,
+  locEnd,
+  isSourceElement,
+};
+const babelFlow = {
+  ...babel,
+  parse: parseFlow,
+};
+const babelTypeScript = {
+  ...babel,
+  parse: parseTypeScript,
+};
+const babelExpression = {
+  ...babel,
+  parse: parseExpression,
+  isSourceElement: undefined,
+};
 
 // Export as a plugin so we can reuse the same bundle for UMD loading
 module.exports = {
@@ -268,6 +286,7 @@ module.exports = {
       hasPragma() {
         return true;
       },
+      isSourceElement: isJsonSourceElement,
     },
     json5: babelExpression,
     "json-stringify": {
@@ -281,6 +300,6 @@ module.exports = {
     /** for vue filter */
     __vue_expression: babelExpression,
     /** for vue event binding to handle semicolon */
-    __vue_event_binding: babel,
+    __vue_event_binding: { ...babel, isSourceElement: undefined },
   },
 };

--- a/src/language-js/parser-espree.js
+++ b/src/language-js/parser-espree.js
@@ -4,6 +4,7 @@ const createError = require("../common/parser-create-error");
 const { hasPragma } = require("./pragma");
 const { locStart, locEnd } = require("./loc");
 const postprocess = require("./parse-postprocess");
+const { isSourceElement } = require("./source-elements");
 
 const espreeOptions = {
   range: true,
@@ -53,6 +54,13 @@ function parse(originalText, parsers, options) {
 
 module.exports = {
   parsers: {
-    espree: { parse, astFormat: "estree", hasPragma, locStart, locEnd },
+    espree: {
+      parse,
+      astFormat: "estree",
+      hasPragma,
+      locStart,
+      locEnd,
+      isSourceElement,
+    },
   },
 };

--- a/src/language-js/parser-flow.js
+++ b/src/language-js/parser-flow.js
@@ -4,6 +4,7 @@ const createError = require("../common/parser-create-error");
 const { hasPragma } = require("./pragma");
 const { locStart, locEnd } = require("./loc");
 const postprocess = require("./parse-postprocess");
+const { isSourceElement } = require("./source-elements");
 
 function parse(text, parsers, opts) {
   // Inline the require to avoid loading all the JS if we don't use it
@@ -39,6 +40,13 @@ function parse(text, parsers, opts) {
 // Export as a plugin so we can reuse the same bundle for UMD loading
 module.exports = {
   parsers: {
-    flow: { parse, astFormat: "estree", hasPragma, locStart, locEnd },
+    flow: {
+      parse,
+      astFormat: "estree",
+      hasPragma,
+      locStart,
+      locEnd,
+      isSourceElement,
+    },
   },
 };

--- a/src/language-js/parser-meriyah.js
+++ b/src/language-js/parser-meriyah.js
@@ -4,6 +4,7 @@ const createError = require("../common/parser-create-error");
 const { hasPragma } = require("./pragma");
 const { locStart, locEnd } = require("./loc");
 const postprocess = require("./parse-postprocess");
+const { isSourceElement } = require("./source-elements");
 
 // https://github.com/meriyah/meriyah/blob/4676f60b6c149d7082bde2c9147f9ae2359c8075/src/parser.ts#L185
 const parseOptions = {
@@ -85,6 +86,13 @@ function parse(text, parsers, options) {
 
 module.exports = {
   parsers: {
-    meriyah: { parse, astFormat: "estree", hasPragma, locStart, locEnd },
+    meriyah: {
+      parse,
+      astFormat: "estree",
+      hasPragma,
+      locStart,
+      locEnd,
+      isSourceElement,
+    },
   },
 };

--- a/src/language-js/parser-typescript.js
+++ b/src/language-js/parser-typescript.js
@@ -4,6 +4,7 @@ const createError = require("../common/parser-create-error");
 const { hasPragma } = require("./pragma");
 const { locStart, locEnd } = require("./loc");
 const postprocess = require("./parse-postprocess");
+const { isSourceElement } = require("./source-elements");
 
 function parse(text, parsers, opts) {
   const jsx = isProbablyJsx(text);
@@ -62,7 +63,14 @@ function isProbablyJsx(text) {
   ).test(text);
 }
 
-const parser = { parse, astFormat: "estree", hasPragma, locStart, locEnd };
+const parser = {
+  parse,
+  astFormat: "estree",
+  hasPragma,
+  locStart,
+  locEnd,
+  isSourceElement,
+};
 
 // Export as a plugin so we can reuse the same bundle for UMD loading
 module.exports = {

--- a/src/language-js/source-elements.js
+++ b/src/language-js/source-elements.js
@@ -1,0 +1,29 @@
+"use strict";
+
+// See https://www.ecma-international.org/ecma-262/5.1/#sec-A.5
+function isSourceElement(node) {
+  const { type } = node;
+  return (
+    type === "Directive" ||
+    type === "TypeAlias" ||
+    type === "TSExportAssignment" ||
+    type.startsWith("Declare") ||
+    type.startsWith("TSDeclare") ||
+    type.endsWith("Statement") ||
+    type.endsWith("Declaration")
+  );
+}
+
+const jsonSourceElements = new Set([
+  "ObjectExpression",
+  "ArrayExpression",
+  "StringLiteral",
+  "NumericLiteral",
+  "BooleanLiteral",
+  "NullLiteral",
+]);
+function isJsonSourceElement(node) {
+  return jsonSourceElements.has(node.type);
+}
+
+module.exports = { isSourceElement, isJsonSourceElement };

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -141,9 +141,14 @@ function coreFormat(originalText, opts, addAlignmentSize) {
   return { formatted: result.formatted, cursorOffset: -1 };
 }
 
-function formatRange(originalText, opts) {
+function formatRange(originalText, opts, selectedParser) {
   const { ast, text } = parser.parse(originalText, opts);
-  const { rangeStart, rangeEnd } = rangeUtil.calculateRange(text, opts, ast);
+  const { rangeStart, rangeEnd } = rangeUtil.calculateRange(
+    text,
+    opts,
+    ast,
+    selectedParser
+  );
   const rangeString = text.slice(rangeStart, rangeEnd);
 
   // Try to extend the range backwards to the beginning of the line.
@@ -290,7 +295,7 @@ function format(originalText, originalOptions) {
   let result;
 
   if (options.rangeStart > 0 || options.rangeEnd < text.length) {
-    result = formatRange(text, options);
+    result = formatRange(text, options, selectedParser);
   } else {
     if (!hasPragma && options.insertPragma && options.printer.insertPragma) {
       text = options.printer.insertPragma(text);

--- a/src/main/range-util.js
+++ b/src/main/range-util.js
@@ -20,8 +20,10 @@ function findSiblingAncestors(
 
   for (const endParent of endNodeAndParents.parentNodes) {
     if (
+      endParent !== root &&
+      // There is little difference between `babel` and other JS parsers,
+      // TODO: remove this condition
       endParent.type !== "Program" &&
-      endParent.type !== "File" &&
       opts.locStart(endParent) >= opts.locStart(startNodeAndParents.node)
     ) {
       resultEndNode = endParent;
@@ -32,8 +34,9 @@ function findSiblingAncestors(
 
   for (const startParent of startNodeAndParents.parentNodes) {
     if (
+      startParent.type !== root &&
+      // See comment above
       startParent.type !== "Program" &&
-      startParent.type !== "File" &&
       opts.locEnd(startParent) <= opts.locEnd(endNodeAndParents.node)
     ) {
       resultStartNode = startParent;


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

This should make plugin able to do range format, #7639, but we need update docs to close it.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
