### PR TITLE
Fix #9702 - Flush line suffix contents at the end of document

### DIFF
--- a/src/document/doc-printer.js
+++ b/src/document/doc-printer.js
@@ -526,6 +526,13 @@ function printDocToString(doc, options) {
         default:
       }
     }
+
+    // Flush remaining line-suffix contents at the end of the document, in case
+    // there is no new line after the line-suffix.
+    if (cmds.length === 0 && lineSuffix.length) {
+      cmds.push(...lineSuffix.reverse());
+      lineSuffix = [];
+    }
   }
 
   const cursorPlaceholderIndex = out.indexOf(cursor.placeholder);

--- a/tests_integration/__tests__/plugin-flush-line-suffix.js
+++ b/tests_integration/__tests__/plugin-flush-line-suffix.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const runPrettier = require("../runPrettier");
+
+describe("flush all line-suffix content", () => {
+  runPrettier("plugins/flushLineSuffix", ["*.foo", "--plugin=./plugin"], {
+    ignoreLineEndings: true,
+  }).test({
+    stdout: "contents",
+    stderr: "",
+    status: 0,
+    write: [],
+  });
+});

--- a/tests_integration/plugins/flushLineSuffix/file.foo
+++ b/tests_integration/plugins/flushLineSuffix/file.foo
@@ -1,0 +1,1 @@
+contents

--- a/tests_integration/plugins/flushLineSuffix/plugin.js
+++ b/tests_integration/plugins/flushLineSuffix/plugin.js
@@ -1,0 +1,25 @@
+"use strict";
+
+const prettier = require("prettier-local");
+const { lineSuffix } = prettier.doc.builders;
+
+module.exports = {
+  languages: [
+    {
+      name: "foo",
+      parsers: ["foo-parser"],
+      extensions: [".foo"]
+    }
+  ],
+  parsers: {
+    "foo-parser": {
+      parse: text => ({ text }),
+      astFormat: "foo-ast"
+    }
+  },
+  printers: {
+    "foo-ast": {
+      print: path => lineSuffix(path.getValue().text.trim())
+    }
+  }
+};


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

As noted in #9702, currently Prettier core does not flush line-suffix contents at the end of the document if there is no trailing newline. This fix forces all of those contents to be flushed even without trailing newlines.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
