### PR TITLE
add idempotenceHazard property to groups for willBreak to check

### DIFF
--- a/src/document/doc-builders.js
+++ b/src/document/doc-builders.js
@@ -70,7 +70,12 @@ function align(n, contents) {
 
 /**
  * @param {Doc} contents
- * @param {object} [opts] - TBD ???
+ * @param {{
+ *    id?: symbol,
+ *    shouldBreak?: boolean,
+ *    expandedStates?: Doc[],
+ *    idempotenceHazard?: boolean
+ * }} [opts]
  * @returns Doc
  */
 function group(contents, opts) {
@@ -86,6 +91,7 @@ function group(contents, opts) {
     contents,
     break: !!opts.shouldBreak,
     expandedStates: opts.expandedStates,
+    idempotenceHazard: opts.idempotenceHazard,
   };
 }
 

--- a/src/document/doc-utils.js
+++ b/src/document/doc-utils.js
@@ -105,7 +105,7 @@ function isLineNext(doc) {
 }
 
 function willBreakFn(doc) {
-  if (doc.type === "group" && doc.break) {
+  if (doc.type === "group" && (doc.break || doc.idempotenceHazard)) {
     return true;
   }
   if (doc.type === "line" && doc.hard) {

--- a/src/language-js/print/object.js
+++ b/src/language-js/print/object.js
@@ -233,7 +233,7 @@ function printObject(path, options, print) {
     return content;
   }
 
-  return group(content, { shouldBreak });
+  return group(content, { shouldBreak, idempotenceHazard: !shouldBreak });
 }
 
 module.exports = { printObject };

--- a/tests/flow-repo/destructuring/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow-repo/destructuring/__snapshots__/jsfmt.spec.js.snap
@@ -230,8 +230,12 @@ function gen<T>(x: T, { p = x }: { p: T }): T {
 }
 
 // Default values in destructuring unwrap optional types
-obj_prop_fun(({}: { p?: { q?: null } })); // ok
-obj_prop_var(({}: { p?: { q?: null } })); // ok
+obj_prop_fun(
+  ({}: { p?: { q?: null } })
+); // ok
+obj_prop_var(
+  ({}: { p?: { q?: null } })
+); // ok
 
 // union-like upper bounds preserved through destructuring
 function obj_prop_opt({ p }: { p?: string } = { p: 0 }) {}

--- a/tests/flow-repo/facebookisms/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow-repo/facebookisms/__snapshots__/jsfmt.spec.js.snap
@@ -75,11 +75,11 @@ let tests = [
   function (copyProperties: Object$Assign) {
     let result = {};
     result.baz = false;
-    (copyProperties(result, { foo: "a" }, { bar: 123 }): {
-      foo: string,
-      bar: number,
-      baz: boolean,
-    });
+    (copyProperties(
+      result,
+      { foo: "a" },
+      { bar: 123 }
+    ): { foo: string, bar: number, baz: boolean });
   },
 
   // module from lib
@@ -234,7 +234,11 @@ let tests = [
   function (mergeInto: $Facebookism$MergeInto) {
     let result = {};
     result.baz = false;
-    (mergeInto(result, { foo: "a" }, { bar: 123 }): void);
+    (mergeInto(
+      result,
+      { foo: "a" },
+      { bar: 123 }
+    ): void);
     (result: { foo: string, bar: number, baz: boolean });
   },
 
@@ -242,7 +246,11 @@ let tests = [
   function () {
     const mergeInto = require("mergeInto");
     let result: { foo?: string, bar?: number, baz: boolean } = { baz: false };
-    (mergeInto(result, { foo: "a" }, { bar: 123 }): void);
+    (mergeInto(
+      result,
+      { foo: "a" },
+      { bar: 123 }
+    ): void);
   },
 
   // too few args

--- a/tests/flow-repo/more_react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow-repo/more_react/__snapshots__/jsfmt.spec.js.snap
@@ -234,8 +234,15 @@ checkPropTypes(
   "TestComponent"
 ); // OK
 
-checkPropTypes({ foo: PropTypes.string }, { foo: "foo" }); // error: missing arguments
-checkPropTypes({ foo: PropTypes.string }, { foo: "foo" }, "value"); // error: missing argument
+checkPropTypes(
+  { foo: PropTypes.string },
+  { foo: "foo" }
+); // error: missing arguments
+checkPropTypes(
+  { foo: PropTypes.string },
+  { foo: "foo" },
+  "value"
+); // error: missing argument
 
 checkPropTypes(
   { bar: PropTypes.string },

--- a/tests/flow-repo/new_spread/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow-repo/new_spread/__snapshots__/jsfmt.spec.js.snap
@@ -382,8 +382,14 @@ declare function spread<A,B>(a: A, b: B): {...A, ...B};
 
 =====================================output=====================================
 declare function spread<A, B>(a: A, b: B): { ...A, ...B };
-(spread({ p: 0 }, { q: 0 }): {| +p: number, +q: number |}); // ok
-(spread({ p: 0 }, { q: 0 }): {| +p: empty, +q: empty |}); // number ~> empty (x2)
+(spread(
+  { p: 0 },
+  { q: 0 }
+): {| +p: number, +q: number |}); // ok
+(spread(
+  { p: 0 },
+  { q: 0 }
+): {| +p: empty, +q: empty |}); // number ~> empty (x2)
 
 ================================================================================
 `;

--- a/tests/flow-repo/node_tests/child_process/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow-repo/node_tests/child_process/__snapshots__/jsfmt.spec.js.snap
@@ -37,9 +37,13 @@ exec("ls", function (error, stdout, stderr) {
 exec("ls", { timeout: 250 });
 
 // options + callback.
-exec("ls", { maxBuffer: 100 }, function (error, stdout, stderr) {
-  console.info(stdout);
-});
+exec(
+  "ls",
+  { maxBuffer: 100 },
+  function (error, stdout, stderr) {
+    console.info(stdout);
+  }
+);
 
 ================================================================================
 `;
@@ -103,9 +107,14 @@ execFile("ls", ["-l"], function (error, stdout, stderr) {
 execFile("ls", ["-l"], { timeout: 250 });
 
 // Put it all together.
-execFile("ls", ["-l"], { timeout: 250 }, function (error, stdout, stderr) {
-  console.info(stdout);
-});
+execFile(
+  "ls",
+  ["-l"],
+  { timeout: 250 },
+  function (error, stdout, stderr) {
+    console.info(stdout);
+  }
+);
 
 ================================================================================
 `;

--- a/tests/flow-repo/node_tests/fs/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow-repo/node_tests/fs/__snapshots__/jsfmt.spec.js.snap
@@ -53,9 +53,13 @@ fs.readFile("file.exp", "blah", (_, data) => {
   (data: string);
 });
 
-fs.readFile("file.exp", { encoding: "blah" }, (_, data) => {
-  (data: string);
-});
+fs.readFile(
+  "file.exp",
+  { encoding: "blah" },
+  (_, data) => {
+    (data: string);
+  }
+);
 
 fs.readFile("file.exp", {}, (_, data) => {
   (data: Buffer);

--- a/tests/flow-repo/object_api/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow-repo/object_api/__snapshots__/jsfmt.spec.js.snap
@@ -34,7 +34,10 @@ module.exports = b;
 /* @flow */
 
 var a = require("./a");
-var b = Object.assign({ bar() {}, ...{} }, a);
+var b = Object.assign(
+  { bar() {}, ...{} },
+  a
+);
 b.a(); // works here
 module.exports = b;
 

--- a/tests/flow-repo/object_assign/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow-repo/object_assign/__snapshots__/jsfmt.spec.js.snap
@@ -152,7 +152,10 @@ Object.assign({a: "foo"}, 123);
 
 Object.assign("123", { a: "foo" });
 Object.assign(123, { a: "foo" });
-Object.assign({ a: "foo" }, 123);
+Object.assign(
+  { a: "foo" },
+  123
+);
 
 ================================================================================
 `;
@@ -190,11 +193,11 @@ declare var tup: [{ foo: string }, { bar: number }];
 (Object.assign({}, ...roArrOfObjs): { foo: number }); // Error: string ~> number
 (Object.assign({}, ...tup): { foo: string, bar: boolean }); // Error: number ~> boolean
 
-(Object.assign({}, ...[{ a: 1 }, { b: "foo" }], ...[{ c: true }]): {
-  a: number,
-  b: true,
-  c: boolean,
-}); // Error: 'foo' => true
+(Object.assign(
+  {},
+  ...[{ a: 1 }, { b: "foo" }],
+  ...[{ c: true }]
+): { a: number, b: true, c: boolean }); // Error: 'foo' => true
 
 ================================================================================
 `;

--- a/tests/flow-repo/react/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow-repo/react/__snapshots__/jsfmt.spec.js.snap
@@ -1913,7 +1913,9 @@ React.createClass({
 
 React.createClass({
   propTypes: {
-    foo: React.PropTypes.shape(({}: { [string]: any })).isRequired,
+    foo: React.PropTypes.shape(
+      ({}: { [string]: any })
+    ).isRequired,
   },
   f() {
     (this.props.foo.bar: empty); // OK

--- a/tests/flow-repo/union_new/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow-repo/union_new/__snapshots__/jsfmt.spec.js.snap
@@ -730,7 +730,9 @@ type B6 = string;
 
 function obj(a: { x: number } | { x: string }) {}
 
-obj(({ x: "" }: A1));
+obj(
+  ({ x: "" }: A1)
+);
 
 type A1 = { x: B1 };
 

--- a/tests/html/js/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html/js/__snapshots__/jsfmt.spec.js.snap
@@ -355,7 +355,8 @@ printWidth: 80
         url: this.props.url,
         dataType: "json",
         cache: false,
-        success: (data) => this.setState({ data: data }),
+        success: (data) =>
+          this.setState({ data: data }),
         error: (xhr, status, err) => console.error(status, err),
       });
     }

--- a/tests/js/arrow-call/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/arrow-call/__snapshots__/jsfmt.spec.js.snap
@@ -58,9 +58,9 @@ it("mocks regexp instances", () => {
   ).not.toThrow();
 });
 
-expect(() => asyncRequest({ url: "/test-endpoint" })).toThrowError(
-  /Required parameter/
-);
+expect(() =>
+  asyncRequest({ url: "/test-endpoint" })
+).toThrowError(/Required parameter/);
 
 expect(() =>
   asyncRequest({ url: "/test-endpoint-but-with-a-long-url" })
@@ -159,9 +159,9 @@ it("mocks regexp instances", () => {
   ).not.toThrow();
 });
 
-expect(() => asyncRequest({ url: "/test-endpoint" })).toThrowError(
-  /Required parameter/,
-);
+expect(() =>
+  asyncRequest({ url: "/test-endpoint" }),
+).toThrowError(/Required parameter/);
 
 expect(() =>
   asyncRequest({ url: "/test-endpoint-but-with-a-long-url" }),
@@ -259,9 +259,9 @@ it("mocks regexp instances", () => {
   ).not.toThrow();
 });
 
-expect(() => asyncRequest({ url: "/test-endpoint" })).toThrowError(
-  /Required parameter/
-);
+expect(() =>
+  asyncRequest({ url: "/test-endpoint" })
+).toThrowError(/Required parameter/);
 
 expect(() =>
   asyncRequest({ url: "/test-endpoint-but-with-a-long-url" })

--- a/tests/js/function-first-param/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/function-first-param/__snapshots__/jsfmt.spec.js.snap
@@ -56,7 +56,10 @@ db.collection("indexOptionDefault").createIndex(
   },
   function (err) {
     test.equal(null, err);
-    test.deepEqual({ w: 2, wtimeout: 1000 }, commandResult.writeConcern);
+    test.deepEqual(
+      { w: 2, wtimeout: 1000 },
+      commandResult.writeConcern
+    );
 
     client.close();
     done();

--- a/tests/js/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -1041,8 +1041,14 @@ something()
   .then((result) => dontForgetThisAsWell(result));
 
 db.branch(
-  db.table("users").filter({ email }).count(),
-  db.table("users").filter({ email: "a@b.com" }).count(),
+  db
+    .table("users")
+    .filter({ email })
+    .count(),
+  db
+    .table("users")
+    .filter({ email: "a@b.com" })
+    .count(),
   db.table("users").insert({ email }),
   db.table("users").filter({ email })
 );
@@ -1353,17 +1359,21 @@ const Profile2 = view.with({ name }).as((props) => (
 ))
 
 =====================================output=====================================
-const Profile = view.with({ name: (state) => state.name }).as((props) => (
-  <div>
-    <h1>Hello, {props.name}</h1>
-  </div>
-));
+const Profile = view
+  .with({ name: (state) => state.name })
+  .as((props) => (
+    <div>
+      <h1>Hello, {props.name}</h1>
+    </div>
+  ));
 
-const Profile2 = view.with({ name }).as((props) => (
-  <div>
-    <h1>Hello, {props.name}</h1>
-  </div>
-));
+const Profile2 = view
+  .with({ name })
+  .as((props) => (
+    <div>
+      <h1>Hello, {props.name}</h1>
+    </div>
+  ));
 
 ================================================================================
 `;

--- a/tests/js/record/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/record/__snapshots__/jsfmt.spec.js.snap
@@ -38,14 +38,26 @@ assert(#{ [9 + 1]: "ten" } === #{ ["10"]: "ten" })
 
 =====================================output=====================================
 const key = "a";
-assert(#{ [key]: 1 } === #{ a: 1 });
-assert(#{ [key.toUpperCase()]: 1 } === #{ A: 1 });
+assert(
+  #{ [key]: 1 } === #{ a: 1 }
+);
+assert(
+  #{ [key.toUpperCase()]: 1 } === #{ A: 1 }
+);
 
-assert(#{ [true]: 1 } === #{ true: 1 });
-assert(#{ [true]: 1 } === #{ ["true"]: 1 });
+assert(
+  #{ [true]: 1 } === #{ true: 1 }
+);
+assert(
+  #{ [true]: 1 } === #{ ["true"]: 1 }
+);
 
-assert(#{ [1 + 1]: "two" } === #{ 2: "two" });
-assert(#{ [9 + 1]: "ten" } === #{ ["10"]: "ten" });
+assert(
+  #{ [1 + 1]: "two" } === #{ 2: "two" }
+);
+assert(
+  #{ [9 + 1]: "ten" } === #{ ["10"]: "ten" }
+);
 
 ================================================================================
 `;
@@ -203,7 +215,9 @@ const record2 = #{ ...record1, b: 5 };
 assert(record1.a === 1);
 assert(record1["a"] === 1);
 assert(record1 !== record2);
-assert(record2 === #{ a: 1, c: 3, b: 5 });
+assert(
+  record2 === #{ a: 1, c: 3, b: 5 }
+);
 assert(record1?.a === 1);
 assert(record1?.d === undefined);
 assert(record1?.d ?? 5 === 5);
@@ -285,7 +299,9 @@ const taskNow = #{ id: 42, status: "WIP", ...formData };
 const taskLater = #{ ...taskNow, status: "DONE" };
 
 // A reminder: The ordering of keys in record literals does not affect equality (and is not retained)
-assert(taskLater === #{ status: "DONE", title: formData.title, id: 42 });
+assert(
+  taskLater === #{ status: "DONE", title: formData.title, id: 42 }
+);
 
 ================================================================================
 `;

--- a/tests/typescript/argument-expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/argument-expansion/__snapshots__/jsfmt.spec.js.snap
@@ -61,13 +61,19 @@ const bar4 = [1, 2, 3].reduce(
   <Array<number>>[1, 2, 3]
 );
 
-const bar5 = [1, 2, 3].reduce((carry, value) => {
-  return { ...carry, [value]: true };
-}, ({} as unknown) as { [key: number]: boolean });
+const bar5 = [1, 2, 3].reduce(
+  (carry, value) => {
+    return { ...carry, [value]: true };
+  },
+  ({} as unknown) as { [key: number]: boolean }
+);
 
-const bar6 = [1, 2, 3].reduce((carry, value) => {
-  return { ...carry, [value]: true };
-}, <{ [key: number]: boolean }>{});
+const bar6 = [1, 2, 3].reduce(
+  (carry, value) => {
+    return { ...carry, [value]: true };
+  },
+  <{ [key: number]: boolean }>{}
+);
 
 const bar7 = [1, 2, 3].reduce(
   (carry, value) => {


### PR DESCRIPTION
If a group is marked as `idempotenceHazard`, it means that while this group isn't necessarily going to break on the current run of Prettier, there is a chance it will break on a subsequent one, so `willBreak` defensively returns `true` for such groups, which prevents idempotence bugs, in particular bugs related to object literals.

This fixes #9390, #7927, partially #2803, and the problem I hit with #8063 (https://github.com/prettier/prettier/pull/7889#issuecomment-614073066).

As you can see from the snapshots, there are some undesired formatting changes. Since it's unlikely we'll find a better solution for the idempotence issues, I suggest that we work around these undesired changes by refraining from preserving line breaks in object literals in some special cases, e.g. see #8055. Object literals in these special cases will be idempotence-safe and thus retain the current behavior with regard to the surrounding code.

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
