### PR TITLE
Refactor: Stop mutating comments during `decorateComment`

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -563,7 +563,7 @@ function isNodeIgnoreComment(comment) {
 
 function addCommentHelper(node, comment) {
   const comments = node.comments || (node.comments = []);
-  comments.push(comment.__isWrapped ? comment.comment : comment);
+  comments.push(comment);
   comment.printed = false;
 
   // For some reason, TypeScript parses `// x` inside of JSXText as a comment

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -563,7 +563,7 @@ function isNodeIgnoreComment(comment) {
 
 function addCommentHelper(node, comment) {
   const comments = node.comments || (node.comments = []);
-  comments.push(comment);
+  comments.push(comment.__isWrapped ? comment.comment : comment);
   comment.printed = false;
 
   // For some reason, TypeScript parses `// x` inside of JSXText as a comment

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -407,12 +407,11 @@ function handleMethodNameComments(data, text) {
   return false;
 }
 
-function handleFunctionNameComments(comment, text) {
+function handleFunctionNameComments(data, text) {
+  const { comment, precedingNode, enclosingNode } = data;
   if (getNextNonSpaceNonCommentCharacter(text, comment, locEnd) !== "(") {
     return false;
   }
-
-  const { precedingNode, enclosingNode } = comment;
   if (
     precedingNode &&
     enclosingNode &&

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -22,63 +22,60 @@ const {
 } = require("./utils");
 const { locStart, locEnd } = require("./loc");
 
-function handleOwnLineComment(context, text, options, ast, isLastComment) {
-  return (
-    handleIgnoreComments(context) ||
-    handleLastFunctionArgComments(context, text) ||
-    handleMemberExpressionComments(context) ||
-    handleIfStatementComments(context, text) ||
-    handleWhileComments(context, text) ||
-    handleTryStatementComments(context) ||
-    handleClassComments(context) ||
-    handleImportSpecifierComments(context) ||
-    handleForComments(context) ||
-    handleUnionTypeComments(context) ||
-    handleOnlyComments(context, ast, isLastComment) ||
-    handleImportDeclarationComments(context, text) ||
-    handleAssignmentPatternComments(context) ||
-    handleMethodNameComments(context, text) ||
-    handleLabeledStatementComments(context)
-  );
+function handleOwnLineComment(context) {
+  return [
+    handleIgnoreComments,
+    handleLastFunctionArgComments,
+    handleMemberExpressionComments,
+    handleIfStatementComments,
+    handleWhileComments,
+    handleTryStatementComments,
+    handleClassComments,
+    handleImportSpecifierComments,
+    handleForComments,
+    handleUnionTypeComments,
+    handleOnlyComments,
+    handleImportDeclarationComments,
+    handleAssignmentPatternComments,
+    handleMethodNameComments,
+    handleLabeledStatementComments,
+  ].some((fn) => fn(context));
 }
 
-function handleEndOfLineComment(context, text, options, ast, isLastComment) {
-  return (
-    handleClosureTypeCastComments(context) ||
-    handleLastFunctionArgComments(context, text) ||
-    handleConditionalExpressionComments(context, text) ||
-    handleImportSpecifierComments(context) ||
-    handleIfStatementComments(context, text) ||
-    handleWhileComments(context, text) ||
-    handleTryStatementComments(context) ||
-    handleClassComments(context) ||
-    handleLabeledStatementComments(context) ||
-    handleCallExpressionComments(context) ||
-    handlePropertyComments(context) ||
-    handleOnlyComments(context, ast, isLastComment) ||
-    handleTypeAliasComments(context) ||
-    handleVariableDeclaratorComments(context)
-  );
+function handleEndOfLineComment(context) {
+  return [
+    handleClosureTypeCastComments,
+    handleLastFunctionArgComments,
+    handleConditionalExpressionComments,
+    handleImportSpecifierComments,
+    handleIfStatementComments,
+    handleWhileComments,
+    handleTryStatementComments,
+    handleClassComments,
+    handleLabeledStatementComments,
+    handleCallExpressionComments,
+    handlePropertyComments,
+    handleOnlyComments,
+    handleTypeAliasComments,
+    handleVariableDeclaratorComments,
+  ].some((fn) => fn(context));
 }
 
-function handleRemainingComment(context, text, options, ast, isLastComment) {
-  if (
-    handleIgnoreComments(context) ||
-    handleIfStatementComments(context, text) ||
-    handleWhileComments(context, text) ||
-    handleObjectPropertyAssignment(context) ||
-    handleCommentInEmptyParens(context, text) ||
-    handleMethodNameComments(context, text) ||
-    handleOnlyComments(context, ast, isLastComment) ||
-    handleCommentAfterArrowParams(context, text) ||
-    handleFunctionNameComments(context, text) ||
-    handleTSMappedTypeComments(context) ||
-    handleBreakAndContinueStatementComments(context) ||
-    handleTSFunctionTrailingComments(context, text)
-  ) {
-    return true;
-  }
-  return false;
+function handleRemainingComment(context) {
+  return [
+    handleIgnoreComments,
+    handleIfStatementComments,
+    handleWhileComments,
+    handleObjectPropertyAssignment,
+    handleCommentInEmptyParens,
+    handleMethodNameComments,
+    handleOnlyComments,
+    handleCommentAfterArrowParams,
+    handleFunctionNameComments,
+    handleTSMappedTypeComments,
+    handleBreakAndContinueStatementComments,
+    handleTSFunctionTrailingComments,
+  ].some((fn) => fn(context));
 }
 
 function addBlockStatementFirstComment(node, comment) {
@@ -125,8 +122,14 @@ function handleClosureTypeCastComments(context) {
 //     // comment
 //     ...
 //   }
-function handleIfStatementComments(context, text) {
-  const { comment, precedingNode, enclosingNode, followingNode } = context;
+function handleIfStatementComments(context) {
+  const {
+    comment,
+    precedingNode,
+    enclosingNode,
+    followingNode,
+    text,
+  } = context;
   if (
     !enclosingNode ||
     enclosingNode.type !== "IfStatement" ||
@@ -188,8 +191,14 @@ function handleIfStatementComments(context, text) {
   return false;
 }
 
-function handleWhileComments(context, text) {
-  const { comment, precedingNode, enclosingNode, followingNode } = context;
+function handleWhileComments(context) {
+  const {
+    comment,
+    precedingNode,
+    enclosingNode,
+    followingNode,
+    text,
+  } = context;
   if (
     !enclosingNode ||
     enclosingNode.type !== "WhileStatement" ||
@@ -278,8 +287,14 @@ function handleMemberExpressionComments(context) {
   return false;
 }
 
-function handleConditionalExpressionComments(context, text) {
-  const { comment, precedingNode, enclosingNode, followingNode } = context;
+function handleConditionalExpressionComments(context) {
+  const {
+    comment,
+    precedingNode,
+    enclosingNode,
+    followingNode,
+    text,
+  } = context;
   const isSameLineAsPrecedingNode =
     precedingNode &&
     !hasNewlineInRange(text, locEnd(precedingNode), locStart(comment));
@@ -364,8 +379,8 @@ function handleClassComments(context) {
   return false;
 }
 
-function handleMethodNameComments(context, text) {
-  const { comment, precedingNode, enclosingNode } = context;
+function handleMethodNameComments(context) {
+  const { comment, precedingNode, enclosingNode, text } = context;
   // This is only needed for estree parsers (flow, typescript) to attach
   // after a method name:
   // obj = { fn /*comment*/() {} };
@@ -407,8 +422,8 @@ function handleMethodNameComments(context, text) {
   return false;
 }
 
-function handleFunctionNameComments(context, text) {
-  const { comment, precedingNode, enclosingNode } = context;
+function handleFunctionNameComments(context) {
+  const { comment, precedingNode, enclosingNode, text } = context;
   if (getNextNonSpaceNonCommentCharacter(text, comment, locEnd) !== "(") {
     return false;
   }
@@ -427,8 +442,8 @@ function handleFunctionNameComments(context, text) {
   return false;
 }
 
-function handleCommentAfterArrowParams(context, text) {
-  const { comment, enclosingNode } = context;
+function handleCommentAfterArrowParams(context) {
+  const { comment, enclosingNode, text } = context;
   if (!(enclosingNode && enclosingNode.type === "ArrowFunctionExpression")) {
     return false;
   }
@@ -442,8 +457,8 @@ function handleCommentAfterArrowParams(context, text) {
   return false;
 }
 
-function handleCommentInEmptyParens(context, text) {
-  const { comment, enclosingNode } = context;
+function handleCommentInEmptyParens(context) {
+  const { comment, enclosingNode, text } = context;
   if (getNextNonSpaceNonCommentCharacter(text, comment, locEnd) !== ")") {
     return false;
   }
@@ -473,8 +488,14 @@ function handleCommentInEmptyParens(context, text) {
   return false;
 }
 
-function handleLastFunctionArgComments(context, text) {
-  const { comment, precedingNode, enclosingNode, followingNode } = context;
+function handleLastFunctionArgComments(context) {
+  const {
+    comment,
+    precedingNode,
+    enclosingNode,
+    followingNode,
+    text,
+  } = context;
 
   // Flow function type definitions
   if (
@@ -629,8 +650,8 @@ function handlePropertyComments(context) {
   return false;
 }
 
-function handleOnlyComments(context, ast, isLastComment) {
-  const { comment, enclosingNode } = context;
+function handleOnlyComments(context) {
+  const { comment, enclosingNode, ast, isLastComment } = context;
   // With Flow the enclosingNode is undefined so use the AST instead.
   if (ast && ast.body && ast.body.length === 0) {
     if (isLastComment) {
@@ -669,8 +690,8 @@ function handleForComments(context) {
   return false;
 }
 
-function handleImportDeclarationComments(context, text) {
-  const { comment, precedingNode, enclosingNode } = context;
+function handleImportDeclarationComments(context) {
+  const { comment, precedingNode, enclosingNode, text } = context;
   if (
     precedingNode &&
     precedingNode.type === "ImportSpecifier" &&
@@ -721,8 +742,8 @@ function handleVariableDeclaratorComments(context) {
   return false;
 }
 
-function handleTSFunctionTrailingComments(context, text) {
-  const { comment, enclosingNode, followingNode } = context;
+function handleTSFunctionTrailingComments(context) {
+  const { comment, enclosingNode, followingNode, text } = context;
   if (
     !followingNode &&
     enclosingNode &&

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -22,59 +22,59 @@ const {
 } = require("./utils");
 const { locStart, locEnd } = require("./loc");
 
-function handleOwnLineComment(comment, text, options, ast, isLastComment) {
+function handleOwnLineComment(data, text, options, ast, isLastComment) {
   return (
-    handleIgnoreComments(comment) ||
-    handleLastFunctionArgComments(comment, text) ||
-    handleMemberExpressionComments(comment) ||
-    handleIfStatementComments(comment, text) ||
-    handleWhileComments(comment, text) ||
-    handleTryStatementComments(comment) ||
-    handleClassComments(comment) ||
-    handleImportSpecifierComments(comment) ||
-    handleForComments(comment) ||
-    handleUnionTypeComments(comment) ||
-    handleOnlyComments(comment, ast, isLastComment) ||
-    handleImportDeclarationComments(comment, text) ||
-    handleAssignmentPatternComments(comment) ||
-    handleMethodNameComments(comment, text) ||
-    handleLabeledStatementComments(comment)
+    handleIgnoreComments(data) ||
+    handleLastFunctionArgComments(data, text) ||
+    handleMemberExpressionComments(data) ||
+    handleIfStatementComments(data, text) ||
+    handleWhileComments(data, text) ||
+    handleTryStatementComments(data) ||
+    handleClassComments(data) ||
+    handleImportSpecifierComments(data) ||
+    handleForComments(data) ||
+    handleUnionTypeComments(data) ||
+    handleOnlyComments(data, ast, isLastComment) ||
+    handleImportDeclarationComments(data, text) ||
+    handleAssignmentPatternComments(data) ||
+    handleMethodNameComments(data, text) ||
+    handleLabeledStatementComments(data)
   );
 }
 
-function handleEndOfLineComment(comment, text, options, ast, isLastComment) {
+function handleEndOfLineComment(data, text, options, ast, isLastComment) {
   return (
-    handleClosureTypeCastComments(comment) ||
-    handleLastFunctionArgComments(comment, text) ||
-    handleConditionalExpressionComments(comment, text) ||
-    handleImportSpecifierComments(comment) ||
-    handleIfStatementComments(comment, text) ||
-    handleWhileComments(comment, text) ||
-    handleTryStatementComments(comment) ||
-    handleClassComments(comment) ||
-    handleLabeledStatementComments(comment) ||
-    handleCallExpressionComments(comment) ||
-    handlePropertyComments(comment) ||
-    handleOnlyComments(comment, ast, isLastComment) ||
-    handleTypeAliasComments(comment) ||
-    handleVariableDeclaratorComments(comment)
+    handleClosureTypeCastComments(data) ||
+    handleLastFunctionArgComments(data, text) ||
+    handleConditionalExpressionComments(data, text) ||
+    handleImportSpecifierComments(data) ||
+    handleIfStatementComments(data, text) ||
+    handleWhileComments(data, text) ||
+    handleTryStatementComments(data) ||
+    handleClassComments(data) ||
+    handleLabeledStatementComments(data) ||
+    handleCallExpressionComments(data) ||
+    handlePropertyComments(data) ||
+    handleOnlyComments(data, ast, isLastComment) ||
+    handleTypeAliasComments(data) ||
+    handleVariableDeclaratorComments(data)
   );
 }
 
-function handleRemainingComment(comment, text, options, ast, isLastComment) {
+function handleRemainingComment(data, text, options, ast, isLastComment) {
   if (
-    handleIgnoreComments(comment) ||
-    handleIfStatementComments(comment, text) ||
-    handleWhileComments(comment, text) ||
-    handleObjectPropertyAssignment(comment) ||
-    handleCommentInEmptyParens(comment, text) ||
-    handleMethodNameComments(comment, text) ||
-    handleOnlyComments(comment, ast, isLastComment) ||
-    handleCommentAfterArrowParams(comment, text) ||
-    handleFunctionNameComments(comment, text) ||
-    handleTSMappedTypeComments(comment) ||
-    handleBreakAndContinueStatementComments(comment) ||
-    handleTSFunctionTrailingComments(comment, text)
+    handleIgnoreComments(data) ||
+    handleIfStatementComments(data, text) ||
+    handleWhileComments(data, text) ||
+    handleObjectPropertyAssignment(data) ||
+    handleCommentInEmptyParens(data, text) ||
+    handleMethodNameComments(data, text) ||
+    handleOnlyComments(data, ast, isLastComment) ||
+    handleCommentAfterArrowParams(data, text) ||
+    handleFunctionNameComments(data, text) ||
+    handleTSMappedTypeComments(data) ||
+    handleBreakAndContinueStatementComments(data) ||
+    handleTSFunctionTrailingComments(data, text)
   ) {
     return true;
   }
@@ -100,8 +100,8 @@ function addBlockOrNotComment(node, comment) {
   }
 }
 
-function handleClosureTypeCastComments(comment) {
-  const { followingNode } = comment;
+function handleClosureTypeCastComments(data) {
+  const { comment, followingNode } = data;
   if (followingNode && isTypeCastComment(comment)) {
     addLeadingComment(followingNode, comment);
     return true;
@@ -125,8 +125,8 @@ function handleClosureTypeCastComments(comment) {
 //     // comment
 //     ...
 //   }
-function handleIfStatementComments(comment, text) {
-  const { precedingNode, enclosingNode, followingNode } = comment;
+function handleIfStatementComments(data, text) {
+  const { comment, precedingNode, enclosingNode, followingNode } = data;
   if (
     !enclosingNode ||
     enclosingNode.type !== "IfStatement" ||
@@ -188,8 +188,8 @@ function handleIfStatementComments(comment, text) {
   return false;
 }
 
-function handleWhileComments(comment, text) {
-  const { precedingNode, enclosingNode, followingNode } = comment;
+function handleWhileComments(data, text) {
+  const { comment, precedingNode, enclosingNode, followingNode } = data;
   if (
     !enclosingNode ||
     enclosingNode.type !== "WhileStatement" ||
@@ -227,8 +227,8 @@ function handleWhileComments(comment, text) {
 }
 
 // Same as IfStatement but for TryStatement
-function handleTryStatementComments(comment) {
-  const { precedingNode, enclosingNode, followingNode } = comment;
+function handleTryStatementComments(data) {
+  const { comment, precedingNode, enclosingNode, followingNode } = data;
   if (
     !enclosingNode ||
     (enclosingNode.type !== "TryStatement" &&
@@ -261,8 +261,8 @@ function handleTryStatementComments(comment) {
   return false;
 }
 
-function handleMemberExpressionComments(comment) {
-  const { enclosingNode, followingNode } = comment;
+function handleMemberExpressionComments(data) {
+  const { comment, enclosingNode, followingNode } = data;
 
   if (
     enclosingNode &&
@@ -278,8 +278,8 @@ function handleMemberExpressionComments(comment) {
   return false;
 }
 
-function handleConditionalExpressionComments(comment, text) {
-  const { precedingNode, enclosingNode, followingNode } = comment;
+function handleConditionalExpressionComments(data, text) {
+  const { comment, precedingNode, enclosingNode, followingNode } = data;
   const isSameLineAsPrecedingNode =
     precedingNode &&
     !hasNewlineInRange(text, locEnd(precedingNode), locStart(comment));
@@ -297,8 +297,8 @@ function handleConditionalExpressionComments(comment, text) {
   return false;
 }
 
-function handleObjectPropertyAssignment(comment) {
-  const { precedingNode, enclosingNode } = comment;
+function handleObjectPropertyAssignment(data) {
+  const { comment, precedingNode, enclosingNode } = data;
   if (
     enclosingNode &&
     (enclosingNode.type === "ObjectProperty" ||
@@ -313,8 +313,8 @@ function handleObjectPropertyAssignment(comment) {
   return false;
 }
 
-function handleClassComments(comment) {
-  const { precedingNode, enclosingNode, followingNode } = comment;
+function handleClassComments(data) {
+  const { comment, precedingNode, enclosingNode, followingNode } = data;
   if (
     enclosingNode &&
     (enclosingNode.type === "ClassDeclaration" ||
@@ -364,8 +364,8 @@ function handleClassComments(comment) {
   return false;
 }
 
-function handleMethodNameComments(comment, text) {
-  const { precedingNode, enclosingNode } = comment;
+function handleMethodNameComments(data, text) {
+  const { comment, precedingNode, enclosingNode, followingNode } = data;
   // This is only needed for estree parsers (flow, typescript) to attach
   // after a method name:
   // obj = { fn /*comment*/() {} };
@@ -428,8 +428,8 @@ function handleFunctionNameComments(comment, text) {
   return false;
 }
 
-function handleCommentAfterArrowParams(comment, text) {
-  const { enclosingNode } = comment;
+function handleCommentAfterArrowParams(data, text) {
+  const { comment, enclosingNode } = data;
   if (!(enclosingNode && enclosingNode.type === "ArrowFunctionExpression")) {
     return false;
   }
@@ -443,12 +443,12 @@ function handleCommentAfterArrowParams(comment, text) {
   return false;
 }
 
-function handleCommentInEmptyParens(comment, text) {
+function handleCommentInEmptyParens(data, text) {
+  const { comment, enclosingNode } = data;
   if (getNextNonSpaceNonCommentCharacter(text, comment, locEnd) !== ")") {
     return false;
   }
 
-  const { enclosingNode } = comment;
   // Only add dangling comments to fix the case when no params are present,
   // i.e. a function without any argument.
   if (
@@ -474,8 +474,8 @@ function handleCommentInEmptyParens(comment, text) {
   return false;
 }
 
-function handleLastFunctionArgComments(comment, text) {
-  const { precedingNode, enclosingNode, followingNode } = comment;
+function handleLastFunctionArgComments(data, text) {
+  const { comment, precedingNode, enclosingNode, followingNode } = data;
 
   // Flow function type definitions
   if (
@@ -538,8 +538,8 @@ function handleLastFunctionArgComments(comment, text) {
   return false;
 }
 
-function handleImportSpecifierComments(comment) {
-  const { enclosingNode } = comment;
+function handleImportSpecifierComments(data) {
+  const { comment, enclosingNode } = data;
   if (enclosingNode && enclosingNode.type === "ImportSpecifier") {
     addLeadingComment(enclosingNode, comment);
     return true;
@@ -547,8 +547,8 @@ function handleImportSpecifierComments(comment) {
   return false;
 }
 
-function handleLabeledStatementComments(comment) {
-  const { enclosingNode } = comment;
+function handleLabeledStatementComments(data) {
+  const { comment, enclosingNode } = data;
   if (enclosingNode && enclosingNode.type === "LabeledStatement") {
     addLeadingComment(enclosingNode, comment);
     return true;
@@ -556,8 +556,8 @@ function handleLabeledStatementComments(comment) {
   return false;
 }
 
-function handleBreakAndContinueStatementComments(comment) {
-  const { enclosingNode } = comment;
+function handleBreakAndContinueStatementComments(data) {
+  const { comment, enclosingNode } = data;
   if (
     enclosingNode &&
     (enclosingNode.type === "ContinueStatement" ||
@@ -570,8 +570,8 @@ function handleBreakAndContinueStatementComments(comment) {
   return false;
 }
 
-function handleCallExpressionComments(comment) {
-  const { precedingNode, enclosingNode } = comment;
+function handleCallExpressionComments(data) {
+  const { comment, precedingNode, enclosingNode } = data;
   if (
     enclosingNode &&
     (enclosingNode.type === "CallExpression" ||
@@ -586,8 +586,8 @@ function handleCallExpressionComments(comment) {
   return false;
 }
 
-function handleUnionTypeComments(comment) {
-  const { precedingNode, enclosingNode, followingNode } = comment;
+function handleUnionTypeComments(data) {
+  const { comment, precedingNode, enclosingNode, followingNode } = data;
   if (
     enclosingNode &&
     (enclosingNode.type === "UnionTypeAnnotation" ||
@@ -617,8 +617,8 @@ function handleUnionTypeComments(comment) {
   return false;
 }
 
-function handlePropertyComments(comment) {
-  const { enclosingNode } = comment;
+function handlePropertyComments(data) {
+  const { comment, enclosingNode } = data;
   if (
     enclosingNode &&
     (enclosingNode.type === "Property" ||
@@ -630,8 +630,8 @@ function handlePropertyComments(comment) {
   return false;
 }
 
-function handleOnlyComments(comment, ast, isLastComment) {
-  const { enclosingNode } = comment;
+function handleOnlyComments(data, ast, isLastComment) {
+  const { comment, enclosingNode } = data;
   // With Flow the enclosingNode is undefined so use the AST instead.
   if (ast && ast.body && ast.body.length === 0) {
     if (isLastComment) {
@@ -657,8 +657,8 @@ function handleOnlyComments(comment, ast, isLastComment) {
   return false;
 }
 
-function handleForComments(comment) {
-  const { enclosingNode } = comment;
+function handleForComments(data) {
+  const { comment, enclosingNode } = data;
   if (
     enclosingNode &&
     (enclosingNode.type === "ForInStatement" ||
@@ -670,8 +670,8 @@ function handleForComments(comment) {
   return false;
 }
 
-function handleImportDeclarationComments(comment, text) {
-  const { precedingNode, enclosingNode } = comment;
+function handleImportDeclarationComments(data, text) {
+  const { comment, precedingNode, enclosingNode } = data;
   if (
     precedingNode &&
     precedingNode.type === "ImportSpecifier" &&
@@ -685,8 +685,8 @@ function handleImportDeclarationComments(comment, text) {
   return false;
 }
 
-function handleAssignmentPatternComments(comment) {
-  const { enclosingNode } = comment;
+function handleAssignmentPatternComments(data) {
+  const { comment, enclosingNode } = data;
   if (enclosingNode && enclosingNode.type === "AssignmentPattern") {
     addLeadingComment(enclosingNode, comment);
     return true;
@@ -694,8 +694,8 @@ function handleAssignmentPatternComments(comment) {
   return false;
 }
 
-function handleTypeAliasComments(comment) {
-  const { enclosingNode } = comment;
+function handleTypeAliasComments(data) {
+  const { comment, enclosingNode } = data;
   if (enclosingNode && enclosingNode.type === "TypeAlias") {
     addLeadingComment(enclosingNode, comment);
     return true;
@@ -703,8 +703,8 @@ function handleTypeAliasComments(comment) {
   return false;
 }
 
-function handleVariableDeclaratorComments(comment) {
-  const { enclosingNode, followingNode } = comment;
+function handleVariableDeclaratorComments(data) {
+  const { comment, enclosingNode, followingNode } = data;
   if (
     enclosingNode &&
     (enclosingNode.type === "VariableDeclarator" ||
@@ -722,8 +722,8 @@ function handleVariableDeclaratorComments(comment) {
   return false;
 }
 
-function handleTSFunctionTrailingComments(comment, text) {
-  const { enclosingNode, followingNode } = comment;
+function handleTSFunctionTrailingComments(data, text) {
+  const { comment, enclosingNode, followingNode } = data;
   if (
     !followingNode &&
     enclosingNode &&
@@ -738,8 +738,8 @@ function handleTSFunctionTrailingComments(comment, text) {
   return false;
 }
 
-function handleIgnoreComments(comment) {
-  const { enclosingNode, followingNode } = comment;
+function handleIgnoreComments(data) {
+  const { comment, enclosingNode, followingNode } = data;
   if (
     isPrettierIgnoreComment(comment) &&
     enclosingNode &&
@@ -754,8 +754,8 @@ function handleIgnoreComments(comment) {
   }
 }
 
-function handleTSMappedTypeComments(comment) {
-  const { precedingNode, enclosingNode, followingNode } = comment;
+function handleTSMappedTypeComments(data) {
+  const { comment, precedingNode, enclosingNode, followingNode } = data;
   if (!enclosingNode || enclosingNode.type !== "TSMappedType") {
     return false;
   }

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -22,59 +22,59 @@ const {
 } = require("./utils");
 const { locStart, locEnd } = require("./loc");
 
-function handleOwnLineComment(data, text, options, ast, isLastComment) {
+function handleOwnLineComment(context, text, options, ast, isLastComment) {
   return (
-    handleIgnoreComments(data) ||
-    handleLastFunctionArgComments(data, text) ||
-    handleMemberExpressionComments(data) ||
-    handleIfStatementComments(data, text) ||
-    handleWhileComments(data, text) ||
-    handleTryStatementComments(data) ||
-    handleClassComments(data) ||
-    handleImportSpecifierComments(data) ||
-    handleForComments(data) ||
-    handleUnionTypeComments(data) ||
-    handleOnlyComments(data, ast, isLastComment) ||
-    handleImportDeclarationComments(data, text) ||
-    handleAssignmentPatternComments(data) ||
-    handleMethodNameComments(data, text) ||
-    handleLabeledStatementComments(data)
+    handleIgnoreComments(context) ||
+    handleLastFunctionArgComments(context, text) ||
+    handleMemberExpressionComments(context) ||
+    handleIfStatementComments(context, text) ||
+    handleWhileComments(context, text) ||
+    handleTryStatementComments(context) ||
+    handleClassComments(context) ||
+    handleImportSpecifierComments(context) ||
+    handleForComments(context) ||
+    handleUnionTypeComments(context) ||
+    handleOnlyComments(context, ast, isLastComment) ||
+    handleImportDeclarationComments(context, text) ||
+    handleAssignmentPatternComments(context) ||
+    handleMethodNameComments(context, text) ||
+    handleLabeledStatementComments(context)
   );
 }
 
-function handleEndOfLineComment(data, text, options, ast, isLastComment) {
+function handleEndOfLineComment(context, text, options, ast, isLastComment) {
   return (
-    handleClosureTypeCastComments(data) ||
-    handleLastFunctionArgComments(data, text) ||
-    handleConditionalExpressionComments(data, text) ||
-    handleImportSpecifierComments(data) ||
-    handleIfStatementComments(data, text) ||
-    handleWhileComments(data, text) ||
-    handleTryStatementComments(data) ||
-    handleClassComments(data) ||
-    handleLabeledStatementComments(data) ||
-    handleCallExpressionComments(data) ||
-    handlePropertyComments(data) ||
-    handleOnlyComments(data, ast, isLastComment) ||
-    handleTypeAliasComments(data) ||
-    handleVariableDeclaratorComments(data)
+    handleClosureTypeCastComments(context) ||
+    handleLastFunctionArgComments(context, text) ||
+    handleConditionalExpressionComments(context, text) ||
+    handleImportSpecifierComments(context) ||
+    handleIfStatementComments(context, text) ||
+    handleWhileComments(context, text) ||
+    handleTryStatementComments(context) ||
+    handleClassComments(context) ||
+    handleLabeledStatementComments(context) ||
+    handleCallExpressionComments(context) ||
+    handlePropertyComments(context) ||
+    handleOnlyComments(context, ast, isLastComment) ||
+    handleTypeAliasComments(context) ||
+    handleVariableDeclaratorComments(context)
   );
 }
 
-function handleRemainingComment(data, text, options, ast, isLastComment) {
+function handleRemainingComment(context, text, options, ast, isLastComment) {
   if (
-    handleIgnoreComments(data) ||
-    handleIfStatementComments(data, text) ||
-    handleWhileComments(data, text) ||
-    handleObjectPropertyAssignment(data) ||
-    handleCommentInEmptyParens(data, text) ||
-    handleMethodNameComments(data, text) ||
-    handleOnlyComments(data, ast, isLastComment) ||
-    handleCommentAfterArrowParams(data, text) ||
-    handleFunctionNameComments(data, text) ||
-    handleTSMappedTypeComments(data) ||
-    handleBreakAndContinueStatementComments(data) ||
-    handleTSFunctionTrailingComments(data, text)
+    handleIgnoreComments(context) ||
+    handleIfStatementComments(context, text) ||
+    handleWhileComments(context, text) ||
+    handleObjectPropertyAssignment(context) ||
+    handleCommentInEmptyParens(context, text) ||
+    handleMethodNameComments(context, text) ||
+    handleOnlyComments(context, ast, isLastComment) ||
+    handleCommentAfterArrowParams(context, text) ||
+    handleFunctionNameComments(context, text) ||
+    handleTSMappedTypeComments(context) ||
+    handleBreakAndContinueStatementComments(context) ||
+    handleTSFunctionTrailingComments(context, text)
   ) {
     return true;
   }
@@ -100,8 +100,8 @@ function addBlockOrNotComment(node, comment) {
   }
 }
 
-function handleClosureTypeCastComments(data) {
-  const { comment, followingNode } = data;
+function handleClosureTypeCastComments(context) {
+  const { comment, followingNode } = context;
   if (followingNode && isTypeCastComment(comment)) {
     addLeadingComment(followingNode, comment);
     return true;
@@ -125,8 +125,8 @@ function handleClosureTypeCastComments(data) {
 //     // comment
 //     ...
 //   }
-function handleIfStatementComments(data, text) {
-  const { comment, precedingNode, enclosingNode, followingNode } = data;
+function handleIfStatementComments(context, text) {
+  const { comment, precedingNode, enclosingNode, followingNode } = context;
   if (
     !enclosingNode ||
     enclosingNode.type !== "IfStatement" ||
@@ -188,8 +188,8 @@ function handleIfStatementComments(data, text) {
   return false;
 }
 
-function handleWhileComments(data, text) {
-  const { comment, precedingNode, enclosingNode, followingNode } = data;
+function handleWhileComments(context, text) {
+  const { comment, precedingNode, enclosingNode, followingNode } = context;
   if (
     !enclosingNode ||
     enclosingNode.type !== "WhileStatement" ||
@@ -227,8 +227,8 @@ function handleWhileComments(data, text) {
 }
 
 // Same as IfStatement but for TryStatement
-function handleTryStatementComments(data) {
-  const { comment, precedingNode, enclosingNode, followingNode } = data;
+function handleTryStatementComments(context) {
+  const { comment, precedingNode, enclosingNode, followingNode } = context;
   if (
     !enclosingNode ||
     (enclosingNode.type !== "TryStatement" &&
@@ -261,8 +261,8 @@ function handleTryStatementComments(data) {
   return false;
 }
 
-function handleMemberExpressionComments(data) {
-  const { comment, enclosingNode, followingNode } = data;
+function handleMemberExpressionComments(context) {
+  const { comment, enclosingNode, followingNode } = context;
 
   if (
     enclosingNode &&
@@ -278,8 +278,8 @@ function handleMemberExpressionComments(data) {
   return false;
 }
 
-function handleConditionalExpressionComments(data, text) {
-  const { comment, precedingNode, enclosingNode, followingNode } = data;
+function handleConditionalExpressionComments(context, text) {
+  const { comment, precedingNode, enclosingNode, followingNode } = context;
   const isSameLineAsPrecedingNode =
     precedingNode &&
     !hasNewlineInRange(text, locEnd(precedingNode), locStart(comment));
@@ -297,8 +297,8 @@ function handleConditionalExpressionComments(data, text) {
   return false;
 }
 
-function handleObjectPropertyAssignment(data) {
-  const { comment, precedingNode, enclosingNode } = data;
+function handleObjectPropertyAssignment(context) {
+  const { comment, precedingNode, enclosingNode } = context;
   if (
     enclosingNode &&
     (enclosingNode.type === "ObjectProperty" ||
@@ -313,8 +313,8 @@ function handleObjectPropertyAssignment(data) {
   return false;
 }
 
-function handleClassComments(data) {
-  const { comment, precedingNode, enclosingNode, followingNode } = data;
+function handleClassComments(context) {
+  const { comment, precedingNode, enclosingNode, followingNode } = context;
   if (
     enclosingNode &&
     (enclosingNode.type === "ClassDeclaration" ||
@@ -364,8 +364,8 @@ function handleClassComments(data) {
   return false;
 }
 
-function handleMethodNameComments(data, text) {
-  const { comment, precedingNode, enclosingNode } = data;
+function handleMethodNameComments(context, text) {
+  const { comment, precedingNode, enclosingNode } = context;
   // This is only needed for estree parsers (flow, typescript) to attach
   // after a method name:
   // obj = { fn /*comment*/() {} };
@@ -407,8 +407,8 @@ function handleMethodNameComments(data, text) {
   return false;
 }
 
-function handleFunctionNameComments(data, text) {
-  const { comment, precedingNode, enclosingNode } = data;
+function handleFunctionNameComments(context, text) {
+  const { comment, precedingNode, enclosingNode } = context;
   if (getNextNonSpaceNonCommentCharacter(text, comment, locEnd) !== "(") {
     return false;
   }
@@ -427,8 +427,8 @@ function handleFunctionNameComments(data, text) {
   return false;
 }
 
-function handleCommentAfterArrowParams(data, text) {
-  const { comment, enclosingNode } = data;
+function handleCommentAfterArrowParams(context, text) {
+  const { comment, enclosingNode } = context;
   if (!(enclosingNode && enclosingNode.type === "ArrowFunctionExpression")) {
     return false;
   }
@@ -442,8 +442,8 @@ function handleCommentAfterArrowParams(data, text) {
   return false;
 }
 
-function handleCommentInEmptyParens(data, text) {
-  const { comment, enclosingNode } = data;
+function handleCommentInEmptyParens(context, text) {
+  const { comment, enclosingNode } = context;
   if (getNextNonSpaceNonCommentCharacter(text, comment, locEnd) !== ")") {
     return false;
   }
@@ -473,8 +473,8 @@ function handleCommentInEmptyParens(data, text) {
   return false;
 }
 
-function handleLastFunctionArgComments(data, text) {
-  const { comment, precedingNode, enclosingNode, followingNode } = data;
+function handleLastFunctionArgComments(context, text) {
+  const { comment, precedingNode, enclosingNode, followingNode } = context;
 
   // Flow function type definitions
   if (
@@ -537,8 +537,8 @@ function handleLastFunctionArgComments(data, text) {
   return false;
 }
 
-function handleImportSpecifierComments(data) {
-  const { comment, enclosingNode } = data;
+function handleImportSpecifierComments(context) {
+  const { comment, enclosingNode } = context;
   if (enclosingNode && enclosingNode.type === "ImportSpecifier") {
     addLeadingComment(enclosingNode, comment);
     return true;
@@ -546,8 +546,8 @@ function handleImportSpecifierComments(data) {
   return false;
 }
 
-function handleLabeledStatementComments(data) {
-  const { comment, enclosingNode } = data;
+function handleLabeledStatementComments(context) {
+  const { comment, enclosingNode } = context;
   if (enclosingNode && enclosingNode.type === "LabeledStatement") {
     addLeadingComment(enclosingNode, comment);
     return true;
@@ -555,8 +555,8 @@ function handleLabeledStatementComments(data) {
   return false;
 }
 
-function handleBreakAndContinueStatementComments(data) {
-  const { comment, enclosingNode } = data;
+function handleBreakAndContinueStatementComments(context) {
+  const { comment, enclosingNode } = context;
   if (
     enclosingNode &&
     (enclosingNode.type === "ContinueStatement" ||
@@ -569,8 +569,8 @@ function handleBreakAndContinueStatementComments(data) {
   return false;
 }
 
-function handleCallExpressionComments(data) {
-  const { comment, precedingNode, enclosingNode } = data;
+function handleCallExpressionComments(context) {
+  const { comment, precedingNode, enclosingNode } = context;
   if (
     enclosingNode &&
     (enclosingNode.type === "CallExpression" ||
@@ -585,8 +585,8 @@ function handleCallExpressionComments(data) {
   return false;
 }
 
-function handleUnionTypeComments(data) {
-  const { comment, precedingNode, enclosingNode, followingNode } = data;
+function handleUnionTypeComments(context) {
+  const { comment, precedingNode, enclosingNode, followingNode } = context;
   if (
     enclosingNode &&
     (enclosingNode.type === "UnionTypeAnnotation" ||
@@ -616,8 +616,8 @@ function handleUnionTypeComments(data) {
   return false;
 }
 
-function handlePropertyComments(data) {
-  const { comment, enclosingNode } = data;
+function handlePropertyComments(context) {
+  const { comment, enclosingNode } = context;
   if (
     enclosingNode &&
     (enclosingNode.type === "Property" ||
@@ -629,8 +629,8 @@ function handlePropertyComments(data) {
   return false;
 }
 
-function handleOnlyComments(data, ast, isLastComment) {
-  const { comment, enclosingNode } = data;
+function handleOnlyComments(context, ast, isLastComment) {
+  const { comment, enclosingNode } = context;
   // With Flow the enclosingNode is undefined so use the AST instead.
   if (ast && ast.body && ast.body.length === 0) {
     if (isLastComment) {
@@ -656,8 +656,8 @@ function handleOnlyComments(data, ast, isLastComment) {
   return false;
 }
 
-function handleForComments(data) {
-  const { comment, enclosingNode } = data;
+function handleForComments(context) {
+  const { comment, enclosingNode } = context;
   if (
     enclosingNode &&
     (enclosingNode.type === "ForInStatement" ||
@@ -669,8 +669,8 @@ function handleForComments(data) {
   return false;
 }
 
-function handleImportDeclarationComments(data, text) {
-  const { comment, precedingNode, enclosingNode } = data;
+function handleImportDeclarationComments(context, text) {
+  const { comment, precedingNode, enclosingNode } = context;
   if (
     precedingNode &&
     precedingNode.type === "ImportSpecifier" &&
@@ -684,8 +684,8 @@ function handleImportDeclarationComments(data, text) {
   return false;
 }
 
-function handleAssignmentPatternComments(data) {
-  const { comment, enclosingNode } = data;
+function handleAssignmentPatternComments(context) {
+  const { comment, enclosingNode } = context;
   if (enclosingNode && enclosingNode.type === "AssignmentPattern") {
     addLeadingComment(enclosingNode, comment);
     return true;
@@ -693,8 +693,8 @@ function handleAssignmentPatternComments(data) {
   return false;
 }
 
-function handleTypeAliasComments(data) {
-  const { comment, enclosingNode } = data;
+function handleTypeAliasComments(context) {
+  const { comment, enclosingNode } = context;
   if (enclosingNode && enclosingNode.type === "TypeAlias") {
     addLeadingComment(enclosingNode, comment);
     return true;
@@ -702,8 +702,8 @@ function handleTypeAliasComments(data) {
   return false;
 }
 
-function handleVariableDeclaratorComments(data) {
-  const { comment, enclosingNode, followingNode } = data;
+function handleVariableDeclaratorComments(context) {
+  const { comment, enclosingNode, followingNode } = context;
   if (
     enclosingNode &&
     (enclosingNode.type === "VariableDeclarator" ||
@@ -721,8 +721,8 @@ function handleVariableDeclaratorComments(data) {
   return false;
 }
 
-function handleTSFunctionTrailingComments(data, text) {
-  const { comment, enclosingNode, followingNode } = data;
+function handleTSFunctionTrailingComments(context, text) {
+  const { comment, enclosingNode, followingNode } = context;
   if (
     !followingNode &&
     enclosingNode &&
@@ -737,8 +737,8 @@ function handleTSFunctionTrailingComments(data, text) {
   return false;
 }
 
-function handleIgnoreComments(data) {
-  const { comment, enclosingNode, followingNode } = data;
+function handleIgnoreComments(context) {
+  const { comment, enclosingNode, followingNode } = context;
   if (
     isPrettierIgnoreComment(comment) &&
     enclosingNode &&
@@ -753,8 +753,8 @@ function handleIgnoreComments(data) {
   }
 }
 
-function handleTSMappedTypeComments(data) {
-  const { comment, precedingNode, enclosingNode, followingNode } = data;
+function handleTSMappedTypeComments(context) {
+  const { comment, precedingNode, enclosingNode, followingNode } = context;
   if (!enclosingNode || enclosingNode.type !== "TSMappedType") {
     return false;
   }

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -902,7 +902,7 @@ function isRealFunctionLikeNode(node) {
 
 /**
  * @param {Node} enclosingNode
- * @returns {RegExp|void}
+ * @returns {RegExp | void}
  */
 function getGapRegex(enclosingNode) {
   if (
@@ -918,7 +918,7 @@ function getGapRegex(enclosingNode) {
 
 /**
  * @param {any} node
- * @returns {Node[]|void}
+ * @returns {Node[] | void}
  */
 function getCommentChildNodes(node, options) {
   // Prevent attaching comments to FunctionExpression in this case:

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -22,6 +22,26 @@ const {
 } = require("./utils");
 const { locStart, locEnd } = require("./loc");
 
+/**
+ * @typedef {import("./types/estree").Node} Node
+ * @typedef {import("./types/estree").Comment} Comment
+ * @typedef {import("../common/fast-path")} FastPath
+ *
+ * @typedef {Object} CommentContext
+ * @property {Comment} comment
+ * @property {Node} precedingNode
+ * @property {Node} enclosingNode
+ * @property {Node} followingNode
+ * @property {string} text
+ * @property {any} options
+ * @property {Node} ast
+ * @property {boolean} isLastComment
+ */
+
+/**
+ * @param {CommentContext} context
+ * @returns {boolean}
+ */
 function handleOwnLineComment(context) {
   return [
     handleIgnoreComments,
@@ -42,6 +62,10 @@ function handleOwnLineComment(context) {
   ].some((fn) => fn(context));
 }
 
+/**
+ * @param {CommentContext} context
+ * @returns {boolean}
+ */
 function handleEndOfLineComment(context) {
   return [
     handleClosureTypeCastComments,
@@ -61,6 +85,10 @@ function handleEndOfLineComment(context) {
   ].some((fn) => fn(context));
 }
 
+/**
+ * @param {CommentContext} context
+ * @returns {boolean}
+ */
 function handleRemainingComment(context) {
   return [
     handleIgnoreComments,
@@ -78,7 +106,12 @@ function handleRemainingComment(context) {
   ].some((fn) => fn(context));
 }
 
+/**
+ * @param {Node} node
+ * @returns {void}
+ */
 function addBlockStatementFirstComment(node, comment) {
+  // @ts-ignore
   const firstNonEmptyNode = (node.body || node.properties).find(
     ({ type }) => type !== "EmptyStatement"
   );
@@ -89,6 +122,10 @@ function addBlockStatementFirstComment(node, comment) {
   }
 }
 
+/**
+ * @param {Node} node
+ * @returns {void}
+ */
 function addBlockOrNotComment(node, comment) {
   if (node.type === "BlockStatement") {
     addBlockStatementFirstComment(node, comment);
@@ -828,8 +865,8 @@ function handleTSMappedTypeComments({
 }
 
 /**
- * @param {any} node
- * @param {(comment: any) => boolean} fn
+ * @param {Node} node
+ * @param {(comment: Comment) => boolean} fn
  * @returns boolean
  */
 function hasLeadingComment(node, fn = () => true) {
@@ -842,6 +879,10 @@ function hasLeadingComment(node, fn = () => true) {
   return false;
 }
 
+/**
+ * @param {Node} node
+ * @returns {boolean}
+ */
 function isRealFunctionLikeNode(node) {
   return (
     node.type === "ArrowFunctionExpression" ||
@@ -859,6 +900,10 @@ function isRealFunctionLikeNode(node) {
   );
 }
 
+/**
+ * @param {Node} enclosingNode
+ * @returns {RegExp|void}
+ */
 function getGapRegex(enclosingNode) {
   if (
     enclosingNode &&
@@ -871,6 +916,10 @@ function getGapRegex(enclosingNode) {
   }
 }
 
+/**
+ * @param {any} node
+ * @returns {Node[]|void}
+ */
 function getCommentChildNodes(node, options) {
   // Prevent attaching comments to FunctionExpression in this case:
   //     class Foo {
@@ -896,6 +945,10 @@ function getCommentChildNodes(node, options) {
   }
 }
 
+/**
+ * @param {Comment} comment
+ * @returns {boolean}
+ */
 function isTypeCastComment(comment) {
   return (
     isBlockComment(comment) &&
@@ -907,6 +960,10 @@ function isTypeCastComment(comment) {
   );
 }
 
+/**
+ * @param {FastPath} path
+ * @returns {boolean}
+ */
 function willPrintOwnComments(path /*, options */) {
   const node = path.getValue();
   const parent = path.getParentNode();

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -365,7 +365,7 @@ function handleClassComments(data) {
 }
 
 function handleMethodNameComments(data, text) {
-  const { comment, precedingNode, enclosingNode, followingNode } = data;
+  const { comment, precedingNode, enclosingNode } = data;
   // This is only needed for estree parsers (flow, typescript) to attach
   // after a method name:
   // obj = { fn /*comment*/() {} };

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -97,8 +97,7 @@ function addBlockOrNotComment(node, comment) {
   }
 }
 
-function handleClosureTypeCastComments(context) {
-  const { comment, followingNode } = context;
+function handleClosureTypeCastComments({ comment, followingNode }) {
   if (followingNode && isTypeCastComment(comment)) {
     addLeadingComment(followingNode, comment);
     return true;
@@ -122,14 +121,13 @@ function handleClosureTypeCastComments(context) {
 //     // comment
 //     ...
 //   }
-function handleIfStatementComments(context) {
-  const {
-    comment,
-    precedingNode,
-    enclosingNode,
-    followingNode,
-    text,
-  } = context;
+function handleIfStatementComments({
+  comment,
+  precedingNode,
+  enclosingNode,
+  followingNode,
+  text,
+}) {
   if (
     !enclosingNode ||
     enclosingNode.type !== "IfStatement" ||
@@ -191,14 +189,13 @@ function handleIfStatementComments(context) {
   return false;
 }
 
-function handleWhileComments(context) {
-  const {
-    comment,
-    precedingNode,
-    enclosingNode,
-    followingNode,
-    text,
-  } = context;
+function handleWhileComments({
+  comment,
+  precedingNode,
+  enclosingNode,
+  followingNode,
+  text,
+}) {
   if (
     !enclosingNode ||
     enclosingNode.type !== "WhileStatement" ||
@@ -236,8 +233,12 @@ function handleWhileComments(context) {
 }
 
 // Same as IfStatement but for TryStatement
-function handleTryStatementComments(context) {
-  const { comment, precedingNode, enclosingNode, followingNode } = context;
+function handleTryStatementComments({
+  comment,
+  precedingNode,
+  enclosingNode,
+  followingNode,
+}) {
   if (
     !enclosingNode ||
     (enclosingNode.type !== "TryStatement" &&
@@ -270,9 +271,11 @@ function handleTryStatementComments(context) {
   return false;
 }
 
-function handleMemberExpressionComments(context) {
-  const { comment, enclosingNode, followingNode } = context;
-
+function handleMemberExpressionComments({
+  comment,
+  enclosingNode,
+  followingNode,
+}) {
   if (
     enclosingNode &&
     (enclosingNode.type === "MemberExpression" ||
@@ -287,14 +290,13 @@ function handleMemberExpressionComments(context) {
   return false;
 }
 
-function handleConditionalExpressionComments(context) {
-  const {
-    comment,
-    precedingNode,
-    enclosingNode,
-    followingNode,
-    text,
-  } = context;
+function handleConditionalExpressionComments({
+  comment,
+  precedingNode,
+  enclosingNode,
+  followingNode,
+  text,
+}) {
   const isSameLineAsPrecedingNode =
     precedingNode &&
     !hasNewlineInRange(text, locEnd(precedingNode), locStart(comment));
@@ -312,8 +314,11 @@ function handleConditionalExpressionComments(context) {
   return false;
 }
 
-function handleObjectPropertyAssignment(context) {
-  const { comment, precedingNode, enclosingNode } = context;
+function handleObjectPropertyAssignment({
+  comment,
+  precedingNode,
+  enclosingNode,
+}) {
   if (
     enclosingNode &&
     (enclosingNode.type === "ObjectProperty" ||
@@ -328,8 +333,12 @@ function handleObjectPropertyAssignment(context) {
   return false;
 }
 
-function handleClassComments(context) {
-  const { comment, precedingNode, enclosingNode, followingNode } = context;
+function handleClassComments({
+  comment,
+  precedingNode,
+  enclosingNode,
+  followingNode,
+}) {
   if (
     enclosingNode &&
     (enclosingNode.type === "ClassDeclaration" ||
@@ -379,8 +388,12 @@ function handleClassComments(context) {
   return false;
 }
 
-function handleMethodNameComments(context) {
-  const { comment, precedingNode, enclosingNode, text } = context;
+function handleMethodNameComments({
+  comment,
+  precedingNode,
+  enclosingNode,
+  text,
+}) {
   // This is only needed for estree parsers (flow, typescript) to attach
   // after a method name:
   // obj = { fn /*comment*/() {} };
@@ -422,8 +435,12 @@ function handleMethodNameComments(context) {
   return false;
 }
 
-function handleFunctionNameComments(context) {
-  const { comment, precedingNode, enclosingNode, text } = context;
+function handleFunctionNameComments({
+  comment,
+  precedingNode,
+  enclosingNode,
+  text,
+}) {
   if (getNextNonSpaceNonCommentCharacter(text, comment, locEnd) !== "(") {
     return false;
   }
@@ -442,8 +459,7 @@ function handleFunctionNameComments(context) {
   return false;
 }
 
-function handleCommentAfterArrowParams(context) {
-  const { comment, enclosingNode, text } = context;
+function handleCommentAfterArrowParams({ comment, enclosingNode, text }) {
   if (!(enclosingNode && enclosingNode.type === "ArrowFunctionExpression")) {
     return false;
   }
@@ -457,8 +473,7 @@ function handleCommentAfterArrowParams(context) {
   return false;
 }
 
-function handleCommentInEmptyParens(context) {
-  const { comment, enclosingNode, text } = context;
+function handleCommentInEmptyParens({ comment, enclosingNode, text }) {
   if (getNextNonSpaceNonCommentCharacter(text, comment, locEnd) !== ")") {
     return false;
   }
@@ -488,15 +503,13 @@ function handleCommentInEmptyParens(context) {
   return false;
 }
 
-function handleLastFunctionArgComments(context) {
-  const {
-    comment,
-    precedingNode,
-    enclosingNode,
-    followingNode,
-    text,
-  } = context;
-
+function handleLastFunctionArgComments({
+  comment,
+  precedingNode,
+  enclosingNode,
+  followingNode,
+  text,
+}) {
   // Flow function type definitions
   if (
     precedingNode &&
@@ -558,8 +571,7 @@ function handleLastFunctionArgComments(context) {
   return false;
 }
 
-function handleImportSpecifierComments(context) {
-  const { comment, enclosingNode } = context;
+function handleImportSpecifierComments({ comment, enclosingNode }) {
   if (enclosingNode && enclosingNode.type === "ImportSpecifier") {
     addLeadingComment(enclosingNode, comment);
     return true;
@@ -567,8 +579,7 @@ function handleImportSpecifierComments(context) {
   return false;
 }
 
-function handleLabeledStatementComments(context) {
-  const { comment, enclosingNode } = context;
+function handleLabeledStatementComments({ comment, enclosingNode }) {
   if (enclosingNode && enclosingNode.type === "LabeledStatement") {
     addLeadingComment(enclosingNode, comment);
     return true;
@@ -576,8 +587,7 @@ function handleLabeledStatementComments(context) {
   return false;
 }
 
-function handleBreakAndContinueStatementComments(context) {
-  const { comment, enclosingNode } = context;
+function handleBreakAndContinueStatementComments({ comment, enclosingNode }) {
   if (
     enclosingNode &&
     (enclosingNode.type === "ContinueStatement" ||
@@ -590,8 +600,11 @@ function handleBreakAndContinueStatementComments(context) {
   return false;
 }
 
-function handleCallExpressionComments(context) {
-  const { comment, precedingNode, enclosingNode } = context;
+function handleCallExpressionComments({
+  comment,
+  precedingNode,
+  enclosingNode,
+}) {
   if (
     enclosingNode &&
     (enclosingNode.type === "CallExpression" ||
@@ -606,8 +619,12 @@ function handleCallExpressionComments(context) {
   return false;
 }
 
-function handleUnionTypeComments(context) {
-  const { comment, precedingNode, enclosingNode, followingNode } = context;
+function handleUnionTypeComments({
+  comment,
+  precedingNode,
+  enclosingNode,
+  followingNode,
+}) {
   if (
     enclosingNode &&
     (enclosingNode.type === "UnionTypeAnnotation" ||
@@ -637,8 +654,7 @@ function handleUnionTypeComments(context) {
   return false;
 }
 
-function handlePropertyComments(context) {
-  const { comment, enclosingNode } = context;
+function handlePropertyComments({ comment, enclosingNode }) {
   if (
     enclosingNode &&
     (enclosingNode.type === "Property" ||
@@ -650,8 +666,7 @@ function handlePropertyComments(context) {
   return false;
 }
 
-function handleOnlyComments(context) {
-  const { comment, enclosingNode, ast, isLastComment } = context;
+function handleOnlyComments({ comment, enclosingNode, ast, isLastComment }) {
   // With Flow the enclosingNode is undefined so use the AST instead.
   if (ast && ast.body && ast.body.length === 0) {
     if (isLastComment) {
@@ -677,8 +692,7 @@ function handleOnlyComments(context) {
   return false;
 }
 
-function handleForComments(context) {
-  const { comment, enclosingNode } = context;
+function handleForComments({ comment, enclosingNode }) {
   if (
     enclosingNode &&
     (enclosingNode.type === "ForInStatement" ||
@@ -690,8 +704,12 @@ function handleForComments(context) {
   return false;
 }
 
-function handleImportDeclarationComments(context) {
-  const { comment, precedingNode, enclosingNode, text } = context;
+function handleImportDeclarationComments({
+  comment,
+  precedingNode,
+  enclosingNode,
+  text,
+}) {
   if (
     precedingNode &&
     precedingNode.type === "ImportSpecifier" &&
@@ -705,8 +723,7 @@ function handleImportDeclarationComments(context) {
   return false;
 }
 
-function handleAssignmentPatternComments(context) {
-  const { comment, enclosingNode } = context;
+function handleAssignmentPatternComments({ comment, enclosingNode }) {
   if (enclosingNode && enclosingNode.type === "AssignmentPattern") {
     addLeadingComment(enclosingNode, comment);
     return true;
@@ -714,8 +731,7 @@ function handleAssignmentPatternComments(context) {
   return false;
 }
 
-function handleTypeAliasComments(context) {
-  const { comment, enclosingNode } = context;
+function handleTypeAliasComments({ comment, enclosingNode }) {
   if (enclosingNode && enclosingNode.type === "TypeAlias") {
     addLeadingComment(enclosingNode, comment);
     return true;
@@ -723,8 +739,11 @@ function handleTypeAliasComments(context) {
   return false;
 }
 
-function handleVariableDeclaratorComments(context) {
-  const { comment, enclosingNode, followingNode } = context;
+function handleVariableDeclaratorComments({
+  comment,
+  enclosingNode,
+  followingNode,
+}) {
   if (
     enclosingNode &&
     (enclosingNode.type === "VariableDeclarator" ||
@@ -742,8 +761,12 @@ function handleVariableDeclaratorComments(context) {
   return false;
 }
 
-function handleTSFunctionTrailingComments(context) {
-  const { comment, enclosingNode, followingNode, text } = context;
+function handleTSFunctionTrailingComments({
+  comment,
+  enclosingNode,
+  followingNode,
+  text,
+}) {
   if (
     !followingNode &&
     enclosingNode &&
@@ -758,8 +781,7 @@ function handleTSFunctionTrailingComments(context) {
   return false;
 }
 
-function handleIgnoreComments(context) {
-  const { comment, enclosingNode, followingNode } = context;
+function handleIgnoreComments({ comment, enclosingNode, followingNode }) {
   if (
     isPrettierIgnoreComment(comment) &&
     enclosingNode &&
@@ -774,8 +796,12 @@ function handleIgnoreComments(context) {
   }
 }
 
-function handleTSMappedTypeComments(context) {
-  const { comment, precedingNode, enclosingNode, followingNode } = context;
+function handleTSMappedTypeComments({
+  comment,
+  precedingNode,
+  enclosingNode,
+  followingNode,
+}) {
   if (!enclosingNode || enclosingNode.type !== "TSMappedType") {
     return false;
   }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2404,6 +2404,8 @@ module.exports = {
   printComment,
   isBlockComment,
   handleComments: {
+    // TODO: Make this as default behavior
+    noMutate: true,
     ownLine: handleComments.handleOwnLineComment,
     endOfLine: handleComments.handleEndOfLineComment,
     remaining: handleComments.handleRemainingComment,

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -2405,7 +2405,7 @@ module.exports = {
   isBlockComment,
   handleComments: {
     // TODO: Make this as default behavior
-    noMutate: true,
+    avoidAstMutation: true,
     ownLine: handleComments.handleOwnLineComment,
     endOfLine: handleComments.handleEndOfLineComment,
     remaining: handleComments.handleRemainingComment,

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -181,7 +181,7 @@ function attach(comments, ast, text, options) {
   } = options;
   // TODO: Make this as default behavior
   const {
-    noMutate: noMutateComments,
+    avoidAstMutation,
     ownLine: handleOwnLineComment = returnFalse,
     endOfLine: handleEndOfLineComment = returnFalse,
     remaining: handleRemainingComment = returnFalse,
@@ -219,7 +219,7 @@ function attach(comments, ast, text, options) {
     };
 
     let args;
-    if (noMutateComments) {
+    if (avoidAstMutation) {
       args = [context];
     } else {
       comment.enclosingNode = enclosingNode;
@@ -294,7 +294,7 @@ function attach(comments, ast, text, options) {
 
   breakTies(tiesToBreak, text, options);
 
-  if (!noMutateComments) {
+  if (!avoidAstMutation) {
     comments.forEach((comment) => {
       // These node references were useful for breaking ties, but we
       // don't need them anymore, and they create cycles in the AST that

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -91,7 +91,7 @@ function getSortedChildNodes(node, options, resultArray) {
 // As efficiently as possible, decorate the comment object with
 // .precedingNode, .enclosingNode, and/or .followingNode properties, at
 // least one of which is guaranteed to be defined.
-function decorateComment(node, comment, options) {
+function decorateComment(node, comment, options, enclosingNode) {
   const { locStart, locEnd } = options;
   const commentStart = locStart(comment);
   const commentEnd = locEnd(comment);
@@ -108,12 +108,10 @@ function decorateComment(node, comment, options) {
     const start = locStart(child);
     const end = locEnd(child);
 
+    // The comment is completely contained by this child node.
     if (start <= commentStart && commentEnd <= end) {
-      // The comment is completely contained by this child node.
-      comment.enclosingNode = child;
-
-      decorateComment(child, comment, options);
-      return; // Abandon the binary search at this level.
+      // Abandon the binary search at this level.
+      return decorateComment(child, comment, options, child);
     }
 
     if (start <= commentStart) {
@@ -142,11 +140,8 @@ function decorateComment(node, comment, options) {
 
   // We don't want comments inside of different expressions inside of the same
   // template literal to move to another expression.
-  if (
-    comment.enclosingNode &&
-    comment.enclosingNode.type === "TemplateLiteral"
-  ) {
-    const { quasis } = comment.enclosingNode;
+  if (enclosingNode && enclosingNode.type === "TemplateLiteral") {
+    const { quasis } = enclosingNode;
     const commentIndex = findExpressionIndexForComment(
       quasis,
       comment,
@@ -169,15 +164,10 @@ function decorateComment(node, comment, options) {
     }
   }
 
-  if (precedingNode) {
-    comment.precedingNode = precedingNode;
-  }
-
-  if (followingNode) {
-    comment.followingNode = followingNode;
-  }
+  return { comment, enclosingNode, precedingNode, followingNode };
 }
 
+const returnFalse = () => false;
 function attach(comments, ast, text, options) {
   if (!Array.isArray(comments)) {
     return;
@@ -185,6 +175,9 @@ function attach(comments, ast, text, options) {
 
   const tiesToBreak = [];
   const { locStart, locEnd } = options;
+  // TODO: Make this as default behavior
+  const noMutateComments =
+    options.printer.handleComments && options.printer.handleComments.noMutate;
 
   comments.forEach((comment, i) => {
     if (
@@ -203,30 +196,56 @@ function attach(comments, ast, text, options) {
       }
     }
 
-    decorateComment(ast, comment, options);
-    const { precedingNode, enclosingNode, followingNode } = comment;
+    const isLastComment = comments.length - 1 === i;
+    const decorated = decorateComment(ast, comment, options);
+    const { precedingNode, enclosingNode, followingNode } = decorated;
+
+    let commentPassToPlugin = decorated;
+    if (!noMutateComments) {
+      comment.enclosingNode = enclosingNode;
+      comment.precedingNode = precedingNode;
+      comment.followingNode = followingNode;
+      commentPassToPlugin = comment;
+    }
 
     const pluginHandleOwnLineComment =
       options.printer.handleComments && options.printer.handleComments.ownLine
-        ? options.printer.handleComments.ownLine
-        : () => false;
+        ? options.printer.handleComments.ownLine.bind(
+            null,
+            commentPassToPlugin,
+            text,
+            options,
+            ast,
+            isLastComment
+          )
+        : returnFalse;
     const pluginHandleEndOfLineComment =
       options.printer.handleComments && options.printer.handleComments.endOfLine
-        ? options.printer.handleComments.endOfLine
-        : () => false;
+        ? options.printer.handleComments.endOfLine.bind(
+            null,
+            commentPassToPlugin,
+            text,
+            options,
+            ast,
+            isLastComment
+          )
+        : returnFalse;
     const pluginHandleRemainingComment =
       options.printer.handleComments && options.printer.handleComments.remaining
-        ? options.printer.handleComments.remaining
-        : () => false;
-
-    const isLastComment = comments.length - 1 === i;
+        ? options.printer.handleComments.remaining.bind(
+            null,
+            commentPassToPlugin,
+            text,
+            options,
+            ast,
+            isLastComment
+          )
+        : returnFalse;
 
     if (hasNewline(text, locStart(comment), { backwards: true })) {
       // If a comment exists on its own line, prefer a leading comment.
       // We also need to check if it's the first line of the file.
-      if (
-        pluginHandleOwnLineComment(comment, text, options, ast, isLastComment)
-      ) {
+      if (pluginHandleOwnLineComment()) {
         // We're good
       } else if (followingNode) {
         // Always a leading comment.
@@ -241,9 +260,7 @@ function attach(comments, ast, text, options) {
         addDanglingComment(ast, comment);
       }
     } else if (hasNewline(text, locEnd(comment))) {
-      if (
-        pluginHandleEndOfLineComment(comment, text, options, ast, isLastComment)
-      ) {
+      if (pluginHandleEndOfLineComment()) {
         // We're good
       } else if (precedingNode) {
         // There is content before this comment on the same line, but
@@ -259,9 +276,7 @@ function attach(comments, ast, text, options) {
         addDanglingComment(ast, comment);
       }
     } else {
-      if (
-        pluginHandleRemainingComment(comment, text, options, ast, isLastComment)
-      ) {
+      if (pluginHandleRemainingComment()) {
         // We're good
       } else if (precedingNode && followingNode) {
         // Otherwise, text exists both before and after the comment on
@@ -272,11 +287,11 @@ function attach(comments, ast, text, options) {
         const tieCount = tiesToBreak.length;
         if (tieCount > 0) {
           const lastTie = tiesToBreak[tieCount - 1];
-          if (lastTie.followingNode !== comment.followingNode) {
+          if (lastTie.followingNode !== followingNode) {
             breakTies(tiesToBreak, text, options);
           }
         }
-        tiesToBreak.push(comment);
+        tiesToBreak.push(decorated);
       } else if (precedingNode) {
         addTrailingComment(precedingNode, comment);
       } else if (followingNode) {
@@ -293,14 +308,16 @@ function attach(comments, ast, text, options) {
 
   breakTies(tiesToBreak, text, options);
 
-  comments.forEach((comment) => {
-    // These node references were useful for breaking ties, but we
-    // don't need them anymore, and they create cycles in the AST that
-    // may lead to infinite recursion if we don't delete them here.
-    delete comment.precedingNode;
-    delete comment.enclosingNode;
-    delete comment.followingNode;
-  });
+  if (!noMutateComments) {
+    comments.forEach((comment) => {
+      // These node references were useful for breaking ties, but we
+      // don't need them anymore, and they create cycles in the AST that
+      // may lead to infinite recursion if we don't delete them here.
+      delete comment.precedingNode;
+      delete comment.enclosingNode;
+      delete comment.followingNode;
+    });
+  }
 }
 
 function breakTies(tiesToBreak, text, options) {
@@ -328,9 +345,13 @@ function breakTies(tiesToBreak, text, options) {
     indexOfFirstLeadingComment > 0;
     --indexOfFirstLeadingComment
   ) {
-    const comment = tiesToBreak[indexOfFirstLeadingComment - 1];
-    assert.strictEqual(comment.precedingNode, precedingNode);
-    assert.strictEqual(comment.followingNode, followingNode);
+    const {
+      comment,
+      precedingNode: currentCommentEnclosingNode,
+      followingNode: currentCommentFollowingNode,
+    } = tiesToBreak[indexOfFirstLeadingComment - 1];
+    assert.strictEqual(currentCommentEnclosingNode, precedingNode);
+    assert.strictEqual(currentCommentFollowingNode, followingNode);
 
     const gap = text.slice(options.locEnd(comment), gapEndPos);
 
@@ -343,7 +364,7 @@ function breakTies(tiesToBreak, text, options) {
     }
   }
 
-  tiesToBreak.forEach((comment, i) => {
+  tiesToBreak.forEach(({ comment }, i) => {
     if (i < indexOfFirstLeadingComment) {
       addTrailingComment(precedingNode, comment);
     } else {


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes: -->

One step to address #8122, stop mutating comments during `decorateComment`, to achieve this, we have to pass decorate info seperately to `handleXXXComment`, I added a flag on printer, but we'll remove it when all done.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory)
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/pr-XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
