### PR TITLE
Use option `vueIndentScriptAndStyle` to dedent 1st level children inside `<html>` tag in HTML files

### DIFF
--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -304,6 +304,11 @@ function genericPrint(path, options, print) {
                         options.parser === "vue" &&
                         !options.vueIndentScriptAndStyle
                       ? childrenDoc
+                      : node.type === "element" &&
+                        node.fullName === "html" &&
+                        options.parser === "html" &&
+                        options.vueIndentScriptAndStyle
+                      ? dedentToRoot(childrenDoc)
                       : indent(childrenDoc))(
                     concat([
                       shouldHugContent


### PR DESCRIPTION
## Description

This is a patch to dedent 1st level children inside `<html>` tag in HTML files by using `vueIndentScriptAndStyle` option.

Currently, HTML files will be formatted like:

```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <title>...</title>
  </head>
  <body>
  </body>
</html>
```

But, by using this patch and enabling `vueIndentScriptAndStyle` option, HTML files will be formatted like:

```html
<!DOCTYPE html>
<html lang="en">
<head>
  <title>...</title>
</head>
<body>
  <main>
    <section>...</section>
  </main>
</body>
</html>
```

## Checklist

I don't have time to make tests or documents, so, get this patch and apply by yourself please.

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
