### PR TITLE
Build: Fix rollup warning

### DIFF
--- a/scripts/build/bundler.js
+++ b/scripts/build/bundler.js
@@ -57,7 +57,7 @@ const entries = [
   // Avoid rollup `SOURCEMAP_ERROR` and `THIS_IS_UNDEFINED` error
   {
     find: "@glimmer/syntax",
-    replacement: require.resolve("@glimmer/syntax/dist/commonjs/es5/index.js"),
+    replacement: require.resolve("@glimmer/syntax"),
   },
 ];
 

--- a/scripts/build/bundler.js
+++ b/scripts/build/bundler.js
@@ -54,6 +54,11 @@ const entries = [
       `${PROJECT_ROOT}/node_modules/@angular/compiler/esm2015/src`
     ),
   },
+  // Avoid rollup `SOURCEMAP_ERROR` and `THIS_IS_UNDEFINED` error
+  {
+    find: "@glimmer/syntax",
+    replacement: require.resolve("@glimmer/syntax/dist/commonjs/es5/index.js"),
+  },
 ];
 
 function webpackNativeShims(config, modules) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->


Fix rollup warnings by replacing `@glimmer/syntax` with another entry

Master branch build log https://github.com/prettier/prettier/runs/1478488011#step:6:22

New log https://github.com/prettier/prettier/runs/1478653306?check_suite_focus=true#step:6:1

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
