### PR TITLE
[WIP] Proof of concept for prettier-ignore-{start,end} in JS

### DIFF
--- a/src/language-js/print-preprocess.js
+++ b/src/language-js/print-preprocess.js
@@ -1,6 +1,8 @@
 "use strict";
 
 function preprocess(ast, options) {
+  markIgnoredNodes(ast, options);
+
   switch (options.parser) {
     case "json":
     case "json5":
@@ -17,6 +19,91 @@ function preprocess(ast, options) {
     default:
       return ast;
   }
+}
+
+function markIgnoredNodes(node, options, key = "root", isIgnoring = false) {
+  if (!node) {
+    return;
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    if (value && typeof value.type === "string") {
+      markIgnoredNodes(value, options, key, isIgnoring);
+    } else if (Array.isArray(value)) {
+      let ignoring = false;
+      value.forEach(elem => {
+        if (hasLeadingStartComment(elem)) {
+          ignoring = true;
+          console.log("ignoring start", elem);
+        }
+        if (hasLeadingEndComment(elem)) {
+          ignoring = false;
+          console.log("ignoring ended", elem);
+        }
+
+        if (ignoring) {
+          elem.prettierIgnore = ignoring;
+          console.log("ignoring contd", elem);
+        } else {
+          markIgnoredNodes(elem, options, key);
+        }
+
+        if (hasTrailingStartComment(elem)) {
+          ignoring = true
+          console.log("ignoring start", elem);
+        }
+        if (hasTrailingEndComment(elem)) {
+          if (!ignoring) { 
+            console.log("Found prettier-ignore-end without a matching prettier-ignore-start", elem);
+          }
+          ignoring = false;
+          console.log("ignoring ended", elem);
+        }
+
+      })
+    }
+  }
+  return node;
+}
+
+function hasLeadingStartComment(node) {
+  // TODO: use util#getComment instead of node.comments
+  if (Array.isArray(node.comments)) {
+    return node.comments
+    .filter(comment => comment.leading)
+    .filter(comment=>comment.value.includes("prettier-ignore-start")).length > 0;
+  }
+  return false;
+}
+function hasLeadingEndComment(node) {
+  // TODO: use util#getComment instead of node.comments
+  if (Array.isArray(node.comments)) {
+    return node.comments
+    .filter(comment => comment.leading)
+    .filter(comment=>comment.value.includes("prettier-ignore-end")).length > 0;
+  }
+  return false;
+}
+
+
+function hasTrailingStartComment(node) {
+  // TODO: use util#getComment instead of node.comments
+  if (Array.isArray(node.comments)) {
+    return node.comments
+    .filter(comment => comment.trailing)
+    .filter(comment=>comment.value.includes("prettier-ignore-start")).length > 0;
+  }
+  return false;
+}
+
+function hasTrailingEndComment(node) {
+  // TODO: use util#getComment instead of node.comments
+  if (Array.isArray(node.comments)) {
+    return node.comments
+    .filter(comment => comment.trailing)
+    .filter(comment=>comment.value.includes("prettier-ignore-end")).length > 0;
+  }
+  return false;
 }
 
 module.exports = preprocess;


### PR DESCRIPTION
## Description

This PR addresses this issue:
https://github.com/prettier/prettier/issues/5287

This is an initial stab at adding `prettier-ignore-start` and `prettier-ignore-end` to JavaScript. The approach is to preprocess the AST, find nodes that occur between start and end comments, and add the `prettierIgnore` property to each of them. It takes advantage of the fact that `main/ast-to-doc` skips over any nodes that have that property.

This implementation currently only works in some cases, and doesn't follow best practices (like using `hasComment()` instead of accessing `node.comments` directly). I'm looking for early feedback on this approach before I investigate further.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
