### PR TITLE
HTML: Remove use of `normalizeParts` in "text" print

### DIFF
--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -3,7 +3,7 @@
 const assert = require("assert");
 const {
   builders,
-  utils: { mapDoc, normalizeParts },
+  utils: { mapDoc, normalizeParts, cleanDoc },
 } = require("../document");
 const { replaceEndOfLineWith } = require("../common/util");
 const { print: printFrontMatter } = require("../utils/front-matter");
@@ -384,11 +384,15 @@ function genericPrint(path, options, print) {
           hasTrailingNewline ? hardline : "",
         ]);
       }
-      return concat([
-        printOpeningTagPrefix(node, options),
-        fill(getTextValueParts(node)),
-        printClosingTagSuffix(node, options),
-      ]);
+
+      const printed = cleanDoc(
+        concat([
+          printOpeningTagPrefix(node, options),
+          ...getTextValueParts(node),
+          printClosingTagSuffix(node, options),
+        ])
+      );
+      return typeof printed === "string" ? printed : fill(printed.parts);
     }
     case "docType":
       return concat([

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -384,15 +384,11 @@ function genericPrint(path, options, print) {
           hasTrailingNewline ? hardline : "",
         ]);
       }
-      return fill(
-        normalizeParts(
-          [].concat(
-            printOpeningTagPrefix(node, options),
-            getTextValueParts(node),
-            printClosingTagSuffix(node, options)
-          )
-        )
-      );
+      return concat([
+        printOpeningTagPrefix(node, options),
+        fill(getTextValueParts(node)),
+        printClosingTagSuffix(node, options),
+      ]);
     }
     case "docType":
       return concat([

--- a/tests/html/text/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html/text/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`tag-should-in-fill.html format 1`] = `
+====================================options=====================================
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<a-long-long-long-element>foo bar foo bar
+  foo bar foo bar foo bar foo bar foo bar
+  foo bar foo bar</a-long-long-long-element>
+<!-- The end tag should stay in 80 print width -->
+
+=====================================output=====================================
+<a-long-long-long-element
+  >foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar</a-long-long-long-element
+>
+<!-- The end tag should stay in 80 print width -->
+
+================================================================================
+`;

--- a/tests/html/text/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html/text/__snapshots__/jsfmt.spec.js.snap
@@ -13,7 +13,8 @@ printWidth: 80
 
 =====================================output=====================================
 <a-long-long-long-element
-  >foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar</a-long-long-long-element
+  >foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo
+  bar</a-long-long-long-element
 >
 <!-- The end tag should stay in 80 print width -->
 

--- a/tests/html/text/jsfmt.spec.js
+++ b/tests/html/text/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["html"]);

--- a/tests/html/text/tag-should-in-fill.html
+++ b/tests/html/text/tag-should-in-fill.html
@@ -1,0 +1,4 @@
+<a-long-long-long-element>foo bar foo bar
+  foo bar foo bar foo bar foo bar foo bar
+  foo bar foo bar</a-long-long-long-element>
+<!-- The end tag should stay in 80 print width -->


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

I think this part only need use `fill` for the text part.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
