### PR TITLE
Simplify `escapeTemplateCharacters`

### DIFF
--- a/src/language-js/print/template-literal.js
+++ b/src/language-js/print/template-literal.js
@@ -217,21 +217,13 @@ function printTemplateExpressions(path, print) {
 
 function escapeTemplateCharacters(doc, raw) {
   return mapDoc(doc, (currentDoc) => {
-    if (!currentDoc.parts) {
-      return currentDoc;
+    if (typeof currentDoc === "string") {
+      return raw
+        ? currentDoc.replace(/(\\*)`/g, "$1$1\\`")
+        : uncookTemplateElementValue(currentDoc);
     }
 
-    const parts = currentDoc.parts.map((part) => {
-      if (typeof part === "string") {
-        return raw
-          ? part.replace(/(\\*)`/g, "$1$1\\`")
-          : uncookTemplateElementValue(part);
-      }
-
-      return part;
-    });
-
-    return { ...currentDoc, parts };
+    return currentDoc;
   });
 }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

`` ` `` could be in other places, not only `concat` and `fill`. I think this may fix the broken case in https://github.com/prettier/prettier/pull/9847 too.

And this function seems should also escape `${`, but since nobody has report any issue about it, I'm not going to change it for now.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
