### PR TITLE
Use `isBlockComment`/`isLineComment` in `canAttachComment`

### DIFF
--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -45,6 +45,7 @@ const {
   isGetterOrSetter,
   isTheOnlyJSXElementInMarkdown,
   isBlockComment,
+  isLineComment,
   needsHardlineAfterDanglingComment,
   rawText,
   shouldPrintComma,
@@ -1271,10 +1272,8 @@ function printRegex(node) {
 function canAttachComment(node) {
   return (
     node.type &&
-    node.type !== "CommentBlock" &&
-    node.type !== "CommentLine" &&
-    node.type !== "Line" &&
-    node.type !== "Block" &&
+    !isBlockComment(node) &&
+    !isLineComment(node) &&
     node.type !== "EmptyStatement" &&
     node.type !== "TemplateElement" &&
     node.type !== "Import"


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

`isBlockComment` and `isLineComment` have complete comment types

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
