### PR TITLE
Fix inconsistent directive print

### DIFF
--- a/changelog_unreleased/javascript/9850.md
+++ b/changelog_unreleased/javascript/9850.md
@@ -1,0 +1,31 @@
+#### Fix extra semicolon added to ignored directives (#9850 by @fisker)
+
+<!-- prettier-ignore -->
+```js
+// Input
+// prettier-ignore
+'use strict';
+
+function foo() {
+// prettier-ignore
+'use strict';
+}
+
+// Prettier stable
+// prettier-ignore
+'use strict';;
+
+function foo() {
+  // prettier-ignore
+  'use strict';;
+}
+
+// Prettier master
+// prettier-ignore
+'use strict';
+
+function foo() {
+  // prettier-ignore
+  'use strict';
+}
+```

--- a/changelog_unreleased/javascript/9850.md
+++ b/changelog_unreleased/javascript/9850.md
@@ -8,7 +8,7 @@
 
 function foo() {
 // prettier-ignore
-'use strict';
+"use strict";;
 }
 
 // Prettier stable
@@ -17,7 +17,7 @@ function foo() {
 
 function foo() {
   // prettier-ignore
-  'use strict';;
+  "use strict";;
 }
 
 // Prettier master
@@ -25,7 +25,7 @@ function foo() {
 'use strict';
 
 function foo() {
-  // prettier-ignore
-  'use strict';
+// prettier-ignore
+"use strict";
 }
 ```

--- a/changelog_unreleased/javascript/9850.md
+++ b/changelog_unreleased/javascript/9850.md
@@ -25,7 +25,7 @@ function foo() {
 'use strict';
 
 function foo() {
-// prettier-ignore
-"use strict";
+  // prettier-ignore
+  "use strict";
 }
 ```

--- a/src/language-js/print/block.js
+++ b/src/language-js/print/block.js
@@ -15,7 +15,6 @@ const { printStatementSequence } = require("./statement");
 function printBlock(path, options, print) {
   const n = path.getValue();
   const parts = [];
-  const semi = options.semi ? ";" : "";
   const naked = path.call((bodyPath) => {
     return printStatementSequence(bodyPath, options, print);
   }, "body");
@@ -56,7 +55,7 @@ function printBlock(path, options, print) {
   // Babel 6
   if (hasDirectives) {
     path.each((childPath) => {
-      parts.push(indent(concat([hardline, print(childPath), semi])));
+      parts.push(indent(concat([hardline, print(childPath)])));
       if (isNextLineEmpty(options.originalText, childPath.getValue(), locEnd)) {
         parts.push(hardline);
       }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -558,9 +558,9 @@ function printPathNoParens(path, options, print, args) {
       }
       return nodeStr(n, options);
     case "Directive":
-      return path.call(print, "value"); // Babel 6
+      return concat([path.call(print, "value"), semi]); // Babel 6
     case "DirectiveLiteral":
-      return concat([nodeStr(n, options), semi]);
+      return nodeStr(n, options);
     case "UnaryExpression":
       parts.push(n.operator);
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -267,7 +267,7 @@ function printPathNoParens(path, options, print, args) {
       if (n.directives) {
         const directivesCount = n.directives.length;
         path.each((childPath, index) => {
-          parts.push(print(childPath), semi, hardline);
+          parts.push(print(childPath), hardline);
           if (
             (index < directivesCount - 1 || hasContents) &&
             isNextLineEmpty(options.originalText, childPath.getValue(), locEnd)
@@ -560,7 +560,7 @@ function printPathNoParens(path, options, print, args) {
     case "Directive":
       return path.call(print, "value"); // Babel 6
     case "DirectiveLiteral":
-      return nodeStr(n, options);
+      return concat([nodeStr(n, options), semi]);
     case "UnaryExpression":
       parts.push(n.operator);
 

--- a/tests/js/ignore/semi/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/ignore/semi/__snapshots__/jsfmt.spec.js.snap
@@ -11,10 +11,22 @@ semi: false
 'use strict';
 [].forEach();
 
+function foo() {
+// prettier-ignore
+'use strict';
+[].forEach();
+}
+
 =====================================output=====================================
 // prettier-ignore
 'use strict';
 ;[].forEach()
+
+function foo() {
+  // prettier-ignore
+  'use strict';
+  ;[].forEach()
+}
 
 ================================================================================
 `;
@@ -29,10 +41,22 @@ printWidth: 80
 'use strict';
 [].forEach();
 
+function foo() {
+// prettier-ignore
+'use strict';
+[].forEach();
+}
+
 =====================================output=====================================
 // prettier-ignore
 'use strict';
 [].forEach();
+
+function foo() {
+  // prettier-ignore
+  'use strict';
+  [].forEach();
+}
 
 ================================================================================
 `;

--- a/tests/js/ignore/semi/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/ignore/semi/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`directive.js - {"semi":false} format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+// prettier-ignore
+'use strict';
+[].forEach();
+
+=====================================output=====================================
+// prettier-ignore
+'use strict';
+;[].forEach()
+
+================================================================================
+`;
+
+exports[`directive.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// prettier-ignore
+'use strict';
+[].forEach();
+
+=====================================output=====================================
+// prettier-ignore
+'use strict';
+[].forEach();
+
+================================================================================
+`;

--- a/tests/js/ignore/semi/directive.js
+++ b/tests/js/ignore/semi/directive.js
@@ -1,0 +1,3 @@
+// prettier-ignore
+'use strict';
+[].forEach();

--- a/tests/js/ignore/semi/directive.js
+++ b/tests/js/ignore/semi/directive.js
@@ -1,3 +1,9 @@
 // prettier-ignore
 'use strict';
 [].forEach();
+
+function foo() {
+// prettier-ignore
+'use strict';
+[].forEach();
+}

--- a/tests/js/ignore/semi/jsfmt.spec.js
+++ b/tests/js/ignore/semi/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname, ["babel", "flow", "typescript"]);
+run_spec(__dirname, ["babel", "flow", "typescript"], { semi: false });


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Other parser [print semi in `ExpressionStatement`](https://github.com/prettier/prettier/blob/19a8df2f572f1bc4504cebe0614f45f868b786fa/src/language-js/printer-estree.js#L303), let's move semi to `Directive`.

Fixes #3009

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
