### PR TITLE
handlebars: Add `htmlWhitespaceSensitivity` option (1/6)

### DIFF
--- a/src/language-handlebars/index.js
+++ b/src/language-handlebars/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const createLanguage = require("../utils/create-language");
+const options = require("./options");
 const printer = require("./printer-glimmer");
 
 const languages = [
@@ -24,5 +25,6 @@ const parsers = {
 module.exports = {
   languages,
   printers,
+  options,
   parsers,
 };

--- a/src/language-handlebars/options.js
+++ b/src/language-handlebars/options.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const CATEGORY_HANDLEBARS = "Handlebars";
+
+// format based on https://github.com/prettier/prettier/blob/master/src/main/core-options.js
+module.exports = {
+  htmlWhitespaceSensitivity: {
+    since: "2.2.1",
+    category: CATEGORY_HANDLEBARS,
+    type: "choice",
+    default: "ignore",
+    description: "How to handle whitespaces in Handlebars.",
+    choices: [
+      // {
+      //   value: "strict",
+      //   description: "Whitespaces are considered sensitive.",
+      // },
+      {
+        value: "ignore",
+        description: "Whitespaces are considered insensitive.",
+      },
+    ],
+  },
+};


### PR DESCRIPTION
## Description

Step 1 out of 6 of https://github.com/prettier/prettier/issues/9881

The only possible and default value is `ignore` for now.

In further steps, we will add tests and implement a `strict` mode to consider whitespaces sensitive.

I have not updated the `docs/` directory yet. I am planning to do it in a following PR (when `strict` mode is implemented).

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
