### PR TITLE
Refactor: Remove `composeLoc` function

### DIFF
--- a/src/language-js/loc.js
+++ b/src/language-js/loc.js
@@ -26,21 +26,6 @@ function locEnd(node) {
 }
 
 /**
- * @param {Node} startNode
- * @param {Node | number} endNodeOrLength
- * @returns {number[]}
- */
-function composeLoc(startNode, endNodeOrLength = startNode) {
-  const start = locStart(startNode);
-  const end =
-    typeof endNodeOrLength === "number"
-      ? start + endNodeOrLength
-      : locEnd(endNodeOrLength);
-
-  return [start, end];
-}
-
-/**
  * @param {Node} nodeA
  * @param {Node} nodeB
  * @returns {boolean}
@@ -70,7 +55,6 @@ function hasSameLoc(nodeA, nodeB) {
 module.exports = {
   locStart,
   locEnd,
-  composeLoc,
   hasSameLocStart,
   hasSameLoc,
 };

--- a/src/language-js/parse-postprocess.js
+++ b/src/language-js/parse-postprocess.js
@@ -6,7 +6,7 @@ const {
   getShebang,
 } = require("../common/util");
 const createError = require("../common/parser-create-error");
-const { composeLoc, locStart, locEnd } = require("./loc");
+const { locStart, locEnd } = require("./loc");
 const { isTypeCastComment } = require("./comments");
 
 function postprocess(ast, options) {
@@ -126,7 +126,7 @@ function postprocess(ast, options) {
       }
       // remove redundant TypeScript nodes
       case "TSParenthesizedType": {
-        node.typeAnnotation.range = composeLoc(node);
+        node.typeAnnotation.range = [locStart(node), locEnd(node)];
         return node.typeAnnotation;
       }
       case "TSUnionType":
@@ -134,26 +134,28 @@ function postprocess(ast, options) {
         if (node.types.length === 1) {
           const [firstType] = node.types;
           // override loc, so that comments are attached properly
-          firstType.range = composeLoc(node);
+          firstType.range = [locStart(node), locEnd(node)];
           return firstType;
         }
         break;
       case "TSTypeParameter":
         // babel-ts
         if (typeof node.name === "string") {
+          const start = locStart(node);
           node.name = {
             type: "Identifier",
             name: node.name,
-            range: composeLoc(node, node.name.length),
+            range: [start, start + node.name.length],
           };
         }
         break;
       case "SequenceExpression": {
         // Babel (unlike other parsers) includes spaces and comments in the range. Let's unify this.
         const lastExpression = getLast(node.expressions);
-        if (locEnd(node) > locEnd(lastExpression)) {
-          node.range = composeLoc(node, lastExpression);
-        }
+        node.range = [
+          locStart(node),
+          Math.min(locEnd(lastExpression), locEnd(node)),
+        ];
         break;
       }
       case "ClassProperty":
@@ -183,7 +185,10 @@ function postprocess(ast, options) {
     if (options.originalText[locEnd(toOverrideNode)] === ";") {
       return;
     }
-    toBeOverriddenNode.range = composeLoc(toBeOverriddenNode, toOverrideNode);
+    toBeOverriddenNode.range = [
+      locStart(toBeOverriddenNode),
+      locEnd(toOverrideNode),
+    ];
   }
 }
 
@@ -253,10 +258,10 @@ function rebalanceLogicalTree(node) {
       operator: node.operator,
       left: node.left,
       right: node.right.left,
-      range: composeLoc(node.left, node.right.left),
+      range: [locStart(node.left), locEnd(node.right.left)],
     }),
     right: node.right.right,
-    range: composeLoc(node),
+    range: [locStart(node), locEnd(node)],
   });
 }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

This function accept too many cases, it makes code less readable.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
