### PR TITLE
Send array to `FastPath#{each,map}` callback

### DIFF
--- a/src/common/fast-path.js
+++ b/src/common/fast-path.js
@@ -92,7 +92,7 @@ class FastPath {
 
     for (let i = 0; i < value.length; ++i) {
       stack.push(i, value[i]);
-      callback(this, i);
+      callback(this, i, value);
       stack.length -= 2;
     }
 
@@ -104,8 +104,8 @@ class FastPath {
   // the end of the iteration.
   map(callback, ...names) {
     const result = [];
-    this.each((path, index) => {
-      result[index] = callback(path, index);
+    this.each((path, index, value) => {
+      result[index] = callback(path, index, value);
     }, ...names);
     return result;
   }

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -978,10 +978,9 @@ function genericPrint(path, options, print) {
 }
 
 function printNodeSequence(path, options, print) {
-  const node = path.getValue();
   const parts = [];
-  path.each((pathChild, i) => {
-    const prevNode = node.nodes[i - 1];
+  path.each((pathChild, i, nodes) => {
+    const prevNode = nodes[i - 1];
     if (
       prevNode &&
       prevNode.type === "css-comment" &&
@@ -995,23 +994,23 @@ function printNodeSequence(path, options, print) {
       parts.push(pathChild.call(print));
     }
 
-    if (i !== node.nodes.length - 1) {
+    if (i !== nodes.length - 1) {
       if (
-        (node.nodes[i + 1].type === "css-comment" &&
-          !hasNewline(options.originalText, locStart(node.nodes[i + 1]), {
+        (nodes[i + 1].type === "css-comment" &&
+          !hasNewline(options.originalText, locStart(nodes[i + 1]), {
             backwards: true,
           }) &&
-          !isFrontMatterNode(node.nodes[i])) ||
-        (node.nodes[i + 1].type === "css-atrule" &&
-          node.nodes[i + 1].name === "else" &&
-          node.nodes[i].type !== "css-comment")
+          !isFrontMatterNode(nodes[i])) ||
+        (nodes[i + 1].type === "css-atrule" &&
+          nodes[i + 1].name === "else" &&
+          nodes[i].type !== "css-comment")
       ) {
         parts.push(" ");
       } else {
         parts.push(options.__isHTMLStyleAttribute ? line : hardline);
         if (
           isNextLineEmpty(options.originalText, pathChild.getValue(), locEnd) &&
-          !isFrontMatterNode(node.nodes[i])
+          !isFrontMatterNode(nodes[i])
         ) {
           parts.push(hardline);
         }

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -20,9 +20,9 @@ function genericPrint(path, options, print) {
   switch (n.kind) {
     case "Document": {
       const parts = [];
-      path.each((pathChild, index) => {
+      path.each((pathChild, index, definitions) => {
         parts.push(concat([pathChild.call(print)]));
-        if (index !== n.definitions.length - 1) {
+        if (index !== definitions.length - 1) {
           parts.push(hardline);
           if (
             isNextLineEmpty(options.originalText, pathChild.getValue(), locEnd)

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -278,10 +278,8 @@ function printJsxChildren(
   jsxWhitespace,
   isFacebookTranslationTag
 ) {
-  const n = path.getValue();
-  const children = [];
-
-  path.each((childPath, i) => {
+  const parts = [];
+  path.each((childPath, i, children) => {
     const child = childPath.getValue();
     if (isLiteral(child)) {
       const text = rawText(child);
@@ -292,11 +290,11 @@ function printJsxChildren(
 
         // Starts with whitespace
         if (words[0] === "") {
-          children.push("");
+          parts.push("");
           words.shift();
           if (/\n/.test(words[0])) {
-            const next = n.children[i + 1];
-            children.push(
+            const next = children[i + 1];
+            parts.push(
               separatorWithWhitespace(
                 isFacebookTranslationTag,
                 words[1],
@@ -305,7 +303,7 @@ function printJsxChildren(
               )
             );
           } else {
-            children.push(jsxWhitespace);
+            parts.push(jsxWhitespace);
           }
           words.shift();
         }
@@ -324,32 +322,32 @@ function printJsxChildren(
 
         words.forEach((word, i) => {
           if (i % 2 === 1) {
-            children.push(line);
+            parts.push(line);
           } else {
-            children.push(word);
+            parts.push(word);
           }
         });
 
         if (endWhitespace !== undefined) {
           if (/\n/.test(endWhitespace)) {
-            const next = n.children[i + 1];
-            children.push(
+            const next = children[i + 1];
+            parts.push(
               separatorWithWhitespace(
                 isFacebookTranslationTag,
-                getLast(children),
+                getLast(parts),
                 child,
                 next
               )
             );
           } else {
-            children.push(jsxWhitespace);
+            parts.push(jsxWhitespace);
           }
         } else {
-          const next = n.children[i + 1];
-          children.push(
+          const next = children[i + 1];
+          parts.push(
             separatorNoWhitespace(
               isFacebookTranslationTag,
-              getLast(children),
+              getLast(parts),
               child,
               next
             )
@@ -359,25 +357,25 @@ function printJsxChildren(
         // Keep (up to one) blank line between tags/expressions/text.
         // Note: We don't keep blank lines between text elements.
         if (text.match(/\n/g).length > 1) {
-          children.push("");
-          children.push(hardline);
+          parts.push("");
+          parts.push(hardline);
         }
       } else {
-        children.push("");
-        children.push(jsxWhitespace);
+        parts.push("");
+        parts.push(jsxWhitespace);
       }
     } else {
       const printedChild = print(childPath);
-      children.push(printedChild);
+      parts.push(printedChild);
 
-      const next = n.children[i + 1];
+      const next = children[i + 1];
       const directlyFollowedByMeaningfulText =
         next && isMeaningfulJsxText(next);
       if (directlyFollowedByMeaningfulText) {
         const firstWord = trimJsxWhitespace(rawText(next)).split(
           matchJsxWhitespaceRegex
         )[0];
-        children.push(
+        parts.push(
           separatorNoWhitespace(
             isFacebookTranslationTag,
             firstWord,
@@ -386,12 +384,12 @@ function printJsxChildren(
           )
         );
       } else {
-        children.push(hardline);
+        parts.push(hardline);
       }
     }
   }, "children");
 
-  return children;
+  return parts;
 }
 
 function separatorNoWhitespace(

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -266,11 +266,10 @@ function printPathNoParens(path, options, print, args) {
 
       // Babel 6
       if (n.directives) {
-        const directivesCount = n.directives.length;
-        path.each((childPath, index) => {
+        path.each((childPath, index, directives) => {
           parts.push(print(childPath), hardline);
           if (
-            (index < directivesCount - 1 || hasContents) &&
+            (index < directives.length - 1 || hasContents) &&
             isNextLineEmpty(options.originalText, childPath.getValue(), locEnd)
           ) {
             parts.push(hardline);
@@ -886,11 +885,11 @@ function printPathNoParens(path, options, print, args) {
                 hardline,
                 join(
                   hardline,
-                  path.map((casePath) => {
+                  path.map((casePath, index, cases) => {
                     const caseNode = casePath.getValue();
                     return concat([
                       casePath.call(print),
-                      n.cases.indexOf(caseNode) !== n.cases.length - 1 &&
+                      index !== cases.length - 1 &&
                       isNextLineEmpty(options.originalText, caseNode, locEnd)
                         ? hardline
                         : "",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Similar to [`Array#map()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map#Parameters), send array as third argument, this is useful when need access array in the callback.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
