### PR TITLE
Add JS version `isNextLineEmpty`

### DIFF
--- a/src/language-js/print/array.js
+++ b/src/language-js/print/array.js
@@ -4,9 +4,13 @@ const { printDanglingComments } = require("../../main/comments");
 const {
   builders: { concat, line, softline, group, indent, ifBreak },
 } = require("../../document");
-const { getLast, isNextLineEmpty } = require("../../common/util");
-const { shouldPrintComma, hasComment, CommentCheckFlags } = require("../utils");
-const { locEnd } = require("../loc");
+const { getLast } = require("../../common/util");
+const {
+  shouldPrintComma,
+  hasComment,
+  CommentCheckFlags,
+  isNextLineEmpty,
+} = require("../utils");
 
 const { printOptionalToken, printTypeAnnotation } = require("./misc");
 
@@ -119,7 +123,7 @@ function printArrayItems(path, options, printPath, print) {
     separatorParts = [",", line];
     if (
       childPath.getValue() &&
-      isNextLineEmpty(options.originalText, childPath.getValue(), locEnd)
+      isNextLineEmpty(childPath.getValue(), options)
     ) {
       separatorParts.push(softline);
     }

--- a/src/language-js/print/block.js
+++ b/src/language-js/print/block.js
@@ -1,12 +1,11 @@
 "use strict";
 
 const { printDanglingComments } = require("../../main/comments");
-const { isNextLineEmpty, isNonEmptyArray } = require("../../common/util");
+const { isNonEmptyArray } = require("../../common/util");
 const {
   builders: { concat, hardline, indent },
 } = require("../../document");
-const { hasComment, CommentCheckFlags } = require("../utils");
-const { locEnd } = require("../loc");
+const { hasComment, CommentCheckFlags, isNextLineEmpty } = require("../utils");
 
 const { printBody } = require("./statement");
 
@@ -73,9 +72,7 @@ function printBlockBody(path, options, print) {
       parts.push(print(childPath));
       if (index < lastDirectiveIndex || nodeHasBody || nodeHasComment) {
         parts.push(hardline);
-        if (
-          isNextLineEmpty(options.originalText, childPath.getValue(), locEnd)
-        ) {
+        if (isNextLineEmpty(childPath.getValue(), options)) {
           parts.push(hardline);
         }
       }

--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -1,11 +1,7 @@
 "use strict";
 
 const { printDanglingComments } = require("../../main/comments");
-const {
-  getLast,
-  getPenultimate,
-  isNextLineEmpty,
-} = require("../../common/util");
+const { getLast, getPenultimate } = require("../../common/util");
 const {
   getFunctionParameters,
   iterateFunctionParametersPath,
@@ -17,8 +13,8 @@ const {
   shouldPrintComma,
   getCallArguments,
   iterateCallArgumentsPath,
+  isNextLineEmpty,
 } = require("../utils");
-const { locEnd } = require("../loc");
 
 const {
   builders: {
@@ -103,7 +99,7 @@ function printCallArguments(path, options, print) {
 
     if (index === lastArgIndex) {
       // do nothing
-    } else if (isNextLineEmpty(options.originalText, arg, locEnd)) {
+    } else if (isNextLineEmpty(arg, options)) {
       if (index === 0) {
         hasEmptyLineFollowingFirstArg = true;
       }

--- a/src/language-js/print/function-parameters.js
+++ b/src/language-js/print/function-parameters.js
@@ -1,9 +1,6 @@
 "use strict";
 
-const {
-  getNextNonSpaceNonCommentCharacter,
-  isNextLineEmpty,
-} = require("../../common/util");
+const { getNextNonSpaceNonCommentCharacter } = require("../../common/util");
 const { printDanglingComments } = require("../../main/comments");
 const {
   builders: { concat, line, hardline, softline, group, indent, ifBreak },
@@ -20,6 +17,7 @@ const {
   hasRestParameter,
   shouldPrintComma,
   hasComment,
+  isNextLineEmpty,
 } = require("../utils");
 const { locEnd } = require("../loc");
 const { printFunctionTypeParameters } = require("./misc");
@@ -78,9 +76,7 @@ function printFunctionParameters(
       shouldExpandParameters
     ) {
       printed.push(" ");
-    } else if (
-      isNextLineEmpty(options.originalText, parameters[index], locEnd)
-    ) {
+    } else if (isNextLineEmpty(parameters[index], options)) {
       printed.push(hardline, hardline);
     } else {
       printed.push(line);

--- a/src/language-js/print/member-chain.js
+++ b/src/language-js/print/member-chain.js
@@ -5,7 +5,6 @@ const flat = require("lodash/flatten");
 const { printComments } = require("../../main/comments");
 const {
   getLast,
-  isNextLineEmpty,
   isNextLineEmptyAfterIndex,
   getNextNonSpaceNonCommentCharacterIndex,
 } = require("../../common/util");
@@ -19,6 +18,7 @@ const {
   isSimpleCallArgument,
   hasComment,
   CommentCheckFlags,
+  isNextLineEmpty,
 } = require("../utils");
 const { locEnd } = require("../loc");
 
@@ -87,7 +87,7 @@ function printMemberChain(path, options, print) {
       );
     }
 
-    return isNextLineEmpty(originalText, node, locEnd);
+    return isNextLineEmpty(node, options);
   }
 
   function rec(path) {

--- a/src/language-js/print/object.js
+++ b/src/language-js/print/object.js
@@ -4,17 +4,13 @@ const { printDanglingComments } = require("../../main/comments");
 const {
   builders: { concat, line, softline, group, indent, ifBreak, hardline },
 } = require("../../document");
-const {
-  getLast,
-  isNextLineEmpty,
-  hasNewlineInRange,
-  hasNewline,
-} = require("../../common/util");
+const { getLast, hasNewlineInRange, hasNewline } = require("../../common/util");
 const {
   shouldPrintComma,
   hasComment,
   getComments,
   CommentCheckFlags,
+  isNextLineEmpty,
 } = require("../utils");
 const { locStart, locEnd } = require("../loc");
 
@@ -120,7 +116,7 @@ function printObject(path, options, print) {
       ) {
         separatorParts.shift();
       }
-      if (isNextLineEmpty(options.originalText, prop.node, locEnd)) {
+      if (isNextLineEmpty(prop.node, options)) {
         separatorParts.push(hardline);
       }
       return result;

--- a/src/language-js/print/statement.js
+++ b/src/language-js/print/statement.js
@@ -39,7 +39,6 @@ function printStatement({ path, index, bodyNode, isClass }, options, print) {
   }
 
   const printed = print(path);
-  const text = options.originalText;
   const parts = [];
 
   // in no-semi mode, prepend statement with semicolon if it might break ASI

--- a/src/language-js/print/statement.js
+++ b/src/language-js/print/statement.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const { isNextLineEmpty } = require("../../common/util");
 const {
   builders: { concat, join, hardline },
 } = require("../../document");
@@ -14,8 +13,8 @@ const {
   isTheOnlyJsxElementInMarkdown,
   hasComment,
   CommentCheckFlags,
+  isNextLineEmpty,
 } = require("../utils");
-const { locEnd } = require("../loc");
 const { shouldPrintParamsWithoutParens } = require("./function");
 
 /**
@@ -74,7 +73,7 @@ function printStatement({ path, index, bodyNode, isClass }, options, print) {
     }
   }
 
-  if (isNextLineEmpty(text, node, locEnd) && !isLastStatement(path)) {
+  if (isNextLineEmpty(node, options) && !isLastStatement(path)) {
     parts.push(hardline);
   }
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -11,7 +11,6 @@ const {
   hasNewline,
   printString,
   printNumber,
-  isNextLineEmpty,
   isNonEmptyArray,
 } = require("../common/util");
 const {
@@ -47,6 +46,7 @@ const {
   isTheOnlyJsxElementInMarkdown,
   isBlockComment,
   isLineComment,
+  isNextLineEmpty,
   needsHardlineAfterDanglingComment,
   rawText,
   shouldPrintComma,
@@ -859,7 +859,7 @@ function printPathNoParens(path, options, print, args) {
                     return concat([
                       casePath.call(print),
                       n.cases.indexOf(caseNode) !== n.cases.length - 1 &&
-                      isNextLineEmpty(options.originalText, caseNode, locEnd)
+                      isNextLineEmpty(caseNode, options)
                         ? hardline
                         : "",
                     ]);
@@ -1186,7 +1186,7 @@ function printPathNoParens(path, options, print, args) {
     case "InterpreterDirective":
       parts.push("#!", n.value, hardline);
 
-      if (isNextLineEmpty(options.originalText, n, locEnd)) {
+      if (isNextLineEmpty(n, options)) {
         parts.push(hardline);
       }
 

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -7,6 +7,7 @@ const {
   hasNewlineInRange,
   skipWhitespace,
   isNonEmptyArray,
+  isNextLineEmptyAfterIndex,
 } = require("../common/util");
 const { locStart, locEnd, hasSameLocStart } = require("./loc");
 
@@ -1500,6 +1501,13 @@ function getComments(node, flags, fn) {
     : node.comments;
 }
 
+/**
+ * @param {Node} node
+ * @returns {boolean}
+ */
+const isNextLineEmpty = (node, { originalText }) =>
+  isNextLineEmptyAfterIndex(originalText, locEnd(node));
+
 module.exports = {
   classChildNeedsASIProtection,
   classPropMayCauseASIProblems,
@@ -1554,6 +1562,7 @@ module.exports = {
   isTheOnlyJsxElementInMarkdown,
   isTSXFile,
   isTypeAnnotationAFunction,
+  isNextLineEmpty,
   matchJsxWhitespaceRegex,
   needsHardlineAfterDanglingComment,
   rawText,


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Simplify use of `isNextLineEmpty`

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
