### PR TITLE
Refactor: Move `jsx` related function to `jsx.js`

### DIFF
--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -33,6 +33,12 @@ const {
 const pathNeedsParens = require("../needs-parens");
 const { willPrintOwnComments } = require("../comments");
 
+/**
+ * @typedef {import("../../common/fast-path")} FastPath
+ * @typedef {import("../types/estree").Node} Node
+ * @typedef {import("../types/estree").JSXElement} JSXElement
+ */
+
 // JSX expands children from the inside-out, instead of the outside-in.
 // This is both to break children before attributes,
 // and to ensure that when children break, their parents do as well.

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -38,7 +38,6 @@ const {
   getParentExportDeclaration,
   hasFlowShorthandAnnotationComment,
   hasNewlineBetweenOrAfterDecorators,
-  hasPrettierIgnore,
   hasComment,
   CommentCheckFlags,
   isExportDeclaration,
@@ -50,6 +49,7 @@ const {
   needsHardlineAfterDanglingComment,
   rawText,
   shouldPrintComma,
+  hasIgnoreComment,
 } = require("./utils");
 const { locStart, locEnd } = require("./loc");
 
@@ -58,7 +58,7 @@ const {
   isVueEventBindingExpression,
 } = require("./print/html-binding");
 const { printAngular } = require("./print/angular");
-const { printJsx } = require("./print/jsx");
+const { printJsx, hasJsxIgnoreComment } = require("./print/jsx");
 const { printFlow } = require("./print/flow");
 const { printTypescript } = require("./print/typescript");
 const {
@@ -1241,7 +1241,9 @@ module.exports = {
   embed,
   insertPragma,
   massageAstNode: clean,
-  hasPrettierIgnore,
+  hasPrettierIgnore(path) {
+    return hasIgnoreComment(path) || hasJsxIgnoreComment(path);
+  },
   willPrintOwnComments: handleComments.willPrintOwnComments,
   canAttachComment,
   printComment,

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -21,7 +21,6 @@ const { locStart, locEnd, hasSameLocStart } = require("./loc");
  * @typedef {import("./types/estree").Expression} Expression
  * @typedef {import("./types/estree").Property} Property
  * @typedef {import("./types/estree").ObjectTypeProperty} ObjectTypeProperty
- * @typedef {import("./types/estree").JSXElement} JSXElement
  * @typedef {import("./types/estree").TaggedTemplateExpression} TaggedTemplateExpression
  * @typedef {import("./types/estree").Literal} Literal
  *

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -339,16 +339,6 @@ function isTheOnlyJsxElementInMarkdown(options, path) {
   return parent.type === "Program" && parent.body.length === 1;
 }
 
-// Detect an expression node representing `{" "}`
-function isJsxWhitespaceExpression(node) {
-  return (
-    node.type === "JSXExpressionContainer" &&
-    isLiteral(node.expression) &&
-    node.expression.value === " " &&
-    !hasComment(node.expression)
-  );
-}
-
 /**
  * @param {Node} node
  * @returns {boolean}
@@ -729,96 +719,6 @@ function hasNewlineBetweenOrAfterDecorators(node, options) {
       locEnd(getLast(node.decorators))
     ) || hasNewline(options.originalText, locEnd(getLast(node.decorators)))
   );
-}
-
-// Only space, newline, carriage return, and tab are treated as whitespace
-// inside JSX.
-const jsxWhitespaceChars = " \n\r\t";
-const matchJsxWhitespaceRegex = new RegExp("([" + jsxWhitespaceChars + "]+)");
-const containsNonJsxWhitespaceRegex = new RegExp(
-  "[^" + jsxWhitespaceChars + "]"
-);
-const trimJsxWhitespace = (text) =>
-  text.replace(
-    new RegExp(
-      "(?:^" +
-        matchJsxWhitespaceRegex.source +
-        "|" +
-        matchJsxWhitespaceRegex.source +
-        "$)"
-    ),
-    ""
-  );
-
-// Meaningful if it contains non-whitespace characters,
-// or it contains whitespace without a new line.
-/**
- * @param {Node} node
- * @returns {boolean}
- */
-function isMeaningfulJsxText(node) {
-  return (
-    isLiteral(node) &&
-    (containsNonJsxWhitespaceRegex.test(rawText(node)) ||
-      !/\n/.test(rawText(node)))
-  );
-}
-
-/**
- * @param {FastPath} path
- * @returns {boolean}
- */
-function hasJsxIgnoreComment(path) {
-  const node = path.getValue();
-  const parent = path.getParentNode();
-  if (!parent || !node || !isJsxNode(node) || !isJsxNode(parent)) {
-    return false;
-  }
-
-  // Lookup the previous sibling, ignoring any empty JSXText elements
-  const index = parent.children.indexOf(node);
-  let prevSibling = null;
-  for (let i = index; i > 0; i--) {
-    const candidate = parent.children[i - 1];
-    if (candidate.type === "JSXText" && !isMeaningfulJsxText(candidate)) {
-      continue;
-    }
-    prevSibling = candidate;
-    break;
-  }
-
-  return (
-    prevSibling &&
-    prevSibling.type === "JSXExpressionContainer" &&
-    prevSibling.expression.type === "JSXEmptyExpression" &&
-    hasNodeIgnoreComment(prevSibling.expression)
-  );
-}
-
-/**
- * @param {JSXElement} node
- * @returns {boolean}
- */
-function isEmptyJsxElement(node) {
-  if (node.children.length === 0) {
-    return true;
-  }
-  if (node.children.length > 1) {
-    return false;
-  }
-
-  // if there is one text child and does not contain any meaningful text
-  // we can treat the element as empty.
-  const child = node.children[0];
-  return isLiteral(child) && !isMeaningfulJsxText(child);
-}
-
-/**
- * @param {FastPath} path
- * @returns {boolean}
- */
-function hasPrettierIgnore(path) {
-  return hasIgnoreComment(path) || hasJsxIgnoreComment(path);
 }
 
 /**
@@ -1517,15 +1417,14 @@ module.exports = {
   hasNakedLeftSide,
   hasNewlineBetweenOrAfterDecorators,
   hasNode,
-  hasPrettierIgnore,
   hasIgnoreComment,
+  hasNodeIgnoreComment,
   identity,
   isBinaryish,
   isBlockComment,
   isLineComment,
   isPrettierIgnoreComment,
   isCallOrOptionalCallExpression,
-  isEmptyJsxElement,
   isExportDeclaration,
   isFlowAnnotationComment,
   isFunctionCompositionArgs,
@@ -1534,11 +1433,9 @@ module.exports = {
   isGetterOrSetter,
   isJestEachTemplateLiteral,
   isJsxNode,
-  isJsxWhitespaceExpression,
   isLiteral,
   isLongCurriedCallExpression,
   isSimpleCallArgument,
-  isMeaningfulJsxText,
   isMemberExpressionChain,
   isMemberish,
   isNumericLiteral,
@@ -1554,7 +1451,6 @@ module.exports = {
   isTheOnlyJsxElementInMarkdown,
   isTSXFile,
   isTypeAnnotationAFunction,
-  matchJsxWhitespaceRegex,
   needsHardlineAfterDanglingComment,
   rawText,
   returnArgumentHasLeadingComment,
@@ -1566,5 +1462,4 @@ module.exports = {
   hasComment,
   getComments,
   CommentCheckFlags,
-  trimJsxWhitespace,
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
