### PR TITLE
Html: Enable jsxBracketSameLine option for html (fixes #5377)

### DIFF
--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -40,6 +40,7 @@ const {
   isVueSfcBindingsAttribute,
   isScriptLikeTag,
   isTextLikeNode,
+  isWhitespaceSensitiveNode,
   preferHardlineAsLeadingSpaces,
   shouldNotPrintClosingTag,
   shouldPreserveContent,
@@ -728,7 +729,13 @@ function printAttributes(path, options, print) {
   ) {
     parts.push(node.isSelfClosing ? " " : "");
   } else {
-    parts.push(node.isSelfClosing ? line : softline);
+    const sensitiveEnd = node.isSelfClosing ? line : softline;
+    const insensitiveEnd = node.isSelfClosing ? " " : "";
+    parts.push(
+      options.jsxBracketSameLine && !isWhitespaceSensitiveNode(node)
+        ? insensitiveEnd
+        : sensitiveEnd
+    );
   }
 
   return concat(parts);

--- a/tests/html/last_line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/html/last_line/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,76 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`last_line.html - {"jsxBracketSameLine":false} format 1`] = `
+====================================options=====================================
+jsxBracketSameLine: false
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<article
+  id="electriccars"
+  data-columns="3"
+  data-index-number="12314"
+  data-parent="cars">...</article>
+<span
+id="electriccars"
+  data-columns="3"
+  data-index-number="12314"
+  data-parent="cars">...</span>
+
+=====================================output=====================================
+<article
+  id="electriccars"
+  data-columns="3"
+  data-index-number="12314"
+  data-parent="cars"
+>
+  ...
+</article>
+<span
+  id="electriccars"
+  data-columns="3"
+  data-index-number="12314"
+  data-parent="cars"
+  >...</span
+>
+
+================================================================================
+`;
+
+exports[`last_line.html - {"jsxBracketSameLine":true} format 1`] = `
+====================================options=====================================
+jsxBracketSameLine: true
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<article
+  id="electriccars"
+  data-columns="3"
+  data-index-number="12314"
+  data-parent="cars">...</article>
+<span
+id="electriccars"
+  data-columns="3"
+  data-index-number="12314"
+  data-parent="cars">...</span>
+
+=====================================output=====================================
+<article
+  id="electriccars"
+  data-columns="3"
+  data-index-number="12314"
+  data-parent="cars">
+  ...
+</article>
+<span
+  id="electriccars"
+  data-columns="3"
+  data-index-number="12314"
+  data-parent="cars"
+  >...</span
+>
+
+================================================================================
+`;

--- a/tests/html/last_line/jsfmt.spec.js
+++ b/tests/html/last_line/jsfmt.spec.js
@@ -1,0 +1,2 @@
+run_spec(__dirname, ["html"], { jsxBracketSameLine: true });
+run_spec(__dirname, ["html"], { jsxBracketSameLine: false });

--- a/tests/html/last_line/last_line.html
+++ b/tests/html/last_line/last_line.html
@@ -1,0 +1,10 @@
+<article
+  id="electriccars"
+  data-columns="3"
+  data-index-number="12314"
+  data-parent="cars">...</article>
+<span
+id="electriccars"
+  data-columns="3"
+  data-index-number="12314"
+  data-parent="cars">...</span>


### PR DESCRIPTION
## Description
This is an incomplete first pass at fixing #5377.

Essentially, it makes the `jsxBracketSameLine` option also apply in html files. Separately, this option should be renamed to reflect the new functionality; I suggest that `angleBracketSameLine` is a sensible name.

As you can see in the tests, when `jsxBracketSameLine` is set, this will convert:
```html
<article
  id="electriccars"
  data-columns="3"
  data-index-number="12314"
  data-parent="cars">...</article>
<span
id="electriccars"
  data-columns="3"
  data-index-number="12314"
  data-parent="cars">...</span>
```
to 
```html
<article
  id="electriccars"
  data-columns="3"
  data-index-number="12314"
  data-parent="cars">
  ...
</article>
<span
  id="electriccars"
  data-columns="3"
  data-index-number="12314"
  data-parent="cars"
  >...</span
>
```
Without that setting, this would look like:
```html
<article
  id="electriccars"
  data-columns="3"
  data-index-number="12314"
  data-parent="cars"
>
  ...
</article>
<span
  id="electriccars"
  data-columns="3"
  data-index-number="12314"
  data-parent="cars"
  >...</span
>
```

Note that because of the whitespace sensitivity of a `span`, the span is formatted the same way for each option.
Also note that nothing is done with the final `>` in the closing `span` tag. This isn't something that comes up with jsx, as I understand it, because of how jsx handles whitespace. I'm not sure what the desirable behavior should be here, but if the setting is called `angleBracketSameLine`, perhaps that should be brought up to the previous line as well. But I'm not sure how to accomplish that, if that is the desired behavior.

Thanks to @adamJLev for pointing me in the right direction regarding this fix.

While I have added a test for the above cases, I have no idea what additional test might be desirable. I'm happy to work with someone from the Prettier team if more tests are needed.

I also haven't touched the docs yet. I assume that would come with a change to the name of the new option, or possibly renaming the old option to reflect both options, but that seems like a much larger job.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
