### PR TITLE
Add upload config file button to playground

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -2,7 +2,7 @@
   "license": "MIT",
   "scripts": {
     "build": "webpack && docusaurus-build",
-    "start": "concurrently \"docusaurus-start\" \"webpack -d -w\"",
+    "start": "concurrently \"docusaurus-start\" \"webpack -d eval-cheap-module-source-map -w\"",
     "svgo": "svgo --pretty --indent=2 --config=svgo.yml",
     "svgo-all": "find static | grep '\\.svg$' | xargs -Iz -n 1 yarn svgo z",
     "update-stable-docs": "rm -rf ./versioned_docs ./versions.json && docusaurus-version stable"

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -1,6 +1,6 @@
 import * as React from "react";
 
-import { Button, ClipboardButton } from "./buttons";
+import { Button, ClipboardButton, FileButton } from "./buttons";
 import EditorState from "./EditorState";
 import { DebugPanel, InputPanel, OutputPanel } from "./panels";
 import PrettierFormat from "./PrettierFormat";
@@ -9,6 +9,7 @@ import * as urlHash from "./urlHash";
 import formatMarkdown from "./markdown";
 import * as util from "./util";
 import getCodeSample from "./codeSamples";
+import { parseConfig } from "./parseConfig";
 
 import { Sidebar, SidebarCategory } from "./sidebar/components";
 import SidebarOptions from "./sidebar/SidebarOptions";
@@ -76,6 +77,15 @@ class Playground extends React.Component {
     this.setContent = (content) => this.setState({ content });
     this.clearContent = this.setContent.bind(this, "");
     this.resetOptions = () => this.setState({ options: defaultOptions });
+    this.setOptionsFromFile = (file) => {
+      const opts = parseConfig(file);
+      this.setState((state) => ({
+        options: {
+          ...state.options,
+          ...opts,
+        },
+      }));
+    };
     this.setSelection = (selection) => this.setState({ selection });
     this.setSelectionAsRange = () => {
       const { selection, content, options } = this.state;
@@ -233,6 +243,9 @@ class Playground extends React.Component {
                         <Button onClick={this.resetOptions}>
                           Reset to defaults
                         </Button>
+                        <FileButton onFile={this.setOptionsFromFile}>
+                          Upload config file
+                        </FileButton>
                       </div>
                     </Sidebar>
                     <div className="editors">

--- a/website/playground/buttons.js
+++ b/website/playground/buttons.js
@@ -48,3 +48,51 @@ export class ClipboardButton extends React.Component {
     );
   }
 }
+
+export function FileButton({ children, accept, onFile, ...rest }) {
+  const inputRef = React.useRef();
+
+  function handleClick() {
+    inputRef.current.click();
+  }
+
+  function handleChange(e) {
+    readFile(e.target.files[0])
+      .then(onFile)
+      .catch((err) => {
+        alert(err.message);
+      })
+      .then(() => {
+        // clear the value so the same file may be uploaded again
+        inputRef.current.value = "";
+      });
+  }
+
+  return (
+    <>
+      <Button onClick={handleClick} {...rest}>
+        {children}
+      </Button>
+      <input
+        ref={inputRef}
+        onChange={handleChange}
+        hidden
+        type="file"
+        accept={accept}
+      />
+    </>
+  );
+}
+
+function readFile(file) {
+  const reader = new FileReader();
+  return new Promise((resolve, reject) => {
+    reader.addEventListener("load", (e) => {
+      resolve(e.target.result);
+    });
+    reader.addEventListener("error", (e) => {
+      reject(e);
+    });
+    reader.readAsText(file);
+  });
+}

--- a/website/playground/parseConfig.js
+++ b/website/playground/parseConfig.js
@@ -1,0 +1,3 @@
+export function parseConfig(file) {
+  return JSON.parse(file);
+}

--- a/website/static/separate-css/playground.css
+++ b/website/static/separate-css/playground.css
@@ -224,6 +224,10 @@ header h1 {
   margin-left: 10px;
 }
 
+.sub-options > .btn + .btn {
+  margin-top: 10px;
+}
+
 label {
   font-family: Consolas, Courier New, Courier, monospace;
   margin: 10px 0;


### PR DESCRIPTION
fixes #6142

## Description

<!-- Please provide a brief summary of your changes: -->

Adds an "Upload config file" button at the bottom of the options panel, under "Reset to defaults".

Right now it only handles a json config file, but prettier supports [a bunch of things](https://prettier.io/docs/en/configuration.html) that should probably also be supported. I dunno if you'd want to bring in all these parsers to the docsite (yaml, json5, toml...)

I can also see making the whole options panel a drag/drop zone for config files, but that could come as a separate PR.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
