### PR TITLE
handlebars: Print final blockParam on its own line

### DIFF
--- a/changelog_unreleased/handlebars/9978.md
+++ b/changelog_unreleased/handlebars/9978.md
@@ -1,4 +1,4 @@
-#### handlebars: Print final blockParam on its own line (#9978 by @dcyriller)
+#### Print final blockParam on its own line (#9978 by @dcyriller)
 
 <!-- prettier-ignore -->
 ```hbs

--- a/changelog_unreleased/handlebars/9978.md
+++ b/changelog_unreleased/handlebars/9978.md
@@ -1,0 +1,43 @@
+#### handlebars: Print final blockParam on its own line (#9978 by @dcyriller)
+
+<!-- prettier-ignore -->
+```hbs
+<MyComponent @prop={{true}} @prop2={{true}} @prop3={{true}} @prop4={{true}} as |thing|></MyComponent>
+{{#block param hashKey=hashValue hashKey=hashValue hashKey=hashValue as |blockParam|}}
+  Hello
+{{/block}}
+
+{{!-- Prettier stable --}}
+<MyComponent
+  @prop={{true}}
+  @prop2={{true}}
+  @prop3={{true}}
+  @prop4={{true}} as |thing|
+/>
+{{#block
+  param
+  hashKey=hashValue
+  hashKey=hashValue
+  hashKey=hashValue as |blockParam|
+}}
+  Hello
+{{/block}}
+
+{{!-- Prettier master --}}
+<MyComponent
+  @prop={{true}}
+  @prop2={{true}}
+  @prop3={{true}}
+  @prop4={{true}}
+  as |thing|
+/>
+{{#block
+  param
+  hashKey=hashValue
+  hashKey=hashValue
+  hashKey=hashValue
+  as |blockParam|
+}}
+  Hello
+{{/block}}
+```

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -321,17 +321,17 @@ function printStartingTag(path, print) {
   const node = path.getValue();
 
   const attributesLike = [];
-  if (node.attributes.length > 0) {
+  if (isNonEmptyArray(node.attributes)) {
     const attributes = join(line, path.map(print, "attributes"));
     attributesLike.push(line, attributes);
   }
 
-  if (node.modifiers.length > 0) {
+  if (isNonEmptyArray(node.modifiers)) {
     const modifiers = join(line, path.map(print, "modifiers"));
     attributesLike.push(line, modifiers);
   }
 
-  if (node.comments.length > 0) {
+  if (isNonEmptyArray(node.comments.length)) {
     const comments = join(line, path.map(print, "comments"));
     attributesLike.push(line, comments);
   }

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -196,7 +196,6 @@ function print(path, options, print) {
       const inAttrNode = path.stack.includes("attributes");
       if (inAttrNode) {
         // TODO: format style and srcset attributes
-        // and cleanup concat that is not necessary
         if (!isInAttributeOfName(path, "class")) {
           return n.chars;
         }

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -320,31 +320,33 @@ function print(path, options, print) {
 function printStartingTag(path, print) {
   const node = path.getValue();
 
-  const attributes = indent(
-    concat([
-      node.attributes.length ? line : "",
-      join(line, path.map(print, "attributes")),
-
-      node.modifiers.length ? line : "",
-      join(line, path.map(print, "modifiers")),
-
-      node.comments.length ? line : "",
-      join(line, path.map(print, "comments")),
-    ])
-  );
-  const startingTagEndMarker = printStartingTagEndMarker(node);
-
-  if (isNonEmptyArray(node.blockParams)) {
-    return [
-      "<",
-      node.tag,
-      attributes,
-      printBlockParams(node),
-      startingTagEndMarker,
-    ];
+  const attributesLike = [];
+  if (node.attributes.length > 0) {
+    const attributes = join(line, path.map(print, "attributes"));
+    attributesLike.push(line, attributes);
   }
 
-  return ["<", node.tag, attributes, startingTagEndMarker];
+  if (node.modifiers.length > 0) {
+    const modifiers = join(line, path.map(print, "modifiers"));
+    attributesLike.push(line, modifiers);
+  }
+
+  if (node.comments.length > 0) {
+    const comments = join(line, path.map(print, "comments"));
+    attributesLike.push(line, comments);
+  }
+
+  if (isNonEmptyArray(node.blockParams)) {
+    const blockParams = printBlockParams(node);
+    attributesLike.push(blockParams);
+  }
+
+  return [
+    "<",
+    node.tag,
+    indent(attributesLike),
+    printStartingTagEndMarker(node),
+  ];
 }
 
 function printChildren(path, options, print) {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -338,7 +338,7 @@ function printStartingTag(path, print) {
 
   if (isNonEmptyArray(node.blockParams)) {
     const blockParams = printBlockParams(node);
-    attributesLike.push(blockParams);
+    attributesLike.push(line, blockParams);
   }
 
   return [
@@ -423,20 +423,27 @@ function printOpenBlock(path, print) {
   const node = path.getValue();
 
   const openingMustache = printOpeningBlockOpeningMustache(node);
-  const pathAndParam = printPathAndParams(path, print);
   const closingMustache = printOpeningBlockClosingMustache(node);
 
-  if (isNonEmptyArray(node.program.blockParams)) {
-    return group([
-      openingMustache,
-      pathAndParam,
-      printBlockParams(node.program),
-      softline,
-      closingMustache,
-    ]);
+  const p = printPath(path, print);
+  const pathAndParam = [p];
+
+  const params = printParams(path, print);
+  if (params) {
+    pathAndParam.push(line, params);
   }
 
-  return group([openingMustache, pathAndParam, softline, closingMustache]);
+  if (isNonEmptyArray(node.program.blockParams)) {
+    const block = printBlockParams(node.program);
+    pathAndParam.push(line, block);
+  }
+
+  return group([
+    openingMustache,
+    indent(group(pathAndParam)),
+    softline,
+    closingMustache,
+  ]);
 }
 
 function printElseBlock(node) {
@@ -649,7 +656,7 @@ function printParams(path, print) {
 }
 
 function printBlockParams(node) {
-  return [" as |", node.blockParams.join(" "), "|"];
+  return ["as |", node.blockParams.join(" "), "|"];
 }
 
 function doesNotHaveHashParams(node) {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -331,7 +331,7 @@ function printStartingTag(path, print) {
     attributesLike.push(line, modifiers);
   }
 
-  if (isNonEmptyArray(node.comments.length)) {
+  if (isNonEmptyArray(node.comments)) {
     const comments = join(line, path.map(print, "comments"));
     attributesLike.push(line, comments);
   }
@@ -425,22 +425,21 @@ function printOpenBlock(path, print) {
   const openingMustache = printOpeningBlockOpeningMustache(node);
   const closingMustache = printOpeningBlockClosingMustache(node);
 
-  const p = printPath(path, print);
-  const pathAndParam = [p];
+  const attributes = [printPath(path, print)];
 
   const params = printParams(path, print);
   if (params) {
-    pathAndParam.push(line, params);
+    attributes.push(line, params);
   }
 
   if (isNonEmptyArray(node.program.blockParams)) {
     const block = printBlockParams(node.program);
-    pathAndParam.push(line, block);
+    attributes.push(line, block);
   }
 
   return group([
     openingMustache,
-    indent(group(pathAndParam)),
+    indent(group(attributes)),
     softline,
     closingMustache,
   ]);

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -320,7 +320,18 @@ function print(path, options, print) {
 function printStartingTag(path, print) {
   const node = path.getValue();
 
-  const attributes = printAttributesLike(path, print);
+  const attributes = indent(
+    concat([
+      node.attributes.length ? line : "",
+      join(line, path.map(print, "attributes")),
+
+      node.modifiers.length ? line : "",
+      join(line, path.map(print, "modifiers")),
+
+      node.comments.length ? line : "",
+      join(line, path.map(print, "comments")),
+    ])
+  );
   const startingTagEndMarker = printStartingTagEndMarker(node);
 
   if (isNonEmptyArray(node.blockParams)) {
@@ -334,21 +345,6 @@ function printStartingTag(path, print) {
   }
 
   return ["<", node.tag, attributes, startingTagEndMarker];
-}
-
-function printAttributesLike(path, print) {
-  const node = path.getValue();
-
-  return indent([
-    node.attributes.length > 0 ? line : "",
-    join(line, path.map(print, "attributes")),
-
-    node.modifiers.length > 0 ? line : "",
-    join(line, path.map(print, "modifiers")),
-
-    node.comments.length > 0 ? line : "",
-    join(line, path.map(print, "comments")),
-  ]);
 }
 
 function printChildren(path, options, print) {

--- a/tests/handlebars/block-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/block-statement/__snapshots__/jsfmt.spec.js.snap
@@ -78,7 +78,8 @@ printWidth: 80
   param
   param
   param
-  hashKey=hashValue as |blockParam|
+  hashKey=hashValue
+  as |blockParam|
 }}
   Hello
 {{/block}}

--- a/tests/handlebars/element-node/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/element-node/__snapshots__/jsfmt.spec.js.snap
@@ -43,6 +43,8 @@ printWidth: 80
 <div></div>
 <img />
 
+<MyComponent @prop={{true}} @prop2={{true}} @prop3={{true}} @prop4={{true}} as |thing|></MyComponent>
+
 =====================================output=====================================
 <div class="attribute" {{modifier}} {{! comment}}>
   Hello
@@ -80,5 +82,13 @@ printWidth: 80
 
 <div></div>
 <img />
+
+<MyComponent
+  @prop={{true}}
+  @prop2={{true}}
+  @prop3={{true}}
+  @prop4={{true}}
+  as |thing|
+/>
 ================================================================================
 `;

--- a/tests/handlebars/element-node/element-node.hbs
+++ b/tests/handlebars/element-node/element-node.hbs
@@ -34,3 +34,5 @@
 
 <div></div>
 <img />
+
+<MyComponent @prop={{true}} @prop2={{true}} @prop3={{true}} @prop4={{true}} as |thing|></MyComponent>


### PR DESCRIPTION
## Description

This PR implements the change proposed in https://github.com/prettier/prettier/issues/8502.

Given these options:
```
--parser glimmer
--print-width 40
```

**Input:**
```hbs
<MyComponent @prop={{true}} @prop2={{true}} as |thing|></MyComponent>
```

**Current Output:**
```hbs
<MyComponent
  @prop={{true}}
  @prop2={{true}} as |thing|
/>
```

**Proposal:**
```hbs
<MyComponent
  @prop={{true}}
  @prop2={{true}}
  as |thing|
/>
```

cc @pzuraq

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
