### PR TITLE
Rename jsxBracketSameLine to AngleBracketSameLine

### DIFF
--- a/src/common/common-options.js
+++ b/src/common/common-options.js
@@ -46,4 +46,11 @@ module.exports = {
       },
     ],
   },
+  angleBracketSameLine: {
+    since: "2.3.0",
+    category: CATEGORY_COMMON,
+    type: "boolean",
+    default: false,
+    description: "Put > on the last line instead of at a new line.",
+  },
 };

--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -27,12 +27,14 @@ module.exports = {
     ],
   },
   bracketSpacing: commonOptions.bracketSpacing,
+  angleBracketSameLine: commonOptions.angleBracketSameLine,
   jsxBracketSameLine: {
     since: "0.17.0",
     category: CATEGORY_JAVASCRIPT,
     type: "boolean",
     default: false,
-    description: "Put > on the last line instead of at a new line.",
+    description:
+      "Put > on the last line instead of at a new line. (Deprecated. Use angleBracketSameLine.)",
   },
   semi: {
     since: "1.0.0",

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -595,9 +595,9 @@ function printJsxOpeningElement(path, options, print) {
 
   const bracketSameLine =
     // Simple tags (no attributes and no comment in tag name) should be
-    // kept unbroken regardless of `jsxBracketSameLine`
+    // kept unbroken regardless of `angleBracketSameLine`
     (!n.attributes.length && !nameHasComments) ||
-    (options.jsxBracketSameLine &&
+    ((options.jsxBracketSameLine || options.angleBracketSameLine) &&
       // We should print the bracket in a new line for the following cases:
       // <div
       //   // comment

--- a/tests/jsx/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`eslint-disable.js - {"jsxBracketSameLine":true} format 1`] = `
+exports[`eslint-disable.js - {"angleBracketSameLine":true} format 1`] = `
 ====================================options=====================================
-jsxBracketSameLine: true
+angleBracketSameLine: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -27,7 +27,7 @@ const render = (items) => (
 ================================================================================
 `;
 
-exports[`in-end-tag.js - {"jsxBracketSameLine":true} [typescript] format 1`] = `
+exports[`in-end-tag.js - {"angleBracketSameLine":true} [typescript] format 1`] = `
 "Identifier expected. (2:6)
   1 | /* =========== before slash =========== */
 > 2 | <a><// line
@@ -37,9 +37,9 @@ exports[`in-end-tag.js - {"jsxBracketSameLine":true} [typescript] format 1`] = `
   5 | /a>;"
 `;
 
-exports[`in-end-tag.js - {"jsxBracketSameLine":true} format 1`] = `
+exports[`in-end-tag.js - {"angleBracketSameLine":true} format 1`] = `
 ====================================options=====================================
-jsxBracketSameLine: true
+angleBracketSameLine: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -155,9 +155,9 @@ a>;
 ================================================================================
 `;
 
-exports[`in-tags.js - {"jsxBracketSameLine":true} format 1`] = `
+exports[`in-tags.js - {"angleBracketSameLine":true} format 1`] = `
 ====================================options=====================================
-jsxBracketSameLine: true
+angleBracketSameLine: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -223,9 +223,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`jsx-tag-comment-after-prop.js - {"jsxBracketSameLine":true} format 1`] = `
+exports[`jsx-tag-comment-after-prop.js - {"angleBracketSameLine":true} format 1`] = `
 ====================================options=====================================
-jsxBracketSameLine: true
+angleBracketSameLine: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -259,9 +259,9 @@ const pure = () => {
 ================================================================================
 `;
 
-exports[`like-a-comment-in-jsx-text.js - {"jsxBracketSameLine":true} format 1`] = `
+exports[`like-a-comment-in-jsx-text.js - {"angleBracketSameLine":true} format 1`] = `
 ====================================options=====================================
-jsxBracketSameLine: true
+angleBracketSameLine: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/jsx/comments/jsfmt.spec.js
+++ b/tests/jsx/comments/jsfmt.spec.js
@@ -1,5 +1,5 @@
 run_spec(__dirname, ["flow", "babel", "typescript"], {
-  jsxBracketSameLine: true,
+  angleBracketSameLine: true,
   errors: {
     typescript: ["in-end-tag.js"],
   },

--- a/tests/jsx/last-line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/jsx/last-line/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,70 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`last_line.js - {"angleBracketSameLine":false} format 1`] = `
+====================================options=====================================
+angleBracketSameLine: false
+parsers: ["flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<SomeHighlyConfiguredComponent
+  onEnter={this.onEnter}
+  onLeave={this.onLeave}
+  onChange={this.onChange}
+  initialValue={this.state.initialValue}
+  ignoreStuff={true}
+>
+  <div>and the children go here</div>
+  <div>and here too</div>
+</SomeHighlyConfiguredComponent>
+
+=====================================output=====================================
+<SomeHighlyConfiguredComponent
+  onEnter={this.onEnter}
+  onLeave={this.onLeave}
+  onChange={this.onChange}
+  initialValue={this.state.initialValue}
+  ignoreStuff={true}
+>
+  <div>and the children go here</div>
+  <div>and here too</div>
+</SomeHighlyConfiguredComponent>;
+
+================================================================================
+`;
+
+exports[`last_line.js - {"angleBracketSameLine":true} format 1`] = `
+====================================options=====================================
+angleBracketSameLine: true
+parsers: ["flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<SomeHighlyConfiguredComponent
+  onEnter={this.onEnter}
+  onLeave={this.onLeave}
+  onChange={this.onChange}
+  initialValue={this.state.initialValue}
+  ignoreStuff={true}
+>
+  <div>and the children go here</div>
+  <div>and here too</div>
+</SomeHighlyConfiguredComponent>
+
+=====================================output=====================================
+<SomeHighlyConfiguredComponent
+  onEnter={this.onEnter}
+  onLeave={this.onLeave}
+  onChange={this.onChange}
+  initialValue={this.state.initialValue}
+  ignoreStuff={true}>
+  <div>and the children go here</div>
+  <div>and here too</div>
+</SomeHighlyConfiguredComponent>;
+
+================================================================================
+`;
+
 exports[`last_line.js - {"jsxBracketSameLine":false} format 1`] = `
 ====================================options=====================================
 jsxBracketSameLine: false
@@ -61,6 +126,67 @@ printWidth: 80
   <div>and the children go here</div>
   <div>and here too</div>
 </SomeHighlyConfiguredComponent>;
+
+================================================================================
+`;
+
+exports[`single_prop_multiline_string.js - {"angleBracketSameLine":false} format 1`] = `
+====================================options=====================================
+angleBracketSameLine: false
+parsers: ["flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<path d="M4.765 16.829l3.069-2.946 5.813 5.748
+  11.33-11.232 3.006 3.18-14.36 14.080z" />;
+
+<Component text="Text
+  with
+  newlines">Content</Component>;
+
+=====================================output=====================================
+<path
+  d="M4.765 16.829l3.069-2.946 5.813 5.748
+  11.33-11.232 3.006 3.18-14.36 14.080z"
+/>;
+
+<Component
+  text="Text
+  with
+  newlines"
+>
+  Content
+</Component>;
+
+================================================================================
+`;
+
+exports[`single_prop_multiline_string.js - {"angleBracketSameLine":true} format 1`] = `
+====================================options=====================================
+angleBracketSameLine: true
+parsers: ["flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<path d="M4.765 16.829l3.069-2.946 5.813 5.748
+  11.33-11.232 3.006 3.18-14.36 14.080z" />;
+
+<Component text="Text
+  with
+  newlines">Content</Component>;
+
+=====================================output=====================================
+<path
+  d="M4.765 16.829l3.069-2.946 5.813 5.748
+  11.33-11.232 3.006 3.18-14.36 14.080z"
+/>;
+
+<Component
+  text="Text
+  with
+  newlines">
+  Content
+</Component>;
 
 ================================================================================
 `;

--- a/tests/jsx/last-line/jsfmt.spec.js
+++ b/tests/jsx/last-line/jsfmt.spec.js
@@ -1,2 +1,4 @@
 run_spec(__dirname, ["flow", "typescript"], { jsxBracketSameLine: true });
 run_spec(__dirname, ["flow", "typescript"], { jsxBracketSameLine: false });
+run_spec(__dirname, ["flow", "typescript"], { angleBracketSameLine: true });
+run_spec(__dirname, ["flow", "typescript"], { angleBracketSameLine: false });

--- a/tests/markdown/markdown/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown/markdown/__snapshots__/jsfmt.spec.js.snap
@@ -633,12 +633,12 @@ Default | CLI Override | API Override
 --------|--------------|-------------
 \`true\` | \`--no-bracket-spacing\` | \`bracketSpacing: <bool>\`
 
-### JSX Brackets
-Put the \`>\` of a multi-line JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
+###  Angle Brackets
+Put the \`>\` of a multi-line element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
 
 Default | CLI Override | API Override
 --------|--------------|-------------
-\`false\` | \`--jsx-bracket-same-line\` | \`jsxBracketSameLine: <bool>\`
+\`false\` | \`--angle-bracket-same-line\` | \`angleBracketSameLine: <bool>\`
 
 ### Range
 Format only a segment of a file.
@@ -1653,14 +1653,14 @@ Valid options:
 | ------- | ---------------------- | ------------------------ |
 | \`true\`  | \`--no-bracket-spacing\` | \`bracketSpacing: <bool>\` |
 
-### JSX Brackets
+### Angle Brackets
 
-Put the \`>\` of a multi-line JSX element at the end of the last line instead of
-being alone on the next line (does not apply to self closing elements).
+Put the \`>\` of a multi-line element at the end of the last line instead of being
+alone on the next line (does not apply to self closing elements).
 
-| Default | CLI Override              | API Override                 |
-| ------- | ------------------------- | ---------------------------- |
-| \`false\` | \`--jsx-bracket-same-line\` | \`jsxBracketSameLine: <bool>\` |
+| Default | CLI Override                | API Override                   |
+| ------- | --------------------------- | ------------------------------ |
+| \`false\` | \`--angle-bracket-same-line\` | \`angleBracketSameLine: <bool>\` |
 
 ### Range
 
@@ -2612,12 +2612,12 @@ Default | CLI Override | API Override
 --------|--------------|-------------
 \`true\` | \`--no-bracket-spacing\` | \`bracketSpacing: <bool>\`
 
-### JSX Brackets
-Put the \`>\` of a multi-line JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
+###  Angle Brackets
+Put the \`>\` of a multi-line element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
 
 Default | CLI Override | API Override
 --------|--------------|-------------
-\`false\` | \`--jsx-bracket-same-line\` | \`jsxBracketSameLine: <bool>\`
+\`false\` | \`--angle-bracket-same-line\` | \`angleBracketSameLine: <bool>\`
 
 ### Range
 Format only a segment of a file.
@@ -3632,14 +3632,14 @@ Valid options:
 | ------- | ---------------------- | ------------------------ |
 | \`true\`  | \`--no-bracket-spacing\` | \`bracketSpacing: <bool>\` |
 
-### JSX Brackets
+### Angle Brackets
 
-Put the \`>\` of a multi-line JSX element at the end of the last line instead of
-being alone on the next line (does not apply to self closing elements).
+Put the \`>\` of a multi-line element at the end of the last line instead of being
+alone on the next line (does not apply to self closing elements).
 
-| Default | CLI Override              | API Override                 |
-| ------- | ------------------------- | ---------------------------- |
-| \`false\` | \`--jsx-bracket-same-line\` | \`jsxBracketSameLine: <bool>\` |
+| Default | CLI Override                | API Override                   |
+| ------- | --------------------------- | ------------------------------ |
+| \`false\` | \`--angle-bracket-same-line\` | \`angleBracketSameLine: <bool>\` |
 
 ### Range
 

--- a/tests/markdown/markdown/real-world-case.md
+++ b/tests/markdown/markdown/real-world-case.md
@@ -623,12 +623,12 @@ Default | CLI Override | API Override
 --------|--------------|-------------
 `true` | `--no-bracket-spacing` | `bracketSpacing: <bool>`
 
-### JSX Brackets
-Put the `>` of a multi-line JSX element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
+###  Angle Brackets
+Put the `>` of a multi-line element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).
 
 Default | CLI Override | API Override
 --------|--------------|-------------
-`false` | `--jsx-bracket-same-line` | `jsxBracketSameLine: <bool>`
+`false` | `--angle-bracket-same-line` | `angleBracketSameLine: <bool>`
 
 ### Range
 Format only a segment of a file.

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -67,6 +67,9 @@ Output options:
 
 Format options:
 
+  --angle-bracket-same-line
+                           Put > on the last line instead of at a new line.
+                           Defaults to false.
   --arrow-parens <always|avoid>
                            Include parentheses around a sole arrow function parameter.
                            Defaults to always.
@@ -80,7 +83,7 @@ Format options:
   --html-whitespace-sensitivity <css|strict|ignore>
                            How to handle whitespaces in HTML.
                            Defaults to css.
-  --jsx-bracket-same-line  Put > on the last line instead of at a new line.
+  --jsx-bracket-same-line  Put > on the last line instead of at a new line. (Deprecated. Use angleBracketSameLine.)
                            Defaults to false.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.
@@ -229,6 +232,9 @@ Output options:
 
 Format options:
 
+  --angle-bracket-same-line
+                           Put > on the last line instead of at a new line.
+                           Defaults to false.
   --arrow-parens <always|avoid>
                            Include parentheses around a sole arrow function parameter.
                            Defaults to always.
@@ -242,7 +248,7 @@ Format options:
   --html-whitespace-sensitivity <css|strict|ignore>
                            How to handle whitespaces in HTML.
                            Defaults to css.
-  --jsx-bracket-same-line  Put > on the last line instead of at a new line.
+  --jsx-bracket-same-line  Put > on the last line instead of at a new line. (Deprecated. Use angleBracketSameLine.)
                            Defaults to false.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.

--- a/tests_integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/help-options.js.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`show detailed usage with --help angle-bracket-same-line (stderr) 1`] = `""`;
+
+exports[`show detailed usage with --help angle-bracket-same-line (stdout) 1`] = `
+"--angle-bracket-same-line
+
+  Put > on the last line instead of at a new line.
+
+Default: false
+"
+`;
+
+exports[`show detailed usage with --help angle-bracket-same-line (write) 1`] = `Array []`;
+
 exports[`show detailed usage with --help arrow-parens (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help arrow-parens (stdout) 1`] = `
@@ -250,7 +263,7 @@ exports[`show detailed usage with --help jsx-bracket-same-line (stderr) 1`] = `"
 exports[`show detailed usage with --help jsx-bracket-same-line (stdout) 1`] = `
 "--jsx-bracket-same-line
 
-  Put > on the last line instead of at a new line.
+  Put > on the last line instead of at a new line. (Deprecated. Use angleBracketSameLine.)
 
 Default: false
 "

--- a/tests_integration/__tests__/__snapshots__/plugin-options-string.js.snap
+++ b/tests_integration/__tests__/__snapshots__/plugin-options-string.js.snap
@@ -5,7 +5,7 @@ exports[` 1`] = `
 - First value
 + Second value
 
-@@ -20,18 +20,20 @@
+@@ -23,18 +23,20 @@
                              Control how Prettier formats quoted code embedded in the file.
                              Defaults to auto.
     --end-of-line <lf|crlf|cr|auto>
@@ -16,7 +16,7 @@ exports[` 1`] = `
     --html-whitespace-sensitivity <css|strict|ignore>
                              How to handle whitespaces in HTML.
                              Defaults to css.
-    --jsx-bracket-same-line  Put > on the last line instead of at a new line.
+    --jsx-bracket-same-line  Put > on the last line instead of at a new line. (Deprecated. Use angleBracketSameLine.)
                              Defaults to false.
     --jsx-single-quote       Use single quotes in JSX.
                              Defaults to false.

--- a/tests_integration/__tests__/__snapshots__/plugin-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/plugin-options.js.snap
@@ -5,7 +5,7 @@ exports[` 1`] = `
 - First value
 + Second value
 
-@@ -20,18 +20,20 @@
+@@ -23,18 +23,20 @@
                              Control how Prettier formats quoted code embedded in the file.
                              Defaults to auto.
     --end-of-line <lf|crlf|cr|auto>
@@ -16,7 +16,7 @@ exports[` 1`] = `
     --html-whitespace-sensitivity <css|strict|ignore>
                              How to handle whitespaces in HTML.
                              Defaults to css.
-    --jsx-bracket-same-line  Put > on the last line instead of at a new line.
+    --jsx-bracket-same-line  Put > on the last line instead of at a new line. (Deprecated. Use angleBracketSameLine.)
                              Defaults to false.
     --jsx-single-quote       Use single quotes in JSX.
                              Defaults to false.

--- a/tests_integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests_integration/__tests__/__snapshots__/schema.js.snap
@@ -6,6 +6,11 @@ Object {
   "definitions": Object {
     "optionsDefinition": Object {
       "properties": Object {
+        "angleBracketSameLine": Object {
+          "default": false,
+          "description": "Put > on the last line instead of at a new line.",
+          "type": "boolean",
+        },
         "arrowParens": Object {
           "default": "always",
           "description": "Include parentheses around a sole arrow function parameter.",
@@ -120,7 +125,7 @@ This option cannot be used with --range-start and --range-end.",
         },
         "jsxBracketSameLine": Object {
           "default": false,
-          "description": "Put > on the last line instead of at a new line.",
+          "description": "Put > on the last line instead of at a new line. (Deprecated. Use angleBracketSameLine.)",
           "type": "boolean",
         },
         "jsxSingleQuote": Object {

--- a/tests_integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests_integration/__tests__/__snapshots__/support-info.js.snap
@@ -83,6 +83,10 @@ Object {
     ],
   },
   "options": Object {
+    "angleBracketSameLine": Object {
+      "default": false,
+      "type": "boolean",
+    },
     "arrowParens": Object {
       "choices": Array [
         "always",
@@ -737,6 +741,15 @@ exports[`CLI --support-info (stdout) 1`] = `
   ],
   \\"options\\": [
     {
+      \\"category\\": \\"Common\\",
+      \\"default\\": false,
+      \\"description\\": \\"Put > on the last line instead of at a new line.\\",
+      \\"name\\": \\"angleBracketSameLine\\",
+      \\"pluginDefaults\\": {},
+      \\"since\\": \\"2.3.0\\",
+      \\"type\\": \\"boolean\\"
+    },
+    {
       \\"category\\": \\"JavaScript\\",
       \\"choices\\": [
         {
@@ -864,7 +877,7 @@ exports[`CLI --support-info (stdout) 1`] = `
     {
       \\"category\\": \\"JavaScript\\",
       \\"default\\": false,
-      \\"description\\": \\"Put > on the last line instead of at a new line.\\",
+      \\"description\\": \\"Put > on the last line instead of at a new line. (Deprecated. Use angleBracketSameLine.)\\",
       \\"name\\": \\"jsxBracketSameLine\\",
       \\"pluginDefaults\\": {},
       \\"since\\": \\"0.17.0\\",

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -32,7 +32,7 @@ const ENABLED_OPTIONS = [
   "singleQuote",
   "bracketSpacing",
   "jsxSingleQuote",
-  "jsxBracketSameLine",
+  "angleBracketSameLine",
   "quoteProps",
   "arrowParens",
   "trailingComma",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
This pull request renames the option `jsxBracketSameLine` to `angleBracketSameLine`, in preparation for fixing #5377, as suggested [here](https://github.com/prettier/prettier/pull/9936#discussion_r546799351). 

It probably needs more work in terms of documentation. I'd like to add a deprecation notice to the old option (while still respecting it), but I couldn't make the tests pass when I added `deprecated: true` to it. The behavior I've implemented is  that if either option is set to true, it put brackets on the same line for jsx, which seems reasonable to me. 

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
