### PR TITLE
Forbid use `concat()` in `concat()`

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -110,6 +110,7 @@ overrides:
       prettier-internal-rules/better-parent-property-check-in-needs-parens: error
   - files: src/**/*.js
     rules:
+      prettier-internal-rules/no-concat-in-concat: error
       prettier-internal-rules/no-doc-builder-concat: off
       prettier-internal-rules/no-single-doc-concat: error
       prettier-internal-rules/prefer-fast-path-each: error

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/index.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/index.js
@@ -5,6 +5,7 @@ module.exports = {
     "better-parent-property-check-in-needs-parens": require("./better-parent-property-check-in-needs-parens"),
     "directly-loc-start-end": require("./directly-loc-start-end"),
     "jsx-identifier-case": require("./jsx-identifier-case"),
+    "no-concat-in-concat": require("./no-concat-in-concat"),
     "no-doc-builder-concat": require("./no-doc-builder-concat"),
     "no-node-comments": require("./no-node-comments"),
     "no-single-doc-concat": require("./no-single-doc-concat"),

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/no-concat-in-concat.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/no-concat-in-concat.js
@@ -1,0 +1,75 @@
+"use strict";
+
+// TODO: Remove this rule when deprecated `concat` is not using in codebase, #9993.
+
+const concatCallSelector = [
+  "CallExpression",
+  '[callee.type="Identifier"]',
+  '[callee.name="concat"]',
+  "[arguments.length=1]",
+].join("");
+const selector = [
+  concatCallSelector,
+  ">",
+  "ArrayExpression.arguments",
+  ">",
+  `${concatCallSelector}.elements`,
+].join("");
+
+const messageId = "no-concat-in-concat";
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      url:
+        "https://github.com/prettier/prettier/blob/master/scripts/eslint-plugin-prettier-internal-rules/no-concat-in-concat.js",
+    },
+    messages: {
+      [messageId]: "Do not use `concat()` in `concat()`.",
+    },
+    fixable: "code",
+  },
+  create(context) {
+    const sourceCode = context.getSourceCode();
+    return {
+      [selector](node) {
+        context.report({
+          node,
+          messageId,
+          *fix(fixer) {
+            // Remove `concat`
+            yield fixer.remove(node.callee);
+            const openingParenthesisToken = sourceCode.getTokenAfter(
+              node.callee
+            );
+            yield fixer.remove(openingParenthesisToken);
+            const closingParenthesisToken = sourceCode.getLastToken(node);
+            yield fixer.remove(closingParenthesisToken);
+
+            const [concatParts] = node.arguments;
+            if (concatParts.type === "ArrayExpression") {
+              const firstToken = sourceCode.getFirstToken(concatParts);
+              yield fixer.remove(firstToken);
+              const lastToken = sourceCode.getLastToken(concatParts);
+              yield fixer.remove(lastToken);
+
+              // trailing comma
+              const lastElement =
+                concatParts.elements[concatParts.elements.length - 1];
+              const penultimateToken = sourceCode.getTokenAfter(lastElement);
+              if (
+                penultimateToken.type === "Punctuator" &&
+                penultimateToken.value === ","
+              ) {
+                yield fixer.remove(penultimateToken);
+              }
+            } else {
+              yield fixer.insertTextBefore(concatParts, "...");
+            }
+          },
+        });
+      },
+    };
+  },
+};

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
@@ -94,6 +94,27 @@ test("jsx-identifier-case", {
   ],
 });
 
+test("no-concat-in-concat", {
+  valid: [],
+  invalid: [
+    {
+      code: "concat([concat([hardline, hardline]), 'extra'])",
+      output: "concat([hardline, hardline, 'extra'])",
+      errors: 1,
+    },
+    {
+      code: "concat([concat([hardline, hardline, ]), 'extra'])",
+      output: "concat([hardline, hardline , 'extra'])",
+      errors: 1,
+    },
+    {
+      code: "concat([concat(parts), 'extra'])",
+      output: "concat([...parts, 'extra'])",
+      errors: 1,
+    },
+  ],
+});
+
 test("no-doc-builder-concat", {
   valid: ["notConcat([])", "concat", "[].concat([])"],
   invalid: [

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -341,7 +341,7 @@ function genericPrint(path, options, print) {
       if (!node.nodes) {
         return node.value;
       }
-      return concat(["(", concat(path.map(print, "nodes")), ")"]);
+      return concat(["(", ...path.map(print, "nodes"), ")"]);
     }
     case "media-feature": {
       return maybeToLowerCase(

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -31,7 +31,7 @@ function genericPrint(path, options, print) {
           }
         }
       }, "definitions");
-      return concat([concat(parts), hardline]);
+      return concat([...parts, hardline]);
     }
     case "OperationDefinition": {
       const hasOperation = options.originalText[locStart(n)] !== "{";
@@ -274,10 +274,7 @@ function genericPrint(path, options, print) {
         "type ",
         path.call(print, "name"),
         n.interfaces.length > 0
-          ? concat([
-              " implements ",
-              concat(printInterfaces(path, options, print)),
-            ])
+          ? concat([" implements ", ...printInterfaces(path, options, print)])
           : "",
         printDirectives(path, print, n),
         n.fields.length > 0
@@ -363,7 +360,8 @@ function genericPrint(path, options, print) {
             )
           : "",
         n.repeatable ? " repeatable" : "",
-        concat([" on ", join(" | ", path.map(print, "locations"))]),
+        " on ",
+        join(" | ", path.map(print, "locations")),
       ]);
     }
 
@@ -492,10 +490,7 @@ function genericPrint(path, options, print) {
         "interface ",
         path.call(print, "name"),
         n.interfaces.length > 0
-          ? concat([
-              " implements ",
-              concat(printInterfaces(path, options, print)),
-            ])
+          ? concat([" implements ", ...printInterfaces(path, options, print)])
           : "",
         printDirectives(path, print, n),
         n.fields.length > 0

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -55,7 +55,9 @@ function print(path, options, print) {
           concat([
             isWhitespaceOnly ? "" : indent(printChildren(path, options, print)),
             n.children.length > 0 ? hardline : "",
-            concat(["</", n.tag, ">"]),
+            "</",
+            n.tag,
+            ">",
           ])
         ),
         bim,

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -354,7 +354,7 @@ function genericPrint(path, options, print) {
     case "interpolation":
       return concat([
         printOpeningTagStart(node, options),
-        concat(path.map(print, "children")),
+        ...path.map(print, "children"),
         printClosingTagEnd(node, options),
       ]);
     case "text": {
@@ -366,7 +366,7 @@ function genericPrint(path, options, print) {
           ? node.value.replace(trailingNewlineRegex, "")
           : node.value;
         return concat([
-          concat(replaceEndOfLineWith(value, literalline)),
+          ...replaceEndOfLineWith(value, literalline),
           hasTrailingNewline ? hardline : "",
         ]);
       }
@@ -394,11 +394,10 @@ function genericPrint(path, options, print) {
     case "comment": {
       return concat([
         printOpeningTagPrefix(node, options),
-        concat(
-          replaceEndOfLineWith(
-            options.originalText.slice(locStart(node), locEnd(node)),
-            literalline
-          )
+
+        ...replaceEndOfLineWith(
+          options.originalText.slice(locStart(node), locEnd(node)),
+          literalline
         ),
         printClosingTagSuffix(node, options),
       ]);
@@ -413,19 +412,17 @@ function genericPrint(path, options, print) {
       const quote = singleQuoteCount < doubleQuoteCount ? "'" : '"';
       return concat([
         node.rawName,
-        concat([
-          "=",
-          quote,
-          concat(
-            replaceEndOfLineWith(
-              quote === '"'
-                ? value.replace(/"/g, "&quot;")
-                : value.replace(/'/g, "&apos;"),
-              literalline
-            )
-          ),
-          quote,
-        ]),
+
+        "=",
+        quote,
+
+        ...replaceEndOfLineWith(
+          quote === '"'
+            ? value.replace(/"/g, "&quot;")
+            : value.replace(/'/g, "&apos;"),
+          literalline
+        ),
+        quote,
       ]);
     }
     default:
@@ -440,23 +437,22 @@ function printChildren(path, options, print) {
   if (forceBreakChildren(node)) {
     return concat([
       breakParent,
-      concat(
-        path.map((childPath) => {
-          const childNode = childPath.getValue();
-          const prevBetweenLine = !childNode.prev
+
+      ...path.map((childPath) => {
+        const childNode = childPath.getValue();
+        const prevBetweenLine = !childNode.prev
+          ? ""
+          : printBetweenLine(childNode.prev, childNode);
+        return concat([
+          !prevBetweenLine
             ? ""
-            : printBetweenLine(childNode.prev, childNode);
-          return concat([
-            !prevBetweenLine
-              ? ""
-              : concat([
-                  prevBetweenLine,
-                  forceNextEmptyLine(childNode.prev) ? hardline : "",
-                ]),
-            printChild(childPath),
-          ]);
-        }, "children")
-      ),
+            : concat([
+                prevBetweenLine,
+                forceNextEmptyLine(childNode.prev) ? hardline : "",
+              ]),
+          printChild(childPath),
+        ]);
+      }, "children"),
     ]);
   }
 
@@ -528,8 +524,8 @@ function printChildren(path, options, print) {
           prevParts,
           group(
             concat([
-              concat(leadingParts),
-              group(concat([printChild(childPath), concat(trailingParts)]), {
+              ...leadingParts,
+              group(concat([printChild(childPath), ...trailingParts]), {
                 id: groupIds[childIndex],
               }),
             ])

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -68,7 +68,7 @@ function printBinaryishExpression(path, options, print) {
       parent.type === "OptionalMemberExpression") &&
       !parent.computed)
   ) {
-    return group(concat([indent(concat([softline, concat(parts)])), softline]));
+    return group(concat([indent(concat([softline, ...parts])), softline]));
   }
 
   // Avoid indenting sub-expressions in some cases where the first sub-expression is already

--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -129,7 +129,7 @@ function printCallArguments(path, options, print) {
     return group(
       concat([
         "(",
-        indent(concat([line, concat(printedArguments)])),
+        indent(concat([line, ...printedArguments])),
         maybeTrailingComma,
         line,
         ")",
@@ -177,7 +177,7 @@ function printCallArguments(path, options, print) {
 
     const somePrintedArgumentsWillBreak = printedArguments.some(willBreak);
 
-    const simpleConcat = concat(["(", concat(printedExpanded), ")"]);
+    const simpleConcat = concat(["(", ...printedExpanded, ")"]);
 
     return concat([
       somePrintedArgumentsWillBreak ? breakParent : "",
@@ -192,12 +192,12 @@ function printCallArguments(path, options, print) {
             ? concat([
                 "(",
                 group(printedExpanded[0], { shouldBreak: true }),
-                concat(printedExpanded.slice(1)),
+                ...printedExpanded.slice(1),
                 ")",
               ])
             : concat([
                 "(",
-                concat(printedArguments.slice(0, -1)),
+                ...printedArguments.slice(0, -1),
                 group(getLast(printedExpanded), {
                   shouldBreak: true,
                 }),
@@ -212,7 +212,7 @@ function printCallArguments(path, options, print) {
 
   const contents = concat([
     "(",
-    indent(concat([softline, concat(printedArguments)])),
+    indent(concat([softline, ...printedArguments])),
     ifBreak(maybeTrailingComma),
     softline,
     ")",

--- a/src/language-js/print/call-expression.js
+++ b/src/language-js/print/call-expression.js
@@ -50,7 +50,9 @@ function printCallExpression(path, options, print) {
       path.call(print, "callee"),
       optional,
       printFunctionTypeParameters(path, options, print),
-      concat(["(", join(", ", printed), ")"]),
+      "(",
+      join(", ", printed),
+      ")",
     ]);
   }
 

--- a/src/language-js/print/function-parameters.js
+++ b/src/language-js/print/function-parameters.js
@@ -95,12 +95,7 @@ function printFunctionParameters(
   //                         })
   if (shouldExpandParameters) {
     return group(
-      concat([
-        removeLines(typeParams),
-        "(",
-        concat(printed.map(removeLines)),
-        ")",
-      ])
+      concat([removeLines(typeParams), "(", ...printed.map(removeLines), ")"])
     );
   }
 
@@ -113,12 +108,12 @@ function printFunctionParameters(
   // }) {}
   const hasNotParameterDecorator = parameters.every((node) => !node.decorators);
   if (shouldHugParameters && hasNotParameterDecorator) {
-    return concat([typeParams, "(", concat(printed), ")"]);
+    return concat([typeParams, "(", ...printed, ")"]);
   }
 
   // don't break in specs, eg; `it("should maintain parens around done even when long", (done) => {})`
   if (isParametersInTestCall) {
-    return concat([typeParams, "(", concat(printed), ")"]);
+    return concat([typeParams, "(", ...printed, ")"]);
   }
 
   const isFlowShorthandWithOneArg =
@@ -141,7 +136,7 @@ function printFunctionParameters(
 
   if (isFlowShorthandWithOneArg) {
     if (options.arrowParens === "always") {
-      return concat(["(", concat(printed), ")"]);
+      return concat(["(", ...printed, ")"]);
     }
     return concat(printed);
   }
@@ -149,7 +144,7 @@ function printFunctionParameters(
   return concat([
     typeParams,
     "(",
-    indent(concat([softline, concat(printed)])),
+    indent(concat([softline, ...printed])),
     ifBreak(
       !hasRestParameter(functionNode) && shouldPrintComma(options, "all")
         ? ","

--- a/src/language-js/print/function.js
+++ b/src/language-js/print/function.js
@@ -195,7 +195,7 @@ function printArrowFunctionExpression(path, options, print, args) {
       n.body.type === "ArrowFunctionExpression" ||
       n.body.type === "DoExpression")
   ) {
-    return group(concat([concat(parts), " ", body]));
+    return group(concat([...parts, " ", body]));
   }
 
   // We handle sequence expressions as the body of arrows specially,
@@ -203,7 +203,7 @@ function printArrowFunctionExpression(path, options, print, args) {
   if (n.body.type === "SequenceExpression") {
     return group(
       concat([
-        concat(parts),
+        ...parts,
         group(concat([" (", indent(concat([softline, body])), softline, ")"])),
       ])
     );
@@ -230,7 +230,7 @@ function printArrowFunctionExpression(path, options, print, args) {
 
   return group(
     concat([
-      concat(parts),
+      ...parts,
       group(
         concat([
           indent(

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -79,11 +79,7 @@ function printJsxElementInternal(path, options, print) {
     (n.children[0].expression.type === "TemplateLiteral" ||
       n.children[0].expression.type === "TaggedTemplateExpression")
   ) {
-    return concat([
-      openingLines,
-      concat(path.map(print, "children")),
-      closingLines,
-    ]);
+    return concat([openingLines, ...path.map(print, "children"), closingLines]);
   }
 
   // Convert `{" "}` to text nodes containing a space.
@@ -256,7 +252,7 @@ function printJsxElementInternal(path, options, print) {
   }
 
   return conditionalGroup([
-    group(concat([openingLines, concat(children), closingLines])),
+    group(concat([openingLines, ...children, closingLines])),
     multiLineElem,
   ]);
 }
@@ -583,7 +579,7 @@ function printJsxOpeningElement(path, options, print) {
         path.call(print, "name"),
         path.call(print, "typeParameters"),
         " ",
-        concat(path.map(print, "attributes")),
+        ...path.map(print, "attributes"),
         n.selfClosing ? " />" : ">",
       ])
     );
@@ -624,12 +620,11 @@ function printJsxOpeningElement(path, options, print) {
       "<",
       path.call(print, "name"),
       path.call(print, "typeParameters"),
-      concat([
-        indent(
-          concat(path.map((attr) => concat([line, print(attr)]), "attributes"))
-        ),
-        n.selfClosing ? line : bracketSameLine ? ">" : softline,
-      ]),
+
+      indent(
+        concat(path.map((attr) => concat([line, print(attr)]), "attributes"))
+      ),
+      n.selfClosing ? line : bracketSameLine ? ">" : softline,
       n.selfClosing ? "/>" : bracketSameLine ? "" : ">",
     ]),
     { shouldBreak }

--- a/src/language-js/print/module.js
+++ b/src/language-js/print/module.js
@@ -229,7 +229,7 @@ function printModuleSpecifiers(path, options, print) {
           concat([
             "{",
             options.bracketSpacing ? " " : "",
-            concat(groupedSpecifiers),
+            ...groupedSpecifiers,
             options.bracketSpacing ? " " : "",
             "}",
           ])

--- a/src/language-js/print/object.js
+++ b/src/language-js/print/object.js
@@ -182,14 +182,15 @@ function printObject(path, options, print) {
   } else {
     content = concat([
       leftBrace,
-      indent(concat([options.bracketSpacing ? line : softline, concat(props)])),
+      indent(concat([options.bracketSpacing ? line : softline, ...props])),
       ifBreak(
         canHaveTrailingSeparator &&
           (separator !== "," || shouldPrintComma(options))
           ? separator
           : ""
       ),
-      concat([options.bracketSpacing ? line : softline, rightBrace]),
+      options.bracketSpacing ? line : softline,
+      rightBrace,
       printOptionalToken(path),
       printTypeAnnotation(path, options, print),
     ]);

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -397,9 +397,7 @@ function printPathNoParens(path, options, print, args) {
           parent.type === "OptionalMemberExpression") &&
           parent.object === n)
       ) {
-        return group(
-          concat([indent(concat([softline, concat(parts)])), softline])
-        );
+        return group(concat([indent(concat([softline, ...parts])), softline]));
       }
       return concat(parts);
     }

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -248,10 +248,7 @@ function genericPrint(path, options, print) {
         const alignment = " ".repeat(4);
         return align(
           alignment,
-          concat([
-            alignment,
-            concat(replaceEndOfLineWith(node.value, hardline)),
-          ])
+          concat([alignment, ...replaceEndOfLineWith(node.value, hardline)])
         );
       }
 
@@ -265,11 +262,10 @@ function genericPrint(path, options, print) {
         node.lang || "",
         node.meta ? " " + node.meta : "",
         hardline,
-        concat(
-          replaceEndOfLineWith(
-            getFencedCodeBlockValue(node, options.originalText),
-            hardline
-          )
+
+        ...replaceEndOfLineWith(
+          getFencedCodeBlockValue(node, options.originalText),
+          hardline
         ),
         hardline,
         style,
@@ -383,7 +379,9 @@ function genericPrint(path, options, print) {
       const lineOrSpace = options.proseWrap === "always" ? line : " ";
       return group(
         concat([
-          concat(["[", node.identifier, "]:"]),
+          "[",
+          node.identifier,
+          "]:",
           indent(
             concat([
               lineOrSpace,
@@ -458,10 +456,7 @@ function genericPrint(path, options, print) {
         "$$",
         hardline,
         node.value
-          ? concat([
-              concat(replaceEndOfLineWith(node.value, hardline)),
-              hardline,
-            ])
+          ? concat([...replaceEndOfLineWith(node.value, hardline), hardline])
           : "",
         "$$",
       ]);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Another simplification before we merge #9993

The only possible effect should be https://github.com/prettier/prettier/blob/181a325c1c07f1a4f3738665b7b28288dfb960bc/src/language-markdown/printer-markdown.js#L95-L97
But we are not having this problem in `printChildren` function.

Any other place convert `concat` to other doc type?

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
