### PR TITLE
Update subtitle for version 2.0 release

### DIFF
--- a/website/blog/2020-03-21-2.0.0.md
+++ b/website/blog/2020-03-21-2.0.0.md
@@ -1,7 +1,7 @@
 ---
 author: "Georgii Dolzhykov (@thorn0)"
 authorURL: "https://github.com/thorn0"
-title: "Prettier 2.0 “2020”"
+title: "Prettier 2.0 “Even Prettier”"
 ---
 
 Better defaults, a better CLI and better heuristics. Oh, and TypeScript 3.8.


### PR DESCRIPTION
I'm 9 months late, but I feel like like this was a missed opportunity. Or maybe for version 3.0?

## Description

Update the version 2.0 release post to be titled `Prettier 2.0 “Even Prettier”`


<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
