### PR TITLE
Move checkCache to Cache class

### DIFF
--- a/scripts/build/bundler.js
+++ b/scripts/build/bundler.js
@@ -2,7 +2,6 @@
 
 const path = require("path");
 const fs = require("fs");
-const execa = require("execa");
 const { rollup } = require("rollup");
 const webpack = require("webpack");
 const { nodeResolve } = require("@rollup/plugin-node-resolve");
@@ -336,29 +335,6 @@ function runWebpack(config) {
   });
 }
 
-async function checkCache(cache, inputOptions, outputOption) {
-  const useCache = await cache.checkBundle(
-    outputOption.file,
-    inputOptions,
-    outputOption
-  );
-
-  if (useCache) {
-    try {
-      await execa("cp", [
-        path.join(cache.cacheDir, outputOption.file.replace("dist", "files")),
-        outputOption.file,
-      ]);
-      return true;
-    } catch (err) {
-      console.log(err);
-      // Proceed to build
-    }
-  }
-
-  return false;
-}
-
 module.exports = async function createBundle(bundle, cache, options) {
   const inputOptions = getRollupConfig(bundle);
   const outputOptions = getRollupOutputOptions(bundle, options);
@@ -372,7 +348,7 @@ module.exports = async function createBundle(bundle, cache, options) {
     (
       await Promise.all(
         outputOptions.map((outputOption) =>
-          checkCache(cache, inputOptions, outputOption)
+          cache.checkCache(cache, inputOptions, outputOption)
         )
       )
     ).every((cached) => cached)

--- a/scripts/build/bundler.js
+++ b/scripts/build/bundler.js
@@ -348,7 +348,7 @@ module.exports = async function createBundle(bundle, cache, options) {
     (
       await Promise.all(
         outputOptions.map((outputOption) =>
-          cache.checkCache(cache, inputOptions, outputOption)
+          cache.isCached(inputOptions, outputOption)
         )
       )
     ).every((cached) => cached)

--- a/scripts/build/cache.js
+++ b/scripts/build/cache.js
@@ -102,7 +102,7 @@ class Cache {
     }
   }
 
-  async checkCache(inputOptions, outputOption) {
+  async isCached(inputOptions, outputOption) {
     const useCache = await this.checkBundle(
       outputOption.file,
       inputOptions,

--- a/scripts/build/cache.js
+++ b/scripts/build/cache.js
@@ -4,6 +4,7 @@ const assert = require("assert").strict;
 const crypto = require("crypto");
 const fs = require("fs").promises;
 const path = require("path");
+const execa = require("execa");
 const { rollup } = require("rollup");
 
 const ROOT = path.join(__dirname, "..", "..");
@@ -99,6 +100,27 @@ class Cache {
     } catch (err) {
       // Don't fail the build
     }
+  }
+
+  async checkCache(inputOptions, outputOption) {
+    const useCache = await this.checkBundle(
+      outputOption.file,
+      inputOptions,
+      outputOption
+    );
+    if (useCache) {
+      try {
+        await execa("cp", [
+          path.join(this.cacheDir, outputOption.file.replace("dist", "files")),
+          outputOption.file,
+        ]);
+        return true;
+      } catch (err) {
+        console.log(err);
+        // Proceed to build
+      }
+    }
+    return false;
   }
 }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Tiny refactoring. Move `checkCache` function to `Cache` class as as instance method.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
