### PR TITLE
Check cache only when purge-cache is off

### DIFF
--- a/scripts/build/bundler.js
+++ b/scripts/build/bundler.js
@@ -367,13 +367,15 @@ module.exports = async function createBundle(bundle, cache, options) {
     return { skipped: true };
   }
 
-  const checkCacheResults = await Promise.all(
-    outputOptions.map((outputOption) =>
-      checkCache(cache, inputOptions, outputOption)
-    )
-  );
-  if (checkCacheResults.every((r) => r === true)) {
-    return { cached: true };
+  if (!options["purge-cache"]) {
+    const checkCacheResults = await Promise.all(
+      outputOptions.map((outputOption) =>
+        checkCache(cache, inputOptions, outputOption)
+      )
+    );
+    if (checkCacheResults.every((r) => r === true)) {
+      return { cached: true };
+    }
   }
 
   if (bundle.bundler === "webpack") {

--- a/scripts/build/bundler.js
+++ b/scripts/build/bundler.js
@@ -367,15 +367,17 @@ module.exports = async function createBundle(bundle, cache, options) {
     return { skipped: true };
   }
 
-  if (!options["purge-cache"]) {
-    const checkCacheResults = await Promise.all(
-      outputOptions.map((outputOption) =>
-        checkCache(cache, inputOptions, outputOption)
+  if (
+    !options["purge-cache"] &&
+    (
+      await Promise.all(
+        outputOptions.map((outputOption) =>
+          checkCache(cache, inputOptions, outputOption)
+        )
       )
-    );
-    if (checkCacheResults.every((r) => r === true)) {
-      return { cached: true };
-    }
+    ).every((cached) => cached)
+  ) {
+    return { cached: true };
   }
 
   if (bundle.bundler === "webpack") {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

When `--purge-cache` is `true`,  always `cached` isn't `true`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
