### PR TITLE
Remove unnecessary conditions for printing type parameters

### DIFF
--- a/src/language-js/print/type-parameters.js
+++ b/src/language-js/print/type-parameters.js
@@ -37,10 +37,6 @@ function printTypeParameters(path, options, print, paramsKey) {
     n[paramsKey].length === 0 ||
     (n[paramsKey].length === 1 &&
       (shouldHugType(n[paramsKey][0]) ||
-        (n[paramsKey][0].type === "GenericTypeAnnotation" &&
-          shouldHugType(n[paramsKey][0].id)) ||
-        (n[paramsKey][0].type === "TSTypeReference" &&
-          shouldHugType(n[paramsKey][0].typeName)) ||
         n[paramsKey][0].type === "NullableTypeAnnotation"));
 
   if (shouldInline) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Maybe those conditions are unnecessary because there is a condition that validate `GenericTypeAnnotation` and `TSTypeReference` in `isSimpleType` function called by `shouldHugType`.

https://github.com/prettier/prettier/blob/3efa3d3c58fbf563809d7cf205c1830d22364cf4/src/language-js/utils.js#L477-L483

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
