### PR TITLE
Add CLI option to prevent errors on unmatched patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ package-lock.json
 .pnp.*
 .nyc_output
 /scripts/tools/eslint-plugin-prettier-internal-rules/node_modules
+.devcontainer

--- a/changelog_unreleased/cli/8233.md
+++ b/changelog_unreleased/cli/8233.md
@@ -1,6 +1,6 @@
 #### Add CLI option to prevent errors on unmatched pattern (#8233 by @daronmcintosh)
 
-The following command will not throw an error when it doesn't find a js file.
+The following command will not throw an error when it doesn't find a YAML file.
 
 ```sh
 // Prettier stable

--- a/changelog_unreleased/cli/8233.md
+++ b/changelog_unreleased/cli/8233.md
@@ -1,0 +1,16 @@
+#### Add CLI option to prevent errors on unmatched pattern (#8233 by @daronmcintosh)
+
+The following command will not throw an error when it doesn't find a js file.
+
+```sh
+// Prettier stable
+$ npx prettier --check "prettier/docs/*.yaml"
+Checking formatting...
+[error] No files matching the pattern were found: "prettier/docs/*.yaml".
+All matched files use Prettier code style!
+
+// Prettier master
+$ npx prettier --check --no-error-on-unmatched-pattern "prettier/docs/*.yaml"
+Checking formatting...
+All matched files use Prettier code style!
+```

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -212,3 +212,7 @@ With `--ignore-unknown` (or `-u`), prettier will ignore unknown files matched by
 ```console
 $ prettier "**/*" --write --ignore-unknown
 ```
+
+## `--no-error-on-unmatched-pattern`
+
+Prevent errors when pattern is unmatched.

--- a/src/cli/constant.js
+++ b/src/cli/constant.js
@@ -145,6 +145,10 @@ const options = {
       "Don't take .editorconfig into account when parsing configuration.",
     default: true,
   },
+  "error-on-unmatched-pattern": {
+    type: "boolean",
+    oppositeDescription: "Prevent errors when pattern is unmatched.",
+  },
   "find-config-path": {
     type: "path",
     category: coreOptions.CATEGORY_CONFIG,

--- a/src/cli/expand-patterns.js
+++ b/src/cli/expand-patterns.js
@@ -33,7 +33,7 @@ function* expandPatterns(context) {
     yield relativePath;
   }
 
-  if (noResults) {
+  if (noResults && context.argv["error-on-unmatched-pattern"] !== false) {
     // If there was no files and no other errors, let's yield a general error.
     yield {
       error: `No matching files. Patterns: ${context.filePatterns.join(" ")}`,
@@ -116,7 +116,9 @@ function* expandPatternsInternal(context) {
     }
 
     if (result.length === 0) {
-      yield { error: `${errorMessages.emptyResults[type]}: "${input}".` };
+      if (context.argv["error-on-unmatched-pattern"] !== false) {
+        yield { error: `${errorMessages.emptyResults[type]}: "${input}".` };
+      }
     } else {
       yield* sortPaths(result);
     }

--- a/tests_integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests_integration/__tests__/__snapshots__/early-exit.js.snap
@@ -146,6 +146,8 @@ Editor options:
 Other options:
 
   --no-color               Do not colorize error messages.
+  --no-error-on-unmatched-pattern
+                           Prevent errors when pattern is unmatched.
   --file-info <path>       Extract the following info (as JSON) for a given file path. Reported fields:
                            * ignored (boolean) - true if file path is filtered by --ignore-path
                            * inferredParser (string | null) - name of parser inferred from file path
@@ -308,6 +310,8 @@ Editor options:
 Other options:
 
   --no-color               Do not colorize error messages.
+  --no-error-on-unmatched-pattern
+                           Prevent errors when pattern is unmatched.
   --file-info <path>       Extract the following info (as JSON) for a given file path. Reported fields:
                            * ignored (boolean) - true if file path is filtered by --ignore-path
                            * inferredParser (string | null) - name of parser inferred from file path

--- a/tests_integration/__tests__/__snapshots__/error-on-unmatched-pattern.js.snap
+++ b/tests_integration/__tests__/__snapshots__/error-on-unmatched-pattern.js.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`error on unmatched pattern (stderr) 1`] = `
+"[error] No files matching the pattern were found: \\"**/*.toml\\".
+"
+`;
+
+exports[`error on unmatched pattern (stdout) 1`] = `""`;
+
+exports[`error on unmatched pattern (write) 1`] = `Array []`;
+
+exports[`error on unmatched pattern when 2nd glob has no match (stderr) 1`] = `
+"[error] No files matching the pattern were found: \\"**/*.toml\\".
+"
+`;
+
+exports[`error on unmatched pattern when 2nd glob has no match (stdout) 1`] = `
+"const hello = \\"there\\";
+{
+  \\"hello\\": \\"there\\"
+}
+hello: there
+"
+`;
+
+exports[`error on unmatched pattern when 2nd glob has no match (write) 1`] = `Array []`;
+
+exports[`no error on unmatched pattern (stderr) 1`] = `""`;
+
+exports[`no error on unmatched pattern (stdout) 1`] = `
+"const hello = \\"there\\";
+"
+`;
+
+exports[`no error on unmatched pattern (write) 1`] = `Array []`;
+
+exports[`no error on unmatched pattern when 2nd glob has no match (stderr) 1`] = `""`;
+
+exports[`no error on unmatched pattern when 2nd glob has no match (stdout) 1`] = `
+"const hello = \\"there\\";
+{
+  \\"hello\\": \\"there\\"
+}
+hello: there
+"
+`;
+
+exports[`no error on unmatched pattern when 2nd glob has no match (write) 1`] = `Array []`;

--- a/tests_integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests_integration/__tests__/__snapshots__/help-options.js.snap
@@ -347,6 +347,17 @@ exports[`show detailed usage with --help no-editorconfig (stdout) 1`] = `
 
 exports[`show detailed usage with --help no-editorconfig (write) 1`] = `Array []`;
 
+exports[`show detailed usage with --help no-error-on-unmatched-pattern (stderr) 1`] = `""`;
+
+exports[`show detailed usage with --help no-error-on-unmatched-pattern (stdout) 1`] = `
+"--no-error-on-unmatched-pattern
+
+  Prevent errors when pattern is unmatched.
+"
+`;
+
+exports[`show detailed usage with --help no-error-on-unmatched-pattern (write) 1`] = `Array []`;
+
 exports[`show detailed usage with --help no-semi (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help no-semi (stdout) 1`] = `

--- a/tests_integration/__tests__/error-on-unmatched-pattern.js
+++ b/tests_integration/__tests__/error-on-unmatched-pattern.js
@@ -1,0 +1,37 @@
+"use strict";
+
+const runPrettier = require("../runPrettier");
+
+describe("no error on unmatched pattern", () => {
+  runPrettier("cli/error-on-unmatched-pattern", [
+    "--no-error-on-unmatched-pattern",
+    "**/*.js",
+  ]).test({
+    status: 0,
+  });
+});
+
+describe("error on unmatched pattern", () => {
+  runPrettier("cli/error-on-unmatched-pattern", ["**/*.toml"]).test({
+    status: 2,
+  });
+});
+
+describe("no error on unmatched pattern when 2nd glob has no match", () => {
+  runPrettier("cli/error-on-unmatched-pattern", [
+    "--no-error-on-unmatched-pattern",
+    "**/*.{json,js,yml}",
+    "**/*.toml",
+  ]).test({
+    status: 0,
+  });
+});
+
+describe("error on unmatched pattern when 2nd glob has no match", () => {
+  runPrettier("cli/error-on-unmatched-pattern", [
+    "**/*.{json,js,yml}",
+    "**/*.toml",
+  ]).test({
+    status: 2,
+  });
+});

--- a/tests_integration/cli/error-on-unmatched-pattern/some.js
+++ b/tests_integration/cli/error-on-unmatched-pattern/some.js
@@ -1,0 +1,1 @@
+const hello = "there";

--- a/tests_integration/cli/error-on-unmatched-pattern/some.json
+++ b/tests_integration/cli/error-on-unmatched-pattern/some.json
@@ -1,0 +1,3 @@
+{
+  "hello": "there"
+}

--- a/tests_integration/cli/error-on-unmatched-pattern/some.yml
+++ b/tests_integration/cli/error-on-unmatched-pattern/some.yml
@@ -1,0 +1,1 @@
+hello: there


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
Fixes: https://github.com/prettier/prettier/issues/8233

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
