### PR TITLE
Remove incorrect statement about ESLint plugin speed

### DIFF
--- a/docs/integrating-with-linters.md
+++ b/docs/integrating-with-linters.md
@@ -28,7 +28,6 @@ These plugins were especially useful when Prettier was new. By running Prettier 
 The downsides of those plugins are:
 
 - You end up with a lot of red squiggly lines in your editor, which gets annoying. Prettier is supposed to make you forget about formatting – and not be in your face about it!
-- They are slower than running Prettier directly.
 - They’re yet one layer of indirection where things may break.
 
 Finally, we have tools that runs `prettier` and then immediately for example `eslint --fix` on files.


### PR DESCRIPTION
Remove the sentence in the docs which claims that running Prettier directly is faster than running it as an ESLint plugin.

## Description

* In this repository, running `yarn eslint src --ext=.js` takes 3.4s and running `yarn prettier 'src/**/*.js' --check` takes 2.7s, so in total they take 6.1s.
* In this repository, running `yarn eslint src --ext=.js` after adding the `prettier` ESLint rules (by adding `plugin:prettier/recommended` into the `extends` list in `.eslintrc.yml`) takes 5.6s, which is faster than running the tools independently.

Therefore, it's incorrect to say that running the Prettier rules in ESLint is slower than running Prettier directly.
