### PR TITLE
Refactor: Use getLastStatement function in printStatementSequence

### DIFF
--- a/src/language-js/print/statement.js
+++ b/src/language-js/print/statement.js
@@ -25,9 +25,7 @@ function printStatementSequence(path, options, print, property) {
   const node = path.getValue();
   const parts = [];
   const isClassBody = node.type === "ClassBody";
-  const lastStatement = getLast(
-    node[property].filter(({ type }) => type !== "EmptyStatement")
-  );
+  const lastStatement = getLastStatement(node[property]);
 
   path.each((path, index, statements) => {
     const node = path.getValue();
@@ -82,6 +80,14 @@ function printStatementSequence(path, options, print, property) {
   }, property);
 
   return parts;
+}
+
+function getLastStatement(statements) {
+  const last = getLast(statements);
+  if (last.type !== "EmptyStatement") {
+    return last;
+  }
+  return getLast(statements.filter(({ type }) => type !== "EmptyStatement"));
 }
 
 function statementNeedsASIProtection(path, options) {

--- a/src/language-js/print/statement.js
+++ b/src/language-js/print/statement.js
@@ -1,6 +1,5 @@
 "use strict";
 
-const { getLast } = require("../../common/util");
 const {
   builders: { hardline },
 } = require("../../document");

--- a/src/language-js/print/statement.js
+++ b/src/language-js/print/statement.js
@@ -83,11 +83,12 @@ function printStatementSequence(path, options, print, property) {
 }
 
 function getLastStatement(statements) {
-  const last = getLast(statements);
-  if (last.type !== "EmptyStatement") {
-    return last;
+  for (let i = statements.length - 1; i >= 0; i--) {
+    const statement = statements[i];
+    if (statement.type !== "EmptyStatement") {
+      return statement;
+    }
   }
-  return getLast(statements.filter(({ type }) => type !== "EmptyStatement"));
 }
 
 function statementNeedsASIProtection(path, options) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Tiny refactoring.

It is often the case that the last statement is not an `EmptyStatement`. it is useless to run the `filter` in that case.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
