### PR TITLE
refactor: Rename shouldNotPrePrintHardline to shouldPrePrintHardline

### DIFF
--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -721,7 +721,7 @@ function printChildren(path, options, print, events) {
         options,
       };
 
-      if (!shouldNotPrePrintHardline(childNode, data)) {
+      if (shouldPrePrintHardline(childNode, data)) {
         parts.push(hardline);
 
         // Can't find a case to pass `shouldPrePrintTripleHardline`
@@ -772,7 +772,7 @@ function isPrettierIgnore(node) {
   return match === null ? false : match[1] ? match[1] : "next";
 }
 
-function shouldNotPrePrintHardline(node, data) {
+function shouldPrePrintHardline(node, data) {
   const isFirstNode = data.parts.length === 0;
   const isInlineNode = INLINE_NODE_TYPES.includes(node.type);
 
@@ -780,7 +780,7 @@ function shouldNotPrePrintHardline(node, data) {
     node.type === "html" &&
     INLINE_NODE_WRAPPER_TYPES.includes(data.parentNode.type);
 
-  return isFirstNode || isInlineNode || isInlineHTML;
+  return !isFirstNode && !isInlineNode && !isInlineHTML;
 }
 
 function shouldPrePrintDoubleHardline(node, data) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
Double negative is hard to read, so rename it

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
