### PR TITLE
Remove workaround for @rollup/plugin-node-resolve 11

### DIFF
--- a/scripts/build/bundler.js
+++ b/scripts/build/bundler.js
@@ -58,15 +58,6 @@ const entries = [
     find: "@glimmer/syntax",
     replacement: require.resolve("@glimmer/syntax"),
   },
-  // https://github.com/rollup/plugins/issues/670
-  {
-    find: "is-core-module",
-    replacement: require.resolve("is-core-module"),
-  },
-  {
-    find: "yaml/util",
-    replacement: require.resolve("yaml/util"),
-  },
 ];
 
 function webpackNativeShims(config, modules) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

A workaround is added in #9804. It is unnecessary now because it's fixed in rollup/plugin-node-resolve 11.1.0.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
