### PR TITLE
Improve destructured object formatting

### DIFF
--- a/src/language-js/print/object.js
+++ b/src/language-js/print/object.js
@@ -65,12 +65,12 @@ function printObject(path, options, print) {
       parent.type !== "ClassPrivateMethod" &&
       parent.type !== "AssignmentPattern" &&
       parent.type !== "CatchClause" &&
-      n.properties.some(
+      n.properties.filter(
         (property) =>
           property.value &&
           (property.value.type === "ObjectPattern" ||
             property.value.type === "ArrayPattern")
-      )) ||
+      ).length > 1) ||
     (n.type !== "ObjectPattern" &&
       firstProperty &&
       hasNewlineInRange(

--- a/tests/js/destructuring/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/destructuring/__snapshots__/jsfmt.spec.js.snap
@@ -57,9 +57,7 @@ const [one, two = null, three = null] = arr;
 a = ([s = 1]) => 1;
 const { children, ...props } = this.props;
 
-const {
-  user: { firstName, lastName },
-} = this.props;
+const { user: { firstName, lastName } } = this.props;
 
 const {
   name: { first, last },
@@ -79,12 +77,7 @@ const UserComponent = function ({
   return;
 };
 
-const {
-  a,
-  b,
-  c,
-  d: { e },
-} = someObject;
+const { a, b, c, d: { e } } = someObject;
 
 try {
   // code
@@ -94,11 +87,7 @@ try {
 
 try {
   // code
-} catch ({
-  data: {
-    message: { errors },
-  },
-}) {
+} catch ({ data: { message: { errors } } }) {
   // code
 }
 

--- a/tests/vue/vue-3/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/vue/vue-3/__snapshots__/jsfmt.spec.js.snap
@@ -29,13 +29,7 @@ printWidth: 80
 <script setup></script>
 <script setup="foo"></script>
 <script setup="{ row }"></script>
-<script
-  setup="{
-    destructuring: {
-      a: { b },
-    },
-  }"
-></script>
+<script setup="{ destructuring: { a: { b } } }"></script>
 
 <!-- Not script -->
 <custom setup="     {row   }">Not A script</custom>
@@ -83,13 +77,7 @@ printWidth: 80
 <style vars></style>
 <style vars="foo"></style>
 <style vars="{ row }"></style>
-<style
-  vars="{
-    destructuring: {
-      a: { b },
-    },
-  }"
-></style>
+<style vars="{ destructuring: { a: { b } } }"></style>
 
 <!-- Not style -->
 <custom vars="     {row   }">Not A style</custom>

--- a/tests/vue/vue/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/vue/vue/__snapshots__/jsfmt.spec.js.snap
@@ -301,32 +301,16 @@ semi: false
     "
     slot-scope="foo"
     slot-scope="{ row }"
-    slot-scope="{
-      destructuring: {
-        a: { b },
-      },
-    }"
+    slot-scope="{ destructuring: { a: { b } } }"
     #default="foo"
     #default="{ row }"
-    #default="{
-      destructuring: {
-        a: { b },
-      },
-    }"
+    #default="{ destructuring: { a: { b } } }"
     v-slot="foo"
     v-slot="{ row }"
-    v-slot="{
-      destructuring: {
-        a: { b },
-      },
-    }"
+    v-slot="{ destructuring: { a: { b } } }"
     v-slot:name="foo"
     v-slot:name="{ row }"
-    v-slot:name="{
-      destructuring: {
-        a: { b },
-      },
-    }"
+    v-slot:name="{ destructuring: { a: { b } } }"
     :class="{
       longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true,
     }"
@@ -355,11 +339,7 @@ semi: false
     @click="a[1];"
     @click="a['b'];"
     @click="a[null]"
-    #default="{
-      foo: {
-        bar: { baz },
-      },
-    }"
+    #default="{ foo: { bar: { baz } } }"
   ></div>
 </template>
 
@@ -667,32 +647,16 @@ trailingComma: "none"
     "
     slot-scope="foo"
     slot-scope="{ row }"
-    slot-scope="{
-      destructuring: {
-        a: { b }
-      }
-    }"
+    slot-scope="{ destructuring: { a: { b } } }"
     #default="foo"
     #default="{ row }"
-    #default="{
-      destructuring: {
-        a: { b }
-      }
-    }"
+    #default="{ destructuring: { a: { b } } }"
     v-slot="foo"
     v-slot="{ row }"
-    v-slot="{
-      destructuring: {
-        a: { b }
-      }
-    }"
+    v-slot="{ destructuring: { a: { b } } }"
     v-slot:name="foo"
     v-slot:name="{ row }"
-    v-slot:name="{
-      destructuring: {
-        a: { b }
-      }
-    }"
+    v-slot:name="{ destructuring: { a: { b } } }"
     :class="{
       longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true
     }"
@@ -721,11 +685,7 @@ trailingComma: "none"
     @click="a[1];"
     @click="a['b'];"
     @click="a[null]"
-    #default="{
-      foo: {
-        bar: { baz }
-      }
-    }"
+    #default="{ foo: { bar: { baz } } }"
   ></div>
 </template>
 
@@ -1032,32 +992,16 @@ printWidth: 80
     "
     slot-scope="foo"
     slot-scope="{ row }"
-    slot-scope="{
-      destructuring: {
-        a: { b },
-      },
-    }"
+    slot-scope="{ destructuring: { a: { b } } }"
     #default="foo"
     #default="{ row }"
-    #default="{
-      destructuring: {
-        a: { b },
-      },
-    }"
+    #default="{ destructuring: { a: { b } } }"
     v-slot="foo"
     v-slot="{ row }"
-    v-slot="{
-      destructuring: {
-        a: { b },
-      },
-    }"
+    v-slot="{ destructuring: { a: { b } } }"
     v-slot:name="foo"
     v-slot:name="{ row }"
-    v-slot:name="{
-      destructuring: {
-        a: { b },
-      },
-    }"
+    v-slot:name="{ destructuring: { a: { b } } }"
     :class="{
       longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true,
     }"
@@ -1086,11 +1030,7 @@ printWidth: 80
     @click="a[1];"
     @click="a['b'];"
     @click="a[null]"
-    #default="{
-      foo: {
-        bar: { baz },
-      },
-    }"
+    #default="{ foo: { bar: { baz } } }"
   ></div>
 </template>
 


### PR DESCRIPTION
## Description

- Only break up destructured objects in case of multiple nested siblings, as suggested in: <https://github.com/prettier/prettier/issues/5939#issuecomment-660471411>

resolves #5939

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- ~~I’ve added tests to confirm my change works.~~
- ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~~
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
