### PR TITLE
Stabilize the formatting for a line comment in empty method parameters

### DIFF
--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -520,22 +520,14 @@ function handleCommentInEmptyParens({ comment, enclosingNode, text }) {
   if (
     enclosingNode &&
     ((isRealFunctionLikeNode(enclosingNode) &&
-      getFunctionParameters(enclosingNode).length === 0) ||
+      getFunctionParameters(getRealFunctionLikeValue(enclosingNode)).length ===
+        0) ||
       ((enclosingNode.type === "CallExpression" ||
         enclosingNode.type === "OptionalCallExpression" ||
         enclosingNode.type === "NewExpression") &&
         enclosingNode.arguments.length === 0))
   ) {
-    addDanglingComment(enclosingNode, comment);
-    return true;
-  }
-  if (
-    enclosingNode &&
-    (enclosingNode.type === "MethodDefinition" ||
-      enclosingNode.type === "TSAbstractMethodDefinition") &&
-    getFunctionParameters(enclosingNode.value).length === 0
-  ) {
-    addDanglingComment(enclosingNode.value, comment);
+    addDanglingComment(getRealFunctionLikeValue(enclosingNode), comment);
     return true;
   }
   return false;
@@ -882,8 +874,24 @@ function isRealFunctionLikeNode(node) {
     node.type === "TSMethodSignature" ||
     node.type === "TSConstructorType" ||
     node.type === "TSFunctionType" ||
-    node.type === "TSDeclareMethod"
+    node.type === "TSDeclareMethod" ||
+    node.type === "MethodDefinition" ||
+    node.type === "TSAbstractMethodDefinition"
   );
+}
+
+/**
+ * @param {Node} node
+ * @returns {Node}
+ */
+function getRealFunctionLikeValue(node) {
+  if (
+    node.type === "MethodDefinition" ||
+    node.type === "TSAbstractMethodDefinition"
+  ) {
+    return node.value;
+  }
+  return node;
 }
 
 /**

--- a/tests/typescript/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/comments/__snapshots__/jsfmt.spec.js.snap
@@ -482,6 +482,16 @@ class Foo {
   method(/* bar */);
 }
 
+class Foo {
+  abstract method(
+    // comment
+  );
+}
+
+class Foo {
+  abstract method(/* bar */);
+}
+
 =====================================output=====================================
 class Foo {
   method() {}
@@ -495,6 +505,15 @@ class Foo {
 
 class Foo {
   method(/* bar */);
+}
+
+class Foo {
+  abstract method();
+  // comment
+}
+
+class Foo {
+  abstract method(/* bar */);
 }
 
 ================================================================================

--- a/tests/typescript/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/comments/__snapshots__/jsfmt.spec.js.snap
@@ -460,6 +460,46 @@ type M = { [m in M /* commentG */]: string };
 ================================================================================
 `;
 
+exports[`method_2.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+class Foo {
+  method(
+    // comment
+  ) {}
+}
+
+class Foo {
+  method(
+    // comment
+  );
+}
+
+class Foo {
+  method(/* bar */);
+}
+
+=====================================output=====================================
+class Foo {
+  method() {}
+  // comment
+}
+
+class Foo {
+  method();
+  // comment
+}
+
+class Foo {
+  method(/* bar */);
+}
+
+================================================================================
+`;
+
 exports[`method_types.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/typescript/comments/method_2.ts
+++ b/tests/typescript/comments/method_2.ts
@@ -13,3 +13,13 @@ class Foo {
 class Foo {
   method(/* bar */);
 }
+
+class Foo {
+  abstract method(
+    // comment
+  );
+}
+
+class Foo {
+  abstract method(/* bar */);
+}

--- a/tests/typescript/comments/method_2.ts
+++ b/tests/typescript/comments/method_2.ts
@@ -1,0 +1,15 @@
+class Foo {
+  method(
+    // comment
+  ) {}
+}
+
+class Foo {
+  method(
+    // comment
+  );
+}
+
+class Foo {
+  method(/* bar */);
+}


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

It still needs to be improved, but just to stabilize it, this is good enough.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/master/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
