### PR TITLE
Fix lineSuffixBoundary

### DIFF
--- a/changelog_unreleased/api/10122.md
+++ b/changelog_unreleased/api/10122.md
@@ -1,0 +1,34 @@
+#### Fix `lineSuffixBoundary` (#10122 by @thorn0)
+
+There was a bug in the implementation of the [`lineSuffixBoundary`][lsb] command that significantly limited its usefulness: the printer algorithm didn't correctly consider it a potential line break. Now that the bug has been fixed, we urge plugin authors to give this command another try and see if it can help them simplify printing of trailing comments.
+
+[lsb]: https://github.com/prettier/prettier/blob/main/commands.md#linesuffixboundary
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+group([
+  "let foo = [",
+  indent([
+    softline,
+    [lineSuffixBoundary, "item1,"],
+    line,
+    [lineSuffixBoundary, "item2,", lineSuffix(" // comment")],
+    line,
+    [lineSuffixBoundary, "item3"],
+  ]),
+  softline,
+  "];",
+])
+
+// Prettier stable
+let foo = [item1, item2,  // comment
+  item3];
+
+// Prettier main
+let foo = [
+  item1,
+  item2, // comment
+  item3
+];
+```

--- a/src/document/doc-printer.js
+++ b/src/document/doc-printer.js
@@ -144,7 +144,7 @@ function trim(out) {
   return trimCount;
 }
 
-function fits(next, restCommands, width, options, mustBeFlat) {
+function fits(next, restCommands, width, options, hasLineSuffix, mustBeFlat) {
   let restIdx = restCommands.length;
   const cmds = [next];
   // `out` is only used for width counting because `trim` requires to look
@@ -237,6 +237,14 @@ function fits(next, restCommands, width, options, mustBeFlat) {
               return true;
           }
           break;
+        case "line-suffix":
+          hasLineSuffix = true;
+          break;
+        case "line-suffix-boundary":
+          if (hasLineSuffix) {
+            return false;
+          }
+          break;
       }
     }
   }
@@ -306,8 +314,9 @@ function printDocToString(doc, options) {
 
               const next = [ind, MODE_FLAT, doc.contents];
               const rem = width - pos;
+              const hasLineSuffix = lineSuffix.length > 0;
 
-              if (!doc.break && fits(next, cmds, rem, options)) {
+              if (!doc.break && fits(next, cmds, rem, options, hasLineSuffix)) {
                 cmds.push(next);
               } else {
                 // Expanded states are a rare case where a document
@@ -335,7 +344,7 @@ function printDocToString(doc, options) {
                         const state = doc.expandedStates[i];
                         const cmd = [ind, MODE_FLAT, state];
 
-                        if (fits(cmd, cmds, rem, options)) {
+                        if (fits(cmd, cmds, rem, options, hasLineSuffix)) {
                           cmds.push(cmd);
 
                           break;
@@ -387,7 +396,14 @@ function printDocToString(doc, options) {
           const [content, whitespace] = parts;
           const contentFlatCmd = [ind, MODE_FLAT, content];
           const contentBreakCmd = [ind, MODE_BREAK, content];
-          const contentFits = fits(contentFlatCmd, [], rem, options, true);
+          const contentFits = fits(
+            contentFlatCmd,
+            [],
+            rem,
+            options,
+            lineSuffix.length > 0,
+            true
+          );
 
           if (parts.length === 1) {
             if (contentFits) {
@@ -430,6 +446,7 @@ function printDocToString(doc, options) {
             [],
             rem,
             options,
+            lineSuffix.length > 0,
             true
           );
 

--- a/tests_integration/__tests__/line-suffix-boundary.js
+++ b/tests_integration/__tests__/line-suffix-boundary.js
@@ -1,0 +1,41 @@
+"use strict";
+
+/** @type {import('prettier')} */
+const prettier = require("prettier-local");
+
+const {
+  group,
+  indent,
+  line,
+  lineSuffix,
+  lineSuffixBoundary,
+  softline,
+} = prettier.doc.builders;
+
+const printDoc = require("../printDoc");
+
+describe("lineSuffixBoundary", () => {
+  test("should be correctly treated as a potential line break in `fits`", () => {
+    const doc = group([
+      "let foo = [",
+      indent([
+        softline,
+        [lineSuffixBoundary, "item1,"],
+        line,
+        [lineSuffixBoundary, "item2,", lineSuffix(" // comment")],
+        line,
+        [lineSuffixBoundary, "item3"],
+      ]),
+      softline,
+      "];",
+    ]);
+
+    const expected = `let foo = [
+  item1,
+  item2, // comment
+  item3
+];`;
+
+    expect(printDoc(doc)).toBe(expected);
+  });
+});

--- a/tests_integration/printDoc.js
+++ b/tests_integration/printDoc.js
@@ -4,24 +4,26 @@
 const prettier = require("prettier-local");
 
 function printDoc(doc) {
-  return prettier.format("_", {
-    plugins: [
-      {
-        parsers: {
-          doc: {
-            parse: () => doc,
-            astFormat: "doc",
-          },
-        },
-        printers: {
-          doc: {
-            print: (path) => path.getValue(),
-          },
-        },
-        languages: [{ name: "doc", parsers: ["doc"] }],
+  // This dummy plugin ignores the input and simply returns the given doc.
+  // This is to make sure that the doc will go through all the stages a real doc
+  // returned by a real plugin would go (e.g. `propagateBreaks`).
+  const dummyPlugin = {
+    parsers: {
+      dummy: {
+        parse: () => ({}),
+        astFormat: "dummy",
       },
-    ],
-    parser: "doc",
+    },
+    printers: {
+      dummy: {
+        print: () => doc,
+      },
+    },
+  };
+
+  return prettier.format("_", {
+    plugins: [dummyPlugin],
+    parser: "dummy",
   });
 }
 

--- a/tests_integration/printDoc.js
+++ b/tests_integration/printDoc.js
@@ -1,0 +1,28 @@
+"use strict";
+
+/** @type {import('prettier')} */
+const prettier = require("prettier-local");
+
+function printDoc(doc) {
+  return prettier.format("_", {
+    plugins: [
+      {
+        parsers: {
+          doc: {
+            parse: () => doc,
+            astFormat: "doc",
+          },
+        },
+        printers: {
+          doc: {
+            print: (path) => path.getValue(),
+          },
+        },
+        languages: [{ name: "doc", parsers: ["doc"] }],
+      },
+    ],
+    parser: "doc",
+  });
+}
+
+module.exports = printDoc;


### PR DESCRIPTION
There is a bug in the implementation of the `lineSuffixBoundary` command: the [`fits` function][fits] in the doc printer doesn't consider `lineSuffixBoundary` to be a potential line break. That's why `lineSuffixBoundary` doesn't break groups, the line length limit is calculated incorrectly after a line break caused by `lineSuffixBoundary`, etc. This PR fixes this bug.

[fits]: https://github.com/prettier/prettier/blob/dd606d9ce1810f970c57e09f2f8cde5adcfbdb01/src/document/doc-printer.js#L147

I couldn't find any open issues that this PR would directly fix. This is because `lineSuffixBoundary` is very little used. It hasn't really been useful because of this bug. I got ugly results every time I tried to use it. But now it should become a great help in solving comments-related issues.

For example, consider this doc:
```js
    group([
      "let foo = [",
      indent([
        softline,
        [lineSuffixBoundary, "item1,"],
        line,
        [lineSuffixBoundary, "item2,", lineSuffix(" // comment")],
        line,
        [lineSuffixBoundary, "item3"],
      ]),
      softline,
      "];",
    ])
```
That's how it is printed now:
```js
let foo = [item1, item2,  // comment
  item3];
```
And with the fix:
```js
let foo = [
  item1,
  item2, // comment
  item3
];
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
