### PR TITLE
Add CLI flag for debugging comment attachment issues

### DIFF
--- a/changelog_unreleased/cli/10124.md
+++ b/changelog_unreleased/cli/10124.md
@@ -1,0 +1,3 @@
+#### Add CLI flag for debugging comment attachment issues (#10124 by @thorn0)
+
+A new `--debug-print-comments` CLI flag and corresponding functionality for the Playground.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -351,7 +351,7 @@ Nodes with comments are expected to have a `comments` property containing an arr
 
 The example above uses `util.addTrailingComment`, which automatically sets `comment.leading`/`trailing`/`printed` to appropriate values and adds the comment to the AST node's `comments` array.
 
-The `--debug-print-comments` CLI flag can help with debugging comment attachment issues. It prints a detailed list of comments which includes information on how and to which node every comment was attached. For Prettier’s built-in languages, this information is also available on the Playground (the 'show comments' checkbox in the Debug section).
+The `--debug-print-comments` CLI flag can help with debugging comment attachment issues. It prints a detailed list of comments, which includes information on how every comment was classified (`ownLine`/`endOfLine`/`remaining`, `leading`/`trailing`/`dangling`) and to which node it was attached. For Prettier’s built-in languages, this information is also available on the Playground (the 'show comments' checkbox in the Debug section).
 
 ### `options`
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -351,6 +351,8 @@ Nodes with comments are expected to have a `comments` property containing an arr
 
 The example above uses `util.addTrailingComment`, which automatically sets `comment.leading`/`trailing`/`printed` to appropriate values and adds the comment to the AST node's `comments` array.
 
+The `--debug-print-comments` CLI flag can help with debugging comment attachment issues. It prints a detailed list of comments which includes information on how and to which node every comment was attached. For Prettier’s built-in languages, this information is also available on the Playground (the 'show comments' checkbox in the Debug section).
+
 ### `options`
 
 `options` is an object containing the custom options your plugin supports.

--- a/src/cli/constant.js
+++ b/src/cli/constant.js
@@ -132,6 +132,9 @@ const options = {
   "debug-print-doc": {
     type: "boolean",
   },
+  "debug-print-comments": {
+    type: "boolean",
+  },
   "debug-repeat": {
     // Repeat the formatting a few times and measure the average duration.
     type: "int",

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -116,6 +116,15 @@ function format(context, input, opt) {
     return { formatted: prettier.__debug.formatDoc(doc) };
   }
 
+  if (context.argv["debug-print-comments"]) {
+    return {
+      formatted: prettier.format(
+        JSON.stringify(prettier.formatWithCursor(input, opt).comments || []),
+        { parser: "json" }
+      ),
+    };
+  }
+
   if (context.argv["debug-check"]) {
     const pp = prettier.format(input, opt);
     const pppp = prettier.format(pp, opt);

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -557,6 +557,7 @@ function addCommentHelper(node, comment) {
   const comments = node.comments || (node.comments = []);
   comments.push(comment);
   comment.printed = false;
+  comment.nodeDescription = describeNodeForDebugging(node);
 }
 
 function addLeadingComment(node, comment) {
@@ -636,6 +637,23 @@ function createGroupIdMapper(description) {
     }
     return groupIds.get(node);
   };
+}
+
+function describeNodeForDebugging(node) {
+  const nodeType = node.type || node.kind || "-none-";
+  let nodeName = String(
+    node.name ||
+      (node.id && (typeof node.id === "object" ? node.id.name : node.id)) ||
+      (node.key && (typeof node.key === "object" ? node.key.name : node.key)) ||
+      (node.value &&
+        (typeof node.value === "object" ? "" : String(node.value))) ||
+      node.operator ||
+      ""
+  );
+  if (nodeName.length > 20) {
+    nodeName = nodeName.slice(0, 19) + "…";
+  }
+  return nodeType + (nodeName ? " " + nodeName : "");
 }
 
 module.exports = {

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -640,7 +640,7 @@ function createGroupIdMapper(description) {
 }
 
 function describeNodeForDebugging(node) {
-  const nodeType = node.type || node.kind || "-none-";
+  const nodeType = node.type || node.kind || "(unknown type)";
   let nodeName = String(
     node.name ||
       (node.id && (typeof node.id === "object" ? node.id.name : node.id)) ||

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -224,7 +224,7 @@ function attach(comments, ast, text, options) {
     }
 
     if (isOwnLineComment(text, options, decoratedComments, index)) {
-      comment.placement = "own-line";
+      comment.placement = "ownLine";
       // If a comment exists on its own line, prefer a leading comment.
       // We also need to check if it's the first line of the file.
       if (handleOwnLineComment(...args)) {
@@ -242,7 +242,7 @@ function attach(comments, ast, text, options) {
         addDanglingComment(ast, comment);
       }
     } else if (isEndOfLineComment(text, options, decoratedComments, index)) {
-      comment.placement = "end-of-line";
+      comment.placement = "endOfLine";
       if (handleEndOfLineComment(...args)) {
         // We're good
       } else if (precedingNode) {

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -224,6 +224,7 @@ function attach(comments, ast, text, options) {
     }
 
     if (isOwnLineComment(text, options, decoratedComments, index)) {
+      comment.placement = "own-line";
       // If a comment exists on its own line, prefer a leading comment.
       // We also need to check if it's the first line of the file.
       if (handleOwnLineComment(...args)) {
@@ -241,6 +242,7 @@ function attach(comments, ast, text, options) {
         addDanglingComment(ast, comment);
       }
     } else if (isEndOfLineComment(text, options, decoratedComments, index)) {
+      comment.placement = "end-of-line";
       if (handleEndOfLineComment(...args)) {
         // We're good
       } else if (precedingNode) {
@@ -257,6 +259,7 @@ function attach(comments, ast, text, options) {
         addDanglingComment(ast, comment);
       }
     } else {
+      comment.placement = "remaining";
       if (handleRemainingComment(...args)) {
         // We're good
       } else if (precedingNode && followingNode) {

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -136,7 +136,11 @@ function coreFormat(originalText, opts, addAlignmentSize = 0) {
     return { formatted: result.formatted, cursorOffset };
   }
 
-  return { formatted: result.formatted, cursorOffset: -1 };
+  return {
+    formatted: result.formatted,
+    cursorOffset: -1,
+    comments: astComments,
+  };
 }
 
 function formatRange(originalText, opts) {

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -38,7 +38,7 @@ function attachComments(text, ast, opts) {
 
 function coreFormat(originalText, opts, addAlignmentSize = 0) {
   if (!originalText || originalText.trim().length === 0) {
-    return { formatted: "", cursorOffset: -1 };
+    return { formatted: "", cursorOffset: -1, comments: [] };
   }
 
   const { ast, text } = parser.parse(originalText, opts);
@@ -102,6 +102,7 @@ function coreFormat(originalText, opts, addAlignmentSize = 0) {
       return {
         formatted: result.formatted,
         cursorOffset: newCursorNodeStart + cursorOffsetRelativeToOldCursorNode,
+        comments: astComments,
       };
     }
 
@@ -133,7 +134,7 @@ function coreFormat(originalText, opts, addAlignmentSize = 0) {
       }
     }
 
-    return { formatted: result.formatted, cursorOffset };
+    return { formatted: result.formatted, cursorOffset, comments: astComments };
   }
 
   return {
@@ -204,7 +205,7 @@ function formatRange(originalText, opts) {
     formatted = formatted.replace(/\n/g, eol);
   }
 
-  return { formatted, cursorOffset };
+  return { formatted, cursorOffset, comments: rangeResult.comments };
 }
 
 function ensureIndexInText(text, index, defaultValue) {
@@ -291,6 +292,7 @@ function formatWithCursor(originalText, originalOptions) {
     return {
       formatted: originalText,
       cursorOffset: originalOptions.cursorOffset,
+      comments: [],
     };
   }
 

--- a/tests/js/cursor/jsfmt.spec.js
+++ b/tests/js/cursor/jsfmt.spec.js
@@ -5,7 +5,7 @@ const prettier = require("prettier-local");
 test("translates cursor correctly in basic case", () => {
   expect(
     prettier.formatWithCursor(" 1", { parser: "babel", cursorOffset: 2 })
-  ).toEqual({
+  ).toMatchObject({
     formatted: "1;\n",
     cursorOffset: 1,
   });
@@ -15,7 +15,7 @@ test("positions cursor relative to closest node, not SourceElement", () => {
   const code = "return         15";
   expect(
     prettier.formatWithCursor(code, { parser: "babel", cursorOffset: 15 })
-  ).toEqual({
+  ).toMatchObject({
     formatted: "return 15;\n",
     cursorOffset: 7,
   });
@@ -25,7 +25,7 @@ test("keeps cursor inside formatted node", () => {
   const code = "return         15";
   expect(
     prettier.formatWithCursor(code, { parser: "babel", cursorOffset: 14 })
-  ).toEqual({
+  ).toMatchObject({
     formatted: "return 15;\n",
     cursorOffset: 7,
   });
@@ -38,7 +38,7 @@ foo('bar', cb => {
 })`;
   expect(
     prettier.formatWithCursor(code, { parser: "babel", cursorOffset: 24 })
-  ).toEqual({
+  ).toMatchObject({
     formatted: `foo("bar", (cb) => {
   console.log("stuff");
 });
@@ -57,7 +57,7 @@ test("cursorOffset === rangeStart", () => {
       rangeStart: 7,
       rangeEnd: 8,
     })
-  ).toEqual({
+  ).toMatchObject({
     formatted: "1.0000\n2.0;\n3.0000",
     cursorOffset: 7,
   });

--- a/tests_integration/__tests__/__snapshots__/debug-print-comments.js.snap
+++ b/tests_integration/__tests__/__snapshots__/debug-print-comments.js.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`prints information for debugging comment attachment with --debug-print-comments (stdout) 1`] = `
+"[
+  {
+    \\"type\\": \\"CommentBlock\\",
+    \\"value\\": \\" 1 \\",
+    \\"start\\": 0,
+    \\"end\\": 7,
+    \\"loc\\": {
+      \\"start\\": { \\"line\\": 1, \\"column\\": 0 },
+      \\"end\\": { \\"line\\": 1, \\"column\\": 7 }
+    },
+    \\"placement\\": \\"end-of-line\\",
+    \\"leading\\": true,
+    \\"trailing\\": false,
+    \\"nodeDescription\\": \\"ExpressionStatement\\"
+  },
+  {
+    \\"type\\": \\"CommentBlock\\",
+    \\"value\\": \\" 2 \\",
+    \\"start\\": 24,
+    \\"end\\": 31,
+    \\"loc\\": {
+      \\"start\\": { \\"line\\": 2, \\"column\\": 16 },
+      \\"end\\": { \\"line\\": 2, \\"column\\": 23 }
+    },
+    \\"placement\\": \\"remaining\\",
+    \\"leading\\": false,
+    \\"trailing\\": true,
+    \\"nodeDescription\\": \\"Identifier foo\\"
+  },
+  {
+    \\"type\\": \\"CommentLine\\",
+    \\"value\\": \\" 3\\",
+    \\"start\\": 34,
+    \\"end\\": 38,
+    \\"loc\\": {
+      \\"start\\": { \\"line\\": 2, \\"column\\": 26 },
+      \\"end\\": { \\"line\\": 2, \\"column\\": 30 }
+    },
+    \\"placement\\": \\"remaining\\",
+    \\"leading\\": false,
+    \\"trailing\\": true,
+    \\"nodeDescription\\": \\"ExpressionStatement\\"
+  }
+]
+"
+`;
+
+exports[`prints information for debugging comment attachment with --debug-print-comments (write) 1`] = `Array []`;

--- a/tests_integration/__tests__/__snapshots__/debug-print-comments.js.snap
+++ b/tests_integration/__tests__/__snapshots__/debug-print-comments.js.snap
@@ -11,7 +11,7 @@ exports[`prints information for debugging comment attachment with --debug-print-
       \\"start\\": { \\"line\\": 1, \\"column\\": 0 },
       \\"end\\": { \\"line\\": 1, \\"column\\": 7 }
     },
-    \\"placement\\": \\"end-of-line\\",
+    \\"placement\\": \\"endOfLine\\",
     \\"leading\\": true,
     \\"trailing\\": false,
     \\"nodeDescription\\": \\"ExpressionStatement\\"

--- a/tests_integration/__tests__/debug-print-comments.js
+++ b/tests_integration/__tests__/debug-print-comments.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const runPrettier = require("../runPrettier");
+
+describe("prints information for debugging comment attachment with --debug-print-comments", () => {
+  runPrettier(
+    "cli/with-shebang",
+    ["--debug-print-comments", "--parser", "babel"],
+    { input: "/* 1 */\nconsole.log(foo /* 2 */); // 3" }
+  ).test({
+    stderr: "",
+    status: 0,
+  });
+});

--- a/website/playground/EditorState.js
+++ b/website/playground/EditorState.js
@@ -10,10 +10,12 @@ export default class extends React.Component {
       showSidebar: false,
       showAst: false,
       showDoc: false,
+      showComments: false,
       showSecondFormat: false,
       toggleSidebar: () => this.setState(stateToggler("showSidebar")),
       toggleAst: () => this.setState(stateToggler("showAst")),
       toggleDoc: () => this.setState(stateToggler("showDoc")),
+      toggleComments: () => this.setState(stateToggler("showComments")),
       toggleSecondFormat: () => this.setState(stateToggler("showSecondFormat")),
       ...storage.get("editor_state"),
     };

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -151,8 +151,13 @@ class Playground extends React.Component {
   }
 
   render() {
-    const { worker } = this.props;
+    const { worker, version } = this.props;
     const { content, options } = this.state;
+
+    // TODO: remove this when v2.3.0 is released
+    const [major, minor] = version.split(".", 2).map(Number);
+    const showShowComments =
+      Number.isNaN(major) || (major === 2 && minor >= 3) || major > 2;
 
     return (
       <EditorState>
@@ -163,7 +168,7 @@ class Playground extends React.Component {
             options={options}
             debugAst={editorState.showAst}
             debugDoc={editorState.showDoc}
-            debugComments={editorState.showComments}
+            debugComments={showShowComments && editorState.showComments}
             reformat={editorState.showSecondFormat}
           >
             {({ formatted, debug }) => {
@@ -224,11 +229,13 @@ class Playground extends React.Component {
                           checked={editorState.showDoc}
                           onChange={editorState.toggleDoc}
                         />
-                        <Checkbox
-                          label="show comments"
-                          checked={editorState.showComments}
-                          onChange={editorState.toggleComments}
-                        />
+                        {showShowComments && (
+                          <Checkbox
+                            label="show comments"
+                            checked={editorState.showComments}
+                            onChange={editorState.toggleComments}
+                          />
+                        )}
                         <Checkbox
                           label="show second format"
                           checked={editorState.showSecondFormat}
@@ -261,7 +268,7 @@ class Playground extends React.Component {
                       {editorState.showDoc ? (
                         <DebugPanel value={debug.doc || ""} />
                       ) : null}
-                      {editorState.showComments ? (
+                      {showShowComments && editorState.showComments ? (
                         <DebugPanel
                           value={debug.comments || ""}
                           autoFold={util.getAstAutoFold(options.parser)}

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -163,6 +163,7 @@ class Playground extends React.Component {
             options={options}
             debugAst={editorState.showAst}
             debugDoc={editorState.showDoc}
+            debugComments={editorState.showComments}
             reformat={editorState.showSecondFormat}
           >
             {({ formatted, debug }) => {
@@ -224,6 +225,11 @@ class Playground extends React.Component {
                           onChange={editorState.toggleDoc}
                         />
                         <Checkbox
+                          label="show comments"
+                          checked={editorState.showComments}
+                          onChange={editorState.toggleComments}
+                        />
+                        <Checkbox
                           label="show second format"
                           checked={editorState.showSecondFormat}
                           onChange={editorState.toggleSecondFormat}
@@ -254,6 +260,12 @@ class Playground extends React.Component {
                       ) : null}
                       {editorState.showDoc ? (
                         <DebugPanel value={debug.doc || ""} />
+                      ) : null}
+                      {editorState.showComments ? (
+                        <DebugPanel
+                          value={debug.comments || ""}
+                          autoFold={util.getAstAutoFold(options.parser)}
+                        />
                       ) : null}
                       <OutputPanel
                         mode={util.getCodemirrorMode(options.parser)}

--- a/website/playground/PrettierFormat.js
+++ b/website/playground/PrettierFormat.js
@@ -11,7 +11,14 @@ export default class PrettierFormat extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    for (const key of ["code", "options", "debugAst", "debugDoc", "reformat"]) {
+    for (const key of [
+      "code",
+      "options",
+      "debugAst",
+      "debugDoc",
+      "debugComments",
+      "reformat",
+    ]) {
       if (prevProps[key] !== this.props[key]) {
         this.format();
         break;
@@ -26,11 +33,12 @@ export default class PrettierFormat extends React.Component {
       options,
       debugAst: ast,
       debugDoc: doc,
+      debugComments: comments,
       reformat,
     } = this.props;
 
     worker
-      .format(code, options, { ast, doc, reformat })
+      .format(code, options, { ast, doc, comments, reformat })
       .then((result) => this.setState(result));
   }
 


### PR DESCRIPTION
A new `--debug-print-comments` CLI flag and corresponding functionality for the Playground.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
