### PR TITLE
Enable `unicorn/prefer-spread`

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -75,6 +75,7 @@ rules:
   unicorn/prefer-includes: error
   unicorn/prefer-number-properties: error
   unicorn/prefer-regexp-test: error
+  unicorn/prefer-spread: error
   unicorn/prefer-string-slice: error
 overrides:
   - files:

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -98,7 +98,7 @@ async function createBundle(bundleConfig, cache, options) {
         sizeTexts.push(`esm ${await getSizeText(esmFile)}`);
       }
       process.stdout.write(
-        fitTerminal(output, sizeTexts.join(", ").concat(" "))
+        fitTerminal(output, [...sizeTexts.join(", "), " "])
       );
     }
 

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -97,9 +97,7 @@ async function createBundle(bundleConfig, cache, options) {
         const esmFile = path.join("dist/esm", output.replace(".js", ".mjs"));
         sizeTexts.push(`esm ${await getSizeText(esmFile)}`);
       }
-      process.stdout.write(
-        fitTerminal(output, [...sizeTexts.join(", "), " "])
-      );
+      process.stdout.write(fitTerminal(output, `${sizeTexts.join(", ")} `));
     }
 
     console.log(status.DONE);

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -168,7 +168,7 @@ function getFileOutput(bundle) {
   return bundle.output || path.basename(bundle.input);
 }
 
-module.exports = coreBundles.concat(parsers).map((bundle) => ({
+module.exports = [...coreBundles, ...parsers].map((bundle) => ({
   ...bundle,
   output: getFileOutput(bundle),
 }));

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -34,10 +34,10 @@ function logPromise(name, promise) {
 }
 
 function runYarn(script) {
-  if (typeof script === "string") {
-    script = [script];
-  }
-  return execa("yarn", ["--silent"].concat(script)).catch((error) => {
+  return execa("yarn", [
+    "--silent",
+    ...(Array.isArray(script) ? script : [script]),
+  ]).catch((error) => {
     throw new Error(`\`yarn ${script}\` failed\n${error.stdout}`);
   });
 }

--- a/scripts/sync-flow-tests.js
+++ b/scripts/sync-flow-tests.js
@@ -101,9 +101,9 @@ function run(argv) {
         "but that's not interesting for Prettier's tests.",
         "This is the skipped stuff:",
         "",
-      ]
-        .concat(skipped, "")
-        .join("\n")
+        ...skipped,
+        "",
+      ].join("\n")
     );
   }
 

--- a/src/cli/expand-patterns.js
+++ b/src/cli/expand-patterns.js
@@ -130,9 +130,10 @@ function* expandPatternsInternal(context) {
       const filenames = flat(
         context.languages.map((lang) => lang.filenames || [])
       );
-      supportedFilesGlob = `**/{${extensions
-        .map((ext) => "*" + (ext[0] === "." ? ext : "." + ext))
-        .concat(filenames)}}`;
+      supportedFilesGlob = `**/{${[
+        ...extensions.map((ext) => "*" + (ext[0] === "." ? ext : "." + ext)),
+        ...filenames,
+      ]}}`;
     }
     return supportedFilesGlob;
   }

--- a/src/cli/usage.js
+++ b/src/cli/usage.js
@@ -148,7 +148,7 @@ function createUsage(context) {
     return `${category} options:\n\n${indent(categoryOptions, 2)}`;
   });
 
-  return [constant.usageSummary].concat(optionsUsage, [""]).join("\n\n");
+  return [constant.usageSummary, ...optionsUsage, ""].join("\n\n");
 }
 
 function createDetailedUsage(context, flag) {

--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const uniqBy = require("lodash/uniqBy");
 const partition = require("lodash/partition");
+const flatten = require("lodash/flatten");
 const globby = require("globby");
 const mem = require("mem");
 const internalPlugins = require("../languages");
@@ -56,8 +57,8 @@ function load(plugins, pluginSearchDirs) {
     }
   );
 
-  const externalAutoLoadPluginInfos = pluginSearchDirs
-    .map((pluginSearchDir) => {
+  const externalAutoLoadPluginInfos = flatten(
+    pluginSearchDirs.map((pluginSearchDir) => {
       const resolvedPluginSearchDir = path.resolve(
         process.cwd(),
         pluginSearchDir
@@ -85,19 +86,20 @@ function load(plugins, pluginSearchDirs) {
         requirePath: resolve(pluginName, { paths: [resolvedPluginSearchDir] }),
       }));
     })
-    .reduce((a, b) => a.concat(b), []);
+  );
 
-  const externalPlugins = uniqBy(
-    externalManualLoadPluginInfos.concat(externalAutoLoadPluginInfos),
-    "requirePath"
-  )
-    .map((externalPluginInfo) => ({
+  const externalPlugins = [
+    ...uniqBy(
+      [...externalManualLoadPluginInfos, ...externalAutoLoadPluginInfos],
+      "requirePath"
+    ).map((externalPluginInfo) => ({
       name: externalPluginInfo.name,
       ...eval("require")(externalPluginInfo.requirePath),
-    }))
-    .concat(externalPluginInstances);
+    })),
+    ...externalPluginInstances,
+  ];
 
-  return internalPlugins.concat(externalPlugins);
+  return [...internalPlugins, ...externalPlugins];
 }
 
 function findPluginsInNodeModules(nodeModulesDir) {

--- a/src/config/resolve-config.js
+++ b/src/config/resolve-config.js
@@ -155,8 +155,8 @@ function mergeOverrides(configResult, filePath) {
 
 // Based on eslint: https://github.com/eslint/eslint/blob/master/lib/config/config-ops.js
 function pathMatchesGlobs(filePath, patterns, excludedPatterns) {
-  const patternList = [].concat(patterns);
-  const excludedPatternList = [].concat(excludedPatterns || []);
+  const patternList = [...patterns];
+  const excludedPatternList = [...(excludedPatterns || [])];
   const opts = { matchBase: true, dot: true };
 
   return (

--- a/src/config/resolve-config.js
+++ b/src/config/resolve-config.js
@@ -154,9 +154,11 @@ function mergeOverrides(configResult, filePath) {
 }
 
 // Based on eslint: https://github.com/eslint/eslint/blob/master/lib/config/config-ops.js
-function pathMatchesGlobs(filePath, patterns, excludedPatterns) {
-  const patternList = [...patterns];
-  const excludedPatternList = [...(excludedPatterns || [])];
+function pathMatchesGlobs(filePath, patterns, excludedPatterns = []) {
+  const patternList = Array.isArray(patterns) ? patterns : [patterns];
+  const excludedPatternList = Array.isArray(excludedPatterns)
+    ? excludedPatterns
+    : [excludedPatterns];
   const opts = { matchBase: true, dot: true };
 
   return (

--- a/src/document/doc-printer.js
+++ b/src/document/doc-printer.js
@@ -45,7 +45,7 @@ function generateInd(ind, newPart, options) {
   const queue =
     newPart.type === "dedent"
       ? ind.queue.slice(0, -1)
-      : ind.queue.concat(newPart);
+      : [...ind.queue, newPart];
 
   let value = "";
   let length = 0;

--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -73,7 +73,7 @@ function parseValueNode(valueNode, options) {
       for (let i = 0; i < groups.length; i++) {
         const group = groups[i];
         if (group.type === "comma_group") {
-          groupList = groupList.concat(group.groups);
+          groupList = [...groupList, ...group.groups];
         } else {
           groupList.push(group);
         }

--- a/src/language-css/utils.js
+++ b/src/language-css/utils.js
@@ -30,7 +30,7 @@ const colorAdjusterFunctions = new Set([
 ]);
 
 function getAncestorCounter(path, typeOrTypes) {
-  const types = [].concat(typeOrTypes);
+  const types = Array.isArray(typeOrTypes) ? typeOrTypes : [typeOrTypes];
 
   let counter = -1;
   let ancestorNode;
@@ -149,7 +149,9 @@ function insideICSSRuleNode(path) {
 }
 
 function insideAtRuleNode(path, atRuleNameOrAtRuleNames) {
-  const atRuleNames = [].concat(atRuleNameOrAtRuleNames);
+  const atRuleNames = Array.isArray(atRuleNameOrAtRuleNames)
+    ? atRuleNameOrAtRuleNames
+    : [atRuleNameOrAtRuleNames];
   const atRuleAncestorNode = getAncestorNode(path, "css-atrule");
 
   return (

--- a/src/language-html/index.js
+++ b/src/language-html/index.js
@@ -17,7 +17,8 @@ const languages = [
     since: "1.15.0",
     parsers: ["html"],
     vscodeLanguageIds: ["html"],
-    extensions: [...data.extensions, 
+    extensions: [
+      ...data.extensions,
       ".mjml", // MJML is considered XML in Linguist but it should be formatted as HTML
     ],
   })),

--- a/src/language-html/index.js
+++ b/src/language-html/index.js
@@ -17,9 +17,9 @@ const languages = [
     since: "1.15.0",
     parsers: ["html"],
     vscodeLanguageIds: ["html"],
-    extensions: data.extensions.concat([
+    extensions: [...data.extensions, 
       ".mjml", // MJML is considered XML in Linguist but it should be formatted as HTML
-    ]),
+    ],
   })),
   createLanguage(require("linguist-languages/data/HTML.json"), () => ({
     name: "Lightning Web Components",

--- a/src/language-html/print-preprocess.js
+++ b/src/language-html/print-preprocess.js
@@ -331,7 +331,7 @@ function extractWhitespaces(ast /*, options*/) {
         // extract whitespace nodes
         .reduce((newChildren, child) => {
           if (child.type !== "text" || isWhitespaceSensitive) {
-            return newChildren.concat(child);
+            return [...newChildren, child];
           }
 
           const localChildren = [];
@@ -375,11 +375,14 @@ function extractWhitespaces(ast /*, options*/) {
             i !== children.length - 1 &&
             children[i + 1].type === TYPE_WHITESPACE;
 
-          return newChildren.concat({
-            ...child,
-            hasLeadingSpaces,
-            hasTrailingSpaces,
-          });
+          return [
+            ...newChildren,
+            {
+              ...child,
+              hasLeadingSpaces,
+              hasTrailingSpaces,
+            },
+          ];
         }, []),
     });
   });

--- a/src/language-html/print-preprocess.js
+++ b/src/language-html/print-preprocess.js
@@ -361,7 +361,7 @@ function extractWhitespaces(ast /*, options*/) {
             localChildren.push({ type: TYPE_WHITESPACE });
           }
 
-          return newChildren.concat(localChildren);
+          return [...newChildren, ...localChildren];
         }, [])
         // set hasLeadingSpaces/hasTrailingSpaces and filter whitespace nodes
         .reduce((newChildren, child, i, children) => {

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -505,8 +505,7 @@ function printChildren(path, options, print) {
       }
     }
 
-    return [].concat(
-      prevParts,
+    return [...prevParts].concat(
       group([
         ...leadingParts,
         group([printChild(childPath), ...trailingParts], {

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -228,13 +228,13 @@ function genericPrint(path, options, print) {
     case "element":
     case "ieConditionalComment": {
       if (shouldPreserveContent(node, options)) {
-        return [].concat(
+        return [
           printOpeningTagPrefix(node, options),
           group(printOpeningTag(path, options, print)),
-          replaceEndOfLineWith(getNodeContent(node, options), literalline),
-          printClosingTag(node, options),
-          printClosingTagSuffix(node, options)
-        );
+          ...replaceEndOfLineWith(getNodeContent(node, options), literalline),
+          ...printClosingTag(node, options),
+          printClosingTagSuffix(node, options),
+        ];
       }
       /**
        * do not break:
@@ -521,9 +521,9 @@ function printChildren(path, options, print) {
     const child = childPath.getValue();
 
     if (hasPrettierIgnore(child)) {
-      return [].concat(
+      return [
         printOpeningTagPrefix(child, options),
-        replaceEndOfLineWith(
+        ...replaceEndOfLineWith(
           options.originalText.slice(
             locStart(child) +
               (child.prev && needsToBorrowNextOpeningTagStartMarker(child.prev)
@@ -536,8 +536,8 @@ function printChildren(path, options, print) {
           ),
           literalline
         ),
-        printClosingTagSuffix(child, options)
-      );
+        printClosingTagSuffix(child, options),
+      ];
     }
 
     return print(childPath);

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -505,15 +505,16 @@ function printChildren(path, options, print) {
       }
     }
 
-    return [...prevParts].concat(
+    return [
+      ...prevParts,
       group([
         ...leadingParts,
         group([printChild(childPath), ...trailingParts], {
           id: groupIds[childIndex],
         }),
       ]),
-      nextParts
-    );
+      ...nextParts,
+    ];
   }, "children");
 
   function printChild(childPath) {

--- a/src/language-js/clean.js
+++ b/src/language-js/clean.js
@@ -103,7 +103,7 @@ function clean(ast, newObj, parent) {
       .map((container) => container.expression);
 
     const quasis = templateLiterals.reduce(
-      (quasis, templateLiteral) => quasis.concat(templateLiteral.quasis),
+      (quasis, templateLiteral) => [...quasis, ...templateLiteral.quasis],
       []
     );
 

--- a/src/language-js/print/angular.js
+++ b/src/language-js/print/angular.js
@@ -12,12 +12,12 @@ function printAngular(path, options, print) {
   const n = path.getValue();
   switch (n.type) {
     case "NGRoot":
-      return [].concat(
+      return [
         path.call(print, "node"),
         !hasComment(n.node)
-          ? []
-          : [" //", getComments(n.node)[0].value.trimEnd()]
-      );
+          ? ""
+          : " //" + getComments(n.node)[0].value.trimEnd(),
+      ];
     case "NGPipeExpression":
       return printBinaryishExpression(path, options, print);
     case "NGChainedExpression":

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -196,7 +196,8 @@ function printBinaryishExpressions(
     // which is unique in that it is right-associative.)
     if (shouldFlatten(node.operator, node.left.operator)) {
       // Flatten them out by recursively calling this function.
-      parts = parts.concat(
+      parts = [
+        ...parts,
         path.call(
           (left) =>
             printBinaryishExpressions(
@@ -207,8 +208,8 @@ function printBinaryishExpressions(
               isInsideParenthesis
             ),
           "left"
-        )
-      );
+        ),
+      ];
     } else {
       parts.push(group(path.call(print, "left")));
     }

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -198,7 +198,7 @@ function printBinaryishExpressions(
       // Flatten them out by recursively calling this function.
       parts = [
         ...parts,
-        path.call(
+        ...path.call(
           (left) =>
             printBinaryishExpressions(
               left,

--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -159,12 +159,14 @@ function printCallArguments(path, options, print) {
             hasEmptyLineFollowingFirstArg ? hardline : line,
             hasEmptyLineFollowingFirstArg ? hardline : "",
           ],
-        ].concat(printedArguments.slice(1));
+          ...printedArguments.slice(1),
+        ];
       }
       if (shouldGroupLast && i === args.length - 1) {
-        printedExpanded = printedArguments
-          .slice(0, -1)
-          .concat(argPath.call((p) => print(p, { expandLastArg: true })));
+        printedExpanded = [
+          ...printedArguments.slice(0, -1),
+          argPath.call((p) => print(p, { expandLastArg: true })),
+        ];
       }
     });
 

--- a/src/language-js/print/interface.js
+++ b/src/language-js/print/interface.js
@@ -68,7 +68,7 @@ function printInterface(path, options, print) {
         )
       );
     } else {
-      parts.push(group(indent(partsGroup.concat(printedExtends))));
+      parts.push(group(indent([...partsGroup, ...printedExtends])));
     }
   } else {
     parts.push(...partsGroup, ...extendsParts);

--- a/src/language-js/print/interface.js
+++ b/src/language-js/print/interface.js
@@ -63,9 +63,7 @@ function printInterface(path, options, print) {
     const printedExtends = extendsParts;
     if (shouldIndentOnlyHeritageClauses) {
       parts.push(
-        group(
-          partsGroup.concat(ifBreak(indent(printedExtends), printedExtends))
-        )
+        group([...partsGroup, ifBreak(indent(printedExtends), printedExtends)])
       );
     } else {
       parts.push(group(indent([...partsGroup, ...printedExtends])));

--- a/src/language-js/print/object.js
+++ b/src/language-js/print/object.js
@@ -113,7 +113,7 @@ function printObject(path, options, print) {
   const props = propsAndLoc
     .sort((a, b) => a.loc - b.loc)
     .map((prop) => {
-      const result = separatorParts.concat(group(prop.printed));
+      const result = [...separatorParts, group(prop.printed)];
       separatorParts = [separator, line];
       if (
         (prop.node.type === "TSPropertySignature" ||
@@ -147,9 +147,9 @@ function printObject(path, options, print) {
         "...",
       ];
     } else {
-      printed = "...";
+      printed = ["..."];
     }
-    props.push(separatorParts.concat(printed));
+    props.push([...separatorParts, ...printed]);
   }
 
   const lastElem = getLast(n[propertiesField]);

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -193,7 +193,7 @@ function genericPrint(path, options, printPath, args) {
   }
 
   if (decorators.length > 0) {
-    return group(decorators.concat(parts));
+    return group([...decorators, ...parts]);
   }
   return parts;
 }

--- a/src/language-markdown/index.js
+++ b/src/language-markdown/index.js
@@ -9,7 +9,7 @@ const languages = [
     since: "1.8.0",
     parsers: ["markdown"],
     vscodeLanguageIds: ["markdown"],
-    filenames: data.filenames.concat(["README"]),
+    filenames: [...data.filenames, "README"],
     extensions: data.extensions.filter((extension) => extension !== ".mdx"),
   })),
   createLanguage(require("linguist-languages/data/Markdown.json"), () => ({

--- a/src/language-markdown/parser-markdown.js
+++ b/src/language-markdown/parser-markdown.js
@@ -64,7 +64,7 @@ function htmlToJsx() {
 
 function frontMatter() {
   const proto = this.Parser.prototype;
-  proto.blockMethods = ["frontMatter"].concat(proto.blockMethods);
+  proto.blockMethods = ["frontMatter", ...proto.blockMethods];
   proto.blockTokenizers.frontMatter = tokenizer;
 
   function tokenizer(eat, value) {

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -522,7 +522,7 @@ function getNthSiblingIndex(node, parentNode, condition) {
 }
 
 function getAncestorCounter(path, typeOrTypes) {
-  const types = [].concat(typeOrTypes);
+  const types = Array.isArray(typeOrTypes) ? typeOrTypes : [typeOrTypes];
 
   let counter = -1;
   let ancestorNode;
@@ -840,8 +840,13 @@ function shouldRemainTheSameContent(path) {
   );
 }
 
-function printUrl(url, dangerousCharOrChars) {
-  const dangerousChars = [" "].concat(dangerousCharOrChars || []);
+function printUrl(url, dangerousCharOrChars = []) {
+  const dangerousChars = [
+    " ",
+    ...(Array.isArray(dangerousCharOrChars)
+      ? dangerousCharOrChars
+      : [dangerousCharOrChars]),
+  ];
   return new RegExp(dangerousChars.map((x) => `\\${x}`).join("|")).test(url)
     ? `<${url}>`
     : url;

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -840,6 +840,11 @@ function shouldRemainTheSameContent(path) {
   );
 }
 
+/**
+ * @param {string} url
+ * @param {string[] | string} [dangerousCharOrChars]
+ * @returns {string}
+ */
 function printUrl(url, dangerousCharOrChars = []) {
   const dangerousChars = [
     " ",

--- a/src/language-markdown/utils.js
+++ b/src/language-markdown/utils.js
@@ -28,11 +28,11 @@ const INLINE_NODE_TYPES = [
   "inlineMath",
 ];
 
-const INLINE_NODE_WRAPPER_TYPES = INLINE_NODE_TYPES.concat([
+const INLINE_NODE_WRAPPER_TYPES = [...INLINE_NODE_TYPES, 
   "tableCell",
   "paragraph",
   "heading",
-]);
+];
 
 const kRegex = new RegExp(kPattern);
 const punctuationRegex = new RegExp(punctuationPattern);

--- a/src/language-markdown/utils.js
+++ b/src/language-markdown/utils.js
@@ -28,7 +28,8 @@ const INLINE_NODE_TYPES = [
   "inlineMath",
 ];
 
-const INLINE_NODE_WRAPPER_TYPES = [...INLINE_NODE_TYPES, 
+const INLINE_NODE_WRAPPER_TYPES = [
+  ...INLINE_NODE_TYPES,
   "tableCell",
   "paragraph",
   "heading",
@@ -208,7 +209,7 @@ function mapAst(ast, handler) {
     const newNode = { ...handler(node, index, parentStack) };
     if (newNode.children) {
       newNode.children = newNode.children.map((child, index) =>
-        preorder(child, index, [newNode].concat(parentStack))
+        preorder(child, index, [newNode, ...parentStack])
       );
     }
 

--- a/src/language-yaml/printer-yaml.js
+++ b/src/language-yaml/printer-yaml.js
@@ -241,7 +241,7 @@ function printNode(node, parentNode, path, options, print) {
       ];
     }
     case "directive":
-      return ["%", join(" ", [node.name].concat(node.parameters))];
+      return ["%", join(" ", [node.name, ...node.parameters])];
     case "comment":
       return ["#", node.value];
     case "alias":

--- a/src/language-yaml/utils.js
+++ b/src/language-yaml/utils.js
@@ -227,7 +227,10 @@ function getFlowScalarLineContents(nodeType, content, options) {
             getLast(getLast(reduced)).endsWith("\\")
           )
         )
-          ? [...reduced.slice(0, -1), [...reduced.pop(), ...lineContentWords]]
+          ? [
+              ...reduced.slice(0, -1),
+              [...getLast(reduced), ...lineContentWords],
+            ]
           : [...reduced, lineContentWords],
       []
     )

--- a/src/language-yaml/utils.js
+++ b/src/language-yaml/utils.js
@@ -227,7 +227,7 @@ function getFlowScalarLineContents(nodeType, content, options) {
             getLast(getLast(reduced)).endsWith("\\")
           )
         )
-          ? [...reduced, [...reduced.pop(), ...lineContentWords]]
+          ? [...reduced.slice(0, -1), [...reduced.pop(), ...lineContentWords]]
           : [...reduced, lineContentWords],
       []
     )

--- a/src/language-yaml/utils.js
+++ b/src/language-yaml/utils.js
@@ -227,8 +227,8 @@ function getFlowScalarLineContents(nodeType, content, options) {
             getLast(getLast(reduced)).endsWith("\\")
           )
         )
-          ? reduced.concat([reduced.pop().concat(lineContentWords)])
-          : reduced.concat([lineContentWords]),
+          ? [...reduced, reduced.pop().concat(lineContentWords)]
+          : [...reduced, lineContentWords],
       []
     )
     .map((lineContentWords) =>
@@ -281,8 +281,8 @@ function getBlockValueLineContents(
           lineContentWords.length > 0 &&
           !/^\s/.test(lineContentWords[0]) &&
           !/^\s|\s$/.test(getLast(reduced))
-            ? reduced.concat([reduced.pop().concat(lineContentWords)])
-            : reduced.concat([lineContentWords]),
+            ? [...reduced, reduced.pop().concat(lineContentWords)]
+            : [...reduced, lineContentWords],
         []
       )
       .map((lineContentWords) =>

--- a/src/language-yaml/utils.js
+++ b/src/language-yaml/utils.js
@@ -284,7 +284,10 @@ function getBlockValueLineContents(
           lineContentWords.length > 0 &&
           !/^\s/.test(lineContentWords[0]) &&
           !/^\s|\s$/.test(getLast(reduced))
-            ? [...reduced, [...reduced.pop(), ...lineContentWords]]
+            ? [
+                ...reduced.slice(0, -1),
+                [...getLast(reduced), ...lineContentWords],
+              ]
             : [...reduced, lineContentWords],
         []
       )
@@ -293,7 +296,7 @@ function getBlockValueLineContents(
           (reduced, word) =>
             // disallow trailing spaces
             reduced.length > 0 && /\s$/.test(getLast(reduced))
-              ? [...reduced, reduced.pop() + " " + word]
+              ? [...reduced.slice(0, -1), getLast(reduced) + " " + word]
               : [...reduced, word],
           []
         )

--- a/src/language-yaml/utils.js
+++ b/src/language-yaml/utils.js
@@ -227,7 +227,7 @@ function getFlowScalarLineContents(nodeType, content, options) {
             getLast(getLast(reduced)).endsWith("\\")
           )
         )
-          ? [...reduced, reduced.pop().concat(lineContentWords)]
+          ? [...reduced, [...reduced.pop(), ...lineContentWords]]
           : [...reduced, lineContentWords],
       []
     )
@@ -281,7 +281,7 @@ function getBlockValueLineContents(
           lineContentWords.length > 0 &&
           !/^\s/.test(lineContentWords[0]) &&
           !/^\s|\s$/.test(getLast(reduced))
-            ? [...reduced, reduced.pop().concat(lineContentWords)]
+            ? [...reduced, [...reduced.pop(), ...lineContentWords]]
             : [...reduced, lineContentWords],
         []
       )
@@ -290,8 +290,8 @@ function getBlockValueLineContents(
           (reduced, word) =>
             // disallow trailing spaces
             reduced.length > 0 && /\s$/.test(getLast(reduced))
-              ? reduced.concat(reduced.pop() + " " + word)
-              : reduced.concat(word),
+              ? [...reduced, reduced.pop() + " " + word]
+              : [...reduced, word],
           []
         )
       )

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -581,11 +581,10 @@ function printComments(path, print, options, needsSemi) {
     }
   }, "comments");
 
-  return prependCursorPlaceholder(
-    path,
-    options,
-    leadingParts.concat(trailingParts)
-  );
+  return prependCursorPlaceholder(path, options, [
+    ...leadingParts,
+    ...trailingParts,
+  ]);
 }
 
 function ensureAllCommentsPrinted(astComments) {

--- a/src/main/options-normalizer.js
+++ b/src/main/options-normalizer.js
@@ -205,7 +205,7 @@ function optionInfoToSchema(optionInfo, { isCLI, optionInfos }) {
 
   return optionInfo.array
     ? vnopts.ArraySchema.create({
-        ...(isCLI ? { preprocess: (v) => [].concat(v) } : {}),
+        ...(isCLI ? { preprocess: (v) => (Array.isArray(v) ? v : [v]) } : {}),
         ...handlers,
         valueSchema: SchemaConstructor.create(parameters),
       })

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -30,7 +30,7 @@ function getSupportInfo({
   const version = currentVersion.split("-", 1)[0];
 
   const languages = plugins
-    .reduce((all, plugin) => all.concat(plugin.languages || []), [])
+    .reduce((all, plugin) => [...all, ...(plugin.languages || [])], [])
     .filter(filterSince);
 
   const options = arrayify(

--- a/tests_config/utils/create-snapshot.js
+++ b/tests_config/utils/create-snapshot.js
@@ -25,15 +25,17 @@ function createSnapshot(input, output, options, { codeOffset }) {
   const separatorWidth = 80;
   const printWidthIndicator =
     options.printWidth > 0 && Number.isFinite(options.printWidth)
-      ? (codeOffset ? " ".repeat(codeOffset - 1) + "|" : "") +
-        " ".repeat(options.printWidth) +
-        "| printWidth"
-      : "";
+      ? [
+          (codeOffset ? " ".repeat(codeOffset - 1) + "|" : "") +
+            " ".repeat(options.printWidth) +
+            "| printWidth",
+        ]
+      : [];
   return raw(
     [
       printSeparator(separatorWidth, "options"),
       printOptions(options),
-      printWidthIndicator,
+      ...printWidthIndicator,
       printSeparator(separatorWidth, "input"),
       input,
       printSeparator(separatorWidth, "output"),

--- a/tests_config/utils/create-snapshot.js
+++ b/tests_config/utils/create-snapshot.js
@@ -28,20 +28,18 @@ function createSnapshot(input, output, options, { codeOffset }) {
       ? (codeOffset ? " ".repeat(codeOffset - 1) + "|" : "") +
         " ".repeat(options.printWidth) +
         "| printWidth"
-      : [];
+      : "";
   return raw(
-    []
-      .concat(
-        printSeparator(separatorWidth, "options"),
-        printOptions(options),
-        printWidthIndicator,
-        printSeparator(separatorWidth, "input"),
-        input,
-        printSeparator(separatorWidth, "output"),
-        output,
-        printSeparator(separatorWidth)
-      )
-      .join("\n")
+    [
+      printSeparator(separatorWidth, "options"),
+      printOptions(options),
+      printWidthIndicator,
+      printSeparator(separatorWidth, "input"),
+      input,
+      printSeparator(separatorWidth, "output"),
+      output,
+      printSeparator(separatorWidth),
+    ].join("\n")
   );
 }
 

--- a/tests_integration/runPrettier.js
+++ b/tests_integration/runPrettier.js
@@ -66,7 +66,7 @@ function runPrettier(dir, args, options) {
   process.chdir(normalizeDir(dir));
   process.stdin.isTTY = !!options.isTTY;
   process.stdout.isTTY = !!options.stdoutIsTTY;
-  process.argv = ["path/to/node", "path/to/prettier/bin"].concat(args);
+  process.argv = ["path/to/node", "path/to/prettier/bin", ...args];
 
   jest.resetModules();
 

--- a/tests_integration/runPrettier.js
+++ b/tests_integration/runPrettier.js
@@ -6,9 +6,8 @@ const stripAnsi = require("strip-ansi");
 const { SynchronousPromise } = require("synchronous-promise");
 const { prettierCli, thirdParty } = require("./env");
 
-function runPrettier(dir, args, options) {
-  args = args || [];
-  options = options || {};
+function runPrettier(dir, args = [], options = {}) {
+  args = Array.isArray(args) ? args : [args];
 
   let status;
   let stdout = "";

--- a/website/playground/markdown.js
+++ b/website/playground/markdown.js
@@ -22,11 +22,11 @@ function formatMarkdown(
     "",
     "**Output:**",
     codeBlock(output, syntax),
+    ...(isIdempotent
+      ? []
+      : ["", "**Second Output:**", codeBlock(output2, syntax)]),
+    ...(full ? ["", "**Expected behavior:**", ""] : []),
   ]
-    .concat(
-      isIdempotent ? [] : ["", "**Second Output:**", codeBlock(output2, syntax)]
-    )
-    .concat(full ? ["", "**Expected behavior:**", ""] : [])
     .filter((part) => part != null)
     .join("\n");
 }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Enfore use `...` instead of `Array#concat()`, in some place, it's very unclear the argument is an array or not.
This also prevent unexpected spreading the new `concat` doc (array).

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
