### PR TITLE
CI: Add `Mark issue duplicate` job

### DIFF
--- a/.github/workflows/issue-mark-duplicate.yml
+++ b/.github/workflows/issue-mark-duplicate.yml
@@ -9,11 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: mark-duplicate
-        uses: actions-cool/issues-helper@1.x
+        uses: actions-cool/issues-helper@v2
         with:
           actions: "mark-duplicate"
           token: ${{ secrets.GITHUB_TOKEN }}
           duplicate-labels: "type:duplicate"
-          allow-permissions: "admin, write"
           close-issue: true
-

--- a/.github/workflows/issue-mark-duplicate.yml
+++ b/.github/workflows/issue-mark-duplicate.yml
@@ -14,4 +14,5 @@ jobs:
           actions: 'mark-duplicate'
           token: ${{ secrets.GITHUB_TOKEN }}
           duplicate-labels: 'type:duplicate'
+          allow-permissions: 'admin, write'
           close-issue: true

--- a/.github/workflows/issue-mark-duplicate.yml
+++ b/.github/workflows/issue-mark-duplicate.yml
@@ -1,4 +1,4 @@
-name: Issue Mark Duplicate
+name: Mark Issue Duplicate
 
 on:
   issue_comment:
@@ -11,8 +11,9 @@ jobs:
       - name: mark-duplicate
         uses: actions-cool/issues-helper@1.x
         with:
-          actions: 'mark-duplicate'
+          actions: "mark-duplicate"
           token: ${{ secrets.GITHUB_TOKEN }}
-          duplicate-labels: 'type:duplicate'
-          allow-permissions: 'admin, write'
+          duplicate-labels: "type:duplicate"
+          allow-permissions: "admin, write"
           close-issue: true
+

--- a/.github/workflows/issue-mark-duplicate.yml
+++ b/.github/workflows/issue-mark-duplicate.yml
@@ -1,0 +1,17 @@
+name: Issue Mark Duplicate
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  mark-duplicate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: mark-duplicate
+        uses: actions-cool/issues-helper@1.x
+        with:
+          actions: 'mark-duplicate'
+          token: ${{ secrets.GITHUB_TOKEN }}
+          duplicate-labels: 'type:duplicate'
+          close-issue: true

--- a/.github/workflows/mark-issue-duplicate.yml
+++ b/.github/workflows/mark-issue-duplicate.yml
@@ -9,7 +9,7 @@ jobs:
   mark-duplicate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions-cool/issues-helper@v2
+      - uses: actions-cool/issues-helper@v2.0.0
         with:
           actions: "mark-duplicate"
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/mark-issue-duplicate.yml
+++ b/.github/workflows/mark-issue-duplicate.yml
@@ -2,14 +2,14 @@ name: Mark Issue Duplicate
 
 on:
   issue_comment:
-    types: [created]
+    types:
+      - created
 
 jobs:
   mark-duplicate:
     runs-on: ubuntu-latest
     steps:
-      - name: mark-duplicate
-        uses: actions-cool/issues-helper@v2
+      - uses: actions-cool/issues-helper@v2
         with:
           actions: "mark-duplicate"
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Add a workflow help you automatically manage issues.

ref: https://github.com/prettier/prettier/issues/9601 https://github.com/prettier/prettier/issues/10036

When you enter "Duplicate of #xxx",  the GitHub Actions will help you add the label `type:duplicate` and close the issue.

At the same time it supports concise commands, such as "/d", I don't know if you need it.

More details can see https://github.com/actions-cool/issues-helper/blob/main/README.en-US.md#mark-duplicate

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
