### PR TITLE
website: bigger font for <h5> in blog

### DIFF
--- a/website/static/overrides.css
+++ b/website/static/overrides.css
@@ -513,6 +513,10 @@ a {
   margin-top: 10px;
 }
 
+.mainContainer .wrapper .post h5 {
+  font-size: 1.125em;
+}
+
 .hljs {
   padding: 16px;
   overflow: auto;


### PR DESCRIPTION
## Description

Now it doesn't look like a heading at all:

> ![image](https://user-images.githubusercontent.com/94334/105849461-1a686500-5fe9-11eb-8cb1-b8ddd429d754.png)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
