### PR TITLE
Simplify `printStartingTag` in glimmer printer

### DIFF
--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -319,26 +319,14 @@ function print(path, options, print) {
 function printStartingTag(path, print) {
   const node = path.getValue();
 
-  const attributesLike = [];
-  if (isNonEmptyArray(node.attributes)) {
-    const attributes = join(line, path.map(print, "attributes"));
-    attributesLike.push(line, attributes);
-  }
-
-  if (isNonEmptyArray(node.modifiers)) {
-    const modifiers = join(line, path.map(print, "modifiers"));
-    attributesLike.push(line, modifiers);
-  }
-
-  if (isNonEmptyArray(node.comments)) {
-    const comments = join(line, path.map(print, "comments"));
-    attributesLike.push(line, comments);
-  }
-
-  if (isNonEmptyArray(node.blockParams)) {
-    const blockParams = printBlockParams(node);
-    attributesLike.push(line, blockParams);
-  }
+  const attributesLike = ["attributes", "modifiers", "comments", "blockParams"]
+    .filter((property) => isNonEmptyArray(node[property]))
+    .map((property) => [
+      line,
+      property === "blockParams"
+        ? printBlockParams(node)
+        : join(line, path.map(print, property)),
+    ]);
 
   return [
     "<",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Simplify this part, the docs changed a little bit, before `[line, doc, line, doc]`, now it's `[[line, doc], [line, doc]]`.

/cc @dcyriller

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
