### PR TITLE
Refactor CLI

### DIFF
--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -29,7 +29,6 @@ const createMinimistOptions = require("./create-minimist-options");
  * @property apiDefaultOptions
  * @property languages
  * @property {Partial<Context>[]} stack
- * @property initContext
  * @property pushContextPlugins
  * @property popContextPlugins
  */

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -101,37 +101,41 @@ class Context {
    * @param {string[]=} pluginSearchDirs
    */
   _updateContextOptions(plugins, pluginSearchDirs) {
-    const { options: supportOptions, languages } = prettier.getSupportInfo({
-      showDeprecated: true,
-      showUnreleased: true,
-      showInternal: true,
-      plugins,
-      pluginSearchDirs,
-    });
-    const detailedOptionMap = normalizeDetailedOptionMap({
-      ...createDetailedOptionMap(supportOptions),
-      ...constant.options,
-    });
-
-    const detailedOptions = arrayify(detailedOptionMap, "name");
-
-    const apiDefaultOptions = {
-      ...optionsModule.hiddenDefaults,
-      ...fromPairs(
-        supportOptions
-          .filter(({ deprecated }) => !deprecated)
-          .map((option) => [option.name, option.default])
-      ),
-    };
-
-    Object.assign(this, {
-      supportOptions,
-      detailedOptions,
-      detailedOptionMap,
-      apiDefaultOptions,
-      languages,
-    });
+    Object.assign(this, getContextOptions(plugins, pluginSearchDirs));
   }
+}
+
+function getContextOptions(plugins, pluginSearchDirs) {
+  const { options: supportOptions, languages } = prettier.getSupportInfo({
+    showDeprecated: true,
+    showUnreleased: true,
+    showInternal: true,
+    plugins,
+    pluginSearchDirs,
+  });
+  const detailedOptionMap = normalizeDetailedOptionMap({
+    ...createDetailedOptionMap(supportOptions),
+    ...constant.options,
+  });
+
+  const detailedOptions = arrayify(detailedOptionMap, "name");
+
+  const apiDefaultOptions = {
+    ...optionsModule.hiddenDefaults,
+    ...fromPairs(
+      supportOptions
+        .filter(({ deprecated }) => !deprecated)
+        .map((option) => [option.name, option.default])
+    ),
+  };
+
+  return {
+    supportOptions,
+    detailedOptions,
+    detailedOptionMap,
+    apiDefaultOptions,
+    languages,
+  };
 }
 
 module.exports = Context;

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -38,9 +38,7 @@ class Context {
   constructor({ rawArguments, plugins, pluginSearchDirs, logger }) {
     this.args = rawArguments;
     this.logger = logger;
-    this.stack = [{}];
-
-    this.pushContextPlugins();
+    this.stack = [];
     this.pushContextPlugins(plugins, pluginSearchDirs);
     const argv = parseArgv(
       rawArguments,
@@ -109,6 +107,7 @@ function getContextOptions(plugins, pluginSearchDirs) {
 }
 
 function parseArgv(rawArguments, detailedOptions, keys, logger) {
+  detailedOptions = detailedOptions || getContextOptions().detailedOptions;
   const minimistOptions = createMinimistOptions(detailedOptions);
   const parsed = minimist(rawArguments, minimistOptions);
   const normalized = normalizeContextArgv(
@@ -131,14 +130,4 @@ function normalizeContextArgv(argv, detailedOptions, keys, logger) {
   return normalizeCliOptions(argv, detailedOptions, { logger });
 }
 
-function init(rawArguments) {
-  const { detailedOptions } = getContextOptions();
-  const argv = parseArgv(rawArguments, detailedOptions, [
-    "loglevel",
-    "plugin",
-    "plugin-search-dir",
-  ]);
-  return argv;
-}
-
-module.exports = { init, Context };
+module.exports = { parseArgv, Context };

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -49,16 +49,15 @@ class Context {
     const pluginSearchDirs = argv["plugin-search-dir"];
 
     this.pushContextPlugins(plugin, pluginSearchDirs);
-    const argv2 = parseArgv(this.args, this.detailedOptions);
-    this.argv = argv2;
-    this.filePatterns = argv2._.map((file) => String(file));
-
-    this.argv = normalizeContextArgv(
+    const argv2 = parseArgv(
+      this.args,
       this.detailedOptions,
-      this.argv,
       undefined,
       this.logger
     );
+
+    this.argv = argv2;
+    this.filePatterns = argv2._.map((file) => String(file));
   }
 
   /**
@@ -124,9 +123,16 @@ function getContextOptions(plugins, pluginSearchDirs) {
   };
 }
 
-function parseArgv(args, detailedOptions) {
+function parseArgv(args, detailedOptions, keys, logger) {
   const minimistOptions = createMinimistOptions(detailedOptions);
-  return minimist(args, minimistOptions);
+  const parsed = minimist(args, minimistOptions);
+  const normalized = normalizeContextArgv(
+    detailedOptions,
+    parsed,
+    keys,
+    logger
+  );
+  return normalized;
 }
 
 function normalizeContextArgv(detailedOptions, argv, keys, logger) {
@@ -144,9 +150,7 @@ function normalizeContextArgv(detailedOptions, argv, keys, logger) {
 
 function init(args) {
   const contextOptions = getContextOptions();
-  let argv = parseArgv(args, contextOptions.detailedOptions);
-
-  argv = normalizeContextArgv(contextOptions.detailedOptions, argv, [
+  const argv = parseArgv(args, contextOptions.detailedOptions, [
     "loglevel",
     "plugin",
     "plugin-search-dir",

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -45,7 +45,13 @@ class Context {
     const argv = parseArgv(args, contextOptions.detailedOptions);
     this.argv = argv;
     this.filePatterns = argv._.map((file) => String(file));
-    this._normalizeContextArgv(["loglevel", "plugin", "plugin-search-dir"]);
+
+    this.argv = normalizeContextArgv(contextOptions.detailedOptions, argv, [
+      "loglevel",
+      "plugin",
+      "plugin-search-dir",
+    ]);
+
     this.logger = createLogger(this.argv.loglevel);
     this._updateContextArgv(this.argv.plugin, this.argv["plugin-search-dir"]);
   }

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -38,17 +38,8 @@ const createMinimistOptions = require("./create-minimist-options");
 class Context {
   constructor(args) {
     this.args = args;
-    this.stack = [];
+    this.stack = [{}];
 
-    this.stack.push(
-      pick(this, [
-        "supportOptions",
-        "detailedOptions",
-        "detailedOptionMap",
-        "apiDefaultOptions",
-        "languages",
-      ])
-    );
     this._updateContextOptions();
 
     const minimistOptions = createMinimistOptions(this.detailedOptions);

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -34,11 +34,22 @@ const createMinimistOptions = require("./create-minimist-options");
  */
 
 class Context {
-  constructor({ rawArguments, plugins, pluginSearchDirs, logger }) {
+  constructor({ rawArguments, logger }) {
     this.rawArguments = rawArguments;
     this.logger = logger;
     this.stack = [];
+
+    const {
+      plugin: plugins,
+      "plugin-search-dir": pluginSearchDirs,
+    } = parseArgvWithoutPlugin(
+      rawArguments,
+      ["plugin", '"plugin-search-dir"'],
+      logger
+    );
+
     this.pushContextPlugins(plugins, pluginSearchDirs);
+
     const argv = parseArgv(
       rawArguments,
       this.detailedOptions,
@@ -124,7 +135,7 @@ function parseArgvWithoutPlugin(rawArguments, keys, logger) {
   return parseArgv(
     rawArguments,
     contextOptionsWithoutPlugin.detailedOptions,
-    keys,
+    Array.isArray(keys) ? keys : [keys],
     logger
   );
 }

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -41,7 +41,6 @@ class Context {
     const { args, contextOptions, argv, filePatterns, logger } = result;
     this.args = args;
 
-
     Object.assign(this, contextOptions);
     this.argv = argv;
     this.filePatterns = filePatterns;
@@ -54,11 +53,13 @@ class Context {
     const argv2 = parseArgv(this.args, this.detailedOptions);
     this.argv = argv2;
     this.filePatterns = argv2._.map((file) => String(file));
-  }
 
-  initContext() {
-    // split into 2 step so that we could wrap this in a `try..catch` in cli/index.js
-    this._normalizeContextArgv();
+    this.argv = normalizeContextArgv(
+      this.detailedOptions,
+      this.argv,
+      undefined,
+      this.logger
+    );
   }
 
   /**
@@ -80,15 +81,6 @@ class Context {
 
   popContextPlugins() {
     Object.assign(this, this.stack.pop());
-  }
-
-  _normalizeContextArgv(keys) {
-    this.argv = normalizeContextArgv(
-      this.detailedOptions,
-      this.argv,
-      keys,
-      this.logger
-    );
   }
 
   /**

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -39,7 +39,13 @@ class Context {
   constructor(args) {
     this.args = args;
     this.stack = [];
-    this._updateContextArgv();
+
+    this.pushContextPlugins();
+    const minimistOptions = createMinimistOptions(this.detailedOptions);
+    const argv = minimist(this.args, minimistOptions);
+    this.argv = argv;
+    this.filePatterns = argv._.map((file) => String(file));
+
     this._normalizeContextArgv(["loglevel", "plugin", "plugin-search-dir"]);
     this.logger = createLogger(this.argv.loglevel);
     this._updateContextArgv(this.argv.plugin, this.argv["plugin-search-dir"]);

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -35,11 +35,11 @@ const createMinimistOptions = require("./create-minimist-options");
  */
 
 class Context {
-  constructor(args, result) {
-    this.args = args;
+  constructor(result) {
     this.stack = [{}];
 
-    const { contextOptions, argv, filePatterns, logger } = result;
+    const { args, contextOptions, argv, filePatterns, logger } = result;
+    this.args = args;
 
     Object.assign(this, contextOptions);
     this.argv = argv;
@@ -161,7 +161,7 @@ function init(args) {
     "plugin-search-dir",
   ]);
 
-  return { contextOptions, argv, filePatterns };
+  return { args, contextOptions, argv, filePatterns };
 }
 
 module.exports = { init, Context };

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -40,9 +40,11 @@ class Context {
     this.args = args;
     this.stack = [{}];
 
-    Object.assign(this, getContextOptions());
+    const contextOptions = getContextOptions();
+    Object.assign(this, contextOptions);
+    const { detailedOptions } = contextOptions;
+    const minimistOptions = createMinimistOptions(detailedOptions);
 
-    const minimistOptions = createMinimistOptions(this.detailedOptions);
     const argv = minimist(this.args, minimistOptions);
     this.argv = argv;
     this.filePatterns = argv._.map((file) => String(file));

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -40,7 +40,17 @@ class Context {
     this.args = args;
     this.stack = [];
 
-    this.pushContextPlugins();
+    this.stack.push(
+      pick(this, [
+        "supportOptions",
+        "detailedOptions",
+        "detailedOptionMap",
+        "apiDefaultOptions",
+        "languages",
+      ])
+    );
+    this._updateContextOptions();
+
     const minimistOptions = createMinimistOptions(this.detailedOptions);
     const argv = minimist(this.args, minimistOptions);
     this.argv = argv;

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -41,6 +41,7 @@ class Context {
     const { args, contextOptions, argv, filePatterns, logger } = result;
     this.args = args;
 
+
     Object.assign(this, contextOptions);
     this.argv = argv;
     this.filePatterns = filePatterns;

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -42,11 +42,8 @@ class Context {
 
     const contextOptions = getContextOptions();
     Object.assign(this, contextOptions);
-    const { detailedOptions } = contextOptions;
-    const minimistOptions = createMinimistOptions(detailedOptions);
 
-    const argv = minimist(this.args, minimistOptions);
-    this.argv = argv;
+    this.argv = parseArgv(args, contextOptions);
     this.filePatterns = argv._.map((file) => String(file));
 
     this._normalizeContextArgv(["loglevel", "plugin", "plugin-search-dir"]);
@@ -138,6 +135,12 @@ function getContextOptions(plugins, pluginSearchDirs) {
     apiDefaultOptions,
     languages,
   };
+}
+
+function parseArgv(args, contextOptions) {
+  const { detailedOptions } = contextOptions;
+  const minimistOptions = createMinimistOptions(detailedOptions);
+  return minimist(args, minimistOptions);
 }
 
 module.exports = Context;

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -44,7 +44,7 @@ class Context {
       "plugin-search-dir": pluginSearchDirs,
     } = parseArgvWithoutPlugin(
       rawArguments,
-      ["plugin", '"plugin-search-dir"'],
+      ["plugin", "plugin-search-dir"],
       logger
     );
 
@@ -135,7 +135,7 @@ function parseArgvWithoutPlugin(rawArguments, keys, logger) {
   return parseArgv(
     rawArguments,
     contextOptionsWithoutPlugin.detailedOptions,
-    Array.isArray(keys) ? keys : [keys],
+    typeof keys === "string" ? [keys] : keys,
     logger
   );
 }

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -40,7 +40,7 @@ class Context {
     this.args = args;
     this.stack = [{}];
 
-    this._updateContextOptions();
+    Object.assign(this, getContextOptions());
 
     const minimistOptions = createMinimistOptions(this.detailedOptions);
     const argv = minimist(this.args, minimistOptions);

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -84,13 +84,12 @@ class Context {
   }
 
   _normalizeContextArgv(keys) {
-    const detailedOptions = !keys
-      ? this.detailedOptions
-      : this.detailedOptions.filter((option) => keys.includes(option.name));
-    const argv = !keys ? this.argv : pick(this.argv, keys);
-    this.argv = optionsNormalizer.normalizeCliOptions(argv, detailedOptions, {
-      logger: this.logger,
-    });
+    this.argv = normalizeContextArgv(
+      this.detailedOptions,
+      this.argv,
+      keys,
+      this.logger
+    );
   }
 
   /**
@@ -138,6 +137,19 @@ function getContextOptions(plugins, pluginSearchDirs) {
 function parseArgv(args, detailedOptions) {
   const minimistOptions = createMinimistOptions(detailedOptions);
   return minimist(args, minimistOptions);
+}
+
+function normalizeContextArgv(detailedOptions, argv, keys, logger) {
+  if (keys) {
+    detailedOptions = detailedOptions.filter((option) =>
+      keys.includes(option.name)
+    );
+    argv = pick(argv, keys);
+  }
+
+  return optionsNormalizer.normalizeCliOptions(argv, detailedOptions, {
+    logger,
+  });
 }
 
 module.exports = Context;

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -130,11 +130,11 @@ function parseArgv(rawArguments, detailedOptions, keys, logger) {
   return normalizeCliOptions(argv, detailedOptions, { logger });
 }
 
-const contextOptionsWithoutPlugins = getContextOptions();
+const detailedOptionsWithoutPlugins = getContextOptions().detailedOptions;
 function parseArgvWithoutPlugins(rawArguments, keys, logger) {
   return parseArgv(
     rawArguments,
-    contextOptionsWithoutPlugins.detailedOptions,
+    detailedOptionsWithoutPlugins,
     typeof keys === "string" ? [keys] : keys,
     logger
   );

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -63,7 +63,13 @@ class Context {
     this.filePatterns = filePatterns;
     this.logger = logger;
 
-    this._updateContextArgv(this.argv.plugin, this.argv["plugin-search-dir"]);
+    const { plugin } = argv;
+    const pluginSearchDirs = argv["plugin-search-dir"];
+
+    this.pushContextPlugins(plugin, pluginSearchDirs);
+    const argv2 = parseArgv(this.args, this.detailedOptions);
+    this.argv = argv2;
+    this.filePatterns = argv2._.map((file) => String(file));
   }
 
   initContext() {
@@ -90,13 +96,6 @@ class Context {
 
   popContextPlugins() {
     Object.assign(this, this.stack.pop());
-  }
-
-  _updateContextArgv(plugins, pluginSearchDirs) {
-    this.pushContextPlugins(plugins, pluginSearchDirs);
-    const argv = parseArgv(this.args, this.detailedOptions);
-    this.argv = argv;
-    this.filePatterns = argv._.map((file) => String(file));
   }
 
   _normalizeContextArgv(keys) {

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -42,7 +42,7 @@ class Context {
     const {
       plugin: plugins,
       "plugin-search-dir": pluginSearchDirs,
-    } = parseArgvWithoutPlugin(
+    } = parseArgvWithoutPlugins(
       rawArguments,
       ["plugin", "plugin-search-dir"],
       logger
@@ -130,14 +130,14 @@ function parseArgv(rawArguments, detailedOptions, keys, logger) {
   return normalizeCliOptions(argv, detailedOptions, { logger });
 }
 
-const contextOptionsWithoutPlugin = getContextOptions();
-function parseArgvWithoutPlugin(rawArguments, keys, logger) {
+const contextOptionsWithoutPlugins = getContextOptions();
+function parseArgvWithoutPlugins(rawArguments, keys, logger) {
   return parseArgv(
     rawArguments,
-    contextOptionsWithoutPlugin.detailedOptions,
+    contextOptionsWithoutPlugins.detailedOptions,
     typeof keys === "string" ? [keys] : keys,
     logger
   );
 }
 
-module.exports = { Context, parseArgvWithoutPlugin };
+module.exports = { Context, parseArgvWithoutPlugins };

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -35,29 +35,21 @@ const createMinimistOptions = require("./create-minimist-options");
  */
 
 class Context {
-  constructor(result) {
+  constructor({ rawArguments, plugins, pluginSearchDirs, logger }) {
+    this.args = rawArguments;
+    this.logger = logger;
     this.stack = [{}];
 
-    const { args, contextOptions, argv, logger } = result;
-    this.args = args;
-
-    Object.assign(this, contextOptions);
-    this.argv = argv;
-    this.logger = logger;
-
-    const { plugin } = argv;
-    const pluginSearchDirs = argv["plugin-search-dir"];
-
-    this.pushContextPlugins(plugin, pluginSearchDirs);
-    const argv2 = parseArgv(
-      this.args,
+    Object.assign(this, getContextOptions());
+    this.pushContextPlugins(plugins, pluginSearchDirs);
+    const argv = parseArgv(
+      rawArguments,
       this.detailedOptions,
       undefined,
-      this.logger
+      logger
     );
-
-    this.argv = argv2;
-    this.filePatterns = argv2._.map((file) => String(file));
+    this.argv = argv;
+    this.filePatterns = argv._.map((file) => String(file));
   }
 
   /**
@@ -148,15 +140,14 @@ function normalizeContextArgv(detailedOptions, argv, keys, logger) {
   });
 }
 
-function init(args) {
-  const contextOptions = getContextOptions();
-  const argv = parseArgv(args, contextOptions.detailedOptions, [
+function init(rawArguments) {
+  const { detailedOptions } = getContextOptions();
+  const argv = parseArgv(rawArguments, detailedOptions, [
     "loglevel",
     "plugin",
     "plugin-search-dir",
   ]);
-
-  return { args, contextOptions, argv };
+  return argv;
 }
 
 module.exports = { init, Context };

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -4,7 +4,6 @@ const pick = require("lodash/pick");
 
 // eslint-disable-next-line no-restricted-modules
 const prettier = require("../index");
-const { createLogger } = require("./logger");
 const {
   optionsModule,
   optionsNormalizer,
@@ -35,28 +34,12 @@ const createMinimistOptions = require("./create-minimist-options");
  * @property popContextPlugins
  */
 
-function init(args) {
-  const contextOptions = getContextOptions();
-  let argv = parseArgv(args, contextOptions.detailedOptions);
-  const filePatterns = argv._.map((file) => String(file));
-
-  argv = normalizeContextArgv(contextOptions.detailedOptions, argv, [
-    "loglevel",
-    "plugin",
-    "plugin-search-dir",
-  ]);
-
-  const logger = createLogger(argv.loglevel);
-
-  return { contextOptions, argv, filePatterns, logger };
-}
-
 class Context {
-  constructor(args) {
+  constructor(args, result) {
     this.args = args;
     this.stack = [{}];
 
-    const { contextOptions, argv, filePatterns, logger } = init(args);
+    const { contextOptions, argv, filePatterns, logger } = result;
 
     Object.assign(this, contextOptions);
     this.argv = argv;
@@ -167,4 +150,18 @@ function normalizeContextArgv(detailedOptions, argv, keys, logger) {
   });
 }
 
-module.exports = Context;
+function init(args) {
+  const contextOptions = getContextOptions();
+  let argv = parseArgv(args, contextOptions.detailedOptions);
+  const filePatterns = argv._.map((file) => String(file));
+
+  argv = normalizeContextArgv(contextOptions.detailedOptions, argv, [
+    "loglevel",
+    "plugin",
+    "plugin-search-dir",
+  ]);
+
+  return { contextOptions, argv, filePatterns };
+}
+
+module.exports = { init, Context };

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -35,24 +35,34 @@ const createMinimistOptions = require("./create-minimist-options");
  * @property popContextPlugins
  */
 
+function init(args) {
+  const contextOptions = getContextOptions();
+  let argv = parseArgv(args, contextOptions.detailedOptions);
+  const filePatterns = argv._.map((file) => String(file));
+
+  argv = normalizeContextArgv(contextOptions.detailedOptions, argv, [
+    "loglevel",
+    "plugin",
+    "plugin-search-dir",
+  ]);
+
+  const logger = createLogger(argv.loglevel);
+
+  return { contextOptions, argv, filePatterns, logger };
+}
+
 class Context {
   constructor(args) {
     this.args = args;
     this.stack = [{}];
 
-    const contextOptions = getContextOptions();
+    const { contextOptions, argv, filePatterns, logger } = init(args);
+
     Object.assign(this, contextOptions);
-    const argv = parseArgv(args, contextOptions.detailedOptions);
     this.argv = argv;
-    this.filePatterns = argv._.map((file) => String(file));
+    this.filePatterns = filePatterns;
+    this.logger = logger;
 
-    this.argv = normalizeContextArgv(contextOptions.detailedOptions, argv, [
-      "loglevel",
-      "plugin",
-      "plugin-search-dir",
-    ]);
-
-    this.logger = createLogger(this.argv.loglevel);
     this._updateContextArgv(this.argv.plugin, this.argv["plugin-search-dir"]);
   }
 

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -107,9 +107,9 @@ function getContextOptions(plugins, pluginSearchDirs) {
 }
 
 function parseArgv(rawArguments, detailedOptions, keys, logger) {
-  detailedOptions = detailedOptions || getContextOptions().detailedOptions;
   const minimistOptions = createMinimistOptions(detailedOptions);
   const parsed = minimist(rawArguments, minimistOptions);
+
   const normalized = normalizeContextArgv(
     parsed,
     detailedOptions,
@@ -130,4 +130,14 @@ function normalizeContextArgv(argv, detailedOptions, keys, logger) {
   return normalizeCliOptions(argv, detailedOptions, { logger });
 }
 
-module.exports = { parseArgv, Context };
+const contextOptionsWithoutPlugin = getContextOptions();
+function parseArgvWithoutPlugin(rawArguments, keys, logger) {
+  return parseArgv(
+    rawArguments,
+    contextOptionsWithoutPlugin.detailedOptions,
+    keys,
+    logger
+  );
+}
+
+module.exports = { Context, parseArgvWithoutPlugin };

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -38,12 +38,11 @@ class Context {
   constructor(result) {
     this.stack = [{}];
 
-    const { args, contextOptions, argv, filePatterns, logger } = result;
+    const { args, contextOptions, argv, logger } = result;
     this.args = args;
 
     Object.assign(this, contextOptions);
     this.argv = argv;
-    this.filePatterns = filePatterns;
     this.logger = logger;
 
     const { plugin } = argv;
@@ -146,7 +145,6 @@ function normalizeContextArgv(detailedOptions, argv, keys, logger) {
 function init(args) {
   const contextOptions = getContextOptions();
   let argv = parseArgv(args, contextOptions.detailedOptions);
-  const filePatterns = argv._.map((file) => String(file));
 
   argv = normalizeContextArgv(contextOptions.detailedOptions, argv, [
     "loglevel",
@@ -154,7 +152,7 @@ function init(args) {
     "plugin-search-dir",
   ]);
 
-  return { args, contextOptions, argv, filePatterns };
+  return { args, contextOptions, argv };
 }
 
 module.exports = { init, Context };

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -20,7 +20,7 @@ const createMinimistOptions = require("./create-minimist-options");
 /**
  * @typedef {Object} Context
  * @property logger
- * @property {string[]} args
+ * @property {string[]} rawArguments
  * @property argv
  * @property {string[]} filePatterns
  * @property {any[]} supportOptions
@@ -35,7 +35,7 @@ const createMinimistOptions = require("./create-minimist-options");
 
 class Context {
   constructor({ rawArguments, plugins, pluginSearchDirs, logger }) {
-    this.args = rawArguments;
+    this.rawArguments = rawArguments;
     this.logger = logger;
     this.stack = [];
     this.pushContextPlugins(plugins, pluginSearchDirs);

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -42,10 +42,9 @@ class Context {
 
     const contextOptions = getContextOptions();
     Object.assign(this, contextOptions);
-
-    this.argv = parseArgv(args, contextOptions);
+    const argv = parseArgv(args, contextOptions.detailedOptions);
+    this.argv = argv;
     this.filePatterns = argv._.map((file) => String(file));
-
     this._normalizeContextArgv(["loglevel", "plugin", "plugin-search-dir"]);
     this.logger = createLogger(this.argv.loglevel);
     this._updateContextArgv(this.argv.plugin, this.argv["plugin-search-dir"]);
@@ -79,8 +78,7 @@ class Context {
 
   _updateContextArgv(plugins, pluginSearchDirs) {
     this.pushContextPlugins(plugins, pluginSearchDirs);
-    const minimistOptions = createMinimistOptions(this.detailedOptions);
-    const argv = minimist(this.args, minimistOptions);
+    const argv = parseArgv(this.args, this.detailedOptions);
     this.argv = argv;
     this.filePatterns = argv._.map((file) => String(file));
   }
@@ -137,8 +135,7 @@ function getContextOptions(plugins, pluginSearchDirs) {
   };
 }
 
-function parseArgv(args, contextOptions) {
-  const { detailedOptions } = contextOptions;
+function parseArgv(args, detailedOptions) {
   const minimistOptions = createMinimistOptions(detailedOptions);
   return minimist(args, minimistOptions);
 }

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -108,18 +108,8 @@ function getContextOptions(plugins, pluginSearchDirs) {
 
 function parseArgv(rawArguments, detailedOptions, keys, logger) {
   const minimistOptions = createMinimistOptions(detailedOptions);
-  const parsed = minimist(rawArguments, minimistOptions);
+  let argv = minimist(rawArguments, minimistOptions);
 
-  const normalized = normalizeContextArgv(
-    parsed,
-    detailedOptions,
-    keys,
-    logger
-  );
-  return normalized;
-}
-
-function normalizeContextArgv(argv, detailedOptions, keys, logger) {
   if (keys) {
     detailedOptions = detailedOptions.filter((option) =>
       keys.includes(option.name)

--- a/src/cli/core.js
+++ b/src/cli/core.js
@@ -8,7 +8,7 @@ const stringify = require("fast-json-stable-stringify");
 const prettier = require("../index");
 
 const { format, formatStdin, formatFiles } = require("./format");
-const { Context, parseArgvWithoutPlugin } = require("./context");
+const { Context, parseArgvWithoutPlugins } = require("./context");
 const {
   normalizeDetailedOptionMap,
   createDetailedOptionMap,
@@ -55,6 +55,6 @@ module.exports = {
   logResolvedConfigPathOrDie,
   logFileInfoOrDie,
   normalizeDetailedOptionMap,
-  parseArgvWithoutPlugin,
+  parseArgvWithoutPlugins,
   createLogger,
 };

--- a/src/cli/core.js
+++ b/src/cli/core.js
@@ -8,12 +8,13 @@ const stringify = require("fast-json-stable-stringify");
 const prettier = require("../index");
 
 const { format, formatStdin, formatFiles } = require("./format");
-const { Context } = require("./context");
+const { Context, parseArgvWithoutPlugin } = require("./context");
 const {
   normalizeDetailedOptionMap,
   createDetailedOptionMap,
 } = require("./option-map");
 const { createDetailedUsage, createUsage } = require("./usage");
+const { createLogger } = require("./logger");
 
 function logResolvedConfigPathOrDie(context) {
   const configFile = prettier.resolveConfigFile.sync(
@@ -54,4 +55,6 @@ module.exports = {
   logResolvedConfigPathOrDie,
   logFileInfoOrDie,
   normalizeDetailedOptionMap,
+  parseArgvWithoutPlugin,
+  createLogger,
 };

--- a/src/cli/core.js
+++ b/src/cli/core.js
@@ -8,7 +8,7 @@ const stringify = require("fast-json-stable-stringify");
 const prettier = require("../index");
 
 const { format, formatStdin, formatFiles } = require("./format");
-const Context = require("./context");
+const { Context } = require("./context");
 const {
   normalizeDetailedOptionMap,
   createDetailedOptionMap,

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -9,19 +9,11 @@ const prettier = require("../index");
 const core = require("./core");
 
 function run(rawArguments) {
-  const {
-    loglevel: logLevel,
-    plugin: plugins,
-    "plugin-search-dir": pluginSearchDirs,
-  } = core.parseArgvWithoutPlugin(rawArguments, [
-    "loglevel",
-    "plugin",
-    "plugin-search-dir",
-  ]);
-  const logger = core.createLogger(logLevel);
-  const options = { rawArguments, plugins, pluginSearchDirs, logger };
+  const { loglevel } = core.parseArgvWithoutPlugin(rawArguments, "loglevel");
+  const logger = core.createLogger(loglevel);
+
   try {
-    main(options);
+    main({ rawArguments, logger });
   } catch (error) {
     logger.error(error.message);
     process.exitCode = 1;

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -78,7 +78,7 @@ function run(args) {
       process.exit(1);
     }
   } catch (error) {
-    context.logger.error(error.message);
+    logger.error(error.message);
     process.exit(1);
   }
 }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -10,10 +10,14 @@ const core = require("./core");
 const { createLogger } = require("./logger");
 const { init } = require("./context");
 
-function run(args) {
-  const result = init(args);
-  const logger = createLogger(result.argv.loglevel);
-  const options = { ...result, logger };
+function run(rawArguments) {
+  const {
+    loglevel: logLevel,
+    plugin: plugins,
+    "plugin-search-dir": pluginSearchDirs,
+  } = init(rawArguments);
+  const logger = createLogger(logLevel);
+  const options = { rawArguments, plugins, pluginSearchDirs, logger };
   try {
     main(options);
   } catch (error) {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -14,11 +14,7 @@ function run(args) {
   const result = init(args);
   const logger = createLogger(result.argv.loglevel);
 
-  main({ ...result, logger });
-}
-
-function main(options) {
-  const context = new core.Context(options);
+  const context = new core.Context({ ...result, logger });
 
   try {
     context.initContext();
@@ -26,28 +22,24 @@ function main(options) {
     context.logger.debug(`normalized argv: ${JSON.stringify(context.argv)}`);
 
     if (context.argv.check && context.argv["list-different"]) {
-      context.logger.error("Cannot use --check and --list-different together.");
-      process.exit(1);
+      throw new Error("Cannot use --check and --list-different together.");
     }
 
     if (context.argv.write && context.argv["debug-check"]) {
-      context.logger.error("Cannot use --write and --debug-check together.");
-      process.exit(1);
+      throw new Error("Cannot use --write and --debug-check together.");
     }
 
     if (context.argv["find-config-path"] && context.filePatterns.length > 0) {
-      context.logger.error("Cannot use --find-config-path with multiple files");
-      process.exit(1);
+      throw new Error("Cannot use --find-config-path with multiple files");
     }
 
     if (context.argv["file-info"] && context.filePatterns.length > 0) {
-      context.logger.error("Cannot use --file-info with multiple files");
-      process.exit(1);
+      throw new Error("Cannot use --file-info with multiple files");
     }
 
     if (context.argv.version) {
       context.logger.log(prettier.version);
-      process.exit(0);
+      return;
     }
 
     if (context.argv.help !== undefined) {
@@ -56,7 +48,7 @@ function main(options) {
           ? core.createDetailedUsage(context, context.argv.help)
           : core.createUsage(context)
       );
-      process.exit(0);
+      return;
     }
 
     if (context.argv["support-info"]) {
@@ -65,7 +57,7 @@ function main(options) {
           parser: "json",
         })
       );
-      process.exit(0);
+      return;
     }
 
     const hasFilePatterns = context.filePatterns.length > 0;

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -24,7 +24,7 @@ function run(rawArguments) {
     main(options);
   } catch (error) {
     logger.error(error.message);
-    process.exit(1);
+    process.exitCode = 1;
   }
 }
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -24,7 +24,6 @@ function run(args) {
 
 function main(options) {
   const context = new core.Context(options);
-  context.initContext();
 
   context.logger.debug(`normalized argv: ${JSON.stringify(context.argv)}`);
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -7,20 +7,18 @@ const stringify = require("fast-json-stable-stringify");
 // eslint-disable-next-line no-restricted-modules
 const prettier = require("../index");
 const core = require("./core");
-const { createLogger } = require("./logger");
-const { parseArgv } = require("./context");
 
 function run(rawArguments) {
   const {
     loglevel: logLevel,
     plugin: plugins,
     "plugin-search-dir": pluginSearchDirs,
-  } = parseArgv(rawArguments, undefined, [
+  } = core.parseArgvWithoutPlugin(rawArguments, [
     "loglevel",
     "plugin",
     "plugin-search-dir",
   ]);
-  const logger = createLogger(logLevel);
+  const logger = core.createLogger(logLevel);
   const options = { rawArguments, plugins, pluginSearchDirs, logger };
   try {
     main(options);

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -81,7 +81,7 @@ function main(options) {
     core.formatFiles(context);
   } else {
     context.logger.log(core.createUsage(context));
-    process.exit(1);
+    process.exitCode = 1;
   }
 }
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -8,14 +8,18 @@ const stringify = require("fast-json-stable-stringify");
 const prettier = require("../index");
 const core = require("./core");
 const { createLogger } = require("./logger");
-const { init } = require("./context");
+const { parseArgv } = require("./context");
 
 function run(rawArguments) {
   const {
     loglevel: logLevel,
     plugin: plugins,
     "plugin-search-dir": pluginSearchDirs,
-  } = init(rawArguments);
+  } = parseArgv(rawArguments, undefined, [
+    "loglevel",
+    "plugin",
+    "plugin-search-dir",
+  ]);
   const logger = createLogger(logLevel);
   const options = { rawArguments, plugins, pluginSearchDirs, logger };
   try {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -14,7 +14,11 @@ function run(args) {
   const result = init(args);
   const logger = createLogger(result.argv.loglevel);
 
-  const context = new core.Context(args, { ...result, logger });
+  main({ ...result, logger });
+}
+
+function main(options) {
+  const context = new core.Context(options);
 
   try {
     context.initContext();

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -67,7 +67,7 @@ function main(options) {
   const hasFilePatterns = context.filePatterns.length > 0;
   const useStdin =
     !hasFilePatterns &&
-    (!process.stdin.isTTY || context.args["stdin-filepath"]);
+    (!process.stdin.isTTY || context.argv["stdin-filepath"]);
 
   if (context.argv["find-config-path"]) {
     core.logResolvedConfigPathOrDie(context);

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -7,9 +7,14 @@ const stringify = require("fast-json-stable-stringify");
 // eslint-disable-next-line no-restricted-modules
 const prettier = require("../index");
 const core = require("./core");
+const { createLogger } = require("./logger");
+const { init } = require("./context");
 
 function run(args) {
-  const context = new core.Context(args);
+  const result = init(args);
+  const logger = createLogger(result.argv.loglevel);
+
+  const context = new core.Context(args, { ...result, logger });
 
   try {
     context.initContext();

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -13,72 +13,75 @@ const { init } = require("./context");
 function run(args) {
   const result = init(args);
   const logger = createLogger(result.argv.loglevel);
-
-  const context = new core.Context({ ...result, logger });
-
+  const options = { ...result, logger };
   try {
-    context.initContext();
-
-    context.logger.debug(`normalized argv: ${JSON.stringify(context.argv)}`);
-
-    if (context.argv.check && context.argv["list-different"]) {
-      throw new Error("Cannot use --check and --list-different together.");
-    }
-
-    if (context.argv.write && context.argv["debug-check"]) {
-      throw new Error("Cannot use --write and --debug-check together.");
-    }
-
-    if (context.argv["find-config-path"] && context.filePatterns.length > 0) {
-      throw new Error("Cannot use --find-config-path with multiple files");
-    }
-
-    if (context.argv["file-info"] && context.filePatterns.length > 0) {
-      throw new Error("Cannot use --file-info with multiple files");
-    }
-
-    if (context.argv.version) {
-      context.logger.log(prettier.version);
-      return;
-    }
-
-    if (context.argv.help !== undefined) {
-      context.logger.log(
-        typeof context.argv.help === "string" && context.argv.help !== ""
-          ? core.createDetailedUsage(context, context.argv.help)
-          : core.createUsage(context)
-      );
-      return;
-    }
-
-    if (context.argv["support-info"]) {
-      context.logger.log(
-        prettier.format(stringify(prettier.getSupportInfo()), {
-          parser: "json",
-        })
-      );
-      return;
-    }
-
-    const hasFilePatterns = context.filePatterns.length > 0;
-    const useStdin =
-      !hasFilePatterns &&
-      (!process.stdin.isTTY || context.args["stdin-filepath"]);
-
-    if (context.argv["find-config-path"]) {
-      core.logResolvedConfigPathOrDie(context);
-    } else if (context.argv["file-info"]) {
-      core.logFileInfoOrDie(context);
-    } else if (useStdin) {
-      core.formatStdin(context);
-    } else if (hasFilePatterns) {
-      core.formatFiles(context);
-    } else {
-      context.logger.log(core.createUsage(context));
-      process.exit(1);
-    }
+    main(options);
   } catch (error) {
     logger.error(error.message);
+    process.exit(1);
+  }
+}
+
+function main(options) {
+  const context = new core.Context(options);
+  context.initContext();
+
+  context.logger.debug(`normalized argv: ${JSON.stringify(context.argv)}`);
+
+  if (context.argv.check && context.argv["list-different"]) {
+    throw new Error("Cannot use --check and --list-different together.");
+  }
+
+  if (context.argv.write && context.argv["debug-check"]) {
+    throw new Error("Cannot use --write and --debug-check together.");
+  }
+
+  if (context.argv["find-config-path"] && context.filePatterns.length > 0) {
+    throw new Error("Cannot use --find-config-path with multiple files");
+  }
+
+  if (context.argv["file-info"] && context.filePatterns.length > 0) {
+    throw new Error("Cannot use --file-info with multiple files");
+  }
+
+  if (context.argv.version) {
+    context.logger.log(prettier.version);
+    return;
+  }
+
+  if (context.argv.help !== undefined) {
+    context.logger.log(
+      typeof context.argv.help === "string" && context.argv.help !== ""
+        ? core.createDetailedUsage(context, context.argv.help)
+        : core.createUsage(context)
+    );
+    return;
+  }
+
+  if (context.argv["support-info"]) {
+    context.logger.log(
+      prettier.format(stringify(prettier.getSupportInfo()), {
+        parser: "json",
+      })
+    );
+    return;
+  }
+
+  const hasFilePatterns = context.filePatterns.length > 0;
+  const useStdin =
+    !hasFilePatterns &&
+    (!process.stdin.isTTY || context.args["stdin-filepath"]);
+
+  if (context.argv["find-config-path"]) {
+    core.logResolvedConfigPathOrDie(context);
+  } else if (context.argv["file-info"]) {
+    core.logFileInfoOrDie(context);
+  } else if (useStdin) {
+    core.formatStdin(context);
+  } else if (hasFilePatterns) {
+    core.formatFiles(context);
+  } else {
+    context.logger.log(core.createUsage(context));
     process.exit(1);
   }
 }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -13,17 +13,17 @@ function run(rawArguments) {
   const logger = core.createLogger(loglevel);
 
   try {
-    main({ rawArguments, logger });
+    main(rawArguments, logger);
   } catch (error) {
     logger.error(error.message);
     process.exitCode = 1;
   }
 }
 
-function main(options) {
-  const context = new core.Context(options);
+function main(rawArguments, logger) {
+  const context = new core.Context({ rawArguments, logger });
 
-  context.logger.debug(`normalized argv: ${JSON.stringify(context.argv)}`);
+  logger.debug(`normalized argv: ${JSON.stringify(context.argv)}`);
 
   if (context.argv.check && context.argv["list-different"]) {
     throw new Error("Cannot use --check and --list-different together.");
@@ -42,12 +42,12 @@ function main(options) {
   }
 
   if (context.argv.version) {
-    context.logger.log(prettier.version);
+    logger.log(prettier.version);
     return;
   }
 
   if (context.argv.help !== undefined) {
-    context.logger.log(
+    logger.log(
       typeof context.argv.help === "string" && context.argv.help !== ""
         ? core.createDetailedUsage(context, context.argv.help)
         : core.createUsage(context)
@@ -56,7 +56,7 @@ function main(options) {
   }
 
   if (context.argv["support-info"]) {
-    context.logger.log(
+    logger.log(
       prettier.format(stringify(prettier.getSupportInfo()), {
         parser: "json",
       })
@@ -78,7 +78,7 @@ function main(options) {
   } else if (hasFilePatterns) {
     core.formatFiles(context);
   } else {
-    context.logger.log(core.createUsage(context));
+    logger.log(core.createUsage(context));
     process.exitCode = 1;
   }
 }

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -9,9 +9,9 @@ const prettier = require("../index");
 const core = require("./core");
 
 function run(rawArguments) {
-  const { loglevel } = core.parseArgvWithoutPlugins(rawArguments, "loglevel");
-  const logger = core.createLogger(loglevel);
-
+  const logLevel = core.parseArgvWithoutPlugins(rawArguments, "loglevel")
+    .loglevel;
+  const logger = core.createLogger(logLevel);
   try {
     main(rawArguments, logger);
   } catch (error) {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -9,7 +9,7 @@ const prettier = require("../index");
 const core = require("./core");
 
 function run(rawArguments) {
-  const { loglevel } = core.parseArgvWithoutPlugin(rawArguments, "loglevel");
+  const { loglevel } = core.parseArgvWithoutPlugins(rawArguments, "loglevel");
   const logger = core.createLogger(loglevel);
 
   try {

--- a/src/cli/option.js
+++ b/src/cli/option.js
@@ -47,7 +47,7 @@ function parseArgsToOptions(context, overrideDefaults) {
   );
   return getOptions(
     optionsNormalizer.normalizeCliOptions(
-      minimist(context.args, {
+      minimist(context.rawArguments, {
         string: minimistOptions.string,
         boolean: minimistOptions.boolean,
         default: cliifyOptions(overrideDefaults, apiDetailedOptionMap),

--- a/tests_integration/__tests__/plugin-resolution.js
+++ b/tests_integration/__tests__/plugin-resolution.js
@@ -122,7 +122,7 @@ describe("crashes when one of --plugin-search-dir does not exist", () => {
     "--plugin-search-dir=.",
   ]).test({
     stdout: "",
-    stderr: "non-existing-dir does not exist or is not a directory",
+    stderr: "[error] non-existing-dir does not exist or is not a directory\n",
     status: 1,
     write: [],
   });


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

1. Move `logger` out `Context`, so we don't need a extra `Context#initContext()` call.
2. Parse `plugin`/`plugin-search-dir` argument in a later stage, so we can use logger to log errors.

stable:

```console
npx prettier --plugin=ninjia
Cannot find module 'ninjia'
Require stack:
- ...
```

this pr:

```console
node bin/prettier --plugin=ninjia
[error] Cannot find module 'ninjia'
[error] Require stack:
[error] - ...
```

stable:

```console
npx prettier --plugin-search-dir=ninjia
ninjia does not exist or is not a directory
```

this pr:
```console
node bin/prettier --plugin-search-dir=ninjia
[error] ninjia does not exist or is not a directory
```

3. Fix a possible bug 

This line https://github.com/prettier/prettier/blob/main/src/cli/index.js#L65 , should not use `context.args["stdin-filepath"]`, `context.args`(renamed to `context.rawArguments` in this PR) is an array, should be `context.argv`

4. Simplified a lot

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
