### PR TITLE
Round-trippable --debug-print-doc

### DIFF
--- a/changelog_unreleased/cli/10169.md
+++ b/changelog_unreleased/cli/10169.md
@@ -1,0 +1,3 @@
+#### Round-trippable `--debug-print-doc` (#10169 by @thorn0)
+
+The idea is to make the output of `--debug-print-doc` closer to actual code for generating docs (Prettier's intermediate representation). Ideally, it should be possible for it to work without modification after copy-pasting into a JS file. That ideal hasn't probably been reached by this PR, but it's pretty close. This is going to make `--debug-print-doc` and the corresponding part of the Playground a bit more useful.

--- a/commands.md
+++ b/commands.md
@@ -237,6 +237,15 @@ declare var trim: Doc;
 
 This will trim any whitespace or tab character on the current line. This is used for preprocessor directives.
 
+### hardlineWithoutBreakParent and literallineWithoutBreakParent
+
+These are used very rarely, for advanced formatting tricks.
+
+Examples:
+
+- `hardlineWithoutBreakParent` is used for printing tables in Prettier's Markdown printer. With `proseWrap` set to `never`, the columns are aligned only if none of the rows exceeds `printWidth`.
+- `literallineWithoutBreakParent` (called `literalLineNoBreak` [there](https://github.com/prettier/plugin-ruby/blob/9e658db13d3f0524d816528e060b1381e0431559/src/ruby/nodes/heredocs.js)) is used in the [Ruby plugin](https://github.com/prettier/plugin-ruby) for printing heredoc syntax.
+
 ### cursor
 
 ```ts

--- a/cspell.json
+++ b/cspell.json
@@ -370,6 +370,7 @@
         "Tomasek",
         "Tradeshift",
         "Transloadit",
+        "trippable",
         "TSAs",
         "tsep",
         "TSESTree",

--- a/src/document/doc-builders.js
+++ b/src/document/doc-builders.js
@@ -186,13 +186,15 @@ function lineSuffix(contents) {
 const lineSuffixBoundary = { type: "line-suffix-boundary" };
 const breakParent = { type: "break-parent" };
 const trim = { type: "trim" };
+
+const hardlineNoBreak = { type: "line", hard: true };
+const literallineNoBreak = { type: "line", hard: true, literal: true };
+
 const line = { type: "line" };
 const softline = { type: "line", soft: true };
-const hardline = concat([{ type: "line", hard: true }, breakParent]);
-const literalline = concat([
-  { type: "line", hard: true, literal: true },
-  breakParent,
-]);
+const hardline = concat([hardlineNoBreak, breakParent]);
+const literalline = concat([literallineNoBreak, breakParent]);
+
 const cursor = { type: "cursor", placeholder: Symbol("cursor") };
 
 /**
@@ -257,4 +259,6 @@ module.exports = {
   markAsRoot,
   dedentToRoot,
   dedent,
+  hardlineNoBreak,
+  literallineNoBreak,
 };

--- a/src/document/doc-builders.js
+++ b/src/document/doc-builders.js
@@ -187,13 +187,17 @@ const lineSuffixBoundary = { type: "line-suffix-boundary" };
 const breakParent = { type: "break-parent" };
 const trim = { type: "trim" };
 
-const hardlineNoBreak = { type: "line", hard: true };
-const literallineNoBreak = { type: "line", hard: true, literal: true };
+const hardlineWithoutBreakParent = { type: "line", hard: true };
+const literallineWithoutBreakParent = {
+  type: "line",
+  hard: true,
+  literal: true,
+};
 
 const line = { type: "line" };
 const softline = { type: "line", soft: true };
-const hardline = concat([hardlineNoBreak, breakParent]);
-const literalline = concat([literallineNoBreak, breakParent]);
+const hardline = concat([hardlineWithoutBreakParent, breakParent]);
+const literalline = concat([literallineWithoutBreakParent, breakParent]);
 
 const cursor = { type: "cursor", placeholder: Symbol("cursor") };
 
@@ -259,6 +263,6 @@ module.exports = {
   markAsRoot,
   dedentToRoot,
   dedent,
-  hardlineNoBreak,
-  literallineNoBreak,
+  hardlineWithoutBreakParent,
+  literallineWithoutBreakParent,
 };

--- a/src/document/doc-debug.js
+++ b/src/document/doc-debug.js
@@ -41,136 +41,139 @@ function flattenDoc(doc) {
   return doc;
 }
 
-function printDoc(doc, index, parentParts) {
-  if (typeof doc === "string") {
-    return JSON.stringify(doc);
-  }
-
-  if (isConcat(doc)) {
-    return `[${getDocParts(doc).map(printDoc).filter(Boolean).join(", ")}]`;
-  }
-
-  if (doc.type === "line") {
-    const withBreakParent =
-      Array.isArray(parentParts) &&
-      parentParts[index + 1] &&
-      parentParts[index + 1].type === "break-parent";
-    if (doc.literal) {
-      return withBreakParent ? "literalline" : "literallineWithoutBreakParent";
-    }
-    if (doc.hard) {
-      return withBreakParent ? "hardline" : "hardlineWithoutBreakParent";
-    }
-    if (doc.soft) {
-      return "softline";
-    }
-    return "line";
-  }
-
-  if (doc.type === "break-parent") {
-    const afterHardline =
-      Array.isArray(parentParts) &&
-      parentParts[index - 1] &&
-      parentParts[index - 1].type === "line" &&
-      parentParts[index - 1].hard;
-    return afterHardline ? undefined : "breakParent";
-  }
-
-  if (doc.type === "trim") {
-    return "trim";
-  }
-
-  if (doc.type === "indent") {
-    return "indent(" + printDoc(doc.contents) + ")";
-  }
-
-  if (doc.type === "align") {
-    return doc.n === Number.NEGATIVE_INFINITY
-      ? "dedentToRoot(" + printDoc(doc.contents) + ")"
-      : doc.n < 0
-      ? "dedent(" + printDoc(doc.contents) + ")"
-      : doc.n.type === "root"
-      ? "markAsRoot(" + printDoc(doc.contents) + ")"
-      : "align(" + JSON.stringify(doc.n) + ", " + printDoc(doc.contents) + ")";
-  }
-
-  if (doc.type === "if-break") {
-    return (
-      "ifBreak(" +
-      printDoc(doc.breakContents) +
-      (doc.flatContents ? ", " + printDoc(doc.flatContents) : "") +
-      (doc.groupId
-        ? (!doc.flatContents ? ', ""' : "") +
-          `, { groupId: ${JSON.stringify(printGroupId(doc.groupId))} }`
-        : "") +
-      ")"
-    );
-  }
-
-  if (doc.type === "group") {
-    const optionsParts = [];
-
-    if (doc.break && doc.break !== "propagated") {
-      optionsParts.push("break: true");
-    }
-
-    if (doc.id) {
-      optionsParts.push(`id: ${JSON.stringify(printGroupId(doc.id))}`);
-    }
-
-    const options =
-      optionsParts.length > 0 ? `, { ${optionsParts.join(", ")} }` : "";
-
-    if (doc.expandedStates) {
-      return `conditionalGroup([${doc.expandedStates
-        .map(printDoc)
-        .join(",")}]${options})`;
-    }
-
-    return `group(${printDoc(doc.contents)}${options})`;
-  }
-
-  if (doc.type === "fill") {
-    return `fill([${doc.parts.map(printDoc).join(", ")}])`;
-  }
-
-  if (doc.type === "line-suffix") {
-    return "lineSuffix(" + printDoc(doc.contents) + ")";
-  }
-
-  if (doc.type === "line-suffix-boundary") {
-    return "lineSuffixBoundary";
-  }
-
-  throw new Error("Unknown doc type " + doc.type);
-}
-
-let symbolMap;
-let usedStrings;
-
-function printGroupId(id) {
-  if (typeof id !== "symbol") {
-    return JSON.stringify(String(id));
-  }
-
-  if (id in symbolMap) {
-    return symbolMap[id];
-  }
-
-  const prefix = id.description || "symbol";
-  for (let counter = 0; ; counter++) {
-    const string = prefix + (counter > 0 ? ` #${counter}` : "");
-    if (!usedStrings.has(string)) {
-      usedStrings.add(string);
-      return (symbolMap[id] = `Symbol.for(${JSON.stringify(string)})`);
-    }
-  }
-}
-
 function printDocToDebug(doc) {
-  symbolMap = Object.create(null);
-  usedStrings = new Set();
+  const symbolMap = Object.create(null);
+  const usedStrings = new Set();
   return printDoc(flattenDoc(doc));
+
+  function printDoc(doc, index, parentParts) {
+    if (typeof doc === "string") {
+      return JSON.stringify(doc);
+    }
+
+    if (isConcat(doc)) {
+      return `[${getDocParts(doc).map(printDoc).filter(Boolean).join(", ")}]`;
+    }
+
+    if (doc.type === "line") {
+      const withBreakParent =
+        Array.isArray(parentParts) &&
+        parentParts[index + 1] &&
+        parentParts[index + 1].type === "break-parent";
+      if (doc.literal) {
+        return withBreakParent
+          ? "literalline"
+          : "literallineWithoutBreakParent";
+      }
+      if (doc.hard) {
+        return withBreakParent ? "hardline" : "hardlineWithoutBreakParent";
+      }
+      if (doc.soft) {
+        return "softline";
+      }
+      return "line";
+    }
+
+    if (doc.type === "break-parent") {
+      const afterHardline =
+        Array.isArray(parentParts) &&
+        parentParts[index - 1] &&
+        parentParts[index - 1].type === "line" &&
+        parentParts[index - 1].hard;
+      return afterHardline ? undefined : "breakParent";
+    }
+
+    if (doc.type === "trim") {
+      return "trim";
+    }
+
+    if (doc.type === "indent") {
+      return "indent(" + printDoc(doc.contents) + ")";
+    }
+
+    if (doc.type === "align") {
+      return doc.n === Number.NEGATIVE_INFINITY
+        ? "dedentToRoot(" + printDoc(doc.contents) + ")"
+        : doc.n < 0
+        ? "dedent(" + printDoc(doc.contents) + ")"
+        : doc.n.type === "root"
+        ? "markAsRoot(" + printDoc(doc.contents) + ")"
+        : "align(" +
+          JSON.stringify(doc.n) +
+          ", " +
+          printDoc(doc.contents) +
+          ")";
+    }
+
+    if (doc.type === "if-break") {
+      return (
+        "ifBreak(" +
+        printDoc(doc.breakContents) +
+        (doc.flatContents ? ", " + printDoc(doc.flatContents) : "") +
+        (doc.groupId
+          ? (!doc.flatContents ? ', ""' : "") +
+            `, { groupId: ${JSON.stringify(printGroupId(doc.groupId))} }`
+          : "") +
+        ")"
+      );
+    }
+
+    if (doc.type === "group") {
+      const optionsParts = [];
+
+      if (doc.break && doc.break !== "propagated") {
+        optionsParts.push("break: true");
+      }
+
+      if (doc.id) {
+        optionsParts.push(`id: ${JSON.stringify(printGroupId(doc.id))}`);
+      }
+
+      const options =
+        optionsParts.length > 0 ? `, { ${optionsParts.join(", ")} }` : "";
+
+      if (doc.expandedStates) {
+        return `conditionalGroup([${doc.expandedStates
+          .map(printDoc)
+          .join(",")}]${options})`;
+      }
+
+      return `group(${printDoc(doc.contents)}${options})`;
+    }
+
+    if (doc.type === "fill") {
+      return `fill([${doc.parts.map(printDoc).join(", ")}])`;
+    }
+
+    if (doc.type === "line-suffix") {
+      return "lineSuffix(" + printDoc(doc.contents) + ")";
+    }
+
+    if (doc.type === "line-suffix-boundary") {
+      return "lineSuffixBoundary";
+    }
+
+    throw new Error("Unknown doc type " + doc.type);
+  }
+
+  function printGroupId(id) {
+    if (typeof id !== "symbol") {
+      return JSON.stringify(String(id));
+    }
+
+    if (id in symbolMap) {
+      return symbolMap[id];
+    }
+
+    const prefix = id.description || "symbol";
+    for (let counter = 0; ; counter++) {
+      const string = prefix + (counter > 0 ? ` #${counter}` : "");
+      if (!usedStrings.has(string)) {
+        usedStrings.add(string);
+        return (symbolMap[id] = `Symbol.for(${JSON.stringify(string)})`);
+      }
+    }
+  }
 }
 
 module.exports = { printDocToDebug };

--- a/src/document/doc-debug.js
+++ b/src/document/doc-debug.js
@@ -158,8 +158,8 @@ function printGroupId(id) {
   }
 
   const prefix = id.description || "symbol";
-  for (let i = 0; ; i++) {
-    const string = prefix + (i > 0 ? " #" + i : "");
+  for (let counter = 0; ; counter++) {
+    const string = prefix + (counter > 0 ? ` #${counter}` : "");
     if (!usedStrings.has(string)) {
       symbolMap[id] = string;
       usedStrings.add(string);

--- a/src/document/doc-debug.js
+++ b/src/document/doc-debug.js
@@ -56,10 +56,10 @@ function printDoc(doc, index, parentParts) {
       parentParts[index + 1] &&
       parentParts[index + 1].type === "break-parent";
     if (doc.literal) {
-      return withBreakParent ? "literalline" : "literallineNoBreak";
+      return withBreakParent ? "literalline" : "literallineWithoutBreakParent";
     }
     if (doc.hard) {
-      return withBreakParent ? "hardline" : "hardlineNoBreak";
+      return withBreakParent ? "hardline" : "hardlineWithoutBreakParent";
     }
     if (doc.soft) {
       return "softline";

--- a/src/document/doc-debug.js
+++ b/src/document/doc-debug.js
@@ -42,7 +42,9 @@ function flattenDoc(doc) {
 }
 
 function printDocToDebug(doc) {
+  /** @type Record<symbol, string> */
   const printedSymbols = Object.create(null);
+  /** @type Set<string> */
   const usedKeysForSymbols = new Set();
   return printDoc(flattenDoc(doc));
 

--- a/src/document/doc-debug.js
+++ b/src/document/doc-debug.js
@@ -42,8 +42,8 @@ function flattenDoc(doc) {
 }
 
 function printDocToDebug(doc) {
-  const symbolMap = Object.create(null);
-  const usedStrings = new Set();
+  const symbolsToKeysMap = Object.create(null);
+  const usedKeysForSymbols = new Set();
   return printDoc(flattenDoc(doc));
 
   function printDoc(doc, index, parentParts) {
@@ -112,7 +112,7 @@ function printDocToDebug(doc) {
         (doc.flatContents ? ", " + printDoc(doc.flatContents) : "") +
         (doc.groupId
           ? (!doc.flatContents ? ', ""' : "") +
-            `, { groupId: ${JSON.stringify(printGroupId(doc.groupId))} }`
+            `, { groupId: ${printGroupId(doc.groupId)} }`
           : "") +
         ")"
       );
@@ -126,7 +126,7 @@ function printDocToDebug(doc) {
       }
 
       if (doc.id) {
-        optionsParts.push(`id: ${JSON.stringify(printGroupId(doc.id))}`);
+        optionsParts.push(`id: ${printGroupId(doc.id)}`);
       }
 
       const options =
@@ -161,16 +161,16 @@ function printDocToDebug(doc) {
       return JSON.stringify(String(id));
     }
 
-    if (id in symbolMap) {
-      return symbolMap[id];
+    if (id in symbolsToKeysMap) {
+      return symbolsToKeysMap[id];
     }
 
     const prefix = id.description || "symbol";
     for (let counter = 0; ; counter++) {
       const string = prefix + (counter > 0 ? ` #${counter}` : "");
-      if (!usedStrings.has(string)) {
-        usedStrings.add(string);
-        return (symbolMap[id] = `Symbol.for(${JSON.stringify(string)})`);
+      if (!usedKeysForSymbols.has(string)) {
+        usedKeysForSymbols.add(string);
+        return (symbolsToKeysMap[id] = `Symbol.for(${JSON.stringify(string)})`);
       }
     }
   }

--- a/src/document/doc-debug.js
+++ b/src/document/doc-debug.js
@@ -150,7 +150,7 @@ let usedStrings;
 
 function printGroupId(id) {
   if (typeof id !== "symbol") {
-    return String(id);
+    return JSON.stringify(String(id));
   }
 
   if (id in symbolMap) {
@@ -161,9 +161,8 @@ function printGroupId(id) {
   for (let counter = 0; ; counter++) {
     const string = prefix + (counter > 0 ? ` #${counter}` : "");
     if (!usedStrings.has(string)) {
-      symbolMap[id] = string;
       usedStrings.add(string);
-      return string;
+      return (symbolMap[id] = `Symbol.for(${JSON.stringify(string)})`);
     }
   }
 }

--- a/src/document/doc-debug.js
+++ b/src/document/doc-debug.js
@@ -101,7 +101,7 @@ function printDoc(doc, index, parentParts) {
       (doc.flatContents ? ", " + printDoc(doc.flatContents) : "") +
       (doc.groupId
         ? (!doc.flatContents ? ', ""' : "") +
-          (", { groupId: " + JSON.stringify(printGroupId(doc.groupId)) + " }")
+          `, { groupId: ${JSON.stringify(printGroupId(doc.groupId))} }`
         : "") +
       ")"
     );
@@ -115,27 +115,23 @@ function printDoc(doc, index, parentParts) {
     }
 
     if (doc.id) {
-      optionsParts.push("id: " + JSON.stringify(printGroupId(doc.id)));
+      optionsParts.push(`id: ${JSON.stringify(printGroupId(doc.id))}`);
     }
 
     const options =
-      optionsParts.length > 0 ? ", { " + optionsParts.join(", ") + " }" : "";
+      optionsParts.length > 0 ? `, { ${optionsParts.join(", ")} }` : "";
 
     if (doc.expandedStates) {
-      return (
-        "conditionalGroup([" +
-        doc.expandedStates.map(printDoc).join(",") +
-        "]" +
-        options +
-        ")"
-      );
+      return `conditionalGroup([${doc.expandedStates
+        .map(printDoc)
+        .join(",")}]${options})`;
     }
 
-    return "group(" + printDoc(doc.contents) + options + ")";
+    return `group(${printDoc(doc.contents)}${options})`;
   }
 
   if (doc.type === "fill") {
-    return "fill([" + doc.parts.map(printDoc).join(", ") + "])";
+    return `fill([${doc.parts.map(printDoc).join(", ")}])`;
   }
 
   if (doc.type === "line-suffix") {

--- a/src/document/doc-debug.js
+++ b/src/document/doc-debug.js
@@ -42,7 +42,7 @@ function flattenDoc(doc) {
 }
 
 function printDocToDebug(doc) {
-  const symbolsToKeysMap = Object.create(null);
+  const printedSymbols = Object.create(null);
   const usedKeysForSymbols = new Set();
   return printDoc(flattenDoc(doc));
 
@@ -161,16 +161,16 @@ function printDocToDebug(doc) {
       return JSON.stringify(String(id));
     }
 
-    if (id in symbolsToKeysMap) {
-      return symbolsToKeysMap[id];
+    if (id in printedSymbols) {
+      return printedSymbols[id];
     }
 
     const prefix = id.description || "symbol";
     for (let counter = 0; ; counter++) {
-      const string = prefix + (counter > 0 ? ` #${counter}` : "");
-      if (!usedKeysForSymbols.has(string)) {
-        usedKeysForSymbols.add(string);
-        return (symbolsToKeysMap[id] = `Symbol.for(${JSON.stringify(string)})`);
+      const key = prefix + (counter > 0 ? ` #${counter}` : "");
+      if (!usedKeysForSymbols.has(key)) {
+        usedKeysForSymbols.add(key);
+        return (printedSymbols[id] = `Symbol.for(${JSON.stringify(key)})`);
       }
     }
   }

--- a/src/document/doc-utils.js
+++ b/src/document/doc-utils.js
@@ -131,8 +131,9 @@ function breakParentGroup(groupStack) {
     const parentGroup = groupStack[groupStack.length - 1];
     // Breaks are not propagated through conditional groups because
     // the user is expected to manually handle what breaks.
-    if (!parentGroup.expandedStates) {
-      parentGroup.break = true;
+    if (!parentGroup.expandedStates && !parentGroup.break) {
+      // An alternative truthy value allows to distinguish propagated group breaks.
+      parentGroup.break = "propagated";
     }
   }
   return null;

--- a/src/document/doc-utils.js
+++ b/src/document/doc-utils.js
@@ -132,7 +132,8 @@ function breakParentGroup(groupStack) {
     // Breaks are not propagated through conditional groups because
     // the user is expected to manually handle what breaks.
     if (!parentGroup.expandedStates && !parentGroup.break) {
-      // An alternative truthy value allows to distinguish propagated group breaks.
+      // An alternative truthy value allows to distinguish propagated group breaks
+      // and not to print them as `group(..., { break: true })` in `--debug-print-doc`.
       parentGroup.break = "propagated";
     }
   }

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -21,8 +21,9 @@ const {
     align,
     indent,
     group,
+    hardlineWithoutBreakParent,
   },
-  utils: { normalizeDoc, getDocParts },
+  utils: { normalizeDoc },
   printer: { printDocToString },
 } = require("../document");
 const { replaceEndOfLineWith } = require("../common/util");
@@ -557,7 +558,6 @@ function printLine(path, value, options) {
 }
 
 function printTable(path, options, print) {
-  const hardlineWithoutBreakParent = getDocParts(hardline)[0];
   const node = path.getValue();
 
   const columnMaxWidths = [];

--- a/tests_integration/__tests__/__snapshots__/debug-api.js.snap
+++ b/tests_integration/__tests__/__snapshots__/debug-api.js.snap
@@ -10,7 +10,6 @@ exports[`API prettier.formatDoc 1`] = `
     \\";\\",
   ]),
   hardline,
-  breakParent,
 ];
 "
 `;

--- a/tests_integration/__tests__/debug-api.js
+++ b/tests_integration/__tests__/debug-api.js
@@ -1,12 +1,9 @@
 "use strict";
 
 const {
-  parse,
-  formatAST,
-  formatDoc,
-  printToDoc,
-  printDocToString,
-} = require("prettier-local").__debug;
+  __debug: { parse, formatAST, formatDoc, printToDoc, printDocToString },
+  doc: { builders },
+} = require("prettier-local");
 const { outdent } = require("outdent");
 
 const code = outdent`
@@ -44,5 +41,14 @@ describe("API", () => {
   const { formatted: stringFromDoc } = printDocToString(doc, options);
   test("prettier.printDocToString", () => {
     expect(stringFromDoc).toBe(formatted);
+  });
+
+  const doc2 = new Function(
+    `{${Object.keys(builders)}}`,
+    "return " + formatResultFromDoc
+  )(builders);
+  const { formatted: stringFromDoc2 } = printDocToString(doc2, options);
+  test("output of prettier.formatDoc can be reused as code", () => {
+    expect(stringFromDoc2).toBe(formatted);
   });
 });

--- a/tests_integration/__tests__/debug-api.js
+++ b/tests_integration/__tests__/debug-api.js
@@ -44,11 +44,13 @@ describe("API", () => {
   });
 
   const doc2 = new Function(
-    `{${Object.keys(builders)}}`,
+    `{ ${Object.keys(builders)} }`,
     "return " + formatResultFromDoc
   )(builders);
   const { formatted: stringFromDoc2 } = printDocToString(doc2, options);
+  const formatResultFromDoc2 = formatDoc(doc2, options);
   test("output of prettier.formatDoc can be reused as code", () => {
     expect(stringFromDoc2).toBe(formatted);
+    expect(formatResultFromDoc2).toBe(formatResultFromDoc);
   });
 });

--- a/tests_integration/__tests__/debug-api.js
+++ b/tests_integration/__tests__/debug-api.js
@@ -45,7 +45,7 @@ describe("API", () => {
 
   const doc2 = new Function(
     `{ ${Object.keys(builders)} }`,
-    "return " + formatResultFromDoc
+    `return ${formatResultFromDoc}`
   )(builders);
   const { formatted: stringFromDoc2 } = printDocToString(doc2, options);
   const formatResultFromDoc2 = formatDoc(doc2, options);

--- a/tests_integration/__tests__/debug-print-doc.js
+++ b/tests_integration/__tests__/debug-print-doc.js
@@ -6,7 +6,7 @@ describe("prints doc with --debug-print-doc", () => {
   runPrettier("cli/with-shebang", ["--debug-print-doc", "--parser", "babel"], {
     input: "0",
   }).test({
-    stdout: '["0", ";", hardline, breakParent];\n',
+    stdout: '["0", ";", hardline];\n',
     stderr: "",
     status: 0,
   });


### PR DESCRIPTION
## Description

The idea is to make the output of `--debug-print-doc` closer to actual code for generating docs. Ideally, it should be possible for it to work without modification after copy-pasting into a JS file. That ideal probably hasn't been reached by this PR, but it's pretty close. I believe this will make `--debug-print-doc` (and the corresponding part of the Playground) more useful.

[Before:](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEwA64NIATqt7DAIy2wCY0oBfKkAGhAgAcYBLaAZ2VAEMAnPhADuABX4IuKHgBshPAJ5cGRPjzABrODADKTNaygBzZDD4BXOAzgBbInAAm9hwBkeRsz0NwAYhD7WeGDYjZBAeMxgIehAACxhraQB1GNZ4Dj0wOG0JVNYAN1T5ULAOJRADDjg+GBFVQwDkADMZSoYAKw4ADwAhVQ0tbR5rOGcDOCaWyxAOzu0DQ2k4AEUzCHgJ6VaQPT5KvlCO6GimPgMYRNZ7GBjkAA4ABgYTiErE1SZQk7g9vPGGAEdVvBasxJGEOABaKBwBwOaJ8OCA1gI2qeBpIZqbKaVaysEzmbHzRYrNbjDGTBgwHhEC5XG5IMiU1SsaTzADCEGs6JA3wArNEzJUACrUySYrZ5CwASSgTlg2jApxYAEFZdoYPJFhtKjQgA)
```js
[
  wrappedGroup([
    "{",
    indent([
      line,
      wrappedGroup([
        wrappedGroup([
          '"c"',
          ":",
          " ",
          wrappedGroup([
            "{",
            indent([line, group([group(['"b"', ":", " ", "2"])])]),
            ifBreak(""),
            line,
            "}",
          ]),
        ]),
      ]),
    ]),
    ifBreak(""),
    line,
    "}",
  ]),
  hardline,
  breakParent,
];
```

[After:](https://deploy-preview-10169--prettier.netlify.app/playground/#N4Igxg9gdgLgprEAuEwA64NIATqt7DAIy2wCY0oBfKkAGhAgAcYBLaAZ2VAEMAnPhADuABX4IuKHgBshPAJ5cGRPjzABrODADKTNaygBzZDD4BXOAzgBbInAAm9hwBkeRsz0NwAYhD7WeGDYjZBAeMxgIehAACxhraQB1GNZ4Dj0wOG0JVNYAN1T5ULAOJRADDjg+GBFVQwDkADMZSoYAKw4ADwAhVQ0tbR5rOGcDOCaWyxAOzu0DQ2k4AEUzCHgJ6VaQPT5KvlCO6GimPgMYRNZ7GBjkAA4ABgYTiErE1SZQk7g9vPGGAEdVvBasxJGEOABaKBwBwOaJ8OCA1gI2qeBpIZqbKaVaysEzmbHzRYrNbjDGTBgwHhEC5XG5IMiU1SsaTzADCEGs6JA3wArNEzJUACrUySYrZ5CwASSgTlg2jApxYAEFZdoYPJFhtKjQgA)
```js
[
  group([
    "{",
    indent([
      line,
      group([
        group([
          '"c"',
          ":",
          " ",
          group(
            [
              "{",
              indent([line, group([group(['"b"', ":", " ", "2"])])]),
              ifBreak(""),
              line,
              "}",
            ],
            { break: true }
          ),
        ]),
      ]),
    ]),
    ifBreak(""),
    line,
    "}",
  ]),
  hardline,
];

```


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
