### PR TITLE
CLI: Refactor `createLogger` to `Logger` class

### DIFF
--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -4,7 +4,7 @@ const pick = require("lodash/pick");
 
 // eslint-disable-next-line no-restricted-modules
 const prettier = require("../index");
-const { createLogger } = require("./logger");
+const Logger = require("./logger");
 const {
   optionsModule,
   optionsNormalizer,
@@ -41,7 +41,7 @@ class Context {
     this.stack = [];
     this._updateContextArgv();
     this._normalizeContextArgv(["loglevel", "plugin", "plugin-search-dir"]);
-    this.logger = createLogger(this.argv.loglevel);
+    this.logger = new Logger(this.argv.loglevel);
     this._updateContextArgv(this.argv.plugin, this.argv["plugin-search-dir"]);
   }
 

--- a/src/cli/logger.js
+++ b/src/cli/logger.js
@@ -2,29 +2,14 @@
 
 const chalk = require("chalk");
 
-function createLogger(logLevel) {
-  return {
-    warn: createLogFunc("warn", "yellow"),
-    error: createLogFunc("error", "red"),
-    debug: createLogFunc("debug", "blue"),
-    log: createLogFunc("log"),
-  };
-
-  function createLogFunc(loggerName, color) {
-    if (!shouldLog(loggerName)) {
-      return () => {};
-    }
-
-    const prefix = color ? `[${chalk[color](loggerName)}] ` : "";
-    return function (message, opts) {
-      opts = { newline: true, ...opts };
-      const stream = process[loggerName === "log" ? "stdout" : "stderr"];
-      stream.write(message.replace(/^/gm, prefix) + (opts.newline ? "\n" : ""));
-    };
+class Logger {
+  constructor(logLevel = "log") {
+    this.logLevel = logLevel;
   }
 
-  function shouldLog(loggerName) {
-    switch (logLevel) {
+  // @private
+  shouldLog(loggerName) {
+    switch (this.logLevel) {
       case "silent":
         return false;
       case "debug":
@@ -48,4 +33,21 @@ function createLogger(logLevel) {
   }
 }
 
-module.exports = { createLogger };
+Logger.prototype.warn = createLogFunc("warn", "yellow");
+Logger.prototype.error = createLogFunc("error", "red");
+Logger.prototype.debug = createLogFunc("debug", "blue");
+Logger.prototype.log = createLogFunc("log");
+
+function createLogFunc(loggerName, color) {
+  const prefix = color ? `[${chalk[color](loggerName)}] ` : "";
+  return function (message, options) {
+    if (!this.shouldLog(loggerName)) {
+      return;
+    }
+    const { newline } = { newline: true, ...options };
+    const stream = process[loggerName === "log" ? "stdout" : "stderr"];
+    stream.write(message.replace(/^/gm, prefix) + (newline ? "\n" : ""));
+  };
+}
+
+module.exports = Logger;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Switch to `Logger` class, so we can dynamic change the `logLevel`, after we merge #10168, we'll only have `loglevel` argument parse process without a `logger`, I'm planning add use a default `logger` during `loglevel` argument parse, after we get the correct `loglevel`, change it to correct level, if we don't use this class, we may need `createLogger` twice.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
