### PR TITLE
Followup for #10169: minor tweaks

### DIFF
--- a/changelog_unreleased/cli/10169.md
+++ b/changelog_unreleased/cli/10169.md
@@ -1,3 +1,3 @@
-#### Round-trippable `--debug-print-doc` (#10169 by @thorn0)
+#### Round-trippable `--debug-print-doc` (#10169, #10177 by @thorn0)
 
 The idea is to make the output of `--debug-print-doc` closer to actual code for generating docs (Prettier's intermediate representation). Ideally, it should be possible for it to work without modification after copy-pasting into a JS file. That ideal hasn't probably been reached by this PR, but it's pretty close. This is going to make `--debug-print-doc` and the corresponding part of the Playground a bit more useful.

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -113,7 +113,7 @@ function format(context, input, opt) {
 
   if (context.argv["debug-print-doc"]) {
     const doc = prettier.__debug.printToDoc(input, opt);
-    return { formatted: prettier.__debug.formatDoc(doc) };
+    return { formatted: prettier.__debug.formatDoc(doc) + "\n" };
   }
 
   if (context.argv["debug-print-comments"]) {

--- a/src/document/doc-debug.js
+++ b/src/document/doc-debug.js
@@ -54,7 +54,8 @@ function printDocToDebug(doc) {
     }
 
     if (isConcat(doc)) {
-      return `[${getDocParts(doc).map(printDoc).filter(Boolean).join(", ")}]`;
+      const printed = getDocParts(doc).map(printDoc).filter(Boolean);
+      return printed.length === 1 ? printed[0] : `[${printed.join(", ")}]`;
     }
 
     if (doc.type === "line") {
@@ -144,7 +145,7 @@ function printDocToDebug(doc) {
     }
 
     if (doc.type === "fill") {
-      return `fill([${doc.parts.map(printDoc).join(", ")}])`;
+      return `fill([${doc.parts.map((part) => printDoc(part)).join(", ")}])`;
     }
 
     if (doc.type === "line-suffix") {

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -348,7 +348,7 @@ module.exports = {
   formatDoc(doc, options) {
     return formatWithCursor(printDocToDebug(doc), {
       ...options,
-      parser: "babel",
+      parser: "__js_expression",
     }).formatted;
   },
 

--- a/tests_integration/__tests__/__snapshots__/debug-api.js.snap
+++ b/tests_integration/__tests__/__snapshots__/debug-api.js.snap
@@ -10,6 +10,5 @@ exports[`API prettier.formatDoc 1`] = `
     \\";\\",
   ]),
   hardline,
-];
-"
+]"
 `;

--- a/tests_integration/__tests__/__snapshots__/debug-print-doc.js.snap
+++ b/tests_integration/__tests__/__snapshots__/debug-print-doc.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`prints doc with --debug-print-doc (write) 1`] = `Array []`;

--- a/tests_integration/__tests__/debug-api.js
+++ b/tests_integration/__tests__/debug-api.js
@@ -2,7 +2,10 @@
 
 const {
   __debug: { parse, formatAST, formatDoc, printToDoc, printDocToString },
-  doc: { builders },
+  doc: {
+    builders,
+    utils: { cleanDoc },
+  },
 } = require("prettier-local");
 const { outdent } = require("outdent");
 
@@ -52,5 +55,24 @@ describe("API", () => {
   test("output of prettier.formatDoc can be reused as code", () => {
     expect(stringFromDoc2).toBe(formatted);
     expect(formatResultFromDoc2).toBe(formatResultFromDoc);
+  });
+
+  test("prettier.formatDoc prints things as expected", () => {
+    const { indent, hardline, literalline, fill } = builders;
+
+    expect(formatDoc([indent(hardline), indent(literalline)])).toBe(
+      "[indent(hardline), indent(literalline)]"
+    );
+
+    expect(formatDoc(fill(["foo", hardline, "bar", literalline, "baz"]))).toBe(
+      'fill(["foo", hardline, "bar", literalline, "baz"])'
+    );
+
+    expect(
+      formatDoc(
+        // The argument of fill must not be passed to cleanDoc because it's not a doc
+        fill(cleanDoc(["foo", literalline, "bar"])) // invalid fill
+      )
+    ).toBe('fill(["foo", literallineWithoutBreakParent, breakParent, "bar"])');
   });
 });

--- a/tests_integration/__tests__/debug-print-doc.js
+++ b/tests_integration/__tests__/debug-print-doc.js
@@ -6,8 +6,9 @@ describe("prints doc with --debug-print-doc", () => {
   runPrettier("cli/with-shebang", ["--debug-print-doc", "--parser", "babel"], {
     input: "0",
   }).test({
-    stdout: '["0", ";", hardline];\n',
+    stdout: '["0", ";", hardline]\n',
     stderr: "",
     status: 0,
+    write: [],
   });
 });

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -134,20 +134,21 @@ class Playground extends React.Component {
     });
   }
 
-  getMarkdown(formatted, reformatted, full) {
+  getMarkdown({ formatted, reformatted, full, doc }) {
     const { content, options } = this.state;
     const { availableOptions, version } = this.props;
 
-    return formatMarkdown(
-      content,
-      formatted,
-      reformatted || "",
+    return formatMarkdown({
+      input: content,
+      output: formatted,
+      output2: reformatted,
+      doc,
       version,
-      window.location.href,
+      url: window.location.href,
       options,
-      util.buildCliArgs(availableOptions, options),
-      full
-    );
+      cliOptions: util.buildCliArgs(availableOptions, options),
+      full,
+    });
   }
 
   render() {
@@ -172,11 +173,11 @@ class Playground extends React.Component {
             reformat={editorState.showSecondFormat}
           >
             {({ formatted, debug }) => {
-              const fullReport = this.getMarkdown(
+              const fullReport = this.getMarkdown({
                 formatted,
-                debug.reformatted,
-                true
-              );
+                reformatted: debug.reformatted,
+                full: true,
+              });
               const showFullReport =
                 encodeURIComponent(fullReport).length < MAX_LENGTH;
               return (
@@ -241,6 +242,13 @@ class Playground extends React.Component {
                           checked={editorState.showSecondFormat}
                           onChange={editorState.toggleSecondFormat}
                         />
+                        {editorState.showDoc && debug.doc && (
+                          <ClipboardButton
+                            copy={() => this.getMarkdown({ doc: debug.doc })}
+                          >
+                            Copy doc
+                          </ClipboardButton>
+                        )}
                       </SidebarCategory>
                       <div className="sub-options">
                         <Button onClick={this.resetOptions}>
@@ -315,7 +323,10 @@ class Playground extends React.Component {
                       </ClipboardButton>
                       <ClipboardButton
                         copy={() =>
-                          this.getMarkdown(formatted, debug.reformatted)
+                          this.getMarkdown({
+                            formatted,
+                            reformatted: debug.reformatted,
+                          })
                         }
                       >
                         Copy markdown

--- a/website/playground/markdown.js
+++ b/website/playground/markdown.js
@@ -1,16 +1,17 @@
-function formatMarkdown(
+function formatMarkdown({
   input,
   output,
   output2,
+  doc,
   version,
   url,
   options,
   cliOptions,
-  full
-) {
+  full,
+}) {
   const syntax = getMarkdownSyntax(options);
   const optionsString = formatCLIOptions(cliOptions);
-  const isIdempotent = output2 === "" || output === output2;
+  const isIdempotent = !output2 || output === output2;
 
   return [
     `**Prettier ${version}**`,
@@ -19,9 +20,10 @@ function formatMarkdown(
     "",
     "**Input:**",
     codeBlock(input, syntax),
-    "",
-    "**Output:**",
-    codeBlock(output, syntax),
+    ...(doc ? ["", "**Doc:**", codeBlock(doc, "js")] : []),
+    ...(output === undefined
+      ? []
+      : ["", "**Output:**", codeBlock(output, syntax)]),
     ...(isIdempotent
       ? []
       : ["", "**Second Output:**", codeBlock(output2, syntax)]),


### PR DESCRIPTION
## Description

* I overlooked how things like `dedentToRoot(hardline)` are printed (`dedentToRoot([hardline])` instead of the expected result)
* Print without the trailing semicolon
* Fix printing for invalid `fill`
* Add a "Copy doc" button to the Playground

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
