### PR TITLE
handlebars: Split text content on multiple lines

### DIFF
--- a/changelog_unreleased/handlebars/10179.md
+++ b/changelog_unreleased/handlebars/10179.md
@@ -1,0 +1,20 @@
+#### Split text content on multiple lines (#10179 by @dcyriller)
+
+<!-- prettier-ignore -->
+```handlebars
+{{!-- Input --}}
+<div>
+  A long enough string to trigger a line break that would prevent wrapping more and more.
+</div>
+
+{{!-- Prettier stable --}}
+<div>
+  A long enough string to trigger a line break that would prevent wrapping more and more.
+</div>
+
+{{!-- Prettier main --}}
+<div>
+  A long enough string to trigger a line break that would prevent wrapping more
+  and more.
+</div>
+```

--- a/src/language-handlebars/clean.js
+++ b/src/language-handlebars/clean.js
@@ -3,7 +3,11 @@
 function clean(ast, newNode /*, parent*/) {
   // (Glimmer/HTML) ignore TextNode
   if (ast.type === "TextNode") {
-    return null;
+    const trimmed = ast.chars.trim();
+    if (!trimmed) {
+      return null;
+    }
+    newNode.chars = trimmed.replace(/[\t\n\f\r ]+/g, " ");
   }
 
   // `class` is reformatted

--- a/src/language-handlebars/clean.js
+++ b/src/language-handlebars/clean.js
@@ -1,13 +1,9 @@
 "use strict";
 
 function clean(ast, newNode /*, parent*/) {
-  // (Glimmer/HTML) ignore TextNode whitespace
+  // (Glimmer/HTML) ignore TextNode
   if (ast.type === "TextNode") {
-    const trimmed = ast.chars.trim();
-    if (!trimmed) {
-      return null;
-    }
-    newNode.chars = trimmed;
+    return null;
   }
 
   // `class` is reformatted
@@ -15,6 +11,7 @@ function clean(ast, newNode /*, parent*/) {
     delete newNode.value;
   }
 }
+
 clean.ignoredProperties = new Set(["loc", "selfClosing"]);
 
 module.exports = clean;

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -356,7 +356,9 @@ function print(path, options, print) {
         trailingSpace = "";
       }
 
-      text = text.replace(/^\s+/g, leadingSpace).replace(/\s+$/, trailingSpace);
+      text = text
+        .replace(/^[\t\n\f\r ]+/g, leadingSpace)
+        .replace(/[\t\n\f\r ]+$/, trailingSpace);
 
       return [
         ...generateHardlines(leadingLineBreaksCount, maxLineBreaksToPreserve),

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -1,7 +1,18 @@
 "use strict";
 
 const {
-  builders: { dedent, group, hardline, ifBreak, indent, join, line, softline },
+  builders: {
+    dedent,
+    fill,
+    group,
+    hardline,
+    ifBreak,
+    indent,
+    join,
+    line,
+    softline,
+  },
+  utils: { getDocParts },
 } = require("../document");
 const { isNonEmptyArray, replaceEndOfLineWith } = require("../common/util");
 
@@ -282,7 +293,7 @@ function print(path, options, print) {
           text = text.replace(trailingWhitespacesRE, "");
         }
 
-        return [...leadBreaks, text, ...trailBreaks];
+        return [...leadBreaks, fill(getTextValueParts(text)), ...trailBreaks];
       }
 
       const maxLineBreaksToPreserve = 2;
@@ -345,9 +356,11 @@ function print(path, options, print) {
         trailingSpace = "";
       }
 
+      text = text.replace(/^\s+/g, leadingSpace).replace(/\s+$/, trailingSpace);
+
       return [
         ...generateHardlines(leadingLineBreaksCount, maxLineBreaksToPreserve),
-        text.replace(/^\s+/g, leadingSpace).replace(/\s+$/, trailingSpace),
+        fill(getTextValueParts(text)),
         ...generateHardlines(trailingLineBreaksCount, maxLineBreaksToPreserve),
       ];
     }
@@ -627,6 +640,14 @@ function printInverse(path, print, options) {
 }
 
 /* TextNode print helpers */
+
+function getTextValueParts(value) {
+  return getDocParts(join(line, splitByHtmlWhitespace(value)));
+}
+
+function splitByHtmlWhitespace(string) {
+  return string.split(/[\t\n\f\r ]+/);
+}
 
 function getCurrentAttributeName(path) {
   for (let depth = 0; depth < 2; depth++) {

--- a/tests/handlebars/block-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/block-statement/__snapshots__/jsfmt.spec.js.snap
@@ -399,8 +399,7 @@ printWidth: 80
   c
 {{else}}
   {{#if c}}
-    a
-    b
+    a b
     <div>
       c
     </div>
@@ -408,8 +407,7 @@ printWidth: 80
   <div>
     a
   </div>
-  b
-  c
+  b c
 {{/if}}
 
 {{~#if someCondition~}}

--- a/tests/handlebars/element-node/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/element-node/__snapshots__/jsfmt.spec.js.snap
@@ -67,7 +67,8 @@ printWidth: 80
 </div>
 
 <div>
-  A long enough string to trigger a line break that would prevent wrapping more and more.
+  A long enough string to trigger a line break that would prevent wrapping more
+  and more.
 </div>
 
 <div>

--- a/tests/handlebars/html-whitespace-sensitivity/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/html-whitespace-sensitivity/__snapshots__/jsfmt.spec.js.snap
@@ -126,9 +126,8 @@ sometimes{{nogaps}}areimportant<Hello></Hello>
 
 =====================================output=====================================
 <p>
-  Hi {{firstName}} {{
-    lastName
-  }} , welcome!
+  Hi {{firstName}} {{lastName}} ,
+  welcome!
 </p>
 {{#component propA}}
   for {{propB}} do {{propC}} f
@@ -152,25 +151,31 @@ sometimes{{nogaps}}areimportant<Hello></Hello>
 hey
 
 <button>
-  Click here! Click here! Click here! Click here! Click here! Click here!
+  Click here! Click here! Click here!
+  Click here! Click here! Click here!
 </button>
 <button>
-  Click here! Click here! Click here! Click here! Click here! Click here!
+  Click here! Click here! Click here!
+  Click here! Click here! Click here!
 </button>
 <div>
   <button>
-    Click here! Click here! Click here! Click here! Click here! Click here!
+    Click here! Click here! Click here!
+    Click here! Click here! Click here!
   </button>
   <button>
-    Click here! Click here! Click here! Click here! Click here! Click here!
+    Click here! Click here! Click here!
+    Click here! Click here! Click here!
   </button>
 </div>
 <div>
   <button>
-    Click here! Click here! Click here! Click here! Click here! Click here!
+    Click here! Click here! Click here!
+    Click here! Click here! Click here!
   </button>
   <button>
-    Click here! Click here! Click here! Click here! Click here! Click here!
+    Click here! Click here! Click here!
+    Click here! Click here! Click here!
   </button>
 </div>
 <video src="brave.webm"></video>
@@ -178,10 +183,8 @@ hey
 <SomeComponent />
 {{name}}
 
-Some sentence with {{dynamic
-}} expressions.
-
-sometimes{{nogaps
+Some sentence with {{dynamic}}
+expressions. sometimes{{nogaps
 }}areimportant
 <Hello />
 
@@ -459,21 +462,27 @@ sometimes{{nogaps}}areimportant<Hello></Hello>
 
 hey
 
-<button
->Click here! Click here! Click here! Click here! Click here! Click here!</button>
+<button>Click here! Click here! Click
+  here! Click here! Click here! Click
+  here!</button>
 <button>
-  Click here! Click here! Click here! Click here! Click here! Click here!
+  Click here! Click here! Click here!
+  Click here! Click here! Click here!
 </button>
 <div>
-  <button
-  >Click here! Click here! Click here! Click here! Click here! Click here!</button><button
-  >Click here! Click here! Click here! Click here! Click here! Click here!</button>
+  <button>Click here! Click here! Click
+    here! Click here! Click here! Click
+    here!</button><button>Click here!
+    Click here! Click here! Click here!
+    Click here! Click here!</button>
 </div>
 <div>
-  <button
-  >Click here! Click here! Click here! Click here! Click here! Click here!</button>
-  <button
-  >Click here! Click here! Click here! Click here! Click here! Click here!</button>
+  <button>Click here! Click here! Click
+    here! Click here! Click here! Click
+    here!</button>
+  <button>Click here! Click here! Click
+    here! Click here! Click here! Click
+    here!</button>
 </div>
 <video src="brave.webm"></video>
 
@@ -482,9 +491,7 @@ hey
 
 Some sentence with
 {{dynamic}}
-expressions.
-
-sometimes{{nogaps
+expressions. sometimes{{nogaps
 }}areimportant<Hello />
 
 {{name}}
@@ -632,7 +639,7 @@ printWidth: 40
 =====================================input======================================
 <div>                   </div>
 =====================================output=====================================
-<div>            </div>
+<div>     </div>
 ================================================================================
 `;
 
@@ -684,7 +691,7 @@ printWidth: 40
 =====================================input======================================
 <img/>                   <img/>
 =====================================output=====================================
-<img />            <img />
+<img />     <img />
 ================================================================================
 `;
 

--- a/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
@@ -496,11 +496,9 @@ another non-escaped mustache:
 
 =====================================output=====================================
 an escaped mustache:
-\\{{my-component}}
-a non-escaped mustache:
+\\{{my-component}} a non-escaped mustache:
 \\\\{{my-component}}
-another non-escaped mustache:
-\\\\\\{{my-component}}
+another non-escaped mustache: \\\\\\{{my-component}}
 ================================================================================
 `;
 
@@ -519,10 +517,8 @@ another non-escaped mustache:
 
 =====================================output=====================================
 an escaped mustache:
-\\{{my-component}}
-a non-escaped mustache:
+\\{{my-component}} a non-escaped mustache:
 \\\\{{my-component}}
-another non-escaped mustache:
-\\\\\\{{my-component}}
+another non-escaped mustache: \\\\\\{{my-component}}
 ================================================================================
 `;

--- a/tests/handlebars/newline/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/newline/__snapshots__/jsfmt.spec.js.snap
@@ -82,27 +82,17 @@ printWidth: 80
   <strong>
     Ember.js Guides
   </strong>
-  .
-  This documentation will take you from total beginner to Ember expert.
+  . This documentation will take you from total beginner to Ember expert.
 </p>
 
 {{! newlines text }}
 <div>
-  hi
-  there
-  how
-
-  are you
-
-
-  are you fine today?
+  hi there how are you are you fine today?
 </div>
 
 {{! newlines text spaced }}
 <div>
-  space above
-
-  space below
+  space above space below
 </div>
 
 {{! newlines elems spaced }}
@@ -123,9 +113,7 @@ printWidth: 80
     there
   </span>
 
-  how
-
-  are
+  how are
   <strong>
     you
   </strong>

--- a/tests/handlebars/text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -155,7 +155,8 @@ printWidth: 80
 =====================================output=====================================
 {{! Wrapping text }}
 <div>
-  Some text that would need to wrap on to a new line in order to display correctly and nicely
+  Some text that would need to wrap on to a new line in order to display
+  correctly and nicely
 </div>
 
 {{! Wrapping tags }}
@@ -221,7 +222,8 @@ printWidth: 80
 <div>
   before
   <div>
-    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur at mollis lorem.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur at mollis
+    lorem.
   </div>
   after
 </div>
@@ -281,17 +283,20 @@ printWidth: 80
 
 {{! leading whitespace }}
 <div>
-  First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth
+  First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh
+  Twelfth Thirteenth Fourteenth
 </div>
 
 {{! trailing whitespace }}
 <div>
-  First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth
+  First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh
+  Twelfth Thirteenth Fourteenth
 </div>
 
 {{! no leading or trailing whitespace }}
 <div>
-  First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh Twelfth Thirteenth Fourteenth
+  First Second Third Fourth Fifth Sixth Seventh Eighth Ninth Tenth Eleventh
+  Twelfth Thirteenth Fourteenth
 </div>
 
 {{! translation leave text around tag }}
@@ -299,8 +304,7 @@ printWidth: 80
   <span>
     First
   </span>
-  ,
-  (
+  , (
   <span>
     Second
   </span>
@@ -311,8 +315,7 @@ printWidth: 80
   <span>
     First second third fourth fifth sixth seventh
   </span>
-  ,
-  (
+  , (
   <span>
     Second
   </span>
@@ -358,7 +361,8 @@ printWidth: 80
 <div>
   Before
   <div>
-    {"Enough text to make this element wrap on to multiple lines when formatting"}
+    {"Enough text to make this element wrap on to multiple lines when
+    formatting"}
   </div>
   After
 </div>
@@ -367,12 +371,10 @@ printWidth: 80
 <div>
   Before{" "}
   <div>
-    {
-      "Enough text to make this element wrap on to multiple lines when formatting"
-    }
+    { "Enough text to make this element wrap on to multiple lines when
+    formatting" }
   </div>
-  {" "}
-  After
+  {" "} After
 </div>
 
 {{! dont preserve blank lines when contains text }}

--- a/tests/handlebars/text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -58,7 +58,7 @@ printWidth: 80
 </div>
 
 <div>
-  First <div>
+  First&#11;<div>
     Second
   </div> Third
 </div>

--- a/tests/handlebars/text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -274,7 +274,7 @@ printWidth: 80
 </div>
 
 <div>
-  First
+  First
   <div>
     Second
   </div>

--- a/tests/handlebars/text-wrap/test.hbs
+++ b/tests/handlebars/text-wrap/test.hbs
@@ -50,7 +50,7 @@
 </div>
 
 <div>
-  First <div>
+  First&#11;<div>
     Second
   </div> Third
 </div>

--- a/tests/handlebars/whitespace/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/whitespace/__snapshots__/jsfmt.spec.js.snap
@@ -118,9 +118,8 @@ hey
 
 =====================================output=====================================
 <p>
-  Hi {{firstName}} {{
-    lastName
-  }} , welcome!
+  Hi {{firstName}} {{lastName}} ,
+  welcome!
 </p>
 {{#component propA}}
   for {{propB}} do {{propC}} f
@@ -184,25 +183,31 @@ Click here! Click here! Click here! Click here! Click here! Click here!
 
 =====================================output=====================================
 <button>
-  Click here! Click here! Click here! Click here! Click here! Click here!
+  Click here! Click here! Click here!
+  Click here! Click here! Click here!
 </button>
 <button>
-  Click here! Click here! Click here! Click here! Click here! Click here!
+  Click here! Click here! Click here!
+  Click here! Click here! Click here!
 </button>
 <div>
   <button>
-    Click here! Click here! Click here! Click here! Click here! Click here!
+    Click here! Click here! Click here!
+    Click here! Click here! Click here!
   </button>
   <button>
-    Click here! Click here! Click here! Click here! Click here! Click here!
+    Click here! Click here! Click here!
+    Click here! Click here! Click here!
   </button>
 </div>
 <div>
   <button>
-    Click here! Click here! Click here! Click here! Click here! Click here!
+    Click here! Click here! Click here!
+    Click here! Click here! Click here!
   </button>
   <button>
-    Click here! Click here! Click here! Click here! Click here! Click here!
+    Click here! Click here! Click here!
+    Click here! Click here! Click here!
   </button>
 </div>
 <video src="brave.webm"></video>
@@ -261,11 +266,16 @@ printWidth: 40
   <strong>
     We are a cooperative
   </strong>
-  , one of the few seed companies so organized
-  in the United States. Because we do not have an individual owner or beneficiary,
-  profit is not our primary goal. Consumers own 60% of the cooperative and worker
-  members 40%. Consumer and worker members share proportionately in the cooperative’s
-  profits through our annual patronage dividends.
+  , one of the few seed companies so
+  organized in the United States.
+  Because we do not have an individual
+  owner or beneficiary, profit is not
+  our primary goal. Consumers own 60% of
+  the cooperative and worker members
+  40%. Consumer and worker members share
+  proportionately in the cooperative’s
+  profits through our annual patronage
+  dividends.
 </p>
 ================================================================================
 `;
@@ -296,33 +306,51 @@ conubia nostra, per inceptos himenaeos. Donec in ornare velit.</p>
 =====================================output=====================================
 {{! TO FIX }}
 <p>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce cursus massa vel augue 
-vestibulum facilisis in porta turpis. Ut faucibus lectus sit amet urna consectetur dignissim.
-Sam vitae neque quis ex dapibus faucibus at sed ligula. Nulla sit amet aliquet nibh.
-Vestibulum at congue mi. Suspendisse vitae odio vitae massa hendrerit mattis sed eget dui.
-Sed eu scelerisque neque. Donec
+  Lorem ipsum dolor sit amet,
+  consectetur adipiscing elit. Fusce
+  cursus massa vel augue vestibulum
+  facilisis in porta turpis. Ut faucibus
+  lectus sit amet urna consectetur
+  dignissim. Sam vitae neque quis ex
+  dapibus faucibus at sed ligula. Nulla
+  sit amet aliquet nibh. Vestibulum at
+  congue mi. Suspendisse vitae odio
+  vitae massa hendrerit mattis sed eget
+  dui. Sed eu scelerisque neque. Donec
   <b>
     maximus
   </b>
-  rhoncus pellentesque. Aenean purus turpis, vehicula 
-euismod ante vel, ultricies eleifend dui. Class aptent taciti sociosqu ad litora torquent per 
-conubia nostra, per inceptos himenaeos. Donec in ornare velit.
+  rhoncus pellentesque. Aenean purus
+  turpis, vehicula euismod ante vel,
+  ultricies eleifend dui. Class aptent
+  taciti sociosqu ad litora torquent per
+  conubia nostra, per inceptos
+  himenaeos. Donec in ornare velit.
 </p>
 
 <p>
-  Lorem ipsum dolor sit amet, consectetur adipiscing elit. Fusce cursus massa vel augue 
-vestibulum facilisis in porta turpis. Ut faucibus lectus sit amet urna consectetur dignissim.
-Sam vitae neque quis ex dapibus faucibus at sed ligula. Nulla sit amet aliquet nibh.
-Vestibulum at congue mi. Suspendisse vitae odio vitae massa hendrerit mattis sed eget dui.
-Sed eu scelerisque neque. Donec
+  Lorem ipsum dolor sit amet,
+  consectetur adipiscing elit. Fusce
+  cursus massa vel augue vestibulum
+  facilisis in porta turpis. Ut faucibus
+  lectus sit amet urna consectetur
+  dignissim. Sam vitae neque quis ex
+  dapibus faucibus at sed ligula. Nulla
+  sit amet aliquet nibh. Vestibulum at
+  congue mi. Suspendisse vitae odio
+  vitae massa hendrerit mattis sed eget
+  dui. Sed eu scelerisque neque. Donec
   <a href="#">
     <b>
       maximus
     </b>
   </a>
-  rhoncus pellentesque. Aenean purus turpis, vehicula 
-euismod ante vel, ultricies eleifend dui. Class aptent taciti sociosqu ad litora torquent per 
-conubia nostra, per inceptos himenaeos. Donec in ornare velit.
+  rhoncus pellentesque. Aenean purus
+  turpis, vehicula euismod ante vel,
+  ultricies eleifend dui. Class aptent
+  taciti sociosqu ad litora torquent per
+  conubia nostra, per inceptos
+  himenaeos. Donec in ornare velit.
 </p>
 ================================================================================
 `;
@@ -343,7 +371,10 @@ printWidth: 40
 =====================================output=====================================
 <!-- normal whitespaces -->
 <span>
-  Nihil aut odit omnis. Quam maxime est molestiae. Maxime dolorem dolores voluptas quaerat ut qui sunt vitae error.
+  Nihil aut odit omnis. Quam maxime est
+  molestiae. Maxime dolorem dolores
+  voluptas quaerat ut qui sunt vitae
+  error.
 </span>
 <!-- non-breaking whitespaces -->
 <span>
@@ -411,10 +442,8 @@ sometimes{{nogaps}}areimportant<Hello></Hello>
 <SomeComponent />
 {{name}}
 
-Some sentence with {{dynamic
-}} expressions.
-
-sometimes{{nogaps
+Some sentence with {{dynamic}}
+expressions. sometimes{{nogaps
 }}areimportant
 <Hello />
 


### PR DESCRIPTION
## Description

```handlebars
{{!-- Input --}}
<div>
  A long enough string to trigger a line break that would prevent wrapping more and more.
</div>

{{!-- Prettier stable --}}
<div>
  A long enough string to trigger a line break that would prevent wrapping more and more.
</div>

{{!-- Prettier main --}}
<div>
  A long enough string to trigger a line break that would prevent wrapping more
  and more.
</div>
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
