### PR TITLE
Playground: Allow hide `input` and `output`

### DIFF
--- a/website/playground/EditorState.js
+++ b/website/playground/EditorState.js
@@ -12,11 +12,15 @@ export default class extends React.Component {
       showDoc: false,
       showComments: false,
       showSecondFormat: false,
+      showInput: true,
+      showOutput: true,
       toggleSidebar: () => this.setState(stateToggler("showSidebar")),
       toggleAst: () => this.setState(stateToggler("showAst")),
       toggleDoc: () => this.setState(stateToggler("showDoc")),
       toggleComments: () => this.setState(stateToggler("showComments")),
       toggleSecondFormat: () => this.setState(stateToggler("showSecondFormat")),
+      toggleInput: () => this.setState(stateToggler("showInput")),
+      toggleOutput: () => this.setState(stateToggler("showOutput")),
       ...storage.get("editor_state"),
     };
   }

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -242,6 +242,16 @@ class Playground extends React.Component {
                           checked={editorState.showSecondFormat}
                           onChange={editorState.toggleSecondFormat}
                         />
+                        <Checkbox
+                          label="show output"
+                          checked={editorState.showOutput}
+                          onChange={editorState.toggleOutput}
+                        />
+                        <Checkbox
+                          label="show input"
+                          checked={editorState.showInput}
+                          onChange={editorState.toggleInput}
+                        />
                         {editorState.showDoc && debug.doc && (
                           <ClipboardButton
                             copy={() => this.getMarkdown({ doc: debug.doc })}
@@ -257,16 +267,18 @@ class Playground extends React.Component {
                       </div>
                     </Sidebar>
                     <div className="editors">
-                      <InputPanel
-                        mode={util.getCodemirrorMode(options.parser)}
-                        ruler={options.printWidth}
-                        value={content}
-                        codeSample={getCodeSample(options.parser)}
-                        overlayStart={options.rangeStart}
-                        overlayEnd={options.rangeEnd}
-                        onChange={this.setContent}
-                        onSelectionChange={this.setSelection}
-                      />
+                      {editorState.showInput ? (
+                        <InputPanel
+                          mode={util.getCodemirrorMode(options.parser)}
+                          ruler={options.printWidth}
+                          value={content}
+                          codeSample={getCodeSample(options.parser)}
+                          overlayStart={options.rangeStart}
+                          overlayEnd={options.rangeEnd}
+                          onChange={this.setContent}
+                          onSelectionChange={this.setSelection}
+                        />
+                      ) : null}
                       {editorState.showAst ? (
                         <DebugPanel
                           value={debug.ast || ""}
@@ -275,17 +287,18 @@ class Playground extends React.Component {
                       ) : null}
                       {editorState.showDoc ? (
                         <DebugPanel value={debug.doc || ""} />
-                      ) : (
-                        <OutputPanel
-                          mode={util.getCodemirrorMode(options.parser)}
-                          value={formatted}
-                          ruler={options.printWidth}
-                        />
-                      )}
+                      ) : null}
                       {showShowComments && editorState.showComments ? (
                         <DebugPanel
                           value={debug.comments || ""}
                           autoFold={util.getAstAutoFold(options.parser)}
+                        />
+                      ) : null}
+                      {editorState.showOutput ? (
+                        <OutputPanel
+                          mode={util.getCodemirrorMode(options.parser)}
+                          value={formatted}
+                          ruler={options.printWidth}
                         />
                       ) : null}
                       {editorState.showSecondFormat ? (

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -275,18 +275,19 @@ class Playground extends React.Component {
                       ) : null}
                       {editorState.showDoc ? (
                         <DebugPanel value={debug.doc || ""} />
-                      ) : null}
+                      ) : (
+                        <OutputPanel
+                          mode={util.getCodemirrorMode(options.parser)}
+                          value={formatted}
+                          ruler={options.printWidth}
+                        />
+                      )}
                       {showShowComments && editorState.showComments ? (
                         <DebugPanel
                           value={debug.comments || ""}
                           autoFold={util.getAstAutoFold(options.parser)}
                         />
                       ) : null}
-                      <OutputPanel
-                        mode={util.getCodemirrorMode(options.parser)}
-                        value={formatted}
-                        ruler={options.printWidth}
-                      />
                       {editorState.showSecondFormat ? (
                         <OutputPanel
                           mode={util.getCodemirrorMode(options.parser)}

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -221,6 +221,11 @@ class Playground extends React.Component {
                       </SidebarCategory>
                       <SidebarCategory title="Debug">
                         <Checkbox
+                          label="show input"
+                          checked={editorState.showInput}
+                          onChange={editorState.toggleInput}
+                        />
+                        <Checkbox
                           label="show AST"
                           checked={editorState.showAst}
                           onChange={editorState.toggleAst}
@@ -238,19 +243,14 @@ class Playground extends React.Component {
                           />
                         )}
                         <Checkbox
-                          label="show second format"
-                          checked={editorState.showSecondFormat}
-                          onChange={editorState.toggleSecondFormat}
-                        />
-                        <Checkbox
                           label="show output"
                           checked={editorState.showOutput}
                           onChange={editorState.toggleOutput}
                         />
                         <Checkbox
-                          label="show input"
-                          checked={editorState.showInput}
-                          onChange={editorState.toggleInput}
+                          label="show second format"
+                          checked={editorState.showSecondFormat}
+                          onChange={editorState.toggleSecondFormat}
                         />
                         {editorState.showDoc && debug.doc && (
                           <ClipboardButton


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

When `show doc`, I think user mean to focus checking `Doc`, don't care "output" that much.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
