### PR TITLE
Add a link to `prettier-doc/no-concat` ESLint rule

### DIFF
--- a/changelog_unreleased/api/9733.md
+++ b/changelog_unreleased/api/9733.md
@@ -4,6 +4,8 @@ To simplify the code of AST printers, the data structure for the concatenation c
 
 If you're a plugin author, this change should only concern you if your plugin introspects or modifies composed docs. If it happens to be the case, please make your plugin compatible with future versions of Prettier by tweaking the introspecting code to support the new format. There also is an off-chance where this change can break things, namely if a plugin calls another plugin to [print an embedded language](https://prettier.io/docs/en/plugins.html#optional-embed) and then introspects the returned doc. There seems to be no reason for plugins to do that though.
 
+To replace `concat(…)` calls in your plugins, you can try auto-fix by this ESLint rule [`prettier-doc/no-concat`](https://github.com/fisker/eslint-plugin-prettier-doc#no-concat).
+
 ```jsx
 // Prettier stable
 myDoc = group(concat(["foo", line, "bar"]));


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

I think this can help plugin authors migrate with the `concat()` deprecation.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
