### PR TITLE
Playground: show sidebar by default

### DIFF
--- a/website/playground/EditorState.js
+++ b/website/playground/EditorState.js
@@ -7,7 +7,7 @@ export default class extends React.Component {
   constructor() {
     super();
     this.state = {
-      showSidebar: true,
+      showSidebar: window.innerWidth > window.innerHeight,
       showAst: false,
       showDoc: false,
       showComments: false,

--- a/website/playground/EditorState.js
+++ b/website/playground/EditorState.js
@@ -7,7 +7,7 @@ export default class extends React.Component {
   constructor() {
     super();
     this.state = {
-      showSidebar: false,
+      showSidebar: true,
       showAst: false,
       showDoc: false,
       showComments: false,


### PR DESCRIPTION
## Description

Why do we need that extra click?

## Checklist

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
