### PR TITLE
CLI: Print error message when `--find-config-path` can't find config file

### DIFF
--- a/changelog_unreleased/cli/10208.md
+++ b/changelog_unreleased/cli/10208.md
@@ -1,0 +1,11 @@
+#### Print an error message when `--find-config-path` can't find config file (#10208 by @fisker)
+
+```console
+# Prettier stable
+$ prettier --find-config-path /prettier.js
+# Silently failed
+
+# Prettier main
+$ prettier --find-config-path /prettier.js
+[error] Can not find configure file for "/prettier.js"
+```

--- a/src/cli/core.js
+++ b/src/cli/core.js
@@ -17,13 +17,12 @@ const { createDetailedUsage, createUsage } = require("./usage");
 const { createLogger } = require("./logger");
 
 function logResolvedConfigPathOrDie(context) {
-  const configFile = prettier.resolveConfigFile.sync(
-    context.argv["find-config-path"]
-  );
+  const file = context.argv["find-config-path"];
+  const configFile = prettier.resolveConfigFile.sync(file);
   if (configFile) {
     context.logger.log(path.relative(process.cwd(), configFile));
   } else {
-    process.exit(1);
+    throw new Error(`Can not find configure file for "${file}"`);
   }
 }
 

--- a/tests_integration/__tests__/__snapshots__/config-resolution.js.snap
+++ b/tests_integration/__tests__/__snapshots__/config-resolution.js.snap
@@ -106,12 +106,12 @@ exports[`accepts configuration from --config (stdout) 1`] = `
 
 exports[`accepts configuration from --config (write) 1`] = `Array []`;
 
-exports[`prints nothing when no file found with --find-config-path (stderr) 1`] = `
+exports[`prints error message when no file found with --find-config-path (stderr) 1`] = `
 "[error] Can not find configure file for \\"..\\"
 "
 `;
 
-exports[`prints nothing when no file found with --find-config-path (write) 1`] = `Array []`;
+exports[`prints error message when no file found with --find-config-path (write) 1`] = `Array []`;
 
 exports[`resolves configuration file with --find-config-path file (stderr) 1`] = `""`;
 

--- a/tests_integration/__tests__/__snapshots__/config-resolution.js.snap
+++ b/tests_integration/__tests__/__snapshots__/config-resolution.js.snap
@@ -106,7 +106,10 @@ exports[`accepts configuration from --config (stdout) 1`] = `
 
 exports[`accepts configuration from --config (write) 1`] = `Array []`;
 
-exports[`prints nothing when no file found with --find-config-path (stderr) 1`] = `""`;
+exports[`prints nothing when no file found with --find-config-path (stderr) 1`] = `
+"[error] Can not find configure file for \\"..\\"
+"
+`;
 
 exports[`prints nothing when no file found with --find-config-path (write) 1`] = `Array []`;
 

--- a/tests_integration/__tests__/config-resolution.js
+++ b/tests_integration/__tests__/config-resolution.js
@@ -55,7 +55,7 @@ describe("resolves toml configuration file with --find-config-path file", () => 
   });
 });
 
-describe("prints nothing when no file found with --find-config-path", () => {
+describe("prints error message when no file found with --find-config-path", () => {
   runPrettier("cli/config/", [
     "--end-of-line",
     "lf",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
