### PR TITLE
CLI: clear printed long filenames

### DIFF
--- a/changelog_unreleased/cli/10217.md
+++ b/changelog_unreleased/cli/10217.md
@@ -1,0 +1,17 @@
+#### Clear printed long filenames of formatting file (#10217 by @fisker)
+
+<!-- prettier-ignore -->
+```console
+# Prettier stable
+$ prettier tests/flow-repo/config_module_system_node_resolve_dirname --check
+Checking formatting...
+tests\flow-repo\config_module_system_node_resolve_dirname\custom_resolve_dir\tes
+tests\flow-repo\config_module_system_node_resolve_dirname\custom_resolve_dir\tes
+tests\flow-repo\config_module_system_node_resolve_dirname\subdir\custom_resolve_
+All matched files use Prettier code style!
+
+// Prettier main
+$ prettier tests/flow-repo/config_module_system_node_resolve_dirname --check
+Checking formatting...
+All matched files use Prettier code style!
+```

--- a/cspell.json
+++ b/cspell.json
@@ -411,6 +411,7 @@
         "Vue's",
         "Wadler",
         "Wadler's",
+        "wcwidth",
         "webcompat",
         "webstorm",
         "Weixin",

--- a/package.json
+++ b/package.json
@@ -78,10 +78,12 @@
     "resolve": "1.19.0",
     "semver": "7.3.4",
     "string-width": "4.2.0",
+    "strip-ansi": "6.0.0",
     "typescript": "4.1.3",
     "unicode-regex": "3.0.0",
     "unified": "9.2.0",
     "vnopts": "1.0.2",
+    "wcwidth": "1.0.1",
     "yaml-unist-parser": "1.3.1"
   },
   "devDependencies": {
@@ -127,7 +129,6 @@
     "rollup-plugin-terser": "7.0.2",
     "shelljs": "0.8.4",
     "snapshot-diff": "0.8.1",
-    "strip-ansi": "6.0.0",
     "synchronous-promise": "2.0.15",
     "tempy": "1.0.0",
     "terser-webpack-plugin": "5.1.1",

--- a/src/cli/logger.js
+++ b/src/cli/logger.js
@@ -13,11 +13,11 @@ const countLines = (stream, text) => {
   return lineCount;
 };
 
-const clearLines = (stream, text) => () => {
-  const lines = countLines(stream, text);
+const clear = (stream, text) => () => {
+  const lineCount = countLines(stream, text);
 
-  for (let i = 0; i < lines; i++) {
-    if (i > 0) {
+  for (let line = 0; line < lineCount; line++) {
+    if (line > 0) {
       stream.moveCursor(0, -1);
     }
 
@@ -54,7 +54,7 @@ function createLogger(logLevel) {
 
       if (options.clearable) {
         return {
-          clear: clearLines(stream, message),
+          clear: clear(stream, message),
         };
       }
     };

--- a/src/cli/logger.js
+++ b/src/cli/logger.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const readline = require("readline");
 const chalk = require("chalk");
 const stripAnsi = require("strip-ansi");
 const wcwidth = require("wcwidth");
@@ -18,11 +19,11 @@ const clear = (stream, text) => () => {
 
   for (let line = 0; line < lineCount; line++) {
     if (line > 0) {
-      stream.moveCursor(0, -1);
+      readline.moveCursor(stream, 0, -1);
     }
 
-    stream.clearLine();
-    stream.cursorTo(0);
+    readline.clearLine(stream, 0);
+    readline.cursorTo(stream, 0);
   }
 };
 

--- a/src/cli/logger.js
+++ b/src/cli/logger.js
@@ -43,16 +43,16 @@ function createLogger(logLevel) {
     const prefix = color ? `[${chalk[color](loggerName)}] ` : "";
     const stream = process[loggerName === "log" ? "stdout" : "stderr"];
 
-    return function (message, options) {
-      const { newline, clearable } = {
+    return (message, options) => {
+      options = {
         newline: true,
         clearable: false,
         ...options,
       };
-      message = message.replace(/^/gm, prefix) + (newline ? "\n" : "");
+      message = message.replace(/^/gm, prefix) + (options.newline ? "\n" : "");
       stream.write(message);
 
-      if (clearable) {
+      if (options.clearable) {
         return {
           clear: clearLines(stream, message),
         };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2393,6 +2393,11 @@ cliui@^6.0.0:
     strip-ansi "^6.0.0"
     wrap-ansi "^6.2.0"
 
+clone@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/clone/-/clone-1.0.4.tgz#da309cc263df15994c688ca902179ca3c7cd7c7e"
+  integrity sha1-2jCcwmPfFZlMaIypAheco8fNfH4=
+
 co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
@@ -2743,6 +2748,13 @@ deepmerge@^4.2.2:
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
   integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
 
+defaults@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"
+  integrity sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=
+  dependencies:
+    clone "^1.0.2"
+
 define-properties@^1.1.2, define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
@@ -3067,6 +3079,7 @@ eslint-plugin-jest@24.1.3:
 
 "eslint-plugin-prettier-internal-rules@link:scripts/tools/eslint-plugin-prettier-internal-rules":
   version "0.0.0"
+  uid ""
 
 eslint-plugin-react@7.22.0:
   version "7.22.0"
@@ -7315,6 +7328,13 @@ watchpack@^2.0.0:
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
+
+wcwidth@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/wcwidth/-/wcwidth-1.0.1.tgz#f0b0dcf915bc5ff1528afadb2c0e17b532da2fe8"
+  integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
+  dependencies:
+    defaults "^1.0.3"
 
 webidl-conversions@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #9061

This can't be tested on CI, local test try 
`npx prettier tests/flow-repo/config_module_system_node_resolve_dirname --check`
and 
`node bin/prettier tests/flow-repo/config_module_system_node_resolve_dirname --check`
to see differences.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
