### PR TITLE
RFC: indentIfBreak

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -116,9 +116,10 @@ overrides:
   - files: src/**/*.js
     rules:
       prettier-internal-rules/no-doc-builder-concat: error
-      prettier-internal-rules/prefer-fast-path-each: error
-      prettier-internal-rules/prefer-is-non-empty-array: error
       prettier-internal-rules/no-empty-flat-contents-for-if-break: error
+      prettier-internal-rules/prefer-fast-path-each: error
+      prettier-internal-rules/prefer-indent-if-break: error
+      prettier-internal-rules/prefer-is-non-empty-array: error
   - files: src/document/*.js
     rules:
       prettier-internal-rules/no-doc-builder-concat: off

--- a/changelog_unreleased/api/10221.md
+++ b/changelog_unreleased/api/10221.md
@@ -1,0 +1,3 @@
+#### Add `indentIfBreak` IR command (#10221 by @thorn)
+
+`indentIfBreak(doc, { groupId })` is an optimized version of `ifBreak(indent(doc), doc, { groupId })`.

--- a/commands.md
+++ b/commands.md
@@ -254,6 +254,23 @@ declare const trim: Doc;
 
 Trim all the indentation on the current line. This can be used for preprocessor directives. Should be placed after a line break.
 
+### `indentIfBreak`
+
+_Added in v2.3.0_
+
+```ts
+declare function indentIfBreak(
+  doc: Doc,
+  opts: { groupId: symbol; negate?: boolean }
+): Doc;
+```
+
+An optimized version of `ifBreak(indent(doc), doc, { groupId })`.
+
+With `negate: true`, corresponds to `ifBreak(doc, indent(doc), { groupId })`
+
+It doesn't make sense to apply `indentIfBreak` to the current group because "indent if the current group is broken" is the normal behavior of `indent`. That's why `groupId` is required.
+
 ### `hardlineWithoutBreakParent` and `literallineWithoutBreakParent`
 
 _Added in v2.3.0_

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/index.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/index.js
@@ -6,10 +6,11 @@ module.exports = {
     "directly-loc-start-end": require("./directly-loc-start-end"),
     "jsx-identifier-case": require("./jsx-identifier-case"),
     "no-doc-builder-concat": require("./no-doc-builder-concat"),
+    "no-empty-flat-contents-for-if-break": require("./no-empty-flat-contents-for-if-break"),
     "no-node-comments": require("./no-node-comments"),
     "prefer-fast-path-each": require("./prefer-fast-path-each"),
+    "prefer-indent-if-break": require("./prefer-indent-if-break"),
     "prefer-is-non-empty-array": require("./prefer-is-non-empty-array"),
     "require-json-extensions": require("./require-json-extensions"),
-    "no-empty-flat-contents-for-if-break": require("./no-empty-flat-contents-for-if-break"),
   },
 };

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-indent-if-break.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-indent-if-break.js
@@ -1,0 +1,67 @@
+"use strict";
+
+const selector = [
+  "CallExpression",
+  "[optional=false]",
+  '[callee.type="Identifier"]',
+  '[callee.name="ifBreak"]',
+  "[arguments.length=3]",
+  '[arguments.0.type="CallExpression"]',
+  "[arguments.0.optional=false]",
+  '[arguments.0.callee.type="Identifier"]',
+  '[arguments.0.callee.name="indent"]',
+  "[arguments.0.arguments.length=1]",
+  '[arguments.0.arguments.0.type!="SpreadElement"]',
+  '[arguments.1.type!="SpreadElement"]',
+  '[arguments.2.type!="SpreadElement"]',
+].join("");
+
+const messageId = "prefer-indent-if-break";
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      url:
+        "https://github.com/prettier/prettier/blob/main/scripts/eslint-plugin-prettier-internal-rules/prefer-indent-if-break.js",
+    },
+    messages: {
+      [messageId]: "Prefer `indentIfBreak(…)` over `ifBreak(indent(…), …)`.",
+    },
+    fixable: "code",
+  },
+  create(context) {
+    const sourceCode = context.getSourceCode();
+
+    return {
+      [selector](node) {
+        const indentDoc = node.arguments[0].arguments[0];
+        const doc = node.arguments[1];
+
+        // Use text to compare same `doc`
+        if (sourceCode.getText(indentDoc) !== sourceCode.getText(doc)) {
+          return;
+        }
+
+        context.report({
+          node,
+          messageId,
+          *fix(fixer) {
+            yield fixer.replaceText(node.callee, "indentIfBreak");
+            const openingParenthesisToken = sourceCode.getTokenAfter(
+              node.callee
+            );
+            const commaToken = sourceCode.getTokenBefore(
+              doc,
+              ({ type, value }) => type === "Punctuator" && value === ","
+            );
+            yield fixer.replaceTextRange(
+              [openingParenthesisToken.range[1], commaToken.range[1]],
+              ""
+            );
+          },
+        });
+      },
+    };
+  },
+};

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
@@ -155,6 +155,35 @@ test("prefer-fast-path-each", {
   ],
 });
 
+test("prefer-indent-if-break", {
+  valid: [
+    "ifBreak(indent(doc))",
+    "notIfBreak(indent(doc), doc, options)",
+    "ifBreak(indent(doc), doc, )",
+    "ifBreak(...a, ...b, ...c)",
+    "ifBreak(notIndent(doc), doc, options)",
+    "ifBreak(indent(doc), notSameDoc, options)",
+    "ifBreak(indent(...a), a, options)",
+    "ifBreak(indent(a, b), a, options)",
+  ],
+  invalid: [
+    {
+      code: "ifBreak(indent(doc), doc, options)",
+      output: "indentIfBreak( doc, options)",
+      errors: [
+        {
+          message: "Prefer `indentIfBreak(…)` over `ifBreak(indent(…), …)`.",
+        },
+      ],
+    },
+    {
+      code: "ifBreak((indent(doc)), (doc), options)",
+      output: "indentIfBreak( (doc), options)",
+      errors: 1,
+    },
+  ],
+});
+
 test("prefer-is-non-empty-array", {
   valid: [
     // `isNonEmptyArray` self is ignored

--- a/src/document/doc-builders.js
+++ b/src/document/doc-builders.js
@@ -175,13 +175,14 @@ function ifBreak(breakContents, flatContents, opts = {}) {
 /**
  * Optimized version of `ifBreak(indent(doc), doc)`
  * @param {Doc} [contents]
- * @param {{ groupId?: symbol }} [opts]
+ * @param {{ negate?: boolean, groupId?: symbol }} [opts]
  * @returns Doc
  */
 function indentIfBreak(contents, opts = {}) {
   return {
     type: "indent-if-break",
     contents,
+    negate: opts.negate,
     groupId: opts.groupId,
   };
 }

--- a/src/document/doc-builders.js
+++ b/src/document/doc-builders.js
@@ -173,17 +173,17 @@ function ifBreak(breakContents, flatContents, opts = {}) {
 }
 
 /**
- * Optimized version of `ifBreak(indent(doc), doc)`
- * @param {Doc} [contents]
- * @param {{ negate?: boolean, groupId?: symbol }} [opts]
+ * Optimized version of `ifBreak(indent(doc), doc, { groupId: ... })`
+ * @param {Doc} contents
+ * @param {{ groupId: symbol, negate?: boolean }} opts
  * @returns Doc
  */
-function indentIfBreak(contents, opts = {}) {
+function indentIfBreak(contents, opts) {
   return {
     type: "indent-if-break",
     contents,
-    negate: opts.negate,
     groupId: opts.groupId,
+    negate: opts.negate,
   };
 }
 

--- a/src/document/doc-builders.js
+++ b/src/document/doc-builders.js
@@ -173,6 +173,20 @@ function ifBreak(breakContents, flatContents, opts = {}) {
 }
 
 /**
+ * Optimized version of `ifBreak(indent(doc), doc)`
+ * @param {Doc} [contents]
+ * @param {{ groupId?: symbol }} [opts]
+ * @returns Doc
+ */
+function indentIfBreak(contents, opts = {}) {
+  return {
+    type: "indent-if-break",
+    contents,
+    groupId: opts.groupId,
+  };
+}
+
+/**
  * @param {Doc} contents
  * @returns Doc
  */
@@ -258,6 +272,7 @@ module.exports = {
   ifBreak,
   trim,
   indent,
+  indentIfBreak,
   align,
   addAlignmentToDoc,
   markAsRoot,

--- a/src/document/doc-debug.js
+++ b/src/document/doc-debug.js
@@ -121,6 +121,15 @@ function printDocToDebug(doc) {
       );
     }
 
+    if (doc.type === "indent-if-break") {
+      return (
+        "indentIfBreak(" +
+        printDoc(doc.contents) +
+        (doc.groupId ? `, { groupId: ${printGroupId(doc.groupId)} }` : "") +
+        ")"
+      );
+    }
+
     if (doc.type === "group") {
       const optionsParts = [];
 

--- a/src/document/doc-debug.js
+++ b/src/document/doc-debug.js
@@ -122,12 +122,20 @@ function printDocToDebug(doc) {
     }
 
     if (doc.type === "indent-if-break") {
-      return (
-        "indentIfBreak(" +
-        printDoc(doc.contents) +
-        (doc.groupId ? `, { groupId: ${printGroupId(doc.groupId)} }` : "") +
-        ")"
-      );
+      const optionsParts = [];
+
+      if (doc.negate) {
+        optionsParts.push("negate: true");
+      }
+
+      if (doc.groupId) {
+        optionsParts.push(`groupId: ${printGroupId(doc.groupId)}`);
+      }
+
+      const options =
+        optionsParts.length > 0 ? `, { ${optionsParts.join(", ")} }` : "";
+
+      return `indentIfBreak(${printDoc(doc.contents)}${options})`;
     }
 
     if (doc.type === "group") {

--- a/src/document/doc-printer.js
+++ b/src/document/doc-printer.js
@@ -2,7 +2,7 @@
 
 const { getStringWidth } = require("../common/util");
 const { convertEndOfLineToChars } = require("../common/end-of-line");
-const { concat, fill, cursor } = require("./doc-builders");
+const { concat, fill, cursor, indent } = require("./doc-builders");
 const { isConcat, getDocParts } = require("./doc-utils");
 
 /** @type {Record<symbol, typeof MODE_BREAK | typeof MODE_FLAT>} */
@@ -203,16 +203,25 @@ function fits(next, restCommands, width, options, hasLineSuffix, mustBeFlat) {
           }
 
           break;
-        case "if-break": {
+        case "if-break":
+        case "indent-if-break": {
           const groupMode = doc.groupId ? groupModeMap[doc.groupId] : mode;
           if (groupMode === MODE_BREAK) {
-            if (doc.breakContents) {
-              cmds.push([ind, mode, doc.breakContents]);
+            const breakContents =
+              doc.type === "if-break"
+                ? doc.breakContents
+                : doc.contents
+                ? indent(doc.contents)
+                : undefined;
+            if (breakContents) {
+              cmds.push([ind, mode, breakContents]);
             }
           }
           if (groupMode === MODE_FLAT) {
-            if (doc.flatContents) {
-              cmds.push([ind, mode, doc.flatContents]);
+            const flatContents =
+              doc.type === "if-break" ? doc.flatContents : doc.contents;
+            if (flatContents) {
+              cmds.push([ind, mode, flatContents]);
             }
           }
 
@@ -459,16 +468,25 @@ function printDocToString(doc, options) {
           }
           break;
         }
-        case "if-break": {
+        case "if-break":
+        case "indent-if-break": {
           const groupMode = doc.groupId ? groupModeMap[doc.groupId] : mode;
           if (groupMode === MODE_BREAK) {
-            if (doc.breakContents) {
-              cmds.push([ind, mode, doc.breakContents]);
+            const breakContents =
+              doc.type === "if-break"
+                ? doc.breakContents
+                : doc.contents
+                ? indent(doc.contents)
+                : undefined;
+            if (breakContents) {
+              cmds.push([ind, mode, breakContents]);
             }
           }
           if (groupMode === MODE_FLAT) {
-            if (doc.flatContents) {
-              cmds.push([ind, mode, doc.flatContents]);
+            const flatContents =
+              doc.type === "if-break" ? doc.flatContents : doc.contents;
+            if (flatContents) {
+              cmds.push([ind, mode, flatContents]);
             }
           }
 

--- a/src/document/doc-printer.js
+++ b/src/document/doc-printer.js
@@ -210,16 +210,20 @@ function fits(next, restCommands, width, options, hasLineSuffix, mustBeFlat) {
             const breakContents =
               doc.type === "if-break"
                 ? doc.breakContents
-                : doc.contents
-                ? indent(doc.contents)
-                : undefined;
+                : doc.negate
+                ? doc.contents
+                : indent(doc.contents);
             if (breakContents) {
               cmds.push([ind, mode, breakContents]);
             }
           }
           if (groupMode === MODE_FLAT) {
             const flatContents =
-              doc.type === "if-break" ? doc.flatContents : doc.contents;
+              doc.type === "if-break"
+                ? doc.flatContents
+                : doc.negate
+                ? indent(doc.contents)
+                : doc.contents;
             if (flatContents) {
               cmds.push([ind, mode, flatContents]);
             }
@@ -475,16 +479,20 @@ function printDocToString(doc, options) {
             const breakContents =
               doc.type === "if-break"
                 ? doc.breakContents
-                : doc.contents
-                ? indent(doc.contents)
-                : undefined;
+                : doc.negate
+                ? doc.contents
+                : indent(doc.contents);
             if (breakContents) {
               cmds.push([ind, mode, breakContents]);
             }
           }
           if (groupMode === MODE_FLAT) {
             const flatContents =
-              doc.type === "if-break" ? doc.flatContents : doc.contents;
+              doc.type === "if-break"
+                ? doc.flatContents
+                : doc.negate
+                ? indent(doc.contents)
+                : doc.contents;
             if (flatContents) {
               cmds.push([ind, mode, flatContents]);
             }

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -9,6 +9,7 @@ const {
     group,
     hardline,
     ifBreak,
+    indentIfBreak,
     indent,
     join,
     line,
@@ -275,9 +276,7 @@ function genericPrint(path, options, print) {
                 forceBreakContent(node) ? breakParent : "",
                 ((childrenDoc) =>
                   shouldHugContent
-                    ? ifBreak(indent(childrenDoc), childrenDoc, {
-                        groupId: attrGroupId,
-                      })
+                    ? indentIfBreak(childrenDoc, { groupId: attrGroupId })
                     : (isScriptLikeTag(node) ||
                         isVueCustomBlock(node, options)) &&
                       node.parent.type === "root" &&

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -3,7 +3,16 @@
 const { printComments } = require("../../main/comments");
 const { getLast } = require("../../common/util");
 const {
-  builders: { join, line, softline, group, indent, align, ifBreak },
+  builders: {
+    join,
+    line,
+    softline,
+    group,
+    indent,
+    align,
+    ifBreak,
+    indentIfBreak,
+  },
   utils: { cleanDoc, getDocParts },
 } = require("../../document");
 const {
@@ -160,7 +169,7 @@ function printBinaryishExpression(path, options, print) {
   }
 
   const jsxPart = getLast(parts);
-  return group([chain, ifBreak(indent(jsxPart), jsxPart, { groupId })]);
+  return group([chain, indentIfBreak(jsxPart, { groupId })]);
 }
 
 // For binary expressions to be consistent, we need to group

--- a/src/language-js/print/class.js
+++ b/src/language-js/print/class.js
@@ -3,7 +3,16 @@
 const { isNonEmptyArray, createGroupIdMapper } = require("../../common/util");
 const { printComments, printDanglingComments } = require("../../main/comments");
 const {
-  builders: { join, line, hardline, softline, group, indent, ifBreak },
+  builders: {
+    join,
+    line,
+    hardline,
+    softline,
+    group,
+    indent,
+    ifBreak,
+    indentIfBreak,
+  },
 } = require("../../document");
 const {
   hasComment,
@@ -73,15 +82,11 @@ function printClass(path, options, print) {
   );
 
   if (groupMode) {
-    const printedExtends = extendsParts;
     let printedPartsGroup;
     if (shouldIndentOnlyHeritageClauses(n)) {
-      printedPartsGroup = [
-        ...partsGroup,
-        ifBreak(indent(printedExtends), printedExtends),
-      ];
+      printedPartsGroup = [...partsGroup, indentIfBreak(extendsParts)];
     } else {
-      printedPartsGroup = indent([...partsGroup, printedExtends]);
+      printedPartsGroup = indent([...partsGroup, extendsParts]);
     }
     parts.push(group(printedPartsGroup, { id: getHeritageGroupId(n) }));
   } else {

--- a/src/language-js/print/class.js
+++ b/src/language-js/print/class.js
@@ -3,16 +3,7 @@
 const { isNonEmptyArray, createGroupIdMapper } = require("../../common/util");
 const { printComments, printDanglingComments } = require("../../main/comments");
 const {
-  builders: {
-    join,
-    line,
-    hardline,
-    softline,
-    group,
-    indent,
-    ifBreak,
-    indentIfBreak,
-  },
+  builders: { join, line, hardline, softline, group, indent, ifBreak },
 } = require("../../document");
 const {
   hasComment,
@@ -84,7 +75,7 @@ function printClass(path, options, print) {
   if (groupMode) {
     let printedPartsGroup;
     if (shouldIndentOnlyHeritageClauses(n)) {
-      printedPartsGroup = [...partsGroup, indentIfBreak(extendsParts)];
+      printedPartsGroup = [...partsGroup, indent(extendsParts)];
     } else {
       printedPartsGroup = indent([...partsGroup, extendsParts]);
     }

--- a/src/language-js/print/interface.js
+++ b/src/language-js/print/interface.js
@@ -2,7 +2,7 @@
 
 const { isNonEmptyArray } = require("../../common/util");
 const {
-  builders: { join, line, group, indent, ifBreak },
+  builders: { join, line, group, indent, ifBreak, indentIfBreak },
 } = require("../../document");
 const { hasComment, identity, CommentCheckFlags } = require("../utils");
 const { getTypeParametersGroupId } = require("./type-parameters");
@@ -60,13 +60,10 @@ function printInterface(path, options, print) {
     (n.id && hasComment(n.id, CommentCheckFlags.Trailing)) ||
     isNonEmptyArray(n.extends)
   ) {
-    const printedExtends = extendsParts;
     if (shouldIndentOnlyHeritageClauses) {
-      parts.push(
-        group([...partsGroup, ifBreak(indent(printedExtends), printedExtends)])
-      );
+      parts.push(group([...partsGroup, indentIfBreak(extendsParts)]));
     } else {
-      parts.push(group(indent([...partsGroup, ...printedExtends])));
+      parts.push(group(indent([...partsGroup, ...extendsParts])));
     }
   } else {
     parts.push(...partsGroup, ...extendsParts);

--- a/src/language-js/print/interface.js
+++ b/src/language-js/print/interface.js
@@ -2,7 +2,7 @@
 
 const { isNonEmptyArray } = require("../../common/util");
 const {
-  builders: { join, line, group, indent, ifBreak, indentIfBreak },
+  builders: { join, line, group, indent, ifBreak },
 } = require("../../document");
 const { hasComment, identity, CommentCheckFlags } = require("../utils");
 const { getTypeParametersGroupId } = require("./type-parameters");
@@ -61,7 +61,7 @@ function printInterface(path, options, print) {
     isNonEmptyArray(n.extends)
   ) {
     if (shouldIndentOnlyHeritageClauses) {
-      parts.push(group([...partsGroup, indentIfBreak(extendsParts)]));
+      parts.push(group([...partsGroup, indent(extendsParts)]));
     } else {
       parts.push(group(indent([...partsGroup, ...extendsParts])));
     }

--- a/tests_integration/__tests__/debug-api.js
+++ b/tests_integration/__tests__/debug-api.js
@@ -84,11 +84,7 @@ describe("API", () => {
     ).toBe('fill(["foo", literallineWithoutBreakParent, breakParent, "bar"])');
 
     expect(
-      formatDoc(
-        indentIfBreak(group(["1", line, "2"]), { groupId: Symbol("Q") })
-      )
-    ).toBe(
-      'indentIfBreak(group(["1", line, "2"]), { groupId: Symbol.for("Q") })'
-    );
+      formatDoc(indentIfBreak(group(["1", line, "2"]), { groupId: "Q" }))
+    ).toBe('indentIfBreak(group(["1", line, "2"]), { groupId: "Q" })');
   });
 });

--- a/tests_integration/__tests__/debug-api.js
+++ b/tests_integration/__tests__/debug-api.js
@@ -58,7 +58,15 @@ describe("API", () => {
   });
 
   test("prettier.formatDoc prints things as expected", () => {
-    const { indent, hardline, literalline, fill } = builders;
+    const {
+      indent,
+      hardline,
+      literalline,
+      fill,
+      indentIfBreak,
+      group,
+      line,
+    } = builders;
 
     expect(formatDoc([indent(hardline), indent(literalline)])).toBe(
       "[indent(hardline), indent(literalline)]"
@@ -74,5 +82,13 @@ describe("API", () => {
         fill(cleanDoc(["foo", literalline, "bar"])) // invalid fill
       )
     ).toBe('fill(["foo", literallineWithoutBreakParent, breakParent, "bar"])');
+
+    expect(
+      formatDoc(
+        indentIfBreak(group(["1", line, "2"]), { groupId: Symbol("Q") })
+      )
+    ).toBe(
+      'indentIfBreak(group(["1", line, "2"]), { groupId: Symbol.for("Q") })'
+    );
   });
 });


### PR DESCRIPTION
## Description

`indentIfBreak(doc, { groupId })` is an optimized version of `ifBreak(indent(doc), doc, { groupId })`.

- a convenient shortcut
- reduces the size of the doc
- processed faster by doc traversing functions like `mapDoc`

`indentIfBreak(doc, { groupId, negate: true })` corresponds to `ifBreak(doc, indent(doc), { groupId })`

`groupId` is required because "indent only if broken" is the default behavior of `indent`, so it doesn't make sense to apply `indentIfBreak` to the current group.

This is intended to be used for solving issues with assignments, for which conditional indentation seems to be a [useful tool](https://deploy-preview-10183--prettier.netlify.app/playground/#N4Igxg9gdgLgprEAuEAKVBKABAXgHxbAA6UWWAZgK5RgwCW0WdUAJgjAKpQA2cAznwBCAJzgBDANaoWEMABosAc2ERKABwCSLbMVJksomJWGk65EeKkz5TVu2myMC4EpXqtWAL4YA3CTKeJP4GcEYmWADawWTKqmqoUXr6WETg0HwwqXLR+qkpINlJ+rHqCTnJJfHlyZHVNfnEBXU1zGywZUX1ydzMcIVdXZUJQ1EgYnwSACoqAG4IYoJw8wAicGoILHwAShAA7mJQfEhYAIwADGepALoYN-0DNVlPnQ89UH3N9SOfg27xo4oegBbPhwADi3AAnmoABZ8AASYgAXmJhCwAHIQCBqPiTOhwPFwY4AJgu1ycP2Sd0pWGpL3qZgsklQTxAFPpNTeHw5yVSgSaPNp9wGLjoLGOqQAinlAhz2QM8jhngMhj9WuwuLwBEypIkHvpGaJmXkslguc5XHEtBKQNKQF55fr8iwxDAxMqnarBcl1e0InwIOQYOb8gA6U2pMBG+CTfgwACy-D4YkUcAA6nQYDCAIJbcTcKEAGWginRYiBcHJNMd+qGvpgCQDQZDqXDBXyAYrADU4MJIcWoIoAAoqdbCGCQ8k1h51ux+pvB3oKVsRkBZuh8DR8bPcAPZgfD0e9idT4VdK7L22pDDNadkOkMucNiIPx4gPwCqnTmGoljmnIAEZGhIQ6ouw9xXH4UDeJgBQgNi9DpMgoCoiouygaIhzIGM3D7JCfBwUBYhgBIoQAMpqMRzCKMgMDCJQfQgHAQIAXALBsCwhYHIolApnAABiEDCECrr0IO2FiJQMAQHBMIwEC3BpjCmb8JRYBwGRCB8JmdAzJmkLYWAAhwcwoLjiOKYicg5BiLujEAFZ8AAHiIxGkTAZHlnAha9NZtmgnIICOU5ZHUbwkqUBA8B+XZgWUcIZnYdYAC0cBOWo3BCb2cFqMIzAwBmLBZsgAAcJxxSooJpsIYhqNhuX8L2cxwQAjpF8AjtiBEoOMyXvGxbFwaIbV0KIFmKFZSA2bFICgkCdC0fRjHaYO4XtXAMUBWuYgAYVxVIMSgV0WIdBvIoADCEBApNTF8AArHBlCgpMO3ddNW0zAxGhPmRUZ0GoMDZqwZETrwm1wJ4nhAA).

#10222 uses this code.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
