### PR TITLE
Test: Switch `coverageProvider` to `v8`

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -54,6 +54,7 @@ module.exports = {
   testPathIgnorePatterns,
   collectCoverage: ENABLE_CODE_COVERAGE,
   collectCoverageFrom: ["<rootDir>/src/**/*.js", "<rootDir>/bin/**/*.js"],
+  coverageProvider: "v8",
   coveragePathIgnorePatterns: [
     "<rootDir>/src/standalone.js",
     "<rootDir>/src/document/doc-debug.js",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

I'm not sure about this, let's see how coverage changes, previous attempt by @thorn0 #7896

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
