### PR TITLE
Refactor `ChainElement` related parts

### DIFF
--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -20,6 +20,7 @@ const {
   hasFlowShorthandAnnotationComment,
   hasFlowAnnotationComment,
   hasIgnoreComment,
+  isCallExpression,
 } = require("./utils");
 const { locStart, locEnd } = require("./loc");
 
@@ -521,8 +522,7 @@ function handleCommentInEmptyParens({ comment, enclosingNode, text }) {
     enclosingNode &&
     ((isRealFunctionLikeNode(enclosingNode) &&
       getFunctionParameters(enclosingNode).length === 0) ||
-      ((enclosingNode.type === "CallExpression" ||
-        enclosingNode.type === "OptionalCallExpression" ||
+      ((isCallExpression(enclosingNode) ||
         enclosingNode.type === "NewExpression") &&
         enclosingNode.arguments.length === 0))
   ) {
@@ -645,8 +645,7 @@ function handleCallExpressionComments({
 }) {
   if (
     enclosingNode &&
-    (enclosingNode.type === "CallExpression" ||
-      enclosingNode.type === "OptionalCallExpression") &&
+    isCallExpression(enclosingNode) &&
     precedingNode &&
     enclosingNode.callee === precedingNode &&
     enclosingNode.arguments.length > 0
@@ -959,8 +958,7 @@ function willPrintOwnComments(path /*, options */) {
       (isJsxNode(node) ||
         hasFlowShorthandAnnotationComment(node) ||
         (parent &&
-          (parent.type === "CallExpression" ||
-            parent.type === "OptionalCallExpression") &&
+          isCallExpression(parent) &&
           (hasFlowAnnotationComment(node.leadingComments) ||
             hasFlowAnnotationComment(node.trailingComments))))) ||
       (parent &&

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -21,6 +21,7 @@ const {
   hasFlowAnnotationComment,
   hasIgnoreComment,
   isCallExpression,
+  isMemberExpression,
 } = require("./utils");
 const { locStart, locEnd } = require("./loc");
 
@@ -316,9 +317,7 @@ function handleMemberExpressionComments({
   followingNode,
 }) {
   if (
-    enclosingNode &&
-    (enclosingNode.type === "MemberExpression" ||
-      enclosingNode.type === "OptionalMemberExpression") &&
+    isMemberExpression(enclosingNode) &&
     followingNode &&
     followingNode.type === "Identifier"
   ) {

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -643,7 +643,6 @@ function handleCallExpressionComments({
   enclosingNode,
 }) {
   if (
-    enclosingNode &&
     isCallExpression(enclosingNode) &&
     precedingNode &&
     enclosingNode.callee === precedingNode &&
@@ -956,8 +955,7 @@ function willPrintOwnComments(path /*, options */) {
     ((node &&
       (isJsxNode(node) ||
         hasFlowShorthandAnnotationComment(node) ||
-        (parent &&
-          isCallExpression(parent) &&
+        (isCallExpression(parent) &&
           (hasFlowAnnotationComment(node.leadingComments) ||
             hasFlowAnnotationComment(node.trailingComments))))) ||
       (parent &&

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -10,6 +10,7 @@ const {
   startsWithNoLookaheadToken,
   shouldFlatten,
   getPrecedence,
+  isCallExpression,
 } = require("./utils");
 
 function needsParens(path, options) {
@@ -687,9 +688,7 @@ function needsParens(path, options) {
           // Preserve parens for compatibility with AngularJS expressions
           !(node.extra && node.extra.parenthesized)) ||
         parent.type === "ArrayExpression" ||
-        ((parent.type === "CallExpression" ||
-          parent.type === "OptionalCallExpression") &&
-          parent.arguments[name] === node) ||
+        (isCallExpression(parent) && parent.arguments[name] === node) ||
         (name === "right" && parent.type === "NGPipeExpression") ||
         (name === "property" && parent.type === "MemberExpression") ||
         parent.type === "AssignmentExpression"
@@ -709,7 +708,6 @@ function needsParens(path, options) {
           parent.type !== "AssignmentExpression" &&
           parent.type !== "AssignmentPattern" &&
           parent.type !== "BinaryExpression" &&
-          parent.type !== "CallExpression" &&
           parent.type !== "NewExpression" &&
           parent.type !== "ConditionalExpression" &&
           parent.type !== "ExpressionStatement" &&
@@ -720,7 +718,7 @@ function needsParens(path, options) {
           parent.type !== "JSXFragment" &&
           parent.type !== "LogicalExpression" &&
           parent.type !== "ObjectProperty" &&
-          parent.type !== "OptionalCallExpression" &&
+          !isCallExpression(parent) &&
           parent.type !== "Property" &&
           parent.type !== "ReturnStatement" &&
           parent.type !== "ThrowStatement" &&

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -11,6 +11,7 @@ const {
   shouldFlatten,
   getPrecedence,
   isCallExpression,
+  isMemberExpression,
 } = require("./utils");
 
 function needsParens(path, options) {
@@ -676,9 +677,7 @@ function needsParens(path, options) {
         (name === "callee" &&
           (parent.type === "BindExpression" ||
             parent.type === "NewExpression")) ||
-        (name === "object" &&
-          (parent.type === "MemberExpression" ||
-            parent.type === "OptionalMemberExpression"))
+        (name === "object" && isMemberExpression(parent))
       );
     case "NGPipeExpression":
       if (

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -88,7 +88,7 @@ function printBinaryishExpression(path, options, print) {
     (parent.type === "ConditionalExpression" &&
       parentParent.type !== "ReturnStatement" &&
       parentParent.type !== "ThrowStatement" &&
-      !isCallExpression(parentParent) ||
+      !isCallExpression(parentParent)) ||
     parent.type === "TemplateLiteral";
 
   const shouldIndentIfInlining =

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -13,6 +13,7 @@ const {
   shouldFlatten,
   hasComment,
   CommentCheckFlags,
+  isCallExpression,
 } = require("../utils");
 
 /** @typedef {import("../../document").Doc} Doc */
@@ -60,9 +61,7 @@ function printBinaryishExpression(path, options, print) {
   //     c
   //   ).call()
   if (
-    ((parent.type === "CallExpression" ||
-      parent.type === "OptionalCallExpression") &&
-      parent.callee === n) ||
+    (isCallExpression(parent) && parent.callee === n) ||
     parent.type === "UnaryExpression" ||
     ((parent.type === "MemberExpression" ||
       parent.type === "OptionalMemberExpression") &&
@@ -89,8 +88,7 @@ function printBinaryishExpression(path, options, print) {
     (parent.type === "ConditionalExpression" &&
       parentParent.type !== "ReturnStatement" &&
       parentParent.type !== "ThrowStatement" &&
-      parentParent.type !== "CallExpression" &&
-      parentParent.type !== "OptionalCallExpression") ||
+      !isCallExpression(parentParent) ||
     parent.type === "TemplateLiteral";
 
   const shouldIndentIfInlining =

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -14,6 +14,7 @@ const {
   hasComment,
   CommentCheckFlags,
   isCallExpression,
+  isMemberExpression,
 } = require("../utils");
 
 /** @typedef {import("../../document").Doc} Doc */
@@ -63,9 +64,7 @@ function printBinaryishExpression(path, options, print) {
   if (
     (isCallExpression(parent) && parent.callee === n) ||
     parent.type === "UnaryExpression" ||
-    ((parent.type === "MemberExpression" ||
-      parent.type === "OptionalMemberExpression") &&
-      !parent.computed)
+    (isMemberExpression(parent) && !parent.computed)
   ) {
     return group([indent([softline, ...parts]), softline]);
   }

--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -14,6 +14,7 @@ const {
   getCallArguments,
   iterateCallArgumentsPath,
   isNextLineEmpty,
+  isCallExpression,
 } = require("../utils");
 
 const {
@@ -251,8 +252,7 @@ function couldGroupArg(arg) {
         arg.body.type === "ArrowFunctionExpression" ||
         arg.body.type === "ObjectExpression" ||
         arg.body.type === "ArrayExpression" ||
-        arg.body.type === "CallExpression" ||
-        arg.body.type === "OptionalCallExpression" ||
+        isCallExpression(arg.body) ||
         arg.body.type === "ConditionalExpression" ||
         isJsxNode(arg.body)))
   );

--- a/src/language-js/print/call-expression.js
+++ b/src/language-js/print/call-expression.js
@@ -7,7 +7,7 @@ const pathNeedsParens = require("../needs-parens");
 const {
   getCallArguments,
   hasFlowAnnotationComment,
-  isCallOrOptionalCallExpression,
+  isCallExpression,
   isMemberish,
   isTemplateOnItsOwnLine,
   isTestCall,
@@ -95,7 +95,7 @@ function printCallExpression(path, options, print) {
 
   // We group here when the callee is itself a call expression.
   // See `isLongCurriedCallExpression` for more info.
-  if (isDynamicImport || isCallOrOptionalCallExpression(n.callee)) {
+  if (isDynamicImport || isCallExpression(n.callee)) {
     return group(contents);
   }
 

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -505,8 +505,7 @@ function printJsxExpressionContainer(path, options, print) {
       (n.expression.type === "ArrayExpression" ||
         n.expression.type === "ObjectExpression" ||
         n.expression.type === "ArrowFunctionExpression" ||
-        n.expression.type === "CallExpression" ||
-        n.expression.type === "OptionalCallExpression" ||
+        isCallExpression(n.expression) ||
         n.expression.type === "FunctionExpression" ||
         n.expression.type === "TemplateLiteral" ||
         n.expression.type === "TaggedTemplateExpression" ||

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -22,7 +22,7 @@ const {
   isJsxNode,
   rawText,
   isLiteral,
-  isCallOrOptionalCallExpression,
+  isCallExpression,
   isStringLiteral,
   isBinaryish,
   hasComment,
@@ -451,7 +451,7 @@ function maybeWrapJsxElementInParens(path, elem, options) {
   const shouldBreak = path.match(
     undefined,
     (node) => node.type === "ArrowFunctionExpression",
-    isCallOrOptionalCallExpression,
+    isCallExpression,
     (node) => node.type === "JSXExpressionContainer"
   );
 

--- a/src/language-js/print/member-chain.js
+++ b/src/language-js/print/member-chain.js
@@ -11,6 +11,7 @@ const {
 const pathNeedsParens = require("../needs-parens");
 const {
   isCallExpression,
+  isMemberExpression,
   isFunctionOrArrowExpression,
   isLongCurriedCallExpression,
   isMemberish,
@@ -111,8 +112,7 @@ function printMemberChain(path, options, print) {
         printed: printComments(
           path,
           () =>
-            node.type === "OptionalMemberExpression" ||
-            node.type === "MemberExpression"
+            isMemberExpression(node)
               ? printMemberLookup(path, options, print)
               : printBindExpressionCallee(path, options, print),
           options
@@ -180,8 +180,7 @@ function printMemberChain(path, options, print) {
     if (
       printedNodes[i].node.type === "TSNonNullExpression" ||
       isCallExpression(printedNodes[i].node) ||
-      ((printedNodes[i].node.type === "MemberExpression" ||
-        printedNodes[i].node.type === "OptionalMemberExpression") &&
+      (isMemberExpression(printedNodes[i].node) &&
         printedNodes[i].node.computed &&
         isNumericLiteral(printedNodes[i].node.property))
     ) {
@@ -288,8 +287,7 @@ function printMemberChain(path, options, print) {
 
     const lastNode = getLast(groups[0]).node;
     return (
-      (lastNode.type === "MemberExpression" ||
-        lastNode.type === "OptionalMemberExpression") &&
+      isMemberExpression(lastNode) &&
       lastNode.property.type === "Identifier" &&
       (isFactory(lastNode.property.name) || hasComputed)
     );

--- a/src/language-js/print/member-chain.js
+++ b/src/language-js/print/member-chain.js
@@ -10,7 +10,7 @@ const {
 } = require("../../common/util");
 const pathNeedsParens = require("../needs-parens");
 const {
-  isCallOrOptionalCallExpression,
+  isCallExpression,
   isFunctionOrArrowExpression,
   isLongCurriedCallExpression,
   isMemberish,
@@ -85,8 +85,8 @@ function printMemberChain(path, options, print) {
   function rec(path) {
     const node = path.getValue();
     if (
-      isCallOrOptionalCallExpression(node) &&
-      (isMemberish(node.callee) || isCallOrOptionalCallExpression(node.callee))
+      isCallExpression(node) &&
+      (isMemberish(node.callee) || isCallExpression(node.callee))
     ) {
       printedNodes.unshift({
         node,
@@ -179,7 +179,7 @@ function printMemberChain(path, options, print) {
   for (; i < printedNodes.length; ++i) {
     if (
       printedNodes[i].node.type === "TSNonNullExpression" ||
-      isCallOrOptionalCallExpression(printedNodes[i].node) ||
+      isCallExpression(printedNodes[i].node) ||
       ((printedNodes[i].node.type === "MemberExpression" ||
         printedNodes[i].node.type === "OptionalMemberExpression") &&
         printedNodes[i].node.computed &&
@@ -190,7 +190,7 @@ function printMemberChain(path, options, print) {
       break;
     }
   }
-  if (!isCallOrOptionalCallExpression(printedNodes[0].node)) {
+  if (!isCallExpression(printedNodes[0].node)) {
     for (; i + 1 < printedNodes.length; ++i) {
       if (
         isMemberish(printedNodes[i].node) &&
@@ -228,7 +228,7 @@ function printMemberChain(path, options, print) {
     }
 
     if (
-      isCallOrOptionalCallExpression(printedNodes[i].node) ||
+      isCallExpression(printedNodes[i].node) ||
       printedNodes[i].node.type === "ImportExpression"
     ) {
       hasSeenCallExpression = true;
@@ -350,7 +350,7 @@ function printMemberChain(path, options, print) {
   // empty line after
   const lastNodeBeforeIndent = getLast(groups[shouldMerge ? 1 : 0]).node;
   const shouldHaveEmptyLineBeforeIndent =
-    !isCallOrOptionalCallExpression(lastNodeBeforeIndent) &&
+    !isCallExpression(lastNodeBeforeIndent) &&
     shouldInsertEmptyLineAfter(lastNodeBeforeIndent);
 
   const expanded = [
@@ -362,13 +362,13 @@ function printMemberChain(path, options, print) {
 
   const callExpressions = printedNodes
     .map(({ node }) => node)
-    .filter(isCallOrOptionalCallExpression);
+    .filter(isCallExpression);
 
   function lastGroupWillBreakAndOtherCallsHaveFunctionArguments() {
     const lastGroupNode = getLast(getLast(groups)).node;
     const lastGroupDoc = getLast(printedGroups);
     return (
-      isCallOrOptionalCallExpression(lastGroupNode) &&
+      isCallExpression(lastGroupNode) &&
       willBreak(lastGroupDoc) &&
       callExpressions
         .slice(0, -1)

--- a/src/language-js/print/member.js
+++ b/src/language-js/print/member.js
@@ -3,7 +3,7 @@
 const {
   builders: { softline, group, indent },
 } = require("../../document");
-const { isNumericLiteral } = require("../utils");
+const { isNumericLiteral, isMemberExpression } = require("../utils");
 const { printOptionalToken } = require("./misc");
 
 function printMemberExpression(path, options, print) {
@@ -17,8 +17,7 @@ function printMemberExpression(path, options, print) {
     i++;
   } while (
     firstNonMemberParent &&
-    (firstNonMemberParent.type === "MemberExpression" ||
-      firstNonMemberParent.type === "OptionalMemberExpression" ||
+    (isMemberExpression(firstNonMemberParent) ||
       firstNonMemberParent.type === "TSNonNullExpression")
   );
 
@@ -33,8 +32,7 @@ function printMemberExpression(path, options, print) {
     n.computed ||
     (n.object.type === "Identifier" &&
       n.property.type === "Identifier" &&
-      parent.type !== "MemberExpression" &&
-      parent.type !== "OptionalMemberExpression");
+      !isMemberExpression(parent));
 
   return [
     path.call(print, "object"),

--- a/src/language-js/print/template-literal.js
+++ b/src/language-js/print/template-literal.js
@@ -20,6 +20,7 @@ const {
   isJestEachTemplateLiteral,
   isSimpleTemplateLiteral,
   hasComment,
+  isMemberExpression,
 } = require("../utils");
 
 function printTemplateLiteral(path, print, options) {
@@ -85,8 +86,7 @@ function printTemplateLiteral(path, print, options) {
         // in the middle of a MemberExpression
         if (
           hasComment(expression) ||
-          expression.type === "MemberExpression" ||
-          expression.type === "OptionalMemberExpression" ||
+          isMemberExpression(expression) ||
           expression.type === "ConditionalExpression" ||
           expression.type === "SequenceExpression" ||
           expression.type === "TSAsExpression" ||

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -2,7 +2,12 @@
 
 const flat = require("lodash/flatten");
 const { hasNewlineInRange } = require("../../common/util");
-const { isJsxNode, isBlockComment, getComments } = require("../utils");
+const {
+  isJsxNode,
+  isBlockComment,
+  getComments,
+  isMemberExpression,
+} = require("../utils");
 const { locStart, locEnd } = require("../loc");
 const {
   builders: {
@@ -304,8 +309,7 @@ function printTernary(path, options, print) {
   // ).call()
   const breakClosingParen =
     !jsxMode &&
-    (parent.type === "MemberExpression" ||
-      parent.type === "OptionalMemberExpression" ||
+    (isMemberExpression(parent) ||
       (parent.type === "NGPipeExpression" && parent.left === node)) &&
     !parent.computed;
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -42,6 +42,7 @@ const {
   shouldPrintComma,
   hasIgnoreComment,
   isCallExpression,
+  isMemberExpression,
 } = require("./utils");
 const { locStart, locEnd } = require("./loc");
 
@@ -369,9 +370,7 @@ function printPathNoParens(path, options, print, args) {
       const parent = path.getParentNode();
       if (
         (isCallExpression(parent) && parent.callee === n) ||
-        ((parent.type === "MemberExpression" ||
-          parent.type === "OptionalMemberExpression") &&
-          parent.object === n)
+        (isMemberExpression(parent) && parent.object === n)
       ) {
         return group([indent([softline, ...parts]), softline]);
       }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -41,6 +41,7 @@ const {
   rawText,
   shouldPrintComma,
   hasIgnoreComment,
+  isCallExpression,
 } = require("./utils");
 const { locStart, locEnd } = require("./loc");
 
@@ -367,9 +368,7 @@ function printPathNoParens(path, options, print, args) {
       }
       const parent = path.getParentNode();
       if (
-        ((parent.type === "CallExpression" ||
-          parent.type === "OptionalCallExpression") &&
-          parent.callee === n) ||
+        (isCallExpression(parent) && parent.callee === n) ||
         ((parent.type === "MemberExpression" ||
           parent.type === "OptionalMemberExpression") &&
           parent.object === n)

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -102,8 +102,7 @@ function hasNakedLeftSide(node) {
     node.type === "NGPipeExpression" ||
     node.type === "ConditionalExpression" ||
     isCallExpression(node) ||
-    node.type === "MemberExpression" ||
-    node.type === "OptionalMemberExpression" ||
+    isMemberExpression(node) ||
     node.type === "SequenceExpression" ||
     node.type === "TaggedTemplateExpression" ||
     node.type === "BindExpression" ||
@@ -350,10 +349,7 @@ function isTheOnlyJsxElementInMarkdown(options, path) {
  * @returns {boolean}
  */
 function isMemberExpressionChain(node) {
-  if (
-    node.type !== "MemberExpression" &&
-    node.type !== "OptionalMemberExpression"
-  ) {
+  if (!isMemberExpression(node)) {
     return false;
   }
   if (node.object.type === "Identifier") {
@@ -421,8 +417,7 @@ function isBinaryish(node) {
  */
 function isMemberish(node) {
   return (
-    node.type === "MemberExpression" ||
-    node.type === "OptionalMemberExpression" ||
+    isMemberExpression(node) ||
     (node.type === "BindExpression" && Boolean(node.object))
   );
 }
@@ -503,8 +498,7 @@ const unitTestRe = /^(skip|[fx]?(it|describe|test))$/;
  */
 function isSkipOrOnlyBlock(node) {
   return (
-    (node.callee.type === "MemberExpression" ||
-      node.callee.type === "OptionalMemberExpression") &&
+    isMemberExpression(node.callee) &&
     node.callee.object.type === "Identifier" &&
     node.callee.property.type === "Identifier" &&
     unitTestRe.test(node.callee.object.name) &&
@@ -612,15 +606,9 @@ function isSimpleTemplateLiteral(node) {
     }
 
     // Allow `a.b.c`, `a.b[c]`, and `this.x.y`
-    if (
-      expr.type === "MemberExpression" ||
-      expr.type === "OptionalMemberExpression"
-    ) {
+    if (isMemberExpression(expr)) {
       let head = expr;
-      while (
-        head.type === "MemberExpression" ||
-        head.type === "OptionalMemberExpression"
-      ) {
+      while (isMemberExpression(head)) {
         if (
           head.property.type !== "Identifier" &&
           head.property.type !== "Literal" &&
@@ -956,10 +944,7 @@ function isSimpleCallArgument(node, depth) {
     );
   }
 
-  if (
-    node.type === "MemberExpression" ||
-    node.type === "OptionalMemberExpression"
-  ) {
+  if (isMemberExpression(node)) {
     return (
       isSimpleCallArgument(node.object, depth) &&
       isSimpleCallArgument(node.property, depth)

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -101,8 +101,7 @@ function hasNakedLeftSide(node) {
     node.type === "LogicalExpression" ||
     node.type === "NGPipeExpression" ||
     node.type === "ConditionalExpression" ||
-    node.type === "CallExpression" ||
-    node.type === "OptionalCallExpression" ||
+    isCallExpression(node) ||
     node.type === "MemberExpression" ||
     node.type === "OptionalMemberExpression" ||
     node.type === "SequenceExpression" ||
@@ -314,8 +313,7 @@ function isTemplateLiteral(node) {
  */
 function isAngularTestWrapper(node) {
   return (
-    (node.type === "CallExpression" ||
-      node.type === "OptionalCallExpression") &&
+    isCallExpression(node) &&
     node.callee.type === "Identifier" &&
     (node.callee.name === "async" ||
       node.callee.name === "inject" ||
@@ -938,11 +936,7 @@ function isSimpleCallArgument(node, depth) {
     return isChildSimple(node.source);
   }
 
-  if (
-    node.type === "CallExpression" ||
-    node.type === "OptionalCallExpression" ||
-    node.type === "NewExpression"
-  ) {
+  if (isCallExpression(node) || node.type === "NewExpression") {
     return (
       isSimpleCallArgument(node.callee, depth) &&
       node.arguments.every(isChildSimple)

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -567,7 +567,7 @@ function isTestCall(n, parent) {
  * @param {CallExpression | OptionalCallExpression} node
  * @returns {boolean}
  */
-function isCallOrOptionalCallExpression(node) {
+function isCallExpression(node) {
   return (
     node.type === "CallExpression" || node.type === "OptionalCallExpression"
   );
@@ -847,7 +847,7 @@ function isFunctionCompositionArgs(args) {
       if (count > 1) {
         return true;
       }
-    } else if (isCallOrOptionalCallExpression(arg)) {
+    } else if (isCallExpression(arg)) {
       for (const childArg of arg.arguments) {
         if (isFunctionOrArrowExpression(childArg)) {
           return true;
@@ -872,8 +872,8 @@ function isLongCurriedCallExpression(path) {
   const node = path.getValue();
   const parent = path.getParentNode();
   return (
-    isCallOrOptionalCallExpression(node) &&
-    isCallOrOptionalCallExpression(parent) &&
+    isCallExpression(node) &&
+    isCallExpression(parent) &&
     parent.callee === node &&
     node.arguments.length > parent.arguments.length &&
     parent.arguments.length > 0
@@ -1355,7 +1355,7 @@ module.exports = {
   isBlockComment,
   isLineComment,
   isPrettierIgnoreComment,
-  isCallOrOptionalCallExpression,
+  isCallExpression,
   isExportDeclaration,
   isFlowAnnotationComment,
   isFunctionCompositionArgs,

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -567,13 +567,20 @@ function isTestCall(n, parent) {
  */
 function isCallExpression(node) {
   return (
-    node.type === "CallExpression" || node.type === "OptionalCallExpression"
+    node &&
+    (node.type === "CallExpression" || node.type === "OptionalCallExpression")
   );
 }
 
+/**
+ * @param {Node} node
+ * @returns {boolean}
+ */
 function isMemberExpression(node) {
   return (
-    node.type === "MemberExpression" || node.type === "OptionalMemberExpression"
+    node &&
+    (node.type === "MemberExpression" ||
+      node.type === "OptionalMemberExpression")
   );
 }
 

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -307,7 +307,7 @@ function isTemplateLiteral(node) {
  * Note: `inject` is used in AngularJS 1.x, `async` in Angular 2+
  * example: https://docs.angularjs.org/guide/unit-testing#using-beforeall-
  *
- * @param {Node} node
+ * @param {CallExpression} node
  * @returns {boolean}
  */
 function isAngularTestWrapper(node) {
@@ -352,9 +352,11 @@ function isMemberExpressionChain(node) {
   if (!isMemberExpression(node)) {
     return false;
   }
+  // @ts-ignore
   if (node.object.type === "Identifier") {
     return true;
   }
+  // @ts-ignore
   return isMemberExpressionChain(node.object);
 }
 
@@ -493,7 +495,7 @@ function isSimpleType(node) {
 const unitTestRe = /^(skip|[fx]?(it|describe|test))$/;
 
 /**
- * @param {CallExpression} node
+ * @param {{callee: MemberExpression | OptionalMemberExpression}} node
  * @returns {boolean}
  */
 function isSkipOrOnlyBlock(node) {
@@ -556,7 +558,7 @@ function isTestCall(n, parent) {
 }
 
 /**
- * @param {CallExpression | OptionalCallExpression} node
+ * @param {Node} node
  * @returns {boolean}
  */
 function isCallExpression(node) {

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -571,6 +571,12 @@ function isCallExpression(node) {
   );
 }
 
+function isMemberExpression(node) {
+  return (
+    node.type === "MemberExpression" || node.type === "OptionalMemberExpression"
+  );
+}
+
 /**
  *
  * @param {any} node
@@ -1350,6 +1356,7 @@ module.exports = {
   isLineComment,
   isPrettierIgnoreComment,
   isCallExpression,
+  isMemberExpression,
   isExportDeclaration,
   isFlowAnnotationComment,
   isFunctionCompositionArgs,


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

- Rename `isCallOrOptionalCallExpression` to `isCallExpression`, they are all `CallExpression` in ESTree
- Add `isMemberExpression`
- Replace related checks

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
