### PR TITLE
Check `fill` parts

### DIFF
--- a/src/document/doc-builders.js
+++ b/src/document/doc-builders.js
@@ -140,8 +140,15 @@ function conditionalGroup(states, opts) {
  */
 function fill(parts) {
   if (process.env.NODE_ENV !== "production") {
-    for (const part of parts) {
+    for (const [index, part] of parts.entries()) {
       assertDoc(part);
+      if (index % 2 === 1 && part.type !== "line") {
+        const type = part.type || (Array.isArray(part) ? "array" : "string");
+        console.log(parts);
+        throw new Error(
+          `elements with odd indices expected to be line breaks, got "${type}".`
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

> Expects the docs argument to be an array of alternating content and line breaks. In other words, elements with odd indices must be line breaks

Ref: https://github.com/prettier/prettier/pull/10235#issuecomment-773209893

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
