### PR TITLE
Add `cleanAst` to format result

### DIFF
--- a/src/main/core.js
+++ b/src/main/core.js
@@ -38,7 +38,11 @@ function attachComments(text, ast, opts) {
 
 function coreFormat(originalText, opts, addAlignmentSize = 0) {
   if (!originalText || originalText.trim().length === 0) {
-    return { formatted: "", cursorOffset: -1, comments: [] };
+    return formatResult({
+      formatted: "",
+      cursorOffset: -1,
+      options: opts,
+    });
   }
 
   const { ast, text } = parser.parse(originalText, opts);
@@ -99,11 +103,13 @@ function coreFormat(originalText, opts, addAlignmentSize = 0) {
     }
 
     if (oldCursorNodeText === newCursorNodeText) {
-      return {
+      return formatResult({
         formatted: result.formatted,
         cursorOffset: newCursorNodeStart + cursorOffsetRelativeToOldCursorNode,
+        ast,
         comments: astComments,
-      };
+        options: opts,
+      });
     }
 
     // diff old and new cursor node texts, with a special cursor
@@ -134,14 +140,22 @@ function coreFormat(originalText, opts, addAlignmentSize = 0) {
       }
     }
 
-    return { formatted: result.formatted, cursorOffset, comments: astComments };
+    return formatResult({
+      formatted: result.formatted,
+      cursorOffset,
+      ast,
+      comments: astComments,
+      options: opts,
+    });
   }
 
-  return {
+  return formatResult({
     formatted: result.formatted,
     cursorOffset: -1,
+    ast,
     comments: astComments,
-  };
+    options: opts,
+  });
 }
 
 function formatRange(originalText, opts) {
@@ -279,6 +293,33 @@ function hasPragma(text, options) {
   return !selectedParser.hasPragma || selectedParser.hasPragma(text);
 }
 
+function formatResult({
+  formatted,
+  cursorOffset,
+  comments = [],
+  ast,
+  options,
+}) {
+  let cleanAst;
+
+  return {
+    formatted,
+    cursorOffset,
+    comments,
+    get cleanAst() {
+      if (!ast) {
+        return ast;
+      }
+
+      if (!cleanAst) {
+        cleanAst = massageAST(ast, options);
+      }
+
+      return cleanAst;
+    },
+  };
+}
+
 function formatWithCursor(originalText, originalOptions) {
   let { hasBOM, text, options } = normalizeInputAndOptions(
     originalText,
@@ -289,11 +330,11 @@ function formatWithCursor(originalText, originalOptions) {
     (options.rangeStart >= options.rangeEnd && text !== "") ||
     (options.requirePragma && !hasPragma(text, options))
   ) {
-    return {
+    return formatResult({
       formatted: originalText,
       cursorOffset: originalOptions.cursorOffset,
-      comments: [],
-    };
+      options,
+    });
   }
 
   let result;

--- a/tests_config/run_spec.js
+++ b/tests_config/run_spec.js
@@ -303,6 +303,7 @@ function runTest({
   }
 
   const isUnstableTest = isUnstable(filename, formatOptions);
+  let secondFormatResult;
   if (
     (formatResult.changed || isUnstableTest) &&
     // No range and cursor
@@ -310,10 +311,8 @@ function runTest({
   ) {
     test(`[${parser}] second format`, () => {
       const { eolVisualizedOutput: firstOutput, output } = formatResult;
-      const { eolVisualizedOutput: secondOutput } = format(
-        output,
-        formatOptions
-      );
+      secondFormatResult = format(output, formatOptions);
+      const { eolVisualizedOutput: secondOutput } = secondFormatResult;
       if (isUnstableTest) {
         // To keep eye on failed tests, this assert never supposed to pass,
         // if it fails, just remove the file from `unstableTests`
@@ -327,10 +326,10 @@ function runTest({
   // Some parsers skip parsing empty files
   if (formatResult.changed && code.trim()) {
     test(`[${parser}] compare AST`, () => {
-      const { input, output } = formatResult;
-      const originalAst = parse(input, formatOptions);
-      const formattedAst = parse(output, formatOptions);
-      expect(formattedAst).toEqual(originalAst);
+      const formattedAst = secondFormatResult
+        ? secondFormatResult.cleanAst
+        : parse(formatResult.output, formatOptions);
+      expect(formattedAst).toEqual(formatResult.cleanAst);
     });
   }
 
@@ -431,10 +430,8 @@ function format(originalText, originalOptions) {
   );
   const inputWithCursor = insertCursor(input, options.cursorOffset);
 
-  const { formatted: output, cursorOffset } = prettier.formatWithCursor(
-    input,
-    options
-  );
+  const result = prettier.formatWithCursor(input, options);
+  const { formatted: output, cursorOffset } = result;
   const outputWithCursor = insertCursor(output, cursorOffset);
   const eolVisualizedOutput = visualizeEndOfLine(outputWithCursor);
 
@@ -448,6 +445,9 @@ function format(originalText, originalOptions) {
     output,
     outputWithCursor,
     eolVisualizedOutput,
+    get cleanAst() {
+      return result.cleanAst;
+    },
   };
 }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

This will skip two `.parse` call in tests.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
