### PR TITLE
Refactor: Use `fromPairs` instead of `Array#reduce`

### DIFF
--- a/src/language-html/ast.js
+++ b/src/language-html/ast.js
@@ -23,10 +23,9 @@ class Node {
       this[key] = cloneAndUpdateNodes(nodes, this);
       if (key === "attrs") {
         setNonEnumerableProperties(this, {
-          attrMap: this[key].reduce((reduced, attr) => {
-            reduced[attr.fullName] = attr.value;
-            return reduced;
-          }, Object.create(null)),
+          attrMap: fromPairs(
+            this[key].map((attr) => [attr.fullName, attr.value])
+          ),
         });
       }
     }

--- a/src/main/options.js
+++ b/src/main/options.js
@@ -68,19 +68,18 @@ function normalize(options, opts = {}) {
   const plugin = getPlugin(rawOptions);
   rawOptions.printer = plugin.printers[rawOptions.astFormat];
 
-  const pluginDefaults = supportOptions
-    .filter(
-      (optionInfo) =>
-        optionInfo.pluginDefaults &&
-        optionInfo.pluginDefaults[plugin.name] !== undefined
-    )
-    .reduce(
-      (reduced, optionInfo) =>
-        Object.assign(reduced, {
-          [optionInfo.name]: optionInfo.pluginDefaults[plugin.name],
-        }),
-      {}
-    );
+  const pluginDefaults = fromPairs(
+    supportOptions
+      .filter(
+        (optionInfo) =>
+          optionInfo.pluginDefaults &&
+          optionInfo.pluginDefaults[plugin.name] !== undefined
+      )
+      .map((optionInfo) => [
+        optionInfo.name,
+        optionInfo.pluginDefaults[plugin.name],
+      ])
+  );
 
   const mixedDefaults = { ...defaults, ...pluginDefaults };
 

--- a/src/main/parser.js
+++ b/src/main/parser.js
@@ -69,12 +69,12 @@ function parse(text, opts) {
 
   // Create a new object {parserName: parseFn}. Uses defineProperty() to only call
   // the parsers getters when actually calling the parser `parse` function.
-  const parsersForCustomParserApi = Object.entries(parsers).reduce(
-    (object, [parserName, parser]) =>
+  const parsersForCustomParserApi = Object.keys(parsers).reduce(
+    (object, parserName) =>
       Object.defineProperty(object, parserName, {
         enumerable: true,
         get() {
-          return parser.parse;
+          return parsers[parserName].parse;
         },
       }),
     {}

--- a/src/main/parser.js
+++ b/src/main/parser.js
@@ -69,12 +69,12 @@ function parse(text, opts) {
 
   // Create a new object {parserName: parseFn}. Uses defineProperty() to only call
   // the parsers getters when actually calling the parser `parse` function.
-  const parsersForCustomParserApi = Object.keys(parsers).reduce(
-    (object, parserName) =>
+  const parsersForCustomParserApi = Object.entries(parsers).reduce(
+    (object, [parserName, parser]) =>
       Object.defineProperty(object, parserName, {
         enumerable: true,
         get() {
-          return parsers[parserName].parse;
+          return parser.parse;
         },
       }),
     {}

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const fromPairs = require("lodash/fromPairs");
 const semver = {
   compare: require("semver/functions/compare"),
   lt: require("semver/functions/lt"),
@@ -64,16 +65,15 @@ function getSupportInfo({
         }
       }
 
-      const pluginDefaults = plugins
-        .filter(
-          (plugin) =>
-            plugin.defaultOptions &&
-            plugin.defaultOptions[option.name] !== undefined
-        )
-        .reduce((reduced, plugin) => {
-          reduced[plugin.name] = plugin.defaultOptions[option.name];
-          return reduced;
-        }, {});
+      const pluginDefaults = fromPairs(
+        plugins
+          .filter(
+            (plugin) =>
+              plugin.defaultOptions &&
+              plugin.defaultOptions[option.name] !== undefined
+          )
+          .map((plugin) => [plugin.name, plugin.defaultOptions[option.name]])
+      );
 
       return { ...option, pluginDefaults };
     });


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
