### PR TITLE
Fix inconsistent indentation for ternary in call expressions

### DIFF
--- a/changelog_unreleased/javascript/10187.md
+++ b/changelog_unreleased/javascript/10187.md
@@ -1,4 +1,4 @@
-#### Consistent indentations for conditional operators (#10187 by @sosukesuzuki)
+#### Consistent indentations for conditional operators (#10187, #10266 by @sosukesuzuki)
 
 <!-- prettier-ignore -->
 ```ts

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -174,14 +174,15 @@ function shouldExtraIndentForConditionalExpression(path) {
     return false;
   }
 
-  let ancestorCount = 1;
-  let ancestor = path.getParentNode(ancestorCount);
-  if (!ancestor) {
-    return false;
-  }
-  while (isChainElement(ancestor)) {
+  let ancestor;
+  let ancestorCount = 0;
+  do {
     ancestor = path.getParentNode(++ancestorCount);
-  }
+    if (ancestor == null) {
+      return false;
+    }
+  } while (isChainElement(ancestor));
+
   const checkAncestor = (node) => {
     const name = ancestorNameMap.get(ancestor.type);
     return ancestor[name] === node;

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -178,11 +178,14 @@ function shouldExtraIndentForConditionalExpression(path) {
   let ancestorCount = 0;
   do {
     ancestor = path.getParentNode(++ancestorCount);
+    const getAncestorName = () =>
+      path.callParent((path) => path.getName(), ancestorCount - 1);
     if (
       ancestor == null ||
-      (isCallExpression(ancestor) &&
-        path.callParent((path) => path.getName(), ancestorCount - 1) !==
-          "callee")
+      (isCallExpression(ancestor) && getAncestorName() !== "callee") ||
+      (isMemberExpression(ancestor) &&
+        ancestor.computed &&
+        getAncestorName() !== "object")
     ) {
       return false;
     }

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -196,13 +196,13 @@ function shouldExtraIndentForConditionalExpression(path) {
       parent = path.getParentNode(ancestorCount + 1);
       child = node;
     } else {
-      // Do not add indent to direct `ConditionalExpression`
-      if (ancestorCount === 0) {
-        return false;
-      }
-
       parent = node;
     }
+  }
+
+  // Do not add indent to direct `ConditionalExpression`
+  if (child === node) {
+    return false;
   }
 
   return parent[ancestorNameMap.get(parent.type)] === child;

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -178,7 +178,12 @@ function shouldExtraIndentForConditionalExpression(path) {
   let ancestorCount = 0;
   do {
     ancestor = path.getParentNode(++ancestorCount);
-    if (ancestor == null) {
+    if (
+      ancestor == null ||
+      (isCallExpression(ancestor) &&
+        path.callParent((path) => path.getName(), ancestorCount - 1) !==
+          "callee")
+    ) {
       return false;
     }
   } while (isChainElement(ancestor));

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -176,10 +176,10 @@ function shouldExtraIndentForConditionalExpression(path) {
 
   let ancestor;
   let ancestorCount = 0;
+  const getAncestorName = () =>
+    path.callParent((path) => path.getName(), ancestorCount - 1);
   do {
     ancestor = path.getParentNode(++ancestorCount);
-    const getAncestorName = () =>
-      path.callParent((path) => path.getName(), ancestorCount - 1);
     if (
       ancestor == null ||
       (isCallExpression(ancestor) && getAncestorName() !== "callee") ||

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -1327,16 +1327,6 @@ function getComments(node, flags, fn) {
 const isNextLineEmpty = (node, { originalText }) =>
   isNextLineEmptyAfterIndex(originalText, locEnd(node));
 
-function isChainElement(node) {
-  return (
-    node.type === "MemberExpression" ||
-    node.type === "OptionalMemberExpression" ||
-    node.type === "CallExpression" ||
-    node.type === "OptionalCallExpression" ||
-    node.type === "TSNonNullExpression"
-  );
-}
-
 module.exports = {
   getFunctionParameters,
   iterateFunctionParametersPath,
@@ -1357,7 +1347,6 @@ module.exports = {
   identity,
   isBinaryish,
   isBlockComment,
-  isChainElement,
   isLineComment,
   isPrettierIgnoreComment,
   isCallExpression,

--- a/tests/js/ternaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/ternaries/__snapshots__/jsfmt.spec.js.snap
@@ -1878,6 +1878,36 @@ fn?.(
   ).prop
 )
 
+bifornCringerMoshedPerplexSawder =
+  fn[
+    (glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol
+    ).prop
+  ];
+
+fn[
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+];
+
+bifornCringerMoshedPerplexSawder =
+  fn?.[
+    (glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol
+    ).prop
+  ];
+
+fn?.[
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+];
+
 =====================================output=====================================
 foo7 = (
     coooooooooooooooooooooooooooooooooooooooooooooooooooond
@@ -2196,6 +2226,36 @@ fn?.(
     ).prop
 );
 
+bifornCringerMoshedPerplexSawder =
+    fn[
+        (glimseGlyphsHazardNoopsTieTie === 0
+            ? averredBathersBoxroomBuggyNurl
+            : anodyneCondosMalateOverateRetinol
+        ).prop
+    ];
+
+fn[
+    (glimseGlyphsHazardNoopsTieTie === 0
+        ? averredBathersBoxroomBuggyNurl
+        : anodyneCondosMalateOverateRetinol
+    ).prop
+];
+
+bifornCringerMoshedPerplexSawder =
+    fn?.[
+        (glimseGlyphsHazardNoopsTieTie === 0
+            ? averredBathersBoxroomBuggyNurl
+            : anodyneCondosMalateOverateRetinol
+        ).prop
+    ];
+
+fn?.[
+    (glimseGlyphsHazardNoopsTieTie === 0
+        ? averredBathersBoxroomBuggyNurl
+        : anodyneCondosMalateOverateRetinol
+    ).prop
+];
+
 ================================================================================
 `;
 
@@ -2470,6 +2530,36 @@ fn?.(
   ).prop
 )
 
+bifornCringerMoshedPerplexSawder =
+  fn[
+    (glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol
+    ).prop
+  ];
+
+fn[
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+];
+
+bifornCringerMoshedPerplexSawder =
+  fn?.[
+    (glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol
+    ).prop
+  ];
+
+fn?.[
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+];
+
 =====================================output=====================================
 foo7 = (
 	coooooooooooooooooooooooooooooooooooooooooooooooooooond
@@ -2787,6 +2877,36 @@ fn?.(
 		: anodyneCondosMalateOverateRetinol
 	).prop
 );
+
+bifornCringerMoshedPerplexSawder =
+	fn[
+		(glimseGlyphsHazardNoopsTieTie === 0
+			? averredBathersBoxroomBuggyNurl
+			: anodyneCondosMalateOverateRetinol
+		).prop
+	];
+
+fn[
+	(glimseGlyphsHazardNoopsTieTie === 0
+		? averredBathersBoxroomBuggyNurl
+		: anodyneCondosMalateOverateRetinol
+	).prop
+];
+
+bifornCringerMoshedPerplexSawder =
+	fn?.[
+		(glimseGlyphsHazardNoopsTieTie === 0
+			? averredBathersBoxroomBuggyNurl
+			: anodyneCondosMalateOverateRetinol
+		).prop
+	];
+
+fn?.[
+	(glimseGlyphsHazardNoopsTieTie === 0
+		? averredBathersBoxroomBuggyNurl
+		: anodyneCondosMalateOverateRetinol
+	).prop
+];
 
 ================================================================================
 `;
@@ -3061,6 +3181,36 @@ fn?.(
   ).prop
 )
 
+bifornCringerMoshedPerplexSawder =
+  fn[
+    (glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol
+    ).prop
+  ];
+
+fn[
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+];
+
+bifornCringerMoshedPerplexSawder =
+  fn?.[
+    (glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol
+    ).prop
+  ];
+
+fn?.[
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+];
+
 =====================================output=====================================
 foo7 = (
 	coooooooooooooooooooooooooooooooooooooooooooooooooooond
@@ -3379,6 +3529,36 @@ fn?.(
 	).prop
 );
 
+bifornCringerMoshedPerplexSawder =
+	fn[
+		(glimseGlyphsHazardNoopsTieTie === 0
+			? averredBathersBoxroomBuggyNurl
+			: anodyneCondosMalateOverateRetinol
+		).prop
+	];
+
+fn[
+	(glimseGlyphsHazardNoopsTieTie === 0
+		? averredBathersBoxroomBuggyNurl
+		: anodyneCondosMalateOverateRetinol
+	).prop
+];
+
+bifornCringerMoshedPerplexSawder =
+	fn?.[
+		(glimseGlyphsHazardNoopsTieTie === 0
+			? averredBathersBoxroomBuggyNurl
+			: anodyneCondosMalateOverateRetinol
+		).prop
+	];
+
+fn?.[
+	(glimseGlyphsHazardNoopsTieTie === 0
+		? averredBathersBoxroomBuggyNurl
+		: anodyneCondosMalateOverateRetinol
+	).prop
+];
+
 ================================================================================
 `;
 
@@ -3650,6 +3830,36 @@ fn?.(
     : anodyneCondosMalateOverateRetinol
   ).prop
 )
+
+bifornCringerMoshedPerplexSawder =
+  fn[
+    (glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol
+    ).prop
+  ];
+
+fn[
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+];
+
+bifornCringerMoshedPerplexSawder =
+  fn?.[
+    (glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol
+    ).prop
+  ];
+
+fn?.[
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+];
 
 =====================================output=====================================
 foo7 = (
@@ -3968,6 +4178,36 @@ fn?.(
     : anodyneCondosMalateOverateRetinol
   ).prop
 );
+
+bifornCringerMoshedPerplexSawder =
+  fn[
+    (glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol
+    ).prop
+  ];
+
+fn[
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+];
+
+bifornCringerMoshedPerplexSawder =
+  fn?.[
+    (glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol
+    ).prop
+  ];
+
+fn?.[
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+];
 
 ================================================================================
 `;

--- a/tests/js/ternaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/ternaries/__snapshots__/jsfmt.spec.js.snap
@@ -1850,6 +1850,34 @@ const decorated = (arg, ignoreRequestError) => {
   ).foo();
 };
 
+bifornCringerMoshedPerplexSawder = fn(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+);
+
+fn(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+)
+
+bifornCringerMoshedPerplexSawder = fn?.(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+);
+
+fn?.(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+)
+
 =====================================output=====================================
 foo7 = (
     coooooooooooooooooooooooooooooooooooooooooooooooooooond
@@ -2140,6 +2168,34 @@ const decorated = (arg, ignoreRequestError) => {
     ).foo();
 };
 
+bifornCringerMoshedPerplexSawder = fn(
+    (glimseGlyphsHazardNoopsTieTie === 0
+        ? averredBathersBoxroomBuggyNurl
+        : anodyneCondosMalateOverateRetinol
+    ).prop
+);
+
+fn(
+    (glimseGlyphsHazardNoopsTieTie === 0
+        ? averredBathersBoxroomBuggyNurl
+        : anodyneCondosMalateOverateRetinol
+    ).prop
+);
+
+bifornCringerMoshedPerplexSawder = fn?.(
+    (glimseGlyphsHazardNoopsTieTie === 0
+        ? averredBathersBoxroomBuggyNurl
+        : anodyneCondosMalateOverateRetinol
+    ).prop
+);
+
+fn?.(
+    (glimseGlyphsHazardNoopsTieTie === 0
+        ? averredBathersBoxroomBuggyNurl
+        : anodyneCondosMalateOverateRetinol
+    ).prop
+);
+
 ================================================================================
 `;
 
@@ -2386,6 +2442,34 @@ const decorated = (arg, ignoreRequestError) => {
   ).foo();
 };
 
+bifornCringerMoshedPerplexSawder = fn(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+);
+
+fn(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+)
+
+bifornCringerMoshedPerplexSawder = fn?.(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+);
+
+fn?.(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+)
+
 =====================================output=====================================
 foo7 = (
 	coooooooooooooooooooooooooooooooooooooooooooooooooooond
@@ -2675,6 +2759,34 @@ const decorated = (arg, ignoreRequestError) => {
 			: handleAsyncOperations(arg, ignoreRequestError)
 	).foo();
 };
+
+bifornCringerMoshedPerplexSawder = fn(
+	(glimseGlyphsHazardNoopsTieTie === 0
+		? averredBathersBoxroomBuggyNurl
+		: anodyneCondosMalateOverateRetinol
+	).prop
+);
+
+fn(
+	(glimseGlyphsHazardNoopsTieTie === 0
+		? averredBathersBoxroomBuggyNurl
+		: anodyneCondosMalateOverateRetinol
+	).prop
+);
+
+bifornCringerMoshedPerplexSawder = fn?.(
+	(glimseGlyphsHazardNoopsTieTie === 0
+		? averredBathersBoxroomBuggyNurl
+		: anodyneCondosMalateOverateRetinol
+	).prop
+);
+
+fn?.(
+	(glimseGlyphsHazardNoopsTieTie === 0
+		? averredBathersBoxroomBuggyNurl
+		: anodyneCondosMalateOverateRetinol
+	).prop
+);
 
 ================================================================================
 `;
@@ -2921,6 +3033,34 @@ const decorated = (arg, ignoreRequestError) => {
   ).foo();
 };
 
+bifornCringerMoshedPerplexSawder = fn(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+);
+
+fn(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+)
+
+bifornCringerMoshedPerplexSawder = fn?.(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+);
+
+fn?.(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+)
+
 =====================================output=====================================
 foo7 = (
 	coooooooooooooooooooooooooooooooooooooooooooooooooooond
@@ -3211,6 +3351,34 @@ const decorated = (arg, ignoreRequestError) => {
 	).foo();
 };
 
+bifornCringerMoshedPerplexSawder = fn(
+	(glimseGlyphsHazardNoopsTieTie === 0
+		? averredBathersBoxroomBuggyNurl
+		: anodyneCondosMalateOverateRetinol
+	).prop
+);
+
+fn(
+	(glimseGlyphsHazardNoopsTieTie === 0
+		? averredBathersBoxroomBuggyNurl
+		: anodyneCondosMalateOverateRetinol
+	).prop
+);
+
+bifornCringerMoshedPerplexSawder = fn?.(
+	(glimseGlyphsHazardNoopsTieTie === 0
+		? averredBathersBoxroomBuggyNurl
+		: anodyneCondosMalateOverateRetinol
+	).prop
+);
+
+fn?.(
+	(glimseGlyphsHazardNoopsTieTie === 0
+		? averredBathersBoxroomBuggyNurl
+		: anodyneCondosMalateOverateRetinol
+	).prop
+);
+
 ================================================================================
 `;
 
@@ -3454,6 +3622,34 @@ const decorated = (arg, ignoreRequestError) => {
       : handleAsyncOperations(arg, ignoreRequestError)
   ).foo();
 };
+
+bifornCringerMoshedPerplexSawder = fn(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+);
+
+fn(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+)
+
+bifornCringerMoshedPerplexSawder = fn?.(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+);
+
+fn?.(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+)
 
 =====================================output=====================================
 foo7 = (
@@ -3744,6 +3940,34 @@ const decorated = (arg, ignoreRequestError) => {
       : handleAsyncOperations(arg, ignoreRequestError)
   ).foo();
 };
+
+bifornCringerMoshedPerplexSawder = fn(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+);
+
+fn(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+);
+
+bifornCringerMoshedPerplexSawder = fn?.(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+);
+
+fn?.(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+);
 
 ================================================================================
 `;

--- a/tests/js/ternaries/indent-after-paren.js
+++ b/tests/js/ternaries/indent-after-paren.js
@@ -260,3 +260,33 @@ fn?.(
     : anodyneCondosMalateOverateRetinol
   ).prop
 )
+
+bifornCringerMoshedPerplexSawder =
+  fn[
+    (glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol
+    ).prop
+  ];
+
+fn[
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+];
+
+bifornCringerMoshedPerplexSawder =
+  fn?.[
+    (glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol
+    ).prop
+  ];
+
+fn?.[
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+];

--- a/tests/js/ternaries/indent-after-paren.js
+++ b/tests/js/ternaries/indent-after-paren.js
@@ -232,3 +232,31 @@ const decorated = (arg, ignoreRequestError) => {
       : handleAsyncOperations(arg, ignoreRequestError)
   ).foo();
 };
+
+bifornCringerMoshedPerplexSawder = fn(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+);
+
+fn(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+)
+
+bifornCringerMoshedPerplexSawder = fn?.(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+);
+
+fn?.(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+)


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #10265

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
