### PR TITLE
Refactor: rename FastPath → AstPath

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -117,7 +117,7 @@ overrides:
     rules:
       prettier-internal-rules/no-doc-builder-concat: error
       prettier-internal-rules/no-empty-flat-contents-for-if-break: error
-      prettier-internal-rules/prefer-fast-path-each: error
+      prettier-internal-rules/prefer-ast-path-each: error
       prettier-internal-rules/prefer-indent-if-break: error
       prettier-internal-rules/prefer-is-non-empty-array: error
   - files:

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -177,7 +177,7 @@ The printing process works as follows:
 
 1. `preprocess(ast: AST, options: object): AST`, if available, is called. It is passed the AST from the _parser_. The AST returned by `preprocess` will be used by Prettier. If `preprocess` is not defined, the AST returned from the _parser_ will be used.
 2. Comments are attached to the AST (see _Handling comments in a printer_ for details).
-3. A Doc is recursively constructed from the AST. i) `embed(path: FastPath, print, textToDoc, options: object): Doc | null` is called on each AST node. If `embed` returns a Doc, that Doc is used. ii) If `embed` is undefined or returns a falsy value, `print(path: FastPath, options: object, print): Doc` is called on each AST node.
+3. A Doc is recursively constructed from the AST. i) `embed(path: AstPath, print, textToDoc, options: object): Doc | null` is called on each AST node. If `embed` returns a Doc, that Doc is used. ii) If `embed` is undefined or returns a falsy value, `print(path: AstPath, options: object, print): Doc` is called on each AST node.
 
 #### `print`
 
@@ -186,10 +186,10 @@ Most of the work of a plugin's printer will take place in its `print` function, 
 ```ts
 function print(
   // Path to the AST node to print
-  path: FastPath,
+  path: AstPath,
   options: object,
   // Recursively print a child node
-  print: (path: FastPath) => Doc
+  print: (path: AstPath) => Doc
 ): Doc;
 ```
 
@@ -217,9 +217,9 @@ The `embed` function is called when the plugin needs to print one language insid
 ```ts
 function embed(
   // Path to the current AST node
-  path: FastPath,
+  path: AstPath,
   // Print a node with the current printer
-  print: (path: FastPath) => Doc,
+  print: (path: AstPath) => Doc,
   // Parse and print some text using a different parser.
   // You should set `options.parser` to specify which parser to use.
   textToDoc: (text: string, options: object) => Doc,
@@ -271,7 +271,7 @@ Called whenever a comment node needs to be printed. It has the signature:
 ```ts
 function printComment(
   // Path to the current comment node
-  commentPath: FastPath,
+  commentPath: AstPath,
   // Current options
   options: object
 ): Doc;

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/index.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/index.js
@@ -8,7 +8,7 @@ module.exports = {
     "no-doc-builder-concat": require("./no-doc-builder-concat"),
     "no-empty-flat-contents-for-if-break": require("./no-empty-flat-contents-for-if-break"),
     "no-node-comments": require("./no-node-comments"),
-    "prefer-fast-path-each": require("./prefer-fast-path-each"),
+    "prefer-ast-path-each": require("./prefer-ast-path-each"),
     "prefer-indent-if-break": require("./prefer-indent-if-break"),
     "prefer-is-non-empty-array": require("./prefer-is-non-empty-array"),
     "require-json-extensions": require("./require-json-extensions"),

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-each.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-each.js
@@ -14,7 +14,7 @@ const selector = [
   '[name="map"]',
 ].join("");
 
-const messageId = "prefer-fast-path-each";
+const messageId = "prefer-ast-path-each";
 
 module.exports = {
   meta: {
@@ -24,7 +24,7 @@ module.exports = {
         "https://github.com/prettier/prettier/blob/main/scripts/eslint-plugin-prettier-internal-rules/require-json-extensions.js",
     },
     messages: {
-      [messageId]: "Prefer `FastPath#each()` over `FastPath#map()`.",
+      [messageId]: "Prefer `AstPath#each()` over `AstPath#map()`.",
     },
     fixable: "code",
   },

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
@@ -144,7 +144,7 @@ test("no-node-comments", {
   ],
 });
 
-test("prefer-fast-path-each", {
+test("prefer-ast-path-each", {
   valid: ["const foo = path.map()"],
   invalid: [
     {

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -16,7 +16,7 @@ function getNodeStackIndexHelper(stack, count) {
   return -1;
 }
 
-class FastPath {
+class AstPath {
   constructor(value) {
     this.stack = [value];
   }
@@ -51,7 +51,7 @@ class FastPath {
 
   // Temporarily push properties named by string arguments given after the
   // callback function onto this.stack, then call the callback with a
-  // reference to this (modified) FastPath object. Note that the stack will
+  // reference to this (modified) AstPath object. Note that the stack will
   // be restored to its original state after the callback is finished, so it
   // is probably a mistake to retain a reference to the path.
   call(callback, ...names) {
@@ -76,7 +76,7 @@ class FastPath {
     return result;
   }
 
-  // Similar to FastPath.prototype.call, except that the value obtained by
+  // Similar to AstPath.prototype.call, except that the value obtained by
   // accessing this.getValue()[name1][name2]... should be array. The
   // callback will be called with a reference to this path object for each
   // element of the array.
@@ -99,7 +99,7 @@ class FastPath {
     stack.length = length;
   }
 
-  // Similar to FastPath.prototype.each, except that the results of the
+  // Similar to AstPath.prototype.each, except that the results of the
   // callback function invocations are stored in an array and returned at
   // the end of the iteration.
   map(callback, ...names) {
@@ -148,4 +148,4 @@ class FastPath {
   }
 }
 
-module.exports = FastPath;
+module.exports = AstPath;

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -28,7 +28,7 @@ const { locStart, locEnd } = require("./loc");
 /**
  * @typedef {import("./types/estree").Node} Node
  * @typedef {import("./types/estree").Comment} Comment
- * @typedef {import("../common/fast-path")} FastPath
+ * @typedef {import("../common/ast-path")} AstPath
  *
  * @typedef {Object} CommentContext
  * @property {Comment} comment
@@ -944,7 +944,7 @@ function isTypeCastComment(comment) {
 }
 
 /**
- * @param {FastPath} path
+ * @param {AstPath} path
  * @returns {boolean}
  */
 function willPrintOwnComments(path /*, options */) {

--- a/src/language-js/print/angular.js
+++ b/src/language-js/print/angular.js
@@ -6,7 +6,7 @@ const {
 const { hasNode, hasComment, getComments } = require("../utils");
 const { printBinaryishExpression } = require("./binaryish");
 
-/** @typedef {import("../../common/fast-path")} FastPath */
+/** @typedef {import("../../common/ast-path")} AstPath */
 
 function printAngular(path, options, print) {
   const n = path.getValue();
@@ -99,7 +99,7 @@ function isNgForOf(node, index, parentNode) {
 
 /** identify if an angular expression seems to have side effects */
 /**
- * @param {FastPath} path
+ * @param {AstPath} path
  * @returns {boolean}
  */
 function hasNgSideEffect(path) {

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -33,7 +33,7 @@ const pathNeedsParens = require("../needs-parens");
 const { willPrintOwnComments } = require("../comments");
 
 /**
- * @typedef {import("../../common/fast-path")} FastPath
+ * @typedef {import("../../common/ast-path")} AstPath
  * @typedef {import("../types/estree").Node} Node
  * @typedef {import("../types/estree").JSXElement} JSXElement
  */
@@ -812,7 +812,7 @@ function isJsxWhitespaceExpression(node) {
 }
 
 /**
- * @param {FastPath} path
+ * @param {AstPath} path
  * @returns {boolean}
  */
 function hasJsxIgnoreComment(path) {

--- a/src/language-js/print/statement.js
+++ b/src/language-js/print/statement.js
@@ -17,7 +17,7 @@ const { shouldPrintParamsWithoutParens } = require("./function");
 
 /**
  * @typedef {import("../../document").Doc} Doc
- * @typedef {import("../../common/fast-path")} FastPath
+ * @typedef {import("../../common/ast-path")} AstPath
  */
 
 function printStatementSequence(path, options, print, property) {

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -26,7 +26,7 @@ const {
 
 /**
  * @typedef {import("../../document").Doc} Doc
- * @typedef {import("../../common/fast-path")} FastPath
+ * @typedef {import("../../common/ast-path")} AstPath
  *
  * @typedef {any} Options - Prettier options (TBD ...)
  */
@@ -214,7 +214,7 @@ function shouldExtraIndentForConditionalExpression(path) {
  * The following is the shared logic for
  * ternary operators, namely ConditionalExpression
  * and TSConditionalType
- * @param {FastPath} path - The path to the ConditionalExpression/TSConditionalType node.
+ * @param {AstPath} path - The path to the ConditionalExpression/TSConditionalType node.
  * @param {Options} options - Prettier options
  * @param {Function} print - Print function to call recursively
  * @returns {Doc}

--- a/src/language-js/print/type-annotation.js
+++ b/src/language-js/print/type-annotation.js
@@ -233,7 +233,7 @@ function printFunctionType(path, options, print) {
     isArrowFunctionTypeAnnotation &&
     (parent.type === "TypeAnnotation" || parent.type === "TSTypeAnnotation");
 
-  // Sadly we can't put it inside of FastPath::needsColon because we are
+  // Sadly we can't put it inside of AstPath::needsColon because we are
   // printing ":" as part of the expression and it would put parenthesis
   // around :(
   const needsParens =

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -25,7 +25,7 @@ const { locStart, locEnd, hasSameLocStart } = require("./loc");
  * @typedef {import("./types/estree").TaggedTemplateExpression} TaggedTemplateExpression
  * @typedef {import("./types/estree").Literal} Literal
  *
- * @typedef {import("../common/fast-path")} FastPath
+ * @typedef {import("../common/ast-path")} AstPath
  */
 
 // We match any whitespace except line terminators because
@@ -201,7 +201,7 @@ function isExportDeclaration(node) {
 }
 
 /**
- * @param {FastPath} path
+ * @param {AstPath} path
  * @returns {Node | null}
  */
 function getParentExportDeclaration(path) {
@@ -866,7 +866,7 @@ function isFunctionCompositionArgs(args) {
 // In the above call expression, the second call is the parent node and the
 // first call is the current node.
 /**
- * @param {FastPath} path
+ * @param {AstPath} path
  * @returns {boolean}
  */
 function isLongCurriedCallExpression(path) {

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const assert = require("assert");
-const FastPath = require("../common/fast-path");
+const AstPath = require("../common/ast-path");
 const doc = require("../document");
 const { printComments } = require("./comments");
 const multiparser = require("./multiparser");
@@ -27,7 +27,7 @@ const docUtils = doc.utils;
  * plugin function again, and so on.
  *
  * All the while, these functions pass a "path" variable around, which
- * is a stack-like data structure (FastPath) that maintains the current
+ * is a stack-like data structure (AstPath) that maintains the current
  * state of the recursion. It is called "path", because it represents
  * the path to the current node through the Abstract Syntax Tree.
  */
@@ -74,7 +74,7 @@ function printAstToDoc(ast, options, alignmentSize = 0) {
     return res;
   }
 
-  let doc = printGenerically(new FastPath(ast));
+  let doc = printGenerically(new AstPath(ast));
   if (alignmentSize > 0) {
     // Add a hardline to make the indents take effect
     // It should be removed in index.js format()
@@ -106,7 +106,7 @@ function printPrettierIgnoredNode(node, options) {
 }
 
 function callPluginPrintFunction(path, options, printPath, args) {
-  assert.ok(path instanceof FastPath);
+  assert.ok(path instanceof AstPath);
 
   const node = path.getValue();
   const { printer } = options;

--- a/website/versioned_docs/version-stable/plugins.md
+++ b/website/versioned_docs/version-stable/plugins.md
@@ -178,7 +178,7 @@ The printing process works as follows:
 
 1. `preprocess(ast: AST, options: object): AST`, if available, is called. It is passed the AST from the _parser_. The AST returned by `preprocess` will be used by Prettier. If `preprocess` is not defined, the AST returned from the _parser_ will be used.
 2. Comments are attached to the AST (see _Handling comments in a printer_ for details).
-3. A Doc is recursively constructed from the AST. i) `embed(path: FastPath, print, textToDoc, options: object): Doc | null` is called on each AST node. If `embed` returns a Doc, that Doc is used. ii) If `embed` is undefined or returns a falsy value, `print(path: FastPath, options: object, print): Doc` is called on each AST node.
+3. A Doc is recursively constructed from the AST. i) `embed(path: AstPath, print, textToDoc, options: object): Doc | null` is called on each AST node. If `embed` returns a Doc, that Doc is used. ii) If `embed` is undefined or returns a falsy value, `print(path: AstPath, options: object, print): Doc` is called on each AST node.
 
 #### `print`
 
@@ -187,10 +187,10 @@ Most of the work of a plugin's printer will take place in its `print` function, 
 ```ts
 function print(
   // Path to the AST node to print
-  path: FastPath,
+  path: AstPath,
   options: object,
   // Recursively print a child node
-  print: (path: FastPath) => Doc
+  print: (path: AstPath) => Doc
 ): Doc;
 ```
 
@@ -218,9 +218,9 @@ The `embed` function is called when the plugin needs to print one language insid
 ```ts
 function embed(
   // Path to the current AST node
-  path: FastPath,
+  path: AstPath,
   // Print a node with the current printer
-  print: (path: FastPath) => Doc,
+  print: (path: AstPath) => Doc,
   // Parse and print some text using a different parser.
   // You should set `options.parser` to specify which parser to use.
   textToDoc: (text: string, options: object) => Doc,
@@ -272,7 +272,7 @@ Called whenever a comment node needs to be printed. It has the signature:
 ```ts
 function printComment(
   // Path to the current comment node
-  commentPath: FastPath,
+  commentPath: AstPath,
   // Current options
   options: object
 ): Doc;


### PR DESCRIPTION
## Description

`FastPath` is a misleading name. Is there also a `SlowPath`? 

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
