### PR TITLE
Handlebars printer: two small refactorings

### DIFF
--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -243,6 +243,9 @@ function print(path, options, print) {
         return replaceEndOfLineWith(text, literalline);
       }
 
+      const whitespacesOnlyRE = /^[\t\n\f\r ]*$/;
+      const isWhitespaceOnly = whitespacesOnlyRE.test(text);
+
       if (options.htmlWhitespaceSensitivity === "strict") {
         // https://infra.spec.whatwg.org/#ascii-whitespace
         const leadingWhitespacesRE = /^[\t\n\f\r ]*/;
@@ -300,7 +303,6 @@ function print(path, options, print) {
 
       const isFirstElement = !getPreviousNode(path);
       const isLastElement = !getNextNode(path);
-      const isWhitespaceOnly = !/\S/.test(text);
       const lineBreaksCount = countNewLines(text);
 
       let leadingLineBreaksCount = countLeadingNewLines(text);

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -32,6 +32,8 @@ const {
   isWhitespaceNode,
 } = require("./utils");
 
+const NEWLINES_TO_PRESERVE_MAX = 2;
+
 // Formatter based on @glimmerjs/syntax's built-in test formatter:
 // https://github.com/glimmerjs/glimmer-vm/blob/master/packages/%40glimmer/syntax/lib/generation/print.ts
 
@@ -252,7 +254,7 @@ function print(path, options, print) {
 
           const newlines = countNewLines(text);
           if (newlines) {
-            breaks = generateHardlines(newlines, 2);
+            breaks = generateHardlines(newlines);
           }
 
           if (isLastNodeOfSiblings(path)) {
@@ -271,7 +273,7 @@ function print(path, options, print) {
 
           const leadingNewlines = countNewLines(lead);
           if (leadingNewlines) {
-            leadBreaks = generateHardlines(countNewLines(lead) || 1, 2);
+            leadBreaks = generateHardlines(countNewLines(lead) || 1);
           }
 
           text = text.replace(leadingWhitespacesRE, "");
@@ -283,7 +285,7 @@ function print(path, options, print) {
 
           const trailingNewlines = countNewLines(tail);
           if (trailingNewlines) {
-            trailBreaks = generateHardlines(trailingNewlines || 1, 2);
+            trailBreaks = generateHardlines(trailingNewlines || 1);
 
             if (isLastNodeOfSiblings(path)) {
               trailBreaks = trailBreaks.map((hardline) => dedent(hardline));
@@ -296,7 +298,6 @@ function print(path, options, print) {
         return [...leadBreaks, fill(getTextValueParts(text)), ...trailBreaks];
       }
 
-      const maxLineBreaksToPreserve = 2;
       const isFirstElement = !getPreviousNode(path);
       const isLastElement = !getNextNode(path);
       const isWhitespaceOnly = !/\S/.test(text);
@@ -316,7 +317,7 @@ function print(path, options, print) {
       if (isWhitespaceOnly && lineBreaksCount) {
         leadingLineBreaksCount = Math.min(
           lineBreaksCount,
-          maxLineBreaksToPreserve
+          NEWLINES_TO_PRESERVE_MAX
         );
         trailingLineBreaksCount = 0;
       } else {
@@ -361,9 +362,9 @@ function print(path, options, print) {
         .replace(/[\t\n\f\r ]+$/, trailingSpace);
 
       return [
-        ...generateHardlines(leadingLineBreaksCount, maxLineBreaksToPreserve),
+        ...generateHardlines(leadingLineBreaksCount),
         fill(getTextValueParts(text)),
-        ...generateHardlines(trailingLineBreaksCount, maxLineBreaksToPreserve),
+        ...generateHardlines(trailingLineBreaksCount),
       ];
     }
     case "MustacheCommentStatement": {
@@ -680,8 +681,8 @@ function countTrailingNewLines(string) {
   return countNewLines(newLines);
 }
 
-function generateHardlines(number = 0, max = 0) {
-  return new Array(Math.min(number, max)).fill(hardline);
+function generateHardlines(number = 0) {
+  return new Array(Math.min(number, NEWLINES_TO_PRESERVE_MAX)).fill(hardline);
 }
 
 /* StringLiteral print helpers */

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -250,9 +250,8 @@ function print(path, options, print) {
         // https://infra.spec.whatwg.org/#ascii-whitespace
         const leadingWhitespacesRE = /^[\t\n\f\r ]*/;
         const trailingWhitespacesRE = /[\t\n\f\r ]*$/;
-        const whitespacesOnlyRE = /^[\t\n\f\r ]*$/;
 
-        if (whitespacesOnlyRE.test(text)) {
+        if (isWhitespaceOnly) {
           let breaks = [line];
 
           const newlines = countNewLines(text);


### PR DESCRIPTION
## Description

This PR brings two small refactoring to Handlebars printer:
- simplify `generateHardlines` function by removing the second argument (the max number of newlines to preserve is documented [here](https://prettier.io/docs/en/rationale.html#empty-lines) so it is not necessary to make the function configurable with a second argument)
- use the right regex to assess a TextNode is whitespace only (`!/\S/.test(text)` -> `/^[\t\n\f\r ]*$/.test(text)`)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
