### PR TITLE
RFC: break method chains in assignments if they don't fit after operator

### DIFF
--- a/src/language-js/print/call-expression.js
+++ b/src/language-js/print/call-expression.js
@@ -17,7 +17,7 @@ const printMemberChain = require("./member-chain");
 const printCallArguments = require("./call-arguments");
 const { printOptionalToken, printFunctionTypeParameters } = require("./misc");
 
-function printCallExpression(path, options, print) {
+function printCallExpression(path, options, print, printArgs) {
   const n = path.getValue();
   const isNew = n.type === "NewExpression";
   const isDynamicImport = n.type === "ImportExpression";
@@ -79,7 +79,7 @@ function printCallExpression(path, options, print) {
     isMemberish(n.callee) &&
     !path.call((path) => pathNeedsParens(path, options), "callee")
   ) {
-    return printMemberChain(path, options, print);
+    return printMemberChain(path, options, print, printArgs);
   }
 
   const contents = [

--- a/src/language-js/print/member-chain.js
+++ b/src/language-js/print/member-chain.js
@@ -54,7 +54,7 @@ const {
 // The way it is structured in the AST is via a nested sequence of
 // MemberExpression and CallExpression. We need to traverse the AST
 // and make groups out of it to print it in the desired way.
-function printMemberChain(path, options, print) {
+function printMemberChain(path, options, print, printArgs) {
   const parent = path.getParentNode();
   const isExpressionStatement =
     !parent || parent.type === "ExpressionStatement";
@@ -386,12 +386,13 @@ function printMemberChain(path, options, print) {
 
   // We don't want to print in one line if at least one of these conditions occurs:
   //  * the chain has comments,
-  //  * the chain is an expression statement and all the arguments are literal-like ("fluent configuration" pattern),
+  //  * the chain is the right-hand side of an assignment and has a leading comment
   //  * the chain is longer than 2 calls and has non-trivial arguments or more than 2 arguments in any call but the first one,
   //  * any group but the last one has a hard line,
   //  * the last call's arguments have a hard line and other calls have non-trivial arguments.
   if (
     nodeHasComment ||
+    (printArgs && printArgs.assignmentRightHandSide && hasComment(node)) ||
     (callExpressions.length > 2 &&
       callExpressions.some(
         (expr) => !expr.arguments.every((arg) => isSimpleCallArgument(arg, 0))

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -408,7 +408,7 @@ function printPathNoParens(path, options, print, args) {
     case "ImportExpression":
     case "OptionalCallExpression":
     case "CallExpression":
-      return printCallExpression(path, options, print);
+      return printCallExpression(path, options, print, args);
     case "ObjectTypeInternalSlot":
       return [
         n.static ? "static " : "",

--- a/tests/flow-repo/union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow-repo/union/__snapshots__/jsfmt.spec.js.snap
@@ -227,16 +227,17 @@ var p = new Promise(function(resolve, reject) {
     });
 
 =====================================output=====================================
-var p = new Promise(function (resolve, reject) {
-  resolve(5);
-})
-  .then(function (num) {
-    return num.toFixed();
+var p =
+  new Promise(function (resolve, reject) {
+    resolve(5);
   })
-  .then(function (str) {
-    // This should fail because str is string, not number
-    return str.toFixed();
-  });
+    .then(function (num) {
+      return num.toFixed();
+    })
+    .then(function (str) {
+      // This should fail because str is string, not number
+      return str.toFixed();
+    });
 
 ================================================================================
 `;

--- a/tests/js/assignment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/assignment/__snapshots__/jsfmt.spec.js.snap
@@ -600,6 +600,58 @@ const { _id: id3 } =
 ================================================================================
 `;
 
+exports[`method-chains.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+let column = new ColumnColumn(null, conn).table(data.table).json(data.column);
+
+let column0 = new Column(null, conn).table({
+  x:data.t}).json(data.column);
+
+let column1 = new ColumnColumnColumn(null, conn).table(data.table).json(data.column);
+
+let column2 =
+  // comment
+  new ColumnColumnColumn(null, conn).table(data.table).json(data.column);
+
+call(column3 = new Column(null, conn).table(data.table).json(data.column));
+call(column4 = new ColumnColumnColumn(null, conn).table(data.table).json(data.column));
+
+=====================================output=====================================
+let column = new ColumnColumn(null, conn).table(data.table).json(data.column);
+
+let column0 =
+  new Column(null, conn)
+    .table({
+      x: data.t,
+    })
+    .json(data.column);
+
+let column1 =
+  new ColumnColumnColumn(null, conn)
+    .table(data.table)
+    .json(data.column);
+
+let column2 =
+  // comment
+  new ColumnColumnColumn(null, conn)
+    .table(data.table)
+    .json(data.column);
+
+call((column3 = new Column(null, conn).table(data.table).json(data.column)));
+call(
+  (column4 =
+    new ColumnColumnColumn(null, conn)
+      .table(data.table)
+      .json(data.column))
+);
+
+================================================================================
+`;
+
 exports[`sequence.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/js/assignment/method-chains.js
+++ b/tests/js/assignment/method-chains.js
@@ -1,0 +1,13 @@
+let column = new ColumnColumn(null, conn).table(data.table).json(data.column);
+
+let column0 = new Column(null, conn).table({
+  x:data.t}).json(data.column);
+
+let column1 = new ColumnColumnColumn(null, conn).table(data.table).json(data.column);
+
+let column2 =
+  // comment
+  new ColumnColumnColumn(null, conn).table(data.table).json(data.column);
+
+call(column3 = new Column(null, conn).table(data.table).json(data.column));
+call(column4 = new ColumnColumnColumn(null, conn).table(data.table).json(data.column));

--- a/tests/js/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -357,10 +357,11 @@ measure() // Warm-up first
     SomethingLong();
   });
 
-const configModel = this.baseConfigurationService
-  .getCache()
-  .consolidated // global/default values (do NOT modify)
-  .merge(this.cachedWorkspaceConfig);
+const configModel =
+  this.baseConfigurationService
+    .getCache()
+    .consolidated // global/default values (do NOT modify)
+    .merge(this.cachedWorkspaceConfig);
 
 this.doWriteConfiguration(target, value, options) // queue up writes to prevent race conditions
   .then(
@@ -1390,10 +1391,11 @@ const svgJsFiles = fs
   .map(f => path.join(svgDir, f));
 
 =====================================output=====================================
-const svgJsFiles = fs
-  .readdirSync(svgDir)
-  .filter((f) => svgJsFileExtRegex.test(f))
-  .map((f) => path.join(svgDir, f));
+const svgJsFiles =
+  fs
+    .readdirSync(svgDir)
+    .filter((f) => svgJsFileExtRegex.test(f))
+    .map((f) => path.join(svgDir, f));
 
 ================================================================================
 `;
@@ -1433,15 +1435,17 @@ const component = find('.org-lclp-edit-copy-url-banner__link')[0]
   .indexOf(this.landingPageLink);
 
 =====================================output=====================================
-const version = someLongString
-  .split("jest version =")
-  .pop()
-  .split(EOL)[0]
-  .trim();
+const version =
+  someLongString
+    .split("jest version =")
+    .pop()
+    .split(EOL)[0]
+    .trim();
 
-const component = find(".org-lclp-edit-copy-url-banner__link")[0]
-  .getAttribute("href")
-  .indexOf(this.landingPageLink);
+const component =
+  find(".org-lclp-edit-copy-url-banner__link")[0]
+    .getAttribute("href")
+    .indexOf(this.landingPageLink);
 
 ================================================================================
 `;
@@ -1482,9 +1486,10 @@ const sel = this.connections
   .filter(x => x.selected);
 
 =====================================output=====================================
-const sel = this.connections
-  .concat(this.activities.concat(this.operators))
-  .filter((x) => x.selected);
+const sel =
+  this.connections
+    .concat(this.activities.concat(this.operators))
+    .filter((x) => x.selected);
 
 ================================================================================
 `;


### PR DESCRIPTION
## Description


**Proposal**: if the right-hand side of an assignment is a member chain, then:
- If the entire assignment fits on one line, keep it that way.
- If the member chain doesn't fit after the operator, it's moved to the next line *and is always split onto multiple lines* at that.

**Input:**
```jsx
const kochabCooieGameOnOboleUnweaveWayWay = someLongString.split("jest version =").pop().split(EOL)[0].trim();
```

**Current output ([playground](https://deploy-preview-10222--prettier.netlify.app/playground/#N4Igxg9gdgLgprEAuc0DOMAEBrCYAWAhgEYDCEEAlnAOKEC2cA8lE8RADZwCqUA7nEIA3OAHVCAT3ETMAXkxoIjADLQA5gGUYAJ0pQ1AOjQAHDpRgAKADogAVnAyYR2tJWhybASgPGIxi94mZpYAokzKngDaAAwAugY6lPQBANwgADQgfjBuUGjIoITa2hB8AApFCPkohBx8kvmZxNqEYNhwMBrGrXpqyDoArnCZcPTEcAAmE5PKhPoDhGpwAGIQ2vSEMDn6yCCEAzAQGSD4MPQcovjmDt1gcBpV5pRC5hK7YGiNIHpocNowZRaag2yAAZrVfplbGgAB4AIRabQ6GgYcGUejgYIhwzssI0vS4AEUBhB4FiOJCQN0XH9dsQSHAOMdjLpYKJKBMYPhkAAOaKZFkQX6iFrGXYshx-ETHACOJPggL81T2aAAtFA4JNJsdtHA5ZRdYDFiCkOCKTjfvRKP1tENMq59ET5ZjTdjMjASOzOdykAAmd0tShmfTkegmkAOACsxwGvwAKiRqmbKUIhgBJKDTWAaMC6YwwACCma0Ei45N+AF8K0A)):**
```jsx
const kochabCooieGameOnOboleUnweaveWayWay = someLongString
  .split("jest version =")
  .pop()
  .split(EOL)[0]
  .trim();
```

**Output, this PR ([playground](https://deploy-preview-10297--prettier.netlify.app/playground/#N4Igxg9gdgLgprEAuc0DOMAEBrCYAWAhgEYDCEEAlnAOKEC2cA8lE8RADZwCqUA7nEIA3OAHVCAT3ETMAXkxoIjADLQA5gGUYAJ0pQ1AOjQAHDpRgAKADogAVnAyYR2tJWhybASgPGIxi94mZpYAokzKngDaAAwAugY6lPQBANxWUCAANCB+MG5QaMighNraEHwACiUIhSiEHHyShdnE2oRg2HAwGsbtemrIOgCucNlw9MRwACZT08qE+kOEanAAYhDa9IQwefrIIIRDMBBZIPgw9Byi+OYOvWBwGjXmlELmEvtgaM0gemhw2hgFTaai2yAAZvV-tlbGgAB4AITaHS6GgYcGUejgEKhozs8I0-S4AEUhhB4DiONCQL0XAD9sQSHAOKdjLpYKJKFMYPhkAAOaLZNkQf6iNrGfZshwAkSnACOZPgwL8tQOaAAtFA4NNpqdtHAFZR9cDlmCkJCqXj-vRKINtCNsq59CTFdjzbjsjASJzubykAAmT1tShmfTkehmkAOACspyG-wAKiRahbqUIRgBJKCzWAaMC6YwwACC2a0Ei4lP+AF8q0A)):**
```jsx
const kochabCooieGameOnOboleUnweaveWayWay =
  someLongString
    .split("jest version =")
    .pop()
    .split(EOL)[0]
    .trim();
```

**Alternative output (should we prefer it probably?):**
```jsx
const kochabCooieGameOnOboleUnweaveWayWay =
  someLongString.split("jest version =").pop().split(EOL)[0].trim();
```

I like this idea, but 1) I somewhat dislike the implementation (this is just a PoC, I'll refactor/fix it if we decide to go this way), 2) would be good to hear opinions.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
