### PR TITLE
Remove `isLineNext`

### DIFF
--- a/src/document/doc-utils.js
+++ b/src/document/doc-utils.js
@@ -104,19 +104,6 @@ function findInDoc(doc, fn, defaultValue) {
   return result;
 }
 
-function isLineNextFn(doc) {
-  if (typeof doc === "string") {
-    return false;
-  }
-  if (doc.type === "line") {
-    return true;
-  }
-}
-
-function isLineNext(doc) {
-  return findInDoc(doc, isLineNextFn, false);
-}
-
 function willBreakFn(doc) {
   if (doc.type === "group" && doc.break) {
     return true;
@@ -379,7 +366,6 @@ module.exports = {
   isConcat,
   getDocParts,
   willBreak,
-  isLineNext,
   traverseDoc,
   findInDoc,
   mapDoc,

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -32,6 +32,9 @@ const {
 const pathNeedsParens = require("../needs-parens");
 const { willPrintOwnComments } = require("../comments");
 
+const isLineOrHardlineOrSoftline = (doc) =>
+  doc === line || doc === hardline || doc === softline;
+
 /**
  * @typedef {import("../../common/ast-path")} AstPath
  * @typedef {import("../types/estree").Node} Node
@@ -177,7 +180,7 @@ function printJsxElementInternal(path, options, print) {
   // Trim trailing lines (or empty strings)
   while (
     children.length > 0 &&
-    (!getLast(children) || isLineNext(getLast(children)))
+    (!getLast(children) || isLineOrHardlineOrSoftline(getLast(children)))
   ) {
     children.pop();
   }
@@ -185,8 +188,8 @@ function printJsxElementInternal(path, options, print) {
   // Trim leading lines (or empty strings)
   while (
     children.length > 0 &&
-    (!children[0] || isLineNext(children[0])) &&
-    (!children[1] || isLineNext(children[1]))
+    (!children[0] || isLineOrHardlineOrSoftline(children[0])) &&
+    (!children[1] || isLineOrHardlineOrSoftline(children[1]))
   ) {
     children.shift();
     children.shift();

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -32,8 +32,8 @@ const {
 const pathNeedsParens = require("../needs-parens");
 const { willPrintOwnComments } = require("../comments");
 
-const isLineOrHardlineOrSoftline = (doc) =>
-  doc === line || doc === hardline || doc === softline;
+const isEmptyStringOrAnyLine = (doc) =>
+  doc === "" || doc === line || doc === hardline || doc === softline;
 
 /**
  * @typedef {import("../../common/ast-path")} AstPath
@@ -178,18 +178,15 @@ function printJsxElementInternal(path, options, print) {
   }
 
   // Trim trailing lines (or empty strings)
-  while (
-    children.length > 0 &&
-    (!getLast(children) || isLineOrHardlineOrSoftline(getLast(children)))
-  ) {
+  while (children.length > 0 && isEmptyStringOrAnyLine(getLast(children))) {
     children.pop();
   }
 
   // Trim leading lines (or empty strings)
   while (
     children.length > 0 &&
-    (!children[0] || isLineOrHardlineOrSoftline(children[0])) &&
-    (!children[1] || isLineOrHardlineOrSoftline(children[1]))
+    isEmptyStringOrAnyLine(children[0]) &&
+    isEmptyStringOrAnyLine(children[1])
   ) {
     children.shift();
     children.shift();

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -14,7 +14,7 @@ const {
     lineSuffixBoundary,
     join,
   },
-  utils: { willBreak, isLineNext },
+  utils: { willBreak },
 } = require("../../document");
 
 const { getLast, getPreferredQuote } = require("../../common/util");

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -184,7 +184,7 @@ function printJsxElementInternal(path, options, print) {
 
   // Trim leading lines (or empty strings)
   while (
-    children.length > 0 &&
+    children.length > 1 &&
     isEmptyStringOrAnyLine(children[0]) &&
     isEmptyStringOrAnyLine(children[1])
   ) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

This function is testing `Doc` contains `{type: 'line'}`, but obviously should only allow `line`, `softline`, `hardline`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
