### PR TITLE
Allow arg hugging for non-concise arrow functions with return type

### DIFF
--- a/changelog_unreleased/typescript/10316.md
+++ b/changelog_unreleased/typescript/10316.md
@@ -1,0 +1,21 @@
+#### Allow hugging arguments that are non-concise arrow functions with return type annotations (#10316 by @thorn0)
+
+<!-- prettier-ignore -->
+```ts
+// Input
+users.map((user: User): User => {
+  return user;
+})
+
+// Prettier stable
+users.map(
+  (user: User): User => {
+    return user;
+  }
+);
+
+// Prettier main
+users.map((user: User): User => {
+  return user;
+})
+```

--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -238,13 +238,11 @@ function couldGroupArg(arg) {
       // app.get("/", (req, res): void => {
       //   res.send("Hello World!");
       // });
-      !(
-        arg.returnType &&
-        arg.returnType.typeAnnotation &&
-        arg.returnType.typeAnnotation.type === "TSTypeReference" &&
+      (!arg.returnType ||
+        !arg.returnType.typeAnnotation ||
+        arg.returnType.typeAnnotation.type !== "TSTypeReference" ||
         // https://github.com/prettier/prettier/issues/7542
-        (arg.body.type !== "BlockStatement" || arg.body.body.length === 0)
-      ) &&
+        isNonEmptyBlockStatement(arg.body)) &&
       (arg.body.type === "BlockStatement" ||
         arg.body.type === "ArrowFunctionExpression" ||
         arg.body.type === "ObjectExpression" ||
@@ -298,6 +296,14 @@ function isReactHookCallWithDepsArray(args) {
     args[0].body.type === "BlockStatement" &&
     args[1].type === "ArrayExpression" &&
     !args.some((arg) => hasComment(arg))
+  );
+}
+
+function isNonEmptyBlockStatement(node) {
+  return (
+    node.type === "BlockStatement" &&
+    (node.body.some((node) => node.type !== "EmptyStatement") ||
+      hasComment(node, CommentCheckFlags.Dangling))
   );
 }
 

--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -238,9 +238,13 @@ function couldGroupArg(arg) {
       // app.get("/", (req, res): void => {
       //   res.send("Hello World!");
       // });
-      (!arg.returnType ||
-        !arg.returnType.typeAnnotation ||
-        arg.returnType.typeAnnotation.type !== "TSTypeReference") &&
+      !(
+        arg.returnType &&
+        arg.returnType.typeAnnotation &&
+        arg.returnType.typeAnnotation.type === "TSTypeReference" &&
+        // https://github.com/prettier/prettier/issues/7542
+        (arg.body.type !== "BlockStatement" || arg.body.body.length === 0)
+      ) &&
       (arg.body.type === "BlockStatement" ||
         arg.body.type === "ArrowFunctionExpression" ||
         arg.body.type === "ObjectExpression" ||

--- a/tests/typescript/typeparams/print-width-120/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/typeparams/print-width-120/__snapshots__/jsfmt.spec.js.snap
@@ -18,6 +18,14 @@ users.map((user: User): User => {
   return user;
 })
 
+users.map((user: User): User => {
+  ; // comment
+})
+
+users.map((user: User): User => {
+  // comment
+})
+
 =====================================output=====================================
 export const Foo = forwardRef((props: FooProps, ref: Ref<HTMLElement>): JSX.Element => {
   return <div />;
@@ -29,6 +37,14 @@ export const Bar = forwardRef((props: BarProps, ref: Ref<HTMLElement>): JSX.Elem
 
 users.map((user: User): User => {
   return user;
+});
+
+users.map((user: User): User => {
+  // comment
+});
+
+users.map((user: User): User => {
+  // comment
 });
 
 ================================================================================

--- a/tests/typescript/typeparams/print-width-120/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/typeparams/print-width-120/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`issue-7542.ts - {"printWidth":120} format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 120
+                                                                                                                        | printWidth
+=====================================input======================================
+export const Foo = forwardRef((props: FooProps, ref: Ref<HTMLElement>): JSX.Element => {
+  return <div />;
+});
+
+export const Bar = forwardRef((props: BarProps, ref: Ref<HTMLElement>): JSX.Element | null => {
+  return <div />;
+});
+
+users.map((user: User): User => {
+  return user;
+})
+
+=====================================output=====================================
+export const Foo = forwardRef((props: FooProps, ref: Ref<HTMLElement>): JSX.Element => {
+  return <div />;
+});
+
+export const Bar = forwardRef((props: BarProps, ref: Ref<HTMLElement>): JSX.Element | null => {
+  return <div />;
+});
+
+users.map((user: User): User => {
+  return user;
+});
+
+================================================================================
+`;

--- a/tests/typescript/typeparams/print-width-120/issue-7542.ts
+++ b/tests/typescript/typeparams/print-width-120/issue-7542.ts
@@ -9,3 +9,11 @@ export const Bar = forwardRef((props: BarProps, ref: Ref<HTMLElement>): JSX.Elem
 users.map((user: User): User => {
   return user;
 })
+
+users.map((user: User): User => {
+  ; // comment
+})
+
+users.map((user: User): User => {
+  // comment
+})

--- a/tests/typescript/typeparams/print-width-120/issue-7542.ts
+++ b/tests/typescript/typeparams/print-width-120/issue-7542.ts
@@ -1,0 +1,11 @@
+export const Foo = forwardRef((props: FooProps, ref: Ref<HTMLElement>): JSX.Element => {
+  return <div />;
+});
+
+export const Bar = forwardRef((props: BarProps, ref: Ref<HTMLElement>): JSX.Element | null => {
+  return <div />;
+});
+
+users.map((user: User): User => {
+  return user;
+})

--- a/tests/typescript/typeparams/print-width-120/jsfmt.spec.js
+++ b/tests/typescript/typeparams/print-width-120/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["typescript"], { printWidth: 120 });


### PR DESCRIPTION
## Description

Fixes #7542

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
