### PR TITLE
Don't use smart quotes for JSON5 with --quote-props=preserve

### DIFF
--- a/changelog_unreleased/json/10323.md
+++ b/changelog_unreleased/json/10323.md
@@ -1,0 +1,21 @@
+#### Don't use smart quotes for JSON5 with `--quote-props=preserve` (#10323 by @thorn0)
+
+With the `quoteProps` option set to `preserve` and `singleQuotes` to `false` (default), double quotes are always used for printing strings, including situations like `"bla\"bla"`. This effectively allows using `--parser json5` for "JSON with comments and trailing commas".
+
+<!-- prettier-ignore -->
+```js
+// Input
+{
+  "char": "\"",
+}
+
+// Prettier stable
+{
+  "char": '"',
+}
+
+// Prettier main
+{
+  "char": "\"",
+}
+```

--- a/docs/options.md
+++ b/docs/options.md
@@ -96,6 +96,8 @@ Note that Prettier never unquotes numeric property names in Angular expressions,
 [quote-props-flow]: https://flow.org/try/#0PQKgBAAgZgNg9gdzCYAoVBjOA7AzgFzAA8wBeMAb1TDAAYAuMARlQF8g
 [quote-props-vue]: https://github.com/prettier/prettier/issues/10127
 
+If this option is set to `preserve`, `singleQuote` to `false` (default value), and `parser` to `json5`, double quotes are always used for strings. This effectively allows using the `json5` parser for “JSON with comments and trailing commas”.
+
 ## JSX Quotes
 
 Use single quotes instead of double quotes in JSX.

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -393,7 +393,10 @@ function printString(raw, options, isDirectiveLiteral) {
 
   /** @type {Quote} */
   const enclosingQuote =
-    options.parser === "json"
+    options.parser === "json" ||
+    (options.parser === "json5" &&
+      options.quoteProps === "preserve" &&
+      !options.singleQuote)
       ? '"'
       : options.__isInHtmlAttribute
       ? "'"

--- a/tests/json/json5-as-json-with-trailing-commas/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/json/json5-as-json-with-trailing-commas/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`nested-quotes.json - {"quoteProps":"preserve"} format 1`] = `
+====================================options=====================================
+parsers: ["json5"]
+printWidth: 80
+quoteProps: "preserve"
+                                                                                | printWidth
+=====================================input======================================
+{"allOn": "Single", "Line": "example",
+"noSpace":true,
+  "quote": {
+    'singleQuote': 'exa"mple',
+                  "indented": true,
+  },
+  "phoneNumbers": [
+    {"type'": "home",
+      "number\\"": "212 555-1234"},
+    {"type": "office",
+      "trailing": "commas by accident"},
+  ],
+}
+
+=====================================output=====================================
+{
+  "allOn": "Single",
+  "Line": "example",
+  "noSpace": true,
+  "quote": {
+    "singleQuote": "exa\\"mple",
+    "indented": true,
+  },
+  "phoneNumbers": [
+    { "type'": "home", "number\\"": "212 555-1234" },
+    { "type": "office", "trailing": "commas by accident" },
+  ],
+}
+
+================================================================================
+`;

--- a/tests/json/json5-as-json-with-trailing-commas/jsfmt.spec.js
+++ b/tests/json/json5-as-json-with-trailing-commas/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["json5"], { quoteProps: "preserve" });

--- a/tests/json/json5-as-json-with-trailing-commas/nested-quotes.json
+++ b/tests/json/json5-as-json-with-trailing-commas/nested-quotes.json
@@ -1,0 +1,13 @@
+{"allOn": "Single", "Line": "example",
+"noSpace":true,
+  "quote": {
+    'singleQuote': 'exa"mple',
+                  "indented": true,
+  },
+  "phoneNumbers": [
+    {"type'": "home",
+      "number\"": "212 555-1234"},
+    {"type": "office",
+      "trailing": "commas by accident"},
+  ],
+}


### PR DESCRIPTION
## Description

Fixes #5708
More specifically, addresses https://github.com/prettier/prettier/issues/5708#issuecomment-510571797

With the `quoteProps` option set to `preserve` and `singleQuotes` to `false` (default), double quotes are always used for printing strings, including situations like this: `"bla\"bla"`. This effectively allows using `--parser json5` for "JSON with comments and trailing commas".

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
