### PR TITLE
Correct parentheses for non-null assertions

### DIFF
--- a/changelog_unreleased/typescript/10337.md
+++ b/changelog_unreleased/typescript/10337.md
@@ -1,0 +1,27 @@
+#### Correct parentheses for non-null assertions (#10337 by @thorn0)
+
+Necessary parentheses sometimes weren't printed in expressions containing non-null assertions. This has been fixed.
+
+<!-- prettier-ignore -->
+```ts
+// Input
+const myFunction2 = (key: string): number =>
+  ({
+    a: 42,
+    b: 42,
+  }[key]!)
+
+// Prettier stable (invalid syntax)
+const myFunction2 = (key: string): number =>
+  {
+    a: 42,
+    b: 42,
+  }[key]!;
+
+// Prettier main
+const myFunction2 = (key: string): number =>
+  ({
+    a: 42,
+    b: 42,
+  }[key]!);
+```

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -87,7 +87,8 @@ function needsParens(path, options) {
           node.type === "TaggedTemplateExpression" ||
           node.type === "UnaryExpression" ||
           node.type === "UpdateExpression" ||
-          node.type === "YieldExpression")
+          node.type === "YieldExpression" ||
+          node.type === "TSNonNullExpression")
       ) {
         return true;
       }
@@ -616,6 +617,7 @@ function needsParens(path, options) {
           return name === "object";
 
         case "TSAsExpression":
+        case "TSNonNullExpression":
         case "BindExpression":
         case "TaggedTemplateExpression":
         case "UnaryExpression":

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -1042,6 +1042,7 @@ function startsWithNoLookaheadToken(node, forbidFunctionClassAndDoExpr) {
         forbidFunctionClassAndDoExpr
       );
     case "TSAsExpression":
+    case "TSNonNullExpression":
       return startsWithNoLookaheadToken(
         node.expression,
         forbidFunctionClassAndDoExpr

--- a/tests/typescript/non-null/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/non-null/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`braces.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const myFunction2 = (key: string): number =>
+  ({
+    a: 42,
+    b: 42,
+  }[key]!)
+
+const myFunction3 = key => ({}!.a);
+
+const f = ((a) => {log(a)})!;
+
+if (a) ({ a, ...b }.a())!.c();
+
+(function() {})!()
+
+class a extends ({}!) {}
+
+=====================================output=====================================
+const myFunction2 = (key: string): number =>
+  ({
+    a: 42,
+    b: 42,
+  }[key]!);
+
+const myFunction3 = (key) => ({}!.a);
+
+const f = ((a) => {
+  log(a);
+})!;
+
+if (a) ({ a, ...b }.a()!.c());
+
+(function () {}!());
+
+class a extends ({}!) {}
+
+================================================================================
+`;
+
 exports[`member-chain.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/typescript/non-null/braces.ts
+++ b/tests/typescript/non-null/braces.ts
@@ -1,0 +1,15 @@
+const myFunction2 = (key: string): number =>
+  ({
+    a: 42,
+    b: 42,
+  }[key]!)
+
+const myFunction3 = key => ({}!.a);
+
+const f = ((a) => {log(a)})!;
+
+if (a) ({ a, ...b }.a())!.c();
+
+(function() {})!()
+
+class a extends ({}!) {}


### PR DESCRIPTION
## Description

Fixes #10336

## Checklist

Necessary parentheses sometimes weren't printed in expressions containing non-null assertions. This has been fixed.

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
