### PR TITLE
Better formatting for nested await in member/call expression heads

### DIFF
--- a/changelog_unreleased/javascript/10342.md
+++ b/changelog_unreleased/javascript/10342.md
@@ -1,0 +1,34 @@
+#### Force line breaks for nested await expressions in member/call expression heads (#10342 by @thorn0)
+
+Even though Prettier tries to be helpful here, please don't write code like this. Have mercy upon your teammates and use intermediate variables.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+const getAccountCount = async () =>
+  (await
+    (await (
+      await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
+    ).findItem("My bookmarks")).getChildren()
+  ).length
+
+// Prettier stable
+const getAccountCount = async () =>
+  (
+    await (
+      await (await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)).findItem(
+        "My bookmarks"
+      )
+    ).getChildren()
+  ).length;
+
+// Prettier main
+const getAccountCount = async () =>
+  (
+    await (
+      await (
+        await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
+      ).findItem("My bookmarks")
+    ).getChildren()
+  ).length;
+```

--- a/changelog_unreleased/javascript/10342.md
+++ b/changelog_unreleased/javascript/10342.md
@@ -1,4 +1,4 @@
-#### Force line breaks for nested await expressions in member/call expression heads (#10342 by @thorn0)
+#### Improve formatting for nested await expressions in heads of member and call expressions (#10342 by @thorn0)
 
 Even though Prettier tries to be helpful here, please don't write code like this. Have mercy upon your teammates and use intermediate variables.
 

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -146,6 +146,39 @@ class AstPath {
 
     return true;
   }
+
+  /**
+   * Inspired by https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
+   * @param {(node: any, name: string | null, number: number | null) => boolean} predicate
+   */
+  closest(predicate) {
+    let stackPointer = this.stack.length - 1;
+
+    let name = null;
+    let node = this.stack[stackPointer--];
+
+    for (;;) {
+      /* istanbul ignore next */
+      if (node === undefined) {
+        return;
+      }
+
+      // skip index/array
+      let number = null;
+      if (typeof name === "number") {
+        number = name;
+        name = this.stack[stackPointer--];
+        node = this.stack[stackPointer--];
+      }
+
+      if (predicate(node, name, number)) {
+        return node;
+      }
+
+      name = this.stack[stackPointer--];
+      node = this.stack[stackPointer--];
+    }
+  }
 }
 
 module.exports = AstPath;

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -148,6 +148,10 @@ class AstPath {
   }
 
   /**
+   * Traverses the current node and its parents (heading toward the tree root)
+   * until it finds a node that matches the provided predicate function. Will
+   * return the current node or the matching ancestor. If no such node exists,
+   * it returns undefined.
    * Inspired by https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
    * @param {(node: any, name: string | null, number: number | null) => boolean} predicate
    */
@@ -157,12 +161,7 @@ class AstPath {
     let name = null;
     let node = this.stack[stackPointer--];
 
-    for (;;) {
-      /* istanbul ignore next */
-      if (node === undefined) {
-        return;
-      }
-
+    while (node) {
       // skip index/array
       let number = null;
       if (typeof name === "number") {

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -148,14 +148,13 @@ class AstPath {
   }
 
   /**
-   * Traverses the current node and its parents (heading toward the tree root)
+   * Traverses the ancestors of the current node heading toward the tree root
    * until it finds a node that matches the provided predicate function. Will
-   * return the current node or the matching ancestor. If no such node exists,
-   * it returns undefined.
-   * Inspired by https://developer.mozilla.org/en-US/docs/Web/API/Element/closest
-   * @param {(node: any, name: string | null, number: number | null) => boolean} predicate
+   * return the first matching ancestor. If no such node exists, returns undefined.
+   * @param {(node: any, name: string, number: number | null) => boolean} predicate
+   * @internal Unstable API. Don't use in plugins for now.
    */
-  closest(predicate) {
+  findClosestAncestor(predicate) {
     let stackPointer = this.stack.length - 1;
 
     let name = null;
@@ -170,7 +169,7 @@ class AstPath {
         node = this.stack[stackPointer--];
       }
 
-      if (predicate(node, name, number)) {
+      if (name !== null && predicate(node, name, number)) {
         return node;
       }
 

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -154,7 +154,7 @@ class AstPath {
    * @param {(node: any, name: string, number: number | null) => boolean} predicate
    * @internal Unstable API. Don't use in plugins for now.
    */
-  findClosestAncestor(predicate) {
+  findAncestor(predicate) {
     let stackPointer = this.stack.length - 1;
 
     let name = null;

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -373,16 +373,17 @@ function printPathNoParens(path, options, print, args) {
           (isCallExpression(parent) && parent.callee === n) ||
           (isMemberExpression(parent) && parent.object === n)
         ) {
-          const parentAwaitOrBlock = path.closest(
-            (node) =>
-              (node.type === "AwaitExpression" && node !== n) ||
-              node.type === "BlockStatement"
-          );
-          const shouldGroup =
-            !parentAwaitOrBlock ||
-            parentAwaitOrBlock.type !== "AwaitExpression";
           parts = [indent([softline, ...parts]), softline];
-          return shouldGroup ? group(parts) : parts;
+          const parentAwaitOrBlock = path.findClosestAncestor(
+            (node) =>
+              node.type === "AwaitExpression" || node.type === "BlockStatement"
+          );
+          if (
+            !parentAwaitOrBlock ||
+            parentAwaitOrBlock.type !== "AwaitExpression"
+          ) {
+            return group(parts);
+          }
         }
       }
       return parts;

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -378,11 +378,11 @@ function printPathNoParens(path, options, print, args) {
               (node.type === "AwaitExpression" && node !== n) ||
               node.type === "BlockStatement"
           );
-          const lineBreak =
-            parentAwaitOrBlock && parentAwaitOrBlock.type === "AwaitExpression"
-              ? hardline
-              : softline;
-          return group([indent([lineBreak, ...parts]), lineBreak]);
+          const shouldGroup =
+            !parentAwaitOrBlock ||
+            parentAwaitOrBlock.type !== "AwaitExpression";
+          parts = [indent([softline, ...parts]), softline];
+          return shouldGroup ? group(parts) : parts;
         }
       }
       return parts;

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -368,13 +368,22 @@ function printPathNoParens(path, options, print, args) {
       parts.push("await");
       if (n.argument) {
         parts.push(" ", path.call(print, "argument"));
-      }
-      const parent = path.getParentNode();
-      if (
-        (isCallExpression(parent) && parent.callee === n) ||
-        (isMemberExpression(parent) && parent.object === n)
-      ) {
-        return group([indent([softline, ...parts]), softline]);
+        const parent = path.getParentNode();
+        if (
+          (isCallExpression(parent) && parent.callee === n) ||
+          (isMemberExpression(parent) && parent.object === n)
+        ) {
+          const parentAwaitOrBlock = path.closest(
+            (node) =>
+              (node.type === "AwaitExpression" && node !== n) ||
+              node.type === "BlockStatement"
+          );
+          const lineBreak =
+            parentAwaitOrBlock && parentAwaitOrBlock.type === "AwaitExpression"
+              ? hardline
+              : softline;
+          return group([indent([lineBreak, ...parts]), lineBreak]);
+        }
       }
       return parts;
     }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -374,7 +374,7 @@ function printPathNoParens(path, options, print, args) {
           (isMemberExpression(parent) && parent.object === n)
         ) {
           parts = [indent([softline, ...parts]), softline];
-          const parentAwaitOrBlock = path.findClosestAncestor(
+          const parentAwaitOrBlock = path.findAncestor(
             (node) =>
               node.type === "AwaitExpression" || node.type === "BlockStatement"
           );

--- a/tests/js/async/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/async/__snapshots__/jsfmt.spec.js.snap
@@ -157,6 +157,33 @@ async function f() {
 ================================================================================
 `;
 
+exports[`nested.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const getAccountCount = async () =>
+  (await
+    (await (
+      await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
+    ).findItem("My bookmarks")
+  ).getChildren()
+  ).length
+
+=====================================output=====================================
+const getAccountCount = async () =>
+  (
+    await (
+      await (
+        await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
+      ).findItem("My bookmarks")
+    ).getChildren()
+  ).length;
+
+================================================================================
+`;
+
 exports[`parens.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/js/async/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/async/__snapshots__/jsfmt.spec.js.snap
@@ -205,3 +205,23 @@ async function f2() {
 
 ================================================================================
 `;
+
+exports[`simple-nested-await.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+async function f() {
+  const a = await (await request()).json();
+  const b = await fs.writeFile(file, await (await request()).text());
+}
+
+=====================================output=====================================
+async function f() {
+  const a = await (await request()).json();
+  const b = await fs.writeFile(file, await (await request()).text());
+}
+
+================================================================================
+`;

--- a/tests/js/async/nested.js
+++ b/tests/js/async/nested.js
@@ -1,0 +1,7 @@
+const getAccountCount = async () =>
+  (await
+    (await (
+      await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
+    ).findItem("My bookmarks")
+  ).getChildren()
+  ).length

--- a/tests/js/async/simple-nested-await.js
+++ b/tests/js/async/simple-nested-await.js
@@ -1,0 +1,4 @@
+async function f() {
+  const a = await (await request()).json();
+  const b = await fs.writeFile(file, await (await request()).text());
+}


### PR DESCRIPTION
## Description

Part II for #10340

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
