### PR TITLE
Add prettier-ignore comment for copying markdown from Playground

### DIFF
--- a/website/playground/markdown.js
+++ b/website/playground/markdown.js
@@ -68,9 +68,12 @@ function codeBlock(content, syntax) {
   const longestBacktickSequenceLength = Math.max(
     ...backtickSequences.map(({ length }) => length)
   );
+  const prettierIgnoreComment = "<!-- prettier-ignore -->";
   const fenceLength = Math.max(3, longestBacktickSequenceLength + 1);
   const fence = "`".repeat(fenceLength);
-  return [fence + (syntax || ""), content, fence].join("\n");
+  return [prettierIgnoreComment, fence + (syntax || ""), content, fence].join(
+    "\n"
+  );
 }
 
 module.exports = formatMarkdown;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

I often paste copied markdown from playground to a text editor that support Prettier integration.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
