### PR TITLE
Make JSON parser stricter

### DIFF
--- a/changelog_unreleased/json/10346.md
+++ b/changelog_unreleased/json/10346.md
@@ -1,4 +1,4 @@
-#### Stricter JSON parser (#10323 by @thorn0)
+#### Stricter JSON parser (#10346 by @fisker)
 
 Previously we allow all kinds of JavaScript expressions in `json` and `json5` parser, now they are stricter.
 

--- a/changelog_unreleased/json/10346.md
+++ b/changelog_unreleased/json/10346.md
@@ -1,0 +1,17 @@
+#### Stricter JSON parser (#10323 by @thorn0)
+
+Previously we allow all kinds of JavaScript expressions in `json` and `json5` parser, now they are stricter.
+
+<!-- prettier-ignore -->
+```js
+// Input
+[1, 2, 1 + 2]
+
+// Prettier stable
+[1, 2, 1 + 2]
+
+// Prettier main
+SyntaxError: BinaryExpression is not allowed in JSON. (1:8)
+> 1 | [1, 2, 1 + 2]
+    |        ^
+```

--- a/src/language-js/parser-babel.js
+++ b/src/language-js/parser-babel.js
@@ -180,9 +180,8 @@ function shouldRethrowRecoveredError(error) {
   return messagesShouldThrow.has(message);
 }
 
-function createJsonParse(options) {
-  // @ts-ignore
-  const { allowComments } = { allowComments: true, ...options };
+function createJsonParse(options = {}) {
+  const { allowComments = true } = options;
 
   return function parse(text /*, parsers, options*/) {
     let ast;

--- a/src/language-js/parser-babel.js
+++ b/src/language-js/parser-babel.js
@@ -153,6 +153,7 @@ const parseTypeScript = createParse(
   ["typescript"]
 );
 const parseExpression = createParse("parseExpression", ["jsx"]);
+const parseJson = createJsonParse();
 
 const messagesShouldThrow = new Set([
   // TSErrors.UnexpectedTypeAnnotation
@@ -179,7 +180,7 @@ function shouldRethrowRecoveredError(error) {
   return messagesShouldThrow.has(message);
 }
 
-function createJsonParser(options) {
+function createJsonParse(options) {
   const { allowComments } = { allowComments: true, ...options };
 
   return function parse(text, parsers, opts) {
@@ -270,7 +271,6 @@ function assertJsonNode(node, parent) {
 
 const babel = createParser(parse);
 const babelExpression = createParser(parseExpression);
-const parseJson = createJsonParser();
 
 // Export as a plugin so we can reuse the same bundle for UMD loading
 module.exports = {
@@ -286,7 +286,7 @@ module.exports = {
     }),
     json5: createParser(parseJson),
     "json-stringify": createParser({
-      parse: createJsonParser({ allowComments: false }),
+      parse: createJsonParse({ allowComments: false }),
       astFormat: "estree-json",
     }),
     /** @internal */

--- a/src/language-js/parser-babel.js
+++ b/src/language-js/parser-babel.js
@@ -181,6 +181,7 @@ function shouldRethrowRecoveredError(error) {
 }
 
 function createJsonParse(options) {
+  // @ts-ignore
   const { allowComments } = { allowComments: true, ...options };
 
   return function parse(text, parsers, opts) {
@@ -195,6 +196,7 @@ function createJsonParse(options) {
     }
 
     if (!allowComments) {
+      // @ts-ignore
       for (const comment of ast.comments) {
         assertJsonNode(comment);
       }

--- a/src/language-js/parser-babel.js
+++ b/src/language-js/parser-babel.js
@@ -184,7 +184,7 @@ function createJsonParse(options) {
   // @ts-ignore
   const { allowComments } = { allowComments: true, ...options };
 
-  return function parse(text, parsers, opts) {
+  return function parse(text /*, parsers, options*/) {
     let ast;
     try {
       ast = require("@babel/parser").parseExpression(text, {

--- a/tests/markdown/multiparser-json/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/markdown/multiparser-json/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`invalid-json.md - {"trailingComma":"all"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+<!-- #10333 -->
+\`\`\`json
+packages\\the-hub\\cypress\\fixtures\\gridConfiguration.json
+\`\`\`
+=====================================output=====================================
+<!-- #10333 -->
+
+\`\`\`json
+packages\\the-hub\\cypress\\fixtures\\gridConfiguration.json
+\`\`\`
+
+================================================================================
+`;
+
 exports[`jsonc.md - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
 parsers: ["markdown"]

--- a/tests/markdown/multiparser-json/invalid-json.md
+++ b/tests/markdown/multiparser-json/invalid-json.md
@@ -1,0 +1,4 @@
+<!-- #10333 -->
+```json
+packages\the-hub\cypress\fixtures\gridConfiguration.json
+```

--- a/tests/misc/errors/json/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/misc/errors/json/__snapshots__/jsfmt.spec.js.snap
@@ -47,3 +47,16 @@ exports[`snippet: #5 [json-stringify] format 1`] = `
 > 1 | {\\"foo\\": () => {}}
     |         ^"
 `;
+
+exports[`snippet: #6 [json-stringify] format 1`] = `
+"CommentBlock is not allowed in JSON. (1:1)
+> 1 | /* comment */{\\"foo\\": 1}
+    | ^"
+`;
+
+exports[`snippet: #7 [json-stringify] format 1`] = `
+"CommentLine is not allowed in JSON. (1:1)
+> 1 | // comment
+    | ^
+  2 | {\\"foo\\": 1}"
+`;

--- a/tests/misc/errors/json/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/misc/errors/json/__snapshots__/jsfmt.spec.js.snap
@@ -1,9 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`snippet: #0 [json] format 1`] = `
+"Expecting Unicode escape sequence \\\\uXXXX (1:10)
+> 1 | packages\\\\the-hub\\\\cypress\\\\fixtures\\\\gridConfiguration.json
+    |          ^"
+`;
+
 exports[`snippet: #0 [json-stringify] format 1`] = `
 "ObjectProperty with shorthand=true is not allowed in JSON. (1:2)
 > 1 | {foo}
     |  ^"
+`;
+
+exports[`snippet: #1 [json] format 1`] = `
+"BinaryExpression is not allowed in JSON. (1:1)
+> 1 | 1+2
+    | ^"
 `;
 
 exports[`snippet: #1 [json-stringify] format 1`] = `

--- a/tests/misc/errors/json/jsfmt.spec.js
+++ b/tests/misc/errors/json/jsfmt.spec.js
@@ -8,6 +8,8 @@ run_spec(
       '{"foo": false || "bar"}',
       '{"foo": undefined}',
       '{"foo": () => {}}',
+      '/* comment */{"foo": 1}',
+      '// comment\n{"foo": 1}',
     ],
   },
   ["json-stringify"]

--- a/tests/misc/errors/json/jsfmt.spec.js
+++ b/tests/misc/errors/json/jsfmt.spec.js
@@ -12,3 +12,14 @@ run_spec(
   },
   ["json-stringify"]
 );
+
+run_spec(
+  {
+    dirname: __dirname,
+    snippets: [
+      "packages\\the-hub\\cypress\\fixtures\\gridConfiguration.json",
+      "1+2",
+    ],
+  },
+  ["json"]
+);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Make JSON parser stricter, I don't think we should allow all expressions.
And we don't need all the `plugins` and `errorRecovery`.


Fixes #10333


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
