### PR TITLE
Refactor `Hashbang` parse

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -137,5 +137,6 @@ overrides:
             - getComments
         - "src/language-js/parse-postprocess.js"
         - "src/language-js/parser-babel.js"
+        - "src/language-js/parser-espree.js"
         - "src/language-js/parser-meriyah.js"
         - "src/language-js/pragma.js"

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -613,17 +613,6 @@ function isFrontMatterNode(node) {
   return node && node.type === "front-matter";
 }
 
-function getShebang(text) {
-  if (!text.startsWith("#!")) {
-    return "";
-  }
-  const index = text.indexOf("\n");
-  if (index === -1) {
-    return text;
-  }
-  return text.slice(0, index);
-}
-
 function isNonEmptyArray(object) {
   return Array.isArray(object) && object.length > 0;
 }
@@ -694,7 +683,6 @@ module.exports = {
   addDanglingComment,
   addTrailingComment,
   isFrontMatterNode,
-  getShebang,
   isNonEmptyArray,
   createGroupIdMapper,
 };

--- a/src/language-js/parse-postprocess.js
+++ b/src/language-js/parse-postprocess.js
@@ -3,19 +3,19 @@
 const {
   getLast,
   getNextNonSpaceNonCommentCharacter,
-  getShebang,
 } = require("../common/util");
+const parseHashbang = require("../utils/hashbang");
 const createError = require("../common/parser-create-error");
 const { locStart, locEnd } = require("./loc");
 const { isTypeCastComment } = require("./comments");
 
 function postprocess(ast, options) {
-  if (
-    options.parser === "typescript" ||
-    options.parser === "flow" ||
-    options.parser === "espree"
-  ) {
-    includeShebang(ast, options);
+  if (options.parser === "typescript" || options.parser === "flow") {
+    const hashbang = parseHashbang(options.originalText);
+
+    if (hashbang) {
+      ast.comments.unshift(hashbang);
+    }
   }
 
   // Invalid decorators are removed since `@typescript-eslint/typescript-estree` v4
@@ -263,18 +263,6 @@ function rebalanceLogicalTree(node) {
     right: node.right.right,
     range: [locStart(node), locEnd(node)],
   });
-}
-
-function includeShebang(ast, options) {
-  const shebang = getShebang(options.originalText);
-
-  if (shebang) {
-    ast.comments.unshift({
-      type: "Line",
-      value: shebang.slice(2),
-      range: [0, shebang.length],
-    });
-  }
 }
 
 module.exports = postprocess;

--- a/src/language-js/parser-babel.js
+++ b/src/language-js/parser-babel.js
@@ -5,8 +5,8 @@ const createError = require("../common/parser-create-error");
 const tryCombinations = require("../utils/try-combinations");
 const {
   getNextNonSpaceNonCommentCharacterIndexWithStartIndex,
-  getShebang,
 } = require("../common/util");
+const parseHashbang = require("../utils/hashbang");
 const postprocess = require("./parse-postprocess");
 const createParser = require("./parser/create-parser");
 
@@ -57,9 +57,9 @@ function isFlowFile(text, options) {
     return true;
   }
 
-  const shebang = getShebang(text);
-  if (shebang) {
-    text = text.slice(shebang.length);
+  const hashbang = parseHashbang(text);
+  if (hashbang) {
+    text = text.slice(hashbang.range[1]);
   }
 
   const firstNonSpaceNonCommentCharacterIndex = getNextNonSpaceNonCommentCharacterIndexWithStartIndex(

--- a/src/language-js/pragma.js
+++ b/src/language-js/pragma.js
@@ -1,19 +1,19 @@
 "use strict";
 
 const { parseWithComments, strip, extract, print } = require("jest-docblock");
-const { getShebang } = require("../common/util");
+const parseHashbang = require("../utils/hashbang");
 const { normalizeEndOfLine } = require("../common/end-of-line");
 
 function parseDocBlock(text) {
-  const shebang = getShebang(text);
-  if (shebang) {
-    text = text.slice(shebang.length + 1);
+  const hashbang = parseHashbang(text);
+  if (hashbang) {
+    text = text.slice(hashbang.range[1] + 1);
   }
 
   const docBlock = extract(text);
   const { pragmas, comments } = parseWithComments(docBlock);
 
-  return { shebang, text, pragmas, comments };
+  return { hashbang, text, pragmas, comments };
 }
 
 function hasPragma(text) {
@@ -22,7 +22,7 @@ function hasPragma(text) {
 }
 
 function insertPragma(originalText) {
-  const { shebang, text, pragmas, comments } = parseDocBlock(originalText);
+  const { hashbang, text, pragmas, comments } = parseDocBlock(originalText);
   const strippedText = strip(text);
 
   const docBlock = print({
@@ -34,7 +34,7 @@ function insertPragma(originalText) {
   });
 
   return (
-    (shebang ? `${shebang}\n` : "") +
+    (hashbang ? `#!${hashbang.value}\n` : "") +
     // normalise newlines (mitigate use of os.EOL by jest-docblock)
     normalizeEndOfLine(docBlock) +
     (strippedText.startsWith("\n") ? "\n" : "\n\n") +

--- a/src/utils/hashbang.js
+++ b/src/utils/hashbang.js
@@ -1,0 +1,21 @@
+"use strict";
+
+function parseHashbang(text) {
+  if (!text.startsWith("#!")) {
+    return;
+  }
+
+  let end = text.indexOf("\n");
+  if (end === -1) {
+    end = text.length;
+  }
+  const value = text.slice(2, end);
+
+  return {
+    type: "Line",
+    value,
+    range: [0, end],
+  };
+}
+
+module.exports = parseHashbang;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

- Use `hashbang` term instead of `shebang` to align with [`proposal-hashbang`](https://github.com/tc39/proposal-hashbang)
- Avoid parse twice in `espree` parser
- Return an ESTree node, instead of hashbang string

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
