### PR TITLE
Heuristic for grouping parameters in method signatures

### DIFF
--- a/changelog_unreleased/typescript/10024.md
+++ b/changelog_unreleased/typescript/10024.md
@@ -1,4 +1,4 @@
-#### Fix unnecessary line breaks in method type declaration parameters (#10024 by @sosukesuzuki)
+#### Fix unnecessary line breaks in method type declaration parameters (#10024 by @sosukesuzuki, #10357 by @thorn0)
 
 <!-- prettier-ignore -->
 ```js

--- a/src/language-js/print/function-parameters.js
+++ b/src/language-js/print/function-parameters.js
@@ -4,7 +4,7 @@ const { getNextNonSpaceNonCommentCharacter } = require("../../common/util");
 const { printDanglingComments } = require("../../main/comments");
 const {
   builders: { line, hardline, softline, group, indent, ifBreak },
-  utils: { removeLines },
+  utils: { removeLines, willBreak },
 } = require("../../document");
 const {
   getFunctionParameters,
@@ -189,4 +189,18 @@ function shouldHugFunctionParameters(node) {
   );
 }
 
-module.exports = { printFunctionParameters, shouldHugFunctionParameters };
+function shouldGroupFunctionParameters(returnTypeNode, returnTypeDoc) {
+  if (returnTypeNode && returnTypeNode.typeAnnotation) {
+    returnTypeNode = returnTypeNode.typeAnnotation;
+  }
+  if (!returnTypeNode) {
+    return false;
+  }
+  return isObjectType(returnTypeNode) || willBreak(returnTypeDoc);
+}
+
+module.exports = {
+  printFunctionParameters,
+  shouldHugFunctionParameters,
+  shouldGroupFunctionParameters,
+};

--- a/src/language-js/print/function-parameters.js
+++ b/src/language-js/print/function-parameters.js
@@ -189,14 +189,24 @@ function shouldHugFunctionParameters(node) {
   );
 }
 
-function shouldGroupFunctionParameters(returnTypeNode, returnTypeDoc) {
-  if (returnTypeNode && returnTypeNode.typeAnnotation) {
-    returnTypeNode = returnTypeNode.typeAnnotation;
-  }
-  if (!returnTypeNode) {
+// When parameters are grouped, the return type annotation breaks first.
+function shouldGroupFunctionParameters(functionNode, returnTypeDoc) {
+  let returnTypeNode;
+  if (functionNode.returnType) {
+    returnTypeNode = functionNode.returnType;
+    if (returnTypeNode.typeAnnotation) {
+      returnTypeNode = returnTypeNode.typeAnnotation;
+    }
+  } else if (functionNode.typeAnnotation) {
+    returnTypeNode = functionNode.typeAnnotation;
+  } else {
     return false;
   }
-  return isObjectType(returnTypeNode) || willBreak(returnTypeDoc);
+
+  return (
+    getFunctionParameters(functionNode).length === 1 &&
+    (isObjectType(returnTypeNode) || willBreak(returnTypeDoc))
+  );
 }
 
 module.exports = {

--- a/src/language-js/print/function-parameters.js
+++ b/src/language-js/print/function-parameters.js
@@ -189,8 +189,7 @@ function shouldHugFunctionParameters(node) {
   );
 }
 
-// When parameters are grouped, the return type annotation breaks first.
-function shouldGroupFunctionParameters(functionNode, returnTypeDoc) {
+function getReturnTypeNode(functionNode) {
   let returnTypeNode;
   if (functionNode.returnType) {
     returnTypeNode = functionNode.returnType;
@@ -199,8 +198,29 @@ function shouldGroupFunctionParameters(functionNode, returnTypeDoc) {
     }
   } else if (functionNode.typeAnnotation) {
     returnTypeNode = functionNode.typeAnnotation;
-  } else {
+  }
+  return returnTypeNode;
+}
+
+// When parameters are grouped, the return type annotation breaks first.
+function shouldGroupFunctionParameters(functionNode, returnTypeDoc) {
+  const returnTypeNode = getReturnTypeNode(functionNode);
+  if (!returnTypeNode) {
     return false;
+  }
+
+  const typeParameters =
+    functionNode.typeParameters && functionNode.typeParameters.params;
+  if (typeParameters) {
+    if (typeParameters.length > 1) {
+      return false;
+    }
+    if (typeParameters.length === 1) {
+      const typeParameter = typeParameters[0];
+      if (typeParameter.constraint || typeParameter.default) {
+        return false;
+      }
+    }
   }
 
   return (

--- a/src/language-js/print/function.js
+++ b/src/language-js/print/function.js
@@ -63,10 +63,7 @@ function printFunctionDeclaration(path, print, options, expandArg) {
     expandArg
   );
   const returnTypeDoc = printReturnType(path, print, options);
-  const shouldGroupParameters = shouldGroupFunctionParameters(
-    n.returnType,
-    returnTypeDoc
-  );
+  const shouldGroupParameters = shouldGroupFunctionParameters(n, returnTypeDoc);
 
   parts.push(
     printFunctionTypeParameters(path, options, print),
@@ -129,7 +126,7 @@ function printMethodInternal(path, options, print) {
   const parametersDoc = printFunctionParameters(path, print, options);
   const returnTypeDoc = printReturnType(path, print, options);
   const shouldGroupParameters = shouldGroupFunctionParameters(
-    node.returnType,
+    node,
     returnTypeDoc
   );
   const parts = [

--- a/src/language-js/print/type-annotation.js
+++ b/src/language-js/print/type-annotation.js
@@ -267,10 +267,7 @@ function printFunctionType(path, options, print) {
         ]
       : "";
 
-  const shouldGroupParameters = shouldGroupFunctionParameters(
-    n.returnType || n.typeAnnotation,
-    returnTypeDoc
-  );
+  const shouldGroupParameters = shouldGroupFunctionParameters(n, returnTypeDoc);
 
   parts.push(shouldGroupParameters ? group(parametersDoc) : parametersDoc);
 

--- a/src/language-js/print/type-annotation.js
+++ b/src/language-js/print/type-annotation.js
@@ -15,7 +15,10 @@ const {
   shouldPrintComma,
 } = require("../utils");
 const { printAssignment } = require("./assignment");
-const { printFunctionParameters } = require("./function-parameters");
+const {
+  printFunctionParameters,
+  shouldGroupFunctionParameters,
+} = require("./function-parameters");
 const { printArrayItems } = require("./array");
 
 function shouldHugType(node) {
@@ -244,26 +247,37 @@ function printFunctionType(path, options, print) {
     parts.push("(");
   }
 
-  parts.push(
-    printFunctionParameters(
-      path,
-      print,
-      options,
-      /* expandArg */ false,
-      /* printTypeParams */ true
-    )
+  const parametersDoc = printFunctionParameters(
+    path,
+    print,
+    options,
+    /* expandArg */ false,
+    /* printTypeParams */ true
   );
 
   // The returnType is not wrapped in a TypeAnnotation, so the colon
   // needs to be added separately.
-  if (n.returnType || n.predicate || n.typeAnnotation) {
-    parts.push(
-      isArrowFunctionTypeAnnotation ? " => " : ": ",
-      path.call(print, "returnType"),
-      path.call(print, "predicate"),
-      path.call(print, "typeAnnotation")
-    );
+  const returnTypeDoc =
+    n.returnType || n.predicate || n.typeAnnotation
+      ? [
+          isArrowFunctionTypeAnnotation ? " => " : ": ",
+          path.call(print, "returnType"),
+          path.call(print, "predicate"),
+          path.call(print, "typeAnnotation"),
+        ]
+      : "";
+
+  const shouldGroupParameters = shouldGroupFunctionParameters(
+    n.returnType || n.typeAnnotation,
+    returnTypeDoc
+  );
+
+  parts.push(shouldGroupParameters ? group(parametersDoc) : parametersDoc);
+
+  if (returnTypeDoc) {
+    parts.push(returnTypeDoc);
   }
+
   if (needsParens) {
     parts.push(")");
   }

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -370,15 +370,15 @@ function printTypescript(path, options, print) {
         /* printTypeParams */ true
       );
 
-      const returnTypePropertyName = n.typeAnnotation
-        ? "typeAnnotation"
-        : "returnType";
+      const returnTypePropertyName = n.returnType
+        ? "returnType"
+        : "typeAnnotation";
       const returnTypeNode = n[returnTypePropertyName];
       const returnTypeDoc = returnTypeNode
         ? path.call(print, returnTypePropertyName)
         : "";
       const shouldGroupParameters = shouldGroupFunctionParameters(
-        returnTypeNode,
+        n,
         returnTypeDoc
       );
 

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -25,7 +25,10 @@ const { locStart, locEnd } = require("../loc");
 
 const { printOptionalToken, printTypeScriptModifiers } = require("./misc");
 const { printTernary } = require("./ternary");
-const { printFunctionParameters } = require("./function-parameters");
+const {
+  printFunctionParameters,
+  shouldGroupFunctionParameters,
+} = require("./function-parameters");
 const { printTemplateLiteral } = require("./template-literal");
 const { printArrayItems } = require("./array");
 const { printObject } = require("./object");
@@ -35,11 +38,7 @@ const {
   printTypeParameters,
 } = require("./type-parameters");
 const { printPropertyKey } = require("./property");
-const {
-  printFunctionDeclaration,
-  printMethodInternal,
-  shouldGroupMethodParameters,
-} = require("./function");
+const { printFunctionDeclaration, printMethodInternal } = require("./function");
 const { printInterface } = require("./interface");
 const { printBlock } = require("./block");
 const {
@@ -378,7 +377,7 @@ function printTypescript(path, options, print) {
       const returnTypeDoc = returnTypeNode
         ? path.call(print, returnTypePropertyName)
         : "";
-      const shouldGroupParameters = shouldGroupMethodParameters(
+      const shouldGroupParameters = shouldGroupFunctionParameters(
         returnTypeNode,
         returnTypeDoc
       );

--- a/tests/flow-repo/dictionary/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow-repo/dictionary/__snapshots__/jsfmt.spec.js.snap
@@ -56,9 +56,10 @@ function foo0(
   return x;
 }
 
-function foo2(x: {
+function foo2(x: { [key: string]: number }): {
   [key: string]: number,
-}): { [key: string]: number, +toString: () => string } {
+  +toString: () => string,
+} {
   // x's prototype has a toString method
   return x;
 }
@@ -468,9 +469,10 @@ function mix_with_declared_props(o: { [k: number]: X, p: Y }, x: X, y: Y) {
 }
 
 // Indeed, dict types are still Objects and have Object.prototype stuff
-function object_prototype(o: {
+function object_prototype(o: { [k: string]: number }): {
   [k: string]: number,
-}): { [k: string]: number, +toString: () => string } {
+  +toString: () => string,
+} {
   (o.toString(): boolean); // error: string ~> boolean
   return o; // ok
 }
@@ -776,9 +778,10 @@ function foo3(x: { [key: string]: number }): { foo: number } {
 }
 
 // error: foo can't exist in x
-function foo4(x: {
+function foo4(x: { [key: string]: number }): {
   [key: string]: number,
-}): { [key: string]: number, foo: string } {
+  foo: string,
+} {
   return x;
 }
 

--- a/tests/flow-repo/missing_annotation/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow-repo/missing_annotation/__snapshots__/jsfmt.spec.js.snap
@@ -132,9 +132,7 @@ var Foo = {
     };
   },
 
-  d: function (
-    arg: string
-  ): {
+  d: function (arg: string): {
     bar: string,
   } {
     return {

--- a/tests/flow-repo/spread/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow-repo/spread/__snapshots__/jsfmt.spec.js.snap
@@ -46,9 +46,7 @@ function parseCounter(line: string): number {
   return 0;
 }
 
-function parseGroup(
-  lines: Array<string>
-): {
+function parseGroup(lines: Array<string>): {
   counter: number,
   begin: number,
   end: number,

--- a/tests/flow/method/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/flow/method/__snapshots__/jsfmt.spec.js.snap
@@ -24,6 +24,63 @@ type Foo = {
 ================================================================================
 `;
 
+exports[`consistent-breaking.js format 1`] = `
+====================================options=====================================
+parsers: ["flow", "babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+class Foo1 {
+  flowParseFunctionTypeParams(
+    params: N.FlowFunctionTypeParam[] = [],
+  ): { params: N.FlowFunctionTypeParam[], rest: ?N.FlowFunctionTypeParam } {
+    // ...
+  }
+}
+
+type Foo2 = {
+  flowParseFunctionTypeParams(
+    params: N.FlowFunctionTypeParam[]
+  ): { params: N.FlowFunctionTypeParam[], rest: ?N.FlowFunctionTypeParam }
+}
+
+{
+  function flowParseFunctionTypeParams(
+    params: N.FlowFunctionTypeParam[]
+  ): { params: N.FlowFunctionTypeParam[], rest: ?N.FlowFunctionTypeParam } {
+    // ...
+  }
+}
+
+=====================================output=====================================
+class Foo1 {
+  flowParseFunctionTypeParams(params: N.FlowFunctionTypeParam[] = []): {
+    params: N.FlowFunctionTypeParam[],
+    rest: ?N.FlowFunctionTypeParam,
+  } {
+    // ...
+  }
+}
+
+type Foo2 = {
+  flowParseFunctionTypeParams(params: N.FlowFunctionTypeParam[]): {
+    params: N.FlowFunctionTypeParam[],
+    rest: ?N.FlowFunctionTypeParam,
+  },
+};
+
+{
+  function flowParseFunctionTypeParams(params: N.FlowFunctionTypeParam[]): {
+    params: N.FlowFunctionTypeParam[],
+    rest: ?N.FlowFunctionTypeParam,
+  } {
+    // ...
+  }
+}
+
+================================================================================
+`;
+
 exports[`method.js format 1`] = `
 ====================================options=====================================
 parsers: ["flow", "babel"]

--- a/tests/flow/method/consistent-breaking.js
+++ b/tests/flow/method/consistent-breaking.js
@@ -1,0 +1,21 @@
+class Foo1 {
+  flowParseFunctionTypeParams(
+    params: N.FlowFunctionTypeParam[] = [],
+  ): { params: N.FlowFunctionTypeParam[], rest: ?N.FlowFunctionTypeParam } {
+    // ...
+  }
+}
+
+type Foo2 = {
+  flowParseFunctionTypeParams(
+    params: N.FlowFunctionTypeParam[]
+  ): { params: N.FlowFunctionTypeParam[], rest: ?N.FlowFunctionTypeParam }
+}
+
+{
+  function flowParseFunctionTypeParams(
+    params: N.FlowFunctionTypeParam[]
+  ): { params: N.FlowFunctionTypeParam[], rest: ?N.FlowFunctionTypeParam } {
+    // ...
+  }
+}

--- a/tests/typescript/generic/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/generic/__snapshots__/jsfmt.spec.js.snap
@@ -181,3 +181,43 @@ export default {
 
 ================================================================================
 `;
+
+exports[`ungrouped-parameters.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function filterTooltipWithFoo<F extends Field>(oldEncoding: Encoding<F>): {
+  customTooltipWithoutAggregatedField?:
+    | StringFieldDefWithCondition<F>
+    | StringValueDefWithCondition<F>
+    | StringFieldDef<F>[];
+  filteredEncoding: Encoding<F>;
+} {
+  const {tooltip, ...filteredEncoding} = oldEncoding;
+  if (!tooltip) {
+    return {filteredEncoding};
+  }
+  // ...
+}
+
+=====================================output=====================================
+function filterTooltipWithFoo<F extends Field>(
+  oldEncoding: Encoding<F>
+): {
+  customTooltipWithoutAggregatedField?:
+    | StringFieldDefWithCondition<F>
+    | StringValueDefWithCondition<F>
+    | StringFieldDef<F>[];
+  filteredEncoding: Encoding<F>;
+} {
+  const { tooltip, ...filteredEncoding } = oldEncoding;
+  if (!tooltip) {
+    return { filteredEncoding };
+  }
+  // ...
+}
+
+================================================================================
+`;

--- a/tests/typescript/generic/ungrouped-parameters.ts
+++ b/tests/typescript/generic/ungrouped-parameters.ts
@@ -1,0 +1,13 @@
+function filterTooltipWithFoo<F extends Field>(oldEncoding: Encoding<F>): {
+  customTooltipWithoutAggregatedField?:
+    | StringFieldDefWithCondition<F>
+    | StringValueDefWithCondition<F>
+    | StringFieldDef<F>[];
+  filteredEncoding: Encoding<F>;
+} {
+  const {tooltip, ...filteredEncoding} = oldEncoding;
+  if (!tooltip) {
+    return {filteredEncoding};
+  }
+  // ...
+}

--- a/tests/typescript/method/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/method/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`issue-10352-consistency.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export interface Store {
+  getRecord(collectionName: string, documentPath: string): TaskEither<Error, Option<GenericRecord>>;
+}
+
+export default class StoreImpl extends Service implements Store {
+  getRecord(collectionName: string, documentPath: string): TaskEither<Error, Option<GenericRecord>> {
+    // Do some stuff.
+  }
+}
+
+=====================================output=====================================
+export interface Store {
+  getRecord(
+    collectionName: string,
+    documentPath: string
+  ): TaskEither<Error, Option<GenericRecord>>;
+}
+
+export default class StoreImpl extends Service implements Store {
+  getRecord(
+    collectionName: string,
+    documentPath: string
+  ): TaskEither<Error, Option<GenericRecord>> {
+    // Do some stuff.
+  }
+}
+
+================================================================================
+`;
+
 exports[`method-signature.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -39,6 +75,40 @@ type Bar = {
 };
 type Bar = {
   get(key: "bar"): { bar: "bar" };
+};
+
+================================================================================
+`;
+
+exports[`method-signature-with-wrapped-return-type.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type ReleaseToolConfig = {
+  get(key: "changelog"): {
+    get(key: "repo"): string;
+    get(key: "labels"): Map<string, string>;
+  };
+};
+
+type ReleaseToolConfig2 = {
+  get(key: "changelog"): \`
+  \`
+};
+
+=====================================output=====================================
+type ReleaseToolConfig = {
+  get(key: "changelog"): {
+    get(key: "repo"): string;
+    get(key: "labels"): Map<string, string>;
+  };
+};
+
+type ReleaseToolConfig2 = {
+  get(key: "changelog"): \`
+  \`;
 };
 
 ================================================================================

--- a/tests/typescript/method/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/method/__snapshots__/jsfmt.spec.js.snap
@@ -16,6 +16,13 @@ export default class StoreImpl extends Service implements Store {
   }
 }
 
+export function loadPlugin(
+  name: string,
+  dirname: string,
+): { filepath: string, value: mixed } {
+  // ...
+}
+
 =====================================output=====================================
 export interface Store {
   getRecord(
@@ -31,6 +38,13 @@ export default class StoreImpl extends Service implements Store {
   ): TaskEither<Error, Option<GenericRecord>> {
     // Do some stuff.
   }
+}
+
+export function loadPlugin(
+  name: string,
+  dirname: string
+): { filepath: string; value: mixed } {
+  // ...
 }
 
 ================================================================================

--- a/tests/typescript/method/issue-10352-consistency.ts
+++ b/tests/typescript/method/issue-10352-consistency.ts
@@ -7,3 +7,10 @@ export default class StoreImpl extends Service implements Store {
     // Do some stuff.
   }
 }
+
+export function loadPlugin(
+  name: string,
+  dirname: string,
+): { filepath: string, value: mixed } {
+  // ...
+}

--- a/tests/typescript/method/issue-10352-consistency.ts
+++ b/tests/typescript/method/issue-10352-consistency.ts
@@ -1,0 +1,9 @@
+export interface Store {
+  getRecord(collectionName: string, documentPath: string): TaskEither<Error, Option<GenericRecord>>;
+}
+
+export default class StoreImpl extends Service implements Store {
+  getRecord(collectionName: string, documentPath: string): TaskEither<Error, Option<GenericRecord>> {
+    // Do some stuff.
+  }
+}

--- a/tests/typescript/method/method-signature-with-wrapped-return-type.ts
+++ b/tests/typescript/method/method-signature-with-wrapped-return-type.ts
@@ -1,0 +1,11 @@
+type ReleaseToolConfig = {
+  get(key: "changelog"): {
+    get(key: "repo"): string;
+    get(key: "labels"): Map<string, string>;
+  };
+};
+
+type ReleaseToolConfig2 = {
+  get(key: "changelog"): `
+  `
+};


### PR DESCRIPTION
## Description

closes #10352

The change looks repetitive and it is. Would be good later to refactor these files and unify the code that prints signatures for different types of function-like nodes to make sure the formatting for them stays consistent.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
