### PR TITLE
Refactor: Switch second parameter of `printComments` from `function` to `Doc`

### DIFF
--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -275,7 +275,7 @@ function printBinaryishExpressions(
     // the other ones since we don't call the normal print on BinaryExpression,
     // only for the left and right parts
     if (isNested && hasComment(node)) {
-      const printed = cleanDoc(printComments(path, () => parts, options));
+      const printed = cleanDoc(printComments(path, parts, options));
       /* istanbul ignore else */
       if (isConcat(printed) || printed.type === "fill") {
         parts = getDocParts(printed);

--- a/src/language-js/print/class.js
+++ b/src/language-js/print/class.js
@@ -55,7 +55,7 @@ function printClass(path, options, print) {
       path.call(print, "superTypeParameters"),
     ];
     const printedWithComments = path.call(
-      (superClass) => printComments(superClass, () => printed, options),
+      (superClass) => printComments(superClass, printed, options),
       "superClass"
     );
     if (groupMode) {

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -667,7 +667,7 @@ function printJsxOpeningClosingFragment(path, options /*, print*/) {
 function printJsxElement(path, options, print) {
   const elem = printComments(
     path,
-    () => printJsxElementInternal(path, options, print),
+    printJsxElementInternal(path, options, print),
     options
   );
   return maybeWrapJsxElementInParens(path, elem, options);
@@ -696,7 +696,7 @@ function printJsxSpreadAttribute(path, options, print) {
           return printed;
         }
         return [
-          indent([softline, printComments(p, () => printed, options)]),
+          indent([softline, printComments(p, printed, options)]),
           softline,
         ];
       },

--- a/src/language-js/print/member-chain.js
+++ b/src/language-js/print/member-chain.js
@@ -102,7 +102,7 @@ function printMemberChain(path, options, print) {
         printed: [
           printComments(
             path,
-            () => [
+            [
               printOptionalToken(path),
               printFunctionTypeParameters(path, options, print),
               printCallArguments(path, options, print),
@@ -119,10 +119,9 @@ function printMemberChain(path, options, print) {
         needsParens: pathNeedsParens(path, options),
         printed: printComments(
           path,
-          () =>
-            isMemberExpression(node)
-              ? printMemberLookup(path, options, print)
-              : printBindExpressionCallee(path, options, print),
+          isMemberExpression(node)
+            ? printMemberLookup(path, options, print)
+            : printBindExpressionCallee(path, options, print),
           options
         ),
       });
@@ -130,7 +129,7 @@ function printMemberChain(path, options, print) {
     } else if (node.type === "TSNonNullExpression") {
       printedNodes.unshift({
         node,
-        printed: printComments(path, () => "!", options),
+        printed: printComments(path, "!", options),
       });
       path.call((expression) => rec(expression), "expression");
     } else {

--- a/src/language-js/print/property.js
+++ b/src/language-js/print/property.js
@@ -64,10 +64,7 @@ function printPropertyKey(path, options, print) {
       ),
       options
     );
-    return path.call(
-      (keyPath) => printComments(keyPath, () => prop, options),
-      "key"
-    );
+    return path.call((keyPath) => printComments(keyPath, prop, options), "key");
   }
 
   if (
@@ -82,7 +79,7 @@ function printPropertyKey(path, options, print) {
       (keyPath) =>
         printComments(
           keyPath,
-          () => (/^\d/.test(key.value) ? printNumber(key.value) : key.value),
+          /^\d/.test(key.value) ? printNumber(key.value) : key.value,
           options
         ),
       "key"

--- a/src/language-js/print/type-annotation.js
+++ b/src/language-js/print/type-annotation.js
@@ -167,7 +167,7 @@ function printUnionType(path, options, print) {
     if (!shouldHug) {
       printedType = align(2, printedType);
     }
-    return printComments(typePath, () => printedType, options);
+    return printComments(typePath, printedType, options);
   }, "types");
 
   if (shouldHug) {

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -48,30 +48,24 @@ function printAstToDoc(ast, options, alignmentSize = 0) {
       return cache.get(node);
     }
 
+    let doc = callPluginPrintFunction(path, options, printGenerically, args);
+
     // We let JSXElement print its comments itself because it adds () around
     // UnionTypeAnnotation has to align the child without the comments
-    let res;
     if (
-      printer.willPrintOwnComments &&
-      printer.willPrintOwnComments(path, options)
+      !printer.willPrintOwnComments ||
+      !printer.willPrintOwnComments(path, options)
     ) {
-      res = callPluginPrintFunction(path, options, printGenerically, args);
-    } else {
       // printComments will call the plugin print function and check for
       // comments to print
-      res = printComments(
-        path,
-        (p) => callPluginPrintFunction(p, options, printGenerically, args),
-        options,
-        args && args.needsSemi
-      );
+      doc = printComments(path, doc, options, args && args.needsSemi);
     }
 
     if (shouldCache) {
-      cache.set(node, res);
+      cache.set(node, doc);
     }
 
-    return res;
+    return doc;
   }
 
   let doc = printGenerically(new AstPath(ast));

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -547,9 +547,8 @@ function prependCursorPlaceholder(path, options, printed) {
   return printed;
 }
 
-function printComments(path, print, options, needsSemi) {
+function printComments(path, printed, options, needsSemi) {
   const value = path.getValue();
-  const printed = print(path);
   const comments = value && value.comments;
 
   if (!isNonEmptyArray(comments)) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
