### PR TITLE
Only pass `Node` to `printer.print` function

### DIFF
--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -83,15 +83,6 @@ function shouldPrintComma(options) {
 function genericPrint(path, options, print) {
   const node = path.getValue();
 
-  /* istanbul ignore if */
-  if (!node) {
-    return "";
-  }
-
-  if (typeof node === "string") {
-    return node;
-  }
-
   switch (node.type) {
     case "front-matter":
       return [node.raw, hardline];

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -9,13 +9,6 @@ const { locStart, locEnd } = require("./loc");
 
 function genericPrint(path, options, print) {
   const n = path.getValue();
-  if (!n) {
-    return "";
-  }
-
-  if (typeof n === "string") {
-    return n;
-  }
 
   switch (n.kind) {
     case "Document": {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -40,11 +40,6 @@ const NEWLINES_TO_PRESERVE_MAX = 2;
 function print(path, options, print) {
   const n = path.getValue();
 
-  /* istanbul ignore if*/
-  if (!n) {
-    return "";
-  }
-
   if (hasPrettierIgnore(path)) {
     return options.originalText.slice(locStart(n), locEnd(n));
   }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -202,14 +202,6 @@ function printPathNoParens(path, options, print, args) {
   const n = path.getValue();
   const semi = options.semi ? ";" : "";
 
-  if (!n) {
-    return "";
-  }
-
-  if (typeof n === "string") {
-    return n;
-  }
-
   for (const printer of [
     printHtmlBinding,
     printAngular,

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -125,25 +125,23 @@ function callPluginPrintFunction(path, options, printPath, args) {
     return printPrettierIgnoredNode(node, options);
   }
 
-  if (node) {
-    try {
-      // Potentially switch to a different parser
-      const sub = multiparser.printSubtree(
-        path,
-        printPath,
-        options,
-        printAstToDoc
-      );
-      if (sub) {
-        return sub;
-      }
-    } catch (error) {
-      /* istanbul ignore if */
-      if (process.env.PRETTIER_DEBUG) {
-        throw error;
-      }
-      // Continue with current parser
+  try {
+    // Potentially switch to a different parser
+    const sub = multiparser.printSubtree(
+      path,
+      printPath,
+      options,
+      printAstToDoc
+    );
+    if (sub) {
+      return sub;
     }
+  } catch (error) {
+    /* istanbul ignore if */
+    if (process.env.PRETTIER_DEBUG) {
+      throw error;
+    }
+    // Continue with current parser
   }
 
   return printer.print(path, options, printPath, args);

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -109,6 +109,15 @@ function callPluginPrintFunction(path, options, printPath, args) {
   assert.ok(path instanceof AstPath);
 
   const node = path.getValue();
+
+  if (!node) {
+    return "";
+  }
+
+  if (typeof node === "string") {
+    return node;
+  }
+
   const { printer } = options;
 
   // Escape hatch


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Not sure about this yet.
This could break something.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
