### PR TITLE
Add issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 🤔 Support question
+    url: https://stackoverflow.com/questions/ask?tags=prettier
+    about: Issues are dedicated to development purposes, if you have questions, please use Stack Overflow.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: true
 contact_links:
   - name: 🤔 Support question
     url: https://stackoverflow.com/questions/ask?tags=prettier
-    about: Issues are dedicated to development purposes, if you have questions, please use Stack Overflow.
+    about: Issues are dedicated to development purposes. If you have questions, please use Stack Overflow.


### PR DESCRIPTION
## Description

Let's start with this simple configuration.

The next step is to add a link to the playground for reporting formatting issues. But for that I think the playground needs to be tweaked, namely the "Report issue" button should be made more noticeable if `issue=1` (or something like that) is passed in the URL.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
