### PR TITLE
JS: Split `locStart` into two functions

### DIFF
--- a/src/language-js/loc.js
+++ b/src/language-js/loc.js
@@ -6,19 +6,18 @@ const { isNonEmptyArray } = require("../common/util");
  * @typedef {import("./types/estree").Node} Node
  */
 
-function locStart(node, opts) {
-  const { ignoreDecorators } = opts || {};
-
+function locStart(node) {
   // Handle nodes with decorators. They should start at the first decorator
-  if (!ignoreDecorators) {
-    const decorators =
-      (node.declaration && node.declaration.decorators) || node.decorators;
-
-    if (isNonEmptyArray(decorators)) {
-      return locStart(decorators[0]);
-    }
+  const decorators =
+    (node.declaration && node.declaration.decorators) || node.decorators;
+  if (isNonEmptyArray(decorators)) {
+    return locStartWithoutDecorator(decorators[0]);
   }
 
+  return locStartWithoutDecorator(node);
+}
+
+function locStartWithoutDecorator(node) {
   return node.range ? node.range[0] : node.start;
 }
 
@@ -57,6 +56,7 @@ function hasSameLoc(nodeA, nodeB) {
 module.exports = {
   locStart,
   locEnd,
+  locStartWithoutDecorator,
   hasSameLocStart,
   hasSameLoc,
 };

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -43,7 +43,7 @@ const {
   isCallExpression,
   isMemberExpression,
 } = require("./utils");
-const { locStart, locEnd } = require("./loc");
+const { locStart, locStartWithoutDecorator, locEnd } = require("./loc");
 
 const {
   printHtmlBinding,
@@ -124,8 +124,7 @@ function genericPrint(path, options, printPath, args) {
     // for printing the decorators.
     !(
       parentExportDecl &&
-      locStart(parentExportDecl, { ignoreDecorators: true }) >
-        locStart(node.decorators[0])
+      locStartWithoutDecorator(parentExportDecl) > locStart(node.decorators[0])
     )
   ) {
     const shouldBreak =
@@ -155,8 +154,7 @@ function genericPrint(path, options, printPath, args) {
     isNonEmptyArray(node.declaration.decorators) &&
     // Only print decorators here if they were written before the export,
     // otherwise they are printed by the node.declaration
-    locStart(node, { ignoreDecorators: true }) >
-      locStart(node.declaration.decorators[0])
+    locStartWithoutDecorator(node) > locStart(node.declaration.decorators[0])
   ) {
     // Export declarations are responsible for printing any decorators
     // that logically apply to node.declaration.


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Remove the `opt` parameter, I'm planning use `locStartWithoutDecorator` for `Node`s that can't have a decorator, eg: `Comment`

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
