### PR TITLE
Add `css` version `printString`

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -417,16 +417,7 @@ function printString(raw, options, isDirectiveLiteral) {
   // is enclosed with `enclosingQuote`, but it isn't. The string could contain
   // unnecessary escapes (such as in `"\'"`). Always using `makeString` makes
   // sure that we consistently output the minimum amount of escaped quotes.
-  return makeString(
-    rawContent,
-    enclosingQuote,
-    !(
-      options.parser === "css" ||
-      options.parser === "less" ||
-      options.parser === "scss" ||
-      options.__embeddedInHtml
-    )
-  );
+  return makeString(rawContent, enclosingQuote, !options.__embeddedInHtml);
 }
 
 /**

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -2,7 +2,8 @@
 
 const {
   printNumber,
-  printString,
+  getPreferredQuote,
+  makeString,
   hasNewline,
   isFrontMatterNode,
   isNextLineEmpty,
@@ -1033,6 +1034,18 @@ const ADJUST_NUMBERS_REGEX = new RegExp(
 
 function adjustStrings(value, options) {
   return value.replace(STRING_REGEX, (match) => printString(match, options));
+}
+
+function printString(raw, options) {
+  // `rawContent` is the string exactly like it appeared in the input source
+  // code, without its enclosing quotes.
+  const rawContent = raw.slice(1, -1);
+
+  const enclosingQuote = options.__isInHtmlAttribute
+    ? "'"
+    : getPreferredQuote(raw, options.singleQuote ? "'" : '"');
+
+  return makeString(rawContent, enclosingQuote, false);
 }
 
 function quoteAttributeValue(value, options) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

One step to get ride of `parser` check in `printString` util.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
