### PR TITLE
Add `printDirective`

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -381,15 +381,10 @@ function getPreferredQuote(raw, preferredQuote) {
   return result;
 }
 
-function printString(raw, options, isDirectiveLiteral) {
+function printString(raw, options) {
   // `rawContent` is the string exactly like it appeared in the input source
   // code, without its enclosing quotes.
   const rawContent = raw.slice(1, -1);
-
-  // Check for the alternate quote, to determine if we're allowed to swap
-  // the quotes on a DirectiveLiteral.
-  const canChangeDirectiveQuotes =
-    !rawContent.includes('"') && !rawContent.includes("'");
 
   /** @type {Quote} */
   const enclosingQuote =
@@ -401,17 +396,6 @@ function printString(raw, options, isDirectiveLiteral) {
       : options.__isInHtmlAttribute
       ? "'"
       : getPreferredQuote(raw, options.singleQuote ? "'" : '"');
-
-  // Directives are exact code unit sequences, which means that you can't
-  // change the escape sequences they use.
-  // See https://github.com/prettier/prettier/issues/1555
-  // and https://tc39.github.io/ecma262/#directive-prologue
-  if (isDirectiveLiteral) {
-    if (canChangeDirectiveQuotes) {
-      return enclosingQuote + rawContent + enclosingQuote;
-    }
-    return raw;
-  }
 
   // It might sound unnecessary to use `makeString` even if the string already
   // is enclosed with `enclosingQuote`, but it isn't. The string could contain

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -11,7 +11,6 @@ const {
   hasNewline,
   printString,
   printNumber,
-  getPreferredQuote,
   isNonEmptyArray,
 } = require("../common/util");
 const {
@@ -1114,10 +1113,7 @@ function printDirective(node, options) {
     return raw;
   }
 
-  const enclosingQuote = getPreferredQuote(
-    raw,
-    options.singleQuote ? "'" : '"'
-  );
+  const enclosingQuote = options.singleQuote ? "'" : '"';
 
   // Directives are exact code unit sequences, which means that you can't
   // change the escape sequences they use.

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1114,7 +1114,10 @@ function printDirective(node, options) {
     return raw;
   }
 
-  const enclosingQuote = getPreferredQuote(raw, options.singleQuote ? "'" : '"');
+  const enclosingQuote = getPreferredQuote(
+    raw,
+    options.singleQuote ? "'" : '"'
+  );
 
   // Directives are exact code unit sequences, which means that you can't
   // change the escape sequences they use.

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -257,7 +257,7 @@ function printPathNoParens(path, options, print, args) {
     case "ExpressionStatement":
       // Detect Flow and TypeScript directives
       if (n.directive) {
-        return [nodeStr(n.expression, options, true), semi];
+        return [printDirective(n.expression, options), semi];
       }
 
       if (options.parser === "__vue_event_binding") {
@@ -480,7 +480,7 @@ function printPathNoParens(path, options, print, args) {
     case "Directive":
       return [path.call(print, "value"), semi]; // Babel 6
     case "DirectiveLiteral":
-      return nodeStr(n, options);
+      return printDirective(n, options);
     case "UnaryExpression":
       parts.push(n.operator);
 
@@ -990,7 +990,7 @@ function printPathNoParens(path, options, print, args) {
     case "QualifiedTypeIdentifier":
       return [path.call(print, "qualification"), ".", path.call(print, "id")];
     case "StringLiteralTypeAnnotation":
-      return nodeStr(n, options);
+      return printString(rawText(n), options);
     case "NumberLiteralTypeAnnotation":
       assert.strictEqual(typeof n.value, "number");
     // fall through
@@ -1103,11 +1103,8 @@ function printPathNoParens(path, options, print, args) {
   }
 }
 
-function nodeStr(node, options, isFlowOrTypeScriptDirectiveLiteral) {
-  const raw = rawText(node);
-  const isDirectiveLiteral =
-    isFlowOrTypeScriptDirectiveLiteral || node.type === "DirectiveLiteral";
-  return printString(raw, options, isDirectiveLiteral);
+function printDirective(node, options) {
+  return printString(rawText(node), options, true);
 }
 
 function canAttachComment(node) {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -1106,15 +1106,11 @@ function printPathNoParens(path, options, print, args) {
 
 function printDirective(node, options) {
   const raw = rawText(node);
-
   const rawContent = raw.slice(1, -1);
 
   // Check for the alternate quote, to determine if we're allowed to swap
   // the quotes on a DirectiveLiteral.
-  const canChangeDirectiveQuotes =
-    !rawContent.includes('"') && !rawContent.includes("'");
-
-  if (!canChangeDirectiveQuotes) {
+  if (rawContent.includes('"') || rawContent.includes("'")) {
     return raw;
   }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Another step to simplify `printString`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
