### PR TITLE
Support TS 4.2 abstract constructor signature

### DIFF
--- a/changelog_unreleased/typescript/10418.md
+++ b/changelog_unreleased/typescript/10418.md
@@ -1,0 +1,16 @@
+#### Support TypeScript 4.2 `abstract` Construct Signatures via `babel-ts` (#10418 by @sosukesuzuki)
+
+Support [`abstract` Construct Signatures](https://devblogs.microsoft.com/typescript/announcing-typescript-4-2/#abstract-construct-signatures).
+
+<!-- prettier-ignore -->
+```ts
+// Input
+type T = abstract new () => void;
+
+// Prettier main
+SyntaxError: Unexpected token, expected ";" (1:19)
+
+// Prettier stable
+type T = abstract new () => void;
+
+```

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -297,6 +297,9 @@ function printTypescript(path, options, print) {
     case "TSCallSignatureDeclaration":
     case "TSConstructorType": {
       if (n.type !== "TSCallSignatureDeclaration") {
+        if (n.abstract) {
+          parts.push("abstract ");
+        }
         parts.push("new ");
       }
 

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -296,10 +296,10 @@ function printTypescript(path, options, print) {
     case "TSConstructSignatureDeclaration":
     case "TSCallSignatureDeclaration":
     case "TSConstructorType": {
+      if (n.type === "TSConstructorType" && n.abstract) {
+        parts.push("abstract ");
+      }
       if (n.type !== "TSCallSignatureDeclaration") {
-        if (n.abstract) {
-          parts.push("abstract ");
-        }
         parts.push("new ");
       }
 

--- a/tests/misc/typescript-babel-only/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/misc/typescript-babel-only/__snapshots__/jsfmt.spec.js.snap
@@ -62,6 +62,25 @@ class Bar {
 ================================================================================
 `;
 
+exports[`ts-4.2-abstract-constructor-type.ts format 1`] = `
+====================================options=====================================
+parsers: ["babel-ts"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type T = abstract new () => void;
+type T = abstract    new () => void;
+type T = abstract
+  new () => void;
+
+=====================================output=====================================
+type T = abstract new () => void;
+type T = abstract new () => void;
+type T = abstract new () => void;
+
+================================================================================
+`;
+
 exports[`tuple-labeled-ts.ts format 1`] = `
 ====================================options=====================================
 parsers: ["babel-ts"]

--- a/tests/misc/typescript-babel-only/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/misc/typescript-babel-only/__snapshots__/jsfmt.spec.js.snap
@@ -68,12 +68,14 @@ parsers: ["babel-ts"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
+// typescript-estree does not support abstract constructor type yet
 type T = abstract new () => void;
 type T = abstract    new () => void;
 type T = abstract
   new () => void;
 
 =====================================output=====================================
+// typescript-estree does not support abstract constructor type yet
 type T = abstract new () => void;
 type T = abstract new () => void;
 type T = abstract new () => void;

--- a/tests/misc/typescript-babel-only/ts-4.2-abstract-constructor-type.ts
+++ b/tests/misc/typescript-babel-only/ts-4.2-abstract-constructor-type.ts
@@ -1,0 +1,5 @@
+// typescript-estree does not support abstract constructor type yet
+type T = abstract new () => void;
+type T = abstract    new () => void;
+type T = abstract
+  new () => void;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

TS 4.2 supports [abstract constructor signature](https://devblogs.microsoft.com/typescript/announcing-typescript-4-2/#abstract-construct-signatures).

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
