### PR TITLE
Disable Jest's default transformer (Babel)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -46,6 +46,7 @@ if (isProduction) {
     ],
   };
 } else {
+  transform = {};
   // Only test bundles for production
   testPathIgnorePatterns.push(
     "<rootDir>/tests_integration/__tests__/bundle.js"

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,7 @@ if (INSTALL_PACKAGE || (isProduction && !TEST_STANDALONE)) {
 process.env.PRETTIER_DIR = PRETTIER_DIR;
 
 const testPathIgnorePatterns = [];
-let transform;
+let transform = {};
 if (TEST_STANDALONE) {
   testPathIgnorePatterns.push("<rootDir>/tests_integration/");
 }
@@ -46,7 +46,6 @@ if (isProduction) {
     ],
   };
 } else {
-  transform = {};
   // Only test bundles for production
   testPathIgnorePatterns.push(
     "<rootDir>/tests_integration/__tests__/bundle.js"


### PR DESCRIPTION
## Description

https://jestjs.io/docs/en/next/code-transformation#defaults

Without this change, I get an error when Babel tries to resolve Browserslist, but `fs.statSync` is mocked.
I get this error not always, but I wasn't able to find what exactly triggers it. E.g., this error disappears if I rename the directory with the repo from `prettier` to `prttrtmp`. =) I use WSL/Ubuntu on Windows 10.

If the test setup depends on this default transformer, and it can't be disabled, then I'll try to debug this deeper. Otherwise, let's just disable it.

````
  ● plugin search should not crash when prettier isn't inside a directory › encountered a declaration exception

    ENOENT: no such file or directory, stat '/mnt/d/dev/prettier/tests_integration/mnt/d/dev/prettier/tests_integration/runPrettier.js'

      52 |   jest.spyOn(fs, "statSync").mockImplementation((filename) => {
      53 |     if (path.basename(filename) === "virtualDirectory") {
    > 54 |       return origStatSync(path.join(__dirname, __filename));
         |              ^
      55 |     }
      56 |     return origStatSync(filename);
      57 |   });

      at Object.<anonymous> (tests_integration/runPrettier.js:54:14)
      at isFile (node_modules/browserslist/node.js:38:42)
      at eachParent (node_modules/browserslist/node.js:46:13)
      at Object.getStat (node_modules/browserslist/node.js:197:15)
      at browserslist (node_modules/browserslist/index.js:433:19)
      at resolveTargets (node_modules/@babel/helper-compilation-targets/lib/index.js:174:46)
````


<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
