### PR TITLE
Format svg tags in the same way html tags are formatted

### DIFF
--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -20,7 +20,7 @@ function getLanguage(path) {
     return "graphql";
   }
 
-  if (isHtml(path)) {
+  if (isHtml(path) || isSvg(path)) {
     return "html";
   }
 
@@ -286,6 +286,24 @@ function isHtml(path) {
         node.type === "TaggedTemplateExpression" &&
         node.tag.type === "Identifier" &&
         node.tag.name === "html" &&
+        name === "quasi"
+    )
+  );
+}
+
+/**
+ *     - svg`...`
+ *     - SVG comment block
+ */
+function isSvg(path) {
+  return (
+    hasLanguageComment(path.getValue(), "SVG") ||
+    path.match(
+      (node) => node.type === "TemplateLiteral",
+      (node, name) =>
+        node.type === "TaggedTemplateExpression" &&
+        node.tag.type === "Identifier" &&
+        node.tag.name === "svg" &&
         name === "quasi"
     )
   );

--- a/tests/js/multiparser-html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/multiparser-html/__snapshots__/jsfmt.spec.js.snap
@@ -621,3 +621,196 @@ html\`<div
 
 ================================================================================
 `;
+
+exports[`lit-html-svg.js - {"htmlWhitespaceSensitivity":"ignore"} format 1`] = `
+====================================options=====================================
+htmlWhitespaceSensitivity: "ignore"
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+import { LitElement, html, svg } from '@polymer/lit-element';
+
+class MyElement extends LitElement {
+  static get properties() {
+    return {
+      mood: { type: String }
+    };
+  }
+
+  constructor() {
+    super();
+    this.mood = 'happy';
+  }
+
+    render() {
+      return html\`
+<header>
+                    <p>This is HTML</p>
+              </header>
+        \${svg\`
+          <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+          <svg
+    id="some-svg"
+                  xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 125 70"
+            version="1.1"
+          ><defs>
+              <path
+                id="poly"
+                d="m 0,10 20,10 20,-10 -20,-10 z"
+                style="stroke:#000000;stroke-width:0.2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+              ></path>
+              </defs>
+              </svg>\`}
+              <footer>
+              
+              Good  bye</footer>
+              \`;
+      }
+}
+
+customElements.define('my-element', MyElement);
+
+
+=====================================output=====================================
+import { LitElement, html, svg } from "@polymer/lit-element";
+
+class MyElement extends LitElement {
+  static get properties() {
+    return {
+      mood: { type: String },
+    };
+  }
+
+  constructor() {
+    super();
+    this.mood = "happy";
+  }
+
+  render() {
+    return html\`
+      <header>
+        <p>This is HTML</p>
+      </header>
+      \${svg\`
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        <svg
+          id="some-svg"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 125 70"
+          version="1.1"
+        >
+          <defs>
+            <path
+              id="poly"
+              d="m 0,10 20,10 20,-10 -20,-10 z"
+              style="stroke:#000000;stroke-width:0.2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+            ></path>
+          </defs>
+        </svg>
+      \`}
+      <footer>Good bye</footer>
+    \`;
+  }
+}
+
+customElements.define("my-element", MyElement);
+
+================================================================================
+`;
+
+exports[`lit-html-svg.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+import { LitElement, html, svg } from '@polymer/lit-element';
+
+class MyElement extends LitElement {
+  static get properties() {
+    return {
+      mood: { type: String }
+    };
+  }
+
+  constructor() {
+    super();
+    this.mood = 'happy';
+  }
+
+    render() {
+      return html\`
+<header>
+                    <p>This is HTML</p>
+              </header>
+        \${svg\`
+          <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+          <svg
+    id="some-svg"
+                  xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 125 70"
+            version="1.1"
+          ><defs>
+              <path
+                id="poly"
+                d="m 0,10 20,10 20,-10 -20,-10 z"
+                style="stroke:#000000;stroke-width:0.2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+              ></path>
+              </defs>
+              </svg>\`}
+              <footer>
+              
+              Good  bye</footer>
+              \`;
+      }
+}
+
+customElements.define('my-element', MyElement);
+
+
+=====================================output=====================================
+import { LitElement, html, svg } from "@polymer/lit-element";
+
+class MyElement extends LitElement {
+  static get properties() {
+    return {
+      mood: { type: String },
+    };
+  }
+
+  constructor() {
+    super();
+    this.mood = "happy";
+  }
+
+  render() {
+    return html\`
+      <header>
+        <p>This is HTML</p>
+      </header>
+      \${svg\` <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        <svg
+          id="some-svg"
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 125 70"
+          version="1.1"
+        >
+          <defs>
+            <path
+              id="poly"
+              d="m 0,10 20,10 20,-10 -20,-10 z"
+              style="stroke:#000000;stroke-width:0.2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+            ></path>
+          </defs>
+        </svg>\`}
+      <footer>Good bye</footer>
+    \`;
+  }
+}
+
+customElements.define("my-element", MyElement);
+
+================================================================================
+`;

--- a/tests/js/multiparser-html/lit-html-svg.js
+++ b/tests/js/multiparser-html/lit-html-svg.js
@@ -1,0 +1,43 @@
+import { LitElement, html, svg } from '@polymer/lit-element';
+
+class MyElement extends LitElement {
+  static get properties() {
+    return {
+      mood: { type: String }
+    };
+  }
+
+  constructor() {
+    super();
+    this.mood = 'happy';
+  }
+
+    render() {
+      return html`
+<header>
+                    <p>This is HTML</p>
+              </header>
+        ${svg`
+          <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+          <svg
+    id="some-svg"
+                  xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 125 70"
+            version="1.1"
+          ><defs>
+              <path
+                id="poly"
+                d="m 0,10 20,10 20,-10 -20,-10 z"
+                style="stroke:#000000;stroke-width:0.2px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+              ></path>
+              </defs>
+              </svg>`}
+              <footer>
+              
+              Good  bye</footer>
+              `;
+      }
+}
+
+customElements.define('my-element', MyElement);
+


### PR DESCRIPTION
## Description

lit-html uses `svg` template tag for rendering svgs or embedding svgs inside html. This change enables prettier to format the contents of the svg tag.


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [X] I’ve added tests to confirm my change works.
- [X] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
