### PR TITLE
typechecking: remove @typescript-eslint/types from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,6 @@
     "@rollup/plugin-replace": "2.4.1",
     "@types/estree": "0.0.46",
     "@types/node": "14.14.0",
-    "@typescript-eslint/types": "4.15.2",
     "babel-jest": "26.6.3",
     "babel-loader": "8.2.2",
     "benchmark": "2.1.4",

--- a/src/language-js/types/estree.d.ts
+++ b/src/language-js/types/estree.d.ts
@@ -1,6 +1,6 @@
 import * as ESTree from "estree";
 import * as Babel from "@babel/types";
-import { TSESTree } from "@typescript-eslint/types";
+import { TSESTree } from "@typescript-eslint/typescript-estree";
 import { ESTree as Meriyah } from "meriyah";
 import * as NGTree from "angular-estree-parser/lib/types";
 


### PR DESCRIPTION
@typescript-eslint/typescript-estree reexports these types.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
