### PR TITLE
Playground: Order options

### DIFF
--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -42,6 +42,8 @@ const ENABLED_OPTIONS = [
   "requirePragma",
   "vueIndentScriptAndStyle",
   "embeddedLanguageFormatting",
+  "rangeStart",
+  "rangeEnd",
 ];
 const ISSUES_URL = "https://github.com/prettier/prettier/issues/new?body=";
 const MAX_LENGTH = 8000 - ISSUES_URL.length; // it seems that GitHub limit is 8195
@@ -137,6 +139,8 @@ class Playground extends React.Component {
   getMarkdown({ formatted, reformatted, full, doc }) {
     const { content, options } = this.state;
     const { availableOptions, version } = this.props;
+    const orderedOptions = orderOptions(availableOptions, ENABLED_OPTIONS);
+    const cliOptions = util.buildCliArgs(orderedOptions, options);
 
     return formatMarkdown({
       input: content,
@@ -146,7 +150,7 @@ class Playground extends React.Component {
       version,
       url: window.location.href,
       options,
-      cliOptions: util.buildCliArgs(availableOptions, options),
+      cliOptions,
       full,
     });
   }

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -42,8 +42,6 @@ const ENABLED_OPTIONS = [
   "requirePragma",
   "vueIndentScriptAndStyle",
   "embeddedLanguageFormatting",
-  "rangeStart",
-  "rangeEnd",
 ];
 const ISSUES_URL = "https://github.com/prettier/prettier/issues/new?body=";
 const MAX_LENGTH = 8000 - ISSUES_URL.length; // it seems that GitHub limit is 8195
@@ -139,7 +137,11 @@ class Playground extends React.Component {
   getMarkdown({ formatted, reformatted, full, doc }) {
     const { content, options } = this.state;
     const { availableOptions, version } = this.props;
-    const orderedOptions = orderOptions(availableOptions, ENABLED_OPTIONS);
+    const orderedOptions = orderOptions(availableOptions, [
+      ...ENABLED_OPTIONS,
+      "rangeStart",
+      "rangeEnd",
+    ]);
     const cliOptions = util.buildCliArgs(orderedOptions, options);
 
     return formatMarkdown({


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Before

```sh
--no-bracket-spacing
--embedded-language-formatting off
--html-whitespace-sensitivity strict
--insert-pragma
--jsx-bracket-same-line
--jsx-single-quote
--parser babel
--print-width 81
--prose-wrap never
--quote-props consistent
--range-end 2
--range-start 1
--require-pragma
--no-semi
--single-quote
--tab-width 3
--trailing-comma none
--use-tabs
--vue-indent-script-and-style
```

After

```sh
--parser babel
--print-width 81
--tab-width 3
--use-tabs
--no-semi
--single-quote
--no-bracket-spacing
--jsx-single-quote
--jsx-bracket-same-line
--quote-props consistent
--trailing-comma none
--prose-wrap never
--html-whitespace-sensitivity strict
--insert-pragma
--require-pragma
--vue-indent-script-and-style
--embedded-language-formatting off
--range-start 1
--range-end 2
```

Especially the `--range-end` was printed before `--range-start` feel odd

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
