### PR TITLE
JS: Simplify print

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -142,4 +142,4 @@ overrides:
         - "src/language-js/parser-meriyah.js"
         - "src/language-js/pragma.js"
         - "src/language-js/parser/json.js"
-      prettier-internal-rules/no-ast-path-call: error
+      prettier-internal-rules/simplified-print: error

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -142,3 +142,4 @@ overrides:
         - "src/language-js/parser-meriyah.js"
         - "src/language-js/pragma.js"
         - "src/language-js/parser/json.js"
+      prettier-internal-rules/no-ast-path-call: error

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/index.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/index.js
@@ -8,12 +8,12 @@ module.exports = {
     "jsx-identifier-case": require("./jsx-identifier-case"),
     "no-doc-builder-concat": require("./no-doc-builder-concat"),
     "no-empty-flat-contents-for-if-break": require("./no-empty-flat-contents-for-if-break"),
-    "no-ast-path-call": require("./no-ast-path-call"),
     "no-identifier-n": require("./no-identifier-n"),
     "no-node-comments": require("./no-node-comments"),
     "prefer-ast-path-each": require("./prefer-ast-path-each"),
     "prefer-indent-if-break": require("./prefer-indent-if-break"),
     "prefer-is-non-empty-array": require("./prefer-is-non-empty-array"),
     "require-json-extensions": require("./require-json-extensions"),
+    "simplified-print": require("./simplified-print"),
   },
 };

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/index.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/index.js
@@ -8,6 +8,7 @@ module.exports = {
     "jsx-identifier-case": require("./jsx-identifier-case"),
     "no-doc-builder-concat": require("./no-doc-builder-concat"),
     "no-empty-flat-contents-for-if-break": require("./no-empty-flat-contents-for-if-break"),
+    "no-ast-path-call": require("./no-ast-path-call"),
     "no-identifier-n": require("./no-identifier-n"),
     "no-node-comments": require("./no-node-comments"),
     "prefer-ast-path-each": require("./prefer-ast-path-each"),

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/no-ast-path-call.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/no-ast-path-call.js
@@ -1,0 +1,71 @@
+"use strict";
+
+const selector = [
+  "CallExpression",
+  "[optional=false]",
+  '[callee.type="MemberExpression"]',
+  "[callee.optional=false]",
+  '[callee.property.type="Identifier"]',
+  '[callee.property.name="call"]',
+  "[arguments.length>0]",
+].join("");
+
+const messageId = "no-ast-path-call";
+
+function getNamesText(node, sourceCode) {
+  const [, firstName, ...restNames] = node.arguments;
+  if (!firstName) {
+    return "";
+  }
+
+  if (restNames.length === 0) {
+    return sourceCode.getText(
+      firstName.type === "SpreadElement" ? firstName.argument : firstName
+    );
+  }
+
+  const start = firstName.range[0];
+  const end = (restNames.length === 0
+    ? firstName
+    : restNames[restNames.length - 1]
+  ).range[1];
+  return `[${sourceCode.text.slice(start, end)}]`;
+}
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      url:
+        "https://github.com/prettier/prettier/blob/main/scripts/eslint-plugin-prettier-internal-rules/no-ast-path-call.js",
+    },
+    messages: {
+      [messageId]: "Do not use `AstPath#call` to print.",
+    },
+    fixable: "code",
+  },
+  create(context) {
+    const sourceCode = context.getSourceCode();
+
+    return {
+      [selector](node) {
+        const problem = {
+          node,
+          messageId,
+        };
+
+        // Only fix cases that first argument is `print`
+        const [firstArgument] = node.arguments;
+        if (
+          firstArgument.type === "Identifier" &&
+          firstArgument.name === "print"
+        ) {
+          problem.fix = (fixer) =>
+            fixer.replaceText(node, `print(${getNamesText(node, sourceCode)})`);
+        }
+
+        context.report(problem);
+      },
+    };
+  },
+};

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/simplified-print.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/simplified-print.js
@@ -1,5 +1,7 @@
 "use strict";
 
+// TODO: check `astPath.map`
+
 const selector = [
   "CallExpression",
   "[optional=false]",
@@ -10,7 +12,7 @@ const selector = [
   "[arguments.length>0]",
 ].join("");
 
-const messageId = "no-ast-path-call";
+const messageId = "simplified-print";
 
 function getNamesText(node, sourceCode) {
   const [, firstName, ...restNames] = node.arguments;
@@ -37,7 +39,7 @@ module.exports = {
     type: "suggestion",
     docs: {
       url:
-        "https://github.com/prettier/prettier/blob/main/scripts/eslint-plugin-prettier-internal-rules/no-ast-path-call.js",
+        "https://github.com/prettier/prettier/blob/main/scripts/eslint-plugin-prettier-internal-rules/simplified-print.js",
     },
     messages: {
       [messageId]: "Do not use `AstPath#call` to print.",

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
@@ -138,6 +138,42 @@ test("no-doc-builder-concat", {
   ],
 });
 
+test("no-ast-path-call", {
+  valid: ["call(print, 'key')", "path.call()"],
+  invalid: [
+    {
+      code: "path.call(print)",
+      output: "print()",
+      errors: 1,
+    },
+    {
+      code: "path.call(print, name)",
+      output: "print(name)",
+      errors: 1,
+    },
+    {
+      code: "path.call(print, ...names)",
+      output: "print(names)",
+      errors: 1,
+    },
+    {
+      code: "path.call(print, name, ...names)",
+      output: "print([name, ...names])",
+      errors: 1,
+    },
+    {
+      code: "path.call(print, ...names, name, )",
+      output: "print([...names, name])",
+      errors: 1,
+    },
+    {
+      code: "path.call(notPrint, )",
+      output: "path.call(notPrint, )",
+      errors: 1,
+    },
+  ],
+});
+
 test("no-identifier-n", {
   valid: ["const a = {n: 1}", "const m = 1", "a.n = 1"],
   invalid: [

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
@@ -138,42 +138,6 @@ test("no-doc-builder-concat", {
   ],
 });
 
-test("no-ast-path-call", {
-  valid: ["call(print, 'key')", "path.call()"],
-  invalid: [
-    {
-      code: "path.call(print)",
-      output: "print()",
-      errors: 1,
-    },
-    {
-      code: "path.call(print, name)",
-      output: "print(name)",
-      errors: 1,
-    },
-    {
-      code: "path.call(print, ...names)",
-      output: "print(names)",
-      errors: 1,
-    },
-    {
-      code: "path.call(print, name, ...names)",
-      output: "print([name, ...names])",
-      errors: 1,
-    },
-    {
-      code: "path.call(print, ...names, name, )",
-      output: "print([...names, name])",
-      errors: 1,
-    },
-    {
-      code: "path.call(notPrint, )",
-      output: "path.call(notPrint, )",
-      errors: 1,
-    },
-  ],
-});
-
 test("no-identifier-n", {
   valid: ["const a = {n: 1}", "const m = 1", "a.n = 1"],
   invalid: [
@@ -400,6 +364,42 @@ test("no-empty-flat-contents-for-if-break", {
             "Please don't pass an empty string to second parameter of ifBreak.",
         },
       ],
+    },
+  ],
+});
+
+test("simplified-print", {
+  valid: ["call(print, 'key')", "path.call()"],
+  invalid: [
+    {
+      code: "path.call(print)",
+      output: "print()",
+      errors: 1,
+    },
+    {
+      code: "path.call(print, name)",
+      output: "print(name)",
+      errors: 1,
+    },
+    {
+      code: "path.call(print, ...names)",
+      output: "print(names)",
+      errors: 1,
+    },
+    {
+      code: "path.call(print, name, ...names)",
+      output: "print([name, ...names])",
+      errors: 1,
+    },
+    {
+      code: "path.call(print, ...names, name, )",
+      output: "print([...names, name])",
+      errors: 1,
+    },
+    {
+      code: "path.call(notPrint, )",
+      output: "path.call(notPrint, )",
+      errors: 1,
     },
   ],
 });

--- a/src/language-js/print/angular.js
+++ b/src/language-js/print/angular.js
@@ -13,7 +13,7 @@ function printAngular(path, options, print) {
   switch (node.type) {
     case "NGRoot":
       return [
-        path.call(print, "node"),
+        print("node"),
         !hasComment(node.node)
           ? ""
           : " //" + getComments(node.node)[0].value.trimEnd(),
@@ -55,8 +55,8 @@ function printAngular(path, options, print) {
         : JSON.stringify(node.name);
     case "NGMicrosyntaxExpression":
       return [
-        path.call(print, "expression"),
-        node.alias === null ? "" : [" as ", path.call(print, "alias")],
+        print("expression"),
+        node.alias === null ? "" : [" as ", print("alias")],
       ];
     case "NGMicrosyntaxKeyedExpression": {
       const index = path.getName();
@@ -72,19 +72,19 @@ function printAngular(path, options, print) {
             parentNode.body[index - 1].key.name === "then")) &&
           parentNode.body[0].type === "NGMicrosyntaxExpression");
       return [
-        path.call(print, "key"),
+        print("key"),
         shouldNotPrintColon ? " " : ": ",
-        path.call(print, "expression"),
+        print("expression"),
       ];
     }
     case "NGMicrosyntaxLet":
       return [
         "let ",
-        path.call(print, "key"),
-        node.value === null ? "" : [" = ", path.call(print, "value")],
+        print("key"),
+        node.value === null ? "" : [" = ", print("value")],
       ];
     case "NGMicrosyntaxAs":
-      return [path.call(print, "key"), " as ", path.call(print, "alias")];
+      return [print("key"), " as ", print("alias")];
   }
 }
 

--- a/src/language-js/print/assignment.js
+++ b/src/language-js/print/assignment.js
@@ -74,7 +74,7 @@ function printAssignmentExpression(path, options, print) {
     path,
     options,
     print,
-    path.call(print, "left"),
+    print("left"),
     [" ", node.operator],
     "right"
   );
@@ -85,7 +85,7 @@ function printVariableDeclarator(path, options, print) {
     path,
     options,
     print,
-    path.call(print, "id"),
+    print("id"),
     " =",
     "init"
   );

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -217,7 +217,7 @@ function printBinaryishExpressions(
         ),
       ];
     } else {
-      parts.push(group(path.call(print, "left")));
+      parts.push(group(print("left")));
     }
 
     const shouldInline = shouldInlineLogicalExpression(node);
@@ -243,12 +243,12 @@ function printBinaryishExpressions(
         : "";
 
     const right = shouldInline
-      ? [operator, " ", path.call(print, "right"), rightSuffix]
+      ? [operator, " ", print("right"), rightSuffix]
       : [
           lineBeforeOperator ? line : "",
           operator,
           lineBeforeOperator ? " " : line,
-          path.call(print, "right"),
+          print("right"),
           rightSuffix,
         ];
 
@@ -285,7 +285,7 @@ function printBinaryishExpressions(
     }
   } else {
     // Our stopping case. Simply print the node normally.
-    parts.push(group(path.call(print)));
+    parts.push(group(print()));
   }
 
   return parts;

--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -48,9 +48,9 @@ function printCallArguments(path, options, print) {
   if (isReactHookCallWithDepsArray(args)) {
     return [
       "(",
-      path.call(print, "arguments", 0),
+      print(["arguments", 0]),
       ", ",
-      path.call(print, "arguments", 1),
+      print(["arguments", 1]),
       ")",
     ];
   }

--- a/src/language-js/print/call-expression.js
+++ b/src/language-js/print/call-expression.js
@@ -47,7 +47,7 @@ function printCallExpression(path, options, print) {
     });
     return [
       isNew ? "new " : "",
-      path.call(print, "callee"),
+      print("callee"),
       optional,
       printFunctionTypeParameters(path, options, print),
       "(",
@@ -84,7 +84,7 @@ function printCallExpression(path, options, print) {
 
   const contents = [
     isNew ? "new " : "",
-    isDynamicImport ? "import" : path.call(print, "callee"),
+    isDynamicImport ? "import" : print("callee"),
     optional,
     isIdentifierWithFlowAnnotation
       ? `/*:: ${node.callee.trailingComments[0].value.slice(2).trim()} */`

--- a/src/language-js/print/class.js
+++ b/src/language-js/print/class.js
@@ -40,16 +40,16 @@ function printClass(path, options, print) {
   const extendsParts = [];
 
   if (node.id) {
-    partsGroup.push(" ", path.call(print, "id"));
+    partsGroup.push(" ", print("id"));
   }
 
-  partsGroup.push(path.call(print, "typeParameters"));
+  partsGroup.push(print("typeParameters"));
 
   if (node.superClass) {
     const printed = [
       "extends ",
       printSuperClass(path, options, print),
-      path.call(print, "superTypeParameters"),
+      print("superTypeParameters"),
     ];
     const printedWithComments = path.call(
       (superClass) => printComments(superClass, printed, options),
@@ -81,7 +81,7 @@ function printClass(path, options, print) {
     parts.push(...partsGroup, ...extendsParts);
   }
 
-  parts.push(" ", path.call(print, "body"));
+  parts.push(" ", print("body"));
 
   return parts;
 }
@@ -137,7 +137,7 @@ function printList(path, options, print, listName) {
 }
 
 function printSuperClass(path, options, print) {
-  const printed = path.call(print, "superClass");
+  const printed = print("superClass");
   const parent = path.getParentNode();
   if (parent.type === "AssignmentExpression") {
     return group(
@@ -202,7 +202,7 @@ function printClassProperty(path, options, print) {
     parts.push("readonly ");
   }
   if (node.variance) {
-    parts.push(path.call(print, "variance"));
+    parts.push(print("variance"));
   }
   parts.push(
     printPropertyKey(path, options, print),

--- a/src/language-js/print/flow.js
+++ b/src/language-js/print/flow.js
@@ -27,27 +27,27 @@ function printFlow(path, options, print) {
     case "DeclareFunction":
       return printFlowDeclaration(path, [
         "function ",
-        path.call(print, "id"),
+        print("id"),
         node.predicate ? " " : "",
-        path.call(print, "predicate"),
+        print("predicate"),
         semi,
       ]);
     case "DeclareModule":
       return printFlowDeclaration(path, [
         "module ",
-        path.call(print, "id"),
+        print("id"),
         " ",
-        path.call(print, "body"),
+        print("body"),
       ]);
     case "DeclareModuleExports":
       return printFlowDeclaration(path, [
         "module.exports",
         ": ",
-        path.call(print, "typeAnnotation"),
+        print("typeAnnotation"),
         semi,
       ]);
     case "DeclareVariable":
-      return printFlowDeclaration(path, ["var ", path.call(print, "id"), semi]);
+      return printFlowDeclaration(path, ["var ", print("id"), semi]);
     case "DeclareOpaqueType":
       return printFlowDeclaration(path, printOpaqueType(path, options, print));
     case "DeclareInterface":
@@ -78,13 +78,13 @@ function printFlow(path, options, print) {
       return printTupleType(path, options, print);
     case "GenericTypeAnnotation":
       return [
-        path.call(print, "id"),
+        print("id"),
         printTypeParameters(path, options, print, "typeParameters"),
       ];
     // Type Annotations for Facebook Flow, typically stripped out or
     // transformed away before printing.
     case "TypeAnnotation":
-      return path.call(print, "typeAnnotation");
+      return print("typeAnnotation");
   }
 }
 

--- a/src/language-js/print/function-parameters.js
+++ b/src/language-js/print/function-parameters.js
@@ -65,7 +65,7 @@ function printFunctionParameters(
     if (isLastParameter && functionNode.rest) {
       printed.push("...");
     }
-    printed.push(parameterPath.call(print));
+    printed.push(print());
     if (isLastParameter) {
       return;
     }

--- a/src/language-js/print/function.js
+++ b/src/language-js/print/function.js
@@ -63,7 +63,7 @@ function printFunctionDeclaration(path, print, options, expandArg) {
   }
 
   if (node.id) {
-    parts.push(path.call(print, "id"));
+    parts.push(print("id"));
   }
 
   const parametersDoc = printFunctionParameters(
@@ -85,7 +85,7 @@ function printFunctionDeclaration(path, print, options, expandArg) {
       returnTypeDoc,
     ]),
     node.body ? " " : "",
-    path.call(print, "body")
+    print("body")
   );
 
   if (options.semi && (node.declare || !node.body)) {
@@ -128,7 +128,7 @@ function printMethod(path, options, print) {
       path.call((path) => printMethodInternal(path, options, print), "value")
     );
   } else {
-    parts.push(path.call(print, "value"));
+    parts.push(print("value"));
   }
 
   return parts;
@@ -151,7 +151,7 @@ function printMethodInternal(path, options, print) {
   ];
 
   if (node.body) {
-    parts.push(" ", path.call(print, "body"));
+    parts.push(" ", print("body"));
   } else {
     parts.push(options.semi ? ";" : "");
   }
@@ -168,7 +168,7 @@ function printArrowFunctionSignature(path, options, print, args) {
   }
 
   if (shouldPrintParamsWithoutParens(path, options)) {
-    parts.push(path.call(print, "params", 0));
+    parts.push(print(["params", 0]));
   } else {
     parts.push(
       group([
@@ -379,7 +379,7 @@ function shouldPrintParamsWithoutParens(path, options) {
 
 function printReturnType(path, print, options) {
   const node = path.getValue();
-  const returnType = path.call(print, "returnType");
+  const returnType = print("returnType");
 
   if (
     node.returnType &&
@@ -398,7 +398,7 @@ function printReturnType(path, print, options) {
   if (node.predicate) {
     // The return type will already add the colon, but otherwise we
     // need to do it ourselves
-    parts.push(node.returnType ? " " : ": ", path.call(print, "predicate"));
+    parts.push(node.returnType ? " " : ": ", print("predicate"));
   }
 
   return parts;
@@ -414,7 +414,7 @@ function printReturnAndThrowArgument(path, options, print) {
     if (returnArgumentHasLeadingComment(options, node.argument)) {
       parts.push([
         " (",
-        indent([hardline, path.call(print, "argument")]),
+        indent([hardline, print("argument")]),
         hardline,
         ")",
       ]);
@@ -425,13 +425,13 @@ function printReturnAndThrowArgument(path, options, print) {
       parts.push(
         group([
           ifBreak(" (", " "),
-          indent([softline, path.call(print, "argument")]),
+          indent([softline, print("argument")]),
           softline,
           ifBreak(")"),
         ])
       );
     } else {
-      parts.push(" ", path.call(print, "argument"));
+      parts.push(" ", print("argument"));
     }
   }
 

--- a/src/language-js/print/interface.js
+++ b/src/language-js/print/interface.js
@@ -30,8 +30,8 @@ function printInterface(path, options, print) {
   if (node.type !== "InterfaceTypeAnnotation") {
     partsGroup.push(
       " ",
-      path.call(print, "id"),
-      path.call(print, "typeParameters")
+      print("id"),
+      print("typeParameters")
     );
   }
 
@@ -69,7 +69,7 @@ function printInterface(path, options, print) {
     parts.push(...partsGroup, ...extendsParts);
   }
 
-  parts.push(" ", path.call(print, "body"));
+  parts.push(" ", print("body"));
 
   return group(parts);
 }

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -61,19 +61,19 @@ function printJsxElementInternal(path, options, print) {
 
   if (node.type === "JSXElement" && isEmptyJsxElement(node)) {
     return [
-      path.call(print, "openingElement"),
-      path.call(print, "closingElement"),
+      print("openingElement"),
+      print("closingElement"),
     ];
   }
 
   const openingLines =
     node.type === "JSXElement"
-      ? path.call(print, "openingElement")
-      : path.call(print, "openingFragment");
+      ? print("openingElement")
+      : print("openingFragment");
   const closingLines =
     node.type === "JSXElement"
-      ? path.call(print, "closingElement")
-      : path.call(print, "closingFragment");
+      ? print("closingElement")
+      : print("closingFragment");
 
   if (
     node.children.length === 1 &&
@@ -473,7 +473,7 @@ function maybeWrapJsxElementInParens(path, elem, options) {
 function printJsxAttribute(path, options, print) {
   const node = path.getValue();
   const parts = [];
-  parts.push(path.call(print, "name"));
+  parts.push(print("name"));
 
   if (node.value) {
     let res;
@@ -489,7 +489,7 @@ function printJsxAttribute(path, options, print) {
       final = final.slice(1, -1).replace(new RegExp(quote, "g"), escape);
       res = [quote, final, quote];
     } else {
-      res = path.call(print, "value");
+      res = print("value");
     }
     parts.push("=", res);
   }
@@ -519,7 +519,7 @@ function printJsxExpressionContainer(path, options, print) {
   if (shouldInline) {
     return group([
       "{",
-      path.call(print, "expression"),
+      print("expression"),
       lineSuffixBoundary,
       "}",
     ]);
@@ -527,7 +527,7 @@ function printJsxExpressionContainer(path, options, print) {
 
   return group([
     "{",
-    indent([softline, path.call(print, "expression")]),
+    indent([softline, print("expression")]),
     softline,
     lineSuffixBoundary,
     "}",
@@ -545,8 +545,8 @@ function printJsxOpeningElement(path, options, print) {
   if (node.selfClosing && node.attributes.length === 0 && !nameHasComments) {
     return [
       "<",
-      path.call(print, "name"),
-      path.call(print, "typeParameters"),
+      print("name"),
+      print("typeParameters"),
       " />",
     ];
   }
@@ -572,8 +572,8 @@ function printJsxOpeningElement(path, options, print) {
   ) {
     return group([
       "<",
-      path.call(print, "name"),
-      path.call(print, "typeParameters"),
+      print("name"),
+      print("typeParameters"),
       " ",
       ...path.map(print, "attributes"),
       node.selfClosing ? " />" : ">",
@@ -613,8 +613,8 @@ function printJsxOpeningElement(path, options, print) {
   return group(
     [
       "<",
-      path.call(print, "name"),
-      path.call(print, "typeParameters"),
+      print("name"),
+      print("typeParameters"),
 
       indent(path.map((attr) => [line, print(attr)], "attributes")),
       node.selfClosing ? line : bracketSameLine ? ">" : softline,
@@ -630,7 +630,7 @@ function printJsxClosingElement(path, options, print) {
 
   parts.push("</");
 
-  const printed = path.call(print, "name");
+  const printed = print("name");
   if (
     hasComment(node.name, CommentCheckFlags.Leading | CommentCheckFlags.Line)
   ) {
@@ -719,13 +719,13 @@ function printJsx(path, options, print) {
       return String(node.name);
     case "JSXNamespacedName":
       return join(":", [
-        path.call(print, "namespace"),
-        path.call(print, "name"),
+        print("namespace"),
+        print("name"),
       ]);
     case "JSXMemberExpression":
       return join(".", [
-        path.call(print, "object"),
-        path.call(print, "property"),
+        print("object"),
+        print("property"),
       ]);
     case "JSXSpreadAttribute":
       return printJsxSpreadAttribute(path, options, print);

--- a/src/language-js/print/member-chain.js
+++ b/src/language-js/print/member-chain.js
@@ -135,7 +135,7 @@ function printMemberChain(path, options, print) {
     } else {
       printedNodes.unshift({
         node,
-        printed: path.call(print),
+        printed: print(),
       });
     }
   }

--- a/src/language-js/print/member.js
+++ b/src/language-js/print/member.js
@@ -33,7 +33,7 @@ function printMemberExpression(path, options, print) {
       !isMemberExpression(parent));
 
   return [
-    path.call(print, "object"),
+    print("object"),
     shouldInline
       ? printMemberLookup(path, options, print)
       : group(indent([softline, printMemberLookup(path, options, print)])),
@@ -41,7 +41,7 @@ function printMemberExpression(path, options, print) {
 }
 
 function printMemberLookup(path, options, print) {
-  const property = path.call(print, "property");
+  const property = print("property");
   const node = path.getValue();
   const optional = printOptionalToken(path);
 

--- a/src/language-js/print/misc.js
+++ b/src/language-js/print/misc.js
@@ -28,10 +28,10 @@ function printOptionalToken(path) {
 function printFunctionTypeParameters(path, options, print) {
   const fun = path.getValue();
   if (fun.typeArguments) {
-    return path.call(print, "typeArguments");
+    return print("typeArguments");
   }
   if (fun.typeParameters) {
-    return path.call(print, "typeParameters");
+    return print("typeParameters");
   }
   return "";
 }
@@ -53,17 +53,17 @@ function printTypeAnnotation(path, options, print) {
     parentNode.type === "DeclareFunction" && parentNode.id === node;
 
   if (isFlowAnnotationComment(options.originalText, node.typeAnnotation)) {
-    return [" /*: ", path.call(print, "typeAnnotation"), " */"];
+    return [" /*: ", print("typeAnnotation"), " */"];
   }
 
   return [
     isFunctionDeclarationIdentifier ? "" : isDefinite ? "!: " : ": ",
-    path.call(print, "typeAnnotation"),
+    print("typeAnnotation"),
   ];
 }
 
 function printBindExpressionCallee(path, options, print) {
-  return ["::", path.call(print, "callee")];
+  return ["::", print("callee")];
 }
 
 function printTypeScriptModifiers(path, options, print) {

--- a/src/language-js/print/module.js
+++ b/src/language-js/print/module.js
@@ -78,7 +78,7 @@ function printExportDeclaration(path, options, print) {
   }
 
   if (declaration) {
-    parts.push(" ", path.call(print, "declaration"));
+    parts.push(" ", print("declaration"));
   } else {
     parts.push(
       exportKind === "type" ? " type" : "",
@@ -112,7 +112,7 @@ function printExportAllDeclaration(path, options, print) {
   parts.push(" *");
 
   if (exported) {
-    parts.push(" as ", path.call(print, "exported"));
+    parts.push(" as ", print("exported"));
   }
 
   parts.push(
@@ -163,7 +163,7 @@ function printModuleSource(path, options, print) {
   if (!shouldNotPrintSpecifiers(node, options)) {
     parts.push(" from");
   }
-  parts.push(" ", path.call(print, "source"));
+  parts.push(" ", print("source"));
 
   return parts;
 }
@@ -297,7 +297,7 @@ function printModuleSpecifier(path, options, print) {
   ) {
     left = "*";
   } else if (node[leftSideProperty]) {
-    left = path.call(print, leftSideProperty);
+    left = print(leftSideProperty);
   }
 
   if (
@@ -306,7 +306,7 @@ function printModuleSpecifier(path, options, print) {
       // import {a as a} from '.'
       !hasSameLoc(node[leftSideProperty], node[rightSideProperty]))
   ) {
-    right = path.call(print, rightSideProperty);
+    right = print(rightSideProperty);
   }
 
   parts.push(left, left && right ? " as " : "", right);

--- a/src/language-js/print/property.js
+++ b/src/language-js/print/property.js
@@ -17,7 +17,7 @@ function printPropertyKey(path, options, print) {
   const node = path.getNode();
 
   if (node.computed) {
-    return ["[", path.call(print, "key"), "]"];
+    return ["[", print("key"), "]"];
   }
 
   const parent = path.getParentNode();
@@ -25,7 +25,7 @@ function printPropertyKey(path, options, print) {
 
   // flow has `Identifier` key, other parsers use `PrivateIdentifier` (ESTree) or `PrivateName`
   if (node.type === "ClassPrivateProperty" && key.type === "Identifier") {
-    return ["#", path.call(print, "key")];
+    return ["#", print("key")];
   }
 
   if (options.quoteProps === "consistent" && !needsQuoteProps.has(parent)) {
@@ -86,13 +86,13 @@ function printPropertyKey(path, options, print) {
     );
   }
 
-  return path.call(print, "key");
+  return print("key");
 }
 
 function printProperty(path, options, print) {
   const node = path.getValue();
   if (node.shorthand) {
-    return path.call(print, "value");
+    return print("value");
   }
 
   return printAssignment(

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -116,13 +116,13 @@ function printTernaryTest(path, options, print) {
   const parent = path.getParentNode();
 
   const printed = isConditionalExpression
-    ? path.call(print, "test")
+    ? print("test")
     : [
-        path.call(print, "checkType"),
+        print("checkType"),
         " ",
         "extends",
         " ",
-        path.call(print, "extendsType"),
+        print("extendsType"),
       ];
   /**
    *     a
@@ -275,12 +275,12 @@ function printTernary(path, options, print) {
     parts.push(
       " ? ",
       isNil(consequentNode)
-        ? path.call(print, consequentNodePropertyName)
-        : wrap(path.call(print, consequentNodePropertyName)),
+        ? print(consequentNodePropertyName)
+        : wrap(print(consequentNodePropertyName)),
       " : ",
       alternateNode.type === node.type || isNil(alternateNode)
-        ? path.call(print, alternateNodePropertyName)
-        : wrap(path.call(print, alternateNodePropertyName))
+        ? print(alternateNodePropertyName)
+        : wrap(print(alternateNodePropertyName))
     );
   } else {
     // normal mode
@@ -288,13 +288,13 @@ function printTernary(path, options, print) {
       line,
       "? ",
       consequentNode.type === node.type ? ifBreak("", "(") : "",
-      align(2, path.call(print, consequentNodePropertyName)),
+      align(2, print(consequentNodePropertyName)),
       consequentNode.type === node.type ? ifBreak("", ")") : "",
       line,
       ": ",
       alternateNode.type === node.type
-        ? path.call(print, alternateNodePropertyName)
-        : align(2, path.call(print, alternateNodePropertyName)),
+        ? print(alternateNodePropertyName)
+        : align(2, print(alternateNodePropertyName)),
     ];
     parts.push(
       parent.type !== node.type ||

--- a/src/language-js/print/type-annotation.js
+++ b/src/language-js/print/type-annotation.js
@@ -58,16 +58,16 @@ function printOpaqueType(path, options, print) {
   const parts = [];
   parts.push(
     "opaque type ",
-    path.call(print, "id"),
-    path.call(print, "typeParameters")
+    print("id"),
+    print("typeParameters")
   );
 
   if (node.supertype) {
-    parts.push(": ", path.call(print, "supertype"));
+    parts.push(": ", print("supertype"));
   }
 
   if (node.impltype) {
-    parts.push(" = ", path.call(print, "impltype"));
+    parts.push(" = ", print("impltype"));
   }
 
   parts.push(semi);
@@ -84,8 +84,8 @@ function printTypeAlias(path, options, print) {
   }
   parts.push(
     "type ",
-    path.call(print, "id"),
-    path.call(print, "typeParameters")
+    print("id"),
+    print("typeParameters")
   );
   const rightPropertyName =
     node.type === "TSTypeAliasDeclaration" ? "typeAnnotation" : "right";
@@ -169,7 +169,7 @@ function printUnionType(path, options, print) {
   // // comment
   // | child2
   const printed = path.map((typePath) => {
-    let printedType = typePath.call(print);
+    let printedType = print();
     if (!shouldHug) {
       printedType = align(2, printedType);
     }
@@ -264,9 +264,9 @@ function printFunctionType(path, options, print) {
     node.returnType || node.predicate || node.typeAnnotation
       ? [
           isArrowFunctionTypeAnnotation ? " => " : ": ",
-          path.call(print, "returnType"),
-          path.call(print, "predicate"),
-          path.call(print, "typeAnnotation"),
+          print("returnType"),
+          print("predicate"),
+          print("typeAnnotation"),
         ]
       : "";
 

--- a/src/language-js/print/type-parameters.js
+++ b/src/language-js/print/type-parameters.js
@@ -26,7 +26,7 @@ function printTypeParameters(path, options, print, paramsKey) {
 
   // for TypeParameterDeclaration typeParameters is a single node
   if (!Array.isArray(node[paramsKey])) {
-    return path.call(print, paramsKey);
+    return print(paramsKey);
   }
 
   const grandparent = path.getNode(2);
@@ -97,14 +97,14 @@ function printTypeParameter(path, options, print) {
   const parts = [];
   const parent = path.getParentNode();
   if (parent.type === "TSMappedType") {
-    parts.push("[", path.call(print, "name"));
+    parts.push("[", print("name"));
     if (node.constraint) {
-      parts.push(" in ", path.call(print, "constraint"));
+      parts.push(" in ", print("constraint"));
     }
     if (parent.nameType) {
       parts.push(
         " as ",
-        path.callParent((path) => path.call(print, "nameType"))
+        path.callParent((path) => print("nameType"))
       );
     }
     parts.push("]");
@@ -112,21 +112,21 @@ function printTypeParameter(path, options, print) {
   }
 
   if (node.variance) {
-    parts.push(path.call(print, "variance"));
+    parts.push(print("variance"));
   }
 
-  parts.push(path.call(print, "name"));
+  parts.push(print("name"));
 
   if (node.bound) {
-    parts.push(": ", path.call(print, "bound"));
+    parts.push(": ", print("bound"));
   }
 
   if (node.constraint) {
-    parts.push(" extends ", path.call(print, "constraint"));
+    parts.push(" extends ", print("constraint"));
   }
 
   if (node.default) {
-    parts.push(" = ", path.call(print, "default"));
+    parts.push(" = ", print("default"));
   }
 
   return parts;

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -62,31 +62,31 @@ function printTypescript(path, options, print) {
 
       const castGroup = group([
         "<",
-        indent([softline, path.call(print, "typeAnnotation")]),
+        indent([softline, print("typeAnnotation")]),
         softline,
         ">",
       ]);
 
       const exprContents = [
         ifBreak("("),
-        indent([softline, path.call(print, "expression")]),
+        indent([softline, print("expression")]),
         softline,
         ifBreak(")"),
       ];
 
       if (shouldBreakAfterCast) {
         return conditionalGroup([
-          [castGroup, path.call(print, "expression")],
+          [castGroup, print("expression")],
           [castGroup, group(exprContents, { shouldBreak: true })],
-          [castGroup, path.call(print, "expression")],
+          [castGroup, print("expression")],
         ]);
       }
-      return group([castGroup, path.call(print, "expression")]);
+      return group([castGroup, print("expression")]);
     }
     case "TSDeclareFunction":
       return printFunctionDeclaration(path, print, options);
     case "TSExportAssignment":
-      return ["export = ", path.call(print, "expression"), semi];
+      return ["export = ", print("expression"), semi];
     case "TSModuleBlock":
       return printBlock(path, options, print);
     case "TSInterfaceBody":
@@ -95,7 +95,7 @@ function printTypescript(path, options, print) {
     case "TSTypeAliasDeclaration":
       return printTypeAlias(path, options, print);
     case "TSQualifiedName":
-      return join(".", [path.call(print, "left"), path.call(print, "right")]);
+      return join(".", [print("left"), print("right")]);
     case "TSAbstractMethodDefinition":
     case "TSDeclareMethod":
       return printClassMethod(path, options, print);
@@ -103,10 +103,10 @@ function printTypescript(path, options, print) {
       return printClassProperty(path, options, print);
     case "TSInterfaceHeritage":
     case "TSExpressionWithTypeArguments": // Babel AST
-      parts.push(path.call(print, "expression"));
+      parts.push(print("expression"));
 
       if (node.typeParameters) {
-        parts.push(path.call(print, "typeParameters"));
+        parts.push(print("typeParameters"));
       }
 
       return parts;
@@ -114,21 +114,21 @@ function printTypescript(path, options, print) {
       return printTemplateLiteral(path, print, options);
     case "TSNamedTupleMember":
       return [
-        path.call(print, "label"),
+        print("label"),
         node.optional ? "?" : "",
         ": ",
-        path.call(print, "elementType"),
+        print("elementType"),
       ];
     case "TSRestType":
-      return ["...", path.call(print, "typeAnnotation")];
+      return ["...", print("typeAnnotation")];
     case "TSOptionalType":
-      return [path.call(print, "typeAnnotation"), "?"];
+      return [print("typeAnnotation"), "?"];
     case "TSInterfaceDeclaration":
       return printInterface(path, options, print);
     case "TSClassImplements":
       return [
-        path.call(print, "expression"),
-        path.call(print, "typeParameters"),
+        print("expression"),
+        print("typeParameters"),
       ];
     case "TSTypeParameterDeclaration":
     case "TSTypeParameterInstantiation":
@@ -138,7 +138,7 @@ function printTypescript(path, options, print) {
     case "TypeParameter":
       return printTypeParameter(path, options, print);
     case "TypeofTypeAnnotation":
-      return ["typeof ", path.call(print, "argument")];
+      return ["typeof ", print("argument")];
     case "TSAbstractKeyword":
       return "abstract";
     case "TSAsyncKeyword":
@@ -169,9 +169,9 @@ function printTypescript(path, options, print) {
       return "intrinsic";
     case "TSAsExpression": {
       parts.push(
-        path.call(print, "expression"),
+        print("expression"),
         " as ",
-        path.call(print, "typeAnnotation")
+        print("typeAnnotation")
       );
       const parent = path.getParentNode();
       if (
@@ -183,7 +183,7 @@ function printTypescript(path, options, print) {
       return parts;
     }
     case "TSArrayType":
-      return [path.call(print, "elementType"), "[]"];
+      return [print("elementType"), "[]"];
     case "TSPropertySignature": {
       if (node.export) {
         parts.push("export ");
@@ -204,12 +204,12 @@ function printTypescript(path, options, print) {
       );
 
       if (node.typeAnnotation) {
-        parts.push(": ", path.call(print, "typeAnnotation"));
+        parts.push(": ", print("typeAnnotation"));
       }
 
       // This isn't valid semantically, but it's in the AST so we can print it.
       if (node.initializer) {
-        parts.push(" = ", path.call(print, "initializer"));
+        parts.push(" = ", print("initializer"));
       }
 
       return parts;
@@ -228,11 +228,11 @@ function printTypescript(path, options, print) {
         parts.push("readonly ");
       }
 
-      parts.push(path.call(print, "parameter"));
+      parts.push(print("parameter"));
 
       return parts;
     case "TSTypeQuery":
-      return ["typeof ", path.call(print, "exprName")];
+      return ["typeof ", print("exprName")];
     case "TSIndexSignature": {
       const parent = path.getParentNode();
 
@@ -263,34 +263,34 @@ function printTypescript(path, options, print) {
         "[",
         node.parameters ? parametersGroup : "",
         node.typeAnnotation ? "]: " : "]",
-        node.typeAnnotation ? path.call(print, "typeAnnotation") : "",
+        node.typeAnnotation ? print("typeAnnotation") : "",
         parent.type === "ClassBody" ? semi : "",
       ];
     }
     case "TSTypePredicate":
       return [
         node.asserts ? "asserts " : "",
-        path.call(print, "parameterName"),
-        node.typeAnnotation ? [" is ", path.call(print, "typeAnnotation")] : "",
+        print("parameterName"),
+        node.typeAnnotation ? [" is ", print("typeAnnotation")] : "",
       ];
     case "TSNonNullExpression":
-      return [path.call(print, "expression"), "!"];
+      return [print("expression"), "!"];
     case "TSImportType":
       return [
         !node.isTypeOf ? "" : "typeof ",
         "import(",
-        path.call(print, node.parameter ? "parameter" : "argument"),
+        print(node.parameter ? "parameter" : "argument"),
         ")",
-        !node.qualifier ? "" : [".", path.call(print, "qualifier")],
+        !node.qualifier ? "" : [".", print("qualifier")],
         printTypeParameters(path, options, print, "typeParameters"),
       ];
     case "TSLiteralType":
-      return path.call(print, "literal");
+      return print("literal");
     case "TSIndexedAccessType":
       return [
-        path.call(print, "objectType"),
+        print("objectType"),
         "[",
-        path.call(print, "indexType"),
+        print("indexType"),
         "]",
       ];
     case "TSConstructSignatureDeclaration":
@@ -319,14 +319,14 @@ function printTypescript(path, options, print) {
         const isType = node.type === "TSConstructorType";
         parts.push(
           isType ? " => " : ": ",
-          path.call(print, "returnType"),
-          path.call(print, "typeAnnotation")
+          print("returnType"),
+          print("typeAnnotation")
         );
       }
       return parts;
     }
     case "TSTypeOperator":
-      return [node.operator, " ", path.call(print, "typeAnnotation")];
+      return [node.operator, " ", print("typeAnnotation")];
     case "TSMappedType": {
       const shouldBreak = hasNewlineInRange(
         options.originalText,
@@ -345,12 +345,12 @@ function printTypescript(path, options, print) {
                 ]
               : "",
             printTypeScriptModifiers(path, options, print),
-            path.call(print, "typeParameter"),
+            print("typeParameter"),
             node.optional
               ? getTypeScriptMappedTypeModifier(node.optional, "?")
               : "",
             node.typeAnnotation ? ": " : "",
-            path.call(print, "typeAnnotation"),
+            print("typeAnnotation"),
             ifBreak(semi),
           ]),
           printDanglingComments(path, options, /* sameIndent */ true),
@@ -371,7 +371,7 @@ function printTypescript(path, options, print) {
         node.abstract ? "abstract " : "",
         node.declare ? "declare " : "",
         node.computed ? "[" : "",
-        path.call(print, "key"),
+        print("key"),
         node.computed ? "]" : "",
         printOptionalToken(path)
       );
@@ -389,7 +389,7 @@ function printTypescript(path, options, print) {
         : "typeAnnotation";
       const returnTypeNode = node[returnTypePropertyName];
       const returnTypeDoc = returnTypeNode
-        ? path.call(print, returnTypePropertyName)
+        ? print(returnTypePropertyName)
         : "";
       const shouldGroupParameters = shouldGroupFunctionParameters(
         node,
@@ -405,7 +405,7 @@ function printTypescript(path, options, print) {
       return group(parts);
     }
     case "TSNamespaceExportDeclaration":
-      parts.push("export as namespace ", path.call(print, "id"));
+      parts.push("export as namespace ", print("id"));
 
       if (options.semi) {
         parts.push(";");
@@ -424,7 +424,7 @@ function printTypescript(path, options, print) {
         parts.push("const ");
       }
 
-      parts.push("enum ", path.call(print, "id"), " ");
+      parts.push("enum ", print("id"), " ");
 
       if (node.members.length === 0) {
         parts.push(
@@ -448,9 +448,9 @@ function printTypescript(path, options, print) {
 
       return parts;
     case "TSEnumMember":
-      parts.push(path.call(print, "id"));
+      parts.push(print("id"));
       if (node.initializer) {
-        parts.push(" = ", path.call(print, "initializer"));
+        parts.push(" = ", print("initializer"));
       }
       return parts;
     case "TSImportEqualsDeclaration":
@@ -459,9 +459,9 @@ function printTypescript(path, options, print) {
       }
       parts.push(
         "import ",
-        path.call(print, "id"),
+        print("id"),
         " = ",
-        path.call(print, "moduleReference")
+        print("moduleReference")
       );
 
       if (options.semi) {
@@ -470,7 +470,7 @@ function printTypescript(path, options, print) {
 
       return group(parts);
     case "TSExternalModuleReference":
-      return ["require(", path.call(print, "expression"), ")"];
+      return ["require(", print("expression"), ")"];
     case "TSModuleDeclaration": {
       const parent = path.getParentNode();
       const isExternalModule = isLiteral(node.id);
@@ -508,12 +508,12 @@ function printTypescript(path, options, print) {
         }
       }
 
-      parts.push(path.call(print, "id"));
+      parts.push(print("id"));
 
       if (bodyIsDeclaration) {
-        parts.push(path.call(print, "body"));
+        parts.push(print("body"));
       } else if (node.body) {
-        parts.push(" ", group(path.call(print, "body")));
+        parts.push(" ", group(print("body")));
       } else {
         parts.push(semi);
       }
@@ -528,7 +528,7 @@ function printTypescript(path, options, print) {
       return printTernary(path, options, print);
 
     case "TSInferType":
-      return ["infer", " ", path.call(print, "typeParameter")];
+      return ["infer", " ", print("typeParameter")];
     case "TSIntersectionType":
       return printIntersectionType(path, options, print);
     case "TSUnionType":
@@ -539,11 +539,11 @@ function printTypescript(path, options, print) {
       return printTupleType(path, options, print);
     case "TSTypeReference":
       return [
-        path.call(print, "typeName"),
+        print("typeName"),
         printTypeParameters(path, options, print, "typeParameters"),
       ];
     case "TSTypeAnnotation":
-      return path.call(print, "typeAnnotation");
+      return print("typeAnnotation");
     case "TSEmptyBodyFunctionExpression":
       return printMethodInternal(path, options, print);
 
@@ -553,15 +553,15 @@ function printTypescript(path, options, print) {
     case "TSJSDocUnknownType":
       return "?";
     case "TSJSDocNullableType":
-      return ["?", path.call(print, "typeAnnotation")];
+      return ["?", print("typeAnnotation")];
     case "TSJSDocNonNullableType":
-      return ["!", path.call(print, "typeAnnotation")];
+      return ["!", print("typeAnnotation")];
     case "TSJSDocFunctionType":
       return [
         "function(",
         // The parameters could be here, but typescript-estree doesn't convert them anyway (throws an error).
         "): ",
-        path.call(print, "typeAnnotation"),
+        print("typeAnnotation"),
       ];
   }
 }

--- a/src/language-js/printer-estree-json.js
+++ b/src/language-js/printer-estree-json.js
@@ -9,7 +9,7 @@ function genericPrint(path, options, print) {
   const node = path.getValue();
   switch (node.type) {
     case "JsonRoot":
-      return [print("node"), hardline];
+      return [path.call(print, "node"), hardline];
     case "ArrayExpression": {
       if (node.elements.length === 0) {
         return "[]";
@@ -41,11 +41,11 @@ function genericPrint(path, options, print) {
             "}",
           ];
     case "ObjectProperty":
-      return [print("key"), ": ", print("value")];
+      return [path.call(print, "key"), ": ", path.call(print, "value")];
     case "UnaryExpression":
       return [
         node.operator === "+" ? "" : node.operator,
-        print("argument"),
+        path.call(print, "argument"),
       ];
     case "NullLiteral":
       return "null";
@@ -63,7 +63,7 @@ function genericPrint(path, options, print) {
     }
     case "TemplateLiteral":
       // There is only one `TemplateElement`
-      return print(["quasis", 0]);
+      return path.call(print, "quasis", 0);
     case "TemplateElement":
       return JSON.stringify(node.value.cooked);
     default:

--- a/src/language-js/printer-estree-json.js
+++ b/src/language-js/printer-estree-json.js
@@ -9,7 +9,7 @@ function genericPrint(path, options, print) {
   const node = path.getValue();
   switch (node.type) {
     case "JsonRoot":
-      return [path.call(print, "node"), hardline];
+      return [print("node"), hardline];
     case "ArrayExpression": {
       if (node.elements.length === 0) {
         return "[]";
@@ -41,11 +41,11 @@ function genericPrint(path, options, print) {
             "}",
           ];
     case "ObjectProperty":
-      return [path.call(print, "key"), ": ", path.call(print, "value")];
+      return [print("key"), ": ", print("value")];
     case "UnaryExpression":
       return [
         node.operator === "+" ? "" : node.operator,
-        path.call(print, "argument"),
+        print("argument"),
       ];
     case "NullLiteral":
       return "null";
@@ -63,7 +63,7 @@ function genericPrint(path, options, print) {
     }
     case "TemplateLiteral":
       // There is only one `TemplateElement`
-      return path.call(print, "quasis", 0);
+      return print(["quasis", 0]);
     case "TemplateElement":
       return JSON.stringify(node.value.cooked);
     default:

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -95,17 +95,27 @@ function genericPrint(path, options, printGenerically, args) {
     return "";
   }
 
-  const print = (property, args) => {
-    if (!property) {
+  const print = (nameOrNames, args) => {
+    // Old `printGenerically` way
+    if (nameOrNames === path) {
+      nameOrNames = "";
+    }
+
+    if (!nameOrNames) {
       return printGenerically(path, args);
     }
 
-    const value = node[property];
-    if (Array.isArray(value)) {
-      return path.map(() => printGenerically(path, args), property);
+    const names = Array.isArray(nameOrNames) ? nameOrNames : [nameOrNames];
+    let value = node;
+    for (const name of names) {
+      value = value ? value[name] : undefined;
     }
 
-    return path.call(() => printGenerically(path, args), property);
+    if (Array.isArray(value)) {
+      return path.map(() => printGenerically(path, args), ...names);
+    }
+
+    return path.call(() => printGenerically(path, args), ...names);
   };
 
   const printed = printPathNoParens(path, options, print, args);

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -191,17 +191,17 @@ function printPathNoParens(path, options, print, args) {
 
   switch (node.type) {
     case "JsExpressionRoot":
-      return path.call(print, "node");
+      return print("node");
     case "JsonRoot":
-      return [path.call(print, "node"), hardline];
+      return [print("node"), hardline];
     case "File":
       // Print @babel/parser's InterpreterDirective here so that
       // leading comments on the `Program` node get printed after the hashbang.
       if (node.program && node.program.interpreter) {
-        parts.push(path.call(print, "program", "interpreter"));
+        parts.push(print(["program", "interpreter"]));
       }
 
-      parts.push(path.call(print, "program"));
+      parts.push(print("program"));
 
       return parts;
 
@@ -224,7 +224,7 @@ function printPathNoParens(path, options, print, args) {
           parent.body[0] === node
         ) {
           return [
-            path.call(print, "expression"),
+            print("expression"),
             isVueEventBindingExpression(node.expression) ? ";" : "",
           ];
         }
@@ -232,7 +232,7 @@ function printPathNoParens(path, options, print, args) {
 
       // Do not append semicolon after the only JSX element in a program
       return [
-        path.call(print, "expression"),
+        print("expression"),
         isTheOnlyJsxElementInMarkdown(options, path) ? "" : semi,
       ];
     // Babel non-standard node. Used for Closure-style type casts. See postprocess.js.
@@ -242,11 +242,11 @@ function printPathNoParens(path, options, print, args) {
         (node.expression.type === "ObjectExpression" ||
           node.expression.type === "ArrayExpression");
       if (shouldHug) {
-        return ["(", path.call(print, "expression"), ")"];
+        return ["(", print("expression"), ")"];
       }
       return group([
         "(",
-        indent([softline, path.call(print, "expression")]),
+        indent([softline, print("expression")]),
         softline,
         ")",
       ]);
@@ -259,16 +259,16 @@ function printPathNoParens(path, options, print, args) {
     case "LogicalExpression":
       return printBinaryishExpression(path, options, print);
     case "AssignmentPattern":
-      return [path.call(print, "left"), " = ", path.call(print, "right")];
+      return [print("left"), " = ", print("right")];
     case "OptionalMemberExpression":
     case "MemberExpression": {
       return printMemberExpression(path, options, print);
     }
     case "MetaProperty":
-      return [path.call(print, "meta"), ".", path.call(print, "property")];
+      return [print("meta"), ".", print("property")];
     case "BindExpression":
       if (node.object) {
-        parts.push(path.call(print, "object"));
+        parts.push(print("object"));
       }
 
       parts.push(
@@ -295,7 +295,7 @@ function printPathNoParens(path, options, print, args) {
     case "ObjectTypeSpreadProperty":
       return [
         "...",
-        path.call(print, "argument"),
+        print("argument"),
         printTypeAnnotation(path, options, print),
       ];
     case "FunctionDeclaration":
@@ -318,14 +318,14 @@ function printPathNoParens(path, options, print, args) {
         parts.push("*");
       }
       if (node.argument) {
-        parts.push(" ", path.call(print, "argument"));
+        parts.push(" ", print("argument"));
       }
 
       return parts;
     case "AwaitExpression": {
       parts.push("await");
       if (node.argument) {
-        parts.push(" ", path.call(print, "argument"));
+        parts.push(" ", print("argument"));
         const parent = path.getParentNode();
         if (
           (isCallExpression(parent) && parent.callee === node) ||
@@ -361,7 +361,7 @@ function printPathNoParens(path, options, print, args) {
     case "ExportDefaultSpecifier":
       return printModuleSpecifier(path, options, print);
     case "ImportAttribute":
-      return [path.call(print, "key"), ": ", path.call(print, "value")];
+      return [print("key"), ": ", print("value")];
     case "Import":
       return "import";
     case "BlockStatement":
@@ -381,11 +381,11 @@ function printPathNoParens(path, options, print, args) {
       return [
         node.static ? "static " : "",
         "[[",
-        path.call(print, "id"),
+        print("id"),
         "]]",
         printOptionalToken(path),
         node.method ? "" : ": ",
-        path.call(print, "value"),
+        print("value"),
       ];
 
     case "ObjectExpression":
@@ -403,7 +403,7 @@ function printPathNoParens(path, options, print, args) {
     case "ObjectMethod":
       return printMethod(path, options, print);
     case "Decorator":
-      return ["@", path.call(print, "expression")];
+      return ["@", print("expression")];
     case "ArrayExpression":
     case "ArrayPattern":
     case "TupleExpression":
@@ -434,7 +434,7 @@ function printPathNoParens(path, options, print, args) {
     case "Super":
       return "super";
     case "Directive":
-      return [path.call(print, "value"), semi]; // Babel 6
+      return [print("value"), semi]; // Babel 6
     case "DirectiveLiteral":
       return printDirective(node, options);
     case "UnaryExpression":
@@ -448,18 +448,18 @@ function printPathNoParens(path, options, print, args) {
         parts.push(
           group([
             "(",
-            indent([softline, path.call(print, "argument")]),
+            indent([softline, print("argument")]),
             softline,
             ")",
           ])
         );
       } else {
-        parts.push(path.call(print, "argument"));
+        parts.push(print("argument"));
       }
 
       return parts;
     case "UpdateExpression":
-      parts.push(path.call(print, "argument"), node.operator);
+      parts.push(print("argument"), node.operator);
 
       if (node.prefix) {
         parts.reverse();
@@ -514,15 +514,15 @@ function printPathNoParens(path, options, print, args) {
     case "WithStatement":
       return group([
         "with (",
-        path.call(print, "object"),
+        print("object"),
         ")",
-        adjustClause(node.body, path.call(print, "body")),
+        adjustClause(node.body, print("body")),
       ]);
     case "IfStatement": {
-      const con = adjustClause(node.consequent, path.call(print, "consequent"));
+      const con = adjustClause(node.consequent, print("consequent"));
       const opening = group([
         "if (",
-        group([indent([softline, path.call(print, "test")]), softline]),
+        group([indent([softline, print("test")]), softline]),
         ")",
         con,
       ]);
@@ -551,7 +551,7 @@ function printPathNoParens(path, options, print, args) {
           group(
             adjustClause(
               node.alternate,
-              path.call(print, "alternate"),
+              print("alternate"),
               node.alternate.type === "IfStatement"
             )
           )
@@ -561,7 +561,7 @@ function printPathNoParens(path, options, print, args) {
       return parts;
     }
     case "ForStatement": {
-      const body = adjustClause(node.body, path.call(print, "body"));
+      const body = adjustClause(node.body, print("body"));
 
       // We want to keep dangling comments above the loop to stay consistent.
       // Any comment positioned between the for statement and the parentheses
@@ -584,13 +584,13 @@ function printPathNoParens(path, options, print, args) {
           group([
             indent([
               softline,
-              path.call(print, "init"),
+              print("init"),
               ";",
               line,
-              path.call(print, "test"),
+              print("test"),
               ";",
               line,
-              path.call(print, "update"),
+              print("update"),
             ]),
             softline,
           ]),
@@ -602,18 +602,18 @@ function printPathNoParens(path, options, print, args) {
     case "WhileStatement":
       return group([
         "while (",
-        group([indent([softline, path.call(print, "test")]), softline]),
+        group([indent([softline, print("test")]), softline]),
         ")",
-        adjustClause(node.body, path.call(print, "body")),
+        adjustClause(node.body, print("body")),
       ]);
     case "ForInStatement":
       return group([
         "for (",
-        path.call(print, "left"),
+        print("left"),
         " in ",
-        path.call(print, "right"),
+        print("right"),
         ")",
-        adjustClause(node.body, path.call(print, "body")),
+        adjustClause(node.body, print("body")),
       ]);
 
     case "ForOfStatement":
@@ -621,15 +621,15 @@ function printPathNoParens(path, options, print, args) {
         "for",
         node.await ? " await" : "",
         " (",
-        path.call(print, "left"),
+        print("left"),
         " of ",
-        path.call(print, "right"),
+        print("right"),
         ")",
-        adjustClause(node.body, path.call(print, "body")),
+        adjustClause(node.body, print("body")),
       ]);
 
     case "DoWhileStatement": {
-      const clause = adjustClause(node.body, path.call(print, "body"));
+      const clause = adjustClause(node.body, print("body"));
       const doBody = group(["do", clause]);
       parts = [doBody];
 
@@ -640,7 +640,7 @@ function printPathNoParens(path, options, print, args) {
       }
       parts.push(
         "while (",
-        group([indent([softline, path.call(print, "test")]), softline]),
+        group([indent([softline, print("test")]), softline]),
         ")",
         semi
       );
@@ -648,12 +648,12 @@ function printPathNoParens(path, options, print, args) {
       return parts;
     }
     case "DoExpression":
-      return ["do ", path.call(print, "body")];
+      return ["do ", print("body")];
     case "BreakStatement":
       parts.push("break");
 
       if (node.label) {
-        parts.push(" ", path.call(print, "label"));
+        parts.push(" ", print("label"));
       }
 
       parts.push(semi);
@@ -663,7 +663,7 @@ function printPathNoParens(path, options, print, args) {
       parts.push("continue");
 
       if (node.label) {
-        parts.push(" ", path.call(print, "label"));
+        parts.push(" ", print("label"));
       }
 
       parts.push(semi);
@@ -671,16 +671,16 @@ function printPathNoParens(path, options, print, args) {
       return parts;
     case "LabeledStatement":
       if (node.body.type === "EmptyStatement") {
-        return [path.call(print, "label"), ":;"];
+        return [print("label"), ":;"];
       }
 
-      return [path.call(print, "label"), ": ", path.call(print, "body")];
+      return [print("label"), ": ", print("body")];
     case "TryStatement":
       return [
         "try ",
-        path.call(print, "block"),
-        node.handler ? [" ", path.call(print, "handler")] : "",
-        node.finalizer ? [" finally ", path.call(print, "finalizer")] : "",
+        print("block"),
+        node.handler ? [" ", print("handler")] : "",
+        node.finalizer ? [" finally ", print("finalizer")] : "",
       ];
     case "CatchClause":
       if (node.param) {
@@ -695,24 +695,24 @@ function printPathNoParens(path, options, print, args) {
                 backwards: true,
               }))
         );
-        const param = path.call(print, "param");
+        const param = print("param");
 
         return [
           "catch ",
           parameterHasComments
             ? ["(", indent([softline, param]), softline, ") "]
             : ["(", param, ") "],
-          path.call(print, "body"),
+          print("body"),
         ];
       }
 
-      return ["catch ", path.call(print, "body")];
+      return ["catch ", print("body")];
     // Note: ignoring n.lexical because it has no printing consequences.
     case "SwitchStatement":
       return [
         group([
           "switch (",
-          indent([softline, path.call(print, "discriminant")]),
+          indent([softline, print("discriminant")]),
           softline,
           ")",
         ]),
@@ -725,7 +725,7 @@ function printPathNoParens(path, options, print, args) {
                 path.map((casePath, index, cases) => {
                   const caseNode = casePath.getValue();
                   return [
-                    casePath.call(print),
+                    print(),
                     index !== cases.length - 1 &&
                     isNextLineEmpty(caseNode, options)
                       ? hardline
@@ -740,7 +740,7 @@ function printPathNoParens(path, options, print, args) {
       ];
     case "SwitchCase": {
       if (node.test) {
-        parts.push("case ", path.call(print, "test"), ":");
+        parts.push("case ", print("test"), ":");
       } else {
         parts.push("default:");
       }
@@ -782,9 +782,9 @@ function printPathNoParens(path, options, print, args) {
       return printTemplateLiteral(path, print, options);
     case "TaggedTemplateExpression":
       return [
-        path.call(print, "tag"),
-        path.call(print, "typeParameters"),
-        path.call(print, "quasi"),
+        print("tag"),
+        print("typeParameters"),
+        print("quasi"),
       ];
     // These types are unprintable because they serve as abstract
     // supertypes for other (printable) types.
@@ -811,12 +811,12 @@ function printPathNoParens(path, options, print, args) {
     case "MixedTypeAnnotation":
       return "mixed";
     case "ArrayTypeAnnotation":
-      return [path.call(print, "elementType"), "[]"];
+      return [print("elementType"), "[]"];
     case "BooleanLiteralTypeAnnotation":
       return String(node.value);
 
     case "EnumDeclaration":
-      return ["enum ", path.call(print, "id"), " ", path.call(print, "body")];
+      return ["enum ", print("id"), " ", print("body")];
     case "EnumBooleanBody":
     case "EnumNumberBody":
     case "EnumStringBody":
@@ -872,17 +872,17 @@ function printPathNoParens(path, options, print, args) {
     case "EnumNumberMember":
     case "EnumStringMember":
       return [
-        path.call(print, "id"),
+        print("id"),
         " = ",
         typeof node.init === "object"
-          ? path.call(print, "init")
+          ? print("init")
           : String(node.init),
       ];
     case "EnumDefaultedMember":
-      return path.call(print, "id");
+      return print("id");
     case "FunctionTypeParam": {
       const name = node.name
-        ? path.call(print, "name")
+        ? print("name")
         : path.getParentNode().this === node
         ? "this"
         : "";
@@ -890,7 +890,7 @@ function printPathNoParens(path, options, print, args) {
         name,
         printOptionalToken(path),
         name ? ": " : "",
-        path.call(print, "typeAnnotation"),
+        print("typeAnnotation"),
       ];
     }
 
@@ -899,9 +899,9 @@ function printPathNoParens(path, options, print, args) {
       return printInterface(path, options, print);
     case "ClassImplements":
     case "InterfaceExtends":
-      return [path.call(print, "id"), path.call(print, "typeParameters")];
+      return [print("id"), print("typeParameters")];
     case "NullableTypeAnnotation":
-      return ["?", path.call(print, "typeAnnotation")];
+      return ["?", print("typeAnnotation")];
     case "Variance": {
       const { kind } = node;
       assert.ok(kind === "plus" || kind === "minus");
@@ -912,18 +912,18 @@ function printPathNoParens(path, options, print, args) {
         parts.push("static ");
       }
 
-      parts.push(path.call(print, "value"));
+      parts.push(print("value"));
 
       return parts;
     case "ObjectTypeIndexer": {
       return [
-        node.variance ? path.call(print, "variance") : "",
+        node.variance ? print("variance") : "",
         "[",
-        path.call(print, "id"),
+        print("id"),
         node.id ? ": " : "",
-        path.call(print, "key"),
+        print("key"),
         "]: ",
-        path.call(print, "value"),
+        print("value"),
       ];
     }
     case "ObjectTypeProperty": {
@@ -938,15 +938,15 @@ function printPathNoParens(path, options, print, args) {
       return [
         modifier,
         isGetterOrSetter(node) ? node.kind + " " : "",
-        node.variance ? path.call(print, "variance") : "",
+        node.variance ? print("variance") : "",
         printPropertyKey(path, options, print),
         printOptionalToken(path),
         isFunctionNotation(node) ? "" : ": ",
-        path.call(print, "value"),
+        print("value"),
       ];
     }
     case "QualifiedTypeIdentifier":
-      return [path.call(print, "qualification"), ".", path.call(print, "id")];
+      return [print("qualification"), ".", print("id")];
     case "StringLiteralTypeAnnotation":
       return printString(rawText(node), options);
     case "NumberLiteralTypeAnnotation":
@@ -960,7 +960,7 @@ function printPathNoParens(path, options, print, args) {
     case "TypeCastExpression": {
       return [
         "(",
-        path.call(print, "expression"),
+        print("expression"),
         printTypeAnnotation(path, options, print),
         ")",
       ];
@@ -998,7 +998,7 @@ function printPathNoParens(path, options, print, args) {
     // be either left alone or desugared into AST types that are fully
     // supported by the pretty-printer.
     case "DeclaredPredicate":
-      return ["%checks(", path.call(print, "value"), ")"];
+      return ["%checks(", print("value"), ")"];
     case "AnyTypeAnnotation":
     case "TSAnyKeyword":
       return "any";
@@ -1030,9 +1030,9 @@ function printPathNoParens(path, options, print, args) {
       return "this";
 
     case "PrivateIdentifier":
-      return ["#", path.call(print, "name")];
+      return ["#", print("name")];
     case "PrivateName":
-      return ["#", path.call(print, "id")];
+      return ["#", print("id")];
 
     case "InterpreterDirective":
       parts.push("#!", node.value, hardline);
@@ -1044,9 +1044,9 @@ function printPathNoParens(path, options, print, args) {
       return parts;
 
     case "PipelineBareFunction":
-      return path.call(print, "callee");
+      return print("callee");
     case "PipelineTopicExpression":
-      return path.call(print, "expression");
+      return print("expression");
     case "PipelinePrimaryTopicReference": {
       parts.push("#");
       return parts;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Added a simpler version `print`, ideally this change should apply to [this function](https://github.com/prettier/prettier/blob/1ce6b8dc3d3a21155bd95cb56824fe8e720837b7/src/main/ast-to-doc.js#L42), but I think this may break some edge case in plugins, so I added it in JS first.

The problem in that `printGenerically`, we meaninglessly passing the same `AstPath` over and over, and it's also missleading, when I first saw code like `path.map(childPath => print(childPath), 'key')`, I thought `path.map(childPath => childPath, 'key').map(print)` should work too, but it's not.

It's not done yet, I want confirm this is the right direction first.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
