### PR TITLE
Avoid last-argument hugging for number-only arrays

### DIFF
--- a/changelog_unreleased/javascript/10517.md
+++ b/changelog_unreleased/javascript/10517.md
@@ -1,0 +1,33 @@
+#### Avoid last-argument hugging for number-only arrays (#10517 by @thorn0)
+
+Another special case for number-only arrays.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+instantiate(game, [
+  transform([-0.7, 0.5, 0]),
+  render_colored_diffuse(game.MaterialDiffuse, game.Meshes["monkey_flat"], [1, 1, 0.3, 1]),
+]);
+
+// Prettier stable
+instantiate(game, [
+  transform([-0.7, 0.5, 0]),
+  render_colored_diffuse(game.MaterialDiffuse, game.Meshes["monkey_flat"], [
+    1,
+    1,
+    0.3,
+    1,
+  ]),
+]);
+
+// Prettier main
+instantiate(game, [
+  transform([-0.7, 0.5, 0]),
+  render_colored_diffuse(
+    game.MaterialDiffuse,
+    game.Meshes["monkey_flat"],
+    [1, 1, 0.3, 1]
+  ),
+]);
+```

--- a/src/language-js/print/array.js
+++ b/src/language-js/print/array.js
@@ -80,23 +80,7 @@ function printArray(path, options, print) {
         return element[itemsKey] && element[itemsKey].length > 1;
       });
 
-    const shouldUseConciseFormatting =
-      node.elements.length > 1 &&
-      node.elements.every(
-        (element) =>
-          element &&
-          (isNumericLiteral(element) ||
-            (isSignedNumericLiteral(element) &&
-              !hasComment(element.argument))) &&
-          !hasComment(
-            element,
-            CommentCheckFlags.Trailing | CommentCheckFlags.Line,
-            (comment) =>
-              !hasNewline(options.originalText, locStart(comment), {
-                backwards: true,
-              })
-          )
-      );
+    const shouldUseConciseFormatting = isConciselyPrintedArray(node, options);
 
     const trailingComma = !canHaveTrailingComma
       ? ""
@@ -136,6 +120,26 @@ function printArray(path, options, print) {
   );
 
   return parts;
+}
+
+function isConciselyPrintedArray(node, options) {
+  return (
+    node.elements.length > 1 &&
+    node.elements.every(
+      (element) =>
+        element &&
+        (isNumericLiteral(element) ||
+          (isSignedNumericLiteral(element) && !hasComment(element.argument))) &&
+        !hasComment(
+          element,
+          CommentCheckFlags.Trailing | CommentCheckFlags.Line,
+          (comment) =>
+            !hasNewline(options.originalText, locStart(comment), {
+              backwards: true,
+            })
+        )
+    )
+  );
 }
 
 function printArrayItems(path, options, printPath, print) {
@@ -182,4 +186,4 @@ function printArrayItemsConcisely(path, options, print, trailingComma) {
   return fill(parts);
 }
 
-module.exports = { printArray, printArrayItems };
+module.exports = { printArray, printArrayItems, isConciselyPrintedArray };

--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -31,6 +31,8 @@ const {
   utils: { willBreak },
 } = require("../../document");
 
+const { isConciselyPrintedArray } = require("./array");
+
 function printCallArguments(path, options, print) {
   const node = path.getValue();
   const isDynamicImport = node.type === "ImportExpression";
@@ -133,7 +135,7 @@ function printCallArguments(path, options, print) {
   }
 
   const shouldGroupFirst = shouldGroupFirstArg(args);
-  const shouldGroupLast = shouldGroupLastArg(args);
+  const shouldGroupLast = shouldGroupLastArg(args, options);
   if (shouldGroupFirst || shouldGroupLast) {
     const shouldBreak =
       (shouldGroupFirst
@@ -255,7 +257,7 @@ function couldGroupArg(arg, arrowChainRecursion = false) {
   );
 }
 
-function shouldGroupLastArg(args) {
+function shouldGroupLastArg(args, options) {
   const lastArg = getLast(args);
   const penultimateArg = getPenultimate(args);
   return (
@@ -267,8 +269,13 @@ function shouldGroupLastArg(args) {
     (!penultimateArg || penultimateArg.type !== lastArg.type) &&
     // useMemo(() => func(), [foo, bar, baz])
     (args.length !== 2 ||
-      args[0].type !== "ArrowFunctionExpression" ||
-      args[1].type !== "ArrayExpression")
+      penultimateArg.type !== "ArrowFunctionExpression" ||
+      lastArg.type !== "ArrayExpression") &&
+    !(
+      args.length > 1 &&
+      lastArg.type === "ArrayExpression" &&
+      isConciselyPrintedArray(lastArg, options)
+    )
   );
 }
 

--- a/tests/js/last-argument-expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/last-argument-expansion/__snapshots__/jsfmt.spec.js.snap
@@ -404,6 +404,30 @@ const els = items.map((item) => (
 ================================================================================
 `;
 
+exports[`number-only-array.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+instantiate(game, [
+  transform([-0.7, 0.5, 0]),
+  render_colored_diffuse(game.MaterialDiffuse, game.Meshes["monkey_flat"], [1, 1, 0.3, 1]),
+]);
+
+=====================================output=====================================
+instantiate(game, [
+  transform([-0.7, 0.5, 0]),
+  render_colored_diffuse(
+    game.MaterialDiffuse,
+    game.Meshes["monkey_flat"],
+    [1, 1, 0.3, 1]
+  ),
+]);
+
+================================================================================
+`;
+
 exports[`object.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow"]

--- a/tests/js/last-argument-expansion/number-only-array.js
+++ b/tests/js/last-argument-expansion/number-only-array.js
@@ -1,0 +1,4 @@
+instantiate(game, [
+  transform([-0.7, 0.5, 0]),
+  render_colored_diffuse(game.MaterialDiffuse, game.Meshes["monkey_flat"], [1, 1, 0.3, 1]),
+]);


### PR DESCRIPTION
## Description

Fixes #10515

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
