### PR TITLE
Fix edge case with trailing comments in arrow chains

### DIFF
--- a/changelog_unreleased/javascript/9992.md
+++ b/changelog_unreleased/javascript/9992.md
@@ -1,4 +1,4 @@
-#### Refine formatting of curried arrow functions (#9992 by @sosukesuzuki and @thorn0)
+#### Refine formatting of curried arrow functions (#9992, #10543 by @sosukesuzuki & @thorn0)
 
 <!-- prettier-ignore -->
 ```js

--- a/src/language-js/print/function.js
+++ b/src/language-js/print/function.js
@@ -262,10 +262,8 @@ function printArrowFunctionExpression(path, options, print, args) {
       signatures.push(doc);
     } else {
       const { leading, trailing } = printCommentsSeparately(path, options);
-      signatures.push(leading ? [leading, doc] : doc);
-      if (trailing) {
-        body.unshift(trailing);
-      }
+      signatures.push([leading, doc]);
+      body.unshift(trailing);
     }
 
     chainShouldBreak =

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -113,7 +113,7 @@ function genericPrint(path, options, print, args) {
   }
 
   const printedDecorators = printDecorators(path, options, print);
-  // Nodes with decorators can't have parentheses
+  // Nodes with decorators can't have parentheses and don't need leading semicolons
   if (printedDecorators) {
     return group([...printedDecorators, printed]);
   }
@@ -121,10 +121,10 @@ function genericPrint(path, options, print, args) {
   const needsParens = pathNeedsParens(path, options);
 
   if (!needsParens) {
-    return printed;
+    return args && args.needsSemi ? [";", printed] : printed;
   }
 
-  const parts = ["(", printed];
+  const parts = [args && args.needsSemi ? ";(" : "(", printed];
 
   if (hasFlowShorthandAnnotationComment(node)) {
     const [comment] = node.trailingComments;

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -57,7 +57,7 @@ function printAstToDoc(ast, options, alignmentSize = 0) {
     ) {
       // printComments will call the plugin print function and check for
       // comments to print
-      doc = printComments(path, doc, options, args && args.needsSemi);
+      doc = printComments(path, doc, options);
     }
 
     if (shouldCache) {

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -586,12 +586,12 @@ function printCommentsSeparately(path, options) {
   return { leading: leadingParts, trailing: trailingParts };
 }
 
-function printComments(path, doc, options, needsSemi) {
+function printComments(path, doc, options) {
   const { leading, trailing } = printCommentsSeparately(path, options);
-  if (!leading && !trailing && !needsSemi) {
+  if (!leading && !trailing) {
     return doc;
   }
-  return [leading || "", needsSemi ? ";" : "", doc, trailing || ""];
+  return [leading || "", doc, trailing || ""];
 }
 
 function ensureAllCommentsPrinted(astComments) {

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -543,7 +543,7 @@ function printDanglingComments(path, options, sameIndent, filter) {
 function printCommentsSeparately(path, options) {
   const value = path.getValue();
   const hasComments = isNonEmptyArray(value && value.comments);
-  const isCursorNode = Boolean(path.getNode() === options.cursorNode && value);
+  const isCursorNode = Boolean(value && value === options.cursorNode);
 
   if (!hasComments) {
     const maybeCursor = isCursorNode ? cursor : "";
@@ -591,7 +591,7 @@ function printComments(path, doc, options) {
   if (!leading && !trailing) {
     return doc;
   }
-  return [leading || "", doc, trailing || ""];
+  return [leading, doc, trailing];
 }
 
 function ensureAllCommentsPrinted(astComments) {

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -550,8 +550,8 @@ function printCommentsSeparately(path, options) {
     return { leading: maybeCursor, trailing: maybeCursor };
   }
 
-  const leadingDocs = [];
-  const trailingDocs = [];
+  const leadingParts = [];
+  const trailingParts = [];
 
   path.each((commentPath) => {
     const comment = commentPath.getValue();
@@ -563,7 +563,7 @@ function printCommentsSeparately(path, options) {
       if (!contents) {
         return;
       }
-      leadingDocs.push(contents);
+      leadingParts.push(contents);
 
       const text = options.originalText;
       const index = skipNewline(
@@ -571,19 +571,19 @@ function printCommentsSeparately(path, options) {
         skipSpaces(text, options.locEnd(comment))
       );
       if (index !== false && hasNewline(text, index)) {
-        leadingDocs.push(hardline);
+        leadingParts.push(hardline);
       }
     } else if (trailing) {
-      trailingDocs.push(printTrailingComment(commentPath, options));
+      trailingParts.push(printTrailingComment(commentPath, options));
     }
   }, "comments");
 
   if (isCursorNode) {
-    leadingDocs.unshift(cursor);
-    trailingDocs.push(cursor);
+    leadingParts.unshift(cursor);
+    trailingParts.push(cursor);
   }
 
-  return { leading: leadingDocs, trailing: trailingDocs };
+  return { leading: leadingParts, trailing: trailingParts };
 }
 
 function printComments(path, doc, options, needsSemi) {

--- a/tests/js/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -164,6 +164,82 @@ a = b => {
 ================================================================================
 `;
 
+exports[`arrow-chain-with-trailing-comments.js - {"arrowParens":"always"} format 1`] = `
+====================================options=====================================
+arrowParens: "always"
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+x = (bifornCringerMoshedPerplexSawder) => ((askTrovenaBeenaDependsRowans, glimseGlyphsHazardNoopsTieTie) => (f00) => {
+  averredBathersBoxroomBuggyNurl();
+} // BOOM
+)
+
+x2 = (a) => ((askTrovenaBeenaDependsRowans1, askTrovenaBeenaDependsRowans2, askTrovenaBeenaDependsRowans3) => {
+  c();
+} /* ! */ // KABOOM
+)
+
+=====================================output=====================================
+x =
+  (bifornCringerMoshedPerplexSawder) =>
+  (askTrovenaBeenaDependsRowans, glimseGlyphsHazardNoopsTieTie) =>
+  (f00) => {
+    averredBathersBoxroomBuggyNurl();
+  }; // BOOM
+
+x2 =
+  (a) =>
+  (
+    askTrovenaBeenaDependsRowans1,
+    askTrovenaBeenaDependsRowans2,
+    askTrovenaBeenaDependsRowans3
+  ) => {
+    c();
+  } /* ! */; // KABOOM
+
+================================================================================
+`;
+
+exports[`arrow-chain-with-trailing-comments.js - {"arrowParens":"avoid"} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+x = (bifornCringerMoshedPerplexSawder) => ((askTrovenaBeenaDependsRowans, glimseGlyphsHazardNoopsTieTie) => (f00) => {
+  averredBathersBoxroomBuggyNurl();
+} // BOOM
+)
+
+x2 = (a) => ((askTrovenaBeenaDependsRowans1, askTrovenaBeenaDependsRowans2, askTrovenaBeenaDependsRowans3) => {
+  c();
+} /* ! */ // KABOOM
+)
+
+=====================================output=====================================
+x =
+  bifornCringerMoshedPerplexSawder =>
+  (askTrovenaBeenaDependsRowans, glimseGlyphsHazardNoopsTieTie) =>
+  f00 => {
+    averredBathersBoxroomBuggyNurl();
+  }; // BOOM
+
+x2 =
+  a =>
+  (
+    askTrovenaBeenaDependsRowans1,
+    askTrovenaBeenaDependsRowans2,
+    askTrovenaBeenaDependsRowans3
+  ) => {
+    c();
+  } /* ! */; // KABOOM
+
+================================================================================
+`;
+
 exports[`assignment-chain-with-arrow-chain.js - {"arrowParens":"always"} format 1`] = `
 ====================================options=====================================
 arrowParens: "always"

--- a/tests/js/arrows/arrow-chain-with-trailing-comments.js
+++ b/tests/js/arrows/arrow-chain-with-trailing-comments.js
@@ -1,0 +1,9 @@
+x = (bifornCringerMoshedPerplexSawder) => ((askTrovenaBeenaDependsRowans, glimseGlyphsHazardNoopsTieTie) => (f00) => {
+  averredBathersBoxroomBuggyNurl();
+} // BOOM
+)
+
+x2 = (a) => ((askTrovenaBeenaDependsRowans1, askTrovenaBeenaDependsRowans2, askTrovenaBeenaDependsRowans3) => {
+  c();
+} /* ! */ // KABOOM
+)


### PR DESCRIPTION
## Description

Fixing this:

**Prettier pr-10511**
[Playground link](https://deploy-preview-10511--prettier.netlify.app/playground/#N4Igxg9gdgLgprEAuEAPABAXnQCgIYCUWAfLjgEZGanAA6U66YOBA3PQL7oD0AVOhAgAHAM7pe3AiAA0IYTACW0EclB4ATuogB3AAoaEKlHgA22vAE8Vs8urxgA1nBgBlIfYVQA5shjqArnCycAC25HAAJhGRADJ43v54XnAAYhDqIXgwit7IIHj+MBAyIAAWMCEmAOqlCvAi7mBwLoZ1CgBudRZ5YCLWIJ4icOowunZemcgAZqZDsgBWIqgAQnaOzi54IXAxnnDTs0Egi6gunl4mcACK-hDwByZzIO7qQ+p55HjhJiVC6p4wKoKCIwUrIAAcAAZZH8IEMqnYhHk-nA3u19rIAI63eBjYRGfIiAC0UDgkUiJXUcGxCipYySkyQM0eRyGIQUvgCrPOlxud32TMOshgXyBILBSAATMK7AoTOcAMIQEKMkCogCsJX8QwAKl8jMynu1AgBJKDRWAuMD-IQwACC5pcMAslweQw4HCAA)
<!-- prettier-ignore -->
```sh
--parser babel
```

**Input:**
<!-- prettier-ignore -->
```jsx
x = (a) => ((b) => {
  c();
} /* oops */)
```

**Output:**
<!-- prettier-ignore -->
```jsx
x = (a) => (b) /* oops */ => {
  c();
};

```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
