### PR TITLE
Fix print cache in `path.map(print, ...)`

### DIFF
--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -17,8 +17,9 @@ function getNodeStackIndexHelper(stack, count) {
 }
 
 class AstPath {
-  constructor(value) {
+  constructor(value, print) {
     this.stack = [value];
+    this.print = print;
   }
 
   // The name of the current property is always the penultimate element of
@@ -104,9 +105,16 @@ class AstPath {
   // the end of the iteration.
   map(callback, ...names) {
     const result = [];
-    this.each((path, index, value) => {
-      result[index] = callback(path, index, value);
-    }, ...names);
+    // Avoid pass `index` as `args` to `print` for this usage `path.map(print, ...)`
+    if (callback === this.print) {
+      this.each((path, index) => {
+        result[index] = callback(path);
+      }, ...names);
+    } else {
+      this.each((path, index, value) => {
+        result[index] = callback(path, index, value);
+      }, ...names);
+    }
     return result;
   }
 

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -67,7 +67,7 @@ function printAstToDoc(ast, options, alignmentSize = 0) {
     return doc;
   }
 
-  let doc = printGenerically(new AstPath(ast));
+  let doc = printGenerically(new AstPath(ast, printGenerically));
   if (alignmentSize > 0) {
     // Add a hardline to make the indents take effect
     // It should be removed in index.js format()


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
