### PR TITLE
Disallow `import` without argument and `new import(…)`

### DIFF
--- a/src/language-js/parser-babel.js
+++ b/src/language-js/parser-babel.js
@@ -180,7 +180,6 @@ const allowedMessages = new Set([
 
   "Using the export keyword between a decorator and a class is not allowed. Please use `export @dec class` instead.",
   "Argument name clash",
-  "import() requires exactly one or two arguments",
   "Invalid decimal",
   "Unexpected trailing comma after rest element",
   "Decorators cannot be used to decorate parameters",
@@ -190,7 +189,6 @@ const allowedMessages = new Set([
   "Unexpected token :",
   "Unexpected reserved word 'package'",
   'Duplicate key "type" is not allowed in module attributes',
-  "Cannot use new with import(...)",
   "No line break is allowed before '=>'",
   "Invalid escape sequence in template",
   "Abstract methods can only appear within an abstract class.",

--- a/tests/js/call/no-argument/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/call/no-argument/__snapshots__/jsfmt.spec.js.snap
@@ -1,53 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`import.js [espree] format 1`] = `
-"Unexpected token ) (1:21)
-> 1 | import(/* comment */)
-    |                     ^
-  2 | new import(/* comment */)
-  3 |"
-`;
-
-exports[`import.js [flow] format 1`] = `
-"Unexpected token \`)\` (1:21)
-> 1 | import(/* comment */)
-    |                     ^
-  2 | new import(/* comment */)
-  3 |"
-`;
-
-exports[`import.js [meriyah] format 1`] = `
-"[1:21]: Unexpected token: ')' (1:21)
-> 1 | import(/* comment */)
-    |                     ^
-  2 | new import(/* comment */)
-  3 |"
-`;
-
-exports[`import.js [typescript] format 1`] = `
-"Expression expected. (2:5)
-  1 | import(/* comment */)
-> 2 | new import(/* comment */)
-    |     ^
-  3 |"
-`;
-
-exports[`import.js format 1`] = `
-====================================options=====================================
-parsers: ["babel", "flow", "typescript"]
-printWidth: 80
-                                                                                | printWidth
-=====================================input======================================
-import(/* comment */)
-new import(/* comment */)
-
-=====================================output=====================================
-import(/* comment */);
-new import(/* comment */);
-
-================================================================================
-`;
-
 exports[`special-cases.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/js/call/no-argument/import.js
+++ b/tests/js/call/no-argument/import.js
@@ -1,2 +1,0 @@
-import(/* comment */)
-new import(/* comment */)

--- a/tests/js/call/no-argument/jsfmt.spec.js
+++ b/tests/js/call/no-argument/jsfmt.spec.js
@@ -1,8 +1,1 @@
-run_spec(__dirname, ["babel", "flow", "typescript"], {
-  errors: {
-    espree: ["import.js"],
-    meriyah: ["import.js"],
-    flow: ["import.js"],
-    typescript: ["import.js"],
-  },
-});
+run_spec(__dirname, ["babel", "flow", "typescript"]);

--- a/tests/misc/errors/js/import/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/misc/errors/js/import/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,169 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snippet: #0 [babel] format 1`] = `
+"import() requires exactly one or two arguments (1:1)
+> 1 | import();
+    | ^"
+`;
+
+exports[`snippet: #0 [babel-flow] format 1`] = `
+"import() requires exactly one or two arguments (1:1)
+> 1 | import();
+    | ^"
+`;
+
+exports[`snippet: #0 [babel-ts] format 1`] = `
+"import() requires exactly one or two arguments (1:1)
+> 1 | import();
+    | ^"
+`;
+
+exports[`snippet: #0 [espree] format 1`] = `
+"Unexpected token ) (1:8)
+> 1 | import();
+    |        ^"
+`;
+
+exports[`snippet: #0 [flow] format 1`] = `
+"Unexpected token \`)\` (1:8)
+> 1 | import();
+    |        ^"
+`;
+
+exports[`snippet: #0 [meriyah] format 1`] = `
+"[1:8]: Unexpected token: ')' (1:8)
+> 1 | import();
+    |        ^"
+`;
+
+exports[`snippet: #0 [typescript] format 1`] = `
+"Dynamic import must have one specifier as an argument. (1:8)
+> 1 | import();
+    |        ^"
+`;
+
+exports[`snippet: #1 [babel] format 1`] = `
+"import() requires exactly one or two arguments (1:1)
+> 1 | import(/* comment */);
+    | ^"
+`;
+
+exports[`snippet: #1 [babel-flow] format 1`] = `
+"import() requires exactly one or two arguments (1:1)
+> 1 | import(/* comment */);
+    | ^"
+`;
+
+exports[`snippet: #1 [babel-ts] format 1`] = `
+"import() requires exactly one or two arguments (1:1)
+> 1 | import(/* comment */);
+    | ^"
+`;
+
+exports[`snippet: #1 [espree] format 1`] = `
+"Unexpected token ) (1:21)
+> 1 | import(/* comment */);
+    |                     ^"
+`;
+
+exports[`snippet: #1 [flow] format 1`] = `
+"Unexpected token \`)\` (1:21)
+> 1 | import(/* comment */);
+    |                     ^"
+`;
+
+exports[`snippet: #1 [meriyah] format 1`] = `
+"[1:21]: Unexpected token: ')' (1:21)
+> 1 | import(/* comment */);
+    |                     ^"
+`;
+
+exports[`snippet: #1 [typescript] format 1`] = `
+"Dynamic import must have one specifier as an argument. (1:8)
+> 1 | import(/* comment */);
+    |        ^"
+`;
+
+exports[`snippet: #2 [babel] format 1`] = `
+"Cannot use new with import(...) (1:5)
+> 1 | new import('./a.mjs');
+    |     ^"
+`;
+
+exports[`snippet: #2 [babel-flow] format 1`] = `
+"Cannot use new with import(...) (1:5)
+> 1 | new import('./a.mjs');
+    |     ^"
+`;
+
+exports[`snippet: #2 [babel-ts] format 1`] = `
+"Cannot use new with import(...) (1:5)
+> 1 | new import('./a.mjs');
+    |     ^"
+`;
+
+exports[`snippet: #2 [espree] format 1`] = `
+"Cannot use new with import() (1:5)
+> 1 | new import('./a.mjs');
+    |     ^"
+`;
+
+exports[`snippet: #2 [flow] format 1`] = `
+"Unexpected token \`import\` (1:5)
+> 1 | new import('./a.mjs');
+    |     ^^^^^^"
+`;
+
+exports[`snippet: #2 [meriyah] format 1`] = `
+"[1:11]: Cannot use new with import(...) (1:11)
+> 1 | new import('./a.mjs');
+    |           ^"
+`;
+
+exports[`snippet: #2 [typescript] format 1`] = `
+"Expression expected. (1:5)
+> 1 | new import('./a.mjs');
+    |     ^"
+`;
+
+exports[`snippet: #3 [babel] format 1`] = `
+"Cannot use new with import(...) (1:5)
+> 1 | new import();
+    |     ^"
+`;
+
+exports[`snippet: #3 [babel-flow] format 1`] = `
+"Cannot use new with import(...) (1:5)
+> 1 | new import();
+    |     ^"
+`;
+
+exports[`snippet: #3 [babel-ts] format 1`] = `
+"Cannot use new with import(...) (1:5)
+> 1 | new import();
+    |     ^"
+`;
+
+exports[`snippet: #3 [espree] format 1`] = `
+"Unexpected token ) (1:12)
+> 1 | new import();
+    |            ^"
+`;
+
+exports[`snippet: #3 [flow] format 1`] = `
+"Unexpected token \`import\` (1:5)
+> 1 | new import();
+    |     ^^^^^^"
+`;
+
+exports[`snippet: #3 [meriyah] format 1`] = `
+"[1:11]: Cannot use new with import(...) (1:11)
+> 1 | new import();
+    |           ^"
+`;
+
+exports[`snippet: #3 [typescript] format 1`] = `
+"Expression expected. (1:5)
+> 1 | new import();
+    |     ^"
+`;

--- a/tests/misc/errors/js/import/jsfmt.spec.js
+++ b/tests/misc/errors/js/import/jsfmt.spec.js
@@ -1,0 +1,12 @@
+run_spec(
+  {
+    dirname: __dirname,
+    snippets: [
+      "import();",
+      "import(/* comment */);",
+      "new import('./a.mjs');",
+      "new import();",
+    ],
+  },
+  ["babel", "espree", "meriyah", "flow", "typescript", "babel-flow", "babel-ts"]
+);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

To avoid unexpected cases, I don't think anyone can use this code in real world, so I'm not going to add changelog for it.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
