### PR TITLE
Ember / Handlebars: Do not break opening mustache and path

### DIFF
--- a/changelog_unreleased/handlebars/10586.md
+++ b/changelog_unreleased/handlebars/10586.md
@@ -1,0 +1,40 @@
+#### Do not break opening mustache and path (#10586 by @dcyriller)
+
+<!-- prettier-ignore -->
+```handlebars
+{{!-- Input --}}
+<GlimmerComponent
+  @errors={{or this.aVeryLongProperty (and this.aProperty (v-get bike "number" "message"))}}
+  data-test-beneficiary-account-number
+/>
+<GlimmerComponent
+  @progress={{aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue}}
+/>
+
+{{!-- Prettier stable --}}
+<GlimmerComponent
+  @errors={{
+    or this.aLongProperty (and this.aProperty (v-get bike 'number' 'message'))
+    this.aLongProperty
+    (and this.aProperty (v-get bike 'number' 'message'))
+  }}
+  data-test-beneficiary-account-number
+/>
+<GlimmerComponent
+  @progress={{
+    aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue
+  }}
+/>
+
+{{!-- Prettier main --}}
+<GlimmerComponent
+  @errors={{or
+    this.aLongProperty
+    (and this.aProperty (v-get bike 'number' 'message'))
+  }}
+  data-test-beneficiary-account-number
+/>
+<GlimmerComponent
+  @progress={{aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue}}
+/>
+```

--- a/changelog_unreleased/handlebars/10586.md
+++ b/changelog_unreleased/handlebars/10586.md
@@ -14,9 +14,9 @@
 {{!-- Prettier stable --}}
 <GlimmerComponent
   @errors={{
-    or this.aLongProperty (and this.aProperty (v-get bike 'number' 'message'))
-    this.aLongProperty
-    (and this.aProperty (v-get bike 'number' 'message'))
+    or
+    this.aVeryLongProperty
+    (and this.aProperty (v-get bike "number" "message"))
   }}
   data-test-beneficiary-account-number
 />
@@ -30,7 +30,7 @@
 <GlimmerComponent
   @errors={{or
     this.aLongProperty
-    (and this.aProperty (v-get bike 'number' 'message'))
+    (and this.aProperty (v-get bike "number" "message"))
   }}
   data-test-beneficiary-account-number
 />

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -121,27 +121,13 @@ function print(path, options, print) {
     }
 
     case "ElementModifierStatement": {
-      return group(["{{", printPathAndParams(path, print), softline, "}}"]);
+      return group(["{{", printPathAndParams(path, print), "}}"]);
     }
+
     case "MustacheStatement": {
-      const isParentOfSpecifiedTypes = isParentOfSomeType(path, [
-        "AttrNode",
-        "ConcatStatement",
-      ]);
-
-      const isChildOfElementNodeAndDoesNotHaveParams =
-        isParentOfSomeType(path, ["ElementNode"]) &&
-        doesNotHaveHashParams(node) &&
-        doesNotHavePositionalParams(node);
-
-      const shouldBreakOpeningMustache =
-        isParentOfSpecifiedTypes || isChildOfElementNodeAndDoesNotHaveParams;
-
       return group([
         printOpeningMustache(node),
-        shouldBreakOpeningMustache ? indent(softline) : "",
         printPathAndParams(path, print),
-        softline,
         printClosingMustache(node),
       ]);
     }
@@ -570,8 +556,8 @@ function printElseIfBlock(path, print) {
 
   return [
     printInverseBlockOpeningMustache(parentNode),
-    "else ",
-    printPathAndParams(path, print),
+    "else if ",
+    printParams(path, print),
     printInverseBlockClosingMustache(parentNode),
   ];
 }
@@ -764,7 +750,7 @@ function printPathAndParams(path, print) {
     return p;
   }
 
-  return indent(group([p, line, params]));
+  return [indent(group([p, line, params])), softline];
 }
 
 function printPath(path, print) {
@@ -794,14 +780,6 @@ function printParams(path, print) {
 
 function printBlockParams(node) {
   return ["as |", node.blockParams.join(" "), "|"];
-}
-
-function doesNotHaveHashParams(node) {
-  return node.hash.pairs.length === 0;
-}
-
-function doesNotHavePositionalParams(node) {
-  return node.params.length === 0;
 }
 
 module.exports = {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -536,7 +536,7 @@ function printOpenBlock(path, print) {
 
   return group([
     openingMustache,
-    indent(group(attributes)),
+    indent(attributes),
     softline,
     closingMustache,
   ]);

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -750,7 +750,7 @@ function printPathAndParams(path, print) {
     return p;
   }
 
-  return [indent(group([p, line, params])), softline];
+  return [indent([p, line, params]), softline];
 }
 
 function printPath(path, print) {

--- a/tests/handlebars/concat-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/concat-statement/__snapshots__/jsfmt.spec.js.snap
@@ -137,14 +137,10 @@ singleQuote: true
     chars with emtpy spaces'
 >hey</div>
 <a
-  href='a-very-long-href-from-a-third-party-marketing-platform{{
-    id
-  }}longer-than-eighty-chars'
+  href='a-very-long-href-from-a-third-party-marketing-platform{{id}}longer-than-eighty-chars'
 >Link</a>
 <button
-  class='uk-padding-remove uk-button uk-button-default uk-button-small uk-width-1-{{
-      intl.locales.length
-    }}
+  class='uk-padding-remove uk-button uk-button-default uk-button-small uk-width-1-{{intl.locales.length}}
     {{if (contains locale intl.locale) 'uk-button-primary'}}'
 >
   test
@@ -173,14 +169,10 @@ printWidth: 80
     chars with emtpy spaces"
 >hey</div>
 <a
-  href="a-very-long-href-from-a-third-party-marketing-platform{{
-    id
-  }}longer-than-eighty-chars"
+  href="a-very-long-href-from-a-third-party-marketing-platform{{id}}longer-than-eighty-chars"
 >Link</a>
 <button
-  class="uk-padding-remove uk-button uk-button-default uk-button-small uk-width-1-{{
-      intl.locales.length
-    }}
+  class="uk-padding-remove uk-button uk-button-default uk-button-small uk-width-1-{{intl.locales.length}}
     {{if (contains locale intl.locale) "uk-button-primary"}}"
 >
   test

--- a/tests/handlebars/html-whitespace-sensitivity/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/html-whitespace-sensitivity/__snapshots__/jsfmt.spec.js.snap
@@ -184,8 +184,7 @@ hey
 {{name}}
 
 Some sentence with {{dynamic}}
-expressions. sometimes{{nogaps
-}}areimportant
+expressions. sometimes{{nogaps}}areimportant
 <Hello />
 
 {{name}} is your name
@@ -491,8 +490,8 @@ hey
 
 Some sentence with
 {{dynamic}}
-expressions. sometimes{{nogaps
-}}areimportant<Hello />
+expressions. sometimes{{nogaps}}areimportant<Hello
+/>
 
 {{name}}
 is your name

--- a/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
@@ -73,16 +73,15 @@ singleQuote: true
 
 =====================================output=====================================
 <GlimmerComponent
-  @progress={{
-    aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue
-  }}
+  @progress={{aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue}}
 />
 
 <GlimmerComponent
   class='medium'
   @autocomplete='off'
-  @errors={{
-    or this.aLongProperty (and this.aProperty (v-get bike 'number' 'message'))
+  @errors={{or
+    this.aLongProperty
+    (and this.aProperty (v-get bike 'number' 'message'))
   }}
   data-test-beneficiary-account-number
 />
@@ -90,8 +89,7 @@ singleQuote: true
 <GlimmerComponent
   class='medium'
   @autocomplete='off'
-  @errors={{
-    or
+  @errors={{or
     this.aVeryLongProperty
     (and this.aProperty (v-get bike 'number' 'message'))
   }}
@@ -236,16 +234,15 @@ printWidth: 80
 
 =====================================output=====================================
 <GlimmerComponent
-  @progress={{
-    aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue
-  }}
+  @progress={{aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue}}
 />
 
 <GlimmerComponent
   class="medium"
   @autocomplete="off"
-  @errors={{
-    or this.aLongProperty (and this.aProperty (v-get bike "number" "message"))
+  @errors={{or
+    this.aLongProperty
+    (and this.aProperty (v-get bike "number" "message"))
   }}
   data-test-beneficiary-account-number
 />
@@ -253,8 +250,7 @@ printWidth: 80
 <GlimmerComponent
   class="medium"
   @autocomplete="off"
-  @errors={{
-    or
+  @errors={{or
     this.aVeryLongProperty
     (and this.aProperty (v-get bike "number" "message"))
   }}
@@ -564,8 +560,7 @@ foo{{/if}}
 
 =====================================output=====================================
 <li
-  class='{{
-      if
+  class='{{if
       showAsCarousel
       'career-interests__pill--slide-item'
       'career-interests__pill'
@@ -583,8 +578,7 @@ foo{{/if}}
 }}
 
 <LinkTo
-  @query={{
-    hash
+  @query={{hash
     filter=(compute
       this.computeFilterWithEmail this.filter campaignPic.userEmail
     )
@@ -647,8 +641,7 @@ foo{{/if}}
 
 =====================================output=====================================
 <li
-  class="{{
-      if
+  class="{{if
       showAsCarousel
       "career-interests__pill--slide-item"
       "career-interests__pill"
@@ -666,8 +659,7 @@ foo{{/if}}
 }}
 
 <LinkTo
-  @query={{
-    hash
+  @query={{hash
     filter=(compute
       this.computeFilterWithEmail this.filter campaignPic.userEmail
     )

--- a/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
@@ -592,7 +592,8 @@ foo{{/if}}
 {{if abcdefghijklmnopqrstuvwxyz (t 'abcdefghijklmnopq') (t 'abcdefghijklmnopq')
 }}
 
-{{#if (eq abcdefghijklmnopqrstuvwxyzabcdefgh abcdefghijklmnopqrstuvwxyzabcdefgh)
+{{#if
+  (eq abcdefghijklmnopqrstuvwxyzabcdefgh abcdefghijklmnopqrstuvwxyzabcdefgh)
 }}
   foo{{/if}}
 
@@ -673,7 +674,8 @@ foo{{/if}}
 {{if abcdefghijklmnopqrstuvwxyz (t "abcdefghijklmnopq") (t "abcdefghijklmnopq")
 }}
 
-{{#if (eq abcdefghijklmnopqrstuvwxyzabcdefgh abcdefghijklmnopqrstuvwxyzabcdefgh)
+{{#if
+  (eq abcdefghijklmnopqrstuvwxyzabcdefgh abcdefghijklmnopqrstuvwxyzabcdefgh)
 }}
   foo{{/if}}
 

--- a/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
@@ -13,7 +13,7 @@ singleQuote: true
 <GlimmerComponent
   class="medium"
   @autocomplete="off"
-  @errors={{or this.aLongProperty (and this.aProperty (v-get bike "number" "message"))}}
+  @errors={{or this.aLProp (and this.aProperty (v-get bike "number" "message"))}}
   data-test-beneficiary-account-number
 />
 
@@ -80,7 +80,7 @@ singleQuote: true
   class='medium'
   @autocomplete='off'
   @errors={{or
-    this.aLongProperty
+    this.aLProp
     (and this.aProperty (v-get bike 'number' 'message'))
   }}
   data-test-beneficiary-account-number
@@ -174,7 +174,7 @@ printWidth: 80
 <GlimmerComponent
   class="medium"
   @autocomplete="off"
-  @errors={{or this.aLongProperty (and this.aProperty (v-get bike "number" "message"))}}
+  @errors={{or this.aLProp (and this.aProperty (v-get bike "number" "message"))}}
   data-test-beneficiary-account-number
 />
 
@@ -241,7 +241,7 @@ printWidth: 80
   class="medium"
   @autocomplete="off"
   @errors={{or
-    this.aLongProperty
+    this.aLProp
     (and this.aProperty (v-get bike "number" "message"))
   }}
   data-test-beneficiary-account-number
@@ -589,7 +589,10 @@ foo{{/if}}
   {{campaignPic.userEmail}}
 </LinkTo>
 
-{{if abcdefghijklmnopqrstuvwxyz (t 'abcdefghijklmnopq') (t 'abcdefghijklmnopq')
+{{if
+  abcdefghijklmnopqrstuvwxyz
+  (t 'abcdefghijklmnopq')
+  (t 'abcdefghijklmnopq')
 }}
 
 {{#if
@@ -597,7 +600,10 @@ foo{{/if}}
 }}
   foo{{/if}}
 
-{{some-helper abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijkl
+{{some-helper
+  abcdefghijklmnopqrstuvwxyz
+  abcdefghijklmnopqrstuvwxyz
+  abcdefghijkl
 }}
 ================================================================================
 `;
@@ -671,7 +677,10 @@ foo{{/if}}
   {{campaignPic.userEmail}}
 </LinkTo>
 
-{{if abcdefghijklmnopqrstuvwxyz (t "abcdefghijklmnopq") (t "abcdefghijklmnopq")
+{{if
+  abcdefghijklmnopqrstuvwxyz
+  (t "abcdefghijklmnopq")
+  (t "abcdefghijklmnopq")
 }}
 
 {{#if
@@ -679,7 +688,10 @@ foo{{/if}}
 }}
   foo{{/if}}
 
-{{some-helper abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijkl
+{{some-helper
+  abcdefghijklmnopqrstuvwxyz
+  abcdefghijklmnopqrstuvwxyz
+  abcdefghijkl
 }}
 ================================================================================
 `;

--- a/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/mustache-statement/__snapshots__/jsfmt.spec.js.snap
@@ -522,3 +522,170 @@ an escaped mustache:
 another non-escaped mustache: \\\\\\{{my-component}}
 ================================================================================
 `;
+
+exports[`issue-8691.hbs - {"singleQuote":true} format 1`] = `
+====================================options=====================================
+parsers: ["glimmer"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+<li class="
+{{if showAsCarousel "career-interests__pill--slide-item" "career-interests__pill"}}
+"></li>
+
+{{
+  yield
+  (hash
+    header=(component "fluid-table/thead")
+    body=(component "fluid-table/tbody")
+    th=(component "fluid-table/th")
+    td=(component "fluid-table/td")
+  )
+}}
+
+<LinkTo
+  @query={{
+    hash
+    filter=(compute this.computeFilterWithEmail this.filter campaignPic.userEmail)
+  }}
+  class="text-xs hover:underline"
+  data-test-user-email
+>
+  {{campaignPic.userEmail}}
+</LinkTo>
+
+{{if abcdefghijklmnopqrstuvwxyz (t 'abcdefghijklmnopq') (t 'abcdefghijklmnopq')}}
+
+{{#if (eq abcdefghijklmnopqrstuvwxyzabcdefgh abcdefghijklmnopqrstuvwxyzabcdefgh)}}
+foo{{/if}}
+
+{{some-helper abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijkl}}
+
+=====================================output=====================================
+<li
+  class='{{
+      if
+      showAsCarousel
+      'career-interests__pill--slide-item'
+      'career-interests__pill'
+    }}
+    '
+></li>
+
+{{yield
+  (hash
+    header=(component 'fluid-table/thead')
+    body=(component 'fluid-table/tbody')
+    th=(component 'fluid-table/th')
+    td=(component 'fluid-table/td')
+  )
+}}
+
+<LinkTo
+  @query={{
+    hash
+    filter=(compute
+      this.computeFilterWithEmail this.filter campaignPic.userEmail
+    )
+  }}
+  class='text-xs hover:underline'
+  data-test-user-email
+>
+  {{campaignPic.userEmail}}
+</LinkTo>
+
+{{if abcdefghijklmnopqrstuvwxyz (t 'abcdefghijklmnopq') (t 'abcdefghijklmnopq')
+}}
+
+{{#if (eq abcdefghijklmnopqrstuvwxyzabcdefgh abcdefghijklmnopqrstuvwxyzabcdefgh)
+}}
+  foo{{/if}}
+
+{{some-helper abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijkl
+}}
+================================================================================
+`;
+
+exports[`issue-8691.hbs format 1`] = `
+====================================options=====================================
+parsers: ["glimmer"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<li class="
+{{if showAsCarousel "career-interests__pill--slide-item" "career-interests__pill"}}
+"></li>
+
+{{
+  yield
+  (hash
+    header=(component "fluid-table/thead")
+    body=(component "fluid-table/tbody")
+    th=(component "fluid-table/th")
+    td=(component "fluid-table/td")
+  )
+}}
+
+<LinkTo
+  @query={{
+    hash
+    filter=(compute this.computeFilterWithEmail this.filter campaignPic.userEmail)
+  }}
+  class="text-xs hover:underline"
+  data-test-user-email
+>
+  {{campaignPic.userEmail}}
+</LinkTo>
+
+{{if abcdefghijklmnopqrstuvwxyz (t 'abcdefghijklmnopq') (t 'abcdefghijklmnopq')}}
+
+{{#if (eq abcdefghijklmnopqrstuvwxyzabcdefgh abcdefghijklmnopqrstuvwxyzabcdefgh)}}
+foo{{/if}}
+
+{{some-helper abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijkl}}
+
+=====================================output=====================================
+<li
+  class="{{
+      if
+      showAsCarousel
+      "career-interests__pill--slide-item"
+      "career-interests__pill"
+    }}
+    "
+></li>
+
+{{yield
+  (hash
+    header=(component "fluid-table/thead")
+    body=(component "fluid-table/tbody")
+    th=(component "fluid-table/th")
+    td=(component "fluid-table/td")
+  )
+}}
+
+<LinkTo
+  @query={{
+    hash
+    filter=(compute
+      this.computeFilterWithEmail this.filter campaignPic.userEmail
+    )
+  }}
+  class="text-xs hover:underline"
+  data-test-user-email
+>
+  {{campaignPic.userEmail}}
+</LinkTo>
+
+{{if abcdefghijklmnopqrstuvwxyz (t "abcdefghijklmnopq") (t "abcdefghijklmnopq")
+}}
+
+{{#if (eq abcdefghijklmnopqrstuvwxyzabcdefgh abcdefghijklmnopqrstuvwxyzabcdefgh)
+}}
+  foo{{/if}}
+
+{{some-helper abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijkl
+}}
+================================================================================
+`;

--- a/tests/handlebars/mustache-statement/basics.hbs
+++ b/tests/handlebars/mustache-statement/basics.hbs
@@ -4,7 +4,7 @@
 <GlimmerComponent
   class="medium"
   @autocomplete="off"
-  @errors={{or this.aLongProperty (and this.aProperty (v-get bike "number" "message"))}}
+  @errors={{or this.aLProp (and this.aProperty (v-get bike "number" "message"))}}
   data-test-beneficiary-account-number
 />
 

--- a/tests/handlebars/mustache-statement/issue-8691.hbs
+++ b/tests/handlebars/mustache-statement/issue-8691.hbs
@@ -1,0 +1,31 @@
+<li class="
+{{if showAsCarousel "career-interests__pill--slide-item" "career-interests__pill"}}
+"></li>
+
+{{
+  yield
+  (hash
+    header=(component "fluid-table/thead")
+    body=(component "fluid-table/tbody")
+    th=(component "fluid-table/th")
+    td=(component "fluid-table/td")
+  )
+}}
+
+<LinkTo
+  @query={{
+    hash
+    filter=(compute this.computeFilterWithEmail this.filter campaignPic.userEmail)
+  }}
+  class="text-xs hover:underline"
+  data-test-user-email
+>
+  {{campaignPic.userEmail}}
+</LinkTo>
+
+{{if abcdefghijklmnopqrstuvwxyz (t 'abcdefghijklmnopq') (t 'abcdefghijklmnopq')}}
+
+{{#if (eq abcdefghijklmnopqrstuvwxyzabcdefgh abcdefghijklmnopqrstuvwxyzabcdefgh)}}
+foo{{/if}}
+
+{{some-helper abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijkl}}

--- a/tests/handlebars/text-wrap/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/text-wrap/__snapshots__/jsfmt.spec.js.snap
@@ -277,11 +277,7 @@ printWidth: 80
 
 {{! this really should split across lines }}
 <div>
-  before{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after{{
-    stuff
-  }}after{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after{{
-    stuff
-  }}after{{stuff}}after{{stuff}}after{{stuff}}after
+  before{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after{{stuff}}after
 </div>
 
 {{! solitary whitespace }}

--- a/tests/handlebars/whitespace/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/handlebars/whitespace/__snapshots__/jsfmt.spec.js.snap
@@ -387,8 +387,8 @@ sometimes{{nogaps}}areimportant<Hello></Hello>
 
 Some sentence with
 {{dynamic}}
-expressions. sometimes{{nogaps
-}}areimportant<Hello />
+expressions. sometimes{{nogaps}}areimportant<Hello
+/>
 
 {{name}}
 is your name


### PR DESCRIPTION
## Description

In Ember ecosystem, the opening mustache and the path are often printed on a same line (see [this comment](https://github.com/prettier/prettier/issues/8691#issuecomment-652589072) and [this comment](https://github.com/prettier/prettier/issues/8691#issuecomment-652557920) for more details).

### Changes

```handlebars
{{!-- Input --}}
<GlimmerComponent
  @errors={{or this.aVeryLongProperty (and this.aProperty (v-get bike "number" "message"))}}
  data-test-beneficiary-account-number
/>
<GlimmerComponent
  @progress={{aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue}}
/>

{{!-- Prettier stable --}}
<GlimmerComponent
  @errors={{
    or
    this.aVeryLongProperty
    (and this.aProperty (v-get bike "number" "message"))
  }}
  data-test-beneficiary-account-number
/>
<GlimmerComponent
  @progress={{
    aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue
  }}
/>

{{!-- Prettier main --}}
<GlimmerComponent
  @errors={{or
    this.aLongProperty
    (and this.aProperty (v-get bike "number" "message"))
  }}
  data-test-beneficiary-account-number
/>
<GlimmerComponent
  @progress={{aPropertyEngdingAfterEightiethColumnToHighlightAWeirdClosingParenIssue}}
/>
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://deploy-preview-10586--prettier.netlify.app/playground/#N4Igxg9gdgLgprEAuEAeA4gGwJYFtdwBOAwhLgA7QIwA6UABPQAJGESEDOAvMMO-TAAW2DgDoAhgDUiATwAy0AOYAFNuSIwZ9ABTioAEwHCx41RHWFNOgG4BaRXBj0ARtgDWcejRBQArrmciby8QAg4OcQdvAEpogF84ukZ9cRhxW3gOGFtAqDgAM2wwbHFCGVtxMEhfWFs-AKCoAHoAPjoMHHwiUgoqWCTmcjZFQjhwnmBTNQ0ZAFEoRX1sBYBBfPhCWexFQRhsR0FSTH8oABUIAAltwRwdmBWAdThsQn1iTAgOZZVShABJcK+OAJOitEAAGhA5j20A4yFApTYAHdlL8oHCUOJMEjxDI4ZDnIRKh4YABlciVb7IGCEIGQuANfT6OD6OR6RS+SJwABi7FwqT2C2QIHEvhgEAhIF2uEwD2EmQpYDgpIQXz21mwmmFYHCkuWHA0qki-OQ+SxBshACsOAAPABCRLAJNJ4gIcmWcFN5rgVttpO+mDgAEVfBB4F7MBaQBTOERhYpOgRCJKhssYA9sPohMgABwABkhQ0+cAeRPIwqGYyI1k9kIAjqH4GZyBiRRw6nAWSzJaMGy84EbFCakGbIz6QAbcNhqbTx18FoGQ2HPSPvZC0s4M1nBMgAEzronYHALHrDkBjACskt8BtO4mcGNHUesQL+BmopLAhGw5HuBlJmiBhGBoJEAA)✨**
