### PR TITLE
[Docs] Change `husky` to `simple-git-hooks`

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -15,7 +15,7 @@ _Make sure Prettier is installed and is in your [`devDependencies`](https://docs
 npx mrm lint-staged
 ```
 
-This will install [husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/okonet/lint-staged), then add a configuration to the project’s `package.json` that will automatically format supported files in a pre-commit hook.
+This will install [simple-git-hooks](https://github.com/toplenboren/simple-git-hooks) and [lint-staged](https://github.com/okonet/lint-staged), then add a configuration to the project’s `package.json` that will automatically format supported files in a pre-commit hook.
 
 Read more at the [lint-staged](https://github.com/okonet/lint-staged#configuration) repo.
 


### PR DESCRIPTION
## Description

`Lint staged` along with `mrm` recently [migrated](https://github.com/okonet/lint-staged/pull/954) from `husky` to `simple-git-hooks`.

It is now reflected in their [docs](https://github.com/okonet/lint-staged):

> It will install and configure simple-git-hooks and lint-staged depending on code quality tools from package.json dependencies so please make sure you install (npm install --save-dev) and configure all code quality tools like Prettier, ESlint prior that.

Migration brought these benefits for users: 

* lighter `node_modules` 
   `simple-git-hooks` (10 kb) is lighter then husky4 (1mb) and husky5 (25kb)
* Out of the box `Yarn 2` support
* No worry for licensing. 
   Simple git hooks has MIT license, like husky 4
   
P.S didn't check the checkboxes. Don't know If I should add challengelog for `docs` change :(

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
