### PR TITLE
docs: Typos and wording in integrating-with-linters.md

### DIFF
--- a/docs/integrating-with-linters.md
+++ b/docs/integrating-with-linters.md
@@ -17,7 +17,7 @@ Check out the above links for instructions on how to install and set things up.
 
 When searching for both Prettier and your linter on the Internet you’ll probably find more related projects. These are **generally not recommended,** but can be useful in certain circumstances.
 
-First, we have plugins that let you run Prettier as if it was a linter rule:
+First, we have plugins that let you run Prettier as if it were a linter rule:
 
 - [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier)
 - [tslint-plugin-prettier](https://github.com/ikatyang/tslint-plugin-prettier)
@@ -29,12 +29,12 @@ The downsides of those plugins are:
 
 - You end up with a lot of red squiggly lines in your editor, which gets annoying. Prettier is supposed to make you forget about formatting – and not be in your face about it!
 - They are slower than running Prettier directly.
-- They’re yet one layer of indirection where things may break.
+- They’re yet another layer of indirection where things may break.
 
-Finally, we have tools that runs `prettier` and then immediately for example `eslint --fix` on files.
+Finally, we have tools that run `prettier` and then immediately apply `eslint --fix` on files.
 
 - [prettier-eslint](https://github.com/prettier/prettier-eslint)
 - [prettier-tslint](https://github.com/azz/prettier-tslint)
 - [prettier-stylelint](https://github.com/hugomrdias/prettier-stylelint)
 
-Those are useful if some aspect of Prettier’s output makes Prettier completely unusable to you. Then you can have for example `eslint --fix` fix that up for you. The downside is that these tools are much slower than just running Prettier.
+These are useful if some aspect of Prettier’s output makes Prettier completely unusable to you, then you can have `eslint --fix` fix that up for you. The downside is that these tools are much slower than just running Prettier.


### PR DESCRIPTION
This is just some minor grammar stuff I picked up as I was reading the docs. I think these changes makes the docs clearer.

Thanks for an awesome library!

## Description

Wording, typos and grammar changes for the Integrating with Linters section of the docs.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
