### PR TITLE
Ignore unknown files + apply prettier on all possible files

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -119,11 +119,11 @@ Alternately you can save this script as `.git/hooks/pre-commit` and give it exec
 
 ```sh
 #!/bin/sh
-FILES=$(git diff --cached --name-only --diff-filter=ACMR "*.js" "*.jsx" | sed 's| |\\ |g')
+FILES=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
 [ -z "$FILES" ] && exit 0
 
 # Prettify all selected files
-echo "$FILES" | xargs ./node_modules/.bin/prettier --write
+echo "$FILES" | xargs ./node_modules/.bin/prettier --ignore-unknown --write
 
 # Add back the modified/prettified files to staging
 echo "$FILES" | xargs git add


### PR DESCRIPTION
Apply prettier on all files.

Without `--ignore-unknown`, files without an extension or with an unknown extension would trigger the following error :
```
.gitignore[error] No parser could be inferred for file: ansible.cfg
```

## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [X] I’ve added tests to confirm my change works.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
