### PR TITLE
JS: Fix duplicated `prettier-ignore` comments

### DIFF
--- a/changelog_unreleased/javascript/10666.md
+++ b/changelog_unreleased/javascript/10666.md
@@ -1,0 +1,21 @@
+#### Fix duplicated prettier-ignore comments (#10666 by @fisker)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+foo = a.
+  // prettier-ignore
+  b;
+
+// Prettier stable
+foo =
+  // prettier-ignore
+  a.
+  // prettier-ignore
+  b;
+
+// Prettier main
+foo = a.
+  // prettier-ignore
+  b;
+```

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -93,12 +93,16 @@ function printPrettierIgnoredNode(node, options) {
 
   const start = locStart(node);
   const end = locEnd(node);
+  const attachedComments = new Set(node.comments);
 
   for (const comment of comments) {
     if (locStart(comment) >= start && locEnd(comment) <= end) {
       comment.printed = true;
+      attachedComments.delete(comment);
     }
   }
+
+  node.comments = [...attachedComments];
 
   return originalText.slice(start, end);
 }

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -539,15 +539,15 @@ function printDanglingComments(path, options, sameIndent, filter) {
   return indent([hardline, join(hardline, parts)]);
 }
 
-function printCommentsSeparately(path, options, skip) {
+function printCommentsSeparately(path, options, ignored) {
   const value = path.getValue();
   if (!value) {
     return {};
   }
 
   let comments = value.comments || [];
-  if (skip) {
-    comments = comments.filter((comment) => !skip.has(comment));
+  if (ignored) {
+    comments = comments.filter((comment) => !ignored.has(comment));
   }
   const isCursorNode = value === options.cursorNode;
 
@@ -561,7 +561,7 @@ function printCommentsSeparately(path, options, skip) {
 
   path.each((commentPath) => {
     const comment = commentPath.getValue();
-    if (skip && skip.has(comment)) {
+    if (ignored && ignored.has(comment)) {
       return;
     }
 
@@ -596,8 +596,8 @@ function printCommentsSeparately(path, options, skip) {
   return { leading: leadingParts, trailing: trailingParts };
 }
 
-function printComments(path, doc, options, skip) {
-  const { leading, trailing } = printCommentsSeparately(path, options, skip);
+function printComments(path, doc, options, ignored) {
+  const { leading, trailing } = printCommentsSeparately(path, options, ignored);
   if (!leading && !trailing) {
     return doc;
   }

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -15,7 +15,6 @@ const {
   addLeadingComment,
   addDanglingComment,
   addTrailingComment,
-  isNonEmptyArray,
 } = require("../common/util");
 
 const childNodesCache = new WeakMap();
@@ -540,12 +539,19 @@ function printDanglingComments(path, options, sameIndent, filter) {
   return indent([hardline, join(hardline, parts)]);
 }
 
-function printCommentsSeparately(path, options) {
+function printCommentsSeparately(path, options, skip) {
   const value = path.getValue();
-  const hasComments = isNonEmptyArray(value && value.comments);
-  const isCursorNode = Boolean(value && value === options.cursorNode);
+  if (!value) {
+    return {};
+  }
 
-  if (!hasComments) {
+  let comments = value.comments || [];
+  if (skip) {
+    comments = comments.filter((comment) => !skip.has(comment));
+  }
+  const isCursorNode = value === options.cursorNode;
+
+  if (comments.length === 0) {
     const maybeCursor = isCursorNode ? cursor : "";
     return { leading: maybeCursor, trailing: maybeCursor };
   }
@@ -555,6 +561,10 @@ function printCommentsSeparately(path, options) {
 
   path.each((commentPath) => {
     const comment = commentPath.getValue();
+    if (skip && skip.has(comment)) {
+      return;
+    }
+
     const { leading, trailing } = comment;
 
     if (leading) {
@@ -586,8 +596,8 @@ function printCommentsSeparately(path, options) {
   return { leading: leadingParts, trailing: trailingParts };
 }
 
-function printComments(path, doc, options) {
-  const { leading, trailing } = printCommentsSeparately(path, options);
+function printComments(path, doc, options, skip) {
+  const { leading, trailing } = printCommentsSeparately(path, options, skip);
   if (!leading && !trailing) {
     return doc;
   }

--- a/tests/js/ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/ignore/__snapshots__/jsfmt.spec.js.snap
@@ -177,3 +177,53 @@ a = <div {...{} /* prettier-ignore */} />;
 
 ================================================================================
 `;
+
+exports[`issue-10661.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+verylongidentifierthatwillwrap123123123123123(
+  a.b
+    // prettier-ignore
+    // Some other comment here
+    .c
+);
+
+call(
+  a(
+/*
+this won't get formatted too,
+because the prettier-ignore comment is attached as MemberExpression leading comment
+*/
+1,
+2.0000, 3
+)
+    // prettier-ignore
+    .c
+)
+
+=====================================output=====================================
+verylongidentifierthatwillwrap123123123123123(
+  a.b
+    // prettier-ignore
+    // Some other comment here
+    .c
+);
+
+call(
+  a(
+/*
+this won't get formatted too,
+because the prettier-ignore comment is attached as MemberExpression leading comment
+*/
+1,
+2.0000, 3
+)
+    // prettier-ignore
+    .c
+);
+
+================================================================================
+`;

--- a/tests/js/ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/js/ignore/__snapshots__/jsfmt.spec.js.snap
@@ -192,6 +192,13 @@ verylongidentifierthatwillwrap123123123123123(
 );
 
 call(
+  // comment
+  a.
+    // prettier-ignore
+    b
+)
+
+call(
   a(
 /*
 this won't get formatted too,
@@ -210,6 +217,13 @@ verylongidentifierthatwillwrap123123123123123(
     // prettier-ignore
     // Some other comment here
     .c
+);
+
+call(
+  // comment
+  a.
+    // prettier-ignore
+    b
 );
 
 call(

--- a/tests/js/ignore/issue-10661.js
+++ b/tests/js/ignore/issue-10661.js
@@ -1,0 +1,19 @@
+verylongidentifierthatwillwrap123123123123123(
+  a.b
+    // prettier-ignore
+    // Some other comment here
+    .c
+);
+
+call(
+  a(
+/*
+this won't get formatted too,
+because the prettier-ignore comment is attached as MemberExpression leading comment
+*/
+1,
+2.0000, 3
+)
+    // prettier-ignore
+    .c
+)

--- a/tests/js/ignore/issue-10661.js
+++ b/tests/js/ignore/issue-10661.js
@@ -6,6 +6,13 @@ verylongidentifierthatwillwrap123123123123123(
 );
 
 call(
+  // comment
+  a.
+    // prettier-ignore
+    b
+)
+
+call(
   a(
 /*
 this won't get formatted too,


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #10661

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
