### PR TITLE
GraphQL: Fix missing space after keyword in anonymous operations

### DIFF
--- a/changelog_unreleased/graphql/10689.md
+++ b/changelog_unreleased/graphql/10689.md
@@ -1,0 +1,19 @@
+#### Fix missing space after keyword in anonymous graphql operations (#10689 by @patriscus)
+
+<!-- prettier-ignore -->
+```graphql
+# Input
+query ($unnamed: String) {
+  id
+}
+
+# Prettier stable
+query ($unnamed: String) {
+  id
+}
+
+# Prettier main
+query($unnamed: String) {
+  id
+}
+```

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -39,6 +39,9 @@ function genericPrint(path, options, print) {
       return [
         hasOperation ? node.operation : "",
         hasOperation && hasName ? [" ", print("name")] : "",
+        hasOperation && !hasName && isNonEmptyArray(node.variableDefinitions)
+          ? " "
+          : "",
         isNonEmptyArray(node.variableDefinitions)
           ? group([
               "(",

--- a/tests/graphql/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql/comments/__snapshots__/jsfmt.spec.js.snap
@@ -15,7 +15,7 @@ query (
  }
 
 =====================================output=====================================
-query(
+query (
   $string: String # Some variable comment
   $bool: Boolean # Some comment
 ) {

--- a/tests/graphql/definitions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/graphql/definitions/__snapshots__/jsfmt.spec.js.snap
@@ -31,6 +31,14 @@ query {
   noOperationType
 }
 
+query ($unnamed: String) {
+  id
+}
+
+query Named($var: String) {
+  id
+}
+
 =====================================output=====================================
 query MyFirstQuery {
   hello
@@ -54,6 +62,14 @@ query {
 
 {
   noOperationType
+}
+
+query ($unnamed: String) {
+  id
+}
+
+query Named($var: String) {
+  id
 }
 
 ================================================================================

--- a/tests/graphql/definitions/fields.graphql
+++ b/tests/graphql/definitions/fields.graphql
@@ -22,3 +22,11 @@ query {
 {
   noOperationType
 }
+
+query ($unnamed: String) {
+  id
+}
+
+query Named($var: String) {
+  id
+}


### PR DESCRIPTION
Fixes #10655 

## Description

Added an additional condition to check if a space (`" "`) should be inserted after the keyword.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
