### PR TITLE
Minor refactoring of printObject

### DIFF
--- a/src/language-js/print/object.js
+++ b/src/language-js/print/object.js
@@ -41,11 +41,10 @@ function printObject(path, options, print) {
   }
 
   const isTypeAnnotation = node.type === "ObjectTypeAnnotation";
-  const fields = [];
+  const fields = [propertiesField];
   if (isTypeAnnotation) {
     fields.push("indexers", "callProperties", "internalSlots");
   }
-  fields.push(propertiesField);
 
   const firstProperty = fields
     .map((field) => node[field][0])
@@ -109,26 +108,28 @@ function printObject(path, options, print) {
     }, field);
   }
 
+  if (fields.length > 1) {
+    propsAndLoc.sort((a, b) => a.loc - b.loc);
+  }
+
   /** @type {Doc[]} */
   let separatorParts = [];
-  const props = propsAndLoc
-    .sort((a, b) => a.loc - b.loc)
-    .map((prop) => {
-      const result = [...separatorParts, group(prop.printed)];
-      separatorParts = [separator, line];
-      if (
-        (prop.node.type === "TSPropertySignature" ||
-          prop.node.type === "TSMethodSignature" ||
-          prop.node.type === "TSConstructSignatureDeclaration") &&
-        hasComment(prop.node, CommentCheckFlags.PrettierIgnore)
-      ) {
-        separatorParts.shift();
-      }
-      if (isNextLineEmpty(prop.node, options)) {
-        separatorParts.push(hardline);
-      }
-      return result;
-    });
+  const props = propsAndLoc.map((prop) => {
+    const result = [...separatorParts, group(prop.printed)];
+    separatorParts = [separator, line];
+    if (
+      (prop.node.type === "TSPropertySignature" ||
+        prop.node.type === "TSMethodSignature" ||
+        prop.node.type === "TSConstructSignatureDeclaration") &&
+      hasComment(prop.node, CommentCheckFlags.PrettierIgnore)
+    ) {
+      separatorParts.shift();
+    }
+    if (isNextLineEmpty(prop.node, options)) {
+      separatorParts.push(hardline);
+    }
+    return result;
+  });
 
   if (node.inexact) {
     let printed;


### PR DESCRIPTION
## Description

Avoid sorting properties of object-literal-like constructions when they're taken only from one source.

## Checklist

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
