### PR TITLE
TS: don't print parens around nested type assertions

### DIFF
--- a/changelog_unreleased/typescript/10702.md
+++ b/changelog_unreleased/typescript/10702.md
@@ -1,0 +1,13 @@
+#### Don’t print parens around nested type assertions (#10702 by @thorn0)
+
+<!-- prettier-ignore -->
+```ts
+// Input
+foo as unknown as Bar
+
+// Prettier stable
+(foo as unknown) as Bar;
+
+// Prettier main
+foo as unknown as Bar;
+```

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -237,6 +237,10 @@ function needsParens(path, options) {
     case "TSAsExpression":
     case "LogicalExpression":
       switch (parent.type) {
+        case "TSAsExpression":
+          // example: foo as unknown as Bar
+          return node.type !== "TSAsExpression";
+
         case "ConditionalExpression":
           return node.type === "TSAsExpression";
 
@@ -257,7 +261,6 @@ function needsParens(path, options) {
         case "SpreadProperty":
         case "BindExpression":
         case "AwaitExpression":
-        case "TSAsExpression":
         case "TSNonNullExpression":
         case "UpdateExpression":
           return true;

--- a/tests/typescript/argument-expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/argument-expansion/__snapshots__/jsfmt.spec.js.snap
@@ -41,7 +41,7 @@ const bar8 = [1,2,3].reduce((carry, value) => {
 =====================================output=====================================
 const bar1 = [1, 2, 3].reduce((carry, value) => {
   return [...carry, value];
-}, ([] as unknown) as number[]);
+}, [] as unknown as number[]);
 
 const bar2 = [1, 2, 3].reduce((carry, value) => {
   return [...carry, value];
@@ -51,7 +51,7 @@ const bar3 = [1, 2, 3].reduce(
   (carry, value) => {
     return [...carry, value];
   },
-  ([1, 2, 3] as unknown) as number[]
+  [1, 2, 3] as unknown as number[]
 );
 
 const bar4 = [1, 2, 3].reduce(
@@ -63,7 +63,7 @@ const bar4 = [1, 2, 3].reduce(
 
 const bar5 = [1, 2, 3].reduce((carry, value) => {
   return { ...carry, [value]: true };
-}, ({} as unknown) as { [key: number]: boolean });
+}, {} as unknown as { [key: number]: boolean });
 
 const bar6 = [1, 2, 3].reduce((carry, value) => {
   return { ...carry, [value]: true };
@@ -73,7 +73,7 @@ const bar7 = [1, 2, 3].reduce(
   (carry, value) => {
     return { ...carry, [value]: true };
   },
-  ({ 1: true } as unknown) as { [key: number]: boolean }
+  { 1: true } as unknown as { [key: number]: boolean }
 );
 
 const bar8 = [1, 2, 3].reduce(

--- a/tests/typescript/as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/as/__snapshots__/jsfmt.spec.js.snap
@@ -177,16 +177,16 @@ const TYPE_MAP = {
   "symbolic link": "link",
 } as Foo;
 
-this.previewPlayerHandle = (setInterval(async () => {
+this.previewPlayerHandle = setInterval(async () => {
   if (this.previewIsPlaying) {
     await this.fetchNextPreviews();
     this.currentPreviewIndex++;
   }
-}, this.refreshDelay) as unknown) as number;
+}, this.refreshDelay) as unknown as number;
 
-this.intervalID = (setInterval(() => {
+this.intervalID = setInterval(() => {
   self.step();
-}, 30) as unknown) as number;
+}, 30) as unknown as number;
 
 ================================================================================
 `;

--- a/tests/typescript/assignment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/typescript/assignment/__snapshots__/jsfmt.spec.js.snap
@@ -199,7 +199,7 @@ printWidth: 80
 x! = null;
 (a as any) = null;
 (a as number) = 42;
-((a as any) as string) = null;
+(a as any as string) = null;
 
 ================================================================================
 `;


### PR DESCRIPTION
## Description

These parens are useless.
https://github.com/prettier/prettier/issues/9732#issuecomment-731074219

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
