### PR TITLE
[Docs] Fix pre-commit hook setup command

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -31,7 +31,7 @@ Install it along with [husky](https://github.com/typicode/husky):
 ```bash
 npx husky-init
 npm install --save-dev pretty-quick
-npx husky set .husky/pre-commit "pretty-quick --staged"
+npx husky set .husky/pre-commit "npx pretty-quick --staged"
 ```
 
 <!--yarn-->
@@ -39,7 +39,7 @@ npx husky set .husky/pre-commit "pretty-quick --staged"
 ```bash
 npx husky-init # add --yarn2 for Yarn 2
 yarn add --dev pretty-quick
-yarn husky set .husky/pre-commit "pretty-quick --staged"
+yarn husky set .husky/pre-commit "npx pretty-quick --staged"
 ```
 
 <!--END_DOCUSAURUS_CODE_TABS-->


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

In the provided example, `pretty-quick` is installed locally, not globally, which may cause the hook to fail:

```
❯ git commit
.husky/pre-commit: 4: pretty-quick: not found
husky - pre-commit hook exited with code 127 (error)
```
This problem can be fixed by running `"npx pretty-quick --staged"` instead of just `"pretty-quick --staged"` 

Maybe @typicode can confirm?
____

**N.B** I've made changes to documentation only, so everything below is not applicable

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
