### PR TITLE
docs: fix incorrect version comment in changelog

### DIFF
--- a/changelog_unreleased/typescript/10418.md
+++ b/changelog_unreleased/typescript/10418.md
@@ -7,10 +7,10 @@
 // Input
 type T = abstract new () => void;
 
-// Prettier main
+// Prettier stable
 SyntaxError: Unexpected token, expected ";" (1:19)
 
-// Prettier stable
+// Prettier main
 type T = abstract new () => void;
 
 ```
@@ -22,10 +22,10 @@ type T = abstract new () => void;
 // Input
 import type A = require("A");
 
-// Prettier main
+// Prettier stable
 SyntaxError: Only ECMAScript imports may use 'import type'.
 
-// Prettier stable
+// Prettier main
 import type A = require("A");
 
 ```


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

I found this issue when reading https://deploy-preview-10659--prettier.netlify.app/blog/2021/04/12/2.3.0.html#support-typescript-42-10418httpsgithubcomprettierprettierpull10418-10466httpsgithubcomprettierprettierpull10466-10546httpsgithubcomprettierprettierpull10546-10589httpsgithubcomprettierprettierpull10589-by-sosukesuzukihttpsgithubcomsosukesuzuki

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
