### PR TITLE
Support for Flow's Optional Indexed Access type

### DIFF
--- a/changelog_unreleased/flow/10788.md
+++ b/changelog_unreleased/flow/10788.md
@@ -1,0 +1,13 @@
+#### Support for Flow's optional indexed access type (#10788 by @gkz)
+
+<!-- prettier-ignore -->
+```js
+// Input
+type T = Obj?.['foo'];
+
+// Prettier stable
+// Error: unsupported node type "OptionalIndexedAccessType"
+
+// Prettier main
+type T = Obj?.['foo'];
+```

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "fast-glob": "3.2.5",
     "fast-json-stable-stringify": "2.1.0",
     "find-parent-dir": "0.3.0",
-    "flow-parser": "0.149.0",
+    "flow-parser": "0.150.0",
     "get-stdin": "8.0.0",
     "globby": "11.0.3",
     "graphql": "15.5.0",

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -481,6 +481,9 @@ function needsParens(path, options) {
       );
     }
 
+    case "OptionalIndexedAccessType":
+      return name === "objectType" && parent.type === "IndexedAccessType";
+
     case "StringLiteral":
     case "NumericLiteral":
     case "Literal":

--- a/src/language-js/print/flow.js
+++ b/src/language-js/print/flow.js
@@ -83,6 +83,7 @@ function printFlow(path, options, print) {
         printTypeParameters(path, options, print, "typeParameters"),
       ];
     case "IndexedAccessType":
+    case "OptionalIndexedAccessType":
       return printIndexedAccessType(path, options, print);
     // Type Annotations for Facebook Flow, typically stripped out or
     // transformed away before printing.

--- a/src/language-js/print/type-annotation.js
+++ b/src/language-js/print/type-annotation.js
@@ -297,9 +297,12 @@ function printTupleType(path, options, print) {
   ]);
 }
 
-// `TSIndexedAccessType` and `IndexedAccessType`
+// `TSIndexedAccessType`, `IndexedAccessType`, and `OptionalIndexedAccessType`
 function printIndexedAccessType(path, options, print) {
-  return [print("objectType"), "[", print("indexType"), "]"];
+  const node = path.getValue();
+  const leftDelimiter =
+    node.type === "OptionalIndexedAccessType" && node.optional ? "?.[" : "[";
+  return [print("objectType"), leftDelimiter, print("indexType"), "]"];
 }
 
 module.exports = {

--- a/tests/format/flow/optional-indexed-access/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/optional-indexed-access/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,28 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`optional-indexed-access.js - {"trailingComma":"all"} format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+type A = Obj?.['foo'];
+
+type B = Obj?.['foo']['bar'];
+
+type C = Obj['foo']?.['bar'];
+
+type D = (Obj?.['foo'])['bar'];
+
+=====================================output=====================================
+type A = Obj?.["foo"];
+
+type B = Obj?.["foo"]["bar"];
+
+type C = Obj["foo"]?.["bar"];
+
+type D = (Obj?.["foo"])["bar"];
+
+================================================================================
+`;

--- a/tests/format/flow/optional-indexed-access/jsfmt.spec.js
+++ b/tests/format/flow/optional-indexed-access/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["flow"], { trailingComma: "all" });

--- a/tests/format/flow/optional-indexed-access/optional-indexed-access.js
+++ b/tests/format/flow/optional-indexed-access/optional-indexed-access.js
@@ -1,0 +1,7 @@
+type A = Obj?.['foo'];
+
+type B = Obj?.['foo']['bar'];
+
+type C = Obj['foo']?.['bar'];
+
+type D = (Obj?.['foo'])['bar'];

--- a/yarn.lock
+++ b/yarn.lock
@@ -3537,10 +3537,10 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
-flow-parser@0.149.0:
-  version "0.149.0"
-  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.149.0.tgz#6e5749ad832ba211968429accdb6a3858706e4f8"
-  integrity sha512-ruUVkZuM9oFQjhSsLO/OJYRYpGnuXJpTnIZmgzna6DyLFb3CLpeO27oJbWyeXaa830hmKf0JRzpcdFsFS8lmpg==
+flow-parser@0.150.0:
+  version "0.150.0"
+  resolved "https://registry.yarnpkg.com/flow-parser/-/flow-parser-0.150.0.tgz#69ba3e90b0d127bc2f0d7025854805eeb09fd2c1"
+  integrity sha512-kYoNG9BH4RlYwEt0A9+30ZiUiYBNB9KLDeDI4rSBb0QsoH5F12ywNUOHp5JD2KVYz6nhapbn/kCIZALSmd3q6w==
 
 for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
## Description

This adds support for Flow's "Optional Indexed Access Types" (e.g `type T = Obj?.[K]`), a follow on to the support for "Indexed Access Types" added in https://github.com/prettier/prettier/pull/10594

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
