### PR TITLE
Switch CLI to async

### DIFF
--- a/bin/prettier.js
+++ b/bin/prettier.js
@@ -2,4 +2,4 @@
 
 "use strict";
 
-require("../src/cli").run(process.argv.slice(2));
+module.exports = require("../src/cli").run(process.argv.slice(2));

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -8,7 +8,7 @@ const stringify = require("fast-json-stable-stringify");
 const prettier = require("../index");
 const core = require("./core");
 
-function run(rawArguments) {
+async function run(rawArguments) {
   // Create a default level logger, so we can log errors during `logLevel` parsing
   let logger = core.createLogger();
 

--- a/tests/integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests/integration/__tests__/__snapshots__/early-exit.js.snap
@@ -1,13 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`node version error (stderr) 1`] = `
-"prettier requires at least version 10.13.0 of Node, please upgrade
-"
+exports[`node version error 1`] = `
+Object {
+  "stderr": "prettier requires at least version 10.13.0 of Node, please upgrade
+",
+  "stdout": "",
+  "write": Array [],
+}
 `;
-
-exports[`node version error (stdout) 1`] = `""`;
-
-exports[`node version error (write) 1`] = `Array []`;
 
 exports[`show detailed usage with --help l (alias) (stderr) 1`] = `""`;
 

--- a/tests/integration/__tests__/__snapshots__/plugin-options-string.js.snap
+++ b/tests/integration/__tests__/__snapshots__/plugin-options-string.js.snap
@@ -1,6 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[` 1`] = `
+exports[`show detailed external option with \`--help foo-string\` (stderr) 1`] = `""`;
+
+exports[`show detailed external option with \`--help foo-string\` (stdout) 1`] = `
+"--foo-string <string>
+
+  foo description
+
+Default: bar
+"
+`;
+
+exports[`show detailed external option with \`--help foo-string\` (write) 1`] = `Array []`;
+
+exports[`show external options with \`--help\` 1`] = `
 "Snapshot Diff:
 - First value
 + Second value
@@ -28,16 +41,3 @@ exports[` 1`] = `
     --prose-wrap <always|never|preserve>
                              How to wrap prose."
 `;
-
-exports[`show detailed external option with \`--help foo-string\` (stderr) 1`] = `""`;
-
-exports[`show detailed external option with \`--help foo-string\` (stdout) 1`] = `
-"--foo-string <string>
-
-  foo description
-
-Default: bar
-"
-`;
-
-exports[`show detailed external option with \`--help foo-string\` (write) 1`] = `Array []`;

--- a/tests/integration/__tests__/__snapshots__/plugin-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/plugin-options.js.snap
@@ -1,34 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[` 1`] = `
-"Snapshot Diff:
-- First value
-+ Second value
-
-@@ -20,18 +20,20 @@
-                             Control how Prettier formats quoted code embedded in the file.
-                             Defaults to auto.
-    --end-of-line <lf|crlf|cr|auto>
-                             Which end of line characters to apply.
-                             Defaults to lf.
-+   --foo-option <bar|baz>   foo description
-+                            Defaults to bar.
-    --html-whitespace-sensitivity <css|strict|ignore>
-                             How to handle whitespaces in HTML.
-                             Defaults to css.
-    --jsx-bracket-same-line  Put > on the last line instead of at a new line.
-                             Defaults to false.
-    --jsx-single-quote       Use single quotes in JSX.
-                             Defaults to false.
--   --parser <flow|babel|babel-flow|babel-ts|typescript|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
-+   --parser <flow|babel|babel-flow|babel-ts|typescript|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc|foo-parser>
-                             Which parser to use.
-    --print-width <int>      The line length where Prettier will try wrap.
-                             Defaults to 80.
-    --prose-wrap <always|never|preserve>
-                             How to wrap prose."
-`;
-
 exports[`include plugin's parsers to the values of the \`parser\` option\` (stderr) 1`] = `""`;
 
 exports[`include plugin's parsers to the values of the \`parser\` option\` (stdout) 1`] = `
@@ -83,3 +54,32 @@ Default: bar
 `;
 
 exports[`show detailed external option with \`--help foo-option\` (write) 1`] = `Array []`;
+
+exports[`show external options with \`--help\` 1`] = `
+"Snapshot Diff:
+- First value
++ Second value
+
+@@ -20,18 +20,20 @@
+                             Control how Prettier formats quoted code embedded in the file.
+                             Defaults to auto.
+    --end-of-line <lf|crlf|cr|auto>
+                             Which end of line characters to apply.
+                             Defaults to lf.
++   --foo-option <bar|baz>   foo description
++                            Defaults to bar.
+    --html-whitespace-sensitivity <css|strict|ignore>
+                             How to handle whitespaces in HTML.
+                             Defaults to css.
+    --jsx-bracket-same-line  Put > on the last line instead of at a new line.
+                             Defaults to false.
+    --jsx-single-quote       Use single quotes in JSX.
+                             Defaults to false.
+-   --parser <flow|babel|babel-flow|babel-ts|typescript|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
++   --parser <flow|babel|babel-flow|babel-ts|typescript|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc|foo-parser>
+                             Which parser to use.
+    --print-width <int>      The line length where Prettier will try wrap.
+                             Defaults to 80.
+    --prose-wrap <always|never|preserve>
+                             How to wrap prose."
+`;

--- a/tests/integration/__tests__/check.js
+++ b/tests/integration/__tests__/check.js
@@ -44,7 +44,7 @@ describe("--checks works in CI just as in a non-TTY mode", () => {
     status: 1,
   });
 
-  test("Should has same stdout", async () => {
+  test("Should have same stdout", async () => {
     expect(await result0.stdout).toEqual(await result1.stdout);
   });
 });

--- a/tests/integration/__tests__/check.js
+++ b/tests/integration/__tests__/check.js
@@ -44,5 +44,7 @@ describe("--checks works in CI just as in a non-TTY mode", () => {
     status: 1,
   });
 
-  expect(result0.stdout).toEqual(result1.stdout);
+  test("Should has same stdout", async () => {
+    expect(await result0.stdout).toEqual(await result1.stdout);
+  });
 });

--- a/tests/integration/__tests__/early-exit.js
+++ b/tests/integration/__tests__/early-exit.js
@@ -90,14 +90,21 @@ describe("throw error and show usage with something unexpected", () => {
   });
 });
 
-describe("node version error", () => {
+test("node version error", async () => {
   const originalProcessVersion = process.version;
+
   try {
     Object.defineProperty(process, "version", {
       value: "v8.0.0",
       writable: false,
     });
-    runPrettier("cli", ["--help"]).test({ status: 1 });
+    const result = runPrettier("cli", ["--help"]);
+    expect(await result.status).toEqual(1);
+    const snapshot = {};
+    for (const name of ["stderr", "stdout", "write"]) {
+      snapshot[name] = await result[name];
+    }
+    expect(snapshot).toMatchSnapshot();
   } finally {
     Object.defineProperty(process, "version", {
       value: originalProcessVersion,

--- a/tests/integration/__tests__/list-different.js
+++ b/tests/integration/__tests__/list-different.js
@@ -44,5 +44,7 @@ describe("--list-different works in CI just as in a non-TTY mode", () => {
     status: 1,
   });
 
-  expect(result0.stdout).toEqual(result1.stdout);
+  test("Should be the same", async () => {
+    expect(await result0.stdout).toEqual(await result1.stdout);
+  });
 });

--- a/tests/integration/__tests__/loglevel.js
+++ b/tests/integration/__tests__/loglevel.js
@@ -3,20 +3,20 @@
 const stripAnsi = require("strip-ansi");
 const runPrettier = require("../runPrettier");
 
-test("do not show logs with --loglevel silent", () => {
-  runPrettierWithLogLevel("silent", null);
+test("do not show logs with --loglevel silent", async () => {
+  await runPrettierWithLogLevel("silent", null);
 });
 
-test("do not show warnings with --loglevel error", () => {
-  runPrettierWithLogLevel("error", ["[error]"]);
+test("do not show warnings with --loglevel error", async () => {
+  await runPrettierWithLogLevel("error", ["[error]"]);
 });
 
-test("show errors and warnings with --loglevel warn", () => {
-  runPrettierWithLogLevel("warn", ["[error]", "[warn]"]);
+test("show errors and warnings with --loglevel warn", async () => {
+  await runPrettierWithLogLevel("warn", ["[error]", "[warn]"]);
 });
 
-test("show all logs with --loglevel debug", () => {
-  runPrettierWithLogLevel("debug", ["[error]", "[warn]", "[debug]"]);
+test("show all logs with --loglevel debug", async () => {
+  await runPrettierWithLogLevel("debug", ["[error]", "[warn]", "[debug]"]);
 });
 
 describe("--write with --loglevel=silent doesn't log filenames", () => {
@@ -37,7 +37,7 @@ describe("Should use default level logger to log `--loglevel` error", () => {
   });
 });
 
-function runPrettierWithLogLevel(logLevel, patterns) {
+async function runPrettierWithLogLevel(logLevel, patterns) {
   const result = runPrettier("cli/loglevel", [
     "--loglevel",
     logLevel,
@@ -47,9 +47,9 @@ function runPrettierWithLogLevel(logLevel, patterns) {
     "not-found.js",
   ]);
 
-  expect(result.status).toEqual(2);
+  expect(await result.status).toEqual(2);
 
-  const stderr = stripAnsi(result.stderr);
+  const stderr = stripAnsi(await result.stderr);
 
   if (patterns) {
     for (const pattern of patterns) {

--- a/tests/integration/__tests__/patterns-dirs.js
+++ b/tests/integration/__tests__/patterns-dirs.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const path = require("path");
-// const fs = require("fs");
+const fs = require("fs");
 const runPrettier = require("../runPrettier");
 const { projectRoot } = require("../env");
 
@@ -87,38 +87,38 @@ describe("plugins `*`", () => {
   });
 });
 
-// TODO: fix this test
-// if (path.sep === "/") {
-//   // Don't use snapshots in these tests as they're conditionally executed on non-Windows only.
+TODO: fix this test
+if (path.sep === "/") {
+  // Don't use snapshots in these tests as they're conditionally executed on non-Windows only.
 
-//   const base = path.resolve(__dirname, "../cli/patterns-dirs");
+  const base = path.resolve(__dirname, "../cli/patterns-dirs");
 
-//   // We can't commit these dirs without causing problems on Windows.
+  describe("Backslashes in names", () => {
+    // We can't commit these dirs without causing problems on Windows.
 
-//   // TODO: these should be moved to a `beforeAll`, but for that to be possible,
-//   // `runPrettier` should be refactored to use `describe` and `beforeEach` for doing setup.
-//   fs.mkdirSync(path.resolve(base, "test-a\\"));
-//   fs.writeFileSync(path.resolve(base, "test-a\\", "test.js"), "x");
-//   fs.mkdirSync(path.resolve(base, "test-b\\?"));
-//   fs.writeFileSync(path.resolve(base, "test-b\\?", "test.js"), "x");
+    beforeAll(() => {
+      fs.mkdirSync(path.resolve(base, "test-a\\"));
+      fs.writeFileSync(path.resolve(base, "test-a\\", "test.js"), "x");
+      fs.mkdirSync(path.resolve(base, "test-b\\?"));
+      fs.writeFileSync(path.resolve(base, "test-b\\?", "test.js"), "x");
+    });
 
-//   describe("Backslashes in names", () => {
-//     afterAll(() => {
-//       fs.unlinkSync(path.resolve(base, "test-a\\", "test.js"));
-//       fs.rmdirSync(path.resolve(base, "test-a\\"));
-//       fs.unlinkSync(path.resolve(base, "test-b\\?", "test.js"));
-//       fs.rmdirSync(path.resolve(base, "test-b\\?"));
-//     });
+    afterAll(() => {
+      fs.unlinkSync(path.resolve(base, "test-a\\", "test.js"));
+      fs.rmdirSync(path.resolve(base, "test-a\\"));
+      fs.unlinkSync(path.resolve(base, "test-b\\?", "test.js"));
+      fs.rmdirSync(path.resolve(base, "test-b\\?"));
+    });
 
-//     testPatterns("", ["test-a\\/test.js"], { stdout: "test-a\\/test.js\n" });
-//     testPatterns("", ["test-a\\"], { stdout: "test-a\\/test.js\n" });
-//     testPatterns("", ["test-a*/*"], { stdout: "test-a\\/test.js\n" });
+    testPatterns("", ["test-a\\/test.js"], { stdout: "test-a\\/test.js\n" });
+    testPatterns("", ["test-a\\"], { stdout: "test-a\\/test.js\n" });
+    testPatterns("", ["test-a*/*"], { stdout: "test-a\\/test.js\n" });
 
-//     testPatterns("", ["test-b\\?/test.js"], { stdout: "test-b\\?/test.js\n" });
-//     testPatterns("", ["test-b\\?"], { stdout: "test-b\\?/test.js\n" });
-//     testPatterns("", ["test-b*/*"], { stdout: "test-b\\?/test.js\n" });
-//   });
-// }
+    testPatterns("", ["test-b\\?/test.js"], { stdout: "test-b\\?/test.js\n" });
+    testPatterns("", ["test-b\\?"], { stdout: "test-b\\?/test.js\n" });
+    testPatterns("", ["test-b*/*"], { stdout: "test-b\\?/test.js\n" });
+  });
+}
 
 function testPatterns(namePrefix, cliArgs, expected = {}) {
   const testName =

--- a/tests/integration/__tests__/patterns-dirs.js
+++ b/tests/integration/__tests__/patterns-dirs.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const path = require("path");
-const fs = require("fs");
+// const fs = require("fs");
 const runPrettier = require("../runPrettier");
 const { projectRoot } = require("../env");
 

--- a/tests/integration/__tests__/patterns-dirs.js
+++ b/tests/integration/__tests__/patterns-dirs.js
@@ -87,7 +87,6 @@ describe("plugins `*`", () => {
   });
 });
 
-TODO: fix this test
 if (path.sep === "/") {
   // Don't use snapshots in these tests as they're conditionally executed on non-Windows only.
 

--- a/tests/integration/__tests__/patterns-dirs.js
+++ b/tests/integration/__tests__/patterns-dirs.js
@@ -87,37 +87,38 @@ describe("plugins `*`", () => {
   });
 });
 
-if (path.sep === "/") {
-  // Don't use snapshots in these tests as they're conditionally executed on non-Windows only.
+// TODO: fix this test
+// if (path.sep === "/") {
+//   // Don't use snapshots in these tests as they're conditionally executed on non-Windows only.
 
-  const base = path.resolve(__dirname, "../cli/patterns-dirs");
+//   const base = path.resolve(__dirname, "../cli/patterns-dirs");
 
-  // We can't commit these dirs without causing problems on Windows.
+//   // We can't commit these dirs without causing problems on Windows.
 
-  // TODO: these should be moved to a `beforeAll`, but for that to be possible,
-  // `runPrettier` should be refactored to use `describe` and `beforeEach` for doing setup.
-  fs.mkdirSync(path.resolve(base, "test-a\\"));
-  fs.writeFileSync(path.resolve(base, "test-a\\", "test.js"), "x");
-  fs.mkdirSync(path.resolve(base, "test-b\\?"));
-  fs.writeFileSync(path.resolve(base, "test-b\\?", "test.js"), "x");
+//   // TODO: these should be moved to a `beforeAll`, but for that to be possible,
+//   // `runPrettier` should be refactored to use `describe` and `beforeEach` for doing setup.
+//   fs.mkdirSync(path.resolve(base, "test-a\\"));
+//   fs.writeFileSync(path.resolve(base, "test-a\\", "test.js"), "x");
+//   fs.mkdirSync(path.resolve(base, "test-b\\?"));
+//   fs.writeFileSync(path.resolve(base, "test-b\\?", "test.js"), "x");
 
-  describe("Backslashes in names", () => {
-    afterAll(() => {
-      fs.unlinkSync(path.resolve(base, "test-a\\", "test.js"));
-      fs.rmdirSync(path.resolve(base, "test-a\\"));
-      fs.unlinkSync(path.resolve(base, "test-b\\?", "test.js"));
-      fs.rmdirSync(path.resolve(base, "test-b\\?"));
-    });
+//   describe("Backslashes in names", () => {
+//     afterAll(() => {
+//       fs.unlinkSync(path.resolve(base, "test-a\\", "test.js"));
+//       fs.rmdirSync(path.resolve(base, "test-a\\"));
+//       fs.unlinkSync(path.resolve(base, "test-b\\?", "test.js"));
+//       fs.rmdirSync(path.resolve(base, "test-b\\?"));
+//     });
 
-    testPatterns("", ["test-a\\/test.js"], { stdout: "test-a\\/test.js\n" });
-    testPatterns("", ["test-a\\"], { stdout: "test-a\\/test.js\n" });
-    testPatterns("", ["test-a*/*"], { stdout: "test-a\\/test.js\n" });
+//     testPatterns("", ["test-a\\/test.js"], { stdout: "test-a\\/test.js\n" });
+//     testPatterns("", ["test-a\\"], { stdout: "test-a\\/test.js\n" });
+//     testPatterns("", ["test-a*/*"], { stdout: "test-a\\/test.js\n" });
 
-    testPatterns("", ["test-b\\?/test.js"], { stdout: "test-b\\?/test.js\n" });
-    testPatterns("", ["test-b\\?"], { stdout: "test-b\\?/test.js\n" });
-    testPatterns("", ["test-b*/*"], { stdout: "test-b\\?/test.js\n" });
-  });
-}
+//     testPatterns("", ["test-b\\?/test.js"], { stdout: "test-b\\?/test.js\n" });
+//     testPatterns("", ["test-b\\?"], { stdout: "test-b\\?/test.js\n" });
+//     testPatterns("", ["test-b*/*"], { stdout: "test-b\\?/test.js\n" });
+//   });
+// }
 
 function testPatterns(namePrefix, cliArgs, expected = {}) {
   const testName =

--- a/tests/integration/__tests__/piped-output.js
+++ b/tests/integration/__tests__/piped-output.js
@@ -19,8 +19,12 @@ describe("output with --check + unformatted differs when piped", () => {
     status: 0,
   });
 
-  expect(result0.stdout.length).toBeGreaterThan(result1.stdout.length);
-  expect(result0.write).toEqual(result1.write);
+  test("Result", async () => {
+    expect((await result0.stdout).length).toBeGreaterThan(
+      (await result1.stdout).length
+    );
+    expect(await result0.write).toEqual(await result1.write);
+  });
 });
 
 describe("no file diffs with --check + formatted file", () => {
@@ -40,9 +44,13 @@ describe("no file diffs with --check + formatted file", () => {
     status: 0,
   });
 
-  expect(result0.stdout).not.toEqual(result1.stdout);
-  expect(result0.stdout.length).toBeGreaterThan(result1.stdout.length);
-  expect(result0.write).toEqual(result1.write);
+  test("Result", async () => {
+    expect(await result0.stdout).not.toEqual(await result1.stdout);
+    expect((await result0.stdout).length).toBeGreaterThan(
+      (await result1.stdout).length
+    );
+    expect(await result0.write).toEqual(await result1.write);
+  });
 });
 
 describe("output with --list-different + unformatted differs when piped", () => {
@@ -62,8 +70,12 @@ describe("output with --list-different + unformatted differs when piped", () => 
     status: 0,
   });
 
-  expect(result0.stdout.length).toBeGreaterThan(result1.stdout.length);
-  expect(result0.write).toEqual(result1.write);
+  test("Result", async () => {
+    expect((await result0.stdout).length).toBeGreaterThan(
+      (await result1.stdout).length
+    );
+    expect(await result0.write).toEqual(await result1.write);
+  });
 });
 
 describe("no file diffs with --list-different + formatted file", () => {
@@ -83,7 +95,11 @@ describe("no file diffs with --list-different + formatted file", () => {
     status: 0,
   });
 
-  expect(result0.stdout).not.toEqual(result1.stdout);
-  expect(result0.stdout.length).toBeGreaterThan(result1.stdout.length);
-  expect(result0.write).toEqual(result1.write);
+  test("Result", async () => {
+    expect(await result0.stdout).not.toEqual(await result1.stdout);
+    expect((await result0.stdout).length).toBeGreaterThan(
+      (await result1.stdout).length
+    );
+    expect(await result0.write).toEqual(await result1.write);
+  });
 });

--- a/tests/integration/__tests__/plugin-options-string.js
+++ b/tests/integration/__tests__/plugin-options-string.js
@@ -3,10 +3,10 @@
 const snapshotDiff = require("snapshot-diff");
 const runPrettier = require("../runPrettier");
 
-describe("show external options with `--help`", () => {
-  const originalStdout = runPrettier("plugins/options-string", ["--help"])
+test("show external options with `--help`", async () => {
+  const originalStdout = await runPrettier("plugins/options-string", ["--help"])
     .stdout;
-  const pluggedStdout = runPrettier("plugins/options-string", [
+  const pluggedStdout = await runPrettier("plugins/options-string", [
     "--help",
     "--plugin=./plugin",
   ]).stdout;

--- a/tests/integration/__tests__/plugin-options.js
+++ b/tests/integration/__tests__/plugin-options.js
@@ -3,12 +3,14 @@
 const snapshotDiff = require("snapshot-diff");
 const runPrettier = require("../runPrettier");
 
-describe("show external options with `--help`", () => {
-  const originalStdout = runPrettier("plugins/options", ["--help"]).stdout;
-  const pluggedStdout = runPrettier("plugins/options", [
+test("show external options with `--help`", async () => {
+  const originalStdout = await runPrettier("plugins/options", ["--help"])
+    .stdout;
+  const pluggedStdout = await runPrettier("plugins/options", [
     "--help",
     "--plugin=./plugin",
   ]).stdout;
+
   expect(snapshotDiff(originalStdout, pluggedStdout)).toMatchSnapshot();
 });
 

--- a/tests/integration/runPrettier.js
+++ b/tests/integration/runPrettier.js
@@ -127,7 +127,7 @@ async function run(dir, args, options) {
   }
 }
 
-let hasRunningCLi = false;
+let hasRunningCli = false;
 function runPrettier(dir, args = [], options = {}) {
   let promise;
   const getters = {
@@ -149,14 +149,15 @@ function runPrettier(dir, args = [], options = {}) {
   return getters;
 
   function runCli() {
-    if (hasRunningCLi) {
+    if (hasRunningCli) {
       throw new Error("Please wait for previous CLI to exit.");
     }
 
     if (!promise) {
+      hasRunningCli = true;
       promise = run(dir, args, options);
       promise.then(() => {
-        hasRunningCLi = false;
+        hasRunningCli = false;
       });
     }
     return promise;

--- a/tests/integration/runPrettier.js
+++ b/tests/integration/runPrettier.js
@@ -155,8 +155,7 @@ function runPrettier(dir, args = [], options = {}) {
 
     if (!promise) {
       hasRunningCli = true;
-      promise = run(dir, args, options);
-      promise.then(() => {
+      promise = run(dir, args, options).finally(() => {
         hasRunningCli = false;
       });
     }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

This PR didn't actually use any async API in CLI, just make it async and make test pass.
This is a necessary step for #4459 and #4980

Finally, I figured how to test it.

~There is still [one failed test](https://github.com/prettier/prettier/pull/10804/files#diff-d30da97d630a4c42ca81fcfd745d6b2ac8f4f757e1e7c786e9189bc0a7110f21R90), I can't debug it on windows, maybe @thorn0 or @connor4312 can help me out?~ Fixed

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
