### PR TITLE
Drop Node.js 10 support for development "build"

### DIFF
--- a/.github/workflows/dev-package-test.yml
+++ b/.github/workflows/dev-package-test.yml
@@ -18,7 +18,7 @@ jobs:
           - "ubuntu-latest"
         node:
           # Run tests on minimal version we support
-          - "10"
+          - "12"
         NPM_CLIENT:
           - "yarn"
           - "npm"

--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -21,7 +21,6 @@ jobs:
           - "16"
           - "14"
           - "12"
-          - "10"
         include:
           # only enable coverage on the fastest job
           - os: "ubuntu-latest"
@@ -32,12 +31,8 @@ jobs:
         exclude:
           - os: "macos-latest"
             node: "14"
-          - os: "macos-latest"
-            node: "12"
           - os: "windows-latest"
             node: "14"
-          - os: "windows-latest"
-            node: "12"
     env:
       ENABLE_CODE_COVERAGE: ${{ matrix.ENABLE_CODE_COVERAGE }}
       FULL_TEST: ${{ matrix.FULL_TEST }}

--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -115,6 +115,10 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
+      - name: Config `ignore-engines=true` (Node.js 10)
+        if: matrix.node == '10'
+        run: yarn config set ignore-engines true
+
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "browser": "./standalone.js",
   "unpkg": "./standalone.js",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.17.0"
   },
   "files": [
     "index.js",

--- a/scripts/build/build.js
+++ b/scripts/build/build.js
@@ -135,6 +135,7 @@ async function cacheFiles(cache) {
 async function preparePackage() {
   const pkg = await util.readJson("package.json");
   pkg.bin = "./bin-prettier.js";
+  pkg.engines.node = ">=10.13.0";
   delete pkg.dependencies;
   delete pkg.devDependencies;
   pkg.scripts = {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -1,8 +1,13 @@
 "use strict";
 
 // eslint-disable-next-line no-restricted-modules
-require("please-upgrade-node")(require("../../package.json"));
+const packageJson = require("../../package.json");
+if (process.env.NODE_ENV === "production") {
+  packageJson.engines.node = ">=10.13.0";
+}
+require("please-upgrade-node")(packageJson);
 
+// eslint-disable-next-line import/order
 const stringify = require("fast-json-stable-stringify");
 // eslint-disable-next-line no-restricted-modules
 const prettier = require("../index");

--- a/tests/integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests/integration/__tests__/__snapshots__/early-exit.js.snap
@@ -1,14 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`node version error 1`] = `
-Object {
-  "stderr": "prettier requires at least version 10.13.0 of Node, please upgrade
-",
-  "stdout": "",
-  "write": Array [],
-}
-`;
-
 exports[`show detailed usage with --help l (alias) (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help l (alias) (stdout) 1`] = `

--- a/tests/integration/__tests__/early-exit.js
+++ b/tests/integration/__tests__/early-exit.js
@@ -2,6 +2,7 @@
 
 const prettier = require("prettier-local");
 const runPrettier = require("../runPrettier");
+const { isProduction } = require("../env");
 
 describe("show version with --version", () => {
   runPrettier("cli/with-shebang", ["--version"]).test({
@@ -99,12 +100,14 @@ test("node version error", async () => {
       writable: false,
     });
     const result = runPrettier("cli", ["--help"]);
-    expect(await result.status).toEqual(1);
-    const snapshot = {};
-    for (const name of ["stderr", "stdout", "write"]) {
-      snapshot[name] = await result[name];
-    }
-    expect(snapshot).toMatchSnapshot();
+    expect(await result.status).toBe(1);
+    expect(await result.stderr).toBe(
+      `prettier requires at least version ${
+        isProduction ? "10.13.0" : "12.17.0"
+      } of Node, please upgrade\n`
+    );
+    expect(await result.stdout).toBe("");
+    expect(await result.write).toEqual([]);
   } finally {
     Object.defineProperty(process, "version", {
       value: originalProcessVersion,


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

The production build still support v10

Like #4537

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
