### PR TITLE
Remove dead code

### DIFF
--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -413,7 +413,6 @@ function needsParens(path, options) {
           return false;
       }
 
-    case "TSJSDocFunctionType":
     case "TSConditionalType":
       if (name === "extendsType" && parent.type === "TSConditionalType") {
         return true;

--- a/src/language-js/print/flow.js
+++ b/src/language-js/print/flow.js
@@ -13,7 +13,10 @@ const {
   printIndexedAccessType,
 } = require("./type-annotation");
 const { printInterface } = require("./interface");
-const { printTypeParameters } = require("./type-parameters");
+const {
+  printTypeParameter,
+  printTypeParameters,
+} = require("./type-parameters");
 const {
   printExportDeclaration,
   printExportAllDeclaration,
@@ -89,6 +92,8 @@ function printFlow(path, options, print) {
     // transformed away before printing.
     case "TypeAnnotation":
       return print("typeAnnotation");
+    case "TypeParameter":
+      return printTypeParameter(path, options, print);
   }
 }
 

--- a/src/language-js/print/flow.js
+++ b/src/language-js/print/flow.js
@@ -94,6 +94,8 @@ function printFlow(path, options, print) {
       return print("typeAnnotation");
     case "TypeParameter":
       return printTypeParameter(path, options, print);
+    case "TypeofTypeAnnotation":
+      return ["typeof ", print("argument")];
   }
 }
 

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -698,6 +698,12 @@ function printJsxSpreadAttribute(path, options, print) {
 
 function printJsx(path, options, print) {
   const node = path.getValue();
+
+  // JSX nodes always starts with `TS`
+  if (!node.type.startsWith("JSX")) {
+    return;
+  }
+
   switch (node.type) {
     case "JSXAttribute":
       return printJsxAttribute(path, options, print);
@@ -731,6 +737,9 @@ function printJsx(path, options, print) {
     case "JSXText":
       /* istanbul ignore next */
       throw new Error("JSXTest should be handled by JSXElement");
+    default:
+      /* istanbul ignore next */
+      throw new Error(`Unknown JSX node type: ${JSON.stringify(node.type)}.`);
   }
 }
 

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -699,7 +699,7 @@ function printJsxSpreadAttribute(path, options, print) {
 function printJsx(path, options, print) {
   const node = path.getValue();
 
-  // JSX nodes always starts with `TS`
+  // JSX nodes always starts with `JSX`
   if (!node.type.startsWith("JSX")) {
     return;
   }

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -141,10 +141,6 @@ function printTypescript(path, options, print) {
       return "abstract";
     case "TSAsyncKeyword":
       return "async";
-    case "TSDeclareKeyword":
-      return "declare";
-    case "TSExportKeyword":
-      return "export";
     case "TSNeverKeyword":
       return "never";
     case "TSObjectKeyword":
@@ -179,15 +175,6 @@ function printTypescript(path, options, print) {
     case "TSArrayType":
       return [print("elementType"), "[]"];
     case "TSPropertySignature": {
-      if (node.export) {
-        parts.push("export ");
-      }
-      if (node.accessibility) {
-        parts.push(node.accessibility + " ");
-      }
-      if (node.static) {
-        parts.push("static ");
-      }
       if (node.readonly) {
         parts.push("readonly ");
       }
@@ -547,13 +534,6 @@ function printTypescript(path, options, print) {
       return ["?", print("typeAnnotation")];
     case "TSJSDocNonNullableType":
       return ["!", print("typeAnnotation")];
-    case "TSJSDocFunctionType":
-      return [
-        "function(",
-        // The parameters could be here, but typescript-estree doesn't convert them anyway (throws an error).
-        "): ",
-        print("typeAnnotation"),
-      ];
   }
 }
 

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -60,6 +60,8 @@ function printTypescript(path, options, print) {
   }
 
   switch (node.type) {
+    case "TSThisType":
+      return "this";
     case "TSTypeAssertion": {
       const shouldBreakAfterCast = !(
         node.expression.type === "ArrayExpression" ||

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -53,7 +53,7 @@ const {
 function printTypescript(path, options, print) {
   const node = path.getValue();
 
-  // Typescript nodes always starts with `TS`
+  // TypeScript nodes always starts with `TS`
   if (!node.type.startsWith("TS")) {
     return;
   }
@@ -524,7 +524,7 @@ function printTypescript(path, options, print) {
     default:
       /* istanbul ignore next */
       throw new Error(
-        `Unknown typescript node type: ${JSON.stringify(node.type)}.`
+        `Unknown TypeScript node type: ${JSON.stringify(node.type)}.`
       );
   }
 }

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -146,9 +146,7 @@ function printTypescript(path, options, print) {
     case "TSTypeParameterDeclaration":
     case "TSTypeParameterInstantiation":
       return printTypeParameters(path, options, print, "params");
-
     case "TSTypeParameter":
-    case "TypeParameter":
       return printTypeParameter(path, options, print);
     case "TypeofTypeAnnotation":
       return ["typeof ", print("argument")];

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -54,6 +54,11 @@ function printTypescript(path, options, print) {
   const node = path.getValue();
   const semi = options.semi ? ";" : "";
   const parts = [];
+
+  if (/^TS[A-Z][a-z]+Keyword$/.test(node.type)) {
+    return node.type.slice(2, -7).toLowerCase();
+  }
+
   switch (node.type) {
     case "TSTypeAssertion": {
       const shouldBreakAfterCast = !(
@@ -137,30 +142,6 @@ function printTypescript(path, options, print) {
       return printTypeParameter(path, options, print);
     case "TypeofTypeAnnotation":
       return ["typeof ", print("argument")];
-    case "TSAbstractKeyword":
-      return "abstract";
-    case "TSAsyncKeyword":
-      return "async";
-    case "TSNeverKeyword":
-      return "never";
-    case "TSObjectKeyword":
-      return "object";
-    case "TSProtectedKeyword":
-      return "protected";
-    case "TSPrivateKeyword":
-      return "private";
-    case "TSPublicKeyword":
-      return "public";
-    case "TSReadonlyKeyword":
-      return "readonly";
-    case "TSStaticKeyword":
-      return "static";
-    case "TSUndefinedKeyword":
-      return "undefined";
-    case "TSUnknownKeyword":
-      return "unknown";
-    case "TSIntrinsicKeyword":
-      return "intrinsic";
     case "TSAsExpression": {
       parts.push(print("expression"), " as ", print("typeAnnotation"));
       const parent = path.getParentNode();

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -58,7 +58,7 @@ function printTypescript(path, options, print) {
     return;
   }
 
-  if (/^TS[A-Z][a-z]+Keyword$/.test(node.type)) {
+  if (node.type.endsWith("Keyword")) {
     return node.type.slice(2, -7).toLowerCase();
   }
 
@@ -66,8 +66,6 @@ function printTypescript(path, options, print) {
   const parts = [];
 
   switch (node.type) {
-    case "TSBigIntKeyword":
-      return "bigint";
     case "TSThisType":
       return "this";
     case "TSTypeAssertion": {

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -60,6 +60,8 @@ function printTypescript(path, options, print) {
   }
 
   switch (node.type) {
+    case "TSBigIntKeyword":
+      return "bigint";
     case "TSThisType":
       return "this";
     case "TSTypeAssertion": {

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -52,12 +52,18 @@ const {
 
 function printTypescript(path, options, print) {
   const node = path.getValue();
-  const semi = options.semi ? ";" : "";
-  const parts = [];
+
+  // Typescript nodes always starts with `TS`
+  if (!node.type.startsWith("TS")) {
+    return;
+  }
 
   if (/^TS[A-Z][a-z]+Keyword$/.test(node.type)) {
     return node.type.slice(2, -7).toLowerCase();
   }
+
+  const semi = options.semi ? ";" : "";
+  const parts = [];
 
   switch (node.type) {
     case "TSBigIntKeyword":
@@ -519,6 +525,11 @@ function printTypescript(path, options, print) {
       return ["?", print("typeAnnotation")];
     case "TSJSDocNonNullableType":
       return ["!", print("typeAnnotation")];
+    default:
+      /* istanbul ignore next */
+      throw new Error(
+        `Unknown typescript node type: ${JSON.stringify(node.type)}.`
+      );
   }
 }
 

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -148,8 +148,6 @@ function printTypescript(path, options, print) {
       return printTypeParameters(path, options, print, "params");
     case "TSTypeParameter":
       return printTypeParameter(path, options, print);
-    case "TypeofTypeAnnotation":
-      return ["typeof ", print("argument")];
     case "TSAsExpression": {
       parts.push(print("expression"), " as ", print("typeAnnotation"));
       const parent = path.getParentNode();

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -966,33 +966,22 @@ function printPathNoParens(path, options, print, args) {
     case "DeclaredPredicate":
       return ["%checks(", print("value"), ")"];
     case "AnyTypeAnnotation":
-    case "TSAnyKeyword":
       return "any";
     case "BooleanTypeAnnotation":
-    case "TSBooleanKeyword":
       return "boolean";
     case "BigIntTypeAnnotation":
-    case "TSBigIntKeyword":
       return "bigint";
-    case "TSConstKeyword":
-      return "const";
     case "NullLiteralTypeAnnotation":
-    case "TSNullKeyword":
       return "null";
     case "NumberTypeAnnotation":
-    case "TSNumberKeyword":
       return "number";
     case "SymbolTypeAnnotation":
-    case "TSSymbolKeyword":
       return "symbol";
     case "StringTypeAnnotation":
-    case "TSStringKeyword":
       return "string";
     case "VoidTypeAnnotation":
-    case "TSVoidKeyword":
       return "void";
     case "ThisTypeAnnotation":
-    case "TSThisType":
       return "this";
 
     case "PrivateIdentifier":


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

According to [coverage](https://codecov.io/gh/prettier/prettier) these types and properties are not covered.

They are still in `node_modules/@typescript-eslint/types/dist/ts-estree.d.ts`, but not in `node_modules/@babel/types/lib/index.d.ts`, someone can confirm they are removed or know how to test?

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
