### PR TITLE
Fix #5599, long yaml keys trigger explicit mapping

### DIFF
--- a/changelog_unreleased/yaml/10874.md
+++ b/changelog_unreleased/yaml/10874.md
@@ -1,24 +1,9 @@
-<!--
-
-
-4. Fill in a title, the PR number and your user name.
-
-5. Optionally write a description. Many times it’s enough with just sample code.
-
-6. Change ```jsx to your language. For example, ```yaml.
-
-7. Change the `// Input` and `// Prettier` comments to the comment syntax of your language. For example, `# Input`.
-
-8. Choose some nice input example code. Paste it along with the output before and after your PR.
-
--->
-
 #### Fix #5599, long yaml keys trigger explicit mapping (#10874 by @pdavies)
 
 Fixes #5599, in which long YAML keys cause us to print using yaml's explicit mapping syntax. The intent of the code was to use explicit mapping syntax to accommodate multiline keys, but it had the unintended effect of using explicit mapping syntax for long single-line keys too. This is bad because:
 
-* Doing so has the effect of further increasing the line length
-* Explicit mappings are obscure and most people have never seen them. It causes confusion to introduce them needlessly, as shown in the issue
+- Doing so has the effect of further increasing the line length
+- Explicit mappings are obscure and most people have never seen them. It causes confusion to introduce them needlessly, as shown in the issue
 
 <!-- prettier-ignore -->
 ```yaml

--- a/changelog_unreleased/yaml/10874.md
+++ b/changelog_unreleased/yaml/10874.md
@@ -1,0 +1,36 @@
+<!--
+
+
+4. Fill in a title, the PR number and your user name.
+
+5. Optionally write a description. Many times it’s enough with just sample code.
+
+6. Change ```jsx to your language. For example, ```yaml.
+
+7. Change the `// Input` and `// Prettier` comments to the comment syntax of your language. For example, `# Input`.
+
+8. Choose some nice input example code. Paste it along with the output before and after your PR.
+
+-->
+
+#### Fix #5599, long yaml keys trigger explicit mapping (#10874 by @pdavies)
+
+Fixes #5599, in which long YAML keys cause us to print using yaml's explicit mapping syntax. The intent of the code was to use explicit mapping syntax to accommodate multiline keys, but it had the unintended effect of using explicit mapping syntax for long single-line keys too. This is bad because:
+
+* Doing so has the effect of further increasing the line length
+* Explicit mappings are obscure and most people have never seen them. It causes confusion to introduce them needlessly, as shown in the issue
+
+<!-- prettier-ignore -->
+```yaml
+# Input
+solongitshouldbreakbutitcannot_longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: # Comment
+  foo: bar
+
+# Output before
+? solongitshouldbreakbutitcannot_longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong # Comment
+: foo: bar
+
+# Output after
+solongitshouldbreakbutitcannot_longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: # Comment
+  foo: bar
+```

--- a/changelog_unreleased/yaml/10874.md
+++ b/changelog_unreleased/yaml/10874.md
@@ -1,21 +1,66 @@
-#### Fix #5599, long yaml keys trigger explicit mapping (#10874 by @pdavies)
+#### Don't switch to explicit mappings needlessly (#10874 by @pdavies)
 
-Fixes #5599, in which long YAML keys cause us to print using yaml's explicit mapping syntax. The intent of the code was to use explicit mapping syntax to accommodate multiline keys, but it had the unintended effect of using explicit mapping syntax for long single-line keys too. This is bad because:
+Previously, Prettier printed long YAML keys using explicit mapping syntax. The intent was to use that syntax to accommodate multiline keys, but it had the unintended effect of using it even for long keys that couldn’t be made multiline – for example, because `--prose-wrap` was set to `preserve` or the key didn’t contain whitespace. This is bad because:
 
-- Doing so has the effect of further increasing the line length
-- Explicit mappings are obscure and most people have never seen them. It causes confusion to introduce them needlessly, as shown in the issue
+- Doing so has the effect of further increasing the line length.
+- Explicit mappings are obscure and most people have never seen them. It causes confusion to introduce them needlessly.
 
 <!-- prettier-ignore -->
 ```yaml
 # Input
-solongitshouldbreakbutitcannot_longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: # Comment
-  foo: bar
+- stage: Process
+  jobs:
+    - template: Process.yml
+      parameters:
+        ${{ if in(parameters.BuildType, 'a') }}:
+          BuildArtifacts:
+            - input: Build.Release.x86
+              output: Processed.Release.x86
+        ${{ if in(parameters.BuildType, 'b                                 ') }}:
+          BuildArtifacts:
+            - input: Build.Release
+              output: Processed.Release
 
-# Output before
-? solongitshouldbreakbutitcannot_longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong # Comment
-: foo: bar
+# Prettier stable
+- stage: Process
+  jobs:
+    - template: Process.yml
+      parameters:
+        ${{ if in(parameters.BuildType, 'a') }}:
+          BuildArtifacts:
+            - input: Build.Release.x86
+              output: Processed.Release.x86
+        ? ${{ if in(parameters.BuildType, 'b                                 ') }}
+        : BuildArtifacts:
+            - input: Build.Release
+              output: Processed.Release
 
-# Output after
-solongitshouldbreakbutitcannot_longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: # Comment
-  foo: bar
+# Prettier main
+- stage: Process
+  jobs:
+    - template: Process.yml
+      parameters:
+        ${{ if in(parameters.BuildType, 'a') }}:
+          BuildArtifacts:
+            - input: Build.Release.x86
+              output: Processed.Release.x86
+        ${{ if in(parameters.BuildType, 'b                                 ') }}:
+          BuildArtifacts:
+            - input: Build.Release
+              output: Processed.Release
+
+# Prettier main (with --prose-wrap always)
+- stage: Process
+  jobs:
+    - template: Process.yml
+      parameters:
+        ${{ if in(parameters.BuildType, 'a') }}:
+          BuildArtifacts:
+            - input: Build.Release.x86
+              output: Processed.Release.x86
+        ? ${{ if in(parameters.BuildType, 'b                                 ')
+          }}
+        : BuildArtifacts:
+            - input: Build.Release
+              output: Processed.Release
 ```

--- a/src/language-yaml/print/mapping-item.js
+++ b/src/language-yaml/print/mapping-item.js
@@ -90,7 +90,11 @@ function printMappingItem(node, parentNode, path, print, options) {
   ]);
 
   // Construct both explicit and implicit mapping values.
-  const explicitMappingValue = [hardline, ": ", alignWithSpaces(2, printedValue)];
+  const explicitMappingValue = [
+    hardline,
+    ": ",
+    alignWithSpaces(2, printedValue),
+  ];
   /** @type {Doc[]} */
   // In the implicit case, it's convenient to treat everything from the key's colon
   // as part of the mapping value
@@ -112,7 +116,10 @@ function printMappingItem(node, parentNode, path, print, options) {
     implicitMappingValueParts.push(line);
   }
   implicitMappingValueParts.push(printedValue);
-  const implicitMappingValue = alignWithSpaces(options.tabWidth, implicitMappingValueParts);
+  const implicitMappingValue = alignWithSpaces(
+    options.tabWidth,
+    implicitMappingValueParts
+  );
 
   // If a key is definitely single-line, forcibly use implicit style to avoid edge cases (very long
   // keys) that would otherwise trigger explicit style as if it was multiline.
@@ -123,12 +130,15 @@ function printMappingItem(node, parentNode, path, print, options) {
     !hasMiddleComments(key.content) &&
     !hasEndComments(key)
   ) {
-    return conditionalGroup([[printedKey, implicitMappingValue],]);
+    return conditionalGroup([[printedKey, implicitMappingValue]]);
   }
 
   // Use explicit mapping syntax if the key breaks, implicit otherwise
   return conditionalGroup([
-    [groupedKey, ifBreak(explicitMappingValue, implicitMappingValue, { groupId })],
+    [
+      groupedKey,
+      ifBreak(explicitMappingValue, implicitMappingValue, { groupId }),
+    ],
   ]);
 }
 
@@ -144,6 +154,7 @@ function isAbsolutelyPrintedAsSingleLineNode(node, options) {
       break;
     case "alias":
       return true;
+
     default:
       return false;
   }

--- a/tests/format/yaml/comment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/yaml/comment/__snapshots__/jsfmt.spec.js.snap
@@ -6,9 +6,9 @@ parsers: ["yaml"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-a:
+a: # a.trailingComment
   123
-  # impicitMappginValue
+  # implicitMappingValue
 
 ? b
   # explicitMappingKey
@@ -37,9 +37,9 @@ empty_content:
   # hello world
 
 =====================================output=====================================
-a:
+a: # a.trailingComment
   123
-  # impicitMappginValue
+  # implicitMappingValue
 
 ? b
   # explicitMappingKey

--- a/tests/format/yaml/comment/collection.yml
+++ b/tests/format/yaml/comment/collection.yml
@@ -1,6 +1,6 @@
-a:
+a: # a.trailingComment
   123
-  # impicitMappginValue
+  # implicitMappingValue
 
 ? b
   # explicitMappingKey

--- a/tests/format/yaml/mapping/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/yaml/mapping/__snapshots__/jsfmt.spec.js.snap
@@ -366,11 +366,25 @@ tabWidth: 4
 : longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
 ? longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
 : value
+? solongitshouldbreakbutitcannot_longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+: # Comment
+  foo: bar
+? multiline
+  scalar
+  key
+: value
 
 =====================================output=====================================
 key1: value
 key2: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
 longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: value
+solongitshouldbreakbutitcannot_longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong:
+    # Comment
+    foo: bar
+? multiline
+  scalar
+  key
+: value
 
 ================================================================================
 `;
@@ -387,11 +401,25 @@ printWidth: 80
 : longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
 ? longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
 : value
+? solongitshouldbreakbutitcannot_longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+: # Comment
+  foo: bar
+? multiline
+  scalar
+  key
+: value
 
 =====================================output=====================================
 key1: value
 key2: longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
 longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: value
+solongitshouldbreakbutitcannot_longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong:
+  # Comment
+  foo: bar
+? multiline
+  scalar
+  key
+: value
 
 ================================================================================
 `;

--- a/tests/format/yaml/mapping/explicit-key.yml
+++ b/tests/format/yaml/mapping/explicit-key.yml
@@ -4,3 +4,10 @@
 : longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
 ? longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
 : value
+? solongitshouldbreakbutitcannot_longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+: # Comment
+  foo: bar
+? multiline
+  scalar
+  key
+: value


### PR DESCRIPTION
## Description

Hi, this PR fixes #5599, in which long YAML keys cause us to print using yaml's explicit mapping syntax. The intent of the code was to use explicit mapping syntax to accommodate multiline keys, but it had the unintended effect of using explicit mapping syntax for long single-line keys too. This is bad because:

* Doing so has the effect of further _increasing_ the line length
* Explicit mappings are obscure and most people have never seen them. It causes confusion to introduce them needlessly, as shown in the issue

As others in the issue have noted, this is a pretty non-obvious area of code, so I've added some comments and used what I believe are more helpful variable names.

### Aside
It might be interesting to someone with more experience to see the (pre-existing) (ab)use of `conditionalGroup` here. Based on the documentation for `conditionalGroup`, it sounds like there shouldn't be any value in calling it only to give it an array with a single `Doc` in it. `conditionalGroup` should just pick the only option you've given it. But actually, whoever wrote this yaml code seems to have discovered that `conditionalGroup` is a crafty way to force printing with `MODE_FLAT`, and the yaml formatter depends extensively on this fact. This is the only use of `conditionalGroup` anywhere in prettier where it's used for this purpose and not for any conditioning. It is perhaps worth considering whether prettier could expose a function to print with `MODE_FLAT` by design, but that would be separate from this PR.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
