### PR TITLE
Merge Tips section with Another Tips section

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -37,7 +37,6 @@ coverage
 ```
 
 > Tip! Base your .prettierignore on .gitignore and .eslintignore (if you have one).
-
 > Another tip! If your project isn’t ready to format, say, HTML files yet, add `*.html`.
 
 Now, format all files with Prettier:


### PR DESCRIPTION
It was confusing at first 'Another tip! If your project isn’t ready to format, say, HTML files yet, add `*.html`.' . as to where `adding *.html` files was required. 
Merging these two tips in one section would appear second tip dependent on first tip. (👍 )

## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
