### PR TITLE
Add heuristics to detect type aliases that has complex typeparameters

### DIFF
--- a/changelog_unreleased/typescript/10901.md
+++ b/changelog_unreleased/typescript/10901.md
@@ -1,0 +1,33 @@
+#### Break the LHS of type alias that has complex type parameters (#10901 by @sosukesusuzki)
+
+<!-- prettier-ignore -->
+```ts
+// Input
+type FieldLayoutWith<
+  T extends string,
+  S extends unknown = { width: string }
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+// Prettier stable
+type FieldLayoutWith<T extends string, S extends unknown = { width: string }> =
+  {
+    type: T;
+    code: string;
+    size: S;
+  };
+
+// Prettier main
+type FieldLayoutWith<
+  T extends string,
+  S extends unknown = { width: string }
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+```

--- a/src/language-js/print/assignment.js
+++ b/src/language-js/print/assignment.js
@@ -136,7 +136,7 @@ function chooseLayout(path, options, print, leftDoc, rightPropertyName) {
     return "never-break-after-operator";
   }
 
-  if (isComplexDestructuring(node) || isCompletxTypeAliasParams(node)) {
+  if (isComplexDestructuring(node) || isComplexTypeAliasParams(node)) {
     return "break-lhs";
   }
 
@@ -243,7 +243,7 @@ function isAssignmentOrVariableDeclarator(node) {
   return isAssignment(node) || node.type === "VariableDeclarator";
 }
 
-function isCompletxTypeAliasParams(node) {
+function isComplexTypeAliasParams(node) {
   const typeParams = getTypeParametersFromTypeAlias(node);
   if (isNonEmptyArray(typeParams)) {
     const constraintPropertyName =

--- a/src/language-js/print/assignment.js
+++ b/src/language-js/print/assignment.js
@@ -136,7 +136,7 @@ function chooseLayout(path, options, print, leftDoc, rightPropertyName) {
     return "never-break-after-operator";
   }
 
-  if (isComplexDestructuring(node)) {
+  if (isComplexDestructuring(node) || isCompletxTypeAliasParams(node)) {
     return "break-lhs";
   }
 
@@ -241,6 +241,31 @@ function isAssignment(node) {
 
 function isAssignmentOrVariableDeclarator(node) {
   return isAssignment(node) || node.type === "VariableDeclarator";
+}
+
+function isCompletxTypeAliasParams(node) {
+  const typeParams = getTypeParametersFromTypeAlias(node);
+  if (isNonEmptyArray(typeParams)) {
+    if (
+      typeParams.length > 1 &&
+      typeParams.some((param) => !!param.default) &&
+      typeParams.every((param) => !!param.constraint)
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function getTypeParametersFromTypeAlias(node) {
+  if (isTypeAlias(node) && node.typeParameters && node.typeParameters.params) {
+    return node.typeParameters.params;
+  }
+  return null;
+}
+
+function isTypeAlias(node) {
+  return node.type === "TSTypeAliasDeclaration" || node.type === "TypeAlias";
 }
 
 /**

--- a/src/language-js/print/assignment.js
+++ b/src/language-js/print/assignment.js
@@ -1,6 +1,10 @@
 "use strict";
 
-const { isNonEmptyArray, getStringWidth } = require("../../common/util");
+const {
+  isNonEmptyArray,
+  getStringWidth,
+  getLast,
+} = require("../../common/util");
 const {
   builders: { line, group, indent, indentIfBreak },
   utils: { cleanDoc },
@@ -248,7 +252,7 @@ function isCompletxTypeAliasParams(node) {
   if (isNonEmptyArray(typeParams)) {
     if (
       typeParams.length > 1 &&
-      typeParams.some((param) => !!param.default) &&
+      !!getLast(typeParams).default &&
       typeParams.every((param) => !!param.constraint)
     ) {
       return true;

--- a/src/language-js/print/assignment.js
+++ b/src/language-js/print/assignment.js
@@ -252,8 +252,8 @@ function isCompletxTypeAliasParams(node) {
   if (isNonEmptyArray(typeParams)) {
     if (
       typeParams.length > 1 &&
-      !!getLast(typeParams).default &&
-      typeParams.every((param) => !!param.constraint)
+      Boolean(getLast(typeParams).default) &&
+      typeParams.every((param) => Boolean(param.constraint))
     ) {
       return true;
     }

--- a/src/language-js/print/assignment.js
+++ b/src/language-js/print/assignment.js
@@ -250,10 +250,12 @@ function isAssignmentOrVariableDeclarator(node) {
 function isCompletxTypeAliasParams(node) {
   const typeParams = getTypeParametersFromTypeAlias(node);
   if (isNonEmptyArray(typeParams)) {
+    const constraintPropertyName =
+      node.type === "TSTypeAliasDeclaration" ? "constraint" : "bound";
     if (
       typeParams.length > 1 &&
       Boolean(getLast(typeParams).default) &&
-      typeParams.every((param) => Boolean(param.constraint))
+      typeParams.every((param) => Boolean(param[constraintPropertyName]))
     ) {
       return true;
     }

--- a/src/language-js/print/assignment.js
+++ b/src/language-js/print/assignment.js
@@ -1,10 +1,6 @@
 "use strict";
 
-const {
-  isNonEmptyArray,
-  getStringWidth,
-  getLast,
-} = require("../../common/util");
+const { isNonEmptyArray, getStringWidth } = require("../../common/util");
 const {
   builders: { line, group, indent, indentIfBreak },
   utils: { cleanDoc },
@@ -254,8 +250,7 @@ function isCompletxTypeAliasParams(node) {
       node.type === "TSTypeAliasDeclaration" ? "constraint" : "bound";
     if (
       typeParams.length > 1 &&
-      Boolean(getLast(typeParams).default) &&
-      typeParams.every((param) => Boolean(param[constraintPropertyName]))
+      typeParams.some((param) => param[constraintPropertyName] || param.default)
     ) {
       return true;
     }

--- a/tests/format/flow/type-alias/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/type-alias/__snapshots__/jsfmt.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`issue-100857.js format 1`] = `
 ====================================options=====================================
-parsers: ["flow", "babel"]
+parsers: ["flow", "babel-flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/flow/type-alias/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/type-alias/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,76 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`issue-100857.js format 1`] = `
+====================================options=====================================
+parsers: ["flow", "babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type FieldLayoutWith<
+  T : string,
+  S : unknown = { xxxxxxxx: number; y: string; }
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+type FieldLayoutWith<
+  T : string,
+  S : unknown,
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+type FieldLayoutWith<
+  T : string,
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+type FieldLayoutWith<
+  T : stringgggggggggggggggggg,
+  S : stringgggggggggggggggggg
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+=====================================output=====================================
+type FieldLayoutWith<
+  T: string,
+  S: unknown = { xxxxxxxx: number, y: string }
+> = {
+  type: T,
+  code: string,
+  size: S,
+};
+
+type FieldLayoutWith<T: string, S: unknown> = {
+  type: T,
+  code: string,
+  size: S,
+};
+
+type FieldLayoutWith<T: string> = {
+  type: T,
+  code: string,
+  size: S,
+};
+
+type FieldLayoutWith<
+  T: stringgggggggggggggggggg,
+  S: stringgggggggggggggggggg
+> = {
+  type: T,
+  code: string,
+  size: S,
+};
+
+================================================================================
+`;

--- a/tests/format/flow/type-alias/issue-100857.js
+++ b/tests/format/flow/type-alias/issue-100857.js
@@ -1,0 +1,34 @@
+type FieldLayoutWith<
+  T : string,
+  S : unknown = { xxxxxxxx: number; y: string; }
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+type FieldLayoutWith<
+  T : string,
+  S : unknown,
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+type FieldLayoutWith<
+  T : string,
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+type FieldLayoutWith<
+  T : stringgggggggggggggggggg,
+  S : stringgggggggggggggggggg
+> = {
+  type: T;
+  code: string;
+  size: S;
+};

--- a/tests/format/flow/type-alias/jsfmt.spec.js
+++ b/tests/format/flow/type-alias/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["flow", "babel"]);

--- a/tests/format/flow/type-alias/jsfmt.spec.js
+++ b/tests/format/flow/type-alias/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, ["flow", "babel"]);
+run_spec(__dirname, ["flow", "babel-flow"]);

--- a/tests/format/typescript/type-alias/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/type-alias/__snapshots__/jsfmt.spec.js.snap
@@ -47,6 +47,24 @@ type FieldLayoutWith<
   size: S;
 };
 
+type FieldLayoutWith<
+  T extends stringggggggggggg,
+  T extends stringggggggggggg
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+type FieldLayoutWith<
+  T extends stringggggggggggg,
+  S = stringggggggggggggggggg
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
 =====================================output=====================================
 type FieldLayoutWith<
   T extends string,
@@ -64,6 +82,24 @@ type FieldLayoutWith<T extends string, S extends unknown> = {
 };
 
 type FieldLayoutWith<S extends unknown = { width: string }> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+type FieldLayoutWith<
+  T extends stringggggggggggg,
+  T extends stringggggggggggg
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+type FieldLayoutWith<
+  T extends stringggggggggggg,
+  S = stringggggggggggggggggg
+> = {
   type: T;
   code: string;
   size: S;

--- a/tests/format/typescript/type-alias/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/type-alias/__snapshots__/jsfmt.spec.js.snap
@@ -15,6 +15,63 @@ export type RequestNextDealAction =
 ================================================================================
 `;
 
+exports[`issue-100857.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type FieldLayoutWith<
+  T extends string,
+  S extends unknown = { width: string }
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+type FieldLayoutWith<
+  T extends string,
+  S extends unknown,
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+type FieldLayoutWith<
+  S extends unknown = { width: string }
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+=====================================output=====================================
+type FieldLayoutWith<
+  T extends string,
+  S extends unknown = { width: string }
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+type FieldLayoutWith<T extends string, S extends unknown> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+type FieldLayoutWith<S extends unknown = { width: string }> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+================================================================================
+`;
+
 exports[`pattern-parameter.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/type-alias/issue-100857.ts
+++ b/tests/format/typescript/type-alias/issue-100857.ts
@@ -1,0 +1,25 @@
+type FieldLayoutWith<
+  T extends string,
+  S extends unknown = { width: string }
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+type FieldLayoutWith<
+  T extends string,
+  S extends unknown,
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+type FieldLayoutWith<
+  S extends unknown = { width: string }
+> = {
+  type: T;
+  code: string;
+  size: S;
+};

--- a/tests/format/typescript/type-alias/issue-100857.ts
+++ b/tests/format/typescript/type-alias/issue-100857.ts
@@ -23,3 +23,21 @@ type FieldLayoutWith<
   code: string;
   size: S;
 };
+
+type FieldLayoutWith<
+  T extends stringggggggggggg,
+  T extends stringggggggggggg
+> = {
+  type: T;
+  code: string;
+  size: S;
+};
+
+type FieldLayoutWith<
+  T extends stringggggggggggg,
+  S = stringggggggggggggggggg
+> = {
+  type: T;
+  code: string;
+  size: S;
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #10857

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
