### PR TITLE
Allow `:` as class prefix-delimeter

### DIFF
--- a/changelog_unreleased/html/10906.md
+++ b/changelog_unreleased/html/10906.md
@@ -1,0 +1,30 @@
+#### Allow : as class prefix delimeter (#10906 by @tkalmar)
+
+<!-- prettier-ignore -->
+```html
+// Input
+<div class="md:foo md:bar xl:foo xl:prefix2 --prefix2--something-else unrelated_class_to_fill_80_chars"></div>
+
+
+// Prettier stable
+<div
+  class="
+    md:foo
+    md:bar
+    xl:foo
+    xl:prefix2
+    --prefix2--something-else
+    unrelated_class_to_fill_80_chars
+  "
+></div>
+
+// Prettier main
+<div
+  class="
+    md:foo md:bar
+    xl:foo xl:prefix2
+    --prefix2--something-else
+    unrelated_class_to_fill_80_chars
+  "
+></div>
+```

--- a/changelog_unreleased/html/10906.md
+++ b/changelog_unreleased/html/10906.md
@@ -1,12 +1,11 @@
-#### Allow : as class prefix delimeter (#10906 by @tkalmar)
+#### Allow `:` as class prefix delimiter (#10906 by @tkalmar)
 
 <!-- prettier-ignore -->
 ```html
-// Input
+<!-- Input -->
 <div class="md:foo md:bar xl:foo xl:prefix2 --prefix2--something-else unrelated_class_to_fill_80_chars"></div>
 
-
-// Prettier stable
+<!-- Prettier stable -->
 <div
   class="
     md:foo
@@ -18,7 +17,7 @@
   "
 ></div>
 
-// Prettier main
+<!-- Prettier main -->
 <div
   class="
     md:foo md:bar

--- a/src/language-html/syntax-attribute.js
+++ b/src/language-html/syntax-attribute.js
@@ -60,7 +60,7 @@ function printImgSrcset(value) {
   );
 }
 
-const prefixDelimiters = ["__", "--", "_", "-", ":"];
+const prefixDelimiters = [":", "__", "--", "_", "-"];
 
 function getClassPrefix(className) {
   const startIndex = className.search(/[^_-]/);

--- a/src/language-html/syntax-attribute.js
+++ b/src/language-html/syntax-attribute.js
@@ -60,7 +60,7 @@ function printImgSrcset(value) {
   );
 }
 
-const prefixDelimiters = ["__", "--", "_", "-"];
+const prefixDelimiters = ["__", "--", "_", "-", ":"];
 
 function getClassPrefix(className) {
   const startIndex = className.search(/[^_-]/);

--- a/tests/format/html/attributes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/html/attributes/__snapshots__/jsfmt.spec.js.snap
@@ -347,12 +347,12 @@ parsers: ["html"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-<my-tag class="md:foo md:bar xl:foo xl:prefix2 --prefix2--something-else unrelated_class_to_fill_80_chars"></my-tag>
+<my-tag class="md:foo-bg md:foo-color md:foo--sub-bg md:foo--sub-color xl:foo xl:prefix2 --prefix2--something-else unrelated_class_to_fill_80_chars"></my-tag>
 
 =====================================output=====================================
 <my-tag
   class="
-    md:foo md:bar
+    md:foo-bg md:foo-color md:foo--sub-bg md:foo--sub-color
     xl:foo xl:prefix2
     --prefix2--something-else
     unrelated_class_to_fill_80_chars

--- a/tests/format/html/attributes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/html/attributes/__snapshots__/jsfmt.spec.js.snap
@@ -341,6 +341,27 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`class-colon.html format 1`] = `
+====================================options=====================================
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<my-tag class="md:foo md:bar xl:foo xl:prefix2 --prefix2--something-else unrelated_class_to_fill_80_chars"></my-tag>
+
+=====================================output=====================================
+<my-tag
+  class="
+    md:foo md:bar
+    xl:foo xl:prefix2
+    --prefix2--something-else
+    unrelated_class_to_fill_80_chars
+  "
+></my-tag>
+
+================================================================================
+`;
+
 exports[`class-leading-dashes.html format 1`] = `
 ====================================options=====================================
 parsers: ["html"]

--- a/tests/format/html/attributes/class-colon.html
+++ b/tests/format/html/attributes/class-colon.html
@@ -1,0 +1,1 @@
+<my-tag class="md:foo-bg md:foo-color md:foo--sub-bg md:foo--sub-color xl:foo xl:prefix2 --prefix2--something-else unrelated_class_to_fill_80_chars"></my-tag>


### PR DESCRIPTION
## Description

Allow colon as class prefix. This is useful when working with tailwind and various breakpoints.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
