### PR TITLE
Fix incorrectly wrapped arrow functions with return types

### DIFF
--- a/changelog_unreleased/typescript/10940.md
+++ b/changelog_unreleased/typescript/10940.md
@@ -1,0 +1,25 @@
+#### Fix incorrectly wrapped arrow functions with return types (#10940 by @thorn0)
+
+<!-- prettier-ignore -->
+```ts
+// Input
+longfunctionWithCall12("bla", foo, (thing: string): complex<type<something>> => {
+  code();
+});
+
+// Prettier stable
+longfunctionWithCall12("bla", foo, (thing: string): complex<
+  type<something>
+> => {
+  code();
+});
+
+// Prettier main
+longfunctionWithCall12(
+  "bla",
+  foo,
+  (thing: string): complex<type<something>> => {
+    code();
+  }
+);
+```

--- a/tests/format/typescript/argument-expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/argument-expansion/__snapshots__/jsfmt.spec.js.snap
@@ -108,6 +108,11 @@ longfunctionWithCallBack("blabla", foobarbazblablabla, (thing: string): complex<
   code();
 });
 
+longfunctionWithCall1("bla", foo, (thing: string): complex<type<\`
+\`>> => {
+  code();
+});
+
 =====================================output=====================================
 longfunctionWithCall1("bla", foo, (thing: string): complex<type<something>> => {
   code();
@@ -133,6 +138,19 @@ longfunctionWithCallBack(
   "blabla",
   foobarbazblablabla,
   (thing: string): complex<type<something>> => {
+    code();
+  }
+);
+
+longfunctionWithCall1(
+  "bla",
+  foo,
+  (
+    thing: string
+  ): complex<
+    type<\`
+\`>
+  > => {
     code();
   }
 );

--- a/tests/format/typescript/argument-expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/argument-expansion/__snapshots__/jsfmt.spec.js.snap
@@ -85,3 +85,57 @@ const bar8 = [1, 2, 3].reduce(
 
 ================================================================================
 `;
+
+exports[`arrow-with-return-type.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+longfunctionWithCall1("bla", foo, (thing: string): complex<type<something>> => {
+  code();
+});
+
+longfunctionWithCall12("bla", foo, (thing: string): complex<type<something>> => {
+  code();
+});
+
+longfunctionWithCallBack("blabla", foobarbazblablablablabla, (thing: string): complex<type<something>> => {
+  code();
+});
+
+longfunctionWithCallBack("blabla", foobarbazblablabla, (thing: string): complex<type<something>> => {
+  code();
+});
+
+=====================================output=====================================
+longfunctionWithCall1("bla", foo, (thing: string): complex<type<something>> => {
+  code();
+});
+
+longfunctionWithCall12(
+  "bla",
+  foo,
+  (thing: string): complex<type<something>> => {
+    code();
+  }
+);
+
+longfunctionWithCallBack(
+  "blabla",
+  foobarbazblablablablabla,
+  (thing: string): complex<type<something>> => {
+    code();
+  }
+);
+
+longfunctionWithCallBack(
+  "blabla",
+  foobarbazblablabla,
+  (thing: string): complex<type<something>> => {
+    code();
+  }
+);
+
+================================================================================
+`;

--- a/tests/format/typescript/argument-expansion/arrow-with-return-type.ts
+++ b/tests/format/typescript/argument-expansion/arrow-with-return-type.ts
@@ -1,0 +1,15 @@
+longfunctionWithCall1("bla", foo, (thing: string): complex<type<something>> => {
+  code();
+});
+
+longfunctionWithCall12("bla", foo, (thing: string): complex<type<something>> => {
+  code();
+});
+
+longfunctionWithCallBack("blabla", foobarbazblablablablabla, (thing: string): complex<type<something>> => {
+  code();
+});
+
+longfunctionWithCallBack("blabla", foobarbazblablabla, (thing: string): complex<type<something>> => {
+  code();
+});

--- a/tests/format/typescript/argument-expansion/arrow-with-return-type.ts
+++ b/tests/format/typescript/argument-expansion/arrow-with-return-type.ts
@@ -13,3 +13,8 @@ longfunctionWithCallBack("blabla", foobarbazblablablablabla, (thing: string): co
 longfunctionWithCallBack("blabla", foobarbazblablabla, (thing: string): complex<type<something>> => {
   code();
 });
+
+longfunctionWithCall1("bla", foo, (thing: string): complex<type<`
+`>> => {
+  code();
+});


### PR DESCRIPTION
## Description

fixes #10923

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
