### PR TITLE
Minor tweak to js printer

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -71,7 +71,7 @@ module.exports = {
     "prettier-local": "<rootDir>/tests/config/require-prettier.js",
     "prettier-standalone": "<rootDir>/tests/config/require-standalone.js",
   },
-  modulePathIgnorePatterns: ["<rootDir>/dist", "<rootDir>/website/static/lib"],
+  modulePathIgnorePatterns: ["<rootDir>/dist", "<rootDir>/website"],
   transform,
   watchPlugins: [
     "jest-watch-typeahead/filename",

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/no-identifier-n.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/no-identifier-n.js
@@ -34,7 +34,7 @@ module.exports = {
 
         /* istanbul ignore next */
         if (!variable) {
-          throw new Error("Unexpected case.");
+          return;
         }
 
         if (!variables.has(variable)) {

--- a/src/language-js/print/angular.js
+++ b/src/language-js/print/angular.js
@@ -10,6 +10,12 @@ const { printBinaryishExpression } = require("./binaryish");
 
 function printAngular(path, options, print) {
   const node = path.getValue();
+
+  // Angular nodes always starts with `NG`
+  if (!node.type.startsWith("NG")) {
+    return;
+  }
+
   switch (node.type) {
     case "NGRoot":
       return [
@@ -83,6 +89,11 @@ function printAngular(path, options, print) {
       ];
     case "NGMicrosyntaxAs":
       return [print("key"), " as ", print("alias")];
+    default:
+      /* istanbul ignore next */
+      throw new Error(
+        `Unknown Angular node type: ${JSON.stringify(node.type)}.`
+      );
   }
 }
 

--- a/src/language-js/print/function.js
+++ b/src/language-js/print/function.js
@@ -34,7 +34,6 @@ const {
   isTemplateOnItsOwnLine,
   shouldPrintComma,
   startsWithNoLookaheadToken,
-  returnArgumentHasLeadingComment,
   isBinaryish,
   isLineComment,
   hasComment,
@@ -43,6 +42,8 @@ const {
   isCallLikeExpression,
   isCallExpression,
   getCallArguments,
+  hasNakedLeftSide,
+  getLeftSide,
 } = require("../utils");
 const { locEnd } = require("../loc");
 const {
@@ -496,6 +497,29 @@ function printReturnStatement(path, options, print) {
 
 function printThrowStatement(path, options, print) {
   return ["throw", printReturnOrThrowArgument(path, options, print)];
+}
+
+// This recurses the return argument, looking for the first token
+// (the leftmost leaf node) and, if it (or its parents) has any
+// leadingComments, returns true (so it can be wrapped in parens).
+function returnArgumentHasLeadingComment(options, argument) {
+  if (hasLeadingOwnLineComment(options.originalText, argument)) {
+    return true;
+  }
+
+  if (hasNakedLeftSide(argument)) {
+    let leftMost = argument;
+    let newLeftMost;
+    while ((newLeftMost = getLeftSide(leftMost))) {
+      leftMost = newLeftMost;
+
+      if (hasLeadingOwnLineComment(options.originalText, leftMost)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
 }
 
 module.exports = {

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -38,7 +38,7 @@ const {
   printTypeParameters,
 } = require("./type-parameters");
 const { printPropertyKey } = require("./property");
-const { printFunctionDeclaration, printMethodInternal } = require("./function");
+const { printFunction, printMethodInternal } = require("./function");
 const { printInterface } = require("./interface");
 const { printBlock } = require("./block");
 const {
@@ -98,7 +98,7 @@ function printTypescript(path, options, print) {
       return group([castGroup, print("expression")]);
     }
     case "TSDeclareFunction":
-      return printFunctionDeclaration(path, print, options);
+      return printFunction(path, print, options);
     case "TSExportAssignment":
       return ["export = ", print("expression"), semi];
     case "TSModuleBlock":

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -267,7 +267,7 @@ function printPathNoParens(path, options, print, args) {
     case "FunctionExpression":
       return printFunction(path, print, options, args);
     case "ArrowFunctionExpression":
-      return printArrowFunction(path, options, print);
+      return printArrowFunction(path, options, print, args);
     case "YieldExpression":
       parts.push("yield");
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -16,7 +16,6 @@ const handleComments = require("./comments");
 const pathNeedsParens = require("./needs-parens");
 const preprocess = require("./print-preprocess");
 const {
-  getCallArguments,
   hasFlowShorthandAnnotationComment,
   hasComment,
   CommentCheckFlags,
@@ -64,8 +63,8 @@ const {
 } = require("./print/class");
 const { printProperty } = require("./print/property");
 const {
-  printFunctionDeclaration,
-  printArrowFunctionExpression,
+  printFunction,
+  printArrowFunction,
   printMethod,
   printReturnStatement,
   printThrowStatement,
@@ -265,18 +264,10 @@ function printPathNoParens(path, options, print, args) {
     case "RestElement":
       return printRestSpread(path, options, print);
     case "FunctionDeclaration":
-    case "FunctionExpression": {
-      let expandArg = false;
-      if (args && args.expandLastArg) {
-        const parent = path.getParentNode();
-        if (isCallExpression(parent) && getCallArguments(parent).length > 1) {
-          expandArg = true;
-        }
-      }
-      return printFunctionDeclaration(path, print, options, expandArg);
-    }
+    case "FunctionExpression":
+      return printFunction(path, options, print, args);
     case "ArrowFunctionExpression":
-      return printArrowFunctionExpression(path, options, print, args);
+      return printArrowFunction(path, options, print);
     case "YieldExpression":
       parts.push("yield");
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -265,7 +265,7 @@ function printPathNoParens(path, options, print, args) {
       return printRestSpread(path, options, print);
     case "FunctionDeclaration":
     case "FunctionExpression":
-      return printFunction(path, options, print, args);
+      return printFunction(path, print, options, args);
     case "ArrowFunctionExpression":
       return printArrowFunction(path, options, print);
     case "YieldExpression":

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -668,29 +668,6 @@ function hasLeadingOwnLineComment(text, node) {
   );
 }
 
-// This recurses the return argument, looking for the first token
-// (the leftmost leaf node) and, if it (or its parents) has any
-// leadingComments, returns true (so it can be wrapped in parens).
-function returnArgumentHasLeadingComment(options, argument) {
-  if (hasLeadingOwnLineComment(options.originalText, argument)) {
-    return true;
-  }
-
-  if (hasNakedLeftSide(argument)) {
-    let leftMost = argument;
-    let newLeftMost;
-    while ((newLeftMost = getLeftSide(leftMost))) {
-      leftMost = newLeftMost;
-
-      if (hasLeadingOwnLineComment(options.originalText, leftMost)) {
-        return true;
-      }
-    }
-  }
-
-  return false;
-}
-
 // Note: Quoting/unquoting numbers in TypeScript is not safe.
 //
 // let a = { 1: 1, 2: 2 }
@@ -1382,7 +1359,6 @@ module.exports = {
   isNextLineEmpty,
   needsHardlineAfterDanglingComment,
   rawText,
-  returnArgumentHasLeadingComment,
   shouldPrintComma,
   isBitwiseOperator,
   shouldFlatten,

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -1311,6 +1311,7 @@ module.exports = {
   getCallArguments,
   iterateCallArgumentsPath,
   hasRestParameter,
+  getLeftSide,
   getLeftSidePathName,
   getParentExportDeclaration,
   getTypeScriptMappedTypeModifier,


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

- Handle `NG-*` node in `angular.js`
- Rename `printFunctionDeclaration` to `printFunction` to be more correct, it handles expressions too.
- Move `expandArg` logic to `printFunction`
- Rename `printReturnAndThrowArgument` to `printReturnOrThrowArgument`
- Move `returnArgumentHasLeadingComment` from `utils.js` to `function.js`

`returnArgumentHasLeadingComment` should have a better name, because it also checks `throw` argument, but `returnOrThrowArgumentHasLeadingComment` seems too long, any idea? 


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
