### PR TITLE
Fix `StringLiteral` print

### DIFF
--- a/src/language-js/print/literal.js
+++ b/src/language-js/print/literal.js
@@ -13,9 +13,7 @@ function printLiteral(path, options /*, print*/) {
     case "NumericLiteral": // Babel 6 Literal split
       return printNumber(node.extra.raw);
     case "StringLiteral": // Babel 6 Literal split
-      // When `estree` plugin is enabled in babel `node.raw`
-      // https://github.com/babel/babel/issues/13329
-      return printString(node.raw || node.extra.raw, options);
+      return printString(node.extra.raw, options);
     case "NullLiteral": // Babel 6 Literal split
       return "null";
     case "BooleanLiteral": // Babel 6 Literal split


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

This workaround was added in #10910, already fixed in babel side.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
