### PR TITLE
Keep editor from removing trailing whitespace in format test files and snapshots

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,9 @@ insert_final_newline = false
 
 [website/blog/*.md]
 trim_trailing_whitespace = false
+
+[tests/{**/__snapshots__/*, tests/format/**/*}]
+trim_trailing_whitespace = false
+
+[tests/format/**/jsfmt.spec.js]
+trim_trailing_whitespace = true


### PR DESCRIPTION
Keep editor from removing trailing whitespace in format test files and snapshots.

## Description

Configures editorconfig to avoid trimming EOL whitespace in format test files and snapshots.

This change was originally proposed downstream in https://github.com/brodybits/prettierx/pull/549 but was determined to be a better candidate for an upstream change. (cc @brodybits)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] N/A ~~I’ve added tests to confirm my change works.~~
- [x] N/A ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~~
- [x] N/A ~~(If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.~~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
