### PR TITLE
Fix docs urls for internal lint rules

### DIFF
--- a/scripts/tools/eslint-plugin-prettier-internal-rules/directly-loc-start-end.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/directly-loc-start-end.js
@@ -13,7 +13,7 @@ module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      url: "https://github.com/prettier/prettier/blob/main/scripts/eslint-plugin-prettier-internal-rules/directly-loc-start-end.js",
+      url: "https://github.com/prettier/prettier/blob/main/scripts/tools/eslint-plugin-prettier-internal-rules/directly-loc-start-end.js",
     },
     messages: {
       [MESSAGE_ID]:

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/jsx-identifier-case.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/jsx-identifier-case.js
@@ -9,7 +9,7 @@ module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      url: "https://github.com/prettier/prettier/blob/main/scripts/eslint-plugin-prettier-internal-rules/jsx-identifier-case.js",
+      url: "https://github.com/prettier/prettier/blob/main/scripts/tools/eslint-plugin-prettier-internal-rules/jsx-identifier-case.js",
     },
     messages: {
       [MESSAGE_ID]: "Please rename '{{name}}' to '{{fixed}}'.",

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/no-conflicting-comment-check-flags.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/no-conflicting-comment-check-flags.js
@@ -41,7 +41,7 @@ module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      url: "https://github.com/prettier/prettier/blob/main/scripts/eslint-plugin-prettier-internal-rules/no-conflicting-comment-check-flags.js",
+      url: "https://github.com/prettier/prettier/blob/main/scripts/tools/eslint-plugin-prettier-internal-rules/no-conflicting-comment-check-flags.js",
     },
     messages: {
       [MESSAGE_ID_UNIQUE]: "Do not use same flag multiple times.",

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/no-doc-builder-concat.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/no-doc-builder-concat.js
@@ -13,7 +13,7 @@ module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      url: "https://github.com/prettier/prettier/blob/main/scripts/eslint-plugin-prettier-internal-rules/no-doc-builder-concat.js",
+      url: "https://github.com/prettier/prettier/blob/main/scripts/tools/eslint-plugin-prettier-internal-rules/no-doc-builder-concat.js",
     },
     messages: {
       [messageId]: "Use array directly instead of `concat([])`",

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/no-empty-flat-contents-for-if-break.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/no-empty-flat-contents-for-if-break.js
@@ -17,7 +17,7 @@ module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      url: "https://github.com/prettier/prettier/blob/main/scripts/eslint-plugin-prettier-internal-rules/no-empty-flat-contents-for-if-break.js",
+      url: "https://github.com/prettier/prettier/blob/main/scripts/tools/eslint-plugin-prettier-internal-rules/no-empty-flat-contents-for-if-break.js",
     },
     messages: {
       [messageId]:

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/no-identifier-n.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/no-identifier-n.js
@@ -17,7 +17,7 @@ module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      url: "https://github.com/prettier/prettier/blob/main/scripts/eslint-plugin-prettier-internal-rules/no-identifier-n.js",
+      url: "https://github.com/prettier/prettier/blob/main/scripts/tools/eslint-plugin-prettier-internal-rules/no-identifier-n.js",
     },
     messages: {
       [ERROR]: "Please rename variable 'n'.",

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/no-node-comments.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/no-node-comments.js
@@ -29,7 +29,7 @@ module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      url: "https://github.com/prettier/prettier/blob/main/scripts/eslint-plugin-prettier-internal-rules/no-node-comments.js",
+      url: "https://github.com/prettier/prettier/blob/main/scripts/tools/eslint-plugin-prettier-internal-rules/no-node-comments.js",
     },
     messages: {
       [messageId]: "Do not access node.comments.",

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/no-unnecessary-ast-path-call.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/no-unnecessary-ast-path-call.js
@@ -18,7 +18,7 @@ module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      url: "https://github.com/prettier/prettier/blob/main/scripts/eslint-plugin-prettier-internal-rules/no-unnecessary-ast-path-call.js",
+      url: "https://github.com/prettier/prettier/blob/main/scripts/tools/eslint-plugin-prettier-internal-rules/no-unnecessary-ast-path-call.js",
     },
     messages: {
       [messageId]: "Do not use `AstPath.call()` with one argument.",

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-each.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-each.js
@@ -20,7 +20,7 @@ module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      url: "https://github.com/prettier/prettier/blob/main/scripts/eslint-plugin-prettier-internal-rules/require-json-extensions.js",
+      url: "https://github.com/prettier/prettier/blob/main/scripts/tools/eslint-plugin-prettier-internal-rules/require-json-extensions.js",
     },
     messages: {
       [messageId]: "Prefer `AstPath#each()` over `AstPath#map()`.",

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-indent-if-break.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-indent-if-break.js
@@ -22,7 +22,7 @@ module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      url: "https://github.com/prettier/prettier/blob/main/scripts/eslint-plugin-prettier-internal-rules/prefer-indent-if-break.js",
+      url: "https://github.com/prettier/prettier/blob/main/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-indent-if-break.js",
     },
     messages: {
       [messageId]: "Prefer `indentIfBreak(…)` over `ifBreak(indent(…), …)`.",

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-is-non-empty-array.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-is-non-empty-array.js
@@ -56,7 +56,7 @@ module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      url: "https://github.com/prettier/prettier/blob/main/scripts/eslint-plugin-prettier-internal-rules/prefer-is-non-empty-array.js",
+      url: "https://github.com/prettier/prettier/blob/main/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-is-non-empty-array.js",
     },
     messages: {
       [MESSAGE_ID]: "Please use `isNonEmptyArray()`.",

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/require-json-extensions.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/require-json-extensions.js
@@ -26,7 +26,7 @@ module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      url: "https://github.com/prettier/prettier/blob/main/scripts/eslint-plugin-prettier-internal-rules/require-json-extensions.js",
+      url: "https://github.com/prettier/prettier/blob/main/scripts/tools/eslint-plugin-prettier-internal-rules/require-json-extensions.js",
     },
     messages: {
       [MESSAGE_ID]: 'Missing file extension ".json" for "{{id}}".',


### PR DESCRIPTION
## Description

The path to `eslint-plugin-prettier-internal-rules` has changed but the URLs haven't all been updated. This PR updates all docs URLs to use the correct path, `scripts/tools/eslint-plugin-prettier-internal-rules`, fixing docs links.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] N/A ~~I’ve added tests to confirm my change works.~~
- [x] N/A ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~~
- [x] N/A ~~(If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.~~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
