### PR TITLE
Revert features for minor

### DIFF
--- a/changelog_unreleased/cli/10924.md
+++ b/changelog_unreleased/cli/10924.md
@@ -1,3 +1,0 @@
-#### Infer parser for `.stylelintrc` (#10924 by @SevenOutman)
-
-A `.stylelintrc` file (without extension) is handled using `json` and `yaml` parsers.

--- a/src/language-yaml/embed.js
+++ b/src/language-yaml/embed.js
@@ -3,11 +3,11 @@
 function embed(path, print, textToDoc, options) {
   const node = path.getValue();
 
-  // Try to format `.prettierrc` and `.stylelintrc` as `json` first
+  // Try to format `.prettierrc` as `json` first
   if (
     node.type === "root" &&
     options.filepath &&
-    /(?:[/\\]|^)\.(?:prettier|stylelint)rc$/.test(options.filepath)
+    /(?:[/\\]|^)\.prettierrc$/.test(options.filepath)
   ) {
     return textToDoc(options.originalText, { ...options, parser: "json" });
   }

--- a/src/language-yaml/index.js
+++ b/src/language-yaml/index.js
@@ -13,7 +13,6 @@ const languages = [
     filenames: [
       ...data.filenames.filter((filename) => filename !== "yarn.lock"),
       ".prettierrc",
-      ".stylelintrc",
     ],
   })),
 ];

--- a/tests/integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests/integration/__tests__/__snapshots__/support-info.js.snap
@@ -742,8 +742,7 @@ exports[`CLI --support-info (stdout) 1`] = `
         \\".clang-tidy\\",
         \\".gemrc\\",
         \\"glide.lock\\",
-        \\".prettierrc\\",
-        \\".stylelintrc\\"
+        \\".prettierrc\\"
       ],
       \\"linguistLanguageId\\": 407,
       \\"name\\": \\"YAML\\",

--- a/tests/integration/__tests__/with-parser-inference.js
+++ b/tests/integration/__tests__/with-parser-inference.js
@@ -28,18 +28,6 @@ describe("infers parser from filename", () => {
     ).toEqual("{}\n");
   });
 
-  test("json from .stylelintrc", () => {
-    expect(
-      prettier.format("  {   }  ", { filepath: "x/y/.stylelintrc" })
-    ).toEqual("{}\n");
-  });
-
-  test("yaml from .stylelintrc", () => {
-    expect(
-      prettier.format("  extends:    ''  ", { filepath: "x/y/.stylelintrc" })
-    ).toEqual('extends: ""\n');
-  });
-
   test("babel from Jakefile", () => {
     expect(
       prettier.format("let foo = ( x = 1 ) => x", { filepath: "x/y/Jakefile" })


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

I'm now preparing for the 2.3.1 release. Some new feature implementations have already been included in the main branch. These features should be released as minor, not as a patch. So this PR reverts commits that adds these features for now.

I'll revert this PR after the release of 2.3.1.

**new features that is reverted by this PR:**

- https://github.com/prettier/prettier/commit/f8cb7857587527267c4cff06631415ced3f06a89

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
