### PR TITLE
Fix lint:deps script

### DIFF
--- a/scripts/check-deps.mjs
+++ b/scripts/check-deps.mjs
@@ -8,7 +8,10 @@ import chalk from "chalk";
 
   validateDependencyObject(packageJson.dependencies);
   validateDependencyObject(packageJson.devDependencies);
-})();
+})().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
 
 function validateDependencyObject(object) {
   for (const key of Object.keys(object)) {

--- a/scripts/check-deps.mjs
+++ b/scripts/check-deps.mjs
@@ -3,7 +3,7 @@ import chalk from "chalk";
 
 (async () => {
   const packageJson = JSON.parse(
-    await fs.readFile(new URL("../package.json", import.meta))
+    await fs.readFile(new URL("../package.json", import.meta.url))
   );
 
   validateDependencyObject(packageJson.dependencies);


### PR DESCRIPTION
## Description

The `check-deps` script is failing because of a mistake from #10867 in creating the URL to read `package.json`. This failure can be [seen in CI runs of lint:deps](https://github.com/prettier/prettier/runs/2572587849#step:5:6), but for whatever reason, it is not causing the `Lint` action to fail.

This PR [allows the script to pass](https://github.com/prettier/prettier/pull/11038/checks?check_run_id=2767164627#step:5:5).

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] N/A ~~I’ve added tests to confirm my change works.~~
- [x] N/A ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~~
- [x] N/A ~~(If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.~~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
