### PR TITLE
Break multiline parenthesized logical expressions

### DIFF
--- a/changelog_unreleased/javascript/TEMPLATE.md
+++ b/changelog_unreleased/javascript/TEMPLATE.md
@@ -1,0 +1,32 @@
+##### Break multiline parenthesized logical expressions by [@alex12058](https://github.com/alex12058)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+const funnelSnapshotCard =
+  (report === MY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2) ||
+  (
+    report === COMPANY_OVERVIEW &&
+    !ReportGK.xar_metrics_active_capitol_v2_company_metrics
+  ) ? (
+    <ReportMetricsFunnelSnapshotCard metrics={metrics} />
+  ) : null;
+
+// Prettier stable
+const funnelSnapshotCard =
+  (report === MY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2) ||
+  (report === COMPANY_OVERVIEW &&
+    !ReportGK.xar_metrics_active_capitol_v2_company_metrics) ? (
+    <ReportMetricsFunnelSnapshotCard metrics={metrics} />
+  ) : null;
+
+// Prettier main
+const funnelSnapshotCard =
+  (report === MY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2) ||
+  (
+    report === COMPANY_OVERVIEW &&
+    !ReportGK.xar_metrics_active_capitol_v2_company_metrics
+  ) ? (
+    <ReportMetricsFunnelSnapshotCard metrics={metrics} />
+  ) : null;
+```

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -26,6 +26,7 @@ const {
   isMemberExpression,
   isObjectProperty,
 } = require("../utils");
+const needsParens = require("../needs-parens");
 
 /** @typedef {import("../../document").Doc} Doc */
 
@@ -74,7 +75,8 @@ function printBinaryishExpression(path, options, print) {
   if (
     (isCallExpression(parent) && parent.callee === node) ||
     parent.type === "UnaryExpression" ||
-    (isMemberExpression(parent) && !parent.computed)
+    (isMemberExpression(parent) && !parent.computed) ||
+    parent.type === "LogicalExpression" && needsParens(path, options)
   ) {
     return group([indent([softline, ...parts]), softline]);
   }

--- a/tests/format/js/binary-expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/binary-expressions/__snapshots__/jsfmt.spec.js.snap
@@ -447,11 +447,13 @@ const user = renderedUser || (
 
 const user2 =
   renderedUser ||
-  (shouldRenderUser && (
-    <div>
-      <User name={this.state.user.name} age={this.state.user.age} />
-    </div>
-  ));
+  (
+    shouldRenderUser && (
+      <div>
+        <User name={this.state.user.name} age={this.state.user.age} />
+      </div>
+    )
+  );
 
 const avatar = hasAvatar && <Gravatar user={author} size={size} />;
 
@@ -578,13 +580,15 @@ prevState = prevState ||
 
 prevState =
   prevState ||
-  (defaultState && {
-    catalogs: [],
-    loadState: LOADED,
-    opened: false,
-    searchQuery: "",
-    selectedCatalog: null,
-  });
+  (
+    defaultState && {
+      catalogs: [],
+      loadState: LOADED,
+      opened: false,
+      searchQuery: "",
+      selectedCatalog: null,
+    }
+  );
 
 prevState = prevState ||
   (useDefault && defaultState) || {
@@ -604,12 +608,14 @@ this.steps = steps || [
 
 this.steps =
   steps ||
-  (checkStep && [
-    {
-      name: "mock-module",
-      path: "/nux/mock-module",
-    },
-  ]);
+  (
+    checkStep && [
+      {
+        name: "mock-module",
+        path: "/nux/mock-module",
+      },
+    ]
+  );
 
 this.steps = (steps && checkStep) || [
   {

--- a/tests/format/js/logical_expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/logical_expressions/__snapshots__/jsfmt.spec.js.snap
@@ -13,8 +13,10 @@ const radioSelectedAttr =
 
 =====================================output=====================================
 const radioSelectedAttr =
-  (isAnyValueSelected &&
-    node.getAttribute(radioAttr.toLowerCase()) === radioValue) ||
+  (
+    isAnyValueSelected &&
+    node.getAttribute(radioAttr.toLowerCase()) === radioValue
+  ) ||
   (!isAnyValueSelected && values[a].default === true) ||
   a === 0;
 

--- a/tests/format/js/return/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/return/__snapshots__/jsfmt.spec.js.snap
@@ -35,8 +35,10 @@ function f() {
   return (
     property.isIdentifier() &&
     FUNCTIONS[property.node.name] &&
-    (object.isIdentifier(JEST_GLOBAL) ||
-      (callee.isMemberExpression() && shouldHoistExpression(object))) &&
+    (
+      object.isIdentifier(JEST_GLOBAL) ||
+      (callee.isMemberExpression() && shouldHoistExpression(object))
+    ) &&
     FUNCTIONS[property.node.name](expr.get("arguments"))
   );
 

--- a/tests/format/js/ternaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/ternaries/__snapshots__/jsfmt.spec.js.snap
@@ -23,8 +23,10 @@ room = room.map((row, rowIndex) => (
 =====================================output=====================================
 const funnelSnapshotCard =
     (report === MY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2) ||
-    (report === COMPANY_OVERVIEW &&
-        !ReportGK.xar_metrics_active_capitol_v2_company_metrics) ? (
+    (
+        report === COMPANY_OVERVIEW &&
+        !ReportGK.xar_metrics_active_capitol_v2_company_metrics
+    ) ? (
         <ReportMetricsFunnelSnapshotCard metrics={metrics} />
     ) : null;
 
@@ -66,8 +68,10 @@ room = room.map((row, rowIndex) => (
 =====================================output=====================================
 const funnelSnapshotCard =
 	(report === MY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2) ||
-	(report === COMPANY_OVERVIEW &&
-		!ReportGK.xar_metrics_active_capitol_v2_company_metrics) ? (
+	(
+		report === COMPANY_OVERVIEW &&
+		!ReportGK.xar_metrics_active_capitol_v2_company_metrics
+	) ? (
 		<ReportMetricsFunnelSnapshotCard metrics={metrics} />
 	) : null;
 
@@ -108,8 +112,10 @@ room = room.map((row, rowIndex) => (
 =====================================output=====================================
 const funnelSnapshotCard =
 	(report === MY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2) ||
-	(report === COMPANY_OVERVIEW &&
-		!ReportGK.xar_metrics_active_capitol_v2_company_metrics) ? (
+	(
+		report === COMPANY_OVERVIEW &&
+		!ReportGK.xar_metrics_active_capitol_v2_company_metrics
+	) ? (
 		<ReportMetricsFunnelSnapshotCard metrics={metrics} />
 	) : null;
 
@@ -149,8 +155,10 @@ room = room.map((row, rowIndex) => (
 =====================================output=====================================
 const funnelSnapshotCard =
   (report === MY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2) ||
-  (report === COMPANY_OVERVIEW &&
-    !ReportGK.xar_metrics_active_capitol_v2_company_metrics) ? (
+  (
+    report === COMPANY_OVERVIEW &&
+    !ReportGK.xar_metrics_active_capitol_v2_company_metrics
+  ) ? (
     <ReportMetricsFunnelSnapshotCard metrics={metrics} />
   ) : null;
 

--- a/tests/format/js/throw_statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/throw_statement/__snapshots__/jsfmt.spec.js.snap
@@ -35,8 +35,10 @@ function f() {
   throw (
     property.isIdentifier() &&
     FUNCTIONS[property.node.name] &&
-    (object.isIdentifier(JEST_GLOBAL) ||
-      (callee.isMemberExpression() && shouldHoistExpression(object))) &&
+    (
+      object.isIdentifier(JEST_GLOBAL) ||
+      (callee.isMemberExpression() && shouldHoistExpression(object))
+    ) &&
     FUNCTIONS[property.node.name](expr.get("arguments"))
   );
 

--- a/tests/format/typescript/as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/as/__snapshots__/jsfmt.spec.js.snap
@@ -250,8 +250,10 @@ angular.module("foo").directive("formIsolator", () => {
   this.initialValues =
     undefined;
 
-const extraRendererAttrs = ((attrs.rendererAttrs &&
-  this.utils.safeParseJsonString(attrs.rendererAttrs)) ||
+const extraRendererAttrs = ((
+  attrs.rendererAttrs &&
+  this.utils.safeParseJsonString(attrs.rendererAttrs)
+) ||
   Object.create(null)) as FieldService.RendererAttributes;
 
 const annotate = (angular.injector as any).$$annotate as (

--- a/tests/format/typescript/webhost/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/webhost/__snapshots__/jsfmt.spec.js.snap
@@ -155,8 +155,10 @@ namespace TypeScript.WebTsc {
             // [0xFF,0xFE] and [0xFE,0xFF] mean utf-16 (little or big endian), otherwise default to utf-8
             fileStream.Charset =
               bom.length >= 2 &&
-              ((bom.charCodeAt(0) === 0xff && bom.charCodeAt(1) === 0xfe) ||
-                (bom.charCodeAt(0) === 0xfe && bom.charCodeAt(1) === 0xff))
+              (
+                (bom.charCodeAt(0) === 0xff && bom.charCodeAt(1) === 0xfe) ||
+                (bom.charCodeAt(0) === 0xfe && bom.charCodeAt(1) === 0xff)
+              )
                 ? "unicode"
                 : "utf-8";
           }

--- a/tests/format/vue/vue/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/vue/vue/__snapshots__/jsfmt.spec.js.snap
@@ -4454,21 +4454,29 @@ long_long_long_long_long_long_long_condition_4
     ></or>
     <mixed
       v-if="
-        (long_long_long_long_long_long_long_condition_1 &&
-          long_long_long_long_long_long_long_condition_2) ||
-        (short_1 &&
+        (
+          long_long_long_long_long_long_long_condition_1 &&
+          long_long_long_long_long_long_long_condition_2
+        ) ||
+        (
+          short_1 &&
           short_2 &&
           long_long_long_long_long_long_long_condition_3 &&
-          long_long_long_long_long_long_long_condition_4)
+          long_long_long_long_long_long_long_condition_4
+        )
       "
     ></mixed>
     <mixed
       v-if="
-        (long_long_long_long_long_long_long_condition_1 &&
-          long_long_long_long_long_long_long_condition_2) ||
-        (short_1 &&
+        (
+          long_long_long_long_long_long_long_condition_1 &&
+          long_long_long_long_long_long_long_condition_2
+        ) ||
+        (
+          short_1 &&
           short_2 &&
-          long_long_long_long_long_long_long_condition_3) ||
+          long_long_long_long_long_long_long_condition_3
+        ) ||
         long_long_long_long_long_long_long_condition_4
       "
     ></mixed>
@@ -4565,21 +4573,29 @@ long_long_long_long_long_long_long_condition_4
     ></or>
     <mixed
       v-if="
-        (long_long_long_long_long_long_long_condition_1 &&
-          long_long_long_long_long_long_long_condition_2) ||
-        (short_1 &&
+        (
+          long_long_long_long_long_long_long_condition_1 &&
+          long_long_long_long_long_long_long_condition_2
+        ) ||
+        (
+          short_1 &&
           short_2 &&
           long_long_long_long_long_long_long_condition_3 &&
-          long_long_long_long_long_long_long_condition_4)
+          long_long_long_long_long_long_long_condition_4
+        )
       "
     ></mixed>
     <mixed
       v-if="
-        (long_long_long_long_long_long_long_condition_1 &&
-          long_long_long_long_long_long_long_condition_2) ||
-        (short_1 &&
+        (
+          long_long_long_long_long_long_long_condition_1 &&
+          long_long_long_long_long_long_long_condition_2
+        ) ||
+        (
+          short_1 &&
           short_2 &&
-          long_long_long_long_long_long_long_condition_3) ||
+          long_long_long_long_long_long_long_condition_3
+        ) ||
         long_long_long_long_long_long_long_condition_4
       "
     ></mixed>
@@ -4675,21 +4691,29 @@ long_long_long_long_long_long_long_condition_4
     ></or>
     <mixed
       v-if="
-        (long_long_long_long_long_long_long_condition_1 &&
-          long_long_long_long_long_long_long_condition_2) ||
-        (short_1 &&
+        (
+          long_long_long_long_long_long_long_condition_1 &&
+          long_long_long_long_long_long_long_condition_2
+        ) ||
+        (
+          short_1 &&
           short_2 &&
           long_long_long_long_long_long_long_condition_3 &&
-          long_long_long_long_long_long_long_condition_4)
+          long_long_long_long_long_long_long_condition_4
+        )
       "
     ></mixed>
     <mixed
       v-if="
-        (long_long_long_long_long_long_long_condition_1 &&
-          long_long_long_long_long_long_long_condition_2) ||
-        (short_1 &&
+        (
+          long_long_long_long_long_long_long_condition_1 &&
+          long_long_long_long_long_long_long_condition_2
+        ) ||
+        (
+          short_1 &&
           short_2 &&
-          long_long_long_long_long_long_long_condition_3) ||
+          long_long_long_long_long_long_long_condition_3
+        ) ||
         long_long_long_long_long_long_long_condition_4
       "
     ></mixed>


### PR DESCRIPTION
## Description
This PR adds line breaks to multiline parenthesized logical expressions. I'm not 100% sure the changes in this PR are the best way to add line breaks to logical expressions as it imports `needsParams` into `src/language-js/print/binaryish.js`

```jsx
// Input
const funnelSnapshotCard =
  (report === MY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2) ||
  (
    report === COMPANY_OVERVIEW &&
    !ReportGK.xar_metrics_active_capitol_v2_company_metrics
  ) ? (
    <ReportMetricsFunnelSnapshotCard metrics={metrics} />
  ) : null;

// Prettier stable
const funnelSnapshotCard =
  (report === MY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2) ||
  (report === COMPANY_OVERVIEW &&
    !ReportGK.xar_metrics_active_capitol_v2_company_metrics) ? (
    <ReportMetricsFunnelSnapshotCard metrics={metrics} />
  ) : null;

// This PR
const funnelSnapshotCard =
  (report === MY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2) ||
  (
    report === COMPANY_OVERVIEW &&
    !ReportGK.xar_metrics_active_capitol_v2_company_metrics
  ) ? (
    <ReportMetricsFunnelSnapshotCard metrics={metrics} />
  ) : null;
```

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**

Closes #9574
