### PR TITLE
Website: Add `mode` to webpack command

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -1,7 +1,7 @@
 {
   "license": "MIT",
   "scripts": {
-    "build": "webpack && docusaurus-build",
+    "build": "webpack --mode=production && docusaurus-build",
     "start": "concurrently \"docusaurus-start\" \"webpack --mode=development --watch\"",
     "update-stable-docs": "rm -rf ./versioned_docs ./versions.json && docusaurus-version stable"
   },


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

There was a warning info printed 

```text
WARNING in configuration
The 'mode' option has not been set, webpack will fallback to 'production' for this value.
Set 'mode' option to 'development' or 'production' to enable defaults for each environment.
You can also set it to 'none' to disable any default behavior. Learn more: https://webpack.js.org/configuration/mode/
```

The script for development was fixed in  https://github.com/prettier/prettier/commit/2bb6cc4bf8fe0f09568d85ebce4e42ea899d5a69

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
