### PR TITLE
Added temporary fix to lint-staged code-snippet

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -12,7 +12,7 @@ You can use Prettier with a pre-commit tool. This can re-format your files that 
 _Make sure Prettier is installed and is in your [`devDependencies`](https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file) before you proceed._
 
 ```bash
-npx mrm lint-staged
+npx mrm@2 lint-staged
 ```
 
 This will install [husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/okonet/lint-staged), then add a configuration to the project’s `package.json` that will automatically format supported files in a pre-commit hook.


### PR DESCRIPTION
## Description

On the [pre-commit hook page](https://prettier.io/docs/en/precommit.html) of the docs, it is recommended under option 1 to get set up with [mrm](https://github.com/sapegin/mrm) using `npx mrm lint-staged`. Normally this is great, but version 3 of mrm broke the `npx mrm lint-staged` command on Windows. You can follow the issue here: https://github.com/sapegin/mrm/issues/168

I have changed the code-snippet to use version 2 until the issue is fixed. This is the temporary solution chosen by lint-staged themselves, seen here: https://github.com/okonet/lint-staged/commit/4f9a146708862b06d19c7627f4dd1b094b2b88ce

## Checklist

Not applicable.

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
