### PR TITLE
Adds type definitions for espree 8.0

### DIFF
--- a/src/language-js/parser-espree.js
+++ b/src/language-js/parser-espree.js
@@ -1,10 +1,12 @@
 "use strict";
+
 const createError = require("../common/parser-create-error");
 const tryCombinations = require("../utils/try-combinations");
 const postprocess = require("./parse-postprocess");
 const createParser = require("./parser/create-parser");
 const replaceHashbang = require("./parser/replace-hashbang");
 
+/** @type {import("espree").Options} */
 const parseOptions = {
   ecmaVersion: "latest",
   range: true,
@@ -31,7 +33,6 @@ function createParseError(error) {
 }
 
 function parse(originalText, parsers, options) {
-  // @ts-ignore
   const { parse } = require("espree");
 
   const textToParse = replaceHashbang(originalText);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "module": "commonjs",
     "resolveJsonModule": true,
     // TBD it is desired to enabled strict type checking at some point:
-    "strict": false
+    "strict": false,
+    "typeRoots": ["./types", "./node_modules/@types"]
   },
   "exclude": [
     "coverage/",
@@ -42,6 +43,7 @@
     "docs/",
     "scripts/",
     "tests/",
-    "website/"
+    "website/",
+    "types/"
   ]
 }

--- a/types/espree/index.d.ts
+++ b/types/espree/index.d.ts
@@ -1,0 +1,38 @@
+declare module "espree" {
+  // https://github.com/eslint/espree#options
+  export interface Options {
+    range?: boolean;
+    loc?: boolean;
+    comment?: boolean;
+    tokens?: boolean;
+    ecmaVersion?:
+      | 3
+      | 5
+      | 6
+      | 7
+      | 8
+      | 9
+      | 10
+      | 11
+      | 12
+      | 2015
+      | 2016
+      | 2017
+      | 2018
+      | 2019
+      | 2020
+      | 2021
+      | 2022
+      | "latest";
+    sourceType?: "script" | "module";
+    ecmaFeatures?: {
+      jsx?: boolean;
+      globalReturn?: boolean;
+      impliedStrict?: boolean;
+    };
+  }
+  // https://github.com/eslint/espree#options
+  export function parse(code: string, options?: Options): any;
+  // https://github.com/eslint/espree#tokenize
+  export function tokenize(code: string, options?: Options): any;
+}


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Adds [espree](https://github.com/eslint/espree)'s type definition.

Because:

- espree has no type definitions (ref: https://github.com/eslint/espree/pull/321#issuecomment-282048994)
- Also there are no type definitions in DefinitelyTyped for espree.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
