### PR TITLE
Print leading comment for readonly modifier of TS Mapped Types

### DIFF
--- a/changelog_unreleased/typescript/11190.md
+++ b/changelog_unreleased/typescript/11190.md
@@ -1,0 +1,23 @@
+#### Print leading comment for readonly modifier of TS Mapped Types (#11190 by @sosukesuzuki)
+
+<!-- prettier-ignore -->
+```ts
+// Input
+type Type = {
+  // comment
+  readonly [key in Foo];
+};
+
+// Prettier stable
+type Type = {
+  readonly // comment
+  [key in Foo];
+};
+
+// Prettier main
+type Type = {
+  // comment
+  readonly [key in Foo];
+};
+
+```

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -334,11 +334,6 @@ function handleMemberExpressionComments({
 }
 
 /**
- * Handle comments:
- *  type Foo = {
- *    // comment
- *    readonly [key in Foo]: Bar;
- *  };
  * @param {CommentContext} context
  * @return {boolean}
  */
@@ -346,7 +341,7 @@ function handleOwnlineMappedTypesComments({ enclosingNode, comment, text }) {
   if (
     enclosingNode &&
     enclosingNode.type === "TSMappedType" &&
-    isCommentOnBeforeMappedTypeReadonly(enclosingNode, text, comment)
+    isCommentBeforeMappedTypeReadonly(enclosingNode, text, comment)
   ) {
     addDanglingComment(
       enclosingNode,
@@ -1008,7 +1003,7 @@ function willPrintOwnComments(path /*, options */) {
  * @param {CommentContext["comment"]} comment
  * @returns {boolean}
  */
-function isCommentOnBeforeMappedTypeReadonly(enclosingNode, text, comment) {
+function isCommentBeforeMappedTypeReadonly(enclosingNode, text, comment) {
   if (!enclosingNode.readonly) {
     return false;
   }

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -66,7 +66,7 @@ function handleOwnLineComment(context) {
     handleAssignmentPatternComments,
     handleMethodNameComments,
     handleLabeledStatementComments,
-    handleOwnlineMappedTypesComments,
+    handleOwnLineMappedTypesComments,
   ].some((fn) => fn(context));
 }
 
@@ -337,7 +337,7 @@ function handleMemberExpressionComments({
  * @param {CommentContext} context
  * @return {boolean}
  */
-function handleOwnlineMappedTypesComments({ enclosingNode, comment, text }) {
+function handleOwnLineMappedTypesComments({ enclosingNode, comment, text }) {
   if (
     enclosingNode &&
     enclosingNode.type === "TSMappedType" &&

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -22,6 +22,7 @@ const {
   isMemberExpression,
   hasComment,
   CommentCheckFlags,
+  danglingCommentMarkerForReadonlyMappedType,
 } = require("../utils");
 const { locStart, locEnd } = require("../loc");
 
@@ -305,7 +306,8 @@ function printTypescript(path, options, print) {
             path,
             options,
             /* sameIndent */ true,
-            ({ marker }) => marker === "ownlineCommentBeforeReadonly"
+            ({ marker }) =>
+              marker === danglingCommentMarkerForReadonlyMappedType
           );
           return printed ? [printed, hardline] : "";
         }
@@ -316,9 +318,9 @@ function printTypescript(path, options, print) {
           "{",
           indent([
             options.bracketSpacing ? line : softline,
-            printOwnlineCommentBeforeReadonly(),
             node.readonly
               ? [
+                  printOwnlineCommentBeforeReadonly(),
                   getTypeScriptMappedTypeModifier(node.readonly, "readonly"),
                   " ",
                 ]
@@ -336,7 +338,8 @@ function printTypescript(path, options, print) {
             path,
             options,
             /* sameIndent */ true,
-            ({ marker }) => marker !== "ownlineCommentBeforeReadonly"
+            ({ marker }) =>
+              marker !== danglingCommentMarkerForReadonlyMappedType
           ),
           options.bracketSpacing ? line : softline,
           "}",

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -20,8 +20,6 @@ const {
   shouldPrintComma,
   isCallExpression,
   isMemberExpression,
-  hasComment,
-  CommentCheckFlags,
   danglingCommentMarkerForReadonlyMappedType,
 } = require("../utils");
 const { locStart, locEnd } = require("../loc");
@@ -300,19 +298,12 @@ function printTypescript(path, options, print) {
         locStart(node),
         locEnd(node)
       );
-      const printOwnlineCommentBeforeReadonly = () => {
-        if (hasComment(node, CommentCheckFlags.Dangling)) {
-          const printed = printDanglingComments(
-            path,
-            options,
-            /* sameIndent */ true,
-            ({ marker }) =>
-              marker === danglingCommentMarkerForReadonlyMappedType
-          );
-          return printed ? [printed, hardline] : "";
-        }
-        return "";
-      };
+      const printedLeadingCommentsForReadonly = printDanglingComments(
+        path,
+        options,
+        /* sameIndent */ true,
+        ({ marker }) => marker === danglingCommentMarkerForReadonlyMappedType
+      );
       return group(
         [
           "{",
@@ -320,7 +311,8 @@ function printTypescript(path, options, print) {
             options.bracketSpacing ? line : softline,
             node.readonly
               ? [
-                  printOwnlineCommentBeforeReadonly(),
+                  printedLeadingCommentsForReadonly,
+                  printedLeadingCommentsForReadonly && hardline,
                   getTypeScriptMappedTypeModifier(node.readonly, "readonly"),
                   " ",
                 ]
@@ -338,8 +330,7 @@ function printTypescript(path, options, print) {
             path,
             options,
             /* sameIndent */ true,
-            ({ marker }) =>
-              marker !== danglingCommentMarkerForReadonlyMappedType
+            ({ marker }) => !marker
           ),
           options.bracketSpacing ? line : softline,
           "}",

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -1305,6 +1305,9 @@ function isObjectProperty(node) {
   );
 }
 
+const danglingCommentMarkerForReadonlyMappedType =
+  "danglingCommentMarkerForReadonlyMappedType";
+
 module.exports = {
   getFunctionParameters,
   iterateFunctionParametersPath,
@@ -1368,4 +1371,5 @@ module.exports = {
   hasComment,
   getComments,
   CommentCheckFlags,
+  danglingCommentMarkerForReadonlyMappedType,
 };

--- a/tests/format/typescript/mapped-type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/mapped-type/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,85 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`issue-11098.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type Type = {
+  // comment
+  readonly [T in number];
+};
+
+type Type = {
+  // comment
+  +readonly [T in number];
+};
+
+type Type = {
+  // comment
+  -readonly [T in number];
+};
+
+type Type = {
+  // comment
+  +    readonly [T in number];
+};
+
+type Type = {
+  // comment
+  +readonly     [T in number];
+};
+
+type Type = {
+  // comment
+  readonly       [T in number];
+};
+
+type Type = {
+  // comment
+  [T in number];
+};
+
+=====================================output=====================================
+type Type = {
+  // comment
+  readonly [T in number];
+};
+
+type Type = {
+  // comment
+  +readonly [T in number];
+};
+
+type Type = {
+  // comment
+  -readonly [T in number];
+};
+
+type Type = {
+  // comment
+  +readonly [T in number];
+};
+
+type Type = {
+  // comment
+  +readonly [T in number];
+};
+
+type Type = {
+  // comment
+  readonly [T in number];
+};
+
+type Type = {
+  // comment
+  [T in number];
+};
+
+================================================================================
+`;
+
 exports[`mapped-type.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/mapped-type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/mapped-type/__snapshots__/jsfmt.spec.js.snap
@@ -12,6 +12,12 @@ type Type = {
 };
 
 type Type = {
+  // comment1
+  // comment2
+  readonly [T in number];
+};
+
+type Type = {
   // comment
   +readonly [T in number];
 };
@@ -44,6 +50,12 @@ type Type = {
 =====================================output=====================================
 type Type = {
   // comment
+  readonly [T in number];
+};
+
+type Type = {
+  // comment1
+  // comment2
   readonly [T in number];
 };
 

--- a/tests/format/typescript/mapped-type/issue-11098.ts
+++ b/tests/format/typescript/mapped-type/issue-11098.ts
@@ -1,0 +1,34 @@
+type Type = {
+  // comment
+  readonly [T in number];
+};
+
+type Type = {
+  // comment
+  +readonly [T in number];
+};
+
+type Type = {
+  // comment
+  -readonly [T in number];
+};
+
+type Type = {
+  // comment
+  +    readonly [T in number];
+};
+
+type Type = {
+  // comment
+  +readonly     [T in number];
+};
+
+type Type = {
+  // comment
+  readonly       [T in number];
+};
+
+type Type = {
+  // comment
+  [T in number];
+};

--- a/tests/format/typescript/mapped-type/issue-11098.ts
+++ b/tests/format/typescript/mapped-type/issue-11098.ts
@@ -4,6 +4,12 @@ type Type = {
 };
 
 type Type = {
+  // comment1
+  // comment2
+  readonly [T in number];
+};
+
+type Type = {
   // comment
   +readonly [T in number];
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #11098

Since `TSMappedType` contains `{` and `}`, it could not be implemented as a simple leading comments.


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
