### PR TITLE
Fix workflow files according to actionlint

### DIFF
--- a/.github/workflows/dev-package-test.yml
+++ b/.github/workflows/dev-package-test.yml
@@ -41,7 +41,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Install Client Package
-        if: matrix.NPM_CLIENT == 'pnpm'
+        if: ${{ matrix.NPM_CLIENT == 'pnpm' }}
         run: npm install --global pnpm@5
 
       - name: Run Tests

--- a/.github/workflows/dev-package-test.yml
+++ b/.github/workflows/dev-package-test.yml
@@ -41,7 +41,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Install Client Package
-        if: ${{ matrix.NPM_CLIENT == 'pnpm' }}
+        if: matrix.NPM_CLIENT == 'pnpm'
         run: npm install --global pnpm@5
 
       - name: Run Tests

--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -55,16 +55,16 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Run Tests (macOS)
-        if: matrix.os == 'macos-latest'
+        if: ${{ matrix.os == 'macos-latest' }}
         run: yarn test --maxWorkers=4
 
       - name: Run Tests (Linux and Windows)
-        if: matrix.os != 'macos-latest'
+        if: ${{ matrix.os != 'macos-latest' }}
         run: yarn test --maxWorkers=2
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v1.5.2
-        if: matrix.ENABLE_CODE_COVERAGE
+        if: ${{ matrix.ENABLE_CODE_COVERAGE }}
         with:
           fail_ci_if_error: true
 
@@ -76,6 +76,6 @@ jobs:
 
       - name: Upload Coverage (PRETTIER_FALLBACK_RESOLVE)
         uses: codecov/codecov-action@v1.5.2
-        if: matrix.ENABLE_CODE_COVERAGE
+        if: ${{ matrix.ENABLE_CODE_COVERAGE }}
         with:
           fail_ci_if_error: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,5 +39,11 @@ jobs:
       - name: Lint Changelog
         run: yarn lint:changelog
 
+      - name: Lint workflow files
+        run: |
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+          ./actionlint -color
+        shell: bash
+
       - name: Check Lock File Changes
         run: yarn && echo "Listing changed files:" && git diff --name-only --exit-code && echo "No files changed during lint."

--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -45,7 +45,7 @@ jobs:
       # It should be the last step
       # The cache step might saving the result of main branch, need investigate
       - name: Check Sizes
-        if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'dependabot/npm_and_yarn/')
+        if: ${{ github.event_name == 'pull_request' && startsWith(github.head_ref, 'dependabot/npm_and_yarn/') }}
         uses: preactjs/compressed-size-action@2.3.0
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
@@ -116,7 +116,7 @@ jobs:
           node-version: ${{ matrix.node }}
 
       - name: Config `ignore-engines=true` (Node.js 10)
-        if: matrix.node == '10'
+        if: ${{ matrix.node == '10' }}
         run: yarn config set ignore-engines true
 
       - name: Install Dependencies
@@ -129,19 +129,19 @@ jobs:
           path: dist
 
       - name: Run Tests (macOS)
-        if: matrix.os == 'macos-latest'
+        if: ${{ matrix.os == 'macos-latest' }}
         run: yarn test:dist --maxWorkers=4
 
       - name: Run Tests (Linux and Windows)
-        if: matrix.os != 'macos-latest'
+        if: ${{ matrix.os != 'macos-latest' }}
         run: yarn test:dist --maxWorkers=2
 
       - name: Run Tests (standalone) (macOS)
-        if: matrix.os == 'macos-latest'
+        if: ${{ matrix.os == 'macos-latest' }}
         run: yarn test:dist-standalone --maxWorkers=4
 
       - name: Run Tests (standalone) (Linux and Windows)
-        if: matrix.os != 'macos-latest'
+        if: ${{ matrix.os != 'macos-latest' }}
         run: yarn test:dist-standalone --maxWorkers=2
 
       # #8073 test

--- a/cspell.json
+++ b/cspell.json
@@ -1,6 +1,7 @@
 {
     "version": "0.1",
     "words": [
+        "actionlint",
         "ACMR",
         "Alexa",
         "algolia",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes workflow files according to [actionlint](https://github.com/rhysd/actionlint).

actionlint says:

```
this expression must be contained within ${{ }} like `if: ${{ ... }}` since it contains operator ".".
see https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idif for more details
```

I want to install and use actionlint, but it is written in Go and not distributed with npm. I'm trying to figure out how to use it from Node.js, but just fix for now.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
