### PR TITLE
chore: drop mem dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "lines-and-columns": "1.1.6",
     "linguist-languages": "7.15.0",
     "lodash": "4.17.21",
-    "mem": "8.1.1",
     "meriyah": "4.2.0",
     "minimatch": "3.0.4",
     "minimist": "1.2.5",

--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -29,7 +29,7 @@ function loadPlugins(plugins, pluginSearchDirs) {
     pluginSearchDirs = defaultPluginSearchDirs;
   }
 
-  const cachedSearchDir = loadCache.get(pluginSearchDirs) ?? new WeakMap();
+  const cachedSearchDir = loadCache.get(pluginSearchDirs) || new WeakMap();
   const cachedPlugins = cachedSearchDir.get(plugins);
   if (cachedPlugins) {
     return cachedPlugins;

--- a/src/config/resolve-config-editorconfig.js
+++ b/src/config/resolve-config-editorconfig.js
@@ -18,7 +18,7 @@ const editorconfigAsyncNoCache = async (filePath) =>
   editorConfigToPrettier(await maybeParse(filePath, editorconfig.parse));
 const editorconfigAsyncWithCache = (filePath) => {
   const result =
-    asyncConfigCache.get(filePath) ?? editorconfigAsyncNoCache(filePath);
+    asyncConfigCache.get(filePath) || editorconfigAsyncNoCache(filePath);
   asyncConfigCache.set(filePath, result);
   return result;
 };
@@ -27,7 +27,7 @@ const editorconfigSyncNoCache = (filePath) =>
   editorConfigToPrettier(maybeParse(filePath, editorconfig.parseSync));
 const editorconfigSyncWithCache = (filePath) => {
   const result =
-    syncConfigCache.get(filePath) ?? editorconfigSyncNoCache(filePath);
+    syncConfigCache.get(filePath) || editorconfigSyncNoCache(filePath);
   syncConfigCache.set(filePath, result);
   return result;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -5023,25 +5023,10 @@ makeerror@1.0.x:
   dependencies:
     tmpl "1.0.x"
 
-map-age-cleaner@^0.1.3:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz#7d583a7306434c055fe474b0f45078e6e1b4b92a"
-  integrity sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==
-  dependencies:
-    p-defer "^1.0.0"
-
 markdown-escapes@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
-
-mem@8.1.1:
-  version "8.1.1"
-  resolved "https://registry.yarnpkg.com/mem/-/mem-8.1.1.tgz#cf118b357c65ab7b7e0817bdf00c8062297c0122"
-  integrity sha512-qFCFUDs7U3b8mBDPyz5EToEKoAkgCzqquIgi9nkkR9bixxOVOre+09lbuH7+9Kn2NFpm56M3GUWVbU2hQgdACA==
-  dependencies:
-    map-age-cleaner "^0.1.3"
-    mimic-fn "^3.1.0"
 
 memorystream@^0.3.1:
   version "0.3.1"
@@ -5087,11 +5072,6 @@ mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
-
-mimic-fn@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-3.1.0.tgz#65755145bbf3e36954b949c16450427451d5ca74"
-  integrity sha512-Ysbi9uYW9hFyfrThdDEQuykN4Ey6BuwPD2kpI5ES/nFTDn/98yxYNLZJcgUAKPT/mcrLLKaGzJR9YVxJrIdASQ==
 
 min-indent@^1.0.0:
   version "1.0.1"
@@ -5332,11 +5312,6 @@ outdent@0.8.0:
   version "0.8.0"
   resolved "https://registry.yarnpkg.com/outdent/-/outdent-0.8.0.tgz#2ebc3e77bf49912543f1008100ff8e7f44428eb0"
   integrity sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==
-
-p-defer@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-defer/-/p-defer-1.0.0.tgz#9f6eb182f6c9aa8cd743004a7d4f96b196b0fb0c"
-  integrity sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=
 
 p-limit@^1.1.0:
   version "1.3.0"


### PR DESCRIPTION
## Description

drop mem entirely to reduce the amount of bloat in the dependency chain.

@fisker as you said, "it's about 350 lines in the bundle", here we have it in a lot less. if you really want to save a few more lines, im sure you could reduce a few of my conditionals etc further

@sosukesuzuki 4 less dependencies, less code in the build, faster CI install. you had concerns in #11230 you never managed to explain to us, presumably you closed to due to a downside we're not aware of so it would be much appreciated if you could share what that is.

## Checklist

- [] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).


**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**

cc @alexander-akait 