### PR TITLE
Use setup-node cache yarn dependencies

### DIFF
--- a/.github/workflows/dev-package-test.yml
+++ b/.github/workflows/dev-package-test.yml
@@ -36,6 +36,7 @@ jobs:
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ matrix.node }}
+          cache: "yarn"
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -50,6 +50,7 @@ jobs:
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ matrix.node }}
+          cache: "yarn"
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/eslint-rules.yml
+++ b/.github/workflows/eslint-rules.yml
@@ -20,6 +20,8 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
+        with:
+          cache: "yarn"
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
+        with:
+          cache: "yarn"
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -17,6 +17,8 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
+        with:
+          cache: "yarn"
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -61,6 +63,8 @@ jobs:
 
       - name: Setup Node.js
         uses: actions/setup-node@v2.2.0
+        with:
+          cache: "yarn"
 
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
@@ -114,6 +118,7 @@ jobs:
         uses: actions/setup-node@v2.2.0
         with:
           node-version: ${{ matrix.node }}
+          cache: "yarn"
 
       - name: Config `ignore-engines=true` (Node.js 10)
         if: ${{ matrix.node == '10' }}


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

To cache dependencies, it's much simpler now. The installation step is actually fast, normally just seconds, bring this up because mentioned in  https://github.com/prettier/prettier/pull/11241 CI installation can be faster.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
