### PR TITLE
Fix a rollup warning

### DIFF
--- a/scripts/build/bundler.mjs
+++ b/scripts/build/bundler.mjs
@@ -125,7 +125,7 @@ function getRollupConfig(bundle) {
         warning.code === "MIXED_EXPORTS" ||
         (warning.code === "CIRCULAR_DEPENDENCY" &&
           (warning.importer.startsWith("node_modules") ||
-            warning.importer.startsWith("\x00polyfill-node:"))) ||
+            warning.importer.startsWith("\x00polyfill-node."))) ||
         warning.code === "SOURCEMAP_ERROR" ||
         warning.code === "THIS_IS_UNDEFINED"
       ) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

This should be introduced by #11261.

`rollup-plugin-polyfill-node` commit https://github.com/snowpackjs/rollup-plugin-polyfill-node/commit/e4776e47224ca905060ee6c519b5ef62627e8d36

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
