### PR TITLE
Update node-actionlint to 1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "jest-snapshot-serializer-ansi": "1.0.0",
     "jest-snapshot-serializer-raw": "1.2.0",
     "jest-watch-typeahead": "0.6.4",
-    "node-actionlint": "1.0.2",
+    "node-actionlint": "1.1.0",
     "npm-run-all": "4.1.5",
     "path-browserify": "1.0.1",
     "prettier": "2.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4945,10 +4945,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-node-actionlint@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/node-actionlint/-/node-actionlint-1.0.2.tgz#a7f666fe6a85e116a84ec42f2f08e3b17badac52"
-  integrity sha512-76U5CVrfHkSFYHqWW/0CCaGkNbzRzgDb6j854bhQnOAgOZsihrYcCLnXCe1jGS24exg3OtyrqoEveoEaIJIAzA==
+node-actionlint@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/node-actionlint/-/node-actionlint-1.1.0.tgz#f081d31648ae41a36227ce89f99cbf122b82d819"
+  integrity sha512-himXYj3e9RTPgT+QTiIut3J13LnJcpf8W4KagvZjyojILIojb5UxGMxYrG+aEwXF6Eo3pgmHsBzqWKF+UUxs0A==
   dependencies:
     "@babel/code-frame" "^7.14.5"
     chalk "^4.1.1"


### PR DESCRIPTION
## Description

update to node-actionlint to 1.1 that uses actionlint 1.5.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
