### PR TITLE
Keep parentheses for type casted node with `export default`

### DIFF
--- a/changelog_unreleased/javascript/11280.md
+++ b/changelog_unreleased/javascript/11280.md
@@ -1,0 +1,17 @@
+#### Keep parentheses for type casted node with `export default` (#11280 by @sosukesuzuki)
+
+<!-- prettier-ignore -->
+```js
+// Input
+/** @type {SomeType} */
+export default ({});
+
+// Prettier stable
+/** @type {SomeType} */
+export default {};
+
+// Prettier main
+/** @type {SomeType} */
+export default ({});
+
+```

--- a/src/language-js/parse/postprocess.js
+++ b/src/language-js/parse/postprocess.js
@@ -69,7 +69,10 @@ function postprocess(ast, options) {
         node.leadingComments &&
         node.leadingComments.some(isTypeCastComment)
       ) {
-        startOffsetsOfTypeCastedNodes.add(locStart(node));
+        // https://github.com/prettier/prettier/issues/11279
+        const castedNode =
+          node.type === "ExportDefaultDeclaration" ? node.declaration : node;
+        startOffsetsOfTypeCastedNodes.add(locStart(castedNode));
       }
     });
 

--- a/tests/format/js/comments-closure-typecast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/comments-closure-typecast/__snapshots__/jsfmt.spec.js.snap
@@ -444,6 +444,32 @@ const fooooba3 = /** @type {Array.<fooo.barr.baaaaaaz>} */ (
 ================================================================================
 `;
 
+exports[`issue-11279.js format 1`] = `
+====================================options=====================================
+parsers: ["babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+/** @type {import('somemodule').Config} */
+export default ({
+  rollup: config => ({
+    ...config,
+    test: 'me'
+  }),
+});
+
+=====================================output=====================================
+/** @type {import('somemodule').Config} */
+export default ({
+  rollup: (config) => ({
+    ...config,
+    test: "me",
+  }),
+});
+
+================================================================================
+`;
+
 exports[`member.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel"]

--- a/tests/format/js/comments-closure-typecast/issue-11279.js
+++ b/tests/format/js/comments-closure-typecast/issue-11279.js
@@ -1,0 +1,7 @@
+/** @type {import('somemodule').Config} */
+export default ({
+  rollup: config => ({
+    ...config,
+    test: 'me'
+  }),
+});


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #11279

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
