### PR TITLE
Set default parameters for HTML parser options

### DIFF
--- a/src/language-html/parser-html.js
+++ b/src/language-html/parser-html.js
@@ -294,12 +294,7 @@ function ngHtmlParser(
  * @param {ParserOptions} parserOptions
  * @param {boolean} shouldParseFrontMatter
  */
-function _parse(
-  text,
-  options = { filepath: "test.html", parser: "html" },
-  parserOptions,
-  shouldParseFrontMatter = true
-) {
+function _parse(text, options, parserOptions, shouldParseFrontMatter = true) {
   const { frontMatter, content } = shouldParseFrontMatter
     ? parseFrontMatter(text)
     : { frontMatter: null, content: text };
@@ -378,15 +373,19 @@ function createParser({
   getTagContentType,
 } = {}) {
   return {
-    parse: (text, parsers, options) =>
-      _parse(text, options, {
+    parse: (text, parsers, options) => {
+      if (!options) {
+        throw new Error("options are required for parsing HTML.");
+      }
+      return _parse(text, options, {
         recognizeSelfClosing,
         normalizeTagName,
         normalizeAttributeName,
         allowHtmComponentClosingTags,
         isTagNameCaseSensitive,
         getTagContentType,
-      }),
+      });
+    },
     hasPragma,
     astFormat: "html",
     locStart,

--- a/src/language-html/parser-html.js
+++ b/src/language-html/parser-html.js
@@ -294,7 +294,12 @@ function ngHtmlParser(
  * @param {ParserOptions} parserOptions
  * @param {boolean} shouldParseFrontMatter
  */
-function _parse(text, options, parserOptions, shouldParseFrontMatter = true) {
+function _parse(
+  text,
+  options = { filepath: "test.html", parser: "html" },
+  parserOptions,
+  shouldParseFrontMatter = true
+) {
   const { frontMatter, content } = shouldParseFrontMatter
     ? parseFrontMatter(text)
     : { frontMatter: null, content: text };


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #11272 (But the code listed in the issue still doesn't work due to another issue...)

In some special environments, such as custom parser APIs, the options may not be present.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
