### PR TITLE
prevent on-same-line `else` for comments in unbraced else statments

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -410,8 +410,8 @@ function skipWhitespace(text: string, index: number | false, opts?: SkipOptions)
 function skipSpaces(text: string, index: number | false, opts?: SkipOptions): number | false;
 function skipToLineEnd(text: string, index: number | false, opts?: SkipOptions): number | false;
 function skipEverythingButNewLine(text: string, index: number | false, opts?: SkipOptions): number | false;
-function skipInlineComment(text: string, index: number | false): number | false;
-function skipTrailingComment(text: string, index: number | false): number | false;
+function skipInlineComment(text: string, index: number | false, opts?: SkipOptions): number | false;
+function skipTrailingComment(text: string, index: number | false, opts?: SkipOptions): number | false;
 function skipNewline(text: string, index: number | false, opts?: SkipOptions): number | false;
 function hasNewline(text: string, index: number, opts?: SkipOptions): boolean;
 function hasNewlineInRange(text: string, start: number, end: number): boolean;

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -471,11 +471,23 @@ function printPathNoParens(path, options, print, args) {
       parts.push(opening);
 
       if (node.alternate) {
-        const commentOnOwnLine =
+        const consequentHasTrailingComment = (node) =>
           hasComment(
             node.consequent,
-            CommentCheckFlags.Trailing | CommentCheckFlags.Line
-          ) || needsHardlineAfterDanglingComment(node);
+            CommentCheckFlags.Line | CommentCheckFlags.Trailing
+          );
+
+        const alternateHasLeadingComment = (node) =>
+          hasComment(
+            node.alternate,
+            CommentCheckFlags.Leading | CommentCheckFlags.Line
+          );
+
+        const commentOnOwnLine =
+          consequentHasTrailingComment(node) ||
+          alternateHasLeadingComment(node) ||
+          needsHardlineAfterDanglingComment(node);
+
         const elseOnSameLine =
           node.consequent.type === "BlockStatement" && !commentOnOwnLine;
         parts.push(elseOnSameLine ? " " : hardline);

--- a/tests/format/js/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1399,6 +1399,223 @@ wrap(import(/* Hello */ "something"));
 ================================================================================
 `;
 
+exports[`else_comment.js - {"semi":false} format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  // comment after else
+  doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doFirstThing();
+else if (secondTrue())
+  // comment
+  doSecondThing();
+else
+  // comment after else
+  doThirdThing();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+// comment before else
+else doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  // comment after else
+  // another comment after else
+  doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  /*
+   * block comment after else
+   */
+  // another comment after else
+  doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  /* inline comment after else */
+  // another comment after else
+  doSomethingElse();
+
+=====================================output=====================================
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  // comment after else
+  doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doFirstThing();
+else if (secondTrue())
+  // comment
+  doSecondThing();
+else
+  // comment after else
+  doThirdThing();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+// comment before else
+else doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  // comment after else
+  // another comment after else
+  doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  /*
+   * block comment after else
+   */
+  // another comment after else
+  doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  /* inline comment after else */
+  // another comment after else
+  doSomethingElse();
+
+================================================================================
+`;
+
+exports[`else_comment.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  // comment after else
+  doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doFirstThing();
+else if (secondTrue())
+  // comment
+  doSecondThing();
+else
+  // comment after else
+  doThirdThing();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+// comment before else
+else doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  // comment after else
+  // another comment after else
+  doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  /*
+   * block comment after else
+   */
+  // another comment after else
+  doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  /* inline comment after else */
+  // another comment after else
+  doSomethingElse();
+
+=====================================output=====================================
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  // comment after else
+  doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doFirstThing();
+else if (secondTrue())
+  // comment
+  doSecondThing();
+else
+  // comment after else
+  doThirdThing();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+// comment before else
+else doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  // comment after else
+  // another comment after else
+  doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  /*
+   * block comment after else
+   */
+  // another comment after else
+  doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  /* inline comment after else */
+  // another comment after else
+  doSomethingElse();
+
+================================================================================
+`;
+
 exports[`emoji.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/format/js/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1458,52 +1458,52 @@ else
 =====================================output=====================================
 if (firstTrue())
   // doSomething
-  doSomething();
+  doSomething()
 else
   // comment after else
-  doSomethingElse();
+  doSomethingElse()
 
 if (firstTrue())
   // doSomething
-  doFirstThing();
+  doFirstThing()
 else if (secondTrue())
   // comment
-  doSecondThing();
+  doSecondThing()
 else
   // comment after else
-  doThirdThing();
+  doThirdThing()
 
 if (firstTrue())
   // doSomething
-  doSomething();
+  doSomething()
 // comment before else
-else doSomethingElse();
+else doSomethingElse()
 
 if (firstTrue())
   // doSomething
-  doSomething();
+  doSomething()
 else
   // comment after else
   // another comment after else
-  doSomethingElse();
+  doSomethingElse()
 
 if (firstTrue())
   // doSomething
-  doSomething();
+  doSomething()
 else
   /*
    * block comment after else
    */
   // another comment after else
-  doSomethingElse();
+  doSomethingElse()
 
 if (firstTrue())
   // doSomething
-  doSomething();
+  doSomething()
 else
   /* inline comment after else */
   // another comment after else
-  doSomethingElse();
+  doSomethingElse()
 
 ================================================================================
 `;

--- a/tests/format/js/comments/else_comment.js
+++ b/tests/format/js/comments/else_comment.js
@@ -1,0 +1,48 @@
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  // comment after else
+  doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doFirstThing();
+else if (secondTrue())
+  // comment
+  doSecondThing();
+else
+  // comment after else
+  doThirdThing();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+// comment before else
+else doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  // comment after else
+  // another comment after else
+  doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  /*
+   * block comment after else
+   */
+  // another comment after else
+  doSomethingElse();
+
+if (firstTrue())
+  // doSomething
+  doSomething();
+else
+  /* inline comment after else */
+  // another comment after else
+  doSomethingElse();

--- a/tests/format/misc/errors/js/async-await/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/js/async-await/__snapshots__/jsfmt.spec.js.snap
@@ -9,7 +9,7 @@ exports[`snippet: #0 [babel] format 1`] = `
 `;
 
 exports[`snippet: #0 [babel] format 2`] = `
-"'await' is not allowed in async function parameters. (1:12)
+"Can not use 'await' as identifier inside an async function. (1:12)
 > 1 | async (x = await (2)) => {};
     |            ^"
 `;

--- a/tests/format/misc/errors/js/smart-pipeline/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/js/smart-pipeline/__snapshots__/jsfmt.spec.js.snap
@@ -55,7 +55,7 @@ exports[`snippet: #8 [babel] format 1`] = `
 `;
 
 exports[`snippet: #9 [babel] format 1`] = `
-"Unexpected yield after pipeline body; any yield expression acting as Hack-style pipe body must be parenthesized due to its loose operator precedence. (1:39)
+"Can not use 'yield' as identifier inside a generator. (1:39)
 > 1 | async function * a() { a |> foo(#) |> yield}
     |                                       ^"
 `;

--- a/tests/format/typescript/namespace/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/namespace/__snapshots__/jsfmt.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`invalid-await.ts [babel-ts] format 1`] = `
-"'await' is only allowed within async functions and at the top levels of modules. (2:13)
+"'await' is only allowed within async functions. (2:13)
   1 | namespace N {
 > 2 |   const x = await 42;
     |             ^


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
Fixes: #11101

Comments in unbraced else statements currently wrap to before the `else` keyword if the statement fits on the same line. This change prevents this (see #11101 for an example).

Three main changes:
1) New util function & more existing utils support `backwards` option.
2) Add detection & registration of comments after `else` but before unbraced statements.
3) Add printing flow for comments involved in (2).

This is my first commit to this repo, so please tear my work down - I wanna get this right!

I could also do with a bit of help for the following please...
1) The naming of the new util function. It's currently called `getPreviousNoSpaceNonCommentStringOnPreviousLines`, but I'm not in love with it.
2) Avoiding the refactoring of the async-await, smart-pipeline, and namespace specs. The changes seem insignificant, but it'd be great to avoid them (I presume they're version-based).
3) Passing `tests/format/typescript/custom/abstract/jsfmt.spec.js`, `tests/format/js/babel-plugins/jsfmt.spec.js`, `tests/format/js/top-level-await/jsfmt.spec.js`, and `tests/format/js/private-in/jsfmt.spec.js`. They seem to fail for reasons unrelated to my change (e.g. syntax problem in the test file); however, they do pass in my forked `main` branch, so I must have done something wrong.
4) Do I need to add a file to changelog_unreleased file? I presume my change would be user-facing but I'm unsure.


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
