### PR TITLE
Use `@ts-expect-error` instead of `@ts-ignore`

### DIFF
--- a/src/common/parser-create-error.js
+++ b/src/common/parser-create-error.js
@@ -5,7 +5,7 @@ function createError(message, loc) {
   const error = new SyntaxError(
     message + " (" + loc.start.line + ":" + loc.start.column + ")"
   );
-  // @ts-ignore - TBD (...)
+  // @ts-expect-error - TBD (...)
   error.loc = loc;
   return error;
 }

--- a/src/common/resolve.js
+++ b/src/common/resolve.js
@@ -4,7 +4,7 @@ let { resolve } = require;
 
 // In the VS Code and Atom extensions `require` is overridden and `require.resolve` doesn't support the 2nd argument.
 if (resolve.length === 1 || process.env.PRETTIER_FALLBACK_RESOLVE) {
-  // @ts-ignore
+  // @ts-expect-error
   resolve = (id, options) => {
     let basedir;
     if (options && options.paths && options.paths.length === 1) {

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -278,7 +278,7 @@ function getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd) {
  */
 function getNextNonSpaceNonCommentCharacter(text, node, locEnd) {
   return text.charAt(
-    // @ts-ignore => TBD: can return false, should we define a fallback?
+    // @ts-expect-error => TBD: can return false, should we define a fallback?
     getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd)
   );
 }

--- a/src/document/doc-builders.js
+++ b/src/document/doc-builders.js
@@ -113,7 +113,7 @@ function dedentToRoot(contents) {
  * @returns Doc
  */
 function markAsRoot(contents) {
-  // @ts-ignore - TBD ???:
+  // @ts-expect-error - TBD ???:
   return align({ type: "root" }, contents);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -27,7 +27,7 @@ function _withPlugins(
 function withPlugins(fn, optsArgIdx) {
   const resultingFn = _withPlugins(fn, optsArgIdx);
   if (fn.sync) {
-    // @ts-ignore
+    // @ts-expect-error
     resultingFn.sync = _withPlugins(fn.sync, optsArgIdx);
   }
   return resultingFn;

--- a/src/language-html/ast.js
+++ b/src/language-html/ast.js
@@ -58,7 +58,7 @@ class Node {
           newNode[key] = this[key];
         }
       }
-      // @ts-ignore
+      // @ts-expect-error
       const { index, siblings, prev, next, parent } = this;
       setNonEnumerableProperties(newNode, {
         index,
@@ -99,22 +99,22 @@ class Node {
   }
 
   get firstChild() {
-    // @ts-ignore
+    // @ts-expect-error
     return isNonEmptyArray(this.children) ? this.children[0] : null;
   }
 
   get lastChild() {
-    // @ts-ignore
+    // @ts-expect-error
     return isNonEmptyArray(this.children) ? getLast(this.children) : null;
   }
 
   // for element and attribute
   get rawName() {
-    // @ts-ignore
+    // @ts-expect-error
     return this.hasExplicitNamespace ? this.fullName : this.name;
   }
   get fullName() {
-    // @ts-ignore
+    // @ts-expect-error
     return this.namespace ? this.namespace + ":" + this.name : this.name;
   }
 }

--- a/src/language-html/parser-html.js
+++ b/src/language-html/parser-html.js
@@ -312,7 +312,7 @@ function _parse(text, options, parserOptions, shouldParseFrontMatter = true) {
     const start = new ParseLocation(file, 0, 0, 0);
     const end = start.moveBy(frontMatter.raw.length);
     frontMatter.sourceSpan = new ParseSourceSpan(start, end);
-    // @ts-ignore
+    // @ts-expect-error
     rawAst.children.unshift(frontMatter);
   }
 

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -119,7 +119,7 @@ function handleRemainingComment(context) {
  * @returns {void}
  */
 function addBlockStatementFirstComment(node, comment) {
-  // @ts-ignore
+  // @ts-expect-error
   const firstNonEmptyNode = (node.body || node.properties).find(
     ({ type }) => type !== "EmptyStatement"
   );

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -77,7 +77,7 @@ function parseWithOptions(parseMethod, text, options) {
   /** @type {import("@babel/parser").parse | import("@babel/parser").parseExpression} */
   const parse = require("@babel/parser")[parseMethod];
   const ast = parse(text, options);
-  // @ts-ignore
+  // @ts-expect-error
   const error = ast.errors.find(
     (error) => !allowedMessageCodes.has(error.reasonCode)
   );

--- a/src/language-js/parse/json.js
+++ b/src/language-js/parse/json.js
@@ -20,9 +20,9 @@ function createJsonParse(options = {}) {
       throw createBabelParseError(error);
     }
 
-    // @ts-ignore
+    // @ts-expect-error
     if (!allowComments && isNonEmptyArray(ast.comments)) {
-      // @ts-ignore
+      // @ts-expect-error
       throw createJsonError(ast.comments[0], "Comment");
     }
 

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -278,7 +278,7 @@ function genericPrint(path, options, print) {
 
       return replaceTextEndOfLine(
         value,
-        // @ts-ignore
+        // @ts-expect-error
         isHtmlComment ? hardline : markAsRoot(literalline)
       );
     }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Use [`@ts-expect-error`](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-9.html#-ts-expect-error-comments).

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
