### PR TITLE
Update `postcss-less` from v4 to v5

### DIFF
--- a/changelog_unreleased/less/11343.md
+++ b/changelog_unreleased/less/11343.md
@@ -1,0 +1,16 @@
+#### Fix interpolation parse error (#11343 by @fisker)
+
+<!-- prettier-ignore -->
+```less
+// Input
+@{selector}-title{ @{prop}-size: @{color} }
+
+// Prettier stable
+SyntaxError: CssSyntaxError: Unknown word (1:20)
+> 1 | @{selector}-title{ @{prop}-size: @{color} }
+
+// Prettier main
+@{selector}-title {
+  @{prop}-size: @{color};
+}
+```

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "parse-srcset": "ikatyang/parse-srcset#54eb9c1cb21db5c62b4d0e275d7249516df6f0ee",
     "please-upgrade-node": "3.2.0",
     "postcss": "8.2.7",
-    "postcss-less": "4.0.1",
+    "postcss-less": "5.0.0",
     "postcss-media-query-parser": "0.2.3",
     "postcss-scss": "3.0.5",
     "postcss-selector-parser": "2.2.3",

--- a/tests/format/less/interpolation/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/less/interpolation/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`interpolation.less format 1`] = `
+====================================options=====================================
+parsers: ["less"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// https://github.com/shellscape/postcss-less/pull/159
+@{selector}-title{ @{prop}-size: @{color} }
+
+=====================================output=====================================
+// https://github.com/shellscape/postcss-less/pull/159
+@{selector}-title {
+  @{prop}-size: @{color};
+}
+
+================================================================================
+`;

--- a/tests/format/less/interpolation/interpolation.less
+++ b/tests/format/less/interpolation/interpolation.less
@@ -1,0 +1,2 @@
+// https://github.com/shellscape/postcss-less/pull/159
+@{selector}-title{ @{prop}-size: @{color} }

--- a/tests/format/less/interpolation/jsfmt.spec.js
+++ b/tests/format/less/interpolation/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["less"]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5171,12 +5171,10 @@ pluralize@^8.0.0:
   resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
   integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
 
-postcss-less@4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-less/-/postcss-less-4.0.1.tgz#73caf5dac056d4b706f4cc136cefeaf4e79067a4"
-  integrity sha512-C92S4sHlbDpefJ2QQJjrucCcypq3+KZPstjfuvgOCNnGx0tF9h8hXgAlOIATGAxMXZXaF+nVp+/Mi8pCAWdSmw==
-  dependencies:
-    postcss "^8.1.2"
+postcss-less@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-less/-/postcss-less-5.0.0.tgz#3fa361ed8e52a9c3e6e4fdb9bb95fd9032f3c62b"
+  integrity sha512-djK6NlApALJeBnNx7CzLatq64eMF3BCyzBH+faYPxrvNHHM/YCimJ6XQkgWgtim2G89EzdQG4Ed0lGNCXPfD7A==
 
 postcss-media-query-parser@0.2.3:
   version "0.2.3"
@@ -5217,7 +5215,7 @@ postcss@8.2.7:
     nanoid "^3.1.20"
     source-map "^0.6.1"
 
-postcss@^8.1.2, postcss@^8.2.7:
+postcss@^8.2.7:
   version "8.3.6"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.3.6.tgz#2730dd76a97969f37f53b9a6096197be311cc4ea"
   integrity sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Targeting `next` branch.
Changelog https://github.com/shellscape/postcss-less/releases/tag/v5.0.0

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
