### PR TITLE
Style: updated failure message to be more formal

### DIFF
--- a/changelog_unreleased/cli/11369.md
+++ b/changelog_unreleased/cli/11369.md
@@ -1,0 +1,7 @@
+#### Updated failure message to be more informative (#11369 by @webark)
+
+Updated the "Forgot to run Prettier?" to "Run Prettier to fix."
+
+This keeps the same spirit of the message, but is less likely to be
+missinterpretted as it's a more formal message rather than being
+somewhat familial.

--- a/changelog_unreleased/cli/11369.md
+++ b/changelog_unreleased/cli/11369.md
@@ -3,5 +3,5 @@
 Updated the "Forgot to run Prettier?" to "Run Prettier to fix."
 
 This keeps the same spirit of the message, but is less likely to be
-missinterpretted as it's a more formal message rather than being
+misinterpreted as it's a more formal message rather than being
 somewhat familial.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -69,7 +69,7 @@ Console output if some of the files require re-formatting:
 Checking formatting...
 [warn] src/fileA.js
 [warn] src/fileB.js
-[warn] Code style issues found in 2 files. Forgot to run Prettier?
+[warn] Code style issues found in 2 files. Run Prettier to fix.
 ```
 
 The command will return exit code `1` in the second case, which is helpful inside the CI pipelines.

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -488,21 +488,15 @@ async function formatFiles(context) {
   if (context.argv.check) {
     if (numberOfUnformattedFilesFound === 0) {
       context.logger.log("All matched files use Prettier code style!");
-    } else if (numberOfUnformattedFilesFound === 1) {
-      context.logger.warn(
-        context.argv.write
-          ? "Code style issues fixed in the above file."
-          : "Code style issues found in the above file. Forgot to run Prettier?"
-      );
     } else {
+      const files =
+        numberOfUnformattedFilesFound === 1
+          ? "the above file"
+          : `${numberOfUnformattedFilesFound} files`;
       context.logger.warn(
         context.argv.write
-          ? "Code style issues fixed in " +
-              numberOfUnformattedFilesFound +
-              " files."
-          : "Code style issues found in " +
-              numberOfUnformattedFilesFound +
-              " files. Run Prettier to fix."
+          ? `Code style issues fixed in ${files}.`
+          : `Code style issues found in ${files}. Run Prettier to fix.`
       );
     }
   }

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -497,12 +497,12 @@ async function formatFiles(context) {
     } else {
       context.logger.warn(
         context.argv.write
-          ? "Code style issues found in " +
+          ? "Code style issues fixed in " +
               numberOfUnformattedFilesFound +
               " files."
           : "Code style issues found in " +
               numberOfUnformattedFilesFound +
-              " files. Forgot to run Prettier?"
+              " files. Run Prettier to fix."
       );
     }
   }

--- a/tests/integration/__tests__/__snapshots__/check.js.snap
+++ b/tests/integration/__tests__/__snapshots__/check.js.snap
@@ -3,7 +3,7 @@
 exports[`--checks should print the number of files that need formatting (stderr) 1`] = `
 "[warn] unformatted.js
 [warn] unformatted2.js
-[warn] Code style issues found in 2 files. Forgot to run Prettier?
+[warn] Code style issues found in 2 files. Run Prettier to fix.
 "
 `;
 
@@ -16,13 +16,13 @@ exports[`--checks should print the number of files that need formatting (write) 
 
 exports[`--checks works in CI just as in a non-TTY mode (stderr) 1`] = `
 "[warn] unformatted.js
-[warn] Code style issues found in the above file. Forgot to run Prettier?
+[warn] Code style issues found in the above file. Run Prettier to fix.
 "
 `;
 
 exports[`--checks works in CI just as in a non-TTY mode (stderr) 2`] = `
 "[warn] unformatted.js
-[warn] Code style issues found in the above file. Forgot to run Prettier?
+[warn] Code style issues found in the above file. Run Prettier to fix.
 "
 `;
 

--- a/tests/integration/__tests__/__snapshots__/ignore-unknown.js.snap
+++ b/tests/integration/__tests__/__snapshots__/ignore-unknown.js.snap
@@ -31,7 +31,7 @@ exports[`ignore-unknown alias (stdout) 1`] = `
 
 exports[`ignore-unknown check (stderr) 1`] = `
 "[warn] javascript.js
-[warn] Code style issues found in the above file. Forgot to run Prettier?
+[warn] Code style issues found in the above file. Run Prettier to fix.
 "
 `;
 

--- a/tests/integration/__tests__/__snapshots__/infer-parser.js.snap
+++ b/tests/integration/__tests__/__snapshots__/infer-parser.js.snap
@@ -3,7 +3,7 @@
 exports[`--check with unknown path and no parser multiple files (stderr) 1`] = `
 "[error] No parser could be inferred for file: FOO
 [warn] foo.js
-[warn] Code style issues found in the above file. Forgot to run Prettier?
+[warn] Code style issues found in the above file. Run Prettier to fix.
 "
 `;
 


### PR DESCRIPTION
## Description

The term "Forgot to run Prettier?" can be offputting for some (as documented in #6885). I believe that informing what needs to be done, rather than assuming someone did something "wrong", no matter how fine that "wrong" thing is, will provide a more even and calming message.

I debated adding more information (like a link to the logs or an example command to run) but I thought that was a separate initiative that could be picked up regardless of this change.

All I was after was attempting to remove some language that some find offputting if not condescending. 

Thanks!

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
