### PR TITLE
markdown: Preserve inline code line breaks if --prose-wrap=preserve

### DIFF
--- a/changelog_unreleased/markdown/11373.md
+++ b/changelog_unreleased/markdown/11373.md
@@ -1,0 +1,15 @@
+#### Preserve inline code line breaks if `--prose-wrap=preserve` (#11373 by @andersk)
+
+<!-- prettier-ignore -->
+```markdown
+<!-- Input -->
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod `tempor
+incididunt` ut labore et dolore magna aliqua.
+
+<!-- Prettier stable -->
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod `tempor incididunt` ut labore et dolore magna aliqua.
+
+<!-- Prettier main -->
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod `tempor
+incididunt` ut labore et dolore magna aliqua.
+```

--- a/src/language-markdown/print-preprocess.js
+++ b/src/language-markdown/print-preprocess.js
@@ -9,7 +9,7 @@ const isSingleCharRegex = /^.$/su;
 function preprocess(ast, options) {
   ast = restoreUnescapedCharacter(ast, options);
   ast = mergeContinuousTexts(ast);
-  ast = transformInlineCode(ast);
+  ast = transformInlineCode(ast, options);
   ast = transformIndentedCodeblockAndMarkItsParentList(ast, options);
   ast = markAlignedList(ast, options);
   ast = splitTextIntoSentences(ast, options);
@@ -28,9 +28,9 @@ function transformImportExport(ast) {
   });
 }
 
-function transformInlineCode(ast) {
+function transformInlineCode(ast, options) {
   return mapAst(ast, (node) => {
-    if (node.type !== "inlineCode") {
+    if (node.type !== "inlineCode" || options.proseWrap === "preserve") {
       return node;
     }
 

--- a/tests/format/markdown/prose-wrap-preserve/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/markdown/prose-wrap-preserve/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,26 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`inline-code-newline.md - {"proseWrap":"preserve"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+printWidth: 80
+proseWrap: "preserve"
+                                                                                | printWidth
+=====================================input======================================
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod \`tempor
+incididunt\` ut labore et dolore magna aliqua. Ut enim ad minim veniam, \`quis
+nostrud\` exercitation ullamco laboris nisi ut aliquip ex ea commodo \`consequat.
+Duis\` aute irure dolor in reprehenderit in voluptate velit esse cillum dolore \`eu
+fugiat\` nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum.
+
+=====================================output=====================================
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod \`tempor
+incididunt\` ut labore et dolore magna aliqua. Ut enim ad minim veniam, \`quis
+nostrud\` exercitation ullamco laboris nisi ut aliquip ex ea commodo \`consequat.
+Duis\` aute irure dolor in reprehenderit in voluptate velit esse cillum dolore \`eu
+fugiat\` nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum.
+
+================================================================================
+`;

--- a/tests/format/markdown/prose-wrap-preserve/inline-code-newline.md
+++ b/tests/format/markdown/prose-wrap-preserve/inline-code-newline.md
@@ -1,0 +1,6 @@
+Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod `tempor
+incididunt` ut labore et dolore magna aliqua. Ut enim ad minim veniam, `quis
+nostrud` exercitation ullamco laboris nisi ut aliquip ex ea commodo `consequat.
+Duis` aute irure dolor in reprehenderit in voluptate velit esse cillum dolore `eu
+fugiat` nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+culpa qui officia deserunt mollit anim id est laborum.

--- a/tests/format/markdown/prose-wrap-preserve/jsfmt.spec.js
+++ b/tests/format/markdown/prose-wrap-preserve/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["markdown"], { proseWrap: "preserve" });


### PR DESCRIPTION
## Description

Fixes #11372.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
