### PR TITLE
JavaScript: Remove extra parentheses in some expressions in unary expressions with comments (remake #7013)

### DIFF
--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -14,6 +14,7 @@ const {
   isCallExpression,
   isMemberExpression,
   isObjectProperty,
+  hasComment
 } = require("./utils.js");
 
 function needsParens(path, options) {
@@ -171,6 +172,23 @@ function needsParens(path, options) {
         return true;
       }
       break;
+    }
+    case "UnaryExpression": {
+      if (
+        (node.type === "BinaryExpression" ||
+          node.type === "LogicalExpression" ||
+          node.type === "ArrowFunctionExpression" ||
+          node.type === "AwaitExpression" ||
+          node.type === "YieldExpression" ||
+          node.type === "SequenceExpression" ||
+          node.type === "ConditionalExpression" ||
+          node.type === "AssignmentExpression" ||
+          node.type === "TSAsExpression" ||
+          node.type === "TSTypeAssertion") &&
+		  hasComment(node)
+      ) {
+        return false;
+      }
     }
   }
 

--- a/tests/format/js/unary-expression/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/unary-expression/__snapshots__/jsfmt.spec.js.snap
@@ -309,33 +309,33 @@ async function bar2() {
 );
 
 !(x + y);
-!((x + y) /* foo */);
-!(/* foo */ (x + y));
+!(x + y /* foo */);
+!(/* foo */ x + y);
 !(
   /* foo */
-  (x + y)
+  x + y
 );
 !(
-  (x + y)
+  x + y
   /* foo */
 );
 !(
-  (x + y) // foo
+  x + y // foo
 );
 
 !(x || y);
-!(/* foo */ (x || y));
-!((x || y) /* foo */);
+!(/* foo */ x || y);
+!(x || y /* foo */);
 !(
   /* foo */
-  (x || y)
+  x || y
 );
 !(
-  (x || y)
+  x || y
   /* foo */
 );
 !(
-  (x || y) // foo
+  x || y // foo
 );
 
 ![1, 2, 3];
@@ -439,18 +439,18 @@ async function bar2() {
 );
 
 !(x = y);
-!((x = y) /* foo */);
-!(/* foo */ (x = y));
+!(x = y /* foo */);
+!(/* foo */ x = y);
 !(
   /* foo */
-  (x = y)
+  x = y
 );
 !(
-  (x = y)
+  x = y
   /* foo */
 );
 !(
-  (x = y) // foo
+  x = y // foo
 );
 
 !x.y;
@@ -469,18 +469,18 @@ async function bar2() {
 );
 
 !(x ? y : z);
-!((x ? y : z) /* foo */);
-!(/* foo */ (x ? y : z));
+!(x ? y : z /* foo */);
+!(/* foo */ x ? y : z);
 !(
   /* foo */
-  (x ? y : z)
+  x ? y : z
 );
 !(
-  (x ? y : z)
+  x ? y : z
   /* foo */
 );
 !(
-  (x ? y : z) // foo
+  x ? y : z // foo
 );
 
 !x();
@@ -514,14 +514,14 @@ async function bar2() {
 );
 
 !(x, y);
-!((x, y) /* foo */);
-!(/* foo */ (x, y));
+!(x, y /* foo */);
+!(/* foo */ x, y);
 !(
   /* foo */
-  (x, y)
+  x, y
 );
 !(
-  (x, y)
+  x, y
   /* foo */
 );
 !(
@@ -529,51 +529,51 @@ async function bar2() {
 );
 
 !(() => 3);
-!((() => 3) /* foo */);
-!(/* foo */ (() => 3));
+!(() => 3 /* foo */);
+!(/* foo */ () => 3);
 !(
   /* foo */
-  (() => 3)
+  () => 3
 );
 !(
-  (() => 3)
+  () => 3
   /* foo */
 );
 !(
-  (() => 3) // foo
+  () => 3 // foo
 );
 
 function* bar() {
   !(yield x);
-  !((yield x) /* foo */);
-  !(/* foo */ (yield x));
+  !(yield x /* foo */);
+  !(/* foo */ yield x);
   !(
     /* foo */
-    (yield x)
+    yield x
   );
   !(
-    (yield x)
+    yield x
     /* foo */
   );
   !(
-    (yield x) // foo
+    yield x // foo
   );
 }
 
 async function bar2() {
   !(await x);
-  !((await x) /* foo */);
-  !(/* foo */ (await x));
+  !(await x /* foo */);
+  !(/* foo */ await x);
   !(
     /* foo */
-    (await x)
+    await x
   );
   !(
-    (await x)
+    await x
     /* foo */
   );
   !(
-    (await x) // foo
+    await x // foo
   );
 }
 

--- a/tests/format/typescript/unary/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/unary/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,70 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`comments.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<null>x;
+!(<null>x /* foo */);
+!(/* foo */ <null>x);
+!(
+  /* foo */
+  <null>x
+);
+!(
+  <null>x
+  /* foo */
+);
+!(
+  <null>x // foo
+);
+
+x as string;
+!(x as string /* foo */);
+!(/* foo */ x as string);
+!(
+  /* foo */
+  x as string
+);
+!(
+  x as string
+  /* foo */
+);
+!(
+  x as string // foo
+);
+=====================================output=====================================
+<null>x;
+!(<null>x /* foo */);
+!(/* foo */ <null>x);
+!(
+  /* foo */
+  <null>x
+);
+!(
+  <null>x
+  /* foo */
+);
+!(
+  <null>x // foo
+);
+
+x as string;
+!(x as string /* foo */);
+!(/* foo */ x as string);
+!(
+  /* foo */
+  x as string
+);
+!(
+  x as string
+  /* foo */
+);
+!(
+  x as string // foo
+);
+
+================================================================================
+`;

--- a/tests/format/typescript/unary/comments.ts
+++ b/tests/format/typescript/unary/comments.ts
@@ -1,0 +1,29 @@
+<null>x;
+!(<null>x /* foo */);
+!(/* foo */ <null>x);
+!(
+  /* foo */
+  <null>x
+);
+!(
+  <null>x
+  /* foo */
+);
+!(
+  <null>x // foo
+);
+
+x as string;
+!(x as string /* foo */);
+!(/* foo */ x as string);
+!(
+  /* foo */
+  x as string
+);
+!(
+  x as string
+  /* foo */
+);
+!(
+  x as string // foo
+);

--- a/tests/format/typescript/unary/jsfmt.spec.js
+++ b/tests/format/typescript/unary/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["typescript"]);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
@sosukesuzuki tried https://github.com/prettier/prettier/pull/7013 about 2 years ago and the following comment is written(https://github.com/prettier/prettier/pull/7013#discussion_r348431173).
>The needsParens function starts to lie here which makes it less reusable. There must be a cleaner solution.

We didn't have `switch (parent.type)` process then, but we do now.
So I add `case "UnaryExpression"`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
