### PR TITLE
Prettier should not re-escape a backslash in a string literal

### DIFF
--- a/tests/format/handlebars/escape/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/handlebars/escape/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`backslash.hbs format 1`] = `
+====================================options=====================================
+parsers: ["glimmer"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<DateFormat @pathFormat="dateFormat:YYYY-MM-DD hh\:mm\:ss" />
+
+
+=====================================output=====================================
+<DateFormat @pathFormat="dateFormat:YYYY-MM-DD hh\:mm\:ss" />
+================================================================================
+`;
+
 exports[`html-entities.hbs format 1`] = `
 ====================================options=====================================
 parsers: ["glimmer"]

--- a/tests/format/handlebars/escape/backslash.hbs
+++ b/tests/format/handlebars/escape/backslash.hbs
@@ -1,0 +1,2 @@
+<DateFormat @pathFormat="dateFormat:YYYY-MM-DD hh\:mm\:ss" />
+


### PR DESCRIPTION
## Description
Formatting handlebars prettier is escaping a backslash with another backslash.

Currently this PR only adds a breaking test. 
 
For this example
```hbs
<DateFormat @pathFormat="dateFormat:YYYY-MM-DD hh\:mm\:ss" />
```

Current output
```hbs
<DateFormat @pathFormat="dateFormat:YYYY-MM-DD hh\\:mm\\:ss" />
```

Expected output
```hbs
<DateFormat @pathFormat="dateFormat:YYYY-MM-DD hh\:mm\:ss" />
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
