### PR TITLE
Reduce ternary operator in `printer-html.js` (after #11425)

### DIFF
--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -368,6 +368,21 @@ function printElement(path, options, print) {
       printClosingTag(node, options),
     ]);
 
+  const printChildrenDoc = (childrenDoc) => {
+    if (shouldHugContent) {
+      return indentIfBreak(childrenDoc, { groupId: attrGroupId });
+    }
+    if (
+      (isScriptLikeTag(node) || isVueCustomBlock(node, options)) &&
+      node.parent.type === "root" &&
+      options.parser === "vue" &&
+      !options.vueIndentScriptAndStyle
+    ) {
+      return childrenDoc;
+    }
+    return indent(childrenDoc);
+  };
+
   if (node.children.length === 0) {
     return printTag(
       node.hasDanglingSpaces && node.isDanglingSpaceSensitive ? line : ""
@@ -376,15 +391,7 @@ function printElement(path, options, print) {
 
   return printTag([
     forceBreakContent(node) ? breakParent : "",
-    ((childrenDoc) =>
-      shouldHugContent
-        ? indentIfBreak(childrenDoc, { groupId: attrGroupId })
-        : (isScriptLikeTag(node) || isVueCustomBlock(node, options)) &&
-          node.parent.type === "root" &&
-          options.parser === "vue" &&
-          !options.vueIndentScriptAndStyle
-        ? childrenDoc
-        : indent(childrenDoc))([
+    printChildrenDoc([
       shouldHugContent
         ? ifBreak(softline, "", { groupId: attrGroupId })
         : node.firstChild.hasLeadingSpaces &&

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -383,6 +383,26 @@ function printElement(path, options, print) {
     return indent(childrenDoc);
   };
 
+  const printBeforeChildrenLine = () => {
+    if (shouldHugContent) {
+      return ifBreak(softline, "", { groupId: attrGroupId });
+    }
+    if (
+      node.firstChild.hasLeadingSpaces &&
+      node.firstChild.isLeadingSpaceSensitive
+    ) {
+      return line;
+    }
+    if (
+      node.firstChild.type === "text" &&
+      node.isWhitespaceSensitive &&
+      node.isIndentationSensitive
+    ) {
+      return dedentToRoot(softline);
+    }
+    return softline;
+  };
+
   if (node.children.length === 0) {
     return printTag(
       node.hasDanglingSpaces && node.isDanglingSpaceSensitive ? line : ""
@@ -392,16 +412,7 @@ function printElement(path, options, print) {
   return printTag([
     forceBreakContent(node) ? breakParent : "",
     printChildrenDoc([
-      shouldHugContent
-        ? ifBreak(softline, "", { groupId: attrGroupId })
-        : node.firstChild.hasLeadingSpaces &&
-          node.firstChild.isLeadingSpaceSensitive
-        ? line
-        : node.firstChild.type === "text" &&
-          node.isWhitespaceSensitive &&
-          node.isIndentationSensitive
-        ? dedentToRoot(softline)
-        : softline,
+      printBeforeChildrenLine(),
       printChildren(path, options, print),
     ]),
     (

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -383,7 +383,7 @@ function printElement(path, options, print) {
     return indent(childrenDoc);
   };
 
-  const printBeforeChildrenLine = () => {
+  const printLineBeforeChildren = () => {
     if (shouldHugContent) {
       return ifBreak(softline, "", { groupId: attrGroupId });
     }
@@ -403,7 +403,7 @@ function printElement(path, options, print) {
     return softline;
   };
 
-  const printAfterChildrenLine = () => {
+  const printLineAfterChildren = () => {
     const needsToBorrow = node.next
       ? needsToBorrowPrevClosingTagEndMarker(node.next)
       : needsToBorrowLastChildClosingTagEndMarker(node.parent);
@@ -454,10 +454,10 @@ function printElement(path, options, print) {
   return printTag([
     forceBreakContent(node) ? breakParent : "",
     printChildrenDoc([
-      printBeforeChildrenLine(),
+      printLineBeforeChildren(),
       printChildren(path, options, print),
     ]),
-    printAfterChildrenLine(),
+    printLineAfterChildren(),
   ]);
 }
 


### PR DESCRIPTION
## Description
Fixes https://github.com/prettier/prettier/pull/11425#issuecomment-908296566
<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
