### PR TITLE
Add file-list option to CLI

### DIFF
--- a/src/cli/constant.js
+++ b/src/cli/constant.js
@@ -166,6 +166,16 @@ const options = {
       * inferredParser (string | null) - name of parser inferred from file path
     `,
   },
+  "file-list": {
+    type: "string",
+    category: coreOptions.CATEGORY_CONFIG,
+    description: outdent`TBD`,
+    array: true,
+  },
+  git: {
+    type: "boolean",
+    description: outdent`TBD`,
+  },
   help: {
     type: "flag",
     alias: "h",

--- a/tests/integration/__tests__/__snapshots__/file-list.js.snap
+++ b/tests/integration/__tests__/__snapshots__/file-list.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`file list (stderr) 1`] = `""`;
+
+exports[`file list (stdout) 1`] = `
+"listed.js
+"
+`;
+
+exports[`file list (write) 1`] = `Array []`;
+
+exports[`multiple file list (stderr) 1`] = `""`;
+
+exports[`multiple file list (stdout) 1`] = `
+"listed.js
+other-listed.js
+"
+`;
+
+exports[`multiple file list (write) 1`] = `Array []`;

--- a/tests/integration/__tests__/file-list.js
+++ b/tests/integration/__tests__/file-list.js
@@ -1,0 +1,19 @@
+"use strict";
+
+const path = require("path");
+const runPrettier = require("../runPrettier.js");
+
+const lsCommand = `node ${path.join(__dirname, "../cli/file-list/ls.js")}`;
+const otherLsCommand = `node ${path.join(__dirname, "../cli/file-list/other-ls.js")}`;
+
+describe("file list", () => {
+  runPrettier("cli/file-list", ["**/*.js", "--file-list", lsCommand, "-l"]).test({
+    status: 1,
+  });
+});
+
+describe("multiple file lists", () => {
+  runPrettier("cli/file-list", ["**/*.js", "--file-list", lsCommand, "--file-list", otherLsCommand, "-l"]).test({
+    status: 1,
+  });
+});

--- a/tests/integration/cli/file-list/listed.js
+++ b/tests/integration/cli/file-list/listed.js
@@ -1,0 +1,1 @@
+'use strict';

--- a/tests/integration/cli/file-list/ls.js
+++ b/tests/integration/cli/file-list/ls.js
@@ -1,0 +1,1 @@
+console.log("listed.js");

--- a/tests/integration/cli/file-list/other-listed.js
+++ b/tests/integration/cli/file-list/other-listed.js
@@ -1,0 +1,1 @@
+'use strict';

--- a/tests/integration/cli/file-list/other-ls.js
+++ b/tests/integration/cli/file-list/other-ls.js
@@ -1,0 +1,1 @@
+console.log("other-listed.js");

--- a/tests/integration/cli/file-list/unlisted.js
+++ b/tests/integration/cli/file-list/unlisted.js
@@ -1,0 +1,1 @@
+'use strict';


### PR DESCRIPTION
## Description
this option allows to specify one or more commands to obtain file lists from. only these listed files may then be
formatted.

this is useful for example to only format/check files in
git, e.g.: `prettier --file-list 'git ls-files' ./**/*.*`

fixes https://github.com/prettier/prettier/issues/4547

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
