### PR TITLE
Fix the `trailingComma` value from `"always"` to `"all"` in v2 blog post

### DIFF
--- a/website/blog/2020-03-21-2.0.0.md
+++ b/website/blog/2020-03-21-2.0.0.md
@@ -116,7 +116,7 @@ Prettier has included an [option to configure trailing commas](https://prettier.
 Finally, the default value becomes `es5` instead of `none` in Prettier v2.0.
 
 If the old behavior is still preferred, please configure Prettier with `{ "trailingComma": "none" }`.
-There is a possibility that the default value will change to `always` (meaning even more trailing commas) in a future major version of Prettier as the JavaScript ecosystem further matures.
+There is a possibility that the default value will change to `all` (meaning even more trailing commas) in a future major version of Prettier as the JavaScript ecosystem further matures.
 
 #### Plugin API: changes in `prettier.util` ([#6993](https://github.com/prettier/prettier/pull/6993) by [@fisker](https://github.com/fisker))
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
