### PR TITLE
Adds more info for release URL

### DIFF
--- a/scripts/release/__tests__/setup.js
+++ b/scripts/release/__tests__/setup.js
@@ -1,0 +1,9 @@
+import { jest } from "@jest/globals";
+
+jest.unstable_mockModule("../get-formatted-date", () => ({
+  default: () => ({
+    year: "2021",
+    month: "09",
+    day: "01",
+  }),
+}));

--- a/scripts/release/__tests__/steps/publish-to-npm.spec.js
+++ b/scripts/release/__tests__/steps/publish-to-npm.spec.js
@@ -1,0 +1,24 @@
+import { getReleaseUrl } from "../../steps/publish-to-npm.js";
+
+describe("publish-to-npm", () => {
+  describe("getReleaseUrl", () => {
+    it("returns URL for patch releasing", () => {
+      const result = getReleaseUrl("2.3.1", "2.3.0");
+      expect(result).toBe(
+        "https://github.com/prettier/prettier/releases/new?tag=2.3.1&title=2.3.1&body=%F0%9F%94%97%20%5BChangelog%5D(https%3A%2F%2Fgithub.com%2Fprettier%2Fprettier%2Fblob%2Fmain%2FCHANGELOG.md%23231)"
+      );
+    });
+    it("returns URL for minor releasing", () => {
+      const result = getReleaseUrl("2.4.0", "2.3.0");
+      expect(result).toBe(
+        "https://github.com/prettier/prettier/releases/new?tag=2.4.0&title=2.4.0&body=%5Bdiff%5D(https%3A%2F%2Fgithub.com%2Fprettier%2Fprettier%2Fcompare%2F2.3.0...2.4.0)%0A%0A%F0%9F%94%97%20%5BRelease%20note%5D(https%3A%2F%2Fprettier.io%2Fblog%2F2021%2F09%2F01%2F2.4.0.html)"
+      );
+    });
+    it("returns URL for major releasing", () => {
+      const result = getReleaseUrl("2.3.0", "2.2.0");
+      expect(result).toBe(
+        "https://github.com/prettier/prettier/releases/new?tag=2.3.0&title=2.3.0&body=%5Bdiff%5D(https%3A%2F%2Fgithub.com%2Fprettier%2Fprettier%2Fcompare%2F2.2.0...2.3.0)%0A%0A%F0%9F%94%97%20%5BRelease%20note%5D(https%3A%2F%2Fprettier.io%2Fblog%2F2021%2F09%2F01%2F2.3.0.html)"
+      );
+    });
+  });
+});

--- a/scripts/release/__tests__/steps/publish-to-npm.spec.js
+++ b/scripts/release/__tests__/steps/publish-to-npm.spec.js
@@ -8,12 +8,14 @@ describe("publish-to-npm", () => {
         "https://github.com/prettier/prettier/releases/new?tag=2.3.1&title=2.3.1&body=%F0%9F%94%97%20%5BChangelog%5D(https%3A%2F%2Fgithub.com%2Fprettier%2Fprettier%2Fblob%2Fmain%2FCHANGELOG.md%23231)"
       );
     });
+
     it("returns URL for minor releasing", () => {
       const result = getReleaseUrl("2.4.0", "2.3.0");
       expect(result).toBe(
         "https://github.com/prettier/prettier/releases/new?tag=2.4.0&title=2.4.0&body=%5Bdiff%5D(https%3A%2F%2Fgithub.com%2Fprettier%2Fprettier%2Fcompare%2F2.3.0...2.4.0)%0A%0A%F0%9F%94%97%20%5BRelease%20note%5D(https%3A%2F%2Fprettier.io%2Fblog%2F2021%2F09%2F01%2F2.4.0.html)"
       );
     });
+
     it("returns URL for major releasing", () => {
       const result = getReleaseUrl("2.3.0", "2.2.0");
       expect(result).toBe(

--- a/scripts/release/get-formatted-date.js
+++ b/scripts/release/get-formatted-date.js
@@ -1,3 +1,4 @@
+// TODO: Implement this in `utils.js` when jest.importActual is landed.
 export default function getFormattedDate() {
   const date = new Date();
   const year = date.getFullYear();

--- a/scripts/release/get-formatted-date.js
+++ b/scripts/release/get-formatted-date.js
@@ -1,0 +1,7 @@
+export default function getFormattedDate() {
+  const date = new Date();
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return { year, month, day };
+}

--- a/scripts/release/jest.config.js
+++ b/scripts/release/jest.config.js
@@ -1,0 +1,6 @@
+const config = {
+  testMatch: ["<rootDir>/__tests__/**/*.spec.js"],
+  setupFiles: ["<rootDir>/__tests__/setup.js"],
+};
+
+export default config;

--- a/scripts/release/package.json
+++ b/scripts/release/package.json
@@ -14,6 +14,6 @@
     "string-width": "5.0.0"
   },
   "devDependencies": {
-    "jest": "27.1.0"
+    "jest": "27.1.1"
   }
 }

--- a/scripts/release/package.json
+++ b/scripts/release/package.json
@@ -14,6 +14,7 @@
     "string-width": "5.0.0"
   },
   "devDependencies": {
+    "@jest/globals": "27.1.1",
     "jest": "27.1.1"
   }
 }

--- a/scripts/release/steps/publish-to-npm.js
+++ b/scripts/release/steps/publish-to-npm.js
@@ -1,7 +1,13 @@
 import chalk from "chalk";
 import outdent from "outdent";
 import execa from "execa";
-import { logPromise, waitForEnter } from "../utils.js";
+import semver from "semver";
+import {
+  getBlogPostInfo,
+  getChangelogContent,
+  logPromise,
+  waitForEnter,
+} from "../utils.js";
 
 const outdentString = outdent.string;
 
@@ -27,18 +33,39 @@ async function retryNpmPublish() {
   }
 }
 
-function getReleaseUrl(version) {
-  return `https://github.com/prettier/prettier/releases/new?tag=${version}}`;
+function getReleaseUrl(version, previousVersion, isPatch) {
+  let body;
+  if (isPatch) {
+    const urlToChangelog =
+      "https://github.com/prettier/prettier/blob/main/CHANGELOG.md#" +
+      version.split(".").join("");
+    body = `[Changelog](${urlToChangelog})`;
+  } else {
+    const blogPostInfo = getBlogPostInfo(version);
+    body = getChangelogContent({
+      version,
+      previousVersion,
+      body: `[Release note](https://prettier.io/${blogPostInfo.path})`,
+    });
+  }
+  body = encodeURIComponent(body);
+  return `https://github.com/prettier/prettier/releases/new?tag=${version}&title=${version}&body=${body}}`;
 }
 
-export default async function publishToNpm({ dry, version }) {
+export default async function publishToNpm({ dry, version, previousVersion }) {
   if (dry) {
     return;
   }
 
+  const semverDiff = semver.diff(version, previousVersion);
+
   await logPromise("Publishing to npm", retryNpmPublish());
 
-  const releaseUrl = getReleaseUrl(version);
+  const releaseUrl = getReleaseUrl(
+    version,
+    previousVersion,
+    /* isPatch */ semverDiff === "patch"
+  );
 
   console.log(
     outdentString(chalk`

--- a/scripts/release/steps/publish-to-npm.js
+++ b/scripts/release/steps/publish-to-npm.js
@@ -33,7 +33,9 @@ async function retryNpmPublish() {
   }
 }
 
-function getReleaseUrl(version, previousVersion, isPatch) {
+export function getReleaseUrl(version, previousVersion) {
+  const semverDiff = semver.diff(version, previousVersion);
+  const isPatch = semverDiff === "patch";
   let body;
   if (isPatch) {
     const urlToChangelog =
@@ -49,7 +51,7 @@ function getReleaseUrl(version, previousVersion, isPatch) {
     });
   }
   body = encodeURIComponent(body);
-  return `https://github.com/prettier/prettier/releases/new?tag=${version}&title=${version}&body=${body}}`;
+  return `https://github.com/prettier/prettier/releases/new?tag=${version}&title=${version}&body=${body}`;
 }
 
 export default async function publishToNpm({ dry, version, previousVersion }) {
@@ -57,15 +59,9 @@ export default async function publishToNpm({ dry, version, previousVersion }) {
     return;
   }
 
-  const semverDiff = semver.diff(version, previousVersion);
-
   await logPromise("Publishing to npm", retryNpmPublish());
 
-  const releaseUrl = getReleaseUrl(
-    version,
-    previousVersion,
-    /* isPatch */ semverDiff === "patch"
-  );
+  const releaseUrl = getReleaseUrl(version, previousVersion);
 
   console.log(
     outdentString(chalk`

--- a/scripts/release/steps/publish-to-npm.js
+++ b/scripts/release/steps/publish-to-npm.js
@@ -39,13 +39,13 @@ function getReleaseUrl(version, previousVersion, isPatch) {
     const urlToChangelog =
       "https://github.com/prettier/prettier/blob/main/CHANGELOG.md#" +
       version.split(".").join("");
-    body = `[Changelog](${urlToChangelog})`;
+    body = `🔗 [Changelog](${urlToChangelog})`;
   } else {
     const blogPostInfo = getBlogPostInfo(version);
     body = getChangelogContent({
       version,
       previousVersion,
-      body: `[Release note](https://prettier.io/${blogPostInfo.path})`,
+      body: `🔗 [Release note](https://prettier.io/${blogPostInfo.path})`,
     });
   }
   body = encodeURIComponent(body);

--- a/scripts/release/steps/publish-to-npm.js
+++ b/scripts/release/steps/publish-to-npm.js
@@ -27,12 +27,18 @@ async function retryNpmPublish() {
   }
 }
 
+function getReleaseUrl(version) {
+  return `https://github.com/prettier/prettier/releases/new?tag=${version}}`;
+}
+
 export default async function publishToNpm({ dry, version }) {
   if (dry) {
     return;
   }
 
   await logPromise("Publishing to npm", retryNpmPublish());
+
+  const releaseUrl = getReleaseUrl(version);
 
   console.log(
     outdentString(chalk`
@@ -41,7 +47,7 @@ export default async function publishToNpm({ dry, version }) {
       {yellow.bold Some manual steps are necessary.}
 
       {bold.underline Create a GitHub Release}
-      - Go to {cyan.underline https://github.com/prettier/prettier/releases/new?tag=${version}}
+      - Go to {cyan.underline ${releaseUrl}}
       - Copy release notes from {yellow CHANGELOG.md}
       - Press {bgGreen.black  Publish release }
 

--- a/scripts/release/steps/update-changelog.js
+++ b/scripts/release/steps/update-changelog.js
@@ -3,31 +3,19 @@ import execa from "execa";
 import chalk from "chalk";
 import outdent from "outdent";
 import semver from "semver";
-import { waitForEnter, runYarn, logPromise } from "../utils.js";
+import {
+  waitForEnter,
+  runYarn,
+  logPromise,
+  getBlogPostInfo,
+  getChangelogContent,
+} from "../utils.js";
 
 const outdentString = outdent.string;
 
-function getBlogPostInfo(version) {
-  const date = new Date();
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
-
-  return {
-    file: `website/blog/${year}-${month}-${day}-${version}.md`,
-    path: `blog/${year}/${month}/${day}/${version}.html`,
-  };
-}
-
-function writeChangelog({ version, previousVersion, body }) {
+function writeChangelog(params) {
   const changelog = fs.readFileSync("CHANGELOG.md", "utf-8");
-  const newEntry = outdent`
-    # ${version}
-
-    [diff](https://github.com/prettier/prettier/compare/${previousVersion}...${version})
-
-    ${body}
-  `;
+  const newEntry = `# ${params.version}\n\n` + getChangelogContent(params);
   fs.writeFileSync("CHANGELOG.md", newEntry + "\n\n" + changelog);
 }
 

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -4,6 +4,7 @@ import chalk from "chalk";
 import execa from "execa";
 import stringWidth from "string-width";
 import fetch from "node-fetch";
+import outdent from "outdent";
 
 readline.emitKeypressEvents(process.stdin);
 
@@ -90,6 +91,26 @@ async function fetchText(url) {
   return response.text();
 }
 
+function getBlogPostInfo(version) {
+  const date = new Date();
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+
+  return {
+    file: `website/blog/${year}-${month}-${day}-${version}.md`,
+    path: `blog/${year}/${month}/${day}/${version}.html`,
+  };
+}
+
+function getChangelogContent({ version, previousVersion, body }) {
+  return outdent`
+  [diff](https://github.com/prettier/prettier/compare/${previousVersion}...${version})
+
+  ${body}
+  `;
+}
+
 export {
   runYarn,
   runGit,
@@ -99,4 +120,6 @@ export {
   readJson,
   writeJson,
   waitForEnter,
+  getBlogPostInfo,
+  getChangelogContent,
 };

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -5,6 +5,7 @@ import execa from "execa";
 import stringWidth from "string-width";
 import fetch from "node-fetch";
 import outdent from "outdent";
+import getFormattedDate from "./get-formatted-date.js";
 
 readline.emitKeypressEvents(process.stdin);
 
@@ -92,10 +93,7 @@ async function fetchText(url) {
 }
 
 function getBlogPostInfo(version) {
-  const date = new Date();
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
+  const { year, month, day } = getFormattedDate();
 
   return {
     file: `website/blog/${year}-${month}-${day}-${version}.md`,

--- a/scripts/release/yarn.lock
+++ b/scripts/release/yarn.lock
@@ -318,94 +318,94 @@
   resolved "https://registry.yarnpkg.com/@istanbuljs/schema/-/schema-0.1.3.tgz#e45e384e4b8ec16bce2fd903af78450f6bf7ec98"
   integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
 
-"@jest/console@^27.1.0":
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/@jest/console/-/console-27.1.0.tgz#de13b603cb1d389b50c0dc6296e86e112381e43c"
-  integrity sha512-+Vl+xmLwAXLNlqT61gmHEixeRbS4L8MUzAjtpBCOPWH+izNI/dR16IeXjkXJdRtIVWVSf9DO1gdp67B1XorZhQ==
+"@jest/console@^27.1.1":
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-27.1.1.tgz#e1eb8ef8a410e75e80bb17429047ed5d43411d20"
+  integrity sha512-VpQJRsWSeAem0zpBjeRtDbcD6DlbNoK11dNYt+PSQ+DDORh9q2/xyEpErfwgnLjWX0EKkSZmTGx/iH9Inzs6vQ==
   dependencies:
-    "@jest/types" "^27.1.0"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
     chalk "^4.0.0"
-    jest-message-util "^27.1.0"
-    jest-util "^27.1.0"
+    jest-message-util "^27.1.1"
+    jest-util "^27.1.1"
     slash "^3.0.0"
 
-"@jest/core@^27.1.0":
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/@jest/core/-/core-27.1.0.tgz#622220f18032f5869e579cecbe744527238648bf"
-  integrity sha512-3l9qmoknrlCFKfGdrmiQiPne+pUR4ALhKwFTYyOeKw6egfDwJkO21RJ1xf41rN8ZNFLg5W+w6+P4fUqq4EMRWA==
+"@jest/core@^27.1.1":
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/@jest/core/-/core-27.1.1.tgz#d9d42214920cb96c2a6cc48517cf62d4351da3aa"
+  integrity sha512-oCkKeTgI0emznKcLoq5OCD0PhxCijA4l7ejDnWW3d5bgSi+zfVaLybVqa+EQOxpNejQWtTna7tmsAXjMN9N43Q==
   dependencies:
-    "@jest/console" "^27.1.0"
-    "@jest/reporters" "^27.1.0"
-    "@jest/test-result" "^27.1.0"
-    "@jest/transform" "^27.1.0"
-    "@jest/types" "^27.1.0"
+    "@jest/console" "^27.1.1"
+    "@jest/reporters" "^27.1.1"
+    "@jest/test-result" "^27.1.1"
+    "@jest/transform" "^27.1.1"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
     emittery "^0.8.1"
     exit "^0.1.2"
     graceful-fs "^4.2.4"
-    jest-changed-files "^27.1.0"
-    jest-config "^27.1.0"
-    jest-haste-map "^27.1.0"
-    jest-message-util "^27.1.0"
+    jest-changed-files "^27.1.1"
+    jest-config "^27.1.1"
+    jest-haste-map "^27.1.1"
+    jest-message-util "^27.1.1"
     jest-regex-util "^27.0.6"
-    jest-resolve "^27.1.0"
-    jest-resolve-dependencies "^27.1.0"
-    jest-runner "^27.1.0"
-    jest-runtime "^27.1.0"
-    jest-snapshot "^27.1.0"
-    jest-util "^27.1.0"
-    jest-validate "^27.1.0"
-    jest-watcher "^27.1.0"
+    jest-resolve "^27.1.1"
+    jest-resolve-dependencies "^27.1.1"
+    jest-runner "^27.1.1"
+    jest-runtime "^27.1.1"
+    jest-snapshot "^27.1.1"
+    jest-util "^27.1.1"
+    jest-validate "^27.1.1"
+    jest-watcher "^27.1.1"
     micromatch "^4.0.4"
     p-each-series "^2.1.0"
     rimraf "^3.0.0"
     slash "^3.0.0"
     strip-ansi "^6.0.0"
 
-"@jest/environment@^27.1.0":
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-27.1.0.tgz#c7224a67004759ec203d8fa44e8bc0db93f66c44"
-  integrity sha512-wRp50aAMY2w1U2jP1G32d6FUVBNYqmk8WaGkiIEisU48qyDV0WPtw3IBLnl7orBeggveommAkuijY+RzVnNDOQ==
+"@jest/environment@^27.1.1":
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/@jest/environment/-/environment-27.1.1.tgz#a1f7a552f7008f773988b9c0e445ede35f77bbb7"
+  integrity sha512-+y882/ZdxhyqF5RzxIrNIANjHj991WH7jifdcplzMDosDUOyCACFYUyVTBGbSTocbU+s1cesroRzkwi8hZ9SHg==
   dependencies:
-    "@jest/fake-timers" "^27.1.0"
-    "@jest/types" "^27.1.0"
+    "@jest/fake-timers" "^27.1.1"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
-    jest-mock "^27.1.0"
+    jest-mock "^27.1.1"
 
-"@jest/fake-timers@^27.1.0":
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-27.1.0.tgz#c0b343d8a16af17eab2cb6862e319947c0ea2abe"
-  integrity sha512-22Zyn8il8DzpS+30jJNVbTlm7vAtnfy1aYvNeOEHloMlGy1PCYLHa4PWlSws0hvNsMM5bON6GISjkLoQUV3oMA==
+"@jest/fake-timers@^27.1.1":
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-27.1.1.tgz#557a1c0d067d33bcda4dfae9a7d8f96a15a954b5"
+  integrity sha512-u8TJ5VlsVYTsGFatoyIae2l25pku4Bu15QCPTx2Gs5z+R//Ee3tHN85462Vc9yGVcdDvgADbqNkhOLxbEwPjMQ==
   dependencies:
-    "@jest/types" "^27.1.0"
+    "@jest/types" "^27.1.1"
     "@sinonjs/fake-timers" "^7.0.2"
     "@types/node" "*"
-    jest-message-util "^27.1.0"
-    jest-mock "^27.1.0"
-    jest-util "^27.1.0"
+    jest-message-util "^27.1.1"
+    jest-mock "^27.1.1"
+    jest-util "^27.1.1"
 
-"@jest/globals@^27.1.0":
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.1.0.tgz#e093a49c718dd678a782c197757775534c88d3f2"
-  integrity sha512-73vLV4aNHAlAgjk0/QcSIzzCZSqVIPbmFROJJv9D3QUR7BI4f517gVdJpSrCHxuRH3VZFhe0yGG/tmttlMll9g==
+"@jest/globals@^27.1.1":
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.1.1.tgz#cfe5f4d5b37483cef62b79612128ccc7e3c951d8"
+  integrity sha512-Q3JcTPmY+DAEHnr4MpnBV3mwy50EGrTC6oSDTNnW7FNGGacTJAfpWNk02D7xv422T1OzK2A2BKx+26xJOvHkyw==
   dependencies:
-    "@jest/environment" "^27.1.0"
-    "@jest/types" "^27.1.0"
-    expect "^27.1.0"
+    "@jest/environment" "^27.1.1"
+    "@jest/types" "^27.1.1"
+    expect "^27.1.1"
 
-"@jest/reporters@^27.1.0":
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-27.1.0.tgz#02ed1e6601552c2f6447378533f77aad002781d4"
-  integrity sha512-5T/zlPkN2HnK3Sboeg64L5eC8iiaZueLpttdktWTJsvALEtP2YMkC5BQxwjRWQACG9SwDmz+XjjkoxXUDMDgdw==
+"@jest/reporters@^27.1.1":
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/@jest/reporters/-/reporters-27.1.1.tgz#ee5724092f197bb78c60affb9c6f34b6777990c2"
+  integrity sha512-cEERs62n1P4Pqox9HWyNOEkP57G95aK2mBjB6D8Ruz1Yc98fKH53b58rlVEnsY5nLmkLNZk65fxNi9C0Yds/8w==
   dependencies:
     "@bcoe/v8-coverage" "^0.2.3"
-    "@jest/console" "^27.1.0"
-    "@jest/test-result" "^27.1.0"
-    "@jest/transform" "^27.1.0"
-    "@jest/types" "^27.1.0"
+    "@jest/console" "^27.1.1"
+    "@jest/test-result" "^27.1.1"
+    "@jest/transform" "^27.1.1"
+    "@jest/types" "^27.1.1"
     chalk "^4.0.0"
     collect-v8-coverage "^1.0.0"
     exit "^0.1.2"
@@ -416,10 +416,10 @@
     istanbul-lib-report "^3.0.0"
     istanbul-lib-source-maps "^4.0.0"
     istanbul-reports "^3.0.2"
-    jest-haste-map "^27.1.0"
-    jest-resolve "^27.1.0"
-    jest-util "^27.1.0"
-    jest-worker "^27.1.0"
+    jest-haste-map "^27.1.1"
+    jest-resolve "^27.1.1"
+    jest-util "^27.1.1"
+    jest-worker "^27.1.1"
     slash "^3.0.0"
     source-map "^0.6.0"
     string-length "^4.0.1"
@@ -435,51 +435,51 @@
     graceful-fs "^4.2.4"
     source-map "^0.6.0"
 
-"@jest/test-result@^27.1.0":
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-27.1.0.tgz#9345ae5f97f6a5287af9ebd54716cd84331d42e8"
-  integrity sha512-Aoz00gpDL528ODLghat3QSy6UBTD5EmmpjrhZZMK/v1Q2/rRRqTGnFxHuEkrD4z/Py96ZdOHxIWkkCKRpmnE1A==
+"@jest/test-result@^27.1.1":
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-27.1.1.tgz#1086b39af5040b932a55e7f1fa1bc4671bed4781"
+  integrity sha512-8vy75A0Jtfz9DqXFUkjC5Co/wRla+D7qRFdShUY8SbPqBS3GBx3tpba7sGKFos8mQrdbe39n+c1zgVKtarfy6A==
   dependencies:
-    "@jest/console" "^27.1.0"
-    "@jest/types" "^27.1.0"
+    "@jest/console" "^27.1.1"
+    "@jest/types" "^27.1.1"
     "@types/istanbul-lib-coverage" "^2.0.0"
     collect-v8-coverage "^1.0.0"
 
-"@jest/test-sequencer@^27.1.0":
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.1.0.tgz#04e8b3bd735570d3d48865e74977a14dc99bff2d"
-  integrity sha512-lnCWawDr6Z1DAAK9l25o3AjmKGgcutq1iIbp+hC10s/HxnB8ZkUsYq1FzjOoxxZ5hW+1+AthBtvS4x9yno3V1A==
+"@jest/test-sequencer@^27.1.1":
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/@jest/test-sequencer/-/test-sequencer-27.1.1.tgz#cea3722ec6f6330000240fd999ad3123adaf5992"
+  integrity sha512-l8zD3EdeixvwmLNlJoMX3hhj8iIze95okj4sqmBzOq/zW8gZLElUveH4bpKEMuR+Nweazjlwc7L6g4C26M/y6Q==
   dependencies:
-    "@jest/test-result" "^27.1.0"
+    "@jest/test-result" "^27.1.1"
     graceful-fs "^4.2.4"
-    jest-haste-map "^27.1.0"
-    jest-runtime "^27.1.0"
+    jest-haste-map "^27.1.1"
+    jest-runtime "^27.1.1"
 
-"@jest/transform@^27.1.0":
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-27.1.0.tgz#962e385517e3d1f62827fa39c305edcc3ca8544b"
-  integrity sha512-ZRGCA2ZEVJ00ubrhkTG87kyLbN6n55g1Ilq0X9nJb5bX3MhMp3O6M7KG+LvYu+nZRqG5cXsQnJEdZbdpTAV8pQ==
+"@jest/transform@^27.1.1":
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-27.1.1.tgz#51a22f5a48d55d796c02757117c02fcfe4da13d7"
+  integrity sha512-qM19Eu75U6Jc5zosXXVnq900Nl9JDpoGaZ4Mg6wZs7oqbu3heYSMOZS19DlwjlhWdfNRjF4UeAgkrCJCK3fEXg==
   dependencies:
     "@babel/core" "^7.1.0"
-    "@jest/types" "^27.1.0"
+    "@jest/types" "^27.1.1"
     babel-plugin-istanbul "^6.0.0"
     chalk "^4.0.0"
     convert-source-map "^1.4.0"
     fast-json-stable-stringify "^2.0.0"
     graceful-fs "^4.2.4"
-    jest-haste-map "^27.1.0"
+    jest-haste-map "^27.1.1"
     jest-regex-util "^27.0.6"
-    jest-util "^27.1.0"
+    jest-util "^27.1.1"
     micromatch "^4.0.4"
     pirates "^4.0.1"
     slash "^3.0.0"
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
 
-"@jest/types@^27.1.0":
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.1.0.tgz#674a40325eab23c857ebc0689e7e191a3c5b10cc"
-  integrity sha512-pRP5cLIzN7I7Vp6mHKRSaZD7YpBTK7hawx5si8trMKqk4+WOdK8NEKOTO2G8PKWD1HbKMVckVB6/XHh/olhf2g==
+"@jest/types@^27.1.1":
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-27.1.1.tgz#77a3fc014f906c65752d12123a0134359707c0ad"
+  integrity sha512-yqJPDDseb0mXgKqmNqypCsb85C22K1aY5+LUxh7syIM9n/b0AsaltxNy+o6tt29VcfGDpYEve175bm3uOhcehA==
   dependencies:
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
@@ -683,13 +683,13 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
-babel-jest@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.1.0.tgz#e96ca04554fd32274439869e2b6d24de9d91bc4e"
-  integrity sha512-6NrdqzaYemALGCuR97QkC/FkFIEBWP5pw5TMJoUHZTVXyOgocujp6A0JE2V6gE0HtqAAv6VKU/nI+OCR1Z4gHA==
+babel-jest@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-27.1.1.tgz#9359c45995d0940b84d2176ab83423f9eed07617"
+  integrity sha512-JA+dzJl4n2RBvWQEnph6HJaTHrsIPiXGQYatt/D8nR4UpX9UG4GaDzykVVPQBbrdTebZREkRb6SOxyIXJRab6Q==
   dependencies:
-    "@jest/transform" "^27.1.0"
-    "@jest/types" "^27.1.0"
+    "@jest/transform" "^27.1.1"
+    "@jest/types" "^27.1.1"
     "@types/babel__core" "^7.1.14"
     babel-plugin-istanbul "^6.0.0"
     babel-preset-jest "^27.0.6"
@@ -1082,16 +1082,16 @@ exit@^0.1.2:
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
   integrity sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
 
-expect@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/expect/-/expect-27.1.0.tgz#380de0abb3a8f2299c4c6c66bbe930483b5dba9b"
-  integrity sha512-9kJngV5hOJgkFil4F/uXm3hVBubUK2nERVfvqNNwxxuW8ZOUwSTTSysgfzckYtv/LBzj/LJXbiAF7okHCXgdug==
+expect@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/expect/-/expect-27.1.1.tgz#020215da67d41cd6ad805fa00bd030985ca7c093"
+  integrity sha512-JQAzp0CJoFFHF1RnOtrMUNMdsfx/Tl0+FhRzVl8q0fa23N+JyWdPXwb3T5rkHCvyo9uttnK7lVdKCBl1b/9EDw==
   dependencies:
-    "@jest/types" "^27.1.0"
+    "@jest/types" "^27.1.1"
     ansi-styles "^5.0.0"
     jest-get-type "^27.0.6"
-    jest-matcher-utils "^27.1.0"
-    jest-message-util "^27.1.0"
+    jest-matcher-utils "^27.1.1"
+    jest-message-util "^27.1.1"
     jest-regex-util "^27.0.6"
 
 fast-json-stable-stringify@^2.0.0:
@@ -1378,94 +1378,94 @@ istanbul-reports@^3.0.2:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-jest-changed-files@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-27.1.0.tgz#42da6ea00f06274172745729d55f42b60a9dffe0"
-  integrity sha512-eRcb13TfQw0xiV2E98EmiEgs9a5uaBIqJChyl0G7jR9fCIvGjXovnDS6Zbku3joij4tXYcSK4SE1AXqOlUxjWg==
+jest-changed-files@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-27.1.1.tgz#9b3f67a34cc58e3e811e2e1e21529837653e4200"
+  integrity sha512-5TV9+fYlC2A6hu3qtoyGHprBwCAn0AuGA77bZdUgYvVlRMjHXo063VcWTEAyx6XAZ85DYHqp0+aHKbPlfRDRvA==
   dependencies:
-    "@jest/types" "^27.1.0"
+    "@jest/types" "^27.1.1"
     execa "^5.0.0"
     throat "^6.0.1"
 
-jest-circus@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.1.0.tgz#24c280c90a625ea57da20ee231d25b1621979a57"
-  integrity sha512-6FWtHs3nZyZlMBhRf1wvAC5CirnflbGJAY1xssSAnERLiiXQRH+wY2ptBVtXjX4gz4AA2EwRV57b038LmifRbA==
+jest-circus@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-circus/-/jest-circus-27.1.1.tgz#08dd3ec5cbaadce68ce6388ebccbe051d1b34bc6"
+  integrity sha512-Xed1ApiMFu/yzqGMBToHr8sp2gkX/ARZf4nXoGrHJrXrTUdVIWiVYheayfcOaPdQvQEE/uyBLgW7I7YBLIrAXQ==
   dependencies:
-    "@jest/environment" "^27.1.0"
-    "@jest/test-result" "^27.1.0"
-    "@jest/types" "^27.1.0"
+    "@jest/environment" "^27.1.1"
+    "@jest/test-result" "^27.1.1"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
     chalk "^4.0.0"
     co "^4.6.0"
     dedent "^0.7.0"
-    expect "^27.1.0"
+    expect "^27.1.1"
     is-generator-fn "^2.0.0"
-    jest-each "^27.1.0"
-    jest-matcher-utils "^27.1.0"
-    jest-message-util "^27.1.0"
-    jest-runtime "^27.1.0"
-    jest-snapshot "^27.1.0"
-    jest-util "^27.1.0"
-    pretty-format "^27.1.0"
+    jest-each "^27.1.1"
+    jest-matcher-utils "^27.1.1"
+    jest-message-util "^27.1.1"
+    jest-runtime "^27.1.1"
+    jest-snapshot "^27.1.1"
+    jest-util "^27.1.1"
+    pretty-format "^27.1.1"
     slash "^3.0.0"
     stack-utils "^2.0.3"
     throat "^6.0.1"
 
-jest-cli@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.1.0.tgz#118438e4d11cf6fb66cb2b2eb5778817eab3daeb"
-  integrity sha512-h6zPUOUu+6oLDrXz0yOWY2YXvBLk8gQinx4HbZ7SF4V3HzasQf+ncoIbKENUMwXyf54/6dBkYXvXJos+gOHYZw==
+jest-cli@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-27.1.1.tgz#6491a0278231ffee61083ad468809328e96a8eb2"
+  integrity sha512-LCjfEYp9D3bcOeVUUpEol9Y1ijZYMWVqflSmtw/wX+6Fb7zP4IlO14/6s9v1pxsoM4Pn46+M2zABgKuQjyDpTw==
   dependencies:
-    "@jest/core" "^27.1.0"
-    "@jest/test-result" "^27.1.0"
-    "@jest/types" "^27.1.0"
+    "@jest/core" "^27.1.1"
+    "@jest/test-result" "^27.1.1"
+    "@jest/types" "^27.1.1"
     chalk "^4.0.0"
     exit "^0.1.2"
     graceful-fs "^4.2.4"
     import-local "^3.0.2"
-    jest-config "^27.1.0"
-    jest-util "^27.1.0"
-    jest-validate "^27.1.0"
+    jest-config "^27.1.1"
+    jest-util "^27.1.1"
+    jest-validate "^27.1.1"
     prompts "^2.0.1"
     yargs "^16.0.3"
 
-jest-config@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-27.1.0.tgz#e6826e2baaa34c07c3839af86466870e339d9ada"
-  integrity sha512-GMo7f76vMYUA3b3xOdlcKeKQhKcBIgurjERO2hojo0eLkKPGcw7fyIoanH+m6KOP2bLad+fGnF8aWOJYxzNPeg==
+jest-config@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-config/-/jest-config-27.1.1.tgz#cde823ad27f7ec0b9440035eabc75d4ac1ea024c"
+  integrity sha512-2iSd5zoJV4MsWPcLCGwUVUY/j6pZXm4Qd3rnbCtrd9EHNTg458iHw8PZztPQXfxKBKJxLfBk7tbZqYF8MGtxJA==
   dependencies:
     "@babel/core" "^7.1.0"
-    "@jest/test-sequencer" "^27.1.0"
-    "@jest/types" "^27.1.0"
-    babel-jest "^27.1.0"
+    "@jest/test-sequencer" "^27.1.1"
+    "@jest/types" "^27.1.1"
+    babel-jest "^27.1.1"
     chalk "^4.0.0"
     deepmerge "^4.2.2"
     glob "^7.1.1"
     graceful-fs "^4.2.4"
     is-ci "^3.0.0"
-    jest-circus "^27.1.0"
-    jest-environment-jsdom "^27.1.0"
-    jest-environment-node "^27.1.0"
+    jest-circus "^27.1.1"
+    jest-environment-jsdom "^27.1.1"
+    jest-environment-node "^27.1.1"
     jest-get-type "^27.0.6"
-    jest-jasmine2 "^27.1.0"
+    jest-jasmine2 "^27.1.1"
     jest-regex-util "^27.0.6"
-    jest-resolve "^27.1.0"
-    jest-runner "^27.1.0"
-    jest-util "^27.1.0"
-    jest-validate "^27.1.0"
+    jest-resolve "^27.1.1"
+    jest-runner "^27.1.1"
+    jest-util "^27.1.1"
+    jest-validate "^27.1.1"
     micromatch "^4.0.4"
-    pretty-format "^27.1.0"
+    pretty-format "^27.1.1"
 
-jest-diff@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.1.0.tgz#c7033f25add95e2218f3c7f4c3d7b634ab6b3cd2"
-  integrity sha512-rjfopEYl58g/SZTsQFmspBODvMSytL16I+cirnScWTLkQVXYVZfxm78DFfdIIXc05RCYuGjxJqrdyG4PIFzcJg==
+jest-diff@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.1.1.tgz#1d1629ca2e3933b10cb27dc260e28e3dba182684"
+  integrity sha512-m/6n5158rqEriTazqHtBpOa2B/gGgXJijX6nsEgZfbJ/3pxQcdpVXBe+FP39b1dxWHyLVVmuVXddmAwtqFO4Lg==
   dependencies:
     chalk "^4.0.0"
     diff-sequences "^27.0.6"
     jest-get-type "^27.0.6"
-    pretty-format "^27.1.0"
+    pretty-format "^27.1.1"
 
 jest-docblock@^27.0.6:
   version "27.0.6"
@@ -1474,53 +1474,53 @@ jest-docblock@^27.0.6:
   dependencies:
     detect-newline "^3.0.0"
 
-jest-each@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-27.1.0.tgz#36ac75f7aeecb3b8da2a8e617ccb30a446df408c"
-  integrity sha512-K/cNvQlmDqQMRHF8CaQ0XPzCfjP5HMJc2bIJglrIqI9fjwpNqITle63IWE+wq4p+3v+iBgh7Wq0IdGpLx5xjDg==
+jest-each@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-each/-/jest-each-27.1.1.tgz#caa1e7eed77144be346eb18712885b990389348a"
+  integrity sha512-r6hOsTLavUBb1xN0uDa89jdDeBmJ+K49fWpbyxeGRA2pLY46PlC4z551/cWNQzrj+IUa5/gSRsCIV/01HdNPug==
   dependencies:
-    "@jest/types" "^27.1.0"
+    "@jest/types" "^27.1.1"
     chalk "^4.0.0"
     jest-get-type "^27.0.6"
-    jest-util "^27.1.0"
-    pretty-format "^27.1.0"
+    jest-util "^27.1.1"
+    pretty-format "^27.1.1"
 
-jest-environment-jsdom@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-27.1.0.tgz#5fb3eb8a67e02e6cc623640388d5f90e33075f18"
-  integrity sha512-JbwOcOxh/HOtsj56ljeXQCUJr3ivnaIlM45F5NBezFLVYdT91N5UofB1ux2B1CATsQiudcHdgTaeuqGXJqjJYQ==
+jest-environment-jsdom@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-environment-jsdom/-/jest-environment-jsdom-27.1.1.tgz#e53e98a16e6a764b8ee8db3b29b3a8c27db06f66"
+  integrity sha512-6vOnoZ6IaExuw7FvnuJhA1qFYv1DDSnN0sQowzolNwxQp7bG1YhLxj2YU1sVXAYA3IR3MbH2mbnJUsLUWfyfzw==
   dependencies:
-    "@jest/environment" "^27.1.0"
-    "@jest/fake-timers" "^27.1.0"
-    "@jest/types" "^27.1.0"
+    "@jest/environment" "^27.1.1"
+    "@jest/fake-timers" "^27.1.1"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
-    jest-mock "^27.1.0"
-    jest-util "^27.1.0"
+    jest-mock "^27.1.1"
+    jest-util "^27.1.1"
     jsdom "^16.6.0"
 
-jest-environment-node@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-27.1.0.tgz#feea6b765f1fd4582284d4f1007df2b0a8d15b7f"
-  integrity sha512-JIyJ8H3wVyM4YCXp7njbjs0dIT87yhGlrXCXhDKNIg1OjurXr6X38yocnnbXvvNyqVTqSI4M9l+YfPKueqL1lw==
+jest-environment-node@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-environment-node/-/jest-environment-node-27.1.1.tgz#97425d4762b2aeab15892ffba08c6cbed7653e75"
+  integrity sha512-OEGeZh0PwzngNIYWYgWrvTcLygopV8OJbC9HNb0j70VBKgEIsdZkYhwcFnaURX83OHACMqf1pa9Tv5Pw5jemrg==
   dependencies:
-    "@jest/environment" "^27.1.0"
-    "@jest/fake-timers" "^27.1.0"
-    "@jest/types" "^27.1.0"
+    "@jest/environment" "^27.1.1"
+    "@jest/fake-timers" "^27.1.1"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
-    jest-mock "^27.1.0"
-    jest-util "^27.1.0"
+    jest-mock "^27.1.1"
+    jest-util "^27.1.1"
 
 jest-get-type@^27.0.6:
   version "27.0.6"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.0.6.tgz#0eb5c7f755854279ce9b68a9f1a4122f69047cfe"
   integrity sha512-XTkK5exIeUbbveehcSR8w0bhH+c0yloW/Wpl+9vZrjzztCPWrxhHwkIFpZzCt71oRBsgxmuUfxEqOYoZI2macg==
 
-jest-haste-map@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.1.0.tgz#a39f456823bd6a74e3c86ad25f6fa870428326bf"
-  integrity sha512-7mz6LopSe+eA6cTFMf10OfLLqRoIPvmMyz5/OnSXnHO7hB0aDP1iIeLWCXzAcYU5eIJVpHr12Bk9yyq2fTW9vg==
+jest-haste-map@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-27.1.1.tgz#f7c646b0e417ec29b80b96cf785b57b581384adf"
+  integrity sha512-NGLYVAdh5C8Ezg5QBFzrNeYsfxptDBPlhvZNaicLiZX77F/rS27a9M6u9ripWAaaD54xnWdZNZpEkdjD5Eo5aQ==
   dependencies:
-    "@jest/types" "^27.1.0"
+    "@jest/types" "^27.1.1"
     "@types/graceful-fs" "^4.1.2"
     "@types/node" "*"
     anymatch "^3.0.3"
@@ -1528,76 +1528,76 @@ jest-haste-map@^27.1.0:
     graceful-fs "^4.2.4"
     jest-regex-util "^27.0.6"
     jest-serializer "^27.0.6"
-    jest-util "^27.1.0"
-    jest-worker "^27.1.0"
+    jest-util "^27.1.1"
+    jest-worker "^27.1.1"
     micromatch "^4.0.4"
     walker "^1.0.7"
   optionalDependencies:
     fsevents "^2.3.2"
 
-jest-jasmine2@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.1.0.tgz#324a3de0b2ee20d238b2b5b844acc4571331a206"
-  integrity sha512-Z/NIt0wBDg3przOW2FCWtYjMn3Ip68t0SL60agD/e67jlhTyV3PIF8IzT9ecwqFbeuUSO2OT8WeJgHcalDGFzQ==
+jest-jasmine2@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-jasmine2/-/jest-jasmine2-27.1.1.tgz#efb9e7b70ce834c35c91e1a2f01bb41b462fad43"
+  integrity sha512-0LAzUmcmvQwjIdJt0cXUVX4G5qjVXE8ELt6nbMNDzv2yAs2hYCCUtQq+Eje70GwAysWCGcS64QeYj5VPHYVxPg==
   dependencies:
     "@babel/traverse" "^7.1.0"
-    "@jest/environment" "^27.1.0"
+    "@jest/environment" "^27.1.1"
     "@jest/source-map" "^27.0.6"
-    "@jest/test-result" "^27.1.0"
-    "@jest/types" "^27.1.0"
+    "@jest/test-result" "^27.1.1"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
     chalk "^4.0.0"
     co "^4.6.0"
-    expect "^27.1.0"
+    expect "^27.1.1"
     is-generator-fn "^2.0.0"
-    jest-each "^27.1.0"
-    jest-matcher-utils "^27.1.0"
-    jest-message-util "^27.1.0"
-    jest-runtime "^27.1.0"
-    jest-snapshot "^27.1.0"
-    jest-util "^27.1.0"
-    pretty-format "^27.1.0"
+    jest-each "^27.1.1"
+    jest-matcher-utils "^27.1.1"
+    jest-message-util "^27.1.1"
+    jest-runtime "^27.1.1"
+    jest-snapshot "^27.1.1"
+    jest-util "^27.1.1"
+    pretty-format "^27.1.1"
     throat "^6.0.1"
 
-jest-leak-detector@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-27.1.0.tgz#fe7eb633c851e06280ec4dd248067fe232c00a79"
-  integrity sha512-oHvSkz1E80VyeTKBvZNnw576qU+cVqRXUD3/wKXh1zpaki47Qty2xeHg2HKie9Hqcd2l4XwircgNOWb/NiGqdA==
+jest-leak-detector@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-leak-detector/-/jest-leak-detector-27.1.1.tgz#8e05ec4b339814fc4202f07d875da65189e3d7d4"
+  integrity sha512-gwSgzmqShoeEsEVpgObymQPrM9P6557jt1EsFW5aCeJ46Cme0EdjYU7xr6llQZ5GpWDl56eOstUaPXiZOfiTKw==
   dependencies:
     jest-get-type "^27.0.6"
-    pretty-format "^27.1.0"
+    pretty-format "^27.1.1"
 
-jest-matcher-utils@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.1.0.tgz#68afda0885db1f0b9472ce98dc4c535080785301"
-  integrity sha512-VmAudus2P6Yt/JVBRdTPFhUzlIN8DYJd+et5Rd9QDsO/Z82Z4iwGjo43U8Z+PTiz8CBvKvlb6Fh3oKy39hykkQ==
+jest-matcher-utils@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.1.1.tgz#1f444d7491ccf9edca746336b056178789a59651"
+  integrity sha512-Q1a10w9Y4sh0wegkdP6reQOa/Dtz7nAvDqBgrat1ItZAUvk4jzXAqyhXPu/ZuEtDaXaNKpdRPRQA8bvkOh2Eaw==
   dependencies:
     chalk "^4.0.0"
-    jest-diff "^27.1.0"
+    jest-diff "^27.1.1"
     jest-get-type "^27.0.6"
-    pretty-format "^27.1.0"
+    pretty-format "^27.1.1"
 
-jest-message-util@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-27.1.0.tgz#e77692c84945d1d10ef00afdfd3d2c20bd8fb468"
-  integrity sha512-Eck8NFnJ5Sg36R9XguD65cf2D5+McC+NF5GIdEninoabcuoOfWrID5qJhufq5FB0DRKoiyxB61hS7MKoMD0trQ==
+jest-message-util@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-27.1.1.tgz#980110fb72fcfa711cd9a95e8f10d335207585c6"
+  integrity sha512-b697BOJV93+AVGvzLRtVZ0cTVRbd59OaWnbB2D75GRaIMc4I+Z9W0wHxbfjW01JWO+TqqW4yevT0aN7Fd0XWng==
   dependencies:
     "@babel/code-frame" "^7.12.13"
-    "@jest/types" "^27.1.0"
+    "@jest/types" "^27.1.1"
     "@types/stack-utils" "^2.0.0"
     chalk "^4.0.0"
     graceful-fs "^4.2.4"
     micromatch "^4.0.4"
-    pretty-format "^27.1.0"
+    pretty-format "^27.1.1"
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
-jest-mock@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.1.0.tgz#7ca6e4d09375c071661642d1c14c4711f3ab4b4f"
-  integrity sha512-iT3/Yhu7DwAg/0HvvLCqLvrTKTRMyJlrrfJYWzuLSf9RCAxBoIXN3HoymZxMnYsC3eD8ewGbUa9jUknwBenx2w==
+jest-mock@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-27.1.1.tgz#c7a2e81301fdcf3dab114931d23d89ec9d0c3a82"
+  integrity sha512-SClsFKuYBf+6SSi8jtAYOuPw8DDMsTElUWEae3zq7vDhH01ayVSIHUSIa8UgbDOUalCFp6gNsaikN0rbxN4dbw==
   dependencies:
-    "@jest/types" "^27.1.0"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
 
 jest-pnp-resolver@^1.2.2:
@@ -1610,72 +1610,72 @@ jest-regex-util@^27.0.6:
   resolved "https://registry.yarnpkg.com/jest-regex-util/-/jest-regex-util-27.0.6.tgz#02e112082935ae949ce5d13b2675db3d8c87d9c5"
   integrity sha512-SUhPzBsGa1IKm8hx2F4NfTGGp+r7BXJ4CulsZ1k2kI+mGLG+lxGrs76veN2LF/aUdGosJBzKgXmNCw+BzFqBDQ==
 
-jest-resolve-dependencies@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-27.1.0.tgz#d32ea4a2c82f76410f6157d0ec6cde24fbff2317"
-  integrity sha512-Kq5XuDAELuBnrERrjFYEzu/A+i2W7l9HnPWqZEeKGEQ7m1R+6ndMbdXCVCx29Se1qwLZLgvoXwinB3SPIaitMQ==
+jest-resolve-dependencies@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-resolve-dependencies/-/jest-resolve-dependencies-27.1.1.tgz#6f3e0916c1764dd1853c6111ed9d66c66c792e40"
+  integrity sha512-sYZR+uBjFDCo4VhYeazZf/T+ryYItvdLKu9vHatqkUqHGjDMrdEPOykiqC2iEpaCFTS+3iL/21CYiJuKdRbniw==
   dependencies:
-    "@jest/types" "^27.1.0"
+    "@jest/types" "^27.1.1"
     jest-regex-util "^27.0.6"
-    jest-snapshot "^27.1.0"
+    jest-snapshot "^27.1.1"
 
-jest-resolve@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-27.1.0.tgz#bb22303c9e240cccdda28562e3c6fbcc6a23ac86"
-  integrity sha512-TXvzrLyPg0vLOwcWX38ZGYeEztSEmW+cQQKqc4HKDUwun31wsBXwotRlUz4/AYU/Fq4GhbMd/ileIWZEtcdmIA==
+jest-resolve@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-resolve/-/jest-resolve-27.1.1.tgz#3a86762f9affcad9697bc88140b0581b623add33"
+  integrity sha512-M41YFmWhvDVstwe7XuV21zynOiBLJB5Sk0GrIsYYgTkjfEWNLVXDjAyq1W7PHseaYNOxIc0nOGq/r5iwcZNC1A==
   dependencies:
-    "@jest/types" "^27.1.0"
+    "@jest/types" "^27.1.1"
     chalk "^4.0.0"
     escalade "^3.1.1"
     graceful-fs "^4.2.4"
-    jest-haste-map "^27.1.0"
+    jest-haste-map "^27.1.1"
     jest-pnp-resolver "^1.2.2"
-    jest-util "^27.1.0"
-    jest-validate "^27.1.0"
+    jest-util "^27.1.1"
+    jest-validate "^27.1.1"
     resolve "^1.20.0"
     slash "^3.0.0"
 
-jest-runner@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-27.1.0.tgz#1b28d114fb3b67407b8354c9385d47395e8ff83f"
-  integrity sha512-ZWPKr9M5w5gDplz1KsJ6iRmQaDT/yyAFLf18fKbb/+BLWsR1sCNC2wMT0H7pP3gDcBz0qZ6aJraSYUNAGSJGaw==
+jest-runner@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-runner/-/jest-runner-27.1.1.tgz#1991fdf13a8fe6e49cef47332db33300649357cd"
+  integrity sha512-lP3MBNQhg75/sQtVkC8dsAQZumvy3lHK/YIwYPfEyqGIX1qEcnYIRxP89q0ZgC5ngvi1vN2P5UFHszQxguWdng==
   dependencies:
-    "@jest/console" "^27.1.0"
-    "@jest/environment" "^27.1.0"
-    "@jest/test-result" "^27.1.0"
-    "@jest/transform" "^27.1.0"
-    "@jest/types" "^27.1.0"
+    "@jest/console" "^27.1.1"
+    "@jest/environment" "^27.1.1"
+    "@jest/test-result" "^27.1.1"
+    "@jest/transform" "^27.1.1"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
     chalk "^4.0.0"
     emittery "^0.8.1"
     exit "^0.1.2"
     graceful-fs "^4.2.4"
     jest-docblock "^27.0.6"
-    jest-environment-jsdom "^27.1.0"
-    jest-environment-node "^27.1.0"
-    jest-haste-map "^27.1.0"
-    jest-leak-detector "^27.1.0"
-    jest-message-util "^27.1.0"
-    jest-resolve "^27.1.0"
-    jest-runtime "^27.1.0"
-    jest-util "^27.1.0"
-    jest-worker "^27.1.0"
+    jest-environment-jsdom "^27.1.1"
+    jest-environment-node "^27.1.1"
+    jest-haste-map "^27.1.1"
+    jest-leak-detector "^27.1.1"
+    jest-message-util "^27.1.1"
+    jest-resolve "^27.1.1"
+    jest-runtime "^27.1.1"
+    jest-util "^27.1.1"
+    jest-worker "^27.1.1"
     source-map-support "^0.5.6"
     throat "^6.0.1"
 
-jest-runtime@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.1.0.tgz#1a98d984ffebc16a0b4f9eaad8ab47c00a750cf5"
-  integrity sha512-okiR2cpGjY0RkWmUGGado6ETpFOi9oG3yV0CioYdoktkVxy5Hv0WRLWnJFuArSYS8cHMCNcceUUMGiIfgxCO9A==
+jest-runtime@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-runtime/-/jest-runtime-27.1.1.tgz#bd0a0958a11c2f7d94d2e5f6f71864ad1c65fe44"
+  integrity sha512-FEwy+tSzmsvuKaQpyYsUyk31KG5vMmA2r2BSTHgv0yNfcooQdm2Ke91LM9Ud8D3xz8CLDHJWAI24haMFTwrsPg==
   dependencies:
-    "@jest/console" "^27.1.0"
-    "@jest/environment" "^27.1.0"
-    "@jest/fake-timers" "^27.1.0"
-    "@jest/globals" "^27.1.0"
+    "@jest/console" "^27.1.1"
+    "@jest/environment" "^27.1.1"
+    "@jest/fake-timers" "^27.1.1"
+    "@jest/globals" "^27.1.1"
     "@jest/source-map" "^27.0.6"
-    "@jest/test-result" "^27.1.0"
-    "@jest/transform" "^27.1.0"
-    "@jest/types" "^27.1.0"
+    "@jest/test-result" "^27.1.1"
+    "@jest/transform" "^27.1.1"
+    "@jest/types" "^27.1.1"
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
     cjs-module-lexer "^1.0.0"
@@ -1684,14 +1684,14 @@ jest-runtime@^27.1.0:
     exit "^0.1.2"
     glob "^7.1.3"
     graceful-fs "^4.2.4"
-    jest-haste-map "^27.1.0"
-    jest-message-util "^27.1.0"
-    jest-mock "^27.1.0"
+    jest-haste-map "^27.1.1"
+    jest-message-util "^27.1.1"
+    jest-mock "^27.1.1"
     jest-regex-util "^27.0.6"
-    jest-resolve "^27.1.0"
-    jest-snapshot "^27.1.0"
-    jest-util "^27.1.0"
-    jest-validate "^27.1.0"
+    jest-resolve "^27.1.1"
+    jest-snapshot "^27.1.1"
+    jest-util "^27.1.1"
+    jest-validate "^27.1.1"
     slash "^3.0.0"
     strip-bom "^4.0.0"
     yargs "^16.0.3"
@@ -1704,10 +1704,10 @@ jest-serializer@^27.0.6:
     "@types/node" "*"
     graceful-fs "^4.2.4"
 
-jest-snapshot@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-27.1.0.tgz#2a063ab90064017a7e9302528be7eaea6da12d17"
-  integrity sha512-eaeUBoEjuuRwmiRI51oTldUsKOohB1F6fPqWKKILuDi/CStxzp2IWekVUXbuHHoz5ik33ioJhshiHpgPFbYgcA==
+jest-snapshot@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-snapshot/-/jest-snapshot-27.1.1.tgz#3b816e0ca4352fbbd1db48dc692e3d9641d2531b"
+  integrity sha512-Wi3QGiuRFo3lU+EbQmZnBOks0CJyAMPHvYoG7iJk00Do10jeOyuOEO0Jfoaoun8+8TDv+Nzl7Aswir/IK9+1jg==
   dependencies:
     "@babel/core" "^7.7.2"
     "@babel/generator" "^7.7.2"
@@ -1715,79 +1715,79 @@ jest-snapshot@^27.1.0:
     "@babel/plugin-syntax-typescript" "^7.7.2"
     "@babel/traverse" "^7.7.2"
     "@babel/types" "^7.0.0"
-    "@jest/transform" "^27.1.0"
-    "@jest/types" "^27.1.0"
+    "@jest/transform" "^27.1.1"
+    "@jest/types" "^27.1.1"
     "@types/babel__traverse" "^7.0.4"
     "@types/prettier" "^2.1.5"
     babel-preset-current-node-syntax "^1.0.0"
     chalk "^4.0.0"
-    expect "^27.1.0"
+    expect "^27.1.1"
     graceful-fs "^4.2.4"
-    jest-diff "^27.1.0"
+    jest-diff "^27.1.1"
     jest-get-type "^27.0.6"
-    jest-haste-map "^27.1.0"
-    jest-matcher-utils "^27.1.0"
-    jest-message-util "^27.1.0"
-    jest-resolve "^27.1.0"
-    jest-util "^27.1.0"
+    jest-haste-map "^27.1.1"
+    jest-matcher-utils "^27.1.1"
+    jest-message-util "^27.1.1"
+    jest-resolve "^27.1.1"
+    jest-util "^27.1.1"
     natural-compare "^1.4.0"
-    pretty-format "^27.1.0"
+    pretty-format "^27.1.1"
     semver "^7.3.2"
 
-jest-util@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.1.0.tgz#06a53777a8cb7e4940ca8e20bf9c67dd65d9bd68"
-  integrity sha512-edSLD2OneYDKC6gZM1yc+wY/877s/fuJNoM1k3sOEpzFyeptSmke3SLnk1dDHk9CgTA+58mnfx3ew3J11Kes/w==
+jest-util@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-27.1.1.tgz#2b06db1391d779ec2bd406ab3690ddc56ac728b9"
+  integrity sha512-zf9nEbrASWn2mC/L91nNb0K+GkhFvi4MP6XJG2HqnHzHvLYcs7ou/In68xYU1i1dSkJlrWcYfWXQE8nVR+nbOA==
   dependencies:
-    "@jest/types" "^27.1.0"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
     chalk "^4.0.0"
     graceful-fs "^4.2.4"
     is-ci "^3.0.0"
     picomatch "^2.2.3"
 
-jest-validate@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-27.1.0.tgz#d9e82024c5e3f5cef52a600cfc456793a84c0998"
-  integrity sha512-QiJ+4XuSuMsfPi9zvdO//IrSRSlG6ybJhOpuqYSsuuaABaNT84h0IoD6vvQhThBOKT+DIKvl5sTM0l6is9+SRA==
+jest-validate@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-27.1.1.tgz#0783733af02c988d503995fc0a07bbdc58c7dd50"
+  integrity sha512-N5Er5FKav/8m2dJwn7BGnZwnoD1BSc8jx5T+diG2OvyeugvZDhPeAt5DrNaGkkaKCrSUvuE7A5E4uHyT7Vj0Mw==
   dependencies:
-    "@jest/types" "^27.1.0"
+    "@jest/types" "^27.1.1"
     camelcase "^6.2.0"
     chalk "^4.0.0"
     jest-get-type "^27.0.6"
     leven "^3.1.0"
-    pretty-format "^27.1.0"
+    pretty-format "^27.1.1"
 
-jest-watcher@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-27.1.0.tgz#2511fcddb0e969a400f3d1daa74265f93f13ce93"
-  integrity sha512-ivaWTrA46aHWdgPDgPypSHiNQjyKnLBpUIHeBaGg11U+pDzZpkffGlcB1l1a014phmG0mHgkOHtOgiqJQM6yKQ==
+jest-watcher@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-27.1.1.tgz#a8147e18703b5d753ada4b287451f2daf40f4118"
+  integrity sha512-XQzyHbxziDe+lZM6Dzs40fEt4q9akOGwitJnxQasJ9WG0bv3JGiRlsBgjw13znGapeMtFaEsyhL0Cl04IbaoWQ==
   dependencies:
-    "@jest/test-result" "^27.1.0"
-    "@jest/types" "^27.1.0"
+    "@jest/test-result" "^27.1.1"
+    "@jest/types" "^27.1.1"
     "@types/node" "*"
     ansi-escapes "^4.2.1"
     chalk "^4.0.0"
-    jest-util "^27.1.0"
+    jest-util "^27.1.1"
     string-length "^4.0.1"
 
-jest-worker@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.1.0.tgz#65f4a88e37148ed984ba8ca8492d6b376938c0aa"
-  integrity sha512-mO4PHb2QWLn9yRXGp7rkvXLAYuxwhq1ZYUo0LoDhg8wqvv4QizP1ZWEJOeolgbEgAWZLIEU0wsku8J+lGWfBhg==
+jest-worker@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.1.1.tgz#eb5f05c4657fdcb702c36c48b20d785bd4599378"
+  integrity sha512-XJKCL7tu+362IUYTWvw8+3S75U7qMiYiRU6u5yqscB48bTvzwN6i8L/7wVTXiFLwkRsxARNM7TISnTvcgv9hxA==
   dependencies:
     "@types/node" "*"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-27.1.0.tgz#eaab62dfdc02d8b7c814cd27b8d2d92bc46d3d69"
-  integrity sha512-pSQDVwRSwb109Ss13lcMtdfS9r8/w2Zz8+mTUA9VORD66GflCdl8nUFCqM96geOD2EBwWCNURrNAfQsLIDNBdg==
+jest@27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-27.1.1.tgz#49f0497fa0fb07dc78898318cc1b737b5fbf72d8"
+  integrity sha512-LFTEZOhoZNR/2DQM3OCaK5xC6c55c1OWhYh0njRsoHX0qd6x4nkcgenkSH0JKjsAGMTmmJAoL7/oqYHMfwhruA==
   dependencies:
-    "@jest/core" "^27.1.0"
+    "@jest/core" "^27.1.1"
     import-local "^3.0.2"
-    jest-cli "^27.1.0"
+    jest-cli "^27.1.1"
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -2094,12 +2094,12 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-pretty-format@^27.1.0:
-  version "27.1.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.1.0.tgz#022f3fdb19121e0a2612f3cff8d724431461b9ca"
-  integrity sha512-4aGaud3w3rxAO6OXmK3fwBFQ0bctIOG3/if+jYEFGNGIs0EvuidQm3bZ9mlP2/t9epLNC/12czabfy7TZNSwVA==
+pretty-format@^27.1.1:
+  version "27.1.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.1.1.tgz#cbaf9ec6cd7cfc3141478b6f6293c0ccdbe968e0"
+  integrity sha512-zdBi/xlstKJL42UH7goQti5Hip/B415w1Mfj+WWWYMBylAYtKESnXGUtVVcMVid9ReVjypCotUV6CEevYPHv2g==
   dependencies:
-    "@jest/types" "^27.1.0"
+    "@jest/types" "^27.1.1"
     ansi-regex "^5.0.0"
     ansi-styles "^5.0.0"
     react-is "^17.0.1"

--- a/scripts/release/yarn.lock
+++ b/scripts/release/yarn.lock
@@ -387,7 +387,7 @@
     jest-mock "^27.1.1"
     jest-util "^27.1.1"
 
-"@jest/globals@^27.1.1":
+"@jest/globals@27.1.1", "@jest/globals@^27.1.1":
   version "27.1.1"
   resolved "https://registry.yarnpkg.com/@jest/globals/-/globals-27.1.1.tgz#cfe5f4d5b37483cef62b79612128ccc7e3c951d8"
   integrity sha512-Q3JcTPmY+DAEHnr4MpnBV3mwy50EGrTC6oSDTNnW7FNGGacTJAfpWNk02D7xv422T1OzK2A2BKx+26xJOvHkyw==


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Currently, release script outputs an URL to create release on GitHub. Like `https://github.com/prettier/prettier/releases/new?tag=2.4.0`.  This is very useful. 

However we can add more info to the URL as query parameters. (ref: https://docs.github.com/en/repositories/releasing-projects-on-github/automation-for-release-forms-with-query-parameters)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
