### PR TITLE
Revert workaround for node 16.9

### DIFF
--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -18,13 +18,13 @@ jobs:
           - "macos-latest"
           - "windows-latest"
         node:
-          - "16.8.0"
+          - "16"
           - "14"
           - "12"
         include:
           # only enable coverage on the fastest job
           - os: "ubuntu-latest"
-            node: "16.8.0"
+            node: "16"
             ENABLE_CODE_COVERAGE: true
             FULL_TEST: true
             CHECK_TEST_PARSERS: true

--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -88,13 +88,13 @@ jobs:
           - "macos-latest"
           - "windows-latest"
         node:
-          - "16.8.0"
+          - "16"
           - "14"
           - "12"
           - "10"
         include:
           - os: "ubuntu-latest"
-            node: "16.8.0"
+            node: "16"
             FULL_TEST: true
         exclude:
           - os: "macos-latest"


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Node.js 16.9.1 is released https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V16.md#16.9.1

Revert #11470

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
