### PR TITLE
Remove `PipelineTopicExpression` and `PipelinePrimaryTopicReference`

### DIFF
--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -218,10 +218,7 @@ function needsParens(path, options) {
       }
 
     case "BinaryExpression": {
-      if (
-        parent.type === "UpdateExpression" ||
-        (parent.type === "PipelineTopicExpression" && node.operator === "|>")
-      ) {
+      if (parent.type === "UpdateExpression") {
         return true;
       }
 
@@ -367,16 +364,6 @@ function needsParens(path, options) {
       ) {
         return true;
       }
-
-      if (
-        name === "expression" &&
-        node.argument &&
-        node.argument.type === "PipelinePrimaryTopicReference" &&
-        parent.type === "PipelineTopicExpression"
-      ) {
-        return true;
-      }
-
     // else fallthrough
     case "AwaitExpression":
       switch (parent.type) {
@@ -646,9 +633,6 @@ function needsParens(path, options) {
 
     case "ArrowFunctionExpression":
       switch (parent.type) {
-        case "PipelineTopicExpression":
-          return Boolean(node.extra && node.extra.parenthesized);
-
         case "BinaryExpression":
           return (
             parent.operator !== "|>" || (node.extra && node.extra.parenthesized)


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
`PipelineTopicExpression` and `PipelinePrimaryTopicReference` are nodes for Smart Pipeline Operator.  But now we have not supported it ([blog](https://prettier.io/blog/2021/09/09/2.4.0.html#support-hack-style-pipeline-proposal-11335httpsgithubcomprettierprettierpull11335-by-sosukesuzukihttpsgithubcomsosukesuzuki)).

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
