### PR TITLE
Support right precedence hack-style pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@angular/compiler": "12.2.6",
     "@babel/code-frame": "7.14.5",
-    "@babel/parser": "7.15.5",
+    "@babel/parser": "7.15.7",
     "@glimmer/syntax": "0.80.0",
     "@iarna/toml": "2.2.5",
     "@typescript-eslint/typescript-estree": "4.31.1",

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -320,7 +320,7 @@ function needsParens(path, options) {
 
           if (
             parentPrecedence === precedence &&
-            !shouldFlatten(parentOperator, operator, options)
+            !shouldFlatten(parentOperator, operator)
           ) {
             return true;
           }

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -229,17 +229,6 @@ function needsParens(path, options) {
         return true;
       }
 
-      // Hack-style pipeline operators are right-associative
-      if (
-        name === "right" &&
-        node.operator === "|>" &&
-        parent.type === "BinaryExpression" &&
-        parent.operator === "|>" &&
-        isEnabledHackPipeline(options)
-      ) {
-        return false;
-      }
-
       if (node.operator === "|>" && node.extra && node.extra.parenthesized) {
         const grandParent = path.getParentNode(1);
         if (

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -14,7 +14,6 @@ const {
   isCallExpression,
   isMemberExpression,
   isObjectProperty,
-  isEnabledHackPipeline,
 } = require("./utils.js");
 
 function needsParens(path, options) {

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -228,7 +228,6 @@ function needsParens(path, options) {
       if (node.operator === "in" && isPathInForStatementInitializer(path)) {
         return true;
       }
-
       if (node.operator === "|>" && node.extra && node.extra.parenthesized) {
         const grandParent = path.getParentNode(1);
         if (

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -140,9 +140,10 @@ function createParse(parseMethod, ...optionsCombinations) {
     }
 
     const { result: ast, error } = tryCombinations(
-      ...combinations.map(
-        (options) => () => parseWithOptions(parseMethod, text, options)
-      )
+      ...combinations.map((options) => () => {
+        opts[Symbol.for("babelParserPlugins")] = options.plugins;
+        return parseWithOptions(parseMethod, text, options);
+      })
     );
 
     if (!ast) {

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -140,17 +140,17 @@ function createParse(parseMethod, ...optionsCombinations) {
     }
 
     const { result: ast, error } = tryCombinations(
-      ...combinations.map((options) => () => {
-        opts[Symbol.for("babelParserPlugins")] = options.plugins;
-        return parseWithOptions(parseMethod, text, options);
-      })
+      ...combinations.map(
+        (options) => () => parseWithOptions(parseMethod, text, options)
+      )
     );
 
     if (!ast) {
       throw createBabelParseError(error);
     }
 
-    return postprocess(ast, { ...opts, originalText: text });
+    opts.originalText = text;
+    return postprocess(ast, opts);
   };
 }
 

--- a/src/language-js/parse/postprocess.js
+++ b/src/language-js/parse/postprocess.js
@@ -152,6 +152,10 @@ function postprocess(ast, options) {
           node.optional = true;
         }
         break;
+      // For hack-style pipeline
+      case "TopicReference":
+        options.__isUsingHackPipeline = true;
+        break;
     }
   });
 

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -117,8 +117,7 @@ function printBinaryishExpression(path, options, print) {
     isObjectProperty(parent);
 
   const samePrecedenceSubExpression =
-    isBinaryish(node.left) &&
-    shouldFlatten(node.operator, node.left.operator, options);
+    isBinaryish(node.left) && shouldFlatten(node.operator, node.left.operator);
 
   if (
     shouldNotIndent ||
@@ -213,7 +212,7 @@ function printBinaryishExpressions(
   // precedence level and should be treated as a separate group, so
   // print them normally. (This doesn't hold for the `**` operator,
   // which is unique in that it is right-associative.)
-  if (shouldFlatten(node.operator, node.left.operator, options)) {
+  if (shouldFlatten(node.operator, node.left.operator)) {
     // Flatten them out by recursively calling this function.
     parts = path.call(
       (left) =>

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -110,7 +110,8 @@ function printBinaryishExpression(path, options, print) {
     isObjectProperty(parent);
 
   const samePrecedenceSubExpression =
-    isBinaryish(node.left) && shouldFlatten(node.operator, node.left.operator);
+    isBinaryish(node.left) &&
+    shouldFlatten(node.operator, node.left.operator, options);
 
   if (
     shouldNotIndent ||
@@ -205,7 +206,7 @@ function printBinaryishExpressions(
   // precedence level and should be treated as a separate group, so
   // print them normally. (This doesn't hold for the `**` operator,
   // which is unique in that it is right-associative.)
-  if (shouldFlatten(node.operator, node.left.operator)) {
+  if (shouldFlatten(node.operator, node.left.operator, options)) {
     // Flatten them out by recursively calling this function.
     parts = path.call(
       (left) =>

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -67,7 +67,7 @@ function printBinaryishExpression(path, options, print) {
   }
 
   if (isHackPipeline) {
-    // return something
+    return parts;
   }
 
   // Break between the parens in

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -25,6 +25,7 @@ const {
   isCallExpression,
   isMemberExpression,
   isObjectProperty,
+  isEnabledHackPipeline,
 } = require("../utils.js");
 
 /** @typedef {import("../../document").Doc} Doc */
@@ -40,6 +41,8 @@ function printBinaryishExpression(path, options, print) {
       parent.type === "WhileStatement" ||
       parent.type === "SwitchStatement" ||
       parent.type === "DoWhileStatement");
+  const isHackPipeline =
+    isEnabledHackPipeline(options) && node.operator === "|>";
 
   const parts = printBinaryishExpressions(
     path,
@@ -61,6 +64,10 @@ function printBinaryishExpression(path, options, print) {
   //   ) {
   if (isInsideParenthesis) {
     return parts;
+  }
+
+  if (isHackPipeline) {
+    // return something
   }
 
   // Break between the parens in

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -1310,6 +1310,17 @@ function isObjectProperty(node) {
   );
 }
 
+function isEnabledHackPipeline(options) {
+  const babelParserPlugins = options[Symbol.for("babelParserPlugins")];
+  const lastPlugin =
+    Array.isArray(babelParserPlugins) && getLast(babelParserPlugins);
+  const enabledHackPipeline =
+    Array.isArray(lastPlugin) &&
+    lastPlugin[0] === "pipelineOperator" &&
+    lastPlugin[1].proposal === "hack";
+  return enabledHackPipeline;
+}
+
 module.exports = {
   getFunctionParameters,
   iterateFunctionParametersPath,
@@ -1331,6 +1342,7 @@ module.exports = {
   isBinaryish,
   isBlockComment,
   isCallLikeExpression,
+  isEnabledHackPipeline,
   isLineComment,
   isPrettierIgnoreComment,
   isCallExpression,

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -1040,7 +1040,7 @@ const bitshiftOperators = {
   "<<": true,
 };
 
-function shouldFlatten(parentOp, nodeOp) {
+function shouldFlatten(parentOp, nodeOp, options) {
   if (getPrecedence(nodeOp) !== getPrecedence(parentOp)) {
     return false;
   }
@@ -1076,6 +1076,11 @@ function shouldFlatten(parentOp, nodeOp) {
 
   // x << y << z --> (x << y) << z
   if (bitshiftOperators[parentOp] && bitshiftOperators[nodeOp]) {
+    return false;
+  }
+
+  // Hack-style pipeline operators are right-associative
+  if (isEnabledHackPipeline(options) && parentOp === "|>" && nodeOp === "|>") {
     return false;
   }
 

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -1040,7 +1040,7 @@ const bitshiftOperators = {
   "<<": true,
 };
 
-function shouldFlatten(parentOp, nodeOp, options) {
+function shouldFlatten(parentOp, nodeOp) {
   if (getPrecedence(nodeOp) !== getPrecedence(parentOp)) {
     return false;
   }
@@ -1076,11 +1076,6 @@ function shouldFlatten(parentOp, nodeOp, options) {
 
   // x << y << z --> (x << y) << z
   if (bitshiftOperators[parentOp] && bitshiftOperators[nodeOp]) {
-    return false;
-  }
-
-  // Hack-style pipeline operators are right-associative
-  if (isEnabledHackPipeline(options) && parentOp === "|>" && nodeOp === "|>") {
     return false;
   }
 

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -1311,14 +1311,7 @@ function isObjectProperty(node) {
 }
 
 function isEnabledHackPipeline(options) {
-  const babelParserPlugins = options[Symbol.for("babelParserPlugins")];
-  const lastPlugin =
-    Array.isArray(babelParserPlugins) && getLast(babelParserPlugins);
-  const enabledHackPipeline =
-    Array.isArray(lastPlugin) &&
-    lastPlugin[0] === "pipelineOperator" &&
-    lastPlugin[1].proposal === "hack";
-  return enabledHackPipeline;
+  return Boolean(options.__isUsingHackPipeline);
 }
 
 module.exports = {

--- a/tests/format/js/pipeline-operator/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/pipeline-operator/__snapshots__/jsfmt.spec.js.snap
@@ -240,14 +240,14 @@ async function * f () {
 a |> (await %) |> % * 3;
 
 foo
-  |> (await %)
-  |> % || throw new Error(\`foo \${bar1}\`)
-  |> bar2(%, ", ")
-  |> bar3(%)
-  |> % + "!"
-  |> new Bar.Foo(%)
-  |> (await bar.bar(%))
-  |> console.log(%);
+|> (await %)
+|> % || throw new Error(\`foo \${bar1}\`)
+|> bar2(%, ", ")
+|> bar3(%)
+|> % + "!"
+|> new Bar.Foo(%)
+|> (await bar.bar(%))
+|> console.log(%);
 
 const result = "hello" |> doubleSay(%) |> capitalize(%, "foo") |> exclaim(%);
 

--- a/tests/format/misc/errors/js/hack-pipeline/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/js/hack-pipeline/__snapshots__/jsfmt.spec.js.snap
@@ -55,7 +55,7 @@ exports[`snippet: #8 [babel] format 1`] = `
 `;
 
 exports[`snippet: #9 [babel] format 1`] = `
-"Unexpected yield after pipeline body; any yield expression acting as Hack-style pipe body must be parenthesized due to its loose operator precedence. (1:39)
+"Hack-style pipe body cannot be an unparenthesized yield expression; please wrap it in parentheses. (1:39)
 > 1 | async function * a() { a |> foo(%) |> yield}
     |                                       ^"
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -281,10 +281,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.15.5", "@babel/parser@^7.1.0", "@babel/parser@^7.15.4", "@babel/parser@^7.15.5", "@babel/parser@^7.7.2":
-  version "7.15.5"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.5.tgz#d33a58ca69facc05b26adfe4abebfed56c1c2dac"
-  integrity sha512-2hQstc6I7T6tQsWzlboMh3SgMRPaS4H6H7cPQsJkdzTzEGqQrpLDsE2BGASU5sBPoEQyHzeqU6C8uKbFeEk6sg==
+"@babel/parser@7.15.7", "@babel/parser@^7.1.0", "@babel/parser@^7.15.4", "@babel/parser@^7.15.5", "@babel/parser@^7.7.2":
+  version "7.15.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.7.tgz#0c3ed4a2eb07b165dfa85b3cc45c727334c4edae"
+  integrity sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.15.4":
   version "7.15.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -281,10 +281,15 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.15.7", "@babel/parser@^7.1.0", "@babel/parser@^7.15.4", "@babel/parser@^7.15.5", "@babel/parser@^7.7.2":
+"@babel/parser@7.15.7":
   version "7.15.7"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.7.tgz#0c3ed4a2eb07b165dfa85b3cc45c727334c4edae"
   integrity sha512-rycZXvQ+xS9QyIcJ9HXeDWf1uxqlbVFAUq0Rq0dbc50Zb/+wUe/ehyfzGfm9KZZF0kBejYgxltBXocP+gKdL2g==
+
+"@babel/parser@^7.1.0", "@babel/parser@^7.15.4", "@babel/parser@^7.15.5", "@babel/parser@^7.7.2":
+  version "7.15.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.15.6.tgz#043b9aa3c303c0722e5377fef9197f4cf1796549"
+  integrity sha512-S/TSCcsRuCkmpUuoWijua0Snt+f3ewU/8spLo+4AXJCZfT0bVCzLD5MuOKdrx0mlAptbKzn5AdgEIIKXxXkz9Q==
 
 "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@^7.15.4":
   version "7.15.4"


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Hack-style pipeline operators are right-associative. `babel/parser@7.15.5` treats it as left-associative, `babel/parser@7.15.6` treats it as right-associative.

ref: https://github.com/babel/babel/pull/13668
ref: https://github.com/babel/babel/pull/13668#issuecomment-896965830

Clsoes #11540

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
