### PR TITLE
Refactor and use `getPreferredQuote` in both jsx and handlebars printers

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -345,18 +345,19 @@ function getIndentSize(value, tabWidth) {
  *
  * @param {string} raw
  * @param {Quote} preferredQuote
- * @returns {Quote}
+ * @returns {{ quote: Quote, regex: RegExp, escaped: string }}
  */
+
 function getPreferredQuote(rawContent, preferredQuote) {
-  /** @type {{ quote: '"', regex: RegExp }} */
-  const double = { quote: '"', regex: /"/g };
-  /** @type {{ quote: "'", regex: RegExp }} */
-  const single = { quote: "'", regex: /'/g };
+  /** @type {{ quote: '"', regex: RegExp, escaped: "&quot;" }} */
+  const double = { quote: '"', regex: /"/g, escaped: "&quot;" };
+  /** @type {{ quote: "'", regex: RegExp, escaped: "&apos;" }} */
+  const single = { quote: "'", regex: /'/g, escaped: "&apos;" };
 
   const preferred = preferredQuote === "'" ? single : double;
   const alternate = preferred === single ? double : single;
 
-  let result = preferred.quote;
+  let result = preferred;
 
   // If `rawContent` contains at least one of the quote preferred for enclosing
   // the string, we might want to enclose with the alternate quote instead, to
@@ -368,10 +369,7 @@ function getPreferredQuote(rawContent, preferredQuote) {
     const numPreferredQuotes = (rawContent.match(preferred.regex) || []).length;
     const numAlternateQuotes = (rawContent.match(alternate.regex) || []).length;
 
-    result =
-      numPreferredQuotes > numAlternateQuotes
-        ? alternate.quote
-        : preferred.quote;
+    result = numPreferredQuotes > numAlternateQuotes ? alternate : preferred;
   }
 
   return result;
@@ -391,7 +389,7 @@ function printString(raw, options) {
       ? '"'
       : options.__isInHtmlAttribute
       ? "'"
-      : getPreferredQuote(rawContent, options.singleQuote ? "'" : '"');
+      : getPreferredQuote(rawContent, options.singleQuote ? "'" : '"').quote;
 
   // It might sound unnecessary to use `makeString` even if the string already
   // is enclosed with `enclosingQuote`, but it isn't. The string could contain

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -343,7 +343,7 @@ function getIndentSize(value, tabWidth) {
 
 /**
  *
- * @param {string} raw
+ * @param {string} rawContent
  * @param {Quote} preferredQuote
  * @returns {{ quote: Quote, regex: RegExp, escaped: string }}
  */

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -347,11 +347,7 @@ function getIndentSize(value, tabWidth) {
  * @param {Quote} preferredQuote
  * @returns {Quote}
  */
-function getPreferredQuote(raw, preferredQuote) {
-  // `rawContent` is the string exactly like it appeared in the input source
-  // code, without its enclosing quotes.
-  const rawContent = raw.slice(1, -1);
-
+function getPreferredQuote(rawContent, preferredQuote) {
   /** @type {{ quote: '"', regex: RegExp }} */
   const double = { quote: '"', regex: /"/g };
   /** @type {{ quote: "'", regex: RegExp }} */
@@ -395,7 +391,7 @@ function printString(raw, options) {
       ? '"'
       : options.__isInHtmlAttribute
       ? "'"
-      : getPreferredQuote(raw, options.singleQuote ? "'" : '"');
+      : getPreferredQuote(rawContent, options.singleQuote ? "'" : '"');
 
   // It might sound unnecessary to use `makeString` even if the string already
   // is enclosed with `enclosingQuote`, but it isn't. The string could contain

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -47,6 +47,8 @@ function print(path, options, print) {
     return options.originalText.slice(locStart(node), locEnd(node));
   }
 
+  const favoriteQuote = options.singleQuote ? "'" : '"';
+
   switch (node.type) {
     case "Block":
     case "Program":
@@ -150,7 +152,6 @@ function print(path, options, print) {
         return node.name;
       }
 
-      const favoriteQuote = options.singleQuote ? "'" : '"';
       // Let's assume quotes inside the content of text nodes are already
       // properly escaped with entities, otherwise the parse wouldn't have parsed them.
       const quote = isText
@@ -398,7 +399,7 @@ function print(path, options, print) {
       return ["<!--", node.value, "-->"];
     }
     case "StringLiteral": {
-      return printStringLiteral(node.value, options);
+      return printStringLiteral(node.value, favoriteQuote);
     }
     case "NumberLiteral": {
       return String(node.value);
@@ -699,10 +700,9 @@ function generateHardlines(number = 0) {
  * in `common/util`, but has differences because of the way escaped characters
  * are treated in hbs string literals.
  * @param {string} stringLiteral - the string literal value
- * @param {object} options - the prettier options object
+ * @param {string} favoriteQuote - the user's preferred quote: `'` or `"`
  */
-function printStringLiteral(stringLiteral, options) {
-  const favoriteQuote = options.singleQuote ? "'" : '"';
+function printStringLiteral(stringLiteral, favoriteQuote) {
   const { quote, regex } = getPreferredQuote(stringLiteral, favoriteQuote);
   return [quote, stringLiteral.replace(regex, `\\${quote}`), quote];
 }

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -693,6 +693,8 @@ function generateHardlines(number = 0) {
 
 /* StringLiteral print helpers */
 
+/** @typedef {import("../common/util").Quote} Quote */
+
 /**
  * Prints a string literal with the correct surrounding quotes based on
  * `options.singleQuote` and the number of escaped quotes contained in
@@ -700,7 +702,7 @@ function generateHardlines(number = 0) {
  * in `common/util`, but has differences because of the way escaped characters
  * are treated in hbs string literals.
  * @param {string} stringLiteral - the string literal value
- * @param {string} favoriteQuote - the user's preferred quote: `'` or `"`
+ * @param {Quote} favoriteQuote - the user's preferred quote: `'` or `"`
  */
 function printStringLiteral(stringLiteral, favoriteQuote) {
   const { quote, regex } = getPreferredQuote(stringLiteral, favoriteQuote);

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -481,8 +481,9 @@ function printJsxAttribute(path, options, print) {
       const raw = rawText(node.value);
       // Unescape all quotes so we get an accurate preferred quote
       let final = raw.replace(/&apos;/g, "'").replace(/&quot;/g, '"');
+
       const quote = getPreferredQuote(
-        final,
+        final.slice(1, -1), // remove enclosing quotes
         options.jsxSingleQuote ? "'" : '"'
       );
       const escape = quote === "'" ? "&apos;" : "&quot;";

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -479,11 +479,12 @@ function printJsxAttribute(path, options, print) {
     let res;
     if (isStringLiteral(node.value)) {
       const raw = rawText(node.value);
-      // Unescape all quotes so we get an accurate preferred quote
+      // Remove enclosing quotes and unescape
+      // all quotes so we get an accurate preferred quote
       let final = raw
+        .slice(1, -1)
         .replace(/&apos;/g, "'")
-        .replace(/&quot;/g, '"')
-        .slice(1, -1); // remove enclosing quotes
+        .replace(/&quot;/g, '"');
       const { escaped, quote, regex } = getPreferredQuote(
         final,
         options.jsxSingleQuote ? "'" : '"'

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -480,14 +480,15 @@ function printJsxAttribute(path, options, print) {
     if (isStringLiteral(node.value)) {
       const raw = rawText(node.value);
       // Unescape all quotes so we get an accurate preferred quote
-      let final = raw.replace(/&apos;/g, "'").replace(/&quot;/g, '"');
-
-      const quote = getPreferredQuote(
-        final.slice(1, -1), // remove enclosing quotes
+      let final = raw
+        .replace(/&apos;/g, "'")
+        .replace(/&quot;/g, '"')
+        .slice(1, -1); // remove enclosing quotes
+      const { escaped, quote, regex } = getPreferredQuote(
+        final,
         options.jsxSingleQuote ? "'" : '"'
       );
-      const escape = quote === "'" ? "&apos;" : "&quot;";
-      final = final.slice(1, -1).replace(new RegExp(quote, "g"), escape);
+      final = final.replace(regex, escaped);
       res = [quote, final, quote];
     } else {
       res = print("value");


### PR DESCRIPTION
## Description

Later on we will be able to use it in HTML's printer (https://github.com/prettier/prettier/pull/11559#discussion_r713525169).

The changes to the `getPreferredQuote`'s arguments and return statement would be possible because it is not exposed (as it is not in the file `src/common/util-shared.js`).

The review should be easier commit by commit.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
