### PR TITLE
[editorconfig] Turn off trim_trailing_whitespace in Markdown in root or changelog_unreleased

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ insert_final_newline = true
 indent_size = 4
 insert_final_newline = false
 
-[website/blog/*.md]
+[{,website/blog/,changelog_unreleased/**/}*.md]
 trim_trailing_whitespace = false
 
 [tests/{**/__snapshots__/*, tests/format/**/*}]


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

When EditorConfig is enabled in your text editor, you cannot use line breaking by adding two whitespaces at the end of lines in Markdown files in the project root or `changelog_unreleased`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
