### PR TITLE
Allow expressions in Markdown in JavaScript

### DIFF
--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -76,12 +76,10 @@ function embed(path, print, textToDoc, options) {
  * markdown`...`
  */
 function isMarkdown(path) {
-  const node = path.getValue();
   const parent = path.getParentNode();
   return (
     parent &&
     parent.type === "TaggedTemplateExpression" &&
-    node.quasis.length === 1 &&
     parent.tag.type === "Identifier" &&
     (parent.tag.name === "md" || parent.tag.name === "markdown")
   );

--- a/tests/format/js/multiparser-comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/multiparser-comments/__snapshots__/jsfmt.spec.js.snap
@@ -116,10 +116,12 @@ css\`
   }
 \`;
 
-markdown\`\${
+markdown\`
+\${
   foo
   /* comment */
-}\`;
+}
+\`;
 markdown\`
 \${
   foo


### PR DESCRIPTION
## Description

We currently support Markdown in JavaScript tagged templates (`` md`*text*` ``) but only if they don't contain expressions, i.e. we ignore `` md`*${text}*` ``. This is unlike our other JavaScript tagged template languages which work with and without expressions.

This PR drops the condition that Markdown tagged templates don't contain expressions (`node.quasis.length === 1`) and implements support for expressions, following the existing HTML tagged templates pattern.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
