### PR TITLE
Enable `jest/prefer-to-be`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -173,6 +173,7 @@ module.exports = {
             alwaysAwait: true,
           },
         ],
+        "jest/prefer-to-be": "error",
       },
     },
     {

--- a/tests/integration/__tests__/infer-parser.js
+++ b/tests/integration/__tests__/infer-parser.js
@@ -181,7 +181,7 @@ describe("API with no path and no parser", () => {
   });
 
   test("prettier.format", () => {
-    expect(prettier.format(" foo  (  )")).toEqual("foo();\n");
+    expect(prettier.format(" foo  (  )")).toBe("foo();\n");
     expect(global.console.warn).toHaveBeenCalledTimes(1);
     expect(global.console.warn.mock.calls[0]).toMatchSnapshot();
   });

--- a/tests/integration/__tests__/loglevel.js
+++ b/tests/integration/__tests__/loglevel.js
@@ -47,7 +47,7 @@ async function runPrettierWithLogLevel(logLevel, patterns) {
     "not-found.js",
   ]);
 
-  expect(await result.status).toEqual(2);
+  expect(await result.status).toBe(2);
 
   const stderr = stripAnsi(await result.stderr);
 

--- a/tests/integration/__tests__/parser-api.js
+++ b/tests/integration/__tests__/parser-api.js
@@ -6,7 +6,7 @@ const runPrettier = require("../runPrettier.js");
 test("allows custom parser provided as object", () => {
   const output = prettier.format("1", {
     parser(text) {
-      expect(text).toEqual("1");
+      expect(text).toBe("1");
       return {
         type: "Literal",
         value: 2,
@@ -14,19 +14,19 @@ test("allows custom parser provided as object", () => {
       };
     },
   });
-  expect(output).toEqual("2");
+  expect(output).toBe("2");
 });
 
 test("allows usage of prettier's supported parsers", () => {
   const output = prettier.format("foo ( )", {
     parser(text, parsers) {
-      expect(typeof parsers.babel).toEqual("function");
+      expect(typeof parsers.babel).toBe("function");
       const ast = parsers.babel(text);
       ast.program.body[0].expression.callee.name = "bar";
       return ast;
     },
   });
-  expect(output).toEqual("bar();\n");
+  expect(output).toBe("bar();\n");
 });
 
 test("allows add empty `trailingComments` array", () => {
@@ -43,7 +43,7 @@ test("allows add empty `trailingComments` array", () => {
       return ast;
     },
   });
-  expect(output).toEqual("foo(/* comment */);\n");
+  expect(output).toBe("foo(/* comment */);\n");
 });
 
 describe("allows passing a string to resolve a parser", () => {

--- a/tests/integration/__tests__/third-party.js
+++ b/tests/integration/__tests__/third-party.js
@@ -64,5 +64,5 @@ describe("cosmiconfig", () => {
 });
 
 test("isCI", () => {
-  expect(typeof isCI()).toEqual("boolean");
+  expect(typeof isCI()).toBe("boolean");
 });

--- a/tests/integration/__tests__/util-shared.js
+++ b/tests/integration/__tests__/util-shared.js
@@ -3,35 +3,35 @@
 const sharedUtil = require("../../../src/common/util-shared.js");
 
 test("shared util has correct structure", () => {
-  expect(typeof sharedUtil.getMaxContinuousCount).toEqual("function");
-  expect(typeof sharedUtil.getStringWidth).toEqual("function");
-  expect(typeof sharedUtil.getAlignmentSize).toEqual("function");
-  expect(typeof sharedUtil.getIndentSize).toEqual("function");
-  expect(typeof sharedUtil.skip).toEqual("function");
-  expect(typeof sharedUtil.skipWhitespace).toEqual("function");
-  expect(typeof sharedUtil.skipSpaces).toEqual("function");
-  expect(typeof sharedUtil.skipToLineEnd).toEqual("function");
-  expect(typeof sharedUtil.skipEverythingButNewLine).toEqual("function");
-  expect(typeof sharedUtil.skipInlineComment).toEqual("function");
-  expect(typeof sharedUtil.skipTrailingComment).toEqual("function");
-  expect(typeof sharedUtil.skipNewline).toEqual("function");
-  expect(typeof sharedUtil.hasNewline).toEqual("function");
-  expect(typeof sharedUtil.hasNewlineInRange).toEqual("function");
-  expect(typeof sharedUtil.hasSpaces).toEqual("function");
-  expect(typeof sharedUtil.isNextLineEmpty).toEqual("function");
-  expect(typeof sharedUtil.isNextLineEmptyAfterIndex).toEqual("function");
-  expect(typeof sharedUtil.isPreviousLineEmpty).toEqual("function");
-  expect(typeof sharedUtil.getNextNonSpaceNonCommentCharacterIndex).toEqual(
+  expect(typeof sharedUtil.getMaxContinuousCount).toBe("function");
+  expect(typeof sharedUtil.getStringWidth).toBe("function");
+  expect(typeof sharedUtil.getAlignmentSize).toBe("function");
+  expect(typeof sharedUtil.getIndentSize).toBe("function");
+  expect(typeof sharedUtil.skip).toBe("function");
+  expect(typeof sharedUtil.skipWhitespace).toBe("function");
+  expect(typeof sharedUtil.skipSpaces).toBe("function");
+  expect(typeof sharedUtil.skipToLineEnd).toBe("function");
+  expect(typeof sharedUtil.skipEverythingButNewLine).toBe("function");
+  expect(typeof sharedUtil.skipInlineComment).toBe("function");
+  expect(typeof sharedUtil.skipTrailingComment).toBe("function");
+  expect(typeof sharedUtil.skipNewline).toBe("function");
+  expect(typeof sharedUtil.hasNewline).toBe("function");
+  expect(typeof sharedUtil.hasNewlineInRange).toBe("function");
+  expect(typeof sharedUtil.hasSpaces).toBe("function");
+  expect(typeof sharedUtil.isNextLineEmpty).toBe("function");
+  expect(typeof sharedUtil.isNextLineEmptyAfterIndex).toBe("function");
+  expect(typeof sharedUtil.isPreviousLineEmpty).toBe("function");
+  expect(typeof sharedUtil.getNextNonSpaceNonCommentCharacterIndex).toBe(
     "function"
   );
-  expect(typeof sharedUtil.makeString).toEqual("function");
+  expect(typeof sharedUtil.makeString).toBe("function");
 });
 
 test("sharedUtil.getMaxContinuousCount", () => {
   const { getMaxContinuousCount } = sharedUtil;
 
-  expect(getMaxContinuousCount("|---|--|-|--|---|", "-")).toEqual(3);
-  expect(getMaxContinuousCount("|...|", ".")).toEqual(3);
+  expect(getMaxContinuousCount("|---|--|-|--|---|", "-")).toBe(3);
+  expect(getMaxContinuousCount("|...|", ".")).toBe(3);
 
   const fixture = [
     "([a-f])([a-f])",
@@ -39,12 +39,12 @@ test("sharedUtil.getMaxContinuousCount", () => {
     "a-fa-fa-fa-f",
     "bbbbbbbbbbbbbbbbbb", // neither `a-f` `[a-f]` `([a-f])` should matches `b`
   ].join("");
-  expect(getMaxContinuousCount(fixture, "([a-f])")).toEqual(2);
-  expect(getMaxContinuousCount(fixture, "[a-f]")).toEqual(3);
-  expect(getMaxContinuousCount(fixture, "a-f")).toEqual(4);
-  expect(getMaxContinuousCount(fixture, "([a\\-f])")).toEqual(0);
-  expect(getMaxContinuousCount(fixture, "[a\\-f]")).toEqual(0);
-  expect(getMaxContinuousCount(fixture, "a\\-f")).toEqual(0);
+  expect(getMaxContinuousCount(fixture, "([a-f])")).toBe(2);
+  expect(getMaxContinuousCount(fixture, "[a-f]")).toBe(3);
+  expect(getMaxContinuousCount(fixture, "a-f")).toBe(4);
+  expect(getMaxContinuousCount(fixture, "([a\\-f])")).toBe(0);
+  expect(getMaxContinuousCount(fixture, "[a\\-f]")).toBe(0);
+  expect(getMaxContinuousCount(fixture, "a\\-f")).toBe(0);
 });
 
 test("sharedUtil.getStringWidth", () => {

--- a/tests/integration/__tests__/with-parser-inference.js
+++ b/tests/integration/__tests__/with-parser-inference.js
@@ -23,26 +23,26 @@ describe("infers postcss parser with --list-different", () => {
 
 describe("infers parser from filename", () => {
   test("json from .prettierrc", () => {
-    expect(
-      prettier.format("  {   }  ", { filepath: "x/y/.prettierrc" })
-    ).toEqual("{}\n");
+    expect(prettier.format("  {   }  ", { filepath: "x/y/.prettierrc" })).toBe(
+      "{}\n"
+    );
   });
 
   test("json from .stylelintrc", () => {
-    expect(
-      prettier.format("  {   }  ", { filepath: "x/y/.stylelintrc" })
-    ).toEqual("{}\n");
+    expect(prettier.format("  {   }  ", { filepath: "x/y/.stylelintrc" })).toBe(
+      "{}\n"
+    );
   });
 
   test("yaml from .stylelintrc", () => {
     expect(
       prettier.format("  extends:    ''  ", { filepath: "x/y/.stylelintrc" })
-    ).toEqual('extends: ""\n');
+    ).toBe('extends: ""\n');
   });
 
   test("babel from Jakefile", () => {
     expect(
       prettier.format("let foo = ( x = 1 ) => x", { filepath: "x/y/Jakefile" })
-    ).toEqual("let foo = (x = 1) => x;\n");
+    ).toBe("let foo = (x = 1) => x;\n");
   });
 });

--- a/tests/integration/runPrettier.js
+++ b/tests/integration/runPrettier.js
@@ -188,7 +188,7 @@ function runPrettier(dir, args = [], options = {}) {
             : result[name];
         if (name in testOptions) {
           if (name === "status" && testOptions[name] === "non-zero") {
-            expect(value).not.toEqual(0);
+            expect(value).not.toBe(0);
           } else {
             expect(value).toEqual(testOptions[name]);
           }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

~~Base on #11616~~

Enables [jest/prefer-to-be](https://github.com/jest-community/eslint-plugin-jest/blob/HEAD/docs/rules/prefer-to-be.md).

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
