### PR TITLE
Use Node.js 16.10.0

### DIFF
--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -18,13 +18,13 @@ jobs:
           - "macos-latest"
           - "windows-latest"
         node:
-          - "16"
+          - "16.10.0"
           - "14"
           - "12"
         include:
           # only enable coverage on the fastest job
           - os: "ubuntu-latest"
-            node: "16"
+            node: "16.10.0"
             ENABLE_CODE_COVERAGE: true
             FULL_TEST: true
             CHECK_TEST_PARSERS: true

--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -88,13 +88,13 @@ jobs:
           - "macos-latest"
           - "windows-latest"
         node:
-          - "16"
+          - "16.10.0"
           - "14"
           - "12"
           - "10"
         include:
           - os: "ubuntu-latest"
-            node: "16"
+            node: "16.10.0"
             FULL_TEST: true
         exclude:
           - os: "macos-latest"


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Some CI may be failing due to Node.js 16.11.0. So, changes it to use 16.10.0 for now.
I'll try to find out why and fix it later.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
