### PR TITLE
Fix empty config file command for PowerShell

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -22,10 +22,10 @@ yarn add --dev --exact prettier
 
 Then, create an empty config file to let editors and other tools know you are using Prettier:
 
-<!-- Note: `echo "{}" > .prettierrc.json` would result in `"{}"<SPACE>` on Windows. The below version works in cmd.exe, bash, zsh, fish. -->
+<!-- Note: `echo "{}" > .prettierrc.json` would result in `"{}"<SPACE>` on Windows cmd. The below version works in cmd.exe, powershell.exe, bash, zsh, fish. -->
 
 ```bash
-echo {}> .prettierrc.json
+echo "{}"> .prettierrc.json
 ```
 
 Next, create a [.prettierignore](ignore.md) file to let the Prettier CLI and editors know which files to _not_ format. Here’s an example:


### PR DESCRIPTION
Since PowerShell tries to interpret {}, the brackets must be enclosed in double quotes.

## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
