### PR TITLE
Improved performance with large HTML files

### DIFF
--- a/src/language-html/ast.js
+++ b/src/language-html/ast.js
@@ -85,6 +85,41 @@ class Node {
   }
 
   /**
+   * @param {Node} [target]
+   * @param {Object} [node]
+   */
+  insertChildBefore(target, node) {
+    const newNode = new Node(node)
+    setNonEnumerableProperties(newNode, {
+      // @ts-expect-error
+      index: target.index,
+      // @ts-expect-error
+      prev: target.prev,
+      next: target,
+      parent: this
+    })
+
+    let next = target
+    while (next) {
+      // @ts-expect-error
+      next.index++
+      // @ts-expect-error
+      next = next.next
+    }
+
+    // @ts-expect-error
+    newNode.next.prev = newNode
+    // @ts-expect-error
+    if (newNode.prev) {
+      // @ts-expect-error
+      newNode.prev.next = newNode
+    }
+
+    // @ts-expect-error
+    this.children.splice(this.children.indexOf(target), 0, newNode)
+  }
+
+  /**
    * @param {Node} [child]
    */
   removeChild(child) {

--- a/src/language-html/ast.js
+++ b/src/language-html/ast.js
@@ -85,10 +85,12 @@ class Node {
    */
   insertChildBefore(target, node) {
     const newNode = new Node(node);
+    setNonEnumerableProperties(newNode, {
+      parent: this,
+    });
 
     // @ts-expect-error
     this.children.splice(this.children.indexOf(target), 0, newNode);
-    this._updateChildrenWithoutClone();
   }
 
   /**
@@ -97,7 +99,6 @@ class Node {
   removeChild(child) {
     // @ts-expect-error
     this.children.splice(this.children.indexOf(child), 1);
-    this._updateChildrenWithoutClone();
   }
 
   /**
@@ -106,20 +107,12 @@ class Node {
    */
   replaceChild(target, node) {
     const newNode = new Node(node);
+    setNonEnumerableProperties(newNode, {
+      parent: this,
+    });
 
     // @ts-expect-error
     this.children.splice(this.children.indexOf(target), 1, newNode);
-    this._updateChildrenWithoutClone();
-  }
-
-  _updateChildrenWithoutClone() {
-    // @ts-expect-error
-    for (let i = 0; i < this.children.length; i++) {
-      // @ts-expect-error
-      setNonEnumerableProperties(this.children[i], {
-        parent: this,
-      });
-    }
   }
 
   /**
@@ -200,7 +193,7 @@ function setNonEnumerableProperties(obj, props) {
   const descriptors = Object.fromEntries(
     Object.entries(props).map(([key, value]) => [
       key,
-      { value, enumerable: false, writable: true },
+      { value, enumerable: false },
     ])
   );
 

--- a/src/language-html/ast.js
+++ b/src/language-html/ast.js
@@ -58,12 +58,9 @@ class Node {
           newNode[key] = this[key];
         }
       }
-      // @ts-expect-error
-      const { prev, next, parent } = this;
       setNonEnumerableProperties(newNode, {
-        prev,
-        next,
-        parent,
+        // @ts-expect-error
+        parent: this.parent,
       });
     }
 
@@ -120,10 +117,6 @@ class Node {
     for (let i = 0; i < this.children.length; i++) {
       // @ts-expect-error
       setNonEnumerableProperties(this.children[i], {
-        // @ts-expect-error
-        prev: this.children[i - 1],
-        // @ts-expect-error
-        next: this.children[i + 1],
         parent: this,
       });
     }
@@ -153,6 +146,24 @@ class Node {
     return isNonEmptyArray(this.children) ? getLast(this.children) : null;
   }
 
+  get prev() {
+    // @ts-expect-error
+    if (!this.parent) {
+      return null;
+    }
+    // @ts-expect-error
+    return this.parent.children[this.parent.children.indexOf(this) - 1];
+  }
+
+  get next() {
+    // @ts-expect-error
+    if (!this.parent) {
+      return null;
+    }
+    // @ts-expect-error
+    return this.parent.children[this.parent.children.indexOf(this) + 1];
+  }
+
   // for element and attribute
   get rawName() {
     // @ts-expect-error
@@ -176,19 +187,10 @@ function cloneAndUpdateNodes(nodes, parent) {
     node instanceof Node ? node.clone() : new Node(node)
   );
 
-  let prev = null;
-  let current = siblings[0];
-  let next = siblings[1] || null;
-
   for (let index = 0; index < siblings.length; index++) {
-    setNonEnumerableProperties(current, {
-      prev,
-      next,
+    setNonEnumerableProperties(siblings[index], {
       parent,
     });
-    prev = current;
-    current = next;
-    next = siblings[index + 2] || null;
   }
 
   return siblings;

--- a/src/language-html/ast.js
+++ b/src/language-html/ast.js
@@ -90,33 +90,10 @@ class Node {
    */
   insertChildBefore(target, node) {
     const newNode = new Node(node);
-    setNonEnumerableProperties(newNode, {
-      // @ts-expect-error
-      index: target.index,
-      // @ts-expect-error
-      prev: target.prev,
-      next: target,
-      parent: this,
-    });
-
-    let next = target;
-    while (next) {
-      // @ts-expect-error
-      next.index++;
-      // @ts-expect-error
-      next = next.next;
-    }
-
-    // @ts-expect-error
-    newNode.next.prev = newNode;
-    // @ts-expect-error
-    if (newNode.prev) {
-      // @ts-expect-error
-      newNode.prev.next = newNode;
-    }
 
     // @ts-expect-error
     this.children.splice(this.children.indexOf(target), 0, newNode);
+    this._updateChildrenWithoutClone();
   }
 
   /**
@@ -124,26 +101,23 @@ class Node {
    */
   removeChild(child) {
     // @ts-expect-error
-    if (child.next) {
-      // @ts-expect-error
-      child.next.prev = child.prev;
-    }
-
-    // @ts-expect-error
-    if (child.prev) {
-      // @ts-expect-error
-      child.prev.next = child.next;
-    }
-
-    // @ts-expect-error
-    let { next } = child;
-    while (next) {
-      next.index--;
-      next = next.next;
-    }
-
-    // @ts-expect-error
     this.children.splice(this.children.indexOf(child), 1);
+    this._updateChildrenWithoutClone();
+  }
+
+  _updateChildrenWithoutClone() {
+    // @ts-expect-error
+    for (let i = 0; i < this.children.length; i++) {
+      // @ts-expect-error
+      setNonEnumerableProperties(this.children[i], {
+        index: i,
+        // @ts-expect-error
+        prev: i > 0 ? this.children[i-1] : undefined,
+        // @ts-expect-error
+        next: i < this.children.length - 1 ? this.children[i+1] : undefined,
+        parent: this,
+      });
+    }
   }
 
   /**

--- a/src/language-html/ast.js
+++ b/src/language-html/ast.js
@@ -112,9 +112,9 @@ class Node {
       setNonEnumerableProperties(this.children[i], {
         index: i,
         // @ts-expect-error
-        prev: i > 0 ? this.children[i-1] : undefined,
+        prev: this.children[i - 1],
         // @ts-expect-error
-        next: i < this.children.length - 1 ? this.children[i+1] : undefined,
+        next: this.children[i + 1],
         parent: this,
       });
     }

--- a/src/language-html/ast.js
+++ b/src/language-html/ast.js
@@ -103,6 +103,18 @@ class Node {
     this._updateChildrenWithoutClone();
   }
 
+  /**
+   * @param {Node} [target]
+   * @param {Object} [node]
+   */
+  replaceChild(target, node) {
+    const newNode = new Node(node);
+
+    // @ts-expect-error
+    this.children.splice(this.children.indexOf(target), 1, newNode);
+    this._updateChildrenWithoutClone();
+  }
+
   _updateChildrenWithoutClone() {
     // @ts-expect-error
     for (let i = 0; i < this.children.length; i++) {

--- a/src/language-html/ast.js
+++ b/src/language-html/ast.js
@@ -26,11 +26,13 @@ class Node {
     if (nodes !== this[key]) {
       this[key] = cloneAndUpdateNodes(nodes, this);
       if (key === "attrs") {
-        setNonEnumerableProperties(this, {
-          attrMap: Object.fromEntries(
+        setNonEnumerableProperty(
+          this,
+          "attrMap",
+          Object.fromEntries(
             this[key].map((attr) => [attr.fullName, attr.value])
-          ),
-        });
+          )
+        );
       }
     }
   }
@@ -58,10 +60,8 @@ class Node {
           newNode[key] = this[key];
         }
       }
-      setNonEnumerableProperties(newNode, {
-        // @ts-expect-error
-        parent: this.parent,
-      });
+      // @ts-expect-error
+      setNonEnumerableProperty(newNode, "parent", this.parent);
     }
 
     return fn(newNode || this);
@@ -85,9 +85,7 @@ class Node {
    */
   insertChildBefore(target, node) {
     const newNode = new Node(node);
-    setNonEnumerableProperties(newNode, {
-      parent: this,
-    });
+    setNonEnumerableProperty(newNode, "parent", this);
 
     // @ts-expect-error
     this.children.splice(this.children.indexOf(target), 0, newNode);
@@ -107,9 +105,7 @@ class Node {
    */
   replaceChild(target, node) {
     const newNode = new Node(node);
-    setNonEnumerableProperties(newNode, {
-      parent: this,
-    });
+    setNonEnumerableProperty(newNode, "parent", this);
 
     // @ts-expect-error
     this.children.splice(this.children.indexOf(target), 1, newNode);
@@ -180,24 +176,15 @@ function cloneAndUpdateNodes(nodes, parent) {
     node instanceof Node ? node.clone() : new Node(node)
   );
 
-  for (let index = 0; index < siblings.length; index++) {
-    setNonEnumerableProperties(siblings[index], {
-      parent,
-    });
+  for (const sibling of siblings) {
+    setNonEnumerableProperty(sibling, "parent", parent);
   }
 
   return siblings;
 }
 
-function setNonEnumerableProperties(obj, props) {
-  const descriptors = Object.fromEntries(
-    Object.entries(props).map(([key, value]) => [
-      key,
-      { value, enumerable: false },
-    ])
-  );
-
-  Object.defineProperties(obj, descriptors);
+function setNonEnumerableProperty(obj, key, value) {
+  Object.defineProperty(obj, key, { value, enumerable: false });
 }
 
 module.exports = {

--- a/src/language-html/ast.js
+++ b/src/language-html/ast.js
@@ -59,10 +59,8 @@ class Node {
         }
       }
       // @ts-expect-error
-      const { index, siblings, prev, next, parent } = this;
+      const { prev, next, parent } = this;
       setNonEnumerableProperties(newNode, {
-        index,
-        siblings,
         prev,
         next,
         parent,
@@ -110,7 +108,6 @@ class Node {
     for (let i = 0; i < this.children.length; i++) {
       // @ts-expect-error
       setNonEnumerableProperties(this.children[i], {
-        index: i,
         // @ts-expect-error
         prev: this.children[i - 1],
         // @ts-expect-error
@@ -173,7 +170,6 @@ function cloneAndUpdateNodes(nodes, parent) {
 
   for (let index = 0; index < siblings.length; index++) {
     setNonEnumerableProperties(current, {
-      index,
       prev,
       next,
       parent,

--- a/src/language-html/ast.js
+++ b/src/language-html/ast.js
@@ -89,34 +89,34 @@ class Node {
    * @param {Object} [node]
    */
   insertChildBefore(target, node) {
-    const newNode = new Node(node)
+    const newNode = new Node(node);
     setNonEnumerableProperties(newNode, {
       // @ts-expect-error
       index: target.index,
       // @ts-expect-error
       prev: target.prev,
       next: target,
-      parent: this
-    })
+      parent: this,
+    });
 
-    let next = target
+    let next = target;
     while (next) {
       // @ts-expect-error
-      next.index++
+      next.index++;
       // @ts-expect-error
-      next = next.next
+      next = next.next;
     }
 
     // @ts-expect-error
-    newNode.next.prev = newNode
+    newNode.next.prev = newNode;
     // @ts-expect-error
     if (newNode.prev) {
       // @ts-expect-error
-      newNode.prev.next = newNode
+      newNode.prev.next = newNode;
     }
 
     // @ts-expect-error
-    this.children.splice(this.children.indexOf(target), 0, newNode)
+    this.children.splice(this.children.indexOf(target), 0, newNode);
   }
 
   /**
@@ -126,24 +126,24 @@ class Node {
     // @ts-expect-error
     if (child.next) {
       // @ts-expect-error
-      child.next.prev = child.prev
+      child.next.prev = child.prev;
     }
 
     // @ts-expect-error
     if (child.prev) {
       // @ts-expect-error
-      child.prev.next = child.next
+      child.prev.next = child.next;
     }
 
     // @ts-expect-error
-    let {next} = child
+    let { next } = child;
     while (next) {
-      next.index--
-      next = next.next
+      next.index--;
+      next = next.next;
     }
 
     // @ts-expect-error
-    this.children.splice(this.children.indexOf(child), 1)
+    this.children.splice(this.children.indexOf(child), 1);
   }
 
   /**

--- a/src/language-html/ast.js
+++ b/src/language-html/ast.js
@@ -108,7 +108,7 @@ class Node {
     const newNode = new Node(node, this);
 
     // @ts-expect-error
-    this.children.splice(this.children.indexOf(target), 1, newNode);
+    this.children[this.children.indexOf(target)] = newNode;
   }
 
   /**

--- a/src/language-html/ast.js
+++ b/src/language-html/ast.js
@@ -85,6 +85,33 @@ class Node {
   }
 
   /**
+   * @param {Node} [child]
+   */
+  removeChild(child) {
+    // @ts-expect-error
+    if (child.next) {
+      // @ts-expect-error
+      child.next.prev = child.prev
+    }
+
+    // @ts-expect-error
+    if (child.prev) {
+      // @ts-expect-error
+      child.prev.next = child.next
+    }
+
+    // @ts-expect-error
+    let {next} = child
+    while (next) {
+      next.index--
+      next = next.next
+    }
+
+    // @ts-expect-error
+    this.children.splice(this.children.indexOf(child), 1)
+  }
+
+  /**
    * @param {Object} [overrides]
    */
   clone(overrides) {
@@ -138,7 +165,6 @@ function cloneAndUpdateNodes(nodes, parent) {
   for (let index = 0; index < siblings.length; index++) {
     setNonEnumerableProperties(current, {
       index,
-      siblings,
       prev,
       next,
       parent,
@@ -155,7 +181,7 @@ function setNonEnumerableProperties(obj, props) {
   const descriptors = Object.fromEntries(
     Object.entries(props).map(([key, value]) => [
       key,
-      { value, enumerable: false },
+      { value, enumerable: false, writable: true },
     ])
   );
 

--- a/src/language-html/ast.js
+++ b/src/language-html/ast.js
@@ -22,7 +22,7 @@ class Node {
     }
 
     if (parent) {
-      setNonEnumerableProperty(this, "parent", parent);
+      this.parent = parent;
     }
   }
 
@@ -51,7 +51,6 @@ class Node {
         const mappedNodes = mapNodesIfChanged(nodes, (node) => node.map(fn));
         if (newNode !== nodes) {
           if (!newNode) {
-            // @ts-expect-error
             newNode = new Node(undefined, this.parent);
           }
           newNode._setNodes(NODES_KEY, mappedNodes);
@@ -137,20 +136,16 @@ class Node {
   }
 
   get prev() {
-    // @ts-expect-error
     if (!this.parent) {
       return null;
     }
-    // @ts-expect-error
     return this.parent.children[this.parent.children.indexOf(this) - 1];
   }
 
   get next() {
-    // @ts-expect-error
     if (!this.parent) {
       return null;
     }
-    // @ts-expect-error
     return this.parent.children[this.parent.children.indexOf(this) + 1];
   }
 

--- a/src/language-html/clean.js
+++ b/src/language-html/clean.js
@@ -8,6 +8,7 @@ const ignoredProperties = new Set([
   "endSourceSpan",
   "nameSpan",
   "valueSpan",
+  "parent",
 ]);
 
 function clean(ast, newNode) {

--- a/src/language-html/parser-html.js
+++ b/src/language-html/parser-html.js
@@ -356,8 +356,7 @@ function _parse(text, options, parserOptions, shouldParseFrontMatter = true) {
         parseSubHtml
       );
       if (ieConditionalComment) {
-        node.parent.insertChildBefore(node, ieConditionalComment);
-        node.parent.removeChild(node);
+        node.parent.replaceChild(node, ieConditionalComment);
       }
     }
   });

--- a/src/language-html/parser-html.js
+++ b/src/language-html/parser-html.js
@@ -328,13 +328,16 @@ function _parse(text, options, parserOptions, shouldParseFrontMatter = true) {
       parserOptions,
       false
     );
+    // @ts-expect-error
     subAst.sourceSpan = new ParseSourceSpan(
       startSpan,
+      // @ts-expect-error
       getLast(subAst.children).sourceSpan.end
     );
+    // @ts-expect-error
     const firstText = subAst.children[0];
     if (firstText.length === offset) {
-      /* istanbul ignore next */
+      /* istanbul ignore next */ // @ts-expect-error
       subAst.children.shift();
     } else {
       firstText.sourceSpan = new ParseSourceSpan(
@@ -346,19 +349,20 @@ function _parse(text, options, parserOptions, shouldParseFrontMatter = true) {
     return subAst;
   };
 
-  return ast.map((node) => {
+  ast.walk((node) => {
     if (node.type === "comment") {
       const ieConditionalComment = parseIeConditionalComment(
         node,
         parseSubHtml
       );
       if (ieConditionalComment) {
-        return ieConditionalComment;
+        node.parent.insertChildBefore(node, ieConditionalComment);
+        node.parent.removeChild(node);
       }
     }
-
-    return node;
   });
+
+  return ast;
 }
 
 /**

--- a/src/language-html/print-preprocess.js
+++ b/src/language-html/print-preprocess.js
@@ -77,7 +77,7 @@ function mergeIeConditonalStartEndCommentIntoElementOpeningTag(
           continue;
         }
 
-        const ieConditionalStartComment = node.children[i - 1];
+        const ieConditionalStartComment = child.prev;
         const ieConditionalEndComment = child.firstChild;
 
         // ieConditionalStartComment
@@ -117,7 +117,7 @@ function mergeNodeIntoText(ast, shouldMerge, getValue) {
           child.value = getValue(child);
         }
 
-        const prevChild = node.children[i - 1];
+        const prevChild = child.prev;
         if (!prevChild || prevChild.type !== "text") {
           continue;
         }
@@ -168,8 +168,8 @@ function mergeSimpleElementIntoText(ast /*, options */) {
           continue;
         }
 
-        const prevChild = node.children[i - 1];
-        const nextChild = node.children[++i];
+        const prevChild = child.prev;
+        const nextChild = child.next;
         prevChild.value +=
           `<${child.rawName}>` +
           child.firstChild.value +
@@ -185,7 +185,6 @@ function mergeSimpleElementIntoText(ast /*, options */) {
         node.removeChild(child);
         i--; // because a node was removed
         node.removeChild(nextChild);
-        i--; // because a node was removed
       }
     }
   });
@@ -291,8 +290,8 @@ function extractWhitespaces(ast /*, options*/) {
         const { leadingWhitespace, text, trailingWhitespace } =
           getLeadingAndTrailingHtmlWhitespace(child.value);
 
-        const prevChild = node.children[i - 1];
-        const nextChild = node.children[i + 1];
+        const prevChild = child.prev;
+        const nextChild = child.next;
 
         if (!text) {
           node.removeChild(child);
@@ -398,12 +397,12 @@ function addIsSpaceSensitive(ast, options) {
       child.isLeadingSpaceSensitive =
         index === 0
           ? child.isLeadingSpaceSensitive
-          : children[index - 1].isTrailingSpaceSensitive &&
+          : child.prev.isTrailingSpaceSensitive &&
             child.isLeadingSpaceSensitive;
       child.isTrailingSpaceSensitive =
         index === children.length - 1
           ? child.isTrailingSpaceSensitive
-          : children[index + 1].isLeadingSpaceSensitive &&
+          : child.next.isLeadingSpaceSensitive &&
             child.isTrailingSpaceSensitive;
     }
   });

--- a/src/language-html/print-preprocess.js
+++ b/src/language-html/print-preprocess.js
@@ -203,11 +203,8 @@ function extractInterpolation(ast, options) {
       return;
     }
 
-    const newChildren = [];
-
     for (const child of node.children) {
       if (child.type !== "text") {
-        newChildren.push(child);
         continue;
       }
 
@@ -224,7 +221,7 @@ function extractInterpolation(ast, options) {
         if (i % 2 === 0) {
           endSourceSpan = startSourceSpan.moveBy(value.length);
           if (value.length > 0) {
-            newChildren.push({
+            node.insertChildBefore(child, {
               type: "text",
               value,
               sourceSpan: new ParseSourceSpan(startSourceSpan, endSourceSpan),
@@ -234,7 +231,7 @@ function extractInterpolation(ast, options) {
         }
 
         endSourceSpan = startSourceSpan.moveBy(value.length + 4); // `{{` + `}}`
-        newChildren.push({
+        node.insertChildBefore(child, {
           type: "interpolation",
           sourceSpan: new ParseSourceSpan(startSourceSpan, endSourceSpan),
           children:
@@ -252,9 +249,9 @@ function extractInterpolation(ast, options) {
                 ],
         });
       }
-    }
 
-    node.setChildren(newChildren);
+      node.removeChild(child);
+    }
   });
 }
 

--- a/src/language-html/print-preprocess.js
+++ b/src/language-html/print-preprocess.js
@@ -414,39 +414,37 @@ function addCssDisplay(ast, options) {
  */
 function addIsSpaceSensitive(ast, options) {
   ast.walk((node) => {
-    if (!node.children) {
+    const { children } = node;
+    if (!children) {
       return;
     }
-
-    if (node.children.length === 0) {
+    if (children.length === 0) {
       node.isDanglingSpaceSensitive = isDanglingSpaceSensitiveNode(node);
       return;
     }
-
-    node.setChildren(
-      node.children
-        .map((child) => ({
-          ...child,
-          isLeadingSpaceSensitive: isLeadingSpaceSensitiveNode(child, options),
-          isTrailingSpaceSensitive: isTrailingSpaceSensitiveNode(
-            child,
-            options
-          ),
-        }))
-        .map((child, index, children) => ({
-          ...child,
-          isLeadingSpaceSensitive:
-            index === 0
-              ? child.isLeadingSpaceSensitive
-              : children[index - 1].isTrailingSpaceSensitive &&
-                child.isLeadingSpaceSensitive,
-          isTrailingSpaceSensitive:
-            index === children.length - 1
-              ? child.isTrailingSpaceSensitive
-              : children[index + 1].isLeadingSpaceSensitive &&
-                child.isTrailingSpaceSensitive,
-        }))
-    );
+    for (const child of children) {
+      child.isLeadingSpaceSensitive = isLeadingSpaceSensitiveNode(
+        child,
+        options
+      );
+      child.isTrailingSpaceSensitive = isTrailingSpaceSensitiveNode(
+        child,
+        options
+      );
+    }
+    for (let index = 0; index < children.length; index++) {
+      const child = children[index];
+      child.isLeadingSpaceSensitive =
+        index === 0
+          ? child.isLeadingSpaceSensitive
+          : children[index - 1].isTrailingSpaceSensitive &&
+            child.isLeadingSpaceSensitive;
+      child.isTrailingSpaceSensitive =
+        index === children.length - 1
+          ? child.isTrailingSpaceSensitive
+          : children[index + 1].isLeadingSpaceSensitive &&
+            child.isTrailingSpaceSensitive;
+    }
   });
 }
 

--- a/src/language-html/print-preprocess.js
+++ b/src/language-html/print-preprocess.js
@@ -374,39 +374,37 @@ function extractWhitespaces(ast /*, options*/) {
 }
 
 function addIsSelfClosing(ast /*, options */) {
-  ast.walk((node) =>
-    Object.assign(node, {
-      isSelfClosing:
-        !node.children ||
-        (node.type === "element" &&
-          (node.tagDefinition.isVoid ||
-            // self-closing
-            node.startSourceSpan === node.endSourceSpan)),
-    })
-  );
+  ast.walk((node) => {
+    node.isSelfClosing =
+      !node.children ||
+      (node.type === "element" &&
+        (node.tagDefinition.isVoid ||
+          // self-closing
+          node.startSourceSpan === node.endSourceSpan));
+  });
 }
 
 function addHasHtmComponentClosingTag(ast, options) {
-  ast.walk((node) =>
-    node.type !== "element"
-      ? node
-      : Object.assign(node, {
-          hasHtmComponentClosingTag:
-            node.endSourceSpan &&
-            /^<\s*\/\s*\/\s*>$/.test(
-              options.originalText.slice(
-                node.endSourceSpan.start.offset,
-                node.endSourceSpan.end.offset
-              )
-            ),
-        })
-  );
+  ast.walk((node) => {
+    if (node.type !== "element") {
+      return;
+    }
+
+    node.hasHtmComponentClosingTag =
+      node.endSourceSpan &&
+      /^<\s*\/\s*\/\s*>$/.test(
+        options.originalText.slice(
+          node.endSourceSpan.start.offset,
+          node.endSourceSpan.end.offset
+        )
+      );
+  });
 }
 
 function addCssDisplay(ast, options) {
-  ast.walk((node) =>
-    Object.assign(node, { cssDisplay: getNodeCssStyleDisplay(node, options) })
-  );
+  ast.walk((node) => {
+    node.cssDisplay = getNodeCssStyleDisplay(node, options);
+  });
 }
 
 /**

--- a/src/language-html/print-preprocess.js
+++ b/src/language-html/print-preprocess.js
@@ -30,11 +30,10 @@ const PREPROCESS_PIPELINE = [
 ];
 
 function preprocess(ast, options) {
-  const res = ast.map((node) => node);
   for (const fn of PREPROCESS_PIPELINE) {
-    fn(res, options);
+    fn(ast, options);
   }
-  return res;
+  return ast;
 }
 
 function removeIgnorableFirstLf(ast /*, options */) {

--- a/src/language-html/print-preprocess.js
+++ b/src/language-html/print-preprocess.js
@@ -47,12 +47,12 @@ function removeIgnorableFirstLf(ast /*, options */) {
       node.children[0].type === "text" &&
       node.children[0].value[0] === "\n"
     ) {
-      const [text, ...rest] = node.children;
-      node.setChildren(
-        text.value.length === 1
-          ? rest
-          : [text.clone({ value: text.value.slice(1) }), ...rest]
-      );
+      const text = node.children[0];
+      if (text.value.length === 1) {
+        node.removeChild(text);
+      } else {
+        text.value = text.value.slice(1);
+      }
     }
   });
 }

--- a/src/language-html/utils.js
+++ b/src/language-html/utils.js
@@ -113,12 +113,11 @@ function hasPrettierIgnore(node) {
     return false;
   }
 
-  if (typeof node.index !== "number" || node.index === 0) {
+  if (!node.prev) {
     return false;
   }
 
-  const prevNode = node.parent.children[node.index - 1];
-  return isPrettierIgnore(prevNode);
+  return isPrettierIgnore(node.prev);
 }
 
 function isPrettierIgnore(node) {

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -55,7 +55,8 @@ function getSortedChildNodes(node, options, resultArray) {
             key !== "precedingNode" &&
             key !== "followingNode" &&
             key !== "tokens" &&
-            key !== "comments"
+            key !== "comments" &&
+            key !== "parent"
         )
         .map(([, value]) => value));
 


### PR DESCRIPTION
## Description

I reduced copying AST like #11108. 

On [this case](https://github.com/prettier/prettier/issues/4776#issuecomment-740791694), the result of `yarn run perf:benchmark` became about 8.6x faster.

before
```
[debug] resolve config from 'test.html'
[debug] loaded options `{"useTabs":false,"tabWidth":2,"endOfLine":"lf"}`
[debug] applied config-precedence (cli-override): {"endOfLine":"lf","tabWidth":2,"useTabs":false}
[debug] '--debug-benchmark' option found, measuring formatWithCursor with 'benchmark' module.
[debug] '--debug-benchmark' measurements for formatWithCursor: {
[debug]   "benchmark": "format x 0.80 ops/sec ±3.60% (7 runs sampled)",
[debug]   "hz": 0.8011225145560241,
[debug]   "ms": 1248.2485285714286
[debug] }
```

after
```
[debug] resolve config from 'test.html'
[debug] loaded options `{"useTabs":false,"tabWidth":2,"endOfLine":"lf"}`
[debug] applied config-precedence (cli-override): {"endOfLine":"lf","tabWidth":2,"useTabs":false}
[debug] '--debug-benchmark' option found, measuring formatWithCursor with 'benchmark' module.
[debug] '--debug-benchmark' measurements for formatWithCursor: {
[debug]   "benchmark": "format x 6.86 ops/sec ±11.89% (23 runs sampled)",
[debug]   "hz": 6.86268975187975,
[debug]   "ms": 145.71546086956522
[debug] }
```


refs #4776 

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
