### PR TITLE
Make `options` argument in parsers optional

### DIFF
--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -619,7 +619,7 @@ function parseWithParser(parse, text, options) {
 }
 
 // TODO: make this only work on css
-function parseCss(text, parsers, options) {
+function parseCss(text, parsers, options = {}) {
   const isSCSSParser = isSCSS(options.parser, text);
   const parseFunctions = isSCSSParser
     ? [parseScss, parseLess]
@@ -640,7 +640,7 @@ function parseCss(text, parsers, options) {
   }
 }
 
-function parseLess(text, parsers, options) {
+function parseLess(text, parsers, options = {}) {
   const lessParser = require("postcss-less");
   return parseWithParser(
     // Workaround for https://github.com/shellscape/postcss-less/issues/145
@@ -651,7 +651,7 @@ function parseLess(text, parsers, options) {
   );
 }
 
-function parseScss(text, parsers, options) {
+function parseScss(text, parsers, options = {}) {
   const { parse } = require("postcss-scss");
   return parseWithParser(parse, text, options);
 }

--- a/src/language-html/parser-html.js
+++ b/src/language-html/parser-html.js
@@ -25,6 +25,7 @@ const { locStart, locEnd } = require("./loc.js");
  * @typedef {import('angular-html-parser/lib/compiler/src/ml_parser/ast').Element} Element
  * @typedef {import('angular-html-parser/lib/compiler/src/ml_parser/parser').ParseTreeResult} ParserTreeResult
  * @typedef {Omit<import('angular-html-parser').ParseOptions, 'canSelfClose'> & {
+ *   name?: 'html' | 'angular' | 'vue' | 'lwc';
  *   recognizeSelfClosing?: boolean;
  *   normalizeTagName?: boolean;
  *   normalizeAttributeName?: boolean;
@@ -365,6 +366,7 @@ function _parse(text, options, parserOptions, shouldParseFrontMatter = true) {
  * @param {ParserOptions} parserOptions
  */
 function createParser({
+  name,
   recognizeSelfClosing = false,
   normalizeTagName = false,
   normalizeAttributeName = false,
@@ -373,15 +375,19 @@ function createParser({
   getTagContentType,
 } = {}) {
   return {
-    parse: (text, parsers, options = {}) =>
-      _parse(text, options, {
-        recognizeSelfClosing,
-        normalizeTagName,
-        normalizeAttributeName,
-        allowHtmComponentClosingTags,
-        isTagNameCaseSensitive,
-        getTagContentType,
-      }),
+    parse: (text, parsers, options) =>
+      _parse(
+        text,
+        { parser: name, ...options },
+        {
+          recognizeSelfClosing,
+          normalizeTagName,
+          normalizeAttributeName,
+          allowHtmComponentClosingTags,
+          isTagNameCaseSensitive,
+          getTagContentType,
+        }
+      ),
     hasPragma,
     astFormat: "html",
     locStart,
@@ -392,13 +398,15 @@ function createParser({
 module.exports = {
   parsers: {
     html: createParser({
+      name: "html",
       recognizeSelfClosing: true,
       normalizeTagName: true,
       normalizeAttributeName: true,
       allowHtmComponentClosingTags: true,
     }),
-    angular: createParser(),
+    angular: createParser({ name: "angular" }),
     vue: createParser({
+      name: "vue",
       recognizeSelfClosing: true,
       isTagNameCaseSensitive: true,
       getTagContentType: (tagName, prefix, hasParent, attrs) => {
@@ -414,6 +422,6 @@ module.exports = {
         }
       },
     }),
-    lwc: createParser(),
+    lwc: createParser({ name: "lwc" }),
   },
 };

--- a/src/language-html/parser-html.js
+++ b/src/language-html/parser-html.js
@@ -373,7 +373,7 @@ function createParser({
   getTagContentType,
 } = {}) {
   return {
-    parse: (text, parsers, options) =>
+    parse: (text, parsers, options = {}) =>
       _parse(text, options, {
         recognizeSelfClosing,
         normalizeTagName,

--- a/src/language-js/parse/espree.js
+++ b/src/language-js/parse/espree.js
@@ -32,7 +32,7 @@ function createParseError(error) {
   return createError(message, { start: { line: lineNumber, column } });
 }
 
-function parse(originalText, parsers, options) {
+function parse(originalText, parsers, options = {}) {
   const { parse } = require("espree");
 
   const textToParse = replaceHashbang(originalText);

--- a/src/language-js/parse/flow.js
+++ b/src/language-js/parse/flow.js
@@ -45,7 +45,7 @@ function createParseError(error) {
   });
 }
 
-function parse(text, parsers, opts) {
+function parse(text, parsers, options = {}) {
   // Inline the require to avoid loading all the JS if we don't use it
   const { parse } = require("flow-parser");
   const ast = parse(replaceHashbang(text), parseOptions);
@@ -54,8 +54,8 @@ function parse(text, parsers, opts) {
     throw createParseError(error);
   }
 
-  opts.originalText = text;
-  return postprocess(ast, opts);
+  options.originalText = text;
+  return postprocess(ast, options);
 }
 
 // Export as a plugin so we can reuse the same bundle for UMD loading

--- a/src/language-js/parse/meriyah.js
+++ b/src/language-js/parse/meriyah.js
@@ -71,7 +71,7 @@ function createParseError(error) {
   return createError(message, { start: { line, column } });
 }
 
-function parse(text, parsers, options) {
+function parse(text, parsers, options = {}) {
   const { result: ast, error: moduleParseError } = tryCombinations(
     () => parseWithOptions(text, /* module */ true),
     () => parseWithOptions(text, /* module */ false)

--- a/src/language-js/parse/typescript.js
+++ b/src/language-js/parse/typescript.js
@@ -32,7 +32,7 @@ function createParseError(error) {
   });
 }
 
-function parse(text, parsers, opts) {
+function parse(text, parsers, options = {}) {
   const textToParse = replaceHashbang(text);
   const jsx = isProbablyJsx(text);
 
@@ -49,9 +49,9 @@ function parse(text, parsers, opts) {
     throw createParseError(firstError);
   }
 
-  opts.originalText = text;
-  opts.tsParseResult = result;
-  return postprocess(result.ast, opts);
+  options.originalText = text;
+  options.tsParseResult = result;
+  return postprocess(result.ast, options);
 }
 
 /**

--- a/tests/integration/__tests__/parser-api.js
+++ b/tests/integration/__tests__/parser-api.js
@@ -29,6 +29,33 @@ test("allows usage of prettier's supported parsers", () => {
   expect(output).toBe("bar();\n");
 });
 
+test("parsers should allow omit optional arguments", () => {
+  let parsers;
+  try {
+    prettier.format("{}", {
+      parser(text, builtinParsers) {
+        parsers = builtinParsers;
+      },
+    });
+  } catch {
+    // noop
+  }
+
+  expect(typeof parsers.babel).toBe("function");
+  const code = {
+    graphql: "type A {hero: Character}",
+    default: "{}",
+  };
+  for (const [name, parse] of Object.entries(parsers)) {
+    // Private parser should not be used by users
+    if (name.startsWith("__")) {
+      continue;
+    }
+
+    expect(() => parse(code[name] || code.default)).not.toThrow();
+  }
+});
+
 test("allows add empty `trailingComments` array", () => {
   const output = prettier.format("(foo /* comment */)( )", {
     parser(text, parsers) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #11888

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
