### PR TITLE
Print descriptions on graphql schema definition nodes

### DIFF
--- a/changelog_unreleased/graphql/11901.md
+++ b/changelog_unreleased/graphql/11901.md
@@ -1,0 +1,24 @@
+#### Print descriptions on graphql schema definition nodes (#11901 by @trevor-scheer)
+
+<!-- prettier-ignore -->
+```graphql
+# Input
+"""SchemaDefinition description is lost"""
+schema {
+  query: Query
+}
+
+# Prettier stable
+schema {
+  query: Query
+}
+
+# Prettier main
+"""
+SchemaDefinition description is lost
+"""
+schema {
+  query: Query
+}
+
+```

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -404,8 +404,8 @@ function genericPrint(path, options, print) {
 
     case "SchemaDefinition": {
       return [
-        // print("description"),
-        // node.description ? hardline : "",
+        print("description"),
+        node.description ? hardline : "",
         "schema",
         printDirectives(path, print, node),
         " {",

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -404,6 +404,8 @@ function genericPrint(path, options, print) {
 
     case "SchemaDefinition": {
       return [
+        // print("description"),
+        // node.description ? hardline : "",
         "schema",
         printDirectives(path, print, node),
         " {",

--- a/tests/format/graphql/schema/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/graphql/schema/__snapshots__/jsfmt.spec.js.snap
@@ -6,6 +6,7 @@ parsers: ["graphql"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
+"""Schema definition description"""
 schema {
   query: Root
   mutation: Mutation
@@ -13,6 +14,9 @@ schema {
 }
 
 =====================================output=====================================
+"""
+Schema definition description
+"""
 schema {
   query: Root
   mutation: Mutation

--- a/tests/format/graphql/schema/schema.graphql
+++ b/tests/format/graphql/schema/schema.graphql
@@ -1,3 +1,4 @@
+"""Schema definition description"""
 schema {
   query: Root
   mutation: Mutation


### PR DESCRIPTION
## Description

This change adds printing descriptions which are attached to a graphql schema definition node. Currently these are omitted.

[Playground reproduction / example](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAdNGDKYAWcC2AhgCJwBmAllBTBdAAQAmcAzmAE4UAOtDFL9ADYQWMdOLRQ2eIvWCoo9egEcArnHYBPJPQCK6rQoC+C0xnQB5AEYArOGBgAVTVzilK1XouZtOPOor89FycsHCMEuKwLnB6BppyCkqEOgCSsMYKIAA0IBD+0CzIoITs7BAA7gAKpQhFKISCFYSaRblW7IRgANZwMJiE+HAAMlRwyGSNLHDtnT19mFxdVADmyDDs6rkEVuHMjMOEUCuqhCtwAGIQ7EQwtMfIIISqMBA5IDgw+IIA6jg0rCWYDgmDqNAoADcaJpHmAWG0QFRpuwYFVOisiBMpjMQDYWAAPTCrQRwfQQeBYwTTXJLdjIx4rTpcHDKQTvEJUGA-CiMGA4ZAADgADDTytMfkzHiFWBoIeNcmpyXA0fl6k8WABaKBwcLhd7sOBqCgGtFnTFISZUnHTfAUdaba3E0mqJWU6kgGCEKzc3n8pAAJlyG0IFEEqwAwhB8OaQKwAKzvVTTRxe+qW90Q9TpZiwbB+GAAQSgjEwME0JLdcCMRiAA)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
