### PR TITLE
Added changelog and updated the "first available in" version for singleAttributePerLine

### DIFF
--- a/changelog_unreleased/html/6644.md
+++ b/changelog_unreleased/html/6644.md
@@ -1,6 +1,6 @@
 #### Enforce Single Attribute Per Line (#6644 by @kankje)
 
-Added the `singleAttributePerLine` option for specifying if Prettier should enforce single attribute per line in HTML, Vue and JSX. Fixes #5501.
+Added the `singleAttributePerLine` option for specifying if Prettier should enforce single attribute per line in HTML, Vue and JSX.
 
 <!-- prettier-ignore -->
 ```html

--- a/changelog_unreleased/html/6644.md
+++ b/changelog_unreleased/html/6644.md
@@ -1,7 +1,6 @@
 #### Enforce Single Attribute Per Line (#6644 by @kankje)
 
-Added the `singleAttributePerLine` option for specifying if Prettier should
-enforce single attribute per line in HTML, Vue and JSX. Fixes #5501.
+Added the `singleAttributePerLine` option for specifying if Prettier should enforce single attribute per line in HTML, Vue and JSX. Fixes #5501.
 
 <!-- prettier-ignore -->
 ```html
@@ -21,7 +20,7 @@ enforce single attribute per line in HTML, Vue and JSX. Fixes #5501.
   Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 </div>
 
-<!-- Prettier main, with option off (default) -->
+<!-- Prettier main, with `{"singleAttributePerLine": false}` -->
 <div data-a="1">
   Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 </div>
@@ -29,7 +28,7 @@ enforce single attribute per line in HTML, Vue and JSX. Fixes #5501.
   Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 </div>
 
-<!-- Prettier main, with option on -->
+<!-- Prettier main, with `{"singleAttributePerLine": true}` -->
 <div data-a="1">
   Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 </div>

--- a/changelog_unreleased/html/6644.md
+++ b/changelog_unreleased/html/6644.md
@@ -1,0 +1,43 @@
+#### Enforce Single Attribute Per Line (#6644 by @kankje)
+
+Added the `singleAttributePerLine` option for specifying if Prettier should
+enforce single attribute per line in HTML, Vue and JSX. Fixes #5501.
+
+<!-- prettier-ignore -->
+```html
+<!-- Input -->
+<div data-a="1">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+</div>
+<div data-a="1" data-b="2" data-c="3">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+</div>
+
+<!-- Prettier stable -->
+<div data-a="1">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+</div>
+<div data-a="1" data-b="2" data-c="3">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+</div>
+
+<!-- Prettier main, with option off (default) -->
+<div data-a="1">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+</div>
+<div data-a="1" data-b="2" data-c="3">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+</div>
+
+<!-- Prettier main, with option on -->
+<div data-a="1">
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+</div>
+<div
+  data-a="1"
+  data-b="2"
+  data-c="3"
+>
+  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+</div>
+```

--- a/docs/options.md
+++ b/docs/options.md
@@ -454,7 +454,7 @@ Valid options:
 
 ## Single Attribute Per Line
 
-_First available in v2.3.3_
+_First available in v2.6.0_
 
 Enforce single attribute per line in HTML, Vue and JSX.
 

--- a/src/common/common-options.js
+++ b/src/common/common-options.js
@@ -55,7 +55,7 @@ module.exports = {
       "Put > of opening tags on the last line instead of on a new line.",
   },
   singleAttributePerLine: {
-    since: "2.3.3",
+    since: "2.6.0",
     category: CATEGORY_COMMON,
     type: "boolean",
     default: false,

--- a/tests/integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests/integration/__tests__/__snapshots__/support-info.js.snap
@@ -1075,7 +1075,7 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"description\\": \\"Enforce single attribute per line in HTML, Vue and JSX.\\",
       \\"name\\": \\"singleAttributePerLine\\",
       \\"pluginDefaults\\": {},
-      \\"since\\": \\"2.3.3\\",
+      \\"since\\": \\"2.6.0\\",
       \\"type\\": \\"boolean\\"
     },
     {


### PR DESCRIPTION
## Description

Added changelog and updated the "first available in" version for the new `singleAttributePerLine` option.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [X] I’ve added tests to confirm my change works.
- [X] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [X] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
