### PR TITLE
Update instructions for configuring Neoformat

### DIFF
--- a/docs/vim.md
+++ b/docs/vim.md
@@ -17,6 +17,12 @@ The best way to install Neoformat is with your favorite plugin manager for Vim, 
 Plug 'sbdchd/neoformat'
 ```
 
+In order for Neoformat to use a project-local version of Prettier (i.e. to use `node_modules/.bin/prettier` instead of looking for `prettier` on `$PATH`), you must set the `neoformat_try_node_exe` option:
+
+```vim
+let g:neoformat_try_node_exe = 1
+```
+
 Run `:Neoformat` or `:Neoformat prettier` in a supported file to run Prettier.
 
 To have Neoformat run Prettier on save:

--- a/website/versioned_docs/version-stable/vim.md
+++ b/website/versioned_docs/version-stable/vim.md
@@ -18,6 +18,12 @@ The best way to install Neoformat is with your favorite plugin manager for Vim, 
 Plug 'sbdchd/neoformat'
 ```
 
+In order for Neoformat to use a project-local version of Prettier (i.e. to use `node_modules/.bin/prettier` instead of looking for `prettier` on `$PATH`), you must set the `neoformat_try_node_exe` option:
+
+```vim
+let g:neoformat_try_node_exe = 1
+```
+
 Run `:Neoformat` or `:Neoformat prettier` in a supported file to run Prettier.
 
 To have Neoformat run Prettier on save:


### PR DESCRIPTION
## Description

Recently addressed in sbdchd/neoformat#363, this calls out the necessary steps to take to ensure that Neoformat uses the locally-installed `prettier`.



## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
