### PR TITLE
Test: Make `runPrettier` result "thenable"

### DIFF
--- a/tests/integration/__tests__/early-exit.js
+++ b/tests/integration/__tests__/early-exit.js
@@ -93,16 +93,20 @@ describe("throw error and show usage with something unexpected", () => {
 
 test("node version error", async () => {
   const originalProcessVersion = process.version;
+  let result;
 
-  Object.defineProperty(process, "version", {
-    value: "v8.0.0",
-    writable: false,
-  });
-  const result = await runPrettier("cli", ["--help"]);
-  Object.defineProperty(process, "version", {
-    value: originalProcessVersion,
-    writable: false,
-  });
+  try {
+    Object.defineProperty(process, "version", {
+      value: "v8.0.0",
+      writable: false,
+    });
+    result = await runPrettier("cli", ["--help"]);
+  } finally {
+    Object.defineProperty(process, "version", {
+      value: originalProcessVersion,
+      writable: false,
+    });
+  }
 
   expect(result.status).toBe(1);
   expect(result.stderr).toBe(

--- a/tests/integration/__tests__/early-exit.js
+++ b/tests/integration/__tests__/early-exit.js
@@ -93,25 +93,27 @@ describe("throw error and show usage with something unexpected", () => {
 
 test("node version error", async () => {
   const originalProcessVersion = process.version;
+  let result;
 
   try {
     Object.defineProperty(process, "version", {
       value: "v8.0.0",
       writable: false,
     });
-    const result = runPrettier("cli", ["--help"]);
-    expect(await result.status).toBe(1);
-    expect(await result.stderr).toBe(
-      `prettier requires at least version ${
-        isProduction ? "10.13.0" : "12.17.0"
-      } of Node, please upgrade\n`
-    );
-    expect(await result.stdout).toBe("");
-    expect(await result.write).toEqual([]);
+    result = await runPrettier("cli", ["--help"]);
   } finally {
     Object.defineProperty(process, "version", {
       value: originalProcessVersion,
       writable: false,
     });
   }
+
+  expect(result.status).toBe(1);
+  expect(result.stderr).toBe(
+    `prettier requires at least version ${
+      isProduction ? "10.13.0" : "12.17.0"
+    } of Node, please upgrade\n`
+  );
+  expect(result.stdout).toBe("");
+  expect(result.write).toEqual([]);
 });

--- a/tests/integration/__tests__/early-exit.js
+++ b/tests/integration/__tests__/early-exit.js
@@ -95,11 +95,11 @@ test("node version error", async () => {
   const originalProcessVersion = process.version;
   let result;
 
+  Object.defineProperty(process, "version", {
+    value: "v8.0.0",
+    writable: false,
+  });
   try {
-    Object.defineProperty(process, "version", {
-      value: "v8.0.0",
-      writable: false,
-    });
     result = await runPrettier("cli", ["--help"]);
   } finally {
     Object.defineProperty(process, "version", {

--- a/tests/integration/__tests__/early-exit.js
+++ b/tests/integration/__tests__/early-exit.js
@@ -93,20 +93,16 @@ describe("throw error and show usage with something unexpected", () => {
 
 test("node version error", async () => {
   const originalProcessVersion = process.version;
-  let result;
 
-  try {
-    Object.defineProperty(process, "version", {
-      value: "v8.0.0",
-      writable: false,
-    });
-    result = await runPrettier("cli", ["--help"]);
-  } finally {
-    Object.defineProperty(process, "version", {
-      value: originalProcessVersion,
-      writable: false,
-    });
-  }
+  Object.defineProperty(process, "version", {
+    value: "v8.0.0",
+    writable: false,
+  });
+  const result = await runPrettier("cli", ["--help"]);
+  Object.defineProperty(process, "version", {
+    value: originalProcessVersion,
+    writable: false,
+  });
 
   expect(result.status).toBe(1);
   expect(result.stderr).toBe(

--- a/tests/integration/__tests__/loglevel.js
+++ b/tests/integration/__tests__/loglevel.js
@@ -38,7 +38,7 @@ describe("Should use default level logger to log `--loglevel` error", () => {
 });
 
 async function runPrettierWithLogLevel(logLevel, patterns) {
-  const result = runPrettier("cli/loglevel", [
+  const result = await runPrettier("cli/loglevel", [
     "--loglevel",
     logLevel,
     "--unknown-option",
@@ -47,9 +47,9 @@ async function runPrettierWithLogLevel(logLevel, patterns) {
     "not-found.js",
   ]);
 
-  expect(await result.status).toBe(2);
+  expect(result.status).toBe(2);
 
-  const stderr = stripAnsi(await result.stderr);
+  const stderr = stripAnsi(result.stderr);
 
   if (patterns) {
     for (const pattern of patterns) {

--- a/tests/integration/__tests__/piped-output.js
+++ b/tests/integration/__tests__/piped-output.js
@@ -3,7 +3,7 @@
 const runPrettier = require("../runPrettier.js");
 
 describe("output with --check + unformatted differs when piped", () => {
-  const result0 = runPrettier(
+  const cli0 = runPrettier(
     "cli/write",
     ["--write", "--check", "--no-color", "unformatted.js"],
     { stdoutIsTTY: true }
@@ -11,7 +11,7 @@ describe("output with --check + unformatted differs when piped", () => {
     status: 0,
   });
 
-  const result1 = runPrettier(
+  const cli1 = runPrettier(
     "cli/write",
     ["--write", "--check", "--no-color", "unformatted.js"],
     { stdoutIsTTY: false }
@@ -20,15 +20,16 @@ describe("output with --check + unformatted differs when piped", () => {
   });
 
   test("Result", async () => {
-    expect((await result0.stdout).length).toBeGreaterThan(
-      (await result1.stdout).length
-    );
-    expect(await result0.write).toEqual(await result1.write);
+    const result0 = await cli0;
+    const result1 = await cli1;
+
+    expect(result0.stdout.length).toBeGreaterThan(result1.stdout.length);
+    expect(result0.write).toEqual(result1.write);
   });
 });
 
 describe("no file diffs with --check + formatted file", () => {
-  const result0 = runPrettier(
+  const cli0 = runPrettier(
     "cli/write",
     ["--write", "--check", "--no-color", "formatted.js"],
     { stdoutIsTTY: true }
@@ -36,7 +37,7 @@ describe("no file diffs with --check + formatted file", () => {
     status: 0,
   });
 
-  const result1 = runPrettier(
+  const cli1 = runPrettier(
     "cli/write",
     ["--write", "--check", "--no-color", "formatted.js"],
     { stdoutIsTTY: false }
@@ -45,16 +46,17 @@ describe("no file diffs with --check + formatted file", () => {
   });
 
   test("Result", async () => {
-    expect(await result0.stdout).not.toEqual(await result1.stdout);
-    expect((await result0.stdout).length).toBeGreaterThan(
-      (await result1.stdout).length
-    );
-    expect(await result0.write).toEqual(await result1.write);
+    const result0 = await cli0;
+    const result1 = await cli1;
+
+    expect(result0.stdout).not.toEqual(result1.stdout);
+    expect(result0.stdout.length).toBeGreaterThan(result1.stdout.length);
+    expect(result0.write).toEqual(result1.write);
   });
 });
 
 describe("output with --list-different + unformatted differs when piped", () => {
-  const result0 = runPrettier(
+  const cli0 = runPrettier(
     "cli/write",
     ["--write", "--list-different", "--no-color", "unformatted.js"],
     { stdoutIsTTY: true }
@@ -62,7 +64,7 @@ describe("output with --list-different + unformatted differs when piped", () => 
     status: 0,
   });
 
-  const result1 = runPrettier(
+  const cli1 = runPrettier(
     "cli/write",
     ["--write", "--list-different", "--no-color", "unformatted.js"],
     { stdoutIsTTY: false }
@@ -71,15 +73,16 @@ describe("output with --list-different + unformatted differs when piped", () => 
   });
 
   test("Result", async () => {
-    expect((await result0.stdout).length).toBeGreaterThan(
-      (await result1.stdout).length
-    );
-    expect(await result0.write).toEqual(await result1.write);
+    const result0 = await cli0;
+    const result1 = await cli1;
+
+    expect(result0.stdout.length).toBeGreaterThan(result1.stdout.length);
+    expect(result0.write).toEqual(result1.write);
   });
 });
 
 describe("no file diffs with --list-different + formatted file", () => {
-  const result0 = runPrettier(
+  const cli0 = runPrettier(
     "cli/write",
     ["--write", "--list-different", "--no-color", "formatted.js"],
     { stdoutIsTTY: true }
@@ -87,7 +90,7 @@ describe("no file diffs with --list-different + formatted file", () => {
     status: 0,
   });
 
-  const result1 = runPrettier(
+  const cli1 = runPrettier(
     "cli/write",
     ["--write", "--list-different", "--no-color", "formatted.js"],
     { stdoutIsTTY: false }
@@ -96,10 +99,11 @@ describe("no file diffs with --list-different + formatted file", () => {
   });
 
   test("Result", async () => {
-    expect(await result0.stdout).not.toEqual(await result1.stdout);
-    expect((await result0.stdout).length).toBeGreaterThan(
-      (await result1.stdout).length
-    );
-    expect(await result0.write).toEqual(await result1.write);
+    const result0 = await cli0;
+    const result1 = await cli1;
+
+    expect(result0.stdout).not.toEqual(result1.stdout);
+    expect(result0.stdout.length).toBeGreaterThan(result1.stdout.length);
+    expect(result0.write).toEqual(result1.write);
   });
 });

--- a/tests/integration/runPrettier.js
+++ b/tests/integration/runPrettier.js
@@ -155,6 +155,9 @@ function runPrettier(dir, args = [], options = {}) {
       return runCli().then(({ write }) => write);
     },
     test: testResult,
+    then(onFulfilled, onRejected) {
+      return runCli().then(onFulfilled, onRejected);
+    },
   };
 
   return getters;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
