### PR TITLE
recognize waitForAsync as test-statement in Angular

### DIFF
--- a/changelog_unreleased/javascript/11992.md
+++ b/changelog_unreleased/javascript/11992.md
@@ -1,0 +1,25 @@
+#### Recognize waitForAsync as test-statement in Angular (#11992 by @HendrikN)
+
+<!-- prettier-ignore -->
+```js
+// Input
+test("foo bar", waitForAsync(() => {
+  const foo = "bar";
+  expect(foo).toEqual("bar")
+}));
+
+// Prettier stable
+test(
+  "foo bar",
+  waitForAsync(() => {
+    const foo = "bar";
+    expect(foo).toEqual("bar");
+  })
+);
+
+// Prettier main
+test("foo bar", waitForAsync(() => {
+  const foo = "bar";
+  expect(foo).toEqual("bar");
+}));
+```

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -308,7 +308,10 @@ function isTemplateLiteral(node) {
 }
 
 /**
- * Note: `inject` is used in AngularJS 1.x, `async` in Angular 2+
+ * Note: `inject` is used in AngularJS 1.x, `async` and `fakeAsync` in
+ * Angular 2+, although `async` is deprecated and replaced by `waitForAsync`
+ * since Angular 12.
+ *
  * example: https://docs.angularjs.org/guide/unit-testing#using-beforeall-
  *
  * @param {CallExpression} node
@@ -318,9 +321,7 @@ function isAngularTestWrapper(node) {
   return (
     isCallExpression(node) &&
     node.callee.type === "Identifier" &&
-    (node.callee.name === "async" ||
-      node.callee.name === "inject" ||
-      node.callee.name === "fakeAsync")
+    ["async", "inject", "fakeAsync", "waitForAsync"].includes(node.callee.name)
   );
 }
 

--- a/tests/format/js/test-declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/test-declarations/__snapshots__/jsfmt.spec.js.snap
@@ -276,6 +276,133 @@ function x() {
 ================================================================================
 `;
 
+exports[`angular_waitForAsync.js - {"arrowParens":"avoid"} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+beforeEach(waitForAsync(() => {
+  // code
+}));
+
+afterAll(waitForAsync(() => {
+  console.log('Hello');
+}));
+
+it('should create the app', waitForAsync(() => {
+  //code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", waitForAsync(() => {
+  // code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", waitForAsync(() => new SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS));
+
+/*
+* isTestCall(parent) should only be called when parent exists
+* and parent.type is CallExpression. This test makes sure that
+* no errors are thrown when calling isTestCall(parent)
+*/
+function x() { waitForAsync(() => {}) }
+
+=====================================output=====================================
+beforeEach(waitForAsync(() => {
+  // code
+}));
+
+afterAll(waitForAsync(() => {
+  console.log("Hello");
+}));
+
+it("should create the app", waitForAsync(() => {
+  //code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", waitForAsync(() => {
+  // code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", waitForAsync(() =>
+  new SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS()));
+
+/*
+ * isTestCall(parent) should only be called when parent exists
+ * and parent.type is CallExpression. This test makes sure that
+ * no errors are thrown when calling isTestCall(parent)
+ */
+function x() {
+  waitForAsync(() => {});
+}
+
+================================================================================
+`;
+
+exports[`angular_waitForAsync.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+beforeEach(waitForAsync(() => {
+  // code
+}));
+
+afterAll(waitForAsync(() => {
+  console.log('Hello');
+}));
+
+it('should create the app', waitForAsync(() => {
+  //code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", waitForAsync(() => {
+  // code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", waitForAsync(() => new SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS));
+
+/*
+* isTestCall(parent) should only be called when parent exists
+* and parent.type is CallExpression. This test makes sure that
+* no errors are thrown when calling isTestCall(parent)
+*/
+function x() { waitForAsync(() => {}) }
+
+=====================================output=====================================
+beforeEach(waitForAsync(() => {
+  // code
+}));
+
+afterAll(waitForAsync(() => {
+  console.log("Hello");
+}));
+
+it("should create the app", waitForAsync(() => {
+  //code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", waitForAsync(() => {
+  // code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", waitForAsync(() =>
+  new SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS()));
+
+/*
+ * isTestCall(parent) should only be called when parent exists
+ * and parent.type is CallExpression. This test makes sure that
+ * no errors are thrown when calling isTestCall(parent)
+ */
+function x() {
+  waitForAsync(() => {});
+}
+
+================================================================================
+`;
+
 exports[`angularjs_inject.js - {"arrowParens":"avoid"} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"

--- a/tests/format/js/test-declarations/angular_waitForAsync.js
+++ b/tests/format/js/test-declarations/angular_waitForAsync.js
@@ -1,0 +1,24 @@
+beforeEach(waitForAsync(() => {
+  // code
+}));
+
+afterAll(waitForAsync(() => {
+  console.log('Hello');
+}));
+
+it('should create the app', waitForAsync(() => {
+  //code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", waitForAsync(() => {
+  // code
+}));
+
+it("does something really long and complicated so I have to write a very long name for the test", waitForAsync(() => new SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS));
+
+/*
+* isTestCall(parent) should only be called when parent exists
+* and parent.type is CallExpression. This test makes sure that
+* no errors are thrown when calling isTestCall(parent)
+*/
+function x() { waitForAsync(() => {}) }


### PR DESCRIPTION
## Description

Would close #11991.

This PR would recognize the usage of `waitForAsync` as a valid test statement.`waitForAsync` replaces `async` in Angular 12.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
