### PR TITLE
Fix Flow's class declaration's  indexer formatting

### DIFF
--- a/changelog_unreleased/flow/12009.md
+++ b/changelog_unreleased/flow/12009.md
@@ -1,0 +1,19 @@
+#### Fix Flow's class declaration's `static` indexer formatting (#12009 by @gkz)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+declare class A {
+  static [string]: boolean;
+}
+
+// Prettier stable
+declare class A {
+  [string]: boolean;
+}
+
+// Prettier main
+declare class A {
+  static [string]: boolean;
+}
+```

--- a/src/language-js/print/flow.js
+++ b/src/language-js/print/flow.js
@@ -230,6 +230,7 @@ function printFlow(path, options, print) {
       return parts;
     case "ObjectTypeIndexer": {
       return [
+        node.static ? "static " : "",
         node.variance ? print("variance") : "",
         "[",
         print("id"),

--- a/tests/format/flow/declare-class/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/declare-class/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`indexer.js format 1`] = `
+====================================options=====================================
+parsers: ["flow", "babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+declare class A {
+  [number]: boolean;
+  static [string]: boolean;
+}
+
+// Read-only
+declare class B {
+  +[number]: boolean;
+  static +[string]: boolean;
+}
+
+=====================================output=====================================
+declare class A {
+  [number]: boolean;
+  static [string]: boolean;
+}
+
+// Read-only
+declare class B {
+  +[number]: boolean;
+  static +[string]: boolean;
+}
+
+================================================================================
+`;

--- a/tests/format/flow/declare-class/indexer.js
+++ b/tests/format/flow/declare-class/indexer.js
@@ -1,0 +1,10 @@
+declare class A {
+  [number]: boolean;
+  static [string]: boolean;
+}
+
+// Read-only
+declare class B {
+  +[number]: boolean;
+  static +[string]: boolean;
+}

--- a/tests/format/flow/declare-class/jsfmt.spec.js
+++ b/tests/format/flow/declare-class/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(__dirname, ["flow", "babel"]);


### PR DESCRIPTION
## Description

Fix Flow's class declaration's  indexer formatting:

```jsx
// Input
declare class A {
  static [string]: boolean;
}
// Before:
declare class A {
  [string]: boolean;
}
// After:
declare class A {
  static [string]: boolean;
}
```

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
