### PR TITLE
Add jsxSpaceBeforeSelfClosingTag option

### DIFF
--- a/changelog_unreleased/javascript/12016.md
+++ b/changelog_unreleased/javascript/12016.md
@@ -1,0 +1,33 @@
+#### Add jsxSpaceBeforeSelfClosingTag option (#12016 by @sryze)
+
+Make it possible to customize whether to put a space before `/>` in self-closing tags in JSX. On by default.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+function Component() {
+  return (
+    <div>
+      <img/>
+    </div>
+  );
+}
+
+// Prettier stable
+function Component() {
+  return (
+    <div>
+      <img />
+    </div>
+  );
+}
+
+// Prettier main
+function Component() {
+  return (
+    <div>
+      <img/>
+    </div>
+  );
+}
+```

--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -99,4 +99,11 @@ module.exports = {
     ],
   },
   singleAttributePerLine: commonOptions.singleAttributePerLine,
+  jsxSpaceBeforeSelfClosingTag: {
+    since: "2.7.0",
+    category: CATEGORY_JAVASCRIPT,
+    type: "boolean",
+    default: true,
+    description: "Put a space before /> in self-closing tags.",
+  },
 };

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -541,7 +541,7 @@ function printJsxOpeningElement(path, options, print) {
 
   // Don't break self-closing elements with no attributes and no comments
   if (node.selfClosing && node.attributes.length === 0 && !nameHasComments) {
-    return ["<", print("name"), print("typeParameters"), " />"];
+    return ["<", print("name"), print("typeParameters"), options.jsxSpaceBeforeSelfClosingTag ? " />" : "/>"];
   }
 
   // don't break up opening elements with a single long text attribute
@@ -569,7 +569,7 @@ function printJsxOpeningElement(path, options, print) {
       print("typeParameters"),
       " ",
       ...path.map(print, "attributes"),
-      node.selfClosing ? " />" : ">",
+      node.selfClosing ? (options.jsxSpaceBeforeSelfClosingTag ?" />" : "/>") : ">",
     ]);
   }
 
@@ -617,7 +617,7 @@ function printJsxOpeningElement(path, options, print) {
       print("typeParameters"),
       indent(path.map(() => [attributeLine, print()], "attributes")),
       node.selfClosing ? line : bracketSameLine ? ">" : softline,
-      node.selfClosing ? "/>" : bracketSameLine ? "" : ">",
+      node.selfClosing ? (options.jsxSpaceBeforeSelfClosingTag ? " />" : "/>") : bracketSameLine ? "" : ">",
     ],
     { shouldBreak }
   );


### PR DESCRIPTION
## Description

Make it possible to customize whether to put a space before the `/>` part in self-closing tags in JSX. 

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
