### PR TITLE
Add internal ESLint rule `no-legacy-format-test-fixtures`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -185,6 +185,12 @@ module.exports = {
       },
     },
     {
+      files: ["tests/format/**/*.js"],
+      rules: {
+        "prettier-internal-rules/no-legacy-format-test-fixtures": "error",
+      },
+    },
+    {
       files: ["tests/integration/**/*.js"],
       rules: {
         "prettier-internal-rules/await-cli-tests": "error",

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/index.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/index.js
@@ -12,6 +12,7 @@ module.exports = {
     "no-doc-builder-concat": require("./no-doc-builder-concat.js"),
     "no-empty-flat-contents-for-if-break": require("./no-empty-flat-contents-for-if-break.js"),
     "no-identifier-n": require("./no-identifier-n.js"),
+    "no-legacy-format-test-fixtures": require("./no-legacy-format-test-fixtures.js"),
     "no-node-comments": require("./no-node-comments.js"),
     "no-unnecessary-ast-path-call": require("./no-unnecessary-ast-path-call.js"),
     "prefer-ast-path-each": require("./prefer-ast-path-each.js"),

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/no-legacy-format-test-fixtures.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/no-legacy-format-test-fixtures.js
@@ -33,9 +33,9 @@ module.exports = {
       url: "https://github.com/prettier/prettier/blob/main/scripts/tools/eslint-plugin-prettier-internal-rules/no-legacy-format-test-fixtures.js",
     },
     messages: {
-      [MESSAGE_ID_ARGUMENT]: "Use `import.meta` insteadof `__dirname`.",
+      [MESSAGE_ID_ARGUMENT]: "Use `import.meta` instead of `__dirname`.",
       [MESSAGE_ID_PROPERTY]:
-        "Use `importMeta: import.meta` insteadof `dirname: __dirname`.",
+        "Use `importMeta: import.meta` instead of `dirname: __dirname`.",
     },
     fixable: "code",
     hasSuggestions: true,

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/no-legacy-format-test-fixtures.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/no-legacy-format-test-fixtures.js
@@ -1,0 +1,64 @@
+"use strict";
+
+const dirnameArgumentSelector = [
+  "CallExpression",
+  '[callee.type="Identifier"]',
+  '[callee.name="run_spec"]',
+  " > ",
+  "Identifier.arguments:first-child",
+  '[name="__dirname"]',
+].join("");
+
+const dirnamePropertySelector = [
+  "CallExpression",
+  '[callee.type="Identifier"]',
+  '[callee.name="run_spec"]',
+  " > ",
+  "ObjectExpression.arguments:first-child",
+  " > ",
+  "Property.properties",
+  '[key.type="Identifier"]',
+  '[key.name="dirname"]',
+  '[value.type="Identifier"]',
+  '[value.name="__dirname"]',
+].join("");
+
+const MESSAGE_ID_ARGUMENT = "dirname-argument";
+const MESSAGE_ID_PROPERTY = "dirname-property";
+
+module.exports = {
+  meta: {
+    type: "suggestion",
+    docs: {
+      url: "https://github.com/prettier/prettier/blob/main/scripts/tools/eslint-plugin-prettier-internal-rules/no-legacy-format-test-fixtures.js",
+    },
+    messages: {
+      [MESSAGE_ID_ARGUMENT]: "Use `import.meta` insteadof `__dirname`.",
+      [MESSAGE_ID_PROPERTY]:
+        "Use `importMeta: import.meta` insteadof `dirname: __dirname`.",
+    },
+    fixable: "code",
+    hasSuggestions: true,
+  },
+  create(context) {
+    return {
+      [dirnameArgumentSelector](node) {
+        context.report({
+          node,
+          messageId: MESSAGE_ID_ARGUMENT,
+          fix: (fixer) => fixer.replaceText(node, "import.meta"),
+        });
+      },
+      [dirnamePropertySelector](node) {
+        context.report({
+          node,
+          messageId: MESSAGE_ID_PROPERTY,
+          fix: (fixer) => [
+            fixer.replaceText(node.key, "importMeta"),
+            fixer.replaceText(node.value, "import.meta"),
+          ],
+        });
+      },
+    };
+  },
+};

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
@@ -331,6 +331,30 @@ test("no-identifier-n", {
   ],
 });
 
+test("no-legacy-format-test-fixtures", {
+  valid: [
+    "run_spec(import.meta, ['babel'])",
+    "run_spec({importMeta: import.meta}, ['babel'])",
+  ].map((code) => ({ code, parserOptions: { sourceType: "module" } })),
+  invalid: [
+    {
+      code: "run_spec(__dirname, ['babel'])",
+      errors: [{ message: "Use `import.meta` insteadof `__dirname`." }],
+      output: "run_spec(import.meta, ['babel'])",
+    },
+    {
+      code: "run_spec({snippets: ['x'], dirname: __dirname}, ['babel'])",
+      errors: [
+        {
+          message:
+            "Use `importMeta: import.meta` insteadof `dirname: __dirname`.",
+        },
+      ],
+      output: "run_spec({snippets: ['x'], importMeta: import.meta}, ['babel'])",
+    },
+  ].map((test) => ({ ...test, parserOptions: { sourceType: "module" } })),
+});
+
 test("no-node-comments", {
   valid: [
     "const comments = node.notComments",

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
@@ -339,7 +339,7 @@ test("no-legacy-format-test-fixtures", {
   invalid: [
     {
       code: "run_spec(__dirname, ['babel'])",
-      errors: [{ message: "Use `import.meta` insteadof `__dirname`." }],
+      errors: [{ message: "Use `import.meta` instead of `__dirname`." }],
       output: "run_spec(import.meta, ['babel'])",
     },
     {
@@ -347,7 +347,7 @@ test("no-legacy-format-test-fixtures", {
       errors: [
         {
           message:
-            "Use `importMeta: import.meta` insteadof `dirname: __dirname`.",
+            "Use `importMeta: import.meta` instead of `dirname: __dirname`.",
         },
       ],
       output: "run_spec({snippets: ['x'], importMeta: import.meta}, ['babel'])",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

New test from `main` branch can run this rule to auto-fix to the new format (changed in #11902).

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
