### PR TITLE
docs: link preserving empty lines to preserving comments

### DIFF
--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -22,7 +22,7 @@ Prettier maintains the way your string is escaped. For example, `"🙂"` won’t
 
 ### Empty lines
 
-It turns out that empty lines are very hard to automatically generate. The approach that Prettier takes is to preserve empty lines the way they were in the original source code. There are two additional rules:
+It turns out that empty lines are very hard to automatically generate. The approach that Prettier takes is to preserve empty lines the way they were in the original source code, in a similar fashion to preserving [comments](#comments). There are two additional rules:
 
 - Prettier collapses multiple blank lines into a single blank line.
 - Empty lines at the start and end of blocks (and whole files) are removed. (Files always end with a single newline, though.)


### PR DESCRIPTION
## Description

Coming from discussion in issue #12078

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
