### PR TITLE
Clarify documentation around proseWrap

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -350,13 +350,13 @@ Note that “in tandem” doesn’t mean “at the same time”. When the two op
 
 _First available in v1.8.2_
 
-By default, Prettier will wrap markdown text as-is since some services use a linebreak-sensitive renderer, e.g. GitHub comment and BitBucket. In some cases you may want to rely on editor/viewer soft wrapping instead, so this option allows you to opt out with `"never"`.
+By default, Prettier will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket. To have Prettier wrap prose to the print width, change this option to "always". If you want Prettier to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use `"never"`.
 
 Valid options:
 
 - `"always"` - Wrap prose if it exceeds the print width.
-- `"never"` - Do not wrap prose.
-- `"preserve"` - Wrap prose as-is. _First available in v1.9.0_
+- `"never"` - Un-wrap each block of prose into one line.
+- `"preserve"` - Do nothing, leave prose as-is. _First available in v1.9.0_
 
 | Default      | CLI Override                                                | API Override                                                |
 | ------------ | ----------------------------------------------------------- | ----------------------------------------------------------- |

--- a/website/versioned_docs/version-stable/options.md
+++ b/website/versioned_docs/version-stable/options.md
@@ -345,13 +345,13 @@ Note that “in tandem” doesn’t mean “at the same time”. When the two op
 
 _First available in v1.8.2_
 
-By default, Prettier will wrap markdown text as-is since some services use a linebreak-sensitive renderer, e.g. GitHub comment and BitBucket. In some cases you may want to rely on editor/viewer soft wrapping instead, so this option allows you to opt out with `"never"`.
+By default, Prettier will not change wrapping in markdown text since some services use a linebreak-sensitive renderer, e.g. GitHub comments and BitBucket. To have Prettier wrap prose to the print width, change this option to "always". If you want Prettier to force all prose blocks to be on a single line and rely on editor/viewer soft wrapping instead, you can use `"never"`.
 
 Valid options:
 
 - `"always"` - Wrap prose if it exceeds the print width.
-- `"never"` - Do not wrap prose.
-- `"preserve"` - Wrap prose as-is. _First available in v1.9.0_
+- `"never"` - Un-wrap each block of prose into one line.
+- `"preserve"` - Do nothing, leave prose as-is. _First available in v1.9.0_
 
 | Default      | CLI Override                                                | API Override                                                |
 | ------------ | ----------------------------------------------------------- | ----------------------------------------------------------- |


### PR DESCRIPTION
## Description

I was trying to understand the proseWrap options, and the existing documentation was very confusing to me. Because `"never"` was described as "opt-out", I thought it meant it would be opting out of Prettier formatting - which is very much not the case. I think it's also unclear what it means to "wrap as-is" - if you're just leaving it as-is, you're not actually doing any _wrapping_ one way or the other - you're just leaving it as-is.

Trying to figure out what "_wrap_ as-is" meant, I thought maybe there was some sort of algorithm where it would not wrap really long lines, but would re-wrap lines that were under or maybe just a little over `printWidth`, so as to wrap blocks that were "supposed" to be wrapped, but not ones that weren't. But it appears that the default `"preserve"` option is actually much simpler, in that it just doesn't do any wrapping of prose at all.

I've attempted to rewrite this section to more clearly reflect my understanding of the behavior, which is as follows:
 - "always" will wrap all prose to `printWidth`
 - "never" will unwrap all prose blocks to one line, leaving no wrapped blocks whatsoever
 - "preserve" will do no wrapping of prose blocks, leaving them wrapped as-is

If I've misunderstood one or more of the behaviors, please let me know and I will adjust accordingly!

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [N/A] I’ve added tests to confirm my change works.
- [N/A] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
