### PR TITLE
Add sql template literals support via plugins

### DIFF
--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -9,6 +9,7 @@ const formatMarkdown = require("./embed/markdown.js");
 const formatCss = require("./embed/css.js");
 const formatGraphql = require("./embed/graphql.js");
 const formatHtml = require("./embed/html.js");
+const formatSql = require("./embed/sql.js");
 
 function getLanguage(path) {
   if (
@@ -34,6 +35,10 @@ function getLanguage(path) {
 
   if (isMarkdown(path)) {
     return "markdown";
+  }
+
+  if (isSql(path)) {
+    return "sql";
   }
 }
 
@@ -69,6 +74,10 @@ function embed(path, print, textToDoc, options) {
   if (language === "html" || language === "angular") {
     return formatHtml(path, print, textToDoc, options, { parser: language });
   }
+
+  if (language === "sql") {
+    return formatSql(path, print, textToDoc, options)
+  }
 }
 
 /**
@@ -84,6 +93,19 @@ function isMarkdown(path) {
     node.quasis.length === 1 &&
     parent.tag.type === "Identifier" &&
     (parent.tag.name === "md" || parent.tag.name === "markdown")
+  );
+}
+
+/**
+ * sql`...`
+ */
+function isSql(path) {
+  const parent = path.getParentNode();
+  return (
+    parent &&
+    parent.type === "TaggedTemplateExpression" &&
+    parent.tag.type === "Identifier" &&
+    parent.tag.name === "sql"
   );
 }
 

--- a/src/language-js/embed/sql.js
+++ b/src/language-js/embed/sql.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const {
+  builders: { softline, group, indent },
+} = require("../../document/index.js");
+
+function format(path, print, textToDoc, options) {
+  const node = path.getValue();
+
+  if (
+    options.plugins.some(
+      (plugin) =>
+        typeof plugin !== "string" &&
+        plugin.parsers &&
+        Object.prototype.hasOwnProperty.call(plugin.parsers, "sql")
+    )
+  ) {
+    const text = node.quasis[0].value.raw.replace(
+      /((?:\\\\)*)\\`/g,
+      (_, backslashes) => "\\".repeat(backslashes.length / 2) + "`"
+    );
+
+    const doc = textToDoc(text, { parser: "sql" }, options);
+
+    return group(["`", indent([softline, group(doc)]), "`"]);
+  }
+}
+
+module.exports = format;

--- a/tests/format/js/template-literals-sql/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/template-literals-sql/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`sql.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const table1Query = sql\`SELECT * FROM table1\`;
+
+const table2Query = sql\`
+  SELECT
+    id
+  FROM table2\`;
+
+=====================================output=====================================
+const table1Query = sql\`sql+SELECT * FROM table1\`;
+
+const table2Query = sql\`sql+
+  SELECT
+    id
+  FROM table2\`;
+
+================================================================================
+`;

--- a/tests/format/js/template-literals-sql/jsfmt.spec.js
+++ b/tests/format/js/template-literals-sql/jsfmt.spec.js
@@ -1,0 +1,3 @@
+run_spec(__dirname, ["babel", "flow", "typescript"], {
+  plugins: ["./tests/integration/plugins/sql/main.js"],
+});

--- a/tests/format/js/template-literals-sql/sql.js
+++ b/tests/format/js/template-literals-sql/sql.js
@@ -1,0 +1,6 @@
+const table1Query = sql`SELECT * FROM table1`;
+
+const table2Query = sql`
+  SELECT
+    id
+  FROM table2`;

--- a/tests/format/js/template-literals/sql.js
+++ b/tests/format/js/template-literals/sql.js
@@ -1,0 +1,6 @@
+const table1Query = sql`SELECT * FROM table1`;
+
+const table2Query = sql`
+  SELECT
+    id
+  FROM table2`;

--- a/tests/integration/plugins/sql/main.js
+++ b/tests/integration/plugins/sql/main.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const prettier = require("prettier-local");
+const concat = prettier.doc.builders.concat;
+
+module.exports = {
+  languages: [
+    {
+      name: "sql",
+      parsers: ["sql"]
+    }
+  ],
+  parsers: {
+    sql: {
+      parse: text => ({ text }),
+      astFormat: "sql"
+    }
+  },
+  printers: {
+    sql: {
+      print: path => concat(["sql+", path.getValue().text])
+    }
+  }
+};

--- a/tests/integration/plugins/sql/packge.json
+++ b/tests/integration/plugins/sql/packge.json
@@ -1,0 +1,4 @@
+{
+  "name": "prettier-plugin-sql",
+  "main": "./main.js"
+}


### PR DESCRIPTION
## Description

Add support for prettifying sql template literals.

```typescript
import { sql } from '@potygen/potygen';

const myQuery = sql`
  SELECT * FROM table1
`;
```

This does not add the support itself, just the ability to do so by plugins, if they provide the "sql" parser/printer. Does not change any behaviour if no plugins like that are present.

---

I'm developing a Postgres sql typescript type generator - [potygen](https://github.com/ivank/potygen). As part of that effort I've ended up with a pretty decent pure JS sql parser and figured - lets do [a sql prettier plugin](https://github.com/ivank/potygen/tree/main/packages/prettier-plugin-pgsql). And that turned out working great too.

To my horror though 😱 all of our `sql` template literals in our service didn't magically become pretty! Reading [the issues](https://github.com/prettier/prettier/issues/4424) and [source](https://github.com/prettier/prettier/blob/4dd195099e533cfa3ac372119eb796c8114b3246/src/language-js/embed.js#L40-L72) it quickly became obvious that there are only several blessed tags that are processed, and my newly minted prettifier would be delegated to the cold wintery post of just dealing with raw sql files. That's great and all, but I was craving for more!

I'm also not the only one figuring "raw sql is better than ORM", and indeed I've found a lot of like minded folk along the way - [squid](https://github.com/andywer/squid), [ts-mysql-analyzer](https://github.com/segmentio/ts-mysql-plugin), [pgtyped](https://github.com/adelsz/pgtyped) and I'm sure many others, so the need and desire for sql template literals is here, we just need prettier to allow us to plug that in.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
