### PR TITLE
Add assert to utils

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -10,6 +10,15 @@ const notAsciiRegex = /[^\x20-\x7F]/;
 const getPenultimate = (arr) => arr[arr.length - 2];
 
 /**
+ * @param {boolean} condition Condition that needs to be truthy
+ */
+function assert(condition) {
+  if (!condition) {
+    throw new Error("Assertion error");
+  }
+}
+
+/**
  * @typedef {{backwards?: boolean}} SkipOptions
  */
 
@@ -631,6 +640,7 @@ function describeNodeForDebugging(node) {
 }
 
 module.exports = {
+  assert,
   inferParserByLanguage,
   getStringWidth,
   getMaxContinuousCount,

--- a/src/language-html/print/tag.js
+++ b/src/language-html/print/tag.js
@@ -4,8 +4,7 @@
  * @typedef {import("../../document").Doc} Doc
  */
 
-const assert = require("assert");
-const { isNonEmptyArray } = require("../../common/util.js");
+const { assert, isNonEmptyArray } = require("../../common/util.js");
 const {
   builders: { indent, join, line, softline, hardline },
   utils: { replaceTextEndOfLine },

--- a/src/language-js/print/flow.js
+++ b/src/language-js/print/flow.js
@@ -2,9 +2,8 @@
 
 /** @typedef {import("../../document").Doc} Doc */
 
-const assert = require("assert");
 const { printDanglingComments } = require("../../main/comments.js");
-const { printString, printNumber } = require("../../common/util.js");
+const { assert, printString, printNumber } = require("../../common/util.js");
 const {
   builders: { hardline, softline, group, indent },
 } = require("../../document/index.js");
@@ -217,7 +216,7 @@ function printFlow(path, options, print) {
       return ["?", print("typeAnnotation")];
     case "Variance": {
       const { kind } = node;
-      assert.ok(kind === "plus" || kind === "minus");
+      assert(kind === "plus" || kind === "minus");
       return kind === "plus" ? "+" : "-";
     }
     case "ObjectTypeCallProperty":
@@ -280,7 +279,7 @@ function printFlow(path, options, print) {
     case "StringLiteralTypeAnnotation":
       return printString(rawText(node), options);
     case "NumberLiteralTypeAnnotation":
-      assert.strictEqual(typeof node.value, "number");
+      assert(typeof node.value === "number");
     // fall through
     case "BigIntLiteralTypeAnnotation":
       if (node.extra) {
@@ -372,7 +371,7 @@ function printFlowDeclaration(path, printed) {
   const parentExportDecl = getParentExportDeclaration(path);
 
   if (parentExportDecl) {
-    assert.strictEqual(parentExportDecl.type, "DeclareExportDeclaration");
+    assert(parentExportDecl.type === "DeclareExportDeclaration");
     return printed;
   }
 

--- a/src/language-js/print/function.js
+++ b/src/language-js/print/function.js
@@ -2,13 +2,13 @@
 
 /** @typedef {import("../../document/doc-builders").Doc} Doc */
 
-const assert = require("assert");
 const {
   printDanglingComments,
   printCommentsSeparately,
 } = require("../../main/comments.js");
 const getLast = require("../../utils/get-last.js");
 const {
+  assert,
   getNextNonSpaceNonCommentCharacterIndex,
 } = require("../../common/util.js");
 const {
@@ -130,7 +130,7 @@ function printMethod(path, options, print) {
       parts.push("async ");
     }
   } else {
-    assert.ok(kind === "get" || kind === "set");
+    assert(kind === "get" || kind === "set");
 
     parts.push(kind, " ");
   }

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -1,12 +1,11 @@
 "use strict";
 
-const assert = require("assert");
-
 const {
   builders: { line, hardline, breakParent, indent, lineSuffix, join, cursor },
 } = require("../document/index.js");
 
 const {
+  assert,
   hasNewline,
   skipNewline,
   skipSpaces,
@@ -384,8 +383,8 @@ function breakTies(tiesToBreak, text, options) {
       precedingNode: currentCommentPrecedingNode,
       followingNode: currentCommentFollowingNode,
     } = tiesToBreak[indexOfFirstLeadingComment - 1];
-    assert.strictEqual(currentCommentPrecedingNode, precedingNode);
-    assert.strictEqual(currentCommentFollowingNode, followingNode);
+    assert(currentCommentPrecedingNode === precedingNode);
+    assert(currentCommentFollowingNode === followingNode);
 
     const gap = text.slice(options.locEnd(comment), gapEndPos);
 

--- a/src/main/range-util.js
+++ b/src/main/range-util.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const assert = require("assert");
+const { assert } = require("../common/util.js");
 const comments = require("./comments.js");
 
 const isJsonParser = ({ parser }) =>
@@ -187,7 +187,7 @@ function isSourceElement(opts, node, parentNode) {
 
 function calculateRange(text, opts, ast) {
   let { rangeStart: start, rangeEnd: end, locStart, locEnd } = opts;
-  assert.ok(end > start);
+  assert(end > start);
   // Contract the range so that it has non-whitespace characters at its endpoints.
   // This ensures we can format a range that doesn't end on a node.
   const firstNonWhitespaceCharacterIndex = text.slice(start, end).search(/\S/);


### PR DESCRIPTION
## Description

By implementing a custom function for assert, we no longer rely on the
Node global polyfill for the assert module. As part of #12144, I
discovered that the node global polyfill is a large contributor to the
file size.

Currently, on main I obtained the following numbers:

```
> yarn build --file=standalone.js --no-minify
> perl -le "map { \$sum += -s } @ARGV; print \$sum" dist/esm/standalone.mjs
< 1207295

> yarn build --file=standalone.js
> perl -le "map { \$sum += -s } @ARGV; print \$sum" dist/esm/standalone.mjs
< 562931
```

With this PR, the numbers change to:

```
> yarn build --file=standalone.js --no-minify
> perl -le "map { \$sum += -s } @ARGV; print \$sum" dist/esm/standalone.mjs
< 1136137

> yarn build --file=standalone.js
> perl -le "map { \$sum += -s } @ARGV; print \$sum" dist/esm/standalone.mjs
< 530682
```

This is a 5.89% and 5.72% size reduction for respectively unminified and
minified standalone bundle output.

## Checklist

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
