### PR TITLE
Do not use Chalk in error message in main bundle

### DIFF
--- a/src/main/options-normalizer.js
+++ b/src/main/options-normalizer.js
@@ -2,7 +2,6 @@
 
 const vnopts = require("vnopts");
 const leven = require("leven");
-const chalk = require("chalk");
 const getLast = require("../utils/get-last.js");
 
 const cliDescriptor = {
@@ -33,8 +32,8 @@ class FlagSchema extends vnopts.ChoiceSchema {
       if (suggestion) {
         utils.logger.warn(
           [
-            `Unknown flag ${chalk.yellow(utils.descriptor.value(value))},`,
-            `did you mean ${chalk.blue(utils.descriptor.value(suggestion))}?`,
+            `Unknown flag ${utils.descriptor.value(value)},`,
+            `did you mean ${utils.descriptor.value(suggestion)}?`,
           ].join(" ")
         );
         return suggestion;


### PR DESCRIPTION
## Description

The CLI uses Chalk for color messages for a better user experience.
However, the standalone bundle does not pull in the CLI and is intended
to be loaded in the browser, which does not have a terminal interface.

By avoiding using Chalk in the main bundle, we obtain the following
numbers:

```
> yarn build --file=standalone.js --no-minify
> perl -le "map { \$sum += -s } @ARGV; print \$sum" dist/esm/standalone.mjs
< 1156128

> yarn build --file=standalone.js
> perl -le "map { \$sum += -s } @ARGV; print \$sum" dist/esm/standalone.mjs
< 539365
```

This is a 4.24% and 4.19% size reduction for respectively unminified and
minified standalone bundle output compared to `main`.

This is part of #12144

## Checklist

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
