### PR TITLE
Update cSpell config

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -370,8 +370,6 @@
     ],
     "files": [
         "*",
-        ".*",
-        ".github/**/*",
         "bin/**/*",
         "changelog_unreleased/**/*",
         "docs/**/*",
@@ -381,14 +379,12 @@
         "website/**/*",
         "tests/config/**/*",
         "tests/integration/**/*",
-        "tests/**/jsfmt.spec.js"
+        "tests/format/**/jsfmt.spec.js"
     ],
     "ignorePaths": [
+        ".git",
         "cspell.json",
-        "**/node_modules/**",
-        "**/yarn.lock",
         "*.{log,svg,snap,png}",
-        "test*.*",
         "website/data/users.yml",
         "website/build/**",
         "website/playground/codeSamples.js",

--- a/package.json
+++ b/package.json
@@ -150,7 +150,7 @@
     "lint:changelog": "node ./scripts/lint-changelog.mjs",
     "lint:prettier": "prettier . \"!test*\" --check",
     "lint:dist": "eslint --no-eslintrc --no-ignore --no-inline-config --config=./scripts/bundle-eslint-config.js \"dist/!(bin-prettier|index|third-party).js\"",
-    "lint:spellcheck": "cspell --no-progress --relative",
+    "lint:spellcheck": "cspell --no-progress --relative --dot --gitignore",
     "lint:deps": "node ./scripts/check-deps.mjs",
     "lint:actionlint": "node-actionlint",
     "fix": "run-s fix:eslint fix:prettier",

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
@@ -272,8 +272,8 @@ test("no-identifier-n", {
   valid: ["const a = {n: 1}", "const m = 1", "a.n = 1"],
   invalid: [
     {
-      code: "const n = 1; alet(n)",
-      output: "const node = 1; alet(node)",
+      code: "const n = 1; alert(n)",
+      output: "const node = 1; alert(node)",
       errors: 1,
     },
     {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Use `--dot` and `--gitignore`  flags, https://github.com/streetsidesoftware/cspell/tree/main/packages/cspell

Before: 

```text
CSpell: Files checked: 1774, Issues found: 0 in 0 files
```

After

```text
CSpell: Files checked: 1837, Issues found: 0 in 0 files
```

Don't know why more files matched. Some dot files in dirs matched?


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
