### PR TITLE
Remove useless `TypeScriptServices` from `parser-typescript.js`

### DIFF
--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -51,6 +51,33 @@ const parsers = [
       "_fs.realpathSync.native": "_fs.realpathSync && _fs.realpathSync.native",
       // Remove useless `ts.sys`
       "ts.sys = ": "ts.sys = undefined && ",
+
+      // Remove useless language service
+      "ts.realizeDiagnostics = ": "ts.realizeDiagnostics = undefined && ",
+      "ts.TypeScriptServicesFactory = ":
+        "ts.TypeScriptServicesFactory = undefined && ",
+      "var ShimBase = ": "var ShimBase = undefined && ",
+      "var TypeScriptServicesFactory = ":
+        "var TypeScriptServicesFactory = undefined && ",
+      "var LanguageServiceShimObject = ":
+        "var LanguageServiceShimObject = undefined && ",
+      "var CoreServicesShimHostAdapter = ":
+        "var CoreServicesShimHostAdapter = undefined && ",
+      "var LanguageServiceShimHostAdapter = ":
+        "var LanguageServiceShimHostAdapter = undefined && ",
+      "var ScriptSnapshotShimAdapter = ":
+        "var ScriptSnapshotShimAdapter = undefined && ",
+      "var ClassifierShimObject = ": "var ClassifierShimObject = undefined && ",
+      "var CoreServicesShimObject = ":
+        "var CoreServicesShimObject = undefined && ",
+      "function simpleForwardCall(": "0 && function simpleForwardCall(",
+      "function forwardJSONCall(": "0 && function forwardJSONCall(",
+      "function forwardCall(": "0 && function forwardCall(",
+      "function realizeDiagnostics(": "0 && function realizeDiagnostics(",
+      "function realizeDiagnostic(": "0 && function realizeDiagnostic(",
+      "function convertClassifications(":
+        "0 && function convertClassifications(",
+
       // Dynamic `require()`s
       "ts.sys && ts.sys.require": "false",
       "require(etwModulePath)": "undefined",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

```text
8756 -rw-r--r-- 1 fisker None 8965844 Jan 26 20:48 parser-typescript.main.js
3488 -rw-r--r-- 1 fisker None 3569944 Jan 26 20:49 parser-typescript.main.min.js
8712 -rw-r--r-- 1 fisker None 8917563 Jan 26 20:47 parser-typescript.working.js
3464 -rw-r--r-- 1 fisker None 3546949 Jan 26 20:46 parser-typescript.working.min.js
```

~25k

esbuild is so stupid, it leaves uncalled functions there, so I have to remove them one by one.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
