### PR TITLE
Reduce JS parsers bundle size

### DIFF
--- a/src/language-js/parse/postprocess/index.js
+++ b/src/language-js/parse/postprocess/index.js
@@ -2,8 +2,8 @@
 
 const { getLast } = require("../../../common/util.js");
 const { locStart, locEnd } = require("../../loc.js");
-const { isTypeCastComment } = require("../../comments.js");
-const { isTsKeywordType } = require("../../utils.js");
+const { isTsKeywordType } = require("../../utils/is-ts-keyword-type.js");
+const { isTypeCastComment } = require("../../utils/is-type-cast-comment.js");
 const visitNode = require("./visitNode.js");
 const { throwErrorForInvalidNodes } = require("./typescript.js");
 

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -20,8 +20,8 @@ const {
   shouldPrintComma,
   isCallExpression,
   isMemberExpression,
-  isTsKeywordType,
 } = require("../utils.js");
+const { isTsKeywordType } = require("../utils/is-ts-keyword-type.js");
 const { locStart, locEnd } = require("../loc.js");
 
 const { printOptionalToken, printTypeScriptModifiers } = require("./misc.js");

--- a/src/language-js/utils.js
+++ b/src/language-js/utils.js
@@ -1322,10 +1322,6 @@ const markerForIfWithoutBlockAndSameLineComment = Symbol(
   "ifWithoutBlockAndSameLineComment"
 );
 
-function isTsKeywordType({ type }) {
-  return type.startsWith("TS") && type.endsWith("Keyword");
-}
-
 module.exports = {
   getFunctionParameters,
   iterateFunctionParametersPath,
@@ -1391,5 +1387,4 @@ module.exports = {
   getComments,
   CommentCheckFlags,
   markerForIfWithoutBlockAndSameLineComment,
-  isTsKeywordType,
 };

--- a/src/language-js/utils/is-block-comment.js
+++ b/src/language-js/utils/is-block-comment.js
@@ -1,0 +1,20 @@
+"use strict";
+
+/**
+ * @typedef {import("../types/estree").Comment} Comment
+ */
+
+/**
+ * @param {Comment} comment
+ * @returns {boolean}
+ */
+function isBlockComment(comment) {
+  return (
+    comment.type === "Block" ||
+    comment.type === "CommentBlock" ||
+    // `meriyah`
+    comment.type === "MultiLine"
+  );
+}
+
+module.exports = { isBlockComment };

--- a/src/language-js/utils/is-ts-keyword-type.js
+++ b/src/language-js/utils/is-ts-keyword-type.js
@@ -1,0 +1,9 @@
+"use strict";
+/**
+ * @returns {boolean}
+ */
+function isTsKeywordType({ type }) {
+  return type.startsWith("TS") && type.endsWith("Keyword");
+}
+
+module.exports = { isTsKeywordType };

--- a/src/language-js/utils/is-type-cast-comment.js
+++ b/src/language-js/utils/is-type-cast-comment.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const { isBlockComment } = require("./is-block-comment.js");
+
+/**
+ * @typedef {import("../types/estree").Comment} Comment
+ */
+
+/**
+ * @param {Comment} comment
+ * @returns {boolean}
+ */
+function isTypeCastComment(comment) {
+  return (
+    isBlockComment(comment) &&
+    comment.value[0] === "*" &&
+    // TypeScript expects the type to be enclosed in curly brackets, however
+    // Closure Compiler accepts types in parens and even without any delimiters at all.
+    // That's why we just search for "@type".
+    /@type\b/.test(comment.value)
+  );
+}
+
+module.exports = { isTypeCastComment };


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
The bundle size of each JS parser will be reduced by about 50kb

**main:**

```
$ node ./scripts/build/build.mjs --print-size
 Building packages 
index.js.......................................................1.63 MB    DONE  
doc.js..........................................................177 kB    DONE  
standalone.js...................................................529 kB    DONE  
bin-prettier.js.................................................487 kB    DONE  
third-party.js..................................................305 kB    DONE  
parser-babel.js.....................................390 kB, esm 390 kB    DONE  
parser-flow.js....................................2.12 MB, esm 2.12 MB    DONE  
parser-typescript.js..............................3.57 MB, esm 3.57 MB    DONE  
parser-espree.js....................................252 kB, esm 251 kB    DONE  
parser-meriyah.js...................................255 kB, esm 254 kB    DONE  
parser-angular.js...................................111 kB, esm 110 kB    DONE  
parser-postcss.js...............................................237 kB    DONE  
parser-graphql.js.................................43.7 kB, esm 43.2 kB    DONE  
parser-markdown.js..................................173 kB, esm 173 kB    DONE  
parser-glimmer.js...................................193 kB, esm 192 kB    DONE  
parser-html.js......................................179 kB, esm 179 kB    DONE  
parser-yaml.js......................................142 kB, esm 141 kB    DONE  
```

**pr:**

```
$ node ./scripts/build/build.mjs --print-size
 Building packages 
index.js.......................................................1.63 MB    DONE  
doc.js..........................................................177 kB    DONE  
standalone.js...................................................529 kB    DONE  
bin-prettier.js.................................................487 kB    DONE  
third-party.js..................................................305 kB    DONE  
parser-babel.js.....................................338 kB, esm 337 kB    DONE  
parser-flow.js....................................2.07 MB, esm 2.07 MB    DONE  
parser-typescript.js..............................3.52 MB, esm 3.52 MB    DONE  
parser-espree.js....................................199 kB, esm 199 kB    DONE  
parser-meriyah.js...................................202 kB, esm 201 kB    DONE  
parser-angular.js...................................111 kB, esm 110 kB    DONE  
parser-postcss.js...............................................237 kB    DONE  
parser-graphql.js.................................43.7 kB, esm 43.2 kB    DONE  
parser-markdown.js..................................173 kB, esm 173 kB    DONE  
parser-glimmer.js...................................193 kB, esm 192 kB    DONE  
parser-html.js......................................179 kB, esm 179 kB    DONE  
parser-yaml.js......................................142 kB, esm 141 kB    DONE  
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
