### PR TITLE
Reduce bundled size of `diff` package

### DIFF
--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -16,9 +16,18 @@ const getOptionsForFile = require("./options/get-options-for-file.js");
 const isTTY = require("./is-tty.js");
 
 function diff(a, b) {
-  return require("diff").createTwoFilesPatch("", "", a, b, "", "", {
-    context: 2,
-  });
+  // Use `diff/lib/patch/create.js` instead of `diff` to reduce bundle size
+  return require("diff/lib/patch/create.js").createTwoFilesPatch(
+    "",
+    "",
+    a,
+    b,
+    "",
+    "",
+    {
+      context: 2,
+    }
+  );
 }
 
 function handleError(context, filename, error, printedFilename) {

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -1,6 +1,7 @@
 "use strict";
 
-const diff = require("diff");
+// Use `diff/lib/diff/array.js` instead of `diff` to reduce bundle size
+const diff = require("diff/lib/diff/array.js");
 
 const {
   printer: { printDocToString },

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -1,7 +1,7 @@
 "use strict";
 
 // Use `diff/lib/diff/array.js` instead of `diff` to reduce bundle size
-const diff = require("diff/lib/diff/array.js");
+const { diffArrays } = require("diff/lib/diff/array.js");
 
 const {
   printer: { printDocToString },
@@ -119,7 +119,7 @@ function coreFormat(originalText, opts, addAlignmentSize = 0) {
 
     const newCursorNodeCharArray = [...newCursorNodeText];
 
-    const cursorNodeDiff = diff.diffArrays(
+    const cursorNodeDiff = diffArrays(
       oldCursorNodeCharArray,
       newCursorNodeCharArray
     );


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

### `standalone.js`

```text
520 -rw-r--r-- 1 fisker None 529175 Jan 27 10:45 main.js
500 -rw-r--r-- 1 fisker None 509950 Jan 27 10:46 working.js
```

~ 20k


### `bin-prettier.js`



```text
440 -rwxr-xr-x 1 fisker None 449592 Jan 27 11:11 after.js
476 -rwxr-xr-x 1 fisker None 486907 Jan 27 11:09 before.js
```

~ 36k

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
