### PR TITLE
Remove `chalk` from `standalone.js`

### DIFF
--- a/src/cli/options/get-options-for-file.js
+++ b/src/cli/options/get-options-for-file.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const dashify = require("dashify");
+const chalk = require("chalk");
 // eslint-disable-next-line no-restricted-modules
 const prettier = require("../../index.js");
 const { optionsNormalizer } = require("../prettier-internal.js");
@@ -49,7 +50,7 @@ function parseArgsToOptions(context, overrideDefaults) {
         default: cliifyOptions(overrideDefaults, apiDetailedOptionMap),
       }),
       context.detailedOptions,
-      { logger: false }
+      { logger: false, colorsModule: chalk }
     ),
     context.detailedOptions
   );

--- a/src/cli/options/parse-cli-arguments.js
+++ b/src/cli/options/parse-cli-arguments.js
@@ -1,6 +1,7 @@
 "use strict";
 const pick = require("lodash/pick");
 const camelCase = require("camelcase");
+const chalk = require("chalk");
 const {
   optionsNormalizer: { normalizeCliOptions },
 } = require("../prettier-internal.js");
@@ -19,7 +20,10 @@ function parseArgv(rawArguments, detailedOptions, logger, keys) {
     argv = pick(argv, keys);
   }
 
-  const normalized = normalizeCliOptions(argv, detailedOptions, { logger });
+  const normalized = normalizeCliOptions(argv, detailedOptions, {
+    logger,
+    colorsModule: chalk,
+  });
 
   return Object.fromEntries(
     Object.entries(normalized).map(([key, value]) => {

--- a/src/main/options-normalizer.js
+++ b/src/main/options-normalizer.js
@@ -2,7 +2,6 @@
 
 const vnopts = require("vnopts");
 const leven = require("leven");
-const chalk = require("chalk");
 const getLast = require("../utils/get-last.js");
 
 const cliDescriptor = {
@@ -18,41 +17,46 @@ const cliDescriptor = {
       : `${cliDescriptor.key(key)}=${value}`,
 };
 
-class FlagSchema extends vnopts.ChoiceSchema {
-  constructor({ name, flags }) {
-    super({ name, choices: flags });
-    this._flags = [...flags].sort();
-  }
-  preprocess(value, utils) {
-    if (
-      typeof value === "string" &&
-      value.length > 0 &&
-      !this._flags.includes(value)
-    ) {
-      const suggestion = this._flags.find((flag) => leven(flag, value) < 3);
-      if (suggestion) {
-        utils.logger.warn(
-          [
-            `Unknown flag ${chalk.yellow(utils.descriptor.value(value))},`,
-            `did you mean ${chalk.blue(utils.descriptor.value(suggestion))}?`,
-          ].join(" ")
-        );
-        return suggestion;
-      }
+const getFlagSchema = (colorsModule) =>
+  class FlagSchema extends vnopts.ChoiceSchema {
+    constructor({ name, flags }) {
+      super({ name, choices: flags });
+      this._flags = [...flags].sort();
     }
-    return value;
-  }
-  expected() {
-    return "a flag";
-  }
-}
+    preprocess(value, utils) {
+      if (
+        typeof value === "string" &&
+        value.length > 0 &&
+        !this._flags.includes(value)
+      ) {
+        const suggestion = this._flags.find((flag) => leven(flag, value) < 3);
+        if (suggestion) {
+          utils.logger.warn(
+            [
+              `Unknown flag ${colorsModule.yellow(
+                utils.descriptor.value(value)
+              )},`,
+              `did you mean ${colorsModule.blue(
+                utils.descriptor.value(suggestion)
+              )}?`,
+            ].join(" ")
+          );
+          return suggestion;
+        }
+      }
+      return value;
+    }
+    expected() {
+      return "a flag";
+    }
+  };
 
 let hasDeprecationWarned;
 
 function normalizeOptions(
   options,
   optionInfos,
-  { logger, isCLI = false, passThrough = false } = {}
+  { logger, isCLI = false, passThrough = false, colorsModule } = {}
 ) {
   const unknown = !passThrough
     ? (key, value, options) => {
@@ -69,7 +73,7 @@ function normalizeOptions(
     : (key, value) => ({ [key]: value });
 
   const descriptor = isCLI ? cliDescriptor : vnopts.apiDescriptor;
-  const schemas = optionInfosToSchemas(optionInfos, { isCLI });
+  const schemas = optionInfosToSchemas(optionInfos, { isCLI, colorsModule });
   const normalizer = new vnopts.Normalizer(schemas, {
     logger,
     unknown,
@@ -91,7 +95,7 @@ function normalizeOptions(
   return normalized;
 }
 
-function optionInfosToSchemas(optionInfos, { isCLI }) {
+function optionInfosToSchemas(optionInfos, { isCLI, colorsModule }) {
   const schemas = [];
 
   if (isCLI) {
@@ -99,7 +103,9 @@ function optionInfosToSchemas(optionInfos, { isCLI }) {
   }
 
   for (const optionInfo of optionInfos) {
-    schemas.push(optionInfoToSchema(optionInfo, { isCLI, optionInfos }));
+    schemas.push(
+      optionInfoToSchema(optionInfo, { isCLI, optionInfos, colorsModule })
+    );
 
     if (optionInfo.alias && isCLI) {
       schemas.push(
@@ -114,7 +120,7 @@ function optionInfosToSchemas(optionInfos, { isCLI }) {
   return schemas;
 }
 
-function optionInfoToSchema(optionInfo, { isCLI, optionInfos }) {
+function optionInfoToSchema(optionInfo, { isCLI, optionInfos, colorsModule }) {
   let SchemaConstructor;
   const parameters = { name: optionInfo.name };
   const handlers = {};
@@ -146,7 +152,7 @@ function optionInfoToSchema(optionInfo, { isCLI, optionInfos }) {
       SchemaConstructor = vnopts.BooleanSchema;
       break;
     case "flag":
-      SchemaConstructor = FlagSchema;
+      SchemaConstructor = getFlagSchema(colorsModule);
       parameters.flags = optionInfos.flatMap((optionInfo) =>
         [
           optionInfo.alias,
@@ -213,6 +219,10 @@ function normalizeApiOptions(options, optionInfos, opts) {
 }
 
 function normalizeCliOptions(options, optionInfos, opts) {
+  if (process.env.NODE_ENV !== "production" && opts.colorsModule) {
+    throw new Error("'colors' module is required.");
+  }
+
   return normalizeOptions(options, optionInfos, { isCLI: true, ...opts });
 }
 

--- a/src/main/options-normalizer.js
+++ b/src/main/options-normalizer.js
@@ -220,7 +220,7 @@ function normalizeApiOptions(options, optionInfos, opts) {
 
 function normalizeCliOptions(options, optionInfos, opts) {
   if (process.env.NODE_ENV !== "production" && !opts.colorsModule) {
-    throw new Error("'colors' module is required.");
+    throw new Error("'colorsModule' option is required.");
   }
 
   return normalizeOptions(options, optionInfos, { isCLI: true, ...opts });

--- a/src/main/options-normalizer.js
+++ b/src/main/options-normalizer.js
@@ -219,7 +219,7 @@ function normalizeApiOptions(options, optionInfos, opts) {
 }
 
 function normalizeCliOptions(options, optionInfos, opts) {
-  if (process.env.NODE_ENV !== "production" && opts.colorsModule) {
+  if (process.env.NODE_ENV !== "production" && !opts.colorsModule) {
     throw new Error("'colors' module is required.");
   }
 

--- a/src/main/options-normalizer.js
+++ b/src/main/options-normalizer.js
@@ -17,6 +17,8 @@ const cliDescriptor = {
       : `${cliDescriptor.key(key)}=${value}`,
 };
 
+// To prevent `chalk` module from being included in the `standalone.js` bundle,
+// it will take that as an argument if needed.
 const getFlagSchema = (colorsModule) =>
   class FlagSchema extends vnopts.ChoiceSchema {
     constructor({ name, flags }) {

--- a/src/main/options-normalizer.js
+++ b/src/main/options-normalizer.js
@@ -219,6 +219,7 @@ function normalizeApiOptions(options, optionInfos, opts) {
 }
 
 function normalizeCliOptions(options, optionInfos, opts) {
+  /* istanbul ignore next */
   if (process.env.NODE_ENV !== "production" && !opts.colorsModule) {
     throw new Error("'colorsModule' option is required.");
   }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Closes #12146, instead of removing colors, pass `chalk` from the cli.

```diff
yarn build --no-babel --print-size
- index.js.......................................................1.61 MB    DONE
+ index.js.......................................................1.56 MB    DONE
- standalone.js...................................................499 kB    DONE
+ standalone.js...................................................477 kB    DONE
-  esm/standalone.mjs............................................499 kB    DONE
+  esm/standalone.mjs............................................476 kB    DONE
- bin-prettier.js.................................................438 kB    DONE
+ bin-prettier.js.................................................439 kB    DONE
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
