### PR TITLE
Reduce JS parsers bundle size 2

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -580,17 +580,6 @@ function isFrontMatterNode(node) {
   return node && node.type === "front-matter";
 }
 
-function getShebang(text) {
-  if (!text.startsWith("#!")) {
-    return "";
-  }
-  const index = text.indexOf("\n");
-  if (index === -1) {
-    return text;
-  }
-  return text.slice(0, index);
-}
-
 /**
  * @param {any} object
  * @returns {object is Array<any>}
@@ -664,7 +653,6 @@ module.exports = {
   addDanglingComment,
   addTrailingComment,
   isFrontMatterNode,
-  getShebang,
   isNonEmptyArray,
   createGroupIdMapper,
 };

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -4,6 +4,7 @@ const stringWidth = require("string-width");
 const escapeStringRegexp = require("escape-string-regexp");
 const getLast = require("../utils/get-last.js");
 const { getSupportInfo } = require("../main/support.js");
+const { isNonEmptyArray } = require("../utils/is-non-empty-array.js");
 
 const notAsciiRegex = /[^\x20-\x7F]/;
 
@@ -578,14 +579,6 @@ function inferParserByLanguage(language, options) {
 
 function isFrontMatterNode(node) {
   return node && node.type === "front-matter";
-}
-
-/**
- * @param {any} object
- * @returns {object is Array<any>}
- */
-function isNonEmptyArray(object) {
-  return Array.isArray(object) && object.length > 0;
 }
 
 /**

--- a/src/language-js/loc.js
+++ b/src/language-js/loc.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { isNonEmptyArray } = require("../common/util.js");
+const { isNonEmptyArray } = require("../utils/is-non-empty-array.js");
 
 /**
  * @typedef {import("./types/estree").Node} Node

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -3,8 +3,8 @@
 const tryCombinations = require("../../utils/try-combinations.js");
 const {
   getNextNonSpaceNonCommentCharacterIndexWithStartIndex,
-  getShebang,
 } = require("../../common/util.js");
+const { getShebang } = require("../utils/get-shebang.js");
 const createParser = require("./utils/create-parser.js");
 const createBabelParseError = require("./utils/create-babel-parse-error.js");
 const postprocess = require("./postprocess/index.js");

--- a/src/language-js/parse/postprocess/index.js
+++ b/src/language-js/parse/postprocess/index.js
@@ -1,9 +1,9 @@
 "use strict";
 
-const { getLast } = require("../../../common/util.js");
 const { locStart, locEnd } = require("../../loc.js");
 const { isTsKeywordType } = require("../../utils/is-ts-keyword-type.js");
 const { isTypeCastComment } = require("../../utils/is-type-cast-comment.js");
+const getLast = require("../../../utils/get-last.js");
 const visitNode = require("./visitNode.js");
 const { throwErrorForInvalidNodes } = require("./typescript.js");
 

--- a/src/language-js/pragma.js
+++ b/src/language-js/pragma.js
@@ -1,8 +1,8 @@
 "use strict";
 
 const { parseWithComments, strip, extract, print } = require("jest-docblock");
-const { getShebang } = require("../common/util.js");
 const { normalizeEndOfLine } = require("../common/end-of-line.js");
+const { getShebang } = require("./utils/get-shebang.js");
 
 function parseDocBlock(text) {
   const shebang = getShebang(text);

--- a/src/language-js/utils/get-shebang.js
+++ b/src/language-js/utils/get-shebang.js
@@ -1,0 +1,14 @@
+"use strict";
+
+function getShebang(text) {
+  if (!text.startsWith("#!")) {
+    return "";
+  }
+  const index = text.indexOf("\n");
+  if (index === -1) {
+    return text;
+  }
+  return text.slice(0, index);
+}
+
+module.exports = { getShebang };

--- a/src/utils/is-non-empty-array.js
+++ b/src/utils/is-non-empty-array.js
@@ -1,0 +1,11 @@
+"use strict";
+
+/**
+ * @param {any} object
+ * @returns {object is Array<any>}
+ */
+function isNonEmptyArray(object) {
+  return Array.isArray(object) && object.length > 0;
+}
+
+module.exports = { isNonEmptyArray };


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Reduce bundle size of `parser-espree.js` and `parser-meriyah.js` by 39kb

**Before:**

```
$ node ./scripts/build/build.mjs --file=parser-meriyah.js --file=parser-espree.js --file=parser-babel.js --print-size
 Building packages 
parser-babel.js.................................................338 kB    DONE  
parser-espree.js................................................199 kB    DONE  
parser-meriyah.js...............................................202 kB    DONE  
```

**After:**

```
$ node ./scripts/build/build.mjs --file=parser-meriyah.js --file=parser-espree.js --file=parser-babel.js --print-size
 Building packages 
parser-babel.js.................................................338 kB    DONE  
parser-espree.js................................................160 kB    DONE  
parser-meriyah.js...............................................163 kB    DONE  
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
