### PR TITLE
Remove `esm/doc.mjs`

### DIFF
--- a/scripts/build/bundler.mjs
+++ b/scripts/build/bundler.mjs
@@ -189,11 +189,13 @@ async function* getEsbuildOptions(bundle, buildOptions) {
       format: "umd",
     };
 
-    yield {
-      ...esbuildOptions,
-      outfile: `esm/${bundle.output.replace(".js", ".mjs")}`,
-      format: "esm",
-    };
+    if (/^(?:standalone|parser-.*)\.js$/.test(bundle.output)) {
+      yield {
+        ...esbuildOptions,
+        outfile: `esm/${bundle.output.replace(".js", ".mjs")}`,
+        format: "esm",
+      };
+    }
   } else {
     esbuildOptions.external.push(
       ...builtinModules,

--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -107,8 +107,6 @@ const parsers = [
   },
   {
     input: "src/language-css/parser-postcss.js",
-    // postcss has dependency cycles that don't work with rollup
-    bundler: "webpack",
     replace: {
       // `postcss-values-parser` uses constructor.name, it will be changed by rollup or terser
       // https://github.com/shellscape/postcss-values-parser/blob/c00f858ab8c86ce9f06fdb702e8f26376f467248/lib/parser.js#L499


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

We didn't ship ESM version `doc.js` in last version https://unpkg.com/browse/prettier@2.5.1/esm/ , this is a mistake during build script refactoring .

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
