### PR TITLE
refactor: Use default export for some utils

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -4,7 +4,7 @@ const stringWidth = require("string-width");
 const escapeStringRegexp = require("escape-string-regexp");
 const getLast = require("../utils/get-last.js");
 const { getSupportInfo } = require("../main/support.js");
-const { isNonEmptyArray } = require("../utils/is-non-empty-array.js");
+const isNonEmptyArray = require("../utils/is-non-empty-array.js");
 
 const notAsciiRegex = /[^\x20-\x7F]/;
 

--- a/src/language-js/clean.js
+++ b/src/language-js/clean.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { isBlockComment } = require("./utils/index.js");
+const isBlockComment = require("./utils/is-block-comment.js");
 
 const ignoredProperties = new Set([
   "range",

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -13,7 +13,6 @@ const {
   isNonEmptyArray,
 } = require("../common/util.js");
 const {
-  isBlockComment,
   getFunctionParameters,
   isPrettierIgnoreComment,
   isJsxNode,
@@ -30,6 +29,7 @@ const {
   markerForIfWithoutBlockAndSameLineComment,
 } = require("./utils/index.js");
 const { locStart, locEnd } = require("./loc.js");
+const isBlockComment = require("./utils/is-block-comment.js");
 
 /**
  * @typedef {import("./types/estree").Node} Node

--- a/src/language-js/loc.js
+++ b/src/language-js/loc.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { isNonEmptyArray } = require("../utils/is-non-empty-array.js");
+const isNonEmptyArray = require("../utils/is-non-empty-array.js");
 
 /**
  * @typedef {import("./types/estree").Node} Node

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -4,7 +4,7 @@ const tryCombinations = require("../../utils/try-combinations.js");
 const {
   getNextNonSpaceNonCommentCharacterIndexWithStartIndex,
 } = require("../../common/util.js");
-const { getShebang } = require("../utils/get-shebang.js");
+const getShebang = require("../utils/get-shebang.js");
 const createParser = require("./utils/create-parser.js");
 const createBabelParseError = require("./utils/create-babel-parse-error.js");
 const postprocess = require("./postprocess/index.js");

--- a/src/language-js/parse/postprocess/index.js
+++ b/src/language-js/parse/postprocess/index.js
@@ -1,8 +1,8 @@
 "use strict";
 
 const { locStart, locEnd } = require("../../loc.js");
-const { isTsKeywordType } = require("../../utils/is-ts-keyword-type.js");
-const { isTypeCastComment } = require("../../utils/is-type-cast-comment.js");
+const isTsKeywordType = require("../../utils/is-ts-keyword-type.js");
+const isTypeCastComment = require("../../utils/is-type-cast-comment.js");
 const getLast = require("../../../utils/get-last.js");
 const visitNode = require("./visitNode.js");
 const { throwErrorForInvalidNodes } = require("./typescript.js");

--- a/src/language-js/pragma.js
+++ b/src/language-js/pragma.js
@@ -2,7 +2,7 @@
 
 const { parseWithComments, strip, extract, print } = require("jest-docblock");
 const { normalizeEndOfLine } = require("../common/end-of-line.js");
-const { getShebang } = require("./utils/get-shebang.js");
+const getShebang = require("./utils/get-shebang.js");
 
 function parseDocBlock(text) {
   const shebang = getShebang(text);

--- a/src/language-js/print/comment.js
+++ b/src/language-js/print/comment.js
@@ -6,8 +6,9 @@ const {
   utils: { replaceTextEndOfLine },
 } = require("../../document/index.js");
 
-const { isLineComment, isBlockComment } = require("../utils/index.js");
+const { isLineComment } = require("../utils/index.js");
 const { locStart, locEnd } = require("../loc.js");
+const isBlockComment = require("../utils/is-block-comment.js");
 
 function printComment(commentPath, options) {
   const comment = commentPath.getValue();

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -3,12 +3,12 @@
 const { hasNewlineInRange } = require("../../common/util.js");
 const {
   isJsxNode,
-  isBlockComment,
   getComments,
   isCallExpression,
   isMemberExpression,
 } = require("../utils/index.js");
 const { locStart, locEnd } = require("../loc.js");
+const isBlockComment = require("../utils/is-block-comment.js");
 const {
   builders: {
     line,

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -21,7 +21,7 @@ const {
   isCallExpression,
   isMemberExpression,
 } = require("../utils/index.js");
-const { isTsKeywordType } = require("../utils/is-ts-keyword-type.js");
+const isTsKeywordType = require("../utils/is-ts-keyword-type.js");
 const { locStart, locEnd } = require("../loc.js");
 
 const { printOptionalToken, printTypeScriptModifiers } = require("./misc.js");

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -20,7 +20,6 @@ const {
   hasComment,
   CommentCheckFlags,
   isTheOnlyJsxElementInMarkdown,
-  isBlockComment,
   isLineComment,
   isNextLineEmpty,
   needsHardlineAfterDanglingComment,
@@ -31,6 +30,7 @@ const {
   markerForIfWithoutBlockAndSameLineComment,
 } = require("./utils/index.js");
 const { locStart, locEnd } = require("./loc.js");
+const isBlockComment = require("./utils/is-block-comment.js");
 
 const {
   printHtmlBinding,

--- a/src/language-js/utils/get-shebang.js
+++ b/src/language-js/utils/get-shebang.js
@@ -11,4 +11,4 @@ function getShebang(text) {
   return text.slice(0, index);
 }
 
-module.exports = { getShebang };
+module.exports = getShebang;

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -10,6 +10,7 @@ const {
   getStringWidth,
 } = require("../../common/util.js");
 const { locStart, locEnd, hasSameLocStart } = require("../loc.js");
+const isBlockComment = require("./is-block-comment.js");
 
 /**
  * @typedef {import("../types/estree").Node} Node
@@ -153,19 +154,6 @@ function getLeftSidePathName(path, node) {
     return ["expression"];
   }
   throw new Error("Unexpected node has no left side.");
-}
-
-/**
- * @param {Comment} comment
- * @returns {boolean}
- */
-function isBlockComment(comment) {
-  return (
-    comment.type === "Block" ||
-    comment.type === "CommentBlock" ||
-    // `meriyah`
-    comment.type === "MultiLine"
-  );
 }
 
 /**
@@ -1341,7 +1329,6 @@ module.exports = {
   hasNodeIgnoreComment,
   identity,
   isBinaryish,
-  isBlockComment,
   isCallLikeExpression,
   isEnabledHackPipeline,
   isLineComment,

--- a/src/language-js/utils/is-block-comment.js
+++ b/src/language-js/utils/is-block-comment.js
@@ -17,4 +17,4 @@ function isBlockComment(comment) {
   );
 }
 
-module.exports = { isBlockComment };
+module.exports = isBlockComment;

--- a/src/language-js/utils/is-ts-keyword-type.js
+++ b/src/language-js/utils/is-ts-keyword-type.js
@@ -6,4 +6,4 @@ function isTsKeywordType({ type }) {
   return type.startsWith("TS") && type.endsWith("Keyword");
 }
 
-module.exports = { isTsKeywordType };
+module.exports = isTsKeywordType;

--- a/src/language-js/utils/is-type-cast-comment.js
+++ b/src/language-js/utils/is-type-cast-comment.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { isBlockComment } = require("./is-block-comment.js");
+const isBlockComment = require("./is-block-comment.js");
 
 /**
  * @typedef {import("../types/estree").Comment} Comment
@@ -21,4 +21,4 @@ function isTypeCastComment(comment) {
   );
 }
 
-module.exports = { isTypeCastComment };
+module.exports = isTypeCastComment;

--- a/src/utils/is-non-empty-array.js
+++ b/src/utils/is-non-empty-array.js
@@ -8,4 +8,4 @@ function isNonEmptyArray(object) {
   return Array.isArray(object) && object.length > 0;
 }
 
-module.exports = { isNonEmptyArray };
+module.exports = isNonEmptyArray;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Address https://github.com/prettier/prettier/pull/12164#discussion_r793308438

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
