### PR TITLE
Replace `tslib` entry when bundling `parser-yaml.js`

### DIFF
--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -133,6 +133,9 @@ const parsers = [
   },
   {
     input: "src/language-yaml/parser-yaml.js",
+    replaceModule: {
+      [require.resolve("tslib")]: require.resolve("tslib/tslib.es6.js"),
+    },
   },
 ].map((bundle) => {
   const { name } = bundle.input.match(

--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -134,7 +134,10 @@ const parsers = [
   {
     input: "src/language-yaml/parser-yaml.js",
     replaceModule: {
-      [require.resolve("tslib")]: require.resolve("tslib/tslib.es6.js"),
+      // Use `tslib.es6.js`, so we can avoid `globalThis` shim
+      [require.resolve("tslib")]: require
+        .resolve("tslib")
+        .replace(/tslib\.js$/, "tslib.es6.js"),
     },
   },
 ].map((bundle) => {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

```diff
yarn build --print-size --file=parser-yaml.js
- parser-yaml.js..................................................142 kB    DONE
+ parser-yaml.js..................................................130 kB    DONE
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
