### PR TITLE
Remove unused API from `espree` at build time

### DIFF
--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -95,6 +95,10 @@ const parsers = [
   },
   {
     input: "src/language-js/parse/espree.js",
+    replace: {
+      "const Syntax = ": "const Syntax = undefined && ",
+      "var visitorKeys = ": "var visitorKeys = undefined && ",
+    },
   },
   {
     input: "src/language-js/parse/meriyah.js",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Reduce bundle size of `parser-espree.js` by 6kb

**Before:**

```
$ node ./scripts/build/build.mjs --file=parser-espree.js --print-size
 Building packages 
parser-espree.js................................................160 kB    DONE  
```

**After:**

```
$ node ./scripts/build/build.mjs --file=parser-espree.js --print-size
 Building packages 
parser-espree.js................................................154 kB    DONE  
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
