### PR TITLE
Add `acorn` parser

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -268,6 +268,7 @@ module.exports = {
           "src/language-js/parse/babel.js",
           "src/language-js/parse/meriyah.js",
           "src/language-js/parse/json.js",
+          "src/language-js/parse/acorn.js",
         ],
       },
     },

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ function run_spec(
 Parameters:
 
 - **`fixtures`**: Must be set to `__dirname` or to an object of the shape `{ dirname: __dirname, ... }`. The object may have the `snippets` property to specify an array of extra input entries in addition to the files in the current directory. For each input entry (a file or a snippet), `run_spec` configures and runs a number of tests. The main check is that for a given input the output should match the snapshot (for snippets, the expected output can also be specified directly). [Additional checks](#deeper-testing) are controlled by options and environment variables.
-- **`parsers`**: A list of parser names. The tests verify that the parsers in this list produce the same output. If the list includes `typescript`, then `babel-ts` is included implicitly. If the list includes `babel`, and the current directory is inside `tests/format/js`, then `espree` and `meriyah` are included implicitly.
+- **`parsers`**: A list of parser names. The tests verify that the parsers in this list produce the same output. If the list includes `typescript`, then `babel-ts` is included implicitly. If the list includes `babel`, and the current directory is inside `tests/format/js`, then `acorn`, `espree`, and `meriyah` are included implicitly.
 - **`options`**: In addition to Prettier's formatting options, can contain the `errors` property to specify that it's expected that the formatting shouldn't be successful and an error should be thrown for all (`errors: true`) or some combinations of input entries and parsers.
 
 The implementation of `run_spec` can be found in [`tests/config/format-test.js`](tests/config/format-test.js).

--- a/changelog_unreleased/javascript/12172.md
+++ b/changelog_unreleased/javascript/12172.md
@@ -1,0 +1,3 @@
+#### Add `acorn` parser (#12172 by @fisker)
+
+A new value for the `parser` option has been added: [`acorn`](https://github.com/acornjs/acorn) - A small, fast, JavaScript-based JavaScript parser.

--- a/docs/options.md
+++ b/docs/options.md
@@ -265,6 +265,7 @@ Valid options:
 - `"typescript"` (via [@typescript-eslint/typescript-estree](https://github.com/typescript-eslint/typescript-eslint)) _First available in v1.4.0_
 - `"espree"` (via [espree](https://github.com/eslint/espree)) _First available in v2.2.0_
 - `"meriyah"` (via [meriyah](https://github.com/meriyah/meriyah)) _First available in v2.2.0_
+- `"acorn"` (via [acorn](https://github.com/acornjs/acorn)) _First available in v2.6.0_
 - `"css"` (via [postcss-scss](https://github.com/postcss/postcss-scss) and [postcss-less](https://github.com/shellscape/postcss-less), autodetects which to use) _First available in v1.7.1_
 - `"scss"` (same parsers as `"css"`, prefers postcss-scss) _First available in v1.7.1_
 - `"less"` (same parsers as `"css"`, prefers postcss-less) _First available in v1.7.1_

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "@glimmer/syntax": "0.83.1",
     "@iarna/toml": "2.2.5",
     "@typescript-eslint/typescript-estree": "5.10.0",
+    "acorn": "8.7.0",
+    "acorn-jsx": "5.3.2",
     "angular-estree-parser": "2.5.0",
     "angular-html-parser": "1.8.0",
     "camelcase": "6.3.0",

--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -95,6 +95,7 @@ const parsers = [
   },
   {
     input: "src/language-js/parse/acorn-and-espree.js",
+    name: "prettierPlugins.espree",
     // TODO: Rename this file to `parser-acorn-and-espree.js` or find a better way
     output: "parser-espree.js",
     replace: {

--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -94,7 +94,8 @@ const parsers = [
     },
   },
   {
-    input: "src/language-js/parse/espree.js",
+    input: "src/language-js/parse/acorn-and-espree.js",
+    name: "prettierPlugins.acornAndEspree",
     replace: {
       "const Syntax = ": "const Syntax = undefined && ",
       "var visitorKeys = ": "var visitorKeys = undefined && ",

--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -95,7 +95,6 @@ const parsers = [
   },
   {
     input: "src/language-js/parse/acorn-and-espree.js",
-    name: "prettierPlugins.acornAndEspree",
     // TODO: Rename this file to `parser-acorn-and-espree.js` or find a better way
     output: "parser-espree.js",
     replace: {

--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -96,6 +96,8 @@ const parsers = [
   {
     input: "src/language-js/parse/acorn-and-espree.js",
     name: "prettierPlugins.acornAndEspree",
+    // TODO: Rename this file to `parser-acorn-and-espree.js` or find a better way
+    output: "parser-espree.js",
     replace: {
       "const Syntax = ": "const Syntax = undefined && ",
       "var visitorKeys = ": "var visitorKeys = undefined && ",

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -933,6 +933,7 @@ function getCommentChildNodes(node, options) {
   if (
     (options.parser === "typescript" ||
       options.parser === "flow" ||
+      options.parser === "acorn" ||
       options.parser === "espree" ||
       options.parser === "meriyah" ||
       options.parser === "__babel_estree") &&

--- a/src/language-js/index.js
+++ b/src/language-js/index.js
@@ -13,6 +13,7 @@ const languages = [
       since: "0.0.0",
       parsers: [
         "babel",
+        "acorn",
         "espree",
         "meriyah",
         "babel-flow",

--- a/src/language-js/parse/acorn-and-espree.js
+++ b/src/language-js/parse/acorn-and-espree.js
@@ -1,0 +1,11 @@
+"use strict";
+
+const acorn = require("./acorn.js");
+const espree = require("./espree.js");
+
+module.exports = {
+  parsers: {
+    acorn,
+    espree,
+  },
+};

--- a/src/language-js/parse/acorn.js
+++ b/src/language-js/parse/acorn.js
@@ -1,0 +1,81 @@
+"use strict";
+
+const createError = require("../../common/parser-create-error.js");
+const tryCombinations = require("../../utils/try-combinations.js");
+const createParser = require("./utils/create-parser.js");
+const postprocess = require("./postprocess/index.js");
+
+/** @type {import("acorn").Options} */
+const parseOptions = {
+  ecmaVersion: "latest",
+  sourceType: "module",
+  allowReserved: true,
+  allowReturnOutsideFunction: true,
+  allowImportExportEverywhere: true,
+  allowAwaitOutsideFunction: true,
+  allowSuperOutsideMethod: true,
+  allowHashBang: true,
+  locations: true,
+  ranges: true,
+};
+
+function createParseError(error) {
+  const { message, loc } = error;
+
+  /* istanbul ignore next */
+  if (!loc) {
+    return error;
+  }
+
+  const { line, column } = loc;
+
+  return createError(message.replace(/ \(\d+:\d+\)$/, ""), {
+    start: { line, column: column + 1 },
+  });
+}
+
+let parser;
+const getParser = () => {
+  if (!parser) {
+    const { Parser: AcornParser } = require("acorn");
+    const acornJsx = require("acorn-jsx");
+    parser = AcornParser.extend(acornJsx());
+  }
+  return parser;
+};
+
+function parseWithOptions(text, sourceType) {
+  const parser = getParser();
+
+  const comments = [];
+  const tokens = [];
+
+  /** @type {any} */
+  const ast = parser.parse(text, {
+    ...parseOptions,
+    sourceType,
+    onComment: comments,
+    onToken: tokens,
+  });
+  ast.comments = comments;
+  ast.tokens = tokens;
+
+  return ast;
+}
+
+function parse(text, parsers, options = {}) {
+  const { result: ast, error: moduleParseError } = tryCombinations(
+    () => parseWithOptions(text, /* sourceType */ "module"),
+    () => parseWithOptions(text, /* sourceType */ "script")
+  );
+
+  if (!ast) {
+    // throw the error for `module` parsing
+    throw createParseError(moduleParseError);
+  }
+
+  options.originalText = text;
+  return postprocess(ast, options);
+}
+
+module.exports = createParser(parse);

--- a/src/language-js/parse/espree.js
+++ b/src/language-js/parse/espree.js
@@ -50,8 +50,4 @@ function parse(originalText, parsers, options = {}) {
   return postprocess(ast, options);
 }
 
-module.exports = {
-  parsers: {
-    espree: createParser(parse),
-  },
-};
+module.exports = createParser(parse);

--- a/src/language-js/parse/parsers.js
+++ b/src/language-js/parse/parsers.js
@@ -53,9 +53,13 @@ module.exports = {
   get __ng_directive() {
     return require("./angular.js").parsers.__ng_directive;
   },
+  // JS - acorn
+  get acorn() {
+    return require("./acorn-and-espree.js").parsers.acorn;
+  },
   // JS - espree
   get espree() {
-    return require("./espree.js").parsers.espree;
+    return require("./acorn-and-espree.js").parsers.espree;
   },
   // JS - meriyah
   get meriyah() {

--- a/src/language-js/parse/postprocess/index.js
+++ b/src/language-js/parse/postprocess/index.js
@@ -20,6 +20,7 @@ function postprocess(ast, options) {
   if (
     options.parser !== "typescript" &&
     options.parser !== "flow" &&
+    options.parser !== "acorn" &&
     options.parser !== "espree" &&
     options.parser !== "meriyah"
   ) {
@@ -134,8 +135,8 @@ function postprocess(ast, options) {
   }
 }
 
-// This is a workaround to transform `ChainExpression` from `espree`, `meriyah`,
-// and `typescript` into `babel` shape AST, we should do the opposite,
+// This is a workaround to transform `ChainExpression` from `acorn`, `espree`,
+// `meriyah`, and `typescript` into `babel` shape AST, we should do the opposite,
 // since `ChainExpression` is the standard `estree` AST for `optional chaining`
 // https://github.com/estree/estree/blob/master/es2020.md
 function transformChainExpression(node) {

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -703,6 +703,7 @@ function isStringPropSafeToUnquote(node, options) {
       (isSimpleNumber(node.key.value) &&
         String(Number(node.key.value)) === node.key.value &&
         (options.parser === "babel" ||
+          options.parser === "acorn" ||
           options.parser === "espree" ||
           options.parser === "meriyah" ||
           options.parser === "__babel_estree")))

--- a/src/main/core-options.js
+++ b/src/main/core-options.js
@@ -129,6 +129,7 @@ const options = {
       { value: "babel-flow", since: "1.16.0", description: "Flow" },
       { value: "babel-ts", since: "2.0.0", description: "TypeScript" },
       { value: "typescript", since: "1.4.0", description: "TypeScript" },
+      { value: "acorn", since: "2.6.0", description: "JavaScript" },
       { value: "espree", since: "2.2.0", description: "JavaScript" },
       { value: "meriyah", since: "2.2.0", description: "JavaScript" },
       { value: "css", since: "1.7.1", description: "CSS" },

--- a/src/main/range-util.js
+++ b/src/main/range-util.js
@@ -169,6 +169,7 @@ function isSourceElement(opts, node, parentNode) {
     case "babel-flow":
     case "babel-ts":
     case "typescript":
+    case "acorn":
     case "espree":
     case "meriyah":
     case "__babel_estree":

--- a/tests/config/format-test.js
+++ b/tests/config/format-test.js
@@ -56,6 +56,7 @@ const espreeDisabledTests = new Set(
     "comments-closure-typecast",
   ].map((directory) => path.join(__dirname, "../format/js", directory))
 );
+const acornDisabledTests = espreeDisabledTests;
 const meriyahDisabledTests = espreeDisabledTests;
 
 const isUnstable = (filename, options) => {
@@ -185,6 +186,9 @@ function runSpec(fixtures, parsers, options) {
       }
       if (!parsers.includes("meriyah") && !meriyahDisabledTests.has(dirname)) {
         allParsers.push("meriyah");
+      }
+      if (!parsers.includes("acorn") && !acornDisabledTests.has(dirname)) {
+        allParsers.push("acorn");
       }
     }
 

--- a/tests/config/utils/check-parsers.js
+++ b/tests/config/utils/check-parsers.js
@@ -50,11 +50,12 @@ const categoryParsers = new Map([
   [
     "js",
     {
-      parsers: ["babel", "meriyah", "espree"],
+      parsers: ["babel", "acorn", "espree", "meriyah"],
       verifyParsers: [
         "babel",
-        "meriyah",
+        "acorn",
         "espree",
+        "meriyah",
         "flow",
         "babel-flow",
         "typescript",

--- a/tests/format/js/arrows-bind/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/arrows-bind/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`arrows-bind.js [acorn] format 1`] = `
+"Unexpected token (1:9)
+> 1 | a => ({}::b()\`\`[''].c++ && 0 ? 0 : 0);
+    |         ^
+  2 | (a => b)::c;
+  3 | a::(b => c);
+  4 |"
+`;
+
 exports[`arrows-bind.js [espree] format 1`] = `
 "Unexpected token : (1:9)
 > 1 | a => ({}::b()\`\`[''].c++ && 0 ? 0 : 0);

--- a/tests/format/js/arrows-bind/jsfmt.spec.js
+++ b/tests/format/js/arrows-bind/jsfmt.spec.js
@@ -1,1 +1,3 @@
-run_spec(__dirname, ["babel"], { errors: { espree: true, meriyah: true } });
+run_spec(__dirname, ["babel"], {
+  errors: { acorn: true, espree: true, meriyah: true },
+});

--- a/tests/format/js/arrows/newline-before-arrow/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/arrows/newline-before-arrow/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`newline-before-arrow.js [acorn] format 1`] = `
+"Unexpected token (2:1)
+  1 | async x
+> 2 | => x
+    | ^
+  3 |"
+`;
+
 exports[`newline-before-arrow.js [espree] format 1`] = `
 "Unexpected token => (2:1)
   1 | async x

--- a/tests/format/js/arrows/newline-before-arrow/jsfmt.spec.js
+++ b/tests/format/js/arrows/newline-before-arrow/jsfmt.spec.js
@@ -1,5 +1,6 @@
 run_spec(__dirname, ["babel"], {
   errors: {
+    acorn: ["newline-before-arrow.js"],
     espree: ["newline-before-arrow.js"],
     meriyah: ["newline-before-arrow.js"],
   },

--- a/tests/format/js/async-do-expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/async-do-expressions/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`async-do-expressions.js [acorn] format 1`] = `
+"Unexpected token (1:7)
+> 1 | async do {
+    |       ^
+  2 |   1;
+  3 | };
+  4 |"
+`;
+
 exports[`async-do-expressions.js [espree] format 1`] = `
 "Unexpected token do (1:7)
 > 1 | async do {

--- a/tests/format/js/async-do-expressions/jsfmt.spec.js
+++ b/tests/format/js/async-do-expressions/jsfmt.spec.js
@@ -1,1 +1,3 @@
-run_spec(__dirname, ["babel"], { errors: { espree: true, meriyah: true } });
+run_spec(__dirname, ["babel"], {
+  errors: { acorn: true, espree: true, meriyah: true },
+});

--- a/tests/format/js/babel-plugins/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/babel-plugins/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`async-do-expressions.js [acorn] format 1`] = `
+"Unexpected token (1:7)
+> 1 | async do { await requestAPI().json() };
+    |       ^
+  2 |"
+`;
+
 exports[`async-do-expressions.js [espree] format 1`] = `
 "Unexpected token do (1:7)
 > 1 | async do { await requestAPI().json() };
@@ -431,6 +438,17 @@ class C {
 ================================================================================
 `;
 
+exports[`decimal.js [acorn] format 1`] = `
+"Identifier directly after number (3:4)
+  1 | // https://github.com/babel/babel/pull/11640
+  2 |
+> 3 | 100m;
+    |    ^
+  4 | 9223372036854775807m;
+  5 | 0.m;
+  6 | 3.1415926535897932m;"
+`;
+
 exports[`decimal.js [espree] format 1`] = `
 "Identifier directly after number (3:4)
   1 | // https://github.com/babel/babel/pull/11640
@@ -516,6 +534,17 @@ typeof 1m === "decimal128";
 ================================================================================
 `;
 
+exports[`decorators.js [acorn] format 1`] = `
+"Unexpected character '@' (3:1)
+  1 | // https://babeljs.io/docs/en/babel-plugin-proposal-decorators
+  2 |
+> 3 | @annotation
+    | ^
+  4 | class MyClass { }
+  5 |
+  6 | function annotation(target) {"
+`;
+
 exports[`decorators.js [espree] format 1`] = `
 "Unexpected character '@' (3:1)
   1 | // https://babeljs.io/docs/en/babel-plugin-proposal-decorators
@@ -595,6 +624,17 @@ function enumerable(value) {
 }
 
 ================================================================================
+`;
+
+exports[`do-expressions.js [acorn] format 1`] = `
+"Unexpected token (3:9)
+  1 | // https://babeljs.io/docs/en/babel-plugin-proposal-do-expressions
+  2 |
+> 3 | let a = do {
+    |         ^
+  4 |   if(x > 10) {
+  5 |     'big';
+  6 |   } else {"
 `;
 
 exports[`do-expressions.js [espree] format 1`] = `
@@ -681,6 +721,15 @@ import(prettier).then((module) => console.log(module));
 ================================================================================
 `;
 
+exports[`export-default-from.js [acorn] format 1`] = `
+"Unexpected token (4:8)
+  2 |
+  3 |
+> 4 | export v from 'mod';
+    |        ^
+  5 |"
+`;
+
 exports[`export-default-from.js [espree] format 1`] = `
 "Unexpected token v (4:8)
   2 |
@@ -736,6 +785,15 @@ export * as ns from "mod";
 ================================================================================
 `;
 
+exports[`flow.js [acorn] format 1`] = `
+"Unexpected token (3:17)
+  1 | // https://babeljs.io/docs/en/babel-preset-flow
+  2 |
+> 3 | function foo(one: any, two: number, three?): string {}
+    |                 ^
+  4 |"
+`;
+
 exports[`flow.js [espree] format 1`] = `
 "Unexpected token : (3:17)
   1 | // https://babeljs.io/docs/en/babel-preset-flow
@@ -770,6 +828,17 @@ function foo(one: any, two: number, three?): string {}
 function foo(one: any, two: number, three?): string {}
 
 ================================================================================
+`;
+
+exports[`function-bind.js [acorn] format 1`] = `
+"Unexpected token (3:5)
+  1 | // https://babeljs.io/docs/en/babel-plugin-proposal-function-bind
+  2 |
+> 3 | obj::func
+    |     ^
+  4 | // is equivalent to:
+  5 | func.bind(obj)
+  6 |"
 `;
 
 exports[`function-bind.js [espree] format 1`] = `
@@ -839,6 +908,17 @@ obj.func.call(obj, val);
 ================================================================================
 `;
 
+exports[`function-sent.js [acorn] format 1`] = `
+"Unexpected token (4:33)
+  2 |
+  3 | function* generator() {
+> 4 |     console.log(\\"Sent\\", function.sent);
+    |                                 ^
+  5 |     console.log(\\"Yield\\", yield);
+  6 | }
+  7 |"
+`;
+
 exports[`function-sent.js [espree] format 1`] = `
 "Unexpected token . (4:33)
   2 |
@@ -893,6 +973,13 @@ iterator.next(2); // Logs "Yield 2"
 ================================================================================
 `;
 
+exports[`import-assertions-dynamic.js [acorn] format 1`] = `
+"Unexpected token (1:20)
+> 1 | import(\\"./foo.json\\", { assert: { type: \\"json\\" } });
+    |                    ^
+  2 |"
+`;
+
 exports[`import-assertions-dynamic.js [espree] format 1`] = `
 "Unexpected token , (1:20)
 > 1 | import(\\"./foo.json\\", { assert: { type: \\"json\\" } });
@@ -919,6 +1006,13 @@ import("./foo.json", { assert: { type: "json" } });
 import("./foo.json", { assert: { type: "json" } });
 
 ================================================================================
+`;
+
+exports[`import-assertions-static.js [acorn] format 1`] = `
+"Unexpected token (1:31)
+> 1 | import json from \\"./foo.json\\" assert { type: \\"json\\" };
+    |                               ^
+  2 |"
 `;
 
 exports[`import-assertions-static.js [espree] format 1`] = `
@@ -1047,6 +1141,15 @@ a &&= b;
 obj.a.b &&= c;
 
 ================================================================================
+`;
+
+exports[`module-blocks.js [acorn] format 1`] = `
+"Unexpected token (1:16)
+> 1 | let m = module {
+    |                ^
+  2 |   export let m = 2;
+  3 |   export let n = 3;
+  4 | };"
 `;
 
 exports[`module-blocks.js [espree] format 1`] = `
@@ -1420,6 +1523,17 @@ const ret = delete obj?.foo?.bar?.baz; // true
 ================================================================================
 `;
 
+exports[`partial-application.js [acorn] format 1`] = `
+"Unexpected token (5:23)
+  3 | function add(x, y) { return x + y; }
+  4 |
+> 5 | const addOne = add(1, ?); // apply from the left
+    |                       ^
+  6 | addOne(2); // 3
+  7 |
+  8 | const addTen = add(?, 10); // apply from the right"
+`;
+
 exports[`partial-application.js [espree] format 1`] = `
 "Unexpected token ? (5:23)
   3 | function add(x, y) { return x + y; }
@@ -1494,6 +1608,17 @@ o.f(?, x, ?); // partial application for any arg
 super.f(?); // partial application allowed for call on |SuperProperty|
 
 ================================================================================
+`;
+
+exports[`pipeline-operator-fsharp.js [acorn] format 1`] = `
+"Unexpected token (5:4)
+  3 |
+  4 | promise
+> 5 |   |> await
+    |    ^
+  6 |   |> x => doubleSay(x, ', ')
+  7 |   |> capitalize
+  8 |   |> x => x + '!'"
 `;
 
 exports[`pipeline-operator-fsharp.js [espree] format 1`] = `
@@ -1593,6 +1718,17 @@ let newScore = boundScore(0, 100, add(7, double(person.score)));
 ================================================================================
 `;
 
+exports[`pipeline-operator-hack.js [acorn] format 1`] = `
+"Unexpected token (5:3)
+  3 |
+  4 | return list
+> 5 |  |> take(prefix.length, %)
+    |   ^
+  6 |  |> equals(%, prefix);
+  7 |
+  8 | // (The % token isn't final; it might instead be @ or ? or #.)"
+`;
+
 exports[`pipeline-operator-hack.js [espree] format 1`] = `
 "Unexpected token > (5:3)
   3 |
@@ -1639,6 +1775,17 @@ return list |> take(prefix.length, %) |> equals(%, prefix);
 // (The % token isn't final; it might instead be @ or ? or #.)
 
 ================================================================================
+`;
+
+exports[`pipeline-operator-minimal.js [acorn] format 1`] = `
+"Identifier 'result' has already been declared (7:5)
+   5 | result //=> \\"Hello, hello!\\"
+   6 |
+>  7 | let result = \\"hello\\"
+     |     ^
+   8 |   |> doubleSay
+   9 |   |> capitalize
+  10 |   |> exclaim;"
 `;
 
 exports[`pipeline-operator-minimal.js [espree] format 1`] = `
@@ -1869,6 +2016,15 @@ class Counter extends HTMLElement {
 ================================================================================
 `;
 
+exports[`record-tuple-record.js [acorn] format 1`] = `
+"Unexpected character '{' (1:18)
+> 1 | const record1 = #{
+    |                  ^
+  2 |     a: 1,
+  3 |     b: 2,
+  4 |     c: 3,"
+`;
+
 exports[`record-tuple-record.js [espree] format 1`] = `
 "Unexpected character '{' (1:18)
 > 1 | const record1 = #{
@@ -1913,6 +2069,13 @@ const record2 = #{ ...record1, b: 5 };
 ================================================================================
 `;
 
+exports[`record-tuple-tuple.js [acorn] format 1`] = `
+"Unexpected character '[' (1:17)
+> 1 | const tuple1 = #[1, 2, 3];
+    |                 ^
+  2 |"
+`;
+
 exports[`record-tuple-tuple.js [espree] format 1`] = `
 "Unexpected character '[' (1:17)
 > 1 | const tuple1 = #[1, 2, 3];
@@ -1939,6 +2102,17 @@ const tuple1 = #[1, 2, 3];
 const tuple1 = #[1, 2, 3];
 
 ================================================================================
+`;
+
+exports[`throw-expressions.js [acorn] format 1`] = `
+"Unexpected token (3:23)
+  1 | // https://babeljs.io/docs/en/babel-plugin-proposal-throw-expressions
+  2 |
+> 3 | function test(param = throw new Error('required!')) {
+    |                       ^
+  4 |   const test = param === true || throw new Error('Falsy!');
+  5 | }
+  6 |"
 `;
 
 exports[`throw-expressions.js [espree] format 1`] = `
@@ -1985,6 +2159,15 @@ function test(param = throw new Error("required!")) {
 ================================================================================
 `;
 
+exports[`typescript.js [acorn] format 1`] = `
+"Unexpected token (3:8)
+  1 | // https://babeljs.io/docs/en/babel-preset-typescript
+  2 |
+> 3 | const x: number = 0;
+    |        ^
+  4 |"
+`;
+
 exports[`typescript.js [espree] format 1`] = `
 "Unexpected token : (3:8)
   1 | // https://babeljs.io/docs/en/babel-preset-typescript
@@ -2019,6 +2202,17 @@ const x: number = 0;
 const x: number = 0;
 
 ================================================================================
+`;
+
+exports[`v8intrinsic.js [acorn] format 1`] = `
+"Unexpected token (3:1)
+  1 | // https://github.com/babel/babel/pull/10148
+  2 |
+> 3 | %DebugPrint(foo);
+    | ^
+  4 |
+  5 |
+  6 | // Invalid code https://github.com/JLHwung/babel/blob/c1a3cbfd65e08b7013fd6f8c62add8cb10b4b169/packages/babel-parser/test/fixtures/v8intrinsic/_errors/in-bind-expression/options.json"
 `;
 
 exports[`v8intrinsic.js [espree] format 1`] = `

--- a/tests/format/js/babel-plugins/jsfmt.spec.js
+++ b/tests/format/js/babel-plugins/jsfmt.spec.js
@@ -3,6 +3,28 @@
 
 run_spec(__dirname, ["babel", "babel-ts", "babel-flow"], {
   errors: {
+    acorn: [
+      "decimal.js",
+      "decorators.js",
+      "do-expressions.js",
+      "export-default-from.js",
+      "flow.js",
+      "function-bind.js",
+      "function-sent.js",
+      "import-assertions-dynamic.js",
+      "import-assertions-static.js",
+      "partial-application.js",
+      "pipeline-operator-fsharp.js",
+      "pipeline-operator-minimal.js",
+      "pipeline-operator-hack.js",
+      "record-tuple-record.js",
+      "record-tuple-tuple.js",
+      "throw-expressions.js",
+      "typescript.js",
+      "v8intrinsic.js",
+      "module-blocks.js",
+      "async-do-expressions.js",
+    ],
     espree: [
       "decimal.js",
       "decorators.js",

--- a/tests/format/js/bind-expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/bind-expressions/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`await.js [acorn] format 1`] = `
+"Unexpected token (3:27)
+  1 | const doBothThings = async () => {
+  2 |     const request = doAsyncThing();
+> 3 |     return (await request)::doSyncThing();
+    |                           ^
+  4 | };
+  5 |"
+`;
+
 exports[`await.js [espree] format 1`] = `
 "Unexpected token : (3:27)
   1 | const doBothThings = async () => {
@@ -12,6 +22,16 @@ exports[`await.js [espree] format 1`] = `
 
 exports[`await.js [meriyah] format 1`] = `
 "[3:27]: Unexpected token: ':' (3:27)
+  1 | const doBothThings = async () => {
+  2 |     const request = doAsyncThing();
+> 3 |     return (await request)::doSyncThing();
+    |                           ^
+  4 | };
+  5 |"
+`;
+
+exports[`await.js - {"semi":false} [acorn] format 1`] = `
+"Unexpected token (3:27)
   1 | const doBothThings = async () => {
   2 |     const request = doAsyncThing();
 > 3 |     return (await request)::doSyncThing();
@@ -81,6 +101,15 @@ const doBothThings = async () => {
 ================================================================================
 `;
 
+exports[`bind_parens.js [acorn] format 1`] = `
+"Unexpected token (1:9)
+> 1 | (a || b)::c;
+    |         ^
+  2 | a || (b::c);
+  3 | ::obj.prop;
+  4 | (void 0)::func();"
+`;
+
 exports[`bind_parens.js [espree] format 1`] = `
 "Unexpected token : (1:9)
 > 1 | (a || b)::c;
@@ -92,6 +121,15 @@ exports[`bind_parens.js [espree] format 1`] = `
 
 exports[`bind_parens.js [meriyah] format 1`] = `
 "[1:9]: Unexpected token: ':' (1:9)
+> 1 | (a || b)::c;
+    |         ^
+  2 | a || (b::c);
+  3 | ::obj.prop;
+  4 | (void 0)::func();"
+`;
+
+exports[`bind_parens.js - {"semi":false} [acorn] format 1`] = `
+"Unexpected token (1:9)
 > 1 | (a || b)::c;
     |         ^
   2 | a || (b::c);
@@ -278,6 +316,17 @@ f[a::b()];
 ================================================================================
 `;
 
+exports[`long_name_method.js [acorn] format 1`] = `
+"Unexpected token (3:54)
+  1 | class X {
+  2 |   constructor() {
+> 3 |     this.testLongNameMethodAndSomethingElseLallala = ::this.testLongNameMethodAndSomethingElseLallala;
+    |                                                      ^
+  4 |   }
+  5 |   
+  6 |   testLongNameMethodAndSomethingElseLallala() {"
+`;
+
 exports[`long_name_method.js [espree] format 1`] = `
 "Unexpected token : (3:54)
   1 | class X {
@@ -291,6 +340,17 @@ exports[`long_name_method.js [espree] format 1`] = `
 
 exports[`long_name_method.js [meriyah] format 1`] = `
 "[3:54]: Unexpected token: ':' (3:54)
+  1 | class X {
+  2 |   constructor() {
+> 3 |     this.testLongNameMethodAndSomethingElseLallala = ::this.testLongNameMethodAndSomethingElseLallala;
+    |                                                      ^
+  4 |   }
+  5 |   
+  6 |   testLongNameMethodAndSomethingElseLallala() {"
+`;
+
+exports[`long_name_method.js - {"semi":false} [acorn] format 1`] = `
+"Unexpected token (3:54)
   1 | class X {
   2 |   constructor() {
 > 3 |     this.testLongNameMethodAndSomethingElseLallala = ::this.testLongNameMethodAndSomethingElseLallala;
@@ -383,6 +443,17 @@ class X {
 ================================================================================
 `;
 
+exports[`method_chain.js [acorn] format 1`] = `
+"Unexpected token (10:9)
+   8 | function test(observable) {
+   9 |     return observable
+> 10 |         ::filter(data => data.someTest)
+     |         ^
+  11 |         ::throttle(() =>
+  12 |             interval(10)
+  13 |                 ::take(1)"
+`;
+
 exports[`method_chain.js [espree] format 1`] = `
 "Unexpected token : (10:9)
    8 | function test(observable) {
@@ -396,6 +467,17 @@ exports[`method_chain.js [espree] format 1`] = `
 
 exports[`method_chain.js [meriyah] format 1`] = `
 "[10:9]: Unexpected token: ':' (10:9)
+   8 | function test(observable) {
+   9 |     return observable
+> 10 |         ::filter(data => data.someTest)
+     |         ^
+  11 |         ::throttle(() =>
+  12 |             interval(10)
+  13 |                 ::take(1)"
+`;
+
+exports[`method_chain.js - {"semi":false} [acorn] format 1`] = `
+"Unexpected token (10:9)
    8 | function test(observable) {
    9 |     return observable
 > 10 |         ::filter(data => data.someTest)
@@ -520,6 +602,17 @@ function test(observable) {
 ================================================================================
 `;
 
+exports[`short_name_method.js [acorn] format 1`] = `
+"Unexpected token (3:24)
+  1 | class X {
+  2 |   constructor() {
+> 3 |     this.shortMethod = ::this.shortMethod;
+    |                        ^
+  4 |   }
+  5 |   
+  6 |   shortMethod() {"
+`;
+
 exports[`short_name_method.js [espree] format 1`] = `
 "Unexpected token : (3:24)
   1 | class X {
@@ -533,6 +626,17 @@ exports[`short_name_method.js [espree] format 1`] = `
 
 exports[`short_name_method.js [meriyah] format 1`] = `
 "[3:24]: Unexpected token: ':' (3:24)
+  1 | class X {
+  2 |   constructor() {
+> 3 |     this.shortMethod = ::this.shortMethod;
+    |                        ^
+  4 |   }
+  5 |   
+  6 |   shortMethod() {"
+`;
+
+exports[`short_name_method.js - {"semi":false} [acorn] format 1`] = `
+"Unexpected token (3:24)
   1 | class X {
   2 |   constructor() {
 > 3 |     this.shortMethod = ::this.shortMethod;
@@ -623,6 +727,15 @@ class X {
 ================================================================================
 `;
 
+exports[`unary.js [acorn] format 1`] = `
+"Unexpected token (1:3)
+> 1 | !x::y;
+    |   ^
+  2 | !(x::y /* foo */);
+  3 | !(/* foo */ x::y);
+  4 | !("
+`;
+
 exports[`unary.js [espree] format 1`] = `
 "Unexpected token : (1:3)
 > 1 | !x::y;
@@ -634,6 +747,15 @@ exports[`unary.js [espree] format 1`] = `
 
 exports[`unary.js [meriyah] format 1`] = `
 "[1:3]: Unexpected token: ':' (1:3)
+> 1 | !x::y;
+    |   ^
+  2 | !(x::y /* foo */);
+  3 | !(/* foo */ x::y);
+  4 | !("
+`;
+
+exports[`unary.js - {"semi":false} [acorn] format 1`] = `
+"Unexpected token (1:3)
 > 1 | !x::y;
     |   ^
   2 | !(x::y /* foo */);

--- a/tests/format/js/bind-expressions/jsfmt.spec.js
+++ b/tests/format/js/bind-expressions/jsfmt.spec.js
@@ -1,5 +1,7 @@
-run_spec(__dirname, ["babel"], { errors: { espree: true, meriyah: true } });
+run_spec(__dirname, ["babel"], {
+  errors: { acorn: true, espree: true, meriyah: true },
+});
 run_spec(__dirname, ["babel"], {
   semi: false,
-  errors: { espree: true, meriyah: true },
+  errors: { acorn: true, espree: true, meriyah: true },
 });

--- a/tests/format/js/call/invalid/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/call/invalid/__snapshots__/jsfmt.spec.js.snap
@@ -9,6 +9,15 @@ exports[`null-arguments-item.js [__babel_estree] format 1`] = `
   4 |     //1"
 `;
 
+exports[`null-arguments-item.js [acorn] format 1`] = `
+"Unexpected token (1:11)
+> 1 | foor('a', , 'b');
+    |           ^
+  2 | foo('looooooooooooooooooooooooooooooooooooooooooooooong', , 'looooooooooooooooooooooooooooooooooooooooooooooong');
+  3 | foo(\\"a\\",
+  4 |     //1"
+`;
+
 exports[`null-arguments-item.js [babel] format 1`] = `
 "Unexpected token ','. (1:12)
 > 1 | foor('a', , 'b');

--- a/tests/format/js/call/invalid/jsfmt.spec.js
+++ b/tests/format/js/call/invalid/jsfmt.spec.js
@@ -2,6 +2,7 @@ run_spec(__dirname, ["babel"], {
   errors: {
     babel: true,
     __babel_estree: true,
+    acorn: true,
     espree: true,
     meriyah: true,
   },

--- a/tests/format/js/classes-private-fields/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/classes-private-fields/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`optional-chaining.js [acorn] format 1`] = `
+"Private field '#x' must be declared in an enclosing class (3:13)
+  1 | // https://github.com/babel/babel/pull/11669
+  2 |
+> 3 | delete obj?.#x.a
+    |             ^
+  4 |"
+`;
+
 exports[`optional-chaining.js [espree] format 1`] = `
 "Private field '#x' must be declared in an enclosing class (3:13)
   1 | // https://github.com/babel/babel/pull/11669
@@ -11,6 +20,15 @@ exports[`optional-chaining.js [espree] format 1`] = `
 
 exports[`optional-chaining.js [meriyah] format 1`] = `
 "[3:13]: Dot property must be an identifier (3:13)
+  1 | // https://github.com/babel/babel/pull/11669
+  2 |
+> 3 | delete obj?.#x.a
+    |             ^
+  4 |"
+`;
+
+exports[`optional-chaining.js - {"semi":false} [acorn] format 1`] = `
+"Private field '#x' must be declared in an enclosing class (3:13)
   1 | // https://github.com/babel/babel/pull/11669
   2 |
 > 3 | delete obj?.#x.a

--- a/tests/format/js/classes-private-fields/jsfmt.spec.js
+++ b/tests/format/js/classes-private-fields/jsfmt.spec.js
@@ -1,6 +1,7 @@
 const errors = {
-  meriyah: ["optional-chaining.js"],
+  acorn: ["optional-chaining.js"],
   espree: ["optional-chaining.js"],
+  meriyah: ["optional-chaining.js"],
 };
 run_spec(__dirname, ["babel"], {
   errors,

--- a/tests/format/js/classes/top-level-super/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/classes/top-level-super/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`example.js [acorn] format 1`] = `
+"super() call outside constructor of a subclass (1:1)
+> 1 | super();
+    | ^
+  2 |"
+`;
+
 exports[`example.js [espree] format 1`] = `
 "'super' keyword outside a method (1:1)
 > 1 | super();

--- a/tests/format/js/classes/top-level-super/jsfmt.spec.js
+++ b/tests/format/js/classes/top-level-super/jsfmt.spec.js
@@ -1,3 +1,3 @@
 run_spec(__dirname, ["babel", "typescript"], {
-  errors: { espree: true, meriyah: true },
+  errors: { acorn: true, espree: true, meriyah: true },
 });

--- a/tests/format/js/comments-pipeline-own-line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/comments-pipeline-own-line/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`pipeline_own_line.js [acorn] format 1`] = `
+"Unexpected token (4:3)
+  2 | 	0
+  3 | 	// Comment
+> 4 | 	|> x
+    | 	 ^
+  5 | }
+  6 |
+  7 | bifornCringerMoshedPerplexSawder("
+`;
+
 exports[`pipeline_own_line.js [espree] format 1`] = `
 "Unexpected token > (4:3)
   2 | 	0

--- a/tests/format/js/comments-pipeline-own-line/jsfmt.spec.js
+++ b/tests/format/js/comments-pipeline-own-line/jsfmt.spec.js
@@ -1,1 +1,3 @@
-run_spec(__dirname, ["babel"], { errors: { espree: true, meriyah: true } });
+run_spec(__dirname, ["babel"], {
+  errors: { acorn: true, espree: true, meriyah: true },
+});

--- a/tests/format/js/decorator-comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/decorator-comments/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`comments.js [acorn] format 1`] = `
+"Unexpected character '@' (2:5)
+  1 | class Something {
+> 2 |     @Annotateme()
+    |     ^
+  3 |     // comment
+  4 |     static property: Array<string>;
+  5 | }"
+`;
+
 exports[`comments.js [espree] format 1`] = `
 "Unexpected character '@' (2:5)
   1 | class Something {

--- a/tests/format/js/decorator-comments/jsfmt.spec.js
+++ b/tests/format/js/decorator-comments/jsfmt.spec.js
@@ -1,3 +1,3 @@
 run_spec(__dirname, ["babel", "typescript"], {
-  errors: { espree: true, meriyah: true },
+  errors: { acorn: true, espree: true, meriyah: true },
 });

--- a/tests/format/js/decorators-export/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/decorators-export/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`after_export.js [acorn] format 1`] = `
+"Unexpected character '@' (1:8)
+> 1 | export @decorator class Foo {}
+    |        ^
+  2 |
+  3 | export default @decorator class {}
+  4 |"
+`;
+
 exports[`after_export.js [espree] format 1`] = `
 "Unexpected character '@' (1:8)
 > 1 | export @decorator class Foo {}
@@ -38,6 +47,15 @@ export default
 class {}
 
 ================================================================================
+`;
+
+exports[`before_export.js [acorn] format 1`] = `
+"Unexpected character '@' (1:1)
+> 1 | @decorator
+    | ^
+  2 | export class Foo {}
+  3 |
+  4 | @decorator"
 `;
 
 exports[`before_export.js [espree] format 1`] = `

--- a/tests/format/js/decorators-export/jsfmt.spec.js
+++ b/tests/format/js/decorators-export/jsfmt.spec.js
@@ -1,4 +1,4 @@
 // TypeScript and Flow don't accept decorator after export
 run_spec(__dirname, ["babel"], {
-  errors: { espree: true, meriyah: ["after_export.js"] },
+  errors: { acorn: true, espree: true, meriyah: ["after_export.js"] },
 });

--- a/tests/format/js/decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/decorators/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`classes.js [acorn] format 1`] = `
+"Unexpected character '@' (1:1)
+> 1 | @deco class Foo {}
+    | ^
+  2 |
+  3 | @deco export class Bar {}
+  4 |"
+`;
+
 exports[`classes.js [espree] format 1`] = `
 "Unexpected character '@' (1:1)
 > 1 | @deco class Foo {}
@@ -54,6 +63,17 @@ const bar =
   };
 
 ================================================================================
+`;
+
+exports[`comments.js [acorn] format 1`] = `
+"Unexpected character '@' (3:1)
+  1 | var x = 100
+  2 |
+> 3 | @Hello({
+    | ^
+  4 |   a: 'a', // Comment is in the wrong place
+  5 |   // test
+  6 |   b: '2'"
 `;
 
 exports[`comments.js [espree] format 1`] = `
@@ -138,6 +158,17 @@ export class Bar {}
 ================================================================================
 `;
 
+exports[`methods.js [acorn] format 1`] = `
+"Unexpected character '@' (3:3)
+  1 |
+  2 | class Yo {
+> 3 |   @foo(\\"hello\\")
+    |   ^
+  4 |   async plop() {}
+  5 |
+  6 |   @anotherDecoratorWithALongName(\\"and a very long string as a first argument\\")"
+`;
+
 exports[`methods.js [espree] format 1`] = `
 "Unexpected character '@' (3:3)
   1 |
@@ -181,6 +212,17 @@ class Yo {
 ================================================================================
 `;
 
+exports[`mixed.js [acorn] format 1`] = `
+"Unexpected character '@' (3:1)
+  1 | // https://github.com/prettier/prettier/issues/6747
+  2 |
+> 3 | @foo
+    | ^
+  4 | export default class MyComponent {
+  5 |   @task
+  6 |   *foo() {"
+`;
+
 exports[`mixed.js [espree] format 1`] = `
 "Unexpected character '@' (3:1)
   1 | // https://github.com/prettier/prettier/issues/6747
@@ -216,6 +258,17 @@ export default class MyComponent {
 }
 
 ================================================================================
+`;
+
+exports[`mobx.js [acorn] format 1`] = `
+"Unexpected character '@' (3:1)
+  1 | import {observable} from \\"mobx\\";
+  2 |
+> 3 | @observer class OrderLine {
+    | ^
+  4 |   @observable price:number = 0;
+  5 |   @observable amount:number = 1;
+  6 |"
 `;
 
 exports[`mobx.js [espree] format 1`] = `
@@ -334,6 +387,16 @@ class OrderLine {
 ================================================================================
 `;
 
+exports[`multiline.js [acorn] format 1`] = `
+"Unexpected character '@' (2:3)
+  1 | class Foo {
+> 2 |   @deco([
+    |   ^
+  3 |     foo,
+  4 |     bar
+  5 |   ]) prop = value;"
+`;
+
 exports[`multiline.js [espree] format 1`] = `
 "Unexpected character '@' (2:3)
   1 | class Foo {
@@ -381,6 +444,16 @@ class Foo {
 }
 
 ================================================================================
+`;
+
+exports[`multiple.js [acorn] format 1`] = `
+"Unexpected character '@' (2:3)
+  1 | const dog = {
+> 2 |   @readonly
+    |   ^
+  3 |   @nonenumerable
+  4 |   @doubledValue
+  5 |   legs: 4,"
 `;
 
 exports[`multiple.js [espree] format 1`] = `
@@ -448,6 +521,16 @@ const foo = {
 ================================================================================
 `;
 
+exports[`parens.js [acorn] format 1`] = `
+"Unexpected character '@' (2:3)
+  1 | class X {
+> 2 |   @(computed().volatile())
+    |   ^
+  3 |   x
+  4 | }
+  5 |"
+`;
+
 exports[`parens.js [espree] format 1`] = `
 "Unexpected character '@' (2:3)
   1 | class X {
@@ -476,6 +559,15 @@ class X {
 }
 
 ================================================================================
+`;
+
+exports[`redux.js [acorn] format 1`] = `
+"Unexpected character '@' (1:1)
+> 1 | @connect(mapStateToProps, mapDispatchToProps)
+    | ^
+  2 | export class MyApp extends React.Component {}
+  3 |
+  4 | @connect(state => ({ todos: state.todos }))"
 `;
 
 exports[`redux.js [espree] format 1`] = `

--- a/tests/format/js/decorators/jsfmt.spec.js
+++ b/tests/format/js/decorators/jsfmt.spec.js
@@ -1,3 +1,3 @@
 run_spec(__dirname, ["babel"], {
-  errors: { espree: true, meriyah: ["multiple.js", "mobx.js"] },
+  errors: { acorn: true, espree: true, meriyah: ["multiple.js", "mobx.js"] },
 });

--- a/tests/format/js/do/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/do/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`call-arguments.js [acorn] format 1`] = `
+"Unexpected token (3:3)
+  1 | // from https://github.com/babel/babel/pull/13122/
+  2 | expect(
+> 3 |   do {
+    |   ^
+  4 |     var bar = \\"foo\\";
+  5 |     if (!bar) throw new Error(
+  6 |       \\"unreachable\\""
+`;
+
 exports[`call-arguments.js [espree] format 1`] = `
 "Unexpected token do (3:3)
   1 | // from https://github.com/babel/babel/pull/13122/
@@ -106,6 +117,17 @@ expect(
 ).toThrow(ReferenceError);
 
 ================================================================================
+`;
+
+exports[`do.js [acorn] format 1`] = `
+"Unexpected token (3:5)
+  1 | const envSpecific = {
+  2 |   domain:
+> 3 |     do {
+    |     ^
+  4 |       if(env === 'production') 'https://abc.mno.com/';
+  5 |       else if(env === 'development') 'http://localhost:4000';
+  6 |     }"
 `;
 
 exports[`do.js [espree] format 1`] = `

--- a/tests/format/js/do/jsfmt.spec.js
+++ b/tests/format/js/do/jsfmt.spec.js
@@ -1,1 +1,3 @@
-run_spec(__dirname, ["babel"], { errors: { espree: true, meriyah: true } });
+run_spec(__dirname, ["babel"], {
+  errors: { acorn: true, espree: true, meriyah: true },
+});

--- a/tests/format/js/dynamic-import/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/dynamic-import/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`assertions.js [acorn] format 1`] = `
+"Unexpected token (1:20)
+> 1 | import(\\"./foo.json\\", { assert: { type: \\"json\\" } });
+    |                    ^
+  2 |"
+`;
+
 exports[`assertions.js [espree] format 1`] = `
 "Unexpected token , (1:20)
 > 1 | import(\\"./foo.json\\", { assert: { type: \\"json\\" } });

--- a/tests/format/js/dynamic-import/jsfmt.spec.js
+++ b/tests/format/js/dynamic-import/jsfmt.spec.js
@@ -1,6 +1,7 @@
 run_spec(__dirname, ["babel", "flow", "typescript"], {
   errors: {
     flow: ["assertions.js"],
+    acorn: ["assertions.js"],
     espree: ["assertions.js"],
     meriyah: ["assertions.js"],
   },

--- a/tests/format/js/export-default/escaped/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/export-default/escaped/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`default-escaped.js [acorn] format 1`] = `
+"Unexpected token (2:8)
+  1 | // export asyn\\\\u{63} from \\"async\\";
+> 2 | export n\\\\u{63} from \\"async\\";
+    |        ^"
+`;
+
 exports[`default-escaped.js [espree] format 1`] = `
 "Unexpected token n\\\\u{63} (2:8)
   1 | // export asyn\\\\u{63} from \\"async\\";

--- a/tests/format/js/export-default/escaped/jsfmt.spec.js
+++ b/tests/format/js/export-default/escaped/jsfmt.spec.js
@@ -1,3 +1,3 @@
 run_spec(__dirname, ["babel"], {
-  errors: { espree: true, meriyah: true },
+  errors: { acorn: true, espree: true, meriyah: true },
 });

--- a/tests/format/js/export-extension/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/export-extension/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`export.js [acorn] format 1`] = `
+"Unexpected token (2:8)
+  1 | export * as ns from 'mod';
+> 2 | export v from 'mod';
+    |        ^
+  3 | export a, * as b from 'mod';
+  4 | export c, { foo } from 'mod';
+  5 | export * as d, { bar } from 'mod';"
+`;
+
 exports[`export.js [espree] format 1`] = `
 "Unexpected token v (2:8)
   1 | export * as ns from 'mod';

--- a/tests/format/js/export-extension/jsfmt.spec.js
+++ b/tests/format/js/export-extension/jsfmt.spec.js
@@ -1,1 +1,3 @@
-run_spec(__dirname, ["babel"], { errors: { espree: true, meriyah: true } });
+run_spec(__dirname, ["babel"], {
+  errors: { acorn: true, espree: true, meriyah: true },
+});

--- a/tests/format/js/exports/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/exports/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`test.js [acorn] format 1`] = `
+"Unexpected token (3:8)
+  1 | export { value1, value2 as value2_renamed, value3, value4 as value4_renamed, value5 } from \\"exports\\";
+  2 |
+> 3 | export a,{b} from \\"./baz\\";
+    |        ^
+  4 |
+  5 | export * as ns from \\"mod\\";
+  6 |"
+`;
+
 exports[`test.js [espree] format 1`] = `
 "Unexpected token a (3:8)
   1 | export { value1, value2 as value2_renamed, value3, value4 as value4_renamed, value5 } from \\"exports\\";

--- a/tests/format/js/exports/jsfmt.spec.js
+++ b/tests/format/js/exports/jsfmt.spec.js
@@ -1,1 +1,3 @@
-run_spec(__dirname, ["babel"], { errors: { espree: true, meriyah: true } });
+run_spec(__dirname, ["babel"], {
+  errors: { acorn: true, espree: true, meriyah: true },
+});

--- a/tests/format/js/functional-composition/jsfmt.spec.js
+++ b/tests/format/js/functional-composition/jsfmt.spec.js
@@ -1,5 +1,6 @@
 run_spec(__dirname, ["babel", "flow", "typescript"], {
   errors: {
+    acorn: [],
     espree: [],
   },
 });

--- a/tests/format/js/import-assertions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/import-assertions/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`dynamic-import.js [acorn] format 1`] = `
+"Unexpected token (1:20)
+> 1 | import(\\"./foo.json\\", { assert: { type: \\"json\\" } });
+    |                    ^
+  2 |"
+`;
+
 exports[`dynamic-import.js [espree] format 1`] = `
 "Unexpected token , (1:20)
 > 1 | import(\\"./foo.json\\", { assert: { type: \\"json\\" } });
@@ -26,6 +33,16 @@ import("./foo.json", { assert: { type: "json" } });
 import("./foo.json", { assert: { type: "json" } });
 
 ================================================================================
+`;
+
+exports[`empty.js [acorn] format 1`] = `
+"Unexpected token (2:33)
+  1 | export * as foo from \\"foo.json\\"
+> 2 | export * as bar from \\"bar.json\\" assert { }
+    |                                 ^
+  3 | export * as baz from \\"baz.json\\" assert { /* comment */ }
+  4 |
+  5 | import * as foo from \\"foo.json\\""
 `;
 
 exports[`empty.js [espree] format 1`] = `
@@ -73,6 +90,13 @@ import * as baz from "baz.json" /* comment */;
 ================================================================================
 `;
 
+exports[`multi-types.js [acorn] format 1`] = `
+"Unexpected token (1:31)
+> 1 | import json from \\"./foo.json\\" assert { type: \\"json\\", type: \\"bar\\" };
+    |                               ^
+  2 |"
+`;
+
 exports[`multi-types.js [espree] format 1`] = `
 "Unexpected token assert (1:31)
 > 1 | import json from \\"./foo.json\\" assert { type: \\"json\\", type: \\"bar\\" };
@@ -99,6 +123,13 @@ import json from "./foo.json" assert { type: "json", type: "bar" };
 import json from "./foo.json" assert { type: "json", type: "bar" };
 
 ================================================================================
+`;
+
+exports[`non-type.js [acorn] format 1`] = `
+"Unexpected token (1:28)
+> 1 | import foo from \\"foo.json\\" assert { lazy: \\"true\\" };
+    |                            ^
+  2 |"
 `;
 
 exports[`non-type.js [espree] format 1`] = `
@@ -145,6 +176,15 @@ assert({ type: "json" });
 ================================================================================
 `;
 
+exports[`re-export.js [acorn] format 1`] = `
+"Unexpected token (1:33)
+> 1 | export { foo2 } from \\"foo.json\\" assert { type: \\"json\\" };
+    |                                 ^
+  2 | export * from \\"foo.json\\" assert { type: \\"json\\" };
+  3 | export * as foo3 from \\"foo.json\\" assert { type: \\"json\\" };
+  4 |"
+`;
+
 exports[`re-export.js [espree] format 1`] = `
 "Unexpected token assert (1:33)
 > 1 | export { foo2 } from \\"foo.json\\" assert { type: \\"json\\" };
@@ -181,6 +221,13 @@ export * as foo3 from "foo.json" assert { type: "json" };
 ================================================================================
 `;
 
+exports[`static-import.js [acorn] format 1`] = `
+"Unexpected token (1:31)
+> 1 | import json from \\"./foo.json\\" assert { type: \\"json\\" };
+    |                               ^
+  2 |"
+`;
+
 exports[`static-import.js [espree] format 1`] = `
 "Unexpected token assert (1:31)
 > 1 | import json from \\"./foo.json\\" assert { type: \\"json\\" };
@@ -207,6 +254,13 @@ import json from "./foo.json" assert { type: "json" };
 import json from "./foo.json" assert { type: "json" };
 
 ================================================================================
+`;
+
+exports[`without-from.js [acorn] format 1`] = `
+"Unexpected token (1:14)
+> 1 | import \\"foo\\" assert { type: \\"json\\" }
+    |              ^
+  2 |"
 `;
 
 exports[`without-from.js [espree] format 1`] = `

--- a/tests/format/js/import-assertions/bracket-spacing/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/import-assertions/bracket-spacing/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`dynamic-import.js - {"bracketSpacing":false} [acorn] format 1`] = `
+"Unexpected token (1:20)
+> 1 | import(\\"./foo.json\\", { assert: { type: \\"json\\" } });
+    |                    ^
+  2 |"
+`;
+
 exports[`dynamic-import.js - {"bracketSpacing":false} [espree] format 1`] = `
 "Unexpected token , (1:20)
 > 1 | import(\\"./foo.json\\", { assert: { type: \\"json\\" } });
@@ -29,6 +36,12 @@ import("./foo.json", {assert: {type: "json"}});
 ================================================================================
 `;
 
+exports[`empty.js - {"bracketSpacing":false} [acorn] format 1`] = `
+"Unexpected token (1:33)
+> 1 | export * as bar from \\"bar.json\\" assert { }
+    |                                 ^"
+`;
+
 exports[`empty.js - {"bracketSpacing":false} [espree] format 1`] = `
 "Unexpected token assert (1:33)
 > 1 | export * as bar from \\"bar.json\\" assert { }
@@ -53,6 +66,13 @@ export * as bar from "bar.json" assert { }
 export * as bar from "bar.json";
 
 ================================================================================
+`;
+
+exports[`re-export.js - {"bracketSpacing":false} [acorn] format 1`] = `
+"Unexpected token (1:33)
+> 1 | export { foo2 } from \\"foo.json\\" assert { type: \\"json\\" };
+    |                                 ^
+  2 |"
 `;
 
 exports[`re-export.js - {"bracketSpacing":false} [espree] format 1`] = `
@@ -82,6 +102,13 @@ export { foo2 } from "foo.json" assert { type: "json" };
 export {foo2} from "foo.json" assert {type: "json"};
 
 ================================================================================
+`;
+
+exports[`static-import.js - {"bracketSpacing":false} [acorn] format 1`] = `
+"Unexpected token (1:31)
+> 1 | import json from \\"./foo.json\\" assert { type: \\"json\\" };
+    |                               ^
+  2 |"
 `;
 
 exports[`static-import.js - {"bracketSpacing":false} [espree] format 1`] = `

--- a/tests/format/js/import-assertions/bracket-spacing/jsfmt.spec.js
+++ b/tests/format/js/import-assertions/bracket-spacing/jsfmt.spec.js
@@ -1,6 +1,12 @@
 run_spec(__dirname, ["babel"], {
   bracketSpacing: false,
   errors: {
+    acorn: [
+      "dynamic-import.js",
+      "static-import.js",
+      "re-export.js",
+      "empty.js",
+    ],
     espree: [
       "dynamic-import.js",
       "static-import.js",

--- a/tests/format/js/import-assertions/jsfmt.spec.js
+++ b/tests/format/js/import-assertions/jsfmt.spec.js
@@ -1,5 +1,14 @@
 run_spec(__dirname, ["babel", "typescript"], {
   errors: {
+    acorn: [
+      "dynamic-import.js",
+      "empty.js",
+      "multi-types.js",
+      "static-import.js",
+      "re-export.js",
+      "without-from.js",
+      "non-type.js",
+    ],
     espree: [
       "dynamic-import.js",
       "empty.js",

--- a/tests/format/js/invalid-code/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/invalid-code/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`duplicate_bindings.js [acorn] format 1`] = `
+"Identifier 'A' has already been declared (1:19)
+> 1 | class A{}   class A{}
+    |                   ^
+  2 |"
+`;
+
 exports[`duplicate_bindings.js [espree] format 1`] = `
 "Identifier 'A' has already been declared (1:19)
 > 1 | class A{}   class A{}

--- a/tests/format/js/invalid-code/jsfmt.spec.js
+++ b/tests/format/js/invalid-code/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, ["babel"], { errors: { espree: true } });
+run_spec(__dirname, ["babel"], { errors: { acorn: true, espree: true } });

--- a/tests/format/js/module-blocks/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/module-blocks/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`comments.js [acorn] format 1`] = `
+"Unexpected token (1:32)
+> 1 | const m = /*A1*/ module /*A2*/ { /*A3*/
+    |                                ^
+  2 |   /*A4*/
+  3 |   export const foo = \\"foo\\";
+  4 |   export { foo }; /*A5*/"
+`;
+
 exports[`comments.js [espree] format 1`] = `
 "Unexpected token { (1:32)
 > 1 | const m = /*A1*/ module /*A2*/ { /*A3*/
@@ -50,6 +59,15 @@ const m2 = module {
 };
 
 ================================================================================
+`;
+
+exports[`module-blocks.js [acorn] format 1`] = `
+"Unexpected token (1:8)
+> 1 | module { await 3 };
+    |        ^
+  2 |
+  3 | class B {
+  4 |   #p() {"
 `;
 
 exports[`module-blocks.js [espree] format 1`] = `
@@ -187,6 +205,15 @@ const m = module;
 ================================================================================
 `;
 
+exports[`range.js [acorn] format 1`] = `
+"Unexpected token (1:26)
+> 1 | let moduleBlock = module {  export let y = 1;
+    |                          ^
+  2 | };
+  3 |
+  4 | foo(module { export let foo = \\"foo\\"; })"
+`;
+
 exports[`range.js [espree] format 1`] = `
 "Unexpected token { (1:26)
 > 1 | let moduleBlock = module {  export let y = 1;
@@ -232,6 +259,15 @@ foo(module {
 });
 
 ================================================================================
+`;
+
+exports[`worker.js [acorn] format 1`] = `
+"Unexpected token (1:32)
+> 1 | let worker = new Worker(module {
+    |                                ^
+  2 |   onmessage = function({data}) {
+  3 |     let mod = import(data);
+  4 |     postMessage(mod.fn());"
 `;
 
 exports[`worker.js [espree] format 1`] = `

--- a/tests/format/js/module-blocks/jsfmt.spec.js
+++ b/tests/format/js/module-blocks/jsfmt.spec.js
@@ -1,5 +1,6 @@
 run_spec(__dirname, ["babel"], {
   errors: {
+    acorn: ["module-blocks.js", "range.js", "comments.js", "worker.js"],
     espree: ["module-blocks.js", "range.js", "comments.js", "worker.js"],
     meriyah: ["module-blocks.js", "range.js", "comments.js", "worker.js"],
   },

--- a/tests/format/js/multiparser-invalid/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/multiparser-invalid/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`text.js [acorn] format 1`] = `
+"Bad escape sequence in untagged template literal (6:18)
+  4 | foo = markdown\`\\\\u{prettier}\\\\u{0065}\`;
+  5 | foo = css\`\\\\u{prettier}\\\\u{0065}\`;
+> 6 | foo = /* HTML */\`\\\\u{prettier}\\\\u{0065}\`;
+    |                  ^
+  7 | foo = /* GraphQL */\`\\\\u{prettier}\\\\u{0065}\`;
+  8 |
+  9 | foo = foo\`\\\\u{prettier}\${foo}pr\\\\u{0065}ttier\`;"
+`;
+
 exports[`text.js [espree] format 1`] = `
 "Bad escape sequence in untagged template literal (6:18)
   4 | foo = markdown\`\\\\u{prettier}\\\\u{0065}\`;

--- a/tests/format/js/multiparser-invalid/jsfmt.spec.js
+++ b/tests/format/js/multiparser-invalid/jsfmt.spec.js
@@ -1,3 +1,9 @@
 run_spec(__dirname, ["babel", "flow", "typescript"], {
-  errors: { espree: true, flow: true, typescript: true, meriyah: true },
+  errors: {
+    acorn: true,
+    espree: true,
+    flow: true,
+    typescript: true,
+    meriyah: true,
+  },
 });

--- a/tests/format/js/no-semi-babylon-extensions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/no-semi-babylon-extensions/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`no-semi.js [acorn] format 1`] = `
+"Unexpected token (2:2)
+  1 | a
+> 2 | ;::b.c
+    |  ^
+  3 |
+  4 | class A {
+  5 |   a = b;"
+`;
+
 exports[`no-semi.js [espree] format 1`] = `
 "Unexpected token : (2:2)
   1 | a
@@ -12,6 +22,16 @@ exports[`no-semi.js [espree] format 1`] = `
 
 exports[`no-semi.js [meriyah] format 1`] = `
 "[2:2]: Unexpected token: ':' (2:2)
+  1 | a
+> 2 | ;::b.c
+    |  ^
+  3 |
+  4 | class A {
+  5 |   a = b;"
+`;
+
+exports[`no-semi.js - {"semi":false} [acorn] format 1`] = `
+"Unexpected token (2:2)
   1 | a
 > 2 | ;::b.c
     |  ^

--- a/tests/format/js/no-semi-babylon-extensions/jsfmt.spec.js
+++ b/tests/format/js/no-semi-babylon-extensions/jsfmt.spec.js
@@ -1,5 +1,7 @@
-run_spec(__dirname, ["babel"], { errors: { espree: true, meriyah: true } });
+run_spec(__dirname, ["babel"], {
+  errors: { acorn: true, espree: true, meriyah: true },
+});
 run_spec(__dirname, ["babel"], {
   semi: false,
-  errors: { espree: true, meriyah: true },
+  errors: { acorn: true, espree: true, meriyah: true },
 });

--- a/tests/format/js/object-property-comment/jsfmt.spec.js
+++ b/tests/format/js/object-property-comment/jsfmt.spec.js
@@ -1,3 +1,3 @@
 run_spec(__dirname, ["babel", "flow"], {
-  errors: { espree: ["comment.js"] },
+  errors: { acorn: ["comment.js"], espree: ["comment.js"] },
 });

--- a/tests/format/js/objects/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/objects/__snapshots__/jsfmt.spec.js.snap
@@ -52,6 +52,17 @@ const Component2 = ({ props }) => <Text>Test</Text>;
 ================================================================================
 `;
 
+exports[`expression.js [acorn] format 1`] = `
+"Unexpected token (5:4)
+  3 | a = () => ({}).x;
+  4 | ({} && a, b);
+> 5 | ({}::b, 0);
+    |    ^
+  6 | ({}::b()\`\`[''].c++ && 0 ? 0 : 0, 0);
+  7 | ({}(), 0);
+  8 | ({} = 0);"
+`;
+
 exports[`expression.js [espree] format 1`] = `
 "Unexpected token : (5:4)
   3 | a = () => ({}).x;

--- a/tests/format/js/objects/jsfmt.spec.js
+++ b/tests/format/js/objects/jsfmt.spec.js
@@ -1,5 +1,6 @@
 run_spec(__dirname, ["babel", "typescript"], {
   errors: {
+    acorn: ["expression.js"],
     espree: ["expression.js"],
     typescript: ["expression.js"],
     meriyah: ["expression.js"],

--- a/tests/format/js/partial-application/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/partial-application/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`test.js [acorn] format 1`] = `
+"Unexpected token (1:23)
+> 1 | const addOne = add(1, ?); // apply from the left
+    |                       ^
+  2 | addOne(2); // 3
+  3 |
+  4 | const addTen = add(?, 10); // apply from the right"
+`;
+
 exports[`test.js [espree] format 1`] = `
 "Unexpected token ? (1:23)
 > 1 | const addOne = add(1, ?); // apply from the left

--- a/tests/format/js/partial-application/jsfmt.spec.js
+++ b/tests/format/js/partial-application/jsfmt.spec.js
@@ -1,1 +1,3 @@
-run_spec(__dirname, ["babel"], { errors: { espree: true, meriyah: true } });
+run_spec(__dirname, ["babel"], {
+  errors: { acorn: true, espree: true, meriyah: true },
+});

--- a/tests/format/js/pipeline-operator/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/pipeline-operator/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`block-comments.js [acorn] format 1`] = `
+"Unexpected token (2:2)
+  1 | bifornCringerMoshedPerplexSawder
+> 2 | |> foo1
+    |  ^
+  3 | |> foo2 /* comment1 */
+  4 | |> foo3 /* comment2 */
+  5 | |> kochabCooieGameOnOboleUnweave"
+`;
+
 exports[`block-comments.js [espree] format 1`] = `
 "Unexpected token > (2:2)
   1 | bifornCringerMoshedPerplexSawder
@@ -42,6 +52,16 @@ bifornCringerMoshedPerplexSawder
   |> glimseGlyphsHazardNoopsTieTie;
 
 ================================================================================
+`;
+
+exports[`fsharp_style_pipeline_operator.js [acorn] format 1`] = `
+"Unexpected token (2:4)
+  1 | promise
+> 2 |   |> await
+    |    ^
+  3 |   |> x => doubleSay(x, ', ')
+  4 |   |> capitalize
+  5 |   |> x => x + '!'"
 `;
 
 exports[`fsharp_style_pipeline_operator.js [espree] format 1`] = `
@@ -157,6 +177,15 @@ const f = x + ((f) => f |> f);
 const f = x |> (f) => f |> f;
 
 ================================================================================
+`;
+
+exports[`hack_pipeline_operator.js [acorn] format 1`] = `
+"Unexpected token (1:4)
+> 1 | a |> await % |> % * 3;
+    |    ^
+  2 |
+  3 | foo
+  4 |   |> await %"
 `;
 
 exports[`hack_pipeline_operator.js [espree] format 1`] = `
@@ -289,6 +318,15 @@ async function* f() {
 }
 
 ================================================================================
+`;
+
+exports[`minimal_pipeline_operator.js [acorn] format 1`] = `
+"Unexpected token (1:4)
+> 1 | a |> b |> c;
+    |    ^
+  2 |
+  3 | a |> (b |> c);
+  4 |"
 `;
 
 exports[`minimal_pipeline_operator.js [espree] format 1`] = `

--- a/tests/format/js/pipeline-operator/jsfmt.spec.js
+++ b/tests/format/js/pipeline-operator/jsfmt.spec.js
@@ -1,1 +1,3 @@
-run_spec(__dirname, ["babel"], { errors: { espree: true, meriyah: true } });
+run_spec(__dirname, ["babel"], {
+  errors: { acorn: true, espree: true, meriyah: true },
+});

--- a/tests/format/js/private-in/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/private-in/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`private-in.js [acorn] format 1`] = `
+"Unexpected token (1:5)
+> 1 | if (#prop in obj) {
+    |     ^
+  2 | }
+  3 |
+  4 | #prop in     obj;"
+`;
+
 exports[`private-in.js [espree] format 1`] = `
 "Unexpected token #prop (1:5)
 > 1 | if (#prop in obj) {

--- a/tests/format/js/private-in/jsfmt.spec.js
+++ b/tests/format/js/private-in/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, ["babel"], { errors: { espree: true } });
+run_spec(__dirname, ["babel"], { errors: { acorn: true, espree: true } });

--- a/tests/format/js/record/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/record/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`computed.js [acorn] format 1`] = `
+"Unexpected character '{' (2:9)
+  1 | const key = \\"a\\";
+> 2 | assert(#{ [key]: 1 } === #{ a: 1 })
+    |         ^
+  3 | assert(#{ [key.toUpperCase()]: 1 } === #{ A: 1 })
+  4 |
+  5 | assert(#{ [true]: 1 } === #{ true: 1 })"
+`;
+
 exports[`computed.js [espree] format 1`] = `
 "Unexpected character '{' (2:9)
   1 | const key = \\"a\\";
@@ -50,6 +60,15 @@ assert(#{ [9 + 1]: "ten" } === #{ ["10"]: "ten" });
 ================================================================================
 `;
 
+exports[`destructuring.js [acorn] format 1`] = `
+"Unexpected character '{' (1:19)
+> 1 | const { a, b } = #{ a: 1, b: 2 };
+    |                   ^
+  2 | assert(a === 1);
+  3 | assert(b === 2);
+  4 |"
+`;
+
 exports[`destructuring.js [espree] format 1`] = `
 "Unexpected character '{' (1:19)
 > 1 | const { a, b } = #{ a: 1, b: 2 };
@@ -96,6 +115,15 @@ assert(rest.b === 2);
 assert(rest.c === 3);
 
 ================================================================================
+`;
+
+exports[`record.js [acorn] format 1`] = `
+"Unexpected character '{' (1:18)
+> 1 | const record1 = #{
+    |                  ^
+  2 |     a: 1,
+  3 |     b: 2,
+  4 |     c: 3,"
 `;
 
 exports[`record.js [espree] format 1`] = `
@@ -160,6 +188,15 @@ assert(record1.d?.a === undefined);
 ================================================================================
 `;
 
+exports[`shorthand.js [acorn] format 1`] = `
+"Unexpected character '{' (2:17)
+  1 | const url = \\"https://github.com/tc39/proposal-record-tuple\\";
+> 2 | const record = #{ url }
+    |                 ^
+  3 | console.log(record.url) // https://github.com/tc39/proposal-record-tuple
+  4 |"
+`;
+
 exports[`shorthand.js [espree] format 1`] = `
 "Unexpected character '{' (2:17)
   1 | const url = \\"https://github.com/tc39/proposal-record-tuple\\";
@@ -194,6 +231,15 @@ const record = #{ url };
 console.log(record.url); // https://github.com/tc39/proposal-record-tuple
 
 ================================================================================
+`;
+
+exports[`spread.js [acorn] format 1`] = `
+"Unexpected character '{' (1:19)
+> 1 | const formData = #{ title: \\"Implement all the things\\" }
+    |                   ^
+  2 | const taskNow = #{ id: 42, status: \\"WIP\\", ...formData }
+  3 | const taskLater = #{ ...taskNow, status: \\"DONE\\" }
+  4 |"
 `;
 
 exports[`spread.js [espree] format 1`] = `
@@ -236,6 +282,15 @@ const taskLater = #{ ...taskNow, status: "DONE" };
 assert(taskLater === #{ status: "DONE", title: formData.title, id: 42 });
 
 ================================================================================
+`;
+
+exports[`syntax.js [acorn] format 1`] = `
+"Unexpected character '{' (1:2)
+> 1 | #{}
+    |  ^
+  2 | #{ a: 1, b: 2 }
+  3 | #{ a: 1, b: #[2, 3, #{ c: 4 }] }
+  4 |"
 `;
 
 exports[`syntax.js [espree] format 1`] = `

--- a/tests/format/js/record/jsfmt.spec.js
+++ b/tests/format/js/record/jsfmt.spec.js
@@ -1,1 +1,3 @@
-run_spec(__dirname, ["babel"], { errors: { espree: true, meriyah: true } });
+run_spec(__dirname, ["babel"], {
+  errors: { acorn: true, espree: true, meriyah: true },
+});

--- a/tests/format/js/reserved-word/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/reserved-word/__snapshots__/jsfmt.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`interfaces.js format 1`] = `
 ====================================options=====================================
-parsers: ["espree", "meriyah", "babel"]
+parsers: ["acorn", "espree", "meriyah", "babel"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/js/reserved-word/jsfmt.spec.js
+++ b/tests/format/js/reserved-word/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, ["espree", "meriyah", "babel"]);
+run_spec(__dirname, ["acorn", "espree", "meriyah", "babel"]);

--- a/tests/format/js/rest/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/rest/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`trailing-commas.js - {"trailingComma":"all"} [acorn] format 1`] = `
+"Unexpected token (1:9)
+> 1 | declare class C {
+    |         ^
+  2 |   f(
+  3 |     superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong,
+  4 |     ...args"
+`;
+
 exports[`trailing-commas.js - {"trailingComma":"all"} [espree] format 1`] = `
 "Unexpected token class (1:9)
 > 1 | declare class C {

--- a/tests/format/js/rest/jsfmt.spec.js
+++ b/tests/format/js/rest/jsfmt.spec.js
@@ -1,4 +1,4 @@
 run_spec(__dirname, ["babel", "flow"], {
   trailingComma: "all",
-  errors: { espree: true, meriyah: true },
+  errors: { acorn: true, espree: true, meriyah: true },
 });

--- a/tests/format/js/sloppy-mode/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/sloppy-mode/__snapshots__/jsfmt.spec.js.snap
@@ -73,6 +73,13 @@ if (false) function foo() {}
 ================================================================================
 `;
 
+exports[`function-declaration-in-while.js [acorn] format 1`] = `
+"Unexpected token (1:15)
+> 1 | while (false) function foo(){}
+    |               ^
+  2 |"
+`;
+
 exports[`function-declaration-in-while.js [espree] format 1`] = `
 "Unexpected token function (1:15)
 > 1 | while (false) function foo(){}

--- a/tests/format/js/sloppy-mode/jsfmt.spec.js
+++ b/tests/format/js/sloppy-mode/jsfmt.spec.js
@@ -1,6 +1,7 @@
 run_spec(__dirname, ["babel", "flow", "typescript"], {
   errors: {
     flow: ["function-declaration-in-while.js"],
+    acorn: ["function-declaration-in-while.js"],
     espree: ["function-declaration-in-while.js"],
     meriyah: ["function-declaration-in-while.js"],
   },

--- a/tests/format/js/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/strings/__snapshots__/jsfmt.spec.js.snap
@@ -1,6 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`non-octal-eight-and-nine.js [acorn] format 1`] = `
+"Invalid escape sequence (3:3)
+  1 | // https://github.com/babel/babel/pull/11852
+  2 |
+> 3 | \\"\\\\8\\",\\"\\\\9\\";
+    |   ^
+  4 | () => {
+  5 |   \\"use strict\\";
+  6 |   \\"\\\\8\\", \\"\\\\9\\";"
+`;
+
 exports[`non-octal-eight-and-nine.js [espree] format 1`] = `
+"Invalid escape sequence (3:3)
+  1 | // https://github.com/babel/babel/pull/11852
+  2 |
+> 3 | \\"\\\\8\\",\\"\\\\9\\";
+    |   ^
+  4 | () => {
+  5 |   \\"use strict\\";
+  6 |   \\"\\\\8\\", \\"\\\\9\\";"
+`;
+
+exports[`non-octal-eight-and-nine.js - {"trailingComma":"all"} [acorn] format 1`] = `
 "Invalid escape sequence (3:3)
   1 | // https://github.com/babel/babel/pull/11852
   2 |

--- a/tests/format/js/strings/jsfmt.spec.js
+++ b/tests/format/js/strings/jsfmt.spec.js
@@ -1,7 +1,13 @@
 run_spec(__dirname, ["babel", "flow"], {
-  errors: { espree: ["non-octal-eight-and-nine.js"] },
+  errors: {
+    acorn: ["non-octal-eight-and-nine.js"],
+    espree: ["non-octal-eight-and-nine.js"],
+  },
 });
 run_spec(__dirname, ["babel", "flow"], {
   trailingComma: "all",
-  errors: { espree: ["non-octal-eight-and-nine.js"] },
+  errors: {
+    acorn: ["non-octal-eight-and-nine.js"],
+    espree: ["non-octal-eight-and-nine.js"],
+  },
 });

--- a/tests/format/js/throw_expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/throw_expressions/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`throw_expression.js [acorn] format 1`] = `
+"Unexpected token (1:26)
+> 1 | function save(filename = throw new TypeError(\\"Argument required\\")) {}
+    |                          ^
+  2 |
+  3 | lint(ast, {
+  4 |   with: () => throw new Error(\\"avoid using 'with' statements.\\")"
+`;
+
 exports[`throw_expression.js [espree] format 1`] = `
 "Unexpected token throw (1:26)
 > 1 | function save(filename = throw new TypeError(\\"Argument required\\")) {}

--- a/tests/format/js/throw_expressions/jsfmt.spec.js
+++ b/tests/format/js/throw_expressions/jsfmt.spec.js
@@ -1,1 +1,3 @@
-run_spec(__dirname, ["babel"], { errors: { espree: true, meriyah: true } });
+run_spec(__dirname, ["babel"], {
+  errors: { acorn: true, espree: true, meriyah: true },
+});

--- a/tests/format/js/trailing-whitespace/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/trailing-whitespace/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`trailing.js [acorn] format 1`] = `
+"Unexpected token (1:8)
+> 1 | export type Result<T, V> = | { kind: \\"not-test-editor1\\" } | { kind: \\"not-test-editor2\\" };
+    |        ^
+  2 |
+  3 | // Note: there are trailing whitespace in this file
+  4 | \`"
+`;
+
 exports[`trailing.js [espree] format 1`] = `
 "Unexpected token type (1:8)
 > 1 | export type Result<T, V> = | { kind: \\"not-test-editor1\\" } | { kind: \\"not-test-editor2\\" };

--- a/tests/format/js/trailing-whitespace/jsfmt.spec.js
+++ b/tests/format/js/trailing-whitespace/jsfmt.spec.js
@@ -1,3 +1,3 @@
 run_spec(__dirname, ["babel", "flow", "typescript"], {
-  errors: { espree: true, meriyah: true },
+  errors: { acorn: true, espree: true, meriyah: true },
 });

--- a/tests/format/js/tuple/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/tuple/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`destructuring.js [acorn] format 1`] = `
+"Unexpected character '[' (1:17)
+> 1 | const [a, b] = #[1, 2];
+    |                 ^
+  2 | assert(a === 1);
+  3 | assert(b === 2);
+  4 |"
+`;
+
 exports[`destructuring.js [espree] format 1`] = `
 "Unexpected character '[' (1:17)
 > 1 | const [a, b] = #[1, 2];
@@ -55,6 +64,13 @@ exports[`invalid-tuple-holes.js [__babel_estree] format 1`] = `
   2 |"
 `;
 
+exports[`invalid-tuple-holes.js [acorn] format 1`] = `
+"Unexpected character '[' (1:2)
+> 1 | #[,]
+    |  ^
+  2 |"
+`;
+
 exports[`invalid-tuple-holes.js [babel] format 1`] = `
 "Unexpected token ','. (1:4)
 > 1 | #[,]
@@ -74,6 +90,15 @@ exports[`invalid-tuple-holes.js [meriyah] format 1`] = `
 > 1 | #[,]
     | ^
   2 |"
+`;
+
+exports[`syntax.js [acorn] format 1`] = `
+"Unexpected character '[' (1:2)
+> 1 | #[]
+    |  ^
+  2 | #[1, 2]
+  3 | #[1, 2, #{ a: 3 }]
+  4 |"
 `;
 
 exports[`syntax.js [espree] format 1`] = `
@@ -110,6 +135,15 @@ printWidth: 80
 #[1, 2, #{ a: 3 }];
 
 ================================================================================
+`;
+
+exports[`tuple.js [acorn] format 1`] = `
+"Unexpected character '[' (1:17)
+> 1 | const tuple1 = #[1, 2, 3];
+    |                 ^
+  2 |
+  3 | assert(tuple1[0] === 1);
+  4 |"
 `;
 
 exports[`tuple.js [espree] format 1`] = `
@@ -174,6 +208,13 @@ const tuple5 = tuple4.popped();
 assert(tuple5 === #[2, 2, 3, 4]);
 
 ================================================================================
+`;
+
+exports[`tuple-trailing-comma.js [acorn] format 1`] = `
+"Unexpected character '[' (1:2)
+> 1 | #[1,]
+    |  ^
+  2 |"
 `;
 
 exports[`tuple-trailing-comma.js [espree] format 1`] = `

--- a/tests/format/js/tuple/jsfmt.spec.js
+++ b/tests/format/js/tuple/jsfmt.spec.js
@@ -2,6 +2,7 @@ run_spec(__dirname, ["babel"], {
   errors: {
     babel: ["invalid-tuple-holes.js"],
     __babel_estree: ["invalid-tuple-holes.js"],
+    acorn: true,
     espree: true,
     meriyah: true,
   },

--- a/tests/format/js/v8_intrinsic/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/v8_intrinsic/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`avoid-conflicts-to-pipeline.js [acorn] format 1`] = `
+"Unexpected token (2:16)
+  1 | // |>
+> 2 | const status = %GetOptimizationStatus(fn);
+    |                ^
+  3 |"
+`;
+
 exports[`avoid-conflicts-to-pipeline.js [espree] format 1`] = `
 "Unexpected token % (2:16)
   1 | // |>
@@ -30,6 +38,16 @@ const status = %GetOptimizationStatus(fn);
 const status = %GetOptimizationStatus(fn);
 
 ================================================================================
+`;
+
+exports[`intrinsic_call.js [acorn] format 1`] = `
+"Unexpected token (2:13)
+  1 | function doSmth()     {
+> 2 |             %DebugPrint
+    |             ^
+  3 |         (
+  4 |                 foo )
+  5 |   }"
 `;
 
 exports[`intrinsic_call.js [espree] format 1`] = `

--- a/tests/format/js/v8_intrinsic/jsfmt.spec.js
+++ b/tests/format/js/v8_intrinsic/jsfmt.spec.js
@@ -1,1 +1,3 @@
-run_spec(__dirname, ["babel"], { errors: { espree: true, meriyah: true } });
+run_spec(__dirname, ["babel"], {
+  errors: { acorn: true, espree: true, meriyah: true },
+});

--- a/tests/format/misc/errors/invalid/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/invalid/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`snippet: #0 [acorn] format 1`] = `
+"Unexpected token (1:5)
+> 1 | for each (a in b) {}
+    |     ^"
+`;
+
 exports[`snippet: #0 [babel] format 1`] = `
 "Unexpected token, expected \\"(\\" (1:5)
 > 1 | for each (a in b) {}
@@ -70,6 +76,12 @@ exports[`snippet: #0 [typescript] format 1`] = `
 "'(' expected. (1:5)
 > 1 | for each (a in b) {}
     |     ^"
+`;
+
+exports[`snippet: #1 [acorn] format 1`] = `
+"Unexpected token (1:7)
+> 1 | class switch() {}
+    |       ^"
 `;
 
 exports[`snippet: #1 [babel] format 1`] = `

--- a/tests/format/misc/errors/invalid/jsfmt.spec.js
+++ b/tests/format/misc/errors/invalid/jsfmt.spec.js
@@ -3,7 +3,16 @@ run_spec(
     dirname: __dirname,
     snippets: ["for each (a in b) {}", "class switch() {}"],
   },
-  ["babel", "flow", "typescript", "babel-flow", "babel-ts", "espree", "meriyah"]
+  [
+    "babel",
+    "flow",
+    "typescript",
+    "babel-flow",
+    "babel-ts",
+    "acorn",
+    "espree",
+    "meriyah",
+  ]
 );
 
 run_spec(

--- a/tests/format/misc/errors/js/assignment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/js/assignment/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`snippet: #0 [acorn] format 1`] = `
+"Parenthesized pattern (1:1)
+> 1 | ({}) = x;
+    | ^"
+`;
+
 exports[`snippet: #0 [babel] format 1`] = `
 "Invalid parenthesized assignment pattern. (1:1)
 > 1 | ({}) = x;

--- a/tests/format/misc/errors/js/assignment/jsfmt.spec.js
+++ b/tests/format/misc/errors/js/assignment/jsfmt.spec.js
@@ -3,5 +3,5 @@ run_spec(
     dirname: __dirname,
     snippets: ["({}) = x;"],
   },
-  ["babel", "babel-ts", "espree", "meriyah"]
+  ["babel", "babel-ts", "acorn", "espree", "meriyah"]
 );

--- a/tests/format/misc/errors/js/async-await/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/js/async-await/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`snippet: #0 [acorn] format 1`] = `
+"Unexpected token (2:26)
+  1 | async function foo() {
+> 2 |   function bar(x = await 2) {}
+    |                          ^
+  3 | }"
+`;
+
+exports[`snippet: #0 [acorn] format 2`] = `
+"Await expression cannot be a default value (1:12)
+> 1 | async (x = await (2)) => {};
+    |            ^"
+`;
+
 exports[`snippet: #0 [babel] format 1`] = `
 "'await' is not allowed in async function parameters. (2:20)
   1 | async function foo() {
@@ -44,6 +58,12 @@ exports[`snippet: #0 [meriyah] format 1`] = `
   3 | }"
 `;
 
+exports[`snippet: #1 [acorn] format 1`] = `
+"Await expression cannot be a default value (1:12)
+> 1 | async (x = await 2) => {};
+    |            ^"
+`;
+
 exports[`snippet: #1 [babel] format 1`] = `
 "'await' is not allowed in async function parameters. (1:12)
 > 1 | async (x = await 2) => {};
@@ -66,6 +86,12 @@ exports[`snippet: #1 [meriyah] format 1`] = `
 "[1:22]: Await expression not allowed in formal parameter (1:22)
 > 1 | async (x = await 2) => {};
     |                      ^"
+`;
+
+exports[`snippet: #2 [acorn] format 1`] = `
+"Unexpected token (1:25)
+> 1 | f = async (a) => await a! ** 6;
+    |                         ^"
 `;
 
 exports[`snippet: #2 [babel] format 1`] = `
@@ -92,6 +118,12 @@ exports[`snippet: #2 [meriyah] format 1`] = `
     |                         ^"
 `;
 
+exports[`snippet: #3 [acorn] format 1`] = `
+"Unexpected token (1:14)
+> 1 | f = (a) => +a! ** 6;
+    |              ^"
+`;
+
 exports[`snippet: #3 [babel] format 1`] = `
 "Unexpected token (1:16)
 > 1 | f = (a) => +a! ** 6;
@@ -114,6 +146,12 @@ exports[`snippet: #3 [meriyah] format 1`] = `
 "[1:14]: Unexpected token: '!' (1:14)
 > 1 | f = (a) => +a! ** 6;
     |              ^"
+`;
+
+exports[`snippet: #4 [acorn] format 1`] = `
+"Unexpected token (1:22)
+> 1 | async (a) => (await a!) ** 6;
+    |                      ^"
 `;
 
 exports[`snippet: #4 [babel] format 1`] = `
@@ -140,6 +178,12 @@ exports[`snippet: #4 [meriyah] format 1`] = `
     |                      ^"
 `;
 
+exports[`snippet: #5 [acorn] format 1`] = `
+"Unexpected token (1:6)
+> 1 | (-+5 ** 6);
+    |      ^"
+`;
+
 exports[`snippet: #5 [babel] format 1`] = `
 "Illegal expression. Wrap left hand side or entire exponentiation in parentheses. (1:3)
 > 1 | (-+5 ** 6);
@@ -162,6 +206,12 @@ exports[`snippet: #5 [meriyah] format 1`] = `
 "[1:7]: Unary expressions as the left operand of an exponentiation expression must be disambiguated with parentheses (1:7)
 > 1 | (-+5 ** 6);
     |       ^"
+`;
+
+exports[`snippet: #6 [acorn] format 1`] = `
+"Unexpected token (1:25)
+> 1 | f = async () => await 5 ** 6;
+    |                         ^"
 `;
 
 exports[`snippet: #6 [babel] format 1`] = `
@@ -188,6 +238,12 @@ exports[`snippet: #6 [meriyah] format 1`] = `
     |                          ^"
 `;
 
+exports[`snippet: #7 [acorn] format 1`] = `
+"Unexpected token (1:26)
+> 1 | f = async () => await -5 ** 6;
+    |                          ^"
+`;
+
 exports[`snippet: #7 [babel] format 1`] = `
 "Illegal expression. Wrap left hand side or entire exponentiation in parentheses. (1:23)
 > 1 | f = async () => await -5 ** 6;
@@ -210,6 +266,12 @@ exports[`snippet: #7 [meriyah] format 1`] = `
 "[1:27]: Unary expressions as the left operand of an exponentiation expression must be disambiguated with parentheses (1:27)
 > 1 | f = async () => await -5 ** 6;
     |                           ^"
+`;
+
+exports[`snippet: #8 [acorn] format 1`] = `
+"Shorthand property assignments are valid only in destructuring patterns (1:15)
+> 1 | async({ foo33 = 1 });
+    |               ^"
 `;
 
 exports[`snippet: #8 [babel] format 1`] = `

--- a/tests/format/misc/errors/js/async-await/jsfmt.spec.js
+++ b/tests/format/misc/errors/js/async-await/jsfmt.spec.js
@@ -19,7 +19,7 @@ run_spec(
       "async({ foo33 = 1 });",
     ],
   },
-  ["babel", "espree", "meriyah", "flow"]
+  ["babel", "acorn", "espree", "meriyah", "flow"]
 );
 
 run_spec(
@@ -30,5 +30,5 @@ run_spec(
       "async (x = await (2)) => {};",
     ],
   },
-  ["babel", "espree"]
+  ["babel", "acorn", "espree"]
 );

--- a/tests/format/misc/errors/js/for-of/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/js/for-of/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`snippet: #0 [acorn] format 1`] = `
+"Unexpected token (1:15)
+> 1 | for (async of []);
+    |               ^"
+`;
+
 exports[`snippet: #0 [babel] format 1`] = `
 "The left-hand side of a for-of loop may not start with 'let'. (1:6)
 > 1 | for (let.foo of []);

--- a/tests/format/misc/errors/js/for-of/jsfmt.spec.js
+++ b/tests/format/misc/errors/js/for-of/jsfmt.spec.js
@@ -26,6 +26,7 @@ run_spec(
   },
   [
     "babel",
+    "acorn",
     "espree",
     // `meriyah` didn't throw https://github.com/meriyah/meriyah/issues/190
     // "meriyah",

--- a/tests/format/misc/errors/js/import/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/js/import/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`snippet: #0 [acorn] format 1`] = `
+"Unexpected token (1:8)
+> 1 | import();
+    |        ^"
+`;
+
 exports[`snippet: #0 [babel] format 1`] = `
 "\`import()\` requires exactly one or two arguments. (1:1)
 > 1 | import();
@@ -40,6 +46,12 @@ exports[`snippet: #0 [typescript] format 1`] = `
 "Dynamic import requires exactly one or two arguments. (1:8)
 > 1 | import();
     |        ^"
+`;
+
+exports[`snippet: #1 [acorn] format 1`] = `
+"Unexpected token (1:21)
+> 1 | import(/* comment */);
+    |                     ^"
 `;
 
 exports[`snippet: #1 [babel] format 1`] = `
@@ -84,6 +96,12 @@ exports[`snippet: #1 [typescript] format 1`] = `
     |        ^"
 `;
 
+exports[`snippet: #2 [acorn] format 1`] = `
+"Cannot use new with import() (1:5)
+> 1 | new import('./a.mjs');
+    |     ^"
+`;
+
 exports[`snippet: #2 [babel] format 1`] = `
 "Cannot use new with import(...). (1:5)
 > 1 | new import('./a.mjs');
@@ -124,6 +142,12 @@ exports[`snippet: #2 [typescript] format 1`] = `
 "Expression expected. (1:5)
 > 1 | new import('./a.mjs');
     |     ^"
+`;
+
+exports[`snippet: #3 [acorn] format 1`] = `
+"Unexpected token (1:12)
+> 1 | new import();
+    |            ^"
 `;
 
 exports[`snippet: #3 [babel] format 1`] = `

--- a/tests/format/misc/errors/js/import/jsfmt.spec.js
+++ b/tests/format/misc/errors/js/import/jsfmt.spec.js
@@ -8,5 +8,14 @@ run_spec(
       "new import();",
     ],
   },
-  ["babel", "espree", "meriyah", "flow", "typescript", "babel-flow", "babel-ts"]
+  [
+    "babel",
+    "acorn",
+    "espree",
+    "meriyah",
+    "flow",
+    "typescript",
+    "babel-flow",
+    "babel-ts",
+  ]
 );

--- a/tests/format/misc/errors/js/literal/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/js/literal/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`invalid-exponent.js [acorn] format 1`] = `
+"Invalid number (1:1)
+> 1 | 12.3e
+    | ^
+  2 |"
+`;
+
 exports[`invalid-exponent.js [babel] format 1`] = `
 "Floating-point numbers require a valid exponent after the 'e'. (1:1)
 > 1 | 12.3e

--- a/tests/format/misc/errors/js/literal/jsfmt.spec.js
+++ b/tests/format/misc/errors/js/literal/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, ["babel", "espree", "meriyah"]);
+run_spec(__dirname, ["babel", "acorn", "espree", "meriyah"]);

--- a/tests/format/misc/errors/js/object/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/js/object/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`getter-generator.js [acorn] format 1`] = `
+"Unexpected token (2:9)
+  1 | ({
+> 2 |     get *iterator() { },
+    |         ^
+  3 | });
+  4 |"
+`;
+
 exports[`getter-generator.js [babel] format 1`] = `
 "A getter cannot be a generator. (2:10)
   1 | ({
@@ -27,6 +36,13 @@ exports[`getter-generator.js [meriyah] format 1`] = `
   4 |"
 `;
 
+exports[`getter-with-parameter.js [acorn] format 1`] = `
+"getter should have no params (1:9)
+> 1 | ({ get x(a){} });
+    |         ^
+  2 |"
+`;
+
 exports[`getter-with-parameter.js [babel] format 1`] = `
 "A 'get' accesor must not have any formal parameters. (1:4)
 > 1 | ({ get x(a){} });
@@ -46,6 +62,15 @@ exports[`getter-with-parameter.js [meriyah] format 1`] = `
 > 1 | ({ get x(a){} });
     |          ^
   2 |"
+`;
+
+exports[`setter-generator.js [acorn] format 1`] = `
+"Unexpected token (2:9)
+  1 | ({
+> 2 |     set *iterator(iter) { },
+    |         ^
+  3 | });
+  4 |"
 `;
 
 exports[`setter-generator.js [babel] format 1`] = `
@@ -73,6 +98,13 @@ exports[`setter-generator.js [meriyah] format 1`] = `
     |         ^
   3 | });
   4 |"
+`;
+
+exports[`setter-without-parameter.js [acorn] format 1`] = `
+"setter should have exactly one param (1:9)
+> 1 | ({ set x(){} });
+    |         ^
+  2 |"
 `;
 
 exports[`setter-without-parameter.js [babel] format 1`] = `

--- a/tests/format/misc/errors/js/object/jsfmt.spec.js
+++ b/tests/format/misc/errors/js/object/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, ["babel", "espree", "meriyah"]);
+run_spec(__dirname, ["babel", "acorn", "espree", "meriyah"]);

--- a/tests/format/misc/errors/js/optional-chaining/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/js/optional-chaining/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`snippet: #0 [acorn] format 1`] = `
+"Optional chaining cannot appear in the callee of new expressions (1:21)
+> 1 | const baz3 = new obj?.foo?.bar?.baz(); // baz instance
+    |                     ^"
+`;
+
 exports[`snippet: #0 [babel] format 1`] = `
 "Constructors in/after an Optional Chain are not allowed. (1:36)
 > 1 | const baz3 = new obj?.foo?.bar?.baz(); // baz instance
@@ -15,6 +21,12 @@ exports[`snippet: #0 [espree] format 1`] = `
 exports[`snippet: #0 [meriyah] format 1`] = `
 "[1:22]: Invalid optional chain from new expression (1:22)
 > 1 | const baz3 = new obj?.foo?.bar?.baz(); // baz instance
+    |                      ^"
+`;
+
+exports[`snippet: #1 [acorn] format 1`] = `
+"Optional chaining cannot appear in the callee of new expressions (1:22)
+> 1 | const safe5 = new obj?.qux?.baz(); // undefined
     |                      ^"
 `;
 
@@ -36,6 +48,12 @@ exports[`snippet: #1 [meriyah] format 1`] = `
     |                       ^"
 `;
 
+exports[`snippet: #2 [acorn] format 1`] = `
+"Optional chaining cannot appear in the callee of new expressions (1:22)
+> 1 | const safe6 = new obj?.foo.bar.qux?.(); // undefined
+    |                      ^"
+`;
+
 exports[`snippet: #2 [babel] format 1`] = `
 "Constructors in/after an Optional Chain are not allowed. (1:35)
 > 1 | const safe6 = new obj?.foo.bar.qux?.(); // undefined
@@ -54,6 +72,12 @@ exports[`snippet: #2 [meriyah] format 1`] = `
     |                       ^"
 `;
 
+exports[`snippet: #3 [acorn] format 1`] = `
+"Optional chaining cannot appear in the callee of new expressions (1:26)
+> 1 | const willThrow = new obj?.foo.bar.qux(); // Error: not a constructor
+    |                          ^"
+`;
+
 exports[`snippet: #3 [babel] format 1`] = `
 "Constructors in/after an Optional Chain are not allowed. (1:39)
 > 1 | const willThrow = new obj?.foo.bar.qux(); // Error: not a constructor
@@ -70,6 +94,14 @@ exports[`snippet: #3 [meriyah] format 1`] = `
 "[1:27]: Invalid optional chain from new expression (1:27)
 > 1 | const willThrow = new obj?.foo.bar.qux(); // Error: not a constructor
     |                           ^"
+`;
+
+exports[`snippet: #4 [acorn] format 1`] = `
+"Optional chaining cannot appear in the callee of new expressions (4:9)
+  2 | class Test {
+  3 | }
+> 4 | new Test?.(); // test instance
+    |         ^"
 `;
 
 exports[`snippet: #4 [babel] format 1`] = `
@@ -94,6 +126,12 @@ exports[`snippet: #4 [meriyah] format 1`] = `
   3 | }
 > 4 | new Test?.(); // test instance
     |          ^"
+`;
+
+exports[`snippet: #5 [acorn] format 1`] = `
+"Optional chaining cannot appear in the callee of new expressions (1:11)
+> 1 | new exists?.(); // undefined
+    |           ^"
 `;
 
 exports[`snippet: #5 [babel] format 1`] = `

--- a/tests/format/misc/errors/js/optional-chaining/jsfmt.spec.js
+++ b/tests/format/misc/errors/js/optional-chaining/jsfmt.spec.js
@@ -17,5 +17,5 @@ run_spec(
       "new exists?.(); // undefined",
     ],
   },
-  ["babel", "espree", "meriyah"]
+  ["babel", "acorn", "espree", "meriyah"]
 );

--- a/tests/format/misc/errors/js/record/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/js/record/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,11 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`snippet: #0 [acorn] format 1`] = `
+"Unexpected character '{' (1:2)
+> 1 | #{a() {}}
+    |  ^"
+`;
+
 exports[`snippet: #0 [babel] format 1`] = `
 "Only properties and spread elements are allowed in record definitions. (1:3)
 > 1 | #{a() {}}
@@ -16,6 +22,12 @@ exports[`snippet: #0 [meriyah] format 1`] = `
 "[1:1]: '#' not followed by identifier (1:1)
 > 1 | #{a() {}}
     | ^"
+`;
+
+exports[`snippet: #1 [acorn] format 1`] = `
+"Unexpected character '{' (1:2)
+> 1 | #{async b() {}}
+    |  ^"
 `;
 
 exports[`snippet: #1 [babel] format 1`] = `
@@ -36,6 +48,12 @@ exports[`snippet: #1 [meriyah] format 1`] = `
     | ^"
 `;
 
+exports[`snippet: #2 [acorn] format 1`] = `
+"Unexpected character '{' (1:2)
+> 1 | #{get c() {}}
+    |  ^"
+`;
+
 exports[`snippet: #2 [babel] format 1`] = `
 "Only properties and spread elements are allowed in record definitions. (1:3)
 > 1 | #{get c() {}}
@@ -54,6 +72,12 @@ exports[`snippet: #2 [meriyah] format 1`] = `
     | ^"
 `;
 
+exports[`snippet: #3 [acorn] format 1`] = `
+"Unexpected character '{' (1:2)
+> 1 | #{set d(_) {}}
+    |  ^"
+`;
+
 exports[`snippet: #3 [babel] format 1`] = `
 "Only properties and spread elements are allowed in record definitions. (1:3)
 > 1 | #{set d(_) {}}
@@ -70,6 +94,12 @@ exports[`snippet: #3 [meriyah] format 1`] = `
 "[1:1]: '#' not followed by identifier (1:1)
 > 1 | #{set d(_) {}}
     | ^"
+`;
+
+exports[`snippet: #4 [acorn] format 1`] = `
+"Unexpected character '{' (1:2)
+> 1 | #{*e() {}}
+    |  ^"
 `;
 
 exports[`snippet: #4 [babel] format 1`] = `

--- a/tests/format/misc/errors/js/record/jsfmt.spec.js
+++ b/tests/format/misc/errors/js/record/jsfmt.spec.js
@@ -9,5 +9,5 @@ run_spec(
       "#{*e() {}}",
     ],
   },
-  ["babel", "espree", "meriyah"]
+  ["babel", "acorn", "espree", "meriyah"]
 );

--- a/tests/format/misc/errors/js/variable-declarator/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/js/variable-declarator/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`invalid-const.js [acorn] format 1`] = `
+"Unexpected token (1:10)
+> 1 | const foo;
+    |          ^
+  2 |"
+`;
+
 exports[`invalid-const.js [babel] format 1`] = `
 "'Const declarations' require an initialization value. (1:10)
 > 1 | const foo;

--- a/tests/format/misc/errors/js/variable-declarator/jsfmt.spec.js
+++ b/tests/format/misc/errors/js/variable-declarator/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(__dirname, ["babel", "espree", "meriyah"]);
+run_spec(__dirname, ["babel", "acorn", "espree", "meriyah"]);

--- a/tests/integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests/integration/__tests__/__snapshots__/early-exit.js.snap
@@ -75,7 +75,7 @@ Format options:
                            Defaults to css.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.
-  --parser <flow|babel|babel-flow|babel-ts|typescript|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
+  --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
                            Which parser to use.
   --print-width <int>      The line length where Prettier will try wrap.
                            Defaults to 80.
@@ -176,7 +176,7 @@ exports[`show warning with --help not-found (typo) (stderr) 1`] = `
 `;
 
 exports[`show warning with --help not-found (typo) (stdout) 1`] = `
-"--parser <flow|babel|babel-flow|babel-ts|typescript|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
+"--parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
 
   Which parser to use.
 
@@ -187,6 +187,7 @@ Valid options:
   babel-flow       Flow
   babel-ts         TypeScript
   typescript       TypeScript
+  acorn            JavaScript
   espree           JavaScript
   meriyah          JavaScript
   css              CSS
@@ -243,7 +244,7 @@ Format options:
                            Defaults to css.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.
-  --parser <flow|babel|babel-flow|babel-ts|typescript|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
+  --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
                            Which parser to use.
   --print-width <int>      The line length where Prettier will try wrap.
                            Defaults to 80.

--- a/tests/integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/help-options.js.snap
@@ -372,7 +372,7 @@ exports[`show detailed usage with --help no-semi (write) 1`] = `Array []`;
 exports[`show detailed usage with --help parser (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help parser (stdout) 1`] = `
-"--parser <flow|babel|babel-flow|babel-ts|typescript|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
+"--parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
 
   Which parser to use.
 
@@ -383,6 +383,7 @@ Valid options:
   babel-flow       Flow
   babel-ts         TypeScript
   typescript       TypeScript
+  acorn            JavaScript
   espree           JavaScript
   meriyah          JavaScript
   css              CSS

--- a/tests/integration/__tests__/__snapshots__/plugin-options-string.js.snap
+++ b/tests/integration/__tests__/__snapshots__/plugin-options-string.js.snap
@@ -31,8 +31,8 @@ exports[`show external options with \`--help\` 1`] = `
                              Defaults to css.
     --jsx-single-quote       Use single quotes in JSX.
                              Defaults to false.
--   --parser <flow|babel|babel-flow|babel-ts|typescript|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
-+   --parser <flow|babel|babel-flow|babel-ts|typescript|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc|foo-parser>
+-   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
++   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc|foo-parser>
                              Which parser to use.
     --print-width <int>      The line length where Prettier will try wrap.
                              Defaults to 80.

--- a/tests/integration/__tests__/__snapshots__/plugin-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/plugin-options.js.snap
@@ -3,7 +3,7 @@
 exports[`include plugin's parsers to the values of the \`parser\` option\` (stderr) 1`] = `""`;
 
 exports[`include plugin's parsers to the values of the \`parser\` option\` (stdout) 1`] = `
-"--parser <flow|babel|babel-flow|babel-ts|typescript|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc|foo-parser>
+"--parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc|foo-parser>
 
   Which parser to use.
 
@@ -14,6 +14,7 @@ Valid options:
   babel-flow       Flow
   babel-ts         TypeScript
   typescript       TypeScript
+  acorn            JavaScript
   espree           JavaScript
   meriyah          JavaScript
   css              CSS
@@ -73,8 +74,8 @@ exports[`show external options with \`--help\` 1`] = `
                              Defaults to css.
     --jsx-single-quote       Use single quotes in JSX.
                              Defaults to false.
--   --parser <flow|babel|babel-flow|babel-ts|typescript|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
-+   --parser <flow|babel|babel-flow|babel-ts|typescript|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc|foo-parser>
+-   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
++   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc|foo-parser>
                              Which parser to use.
     --print-width <int>      The line length where Prettier will try wrap.
                              Defaults to 80.

--- a/tests/integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests/integration/__tests__/__snapshots__/schema.js.snap
@@ -163,6 +163,12 @@ This option cannot be used with --range-start and --range-end.",
             Object {
               "description": "JavaScript",
               "enum": Array [
+                "acorn",
+              ],
+            },
+            Object {
+              "description": "JavaScript",
+              "enum": Array [
                 "espree",
               ],
             },

--- a/tests/integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests/integration/__tests__/__snapshots__/support-info.js.snap
@@ -45,6 +45,7 @@ Object {
     ],
     "JavaScript": Array [
       "babel",
+      "acorn",
       "espree",
       "meriyah",
       "babel-flow",
@@ -157,6 +158,7 @@ Object {
         "babel-flow",
         "babel-ts",
         "typescript",
+        "acorn",
         "espree",
         "meriyah",
         "css",
@@ -330,6 +332,7 @@ exports[`CLI --support-info (stdout) 1`] = `
       \\"name\\": \\"JavaScript\\",
       \\"parsers\\": [
         \\"babel\\",
+        \\"acorn\\",
         \\"espree\\",
         \\"meriyah\\",
         \\"babel-flow\\",
@@ -915,6 +918,7 @@ exports[`CLI --support-info (stdout) 1`] = `
           \\"since\\": \\"1.4.0\\",
           \\"value\\": \\"typescript\\"
         },
+        { \\"description\\": \\"JavaScript\\", \\"since\\": \\"2.6.0\\", \\"value\\": \\"acorn\\" },
         { \\"description\\": \\"JavaScript\\", \\"since\\": \\"2.2.0\\", \\"value\\": \\"espree\\" },
         { \\"description\\": \\"JavaScript\\", \\"since\\": \\"2.2.0\\", \\"value\\": \\"meriyah\\" },
         { \\"description\\": \\"CSS\\", \\"since\\": \\"1.7.1\\", \\"value\\": \\"css\\" },

--- a/website/playground/codeSamples.js
+++ b/website/playground/codeSamples.js
@@ -1,6 +1,7 @@
 export default function getCodeSamples(parser) {
   switch (parser) {
     case "babel":
+    case "acorn":
     case "espree":
     case "meriyah":
       return [

--- a/website/playground/markdown.js
+++ b/website/playground/markdown.js
@@ -38,6 +38,7 @@ function getMarkdownSyntax(options) {
     case "babel":
     case "babel-flow":
     case "flow":
+    case "acorn":
     case "espree":
     case "meriyah":
       return "jsx";

--- a/website/playground/util.js
+++ b/website/playground/util.js
@@ -69,7 +69,9 @@ export function getAstAutoFold(parser) {
     case "babel-flow":
     case "babel-ts":
     case "typescript":
+    case "acorn":
     case "espree":
+    case "meriyah":
     case "json":
     case "json5":
     case "json-stringify":

--- a/yarn.lock
+++ b/yarn.lock
@@ -1823,7 +1823,7 @@ acorn-globals@^6.0.0:
     acorn "^7.1.1"
     acorn-walk "^7.1.1"
 
-acorn-jsx@^5.3.1:
+acorn-jsx@5.3.2, acorn-jsx@^5.3.1:
   version "5.3.2"
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
@@ -1833,15 +1833,15 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn@8.7.0, acorn@^8.2.4, acorn@^8.7.0:
+  version "8.7.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
+  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
+
 acorn@^7.1.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
-
-acorn@^8.2.4, acorn@^8.7.0:
-  version "8.7.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
-  integrity sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==
 
 agent-base@6:
   version "6.0.2"


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

`espree` is build on top of `acorn` parser, support `acorn` is very easy, this may also be needed for #12144, [comment](https://github.com/prettier/prettier/issues/12144#issuecomment-1021231222)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
