### PR TITLE
Reduce bundle size of `doc.js`

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -1,12 +1,10 @@
 "use strict";
 
-const stringWidth = require("string-width");
 const escapeStringRegexp = require("escape-string-regexp");
 const getLast = require("../utils/get-last.js");
 const { getSupportInfo } = require("../main/support.js");
 const isNonEmptyArray = require("../utils/is-non-empty-array.js");
-
-const notAsciiRegex = /[^\x20-\x7F]/;
+const getStringWidth = require("../utils/get-string-width.js");
 
 const getPenultimate = (arr) => arr[arr.length - 2];
 
@@ -516,23 +514,6 @@ function getMinNotPresentContinuousCount(str, target) {
   }
 
   return max + 1;
-}
-
-/**
- * @param {string} text
- * @returns {number}
- */
-function getStringWidth(text) {
-  if (!text) {
-    return 0;
-  }
-
-  // shortcut to avoid needless string `RegExp`s, replacements, and allocations within `string-width`
-  if (!notAsciiRegex.test(text)) {
-    return text.length;
-  }
-
-  return stringWidth(text);
 }
 
 function addCommentHelper(node, comment) {

--- a/src/document/doc-printer.js
+++ b/src/document/doc-printer.js
@@ -1,7 +1,8 @@
 "use strict";
 
-const { getStringWidth, getLast } = require("../common/util.js");
 const { convertEndOfLineToChars } = require("../common/end-of-line.js");
+const getLast = require("../utils/get-last.js");
+const getStringWidth = require("../utils/get-string-width.js");
 const { fill, cursor, indent } = require("./doc-builders.js");
 const { isConcat, getDocParts } = require("./doc-utils.js");
 

--- a/src/document/doc-utils.js
+++ b/src/document/doc-utils.js
@@ -1,4 +1,5 @@
 "use strict";
+
 const getLast = require("../utils/get-last.js");
 const { literalline, join } = require("./doc-builders.js");
 

--- a/src/utils/get-string-width.js
+++ b/src/utils/get-string-width.js
@@ -1,0 +1,24 @@
+"use strict";
+
+const stringWidth = require("string-width");
+
+const notAsciiRegex = /[^\x20-\x7F]/;
+
+/**
+ * @param {string} text
+ * @returns {number}
+ */
+function getStringWidth(text) {
+  if (!text) {
+    return 0;
+  }
+
+  // shortcut to avoid needless string `RegExp`s, replacements, and allocations within `string-width`
+  if (!notAsciiRegex.test(text)) {
+    return text.length;
+  }
+
+  return stringWidth(text);
+}
+
+module.exports = getStringWidth;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Reduce bundle size of `doc.js` by 113.9 kb

Address https://github.com/prettier/prettier/pull/12168#issuecomment-1022946262

**Before:**

```
$ node ./scripts/build/build.mjs --file=doc.js --print-size --report
 Building packages 
doc.js..........................................................178 kB    DONE  
```

**After:**

```
$ node ./scripts/build/build.mjs --file=doc.js --print-size --report
 Building packages 
doc.js.........................................................63.1 kB    DONE  
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
