### PR TITLE
Reduce size of `inherits` module in `parser-markdown.js`

### DIFF
--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -127,7 +127,7 @@ const parsers = [
     replaceModule: {
       [require.resolve("parse-entities/decode-entity.browser.js")]:
         require.resolve("parse-entities/decode-entity.js"),
-      // Avoid `utils` shim
+      // Avoid `node:util` shim
       [require.resolve("inherits")]: require.resolve(
         "inherits/inherits_browser.js"
       ),

--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -127,6 +127,10 @@ const parsers = [
     replaceModule: {
       [require.resolve("parse-entities/decode-entity.browser.js")]:
         require.resolve("parse-entities/decode-entity.js"),
+      // Avoid `utils` shim
+      [require.resolve("inherits")]: require.resolve(
+        "inherits/inherits_browser.js"
+      ),
     },
   },
   {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

```diff
$ node ./scripts/build/build.mjs --file=parser-markdown.js --print-size
- parser-markdown.js..............................................173 kB    DONE
+ parser-markdown.js..............................................163 kB    DONE
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
