### PR TITLE
Reduce bundle size of `parser-html.js`

### DIFF
--- a/src/language-html/embed.js
+++ b/src/language-html/embed.js
@@ -28,7 +28,7 @@ const {
   isVueSlotAttribute,
   isVueSfcBindingsAttribute,
   getTextValueParts,
-} = require("./utils.js");
+} = require("./utils/index.js");
 const getNodeContent = require("./get-node-content.js");
 
 function printEmbeddedAttributeValue(node, htmlTextToDoc, options) {

--- a/src/language-html/parser-html.js
+++ b/src/language-html/parser-html.js
@@ -9,11 +9,9 @@ const parseFrontMatter = require("../utils/front-matter/parse.js");
 const getLast = require("../utils/get-last.js");
 const createError = require("../common/parser-create-error.js");
 const { inferParserByLanguage } = require("../common/util.js");
-const {
-  HTML_ELEMENT_ATTRIBUTES,
-  HTML_TAGS,
-  isUnknownNamespace,
-} = require("./utils.js");
+const HTML_TAGS = require("./utils/html-tag-names.js");
+const HTML_ELEMENT_ATTRIBUTES = require("./utils/html-elements-attributes.js");
+const isUnknownNamespace = require("./utils/is-unknown-namespace.js");
 const { hasPragma } = require("./pragma.js");
 const { Node } = require("./ast.js");
 const { parseIeConditionalComment } = require("./conditional-comment.js");

--- a/src/language-html/print-preprocess.js
+++ b/src/language-html/print-preprocess.js
@@ -14,7 +14,7 @@ const {
   isLeadingSpaceSensitiveNode,
   isTrailingSpaceSensitiveNode,
   isWhitespaceSensitiveNode,
-} = require("./utils.js");
+} = require("./utils/index.js");
 
 const PREPROCESS_PIPELINE = [
   removeIgnorableFirstLf,

--- a/src/language-html/print/children.js
+++ b/src/language-html/print/children.js
@@ -11,7 +11,7 @@ const {
   isTextLikeNode,
   hasPrettierIgnore,
   preferHardlineAsLeadingSpaces,
-} = require("../utils.js");
+} = require("../utils/index.js");
 const {
   printOpeningTagPrefix,
   needsToBorrowNextOpeningTagStartMarker,

--- a/src/language-html/print/element.js
+++ b/src/language-html/print/element.js
@@ -20,7 +20,7 @@ const {
   isVueCustomBlock,
   countParents,
   forceBreakContent,
-} = require("../utils.js");
+} = require("../utils/index.js");
 const {
   printOpeningTagPrefix,
   printOpeningTag,

--- a/src/language-html/print/tag.js
+++ b/src/language-html/print/tag.js
@@ -17,7 +17,7 @@ const {
   isPreLikeNode,
   hasPrettierIgnore,
   shouldPreserveContent,
-} = require("../utils.js");
+} = require("../utils/index.js");
 
 function printClosingTag(node, options) {
   return [

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -13,7 +13,7 @@ const {
   countChars,
   unescapeQuoteEntities,
   getTextValueParts,
-} = require("./utils.js");
+} = require("./utils/index.js");
 const preprocess = require("./print-preprocess.js");
 const { insertPragma } = require("./pragma.js");
 const { locStart, locEnd } = require("./loc.js");

--- a/src/language-html/utils/array-to-map.js
+++ b/src/language-html/utils/array-to-map.js
@@ -1,0 +1,11 @@
+"use strict";
+
+function arrayToMap(array) {
+  const map = Object.create(null);
+  for (const value of array) {
+    map[value] = true;
+  }
+  return map;
+}
+
+module.exports = arrayToMap;

--- a/src/language-html/utils/html-elements-attributes.js
+++ b/src/language-html/utils/html-elements-attributes.js
@@ -1,0 +1,9 @@
+"use strict";
+
+const htmlElementAttributes = require("html-element-attributes");
+const mapObject = require("./map-object.js");
+const arrayToMap = require("./array-to-map.js");
+
+const HTML_ELEMENT_ATTRIBUTES = mapObject(htmlElementAttributes, arrayToMap);
+
+module.exports = HTML_ELEMENT_ATTRIBUTES;

--- a/src/language-html/utils/html-tag-names.js
+++ b/src/language-html/utils/html-tag-names.js
@@ -1,0 +1,8 @@
+"use strict";
+
+const htmlTagNames = require("html-tag-names");
+const arrayToMap = require("./array-to-map.js");
+
+const HTML_TAGS = arrayToMap(htmlTagNames);
+
+module.exports = HTML_TAGS;

--- a/src/language-html/utils/index.js
+++ b/src/language-html/utils/index.js
@@ -1,28 +1,24 @@
 "use strict";
 
 /**
- * @typedef {import("../common/ast-path")} AstPath
+ * @typedef {import("../../common/ast-path")} AstPath
  */
 
-const htmlTagNames = require("html-tag-names");
-const htmlElementAttributes = require("html-element-attributes");
 const {
   inferParserByLanguage,
   isFrontMatterNode,
-} = require("../common/util.js");
+} = require("../../common/util.js");
 const {
   builders: { line, hardline, join },
   utils: { getDocParts, replaceTextEndOfLine },
-} = require("../document/index.js");
+} = require("../../document/index.js");
 const {
   CSS_DISPLAY_TAGS,
   CSS_DISPLAY_DEFAULT,
   CSS_WHITE_SPACE_TAGS,
   CSS_WHITE_SPACE_DEFAULT,
-} = require("./constants.evaluate.js");
-
-const HTML_TAGS = arrayToMap(htmlTagNames);
-const HTML_ELEMENT_ATTRIBUTES = mapObject(htmlElementAttributes, arrayToMap);
+} = require("../constants.evaluate.js");
+const isUnknownNamespace = require("./is-unknown-namespace.js");
 
 // https://infra.spec.whatwg.org/#ascii-whitespace
 const HTML_WHITESPACE = new Set(["\t", "\n", "\f", "\r", " "]);
@@ -46,22 +42,6 @@ const getLeadingAndTrailingHtmlWhitespace = (string) => {
   };
 };
 const hasHtmlWhitespace = (string) => /[\t\n\f\r ]/.test(string);
-
-function arrayToMap(array) {
-  const map = Object.create(null);
-  for (const value of array) {
-    map[value] = true;
-  }
-  return map;
-}
-
-function mapObject(object, fn) {
-  const newObject = Object.create(null);
-  for (const [key, value] of Object.entries(object)) {
-    newObject[key] = fn(value, key);
-  }
-  return newObject;
-}
 
 function shouldPreserveContent(node, options) {
   // unterminated node in ie conditional comment
@@ -539,14 +519,6 @@ function getNodeCssStyleDisplay(node, options) {
   }
 }
 
-function isUnknownNamespace(node) {
-  return (
-    node.type === "element" &&
-    !node.hasExplicitNamespace &&
-    !["html", "svg"].includes(node.namespace)
-  );
-}
-
 function getNodeCssStyleWhiteSpace(node) {
   return (
     (node.type === "element" &&
@@ -667,8 +639,6 @@ function getTextValueParts(node, value = node.value) {
 }
 
 module.exports = {
-  HTML_ELEMENT_ATTRIBUTES,
-  HTML_TAGS,
   htmlTrim,
   htmlTrimPreserveIndentation,
   hasHtmlWhitespace,

--- a/src/language-html/utils/is-unknown-namespace.js
+++ b/src/language-html/utils/is-unknown-namespace.js
@@ -1,0 +1,11 @@
+"use strict";
+
+function isUnknownNamespace(node) {
+  return (
+    node.type === "element" &&
+    !node.hasExplicitNamespace &&
+    !["html", "svg"].includes(node.namespace)
+  );
+}
+
+module.exports = isUnknownNamespace;

--- a/src/language-html/utils/map-object.js
+++ b/src/language-html/utils/map-object.js
@@ -1,0 +1,11 @@
+"use strict";
+
+function mapObject(object, fn) {
+  const newObject = Object.create(null);
+  for (const [key, value] of Object.entries(object)) {
+    newObject[key] = fn(value, key);
+  }
+  return newObject;
+}
+
+module.exports = mapObject;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
**Before:**

```
$ node ./scripts/build/build.mjs --file=parser-html.js --print-size
 Building packages 
parser-html.js..................................................179 kB    DONE  
```

**After:**

```
$ node ./scripts/build/build.mjs --file=parser-html.js --print-size
 Building packages 
parser-html.js..................................................156 kB    DONE  
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
