### PR TITLE
Keep comments of `default` cases in the same line of the case

### DIFF
--- a/changelog_unreleased/javascript/12177.md
+++ b/changelog_unreleased/javascript/12177.md
@@ -1,0 +1,40 @@
+#### Keep comments after `default` cases in the same line (#12177 by @duailibe)
+
+Keep comments right after `default` cases (in switch statements) in the same line, when possible.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+function read_statement() {
+  switch (peek_keyword()) {
+    case Keyword.impl: // impl<T> Growling<T> for Wolf {}
+      return ImplDeclaration.read();
+
+    default: // expression;
+      return ExpressionStatement.read();
+  }
+}
+
+// Prettier stable
+function read_statement() {
+  switch (peek_keyword()) {
+    case Keyword.impl: // impl<T> Growling<T> for Wolf {}
+      return ImplDeclaration.read();
+
+    default:
+      // expression;
+      return ExpressionStatement.read();
+  }
+}
+
+// Prettier main
+function read_statement() {
+  switch (peek_keyword()) {
+    case Keyword.impl: // impl<T> Growling<T> for Wolf {}
+      return ImplDeclaration.read();
+
+    default: // expression;
+      return ExpressionStatement.read();
+  }
+}
+```

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -24,6 +24,7 @@ const {
   isCallExpression,
   isMemberExpression,
   isObjectProperty,
+  isLineComment,
   getComments,
   CommentCheckFlags,
   markerForIfWithoutBlockAndSameLineComment,
@@ -93,6 +94,7 @@ function handleEndOfLineComment(context) {
     handleTypeAliasComments,
     handleVariableDeclaratorComments,
     handleBreakAndContinueStatementComments,
+    handleSwitchDefaultCaseComments,
   ].some((fn) => fn(context));
 }
 
@@ -895,6 +897,28 @@ function handleTSMappedTypeComments({
   }
 
   return false;
+}
+
+function handleSwitchDefaultCaseComments({
+  comment,
+  enclosingNode,
+  followingNode,
+}) {
+  if (
+    !enclosingNode ||
+    enclosingNode.type !== "SwitchCase" ||
+    enclosingNode.test
+  ) {
+    return false;
+  }
+
+  if (followingNode.type === "BlockStatement" && isLineComment(comment)) {
+    addBlockStatementFirstComment(followingNode, comment);
+  } else {
+    addDanglingComment(enclosingNode, comment);
+  }
+
+  return true;
 }
 
 /**

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -696,9 +696,8 @@ function printPathNoParens(path, options, print, args) {
         parts.push("default:");
       }
 
-      const dangling = printDanglingComments(path, options, true);
-      if (dangling) {
-        parts.push(" ", dangling);
+      if (hasComment(node, CommentCheckFlags.Dangling)) {
+        parts.push(" ", printDanglingComments(path, options, true));
       }
 
       const consequent = node.consequent.filter(

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -696,6 +696,11 @@ function printPathNoParens(path, options, print, args) {
         parts.push("default:");
       }
 
+      const dangling = printDanglingComments(path, options, true);
+      if (dangling) {
+        parts.push(" ", dangling);
+      }
+
       const consequent = node.consequent.filter(
         (node) => node.type !== "EmptyStatement"
       );

--- a/tests/format/js/switch/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/switch/__snapshots__/jsfmt.spec.js.snap
@@ -31,17 +31,6 @@ switch(x) {
 }
 
 switch(x) {
-  case 1: // comment
-    break;
-
-  case 2: // comment
-    {break;}
-
-  case 3: { // comment
-    break;}
-}
-
-switch(x) {
   default: // comment
     break;
 }
@@ -98,20 +87,6 @@ switch (x) {
   // other
 
   case y: {
-  }
-}
-
-switch (x) {
-  case 1: // comment
-    break;
-
-  case 2: { // comment
-    break;
-  }
-
-  case 3: {
-    // comment
-    break;
   }
 }
 

--- a/tests/format/js/switch/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/switch/__snapshots__/jsfmt.spec.js.snap
@@ -30,6 +30,52 @@ switch(x) {
   }
 }
 
+switch(x) {
+  case 1: // comment
+    break;
+
+  case 2: // comment
+    {break;}
+
+  case 3: { // comment
+    break;}
+}
+
+switch(x) {
+  default: // comment
+    break;
+}
+
+switch(x) {
+  default: // comment
+    {break;}
+}
+
+switch(x) {
+  default: {// comment
+    break;}
+}
+
+switch(x) {
+  default: /* comment */
+    break;
+}
+
+switch(x) {
+  default: /* comment */
+    {break;}
+}
+
+switch(x) {
+  default: {/* comment */
+    break;}
+}
+
+switch(x) {
+  default: /* comment */ {
+    break;}
+}
+
 =====================================output=====================================
 switch (true) {
   case true:
@@ -52,6 +98,63 @@ switch (x) {
   // other
 
   case y: {
+  }
+}
+
+switch (x) {
+  case 1: // comment
+    break;
+
+  case 2: { // comment
+    break;
+  }
+
+  case 3: {
+    // comment
+    break;
+  }
+}
+
+switch (x) {
+  default: // comment
+    break;
+}
+
+switch (x) {
+  default: {
+    // comment
+    break;
+  }
+}
+
+switch (x) {
+  default: {
+    // comment
+    break;
+  }
+}
+
+switch (x) {
+  default: /* comment */
+    break;
+}
+
+switch (x) {
+  default: /* comment */ {
+    break;
+  }
+}
+
+switch (x) {
+  default: {
+    /* comment */
+    break;
+  }
+}
+
+switch (x) {
+  default: /* comment */ {
+    break;
   }
 }
 

--- a/tests/format/js/switch/comments.js
+++ b/tests/format/js/switch/comments.js
@@ -21,3 +21,49 @@ switch(x) {
   case y: {
   }
 }
+
+switch(x) {
+  case 1: // comment
+    break;
+
+  case 2: // comment
+    {break;}
+
+  case 3: { // comment
+    break;}
+}
+
+switch(x) {
+  default: // comment
+    break;
+}
+
+switch(x) {
+  default: // comment
+    {break;}
+}
+
+switch(x) {
+  default: {// comment
+    break;}
+}
+
+switch(x) {
+  default: /* comment */
+    break;
+}
+
+switch(x) {
+  default: /* comment */
+    {break;}
+}
+
+switch(x) {
+  default: {/* comment */
+    break;}
+}
+
+switch(x) {
+  default: /* comment */ {
+    break;}
+}

--- a/tests/format/js/switch/comments.js
+++ b/tests/format/js/switch/comments.js
@@ -23,17 +23,6 @@ switch(x) {
 }
 
 switch(x) {
-  case 1: // comment
-    break;
-
-  case 2: // comment
-    {break;}
-
-  case 3: { // comment
-    break;}
-}
-
-switch(x) {
   default: // comment
     break;
 }


### PR DESCRIPTION
## Description

Fixes #12108 

`default:` doesn't have a node we can attach the comments to so it requires special handling

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
