### PR TITLE
Build: Verbose text report

### DIFF
--- a/scripts/build/esbuild-plugins/visualizer.mjs
+++ b/scripts/build/esbuild-plugins/visualizer.mjs
@@ -18,7 +18,9 @@ export default function esbuildPluginVisualizer({ formats }) {
         }
 
         if (formats.text || formats.stdout) {
-          const report = await esbuild.analyzeMetafile(metafile);
+          const report = await esbuild.analyzeMetafile(metafile, {
+            verbose: true,
+          });
 
           if (formats.stdout) {
             console.log(report);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Not very pretty, but more useful

<details>
<summary>Before</summary>

```text
parser-babel.js........................................................
  dist/parser-babel.js                                           583.8kb  100.0%
   ├ node_modules/@babel/parser/lib/index.js                     491.5kb   84.2%
   ├ src/common/util.js                                           11.5kb    2.0%
   ├ node_modules/emoji-regex/index.js                            10.2kb    1.7%
   ├ src/main/core-options.js                                      8.1kb    1.4%
   ├ node_modules/semver/classes/semver.js                         7.2kb    1.2%
   ├ src/language-js/parse/babel.js                                5.8kb    1.0%
   ├ node_modules/outdent/lib/index.js                             4.9kb    0.8%
   ├ src/language-js/parse/postprocess/index.js                    4.8kb    0.8%
   ├ node_modules/semver/internal/re.js                            4.1kb    0.7%
   ├ node_modules/jest-docblock/build/index.js                     3.7kb    0.6%
   ├ src/language-js/parse/json.js                                 3.7kb    0.6%
   ├ src/main/support.js                                           3.2kb    0.6%
   ├ src/language-js/parse/postprocess/typescript.js               2.3kb    0.4%
   ├ node-modules-polyfills:os                                     2.0kb    0.3%
   ├ src/language-js/pragma.js                                     1.3kb    0.2%
   ├ src/common/end-of-line.js                                     1.2kb    0.2%
   ├ src/language-js/loc.js                                        1.2kb    0.2%
   ├ node_modules/is-fullwidth-code-point/index.js                 1.1kb    0.2%
   ├ node_modules/string-width/index.js                            1.0kb    0.2%
   ├ node_modules/detect-newline/index.js                          714b     0.1%
   ├ src/language-js/parse/postprocess/visitNode.js                693b     0.1%
   ├ node_modules/semver/internal/identifiers.js                   592b     0.1%
   ├ src/language-js/parse/utils/create-babel-parse-error.js       549b     0.1%
   ├ src/language-js/parse/utils/create-parser.js                  541b     0.1%
   ├ src/utils/try-combinations.js                                 529b     0.1%
   ├ node_modules/ansi-regex/index.js                              518b     0.1%
   ├ src/utils/get-string-width.js                                 470b     0.1%
   ├ node_modules/semver/internal/parse-options.js                 457b     0.1%
   ├ node_modules/semver/internal/constants.js                     448b     0.1%
   ├ src/language-js/utils/get-shebang.js                          421b     0.1%
   ├ node_modules/semver/internal/debug.js                         416b     0.1%
   ├ node-modules-polyfills-commonjs:os                            414b     0.1%
   ├ src/language-js/utils/is-type-cast-comment.js                 413b     0.1%
   ├ node_modules/escape-string-regexp/index.js                    393b     0.1%
   ├ src/common/parser-create-error.js                             385b     0.1%
   ├ src/language-js/utils/is-block-comment.js                     353b     0.1%
   ├ src/language-js/utils/is-ts-keyword-type.js                   327b     0.1%
   ├ node_modules/string-width/node_modules/strip-ansi/index.js    322b     0.1%
   ├ src/utils/is-non-empty-array.js                               297b     0.0%
   ├ node_modules/semver/functions/compare.js                      289b     0.0%
   ├ src/utils/arrayify.js                                         278b     0.0%
   ├ node_modules/semver/functions/gte.js                          250b     0.0%
   ├ node_modules/semver/functions/lt.js                           245b     0.0%
   ├ src/utils/get-last.js                                         215b     0.0%
   ├ <define:process>                                              179b     0.0%
   └ package.json                                                  158b     0.0%
```

</details>

<details>
<summary>After</summary>

```text
 Building packages
parser-babel.js........................................................
  dist/parser-babel.js ────────────────────────────────────────── 583.8kb ─ 100.0%
   ├ node_modules/@babel/parser/lib/index.js ──────────────────── 491.5kb ── 84.2%
   │  └ src/language-js/parse/babel.js
   ├ src/common/util.js ────────────────────────────────────────── 11.5kb ─── 2.0%
   │  └ src/language-js/parse/babel.js
   ├ node_modules/emoji-regex/index.js ─────────────────────────── 10.2kb ─── 1.7%
   │  └ node_modules/string-width/index.js
   │     └ src/utils/get-string-width.js
   │        └ src/common/util.js
   │           └ src/language-js/parse/babel.js
   ├ src/main/core-options.js ───────────────────────────────────── 8.1kb ─── 1.4%
   │  └ src/main/support.js
   │     └ src/common/util.js
   │        └ src/language-js/parse/babel.js
   ├ node_modules/semver/classes/semver.js ──────────────────────── 7.2kb ─── 1.2%
   │  └ node_modules/semver/functions/compare.js
   │     └ src/main/support.js
   │        └ src/common/util.js
   │           └ src/language-js/parse/babel.js
   ├ src/language-js/parse/babel.js ─────────────────────────────── 5.8kb ─── 1.0%
   ├ node_modules/outdent/lib/index.js ──────────────────────────── 4.9kb ─── 0.8%
   │  └ src/main/core-options.js
   │     └ src/main/support.js
   │        └ src/common/util.js
   │           └ src/language-js/parse/babel.js
   ├ src/language-js/parse/postprocess/index.js ─────────────────── 4.8kb ─── 0.8%
   │  └ src/language-js/parse/babel.js
   ├ node_modules/semver/internal/re.js ─────────────────────────── 4.1kb ─── 0.7%
   │  └ node_modules/semver/classes/semver.js
   │     └ node_modules/semver/functions/compare.js
   │        └ src/main/support.js
   │           └ src/common/util.js
   │              └ src/language-js/parse/babel.js
   ├ node_modules/jest-docblock/build/index.js ──────────────────── 3.7kb ─── 0.6%
   │  └ src/language-js/pragma.js
   │     └ src/language-js/parse/utils/create-parser.js
   │        └ src/language-js/parse/babel.js
   ├ src/language-js/parse/json.js ──────────────────────────────── 3.7kb ─── 0.6%
   │  └ src/language-js/parse/babel.js
   ├ src/main/support.js ────────────────────────────────────────── 3.2kb ─── 0.6%
   │  └ src/common/util.js
   │     └ src/language-js/parse/babel.js
   ├ src/language-js/parse/postprocess/typescript.js ────────────── 2.3kb ─── 0.4%
   │  └ src/language-js/parse/postprocess/index.js
   │     └ src/language-js/parse/babel.js
   ├ node-modules-polyfills:os ──────────────────────────────────── 2.0kb ─── 0.3%
   │  └ node-modules-polyfills-commonjs:os
   │     └ node_modules/jest-docblock/build/index.js
   │        └ src/language-js/pragma.js
   │           └ src/language-js/parse/utils/create-parser.js
   │              └ src/language-js/parse/babel.js
   ├ src/language-js/pragma.js ──────────────────────────────────── 1.3kb ─── 0.2%
   │  └ src/language-js/parse/utils/create-parser.js
   │     └ src/language-js/parse/babel.js
   ├ src/common/end-of-line.js ──────────────────────────────────── 1.2kb ─── 0.2%
   │  └ src/language-js/pragma.js
   │     └ src/language-js/parse/utils/create-parser.js
   │        └ src/language-js/parse/babel.js
   ├ src/language-js/loc.js ─────────────────────────────────────── 1.2kb ─── 0.2%
   │  └ src/language-js/parse/postprocess/index.js
   │     └ src/language-js/parse/babel.js
   ├ node_modules/is-fullwidth-code-point/index.js ──────────────── 1.1kb ─── 0.2%
   │  └ node_modules/string-width/index.js
   │     └ src/utils/get-string-width.js
   │        └ src/common/util.js
   │           └ src/language-js/parse/babel.js
   ├ node_modules/string-width/index.js ─────────────────────────── 1.0kb ─── 0.2%
   │  └ src/utils/get-string-width.js
   │     └ src/common/util.js
   │        └ src/language-js/parse/babel.js
   ├ node_modules/detect-newline/index.js ───────────────────────── 714b ──── 0.1%
   │  └ node_modules/jest-docblock/build/index.js
   │     └ src/language-js/pragma.js
   │        └ src/language-js/parse/utils/create-parser.js
   │           └ src/language-js/parse/babel.js
   ├ src/language-js/parse/postprocess/visitNode.js ─────────────── 693b ──── 0.1%
   │  └ src/language-js/parse/postprocess/index.js
   │     └ src/language-js/parse/babel.js
   ├ node_modules/semver/internal/identifiers.js ────────────────── 592b ──── 0.1%
   │  └ node_modules/semver/classes/semver.js
   │     └ node_modules/semver/functions/compare.js
   │        └ src/main/support.js
   │           └ src/common/util.js
   │              └ src/language-js/parse/babel.js
   ├ src/language-js/parse/utils/create-babel-parse-error.js ────── 549b ──── 0.1%
   │  └ src/language-js/parse/babel.js
   ├ src/language-js/parse/utils/create-parser.js ───────────────── 541b ──── 0.1%
   │  └ src/language-js/parse/babel.js
   ├ src/utils/try-combinations.js ──────────────────────────────── 529b ──── 0.1%
   │  └ src/language-js/parse/babel.js
   ├ node_modules/ansi-regex/index.js ───────────────────────────── 518b ──── 0.1%
   │  └ node_modules/string-width/node_modules/strip-ansi/index.js
   │     └ node_modules/string-width/index.js
   │        └ src/utils/get-string-width.js
   │           └ src/common/util.js
   │              └ src/language-js/parse/babel.js
   ├ src/utils/get-string-width.js ──────────────────────────────── 470b ──── 0.1%
   │  └ src/common/util.js
   │     └ src/language-js/parse/babel.js
   ├ node_modules/semver/internal/parse-options.js ──────────────── 457b ──── 0.1%
   │  └ node_modules/semver/classes/semver.js
   │     └ node_modules/semver/functions/compare.js
   │        └ src/main/support.js
   │           └ src/common/util.js
   │              └ src/language-js/parse/babel.js
   ├ node_modules/semver/internal/constants.js ──────────────────── 448b ──── 0.1%
   │  └ node_modules/semver/classes/semver.js
   │     └ node_modules/semver/functions/compare.js
   │        └ src/main/support.js
   │           └ src/common/util.js
   │              └ src/language-js/parse/babel.js
   ├ src/language-js/utils/get-shebang.js ───────────────────────── 421b ──── 0.1%
   │  └ src/language-js/parse/babel.js
   ├ node_modules/semver/internal/debug.js ──────────────────────── 416b ──── 0.1%
   │  └ node_modules/semver/classes/semver.js
   │     └ node_modules/semver/functions/compare.js
   │        └ src/main/support.js
   │           └ src/common/util.js
   │              └ src/language-js/parse/babel.js
   ├ node-modules-polyfills-commonjs:os ─────────────────────────── 414b ──── 0.1%
   │  └ node_modules/jest-docblock/build/index.js
   │     └ src/language-js/pragma.js
   │        └ src/language-js/parse/utils/create-parser.js
   │           └ src/language-js/parse/babel.js
   ├ src/language-js/utils/is-type-cast-comment.js ──────────────── 413b ──── 0.1%
   │  └ src/language-js/parse/postprocess/index.js
   │     └ src/language-js/parse/babel.js
   ├ node_modules/escape-string-regexp/index.js ─────────────────── 393b ──── 0.1%
   │  └ src/common/util.js
   │     └ src/language-js/parse/babel.js
   ├ src/common/parser-create-error.js ──────────────────────────── 385b ──── 0.1%
   │  └ src/language-js/parse/json.js
   │     └ src/language-js/parse/babel.js
   ├ src/language-js/utils/is-block-comment.js ──────────────────── 353b ──── 0.1%
   │  └ src/language-js/utils/is-type-cast-comment.js
   │     └ src/language-js/parse/postprocess/index.js
   │        └ src/language-js/parse/babel.js
   ├ src/language-js/utils/is-ts-keyword-type.js ────────────────── 327b ──── 0.1%
   │  └ src/language-js/parse/postprocess/index.js
   │     └ src/language-js/parse/babel.js
   ├ node_modules/string-width/node_modules/strip-ansi/index.js ─── 322b ──── 0.1%
   │  └ node_modules/string-width/index.js
   │     └ src/utils/get-string-width.js
   │        └ src/common/util.js
   │           └ src/language-js/parse/babel.js
   ├ src/utils/is-non-empty-array.js ────────────────────────────── 297b ──── 0.0%
   │  └ src/common/util.js
   │     └ src/language-js/parse/babel.js
   ├ node_modules/semver/functions/compare.js ───────────────────── 289b ──── 0.0%
   │  └ src/main/support.js
   │     └ src/common/util.js
   │        └ src/language-js/parse/babel.js
   ├ src/utils/arrayify.js ──────────────────────────────────────── 278b ──── 0.0%
   │  └ src/main/support.js
   │     └ src/common/util.js
   │        └ src/language-js/parse/babel.js
   ├ node_modules/semver/functions/gte.js ───────────────────────── 250b ──── 0.0%
   │  └ src/main/support.js
   │     └ src/common/util.js
   │        └ src/language-js/parse/babel.js
   ├ node_modules/semver/functions/lt.js ────────────────────────── 245b ──── 0.0%
   │  └ src/main/support.js
   │     └ src/common/util.js
   │        └ src/language-js/parse/babel.js
   ├ src/utils/get-last.js ──────────────────────────────────────── 215b ──── 0.0%
   │  └ src/language-js/parse/postprocess/index.js
   │     └ src/language-js/parse/babel.js
   ├ <define:process> ───────────────────────────────────────────── 179b ──── 0.0%
   └ package.json ───────────────────────────────────────────────── 158b ──── 0.0%
      └ src/main/support.js
         └ src/common/util.js
            └ src/language-js/parse/babel.js
```

</details>

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
