### PR TITLE
Exclude `getInterpreter` from 'standalone.js'

### DIFF
--- a/src/main/options.js
+++ b/src/main/options.js
@@ -1,8 +1,6 @@
 "use strict";
 
-const fs = require("fs");
 const path = require("path");
-const readlines = require("n-readlines");
 const { UndefinedParserError } = require("../common/errors.js");
 const { getSupportInfo } = require("../main/support.js");
 const normalizer = require("./options-normalizer.js");
@@ -118,52 +116,6 @@ function getPlugin(options) {
   return printerPlugin;
 }
 
-function getInterpreter(filepath) {
-  /* istanbul ignore next */
-  if (typeof filepath !== "string") {
-    return "";
-  }
-
-  let fd;
-  try {
-    fd = fs.openSync(filepath, "r");
-  } catch {
-    // istanbul ignore next
-    return "";
-  }
-
-  try {
-    const liner = new readlines(fd);
-    const firstLine = liner.next().toString("utf8");
-
-    // #!/bin/env node, #!/usr/bin/env node
-    const m1 = firstLine.match(/^#!\/(?:usr\/)?bin\/env\s+(\S+)/);
-    if (m1) {
-      return m1[1];
-    }
-
-    // #!/bin/node, #!/usr/bin/node, #!/usr/local/bin/node
-    const m2 = firstLine.match(/^#!\/(?:usr\/(?:local\/)?)?bin\/(\S+)/);
-    if (m2) {
-      return m2[1];
-    }
-    return "";
-  } catch {
-    // There are some weird cases where paths are missing, causing Jest
-    // failures. It's unclear what these correspond to in the real world.
-    /* istanbul ignore next */
-    return "";
-  } finally {
-    try {
-      // There are some weird cases where paths are missing, causing Jest
-      // failures. It's unclear what these correspond to in the real world.
-      fs.closeSync(fd);
-    } catch {
-      // nop
-    }
-  }
-}
-
 function inferParser(filepath, plugins) {
   const filename = path.basename(filepath).toLowerCase();
   const languages = getSupportInfo({ plugins }).languages.filter(
@@ -183,7 +135,14 @@ function inferParser(filepath, plugins) {
         language.filenames.some((name) => name.toLowerCase() === filename))
   );
 
-  if (!language && !filename.includes(".")) {
+  if (
+    process.env.PRETTIER_TARGET !== "universal" &&
+    !language &&
+    !filename.includes(".")
+  ) {
+    // `getInterpreter` requires file access, put `require()` in the `if` block,
+    // So we can easily remove this part during build
+    const getInterpreter = require("../utils/get-interpreter.js");
     const interpreter = getInterpreter(filepath);
     language = languages.find(
       (language) =>

--- a/src/utils/get-interpreter.js
+++ b/src/utils/get-interpreter.js
@@ -1,0 +1,52 @@
+"use strict";
+
+const fs = require("fs");
+const readlines = require("n-readlines");
+
+function getInterpreter(filepath) {
+  /* istanbul ignore next */
+  if (typeof filepath !== "string") {
+    return "";
+  }
+
+  let fd;
+  try {
+    fd = fs.openSync(filepath, "r");
+  } catch {
+    // istanbul ignore next
+    return "";
+  }
+
+  try {
+    const liner = new readlines(fd);
+    const firstLine = liner.next().toString("utf8");
+
+    // #!/bin/env node, #!/usr/bin/env node
+    const m1 = firstLine.match(/^#!\/(?:usr\/)?bin\/env\s+(\S+)/);
+    if (m1) {
+      return m1[1];
+    }
+
+    // #!/bin/node, #!/usr/bin/node, #!/usr/local/bin/node
+    const m2 = firstLine.match(/^#!\/(?:usr\/(?:local\/)?)?bin\/(\S+)/);
+    if (m2) {
+      return m2[1];
+    }
+    return "";
+  } catch {
+    // There are some weird cases where paths are missing, causing Jest
+    // failures. It's unclear what these correspond to in the real world.
+    /* istanbul ignore next */
+    return "";
+  } finally {
+    try {
+      // There are some weird cases where paths are missing, causing Jest
+      // failures. It's unclear what these correspond to in the real world.
+      fs.closeSync(fd);
+    } catch {
+      // nop
+    }
+  }
+}
+
+module.exports = getInterpreter;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

```diff
$ node ./scripts/build/build.mjs --file=standalone.js --print-size
 Building packages
- standalone.js...................................................487 kB    DONE
+ standalone.js...................................................484 kB    DONE
```

Not too much, but removed `fs` shim and `n-readlines` module.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
