### PR TITLE
Build: Remove `define` on second run

### DIFF
--- a/scripts/build/bundler.mjs
+++ b/scripts/build/bundler.mjs
@@ -238,6 +238,7 @@ async function runBuild(bundle, esbuildOptions, buildOptions) {
 
   await esbuild.build({
     ...esbuildOptions,
+    define: {},
     plugins: plugins.filter(({ name }) => name === "umd"),
     entryPoints: [outfile],
     allowOverwrite: true,


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
