### PR TITLE
Fix comment in abstract methods

### DIFF
--- a/changelog_unreleased/javascript/12185.md
+++ b/changelog_unreleased/javascript/12185.md
@@ -1,0 +1,26 @@
+# Fix misplaced argument comment in abstract methods (#12185 by @duailibe)
+
+<!-- prettier-ignore -->
+```ts
+// Input
+abstract class Foo {
+  abstract bar(
+    /** comment explaining userId param */
+    userId
+  )
+}
+
+// Prettier stable
+abstract class Foo {
+  abstract bar(userId);
+  /** comment explaining userId param */
+}
+
+// Prettier main
+abstract class Foo {
+  abstract bar(
+    /** comment explaining userId param */
+    userId
+  );
+}
+```

--- a/changelog_unreleased/javascript/12185.md
+++ b/changelog_unreleased/javascript/12185.md
@@ -1,4 +1,4 @@
-# Fix misplaced argument comment in abstract methods (#12185 by @duailibe)
+#### Fix misplaced argument comment in abstract methods (#12185 by @duailibe)
 
 <!-- prettier-ignore -->
 ```ts

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -459,6 +459,7 @@ function handleMethodNameComments({
   if (
     enclosingNode &&
     precedingNode &&
+    getNextNonSpaceNonCommentCharacter(text, comment, locEnd) === "(" &&
     // "MethodDefinition" is handled in getCommentChildNodes
     (enclosingNode.type === "Property" ||
       enclosingNode.type === "TSDeclareMethod" ||

--- a/tests/format/typescript/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/comments/__snapshots__/jsfmt.spec.js.snap
@@ -636,6 +636,8 @@ export class Point {
   mismatchedIndentation() {}
 
   inline /* foo*/ (/* bar */) /* baz */ {}
+
+  noBody(/* comment */ arg);
 }
 
 =====================================output=====================================
@@ -685,6 +687,8 @@ export class Point {
   mismatchedIndentation() {}
 
   inline /* foo*/(/* bar */) /* baz */ {}
+
+  noBody(/* comment */ arg);
 }
 
 ================================================================================

--- a/tests/format/typescript/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/comments/__snapshots__/jsfmt.spec.js.snap
@@ -28,6 +28,40 @@ abstract class AbstractRule {
 ================================================================================
 `;
 
+exports[`abstract_methods.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+abstract class AbstractFoo {
+  abstract method1(/* comment */ arg: string);
+  abstract method2(
+    /* comment */
+    arg: string
+  );
+  abstract method3(
+    // comment
+    arg: string
+  );
+}
+
+=====================================output=====================================
+abstract class AbstractFoo {
+  abstract method1(/* comment */ arg: string);
+  abstract method2(
+    /* comment */
+    arg: string
+  );
+  abstract method3(
+    // comment
+    arg: string
+  );
+}
+
+================================================================================
+`;
+
 exports[`after_jsx_generic.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/comments/abstract_methods.ts
+++ b/tests/format/typescript/comments/abstract_methods.ts
@@ -1,0 +1,11 @@
+abstract class AbstractFoo {
+  abstract method1(/* comment */ arg: string);
+  abstract method2(
+    /* comment */
+    arg: string
+  );
+  abstract method3(
+    // comment
+    arg: string
+  );
+}

--- a/tests/format/typescript/comments/methods.ts
+++ b/tests/format/typescript/comments/methods.ts
@@ -44,4 +44,6 @@ export class Point {
   mismatchedIndentation() {}
 
   inline /* foo*/ (/* bar */) /* baz */ {}
+
+  noBody(/* comment */ arg);
 }


### PR DESCRIPTION
## Description

Fixes #11145

When handling comments between the method name and the arguments (i.e. `foo /* comment */ ()`) it was mistakenly affecting cases of `foo(/* comment */ arg)`. This restricts the handling of that case, and let the comments in arguments follow the same path of regular methods.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
