### PR TITLE
Build: Add `--clean` flag

### DIFF
--- a/scripts/build-website.mjs
+++ b/scripts/build-website.mjs
@@ -39,7 +39,7 @@ async function buildPrettier() {
   });
 
   try {
-    await runYarn("build", ["--playground", "--no-babel"], {
+    await runYarn("build", ["--playground", "--no-babel", "--clean"], {
       cwd: PROJECT_ROOT,
     });
   } finally {

--- a/scripts/build/README.md
+++ b/scripts/build/README.md
@@ -12,6 +12,14 @@ yarn build
 
 ## Flags
 
+### `--clean`
+
+Remove `dist` directory before bundle files.
+
+```sh
+yarn build --clean
+```
+
 ### `--playground`
 
 Run script with `--playground` flag will only build files needed for the website.

--- a/scripts/release/steps/generate-bundles.js
+++ b/scripts/release/steps/generate-bundles.js
@@ -2,7 +2,10 @@ import chalk from "chalk";
 import { runYarn, logPromise, readJson } from "../utils.js";
 
 export default async function generateBundles({ version }) {
-  await logPromise("Generating bundles", runYarn(["build"]));
+  await logPromise(
+    "Generating bundles",
+    runYarn(["build", "--clean", "--print-size"])
+  );
 
   const builtPkg = await readJson("dist/package.json");
   if (builtPkg.version !== version) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

I noticed that when running `yarn build`, it doesn't fail when `rimraf` can't remove `dist` dir, this may cause problems when doing release, let's add an explicit flag to ensure an empty `dist`.

I also added `--print-size` to the release script, so we can notice obvious unexpected file size when do release.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
