### PR TITLE
Reduce bundle size of `parser-babel.js`

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -5,6 +5,16 @@ const getLast = require("../utils/get-last.js");
 const { getSupportInfo } = require("../main/support.js");
 const isNonEmptyArray = require("../utils/is-non-empty-array.js");
 const getStringWidth = require("../utils/get-string-width.js");
+const {
+  skipWhitespace,
+  skipSpaces,
+  skipToLineEnd,
+  skipEverythingButNewLine,
+} = require("../utils/text/skip.js");
+const skipInlineComment = require("../utils/text/skip-inline-comment.js");
+const skipTrailingComment = require("../utils/text/skip-trailing-comment.js");
+const skipNewline = require("../utils/text/skip-newline.js");
+const getNextNonSpaceNonCommentCharacterIndexWithStartIndex = require("../utils/text/get-next-non-space-non-comment-character-index-with-start-index.js");
 
 const getPenultimate = (arr) => arr[arr.length - 2];
 
@@ -51,110 +61,6 @@ function skip(chars) {
     }
     return false;
   };
-}
-
-/**
- * @type {(text: string, index: number | false, opts?: SkipOptions) => number | false}
- */
-const skipWhitespace = skip(/\s/);
-/**
- * @type {(text: string, index: number | false, opts?: SkipOptions) => number | false}
- */
-const skipSpaces = skip(" \t");
-/**
- * @type {(text: string, index: number | false, opts?: SkipOptions) => number | false}
- */
-const skipToLineEnd = skip(",; \t");
-/**
- * @type {(text: string, index: number | false, opts?: SkipOptions) => number | false}
- */
-const skipEverythingButNewLine = skip(/[^\n\r]/);
-
-/**
- * @param {string} text
- * @param {number | false} index
- * @returns {number | false}
- */
-function skipInlineComment(text, index) {
-  /* istanbul ignore next */
-  if (index === false) {
-    return false;
-  }
-
-  if (text.charAt(index) === "/" && text.charAt(index + 1) === "*") {
-    for (let i = index + 2; i < text.length; ++i) {
-      if (text.charAt(i) === "*" && text.charAt(i + 1) === "/") {
-        return i + 2;
-      }
-    }
-  }
-  return index;
-}
-
-/**
- * @param {string} text
- * @param {number | false} index
- * @returns {number | false}
- */
-function skipTrailingComment(text, index) {
-  /* istanbul ignore next */
-  if (index === false) {
-    return false;
-  }
-
-  if (text.charAt(index) === "/" && text.charAt(index + 1) === "/") {
-    return skipEverythingButNewLine(text, index);
-  }
-  return index;
-}
-
-// This one doesn't use the above helper function because it wants to
-// test \r\n in order and `skip` doesn't support ordering and we only
-// want to skip one newline. It's simple to implement.
-/**
- * @param {string} text
- * @param {number | false} index
- * @param {SkipOptions=} opts
- * @returns {number | false}
- */
-function skipNewline(text, index, opts) {
-  const backwards = opts && opts.backwards;
-  if (index === false) {
-    return false;
-  }
-
-  const atIndex = text.charAt(index);
-  if (backwards) {
-    // We already replace `\r\n` with `\n` before parsing
-    /* istanbul ignore next */
-    if (text.charAt(index - 1) === "\r" && atIndex === "\n") {
-      return index - 2;
-    }
-    if (
-      atIndex === "\n" ||
-      atIndex === "\r" ||
-      atIndex === "\u2028" ||
-      atIndex === "\u2029"
-    ) {
-      return index - 1;
-    }
-  } else {
-    // We already replace `\r\n` with `\n` before parsing
-    /* istanbul ignore next */
-    if (atIndex === "\r" && text.charAt(index + 1) === "\n") {
-      return index + 2;
-    }
-    if (
-      atIndex === "\n" ||
-      atIndex === "\r" ||
-      atIndex === "\u2028" ||
-      atIndex === "\u2029"
-    ) {
-      return index + 1;
-    }
-  }
-
-  return index;
 }
 
 /**
@@ -232,26 +138,6 @@ function isNextLineEmptyAfterIndex(text, index) {
  */
 function isNextLineEmpty(text, node, locEnd) {
   return isNextLineEmptyAfterIndex(text, locEnd(node));
-}
-
-/**
- * @param {string} text
- * @param {number} idx
- * @returns {number | false}
- */
-function getNextNonSpaceNonCommentCharacterIndexWithStartIndex(text, idx) {
-  /** @type {number | false} */
-  let oldIdx = null;
-  /** @type {number | false} */
-  let nextIdx = idx;
-  while (nextIdx !== oldIdx) {
-    oldIdx = nextIdx;
-    nextIdx = skipSpaces(text, nextIdx);
-    nextIdx = skipInlineComment(text, nextIdx);
-    nextIdx = skipTrailingComment(text, nextIdx);
-    nextIdx = skipNewline(text, nextIdx);
-  }
-  return nextIdx;
 }
 
 /**

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -1,10 +1,8 @@
 "use strict";
 
 const tryCombinations = require("../../utils/try-combinations.js");
-const {
-  getNextNonSpaceNonCommentCharacterIndexWithStartIndex,
-} = require("../../common/util.js");
 const getShebang = require("../utils/get-shebang.js");
+const getNextNonSpaceNonCommentCharacterIndexWithStartIndex = require("../../utils/text/get-next-non-space-non-comment-character-index-with-start-index.js");
 const createParser = require("./utils/create-parser.js");
 const createBabelParseError = require("./utils/create-babel-parse-error.js");
 const postprocess = require("./postprocess/index.js");

--- a/src/language-js/parse/json.js
+++ b/src/language-js/parse/json.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { isNonEmptyArray } = require("../../common/util.js");
+const isNonEmptyArray = require("../../utils/is-non-empty-array.js");
 const createError = require("../../common/parser-create-error.js");
 const createParser = require("./utils/create-parser.js");
 const createBabelParseError = require("./utils/create-babel-parse-error.js");

--- a/src/utils/text/get-next-non-space-non-comment-character-index-with-start-index.js
+++ b/src/utils/text/get-next-non-space-non-comment-character-index-with-start-index.js
@@ -1,0 +1,28 @@
+"use strict";
+
+const skipInlineComment = require("./skip-inline-comment.js");
+const skipNewline = require("./skip-newline.js");
+const skipTrailingComment = require("./skip-trailing-comment.js");
+const { skipSpaces } = require("./skip.js");
+
+/**
+ * @param {string} text
+ * @param {number} idx
+ * @returns {number | false}
+ */
+function getNextNonSpaceNonCommentCharacterIndexWithStartIndex(text, idx) {
+  /** @type {number | false} */
+  let oldIdx = null;
+  /** @type {number | false} */
+  let nextIdx = idx;
+  while (nextIdx !== oldIdx) {
+    oldIdx = nextIdx;
+    nextIdx = skipSpaces(text, nextIdx);
+    nextIdx = skipInlineComment(text, nextIdx);
+    nextIdx = skipTrailingComment(text, nextIdx);
+    nextIdx = skipNewline(text, nextIdx);
+  }
+  return nextIdx;
+}
+
+module.exports = getNextNonSpaceNonCommentCharacterIndexWithStartIndex;

--- a/src/utils/text/skip-inline-comment.js
+++ b/src/utils/text/skip-inline-comment.js
@@ -1,0 +1,24 @@
+"use strict";
+
+/**
+ * @param {string} text
+ * @param {number | false} index
+ * @returns {number | false}
+ */
+function skipInlineComment(text, index) {
+  /* istanbul ignore next */
+  if (index === false) {
+    return false;
+  }
+
+  if (text.charAt(index) === "/" && text.charAt(index + 1) === "*") {
+    for (let i = index + 2; i < text.length; ++i) {
+      if (text.charAt(i) === "*" && text.charAt(i + 1) === "/") {
+        return i + 2;
+      }
+    }
+  }
+  return index;
+}
+
+module.exports = skipInlineComment;

--- a/src/utils/text/skip-newline.js
+++ b/src/utils/text/skip-newline.js
@@ -1,0 +1,54 @@
+"use strict";
+
+/** @typedef {import("./skip").SkipOptions} SkipOptions */
+
+// This one doesn't use the above helper function because it wants to
+// test \r\n in order and `skip` doesn't support ordering and we only
+// want to skip one newline. It's simple to implement.
+/**
+ * @param {string} text
+ * @param {number | false} index
+ * @param {SkipOptions=} opts
+ * @returns {number | false}
+ */
+function skipNewline(text, index, opts) {
+  const backwards = opts && opts.backwards;
+  if (index === false) {
+    return false;
+  }
+
+  const atIndex = text.charAt(index);
+  if (backwards) {
+    // We already replace `\r\n` with `\n` before parsing
+    /* istanbul ignore next */
+    if (text.charAt(index - 1) === "\r" && atIndex === "\n") {
+      return index - 2;
+    }
+    if (
+      atIndex === "\n" ||
+      atIndex === "\r" ||
+      atIndex === "\u2028" ||
+      atIndex === "\u2029"
+    ) {
+      return index - 1;
+    }
+  } else {
+    // We already replace `\r\n` with `\n` before parsing
+    /* istanbul ignore next */
+    if (atIndex === "\r" && text.charAt(index + 1) === "\n") {
+      return index + 2;
+    }
+    if (
+      atIndex === "\n" ||
+      atIndex === "\r" ||
+      atIndex === "\u2028" ||
+      atIndex === "\u2029"
+    ) {
+      return index + 1;
+    }
+  }
+
+  return index;
+}
+
+module.exports = skipNewline;

--- a/src/utils/text/skip-trailing-comment.js
+++ b/src/utils/text/skip-trailing-comment.js
@@ -1,0 +1,22 @@
+"use strict";
+
+const { skipEverythingButNewLine } = require("./skip.js");
+
+/**
+ * @param {string} text
+ * @param {number | false} index
+ * @returns {number | false}
+ */
+function skipTrailingComment(text, index) {
+  /* istanbul ignore next */
+  if (index === false) {
+    return false;
+  }
+
+  if (text.charAt(index) === "/" && text.charAt(index + 1) === "/") {
+    return skipEverythingButNewLine(text, index);
+  }
+  return index;
+}
+
+module.exports = skipTrailingComment;

--- a/src/utils/text/skip.js
+++ b/src/utils/text/skip.js
@@ -1,0 +1,70 @@
+"use strict";
+
+/**
+ * @typedef {{backwards?: boolean}} SkipOptions
+ */
+
+/**
+ * @param {string | RegExp} chars
+ * @returns {(text: string, index: number | false, opts?: SkipOptions) => number | false}
+ */
+function skip(chars) {
+  return (text, index, opts) => {
+    const backwards = opts && opts.backwards;
+
+    // Allow `skip` functions to be threaded together without having
+    // to check for failures (did someone say monads?).
+    /* istanbul ignore next */
+    if (index === false) {
+      return false;
+    }
+
+    const { length } = text;
+    let cursor = index;
+    while (cursor >= 0 && cursor < length) {
+      const c = text.charAt(cursor);
+      if (chars instanceof RegExp) {
+        if (!chars.test(c)) {
+          return cursor;
+        }
+      } else if (!chars.includes(c)) {
+        return cursor;
+      }
+
+      backwards ? cursor-- : cursor++;
+    }
+
+    if (cursor === -1 || cursor === length) {
+      // If we reached the beginning or end of the file, return the
+      // out-of-bounds cursor. It's up to the caller to handle this
+      // correctly. We don't want to indicate `false` though if it
+      // actually skipped valid characters.
+      return cursor;
+    }
+    return false;
+  };
+}
+
+/**
+ * @type {(text: string, index: number | false, opts?: SkipOptions) => number | false}
+ */
+const skipWhitespace = skip(/\s/);
+/**
+ * @type {(text: string, index: number | false, opts?: SkipOptions) => number | false}
+ */
+const skipSpaces = skip(" \t");
+/**
+ * @type {(text: string, index: number | false, opts?: SkipOptions) => number | false}
+ */
+const skipToLineEnd = skip(",; \t");
+/**
+ * @type {(text: string, index: number | false, opts?: SkipOptions) => number | false}
+ */
+const skipEverythingButNewLine = skip(/[^\n\r]/);
+
+module.exports = {
+  skipWhitespace,
+  skipSpaces,
+  skipToLineEnd,
+  skipEverythingButNewLine,
+};


### PR DESCRIPTION

## Description

<!-- Please provide a brief summary of your changes: -->

Reduce `parser-babel.js` by 35kb.

**Before:**

```
$ node ./scripts/build/build.mjs --print-size --report --file=parser-babel.js
 Building packages 
parser-babel.js.................................................337 kB    DONE  
```

**After:**

```
$ node ./scripts/build/build.mjs --print-size --report --file=parser-babel.js
 Building packages 
parser-babel.js.................................................302 kB    DONE  
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
