### PR TITLE
Preserve empty lines in CSS/SCSS paren groups

### DIFF
--- a/changelog_unreleased/css/12210.md
+++ b/changelog_unreleased/css/12210.md
@@ -1,0 +1,32 @@
+#### Preserve empty line in CSS paren groups (#12210 by @duailibe)
+
+<!-- Optional description if it makes sense. -->
+
+<!-- prettier-ignore -->
+```css
+// Input
+$colours: (
+    "text": $light-100,
+
+    "background-primary": $dark-300,
+    "background-secondary": $dark-200,
+    "background-tertiary": $dark-100
+);
+
+// Prettier stable
+$colours: (
+  "text": $light-100,
+  "background-primary": $dark-300,
+  "background-secondary": $dark-200,
+  "background-tertiary": $dark-100
+);
+
+// Prettier main
+$colours: (
+    "text": $light-100,
+
+    "background-primary": $dark-300,
+    "background-secondary": $dark-200,
+    "background-tertiary": $dark-100
+);
+```

--- a/changelog_unreleased/css/12210.md
+++ b/changelog_unreleased/css/12210.md
@@ -4,7 +4,7 @@
 
 <!-- prettier-ignore -->
 ```css
-// Input
+/* Input */
 $colours: (
     "text": $light-100,
 
@@ -13,7 +13,7 @@ $colours: (
     "background-tertiary": $dark-100
 );
 
-// Prettier stable
+/* Prettier stable */
 $colours: (
   "text": $light-100,
   "background-primary": $dark-300,
@@ -21,7 +21,7 @@ $colours: (
   "background-tertiary": $dark-100
 );
 
-// Prettier main
+/* Prettier main */
 $colours: (
     "text": $light-100,
 

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -900,24 +900,38 @@ function genericPrint(path, options, print) {
           indent([
             softline,
             join(
-              [",", line],
-              path.map((childPath) => {
-                const node = childPath.getValue();
-                const printed = print();
+              [line],
+              path.map((childPath, index) => {
+                const child = childPath.getValue();
+                const isLast = index === node.groups.length - 1;
+                const printed = [print(), isLast ? "" : ","];
 
                 // Key/Value pair in open paren already indented
                 if (
-                  isKeyValuePairNode(node) &&
-                  node.type === "value-comma_group" &&
-                  node.groups &&
-                  node.groups[0].type !== "value-paren_group" &&
-                  node.groups[2] &&
-                  node.groups[2].type === "value-paren_group"
+                  isKeyValuePairNode(child) &&
+                  child.type === "value-comma_group" &&
+                  child.groups &&
+                  child.groups[0].type !== "value-paren_group" &&
+                  child.groups[2] &&
+                  child.groups[2].type === "value-paren_group"
                 ) {
-                  const parts = getDocParts(printed.contents.contents);
+                  const parts = getDocParts(printed[0].contents.contents);
                   parts[1] = group(parts[1]);
-
                   return group(dedent(printed));
+                }
+
+                if (
+                  !isLast &&
+                  child.type === "value-comma_group" &&
+                  child.groups &&
+                  child.groups[0].type !== "value-paren_group" &&
+                  isNextLineEmpty(
+                    options.originalText,
+                    getLast(child.groups),
+                    locEnd
+                  )
+                ) {
+                  printed.push(hardline);
                 }
 
                 return printed;

--- a/tests/format/css/atrule/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/css/atrule/__snapshots__/jsfmt.spec.js.snap
@@ -1208,7 +1208,16 @@ h3
 }
 @each $element, $size in (h1: 20px, h2: 16px, h3: 14px) {
 }
-@each $element, $size in (h1: 20px, h2: 16px, h3: 14px) {
+@each $element,
+  $size
+    in (
+      h1: 20px,
+
+      h2: 16px,
+
+      h3: 14px
+    )
+{
 }
 
 ================================================================================
@@ -1926,7 +1935,13 @@ $args
 @function func($arg, $arg1, $arg2: 10, $args...) {
   @return "Func";
 }
-@function func($arg, $arg1, $arg2: 10, $args...) {
+@function func(
+  $arg,
+  $arg1,
+  $arg2: 10,
+
+  $args...
+) {
   @return "Func";
 }
 @function func(
@@ -2547,7 +2562,13 @@ border-color: $very-very-very-very-very-very-very-very-very-very-very-very-very-
 @include mix(1px, 2px, $arg2: 10, 2px 4px 6px);
 @include mix(1px, 2px, $arg2: 10, 2px 4px 6px);
 @include mix(1px, 2px, $arg2: 10, 2px 4px 6px);
-@include mix(1px, 2px, $arg2: 10, 2px 4px 6px);
+@include mix(
+  1px,
+  2px,
+  $arg2: 10,
+
+  2px 4px 6px
+);
 @include mix(
   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-arg:
     1px,
@@ -3491,7 +3512,13 @@ $background
 }
 @mixin mix($arg, $arg1, $arg2: 10, $args...) {
 }
-@mixin mix($arg, $arg1, $arg2: 10, $args...) {
+@mixin mix(
+  $arg,
+  $arg1,
+  $arg2: 10,
+
+  $args...
+) {
 }
 @mixin mix(
   $very-very-very-very-very-very-very-very-very-very-very-very-very-very-long-arg,

--- a/tests/format/css/parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/css/parens/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`empty-lines.css format 1`] = `
+====================================options=====================================
+parsers: ["css"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+$colours: (
+    "text": $light-100,
+    "background-primary": $dark-300,
+
+
+
+
+
+
+    "background-secondary": $dark-200,
+    "background-tertiary": $dark-100
+);
+
+=====================================output=====================================
+$colours: (
+  "text": $light-100,
+  "background-primary": $dark-300,
+
+  "background-secondary": $dark-200,
+  "background-tertiary": $dark-100
+);
+
+================================================================================
+`;
+
 exports[`parens.css format 1`] = `
 ====================================options=====================================
 parsers: ["css"]

--- a/tests/format/css/parens/empty-lines.css
+++ b/tests/format/css/parens/empty-lines.css
@@ -1,0 +1,12 @@
+$colours: (
+    "text": $light-100,
+    "background-primary": $dark-300,
+
+
+
+
+
+
+    "background-secondary": $dark-200,
+    "background-tertiary": $dark-100
+);


### PR DESCRIPTION
## Description

Related to #12053, will improve the comment placement from the example in another PR

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
