### PR TITLE
Fix printing of CSS selector() function

### DIFF
--- a/changelog_unreleased/scss/12213.md
+++ b/changelog_unreleased/scss/12213.md
@@ -1,0 +1,16 @@
+#### Fixes printing parameters of a mixin named `selector()` (#12213 by @duailibe)
+
+<!-- prettier-ignore -->
+```css
+/* Input */
+@mixin selector($param: 'value') {
+}
+
+/* Prettier stable */
+@mixin selector($param: 'value) {
+}
+
+/* Prettier main */
+@mixin selector($param: 'value') {
+}
+```

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -493,7 +493,7 @@ function genericPrint(path, options, print) {
         grandParent.type === "value-func" &&
         grandParent.value === "selector"
       ) {
-        const start = locStart(parentNode.open) + 1;
+        const start = locEnd(parentNode.open) + 1;
         const end = locStart(parentNode.close);
         const selector = options.originalText.slice(start, end).trim();
 

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -494,7 +494,7 @@ function genericPrint(path, options, print) {
         grandParent.value === "selector"
       ) {
         const start = locStart(parentNode.open) + 1;
-        const end = locEnd(parentNode.close) - 1;
+        const end = locStart(parentNode.close);
         const selector = options.originalText.slice(start, end).trim();
 
         return lastLineHasInlineComment(selector)

--- a/tests/format/css/atrule/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/css/atrule/__snapshots__/jsfmt.spec.js.snap
@@ -3482,6 +3482,8 @@ $background
 @mixin button-variant($foo: "  ...  ") {}
 @mixin sexy-border($color, $width, $foo: (color: red)) {}
 
+@mixin selector($param: "value") {}
+
 =====================================output=====================================
 @mixin clearfix {
 }
@@ -3549,6 +3551,9 @@ $background
 @mixin button-variant($foo: "  ...  ") {
 }
 @mixin sexy-border($color, $width, $foo: (color: red)) {
+}
+
+@mixin selector($param: "value") {
 }
 
 ================================================================================

--- a/tests/format/css/atrule/mixin.css
+++ b/tests/format/css/atrule/mixin.css
@@ -105,3 +105,5 @@ $background
 @mixin button-variant($foo: " ... ") {}
 @mixin button-variant($foo: "  ...  ") {}
 @mixin sexy-border($color, $width, $foo: (color: red)) {}
+
+@mixin selector($param: "value") {}


### PR DESCRIPTION
## Description

Fixes #10291, this is an improvement on #8707

What happens here is that when there's a newline before the closing `)`, the parser reports the `endOffset` of that close group is equal to `startOffset + 1`, which is why the code using `locEnd(node.end) - 1` worked. But when there's no newline the parser reports `startOffset == endOffset`, so using `locEnd(node.end) - 1` gets part of the content of the selector.

The fix is to simply use `locStart(node.end)` which works and is also what we really want (get the slice of original text until the *start* of the close group)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
