### PR TITLE
Replace globby with fast-glob

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "find-parent-dir": "0.3.1",
     "flow-parser": "0.170.0",
     "get-stdin": "8.0.0",
-    "globby": "11.0.4",
     "graphql": "15.6.1",
     "html-element-attributes": "2.3.0",
     "html-styles": "1.0.0",

--- a/scripts/build-website.mjs
+++ b/scripts/build-website.mjs
@@ -2,7 +2,7 @@
 
 import path from "node:path";
 import fs from "node:fs/promises";
-import globby from "globby";
+import fastGlob from "fast-glob";
 import prettier from "prettier";
 import createEsmUtils from "esm-utils";
 import execa from "execa";
@@ -49,7 +49,7 @@ async function buildPrettier() {
 }
 
 async function buildPlaygroundFiles() {
-  const files = await globby(["standalone.js", "parser-*.js"], {
+  const files = await fastGlob(["standalone.js", "parser-*.js"], {
     cwd: PRETTIER_DIR,
   });
   const parsers = {};

--- a/scripts/clean-changelog-unreleased.mjs
+++ b/scripts/clean-changelog-unreleased.mjs
@@ -2,13 +2,13 @@
 
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";
-import globby from "globby";
+import fastGlob from "fast-glob";
 
 const changelogUnreleasedDir = fileURLToPath(
   new URL("../changelog_unreleased", import.meta.url)
 );
 
-const files = globby.sync(["blog-post-intro.md", "*/*.md"], {
+const files = fastGlob.sync(["blog-post-intro.md", "*/*.md"], {
   cwd: changelogUnreleasedDir,
   absolute: true,
 });

--- a/scripts/sync-flow-tests.js
+++ b/scripts/sync-flow-tests.js
@@ -3,7 +3,7 @@
 const fs = require("fs");
 const path = require("path");
 const flowParser = require("flow-parser");
-const globby = require("globby");
+const fastGlob = require("fast-glob");
 const rimraf = require("rimraf");
 
 const DEFAULT_SPEC_CONTENT = "run_spec(__dirname);\n";
@@ -27,10 +27,10 @@ function tryParse(file, content) {
 }
 
 function syncTests(syncDir) {
-  const specFiles = globby.sync(
+  const specFiles = fastGlob.sync(
     path.join(FLOW_TESTS_DIR, "**", SPEC_FILE_NAME)
   );
-  const filesToCopy = globby.sync(path.join(syncDir, "**/*.js"));
+  const filesToCopy = fastGlob.sync(path.join(syncDir, "**/*.js"));
 
   if (filesToCopy.length === 0) {
     throw new Error(

--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -4,7 +4,7 @@ const fs = require("fs");
 const path = require("path");
 const uniqBy = require("lodash/uniqBy");
 const partition = require("lodash/partition");
-const globby = require("globby");
+const fastGlob = require("fast-glob");
 const mem = require("mem");
 const internalPlugins = require("../languages.js");
 const thirdParty = require("./third-party.js");
@@ -102,7 +102,7 @@ function load(plugins, pluginSearchDirs) {
 }
 
 function findPluginsInNodeModules(nodeModulesDir) {
-  const pluginPackageJsonPaths = globby.sync(
+  const pluginPackageJsonPaths = fastGlob.sync(
     [
       "prettier-plugin-*/package.json",
       "@*/prettier-plugin-*/package.json",
@@ -110,7 +110,6 @@ function findPluginsInNodeModules(nodeModulesDir) {
     ],
     {
       cwd: nodeModulesDir,
-      expandDirectories: false,
     }
   );
   return pluginPackageJsonPaths.map(path.dirname);

--- a/tests/config/require-standalone.js
+++ b/tests/config/require-standalone.js
@@ -2,11 +2,11 @@
 
 const fs = require("fs");
 const vm = require("vm");
-const globby = require("globby");
+const fastGlob = require("fast-glob");
 
 const sandbox = vm.createContext();
 
-const source = globby
+const source = fastGlob
   .sync(["standalone.js", "parser-*.js"], {
     cwd: process.env.PRETTIER_DIR,
     absolute: true,

--- a/tests/integration/__tests__/bundle.js
+++ b/tests/integration/__tests__/bundle.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const path = require("path");
-const globby = require("globby");
+const fastGlob = require("fast-glob");
 const { projectRoot } = require("../env.js");
 const coreOptions = require("../../../src/main/core-options.js");
 const codeSamples =
@@ -14,7 +14,7 @@ const distDirectory = path.join(projectRoot, "dist");
 
 describe("standalone", () => {
   const standalone = require(path.join(distDirectory, "standalone.js"));
-  const plugins = globby
+  const plugins = fastGlob
     .sync(["parser-*.js"], { cwd: distDirectory, absolute: true })
     .map((file) => require(file));
 
@@ -22,7 +22,7 @@ describe("standalone", () => {
     distDirectory,
     "esm/standalone.mjs"
   )).default;
-  const esmPlugins = globby
+  const esmPlugins = fastGlob
     .sync(["esm/parser-*.mjs"], { cwd: distDirectory, absolute: true })
     .map((file) => require(file).default);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3505,7 +3505,7 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@11.0.4, globby@^11.0.1, globby@^11.0.4:
+globby@^11.0.1, globby@^11.0.4:
   version "11.0.4"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
   integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==


### PR DESCRIPTION
## Description

There is already fast-glob used in src/cli/expand-patterns.js
Here I migrate everywhere to it from globby which is a thin wrapper with
a couple of unused here features.

```
du -ck dist
```
before: 17280 kB
after: 17260 kB


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
