### PR TITLE
Replace `minimatch` with `micromatch`

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "lodash": "4.17.21",
     "mem": "9.0.2",
     "meriyah": "4.2.0",
-    "minimatch": "3.0.4",
+    "micromatch": "4.0.4",
     "minimist": "1.2.5",
     "n-readlines": "1.0.1",
     "outdent": "0.8.0",

--- a/src/config/resolve-config.js
+++ b/src/config/resolve-config.js
@@ -168,7 +168,7 @@ function mergeOverrides(configResult, filePath) {
 function pathMatchesGlobs(filePath, patterns, excludedPatterns) {
   const patternList = Array.isArray(patterns) ? patterns : [patterns];
   // micromatch always matches against basename when the option is enabled
-  // use only patterns without slashes with it to match minimatch bahavior
+  // use only patterns without slashes with it to match minimatch behavior
   const withSlashes = [];
   const withoutSlashes = [];
   for (const pattern of patternList) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4631,7 +4631,7 @@ meriyah@4.2.0:
   resolved "https://registry.yarnpkg.com/meriyah/-/meriyah-4.2.0.tgz#29d28c37ac7b67f8b9aaa92df0b8ac12469fe98b"
   integrity sha512-fCVh5GB9YT53Bq14l00HLYE3i9DywrY0JVZxbk0clXWDuMsUKKwluvC5sY0bMBqHbnIbpIjfSSIsnrzbauA8Yw==
 
-micromatch@^4.0.4:
+micromatch@4.0.4, micromatch@^4.0.4:
   version "4.0.4"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
   integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
@@ -4665,13 +4665,6 @@ min-indent@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/min-indent/-/min-indent-1.0.1.tgz#a63f681673b30571fbe8bc25686ae746eefa9869"
   integrity sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
-
-minimatch@3.0.4:
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
-  integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
-  dependencies:
-    brace-expansion "^1.1.7"
 
 minimatch@^3.0.4:
   version "3.0.5"


### PR DESCRIPTION
## Description

Micromatch already used inside fast-glob. It makes more sense to reuse
it. Though its behaviour slightly different I found a way to match
minimatch.

```
du -ck dist
```
before: 17260 kB
after: 17232



## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
