### PR TITLE
Add an esbuild plugin to add `@ts-nocheck` annotation for vendors

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,4 +10,4 @@ coverage/
 /website/static/lib/
 /website/static/playground.js
 .nyc_output
-vendors/
+/vendors/

--- a/cspell.json
+++ b/cspell.json
@@ -213,6 +213,7 @@
         "neoclide",
         "neoformat",
         "neovim",
+        "nocheck",
         "nnoremap",
         "nonenumerable",
         "Nonspacing",

--- a/scripts/vendors/bundle-vendors.mjs
+++ b/scripts/vendors/bundle-vendors.mjs
@@ -32,7 +32,7 @@ async function lockVersions(vendors) {
 
 async function fileExists(filePath) {
   try {
-    return (await fs.stat(filePath)).isFile()
+    return (await fs.stat(filePath)).isFile();
   } catch {
     return false;
   }
@@ -41,7 +41,7 @@ async function fileExists(filePath) {
 async function cleanExistsBundledJS() {
   for (const file of await fs.readdir(vendorsDir)) {
     const filePath = path.join(vendorsDir, file);
-    if (path.extname(file) === ".js" && await (fileExists(filePath))) {
+    if (path.extname(file) === ".js" && (await fileExists(filePath))) {
       await fs.rm(filePath);
     }
   }

--- a/scripts/vendors/bundle-vendors.mjs
+++ b/scripts/vendors/bundle-vendors.mjs
@@ -9,6 +9,7 @@ import { writePackage } from "write-pkg";
 import { readPackageUp } from "read-pkg-up";
 import vendors from "./vendors.mjs";
 import { writeVendorVersions } from "./vendor-versions.mjs";
+import esbuildPluginTsNocheck from "./esbuild-plugin-ts-nocheck.mjs";
 
 const { __dirname, require } = createEsmUtils(import.meta);
 const rootDir = path.join(__dirname, "..", "..");
@@ -58,6 +59,7 @@ async function bundle(vendor) {
     bundle: true,
     target: ["node12.17.0"],
     platform: "node",
+    plugins: [esbuildPluginTsNocheck()],
     outfile,
   };
   await esbuild.build(esbuildOption);

--- a/scripts/vendors/esbuild-plugin-ts-nocheck.mjs
+++ b/scripts/vendors/esbuild-plugin-ts-nocheck.mjs
@@ -1,0 +1,20 @@
+import fs from "node:fs";
+
+const tsNoCheck = "// @ts-nocheck\n";
+
+export default function esbuildPluginTsNocheck() {
+  return {
+    name: "ts-no-check",
+    setup(build) {
+      const options = build.initialOptions;
+      const { outfile } = options;
+      build.onEnd(() => {
+        if (!fs.existsSync(outfile)) {
+          throw new Error(`${outfile} not exists`);
+        }
+        const text = fs.readFileSync(outfile, "utf8");
+        fs.writeFileSync(outfile, tsNoCheck + text);
+      });
+    },
+  };
+}

--- a/vendors/mem.js
+++ b/vendors/mem.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __defProps = Object.defineProperties;

--- a/vendors/string-width.js
+++ b/vendors/string-width.js
@@ -1,3 +1,4 @@
+// @ts-nocheck
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Tests on Node.js 10(prod), we cannot use `"imports"` in `package.json`. So we should use directly `require` from `/vendors/*.js`. But, TS type checker warns to the `require`.

So this PR adds esbuild plugin to add `@ts-nocheck` annotation for vendors.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
