### PR TITLE
Include vendors/ when installing from GitHub

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -70,7 +70,7 @@ module.exports = {
   moduleNameMapper: {
     "prettier-local": "<rootDir>/tests/config/require-prettier.js",
     "prettier-standalone": "<rootDir>/tests/config/require-standalone.js",
-    "#(.*)": "<rootDir>/vendors/$1",
+    "#(.*)": PRETTIER_DIR + "/vendors/$1",
   },
   modulePathIgnorePatterns: [
     "<rootDir>/dist",

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,11 +9,13 @@ const ENABLE_CODE_COVERAGE = Boolean(process.env.ENABLE_CODE_COVERAGE);
 const TEST_STANDALONE = Boolean(process.env.TEST_STANDALONE);
 const INSTALL_PACKAGE = Boolean(process.env.INSTALL_PACKAGE);
 
+let customPrettierDir = false;
 let PRETTIER_DIR = isProduction
   ? path.join(PROJECT_ROOT, "dist")
   : PROJECT_ROOT;
 if (INSTALL_PACKAGE || (isProduction && !TEST_STANDALONE)) {
   PRETTIER_DIR = installPrettier(PRETTIER_DIR);
+  customPrettierDir = true;
 }
 process.env.PRETTIER_DIR = PRETTIER_DIR;
 
@@ -70,7 +72,7 @@ module.exports = {
   moduleNameMapper: {
     "prettier-local": "<rootDir>/tests/config/require-prettier.js",
     "prettier-standalone": "<rootDir>/tests/config/require-standalone.js",
-    "#(.*)": PRETTIER_DIR + "/vendors/$1",
+    "#(.*)": (customPrettierDir ? PRETTIER_DIR : "<rootDir>") + "/vendors/$1",
   },
   modulePathIgnorePatterns: [
     "<rootDir>/dist",

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,13 +9,11 @@ const ENABLE_CODE_COVERAGE = Boolean(process.env.ENABLE_CODE_COVERAGE);
 const TEST_STANDALONE = Boolean(process.env.TEST_STANDALONE);
 const INSTALL_PACKAGE = Boolean(process.env.INSTALL_PACKAGE);
 
-let customPrettierDir = false;
 let PRETTIER_DIR = isProduction
   ? path.join(PROJECT_ROOT, "dist")
   : PROJECT_ROOT;
 if (INSTALL_PACKAGE || (isProduction && !TEST_STANDALONE)) {
   PRETTIER_DIR = installPrettier(PRETTIER_DIR);
-  customPrettierDir = true;
 }
 process.env.PRETTIER_DIR = PRETTIER_DIR;
 
@@ -72,7 +70,6 @@ module.exports = {
   moduleNameMapper: {
     "prettier-local": "<rootDir>/tests/config/require-prettier.js",
     "prettier-standalone": "<rootDir>/tests/config/require-standalone.js",
-    "#(.*)": (customPrettierDir ? PRETTIER_DIR : "<rootDir>") + "/vendors/$1",
   },
   modulePathIgnorePatterns: [
     "<rootDir>/dist",

--- a/package.json
+++ b/package.json
@@ -89,10 +89,6 @@
     "wcwidth": "1.0.1",
     "yaml-unist-parser": "1.3.1"
   },
-  "imports": {
-    "#string-width": "./vendors/string-width.js",
-    "#mem": "./vendors/mem.js"
-  },
   "devDependencies": {
     "@babel/core": "7.17.0",
     "@babel/preset-env": "7.16.11",
@@ -136,13 +132,11 @@
     "path-browserify": "1.0.1",
     "prettier": "2.5.1",
     "pretty-bytes": "5.6.0",
-    "read-pkg": "7.0.0",
     "read-pkg-up": "9.0.0",
     "rimraf": "3.0.2",
     "rollup-plugin-license": "2.6.1",
     "snapshot-diff": "0.9.0",
-    "tempy": "1.0.1",
-    "write-pkg": "5.0.0"
+    "tempy": "1.0.1"
   },
   "scripts": {
     "prepublishOnly": "echo \"Error: must publish from dist/\" && exit 1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "index.js",
     "standalone.js",
     "src",
-    "bin"
+    "bin",
+    "vendors"
   ],
   "dependencies": {
     "@angular/compiler": "12.2.16",

--- a/scripts/vendors/bundle-vendors.mjs
+++ b/scripts/vendors/bundle-vendors.mjs
@@ -4,8 +4,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import createEsmUtils from "esm-utils";
 import esbuild from "esbuild";
-import { readPackage } from "read-pkg";
-import { writePackage } from "write-pkg";
 import { readPackageUp } from "read-pkg-up";
 import vendors from "./vendors.mjs";
 import { writeVendorVersions } from "./vendor-versions.mjs";
@@ -63,37 +61,27 @@ async function bundle(vendor) {
     outfile,
   };
   await esbuild.build(esbuildOption);
-}
 
-async function updatePackage(imports) {
-  const pkg = await readPackage({ normalize: false });
-  pkg.imports = imports;
-  await writePackage(pkg, { normalize: false });
-}
-
-async function generateDts(vendors) {
-  let dtsContent = "// This file is generate automatically.\n";
-  for (const vendor of vendors) {
-    dtsContent += `declare module "#${vendor}";\n`;
-  }
-  await fs.writeFile(path.join(vendorsDir, "types.d.ts"), dtsContent, "utf-8");
+  await fs.writeFile(
+    path.join(vendorsDir, `${vendor}.d.ts`),
+    [
+      "// This file is generated automatically.",
+      `export {default} from "${vendor}";`,
+      `export * from "${vendor}";`,
+      "",
+    ].join("\n"),
+    "utf-8"
+  );
 }
 
 async function main() {
   await cleanExistsBundledJS();
-  const imports = {};
   for (const vendor of vendors) {
     await bundle(vendor);
-    imports[`#${vendor}`] =
-      "./" + path.relative(rootDir, getVendorFilePath(vendor));
     console.log(`Bundled: ${vendor}`);
   }
-  await updatePackage(imports);
-  console.log("Updated: package.json");
   await lockVersions(vendors);
   console.log("Locked: vendor-versions.json");
-  await generateDts(vendors);
-  console.log("Generated: vendors/types.d.ts");
 }
 
 main();

--- a/scripts/vendors/esbuild-plugin-ts-nocheck.mjs
+++ b/scripts/vendors/esbuild-plugin-ts-nocheck.mjs
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 
-const tsNoCheck = "// @ts-nocheck\n";
+const tsNoCheck = "// @ts-nocheck\n// This file is generated automatically\n";
 
 export default function esbuildPluginTsNocheck() {
   return {

--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -6,9 +6,9 @@ const uniqBy = require("lodash/uniqBy");
 const partition = require("lodash/partition");
 const fastGlob = require("fast-glob");
 const internalPlugins = require("../languages.js");
+const { default: mem, memClear } = require("../../vendors/mem.js");
 const thirdParty = require("./third-party.js");
 const resolve = require("./resolve.js");
-const { default: mem, memClear } = require("#mem");
 
 const memoizedLoad = mem(load, { cacheKey: JSON.stringify });
 const memoizedSearch = mem(findPluginsInNodeModules);

--- a/src/config/resolve-config-editorconfig.js
+++ b/src/config/resolve-config-editorconfig.js
@@ -4,8 +4,8 @@ const path = require("path");
 
 const editorconfig = require("editorconfig");
 const editorConfigToPrettier = require("editorconfig-to-prettier");
+const { default: mem, memClear } = require("../../vendors/mem.js");
 const findProjectRoot = require("./find-project-root.js");
-const { default: mem, memClear } = require("#mem");
 
 const jsonStringifyMem = (fn) => mem(fn, { cacheKey: JSON.stringify });
 

--- a/src/config/resolve-config.js
+++ b/src/config/resolve-config.js
@@ -7,8 +7,8 @@ const thirdParty = require("../common/third-party.js");
 const loadToml = require("../utils/load-toml.js");
 const loadJson5 = require("../utils/load-json5.js");
 const resolve = require("../common/resolve.js");
+const { default: mem, memClear } = require("../../vendors/mem.js");
 const resolveEditorConfig = require("./resolve-config-editorconfig.js");
-const { default: mem, memClear } = require("#mem");
 
 /**
  * @typedef {import("cosmiconfig/dist/Explorer").Explorer} Explorer

--- a/src/utils/get-string-width.js
+++ b/src/utils/get-string-width.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const stringWidth = require("#string-width").default;
+const stringWidth = require("../../vendors/string-width.js").default;
 
 const notAsciiRegex = /[^\x20-\x7F]/;
 

--- a/vendors/mem.d.ts
+++ b/vendors/mem.d.ts
@@ -1,0 +1,3 @@
+// This file is generated automatically.
+export {default} from "mem";
+export * from "mem";

--- a/vendors/mem.js
+++ b/vendors/mem.js
@@ -1,4 +1,5 @@
 // @ts-nocheck
+// This file is generated automatically
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __defProps = Object.defineProperties;

--- a/vendors/string-width.d.ts
+++ b/vendors/string-width.d.ts
@@ -1,0 +1,3 @@
+// This file is generated automatically.
+export {default} from "string-width";
+export * from "string-width";

--- a/vendors/string-width.js
+++ b/vendors/string-width.js
@@ -1,4 +1,5 @@
 // @ts-nocheck
+// This file is generated automatically
 var __create = Object.create;
 var __defProp = Object.defineProperty;
 var __getOwnPropDesc = Object.getOwnPropertyDescriptor;

--- a/vendors/types.d.ts
+++ b/vendors/types.d.ts
@@ -1,3 +1,0 @@
-// This file is generate automatically.
-declare module "#string-width";
-declare module "#mem";

--- a/yarn.lock
+++ b/yarn.lock
@@ -2674,11 +2674,6 @@ delayed-stream@~1.0.0:
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
 
-detect-indent@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-7.0.0.tgz#cab58e6ab1129c669e2101181a6c677917d43577"
-  integrity sha512-/6kJlmVv6RDFPqaHC/ZDcU8bblYcoph2dUQ3kB47QqhkUEqXe3VZPELK9BaEMrC73qu+wn0AQ7iSteceN+yuMw==
-
 detect-newline@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
@@ -3913,11 +3908,6 @@ is-plain-obj@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-2.1.0.tgz#45e42e37fccf1f40da8e5f76ee21515840c09287"
   integrity sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==
-
-is-plain-obj@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-4.0.0.tgz#06c0999fd7574edf5a906ba5644ad0feb3a84d22"
-  integrity sha512-NXRbBtUdBioI73y/HmOhogw/U5msYPC9DAtGkJXeFcFWSFZw0mCUsPxk/snTuJHzNKA8kLBK4rH97RMB1BfCXw==
 
 is-potential-custom-element-name@^1.0.1:
   version "1.0.1"
@@ -5624,16 +5614,6 @@ read-pkg-up@^7.0.1:
     read-pkg "^5.2.0"
     type-fest "^0.8.1"
 
-read-pkg@7.0.0, read-pkg@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-7.0.0.tgz#7009094a9cd58c7efc325d31f1f6cfce1928fa00"
-  integrity sha512-oG2cKegOo2gjy/hrAM+KFHD9IqKdQvWcpWBBxuHbaucziM9PY45EuF6YbenLF7tL9ekXgB6Lfruo9hwdHQZUrA==
-  dependencies:
-    "@types/normalize-package-data" "^2.4.1"
-    normalize-package-data "^3.0.2"
-    parse-json "^5.2.0"
-    type-fest "^2.0.0"
-
 read-pkg@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-3.0.0.tgz#9cbc686978fee65d16c00e2b19c237fcf6e38389"
@@ -5652,6 +5632,16 @@ read-pkg@^5.2.0:
     normalize-package-data "^2.5.0"
     parse-json "^5.0.0"
     type-fest "^0.6.0"
+
+read-pkg@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-7.0.0.tgz#7009094a9cd58c7efc325d31f1f6cfce1928fa00"
+  integrity sha512-oG2cKegOo2gjy/hrAM+KFHD9IqKdQvWcpWBBxuHbaucziM9PY45EuF6YbenLF7tL9ekXgB6Lfruo9hwdHQZUrA==
+  dependencies:
+    "@types/normalize-package-data" "^2.4.1"
+    normalize-package-data "^3.0.2"
+    parse-json "^5.2.0"
+    type-fest "^2.0.0"
 
 refa@^0.9.0:
   version "0.9.1"
@@ -6039,13 +6029,6 @@ snapshot-diff@0.9.0:
     jest-diff "^27.0.2"
     jest-snapshot "^27.0.4"
     pretty-format "^27.0.2"
-
-sort-keys@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/sort-keys/-/sort-keys-5.0.0.tgz#5d775f8ae93ecc29bc7312bbf3acac4e36e3c446"
-  integrity sha512-Pdz01AvCAottHTPQGzndktFNdbRA75BgOfeT1hH+AMnJFv8lynkPi42rfeEhpx1saTEI3YNMWxfqu0sFD1G8pw==
-  dependencies:
-    is-plain-obj "^4.0.0"
 
 source-map-support@^0.5.6:
   version "0.5.21"
@@ -6807,7 +6790,7 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-write-file-atomic@^3.0.0, write-file-atomic@^3.0.3:
+write-file-atomic@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-3.0.3.tgz#56bd5c5a5c70481cd19c571bd39ab965a5de56e8"
   integrity sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
@@ -6816,25 +6799,6 @@ write-file-atomic@^3.0.0, write-file-atomic@^3.0.3:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
-
-write-json-file@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/write-json-file/-/write-json-file-5.0.0.tgz#11c329a8ea9e8e23fb92a87cc27412a15f87708b"
-  integrity sha512-ddSsCLa4aQ3kI21BthINo4q905/wfhvQ3JL3774AcRjBaiQmfn5v4rw77jQ7T6CmAit9VOQO+FsLyPkwxoB1fw==
-  dependencies:
-    detect-indent "^7.0.0"
-    is-plain-obj "^4.0.0"
-    sort-keys "^5.0.0"
-    write-file-atomic "^3.0.3"
-
-write-pkg@5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/write-pkg/-/write-pkg-5.0.0.tgz#b9fab4e78ee0e71b980867f2baff8b8564a77d26"
-  integrity sha512-ihflUwZ8WvVcXD2uhk4JAAe5+x9FT+0n4Z5b/OMZXBG8/hXCvSQXTYDf9raox0aqJGWRBipIE4rWSi6aCaiebw==
-  dependencies:
-    sort-keys "^5.0.0"
-    type-fest "^2.0.0"
-    write-json-file "^5.0.0"
 
 ws@^7.4.6:
   version "7.5.6"


### PR DESCRIPTION
## Description

This includes the `vendors` directory in the package when installing from Github `(i.e. npm install prettier/prettier`).

Previously, Prettier would not be able to run because npm removes everything not listed in `files` when installing from GitHub. I’ve confirmed on a local project that installing Prettier from this branch does work correctly.

Closes #12253.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [N/A] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
