### PR TITLE
Update plugin docs

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -7,7 +7,7 @@ Plugins are ways of adding new languages or formatting rules to Prettier. Pretti
 
 ## Using Plugins
 
-Plugins are automatically loaded if you have them installed in the same `node_modules` directory where `prettier` is located. Plugin package names must start with `prettier-plugin-` or `@prettier/plugin-` or `@<scope>/prettier-plugin-` to be registered.
+Plugins are automatically loaded if you have them installed in the same `node_modules` directory where `prettier` is located. Plugin package names must start with `@prettier/plugin-` or `prettier-plugin-` or `@<scope>/prettier-plugin-` to be registered.
 
 > `<scope>` should be replaced by a name, read more about [NPM scope](https://docs.npmjs.com/misc/scope.html).
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -36,7 +36,7 @@ When plugins cannot be found automatically, you can load them with:
   ```json
   {
     "pluginSearchDirs": ["./dir-with-plugins"],
-    "plugins": ["./foo-plugin"]
+    "plugins": ["prettier-plugin-foo"]
   }
   ```
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -16,7 +16,7 @@ When plugins cannot be found automatically, you can load them with:
 - The [CLI](cli.md), via `--plugin-search-dir` and `--plugin`:
 
   ```bash
-  prettier --write main.foo --plugin-search-dir=./dir-with-plugins --plugin=./foo-plugin
+  prettier --write main.foo --plugin-search-dir=./dir-with-plugins --plugin=prettier-plugin-foo
   ```
 
   > Tip: You can set `--plugin-search-dir` or `--plugin` options multiple times.
@@ -27,11 +27,11 @@ When plugins cannot be found automatically, you can load them with:
   prettier.format("code", {
     parser: "foo",
     pluginSearchDirs: ["./dir-with-plugins"],
-    plugins: ["./foo-plugin"],
+    plugins: ["prettier-plugin-foo"],
   });
   ```
 
-- Or the [Configuration File](configuration.md):
+- The [Configuration File](configuration.md):
 
   ```json
   {
@@ -40,7 +40,11 @@ When plugins cannot be found automatically, you can load them with:
   }
   ```
 
-The path that is provided to `pluginSearchDirs` will be searched for `@prettier/plugin-*`, `prettier-plugin-*`, and `@*/prettier-plugin-*`. For instance, this can be your project directory, a `node_modules` directory, the location of global npm modules, or any arbitrary directory that contains plugins.
+`pluginSearchDirs` and `plugins` are independent and one does not require the other.
+
+The paths that are provided to `pluginSearchDirs` will be searched for `@prettier/plugin-*`, `prettier-plugin-*`, and `@*/prettier-plugin-*`. For instance, these can be your project directory, a `node_modules` directory, the location of global npm modules, or any arbitrary directory that contains plugins.
+
+Strings provided to `plugins` are ultimately passed to `require()`, so you can provide a module/package name, a path, or anything else `require()` takes. (`pluginSearchDirs` works the same way. That is, valid plugin paths that it finds are passed to `require()`.)
 
 Providing at least one path to `--plugin-search-dir`/`pluginSearchDirs` turns off plugin autoloading in the default directory (i.e. `node_modules` above `prettier` binary).
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -13,21 +13,21 @@ Plugins are automatically loaded if you have them installed in the same `node_mo
 
 When plugins cannot be found automatically, you can load them with:
 
-- The [CLI](cli.md), via `--plugin` and `--plugin-search-dir`:
+- The [CLI](cli.md), via `--plugin-search-dir` and `--plugin`:
 
   ```bash
-  prettier --write main.foo --plugin=./foo-plugin --plugin-search-dir=./dir-with-plugins
+  prettier --write main.foo --plugin-search-dir=./dir-with-plugins --plugin=./foo-plugin
   ```
 
-  > Tip: You can set `--plugin` or `--plugin-search-dir` options multiple times.
+  > Tip: You can set `--plugin-search-dir` or `--plugin` options multiple times.
 
-- The [API](api.md), via the `plugins` and `pluginSearchDirs` options:
+- The [API](api.md), via the `pluginSearchDirs` and `plugins` options:
 
   ```js
   prettier.format("code", {
     parser: "foo",
-    plugins: ["./foo-plugin"],
     pluginSearchDirs: ["./dir-with-plugins"],
+    plugins: ["./foo-plugin"],
   });
   ```
 
@@ -35,12 +35,12 @@ When plugins cannot be found automatically, you can load them with:
 
   ```json
   {
-    "plugins": ["./foo-plugin"],
-    "pluginSearchDirs": ["./dir-with-plugins"]
+    "pluginSearchDirs": ["./dir-with-plugins"],
+    "plugins": ["./foo-plugin"]
   }
   ```
 
-The path that is provided to `pluginSearchDirs` should generally contain a `node_modules` subdirectory. For instance, this can be your project directory or the location of global npm modules. You can also provide a path that is the direct parent directory of your plugins if needed. That is, a path directly to `node_modules` or some arbitrary directory that contains your plugins. Either way, the path you provide is where `prettier-plugin-*`, `@prettier/plugin-*`, and `@*/prettier-plugin-*` will be searched.
+The path that is provided to `pluginSearchDirs` will be searched for `@prettier/plugin-*`, `prettier-plugin-*`, and `@*/prettier-plugin-*`. For instance, this can be your project directory, a `node_modules` directory, the location of global npm modules, or any arbitrary directory that contains plugins.
 
 Providing at least one path to `--plugin-search-dir`/`pluginSearchDirs` turns off plugin autoloading in the default directory (i.e. `node_modules` above `prettier` binary).
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -3,35 +3,44 @@ id: plugins
 title: Plugins
 ---
 
-Plugins are ways of adding new languages to Prettier. Prettier’s own implementations of all languages are expressed using the plugin API. The core `prettier` package contains JavaScript and other web-focused languages built in. For additional languages you’ll need to install a plugin.
+Plugins are ways of adding new languages or formatting rules to Prettier. Prettier’s own implementations of all languages are expressed using the plugin API. The core `prettier` package contains JavaScript and other web-focused languages built in. For additional languages you’ll need to install a plugin.
 
 ## Using Plugins
 
-Plugins are automatically loaded if you have them installed in the same `node_modules` directory where `prettier` is located. Plugin package names must start with `@prettier/plugin-` or `prettier-plugin-` or `@<scope>/prettier-plugin-` to be registered.
+Plugins are automatically loaded if you have them installed in the same `node_modules` directory where `prettier` is located. Plugin package names must start with `prettier-plugin-` or `@prettier/plugin-` or `@<scope>/prettier-plugin-` to be registered.
 
 > `<scope>` should be replaced by a name, read more about [NPM scope](https://docs.npmjs.com/misc/scope.html).
 
 When plugins cannot be found automatically, you can load them with:
 
-- The [CLI](cli.md), via the `--plugin` and `--plugin-search-dir`:
+- The [CLI](cli.md), via `--plugin` and `--plugin-search-dir`:
 
   ```bash
-  prettier --write main.foo --plugin-search-dir=./dir-with-plugins --plugin=./foo-plugin
+  prettier --write main.foo --plugin=./foo-plugin --plugin-search-dir=./dir-with-plugins
   ```
 
   > Tip: You can set `--plugin` or `--plugin-search-dir` options multiple times.
 
-- Or the [API](api.md), via the `plugins` and `pluginSearchDirs` options:
+- The [API](api.md), via the `plugins` and `pluginSearchDirs` options:
 
   ```js
   prettier.format("code", {
     parser: "foo",
-    pluginSearchDirs: ["./dir-with-plugins"],
     plugins: ["./foo-plugin"],
+    pluginSearchDirs: ["./dir-with-plugins"],
   });
   ```
 
-Prettier expects each of `pluginSearchDirs` to contain `node_modules` subdirectory, where `@prettier/plugin-*`, `@*/prettier-plugin-*` and `prettier-plugin-*` will be searched. For instance, this can be your project directory or the location of global npm modules.
+- Or the [Configuration File](configuration.md):
+
+  ```json
+  {
+    "plugins": ["./foo-plugin"],
+    "pluginSearchDirs": ["./dir-with-plugins"]
+  }
+  ```
+
+The path that is provided to `pluginSearchDirs` should generally contain a `node_modules` subdirectory. For instance, this can be your project directory or the location of global npm modules. You can also provide a path that is the direct parent directory of your plugins if needed. That is, a path directly to `node_modules` or some arbitrary directory that contains your plugins. Either way, the path you provide is where `prettier-plugin-*`, `@prettier/plugin-*`, and `@*/prettier-plugin-*` will be searched.
 
 Providing at least one path to `--plugin-search-dir`/`pluginSearchDirs` turns off plugin autoloading in the default directory (i.e. `node_modules` above `prettier` binary).
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

I updated the plugin docs to reflect the changes I made in my previous PR (#11248). I did some cleanup to the wording/ordering of some things as well. For example, generally `--plugin` and `--plugin-search-dir` are mentioned in that order. I made that consistent throughout the rest of the page.

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
