### PR TITLE
Improve printing of comments in type aliases

### DIFF
--- a/changelog_unreleased/javascript/12268.md
+++ b/changelog_unreleased/javascript/12268.md
@@ -1,0 +1,54 @@
+#### Improve printing of comments in type aliases in Flow & TS (#12268 by @duailibe)
+
+For Flow, the comments will now be more aligned to how we print comments in assignments where the right-hand side is an object expression:
+
+<!-- prettier-ignore -->
+```js
+// Input
+type Props = // comment explaining the props
+  {
+    isPlaying: boolean
+  };
+
+// Prettier stable
+// comment explaining the props
+type Props = {
+  isPlaying: boolean,
+};
+
+// Prettier main
+type Props =
+  // comment explaining the props
+  {
+    isPlaying: boolean,
+  };
+```
+
+And for TS that comment would not be stable with a second format:
+
+<!-- prettier-ignore -->
+```ts
+// Input
+type Props = // comment explaining the props
+  {
+    isPlaying: boolean
+  };
+
+// Prettier stable
+type Props = { // comment explaining the props
+  isPlaying: boolean;
+};
+
+// Prettier stable (2nd format)
+type Props = {
+  // comment explaining the props
+  isPlaying: boolean;
+};
+
+// Prettier main
+type Props =
+  // comment explaining the props
+  {
+    isPlaying: boolean,
+  };
+```

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -91,7 +91,6 @@ function handleEndOfLineComment(context) {
     handleCallExpressionComments,
     handlePropertyComments,
     handleOnlyComments,
-    handleTypeAliasComments,
     handleVariableDeclaratorComments,
     handleBreakAndContinueStatementComments,
     handleSwitchDefaultCaseComments,
@@ -815,14 +814,6 @@ function handleAssignmentPatternComments({ comment, enclosingNode }) {
   return false;
 }
 
-function handleTypeAliasComments({ comment, enclosingNode }) {
-  if (enclosingNode && enclosingNode.type === "TypeAlias") {
-    addLeadingComment(enclosingNode, comment);
-    return true;
-  }
-  return false;
-}
-
 function handleVariableDeclaratorComments({
   comment,
   enclosingNode,
@@ -831,12 +822,16 @@ function handleVariableDeclaratorComments({
   if (
     enclosingNode &&
     (enclosingNode.type === "VariableDeclarator" ||
-      enclosingNode.type === "AssignmentExpression") &&
+      enclosingNode.type === "AssignmentExpression" ||
+      enclosingNode.type === "TypeAlias" ||
+      enclosingNode.type === "TSTypeAliasDeclaration") &&
     followingNode &&
     (followingNode.type === "ObjectExpression" ||
       followingNode.type === "ArrayExpression" ||
       followingNode.type === "TemplateLiteral" ||
       followingNode.type === "TaggedTemplateExpression" ||
+      followingNode.type === "ObjectTypeAnnotation" ||
+      followingNode.type === "TSTypeLiteral" ||
       isBlockComment(comment))
   ) {
     addLeadingComment(followingNode, comment);

--- a/tests/format/flow/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/comments/__snapshots__/jsfmt.spec.js.snap
@@ -239,10 +239,11 @@ type Props3 = {
 };
 
 =====================================output=====================================
-// (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
-type Props1 = {
-  isPlaying: boolean,
-};
+type Props1 =
+  // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
+  {
+    isPlaying: boolean,
+  };
 
 type Props2 = {
   // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!

--- a/tests/format/typescript/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/comments/__snapshots__/jsfmt.spec.js.snap
@@ -694,6 +694,46 @@ export class Point {
 ================================================================================
 `;
 
+exports[`type_literals.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type Props1 = // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
+{
+  isPlaying: boolean,
+};
+
+type Props2 = { // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
+  isPlaying: boolean
+};
+
+type Props3 = {
+  // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
+  isPlaying: boolean
+};
+
+=====================================output=====================================
+type Props1 =
+  // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
+  {
+    isPlaying: boolean;
+  };
+
+type Props2 = {
+  // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
+  isPlaying: boolean;
+};
+
+type Props3 = {
+  // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
+  isPlaying: boolean;
+};
+
+================================================================================
+`;
+
 exports[`type-parameters.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/comments/type_literals.ts
+++ b/tests/format/typescript/comments/type_literals.ts
@@ -1,0 +1,13 @@
+type Props1 = // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
+{
+  isPlaying: boolean,
+};
+
+type Props2 = { // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
+  isPlaying: boolean
+};
+
+type Props3 = {
+  // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
+  isPlaying: boolean
+};


### PR DESCRIPTION
## Description

While fixing #11521 I noticed this weird behavior introduced in #1214:

**Prettier 2.5.1**
[Playground link](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEMCeAHOACACgJwgwGdsBebAekuwAoARAS2IwEMYwALAo0gMmwBlGOzg8SASgDc2AOoAJAJrZ6AeQByAcgAq2RaoCqc1QCUA0tgBiAGVWyAhI6dOAOlGzZgbjx+a4ANqxojFAA5kjYAEYQEP5wrFDe2AC+Um4gADQgRDCM0MTIoKz4hADuuMUIBSis-qVBBVmR+KxgANZwMIKsALZw1iFwyABmtcRwTS3tnYJsYCGhyDD4AK4TIHA9kXAAJju71gmhK6yhcJYQ+D3suWHIIKwrMBCZIJwwPf6ynIzwLK1wQRVX6MABuvzQ9zAxEaIBC43wMAIp2uIzG6wAVsQAB6CBZxACKKwg8DR-nGWTY+AR92G-ggpVeGHwIRgskYOxgnGQAA4AAyUwjjWQtDD3ZlwBGgoZZACOxPg4mqD2IAFooHBdrtXvg4PLGLrkaFUUhRuT1uMeowlqsLfi4ESSUNTeisiJIuzOdykAAmN0tRj+BYAYQgPRNG2IAFZXitxtpWJFqmaKSBQWsAJJQfawQRgFkYGAAQWzwjQcTJ42SySAA)
<!-- prettier-ignore -->
```sh
--parser flow
```

**Input:**
<!-- prettier-ignore -->
```jsx
type Props = // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
  {
    isPlaying: boolean
  };

```

**Output:**
<!-- prettier-ignore -->
```jsx
// (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
type Props = {
  isPlaying: boolean,
};

```

Which is different from how we print object expressions and TS type literals:

**Prettier 2.5.1**
[Playground link](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEMCeAHOACACgJwgwGdsBebAekuwAoARAS2IwEMYwALAo0gMmwBlGOzg8SASgDc2AOoAJAJrZ6AeQByAcgAq2RaoCqc1QCUA0tgBiAGVWyAhI6dOAOlGzZgbjx+a4ANqxojFAA5kjYAEYQEP5wrFDe2AC+Um5ukFDEMHiEJORUNAzMbBzcefxCIvDixNJySioaOnqGxuZWtg7Ozkle7j5+gcFhETD4AK5wSakgADQgRDCM0MTIoKz4hADuuJsIayis-ttBawuR+KxgANZwMIKsALZw1iFwyABmx8RwF1e3e6CNhgEKhZDjKYLOBPSJwAAm8IR1gSoQmrFCcEsEHwT3YyzCyBArAmMAg8xAnBgT38sk4jHgLGucEEBwZjAAbgy0ESwMRziAQr98DACBi8V8fn8QAArYgAD0EYLiAEUJhB4JL-L8Fmx8MKiegsMQwPhGBgYBSMGbYLJGPCYJxkAAOAAMusIv1kVwwROtcGFHI+CwAjuqahUiaxiABaKBwBEIin4OBhxgpsWhCVIb7a6W-J6MCGTfPKuBqjUfHNShYiSJ2h1OpAAJlrV0Y-jBAGEIE9syAAwBWCkTX7aViRQ65nUgDlTACSUCRsEEpvNMAAgkvhGg4lrfslkkA)
<!-- prettier-ignore -->
```sh
--parser typescript
```

**Input:**
<!-- prettier-ignore -->
```tsx
type Props = // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
  {
    isPlaying: boolean
  };

const Props = // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
  {
    isPlaying: true
  };
```

**Output:**
<!-- prettier-ignore -->
```tsx
type Props = { // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
  isPlaying: boolean;
};

const Props =
  // (DispatchProps & StateProps); WHY DON'T YOU WORK FLOW!!!!!!!!!
  {
    isPlaying: true,
  };

```

(The TS one is actually problematic because it's not stable - which was the point of #1214 -, and this will make it stable)

I think that printing them all equally is an important target so I changed it to make them all print like object expressions, but I'm not convinced that's the best way to print it. It's either making them all printing like the object one, or like the Flow one.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
