### PR TITLE
[DEMO] Migrate CLI to ES Module 

### DIFF
--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -58,11 +58,11 @@ jobs:
 
       - name: Run Integration Tests (macOS)
         if: ${{ matrix.os == 'macos-latest' }}
-        run: yarn test:integration --maxWorkers=4
+        run: yarn test:integration --runInBand
 
       - name: Run Integration Tests (Linux and Windows)
         if: ${{ matrix.os != 'macos-latest' }}
-        run: yarn test:integration --maxWorkers=2
+        run: yarn test:integration --runInBand
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v2.1.0
@@ -72,11 +72,11 @@ jobs:
 
       - name: Run Format Tests (macOS)
         if: ${{ matrix.os == 'macos-latest' }}
-        run: yarn test:format --maxWorkers=4
+        run: yarn test:format --runInBand
 
       - name: Run Format Tests (Linux and Windows)
         if: ${{ matrix.os != 'macos-latest' }}
-        run: yarn c8 yarn test:format --maxWorkers=2
+        run: yarn c8 yarn test:format --runInBand
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v2.1.0

--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -56,19 +56,19 @@ jobs:
       - name: Install Dependencies
         run: yarn install --frozen-lockfile
 
-      # - name: Run Integration Tests (macOS)
-      #   if: ${{ matrix.os == 'macos-latest' }}
-      #   run: yarn test:integration --maxWorkers=4
+      - name: Run Integration Tests (macOS)
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: yarn test:integration --maxWorkers=4
 
-      # - name: Run Integration Tests (Linux and Windows)
-      #   if: ${{ matrix.os != 'macos-latest' }}
-      #   run: yarn test:integration --maxWorkers=2
+      - name: Run Integration Tests (Linux and Windows)
+        if: ${{ matrix.os != 'macos-latest' }}
+        run: yarn test:integration --maxWorkers=2
 
-      # - name: Upload Coverage
-      #   uses: codecov/codecov-action@v2.1.0
-      #   if: ${{ matrix.ENABLE_CODE_COVERAGE }}
-      #   with:
-      #     fail_ci_if_error: true
+      - name: Upload Coverage
+        uses: codecov/codecov-action@v2.1.0
+        if: ${{ matrix.ENABLE_CODE_COVERAGE }}
+        with:
+          fail_ci_if_error: true
 
       - name: Run Format Tests (macOS)
         if: ${{ matrix.os == 'macos-latest' }}
@@ -84,14 +84,14 @@ jobs:
         with:
           fail_ci_if_error: true
 
-      # # #8073 test
-      # - name: Run Tests (PRETTIER_FALLBACK_RESOLVE)
-      #   run: yarn test "tests/integration/__tests__/(config|plugin)"
-      #   env:
-      #     PRETTIER_FALLBACK_RESOLVE: true
+      # #8073 test
+      - name: Run Tests (PRETTIER_FALLBACK_RESOLVE)
+        run: yarn test "tests/integration/__tests__/(config|plugin)"
+        env:
+          PRETTIER_FALLBACK_RESOLVE: true
 
-      # - name: Upload Coverage (PRETTIER_FALLBACK_RESOLVE)
-      #   uses: codecov/codecov-action@v2.1.0
-      #   if: ${{ matrix.ENABLE_CODE_COVERAGE }}
-      #   with:
-      #     fail_ci_if_error: true
+      - name: Upload Coverage (PRETTIER_FALLBACK_RESOLVE)
+        uses: codecov/codecov-action@v2.1.0
+        if: ${{ matrix.ENABLE_CODE_COVERAGE }}
+        with:
+          fail_ci_if_error: true

--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -116,19 +116,19 @@ jobs:
 
       - name: Run Tests (macOS)
         if: ${{ matrix.os == 'macos-latest' }}
-        run: yarn test:dist --maxWorkers=4
+        run: yarn test:dist --runInBand
 
       - name: Run Tests (Linux and Windows)
         if: ${{ matrix.os != 'macos-latest' }}
-        run: yarn test:dist --maxWorkers=2
+        run: yarn test:dist --runInBand
 
       - name: Run Format Tests (standalone) (macOS)
         if: ${{ matrix.os == 'macos-latest' }}
-        run: yarn test:dist-standalone --maxWorkers=4
+        run: yarn test:dist-standalone --runInBand
 
       - name: Run Format Tests (standalone) (Linux and Windows)
         if: ${{ matrix.os != 'macos-latest' }}
-        run: yarn test:dist-standalone --maxWorkers=2
+        run: yarn test:dist-standalone --runInBand
 
       # #8073 test
       - name: Run Tests (PRETTIER_FALLBACK_RESOLVE)

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -31,8 +31,8 @@ if (!isProduction) {
 const config = {
   projects: [
     "<rootDir>/jest-format-test.config.mjs",
-    isProduction && "<rootDir>/jest-integration-test.config.mjs",
-  ].filter(Boolean),
+    "<rootDir>/jest-integration-test.config.mjs",
+  ],
   snapshotSerializers: [
     "jest-snapshot-serializer-raw",
     "jest-snapshot-serializer-ansi",

--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
   "scripts": {
     "prepublishOnly": "echo \"Error: must publish from dist/\" && exit 1",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest",
-    "test:integration": "echo \"Disabled temporary\" && exit 1",
+    "test:integration": "yarn test --config=jest-integration-test.config.mjs",
     "test:format": "yarn test --config=jest-format-test.config.mjs",
     "test:dev-package": "cross-env INSTALL_PACKAGE=1 yarn test",
     "test:dist": "cross-env NODE_ENV=production yarn test",

--- a/tests/integration/run-prettier.js
+++ b/tests/integration/run-prettier.js
@@ -112,7 +112,8 @@ async function run(dir, args, options) {
     .mockImplementation(() => process.cwd());
 
   try {
-    await require(prettierCli).promise;
+    const { promise } = await import(prettierCli);
+    await promise;
     status = (status === undefined ? process.exitCode : status) || 0;
   } catch (error) {
     status = 1;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

In #11903, we skipped dev version "Integration Tests", we are testing bundled cli(in cjs) with `require()`

What we want is,  use `import()` to run tests, so we can test both source(esm), and bundle(cjs) CLI

//cc @SimenB


Checkout this branch, do `yarn && yarn test:integration`