### PR TITLE
Disable wrapping JSXFragment in parens

### DIFF
--- a/changelog_unreleased/javascript/12280.md
+++ b/changelog_unreleased/javascript/12280.md
@@ -1,4 +1,4 @@
-#### Disable wrapping JSX fragments in parens (#12280 by @user)
+#### Disable wrapping JSX fragments in parens (#12280 by @j-f1)
 
 Removing parentheses around JSX `<>` fragments reduces the amount of indentation required for elements inside of them.
 

--- a/changelog_unreleased/javascript/12280.md
+++ b/changelog_unreleased/javascript/12280.md
@@ -1,0 +1,44 @@
+<!--
+1. Fill in a title, the PR number and your user name.
+
+2. Optionally write a description. Many times it’s enough with just sample code.
+
+3. Change ```jsx to your language. For example, ```yaml.
+
+4. Change the `// Input` and `// Prettier` comments to the comment syntax of your language. For example, `# Input`.
+
+5. Choose some nice input example code. Paste it along with the output before and after your PR.
+
+-->
+
+#### Disable wrapping JSX fragments in parens (#12280 by @user)
+
+Removing parentheses around JSX `<>` fragments reduces the amount of indentation required for elements inside of them.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+return (
+  <>
+    <div className="Content">
+      <p>Hello, world!</p>
+    </div>
+  </>
+);
+
+// Prettier stable
+return (
+  <>
+    <div className="Content">
+      <p>Hello, world!</p>
+    </div>
+  </>
+);
+
+// Prettier main
+return <>
+  <div className="Content">
+    <p>Hello, world!</p>
+  </div>
+</>;
+```

--- a/changelog_unreleased/javascript/12280.md
+++ b/changelog_unreleased/javascript/12280.md
@@ -1,16 +1,3 @@
-<!--
-1. Fill in a title, the PR number and your user name.
-
-2. Optionally write a description. Many times it’s enough with just sample code.
-
-3. Change ```jsx to your language. For example, ```yaml.
-
-4. Change the `// Input` and `// Prettier` comments to the comment syntax of your language. For example, `# Input`.
-
-5. Choose some nice input example code. Paste it along with the output before and after your PR.
-
--->
-
 #### Disable wrapping JSX fragments in parens (#12280 by @user)
 
 Removing parentheses around JSX `<>` fragments reduces the amount of indentation required for elements inside of them.

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -459,7 +459,9 @@ function maybeWrapJsxElementInParens(path, elem, options) {
 
   const needsParens = pathNeedsParens(path, options);
 
-  if (path.getValue().type === "JSXFragment" && !needsParens) {
+  const node = path.getValue();
+
+  if (node.type === "JSXFragment" && !needsParens && !hasComment(node)) {
     return elem;
   }
 

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -459,6 +459,10 @@ function maybeWrapJsxElementInParens(path, elem, options) {
 
   const needsParens = pathNeedsParens(path, options);
 
+  if (path.getValue().type === "JSXFragment" && !needsParens) {
+    return elem;
+  }
+
   return group(
     [
       needsParens ? "" : ifBreak("("),

--- a/tests/format/jsx/fragment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/jsx/fragment/__snapshots__/jsfmt.spec.js.snap
@@ -110,8 +110,10 @@ function fun3() {
   </>
 </div>;
 
-foo = // comment
-<></>;
+foo = (
+  // comment
+  <></>
+);
 
 </* open fragment */>
   <Component />

--- a/tests/format/jsx/fragment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/jsx/fragment/__snapshots__/jsfmt.spec.js.snap
@@ -110,10 +110,8 @@ function fun3() {
   </>
 </div>;
 
-foo = (
-  // comment
-  <></>
-);
+foo = // comment
+<></>;
 
 </* open fragment */>
   <Component />

--- a/tests/format/jsx/fragment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/jsx/fragment/__snapshots__/jsfmt.spec.js.snap
@@ -79,6 +79,16 @@ function fun3() {
 (<></>)["computed"];
 (<></>)["computed"]();
 
+const MyComponent = () => <>
+  <div className="test" />
+</>;
+
+function MyOtherComponent() {
+  return <>
+    <div className="test" />
+  </>;
+}
+
 =====================================output=====================================
 <></>;
 
@@ -152,6 +162,16 @@ function fun3() {
 (<></>).props;
 (<></>)["computed"];
 (<></>)["computed"]();
+
+const MyComponent = () => <>
+  <div className="test" />
+</>;
+
+function MyOtherComponent() {
+  return <>
+    <div className="test" />
+  </>;
+}
 
 ================================================================================
 `;

--- a/tests/format/jsx/fragment/fragment.js
+++ b/tests/format/jsx/fragment/fragment.js
@@ -70,3 +70,13 @@ function fun3() {
 (<></>).props;
 (<></>)["computed"];
 (<></>)["computed"]();
+
+const MyComponent = () => <>
+  <div className="test" />
+</>;
+
+function MyOtherComponent() {
+  return <>
+    <div className="test" />
+  </>;
+}

--- a/tests/format/jsx/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/jsx/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -662,53 +662,47 @@ async function testFunction() {
 
 =====================================output=====================================
 async function testFunction() {
-  const short = (
-    <>
-      {await Promise.all(hierarchyCriticism)}
-      {await hierarchyCriticism.ic.me.oa.p}
-      {await hierarchyCriticism}
+  const short = <>
+    {await Promise.all(hierarchyCriticism)}
+    {await hierarchyCriticism.ic.me.oa.p}
+    {await hierarchyCriticism}
 
-      {Promise.all(hierarchyCriticism)}
-      {hierarchyCriticism.ic.me.oa.p}
-      {hierarchyCriticism}
-    </>
-  );
+    {Promise.all(hierarchyCriticism)}
+    {hierarchyCriticism.ic.me.oa.p}
+    {hierarchyCriticism}
+  </>;
 
-  const long = (
-    <>
-      {await Promise.all(
-        hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
-      )}
-      {
-        await hierarchyCriticism.IncongruousCooperate.MaterialEducation
-          .OriginalArticulate.Parameter
-      }
-      {
-        await hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
-      }
+  const long = <>
+    {await Promise.all(
+      hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+    )}
+    {
+      await hierarchyCriticism.IncongruousCooperate.MaterialEducation
+        .OriginalArticulate.Parameter
+    }
+    {
+      await hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+    }
 
-      {Promise.all(
-        hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
-      )}
-      {
-        hierarchyCriticism.IncongruousCooperate.MaterialEducation
-          .OriginalArticulate.Parameter
-      }
-      {
-        hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
-      }
-    </>
-  );
+    {Promise.all(
+      hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+    )}
+    {
+      hierarchyCriticism.IncongruousCooperate.MaterialEducation
+        .OriginalArticulate.Parameter
+    }
+    {
+      hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+    }
+  </>;
 
-  const jsx = (
-    <>
-      {await (
-        <IncongruousCooperate>
-          material education original articulate parameter
-        </IncongruousCooperate>
-      )}
-    </>
-  );
+  const jsx = <>
+    {await (
+      <IncongruousCooperate>
+        material education original articulate parameter
+      </IncongruousCooperate>
+    )}
+  </>;
 }
 
 ================================================================================
@@ -760,53 +754,47 @@ async function testFunction() {
 
 =====================================output=====================================
 async function testFunction() {
-  const short = (
-    <>
-      {await Promise.all(hierarchyCriticism)}
-      {await hierarchyCriticism.ic.me.oa.p}
-      {await hierarchyCriticism}
+  const short = <>
+    {await Promise.all(hierarchyCriticism)}
+    {await hierarchyCriticism.ic.me.oa.p}
+    {await hierarchyCriticism}
 
-      {Promise.all(hierarchyCriticism)}
-      {hierarchyCriticism.ic.me.oa.p}
-      {hierarchyCriticism}
-    </>
-  );
+    {Promise.all(hierarchyCriticism)}
+    {hierarchyCriticism.ic.me.oa.p}
+    {hierarchyCriticism}
+  </>;
 
-  const long = (
-    <>
-      {await Promise.all(
-        hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
-      )}
-      {
-        await hierarchyCriticism.IncongruousCooperate.MaterialEducation
-          .OriginalArticulate.Parameter
-      }
-      {
-        await hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
-      }
+  const long = <>
+    {await Promise.all(
+      hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+    )}
+    {
+      await hierarchyCriticism.IncongruousCooperate.MaterialEducation
+        .OriginalArticulate.Parameter
+    }
+    {
+      await hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+    }
 
-      {Promise.all(
-        hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
-      )}
-      {
-        hierarchyCriticism.IncongruousCooperate.MaterialEducation
-          .OriginalArticulate.Parameter
-      }
-      {
-        hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
-      }
-    </>
-  );
+    {Promise.all(
+      hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+    )}
+    {
+      hierarchyCriticism.IncongruousCooperate.MaterialEducation
+        .OriginalArticulate.Parameter
+    }
+    {
+      hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+    }
+  </>;
 
-  const jsx = (
-    <>
-      {await (
-        <IncongruousCooperate>
-          material education original articulate parameter
-        </IncongruousCooperate>
-      )}
-    </>
-  );
+  const jsx = <>
+    {await (
+      <IncongruousCooperate>
+        material education original articulate parameter
+      </IncongruousCooperate>
+    )}
+  </>;
 }
 
 ================================================================================
@@ -858,53 +846,47 @@ async function testFunction() {
 
 =====================================output=====================================
 async function testFunction() {
-  const short = (
-    <>
-      {await Promise.all(hierarchyCriticism)}
-      {await hierarchyCriticism.ic.me.oa.p}
-      {await hierarchyCriticism}
+  const short = <>
+    {await Promise.all(hierarchyCriticism)}
+    {await hierarchyCriticism.ic.me.oa.p}
+    {await hierarchyCriticism}
 
-      {Promise.all(hierarchyCriticism)}
-      {hierarchyCriticism.ic.me.oa.p}
-      {hierarchyCriticism}
-    </>
-  );
+    {Promise.all(hierarchyCriticism)}
+    {hierarchyCriticism.ic.me.oa.p}
+    {hierarchyCriticism}
+  </>;
 
-  const long = (
-    <>
-      {await Promise.all(
-        hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
-      )}
-      {
-        await hierarchyCriticism.IncongruousCooperate.MaterialEducation
-          .OriginalArticulate.Parameter
-      }
-      {
-        await hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
-      }
+  const long = <>
+    {await Promise.all(
+      hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+    )}
+    {
+      await hierarchyCriticism.IncongruousCooperate.MaterialEducation
+        .OriginalArticulate.Parameter
+    }
+    {
+      await hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+    }
 
-      {Promise.all(
-        hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
-      )}
-      {
-        hierarchyCriticism.IncongruousCooperate.MaterialEducation
-          .OriginalArticulate.Parameter
-      }
-      {
-        hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
-      }
-    </>
-  );
+    {Promise.all(
+      hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+    )}
+    {
+      hierarchyCriticism.IncongruousCooperate.MaterialEducation
+        .OriginalArticulate.Parameter
+    }
+    {
+      hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+    }
+  </>;
 
-  const jsx = (
-    <>
-      {await (
-        <IncongruousCooperate>
-          material education original articulate parameter
-        </IncongruousCooperate>
-      )}
-    </>
-  );
+  const jsx = <>
+    {await (
+      <IncongruousCooperate>
+        material education original articulate parameter
+      </IncongruousCooperate>
+    )}
+  </>;
 }
 
 ================================================================================
@@ -956,53 +938,47 @@ async function testFunction() {
 
 =====================================output=====================================
 async function testFunction() {
-  const short = (
-    <>
-      {await Promise.all(hierarchyCriticism)}
-      {await hierarchyCriticism.ic.me.oa.p}
-      {await hierarchyCriticism}
+  const short = <>
+    {await Promise.all(hierarchyCriticism)}
+    {await hierarchyCriticism.ic.me.oa.p}
+    {await hierarchyCriticism}
 
-      {Promise.all(hierarchyCriticism)}
-      {hierarchyCriticism.ic.me.oa.p}
-      {hierarchyCriticism}
-    </>
-  );
+    {Promise.all(hierarchyCriticism)}
+    {hierarchyCriticism.ic.me.oa.p}
+    {hierarchyCriticism}
+  </>;
 
-  const long = (
-    <>
-      {await Promise.all(
-        hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
-      )}
-      {
-        await hierarchyCriticism.IncongruousCooperate.MaterialEducation
-          .OriginalArticulate.Parameter
-      }
-      {
-        await hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
-      }
+  const long = <>
+    {await Promise.all(
+      hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+    )}
+    {
+      await hierarchyCriticism.IncongruousCooperate.MaterialEducation
+        .OriginalArticulate.Parameter
+    }
+    {
+      await hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+    }
 
-      {Promise.all(
-        hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
-      )}
-      {
-        hierarchyCriticism.IncongruousCooperate.MaterialEducation
-          .OriginalArticulate.Parameter
-      }
-      {
-        hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
-      }
-    </>
-  );
+    {Promise.all(
+      hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+    )}
+    {
+      hierarchyCriticism.IncongruousCooperate.MaterialEducation
+        .OriginalArticulate.Parameter
+    }
+    {
+      hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+    }
+  </>;
 
-  const jsx = (
-    <>
-      {await (
-        <IncongruousCooperate>
-          material education original articulate parameter
-        </IncongruousCooperate>
-      )}
-    </>
-  );
+  const jsx = <>
+    {await (
+      <IncongruousCooperate>
+        material education original articulate parameter
+      </IncongruousCooperate>
+    )}
+  </>;
 }
 
 ================================================================================

--- a/tests/format/typescript/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/comments/__snapshots__/jsfmt.spec.js.snap
@@ -95,31 +95,29 @@ let comp = (
 );
 
 =====================================output=====================================
-let comp = (
-  <>
-    <Component<number> /* comment1 */></Component>
-    <Component<number> foo /* comment2 */></Component>
-    <Component<number> /* comment3 */ bar></Component>
-    <Component<number> foo /* comment4 */ bar></Component>
+let comp = <>
+  <Component<number> /* comment1 */></Component>
+  <Component<number> foo /* comment2 */></Component>
+  <Component<number> /* comment3 */ bar></Component>
+  <Component<number> foo /* comment4 */ bar></Component>
 
-    <Component<number>
-    // comment5
-    ></Component>
-    <Component<number>
-      foo
-      // comment6
-    ></Component>
-    <Component<number>
-      // comment7
-      foo
-    ></Component>
-    <Component<number>
-      foo
-      // comment8
-      bar
-    ></Component>
-  </>
-);
+  <Component<number>
+  // comment5
+  ></Component>
+  <Component<number>
+    foo
+    // comment6
+  ></Component>
+  <Component<number>
+    // comment7
+    foo
+  ></Component>
+  <Component<number>
+    foo
+    // comment8
+    bar
+  ></Component>
+</>;
 
 ================================================================================
 `;


### PR DESCRIPTION
## Description

Since `JSXFragment` nodes can only be `<>` and `</>`, this PR removes the wrapping parens around them in almost all cases. This reduces the indention of child elements by one step, and matches the UX of using parentheses around a single JSX element.

```jsx
// Before
return (
  <>
    <div className="Content">
      <p>Hello, world!</p>
    </div>
  </>
);

// After
return <>
  <div className="Content">
    <p>Hello, world!</p>
  </div>
</>;
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- ~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
