### PR TITLE
Fix plugin Issue when node_modules not at root level within Intellij

### DIFF
--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -49,7 +49,9 @@ function load(plugins, pluginSearchDirs) {
         requirePath = resolve(path.resolve(process.cwd(), pluginName));
       } catch {
         // try node modules
-        requirePath = resolve(pluginName, { paths: [process.cwd()] });
+        requirePath = resolve(pluginName, {
+          paths: [process.cwd(), ...pluginSearchDirs],
+        });
       }
 
       return {


### PR DESCRIPTION
## Description

When utilizing prettier within Intellij and the node modules is not at the root of the project, resolve will throw an error if a plugin is defined within the .prettierrc. The pluginSearchDirs finds the appropriate node_modules, but it is not used in the externalManualPluginInfos.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works. 
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
