### PR TITLE
Build: Improve `replaceModule` plugin

### DIFF
--- a/scripts/build/bundler.mjs
+++ b/scripts/build/bundler.mjs
@@ -72,7 +72,6 @@ function* getEsbuildOptions(bundle, buildOptions) {
       if (item.input !== bundle.input) {
         replaceModule[path.join(PROJECT_ROOT, item.input)] = {
           path: `./${item.output}`,
-          isEsm: item.isEsm,
           external: true,
         };
       }

--- a/scripts/build/esbuild-plugins/replace-module.mjs
+++ b/scripts/build/esbuild-plugins/replace-module.mjs
@@ -1,54 +1,68 @@
 import { dirname } from "node:path";
 
 export default function esbuildPluginReplaceModule(replacements = {}) {
+  replacements = new Map(
+    Object.entries(replacements).map(([file, options]) => [
+      file,
+      typeof options === "string" ? { path: options } : options,
+    ])
+  );
+
   return {
     name: "replace-module",
     setup(build) {
-      build.onLoad({ filter: /./ }, ({ path, namespace }) => {
-        let options = replacements[path];
-
-        if (!options) {
+      build.onResolve({ filter: /./ }, async (args) => {
+        if (args.kind !== "import-statement") {
           return;
         }
 
-        options =
-          typeof options === "string" ? { path: options } : { ...options };
+        const resolveResult = await build.resolve(args.path, {
+          resolveDir: args.resolveDir,
+        });
+
+        if (!replacements.has(resolveResult.file)) {
+          return;
+        }
+        const { external, path } = replacements.get(resolveResult.file);
+
+        if (external) {
+          return { path, external: true };
+        }
+
+        return resolveResult;
+      });
+
+      build.onLoad({ filter: /./ }, (args) => {
+        if (!replacements.has(args.path)) {
+          return;
+        }
 
         let {
-          path: file,
+          path,
           resolveDir,
           contents,
           loader = "js",
-          external: isExternal,
           isEsm,
-        } = options;
+        } = replacements.get(args.path);
+
+        if (loader !== "js") {
+          return { contents, loader };
+        }
 
         // Make this work with `@esbuild-plugins/node-modules-polyfill` plugin
         if (
           !resolveDir &&
-          (namespace === "node-modules-polyfills-commonjs" ||
-            namespace === "node-modules-polyfills") &&
-          file
+          (args.namespace === "node-modules-polyfills-commonjs" ||
+            args.namespace === "node-modules-polyfills") &&
+          path
         ) {
-          resolveDir = dirname(file);
+          resolveDir = dirname(path);
         }
 
-        if (isExternal) {
-          if (!file) {
-            throw new Error("Missing external module path.");
-          }
-
-          // Prevent `esbuild` to resolve
-          contents = `
-            const entry = ${JSON.stringify(`${file}`)};
-            ${isEsm ? "export default" : "module.exports ="} require(entry);
-          `;
-        } else {
-          if (file) {
-            contents = isEsm
-              ? `export { default } from ${JSON.stringify(`${file}`)};`
-              : `module.exports = require(${JSON.stringify(`${file}`)})`;
-          }
+        if (path) {
+          contents = isEsm
+            ? `export { default } from ${JSON.stringify(`${path}`)};`
+            : `module.exports = require(${JSON.stringify(`${path}`)})`;
         }
 
         return { contents, loader, resolveDir };

--- a/scripts/build/esbuild-plugins/replace-module.mjs
+++ b/scripts/build/esbuild-plugins/replace-module.mjs
@@ -20,13 +20,12 @@ export default function esbuildPluginReplaceModule(replacements = {}) {
           resolveDir: args.resolveDir,
         });
 
-        if (!replacements.has(resolveResult.file)) {
-          return;
-        }
-        const { external, path } = replacements.get(resolveResult.file);
+        if (replacements.has(resolveResult.file)) {
+          const { external, path } = replacements.get(resolveResult.file);
 
-        if (external) {
-          return { path, external: true };
+          if (external) {
+            return { ...resolveResult, path, external: true };
+          }
         }
 
         return resolveResult;

--- a/scripts/build/esbuild-plugins/replace-module.mjs
+++ b/scripts/build/esbuild-plugins/replace-module.mjs
@@ -20,11 +20,11 @@ export default function esbuildPluginReplaceModule(replacements = {}) {
           resolveDir: args.resolveDir,
         });
 
-        if (replacements.has(resolveResult.file)) {
-          const { external, path } = replacements.get(resolveResult.file);
+        if (replacements.has(resolveResult.path)) {
+          const { external, path } = replacements.get(resolveResult.path);
 
           if (external) {
-            return { ...resolveResult, path, external: true };
+            return { path, external: true };
           }
         }
 

--- a/scripts/build/esbuild-plugins/replace-module.mjs
+++ b/scripts/build/esbuild-plugins/replace-module.mjs
@@ -1,71 +1,62 @@
-import { dirname } from "node:path";
-
 export default function esbuildPluginReplaceModule(replacements = {}) {
-  replacements = new Map(
-    Object.entries(replacements).map(([file, options]) => [
-      file,
-      typeof options === "string" ? { path: options } : options,
-    ])
-  );
+  const pathReplacements = new Map();
+  const contentsReplacements = new Map();
+
+  for (let [file, options] of Object.entries(replacements)) {
+    if (typeof options === "string") {
+      options = { path: options };
+    }
+
+    if (Reflect.has(options, "path")) {
+      pathReplacements.set(file, options);
+      continue;
+    }
+
+    if (Reflect.has(options, "contents")) {
+      contentsReplacements.set(file, options);
+      continue;
+    }
+
+    throw new Error("'path' or 'contents' is required.");
+  }
 
   return {
     name: "replace-module",
     setup(build) {
+      // `build.resolve()` will call `onResolve` listener
+      // Avoid infinite loop
+      const seen = new Set();
+
       build.onResolve({ filter: /./ }, async (args) => {
-        if (args.kind !== "import-statement") {
+        if (
+          !(args.kind === "require-call" || args.kind === "import-statement") ||
+          args.namespace !== "file"
+        ) {
           return;
         }
+
+        const key = JSON.stringify(args);
+        if (seen.has(key)) {
+          return;
+        }
+        seen.add(key);
 
         const resolveResult = await build.resolve(args.path, {
+          importer: args.importer,
+          namespace: args.namespace,
           resolveDir: args.resolveDir,
+          kind: args.kind,
+          pluginData: args.pluginData,
         });
 
-        if (replacements.has(resolveResult.path)) {
-          const { external, path } = replacements.get(resolveResult.path);
-
-          if (external) {
-            return { path, external: true };
-          }
-        }
-
-        return resolveResult;
+        // `build.resolve()` seems not respecting `browser` field in `package.json`
+        // Return `undefined` instead of `resolveResult` so esbuild can resolve correctly
+        return pathReplacements.get(resolveResult.path);
       });
 
-      build.onLoad({ filter: /./ }, (args) => {
-        if (!replacements.has(args.path)) {
-          return;
-        }
-
-        let {
-          path,
-          resolveDir,
-          contents,
-          loader = "js",
-          isEsm,
-        } = replacements.get(args.path);
-
-        if (loader !== "js") {
-          return { contents, loader };
-        }
-
-        // Make this work with `@esbuild-plugins/node-modules-polyfill` plugin
-        if (
-          !resolveDir &&
-          (args.namespace === "node-modules-polyfills-commonjs" ||
-            args.namespace === "node-modules-polyfills") &&
-          path
-        ) {
-          resolveDir = dirname(path);
-        }
-
-        if (path) {
-          contents = isEsm
-            ? `export { default } from ${JSON.stringify(`${path}`)};`
-            : `module.exports = require(${JSON.stringify(`${path}`)})`;
-        }
-
-        return { contents, loader, resolveDir };
-      });
+      build.onLoad({ filter: /./ }, ({ path }) =>
+        contentsReplacements.get(path)
+      );
     },
   };
 }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

```diff
-    var entry8 = "./third-party.js";
-    module2.exports = require(entry8);
+    module2.exports = require("./third-party.js");
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
