### PR TITLE
CI: Use `node-version` instead of deprecated `version`

### DIFF
--- a/.github/workflows/release-script-test.yml
+++ b/.github/workflows/release-script-test.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          version: "14"
+          node-version: "14"
           cache: "yarn"
 
       - name: Install Dependencies

--- a/.github/workflows/validate-vendor-versions.yml
+++ b/.github/workflows/validate-vendor-versions.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          version: "14"
+          node-version: "14"
           cache: "yarn"
 
       - name: Install Dependencies


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

> We removed deprecated version input (https://github.com/actions/setup-node/pull/424). Please use node-version input instead.

https://github.com/actions/setup-node/releases/tag/v3.0.0

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
