### PR TITLE
Break multiline function arguments

### DIFF
--- a/changelog_unreleased/javascript/12426.md
+++ b/changelog_unreleased/javascript/12426.md
@@ -1,0 +1,40 @@
+#### Break multiline function arguments (#12426 by @alex12058)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+instantiate(
+  game,
+  [
+    transform([-0.7, 0.5, 0]),
+    render_colored_diffuse(
+      game.MaterialDiffuse,
+      game.Meshes["monkey_flat"],
+      [1, 1, 0.3, 1]
+    ),
+  ]
+);
+
+// Prettier stable
+instantiate(game, [
+  transform([-0.7, 0.5, 0]),
+  render_colored_diffuse(
+    game.MaterialDiffuse,
+    game.Meshes["monkey_flat"],
+    [1, 1, 0.3, 1]
+  ),
+]);
+
+// Output
+instantiate(
+  game,
+  [
+    transform([-0.7, 0.5, 0]),
+    render_colored_diffuse(
+      game.MaterialDiffuse,
+      game.Meshes["monkey_flat"],
+      [1, 1, 0.3, 1]
+    ),
+  ]
+);
+```

--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -101,7 +101,7 @@ function printCallArguments(path, options, print) {
 
   const shouldGroupFirst = shouldGroupFirstArg(args);
   const shouldGroupLast = shouldGroupLastArg(args, options);
-  if (shouldGroupFirst || shouldGroupLast) {
+  if (args.length === 1 && (shouldGroupFirst || shouldGroupLast)) {
     if (
       shouldGroupFirst
         ? printedArguments.slice(1).some(willBreak)

--- a/tests/format/flow-repo/arraylib/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow-repo/arraylib/__snapshots__/jsfmt.spec.js.snap
@@ -100,9 +100,12 @@ function reduce_test() {
     return previousValue + currentValue + array[index];
   });
 
-  [0, 1, 2, 3, 4].reduce(function (previousValue, currentValue, index, array) {
-    return previousValue + currentValue + array[index];
-  }, 10);
+  [0, 1, 2, 3, 4].reduce(
+    function (previousValue, currentValue, index, array) {
+      return previousValue + currentValue + array[index];
+    },
+    10
+  );
 
   var total = [0, 1, 2, 3].reduce(function (a, b) {
     return a + b;
@@ -124,12 +127,18 @@ function reduce_test() {
 }
 
 function from_test() {
-  var a: Array<string> = Array.from([1, 2, 3], function (val, index) {
-    return index % 2 ? "foo" : String(val);
-  });
-  var b: Array<string> = Array.from([1, 2, 3], function (val) {
-    return String(val);
-  });
+  var a: Array<string> = Array.from(
+    [1, 2, 3],
+    function (val, index) {
+      return index % 2 ? "foo" : String(val);
+    }
+  );
+  var b: Array<string> = Array.from(
+    [1, 2, 3],
+    function (val) {
+      return String(val);
+    }
+  );
 }
 
 ================================================================================

--- a/tests/format/flow-repo/dom/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow-repo/dom/__snapshots__/jsfmt.spec.js.snap
@@ -485,50 +485,65 @@ let tests = [
 let tests = [
   // should work with Object.create()
   function () {
-    document.registerElement("custom-element", {
-      prototype: Object.create(HTMLElement.prototype, {
-        createdCallback: { value: function createdCallback() {} },
-        attachedCallback: { value: function attachedCallback() {} },
-        detachedCallback: { value: function detachedCallback() {} },
-        attributeChangedCallback: {
-          value: function attributeChangedCallback(
-            attributeLocalName,
-            oldAttributeValue,
-            newAttributeValue,
-            attributeNamespace
-          ) {},
-        },
-      }),
-    });
+    document.registerElement(
+      "custom-element",
+      {
+        prototype: Object.create(
+          HTMLElement.prototype,
+          {
+            createdCallback: { value: function createdCallback() {} },
+            attachedCallback: { value: function attachedCallback() {} },
+            detachedCallback: { value: function detachedCallback() {} },
+            attributeChangedCallback: {
+              value: function attributeChangedCallback(
+                attributeLocalName,
+                oldAttributeValue,
+                newAttributeValue,
+                attributeNamespace
+              ) {},
+            },
+          }
+        ),
+      }
+    );
   },
   // or with Object.assign()
   function () {
-    document.registerElement("custom-element", {
-      prototype: Object.assign(Object.create(HTMLElement.prototype), {
-        createdCallback() {},
-        attachedCallback() {},
-        detachedCallback() {},
-        attributeChangedCallback(
-          attributeLocalName,
-          oldAttributeValue,
-          newAttributeValue,
-          attributeNamespace
-        ) {},
-      }),
-    });
+    document.registerElement(
+      "custom-element",
+      {
+        prototype: Object.assign(
+          Object.create(HTMLElement.prototype),
+          {
+            createdCallback() {},
+            attachedCallback() {},
+            detachedCallback() {},
+            attributeChangedCallback(
+              attributeLocalName,
+              oldAttributeValue,
+              newAttributeValue,
+              attributeNamespace
+            ) {},
+          }
+        ),
+      }
+    );
   },
   // should complain about invalid callback parameters
   function () {
-    document.registerElement("custom-element", {
-      prototype: {
-        attributeChangedCallback(
-          localName: string,
-          oldVal: string, // Error: This might be null
-          newVal: string, // Error: This might be null
-          namespace: string
-        ) {},
-      },
-    });
+    document.registerElement(
+      "custom-element",
+      {
+        prototype: {
+          attributeChangedCallback(
+            localName: string,
+            oldVal: string, // Error: This might be null
+            newVal: string, // Error: This might be null
+            namespace: string
+          ) {},
+        },
+      }
+    );
   },
 ];
 
@@ -929,12 +944,16 @@ let tests = [
       (node) => NodeFilter.FILTER_ACCEPT
     ); // valid
     document.createNodeIterator(document.body, -1, (node) => "accept"); // invalid
-    document.createNodeIterator(document.body, -1, {
-      acceptNode: (node) => NodeFilter.FILTER_ACCEPT,
-    }); // valid
-    document.createNodeIterator(document.body, -1, {
-      acceptNode: (node) => "accept",
-    }); // invalid
+    document.createNodeIterator(
+      document.body,
+      -1,
+      { acceptNode: (node) => NodeFilter.FILTER_ACCEPT }
+    ); // valid
+    document.createNodeIterator(
+      document.body,
+      -1,
+      { acceptNode: (node) => "accept" }
+    ); // invalid
     document.createNodeIterator(document.body, -1, {}); // invalid
   },
   function () {
@@ -944,12 +963,16 @@ let tests = [
       (node) => NodeFilter.FILTER_ACCEPT
     ); // valid
     document.createTreeWalker(document.body, -1, (node) => "accept"); // invalid
-    document.createTreeWalker(document.body, -1, {
-      acceptNode: (node) => NodeFilter.FILTER_ACCEPT,
-    }); // valid
-    document.createTreeWalker(document.body, -1, {
-      acceptNode: (node) => "accept",
-    }); // invalid
+    document.createTreeWalker(
+      document.body,
+      -1,
+      { acceptNode: (node) => NodeFilter.FILTER_ACCEPT }
+    ); // valid
+    document.createTreeWalker(
+      document.body,
+      -1,
+      { acceptNode: (node) => "accept" }
+    ); // invalid
     document.createTreeWalker(document.body, -1, {}); // invalid
   },
 ];

--- a/tests/format/flow-repo/fetch/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow-repo/fetch/__snapshots__/jsfmt.spec.js.snap
@@ -218,14 +218,17 @@ const f: Request = new Request({}); // incorrect
 const g: Request = new Request("http://example.org", {}); // correct
 new Request(new URL("http://example.org")); // correct
 
-const h: Request = new Request("http://example.org", {
-  method: "GET",
-  headers: {
-    "Content-Type": "image/jpeg",
-  },
-  mode: "cors",
-  cache: "default",
-}); // correct
+const h: Request = new Request(
+  "http://example.org",
+  {
+    method: "GET",
+    headers: {
+      "Content-Type": "image/jpeg",
+    },
+    mode: "cors",
+    cache: "default",
+  }
+); // correct
 
 var bodyUsed: boolean = h.bodyUsed;
 
@@ -234,38 +237,50 @@ h.text().then((t: Buffer) => t); // incorrect
 h.arrayBuffer().then((ab: ArrayBuffer) => ab); // correct
 h.arrayBuffer().then((ab: Buffer) => ab); // incorrect
 
-const i: Request = new Request("http://example.org", {
-  method: "POST",
-  headers: {
-    "Content-Type": "application/octet-stream",
-  },
-  body: new ArrayBuffer(10),
-}); // correct
+const i: Request = new Request(
+  "http://example.org",
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/octet-stream",
+    },
+    body: new ArrayBuffer(10),
+  }
+); // correct
 
-const j: Request = new Request("http://example.org", {
-  method: "POST",
-  headers: {
-    "Content-Type": "application/octet-stream",
-  },
-  body: new Uint8Array(10),
-}); // correct
+const j: Request = new Request(
+  "http://example.org",
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/octet-stream",
+    },
+    body: new Uint8Array(10),
+  }
+); // correct
 
-const k: Request = new Request("http://example.org", {
-  method: "POST",
-  headers: {
-    "Content-Type": "image/jpeg",
-  },
-  body: new URLSearchParams("key=value"),
-  mode: "cors",
-  cache: "default",
-}); // correct
+const k: Request = new Request(
+  "http://example.org",
+  {
+    method: "POST",
+    headers: {
+      "Content-Type": "image/jpeg",
+    },
+    body: new URLSearchParams("key=value"),
+    mode: "cors",
+    cache: "default",
+  }
+); // correct
 
-const l: Request = new Request("http://example.org", {
-  method: "GET",
-  headers: "Content-Type: image/jpeg",
-  mode: "cors",
-  cache: "default",
-}); // incorrect - headers is string
+const l: Request = new Request(
+  "http://example.org",
+  {
+    method: "GET",
+    headers: "Content-Type: image/jpeg",
+    mode: "cors",
+    cache: "default",
+  }
+); // incorrect - headers is string
 
 new Request("/", { method: "post" }); // correct
 new Request("/", { method: "hello" }); // correct
@@ -336,24 +351,33 @@ new Response(null, { status: 204 }); // correct
 new Response("", { status: "404" }); // incorrect
 new Response("", { status: null }); // incorrect
 
-const f: Response = new Response("responsebody", {
-  status: 404,
-  headers: "'Content-Type': 'image/jpeg'",
-}); // incorrect
+const f: Response = new Response(
+  "responsebody",
+  {
+    status: 404,
+    headers: "'Content-Type': 'image/jpeg'",
+  }
+); // incorrect
 
-const g: Response = new Response("responsebody", {
-  status: 404,
-  headers: {
-    "Content-Type": "image/jpeg",
-  },
-}); // correct
+const g: Response = new Response(
+  "responsebody",
+  {
+    status: 404,
+    headers: {
+      "Content-Type": "image/jpeg",
+    },
+  }
+); // correct
 
-const h: Response = new Response("responsebody", {
-  status: 404,
-  headers: new Headers({
-    "Content-Type": "image/jpeg",
-  }),
-}); // correct, if verbose
+const h: Response = new Response(
+  "responsebody",
+  {
+    status: 404,
+    headers: new Headers({
+      "Content-Type": "image/jpeg",
+    }),
+  }
+); // correct, if verbose
 
 const i: Response = new Response({
   status: 404,

--- a/tests/format/flow-repo/node_tests/child_process/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow-repo/node_tests/child_process/__snapshots__/jsfmt.spec.js.snap
@@ -29,17 +29,24 @@ exec('ls', {maxBuffer: 100}, function(error, stdout, stderr) {
 var exec = require("child_process").exec;
 
 // callback only.
-exec("ls", function (error, stdout, stderr) {
-  console.info(stdout);
-});
+exec(
+  "ls",
+  function (error, stdout, stderr) {
+    console.info(stdout);
+  }
+);
 
 // options only.
 exec("ls", { timeout: 250 });
 
 // options + callback.
-exec("ls", { maxBuffer: 100 }, function (error, stdout, stderr) {
-  console.info(stdout);
-});
+exec(
+  "ls",
+  { maxBuffer: 100 },
+  function (error, stdout, stderr) {
+    console.info(stdout);
+  }
+);
 
 ================================================================================
 `;
@@ -87,25 +94,37 @@ var execFile = require("child_process").execFile;
 execFile("ls", ["-lh"]);
 
 // callback only.
-execFile("ls", function (error, stdout, stderr) {
-  console.info(stdout);
-});
+execFile(
+  "ls",
+  function (error, stdout, stderr) {
+    console.info(stdout);
+  }
+);
 
 // options only.
 execFile("wc", { timeout: 250 });
 
 // args + callback.
-execFile("ls", ["-l"], function (error, stdout, stderr) {
-  console.info(stdout);
-});
+execFile(
+  "ls",
+  ["-l"],
+  function (error, stdout, stderr) {
+    console.info(stdout);
+  }
+);
 
 // args + options.
 execFile("ls", ["-l"], { timeout: 250 });
 
 // Put it all together.
-execFile("ls", ["-l"], { timeout: 250 }, function (error, stdout, stderr) {
-  console.info(stdout);
-});
+execFile(
+  "ls",
+  ["-l"],
+  { timeout: 250 },
+  function (error, stdout, stderr) {
+    console.info(stdout);
+  }
+);
 
 ================================================================================
 `;
@@ -193,20 +212,29 @@ child_process.spawn("echo", ["-n", '"Testing..."'], { env: { TEST: "foo" } });
 // options only.
 child_process.spawn("echo", { env: { FOO: 2 } });
 
-ls.stdout.on("data", function (data) {
-  wc.stdin.write(data);
-});
-
-ls.stderr.on("data", function (data) {
-  console.warn(data);
-});
-
-ls.on("close", function (code) {
-  if (code !== 0) {
-    console.warn("\`ls\` exited with code %s", code);
+ls.stdout.on(
+  "data",
+  function (data) {
+    wc.stdin.write(data);
   }
-  wc.stdin.end();
-});
+);
+
+ls.stderr.on(
+  "data",
+  function (data) {
+    console.warn(data);
+  }
+);
+
+ls.on(
+  "close",
+  function (code) {
+    if (code !== 0) {
+      console.warn("\`ls\` exited with code %s", code);
+    }
+    wc.stdin.end();
+  }
+);
 
 wc.stdout.pipe(process.stdout);
 wc.stderr.pipe(process.stderr);

--- a/tests/format/flow-repo/node_tests/crypto/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow-repo/node_tests/crypto/__snapshots__/jsfmt.spec.js.snap
@@ -55,10 +55,13 @@ let tests = [
   function () {
     const hmac = crypto.createHmac("sha256", "a secret");
 
-    hmac.on("readable", () => {
-      (hmac.read(): ?(string | Buffer));
-      (hmac.read(): number); // 4 errors: null, void, string, Buffer
-    });
+    hmac.on(
+      "readable",
+      () => {
+        (hmac.read(): ?(string | Buffer));
+        (hmac.read(): number); // 4 errors: null, void, string, Buffer
+      }
+    );
 
     hmac.write("some data to hash");
     hmac.write(123); // 2 errors: not a string or a Buffer

--- a/tests/format/flow-repo/node_tests/fs/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow-repo/node_tests/fs/__snapshots__/jsfmt.spec.js.snap
@@ -45,21 +45,36 @@ var fs = require("fs");
 
 /* readFile */
 
-fs.readFile("file.exp", (_, data) => {
-  (data: Buffer);
-});
+fs.readFile(
+  "file.exp",
+  (_, data) => {
+    (data: Buffer);
+  }
+);
 
-fs.readFile("file.exp", "blah", (_, data) => {
-  (data: string);
-});
+fs.readFile(
+  "file.exp",
+  "blah",
+  (_, data) => {
+    (data: string);
+  }
+);
 
-fs.readFile("file.exp", { encoding: "blah" }, (_, data) => {
-  (data: string);
-});
+fs.readFile(
+  "file.exp",
+  { encoding: "blah" },
+  (_, data) => {
+    (data: string);
+  }
+);
 
-fs.readFile("file.exp", {}, (_, data) => {
-  (data: Buffer);
-});
+fs.readFile(
+  "file.exp",
+  {},
+  (_, data) => {
+    (data: Buffer);
+  }
+);
 
 /* readFileSync */
 

--- a/tests/format/flow-repo/object_assign/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow-repo/object_assign/__snapshots__/jsfmt.spec.js.snap
@@ -41,22 +41,30 @@ module.exports = {
 var EventEmitter = require("events").EventEmitter;
 
 // This pattern seems to cause the trouble.
-var Bad = Object.assign({}, EventEmitter.prototype, {
-  foo: function (): string {
-    return "hi";
-  },
-});
+var Bad = Object.assign(
+  {},
+  EventEmitter.prototype,
+  {
+    foo: function (): string {
+      return "hi";
+    },
+  }
+);
 
 // Calling Bad.foo() in the same file doesn't error
 var bad: number = Bad.foo();
 
 // Doesn't repro if I extend the class myself
 class MyEventEmitter extends events$EventEmitter {}
-var Good = Object.assign({}, MyEventEmitter.prototype, {
-  foo: function (): string {
-    return "hi";
-  },
-});
+var Good = Object.assign(
+  {},
+  MyEventEmitter.prototype,
+  {
+    foo: function (): string {
+      return "hi";
+    },
+  }
+);
 // Calling Good.foo() in the same file doesn't error
 var good: number = Good.foo();
 

--- a/tests/format/flow-repo/requireLazy/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow-repo/requireLazy/__snapshots__/jsfmt.spec.js.snap
@@ -94,17 +94,20 @@ requireLazy(['A']); // Error: No callback expression
  * @flow
  */
 
-requireLazy(["A", "B"], function (A, B) {
-  var num1: number = A.numberValueA;
-  var str1: string = A.stringValueA;
-  var num2: number = A.stringValueA; // Error: string ~> number
-  var str2: string = A.numberValueA; // Error: number ~> string
+requireLazy(
+  ["A", "B"],
+  function (A, B) {
+    var num1: number = A.numberValueA;
+    var str1: string = A.stringValueA;
+    var num2: number = A.stringValueA; // Error: string ~> number
+    var str2: string = A.numberValueA; // Error: number ~> string
 
-  var num3: number = B.numberValueB;
-  var str3: string = B.stringValueB;
-  var num4: number = B.stringValueB; // Error: string ~> number
-  var str4: string = B.numberValueB; // Error: number ~> string
-});
+    var num3: number = B.numberValueB;
+    var str3: string = B.stringValueB;
+    var num4: number = B.stringValueB; // Error: string ~> number
+    var str4: string = B.numberValueB; // Error: number ~> string
+  }
+);
 
 var notA: Object = A;
 var notB: Object = B;

--- a/tests/format/flow-repo/spread/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow-repo/spread/__snapshots__/jsfmt.spec.js.snap
@@ -218,13 +218,16 @@ function test(
   x: { kind: ?string },
   kinds: { [key: string]: string }
 ): Array<{ kind: ?string }> {
-  return map(kinds, (value) => {
-    (value: string); // OK
-    return {
-      ...x,
-      kind: value,
-    };
-  });
+  return map(
+    kinds,
+    (value) => {
+      (value: string); // OK
+      return {
+        ...x,
+        kind: value,
+      };
+    }
+  );
 }
 
 ================================================================================

--- a/tests/format/flow-repo/union_new/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow-repo/union_new/__snapshots__/jsfmt.spec.js.snap
@@ -1816,9 +1816,12 @@ printWidth: 80
 
 [0, 1].reduce((x, y, i) => y);
 
-["a", "b"].reduce((regex, representation, index) => {
-  return regex + (index ? "|" : "") + "(" + representation + ")";
-}, "");
+["a", "b"].reduce(
+  (regex, representation, index) => {
+    return regex + (index ? "|" : "") + "(" + representation + ")";
+  },
+  ""
+);
 
 [""].reduce((acc, str) => acc * str.length);
 

--- a/tests/format/html/script/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/html/script/__snapshots__/jsfmt.spec.js.snap
@@ -100,10 +100,13 @@ async function foo() {
   import prettier from "prettier/standalone";
   import parserGraphql from "prettier/parser-graphql";
 
-  prettier.format("query { }", {
-    parser: "graphql",
-    plugins: [parserGraphql],
-  });
+  prettier.format(
+    "query { }",
+    {
+      parser: "graphql",
+      plugins: [parserGraphql],
+    }
+  );
 </script>
 
 <script type="module">

--- a/tests/format/js/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -877,10 +877,13 @@ foo(
 =====================================output=====================================
 Seq(typeDef.interface.groups).forEach((group) =>
   Seq(group.members).forEach((member, memberName) =>
-    markdownDoc(member.doc, {
-      typePath: typePath.concat(memberName.slice(1)),
-      signatures: member.signatures,
-    })
+    markdownDoc(
+      member.doc,
+      {
+        typePath: typePath.concat(memberName.slice(1)),
+        signatures: member.signatures,
+      }
+    )
   )
 );
 
@@ -1674,10 +1677,13 @@ foo(
 =====================================output=====================================
 Seq(typeDef.interface.groups).forEach(group =>
   Seq(group.members).forEach((member, memberName) =>
-    markdownDoc(member.doc, {
-      typePath: typePath.concat(memberName.slice(1)),
-      signatures: member.signatures,
-    })
+    markdownDoc(
+      member.doc,
+      {
+        typePath: typePath.concat(memberName.slice(1)),
+        signatures: member.signatures,
+      }
+    )
   )
 );
 
@@ -3204,9 +3210,12 @@ request.get('https://preview-9992--prettier.netlify.app', head => body => modyLo
 const a = (x) => (y) => (z) =>
   x / 0.123456789 + (y * calculateSomething(z)) / Math.PI;
 
-request.get("https://preview-9992--prettier.netlify.app", (head) => (body) => {
-  console.log(head, body);
-});
+request.get(
+  "https://preview-9992--prettier.netlify.app",
+  (head) => (body) => {
+    console.log(head, body);
+  }
+);
 
 request.get(
   "https://preview-9992--prettier.netlify.app",
@@ -3253,9 +3262,12 @@ request.get('https://preview-9992--prettier.netlify.app', head => body => modyLo
 const a = x => y => z =>
   x / 0.123456789 + (y * calculateSomething(z)) / Math.PI;
 
-request.get("https://preview-9992--prettier.netlify.app", head => body => {
-  console.log(head, body);
-});
+request.get(
+  "https://preview-9992--prettier.netlify.app",
+  head => body => {
+    console.log(head, body);
+  }
+);
 
 request.get(
   "https://preview-9992--prettier.netlify.app",

--- a/tests/format/js/assignment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/assignment/__snapshots__/jsfmt.spec.js.snap
@@ -550,9 +550,10 @@ async function f() {
   return { data, status };
 }
 
-const data1 = request.delete("----------------------------------------------", {
-  validateStatus: () => true,
-});
+const data1 = request.delete(
+  "----------------------------------------------",
+  { validateStatus: () => true }
+);
 
 const data2 = request.delete(
   "----------------------------------------------x",

--- a/tests/format/js/cursor/jsfmt.spec.js
+++ b/tests/format/js/cursor/jsfmt.spec.js
@@ -39,11 +39,14 @@ foo('bar', cb => {
   expect(
     prettier.formatWithCursor(code, { parser: "babel", cursorOffset: 24 })
   ).toMatchObject({
-    formatted: `foo("bar", (cb) => {
-  console.log("stuff");
-});
+    formatted: `foo(
+  "bar",
+  (cb) => {
+    console.log("stuff");
+  }
+);
 `,
-    cursorOffset: 25,
+    cursorOffset: 32,
   });
 });
 

--- a/tests/format/js/first-argument-expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/first-argument-expansion/__snapshots__/jsfmt.spec.js.snap
@@ -121,41 +121,68 @@ func((args) => {
 }, result => result && console.log("success"))
 
 =====================================output=====================================
-setTimeout(function () {
-  thing();
-}, 500);
+setTimeout(
+  function () {
+    thing();
+  },
+  500
+);
 
-["a", "b", "c"].reduce(function (item, thing) {
-  return thing + " " + item;
-}, "letters:");
+["a", "b", "c"].reduce(
+  function (item, thing) {
+    return thing + " " + item;
+  },
+  "letters:"
+);
 
-func(() => {
-  thing();
-}, identifier);
+func(
+  () => {
+    thing();
+  },
+  identifier
+);
 
-func(function () {
-  thing();
-}, this.props.timeout * 1000);
+func(
+  function () {
+    thing();
+  },
+  this.props.timeout * 1000
+);
 
-func((that) => {
-  thing();
-}, this.props.getTimeout());
+func(
+  (that) => {
+    thing();
+  },
+  this.props.getTimeout()
+);
 
-func(() => {
-  thing();
-}, true);
+func(
+  () => {
+    thing();
+  },
+  true
+);
 
-func(() => {
-  thing();
-}, null);
+func(
+  () => {
+    thing();
+  },
+  null
+);
 
-func(() => {
-  thing();
-}, undefined);
+func(
+  () => {
+    thing();
+  },
+  undefined
+);
 
-func(() => {
-  thing();
-}, /regex.*?/);
+func(
+  () => {
+    thing();
+  },
+  /regex.*?/
+);
 
 func(
   () => {
@@ -208,13 +235,19 @@ compose(
   (b) => b * b
 );
 
-somthing.reduce(function (item, thing) {
-  return (thing.blah = item);
-}, {});
+somthing.reduce(
+  function (item, thing) {
+    return (thing.blah = item);
+  },
+  {}
+);
 
-somthing.reduce(function (item, thing) {
-  return thing.push(item);
-}, []);
+somthing.reduce(
+  function (item, thing) {
+    return thing.push(item);
+  },
+  []
+);
 
 reallyLongLongLongLongLongLongLongLongLongLongLongLongLongLongMethod(
   (f, g, h) => {

--- a/tests/format/js/functional-composition/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/functional-composition/__snapshots__/jsfmt.spec.js.snap
@@ -127,10 +127,13 @@ app.connect(
 
 =====================================output=====================================
 button.connect("clicked", () => doSomething());
-app.connect("activate", async () => {
-  await data.load();
-  win.show_all();
-});
+app.connect(
+  "activate",
+  async () => {
+    await data.load();
+    win.show_all();
+  }
+);
 
 ================================================================================
 `;
@@ -250,10 +253,13 @@ MongoClient.connect(
 );
 
 =====================================output=====================================
-MongoClient.connect("mongodb://localhost:27017/posts", (err, db) => {
-  assert.equal(null, err);
-  db.close();
-});
+MongoClient.connect(
+  "mongodb://localhost:27017/posts",
+  (err, db) => {
+    assert.equal(null, err);
+    db.close();
+  }
+);
 
 ================================================================================
 `;
@@ -674,12 +680,15 @@ const bar = createSelector(
 =====================================output=====================================
 import { createSelector } from "reselect";
 
-const foo = createSelector(getIds, getObjects, (ids, objects) =>
-  ids.map((id) => objects[id])
+const foo = createSelector(
+  getIds,
+  getObjects,
+  (ids, objects) => ids.map((id) => objects[id])
 );
 
-const bar = createSelector([getIds, getObjects], (ids, objects) =>
-  ids.map((id) => objects[id])
+const bar = createSelector(
+  [getIds, getObjects],
+  (ids, objects) => ids.map((id) => objects[id])
 );
 
 ================================================================================

--- a/tests/format/js/last-argument-expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/last-argument-expansion/__snapshots__/jsfmt.spec.js.snap
@@ -551,14 +551,17 @@ instantiate(game, [
 ]);
 
 =====================================output=====================================
-instantiate(game, [
-  transform([-0.7, 0.5, 0]),
-  render_colored_diffuse(
-    game.MaterialDiffuse,
-    game.Meshes["monkey_flat"],
-    [1, 1, 0.3, 1]
-  ),
-]);
+instantiate(
+  game,
+  [
+    transform([-0.7, 0.5, 0]),
+    render_colored_diffuse(
+      game.MaterialDiffuse,
+      game.Meshes["monkey_flat"],
+      [1, 1, 0.3, 1]
+    ),
+  ]
+);
 
 ================================================================================
 `;
@@ -695,12 +698,38 @@ func(
   yes,
   []
 );
-func(one, two, three, four, five, six, seven, eig, is, this, too, long, yes, [
-  // Comments
-]);
-func(five, six, seven, eig, is, this, too, long, yes, [
-  // Comments
-]);
+func(
+  one,
+  two,
+  three,
+  four,
+  five,
+  six,
+  seven,
+  eig,
+  is,
+  this,
+  too,
+  long,
+  yes,
+  [
+    // Comments
+  ]
+);
+func(
+  five,
+  six,
+  seven,
+  eig,
+  is,
+  this,
+  too,
+  long,
+  yes,
+  [
+    // Comments
+  ]
+);
 
 func(one, two, three, four, five, six, seven, eig, is, this, too, long, no, {});
 func(
@@ -719,9 +748,24 @@ func(
   yes,
   {}
 );
-func(one, two, three, four, five, six, seven, eig, is, this, too, long, yes, {
-  // Comments
-});
+func(
+  one,
+  two,
+  three,
+  four,
+  five,
+  six,
+  seven,
+  eig,
+  is,
+  this,
+  too,
+  long,
+  yes,
+  {
+    // Comments
+  }
+);
 
 foo(
   (

--- a/tests/format/js/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -429,9 +429,12 @@ nock(/test/)
 nock(/test/)
   .matchHeader("Accept", "application/json")
   [httpMethodNock(method)]("/foo")
-  .reply(200, {
-    foo: "bar",
-  });
+  .reply(
+    200,
+    {
+      foo: "bar",
+    }
+  );
 
 ================================================================================
 `;
@@ -1044,10 +1047,13 @@ d3.select("body")
 
 Object.keys(props)
   .filter((key) => key in own === false)
-  .reduce((a, key) => {
-    a[key] = props[key];
-    return a;
-  }, {});
+  .reduce(
+    (a, key) => {
+      a[key] = props[key];
+      return a;
+    },
+    {}
+  );
 
 point().x(4).y(3).z(6).plot();
 

--- a/tests/format/js/module-blocks/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/module-blocks/__snapshots__/jsfmt.spec.js.snap
@@ -311,12 +311,15 @@ let worker = new Worker(module {
 worker.postMessage(module { export function fn() { return "hello!" } });
 
 =====================================output=====================================
-let worker = new Worker(module {
-  onmessage = function ({ data }) {
-    let mod = import(data);
-    postMessage(mod.fn());
-  };
-}, { type: "module" });
+let worker = new Worker(
+  module {
+    onmessage = function ({ data }) {
+      let mod = import(data);
+      postMessage(mod.fn());
+    };
+  },
+  { type: "module" }
+);
 
 let worker = new Worker(
   module {

--- a/tests/format/js/multiparser-html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/multiparser-html/__snapshots__/jsfmt.spec.js.snap
@@ -189,8 +189,9 @@ export default function include_photoswipe(
 export default function include_photoswipe(gallery_selector = ".my-gallery") {
   return /* HTML */ \`
     <script>
-      window.addEventListener("load", () =>
-        initPhotoSwipeFromDOM("\${gallery_selector}")
+      window.addEventListener(
+        "load",
+        () => initPhotoSwipeFromDOM("\${gallery_selector}")
       );
     </script>
   \`;
@@ -219,8 +220,9 @@ export default function include_photoswipe(
 =====================================output=====================================
 export default function include_photoswipe(gallery_selector = ".my-gallery") {
   return /* HTML */ \` <script>
-    window.addEventListener("load", () =>
-      initPhotoSwipeFromDOM("\${gallery_selector}")
+    window.addEventListener(
+      "load",
+      () => initPhotoSwipeFromDOM("\${gallery_selector}")
     );
   </script>\`;
 }

--- a/tests/format/js/performance/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/performance/__snapshots__/jsfmt.spec.js.snap
@@ -161,70 +161,83 @@ tap.test("RecordImport.advance", (t) => {
 });
 
 =====================================output=====================================
-tap.test("RecordImport.advance", (t) => {
-  const checkStates = (batches, states) => {
-    t.equal(batches.length, states.length);
-    for (const batch of batches) {
-      t.equal(batch.state, states.shift());
-      t.ok(batch.getCurState().name(i18n));
-    }
-  };
-
-  const batch = init.getRecordBatch();
-  const dataFile = path.resolve(process.cwd(), "testData", "default.json");
-
-  const getBatches = (callback) => {
-    RecordImport.find({}, "", {}, (err, batches) => {
-      callback(
-        null,
-        batches.filter(
-          (batch) => batch.state !== "error" && batch.state !== "completed"
-        )
-      );
-    });
-  };
-
-  mockFS((callback) => {
-    batch.setResults([fs.createReadStream(dataFile)], (err) => {
-      t.error(err, "Error should be empty.");
-      t.equal(batch.results.length, 6, "Check number of results");
-      for (const result of batch.results) {
-        t.equal(result.result, "unknown");
-        t.ok(result.data);
-        t.equal(result.data.lang, "en");
+tap.test(
+  "RecordImport.advance",
+  (t) => {
+    const checkStates = (batches, states) => {
+      t.equal(batches.length, states.length);
+      for (const batch of batches) {
+        t.equal(batch.state, states.shift());
+        t.ok(batch.getCurState().name(i18n));
       }
+    };
 
-      getBatches((err, batches) => {
-        checkStates(batches, ["started"]);
+    const batch = init.getRecordBatch();
+    const dataFile = path.resolve(process.cwd(), "testData", "default.json");
 
-        RecordImport.advance((err) => {
+    const getBatches = (callback) => {
+      RecordImport.find(
+        {},
+        "",
+        {},
+        (err, batches) => {
+          callback(
+            null,
+            batches.filter(
+              (batch) => batch.state !== "error" && batch.state !== "completed"
+            )
+          );
+        }
+      );
+    };
+
+    mockFS((callback) => {
+      batch.setResults(
+        [fs.createReadStream(dataFile)],
+        (err) => {
           t.error(err, "Error should be empty.");
+          t.equal(batch.results.length, 6, "Check number of results");
+          for (const result of batch.results) {
+            t.equal(result.result, "unknown");
+            t.ok(result.data);
+            t.equal(result.data.lang, "en");
+          }
 
           getBatches((err, batches) => {
-            checkStates(batches, ["process.completed"]);
+            checkStates(batches, ["started"]);
 
-            // Need to manually move to the next step
-            batch.importRecords((err) => {
+            RecordImport.advance((err) => {
               t.error(err, "Error should be empty.");
 
               getBatches((err, batches) => {
-                checkStates(batches, ["import.completed"]);
+                checkStates(batches, ["process.completed"]);
 
-                RecordImport.advance((err) => {
+                // Need to manually move to the next step
+                batch.importRecords((err) => {
                   t.error(err, "Error should be empty.");
 
                   getBatches((err, batches) => {
-                    checkStates(batches, ["similarity.sync.completed"]);
+                    checkStates(batches, ["import.completed"]);
 
                     RecordImport.advance((err) => {
                       t.error(err, "Error should be empty.");
 
-                      t.ok(batch.getCurState().name(i18n));
-
                       getBatches((err, batches) => {
-                        checkStates(batches, []);
-                        t.end();
-                        callback();
+                        checkStates(batches, ["similarity.sync.completed"]);
+
+                        RecordImport.advance((err) => {
+                          t.error(err, "Error should be empty.");
+
+                          t.ok(batch.getCurState().name(i18n));
+
+                          getBatches((err, batches) => {
+                            checkStates(batches, []);
+                            t.end();
+                            callback();
+                          });
+                        });
+
+                        t.ok(batch.getCurState().name(i18n));
                       });
                     });
 
@@ -238,13 +251,11 @@ tap.test("RecordImport.advance", (t) => {
 
             t.ok(batch.getCurState().name(i18n));
           });
-        });
-
-        t.ok(batch.getCurState().name(i18n));
-      });
+        }
+      );
     });
-  });
-});
+  }
+);
 
 ================================================================================
 `;

--- a/tests/format/js/template-literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/template-literals/__snapshots__/jsfmt.spec.js.snap
@@ -220,9 +220,12 @@ console.log(
   \`\\nApparently jetbrains changed the release artifact for \${app.name}@\${app.jetbrains.version}.\\n\`
 );
 
-descirbe("something", () => {
-  test(\`{pass: false} expect(\${small}).toBeGreaterThanOrEqual(\${big})\`, () => {});
-});
+descirbe(
+  "something",
+  () => {
+    test(\`{pass: false} expect(\${small}).toBeGreaterThanOrEqual(\${big})\`, () => {});
+  }
+);
 
 throw new Error(
   \`pretty-format: Option "theme" has a key "\${key}" whose value "\${value}" is undefined in ansi-styles.\`

--- a/tests/format/js/template/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/template/__snapshots__/jsfmt.spec.js.snap
@@ -174,10 +174,10 @@ module.exports = Relay.createContainer(
       nodes: ({ solution_type, time_frame }) => Relay.QL\`
         fragment on RelatedNode @relay(plural: true) {
           __typename
-          \${OptimalSolutionsSection.getFragment("node", {
-            solution_type,
-            time_frame,
-          })}
+          \${OptimalSolutionsSection.getFragment(
+            "node",
+            { solution_type, time_frame }
+          )}
         }
       \`,
     },

--- a/tests/format/js/test-declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/test-declarations/__snapshots__/jsfmt.spec.js.snap
@@ -618,19 +618,22 @@ describe.each\`
   \${11}        | \${1}     | \${222}
   \${1 - 1}     | \${2 + 2} | \${3333}
   \${2 + 1 + 2} | \${1111}  | \${3}
-\`("$a + $b", ({ a, b, expected }) => {
-  test(\`returns \${expected}\`, () => {
-    expect(a + b).toBe(expected);
-  });
+\`(
+  "$a + $b",
+  ({ a, b, expected }) => {
+    test(\`returns \${expected}\`, () => {
+      expect(a + b).toBe(expected);
+    });
 
-  test(\`returned value not be greater than \${expected}\`, () => {
-    expect(a + b).not.toBeGreaterThan(expected);
-  });
+    test(\`returned value not be greater than \${expected}\`, () => {
+      expect(a + b).not.toBeGreaterThan(expected);
+    });
 
-  test(\`returned value not be less than \${expected}\`, () => {
-    expect(a + b).not.toBeLessThan(expected);
-  });
-});
+    test(\`returned value not be less than \${expected}\`, () => {
+      expect(a + b).not.toBeLessThan(expected);
+    });
+  }
+);
 
 describe.only.each\`
   a            | b        | expected
@@ -664,25 +667,34 @@ describe.each\`
   \${2} | \${1} | \${3}
 \`;
 
-describe.each([1, 2, 3])("test", a => {
-  expect(a).toBe(a);
-});
+describe.each([1, 2, 3])(
+  "test",
+  a => {
+    expect(a).toBe(a);
+  }
+);
 
 test.only.each([
   [1, 1, 2],
   [1, 2, 3],
   [2, 1, 3],
-])(".add(%i, %i)", (a, b, expected) => {
-  expect(a + b).toBe(expected);
-});
+])(
+  ".add(%i, %i)",
+  (a, b, expected) => {
+    expect(a + b).toBe(expected);
+  }
+);
 
 test.each([
   { a: "1", b: 1 },
   { a: "2", b: 2 },
   { a: "3", b: 3 },
-])("test", ({ a, b }) => {
-  expect(Number(a)).toBe(b);
-});
+])(
+  "test",
+  ({ a, b }) => {
+    expect(Number(a)).toBe(b);
+  }
+);
 
 ================================================================================
 `;
@@ -762,19 +774,22 @@ describe.each\`
   \${11}        | \${1}     | \${222}
   \${1 - 1}     | \${2 + 2} | \${3333}
   \${2 + 1 + 2} | \${1111}  | \${3}
-\`("$a + $b", ({ a, b, expected }) => {
-  test(\`returns \${expected}\`, () => {
-    expect(a + b).toBe(expected);
-  });
+\`(
+  "$a + $b",
+  ({ a, b, expected }) => {
+    test(\`returns \${expected}\`, () => {
+      expect(a + b).toBe(expected);
+    });
 
-  test(\`returned value not be greater than \${expected}\`, () => {
-    expect(a + b).not.toBeGreaterThan(expected);
-  });
+    test(\`returned value not be greater than \${expected}\`, () => {
+      expect(a + b).not.toBeGreaterThan(expected);
+    });
 
-  test(\`returned value not be less than \${expected}\`, () => {
-    expect(a + b).not.toBeLessThan(expected);
-  });
-});
+    test(\`returned value not be less than \${expected}\`, () => {
+      expect(a + b).not.toBeLessThan(expected);
+    });
+  }
+);
 
 describe.only.each\`
   a            | b        | expected
@@ -808,25 +823,34 @@ describe.each\`
   \${2} | \${1} | \${3}
 \`;
 
-describe.each([1, 2, 3])("test", (a) => {
-  expect(a).toBe(a);
-});
+describe.each([1, 2, 3])(
+  "test",
+  (a) => {
+    expect(a).toBe(a);
+  }
+);
 
 test.only.each([
   [1, 1, 2],
   [1, 2, 3],
   [2, 1, 3],
-])(".add(%i, %i)", (a, b, expected) => {
-  expect(a + b).toBe(expected);
-});
+])(
+  ".add(%i, %i)",
+  (a, b, expected) => {
+    expect(a + b).toBe(expected);
+  }
+);
 
 test.each([
   { a: "1", b: 1 },
   { a: "2", b: 2 },
   { a: "3", b: 3 },
-])("test", ({ a, b }) => {
-  expect(Number(a)).toBe(b);
-});
+])(
+  "test",
+  ({ a, b }) => {
+    expect(Number(a)).toBe(b);
+  }
+);
 
 ================================================================================
 `;

--- a/tests/format/js/throw_expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/throw_expressions/__snapshots__/jsfmt.spec.js.snap
@@ -54,9 +54,12 @@ class Product {
 =====================================output=====================================
 function save(filename = throw new TypeError("Argument required")) {}
 
-lint(ast, {
-  with: () => throw new Error("avoid using 'with' statements."),
-});
+lint(
+  ast,
+  {
+    with: () => throw new Error("avoid using 'with' statements."),
+  }
+);
 
 function getEncoder(encoding) {
   const encoder =

--- a/tests/format/js/variable_declarator/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/variable_declarator/__snapshots__/jsfmt.spec.js.snap
@@ -51,9 +51,12 @@ var templateTagsMapping = {
     "%{itemContentMetaTextViews}": "views",
   },
   separator = '<span class="item__content__meta__separator">•</span>',
-  templateTagsList = $.map(templateTagsMapping, function (value, key) {
-    return key;
-  }),
+  templateTagsList = $.map(
+    templateTagsMapping,
+    function (value, key) {
+      return key;
+    }
+  ),
   data;
 
 ================================================================================

--- a/tests/format/jsx/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/jsx/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -54,9 +54,12 @@ const UsersList = ({ users }) => (
 const TodoList = ({ todos }) => (
   <div className="TodoList">
     <ul>
-      {_.map(todos, (todo, i) => (
-        <TodoItem key={i} {...todo} />
-      ))}
+      {_.map(
+        todos,
+        (todo, i) => (
+          <TodoItem key={i} {...todo} />
+        )
+      )}
     </ul>
   </div>
 );
@@ -132,9 +135,12 @@ const UsersList = ({ users }) => (
 const TodoList = ({ todos }) => (
   <div className='TodoList'>
     <ul>
-      {_.map(todos, (todo, i) => (
-        <TodoItem key={i} {...todo} />
-      ))}
+      {_.map(
+        todos,
+        (todo, i) => (
+          <TodoItem key={i} {...todo} />
+        )
+      )}
     </ul>
   </div>
 );
@@ -210,9 +216,12 @@ const UsersList = ({ users }) => (
 const TodoList = ({ todos }) => (
   <div className="TodoList">
     <ul>
-      {_.map(todos, (todo, i) => (
-        <TodoItem key={i} {...todo} />
-      ))}
+      {_.map(
+        todos,
+        (todo, i) => (
+          <TodoItem key={i} {...todo} />
+        )
+      )}
     </ul>
   </div>
 );
@@ -288,9 +297,12 @@ const UsersList = ({ users }) => (
 const TodoList = ({ todos }) => (
   <div className='TodoList'>
     <ul>
-      {_.map(todos, (todo, i) => (
-        <TodoItem key={i} {...todo} />
-      ))}
+      {_.map(
+        todos,
+        (todo, i) => (
+          <TodoItem key={i} {...todo} />
+        )
+      )}
     </ul>
   </div>
 );

--- a/tests/format/markdown/markdown/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/markdown/markdown/__snapshots__/jsfmt.spec.js.snap
@@ -1508,13 +1508,16 @@ function. The function signature of the parser function is:
 Prettier's built-in parsers are exposed as properties on the \`parsers\` argument.
 
 \`\`\`js
-prettier.format('lodash ( )', {
-  parser(text, { babylon }) {
-    const ast = babylon(text);
-    ast.program.body[0].expression.callee.name = '_';
-    return ast;
-  },
-});
+prettier.format(
+  'lodash ( )',
+  {
+    parser(text, { babylon }) {
+      const ast = babylon(text);
+      ast.program.body[0].expression.callee.name = '_';
+      return ast;
+    },
+  }
+);
 // -> "_();\\n"
 \`\`\`
 
@@ -3487,13 +3490,16 @@ function. The function signature of the parser function is:
 Prettier's built-in parsers are exposed as properties on the \`parsers\` argument.
 
 \`\`\`js
-prettier.format("lodash ( )", {
-  parser(text, { babylon }) {
-    const ast = babylon(text);
-    ast.program.body[0].expression.callee.name = "_";
-    return ast;
-  },
-});
+prettier.format(
+  "lodash ( )",
+  {
+    parser(text, { babylon }) {
+      const ast = babylon(text);
+      ast.program.body[0].expression.callee.name = "_";
+      return ast;
+    },
+  }
+);
 // -> "_();\\n"
 \`\`\`
 

--- a/tests/format/typescript/argument-expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/argument-expansion/__snapshots__/jsfmt.spec.js.snap
@@ -39,13 +39,19 @@ const bar8 = [1,2,3].reduce((carry, value) => {
 }, <{[key: number]: boolean}>{1: true});
 
 =====================================output=====================================
-const bar1 = [1, 2, 3].reduce((carry, value) => {
-  return [...carry, value];
-}, [] as unknown as number[]);
+const bar1 = [1, 2, 3].reduce(
+  (carry, value) => {
+    return [...carry, value];
+  },
+  [] as unknown as number[]
+);
 
-const bar2 = [1, 2, 3].reduce((carry, value) => {
-  return [...carry, value];
-}, <Array<number>>[]);
+const bar2 = [1, 2, 3].reduce(
+  (carry, value) => {
+    return [...carry, value];
+  },
+  <Array<number>>[]
+);
 
 const bar3 = [1, 2, 3].reduce(
   (carry, value) => {
@@ -61,13 +67,19 @@ const bar4 = [1, 2, 3].reduce(
   <Array<number>>[1, 2, 3]
 );
 
-const bar5 = [1, 2, 3].reduce((carry, value) => {
-  return { ...carry, [value]: true };
-}, {} as unknown as { [key: number]: boolean });
+const bar5 = [1, 2, 3].reduce(
+  (carry, value) => {
+    return { ...carry, [value]: true };
+  },
+  {} as unknown as { [key: number]: boolean }
+);
 
-const bar6 = [1, 2, 3].reduce((carry, value) => {
-  return { ...carry, [value]: true };
-}, <{ [key: number]: boolean }>{});
+const bar6 = [1, 2, 3].reduce(
+  (carry, value) => {
+    return { ...carry, [value]: true };
+  },
+  <{ [key: number]: boolean }>{}
+);
 
 const bar7 = [1, 2, 3].reduce(
   (carry, value) => {
@@ -114,9 +126,13 @@ longfunctionWithCall1("bla", foo, (thing: string): complex<type<\`
 });
 
 =====================================output=====================================
-longfunctionWithCall1("bla", foo, (thing: string): complex<type<something>> => {
-  code();
-});
+longfunctionWithCall1(
+  "bla",
+  foo,
+  (thing: string): complex<type<something>> => {
+    code();
+  }
+);
 
 longfunctionWithCall12(
   "bla",

--- a/tests/format/typescript/arrow/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/arrow/__snapshots__/jsfmt.spec.js.snap
@@ -35,9 +35,12 @@ const foo = (x: string): void =>
     () => {}
   )
 
-app.get("/", (req, res): void => {
-  res.send("Hello world")
-})
+app.get(
+  "/",
+  (req, res): void => {
+    res.send("Hello world")
+  }
+)
 
 ================================================================================
 `;
@@ -76,9 +79,12 @@ const foo = (x: string): void =>
     () => {}
   );
 
-app.get("/", (req, res): void => {
-  res.send("Hello world");
-});
+app.get(
+  "/",
+  (req, res): void => {
+    res.send("Hello world");
+  }
+);
 
 ================================================================================
 `;

--- a/tests/format/typescript/as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/as/__snapshots__/jsfmt.spec.js.snap
@@ -177,16 +177,22 @@ const TYPE_MAP = {
   "symbolic link": "link",
 } as Foo;
 
-this.previewPlayerHandle = setInterval(async () => {
-  if (this.previewIsPlaying) {
-    await this.fetchNextPreviews();
-    this.currentPreviewIndex++;
-  }
-}, this.refreshDelay) as unknown as number;
+this.previewPlayerHandle = setInterval(
+  async () => {
+    if (this.previewIsPlaying) {
+      await this.fetchNextPreviews();
+      this.currentPreviewIndex++;
+    }
+  },
+  this.refreshDelay
+) as unknown as number;
 
-this.intervalID = setInterval(() => {
-  self.step();
-}, 30) as unknown as number;
+this.intervalID = setInterval(
+  () => {
+    self.step();
+  },
+  30
+) as unknown as number;
 
 ================================================================================
 `;
@@ -236,14 +242,17 @@ const defaultMaskGetter = $parse(attrs[directiveName]) as (
   (this.editorBody as any) =
     undefined;
 
-angular.module("foo").directive("formIsolator", () => {
-  return {
-    name: "form",
-    controller: class FormIsolatorController {
-      $addControl = angular.noop;
-    } as ng.IControllerConstructor,
-  };
-});
+angular.module("foo").directive(
+  "formIsolator",
+  () => {
+    return {
+      name: "form",
+      controller: class FormIsolatorController {
+        $addControl = angular.noop;
+      } as ng.IControllerConstructor,
+    };
+  }
+);
 
 (this.selectorElem as any) =
   this.multiselectWidget =

--- a/tests/format/typescript/last-argument-expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/last-argument-expansion/__snapshots__/jsfmt.spec.js.snap
@@ -19,19 +19,22 @@ export default class AddAssetHtmlPlugin {
 =====================================output=====================================
 export default class AddAssetHtmlPlugin {
   apply(compiler: WebpackCompilerType) {
-    compiler.plugin("compilation", (compilation: WebpackCompilationType) => {
-      compilation.plugin(
-        "html-webpack-plugin-before-html",
-        (callback: Callback<any>) => {
-          addAllAssetsToCompilation(
-            this.assets,
-            compilation,
-            htmlPluginData,
-            callback
-          );
-        }
-      );
-    });
+    compiler.plugin(
+      "compilation",
+      (compilation: WebpackCompilationType) => {
+        compilation.plugin(
+          "html-webpack-plugin-before-html",
+          (callback: Callback<any>) => {
+            addAllAssetsToCompilation(
+              this.assets,
+              compilation,
+              htmlPluginData,
+              callback
+            );
+          }
+        );
+      }
+    );
   }
 }
 
@@ -61,10 +64,10 @@ var listener = DOM.listen(
   "click",
   sigil,
   (event: JavelinEvent): void =>
-    BanzaiLogger.log(config, {
-      ...logData,
-      ...DataStore.get(event.getNode(sigil)),
-    })
+    BanzaiLogger.log(
+      config,
+      { ...logData, ...DataStore.get(event.getNode(sigil)) }
+    )
 );
 
 ================================================================================

--- a/tests/format/vue/html-vue/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/vue/html-vue/__snapshots__/jsfmt.spec.js.snap
@@ -170,67 +170,75 @@ printWidth: 80
     </div>
 
     <script>
-      Vue.component("draggable-header-view", {
-        template: "#header-view-template",
-        data: function () {
-          return {
-            dragging: false,
-            // quadratic bezier control point
-            c: { x: 160, y: 160 },
-            // record drag start point
-            start: { x: 0, y: 0 },
-          };
-        },
-        computed: {
-          headerPath: function () {
-            return (
-              "M0,0 L320,0 320,160" + "Q" + this.c.x + "," + this.c.y + " 0,160"
-            );
-          },
-          contentPosition: function () {
-            var dy = this.c.y - 160;
-            var dampen = dy > 0 ? 2 : 4;
+      Vue.component(
+        "draggable-header-view",
+        {
+          template: "#header-view-template",
+          data: function () {
             return {
-              transform: "translate3d(0," + dy / dampen + "px,0)",
+              dragging: false,
+              // quadratic bezier control point
+              c: { x: 160, y: 160 },
+              // record drag start point
+              start: { x: 0, y: 0 },
             };
           },
-        },
-        methods: {
-          startDrag: function (e) {
-            e = e.changedTouches ? e.changedTouches[0] : e;
-            this.dragging = true;
-            this.start.x = e.pageX;
-            this.start.y = e.pageY;
-          },
-          onDrag: function (e) {
-            e = e.changedTouches ? e.changedTouches[0] : e;
-            if (this.dragging) {
-              this.c.x = 160 + (e.pageX - this.start.x);
-              // dampen vertical drag by a factor
-              var dy = e.pageY - this.start.y;
-              var dampen = dy > 0 ? 1.5 : 4;
-              this.c.y = 160 + dy / dampen;
-            }
-          },
-          stopDrag: function () {
-            if (this.dragging) {
-              this.dragging = false;
-              dynamics.animate(
-                this.c,
-                {
-                  x: 160,
-                  y: 160,
-                },
-                {
-                  type: dynamics.spring,
-                  duration: 700,
-                  friction: 280,
-                }
+          computed: {
+            headerPath: function () {
+              return (
+                "M0,0 L320,0 320,160" +
+                "Q" +
+                this.c.x +
+                "," +
+                this.c.y +
+                " 0,160"
               );
-            }
+            },
+            contentPosition: function () {
+              var dy = this.c.y - 160;
+              var dampen = dy > 0 ? 2 : 4;
+              return {
+                transform: "translate3d(0," + dy / dampen + "px,0)",
+              };
+            },
           },
-        },
-      });
+          methods: {
+            startDrag: function (e) {
+              e = e.changedTouches ? e.changedTouches[0] : e;
+              this.dragging = true;
+              this.start.x = e.pageX;
+              this.start.y = e.pageY;
+            },
+            onDrag: function (e) {
+              e = e.changedTouches ? e.changedTouches[0] : e;
+              if (this.dragging) {
+                this.c.x = 160 + (e.pageX - this.start.x);
+                // dampen vertical drag by a factor
+                var dy = e.pageY - this.start.y;
+                var dampen = dy > 0 ? 1.5 : 4;
+                this.c.y = 160 + dy / dampen;
+              }
+            },
+            stopDrag: function () {
+              if (this.dragging) {
+                this.dragging = false;
+                dynamics.animate(
+                  this.c,
+                  {
+                    x: 160,
+                    y: 160,
+                  },
+                  {
+                    type: dynamics.spring,
+                    duration: 700,
+                    friction: 280,
+                  }
+                );
+              }
+            },
+          },
+        }
+      );
 
       new Vue({ el: "#app" });
     </script>

--- a/tests/integration/__tests__/__snapshots__/config-resolution.js.snap
+++ b/tests/integration/__tests__/__snapshots__/config-resolution.js.snap
@@ -160,25 +160,22 @@ function packageJs() {
    console.log(\\"package/file.js should have tab width 3\\");
 }
 function rcJson() {
-  console.log.apply(null, [
-    'rc-json/file.js',
-    'should have trailing comma',
-    'and single quotes',
-  ]);
+  console.log.apply(
+    null,
+    ['rc-json/file.js', 'should have trailing comma', 'and single quotes'],
+  );
 }
 function rcToml() {
-  console.log.apply(null, [
-    'rc-toml/file.js',
-    'should have trailing comma',
-    'and single quotes',
-  ]);
+  console.log.apply(
+    null,
+    ['rc-toml/file.js', 'should have trailing comma', 'and single quotes'],
+  );
 }
 function rcYaml() {
-  console.log.apply(null, [
-    'rc-yaml/file.js',
-    'should have trailing comma',
-    'and single quotes',
-  ]);
+  console.log.apply(
+    null,
+    ['rc-yaml/file.js', 'should have trailing comma', 'and single quotes'],
+  );
 }
 "
 `;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
When there are multiple function arguments that cannot be displayed in a single line, a line break is added before each argument. This allows the arguments to be read vertically (top down) and keeps opening and closing brackets aligned.

<!-- prettier-ignore -->
```jsx
// Before: using prettier v2.5.1
instantiate(game, [
  transform([-0.7, 0.5, 0]),
  render_colored_diffuse(
    game.MaterialDiffuse,
    game.Meshes["monkey_flat"],
    [1, 1, 0.3, 1]
  ),
]);

// After: this PR
instantiate(
  game,
  [
    transform([-0.7, 0.5, 0]),
    render_colored_diffuse(
      game.MaterialDiffuse,
      game.Meshes["monkey_flat"],
      [1, 1, 0.3, 1]
    ),
  ]
);
```

Fixes #12325

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
