### PR TITLE
Add CSharpier to List of Community Plugins

### DIFF
--- a/website/data/languages.yml
+++ b/website/data/languages.yml
@@ -44,6 +44,7 @@
   image: /images/languages/tools_wip.svg
   variants:
     - "[Apex](https://github.com/dangmai/prettier-plugin-apex)"
+    - "[C#](https://github.com/belav/csharpier/) (CSharpier is a standalone tool based on a port of Prettier)"
     - "[Elm](https://github.com/gicentre/prettier-plugin-elm) (via [`elm-format`](https://github.com/avh4/elm-format))"
     - "[Java](https://github.com/jhipster/prettier-java)"
     - "[PHP](https://github.com/prettier/plugin-php)"


### PR DESCRIPTION
CSharpier is a standalone tool for C# based on a port of Prettier.

## Description

Add a link to CSharpier on the Prettier landing page.

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
