### PR TITLE
Build: Use `globalThis` instead of `new Function()`

### DIFF
--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -30,7 +30,7 @@ const parsers = [
     input: "src/language-js/parse/flow.js",
     replace: {
       // `flow-parser` use this for `globalThis`, can't work in strictMode
-      "(function(){return this}())": '(globalThis)',
+      "(function(){return this}())": "(globalThis)",
     },
   },
   {

--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -30,7 +30,7 @@ const parsers = [
     input: "src/language-js/parse/flow.js",
     replace: {
       // `flow-parser` use this for `globalThis`, can't work in strictMode
-      "(function(){return this}())": '(new Function("return this")())',
+      "(function(){return this}())": '(globalThis)',
     },
   },
   {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

The old one may fail because of "content security policy", we already polyfill `globalThis`, so this won't change the bundle size.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
