### PR TITLE
Replace `parent-module`

### DIFF
--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -263,14 +263,12 @@ const coreBundles = [
   },
   {
     input: "src/common/third-party.js",
-    replaceText: [
+    replaceModule: {
       // cosmiconfig@6 -> import-fresh can't find parentModule, since module is bundled
-      {
-        file: require.resolve("import-fresh"),
-        find: "parentModule(__filename)",
-        replacement: "__filename",
-      },
-    ],
+      [require.resolve("parent-module")]: require.resolve(
+        "./shims/parent-module.cjs"
+      ),
+    },
   },
 ].map((bundle) => ({
   type: "core",

--- a/scripts/build/shims/parent-module.cjs
+++ b/scripts/build/shims/parent-module.cjs
@@ -1,0 +1,3 @@
+"use strict";
+
+module.exports = (module) => module;

--- a/scripts/build/shims/parent-module.cjs
+++ b/scripts/build/shims/parent-module.cjs
@@ -1,3 +1,3 @@
 "use strict";
 
-module.exports = (module) => module;
+module.exports = (file) => file;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Reduce bundled `third-party.js` size a little bit.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
