### PR TITLE
Fix `diff` package import

### DIFF
--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -243,9 +243,7 @@ const coreBundles = [
         replacement: "const utilInspect = require('util').inspect",
       },
     ],
-    replaceModule: {
-      ...replaceDiffPackageEntry("lib/diff/array.js"),
-    },
+    replaceModule: replaceDiffPackageEntry("lib/diff/array.js"),
   },
   {
     input: "src/document/index.js",

--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -276,9 +276,7 @@ const coreBundles = [
     input: "src/cli/index.js",
     output: "cli.js",
     external: ["benchmark"],
-    replaceModule: {
-      ...replaceDiffPackageEntry("lib/patch/create.js"),
-    },
+    replaceModule: replaceDiffPackageEntry("lib/patch/create.js"),
   },
   {
     input: "src/common/third-party.js",

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -17,18 +17,9 @@ const getOptionsForFile = require("./options/get-options-for-file.js");
 const isTTY = require("./is-tty.js");
 
 function diff(a, b) {
-  // Use `diff/lib/patch/create.js` instead of `diff` to reduce bundle size
-  return require("diff/lib/patch/create.js").createTwoFilesPatch(
-    "",
-    "",
-    a,
-    b,
-    "",
-    "",
-    {
-      context: 2,
-    }
-  );
+  return require("diff").createTwoFilesPatch("", "", a, b, "", "", {
+    context: 2,
+  });
 }
 
 function handleError(context, filename, error, printedFilename) {

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const diff = require("diff");
+const { diffArrays } = require("diff");
 
 const {
   printer: { printDocToString },
@@ -118,7 +118,7 @@ function coreFormat(originalText, opts, addAlignmentSize = 0) {
 
     const newCursorNodeCharArray = [...newCursorNodeText];
 
-    const cursorNodeDiff = diff.diffArrays(
+    const cursorNodeDiff = diffArrays(
       oldCursorNodeCharArray,
       newCursorNodeCharArray
     );

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -1,7 +1,6 @@
 "use strict";
 
-// Use `diff/lib/diff/array.js` instead of `diff` to reduce bundle size
-const { diffArrays } = require("diff/lib/diff/array.js");
+const diff = require("diff");
 
 const {
   printer: { printDocToString },
@@ -119,7 +118,7 @@ function coreFormat(originalText, opts, addAlignmentSize = 0) {
 
     const newCursorNodeCharArray = [...newCursorNodeText];
 
-    const cursorNodeDiff = diffArrays(
+    const cursorNodeDiff = diff.diffArrays(
       oldCursorNodeCharArray,
       newCursorNodeCharArray
     );


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Lucky we only use one method in `cli.js`, `index.js`, and `standalone.js`, so we can easily replace them.
This didn't change the output.

This reverts #12160
Fixes #12275

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
