### PR TITLE
Enable `unicorn/template-indent` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -153,6 +153,7 @@ module.exports = {
     "unicorn/prefer-string-starts-ends-with": "error",
     "unicorn/prefer-switch": "error",
     "unicorn/prefer-type-error": "error",
+    "unicorn/template-indent": "error",
   },
   overrides: [
     {

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -103,9 +103,9 @@ function getBlogPostInfo(version) {
 
 function getChangelogContent({ version, previousVersion, body }) {
   return outdent`
-  [diff](https://github.com/prettier/prettier/compare/${previousVersion}...${version})
+    [diff](https://github.com/prettier/prettier/compare/${previousVersion}...${version})
 
-  ${body}
+    ${body}
   `;
 }
 

--- a/tests/config/install-prettier.js
+++ b/tests/config/install-prettier.js
@@ -2,6 +2,7 @@
 
 const path = require("path");
 const fs = require("fs");
+const { outdent } = require("outdent");
 const { default: chalk } = require("../../vendors/chalk.js");
 const { default: tempy } = require("../../vendors/tempy.js");
 const { execaSync } = require("../../vendors/execa.js");
@@ -74,12 +75,12 @@ module.exports = (packageDir) => {
 
   console.log(
     chalk.green(
+      outdent`
+        Prettier installed
+          at ${chalk.inverse(installed)}
+          from ${chalk.inverse(packageDir)}
+          with ${chalk.inverse(client)}.
       `
-Prettier installed
-  at ${chalk.inverse(installed)}
-  from ${chalk.inverse(packageDir)}
-  with ${chalk.inverse(client)}.
-      `.trim()
     )
   );
 

--- a/tests/config/utils/check-parsers.js
+++ b/tests/config/utils/check-parsers.js
@@ -163,13 +163,13 @@ const checkParser = ({ dirname, files }, parsers = []) => {
       suggestCategories.length === 0
         ? ""
         : outdent`
-            Suggest move your tests to:
-            ${suggestCategories
+          Suggest move your tests to:
+          ${suggestCategories
               .map((category) => `- ${path.join(TESTS_ROOT, category)}`)
               .join("\n")}
 
-            Or config to allow use this parser in "${__filename}".
-          `;
+          Or config to allow use this parser in "${__filename}".
+        `;
 
     throw new Error(
       `Parser "${parser}" should not used in "${dirname}".${

--- a/tests/config/utils/check-parsers.js
+++ b/tests/config/utils/check-parsers.js
@@ -165,8 +165,8 @@ const checkParser = ({ dirname, files }, parsers = []) => {
         : outdent`
           Suggest move your tests to:
           ${suggestCategories
-              .map((category) => `- ${path.join(TESTS_ROOT, category)}`)
-              .join("\n")}
+            .map((category) => `- ${path.join(TESTS_ROOT, category)}`)
+            .join("\n")}
 
           Or config to allow use this parser in "${__filename}".
         `;

--- a/tests/format/js/cursor/jsfmt.spec.js
+++ b/tests/format/js/cursor/jsfmt.spec.js
@@ -1,6 +1,7 @@
 run_spec(__dirname, ["babel", "typescript", "flow"]);
 
 const prettier = require("prettier-local");
+const { outdent } = require("outdent");
 
 test("translates cursor correctly in basic case", () => {
   expect(
@@ -32,17 +33,22 @@ test("keeps cursor inside formatted node", () => {
 });
 
 test("doesn't insert second placeholder for nonexistent TypeAnnotation", () => {
-  const code = `
-foo('bar', cb => {
-  console.log('stuff')
-})`;
+  const code =
+    "\n" +
+    outdent`
+      foo('bar', cb => {
+        console.log('stuff')
+      })
+    `;
   expect(
     prettier.formatWithCursor(code, { parser: "babel", cursorOffset: 24 })
   ).toMatchObject({
-    formatted: `foo("bar", (cb) => {
-  console.log("stuff");
-});
-`,
+    formatted:
+      outdent`
+        foo("bar", (cb) => {
+          console.log("stuff");
+        });
+      ` + "\n",
     cursorOffset: 25,
   });
 });

--- a/tests/integration/__tests__/__snapshots__/format.js.snap
+++ b/tests/integration/__tests__/__snapshots__/format.js.snap
@@ -12,12 +12,11 @@ exports[`html parser should handle CRLF correctly 1`] = `"\\"<!--\\\\r\\\\n  tes
 exports[`markdown parser should handle CRLF correctly 1`] = `"\\"\`\`\`\\\\r\\\\n\\\\r\\\\n\\\\r\\\\n\`\`\`\\\\r\\\\n\\""`;
 
 exports[`typescript parser should throw the first error when both JSX and non-JSX mode failed 1`] = `
-"Expression expected. (9:7)
-   7 | );
-   8 |
->  9 | label:
-     |       ^
-  10 |   "
+"Expression expected. (8:7)
+  6 | );
+  7 |
+> 8 | label:
+    |       ^"
 `;
 
 exports[`yaml parser should handle CRLF correctly 1`] = `"\\"a: 123\\\\r\\\\n\\""`;

--- a/tests/integration/__tests__/doc-trim.js
+++ b/tests/integration/__tests__/doc-trim.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const prettier = require("prettier-local");
+const { outdent } = require("outdent");
 const docPrinter = prettier.doc.printer;
 const docBuilders = prettier.doc.builders;
 
@@ -34,12 +35,14 @@ describe("trim", () => {
           "}",
         ])
       ),
-      `function()
-{
-#if DEBUG
-  alert(42);
-#endif
-}`,
+      outdent`
+        function()
+        {
+        #if DEBUG
+          alert(42);
+        #endif
+        }
+      `,
     ],
     [
       "ignores trimmed characters when fitting the line",

--- a/tests/integration/__tests__/format.js
+++ b/tests/integration/__tests__/format.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const prettier = require("prettier-local");
+const { outdent } = require("outdent");
 const fooPlugin = require("../plugins/defaultOptions/plugin.js");
 
 test("yaml parser should handle CRLF correctly", () => {
@@ -14,15 +15,15 @@ test("yaml parser should handle CRLF correctly", () => {
 });
 
 test("typescript parser should throw the first error when both JSX and non-JSX mode failed", () => {
-  const input = `
-import React from "react";
+  const input = outdent`
+    import React from "react";
 
-const App = () => (
-  <div className="App">
-  </div>
-);
+    const App = () => (
+      <div className="App">
+      </div>
+    );
 
-label:
+    label:
   `;
   expect(() =>
     prettier.format(input, { parser: "typescript" })

--- a/tests/integration/__tests__/ignore-in-subdirectories.js
+++ b/tests/integration/__tests__/ignore-in-subdirectories.js
@@ -70,8 +70,7 @@ describe("formats files when executing in a subdirectory and using stdin", () =>
       input: "hello_world( );",
     }
   ).test({
-    stdout: `hello_world();
-`,
+    stdout: "hello_world();\n",
     status: 0,
   });
 });

--- a/tests/integration/__tests__/line-suffix-boundary.js
+++ b/tests/integration/__tests__/line-suffix-boundary.js
@@ -2,6 +2,7 @@
 
 /** @type {import('prettier')} */
 const prettier = require("prettier-local");
+const { outdent } = require("outdent");
 
 const { group, indent, line, lineSuffix, lineSuffixBoundary, softline } =
   prettier.doc.builders;
@@ -24,11 +25,13 @@ describe("lineSuffixBoundary", () => {
       "];",
     ]);
 
-    const expected = `let foo = [
-  item1,
-  item2, // comment
-  item3
-];`;
+    const expected = outdent`
+      let foo = [
+        item1,
+        item2, // comment
+        item3
+      ];
+    `;
 
     expect(printDoc(doc)).toBe(expected);
   });

--- a/tests/integration/__tests__/load-toml.js
+++ b/tests/integration/__tests__/load-toml.js
@@ -1,22 +1,23 @@
 "use strict";
 
+const { outdent } = require("outdent");
 const loadToml = require("../../../src/utils/load-toml.js");
 
 describe("TOML", () => {
   const exampleFilePath = "example.toml";
 
-  const exampleToml = `
-# This is a TOML document.
-title = "TOML Example"
-[owner]
-name = "Tom Preston-Werner"
-dob = 1979-05-27T07:32:00-08:00 # First class dates
-[database]
-server = "192.168.1.1"
-ports = [ 8001, 8001, 8002 ]
-connection_max = 5000
-enabled = true
-`;
+  const exampleToml = outdent`
+    # This is a TOML document.
+    title = "TOML Example"
+    [owner]
+    name = "Tom Preston-Werner"
+    dob = 1979-05-27T07:32:00-08:00 # First class dates
+    [database]
+    server = "192.168.1.1"
+    ports = [ 8001, 8001, 8002 ]
+    connection_max = 5000
+    enabled = true
+  `;
 
   const wrongToml = "///ERROR///";
 

--- a/tests/integration/__tests__/stdin-filepath.js
+++ b/tests/integration/__tests__/stdin-filepath.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const { isCI } = require("ci-info");
+const { outdent } = require("outdent");
 const runPrettier = require("../run-prettier.js");
 
 describe("format correctly if stdin content compatible with stdin-filepath", () => {
@@ -38,11 +39,11 @@ describe("apply editorconfig for stdin-filepath with nonexistent file", () => {
     "cli",
     ["--stdin-filepath", "config/editorconfig/nonexistent.js"],
     {
-      input: `
-function f() {
-  console.log("should be indented with a tab");
-}
-`.trim(), // js
+      input: outdent`
+        function f() {
+          console.log("should be indented with a tab");
+        }
+      `, // js
     }
   ).test({
     status: 0,
@@ -54,11 +55,11 @@ describe("apply editorconfig for stdin-filepath with nonexistent directory", () 
     "cli",
     ["--stdin-filepath", "config/editorconfig/nonexistent/one/two/three.js"],
     {
-      input: `
-function f() {
-  console.log("should be indented with a tab");
-}
-`.trim(), // js
+      input: outdent`
+        function f() {
+          console.log("should be indented with a tab");
+        }
+      `, // js
     }
   ).test({
     status: 0,
@@ -70,11 +71,11 @@ describe("apply editorconfig for stdin-filepath with a deep path", () => {
     "cli",
     ["--stdin-filepath", "config/editorconfig/" + "a/".repeat(30) + "three.js"],
     {
-      input: `
-function f() {
-  console.log("should be indented with a tab");
-}
-`.trim(), // js
+      input: outdent`
+        function f() {
+          console.log("should be indented with a tab");
+        }
+      `, // js
     }
   ).test({
     status: 0,
@@ -83,11 +84,11 @@ function f() {
 
 if (isCI) {
   describe("apply editorconfig for stdin-filepath in root", () => {
-    const code = `
-function f() {
-  console.log("should be indented with a tab");
-}
-`.trim();
+    const code = outdent`
+      function f() {
+        console.log("should be indented with a tab");
+      }
+    `;
     runPrettier("cli", ["--stdin-filepath", "/foo.js"], {
       input: code, // js
     }).test({
@@ -104,11 +105,11 @@ describe("apply editorconfig for stdin-filepath with a deep path", () => {
     "cli",
     ["--stdin-filepath", "config/editorconfig/" + "a/".repeat(30) + "three.js"],
     {
-      input: `
-function f() {
-  console.log("should be indented with a tab");
-}
-`.trim(), // js
+      input: outdent`
+        function f() {
+          console.log("should be indented with a tab");
+        }
+      `, // js
     }
   ).test({
     status: 0,
@@ -123,11 +124,11 @@ describe("don’t apply editorconfig outside project for stdin-filepath with non
       "config/editorconfig/repo-root/nonexistent/one/two/three.js",
     ],
     {
-      input: `
-function f() {
-  console.log("should be indented with 2 spaces");
-}
-`.trim(), // js
+      input: outdent`
+        function f() {
+          console.log("should be indented with 2 spaces");
+        }
+      `, // js
     }
   ).test({
     status: 0,

--- a/tests/integration/__tests__/with-parser-inference.js
+++ b/tests/integration/__tests__/with-parser-inference.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const prettier = require("prettier-local");
+const { outdent } = require("outdent");
 const runPrettier = require("../run-prettier.js");
 
 describe("infers postcss parser", () => {
@@ -49,22 +50,24 @@ describe("infers parser from filename", () => {
   test("json from .swcrc", () => {
     expect(
       prettier.format(
-        `
-    {
-      "jsc": {
-    // Requires v1.2.50 or upper and requires target to be es2016 or upper.
-        "keepClassNames": false
-      }
-    }
-    `,
+        /* indent */ `
+          {
+                      "jsc": {
+                    // Requires v1.2.50 or upper and requires target to be es2016 or upper.
+                        "keepClassNames": false
+                      }}
+        `,
         { filepath: "/path/to/.swcrc" }
       )
-    ).toBe(`{
-  "jsc": {
-    // Requires v1.2.50 or upper and requires target to be es2016 or upper.
-    "keepClassNames": false
-  }
-}
-`);
+    ).toBe(
+      outdent`
+        {
+          "jsc": {
+            // Requires v1.2.50 or upper and requires target to be es2016 or upper.
+            "keepClassNames": false
+          }
+        }
+      ` + "\n"
+    );
   });
 });


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

[unicorn/template-indent](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/template-indent.md)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
