### PR TITLE
Add another example of configuration repository

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -125,7 +125,7 @@ If you don’t want to use `package.json`, you can use any of the supported exte
 "@company/prettier-config"
 ```
 
-An example configuration repository is available [here](https://github.com/azz/prettier-config).
+Example configuration repositories are available [here](https://github.com/azz/prettier-config) and [here](https://github.com/bokub/prettier-config).
 
 > Note: This method does **not** offer a way to _extend_ the configuration to overwrite some properties from the shared configuration. If you need to do that, import the file in a `.prettierrc.js` file and export the modifications, e.g:
 >


### PR DESCRIPTION
## Description

In the documentation, provide [another example](https://github.com/bokub/prettier-config) of configuration repository with a better `README` than the first one, and more documentation.

Yes, it's my own repository, feel free to decline my PR if it's against the rules, but I thought it would be a nice addition.

## Checklist

> Not needed as it's only a documentation change.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
