### PR TITLE
docs: plugins.md: add getCommentChildNodes

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -158,6 +158,7 @@ export const printers = {
     canAttachComment,
     isBlockComment,
     printComment,
+    getCommentChildNodes,
     handleComments: {
       ownLine,
       endOfLine,
@@ -291,6 +292,21 @@ function insertPragma(text: string): string;
 Comments are often not part of a language's AST and present a challenge for pretty printers. A Prettier plugin can either print comments itself in its `print` function or rely on Prettier's comment algorithm.
 
 By default, if the AST has a top-level `comments` property, Prettier assumes that `comments` stores an array of comment nodes. Prettier will then use the provided `parsers[<plugin>].locStart`/`locEnd` functions to search for the AST node that each comment "belongs" to. Comments are then attached to these nodes **mutating the AST in the process**, and the `comments` property is deleted from the AST root. The `*Comment` functions are used to adjust Prettier's algorithm. Once the comments are attached to the AST, Prettier will automatically call the `printComment(path, options): Doc` function and insert the returned doc into the (hopefully) correct place.
+
+#### (optional) `getCommentChildNodes`
+
+By default, Prettier searches all object properties (except for a few predefined ones) of each node recursively. This function can be provided to override that behavior. It has the signature:
+
+```ts
+function getCommentChildNodes(
+  // The node whose children should be returned.
+  node: AST,
+  // Current options
+  options: object
+): AST[] | undefined;
+```
+
+Return `[]` if the node has no children or `undefined` to fall back on the default behavior.
 
 #### (optional) `printComment`
 


### PR DESCRIPTION
## Description

Document `getCommentChildNodes` on the plugins documentation page.

related: https://github.com/prettier/prettier/pull/3639

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
