### PR TITLE
[JavaScript] Add an option to avoid adding line breaks to template literals

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -104,6 +104,19 @@ Note that Prettier never unquotes numeric property names in Angular expressions,
 
 If this option is set to `preserve`, `singleQuote` to `false` (default value), and `parser` to `json5`, double quotes are always used for strings. This effectively allows using the `json5` parser for “JSON with comments and trailing commas”.
 
+## Template literal line breaks
+
+Change whether template literals can have line breaks added to them.
+
+Valid options:
+
+- `true` - Line breaks may be added
+- `false` - Line breaks will never be added
+
+| Default | CLI Override                        | API Override                        |
+| ------- | ----------------------------------- | ----------------------------------- |
+| `true`  | `--no-template-literal-line-breaks` | `templateLiteralLineBreaks: <bool>` |
+
 ## JSX Quotes
 
 Use single quotes instead of double quotes in JSX.

--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -74,6 +74,14 @@ module.exports = {
       },
     ],
   },
+  templateLiteralLineBreaks: {
+    since: "2.7.0",
+    category: CATEGORY_JAVASCRIPT,
+    type: "boolean",
+    default: true,
+    description:
+      "Change whether template literals expressions can have line breaks added",
+  },
   trailingComma: {
     since: "0.0.0",
     category: CATEGORY_JAVASCRIPT,

--- a/src/language-js/print/template-literal.js
+++ b/src/language-js/print/template-literal.js
@@ -44,7 +44,9 @@ function printTemplateLiteral(path, print, options) {
   const parts = [];
 
   let expressions = path.map(print, expressionsKey);
-  const isSimple = isSimpleTemplateLiteral(node);
+  const isSimple = options.templateLiteralLineBreaks
+    ? isSimpleTemplateLiteral(node)
+    : true;
 
   if (isSimple) {
     expressions = expressions.map(

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -38,6 +38,7 @@ const ENABLED_OPTIONS = [
   "bracketSpacing",
   "jsxSingleQuote",
   "quoteProps",
+  "templateLiteralLineBreaks",
   "arrowParens",
   "trailingComma",
   "proseWrap",


### PR DESCRIPTION
## Description

Add an option to avoid having Prettier add line breaks in template literal expressions.
There have been many issues opened for template literals in the past, the top issue that's still active is #3368 .
Although that issue's aim is to improve the formatting, the comments are filled with asks to have a configurable option.

I made this PR hastily to test the waters for whether there's a chance this new option would actually get accepted.
After(if) there's initial traction, I'll work my way through the checklist to make this a proper PR.

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).


**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
