### PR TITLE
Fix non-idempotent formatting of function calls with complex type arguments

### DIFF
--- a/changelog_unreleased/typescript/12508.md
+++ b/changelog_unreleased/typescript/12508.md
@@ -1,0 +1,37 @@
+#### Fix non-idempotent formatting of function calls with complex type arguments (#12508 by @sosukesuzuki)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+const foo =
+  doSomething<{ foo1: "foo1", foo2: "foo2", foo3: "foo3", foo4: "foo4", foo5: "foo5" }>();
+
+// Prettier stable (first)
+const foo =
+  doSomething<{
+    foo1: "foo1";
+    foo2: "foo2";
+    foo3: "foo3";
+    foo4: "foo4";
+    foo5: "foo5";
+  }>();
+
+// Prettier stable (second)
+const foo = doSomething<{
+  foo1: "foo1";
+  foo2: "foo2";
+  foo3: "foo3";
+  foo4: "foo4";
+  foo5: "foo5";
+}>();
+
+// Prettier main
+const foo = doSomething<{
+  foo1: "foo1";
+  foo2: "foo2";
+  foo3: "foo3";
+  foo4: "foo4";
+  foo5: "foo5";
+}>();
+
+```

--- a/src/language-js/print/assignment.js
+++ b/src/language-js/print/assignment.js
@@ -441,7 +441,9 @@ function isCallExpressionWithComplexTypeArguments(node, print) {
         firstArg.type === "TSUnionType" ||
         firstArg.type === "UnionTypeAnnotation" ||
         firstArg.type === "TSIntersectionType" ||
-        firstArg.type === "IntersectionTypeAnnotation"
+        firstArg.type === "IntersectionTypeAnnotation" ||
+        firstArg.type === "TSTypeLiteral" ||
+        firstArg.type === "ObjectTypeAnnotation"
       ) {
         return true;
       }

--- a/tests/format/flow/assignments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/assignments/__snapshots__/jsfmt.spec.js.snap
@@ -110,3 +110,52 @@ const map: Map<Function, Foo<S>> = new Map();
 
 ================================================================================
 `;
+
+exports[`issue-12413.js format 1`] = `
+====================================options=====================================
+parsers: ["babel-flow", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+let emit =
+  defineEmits<{ (event: "ready", canvas: HTMLCanvasElement): void; (event:"resize",canvas:HTMLCanvasElement):void; }>();
+
+let abc =
+  func<{a:2,b:3,d:78,e:9,f:8,g:7,h:6,i:5,j:4,k:3,l:2,m:1,n:0,o:9,p:8,q:7,r:6,s:5,t:4,u:3,v:2,w:1,x:0,y:9,z:8}>();
+
+=====================================output=====================================
+let emit = defineEmits<{
+  (event: "ready", canvas: HTMLCanvasElement): void,
+  (event: "resize", canvas: HTMLCanvasElement): void,
+}>();
+
+let abc = func<{
+  a: 2,
+  b: 3,
+  d: 78,
+  e: 9,
+  f: 8,
+  g: 7,
+  h: 6,
+  i: 5,
+  j: 4,
+  k: 3,
+  l: 2,
+  m: 1,
+  n: 0,
+  o: 9,
+  p: 8,
+  q: 7,
+  r: 6,
+  s: 5,
+  t: 4,
+  u: 3,
+  v: 2,
+  w: 1,
+  x: 0,
+  y: 9,
+  z: 8,
+}>();
+
+================================================================================
+`;

--- a/tests/format/flow/assignments/issue-12413.js
+++ b/tests/format/flow/assignments/issue-12413.js
@@ -1,0 +1,5 @@
+let emit =
+  defineEmits<{ (event: "ready", canvas: HTMLCanvasElement): void; (event:"resize",canvas:HTMLCanvasElement):void; }>();
+
+let abc =
+  func<{a:2,b:3,d:78,e:9,f:8,g:7,h:6,i:5,j:4,k:3,l:2,m:1,n:0,o:9,p:8,q:7,r:6,s:5,t:4,u:3,v:2,w:1,x:0,y:9,z:8}>();

--- a/tests/format/typescript/assignment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/assignment/__snapshots__/jsfmt.spec.js.snap
@@ -443,6 +443,55 @@ const map: Map<Function, Foo<S>> = new Map();
 ================================================================================
 `;
 
+exports[`issue-12413.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+let emit =
+  defineEmits<{ (event: "ready", canvas: HTMLCanvasElement): void; (event:"resize",canvas:HTMLCanvasElement):void; }>();
+
+let abc =
+  func<{a:2,b:3,d:78,e:9,f:8,g:7,h:6,i:5,j:4,k:3,l:2,m:1,n:0,o:9,p:8,q:7,r:6,s:5,t:4,u:3,v:2,w:1,x:0,y:9,z:8}>();
+
+=====================================output=====================================
+let emit = defineEmits<{
+  (event: "ready", canvas: HTMLCanvasElement): void;
+  (event: "resize", canvas: HTMLCanvasElement): void;
+}>();
+
+let abc = func<{
+  a: 2;
+  b: 3;
+  d: 78;
+  e: 9;
+  f: 8;
+  g: 7;
+  h: 6;
+  i: 5;
+  j: 4;
+  k: 3;
+  l: 2;
+  m: 1;
+  n: 0;
+  o: 9;
+  p: 8;
+  q: 7;
+  r: 6;
+  s: 5;
+  t: 4;
+  u: 3;
+  v: 2;
+  w: 1;
+  x: 0;
+  y: 9;
+  z: 8;
+}>();
+
+================================================================================
+`;
+
 exports[`lone-arg.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/assignment/issue-12413.ts
+++ b/tests/format/typescript/assignment/issue-12413.ts
@@ -1,0 +1,5 @@
+let emit =
+  defineEmits<{ (event: "ready", canvas: HTMLCanvasElement): void; (event:"resize",canvas:HTMLCanvasElement):void; }>();
+
+let abc =
+  func<{a:2,b:3,d:78,e:9,f:8,g:7,h:6,i:5,j:4,k:3,l:2,m:1,n:0,o:9,p:8,q:7,r:6,s:5,t:4,u:3,v:2,w:1,x:0,y:9,z:8}>();


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #12413 

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
