### PR TITLE
Enable `unicorn/text-encoding-identifier-case` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -154,6 +154,7 @@ module.exports = {
     "unicorn/prefer-switch": "error",
     "unicorn/prefer-type-error": "error",
     "unicorn/template-indent": "error",
+    "unicorn/text-encoding-identifier-case": "error",
   },
   overrides: [
     {

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -100,7 +100,7 @@ async function createChangelog(title, user, prNumber, category) {
     __dirname,
     "../changelog_unreleased/TEMPLATE.md"
   );
-  const changelogTemplate = await fs.readFile(changelogTemplatePath, "utf-8");
+  const changelogTemplate = await fs.readFile(changelogTemplatePath, "utf8");
 
   const titlePart = "Title";
   const prNumberPart = "#XXXX";

--- a/scripts/release/steps/update-changelog.js
+++ b/scripts/release/steps/update-changelog.js
@@ -14,7 +14,7 @@ import {
 const outdentString = outdent.string;
 
 function writeChangelog(params) {
-  const changelog = fs.readFileSync("CHANGELOG.md", "utf-8");
+  const changelog = fs.readFileSync("CHANGELOG.md", "utf8");
   const newEntry = `# ${params.version}\n\n` + getChangelogContent(params);
   fs.writeFileSync("CHANGELOG.md", newEntry + "\n\n" + changelog);
 }

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -83,7 +83,7 @@ function writeJson(filename, content) {
 }
 
 function processFile(filename, fn) {
-  const content = fs.readFileSync(filename, "utf-8");
+  const content = fs.readFileSync(filename, "utf8");
   fs.writeFileSync(filename, fn(content));
 }
 

--- a/scripts/vendors/bundle-vendors.mjs
+++ b/scripts/vendors/bundle-vendors.mjs
@@ -43,7 +43,7 @@ async function generateDts(vendor) {
     ]
       .filter((line) => line !== null)
       .join("\n"),
-    "utf-8"
+    "utf8"
   );
 }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

[`unicorn/text-encoding-identifier-case`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/text-encoding-identifier-case.md)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
