### PR TITLE
Remove the TSLint from docs

### DIFF
--- a/docs/integrating-with-linters.md
+++ b/docs/integrating-with-linters.md
@@ -8,7 +8,6 @@ Linters usually contain not only code quality rules, but also stylistic rules. M
 Luckily it’s easy to turn off rules that conflict or are unnecessary with Prettier, by using these pre-made configs:
 
 - [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier)
-- [tslint-config-prettier](https://github.com/alexjoverm/tslint-config-prettier)
 - [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier)
 
 Check out the above links for instructions on how to install and set things up.
@@ -20,7 +19,6 @@ When searching for both Prettier and your linter on the Internet you’ll probab
 First, we have plugins that let you run Prettier as if it was a linter rule:
 
 - [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier)
-- [tslint-plugin-prettier](https://github.com/ikatyang/tslint-plugin-prettier)
 - [stylelint-prettier](https://github.com/prettier/stylelint-prettier)
 
 These plugins were especially useful when Prettier was new. By running Prettier inside your linters, you didn’t have to set up any new infrastructure and you could re-use your editor integrations for the linters. But these days you can run `prettier --check .` and most editors have Prettier support.
@@ -34,7 +32,6 @@ The downsides of those plugins are:
 Finally, we have tools that run `prettier` and then immediately for example `eslint --fix` on files.
 
 - [prettier-eslint](https://github.com/prettier/prettier-eslint)
-- [prettier-tslint](https://github.com/azz/prettier-tslint)
 - [prettier-stylelint](https://github.com/hugomrdias/prettier-stylelint)
 
 Those are useful if some aspect of Prettier’s output makes Prettier completely unusable to you. Then you can have for example `eslint --fix` fix that up for you. The downside is that these tools are much slower than just running Prettier.

--- a/docs/related-projects.md
+++ b/docs/related-projects.md
@@ -16,12 +16,6 @@ title: Related Projects
 - [stylelint-prettier](https://github.com/prettier/stylelint-prettier) runs Prettier as a stylelint rule and reports differences as individual stylelint issues
 - [prettier-stylelint](https://github.com/hugomrdias/prettier-stylelint) passes `prettier` output to `stylelint --fix`
 
-## TSLint Integrations
-
-- [tslint-config-prettier](https://github.com/alexjoverm/tslint-config-prettier) use TSLint with Prettier without any conflict
-- [tslint-plugin-prettier](https://github.com/ikatyang/tslint-plugin-prettier) runs Prettier as a TSLint rule and reports differences as individual TSLint issues
-- [prettier-tslint](https://github.com/azz/prettier-tslint) passes `prettier` output to `tslint --fix`
-
 ## Forks
 
 - [prettierx](https://github.com/brodybits/prettierx) less opinionated fork of Prettier


### PR DESCRIPTION
## Description

TSLint [has been deprecated](https://medium.com/palantir/tslint-in-2019-1a144c2317a9) as of 2019.
I want to remove the TSLint description from docs.

### Changes page
- [integrating-with-linters](https://prettier.io/docs/en/integrating-with-linters.html)
- [related-projects](https://prettier.io/docs/en/related-projects)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
