### PR TITLE
Fix for Prettier adds redundant semicolon when formatting javascript #12540

### DIFF
--- a/src/language-js/print/statement.js
+++ b/src/language-js/print/statement.js
@@ -35,7 +35,7 @@ function printStatementSequence(path, options, print, property) {
       return;
     }
 
-    if (node.type == "EmptyStatement" && index != statements.length - 1) {
+    if (node.type === "EmptyStatement" && index !== statements.length - 1) {
       return;
     }
 

--- a/src/language-js/print/statement.js
+++ b/src/language-js/print/statement.js
@@ -35,6 +35,10 @@ function printStatementSequence(path, options, print, property) {
       return;
     }
 
+    if (node.type == "EmptyStatement" && index != statements.length - 1) {
+      return;
+    }
+
     const printed = print();
 
     // in no-semi mode, prepend statement with semicolon if it might break ASI

--- a/tests/format/flow/type-cast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/type-cast/__snapshots__/jsfmt.spec.js.snap
@@ -30,10 +30,14 @@ foo: string;
 bar: number;
 (foo.bar: SomeType);
 
+let i    ="format me!"   ;
+
 =====================================output=====================================
 foo: string;
 bar: number;
 (foo.bar: SomeType);
+
+let i = "format me!";
 
 ================================================================================
 `;

--- a/tests/format/flow/type-cast/statement.js
+++ b/tests/format/flow/type-cast/statement.js
@@ -1,3 +1,5 @@
 foo: string;
 bar: number;
 (foo.bar: SomeType);
+
+let i    ="format me!"   ;


### PR DESCRIPTION
## Description

Fix for Prettier adds redundant semicolon when formatting javascript #12540.

Before Prettier added an unecessary semi colon with badly formatted code. This PR fixes this issue.

```javascript
let i    ="format me!"   ;
```

This code is now ouputted as...
```javascript
let i = "format me!";
```

Instead of the previous...
```javascript
let i = "format me!";   ;
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
