### PR TITLE
Refactor format test to async

### DIFF
--- a/tests/config/format-test.js
+++ b/tests/config/format-test.js
@@ -251,7 +251,7 @@ function runSpec(fixtures, parsers, options) {
         }
 
         const testTitle =
-          formatOptions.parser !== parser
+          formatOptions.parser !== currentParser
             ? `[${currentParser}] format`
             : "format";
 

--- a/tests/config/format-test.js
+++ b/tests/config/format-test.js
@@ -344,7 +344,10 @@ async function runTest({
     formatResult.input === code
   ) {
     const { eolVisualizedOutput: firstOutput, output } = formatResult;
-    const { eolVisualizedOutput: secondOutput } = format(output, formatOptions);
+    const { eolVisualizedOutput: secondOutput } = await format(
+      output,
+      formatOptions
+    );
     if (isUnstableTest) {
       // To keep eye on failed tests, this assert never supposed to pass,
       // if it fails, just remove the file from `unstableTests`

--- a/tests/config/format-test.js
+++ b/tests/config/format-test.js
@@ -294,7 +294,7 @@ async function runTest({
     const runFormat = () => format(code, formatOptions);
 
     if (shouldThrowOnFormat(name, formatOptions)) {
-      expect(runFormat).toThrowErrorMatchingSnapshot();
+      await expect(runFormat()).rejects.toThrowErrorMatchingSnapshot();
       return;
     }
 

--- a/tests/config/format-test.js
+++ b/tests/config/format-test.js
@@ -234,12 +234,19 @@ function runSpec(fixtures, parsers, options) {
         filepath: filename,
         parser,
       };
+      const shouldThrowOnMainParserFormat = shouldThrowOnFormat(
+        name,
+        formatOptions
+      );
+
       let mainParserFormatResult;
-      beforeAll(async () => {
-        mainParserFormatResult = shouldThrowOnFormat(name, formatOptions)
-          ? { options: formatOptions, error: true }
-          : await format(code, formatOptions);
-      });
+      if (shouldThrowOnMainParserFormat) {
+        mainParserFormatResult = { options: formatOptions, error: true };
+      } else {
+        beforeAll(async () => {
+          mainParserFormatResult = await format(code, formatOptions);
+        });
+      }
 
       for (const currentParser of allParsers) {
         if (
@@ -251,6 +258,7 @@ function runSpec(fixtures, parsers, options) {
         }
 
         const testTitle =
+          shouldThrowOnMainParserFormat ||
           formatOptions.parser !== currentParser
             ? `[${currentParser}] format`
             : "format";


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Due to limitation of Jest, we have to move `mainParserFormatResult` to `beforeAll`, because [can't use async function in `describe`](https://github.com/facebook/jest/issues/2235), removed some test title, because `Tests cannot be nested.` 

Prepare for #4459

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
