### PR TITLE
Refactor: Add a wrapped `normalizeCliOptions` version for CLI usage

### DIFF
--- a/src/cli/options/get-options-for-file.js
+++ b/src/cli/options/get-options-for-file.js
@@ -1,14 +1,12 @@
 "use strict";
 
 const dashify = require("dashify");
-const leven = require("leven");
-// eslint-disable-next-line no-restricted-modules
-const { default: chalk } = require("../../../vendors/chalk.js");
 // eslint-disable-next-line no-restricted-modules
 const prettier = require("../../index.js");
 const { optionsNormalizer } = require("../prettier-internal.js");
 const minimist = require("./minimist.js");
 const createMinimistOptions = require("./create-minimist-options.js");
+const normalizeCliOptions = require("./normalize-cli-options.js");
 
 function getOptions(argv, detailedOptions) {
   return Object.fromEntries(
@@ -45,14 +43,14 @@ function parseArgsToOptions(context, overrideDefaults) {
     context.detailedOptions
   );
   return getOptions(
-    optionsNormalizer.normalizeCliOptions(
+    normalizeCliOptions(
       minimist(context.rawArguments, {
         string: minimistOptions.string,
         boolean: minimistOptions.boolean,
         default: cliifyOptions(overrideDefaults, apiDetailedOptionMap),
       }),
       context.detailedOptions,
-      { logger: false, colorsModule: chalk, levenshteinDistance: leven }
+      { logger: false }
     ),
     context.detailedOptions
   );

--- a/src/cli/options/normalize-cli-options.js
+++ b/src/cli/options/normalize-cli-options.js
@@ -1,0 +1,16 @@
+"use strict";
+
+const leven = require("leven");
+const { optionsNormalizer } = require("../prettier-internal.js");
+// eslint-disable-next-line no-restricted-modules
+const { default: chalk } = require("../../../vendors/chalk.js");
+
+function normalizeCliOptions(options, optionInfos, opts) {
+  return optionsNormalizer.normalizeCliOptions(options, optionInfos, {
+    colorsModule: chalk,
+    levenshteinDistance: leven,
+    ...opts,
+  });
+}
+
+module.exports = normalizeCliOptions;

--- a/src/cli/options/parse-cli-arguments.js
+++ b/src/cli/options/parse-cli-arguments.js
@@ -1,15 +1,10 @@
 "use strict";
 const pick = require("lodash/pick");
 const camelCase = require("camelcase");
-const leven = require("leven");
-// eslint-disable-next-line no-restricted-modules
-const { default: chalk } = require("../../../vendors/chalk.js");
-const {
-  optionsNormalizer: { normalizeCliOptions },
-} = require("../prettier-internal.js");
 const getContextOptions = require("./get-context-options.js");
 const minimist = require("./minimist.js");
 const createMinimistOptions = require("./create-minimist-options.js");
+const normalizeCliOptions = require("./normalize-cli-options.js");
 
 function parseArgv(rawArguments, detailedOptions, logger, keys) {
   const minimistOptions = createMinimistOptions(detailedOptions);
@@ -26,11 +21,7 @@ function parseArgv(rawArguments, detailedOptions, logger, keys) {
     argv = pick(argv, keys);
   }
 
-  const normalized = normalizeCliOptions(argv, detailedOptions, {
-    logger,
-    colorsModule: chalk,
-    levenshteinDistance: leven,
-  });
+  const normalized = normalizeCliOptions(argv, detailedOptions, { logger });
 
   return {
     ...Object.fromEntries(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,7 @@
     "src/cli/options/get-options-for-file.js",
     "src/cli/options/option-map.js",
     "src/cli/options/parse-cli-arguments.js",
+    "src/cli/options/normalize-cli-options.js",
     "src/cli/usage.js",
     "src/cli/constant.js",
     "src/cli/prettier-internal.js",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
