### PR TITLE
Enable `unicorn/no-unreadable-iife` and `unicorn/prefer-native-coercion-functions` rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -146,6 +146,7 @@ module.exports = {
     "unicorn/prefer-array-some": "error",
     "unicorn/prefer-includes": "error",
     "unicorn/prefer-json-parse-buffer": "error",
+    "unicorn/prefer-native-coercion-functions": "error",
     "unicorn/prefer-number-properties": "error",
     "unicorn/prefer-optional-catch-binding": "error",
     "unicorn/prefer-regexp-test": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -41,9 +41,6 @@ module.exports = {
       "error",
       // `!foo === bar` and `!foo !== bar`
       'BinaryExpression[operator=/^[!=]==$/] > UnaryExpression.left[operator="!"]',
-      // `(() => (foo ? bar : baz))()`
-      // TODO: Remove this when https://github.com/sindresorhus/eslint-plugin-unicorn/issues/1730 get implemented
-      'CallExpression[callee.type="ArrowFunctionExpression"][callee.body.type="ConditionalExpression"]',
     ],
     "no-return-await": "error",
     "no-unneeded-ternary": "error",
@@ -135,6 +132,7 @@ module.exports = {
     "unicorn/no-array-for-each": "error",
     "unicorn/no-array-push-push": "error",
     "unicorn/no-new-array": "error",
+    "unicorn/no-unreadable-iife": "error",
     "unicorn/no-useless-length-check": "error",
     "unicorn/no-useless-promise-resolve-reject": "error",
     "unicorn/no-useless-undefined": "error",

--- a/src/cli/context.js
+++ b/src/cli/context.js
@@ -40,7 +40,7 @@ class Context {
 
     const argv = parseArgv(rawArguments, this.detailedOptions, logger);
     this.argv = argv;
-    this.filePatterns = argv._.map((file) => String(file));
+    this.filePatterns = argv._.map(String);
   }
 
   /**

--- a/src/main/options-normalizer.js
+++ b/src/main/options-normalizer.js
@@ -180,7 +180,7 @@ function optionInfoToSchema(
     case "int":
       SchemaConstructor = vnopts.IntegerSchema;
       if (isCLI) {
-        parameters.preprocess = (value) => Number(value);
+        parameters.preprocess = Number;
       }
       break;
     case "string":


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

- [unicorn/no-unreadable-iife](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-unreadable-iife.md) Idea come from our codebase https://github.com/prettier/prettier/blob/5a6897fe32eafa497f84e235a7ad878397a94951/.eslintrc.js#L44-L45
- [unicorn/prefer-native-coercion-functions](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-native-coercion-functions.md)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
