### PR TITLE
Add --diff option for outputting diffs of formatting changes.

### DIFF
--- a/changelog_unreleased/cli/12598.md
+++ b/changelog_unreleased/cli/12598.md
@@ -1,0 +1,33 @@
+<!--
+
+1. Choose a folder based on which language your PR is for.
+
+   - For JavaScript, choose `javascript/` etc.
+   - For TypeScript specific syntax, choose `typescript/`.
+   - If your PR applies to multiple languages, such as TypeScript/Flow, choose one folder and mention which languages it applies to.
+
+2. In your chosen folder, create a file with your PR number: `XXXX.md`. For example: `typescript/6728.md`.
+
+3. Copy the content below and paste it in your new file.
+
+4. Fill in a title, the PR number and your user name.
+
+5. Optionally write a description. Many times it’s enough with just sample code.
+
+6. Change ```jsx to your language. For example, ```yaml.
+
+7. Change the `// Input` and `// Prettier` comments to the comment syntax of your language. For example, `# Input`.
+
+8. Choose some nice input example code. Paste it along with the output before and after your PR.
+
+-->
+
+#### Add --diff option for outputting diffs of formatting changes. (#12598 by @Osmose)
+
+Add --diff option to the CLI for outputting diffs with formatting changes.
+
+<!-- prettier-ignore -->
+```sh
+# Prettier main
+$ prettier . --diff
+```

--- a/changelog_unreleased/cli/12598.md
+++ b/changelog_unreleased/cli/12598.md
@@ -1,28 +1,4 @@
-<!--
-
-1. Choose a folder based on which language your PR is for.
-
-   - For JavaScript, choose `javascript/` etc.
-   - For TypeScript specific syntax, choose `typescript/`.
-   - If your PR applies to multiple languages, such as TypeScript/Flow, choose one folder and mention which languages it applies to.
-
-2. In your chosen folder, create a file with your PR number: `XXXX.md`. For example: `typescript/6728.md`.
-
-3. Copy the content below and paste it in your new file.
-
-4. Fill in a title, the PR number and your user name.
-
-5. Optionally write a description. Many times it’s enough with just sample code.
-
-6. Change ```jsx to your language. For example, ```yaml.
-
-7. Change the `// Input` and `// Prettier` comments to the comment syntax of your language. For example, `# Input`.
-
-8. Choose some nice input example code. Paste it along with the output before and after your PR.
-
--->
-
-#### Add --diff option for outputting diffs of formatting changes. (#12598 by @Osmose)
+#### Add --diff option for outputting diffs of formatting changes (#12598 by @Osmose)
 
 Add --diff option to the CLI for outputting diffs with formatting changes.
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -126,7 +126,7 @@ You can also use [`--check`](cli.md#--check) flag, which works the same way as `
 
 ## `--diff`
 
-The `--diff` flag will print a unified diff for each file that is different from PRettier formatting. Like [`--check`](cli.md#--check), it will exit with a non-zero code if there are differences.
+The `--diff` flag will print a unified diff for each file that is different from Prettier formatting. Like [`--check`](cli.md#--check), it will exit with a non-zero code if there are differences.
 
 ```bash
 prettier --single-quote --diff "src/**/*.js"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -124,6 +124,14 @@ prettier --single-quote --list-different "src/**/*.js"
 
 You can also use [`--check`](cli.md#--check) flag, which works the same way as `--list-different`, but also prints a human-friendly summary message to stdout.
 
+## `--diff`
+
+The `--diff` flag will print a unified diff for each file that is different from PRettier formatting. Like [`--check`](cli.md#--check), it will exit with a non-zero code if there are differences.
+
+```bash
+prettier --single-quote --diff "src/**/*.js"
+```
+
 ## `--no-config`
 
 Do not look for a configuration file. The default settings will be used.

--- a/src/cli/constant.js
+++ b/src/cli/constant.js
@@ -167,6 +167,14 @@ const options = {
     default: 0,
     type: "int",
   },
+  diff: {
+    type: "boolean",
+    category: coreOptions.CATEGORY_OUTPUT,
+    description: outdent`
+      Check if the given files are formatted, print a unified diff patch for
+      each unformatted file with formatting changes (see also --check).
+    `,
+  },
   editorconfig: {
     category: coreOptions.CATEGORY_CONFIG,
     default: true,

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -309,7 +309,7 @@ async function formatFiles(context) {
   let numberOfUnformattedFilesFound = 0;
   const { performanceTestFlag } = context;
 
-  if (context.argv.check && !performanceTestFlag) {
+  if (context.argv.check && !context.argv.diff && !performanceTestFlag) {
     context.logger.log("Checking formatting...");
   }
 
@@ -497,12 +497,13 @@ async function formatFiles(context) {
     }
 
     if (isDifferent) {
-      if (context.argv.check) {
+      // Order matters because `--diff --check` should behave the same as `--diff` alone.
+      if (context.argv.diff) {
+        context.logger.log(createPatch(filename, input, output));
+      } else if (context.argv.check) {
         context.logger.warn(filename);
       } else if (context.argv.listDifferent) {
         context.logger.log(filename);
-      } else if (context.argv.diff) {
-        context.logger.log(createPatch(filename, input, output));
       }
       numberOfUnformattedFilesFound += 1;
     }
@@ -511,7 +512,7 @@ async function formatFiles(context) {
   formatResultsCache?.reconcile();
 
   // Print check summary based on expected exit code
-  if (context.argv.check) {
+  if (context.argv.check && !context.argv.diff) {
     if (numberOfUnformattedFilesFound === 0) {
       context.logger.log("All matched files use Prettier code style!");
     } else if (numberOfUnformattedFilesFound === 1) {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -55,8 +55,14 @@ async function main(context) {
     }
   }
 
-  if (context.argv.check && context.argv.listDifferent) {
-    throw new Error("Cannot use --check and --list-different together.");
+  if (
+    [context.argv.check, context.argv.listDifferent, context.argv.diff].filter(
+      (o) => o
+    ).length > 1
+  ) {
+    throw new Error(
+      "Cannot use --check, --list-different, or --diff together."
+    );
   }
 
   if (context.argv.write && context.argv.debugCheck) {

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -56,13 +56,17 @@ async function main(context) {
   }
 
   if (
-    [context.argv.check, context.argv.listDifferent, context.argv.diff].filter(
-      (o) => o
+    [context.argv.check || context.argv.diff, context.argv.listDifferent].filter(
+      Boolean,
     ).length > 1
   ) {
     throw new Error(
       "Cannot use --check, --list-different, or --diff together."
     );
+  }
+
+  if (context.argv.write && context.argv.diff) {
+    throw new Error("Cannot use --write and --diff together.");
   }
 
   if (context.argv.write && context.argv.debugCheck) {

--- a/tests/integration/__tests__/__snapshots__/diff.js.snap
+++ b/tests/integration/__tests__/__snapshots__/diff.js.snap
@@ -1,37 +1,84 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`--diff works in CI just as in a non-TTY mode (stderr) 1`] = `""`;
+exports[`--diff can't be used with --write (stderr) 1`] = `
+"[error] Cannot use --write and --diff together.
+"
+`;
 
-exports[`--diff works in CI just as in a non-TTY mode (stderr) 2`] = `""`;
+exports[`--diff can't be used with --write (stdout) 1`] = `""`;
 
-exports[`--diff works in CI just as in a non-TTY mode (stdout) 1`] = `
+exports[`--diff can't be used with --write (write) 1`] = `[]`;
+
+exports[`--diff works with --check (stderr) 1`] = `""`;
+
+exports[`--diff works with --check (stderr) 2`] = `""`;
+
+exports[`--diff works with --check (stdout) 1`] = `
 "Index: unformatted.js
 ===================================================================
 --- unformatted.js
 +++ unformatted.js
 @@ -1,1 +1,1 @@
 -var x      =      1;
-\\\\ No newline at end of file
+\\ No newline at end of file
 +var x = 1;
 
 "
 `;
 
-exports[`--diff works in CI just as in a non-TTY mode (stdout) 2`] = `
+exports[`--diff works with --check (stdout) 2`] = `
 "Index: unformatted.js
 ===================================================================
 --- unformatted.js
 +++ unformatted.js
 @@ -1,1 +1,1 @@
 -var x      =      1;
-\\\\ No newline at end of file
+\\ No newline at end of file
 +var x = 1;
 
 "
 `;
 
-exports[`--diff works in CI just as in a non-TTY mode (write) 1`] = `Array []`;
+exports[`--diff works with --check (write) 1`] = `[]`;
 
-exports[`--diff works in CI just as in a non-TTY mode (write) 2`] = `Array []`;
+exports[`--diff works with --check (write) 2`] = `[]`;
 
-exports[`checks stdin with --diff (write) 1`] = `Array []`;
+exports[`checks files with --diff (stderr) 1`] = `""`;
+
+exports[`checks files with --diff (stdout) 1`] = `
+"Index: unformatted.js
+===================================================================
+--- unformatted.js
++++ unformatted.js
+@@ -1,1 +1,1 @@
+-var x      =      1;
+\\ No newline at end of file
++var x = 1;
+
+"
+`;
+
+exports[`checks files with --diff (write) 1`] = `[]`;
+
+exports[`checks stdin with --diff (stderr) 1`] = `""`;
+
+exports[`checks stdin with --diff (stderr) 2`] = `""`;
+
+exports[`checks stdin with --diff (stdout) 1`] = `""`;
+
+exports[`checks stdin with --diff (stdout) 2`] = `
+"Index: (stdin)
+===================================================================
+--- (stdin)
++++ (stdin)
+@@ -1,1 +1,1 @@
+-var x      =      1;
+\\ No newline at end of file
++var x = 1;
+
+"
+`;
+
+exports[`checks stdin with --diff (write) 1`] = `[]`;
+
+exports[`checks stdin with --diff (write) 2`] = `[]`;

--- a/tests/integration/__tests__/__snapshots__/diff.js.snap
+++ b/tests/integration/__tests__/__snapshots__/diff.js.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`--diff works in CI just as in a non-TTY mode (stderr) 1`] = `""`;
+
+exports[`--diff works in CI just as in a non-TTY mode (stderr) 2`] = `""`;
+
+exports[`--diff works in CI just as in a non-TTY mode (stdout) 1`] = `
+"Index: unformatted.js
+===================================================================
+--- unformatted.js
++++ unformatted.js
+@@ -1,1 +1,1 @@
+-var x      =      1;
+\\\\ No newline at end of file
++var x = 1;
+
+"
+`;
+
+exports[`--diff works in CI just as in a non-TTY mode (stdout) 2`] = `
+"Index: unformatted.js
+===================================================================
+--- unformatted.js
++++ unformatted.js
+@@ -1,1 +1,1 @@
+-var x      =      1;
+\\\\ No newline at end of file
++var x = 1;
+
+"
+`;
+
+exports[`--diff works in CI just as in a non-TTY mode (write) 1`] = `Array []`;
+
+exports[`--diff works in CI just as in a non-TTY mode (write) 2`] = `Array []`;
+
+exports[`checks stdin with --diff (write) 1`] = `Array []`;

--- a/tests/integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests/integration/__tests__/__snapshots__/early-exit.js.snap
@@ -53,6 +53,8 @@ Output options:
 
   -c, --check              Check if the given files are formatted, print a human-friendly summary
                            message and paths to unformatted files (see also --list-different).
+  --diff                   Check if the given files are formatted, print a unified diff patch for
+                           each unformatted file with formatting changes (see also --check).
   -l, --list-different     Print the names of files that are different from Prettier's formatting (see also --check).
   -w, --write              Edit files in-place. (Beware!)
 
@@ -228,6 +230,8 @@ Output options:
 
   -c, --check              Check if the given files are formatted, print a human-friendly summary
                            message and paths to unformatted files (see also --list-different).
+  --diff                   Check if the given files are formatted, print a unified diff patch for
+                           each unformatted file with formatting changes (see also --check).
   -l, --list-different     Print the names of files that are different from Prettier's formatting (see also --check).
   -w, --write              Edit files in-place. (Beware!)
 
@@ -348,7 +352,7 @@ Other options:
 exports[`throw error and show usage with something unexpected (write) 1`] = `[]`;
 
 exports[`throw error with --check + --list-different (stderr) 1`] = `
-"[error] Cannot use --check and --list-different together.
+"[error] Cannot use --check, --list-different, or --diff together.
 "
 `;
 

--- a/tests/integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/help-options.js.snap
@@ -154,6 +154,18 @@ Default: -1
 
 exports[`show detailed usage with --help cursor-offset (write) 1`] = `[]`;
 
+exports[`show detailed usage with --help diff (stderr) 1`] = `""`;
+
+exports[`show detailed usage with --help diff (stdout) 1`] = `
+"--diff
+
+  Check if the given files are formatted, print a unified diff patch for
+  each unformatted file with formatting changes (see also --check).
+"
+`;
+
+exports[`show detailed usage with --help diff (write) 1`] = `Array []`;
+
 exports[`show detailed usage with --help editorconfig (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help editorconfig (stdout) 1`] = `

--- a/tests/integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/help-options.js.snap
@@ -164,7 +164,7 @@ exports[`show detailed usage with --help diff (stdout) 1`] = `
 "
 `;
 
-exports[`show detailed usage with --help diff (write) 1`] = `Array []`;
+exports[`show detailed usage with --help diff (write) 1`] = `[]`;
 
 exports[`show detailed usage with --help editorconfig (stderr) 1`] = `""`;
 

--- a/tests/integration/__tests__/__snapshots__/plugin-options-string.js.snap
+++ b/tests/integration/__tests__/__snapshots__/plugin-options-string.js.snap
@@ -18,7 +18,7 @@ exports[`show external options with \`--help\` 1`] = `
 - First value
 + Second value
 
-@@ -22,16 +22,18 @@
+@@ -24,16 +24,18 @@
                              Control how Prettier formats quoted code embedded in the file.
                              Defaults to auto.
     --end-of-line <lf|crlf|cr|auto>

--- a/tests/integration/__tests__/__snapshots__/plugin-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/plugin-options.js.snap
@@ -61,7 +61,7 @@ exports[`show external options with \`--help\` 1`] = `
 - First value
 + Second value
 
-@@ -22,16 +22,18 @@
+@@ -24,16 +24,18 @@
                              Control how Prettier formats quoted code embedded in the file.
                              Defaults to auto.
     --end-of-line <lf|crlf|cr|auto>

--- a/tests/integration/__tests__/diff.js
+++ b/tests/integration/__tests__/diff.js
@@ -1,0 +1,51 @@
+"use strict";
+const { outdent } = require("outdent");
+
+const runPrettier = require("../run-prettier.js");
+
+describe("checks stdin with --diff", () => {
+  runPrettier("cli/with-shebang", ["--diff", "--parser", "babel"], {
+    input: "0",
+  }).test({
+    stdout: outdent({ trimTrailingNewline: false })`
+      Index: (stdin)
+      ===================================================================
+      --- (stdin)
+      +++ (stdin)
+      @@ -1,1 +1,1 @@
+      -0
+      \\ No newline at end of file
+      +0;
+
+    `,
+    stderr: "",
+    status: "non-zero",
+  });
+});
+
+describe("--diff works in CI just as in a non-TTY mode", () => {
+  const result0 = runPrettier(
+    "cli/write",
+    ["--diff", "formatted.js", "unformatted.js"],
+    {
+      stdoutIsTTY: true,
+      ci: true,
+    }
+  ).test({
+    status: 1,
+  });
+
+  const result1 = runPrettier(
+    "cli/write",
+    ["--diff", "formatted.js", "unformatted.js"],
+    {
+      stdoutIsTTY: false,
+    }
+  ).test({
+    status: 1,
+  });
+
+  test("Should be the same", async () => {
+    expect(await result0.stdout).toEqual(await result1.stdout);
+  });
+});

--- a/tests/integration/__tests__/diff.js
+++ b/tests/integration/__tests__/diff.js
@@ -1,36 +1,33 @@
 "use strict";
-const { outdent } = require("outdent");
-
 const runPrettier = require("../run-prettier.js");
 
 describe("checks stdin with --diff", () => {
   runPrettier("cli/with-shebang", ["--diff", "--parser", "babel"], {
-    input: "0",
+    input: "0;\n",
   }).test({
-    stdout: outdent({ trimTrailingNewline: false })`
-      Index: (stdin)
-      ===================================================================
-      --- (stdin)
-      +++ (stdin)
-      @@ -1,1 +1,1 @@
-      -0
-      \\ No newline at end of file
-      +0;
+    status: 0,
+  });
 
-    `,
-    stderr: "",
-    status: "non-zero",
+  runPrettier("cli/with-shebang", ["--diff", "--parser", "babel"], {
+    input: "var x      =      1;",
+  }).test({
+    status: 1,
   });
 });
 
-describe("--diff works in CI just as in a non-TTY mode", () => {
-  const result0 = runPrettier(
+describe("checks files with --diff", () => {
+  runPrettier(
     "cli/write",
     ["--diff", "formatted.js", "unformatted.js"],
-    {
-      stdoutIsTTY: true,
-      ci: true,
-    }
+  ).test({
+    status: 1,
+  });
+});
+
+describe("--diff works with --check", () => {
+  const result0 = runPrettier(
+    "cli/write",
+    ["--diff", "--check", "formatted.js", "unformatted.js"],
   ).test({
     status: 1,
   });
@@ -38,14 +35,20 @@ describe("--diff works in CI just as in a non-TTY mode", () => {
   const result1 = runPrettier(
     "cli/write",
     ["--diff", "formatted.js", "unformatted.js"],
-    {
-      stdoutIsTTY: false,
-    }
   ).test({
     status: 1,
   });
 
-  test("Should be the same", async () => {
+  test("`--diff` and `--diff --check` should behave identically", async () => {
     expect(await result0.stdout).toEqual(await result1.stdout);
+  });
+});
+
+describe("--diff can't be used with --write", () => {
+  runPrettier(
+    "cli/write",
+    ["--diff", "--write", "formatted.js"],
+  ).test({
+    status: 1,
   });
 });


### PR DESCRIPTION
## Description

Adds a new `--diff` flag that is similar to `--check` and `--list-different`, but instead of listing filenames, it outputs unified diffs with the changes Prettier would have made to format the file.

This was first requested in #6885 and there isn't really a firm answer one way or another from a maintainer yet, but I figure having a PR to look at could help move the discussion forward.

Thank you!

## Checklist

- [ ] I’ve added tests to confirm my change works.
  - This probably isn't enough testing but I had trouble finding good examples of how `--check` and `--list-different` are tested so any pointers to examples to mimick would be welcome.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
