### PR TITLE
Try add `coverageProvider: 'v8'`

### DIFF
--- a/jest-format-test.config.mjs
+++ b/jest-format-test.config.mjs
@@ -6,6 +6,7 @@ const config = {
   testRegex: "tests/format/.*/jsfmt\\.spec\\.js$",
   setupFiles: ["<rootDir>/tests/config/format-test-setup.js"],
   projects: [],
+  coverageProvider: "v8",
 };
 
 export default config;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Ref: https://github.com/nicolo-ribaudo/jest-light-runner/issues/6#issuecomment-1090208879, just a test

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
