### PR TITLE
Fix `groupBy` usage in playground sidebar

### DIFF
--- a/website/playground/sidebar/SidebarOptions.js
+++ b/website/playground/sidebar/SidebarOptions.js
@@ -10,7 +10,7 @@ export default function SidebarOptions({
   optionValues,
   onOptionValueChange,
 }) {
-  const options = groupBy(availableOptions, "category");
+  const options = groupBy(availableOptions, (option) => option.category);
   return categories.map((category) =>
     options[category] ? (
       <SidebarCategory key={category} title={category}>


### PR DESCRIPTION
## Description

The `groupBy` function added in fa3b95c2e1a3a3351dc1b0168aa2c26f0cc4e9b3 does not support the property name shorthand from lodash.

Fixes #12641

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
