### PR TITLE
docs(pre-commit): Use the new syntax

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -53,8 +53,9 @@ Read more at the [pretty-quick](https://github.com/azz/pretty-quick) repo.
 Copy the following config into your `.pre-commit-config.yaml` file:
 
 ```yaml
+repos:
 - repo: https://github.com/pre-commit/mirrors-prettier
-  rev: "" # Use the sha or tag you want to point at
+  rev: "v2.6.2" # Use the sha or tag you want to point at
   hooks:
     - id: prettier
 ```


### PR DESCRIPTION
## Description

The existing doc example raises a warning with precommit:

```
[WARNING] normalizing pre-commit configuration to a top-level map.  support for top level list will be removed in a future version.  run: `pre-commit migrate-config` to automatically fix this.
[WARNING] The 'rev' field of repo 'https://github.com/pre-commit/mirrors-prettier' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported.
See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details. 
Hint: `pre-commit autoupdate` often fixes this.
prettier.................................................................Failed
```

- No more top-level list, it uses the `repo` at the root
- Always specify version in the rev

## Checklist
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).