### PR TITLE
Test: Disallow useless `input` option

### DIFF
--- a/tests/integration/__tests__/check.js
+++ b/tests/integration/__tests__/check.js
@@ -50,9 +50,11 @@ describe("--checks works in CI just as in a non-TTY mode", () => {
 });
 
 describe("--checks should print the number of files that need formatting", () => {
-  runPrettier("cli/write", ["--check", "unformatted.js", "unformatted2.js"], {
-    input: "0",
-  }).test({
+  runPrettier("cli/write", [
+    "--check",
+    "unformatted.js",
+    "unformatted2.js",
+  ]).test({
     status: 1,
   });
 });

--- a/tests/integration/run-prettier.js
+++ b/tests/integration/run-prettier.js
@@ -82,10 +82,12 @@ async function run(dir, args, options) {
   // We cannot use `jest.setMock("get-stream", impl)` here, because in the
   // production build everything is bundled into one file so there is no
   // "get-stream" module to mock.
-  jest
-    .spyOn(require(thirdParty), "getStdin")
-    // eslint-disable-next-line require-await
-    .mockImplementation(async () => options.input || "");
+  const inputMock = Object.prototype.hasOwnProperty.call(options, "input")
+    ? jest
+        .spyOn(require(thirdParty), "getStdin")
+        // eslint-disable-next-line require-await
+        .mockImplementation(async () => options.input || "")
+    : undefined;
   jest
     .spyOn(require(thirdParty), "isCI")
     .mockImplementation(() => Boolean(options.ci));
@@ -122,6 +124,11 @@ async function run(dir, args, options) {
     process.stdin.isTTY = originalStdinIsTTY;
     process.stdout.isTTY = originalStdoutIsTTY;
     jest.restoreAllMocks();
+  }
+
+  // Disallow unused `input`
+  if (inputMock) {
+    expect(inputMock.mock.calls.length).not.toBe(0);
   }
 
   return { status, stdout, stderr, write };


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
