### PR TITLE
Change videos to embedded

### DIFF
--- a/website/versioned_docs/version-stable/index.md
+++ b/website/versioned_docs/version-stable/index.md
@@ -52,9 +52,9 @@ Prettier enforces a consistent code **style** (i.e. code formatting that won’t
 
 If you want to learn more, these two conference talks are great introductions:
 
-[![A Prettier Printer by James Long on React Conf 2017](/docs/assets/youtube-cover/a-prettier-printer-by-james-long-on-react-conf-2017.png)](https://www.youtube.com/watch?v=hkfBvpEfWdA)
+<iframe width="560" height="315" src="https://www.youtube.com/embed/hkfBvpEfWdA" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
-[![JavaScript Code Formatting by Christopher Chedeau on React London 2017](/docs/assets/youtube-cover/javascript-code-formatting-by-christopher-chedeau-on-react-london-2017.png)](https://www.youtube.com/watch?v=0Q4kUNx85_4)
+<iframe width="560" height="315" src="https://www.youtube.com/embed/0Q4kUNx85_4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 #### Footnotes
 


### PR DESCRIPTION
## Description

Change the youtube videos on the Documentation Intro to embedded meaning that the user does not leave the site when they click on it and can watch in the website.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
