### PR TITLE
Preserve blank line between export specifiers

### DIFF
--- a/changelog_unreleased/javascript/12746.md
+++ b/changelog_unreleased/javascript/12746.md
@@ -1,0 +1,33 @@
+#### Preserve blank line between export specifiers (#12746 by @sosukesuzuki)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+export {
+  // a
+  foo1,
+
+  // b
+  bar1,
+  baz1,
+} from "mod";
+
+// Prettier stable
+export {
+  // a
+  foo1,
+  // b
+  bar1,
+  baz1,
+} from "mod";
+
+// Prettier main
+export {
+  // a
+  foo1,
+
+  // b
+  bar1,
+  baz1,
+} from "mod";
+```

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -65,7 +65,7 @@ function handleOwnLineComment(context) {
     handleForComments,
     handleUnionTypeComments,
     handleOnlyComments,
-    handleImportExportDeclarationComments,
+    handleModuleSpecifiersComments,
     handleAssignmentPatternComments,
     handleMethodNameComments,
     handleLabeledStatementComments,
@@ -787,7 +787,7 @@ function handleForComments({ comment, enclosingNode }) {
   return false;
 }
 
-function handleImportExportDeclarationComments({
+function handleModuleSpecifiersComments({
   comment,
   precedingNode,
   enclosingNode,

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -65,7 +65,7 @@ function handleOwnLineComment(context) {
     handleForComments,
     handleUnionTypeComments,
     handleOnlyComments,
-    handleImportDeclarationComments,
+    handleImportExportDeclarationComments,
     handleAssignmentPatternComments,
     handleMethodNameComments,
     handleLabeledStatementComments,
@@ -787,17 +787,20 @@ function handleForComments({ comment, enclosingNode }) {
   return false;
 }
 
-function handleImportDeclarationComments({
+function handleImportExportDeclarationComments({
   comment,
   precedingNode,
   enclosingNode,
   text,
 }) {
+  const isImportDeclaration =
+    precedingNode?.type === "ImportSpecifier" &&
+    enclosingNode?.type === "ImportDeclaration";
+  const isExportDeclaration =
+    precedingNode?.type === "ExportSpecifier" &&
+    enclosingNode?.type === "ExportNamedDeclaration";
   if (
-    precedingNode &&
-    precedingNode.type === "ImportSpecifier" &&
-    enclosingNode &&
-    enclosingNode.type === "ImportDeclaration" &&
+    (isImportDeclaration || isExportDeclaration) &&
     hasNewline(text, locEnd(comment))
   ) {
     addTrailingComment(precedingNode, comment);

--- a/tests/format/js/export/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/export/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,114 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`blank-line-between-specifiers.js - {"bracketSpacing":false} format 1`] = `
+====================================options=====================================
+bracketSpacing: false
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export {
+  // a
+  foo1,
+
+  // b
+  bar1,
+  baz1,
+} from "mod";
+
+const foo2 = 1;
+const bar2 = 1;
+const baz2 = 1;
+
+export {
+  // a
+  foo2,
+
+  // b
+  bar2,
+  baz2,
+};
+
+=====================================output=====================================
+export {
+  // a
+  foo1,
+
+  // b
+  bar1,
+  baz1,
+} from "mod";
+
+const foo2 = 1;
+const bar2 = 1;
+const baz2 = 1;
+
+export {
+  // a
+  foo2,
+
+  // b
+  bar2,
+  baz2,
+};
+
+================================================================================
+`;
+
+exports[`blank-line-between-specifiers.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export {
+  // a
+  foo1,
+
+  // b
+  bar1,
+  baz1,
+} from "mod";
+
+const foo2 = 1;
+const bar2 = 1;
+const baz2 = 1;
+
+export {
+  // a
+  foo2,
+
+  // b
+  bar2,
+  baz2,
+};
+
+=====================================output=====================================
+export {
+  // a
+  foo1,
+
+  // b
+  bar1,
+  baz1,
+} from "mod";
+
+const foo2 = 1;
+const bar2 = 1;
+const baz2 = 1;
+
+export {
+  // a
+  foo2,
+
+  // b
+  bar2,
+  baz2,
+};
+
+================================================================================
+`;
+
 exports[`bracket.js - {"bracketSpacing":false} format 1`] = `
 ====================================options=====================================
 bracketSpacing: false

--- a/tests/format/js/export/blank-line-between-specifiers.js
+++ b/tests/format/js/export/blank-line-between-specifiers.js
@@ -1,0 +1,21 @@
+export {
+  // a
+  foo1,
+
+  // b
+  bar1,
+  baz1,
+} from "mod";
+
+const foo2 = 1;
+const bar2 = 1;
+const baz2 = 1;
+
+export {
+  // a
+  foo2,
+
+  // b
+  bar2,
+  baz2,
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #12738 

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
