### PR TITLE
Provide an example `.editorconfig`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,9 +176,35 @@ If you’d like a JSON schema to validate your configuration, one is available h
 
 ## EditorConfig
 
-If `options.editorconfig` is `true` and an [`.editorconfig` file](https://editorconfig.org/) is in your project, Prettier will parse it and convert its properties to the corresponding Prettier configuration. This configuration will be overridden by `.prettierrc`, etc. Currently, the following EditorConfig properties are supported:
+If `options.editorconfig` is `true` and an [`.editorconfig` file](https://editorconfig.org/) is in your project, Prettier will parse it and convert its properties to the corresponding Prettier configuration. This configuration will be overridden by `.prettierrc`, etc.
 
-- `end_of_line`
-- `indent_style`
-- `indent_size`/`tab_width`
-- `max_line_length`
+Here’s an annotated description of how different properties map to Prettier’s behavior:
+
+```toml
+[*]
+# Non-configurable Prettier behaviors
+charset = "utf-8"
+insert_final_newline = true
+# Caveat: Prettier won’t trim trailing whitespace inside template strings, but your editor might.
+trim_trailing_whitespace = true
+
+# Configurable Prettier behaviors
+# (change these if your Prettier config differs)
+end_of_line = "lf"
+indent_style = "space"
+indent_size = 2
+max_line_length = 80
+```
+
+Here’s a copy+paste-ready `.editorconfig` file if you use the default options:
+
+```toml
+[*]
+charset = "utf-8"
+insert_final_newline = true
+trim_trailing_whitespace = true
+end_of_line = "lf"
+indent_style = "space"
+indent_size = 2
+max_line_length = 80
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -180,7 +180,7 @@ If `options.editorconfig` is `true` and an [`.editorconfig` file](https://editor
 
 Here’s an annotated description of how different properties map to Prettier’s behavior:
 
-```toml
+```ini
 [*]
 # Non-configurable Prettier behaviors
 charset = "utf-8"
@@ -198,7 +198,7 @@ max_line_length = 80
 
 Here’s a copy+paste-ready `.editorconfig` file if you use the default options:
 
-```toml
+```ini
 [*]
 charset = "utf-8"
 insert_final_newline = true

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -181,6 +181,9 @@ If `options.editorconfig` is `true` and an [`.editorconfig` file](https://editor
 Here’s an annotated description of how different properties map to Prettier’s behavior:
 
 ```ini
+# Stop the editor from looking for .editorconfig files in the parent directories
+# root = true
+
 [*]
 # Non-configurable Prettier behaviors
 charset = "utf-8"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -186,15 +186,15 @@ Here’s an annotated description of how different properties map to Prettier’
 
 [*]
 # Non-configurable Prettier behaviors
-charset = "utf-8"
+charset = utf-8
 insert_final_newline = true
 # Caveat: Prettier won’t trim trailing whitespace inside template strings, but your editor might.
 # trim_trailing_whitespace = true
 
 # Configurable Prettier behaviors
 # (change these if your Prettier config differs)
-end_of_line = "lf"
-indent_style = "space"
+end_of_line = lf
+indent_style = space
 indent_size = 2
 max_line_length = 80
 ```
@@ -203,10 +203,10 @@ Here’s a copy+paste-ready `.editorconfig` file if you use the default options:
 
 ```ini
 [*]
-charset = "utf-8"
+charset = utf-8
 insert_final_newline = true
-end_of_line = "lf"
-indent_style = "space"
+end_of_line = lf
+indent_style = space
 indent_size = 2
 max_line_length = 80
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -186,7 +186,7 @@ Here’s an annotated description of how different properties map to Prettier’
 charset = "utf-8"
 insert_final_newline = true
 # Caveat: Prettier won’t trim trailing whitespace inside template strings, but your editor might.
-trim_trailing_whitespace = true
+# trim_trailing_whitespace = true
 
 # Configurable Prettier behaviors
 # (change these if your Prettier config differs)
@@ -202,7 +202,6 @@ Here’s a copy+paste-ready `.editorconfig` file if you use the default options:
 [*]
 charset = "utf-8"
 insert_final_newline = true
-trim_trailing_whitespace = true
 end_of_line = "lf"
 indent_style = "space"
 indent_size = 2


### PR DESCRIPTION
## Description

This PR adds an example `.editorconfig` file to the documentation that makes it easy to align your editor to Prettier’s behavior. [See the deploy preview here](https://deploy-preview-12756--prettier.netlify.app/docs/en/next/configuration.html#editorconfig)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
