### PR TITLE
Try searching for manually specified plugins in pluginSearchDir's

### DIFF
--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -48,8 +48,17 @@ function load(plugins, pluginSearchDirs) {
         // try local files
         requirePath = resolve(path.resolve(process.cwd(), pluginName));
       } catch {
-        // try node modules
-        requirePath = resolve(pluginName, { paths: [process.cwd()] });
+        try {
+          // try node modules
+          requirePath = resolve(pluginName, { paths: [process.cwd()] });
+        } catch {
+          // try provided plugin search dirs
+          requirePath = resolve(pluginName, {
+            paths: pluginSearchDirs.map((dir) =>
+              path.resolve(process.cwd(), dir)
+            ),
+          });
+        }
       }
 
       return {

--- a/tests/integration/__tests__/plugin-resolution.js
+++ b/tests/integration/__tests__/plugin-resolution.js
@@ -128,6 +128,21 @@ describe("crashes when one of --plugin-search-dir does not exist", () => {
   });
 });
 
+describe("load --plugin using --plugin-search-dir", () => {
+  runPrettier("plugins/extensions", [
+    "file.foo",
+    "--parser=foo",
+    "--plugin=prettier-plugin-bar",
+    "--plugin-search-dir=../automatic",
+    "--plugin-search-dir=.",
+  ]).test({
+    stdout: "foo+contents" + EOL,
+    stderr: "",
+    status: 0,
+    write: [],
+  });
+});
+
 describe("loads --plugin by its relative path", () => {
   runPrettier("plugins", [
     "automatic/file.txt",


### PR DESCRIPTION
## Description

If you specify a `--plugin` that lives outside the current tree (i.e. not resolvable by `require.resolve`), the CLI throws with a MODULE_NOT_FOUND error. Locations provided via `--plugin-search-dir` are _not_ searched.

**After this PR:** Locations provided via `--plugin-search-dir` are searched when resolving manually specified plugins.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
