### PR TITLE
Note that `.editorconfig` settings include `quote_type`.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -197,6 +197,7 @@ end_of_line = lf
 indent_style = space
 indent_size = 2
 max_line_length = 80
+quote_type = double
 ```
 
 Here’s a copy+paste-ready `.editorconfig` file if you use the default options:
@@ -209,4 +210,5 @@ end_of_line = lf
 indent_style = space
 indent_size = 2
 max_line_length = 80
+quote_type = double
 ```

--- a/docs/options.md
+++ b/docs/options.md
@@ -81,6 +81,8 @@ See the [strings rationale](rationale.md#strings) for more information.
 | ------- | ---------------- | --------------------- |
 | `false` | `--single-quote` | `singleQuote: <bool>` |
 
+Setting `quote_type` in an [`.editorconfig` file](https://editorconfig.org/) will configure Prettier’s usage of quotes, unless overridden.
+
 ## Quote Props
 
 Change when properties in objects are quoted.


### PR DESCRIPTION
## Description

Note that `.editorconfig` settings include `quote_type`.

They can include all values mapped in [editorconfig-to-prettier](https://github.com/josephfrazier/editorconfig-to-prettier/blob/master/index.js). I've been using `quote_type` locally for a while and was surprised to see it not in the docs.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve changed only documentation (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
