### PR TITLE
Remove `{resolveConfig,resolveConfigFile,getFileInfo}.sync`

### DIFF
--- a/changelog_unreleased/api/12574.md
+++ b/changelog_unreleased/api/12574.md
@@ -1,7 +1,8 @@
-#### [BREAKING] Change public apis to asynchronous (#12574 by @fisker)
+#### [BREAKING] Change public apis to asynchronous (#12574, #12788 by @fisker)
 
 - `prettier.format()` returns `Promise<string>`
 - `prettier.formatWithCursor()` returns `Promise<{formatted: string, cursorOffset: number}>`
 - `prettier.check()` returns `Promise<boolean>`
-
-More changes are coming...
+- `prettier.resolveConfig.sync` is removed
+- `prettier.resolveConfigFile.sync` is removed
+- `prettier.getFileInfo.sync` is removed

--- a/docs/api.md
+++ b/docs/api.md
@@ -58,8 +58,6 @@ If `options.editorconfig` is `true` and an [`.editorconfig` file](https://editor
 - `indent_size`/`tab_width`
 - `max_line_length`
 
-Use `prettier.resolveConfig.sync(filePath [, options])` if you’d like to use sync version.
-
 ## `prettier.resolveConfigFile([filePath])`
 
 `resolveConfigFile` can be used to find the path of the Prettier configuration file that will be used when resolving the config (i.e. when calling `resolveConfig`). A promise is returned which will resolve to:
@@ -76,8 +74,6 @@ prettier.resolveConfigFile(filePath).then((configFile) => {
   // you got the path of the configuration file
 });
 ```
-
-Use `prettier.resolveConfigFile.sync([filePath])` if you’d like to use sync version.
 
 ## `prettier.clearConfigCache()`
 
@@ -103,8 +99,6 @@ If the given `filePath` is ignored, the `inferredParser` is always `null`.
 Providing [plugin](plugins.md) paths in `options.plugins` (`string[]`) helps extract `inferredParser` for files that are not supported by Prettier core.
 
 When setting `options.resolveConfig` (`boolean`, default `false`), Prettier will resolve the configuration for the given `filePath`. This is useful, for example, when the `inferredParser` might be overridden for a subset of files.
-
-Use `prettier.getFileInfo.sync(filePath [, options])` if you’d like to use sync version.
 
 ## `prettier.getSupportInfo()`
 

--- a/src/common/create-ignorer.js
+++ b/src/common/create-ignorer.js
@@ -11,25 +11,6 @@ async function createIgnorer(ignorePath, withNodeModules) {
     ? await getFileContentOrNull(path.resolve(ignorePath))
     : null;
 
-  return _createIgnorer(ignoreContent, withNodeModules);
-}
-
-/**
- * @param {string?} ignorePath
- * @param {boolean?} withNodeModules
- */
-createIgnorer.sync = function (ignorePath, withNodeModules) {
-  const ignoreContent = !ignorePath
-    ? null
-    : getFileContentOrNull.sync(path.resolve(ignorePath));
-  return _createIgnorer(ignoreContent, withNodeModules);
-};
-
-/**
- * @param {null | string} ignoreContent
- * @param {boolean?} withNodeModules
- */
-function _createIgnorer(ignoreContent, withNodeModules) {
   const ignorer = ignore({ allowRelativePaths: true }).add(ignoreContent || "");
   if (!withNodeModules) {
     ignorer.add("node_modules");

--- a/src/common/get-file-info.js
+++ b/src/common/get-file-info.js
@@ -35,29 +35,6 @@ async function getFileInfo(filePath, opts) {
   });
 }
 
-/**
- * @param {string} filePath
- * @param {FileInfoOptions} opts
- * @returns {FileInfoResult}
- */
-getFileInfo.sync = function (filePath, opts) {
-  if (typeof filePath !== "string") {
-    throw new TypeError(
-      `expect \`filePath\` to be a string, got \`${typeof filePath}\``
-    );
-  }
-
-  const ignorer = createIgnorer.sync(opts.ignorePath, opts.withNodeModules);
-  return _getFileInfo({
-    ignorer,
-    filePath,
-    plugins: opts.plugins,
-    resolveConfig: opts.resolveConfig,
-    ignorePath: opts.ignorePath,
-    sync: true,
-  });
-};
-
 function getFileParser(resolvedConfig, filePath, plugins) {
   if (resolvedConfig && resolvedConfig.parser) {
     return resolvedConfig.parser;

--- a/src/common/get-file-info.js
+++ b/src/common/get-file-info.js
@@ -31,7 +31,6 @@ async function getFileInfo(filePath, opts) {
     plugins: opts.plugins,
     resolveConfig: opts.resolveConfig,
     ignorePath: opts.ignorePath,
-    sync: false,
   });
 }
 
@@ -49,13 +48,12 @@ function getFileParser(resolvedConfig, filePath, plugins) {
   return null;
 }
 
-function _getFileInfo({
+async function _getFileInfo({
   ignorer,
   filePath,
   plugins,
   resolveConfig = false,
   ignorePath,
-  sync = false,
 }) {
   const normalizedFilePath = normalizeFilePath(filePath, ignorePath);
 
@@ -71,18 +69,9 @@ function _getFileInfo({
   let resolvedConfig;
 
   if (resolveConfig) {
-    if (sync) {
-      resolvedConfig = config.resolveConfig.sync(filePath);
-    } else {
-      return config.resolveConfig(filePath).then((resolvedConfig) => {
-        fileInfo.inferredParser = getFileParser(
-          resolvedConfig,
-          filePath,
-          plugins
-        );
-        return fileInfo;
-      });
-    }
+    const resolvedConfig = await config.resolveConfig(filePath);
+    fileInfo.inferredParser = getFileParser(resolvedConfig, filePath, plugins);
+    return fileInfo;
   }
 
   fileInfo.inferredParser = getFileParser(resolvedConfig, filePath, plugins);

--- a/src/common/third-party.cjs
+++ b/src/common/third-party.cjs
@@ -2,7 +2,6 @@
 
 module.exports = {
   cosmiconfig: require("cosmiconfig").cosmiconfig,
-  cosmiconfigSync: require("cosmiconfig").cosmiconfigSync,
   findParentDir: require("find-parent-dir").sync,
   getStdin: require("get-stdin"),
   isCI: () => require("ci-info").isCI,

--- a/src/config/resolve-config-editorconfig.js
+++ b/src/config/resolve-config-editorconfig.js
@@ -17,24 +17,15 @@ const editorconfigAsyncNoCache = async (filePath) =>
   editorConfigToPrettier(await maybeParse(filePath, editorconfig.parse));
 const editorconfigAsyncWithCache = jsonStringifyMem(editorconfigAsyncNoCache);
 
-const editorconfigSyncNoCache = (filePath) =>
-  editorConfigToPrettier(maybeParse(filePath, editorconfig.parseSync));
-const editorconfigSyncWithCache = jsonStringifyMem(editorconfigSyncNoCache);
-
 function getLoadFunction(opts) {
   if (!opts.editorconfig) {
     return () => null;
-  }
-
-  if (opts.sync) {
-    return opts.cache ? editorconfigSyncWithCache : editorconfigSyncNoCache;
   }
 
   return opts.cache ? editorconfigAsyncWithCache : editorconfigAsyncNoCache;
 }
 
 function clearCache() {
-  memClear(editorconfigSyncWithCache);
   memClear(editorconfigAsyncWithCache);
 }
 

--- a/src/config/resolve-config.js
+++ b/src/config/resolve-config.js
@@ -91,7 +91,7 @@ async function resolveConfig(filePath, opts) {
 
   const [result, editorConfigured] = await Promise.all([
     opts.config ? load(opts.config) : search(filePath),
-    loadEditorConfig(filePath)
+    loadEditorConfig(filePath),
   ]);
 
   const merged = {

--- a/src/config/resolve-config.js
+++ b/src/config/resolve-config.js
@@ -75,9 +75,10 @@ const getExplorerMemoized = mem(
  * @return {Opts["sync"] extends true ? SyncExplorer : Explorer}
  */
 function getExplorer(opts) {
-  // Normalize opts before passing to a memoized function
-  opts = { sync: false, cache: false, ...opts };
-  return getExplorerMemoized(opts);
+  return getExplorerMemoized(
+    // Normalize opts before passing to a memoized function
+    { cache: false, ...opts }
+  );
 }
 
 async function resolveConfig(filePath, opts) {

--- a/src/config/resolve-config.js
+++ b/src/config/resolve-config.js
@@ -71,7 +71,7 @@ const getExplorerMemoized = mem(
 /**
  * @template {Options} Opts
  * @param {Opts} opts
- * @return {Opts["sync"] extends true ? SyncExplorer : Explorer}
+ * @return {Explorer}
  */
 function getExplorer(opts) {
   return getExplorerMemoized(

--- a/src/config/resolve-config.js
+++ b/src/config/resolve-config.js
@@ -89,10 +89,10 @@ async function resolveConfig(filePath, opts) {
   const { load, search } = getExplorer(loadOpts);
   const loadEditorConfig = resolveEditorConfig.getLoadFunction(loadOpts);
 
-  const [result, editorConfigured] = await Promise.all(
+  const [result, editorConfigured] = await Promise.all([
     opts.config ? load(opts.config) : search(filePath),
     loadEditorConfig(filePath)
-  );
+  ]);
 
   const merged = {
     ...editorConfigured,

--- a/src/config/resolve-config.js
+++ b/src/config/resolve-config.js
@@ -11,7 +11,7 @@ import * as resolveEditorConfig from "./resolve-config-editorconfig.js";
 
 /**
  * @typedef {ReturnType<import("cosmiconfig").cosmiconfig>} Explorer
- * @typedef {{sync?: boolean; cache?: boolean }} Options
+ * @typedef {{cache?: boolean }} Options
  */
 
 /**

--- a/src/config/resolve-config.js
+++ b/src/config/resolve-config.js
@@ -129,8 +129,6 @@ function _resolveConfig(filePath, opts, sync) {
 
 const resolveConfig = (filePath, opts) => _resolveConfig(filePath, opts, false);
 
-resolveConfig.sync = (filePath, opts) => _resolveConfig(filePath, opts, true);
-
 function clearCache() {
   memClear(getExplorerMemoized);
   resolveEditorConfig.clearCache();
@@ -141,12 +139,6 @@ async function resolveConfigFile(filePath) {
   const result = await search(filePath);
   return result ? result.filepath : null;
 }
-
-resolveConfigFile.sync = (filePath) => {
-  const { search } = getExplorer({ sync: true });
-  const result = search(filePath);
-  return result ? result.filepath : null;
-};
 
 function mergeOverrides(configResult, filePath) {
   const { config, filepath: configPath } = configResult || {};

--- a/src/config/resolve-config.js
+++ b/src/config/resolve-config.js
@@ -69,14 +69,13 @@ const getExplorerMemoized = mem(
 );
 
 /**
- * @template {Options} Opts
- * @param {Opts} opts
+ * @param {Options} [options]
  * @return {Explorer}
  */
-function getExplorer(opts) {
+function getExplorer(options) {
   return getExplorerMemoized(
     // Normalize opts before passing to a memoized function
-    { cache: false, ...opts }
+    { cache: false, ...options }
   );
 }
 
@@ -124,7 +123,7 @@ function clearCache() {
 }
 
 async function resolveConfigFile(filePath) {
-  const { search } = getExplorer({ sync: false });
+  const { search } = getExplorer();
   const result = await search(filePath);
   return result ? result.filepath : null;
 }

--- a/src/config/resolve-config.js
+++ b/src/config/resolve-config.js
@@ -11,14 +11,13 @@ import * as resolveEditorConfig from "./resolve-config-editorconfig.js";
 
 /**
  * @typedef {ReturnType<import("cosmiconfig").cosmiconfig>} Explorer
- * @typedef {ReturnType<import("cosmiconfig").cosmiconfigSync>} SyncExplorer
  * @typedef {{sync?: boolean; cache?: boolean }} Options
  */
 
 /**
  * @template {Options} Opts
  * @param {Opts} opts
- * @return {Opts["sync"] extends true ? SyncExplorer : Explorer}
+ * @return {Explorer}
  */
 const getExplorerMemoized = mem(
   (opts) => {

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,12 @@ const require = createRequire(import.meta.url);
 
 const { version } = require("../package.json");
 
-function _withPlugins(
+/**
+ * @param {*} fn
+ * @param {*} optsArgIdx
+ * @returns {*}
+ */
+function withPlugins(
   fn,
   optsArgIdx = 1 // Usually `opts` is the 2nd argument
 ) {
@@ -45,20 +50,6 @@ function _withPlugins(
     };
     return fn(...args);
   };
-}
-
-/**
- * @param {*} fn
- * @param {*} optsArgIdx
- * @returns {*}
- */
-function withPlugins(fn, optsArgIdx) {
-  const resultingFn = _withPlugins(fn, optsArgIdx);
-  if (fn.sync) {
-    // @ts-expect-error
-    resultingFn.sync = _withPlugins(fn.sync, optsArgIdx);
-  }
-  return resultingFn;
 }
 
 const formatWithCursor = withPlugins(core.formatWithCursor);

--- a/src/utils/get-file-content-or-null.js
+++ b/src/utils/get-file-content-or-null.js
@@ -1,4 +1,4 @@
-import {promises as fsPromises} from "node:fs";
+import { promises as fsPromises } from "node:fs";
 
 /**
  * @param {string} filename

--- a/src/utils/get-file-content-or-null.js
+++ b/src/utils/get-file-content-or-null.js
@@ -1,5 +1,4 @@
-import fs from "node:fs";
-const fsAsync = fs.promises;
+import {promises as fsPromises} from "node:fs";
 
 /**
  * @param {string} filename
@@ -7,30 +6,14 @@ const fsAsync = fs.promises;
  */
 async function getFileContentOrNull(filename) {
   try {
-    return await fsAsync.readFile(filename, "utf8");
+    return await fsPromises.readFile(filename, "utf8");
   } catch (error) {
-    return handleError(filename, error);
-  }
-}
+    if (error && error.code === "ENOENT") {
+      return null;
+    }
 
-/**
- * @param {string} filename
- * @returns {null | string}
- */
-getFileContentOrNull.sync = function (filename) {
-  try {
-    return fs.readFileSync(filename, "utf8");
-  } catch (error) {
-    return handleError(filename, error);
+    throw new Error(`Unable to read ${filename}: ${error.message}`);
   }
-};
-
-function handleError(filename, error) {
-  if (error && error.code === "ENOENT") {
-    return null;
-  }
-
-  throw new Error(`Unable to read ${filename}: ${error.message}`);
 }
 
 export default getFileContentOrNull;

--- a/tests/integration/__tests__/config-resolution.js
+++ b/tests/integration/__tests__/config-resolution.js
@@ -80,148 +80,82 @@ describe("CLI overrides take precedence", () => {
   });
 });
 
-test("API resolveConfig with no args", () =>
-  prettier.resolveConfig().then((result) => {
-    expect(result).toEqual({});
-  }));
-
-test("API resolveConfig.sync with no args", () => {
-  expect(prettier.resolveConfig.sync()).toEqual({});
+test("API resolveConfig with no args", async () => {
+  await expect(prettier.resolveConfig()).resolves.toEqual({});
 });
 
-test("API resolveConfig with file arg", () => {
+test("API resolveConfig with file arg", async () => {
   const file = path.resolve(path.join(__dirname, "../cli/config/js/file.js"));
-  return prettier.resolveConfig(file).then((result) => {
-    expect(result).toMatchObject({
-      tabWidth: 8,
-    });
-  });
-});
-
-test("API resolveConfig.sync with file arg", () => {
-  const file = path.resolve(path.join(__dirname, "../cli/config/js/file.js"));
-  expect(prettier.resolveConfig.sync(file)).toMatchObject({
+  await expect(prettier.resolveConfig(file)).resolves.toMatchObject({
     tabWidth: 8,
   });
 });
 
-test("API resolveConfig with file arg and extension override", () => {
+test("API resolveConfig with file arg and extension override", async () => {
   const file = path.resolve(
     path.join(__dirname, "../cli/config/no-config/file.ts")
   );
-  return prettier.resolveConfig(file).then((result) => {
-    expect(result).toMatchObject({
-      semi: true,
-    });
-  });
-});
-
-test("API resolveConfig.sync with file arg and extension override", () => {
-  const file = path.resolve(
-    path.join(__dirname, "../cli/config/no-config/file.ts")
-  );
-  expect(prettier.resolveConfig.sync(file)).toMatchObject({
+  await expect(prettier.resolveConfig(file)).resolves.toMatchObject({
     semi: true,
   });
 });
 
-test("API resolveConfig with file arg and .editorconfig", () => {
-  const file = path.resolve(
-    path.join(__dirname, "../cli/config/editorconfig/file.js")
-  );
-  return prettier.resolveConfig(file, { editorconfig: true }).then((result) => {
-    expect(result).toMatchObject({
-      useTabs: true,
-      tabWidth: 8,
-      printWidth: 100,
-    });
-  });
-});
-
-test("API resolveConfig.sync with file arg and .editorconfig", () => {
+test("API resolveConfig with file arg and .editorconfig", async () => {
   const file = path.resolve(
     path.join(__dirname, "../cli/config/editorconfig/file.js")
   );
 
-  expect(prettier.resolveConfig.sync(file)).toMatchObject({
+  await expect(prettier.resolveConfig(file)).resolves.toMatchObject({
     semi: false,
   });
 
-  expect(
-    prettier.resolveConfig.sync(file, { editorconfig: true })
-  ).toMatchObject({
+  await expect(
+    prettier.resolveConfig(file, { editorconfig: true })
+  ).resolves.toMatchObject({
     useTabs: true,
     tabWidth: 8,
     printWidth: 100,
   });
 });
 
-test("API resolveConfig.sync with file arg and .editorconfig (key = unset)", () => {
+test("API resolveConfig with file arg and .editorconfig (key = unset)", async () => {
   const file = path.resolve(
     path.join(__dirname, "../cli/config/editorconfig/tab_width=unset.js")
   );
 
-  expect(
-    prettier.resolveConfig.sync(file, { editorconfig: true })
-  ).not.toMatchObject({ tabWidth: "unset" });
+ await expect(
+    prettier.resolveConfig(file, { editorconfig: true })
+  ).resolves.not.toMatchObject({ tabWidth: "unset" });
 });
 
-test("API resolveConfig with nested file arg and .editorconfig", () => {
+test("API resolveConfig with nested file arg and .editorconfig", async () => {
   const file = path.resolve(
     path.join(__dirname, "../cli/config/editorconfig/lib/file.js")
   );
-  return prettier.resolveConfig(file, { editorconfig: true }).then((result) => {
-    expect(result).toMatchObject({
+
+  await expect(prettier.resolveConfig(file)).resolves.toMatchObject({
+    semi: false,
+  });
+
+  await expect(prettier.resolveConfig(file, { editorconfig: true })).resolves.toMatchObject({
       useTabs: false,
       tabWidth: 2,
       printWidth: 100,
     });
-  });
 });
 
-test("API resolveConfig.sync with nested file arg and .editorconfig", () => {
-  const file = path.resolve(
-    path.join(__dirname, "../cli/config/editorconfig/lib/file.js")
-  );
-
-  expect(prettier.resolveConfig.sync(file)).toMatchObject({
-    semi: false,
-  });
-
-  expect(
-    prettier.resolveConfig.sync(file, { editorconfig: true })
-  ).toMatchObject({
-    useTabs: false,
-    tabWidth: 2,
-    printWidth: 100,
-  });
-});
-
-test("API resolveConfig with nested file arg and .editorconfig and indent_size = tab", () => {
-  const file = path.resolve(
-    path.join(__dirname, "../cli/config/editorconfig/lib/indent_size=tab.js")
-  );
-  return prettier.resolveConfig(file, { editorconfig: true }).then((result) => {
-    expect(result).toMatchObject({
-      useTabs: false,
-      tabWidth: 8,
-      printWidth: 100,
-    });
-  });
-});
-
-test("API resolveConfig.sync with nested file arg and .editorconfig and indent_size = tab", () => {
+test("API resolveConfig with nested file arg and .editorconfig and indent_size = tab", async () => {
   const file = path.resolve(
     path.join(__dirname, "../cli/config/editorconfig/lib/indent_size=tab.js")
   );
 
-  expect(prettier.resolveConfig.sync(file)).toMatchObject({
+  await expect(prettier.resolveConfig(file)).resolves.toMatchObject({
     semi: false,
   });
 
-  expect(
-    prettier.resolveConfig.sync(file, { editorconfig: true })
-  ).toMatchObject({
+  await expect(
+    prettier.resolveConfig(file, { editorconfig: true })
+  ).resolves.toMatchObject({
     useTabs: false,
     tabWidth: 8,
     printWidth: 100,
@@ -241,20 +175,20 @@ test("API resolveConfig overrides work with dotfiles", async () => {
   });
 });
 
-test("API resolveConfig.sync overrides work with absolute paths", () => {
+test("API resolveConfig overrides work with absolute paths", async () => {
   // Absolute path
   const file = path.join(__dirname, "../cli/config/filepath/subfolder/file.js");
-  expect(prettier.resolveConfig.sync(file)).toMatchObject({
+  await expect(prettier.resolveConfig(file)).resolves.toMatchObject({
     tabWidth: 6,
   });
 });
 
-test("API resolveConfig.sync overrides excludeFiles", () => {
+test("API resolveConfig overrides excludeFiles", () => {
   const notOverride = path.join(
     __dirname,
     "../cli/config/overrides-exclude-files/foo"
   );
-  expect(prettier.resolveConfig.sync(notOverride)).toMatchObject({
+  await expect(prettier.resolveConfig(notOverride)).resolves.toMatchObject({
     singleQuote: true,
     trailingComma: "all",
   });
@@ -263,7 +197,7 @@ test("API resolveConfig.sync overrides excludeFiles", () => {
     __dirname,
     "../cli/config/overrides-exclude-files/single-quote.js"
   );
-  expect(prettier.resolveConfig.sync(singleQuote)).toMatchObject({
+  await expect(prettier.resolveConfig(singleQuote)).resolves.toMatchObject({
     singleQuote: true,
     trailingComma: "es5",
   });
@@ -272,7 +206,7 @@ test("API resolveConfig.sync overrides excludeFiles", () => {
     __dirname,
     "../cli/config/overrides-exclude-files/double-quote.js"
   );
-  expect(prettier.resolveConfig.sync(doubleQuote)).toMatchObject({
+  await expect(prettier.resolveConfig(doubleQuote)).resolves.toMatchObject({
     singleQuote: false,
     trailingComma: "es5",
   });
@@ -289,35 +223,30 @@ test("API resolveConfig removes $schema option", () => {
   });
 });
 
-test("API resolveConfig.sync removes $schema option", () => {
-  const file = path.resolve(
-    path.join(__dirname, "../cli/config/$schema/index.js")
-  );
-  expect(prettier.resolveConfig.sync(file)).toEqual({
-    tabWidth: 42,
-  });
-});
-
-test("API resolveConfig resolves relative path values based on config filepath", () => {
+test("API resolveConfig resolves relative path values based on config filepath", async () => {
   const currentDir = path.join(__dirname, "../cli/config/resolve-relative");
   const parentDir = path.resolve(currentDir, "..");
-  expect(prettier.resolveConfig.sync(`${currentDir}/index.js`)).toMatchObject({
+  await expect(
+    prettier.resolveConfig(`${currentDir}/index.js`)
+  ).resolves.toMatchObject({
     plugins: [path.join(parentDir, "path-to-plugin")],
     pluginSearchDirs: [path.join(parentDir, "path-to-plugin-search-dir")],
   });
 
-  expect(
-    prettier.resolveConfig.sync(
+  await expect(
+    prettier.resolveConfig(
       path.join(__dirname, "../cli/config/plugin-search-dirs/index.js")
     )
-  ).toMatchObject({
+  ).resolves.toMatchObject({
     pluginSearchDirs: false,
   });
 });
 
-test("API resolveConfig de-references to an external module", () => {
+test("API resolveConfig de-references to an external module", async () => {
   const currentDir = path.join(__dirname, "../cli/config/external-config");
-  expect(prettier.resolveConfig.sync(`${currentDir}/index.js`)).toEqual({
+  await expect(
+    prettier.resolveConfig(`${currentDir}/index.js`)
+  ).resolves.toEqual({
     printWidth: 77,
     semi: false,
   });
@@ -341,7 +270,6 @@ test(".cjs config file", async () => {
   ]) {
     const file = path.join(parentDirectory, directoryName, "foo.js");
 
-    expect(prettier.resolveConfig.sync(file)).toEqual(config);
     await expect(prettier.resolveConfig(file)).resolves.toMatchObject(config);
   }
 });
@@ -355,7 +283,6 @@ test(".json5 config file", async () => {
   };
   const file = path.join(parentDirectory, "json5/foo.js");
 
-  expect(prettier.resolveConfig.sync(file)).toEqual(config);
   await expect(prettier.resolveConfig(file)).resolves.toMatchObject(config);
 });
 
@@ -364,8 +291,5 @@ test(".json5 config file(invalid)", async () => {
   const file = path.join(parentDirectory, "invalid/foo.js");
   const error = /JSON5: invalid end of input at 2:1/;
 
-  expect(() => {
-    prettier.resolveConfig.sync(file);
-  }).toThrowError(error);
   await expect(prettier.resolveConfig(file)).rejects.toThrow(error);
 });

--- a/tests/integration/__tests__/config-resolution.js
+++ b/tests/integration/__tests__/config-resolution.js
@@ -123,7 +123,7 @@ test("API resolveConfig with file arg and .editorconfig (key = unset)", async ()
     path.join(__dirname, "../cli/config/editorconfig/tab_width=unset.js")
   );
 
- await expect(
+  await expect(
     prettier.resolveConfig(file, { editorconfig: true })
   ).resolves.not.toMatchObject({ tabWidth: "unset" });
 });
@@ -137,11 +137,13 @@ test("API resolveConfig with nested file arg and .editorconfig", async () => {
     semi: false,
   });
 
-  await expect(prettier.resolveConfig(file, { editorconfig: true })).resolves.toMatchObject({
-      useTabs: false,
-      tabWidth: 2,
-      printWidth: 100,
-    });
+  await expect(
+    prettier.resolveConfig(file, { editorconfig: true })
+  ).resolves.toMatchObject({
+    useTabs: false,
+    tabWidth: 2,
+    printWidth: 100,
+  });
 });
 
 test("API resolveConfig with nested file arg and .editorconfig and indent_size = tab", async () => {
@@ -183,7 +185,7 @@ test("API resolveConfig overrides work with absolute paths", async () => {
   });
 });
 
-test("API resolveConfig overrides excludeFiles", () => {
+test("API resolveConfig overrides excludeFiles", async () => {
   const notOverride = path.join(
     __dirname,
     "../cli/config/overrides-exclude-files/foo"
@@ -212,14 +214,12 @@ test("API resolveConfig overrides excludeFiles", () => {
   });
 });
 
-test("API resolveConfig removes $schema option", () => {
+test("API resolveConfig removes $schema option", async () => {
   const file = path.resolve(
     path.join(__dirname, "../cli/config/$schema/index.js")
   );
-  return prettier.resolveConfig(file).then((result) => {
-    expect(result).toEqual({
-      tabWidth: 42,
-    });
+  await expect(prettier.resolveConfig(file)).resolves.toEqual({
+    tabWidth: 42,
   });
 });
 

--- a/tests/integration/__tests__/file-info.js
+++ b/tests/integration/__tests__/file-info.js
@@ -140,21 +140,8 @@ test("API getFileInfo with no args", async () => {
   );
 });
 
-test("API getFileInfo.sync with no args", () => {
-  expect(() => prettier.getFileInfo.sync()).toThrow(
-    new TypeError("expect `filePath` to be a string, got `undefined`")
-  );
-});
-
 test("API getFileInfo with filepath only", async () => {
   await expect(prettier.getFileInfo("README")).resolves.toMatchObject({
-    ignored: false,
-    inferredParser: "markdown",
-  });
-});
-
-test("API getFileInfo.sync with filepath only", () => {
-  expect(prettier.getFileInfo.sync("README")).toMatchObject({
     ignored: false,
     inferredParser: "markdown",
   });
@@ -213,58 +200,6 @@ describe("API getFileInfo resolveConfig", () => {
       inferredParser: "css",
     });
   });
-  test("sync {resolveConfig: undefined}", () => {
-    expect(prettier.getFileInfo.sync(files.foo)).toMatchObject({
-      ignored: false,
-      inferredParser: null,
-    });
-    expect(prettier.getFileInfo.sync(files.js)).toMatchObject({
-      ignored: false,
-      inferredParser: "babel",
-    });
-    expect(prettier.getFileInfo.sync(files.bar)).toMatchObject({
-      ignored: false,
-      inferredParser: null,
-    });
-    expect(prettier.getFileInfo.sync(files.css)).toMatchObject({
-      ignored: false,
-      inferredParser: "css",
-    });
-  });
-  test("sync {resolveConfig: true}", () => {
-    expect(
-      prettier.getFileInfo.sync(files.foo, {
-        resolveConfig: true,
-      })
-    ).toMatchObject({
-      ignored: false,
-      inferredParser: "foo-parser",
-    });
-    expect(
-      prettier.getFileInfo.sync(files.js, {
-        resolveConfig: true,
-      })
-    ).toMatchObject({
-      ignored: false,
-      inferredParser: "override-js-parser",
-    });
-    expect(
-      prettier.getFileInfo.sync(files.bar, {
-        resolveConfig: true,
-      })
-    ).toMatchObject({
-      ignored: false,
-      inferredParser: null,
-    });
-    expect(
-      prettier.getFileInfo.sync(files.css, {
-        resolveConfig: true,
-      })
-    ).toMatchObject({
-      ignored: false,
-      inferredParser: "css",
-    });
-  });
 });
 
 describe("API getFileInfo resolveConfig when no config is present", () => {
@@ -294,30 +229,6 @@ describe("API getFileInfo resolveConfig when no config is present", () => {
     await expect(
       prettier.getFileInfo(files.js, { resolveConfig: true })
     ).resolves.toMatchObject({
-      ignored: false,
-      inferredParser: "babel",
-    });
-  });
-  test("sync {resolveConfig: undefined}", () => {
-    expect(prettier.getFileInfo.sync(files.foo)).toMatchObject({
-      ignored: false,
-      inferredParser: null,
-    });
-    expect(prettier.getFileInfo.sync(files.js)).toMatchObject({
-      ignored: false,
-      inferredParser: "babel",
-    });
-  });
-  test("sync {resolveConfig: true}", () => {
-    expect(
-      prettier.getFileInfo.sync(files.foo, { resolveConfig: true })
-    ).toMatchObject({
-      ignored: false,
-      inferredParser: null,
-    });
-    expect(
-      prettier.getFileInfo.sync(files.js, { resolveConfig: true })
-    ).toMatchObject({
       ignored: false,
       inferredParser: "babel",
     });
@@ -369,63 +280,6 @@ test("API getFileInfo with ignorePath containing relative paths", async () => {
   });
 });
 
-test("API getFileInfo.sync with ignorePath", () => {
-  const file = path.resolve(
-    path.join(__dirname, "../cli/ignore-path/regular-module.js")
-  );
-  const ignorePath = path.resolve(
-    path.join(__dirname, "../cli/ignore-path/.prettierignore")
-  );
-
-  expect(prettier.getFileInfo.sync(file)).toMatchObject({
-    ignored: false,
-    inferredParser: "babel",
-  });
-
-  expect(
-    prettier.getFileInfo.sync(file, {
-      ignorePath,
-    })
-  ).toMatchObject({
-    ignored: true,
-    inferredParser: null,
-  });
-});
-
-describe("API getFileInfo.sync with ignorePath", () => {
-  let cwd;
-  let filePath;
-  let options;
-  beforeAll(() => {
-    cwd = process.cwd();
-    const tempDir = tempy.directory();
-    process.chdir(tempDir);
-    const fileDir = "src";
-    filePath = `${fileDir}/should-be-ignored.js`;
-    const ignorePath = path.join(tempDir, ".prettierignore");
-    fs.writeFileSync(ignorePath, filePath, "utf8");
-    options = { ignorePath };
-  });
-  afterAll(() => {
-    process.chdir(cwd);
-  });
-  test("with relative filePath", () => {
-    expect(
-      prettier.getFileInfo.sync(filePath, options).ignored
-    ).toMatchInlineSnapshot("true");
-  });
-  test("with relative filePath starts with dot", () => {
-    expect(
-      prettier.getFileInfo.sync(`./${filePath}`, options).ignored
-    ).toMatchInlineSnapshot("true");
-  });
-  test("with absolute filePath", () => {
-    expect(
-      prettier.getFileInfo.sync(path.resolve(filePath), options).ignored
-    ).toMatchInlineSnapshot("true");
-  });
-});
-
 test("API getFileInfo with withNodeModules", async () => {
   const file = path.resolve(
     path.join(__dirname, "../cli/with-node-modules/node_modules/file.js")
@@ -444,28 +298,28 @@ test("API getFileInfo with withNodeModules", async () => {
   });
 });
 
-describe("extracts file-info for a JS file with no extension but a standard shebang", () => {
-  expect(
-    prettier.getFileInfo.sync("tests/integration/cli/shebang/node-shebang")
-  ).toMatchObject({
+describe("extracts file-info for a JS file with no extension but a standard shebang", async () => {
+  await expect(
+    prettier.getFileInfo("tests/integration/cli/shebang/node-shebang")
+  ).resolves.toMatchObject({
     ignored: false,
     inferredParser: "babel",
   });
 });
 
-describe("extracts file-info for a JS file with no extension but an env-based shebang", () => {
-  expect(
-    prettier.getFileInfo.sync("tests/integration/cli/shebang/env-node-shebang")
-  ).toMatchObject({
+describe("extracts file-info for a JS file with no extension but an env-based shebang", async () => {
+  await expect(
+    prettier.getFileInfo("tests/integration/cli/shebang/env-node-shebang")
+  ).resolves.toMatchObject({
     ignored: false,
     inferredParser: "babel",
   });
 });
 
-describe("returns null parser for unknown shebang", () => {
-  expect(
-    prettier.getFileInfo.sync("tests/integration/cli/shebang/nonsense-shebang")
-  ).toMatchObject({
+describe("returns null parser for unknown shebang", async () => {
+  await expect(
+    prettier.getFileInfo("tests/integration/cli/shebang/nonsense-shebang")
+  ).resolves.toMatchObject({
     ignored: false,
     inferredParser: null,
   });
@@ -522,11 +376,6 @@ test("API getFileInfo with ignorePath and resolveConfig should infer parser with
   };
 
   await expect(prettier.getFileInfo(filePath, options)).resolves.toMatchObject({
-    ignored: false,
-    inferredParser: "parser-for-config-dir",
-  });
-
-  expect(prettier.getFileInfo.sync(filePath, options)).toMatchObject({
     ignored: false,
     inferredParser: "parser-for-config-dir",
   });

--- a/tests/integration/__tests__/file-info.js
+++ b/tests/integration/__tests__/file-info.js
@@ -274,19 +274,19 @@ describe("API getFileInfo with ignorePath", () => {
     process.chdir(cwd);
   });
   test("with relative filePath", async () => {
-    await expect(
-      prettier.getFileInfo.sync(filePath, options).ignored
-    ).resolves.toMatchInlineSnapshot("true");
+    const { ignored } = await prettier.getFileInfo(filePath, options);
+    expect(ignored).toBe(true);
   });
   test("with relative filePath starts with dot", async () => {
-    await expect(
-      prettier.getFileInfo.sync(`./${filePath}`, options).ignored
-    ).resolves.toMatchInlineSnapshot("true");
+    const { ignored } = await prettier.getFileInfo(`./${filePath}`, options);
+    expect(ignored).toBe(true);
   });
   test("with absolute filePath", async () => {
-    await expect(
-      prettier.getFileInfo.sync(path.resolve(filePath), options).ignored
-    ).resolves.toMatchInlineSnapshot("true");
+    const { ignored } = await prettier.getFileInfo(
+      path.resolve(filePath),
+      options
+    );
+    expect(ignored).toBe(true);
   });
 });
 

--- a/tests/integration/__tests__/file-info.js
+++ b/tests/integration/__tests__/file-info.js
@@ -256,6 +256,30 @@ test("API getFileInfo with ignorePath", async () => {
   });
 });
 
+test("API getFileInfo with ignorePath containing relative paths", async () => {
+  const file = path.resolve(
+    path.join(
+      __dirname,
+      "../cli/ignore-relative-path/level1-glob/level2-glob/level3-glob/shouldNotBeFormat.js"
+    )
+  );
+  const ignorePath = path.resolve(
+    path.join(__dirname, "../cli/ignore-relative-path/.prettierignore")
+  );
+
+  await expect(prettier.getFileInfo(file)).resolves.toMatchObject({
+    ignored: false,
+    inferredParser: "babel",
+  });
+
+  await expect(
+    prettier.getFileInfo(file, { ignorePath })
+  ).resolves.toMatchObject({
+    ignored: true,
+    inferredParser: null,
+  });
+});
+
 describe("API getFileInfo with ignorePath", () => {
   let cwd;
   let filePath;
@@ -287,30 +311,6 @@ describe("API getFileInfo with ignorePath", () => {
       options
     );
     expect(ignored).toBe(true);
-  });
-});
-
-test("API getFileInfo with ignorePath containing relative paths", async () => {
-  const file = path.resolve(
-    path.join(
-      __dirname,
-      "../cli/ignore-relative-path/level1-glob/level2-glob/level3-glob/shouldNotBeFormat.js"
-    )
-  );
-  const ignorePath = path.resolve(
-    path.join(__dirname, "../cli/ignore-relative-path/.prettierignore")
-  );
-
-  await expect(prettier.getFileInfo(file)).resolves.toMatchObject({
-    ignored: false,
-    inferredParser: "babel",
-  });
-
-  await expect(
-    prettier.getFileInfo(file, { ignorePath })
-  ).resolves.toMatchObject({
-    ignored: true,
-    inferredParser: null,
   });
 });
 

--- a/tests/integration/__tests__/file-info.js
+++ b/tests/integration/__tests__/file-info.js
@@ -298,7 +298,7 @@ test("API getFileInfo with withNodeModules", async () => {
   });
 });
 
-describe("extracts file-info for a JS file with no extension but a standard shebang", async () => {
+test("extracts file-info for a JS file with no extension but a standard shebang", async () => {
   await expect(
     prettier.getFileInfo("tests/integration/cli/shebang/node-shebang")
   ).resolves.toMatchObject({
@@ -307,7 +307,7 @@ describe("extracts file-info for a JS file with no extension but a standard sheb
   });
 });
 
-describe("extracts file-info for a JS file with no extension but an env-based shebang", async () => {
+test("extracts file-info for a JS file with no extension but an env-based shebang", async () => {
   await expect(
     prettier.getFileInfo("tests/integration/cli/shebang/env-node-shebang")
   ).resolves.toMatchObject({
@@ -316,7 +316,7 @@ describe("extracts file-info for a JS file with no extension but an env-based sh
   });
 });
 
-describe("returns null parser for unknown shebang", async () => {
+test("returns null parser for unknown shebang", async () => {
   await expect(
     prettier.getFileInfo("tests/integration/cli/shebang/nonsense-shebang")
   ).resolves.toMatchObject({

--- a/tests/integration/__tests__/file-info.js
+++ b/tests/integration/__tests__/file-info.js
@@ -256,6 +256,40 @@ test("API getFileInfo with ignorePath", async () => {
   });
 });
 
+describe("API getFileInfo with ignorePath", () => {
+  let cwd;
+  let filePath;
+  let options;
+  beforeAll(() => {
+    cwd = process.cwd();
+    const tempDir = tempy.directory();
+    process.chdir(tempDir);
+    const fileDir = "src";
+    filePath = `${fileDir}/should-be-ignored.js`;
+    const ignorePath = path.join(tempDir, ".prettierignore");
+    fs.writeFileSync(ignorePath, filePath, "utf8");
+    options = { ignorePath };
+  });
+  afterAll(() => {
+    process.chdir(cwd);
+  });
+  test("with relative filePath", async () => {
+    await expect(
+      prettier.getFileInfo.sync(filePath, options).ignored
+    ).resolves.toMatchInlineSnapshot("true");
+  });
+  test("with relative filePath starts with dot", async () => {
+    await expect(
+      prettier.getFileInfo.sync(`./${filePath}`, options).ignored
+    ).resolves.toMatchInlineSnapshot("true");
+  });
+  test("with absolute filePath", async () => {
+    await expect(
+      prettier.getFileInfo.sync(path.resolve(filePath), options).ignored
+    ).resolves.toMatchInlineSnapshot("true");
+  });
+});
+
 test("API getFileInfo with ignorePath containing relative paths", async () => {
   const file = path.resolve(
     path.join(

--- a/tests/integration/__tests__/resolve-config-file.js
+++ b/tests/integration/__tests__/resolve-config-file.js
@@ -8,8 +8,3 @@ test("API resolveConfigFile", async () => {
   const result = await prettier.resolveConfigFile();
   expect(result).toEqual(path.join(__dirname, "../../../.prettierrc"));
 });
-
-test("API resolveConfigFile.sync", () => {
-  const result = prettier.resolveConfigFile.sync();
-  expect(result).toEqual(path.join(__dirname, "../../../.prettierrc"));
-});

--- a/tests/integration/__tests__/third-party.js
+++ b/tests/integration/__tests__/third-party.js
@@ -51,7 +51,7 @@ describe("cosmiconfig", () => {
 
   // #8815, please make sure this error contains code frame
   test("Invalid json file", async () => {
-    await expect(() =>
+    await expect(
       cosmiconfig("prettier").search(
         path.join(__dirname, "../cli/config/invalid/broken-json")
       )

--- a/tests/integration/__tests__/third-party.js
+++ b/tests/integration/__tests__/third-party.js
@@ -4,7 +4,7 @@ import { thirdParty } from "../env.js";
 import jestPathSerializer from "../path-serializer.js";
 
 const { require, __dirname } = createEsmUtils(import.meta);
-const { cosmiconfig, cosmiconfigSync, isCI } = require(thirdParty);
+const { cosmiconfig, isCI } = require(thirdParty);
 
 expect.addSnapshotSerializer(jestPathSerializer);
 
@@ -47,21 +47,15 @@ describe("cosmiconfig", () => {
       expect(config).toEqual(value);
       expect(filepath).toBe(file);
     });
-
-    test(`sync version ${title}`, () => {
-      const { config, filepath } = cosmiconfigSync("prettier").search(dirname);
-      expect(config).toEqual(value);
-      expect(filepath).toBe(file);
-    });
   }
 
   // #8815, please make sure this error contains code frame
-  test("Invalid json file", () => {
-    expect(() => {
-      cosmiconfigSync("prettier").search(
+  test("Invalid json file", async () => {
+    await expect(() =>
+      cosmiconfig("prettier").search(
         path.join(__dirname, "../cli/config/invalid/broken-json")
-      );
-    }).toThrowErrorMatchingSnapshot();
+      )
+    ).rejects.toThrowErrorMatchingSnapshot();
   });
 });
 

--- a/tests/integration/run-prettier.js
+++ b/tests/integration/run-prettier.js
@@ -100,14 +100,6 @@ async function run(dir, args, options) {
       })
     );
   jest
-    .spyOn(require(thirdParty), "cosmiconfigSync")
-    .mockImplementation((moduleName, options) =>
-      require("cosmiconfig").cosmiconfigSync(moduleName, {
-        ...options,
-        stopDir: path.join(__dirname, "cli"),
-      })
-    );
-  jest
     .spyOn(require(thirdParty), "findParentDir")
     .mockImplementation(() => process.cwd());
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Ref: https://github.com/prettier/prettier/issues/4459#issuecomment-982661922

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
