### PR TITLE
Add webpackIgnore to dynamic plugin require

### DIFF
--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -96,7 +96,7 @@ function load(plugins, pluginSearchDirs) {
       "requirePath"
     ).map((externalPluginInfo) => ({
       name: externalPluginInfo.name,
-      ...require(externalPluginInfo.requirePath),
+      ...require(/* webpackIgnore: true */ externalPluginInfo.requirePath),
     })),
     ...externalPluginInstances,
   ];


### PR DESCRIPTION
## Description

Prettier uses dynamic `require` statement with an expression argument when loading manually-specified plugins:

https://github.com/prettier/prettier/blob/b188c905cfaeb238a122b4a95c230da83f2f3226/src/common/load-plugins.js#L98-L100

Webpack is unable to handle to dynamic `require` statements: As stated in [this](https://stackoverflow.com/a/42804941) StackOverflow post:
> You cannot use a variable as argument to require. Webpack needs to know what files to bundle at compile time.

As a result, if a node app runs prettier with a plugin, e.g.

```ts
import { format } from "prettier";

format(text, {
  plugins: ["/path/to/my-plugin"],
});
```

it will fail at runtime with `MODULE_NOT_FOUND`, even if the plugin is included as a dependency in `package.json`.

This PR fixes this by telling webpack _not_ to replace the `require` call with the webpack version. Now, apps built with webpack will work! All that's needed is to enable CommonJS magic webpack comments

```js
// webpack.config.js
module.exports = {
  module: {
    parser: {
      javascript: {
        commonjsMagicComments: true
      }
    }
  }
}
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
