### PR TITLE
Ignore `cursorOffset` in `format()` and `check()`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,14 +55,16 @@ function withPlugins(
 
 const formatWithCursor = withPlugins(core.formatWithCursor);
 
-async function format(text, opts) {
-  const { formatted } = await formatWithCursor(text, opts);
+async function format(text, options) {
+  const { formatted } = await formatWithCursor(text, {
+    ...options,
+    cursorOffset: -1,
+  });
   return formatted;
 }
 
-async function check(text, opts) {
-  const { formatted } = await formatWithCursor(text, opts);
-  return formatted === text;
+async function check(text, options) {
+  return (await format(text, options)) === text;
 }
 
 function clearCache() {

--- a/src/standalone.js
+++ b/src/standalone.js
@@ -30,14 +30,16 @@ function withPlugins(
 
 const formatWithCursor = withPlugins(core.formatWithCursor);
 
-async function format(text, opts) {
-  const { formatted } = await formatWithCursor(text, opts);
+async function format(text, options) {
+  const { formatted } = await formatWithCursor(text, {
+    ...options,
+    cursorOffset: -1,
+  });
   return formatted;
 }
 
-async function check(text, opts) {
-  const { formatted } = await formatWithCursor(text, opts);
-  return formatted === text;
+async function check(text, options) {
+  return (await format(text, options)) === text;
 }
 
 const getSupportInfo = withPlugins(getSupportInfoWithoutPlugins, 0);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Maintain `cursorOffset` seems expensive to me, and it's useless in `format()` and `check()`

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
