### PR TITLE
Test: Add env flag to allow skip production install

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -7,12 +7,16 @@ const isProduction = process.env.NODE_ENV === "production";
 const ENABLE_CODE_COVERAGE = Boolean(process.env.ENABLE_CODE_COVERAGE);
 const TEST_STANDALONE = Boolean(process.env.TEST_STANDALONE);
 const INSTALL_PACKAGE = Boolean(process.env.INSTALL_PACKAGE);
+const SKIP_PRODUCTION_INSTALL = Boolean(process.env.SKIP_PRODUCTION_INSTALL);
 const SKIP_TESTS_WITH_NEW_SYNTAX = process.versions.node.startsWith("12.");
 
 let PRETTIER_DIR = isProduction
   ? path.join(PROJECT_ROOT, "dist")
   : PROJECT_ROOT;
-if (INSTALL_PACKAGE || (isProduction && !TEST_STANDALONE)) {
+if (
+  INSTALL_PACKAGE ||
+  (isProduction && !TEST_STANDALONE && !SKIP_PRODUCTION_INSTALL)
+) {
   PRETTIER_DIR = installPrettier(PRETTIER_DIR);
 }
 process.env.PRETTIER_DIR = PRETTIER_DIR;

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -7,6 +7,7 @@ const isProduction = process.env.NODE_ENV === "production";
 const ENABLE_CODE_COVERAGE = Boolean(process.env.ENABLE_CODE_COVERAGE);
 const TEST_STANDALONE = Boolean(process.env.TEST_STANDALONE);
 const INSTALL_PACKAGE = Boolean(process.env.INSTALL_PACKAGE);
+// When debugging production test, this flag can skip installing package
 const SKIP_PRODUCTION_INSTALL = Boolean(process.env.SKIP_PRODUCTION_INSTALL);
 const SKIP_TESTS_WITH_NEW_SYNTAX = process.versions.node.startsWith("12.");
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

We use a temp dir to run production test, but when debugging tests locally, keep installing packages is annoying, add a env flag to allow skip install.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
