### PR TITLE
Unused-imports for the .eslintrc.js.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,11 +18,13 @@ module.exports = {
     "regexp",
     "unicorn",
     "@typescript-eslint",
+    "unused-imports",
   ],
   settings: {
     "import/internal-regex": "^linguist-languages/",
   },
   rules: {
+    "unused-imports/no-unused-imports": "error",
     "@typescript-eslint/prefer-ts-expect-error": "error",
     "arrow-body-style": ["error", "as-needed"],
     curly: "error",
@@ -45,10 +47,13 @@ module.exports = {
     "no-return-await": "error",
     "no-unneeded-ternary": "error",
     "no-useless-return": "error",
-    "no-unused-vars": [
-      "error",
+    "no-unused-vars": ["off"],
+    "unused-imports/no-unused-vars": [
+      "warn",
       {
-        ignoreRestSiblings: true,
+        vars: "all",
+        args: "after-used",
+        argsIgnorePattern: "^_",
       },
     ],
     "no-var": "error",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "editorconfig": "0.15.3",
     "editorconfig-to-prettier": "0.2.0",
     "escape-string-regexp": "5.0.0",
+    "eslint-plugin-unused-imports": "2.0.0",
     "espree": "9.3.1",
     "esutils": "2.0.3",
     "fast-glob": "3.2.11",

--- a/src/main/options-normalizer.js
+++ b/src/main/options-normalizer.js
@@ -78,7 +78,7 @@ function normalizeOptions(
   const unknown = !passThrough
     ? (key, value, options) => {
         // Don't suggest `_` for unknown flags
-        const { _, ...schemas } = options.schemas;
+        const { ...schemas } = options.schemas;
         return vnopts.levenUnknownHandler(key, value, {
           ...options,
           schemas,

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -105,7 +105,7 @@ function getSupportInfo({
     if (showInternal) {
       return object;
     }
-    const { cliName, cliCategory, cliDescription, ...newObject } = object;
+    const { ...newObject } = object;
     return newObject;
   }
 }

--- a/website/playground/buttons.js
+++ b/website/playground/buttons.js
@@ -37,7 +37,7 @@ export class ClipboardButton extends React.Component {
   }
 
   render() {
-    const { children, copy, ...rest } = this.props;
+    const { children, ...rest } = this.props;
     const { showTooltip, tooltipText } = this.state;
 
     return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -3087,6 +3087,18 @@ eslint-plugin-unicorn@42.0.0:
     semver "^7.3.5"
     strip-indent "^3.0.0"
 
+eslint-plugin-unused-imports@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz#d8db8c4d0cfa0637a8b51ce3fd7d1b6bc3f08520"
+  integrity sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==
+  dependencies:
+    eslint-rule-composer "^0.3.0"
+
+eslint-rule-composer@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
+  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
## Description

Use the no-unused-imports package for errors when importing unused packages. This eslint package also brings in a no-unused-vars option which identifies unused variables with a higher accuracy than the former option of the built in no-unused-vars option with eslint.

Fixed files in order to comply with the .eslintrc.js rules.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
