### PR TITLE
Support TS 4.7 `extends` constraints for `infer` (tests)

### DIFF
--- a/tests/format/misc/typescript-babel-only/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/typescript-babel-only/__snapshots__/jsfmt.spec.js.snap
@@ -184,6 +184,40 @@ type Foo =
 ================================================================================
 `;
 
+exports[`ts-4.7-infer-extends.ts format 1`] = `
+====================================options=====================================
+parsers: ["babel-ts"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type X3<T> = T extends [infer U extends number] ? MustBeNumber<U> : never;
+type X4<T> = T extends [infer U extends number, infer U extends number] ? MustBeNumber<U> : never;
+type X5<T> = T extends [infer U extends number, infer U] ? MustBeNumber<U> : never;
+type X6<T> = T extends [infer U, infer U extends number] ? MustBeNumber<U> : never;
+type X7<T> = T extends [infer U extends string, infer U extends number] ? U : never;
+type X8<U, T> = T extends infer U extends number ? U : T;
+type X9<U, T> = T extends (infer U extends number ? U : T) ? U : T;
+
+=====================================output=====================================
+type X3<T> = T extends [infer U extends number] ? MustBeNumber<U> : never;
+type X4<T> = T extends [infer U extends number, infer U extends number]
+  ? MustBeNumber<U>
+  : never;
+type X5<T> = T extends [infer U extends number, infer U]
+  ? MustBeNumber<U>
+  : never;
+type X6<T> = T extends [infer U, infer U extends number]
+  ? MustBeNumber<U>
+  : never;
+type X7<T> = T extends [infer U extends string, infer U extends number]
+  ? U
+  : never;
+type X8<U, T> = T extends infer U extends number ? U : T;
+type X9<U, T> = T extends (infer U extends number ? U : T) ? U : T;
+
+================================================================================
+`;
+
 exports[`tuple-labeled-ts.ts format 1`] = `
 ====================================options=====================================
 parsers: ["babel-ts"]

--- a/tests/format/misc/typescript-babel-only/ts-4.7-infer-extends.ts
+++ b/tests/format/misc/typescript-babel-only/ts-4.7-infer-extends.ts
@@ -1,0 +1,7 @@
+type X3<T> = T extends [infer U extends number] ? MustBeNumber<U> : never;
+type X4<T> = T extends [infer U extends number, infer U extends number] ? MustBeNumber<U> : never;
+type X5<T> = T extends [infer U extends number, infer U] ? MustBeNumber<U> : never;
+type X6<T> = T extends [infer U, infer U extends number] ? MustBeNumber<U> : never;
+type X7<T> = T extends [infer U extends string, infer U extends number] ? U : never;
+type X8<U, T> = T extends infer U extends number ? U : T;
+type X9<U, T> = T extends (infer U extends number ? U : T) ? U : T;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

(babel-ts only)

Partial of #12640 

Just add tests for https://devblogs.microsoft.com/typescript/announcing-typescript-4-7-rc/#extends-constraints-on-infer-type-variables

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
