### PR TITLE
Support TS 4.7 optional variance

### DIFF
--- a/src/language-js/print/type-parameters.js
+++ b/src/language-js/print/type-parameters.js
@@ -127,6 +127,14 @@ function printTypeParameter(path, options, print) {
     parts.push(print("variance"));
   }
 
+  if (node.in) {
+    parts.push("in ");
+  }
+
+  if (node.out) {
+    parts.push("out ");
+  }
+
   parts.push(print("name"));
 
   if (node.bound) {

--- a/tests/format/misc/typescript-babel-only/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/typescript-babel-only/__snapshots__/jsfmt.spec.js.snap
@@ -246,6 +246,140 @@ new A<T>();
 ================================================================================
 `;
 
+exports[`ts-4.7-optional-variance.ts format 1`] = `
+====================================options=====================================
+parsers: ["babel-ts"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type Covariant<out T> = {
+    x: T;
+}
+type Contravariant<in T> = {
+    f: (x: T) => void;
+}
+type Invariant<in out T> = {
+    f: (x: T) => T;
+}
+type T10<out T> = T;
+type T11<in T> = keyof T;
+type T12<out T, out K extends keyof T> = T[K];
+type T13<in out T> = T[keyof T];
+
+type Covariant1<in T> = {
+    x: T;
+}
+
+type Contravariant1<out T> = keyof T;
+
+type Contravariant2<out T> = {
+    f: (x: T) => void;
+}
+
+type Invariant1<in T> = {
+    f: (x: T) => T;
+}
+
+type Invariant2<out T> = {
+    f: (x: T) => T;
+}
+type Foo1<in T> = {
+    x: T;
+    f: FooFn1<T>;
+}
+
+type Foo2<out T> = {
+    x: T;
+    f: FooFn2<T>;
+}
+
+type Foo3<in out T> = {
+    x: T;
+    f: FooFn3<T>;
+}
+
+type T21<in out T> = T;
+
+interface Baz<out T> {}
+interface Baz<in T> {}
+
+interface Parent<out A> {
+    child: Child<A> | null;
+    parent: Parent<A> | null;
+}
+
+declare class StateNode<TContext, in out TEvent extends { type: string }> {
+    _storedEvent: TEvent;
+    _action: ActionObject<TEvent>;
+    _state: StateNode<TContext, any>;
+}
+
+=====================================output=====================================
+type Covariant<out T> = {
+  x: T;
+};
+type Contravariant<in T> = {
+  f: (x: T) => void;
+};
+type Invariant<in out T> = {
+  f: (x: T) => T;
+};
+type T10<out T> = T;
+type T11<in T> = keyof T;
+type T12<out T, out K extends keyof T> = T[K];
+type T13<in out T> = T[keyof T];
+
+type Covariant1<in T> = {
+  x: T;
+};
+
+type Contravariant1<out T> = keyof T;
+
+type Contravariant2<out T> = {
+  f: (x: T) => void;
+};
+
+type Invariant1<in T> = {
+  f: (x: T) => T;
+};
+
+type Invariant2<out T> = {
+  f: (x: T) => T;
+};
+type Foo1<in T> = {
+  x: T;
+  f: FooFn1<T>;
+};
+
+type Foo2<out T> = {
+  x: T;
+  f: FooFn2<T>;
+};
+
+type Foo3<in out T> = {
+  x: T;
+  f: FooFn3<T>;
+};
+
+type T21<in out T> = T;
+
+interface Baz<out T> {}
+interface Baz<in T> {}
+
+interface Parent<out A> {
+  child: Child<A> | null;
+  parent: Parent<A> | null;
+}
+
+declare class StateNode<TContext, in out TEvent extends { type: string }> {
+  _storedEvent: TEvent;
+  _action: ActionObject<TEvent>;
+  _state: StateNode<TContext, any>;
+}
+
+================================================================================
+`;
+
 exports[`tuple-labeled-ts.ts format 1`] = `
 ====================================options=====================================
 parsers: ["babel-ts"]

--- a/tests/format/misc/typescript-babel-only/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/typescript-babel-only/__snapshots__/jsfmt.spec.js.snap
@@ -380,6 +380,146 @@ declare class StateNode<TContext, in out TEvent extends { type: string }> {
 ================================================================================
 `;
 
+exports[`ts-4.7-optional-variance-with-jsx.tsx format 1`] = `
+====================================options=====================================
+parsers: ["babel-ts"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// valid JSX
+<in T>() => {}</in>;
+
+type Covariant<out T> = {
+    x: T;
+}
+type Contravariant<in T> = {
+    f: (x: T) => void;
+}
+type Invariant<in out T> = {
+    f: (x: T) => T;
+}
+type T10<out T> = T;
+type T11<in T> = keyof T;
+type T12<out T, out K extends keyof T> = T[K];
+type T13<in out T> = T[keyof T];
+
+type Covariant1<in T> = {
+    x: T;
+}
+
+type Contravariant1<out T> = keyof T;
+
+type Contravariant2<out T> = {
+    f: (x: T) => void;
+}
+
+type Invariant1<in T> = {
+    f: (x: T) => T;
+}
+
+type Invariant2<out T> = {
+    f: (x: T) => T;
+}
+type Foo1<in T> = {
+    x: T;
+    f: FooFn1<T>;
+}
+
+type Foo2<out T> = {
+    x: T;
+    f: FooFn2<T>;
+}
+
+type Foo3<in out T> = {
+    x: T;
+    f: FooFn3<T>;
+}
+
+type T21<in out T> = T;
+
+interface Baz<out T> {}
+interface Baz<in T> {}
+
+interface Parent<out A> {
+    child: Child<A> | null;
+    parent: Parent<A> | null;
+}
+
+declare class StateNode<TContext, in out TEvent extends { type: string }> {
+    _storedEvent: TEvent;
+    _action: ActionObject<TEvent>;
+    _state: StateNode<TContext, any>;
+}
+
+=====================================output=====================================
+// valid JSX
+<in T>() => {}</in>;
+
+type Covariant<out T> = {
+  x: T;
+};
+type Contravariant<in T> = {
+  f: (x: T) => void;
+};
+type Invariant<in out T> = {
+  f: (x: T) => T;
+};
+type T10<out T> = T;
+type T11<in T> = keyof T;
+type T12<out T, out K extends keyof T> = T[K];
+type T13<in out T> = T[keyof T];
+
+type Covariant1<in T> = {
+  x: T;
+};
+
+type Contravariant1<out T> = keyof T;
+
+type Contravariant2<out T> = {
+  f: (x: T) => void;
+};
+
+type Invariant1<in T> = {
+  f: (x: T) => T;
+};
+
+type Invariant2<out T> = {
+  f: (x: T) => T;
+};
+type Foo1<in T> = {
+  x: T;
+  f: FooFn1<T>;
+};
+
+type Foo2<out T> = {
+  x: T;
+  f: FooFn2<T>;
+};
+
+type Foo3<in out T> = {
+  x: T;
+  f: FooFn3<T>;
+};
+
+type T21<in out T> = T;
+
+interface Baz<out T> {}
+interface Baz<in T> {}
+
+interface Parent<out A> {
+  child: Child<A> | null;
+  parent: Parent<A> | null;
+}
+
+declare class StateNode<TContext, in out TEvent extends { type: string }> {
+  _storedEvent: TEvent;
+  _action: ActionObject<TEvent>;
+  _state: StateNode<TContext, any>;
+}
+
+================================================================================
+`;
+
 exports[`tuple-labeled-ts.ts format 1`] = `
 ====================================options=====================================
 parsers: ["babel-ts"]

--- a/tests/format/misc/typescript-babel-only/ts-4.7-optional-variance-with-jsx.tsx
+++ b/tests/format/misc/typescript-babel-only/ts-4.7-optional-variance-with-jsx.tsx
@@ -1,0 +1,64 @@
+// valid JSX
+<in T>() => {}</in>;
+
+type Covariant<out T> = {
+    x: T;
+}
+type Contravariant<in T> = {
+    f: (x: T) => void;
+}
+type Invariant<in out T> = {
+    f: (x: T) => T;
+}
+type T10<out T> = T;
+type T11<in T> = keyof T;
+type T12<out T, out K extends keyof T> = T[K];
+type T13<in out T> = T[keyof T];
+
+type Covariant1<in T> = {
+    x: T;
+}
+
+type Contravariant1<out T> = keyof T;
+
+type Contravariant2<out T> = {
+    f: (x: T) => void;
+}
+
+type Invariant1<in T> = {
+    f: (x: T) => T;
+}
+
+type Invariant2<out T> = {
+    f: (x: T) => T;
+}
+type Foo1<in T> = {
+    x: T;
+    f: FooFn1<T>;
+}
+
+type Foo2<out T> = {
+    x: T;
+    f: FooFn2<T>;
+}
+
+type Foo3<in out T> = {
+    x: T;
+    f: FooFn3<T>;
+}
+
+type T21<in out T> = T;
+
+interface Baz<out T> {}
+interface Baz<in T> {}
+
+interface Parent<out A> {
+    child: Child<A> | null;
+    parent: Parent<A> | null;
+}
+
+declare class StateNode<TContext, in out TEvent extends { type: string }> {
+    _storedEvent: TEvent;
+    _action: ActionObject<TEvent>;
+    _state: StateNode<TContext, any>;
+}

--- a/tests/format/misc/typescript-babel-only/ts-4.7-optional-variance.ts
+++ b/tests/format/misc/typescript-babel-only/ts-4.7-optional-variance.ts
@@ -1,0 +1,61 @@
+type Covariant<out T> = {
+    x: T;
+}
+type Contravariant<in T> = {
+    f: (x: T) => void;
+}
+type Invariant<in out T> = {
+    f: (x: T) => T;
+}
+type T10<out T> = T;
+type T11<in T> = keyof T;
+type T12<out T, out K extends keyof T> = T[K];
+type T13<in out T> = T[keyof T];
+
+type Covariant1<in T> = {
+    x: T;
+}
+
+type Contravariant1<out T> = keyof T;
+
+type Contravariant2<out T> = {
+    f: (x: T) => void;
+}
+
+type Invariant1<in T> = {
+    f: (x: T) => T;
+}
+
+type Invariant2<out T> = {
+    f: (x: T) => T;
+}
+type Foo1<in T> = {
+    x: T;
+    f: FooFn1<T>;
+}
+
+type Foo2<out T> = {
+    x: T;
+    f: FooFn2<T>;
+}
+
+type Foo3<in out T> = {
+    x: T;
+    f: FooFn3<T>;
+}
+
+type T21<in out T> = T;
+
+interface Baz<out T> {}
+interface Baz<in T> {}
+
+interface Parent<out A> {
+    child: Child<A> | null;
+    parent: Parent<A> | null;
+}
+
+declare class StateNode<TContext, in out TEvent extends { type: string }> {
+    _storedEvent: TEvent;
+    _action: ActionObject<TEvent>;
+    _state: StateNode<TContext, any>;
+}


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
(babel-ts only)

Partial of https://github.com/prettier/prettier/issues/12640

https://devblogs.microsoft.com/typescript/announcing-typescript-4-7-rc/#optional-variance-annotations-for-type-parameters

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
