### PR TITLE
fix formatting for typescript Enum with computed members

### DIFF
--- a/changelog_unreleased/typescript/12930.md
+++ b/changelog_unreleased/typescript/12930.md
@@ -1,0 +1,49 @@
+#### fix formatting for typescript Enum with computed members (#12930 by @HosokawaR)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+enum A {
+  [i++],
+}
+
+const bar = "bar"
+enum B {
+  [bar] = 2,
+}
+
+const foo = () => "foo";
+enum C {
+  [foo()] = 2,
+}
+
+// Prettier stable
+enum A {
+  i++,
+}
+
+const bar = "bar";
+enum B {
+  bar = 2,
+}
+
+const foo = () => "foo";
+enum C {
+  foo() = 2,
+}
+
+// Prettier main
+enum A {
+  [i++],
+}
+
+const bar = "bar";
+enum B {
+  [bar] = 2,
+}
+
+const foo = () => "foo";
+enum C {
+  [foo()] = 2,
+}
+```

--- a/changelog_unreleased/typescript/12930.md
+++ b/changelog_unreleased/typescript/12930.md
@@ -7,43 +7,13 @@ enum A {
   [i++],
 }
 
-const bar = "bar"
-enum B {
-  [bar] = 2,
-}
-
-const foo = () => "foo";
-enum C {
-  [foo()] = 2,
-}
-
 // Prettier stable
 enum A {
   i++,
 }
 
-const bar = "bar";
-enum B {
-  bar = 2,
-}
-
-const foo = () => "foo";
-enum C {
-  foo() = 2,
-}
-
 // Prettier main
 enum A {
   [i++],
-}
-
-const bar = "bar";
-enum B {
-  [bar] = 2,
-}
-
-const foo = () => "foo";
-enum C {
-  [foo()] = 2,
 }
 ```

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -413,7 +413,12 @@ function printTypescript(path, options, print) {
 
       return parts;
     case "TSEnumMember":
-      parts.push(print("id"));
+      if (node.computed) {
+        parts.push("[", print("id"), "]");
+      } else {
+        parts.push(print("id"));
+      }
+
       if (node.initializer) {
         parts.push(" = ", print("initializer"));
       }

--- a/tests/format/typescript/enum/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/enum/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`computed-members.ts [babel-ts] format 1`] = `
+"Unexpected token (2:3)
+  1 | enum A {
+> 2 |   [i++],
+    |   ^
+  3 | }
+  4 |
+  5 | const bar = "bar""
+`;
+
+exports[`computed-members.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+enum A {
+  [i++],
+}
+
+const bar = "bar"
+enum B {
+  [bar] = 2,
+}
+
+const foo = () => "foo";
+enum C {
+  [foo()] = 2,
+}
+
+=====================================output=====================================
+enum A {
+  [i++],
+}
+
+const bar = "bar";
+enum B {
+  [bar] = 2,
+}
+
+const foo = () => "foo";
+enum C {
+  [foo()] = 2,
+}
+
+================================================================================
+`;
+
 exports[`enum.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/enum/computed-members.ts
+++ b/tests/format/typescript/enum/computed-members.ts
@@ -1,0 +1,13 @@
+enum A {
+  [i++],
+}
+
+const bar = "bar"
+enum B {
+  [bar] = 2,
+}
+
+const foo = () => "foo";
+enum C {
+  [foo()] = 2,
+}

--- a/tests/format/typescript/enum/jsfmt.spec.js
+++ b/tests/format/typescript/enum/jsfmt.spec.js
@@ -1,1 +1,5 @@
-run_spec(__dirname, ["typescript"]);
+run_spec(__dirname, ["typescript"], {
+  errors: {
+    "babel-ts": ["computed-members.ts"],
+  },
+});


### PR DESCRIPTION
## Description

Fixes #12926  

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
