### PR TITLE
Add support for a .prettierrc.ts config file.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,7 +8,7 @@ Prettier uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) for co
 - A `"prettier"` key in your `package.json` file.
 - A `.prettierrc` file written in JSON or YAML.
 - A `.prettierrc.json`, `.prettierrc.yml`, `.prettierrc.yaml`, or `.prettierrc.json5` file.
-- A `.prettierrc.js`, `.prettierrc.cjs`, `prettier.config.js`, or `prettier.config.cjs` file that exports an object using `module.exports`.
+- A `.prettierrc.js`, `.prettierrc.ts`, `.prettierrc.cjs`, `prettier.config.js`, or `prettier.config.cjs` file that exports an object using `module.exports`.
 - A `.prettierrc.toml` file.
 
 The configuration file will be resolved starting from the location of the file being formatted, and searching up the file tree until a config file is (or isn’t) found.
@@ -33,7 +33,7 @@ JSON:
 JS:
 
 ```js
-// prettier.config.js or .prettierrc.js
+// prettier.config.js or .prettierrc.js or .prettierrc.ts
 module.exports = {
   trailingComma: "es5",
   tabWidth: 4,
@@ -134,6 +134,16 @@ An example configuration repository is available [here](https://github.com/azz/p
 >   ...require("@company/prettier-config"),
 >   semi: false,
 > };
+> ```
+
+> Note: You can also import the file in a `.prettierrc.ts` and export the modifications.
+>
+> ```ts
+> module.exports = {
+>   ...require("@company/prettier-config"),
+>   semi: false,
+> };
+> ``;
 > ```
 
 ## Setting the [parser](options.md#parser) option

--- a/src/config/resolve-config.js
+++ b/src/config/resolve-config.js
@@ -54,6 +54,7 @@ const getExplorerMemoized = mem(
         ".prettierrc.yml",
         ".prettierrc.json5",
         ".prettierrc.js",
+        ".prettierrc.ts",
         ".prettierrc.cjs",
         "prettier.config.js",
         "prettier.config.cjs",

--- a/website/blog/2019-04-12-1.17.0.md
+++ b/website/blog/2019-04-12-1.17.0.md
@@ -84,6 +84,16 @@ If you don't want to use `package.json`, you can use any of the supported extens
 > };
 > ```
 
+> Note: You can also import the file in a `.prettierrc.ts` and export the modifications.
+>
+> ```ts
+> module.exports = {
+>   ...require("@company/prettier-config"),
+>   semi: false,
+> };
+> ``;
+> ```
+
 ## General
 
 ### JavaScript

--- a/website/versioned_docs/version-stable/configuration.md
+++ b/website/versioned_docs/version-stable/configuration.md
@@ -9,7 +9,7 @@ Prettier uses [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) for co
 - A `"prettier"` key in your `package.json` file.
 - A `.prettierrc` file written in JSON or YAML.
 - A `.prettierrc.json`, `.prettierrc.yml`, `.prettierrc.yaml`, or `.prettierrc.json5` file.
-- A `.prettierrc.js`, `.prettierrc.cjs`, `prettier.config.js`, or `prettier.config.cjs` file that exports an object using `module.exports`.
+- A `.prettierrc.js`, `.prettierrc.ts`, `.prettierrc.cjs`, `prettier.config.js`, or `prettier.config.cjs` file that exports an object using `module.exports`.
 - A `.prettierrc.toml` file.
 
 The configuration file will be resolved starting from the location of the file being formatted, and searching up the file tree until a config file is (or isn’t) found.
@@ -34,7 +34,7 @@ JSON:
 JS:
 
 ```js
-// prettier.config.js or .prettierrc.js
+// prettier.config.js or .prettierrc.js or .prettierrc.ts
 module.exports = {
   trailingComma: "es5",
   tabWidth: 4,
@@ -135,6 +135,16 @@ An example configuration repository is available [here](https://github.com/azz/p
 >   ...require("@company/prettier-config"),
 >   semi: false,
 > };
+> ```
+
+> Note: You can also import the file in a `.prettierrc.ts` and export the modifications.
+>
+> ```ts
+> module.exports = {
+>   ...require("@company/prettier-config"),
+>   semi: false,
+> };
+> ``;
 > ```
 
 ## Setting the [parser](options.md#parser) option


### PR DESCRIPTION
## Description

Support for a .prettierrc.ts config file and not just .prettierrc.js or .prettierrc.cjs.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
