### PR TITLE
Throw errors for invalid `TSEmptyBodyFunctionExpression` node

### DIFF
--- a/changelog_unreleased/typescript/12982.md
+++ b/changelog_unreleased/typescript/12982.md
@@ -1,4 +1,4 @@
-#### Stop parsing invalid code (#12980 by @fisker)
+#### Stop parsing invalid code (#12982 by @fisker)
 
 <!-- prettier-ignore -->
 ```tsx

--- a/changelog_unreleased/typescript/12982.md
+++ b/changelog_unreleased/typescript/12982.md
@@ -1,0 +1,15 @@
+#### Stop parsing invalid code (#12980 by @fisker)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+const object = ({ methodName() });
+
+// Prettier stable
+const object = { methodName(); };
+
+// Prettier main
+SyntaxError: Unexpected token. (1:28)
+> 1 | const object = { methodName(); };
+    |                            ^^^
+```

--- a/changelog_unreleased/typescript/12982.md
+++ b/changelog_unreleased/typescript/12982.md
@@ -9,7 +9,7 @@ const object = ({ methodName() });
 const object = { methodName(); };
 
 // Prettier main
-SyntaxError: Unexpected token. (1:28)
-> 1 | const object = { methodName(); };
-    |                            ^^^
+SyntaxError: Unexpected token. (1:29)
+> 1 | const object = ({ methodName() });
+    |                             ^^
 ```

--- a/src/language-js/parse/postprocess/index.js
+++ b/src/language-js/parse/postprocess/index.js
@@ -5,10 +5,8 @@ const isTsKeywordType = require("../../utils/is-ts-keyword-type.js");
 const isTypeCastComment = require("../../utils/is-type-cast-comment.js");
 const getLast = require("../../../utils/get-last.js");
 const visitNode = require("./visit-node.js");
-const {
-  throwErrorForInvalidNodes,
-  throwSyntaxError,
-} = require("./typescript.js");
+const { throwErrorForInvalidNodes } = require("./typescript.js");
+const throwSyntaxError = require("./throw-syntax-error.js");
 
 function postprocess(ast, options) {
   if (

--- a/src/language-js/parse/postprocess/index.js
+++ b/src/language-js/parse/postprocess/index.js
@@ -108,12 +108,12 @@ function postprocess(ast, options) {
       case "ObjectExpression":
         // #12963
         if (options.parser === "typescript") {
-          const invalidNode = node.properties.find(
+          const invalidProperty = node.properties.find(
             (property) =>
               property.type === "Property" &&
               property.value.type === "TSEmptyBodyFunctionExpression"
           );
-          throwSyntaxError(invalidNode.value, "Unexpected token.");
+          throwSyntaxError(invalidProperty.value, "Unexpected token.");
         }
         break;
 

--- a/src/language-js/parse/postprocess/index.js
+++ b/src/language-js/parse/postprocess/index.js
@@ -113,7 +113,9 @@ function postprocess(ast, options) {
               property.type === "Property" &&
               property.value.type === "TSEmptyBodyFunctionExpression"
           );
-          throwSyntaxError(invalidProperty.value, "Unexpected token.");
+          if (invalidProperty) {
+            throwSyntaxError(invalidProperty.value, "Unexpected token.");
+          }
         }
         break;
 

--- a/src/language-js/parse/postprocess/throw-syntax-error.js
+++ b/src/language-js/parse/postprocess/throw-syntax-error.js
@@ -1,0 +1,12 @@
+"use strict";
+const createError = require("../../../common/parser-create-error.js");
+
+function throwSyntaxError(node, message) {
+  const { start, end } = node.loc;
+  throw createError(message, {
+    start: { line: start.line, column: start.column + 1 },
+    end: { line: end.line, column: end.column + 1 },
+  });
+}
+
+module.exports = throwSyntaxError;

--- a/src/language-js/parse/postprocess/typescript.js
+++ b/src/language-js/parse/postprocess/typescript.js
@@ -73,9 +73,10 @@ function throwErrorForInvalidNodes(ast, options) {
     if (esTreeNode !== node) {
       return;
     }
+
     throwErrorForInvalidDecorator(tsNode, esTreeNode, tsNodeToESTreeNodeMap);
     throwErrorForInvalidAbstractProperty(tsNode, esTreeNode);
   });
 }
 
-module.exports = { throwErrorForInvalidNodes };
+module.exports = { throwErrorForInvalidNodes, throwSyntaxError };

--- a/src/language-js/parse/postprocess/typescript.js
+++ b/src/language-js/parse/postprocess/typescript.js
@@ -1,15 +1,7 @@
 "use strict";
 
-const createError = require("../../../common/parser-create-error.js");
 const visitNode = require("./visit-node.js");
-
-function throwSyntaxError(node, message) {
-  const { start, end } = node.loc;
-  throw createError(message, {
-    start: { line: start.line, column: start.column + 1 },
-    end: { line: end.line, column: end.column + 1 },
-  });
-}
+const throwSyntaxError = require("./throw-syntax-error.js");
 
 // Invalid decorators are removed since `@typescript-eslint/typescript-estree` v4
 // https://github.com/typescript-eslint/typescript-eslint/pull/2375
@@ -79,4 +71,4 @@ function throwErrorForInvalidNodes(ast, options) {
   });
 }
 
-module.exports = { throwErrorForInvalidNodes, throwSyntaxError };
+module.exports = { throwErrorForInvalidNodes };

--- a/tests/format/misc/errors/invalid/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/invalid/__snapshots__/jsfmt.spec.js.snap
@@ -156,92 +156,236 @@ exports[`snippet: #1 [typescript] format 1`] = `
     |       ^"
 `;
 
+exports[`snippet: #2 [acorn] format 1`] = `
+"Unexpected token (1:13)
+> 1 | ({ method() })
+    |             ^"
+`;
+
 exports[`snippet: #2 [babel] format 1`] = `
+"Unexpected token, expected "{" (1:13)
+> 1 | ({ method() })
+    |             ^"
+`;
+
+exports[`snippet: #2 [babel] format 2`] = `
 "Invalid parenthesized assignment pattern. (1:1)
 > 1 | (a = 1) = 2
     | ^"
 `;
 
 exports[`snippet: #2 [babel-flow] format 1`] = `
+"Unexpected token, expected "{" (1:13)
+> 1 | ({ method() })
+    |             ^"
+`;
+
+exports[`snippet: #2 [babel-flow] format 2`] = `
 "Invalid parenthesized assignment pattern. (1:1)
 > 1 | (a = 1) = 2
     | ^"
 `;
 
 exports[`snippet: #2 [babel-ts] format 1`] = `
+"Unexpected token, expected "{" (1:13)
+> 1 | ({ method() })
+    |             ^"
+`;
+
+exports[`snippet: #2 [babel-ts] format 2`] = `
 "Invalid parenthesized assignment pattern. (1:1)
 > 1 | (a = 1) = 2
     | ^"
 `;
 
+exports[`snippet: #2 [espree] format 1`] = `
+"Unexpected token } (1:13)
+> 1 | ({ method() })
+    |             ^"
+`;
+
 exports[`snippet: #2 [flow] format 1`] = `
+"Unexpected token \`}\`, expected the token \`{\` (1:13)
+> 1 | ({ method() })
+    |             ^"
+`;
+
+exports[`snippet: #2 [flow] format 2`] = `
 "Invalid left-hand side in assignment (1:2)
 > 1 | (a = 1) = 2
     |  ^^^^^"
 `;
 
 exports[`snippet: #2 [meriyah] format 1`] = `
+"Expected '{' (1:13)
+> 1 | ({ method() })
+    |             ^"
+`;
+
+exports[`snippet: #2 [meriyah] format 2`] = `
 "Invalid left-hand side in assignment (1:9)
 > 1 | (a = 1) = 2
     |         ^"
 `;
 
+exports[`snippet: #2 [typescript] format 1`] = `
+"Unexpected token. (1:10)
+> 1 | ({ method() })
+    |          ^^"
+`;
+
+exports[`snippet: #3 [acorn] format 1`] = `
+"Unexpected token (1:15)
+> 1 | ({ method({}) })
+    |               ^"
+`;
+
 exports[`snippet: #3 [babel] format 1`] = `
+"Unexpected token, expected "{" (1:15)
+> 1 | ({ method({}) })
+    |               ^"
+`;
+
+exports[`snippet: #3 [babel] format 2`] = `
 "Invalid parenthesized assignment pattern. (1:1)
 > 1 | (a += b) = 1
     | ^"
 `;
 
 exports[`snippet: #3 [babel-flow] format 1`] = `
+"Unexpected token, expected "{" (1:15)
+> 1 | ({ method({}) })
+    |               ^"
+`;
+
+exports[`snippet: #3 [babel-flow] format 2`] = `
 "Invalid parenthesized assignment pattern. (1:1)
 > 1 | (a += b) = 1
     | ^"
 `;
 
 exports[`snippet: #3 [babel-ts] format 1`] = `
+"Unexpected token, expected "{" (1:15)
+> 1 | ({ method({}) })
+    |               ^"
+`;
+
+exports[`snippet: #3 [babel-ts] format 2`] = `
 "Invalid parenthesized assignment pattern. (1:1)
 > 1 | (a += b) = 1
     | ^"
 `;
 
+exports[`snippet: #3 [espree] format 1`] = `
+"Unexpected token } (1:15)
+> 1 | ({ method({}) })
+    |               ^"
+`;
+
 exports[`snippet: #3 [flow] format 1`] = `
+"Unexpected token \`}\`, expected the token \`{\` (1:15)
+> 1 | ({ method({}) })
+    |               ^"
+`;
+
+exports[`snippet: #3 [flow] format 2`] = `
 "Invalid left-hand side in assignment (1:2)
 > 1 | (a += b) = 1
     |  ^^^^^^"
 `;
 
 exports[`snippet: #3 [meriyah] format 1`] = `
+"Expected '{' (1:15)
+> 1 | ({ method({}) })
+    |               ^"
+`;
+
+exports[`snippet: #3 [meriyah] format 2`] = `
 "Invalid left-hand side in assignment (1:10)
 > 1 | (a += b) = 1
     |          ^"
 `;
 
+exports[`snippet: #3 [typescript] format 1`] = `
+"Unexpected token. (1:10)
+> 1 | ({ method({}) })
+    |          ^^^^"
+`;
+
+exports[`snippet: #4 [acorn] format 1`] = `
+"Unexpected token (1:23)
+> 1 | ({ method(parameter,) })
+    |                       ^"
+`;
+
 exports[`snippet: #4 [babel] format 1`] = `
+"Unexpected token, expected "{" (1:23)
+> 1 | ({ method(parameter,) })
+    |                       ^"
+`;
+
+exports[`snippet: #4 [babel] format 2`] = `
 "Invalid left-hand side in parenthesized expression. (1:2)
 > 1 | (a = b) += 1
     |  ^"
 `;
 
 exports[`snippet: #4 [babel-flow] format 1`] = `
+"Unexpected token, expected "{" (1:23)
+> 1 | ({ method(parameter,) })
+    |                       ^"
+`;
+
+exports[`snippet: #4 [babel-flow] format 2`] = `
 "Invalid left-hand side in parenthesized expression. (1:2)
 > 1 | (a = b) += 1
     |  ^"
 `;
 
 exports[`snippet: #4 [babel-ts] format 1`] = `
+"Unexpected token, expected "{" (1:23)
+> 1 | ({ method(parameter,) })
+    |                       ^"
+`;
+
+exports[`snippet: #4 [babel-ts] format 2`] = `
 "Invalid left-hand side in parenthesized expression. (1:2)
 > 1 | (a = b) += 1
     |  ^"
 `;
 
+exports[`snippet: #4 [espree] format 1`] = `
+"Unexpected token } (1:23)
+> 1 | ({ method(parameter,) })
+    |                       ^"
+`;
+
 exports[`snippet: #4 [flow] format 1`] = `
+"Unexpected token \`}\`, expected the token \`{\` (1:23)
+> 1 | ({ method(parameter,) })
+    |                       ^"
+`;
+
+exports[`snippet: #4 [flow] format 2`] = `
 "Invalid left-hand side in assignment (1:2)
 > 1 | (a = b) += 1
     |  ^^^^^"
 `;
 
 exports[`snippet: #4 [meriyah] format 1`] = `
+"Expected '{' (1:23)
+> 1 | ({ method(parameter,) })
+    |                       ^"
+`;
+
+exports[`snippet: #4 [meriyah] format 2`] = `
 "Invalid left-hand side in assignment (1:10)
 > 1 | (a = b) += 1
     |          ^"
+`;
+
+exports[`snippet: #4 [typescript] format 1`] = `
+"Unexpected token. (1:10)
+> 1 | ({ method(parameter,) })
+    |          ^^^^^^^^^^^^"
 `;

--- a/tests/format/misc/errors/invalid/jsfmt.spec.js
+++ b/tests/format/misc/errors/invalid/jsfmt.spec.js
@@ -1,7 +1,13 @@
 run_spec(
   {
     dirname: __dirname,
-    snippets: ["for each (a in b) {}", "class switch() {}"],
+    snippets: [
+      "for each (a in b) {}",
+      "class switch() {}",
+      "({ method() })",
+      "({ method({}) })",
+      "({ method(parameter,) })",
+    ],
   },
   [
     "babel",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->


Fixes #12963

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
