### PR TITLE
Revert "print as instead of colon for babel-ts parser"

### DIFF
--- a/src/language-js/print/misc.js
+++ b/src/language-js/print/misc.js
@@ -55,11 +55,6 @@ function printTypeAnnotation(path, options, print) {
 
   const parentNode = path.getParentNode();
 
-  // Workaround for https://github.com/babel/babel/issues/14498
-  if (parentNode.type === "ArrayPattern" && options.parser === "babel-ts") {
-    return [" as ", print("typeAnnotation")];
-  }
-
   const isFunctionDeclarationIdentifier =
     parentNode.type === "DeclareFunction" && parentNode.id === node;
 


### PR DESCRIPTION
This reverts commit f49114141a21f4f3cb1bb569e241ce1dbcdece44.

The commit f49114141a21f4f3cb1bb569e241ce1dbcdece44 in https://github.com/prettier/prettier/pull/12706 is a workaround for https://github.com/babel/babel/issues/14498.

Now, https://github.com/babel/babel/issues/14498 had fixed by https://github.com/babel/babel/pull/14500 and this change has released [v7.17.12](https://github.com/babel/babel/releases/tag/v7.17.12), moreover prettier uses v7.18.0 by https://github.com/prettier/prettier/pull/12896.

So, I reverted commit f49114141a21f4f3cb1bb569e241ce1dbcdece44.

## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
