### PR TITLE
Fix --cache set only if with --write or no-different

### DIFF
--- a/src/cli/format-results-cache.js
+++ b/src/cli/format-results-cache.js
@@ -60,20 +60,17 @@ class FormatResultsCache {
    */
   existsAvailableFormatResultsCache(filePath, options) {
     const fileDescriptor = this.fileEntryCache.getFileDescriptor(filePath);
-    const hashOfOptions = getHashOfOptions(options);
-    const meta = getMetadataFromFileDescriptor(fileDescriptor);
-    const changed =
-      fileDescriptor.changed || meta.hashOfOptions !== hashOfOptions;
 
     if (fileDescriptor.notFound) {
       return false;
     }
 
-    if (changed) {
-      return false;
-    }
+    const hashOfOptions = getHashOfOptions(options);
+    const meta = getMetadataFromFileDescriptor(fileDescriptor);
+    const changed =
+      fileDescriptor.changed || meta.hashOfOptions !== hashOfOptions;
 
-    return true;
+    return !changed;
   }
 
   /**

--- a/src/cli/format-results-cache.js
+++ b/src/cli/format-results-cache.js
@@ -85,6 +85,13 @@ class FormatResultsCache {
     }
   }
 
+  /**
+   * @param {string} filePath
+   */
+  removeFormatResultsCache(filePath) {
+    this.fileEntryCache.removeEntry(filePath);
+  }
+
   reconcile() {
     this.fileEntryCache.reconcile();
   }

--- a/src/cli/format-results-cache.js
+++ b/src/cli/format-results-cache.js
@@ -40,7 +40,7 @@ function getMetadataFromFileDescriptor(fileDescriptor) {
 
 class FormatResultsCache {
   /**
-   * @param {string} cacheFileLocation The path of cache file location. (default: `node_modules/.cache/prettier/prettier-cache`)
+   * @param {string} cacheFileLocation The path of cache file location. (default: `node_modules/.cache/prettier/.prettier-cache`)
    * @param {string} cacheStrategy
    */
   constructor(cacheFileLocation, cacheStrategy) {

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -407,9 +407,8 @@ async function formatFiles(context) {
       continue;
     }
 
-    formatResultsCache?.setFormatResultsCache(filename, options);
-
     const isDifferent = output !== input;
+    let shouldSetCache = !isDifferent;
 
     if (printedFilename) {
       // Remove previously printed filename to log it with duration.
@@ -433,6 +432,9 @@ async function formatFiles(context) {
 
         try {
           await fs.writeFile(filename, output, "utf8");
+
+          // Set cache if format succeeds
+          shouldSetCache = true;
         } catch (error) {
           context.logger.error(
             `Unable to write file: ${filename}\n${error.message}`
@@ -458,6 +460,12 @@ async function formatFiles(context) {
       }
     } else if (!context.argv.check && !context.argv.listDifferent) {
       writeOutput(context, result, options);
+    }
+
+    if (shouldSetCache) {
+      formatResultsCache?.setFormatResultsCache(filename, options);
+    } else {
+      formatResultsCache?.removeFormatResultsCache(filename);
     }
 
     if (isDifferent) {

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -434,13 +434,11 @@ async function formatFiles(context) {
         try {
           await fs.writeFile(filename, output, "utf8");
         } catch (error) {
-          /* istanbul ignore next */
           context.logger.error(
             `Unable to write file: ${filename}\n${error.message}`
           );
 
           // Don't exit the process if one file failed
-          /* istanbul ignore next */
           process.exitCode = 2;
         }
       } else if (!context.argv.check && !context.argv.listDifferent) {

--- a/tests/integration/__tests__/cache.js
+++ b/tests/integration/__tests__/cache.js
@@ -96,7 +96,7 @@ describe("--cache option", () => {
       await expect(fs.stat(defaultCacheFile)).resolves.not.toThrowError();
     });
 
-    it("does'nt format when cache is available", async () => {
+    it("doesn't format when cache is available", async () => {
       const { stdout: firstStdout } = await runPrettier(dir, [
         "--cache",
         "--write",
@@ -251,7 +251,7 @@ describe("--cache option", () => {
       await expect(fs.stat(defaultCacheFile)).resolves.not.toThrowError();
     });
 
-    it("does'nt format when cache is available", async () => {
+    it("doesn't format when cache is available", async () => {
       const { stdout: firstStdout } = await runPrettier(dir, [
         "--cache",
         "--cache-strategy",
@@ -315,7 +315,7 @@ describe("--cache option", () => {
       );
     });
 
-    it("does'nt re-format when timestamp has been updated", async () => {
+    it("doesn't re-format when timestamp has been updated", async () => {
       const { stdout: firstStdout } = await runPrettier(dir, [
         "--cache",
         "--cache-strategy",

--- a/tests/integration/__tests__/cache.js
+++ b/tests/integration/__tests__/cache.js
@@ -278,6 +278,44 @@ describe("--cache option", () => {
       );
     });
 
+    it("doesn't cache files when write error.", async () => {
+      const {
+        stdout: firstStdout,
+        stderr: firstStderr,
+        status: firstStatus,
+      } = await runPrettier(
+        dir,
+        ["--write", "--cache", "--cache-strategy", "metadata", "."],
+        {
+          mockWriteFileErrors: {
+            "a.js": "EACCES: permission denied (mock error)",
+          },
+        }
+      );
+      expect(firstStatus).toBe(2);
+      expect(stripAnsi(firstStderr).split("\n").filter(Boolean)).toEqual([
+        "[error] Unable to write file: a.js",
+        "[error] EACCES: permission denied (mock error)",
+      ]);
+      expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms$/),
+        ])
+      );
+
+      const { stdout: secondStdout } = await runPrettier(dir, [
+        "--list-different",
+        "--cache",
+        "--cache-strategy",
+        "metadata",
+        ".",
+      ]);
+      expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual([
+        "a.js",
+      ]);
+    });
+
     it("removes cache file when run Prettier without `--cache` option", async () => {
       await runPrettier(dir, [
         "--cache",
@@ -481,6 +519,44 @@ describe("--cache option", () => {
           expect.stringMatching(/^b\.js .+ms \(cached\)$/),
         ])
       );
+    });
+
+    it("doesn't cache files when write error.", async () => {
+      const {
+        stdout: firstStdout,
+        stderr: firstStderr,
+        status: firstStatus,
+      } = await runPrettier(
+        dir,
+        ["--write", "--cache", "--cache-strategy", "content", "."],
+        {
+          mockWriteFileErrors: {
+            "a.js": "EACCES: permission denied (mock error)",
+          },
+        }
+      );
+      expect(firstStatus).toBe(2);
+      expect(stripAnsi(firstStderr).split("\n").filter(Boolean)).toEqual([
+        "[error] Unable to write file: a.js",
+        "[error] EACCES: permission denied (mock error)",
+      ]);
+      expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms$/),
+        ])
+      );
+
+      const { stdout: secondStdout } = await runPrettier(dir, [
+        "--list-different",
+        "--cache",
+        "--cache-strategy",
+        "content",
+        ".",
+      ]);
+      expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual([
+        "a.js",
+      ]);
     });
 
     it("removes cache file when run Prettier without `--cache` option", async () => {

--- a/tests/integration/__tests__/cache.js
+++ b/tests/integration/__tests__/cache.js
@@ -227,6 +227,57 @@ describe("--cache option", () => {
       );
     });
 
+    it("re-formats after execution without write.", async () => {
+      await runPrettier(dir, ["--cache", "--cache-strategy", "metadata", "."]);
+
+      const { stdout: secondStdout } = await runPrettier(dir, [
+        "--write",
+        "--cache",
+        "--cache-strategy",
+        "metadata",
+        ".",
+      ]);
+      expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+        ])
+      );
+    });
+
+    it("re-formats when multiple cached files are updated.", async () => {
+      await runPrettier(dir, [
+        "--write",
+        "--cache",
+        "--cache-strategy",
+        "metadata",
+        ".",
+      ]);
+
+      // Update `a.js` to unformatted
+      await fs.writeFile(path.join(dir, "a.js"), "const a = `a`;    ");
+
+      // Update `b.js` but still formatted
+      const time = new Date();
+      await fs.utimes(path.join(dir, "b.js"), time, time);
+
+      await runPrettier(dir, ["--cache", "--cache-strategy", "metadata", "."]);
+
+      const { stdout: thirdStdout } = await runPrettier(dir, [
+        "--write",
+        "--cache",
+        "--cache-strategy",
+        "metadata",
+        ".",
+      ]);
+      expect(stripAnsi(thirdStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+        ])
+      );
+    });
+
     it("removes cache file when run Prettier without `--cache` option", async () => {
       await runPrettier(dir, [
         "--cache",
@@ -377,6 +428,57 @@ describe("--cache option", () => {
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
           expect.stringMatching(/^b\.js .+ms$/),
+        ])
+      );
+    });
+
+    it("re-formats after execution without write.", async () => {
+      await runPrettier(dir, ["--cache", "--cache-strategy", "content", "."]);
+
+      const { stdout: secondStdout } = await runPrettier(dir, [
+        "--write",
+        "--cache",
+        "--cache-strategy",
+        "content",
+        ".",
+      ]);
+      expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+        ])
+      );
+    });
+
+    it("re-formats when multiple cached files are updated.", async () => {
+      await runPrettier(dir, [
+        "--write",
+        "--cache",
+        "--cache-strategy",
+        "content",
+        ".",
+      ]);
+
+      // Update `a.js` to unformatted
+      await fs.writeFile(path.join(dir, "a.js"), "const a = `a`;    ");
+
+      // Update `b.js` but still formatted
+      const time = new Date();
+      await fs.utimes(path.join(dir, "b.js"), time, time);
+
+      await runPrettier(dir, ["--cache", "--cache-strategy", "content", "."]);
+
+      const { stdout: thirdStdout } = await runPrettier(dir, [
+        "--write",
+        "--cache",
+        "--cache-strategy",
+        "content",
+        ".",
+      ]);
+      expect(stripAnsi(thirdStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
         ])
       );
     });

--- a/tests/integration/__tests__/cache.js
+++ b/tests/integration/__tests__/cache.js
@@ -86,412 +86,499 @@ describe("--cache option", () => {
     );
   });
 
-  describe("--cache-strategy", () => {
-    const createGetCliArguments =
-      (strategy) =>
-      (
-        { write, listDifferent, trailingCommaAll } = {
-          write: false,
-          listDifferent: false,
-          trailingCommaAll: false,
-        }
-      ) => {
-        return [
-          "--cache",
-          "--cache-strategy",
-          strategy,
-          write && "--write",
-          listDifferent && "--list-different",
-          trailingCommaAll && "--trailing-comma",
-          trailingCommaAll && "all",
-          ".",
-        ].filter(Boolean);
-      };
-
-    describe("--cache-strategy metadata", () => {
-      const getCliArguments = createGetCliArguments("metadata");
-
-      it("creates default cache file named `node_modules/.cache/prettier/.prettier-cache`", async () => {
-        await expect(fs.stat(defaultCacheFile)).rejects.toHaveProperty(
-          "code",
-          "ENOENT"
-        );
-        await runPrettier(dir, getCliArguments());
-        await expect(fs.stat(defaultCacheFile)).resolves.not.toThrowError();
-      });
-
-      it("doesn't format when cache is available", async () => {
-        const cliArguments = getCliArguments({ write: true });
-        const { stdout: firstStdout } = await runPrettier(dir, cliArguments);
-        expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms$/),
-          ])
-        );
-
-        const { stdout: secondStdout } = await runPrettier(dir, cliArguments);
-        expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms \(cached\)$/),
-            expect.stringMatching(/^b\.js .+ms \(cached\)$/),
-          ])
-        );
-      });
-
-      it("re-formats when a file has been updated.", async () => {
-        const cliArguments = getCliArguments({ write: true });
-        const { stdout: firstStdout } = await runPrettier(dir, cliArguments);
-        expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms$/),
-          ])
-        );
-
-        // Update `a.js`
-        await fs.writeFile(path.join(dir, "a.js"), "const a = `a`;");
-
-        const { stdout: secondStdout } = await runPrettier(dir, cliArguments);
-        expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
-          // the cache of `b.js` is only available.
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms \(cached\)$/),
-          ])
-        );
-      });
-
-      it("re-formats when timestamp has been updated", async () => {
-        const cliArguments = getCliArguments({ write: true });
-        const { stdout: firstStdout } = await runPrettier(dir, cliArguments);
-        expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms$/),
-          ])
-        );
-
-        // update timestamp
-        const time = new Date();
-        await fs.utimes(path.join(dir, "a.js"), time, time);
-
-        const { stdout: secondStdout } = await runPrettier(dir, cliArguments);
-        expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
-          // the cache of `b.js` is only available.
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms \(cached\)$/),
-          ])
-        );
-      });
-
-      it("re-formats when options has been updated.", async () => {
-        const { stdout: firstStdout } = await runPrettier(
-          dir,
-          getCliArguments({ write: true })
-        );
-        expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms$/),
-          ])
-        );
-
-        const { stdout: secondStdout } = await runPrettier(
-          dir,
-          getCliArguments({ write: true, trailingCommaAll: true })
-        );
-        expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms$/),
-          ])
-        );
-      });
-
-      it("re-formats after execution without write.", async () => {
-        await runPrettier(dir, getCliArguments());
-
-        const { stdout: secondStdout } = await runPrettier(
-          dir,
-          getCliArguments({ write: true })
-        );
-        expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms \(cached\)$/),
-          ])
-        );
-      });
-
-      it("re-formats when multiple cached files are updated.", async () => {
-        await runPrettier(dir, getCliArguments({ write: true }));
-
-        // Update `a.js` to unformatted
-        await fs.writeFile(path.join(dir, "a.js"), "const a = `a`;    ");
-
-        // Update `b.js` but still formatted
-        const time = new Date();
-        await fs.utimes(path.join(dir, "b.js"), time, time);
-
-        await runPrettier(dir, getCliArguments());
-
-        const { stdout: thirdStdout } = await runPrettier(
-          dir,
-          getCliArguments({ write: true })
-        );
-        expect(stripAnsi(thirdStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms \(cached\)$/),
-          ])
-        );
-      });
-
-      it("doesn't cache files when write error.", async () => {
-        const {
-          stdout: firstStdout,
-          stderr: firstStderr,
-          status: firstStatus,
-        } = await runPrettier(dir, getCliArguments({ write: true }), {
-          mockWriteFileErrors: {
-            "a.js": "EACCES: permission denied (mock error)",
-          },
-        });
-        expect(firstStatus).toBe(2);
-        expect(stripAnsi(firstStderr).split("\n").filter(Boolean)).toEqual([
-          "[error] Unable to write file: a.js",
-          "[error] EACCES: permission denied (mock error)",
-        ]);
-        expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms$/),
-          ])
-        );
-
-        const { stdout: secondStdout } = await runPrettier(
-          dir,
-          getCliArguments({ write: false, listDifferent: true })
-        );
-        expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual([
-          "a.js",
-        ]);
-      });
-
-      it("removes cache file when run Prettier without `--cache` option", async () => {
-        await runPrettier(dir, getCliArguments({ write: true }));
-        await expect(fs.stat(defaultCacheFile)).resolves.not.toThrowError();
-        await runPrettier(dir, ["--write", "."]);
-        await expect(fs.stat(defaultCacheFile)).rejects.toThrowError();
-      });
+  describe("--cache-strategy metadata", () => {
+    it("creates default cache file named `node_modules/.cache/prettier/.prettier-cache`", async () => {
+      await expect(fs.stat(defaultCacheFile)).rejects.toHaveProperty(
+        "code",
+        "ENOENT"
+      );
+      await runPrettier(dir, ["--cache", "--cache-strategy", "metadata", "."]);
+      await expect(fs.stat(defaultCacheFile)).resolves.not.toThrowError();
     });
 
-    describe("--cache-strategy content", () => {
-      const getCliArguments = createGetCliArguments("content");
+    it("doesn't format when cache is available", async () => {
+      const { stdout: firstStdout } = await runPrettier(dir, [
+        "--cache",
+        "--write",
+        "--cache-strategy",
+        "metadata",
+        ".",
+      ]);
+      expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms$/),
+        ])
+      );
 
-      it("creates default cache file named `node_modules/.cache/prettier/.prettier-cache`", async () => {
-        await expect(fs.stat(defaultCacheFile)).rejects.toHaveProperty(
-          "code",
-          "ENOENT"
-        );
-        await runPrettier(dir, getCliArguments());
-        await expect(fs.stat(defaultCacheFile)).resolves.not.toThrowError();
-      });
+      const { stdout: secondStdout } = await runPrettier(dir, [
+        "--cache",
+        "--write",
+        "--cache-strategy",
+        "metadata",
+        ".",
+      ]);
+      expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms \(cached\)$/),
+          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+        ])
+      );
+    });
 
-      it("doesn't format when cache is available", async () => {
-        const cliArguments = getCliArguments({ write: true });
-        const { stdout: firstStdout } = await runPrettier(dir, cliArguments);
-        expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms$/),
-          ])
-        );
+    it("re-formats when a file has been updated.", async () => {
+      const { stdout: firstStdout } = await runPrettier(dir, [
+        "--cache",
+        "--write",
+        "--cache-strategy",
+        "metadata",
+        ".",
+      ]);
+      expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms$/),
+        ])
+      );
 
-        const { stdout: secondStdout } = await runPrettier(dir, cliArguments);
-        expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms \(cached\)$/),
-            expect.stringMatching(/^b\.js .+ms \(cached\)$/),
-          ])
-        );
-      });
+      // Update `a.js`
+      await fs.writeFile(path.join(dir, "a.js"), "const a = `a`;");
 
-      it("re-formats when a file has been updated.", async () => {
-        const cliArguments = getCliArguments({ write: true });
-        const { stdout: firstStdout } = await runPrettier(dir, cliArguments);
-        expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms$/),
-          ])
-        );
+      const { stdout: secondStdout } = await runPrettier(dir, [
+        "--cache",
+        "--write",
+        "--cache-strategy",
+        "metadata",
+        ".",
+      ]);
+      expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
+        // the cache of `b.js` is only available.
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+        ])
+      );
+    });
 
-        // Update `a.js`
-        await fs.writeFile(path.join(dir, "a.js"), "const a = `a`;");
+    it("re-formats when timestamp has been updated", async () => {
+      const { stdout: firstStdout } = await runPrettier(dir, [
+        "--cache",
+        "--write",
+        "--cache-strategy",
+        "metadata",
+        ".",
+      ]);
+      expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms$/),
+        ])
+      );
 
-        const { stdout: secondStdout } = await runPrettier(dir, cliArguments);
-        expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
-          // the cache of `b.js` is only available.
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms \(cached\)$/),
-          ])
-        );
-      });
+      // update timestamp
+      const time = new Date();
+      await fs.utimes(path.join(dir, "a.js"), time, time);
 
-      it("doesn't re-format when timestamp has been updated", async () => {
-        const cliArguments = getCliArguments({ write: true });
-        const { stdout: firstStdout } = await runPrettier(dir, cliArguments);
-        expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms$/),
-          ])
-        );
+      const { stdout: secondStdout } = await runPrettier(dir, [
+        "--cache",
+        "--write",
+        "--cache-strategy",
+        "metadata",
+        ".",
+      ]);
+      expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
+        // the cache of `b.js` is only available.
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+        ])
+      );
+    });
 
-        // update timestamp
-        const time = new Date();
-        await fs.utimes(path.join(dir, "a.js"), time, time);
+    it("re-formats when options has been updated.", async () => {
+      const { stdout: firstStdout } = await runPrettier(dir, [
+        "--cache",
+        "--write",
+        "--cache-strategy",
+        "metadata",
+        ".",
+      ]);
+      expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms$/),
+        ])
+      );
 
-        const { stdout: secondStdout } = await runPrettier(dir, cliArguments);
-        expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms \(cached\)$/),
-            expect.stringMatching(/^b\.js .+ms \(cached\)$/),
-          ])
-        );
-      });
+      const { stdout: secondStdout } = await runPrettier(dir, [
+        "--cache",
+        "--cache-strategy",
+        "metadata",
+        "--write",
+        "--trailing-comma",
+        "all",
+        ".",
+      ]);
+      expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms$/),
+        ])
+      );
+    });
 
-      it("re-formats when options has been updated.", async () => {
-        const { stdout: firstStdout } = await runPrettier(
-          dir,
-          getCliArguments({ write: true })
-        );
-        expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms$/),
-          ])
-        );
+    it("re-formats after execution without write.", async () => {
+      await runPrettier(dir, ["--cache", "--cache-strategy", "metadata", "."]);
 
-        const { stdout: secondStdout } = await runPrettier(
-          dir,
-          getCliArguments({ write: true, trailingCommaAll: true })
-        );
-        expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms$/),
-          ])
-        );
-      });
+      const { stdout: secondStdout } = await runPrettier(dir, [
+        "--write",
+        "--cache",
+        "--cache-strategy",
+        "metadata",
+        ".",
+      ]);
+      expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+        ])
+      );
+    });
 
-      it("re-formats after execution without write.", async () => {
-        await runPrettier(dir, ["--cache", "--cache-strategy", "content", "."]);
+    it("re-formats when multiple cached files are updated.", async () => {
+      await runPrettier(dir, [
+        "--write",
+        "--cache",
+        "--cache-strategy",
+        "metadata",
+        ".",
+      ]);
 
-        const { stdout: secondStdout } = await runPrettier(
-          dir,
-          getCliArguments({ write: true })
-        );
-        expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms \(cached\)$/),
-          ])
-        );
-      });
+      // Update `a.js` to unformatted
+      await fs.writeFile(path.join(dir, "a.js"), "const a = `a`;    ");
 
-      it("re-formats when multiple cached files are updated.", async () => {
-        await runPrettier(dir, getCliArguments({ write: true }));
+      // Update `b.js` but still formatted
+      const time = new Date();
+      await fs.utimes(path.join(dir, "b.js"), time, time);
 
-        // Update `a.js` to unformatted
-        await fs.writeFile(path.join(dir, "a.js"), "const a = `a`;    ");
+      await runPrettier(dir, ["--cache", "--cache-strategy", "metadata", "."]);
 
-        // Update `b.js` but still formatted
-        const time = new Date();
-        await fs.utimes(path.join(dir, "b.js"), time, time);
+      const { stdout: thirdStdout } = await runPrettier(dir, [
+        "--write",
+        "--cache",
+        "--cache-strategy",
+        "metadata",
+        ".",
+      ]);
+      expect(stripAnsi(thirdStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+        ])
+      );
+    });
 
-        await runPrettier(dir, getCliArguments());
-
-        const { stdout: thirdStdout } = await runPrettier(
-          dir,
-          getCliArguments({ write: true })
-        );
-        expect(stripAnsi(thirdStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms \(cached\)$/),
-          ])
-        );
-      });
-
-      it("doesn't cache files when write error.", async () => {
-        const {
-          stdout: firstStdout,
-          stderr: firstStderr,
-          status: firstStatus,
-        } = await runPrettier(dir, getCliArguments({ write: true }), {
+    it("doesn't cache files when write error.", async () => {
+      const {
+        stdout: firstStdout,
+        stderr: firstStderr,
+        status: firstStatus,
+      } = await runPrettier(
+        dir,
+        ["--write", "--cache", "--cache-strategy", "metadata", "."],
+        {
           mockWriteFileErrors: {
             "a.js": "EACCES: permission denied (mock error)",
           },
-        });
-        expect(firstStatus).toBe(2);
-        expect(stripAnsi(firstStderr).split("\n").filter(Boolean)).toEqual([
-          "[error] Unable to write file: a.js",
-          "[error] EACCES: permission denied (mock error)",
-        ]);
-        expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
-          expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms$/),
-          ])
-        );
+        }
+      );
+      expect(firstStatus).toBe(2);
+      expect(stripAnsi(firstStderr).split("\n").filter(Boolean)).toEqual([
+        "[error] Unable to write file: a.js",
+        "[error] EACCES: permission denied (mock error)",
+      ]);
+      expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms$/),
+        ])
+      );
 
-        const { stdout: secondStdout } = await runPrettier(
-          dir,
-          getCliArguments({ listDifferent: true })
-        );
-        expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual([
-          "a.js",
-        ]);
-      });
+      const { stdout: secondStdout } = await runPrettier(dir, [
+        "--list-different",
+        "--cache",
+        "--cache-strategy",
+        "metadata",
+        ".",
+      ]);
+      expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual([
+        "a.js",
+      ]);
+    });
 
-      it("removes cache file when run Prettier without `--cache` option", async () => {
-        await runPrettier(dir, getCliArguments({ write: true }));
-        await expect(fs.stat(defaultCacheFile)).resolves.not.toThrowError();
-        await runPrettier(dir, ["--write", "."]);
-        await expect(fs.stat(defaultCacheFile)).rejects.toThrowError();
-      });
+    it("removes cache file when run Prettier without `--cache` option", async () => {
+      await runPrettier(dir, [
+        "--cache",
+        "--write",
+        "--cache-strategy",
+        "metadata",
+        ".",
+      ]);
+      await expect(fs.stat(defaultCacheFile)).resolves.not.toThrowError();
+      await runPrettier(dir, ["--write", "."]);
+      await expect(fs.stat(defaultCacheFile)).rejects.toThrowError();
+    });
+  });
+
+  describe("--cache-strategy content", () => {
+    it("creates default cache file named `node_modules/.cache/prettier/.prettier-cache`", async () => {
+      await expect(fs.stat(defaultCacheFile)).rejects.toHaveProperty(
+        "code",
+        "ENOENT"
+      );
+      await runPrettier(dir, ["--cache", "--cache-strategy", "content", "."]);
+      await expect(fs.stat(defaultCacheFile)).resolves.not.toThrowError();
+    });
+
+    it("doesn't format when cache is available", async () => {
+      const { stdout: firstStdout } = await runPrettier(dir, [
+        "--cache",
+        "--cache-strategy",
+        "content",
+        "--write",
+        ".",
+      ]);
+      expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms$/),
+        ])
+      );
+
+      const { stdout: secondStdout } = await runPrettier(dir, [
+        "--cache",
+        "--cache-strategy",
+        "content",
+        "--write",
+        ".",
+      ]);
+      expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms \(cached\)$/),
+          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+        ])
+      );
+    });
+
+    it("re-formats when a file has been updated.", async () => {
+      const { stdout: firstStdout } = await runPrettier(dir, [
+        "--cache",
+        "--cache-strategy",
+        "content",
+        "--write",
+        ".",
+      ]);
+      expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms$/),
+        ])
+      );
+
+      // Update `a.js`
+      await fs.writeFile(path.join(dir, "a.js"), "const a = `a`;");
+
+      const { stdout: secondStdout } = await runPrettier(dir, [
+        "--cache",
+        "--cache-strategy",
+        "content",
+        "--write",
+        ".",
+      ]);
+      expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
+        // the cache of `b.js` is only available.
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+        ])
+      );
+    });
+
+    it("doesn't re-format when timestamp has been updated", async () => {
+      const { stdout: firstStdout } = await runPrettier(dir, [
+        "--cache",
+        "--cache-strategy",
+        "content",
+        "--write",
+        ".",
+      ]);
+      expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms$/),
+        ])
+      );
+
+      // update timestamp
+      const time = new Date();
+      await fs.utimes(path.join(dir, "a.js"), time, time);
+
+      const { stdout: secondStdout } = await runPrettier(dir, [
+        "--cache",
+        "--cache-strategy",
+        "content",
+        "--write",
+        ".",
+      ]);
+      expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms \(cached\)$/),
+          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+        ])
+      );
+    });
+
+    it("re-formats when options has been updated.", async () => {
+      const { stdout: firstStdout } = await runPrettier(dir, [
+        "--cache",
+        "--cache-strategy",
+        "content",
+        "--write",
+        ".",
+      ]);
+      expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms$/),
+        ])
+      );
+
+      const { stdout: secondStdout } = await runPrettier(dir, [
+        "--cache",
+        "--write",
+        "--cache-strategy",
+        "content",
+        "--trailing-comma",
+        "all",
+        ".",
+      ]);
+      expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms$/),
+        ])
+      );
+    });
+
+    it("re-formats after execution without write.", async () => {
+      await runPrettier(dir, ["--cache", "--cache-strategy", "content", "."]);
+
+      const { stdout: secondStdout } = await runPrettier(dir, [
+        "--write",
+        "--cache",
+        "--cache-strategy",
+        "content",
+        ".",
+      ]);
+      expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+        ])
+      );
+    });
+
+    it("re-formats when multiple cached files are updated.", async () => {
+      await runPrettier(dir, [
+        "--write",
+        "--cache",
+        "--cache-strategy",
+        "content",
+        ".",
+      ]);
+
+      // Update `a.js` to unformatted
+      await fs.writeFile(path.join(dir, "a.js"), "const a = `a`;    ");
+
+      // Update `b.js` but still formatted
+      const time = new Date();
+      await fs.utimes(path.join(dir, "b.js"), time, time);
+
+      await runPrettier(dir, ["--cache", "--cache-strategy", "content", "."]);
+
+      const { stdout: thirdStdout } = await runPrettier(dir, [
+        "--write",
+        "--cache",
+        "--cache-strategy",
+        "content",
+        ".",
+      ]);
+      expect(stripAnsi(thirdStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+        ])
+      );
+    });
+
+    it("doesn't cache files when write error.", async () => {
+      const {
+        stdout: firstStdout,
+        stderr: firstStderr,
+        status: firstStatus,
+      } = await runPrettier(
+        dir,
+        ["--write", "--cache", "--cache-strategy", "content", "."],
+        {
+          mockWriteFileErrors: {
+            "a.js": "EACCES: permission denied (mock error)",
+          },
+        }
+      );
+      expect(firstStatus).toBe(2);
+      expect(stripAnsi(firstStderr).split("\n").filter(Boolean)).toEqual([
+        "[error] Unable to write file: a.js",
+        "[error] EACCES: permission denied (mock error)",
+      ]);
+      expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching(/^a\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms$/),
+        ])
+      );
+
+      const { stdout: secondStdout } = await runPrettier(dir, [
+        "--list-different",
+        "--cache",
+        "--cache-strategy",
+        "content",
+        ".",
+      ]);
+      expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual([
+        "a.js",
+      ]);
+    });
+
+    it("removes cache file when run Prettier without `--cache` option", async () => {
+      await runPrettier(dir, ["--cache", "--write", "."]);
+      await expect(fs.stat(defaultCacheFile)).resolves.not.toThrowError();
+      await runPrettier(dir, ["--write", "."]);
+      await expect(fs.stat(defaultCacheFile)).rejects.toThrowError();
     });
   });
 
   describe("--cache-location", () => {
-    const getCliArguments = (
-      { write, cacheLocation } = { write: false, cacheLocation: undefined }
-    ) => {
-      return [
-        "--cache",
-        write && "--write",
-        cacheLocation && "--cache-location",
-        cacheLocation,
-        ".",
-      ].filter(Boolean);
-    };
-
     it("doesn't create default cache file when `--cache-location` exists", async () => {
       await expect(fs.stat(defaultCacheFile)).rejects.toHaveProperty(
         "code",
         "ENOENT"
       );
-      await runPrettier(
-        dir,
-        getCliArguments({
-          cacheLocation: nonDefaultCacheFileName,
-        })
-      );
+      await runPrettier(dir, [
+        "--cache",
+        "--cache-location",
+        nonDefaultCacheFileName,
+        ".",
+      ]);
       await expect(fs.stat(defaultCacheFile)).rejects.toHaveProperty(
         "code",
         "ENOENT"
@@ -499,12 +586,12 @@ describe("--cache option", () => {
     });
 
     it("throws error for invalid JSON file", async () => {
-      const { stderr } = await runPrettier(
-        dir,
-        getCliArguments({
-          cacheLocation: "a.js",
-        })
-      );
+      const { stderr } = await runPrettier(dir, [
+        "--cache",
+        "--cache-location",
+        "a.js",
+        ".",
+      ]);
       expect(stripAnsi(stderr).trim()).toEqual(
         expect.stringMatching(/\[error] '.+' isn't a valid JSON file/)
       );
@@ -516,23 +603,25 @@ describe("--cache option", () => {
           "code",
           "ENOENT"
         );
-        await runPrettier(
-          dir,
-          getCliArguments({
-            cacheLocation: nonDefaultCacheFileName,
-          })
-        );
+        await runPrettier(dir, [
+          "--cache",
+          "--cache-location",
+          nonDefaultCacheFileName,
+          ".",
+        ]);
         await expect(
           fs.stat(nonDefaultCacheFilePath)
         ).resolves.not.toThrowError();
       });
 
       it("does'nt format when cache is available", async () => {
-        const cliArguments = getCliArguments({
-          write: true,
-          cacheLocation: nonDefaultCacheFileName,
-        });
-        const { stdout: firstStdout } = await runPrettier(dir, cliArguments);
+        const { stdout: firstStdout } = await runPrettier(dir, [
+          "--cache",
+          "--write",
+          "--cache-location",
+          nonDefaultCacheFileName,
+          ".",
+        ]);
         expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
           expect.arrayContaining([
             expect.stringMatching(/^a\.js .+ms$/),
@@ -540,7 +629,13 @@ describe("--cache option", () => {
           ])
         );
 
-        const { stdout: secondStdout } = await runPrettier(dir, cliArguments);
+        const { stdout: secondStdout } = await runPrettier(dir, [
+          "--cache",
+          "--write",
+          "--cache-location",
+          nonDefaultCacheFileName,
+          ".",
+        ]);
         expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
           expect.arrayContaining([
             expect.stringMatching(/^a\.js .+ms \(cached\)$/),

--- a/tests/integration/__tests__/cache.js
+++ b/tests/integration/__tests__/cache.js
@@ -127,13 +127,14 @@ describe("--cache option", () => {
     });
 
     it("re-formats when a file has been updated.", async () => {
-      const { stdout: firstStdout } = await runPrettier(dir, [
+      const cliArguments = [
         "--cache",
         "--write",
         "--cache-strategy",
         "metadata",
         ".",
-      ]);
+      ];
+      const { stdout: firstStdout } = await runPrettier(dir, cliArguments);
       expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
@@ -144,13 +145,7 @@ describe("--cache option", () => {
       // Update `a.js`
       await fs.writeFile(path.join(dir, "a.js"), "const a = `a`;");
 
-      const { stdout: secondStdout } = await runPrettier(dir, [
-        "--cache",
-        "--write",
-        "--cache-strategy",
-        "metadata",
-        ".",
-      ]);
+      const { stdout: secondStdout } = await runPrettier(dir, cliArguments);
       expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
         // the cache of `b.js` is only available.
         expect.arrayContaining([
@@ -161,13 +156,14 @@ describe("--cache option", () => {
     });
 
     it("re-formats when timestamp has been updated", async () => {
-      const { stdout: firstStdout } = await runPrettier(dir, [
+      const cliArguments = [
         "--cache",
         "--write",
         "--cache-strategy",
         "metadata",
         ".",
-      ]);
+      ];
+      const { stdout: firstStdout } = await runPrettier(dir, cliArguments);
       expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
@@ -179,13 +175,7 @@ describe("--cache option", () => {
       const time = new Date();
       await fs.utimes(path.join(dir, "a.js"), time, time);
 
-      const { stdout: secondStdout } = await runPrettier(dir, [
-        "--cache",
-        "--write",
-        "--cache-strategy",
-        "metadata",
-        ".",
-      ]);
+      const { stdout: secondStdout } = await runPrettier(dir, cliArguments);
       expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
         // the cache of `b.js` is only available.
         expect.arrayContaining([
@@ -246,13 +236,14 @@ describe("--cache option", () => {
     });
 
     it("re-formats when multiple cached files are updated.", async () => {
-      await runPrettier(dir, [
+      const cliArguments = [
         "--write",
         "--cache",
         "--cache-strategy",
         "metadata",
         ".",
-      ]);
+      ];
+      await runPrettier(dir, cliArguments);
 
       // Update `a.js` to unformatted
       await fs.writeFile(path.join(dir, "a.js"), "const a = `a`;    ");
@@ -263,13 +254,7 @@ describe("--cache option", () => {
 
       await runPrettier(dir, ["--cache", "--cache-strategy", "metadata", "."]);
 
-      const { stdout: thirdStdout } = await runPrettier(dir, [
-        "--write",
-        "--cache",
-        "--cache-strategy",
-        "metadata",
-        ".",
-      ]);
+      const { stdout: thirdStdout } = await runPrettier(dir, cliArguments);
       expect(stripAnsi(thirdStdout).split("\n").filter(Boolean)).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
@@ -341,13 +326,14 @@ describe("--cache option", () => {
     });
 
     it("doesn't format when cache is available", async () => {
-      const { stdout: firstStdout } = await runPrettier(dir, [
+      const cliArguments = [
         "--cache",
         "--cache-strategy",
         "content",
         "--write",
         ".",
-      ]);
+      ];
+      const { stdout: firstStdout } = await runPrettier(dir, cliArguments);
       expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
@@ -355,13 +341,7 @@ describe("--cache option", () => {
         ])
       );
 
-      const { stdout: secondStdout } = await runPrettier(dir, [
-        "--cache",
-        "--cache-strategy",
-        "content",
-        "--write",
-        ".",
-      ]);
+      const { stdout: secondStdout } = await runPrettier(dir, cliArguments);
       expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms \(cached\)$/),
@@ -371,13 +351,14 @@ describe("--cache option", () => {
     });
 
     it("re-formats when a file has been updated.", async () => {
-      const { stdout: firstStdout } = await runPrettier(dir, [
+      const cliArguments = [
         "--cache",
         "--cache-strategy",
         "content",
         "--write",
         ".",
-      ]);
+      ];
+      const { stdout: firstStdout } = await runPrettier(dir, cliArguments);
       expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
@@ -388,13 +369,7 @@ describe("--cache option", () => {
       // Update `a.js`
       await fs.writeFile(path.join(dir, "a.js"), "const a = `a`;");
 
-      const { stdout: secondStdout } = await runPrettier(dir, [
-        "--cache",
-        "--cache-strategy",
-        "content",
-        "--write",
-        ".",
-      ]);
+      const { stdout: secondStdout } = await runPrettier(dir, cliArguments);
       expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
         // the cache of `b.js` is only available.
         expect.arrayContaining([
@@ -405,13 +380,14 @@ describe("--cache option", () => {
     });
 
     it("doesn't re-format when timestamp has been updated", async () => {
-      const { stdout: firstStdout } = await runPrettier(dir, [
+      const cliArguments = [
         "--cache",
         "--cache-strategy",
         "content",
         "--write",
         ".",
-      ]);
+      ];
+      const { stdout: firstStdout } = await runPrettier(dir, cliArguments);
       expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
@@ -423,13 +399,7 @@ describe("--cache option", () => {
       const time = new Date();
       await fs.utimes(path.join(dir, "a.js"), time, time);
 
-      const { stdout: secondStdout } = await runPrettier(dir, [
-        "--cache",
-        "--cache-strategy",
-        "content",
-        "--write",
-        ".",
-      ]);
+      const { stdout: secondStdout } = await runPrettier(dir, cliArguments);
       expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms \(cached\)$/),
@@ -489,13 +459,14 @@ describe("--cache option", () => {
     });
 
     it("re-formats when multiple cached files are updated.", async () => {
-      await runPrettier(dir, [
+      const cliArguments = [
         "--write",
         "--cache",
         "--cache-strategy",
         "content",
         ".",
-      ]);
+      ];
+      await runPrettier(dir, cliArguments);
 
       // Update `a.js` to unformatted
       await fs.writeFile(path.join(dir, "a.js"), "const a = `a`;    ");
@@ -506,13 +477,7 @@ describe("--cache option", () => {
 
       await runPrettier(dir, ["--cache", "--cache-strategy", "content", "."]);
 
-      const { stdout: thirdStdout } = await runPrettier(dir, [
-        "--write",
-        "--cache",
-        "--cache-strategy",
-        "content",
-        ".",
-      ]);
+      const { stdout: thirdStdout } = await runPrettier(dir, cliArguments);
       expect(stripAnsi(thirdStdout).split("\n").filter(Boolean)).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
@@ -615,13 +580,14 @@ describe("--cache option", () => {
       });
 
       it("does'nt format when cache is available", async () => {
-        const { stdout: firstStdout } = await runPrettier(dir, [
+        const cliArguments = [
           "--cache",
           "--write",
           "--cache-location",
           nonDefaultCacheFileName,
           ".",
-        ]);
+        ];
+        const { stdout: firstStdout } = await runPrettier(dir, cliArguments);
         expect(stripAnsi(firstStdout).split("\n").filter(Boolean)).toEqual(
           expect.arrayContaining([
             expect.stringMatching(/^a\.js .+ms$/),
@@ -629,13 +595,7 @@ describe("--cache option", () => {
           ])
         );
 
-        const { stdout: secondStdout } = await runPrettier(dir, [
-          "--cache",
-          "--write",
-          "--cache-location",
-          nonDefaultCacheFileName,
-          ".",
-        ]);
+        const { stdout: secondStdout } = await runPrettier(dir, cliArguments);
         expect(stripAnsi(secondStdout).split("\n").filter(Boolean)).toEqual(
           expect.arrayContaining([
             expect.stringMatching(/^a\.js .+ms \(cached\)$/),

--- a/tests/integration/__tests__/cache.js
+++ b/tests/integration/__tests__/cache.js
@@ -95,8 +95,8 @@ describe("--cache option", () => {
           listDifferent: false,
           trailingCommaAll: false,
         }
-      ) =>
-        [
+      ) => {
+        return [
           "--cache",
           "--cache-strategy",
           strategy,
@@ -106,6 +106,7 @@ describe("--cache option", () => {
           trailingCommaAll && "all",
           ".",
         ].filter(Boolean);
+      };
 
     describe("--cache-strategy metadata", () => {
       const getCliArguments = createGetCliArguments("metadata");
@@ -470,14 +471,15 @@ describe("--cache option", () => {
   describe("--cache-location", () => {
     const getCliArguments = (
       { write, cacheLocation } = { write: false, cacheLocation: undefined }
-    ) =>
-      [
+    ) => {
+      return [
         "--cache",
         write && "--write",
         cacheLocation && "--cache-location",
         cacheLocation,
         ".",
       ].filter(Boolean);
+    };
 
     it("doesn't create default cache file when `--cache-location` exists", async () => {
       await expect(fs.stat(defaultCacheFile)).rejects.toHaveProperty(

--- a/tests/integration/__tests__/cache.js
+++ b/tests/integration/__tests__/cache.js
@@ -95,8 +95,8 @@ describe("--cache option", () => {
           listDifferent: false,
           trailingCommaAll: false,
         }
-      ) => {
-        return [
+      ) =>
+        [
           "--cache",
           "--cache-strategy",
           strategy,
@@ -106,7 +106,6 @@ describe("--cache option", () => {
           trailingCommaAll && "all",
           ".",
         ].filter(Boolean);
-      };
 
     describe("--cache-strategy metadata", () => {
       const getCliArguments = createGetCliArguments("metadata");
@@ -471,15 +470,14 @@ describe("--cache option", () => {
   describe("--cache-location", () => {
     const getCliArguments = (
       { write, cacheLocation } = { write: false, cacheLocation: undefined }
-    ) => {
-      return [
+    ) =>
+      [
         "--cache",
         write && "--write",
         cacheLocation && "--cache-location",
         cacheLocation,
         ".",
       ].filter(Boolean);
-    };
 
     it("doesn't create default cache file when `--cache-location` exists", async () => {
       await expect(fs.stat(defaultCacheFile)).rejects.toHaveProperty(

--- a/tests/integration/run-prettier.js
+++ b/tests/integration/run-prettier.js
@@ -46,6 +46,10 @@ async function run(dir, args, options) {
     .spyOn(fs.promises, "writeFile")
     // eslint-disable-next-line require-await
     .mockImplementation(async (filename, content) => {
+      const error = (options.mockWriteFileErrors || {})[filename];
+      if (error) {
+        throw new Error(error);
+      }
       write.push({ filename, content });
     });
 


### PR DESCRIPTION
## Description

Do not save formatted cache if without `--write` option and the file is modifies by prettier.

Before fixed, always save formatted cache if with `--cache` option.
Therefore, unformatted files will never be formatted.

I think this is a bug.

### Before fixed:
```sh
> prettier --cache foo.js
# Show formatted contents of `foo.js`.
# Then the cache is created and `foo.js` is flagged as already formatted.

> prettier --cache --write foo.js
foo.js 2ms (cached)
# "... (cached)" means that the file is already formatted and do nothing this time.
```

### After fixed with this PR:
```sh
> prettier --cache foo.js
# Show formatted contents of `foo.js`.

> prettier --cache --write foo.js
foo.js 2ms
# `foo.js` has been formatted and overwritten.
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
