### PR TITLE
fix: JSON modules disable named exports

### DIFF
--- a/tests/format/js/import-assertions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/import-assertions/__snapshots__/jsfmt.spec.js.snap
@@ -177,27 +177,27 @@ assert({ type: "json" });
 `;
 
 exports[`re-export.js [acorn] format 1`] = `
-"Unexpected token (1:33)
-> 1 | export { foo2 } from "foo.json" assert { type: "json" };
-    |                                 ^
+"Unexpected token (1:44)
+> 1 | export { default as foo2 } from "foo.json" assert { type: "json" };
+    |                                            ^
   2 | export * from "foo.json" assert { type: "json" };
   3 | export * as foo3 from "foo.json" assert { type: "json" };
   4 |"
 `;
 
 exports[`re-export.js [espree] format 1`] = `
-"Unexpected token assert (1:33)
-> 1 | export { foo2 } from "foo.json" assert { type: "json" };
-    |                                 ^
+"Unexpected token assert (1:44)
+> 1 | export { default as foo2 } from "foo.json" assert { type: "json" };
+    |                                            ^
   2 | export * from "foo.json" assert { type: "json" };
   3 | export * as foo3 from "foo.json" assert { type: "json" };
   4 |"
 `;
 
 exports[`re-export.js [meriyah] format 1`] = `
-"Unexpected token: 'identifier' (1:38)
-> 1 | export { foo2 } from "foo.json" assert { type: "json" };
-    |                                      ^
+"Unexpected token: 'identifier' (1:49)
+> 1 | export { default as foo2 } from "foo.json" assert { type: "json" };
+    |                                                 ^
   2 | export * from "foo.json" assert { type: "json" };
   3 | export * as foo3 from "foo.json" assert { type: "json" };
   4 |"
@@ -209,12 +209,12 @@ parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-export { foo2 } from "foo.json" assert { type: "json" };
+export { default as foo2 } from "foo.json" assert { type: "json" };
 export * from "foo.json" assert { type: "json" };
 export * as foo3 from "foo.json" assert { type: "json" };
 
 =====================================output=====================================
-export { foo2 } from "foo.json" assert { type: "json" };
+export { default as foo2 } from "foo.json" assert { type: "json" };
 export * from "foo.json" assert { type: "json" };
 export * as foo3 from "foo.json" assert { type: "json" };
 

--- a/tests/format/js/import-assertions/re-export.js
+++ b/tests/format/js/import-assertions/re-export.js
@@ -1,3 +1,3 @@
-export { foo2 } from "foo.json" assert { type: "json" };
+export { default as foo2 } from "foo.json" assert { type: "json" };
 export * from "foo.json" assert { type: "json" };
 export * as foo3 from "foo.json" assert { type: "json" };


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Updated the import-assertions js formatter test, as the JSON modules spec [disallows named exports](https://github.com/tc39/proposal-json-modules#why-dont-json-modules-support-named-exports). For example, `export { foo2 } from "./foo.json" assert { type: "json" }` is invalid.

Currently blocking https://github.com/babel/babel/pull/14668. Babel plans to throw named JSON module imports/exports in the future, hence I update the test so the Babel update won't break our tests.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
