### PR TITLE
fix: JSON modules disable named exports

### DIFF
--- a/tests/format/js/import-assertions/bracket-spacing/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/import-assertions/bracket-spacing/__snapshots__/jsfmt.spec.js.snap
@@ -69,23 +69,23 @@ export * as bar from "bar.json";
 `;
 
 exports[`re-export.js - {"bracketSpacing":false} [acorn] format 1`] = `
-"Unexpected token (1:33)
-> 1 | export { foo2 } from "foo.json" assert { type: "json" };
-    |                                 ^
+"Unexpected token (1:44)
+> 1 | export { default as foo2 } from "foo.json" assert { type: "json" };
+    |                                            ^
   2 |"
 `;
 
 exports[`re-export.js - {"bracketSpacing":false} [espree] format 1`] = `
-"Unexpected token assert (1:33)
-> 1 | export { foo2 } from "foo.json" assert { type: "json" };
-    |                                 ^
+"Unexpected token assert (1:44)
+> 1 | export { default as foo2 } from "foo.json" assert { type: "json" };
+    |                                            ^
   2 |"
 `;
 
 exports[`re-export.js - {"bracketSpacing":false} [meriyah] format 1`] = `
-"Unexpected token: 'identifier' (1:38)
-> 1 | export { foo2 } from "foo.json" assert { type: "json" };
-    |                                      ^
+"Unexpected token: 'identifier' (1:49)
+> 1 | export { default as foo2 } from "foo.json" assert { type: "json" };
+    |                                                 ^
   2 |"
 `;
 
@@ -96,10 +96,10 @@ parsers: ["babel"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-export { foo2 } from "foo.json" assert { type: "json" };
+export { default as foo2 } from "foo.json" assert { type: "json" };
 
 =====================================output=====================================
-export {foo2} from "foo.json" assert {type: "json"};
+export {default as foo2} from "foo.json" assert {type: "json"};
 
 ================================================================================
 `;

--- a/tests/format/js/import-assertions/bracket-spacing/re-export.js
+++ b/tests/format/js/import-assertions/bracket-spacing/re-export.js
@@ -1,1 +1,1 @@
-export { foo2 } from "foo.json" assert { type: "json" };
+export { default as foo2 } from "foo.json" assert { type: "json" };

--- a/tests/format/misc/errors/js/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/js/__snapshots__/jsfmt.spec.js.snap
@@ -12,9 +12,9 @@ exports[`html-like-comments.js [babel] format 1`] = `
 `;
 
 exports[`import-assertions-for-export-without-from.js [babel] format 1`] = `
-"Missing semicolon. (1:15)
-> 1 | export { foo } assert { type: "json" };
-    |               ^
+"Missing semicolon. (1:26)
+> 1 | export { default as foo } assert { type: "json" };
+    |                          ^
   2 |"
 `;
 

--- a/tests/format/misc/errors/js/import-assertions-for-export-without-from.js
+++ b/tests/format/misc/errors/js/import-assertions-for-export-without-from.js
@@ -1,1 +1,1 @@
-export { foo } assert { type: "json" };
+export { default as foo } assert { type: "json" };


### PR DESCRIPTION
## Description

This is a follow-up to #13031, see that PR for the rationale. I searched `assert { type: "json" }` in our codebase and replaced all named imports, please let me know if I have missed any. Thank you.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
