### PR TITLE
Registers axml file as HTML

### DIFF
--- a/src/language-html/index.js
+++ b/src/language-html/index.js
@@ -17,7 +17,7 @@ const languages = [
   createLanguage(require("linguist-languages/data/HTML.json"), (data) => ({
     since: "1.15.0",
     parsers: ["html"],
-    vscodeLanguageIds: ["html"],
+    vscodeLanguageIds: ["html", "axml"],
     extensions: [
       ...data.extensions,
       ".mjml", // MJML is considered XML in Linguist but it should be formatted as HTML


### PR DESCRIPTION
This is a HTML-like file registered by the vscode extension alipay.minicode. The axml file is used in alipay miniprogram which is a popular web framework in China.

I followed [this doc](https://github.com/prettier/prettier-vscode/wiki/Custom-File-Extension-Configuration#custom-language-identifier) to send the PR for making prettier-vscode support formating axml files in vscode.

## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
