### PR TITLE
Spruce up .editorconfig example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -178,35 +178,26 @@ If you’d like a JSON schema to validate your configuration, one is available h
 
 If `options.editorconfig` is `true` and an [`.editorconfig` file](https://editorconfig.org/) is in your project, Prettier will parse it and convert its properties to the corresponding Prettier configuration. This configuration will be overridden by `.prettierrc`, etc.
 
-Here’s an annotated description of how different properties map to Prettier’s behavior:
+Here’s an annotated description of how different properties map to Prettier’s behavior, which you can copy-paste directly into your project:
 
 ```ini
 # Stop the editor from looking for .editorconfig files in the parent directories
 # root = true
 
+# Copied from: https://prettier.io/docs/en/configuration.html#editorconfig
 [*]
-# Non-configurable Prettier behaviors
-charset = utf-8
-insert_final_newline = true
-# Caveat: Prettier won’t trim trailing whitespace inside template strings, but your editor might.
-# trim_trailing_whitespace = true
+  # Non-configurable Prettier behaviors
+  charset = utf-8
+  insert_final_newline = true
 
-# Configurable Prettier behaviors
-# (change these if your Prettier config differs)
-end_of_line = lf
-indent_style = space
-indent_size = 2
-max_line_length = 80
-```
+  # Caveat: Prettier won’t trim trailing whitespace inside template strings, but your editor might.
+  # Ideally we don't enable this, and let prettier do the smart thing.
+  # trim_trailing_whitespace = true
 
-Here’s a copy+paste-ready `.editorconfig` file if you use the default options:
-
-```ini
-[*]
-charset = utf-8
-insert_final_newline = true
-end_of_line = lf
-indent_style = space
-indent_size = 2
-max_line_length = 80
+  # Configurable Prettier behaviors
+  # (change these if your Prettier config differs)
+  end_of_line = lf
+  indent_style = space
+  indent_size = 2
+  max_line_length = 80
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -186,18 +186,19 @@ Here’s an annotated description of how different properties map to Prettier’
 
 # Copied from: https://prettier.io/docs/en/configuration.html#editorconfig
 [*]
-  # Non-configurable Prettier behaviors
+  # Non-configurable Prettier behaviors:
+  #  (changing these can cause conflicts with prettier)
   charset = utf-8
   insert_final_newline = true
 
-  # Caveat: Prettier won’t trim trailing whitespace inside template strings, but your editor might.
+  # Prettier won’t trim trailing whitespace inside template strings, but your editor might.
   # Ideally we don't enable this, and let prettier do the smart thing.
   # trim_trailing_whitespace = true
 
-  # Configurable Prettier behaviors
-  # (change these if your Prettier config differs)
+  # Match prettier defaults, customize to your hearts content:
   end_of_line = lf
   indent_style = space
   indent_size = 2
   max_line_length = 80
+
 ```


### PR DESCRIPTION
## Description

Spruce up .editorconfig example

## Checklist

- [ ] I’ve added tests to confirm my change works. (???)
- [x] N/A: (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] N/A: (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**