### PR TITLE
Refactor: Extract `printEndOfOpeningTag`

### DIFF
--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -574,27 +574,6 @@ function printJsxOpeningElement(path, options, print) {
     ]);
   }
 
-  const lastAttrHasTrailingComments =
-    node.attributes.length > 0 &&
-    hasComment(getLast(node.attributes), CommentCheckFlags.Trailing);
-
-  const bracketSameLine =
-    // Simple tags (no attributes and no comment in tag name) should be
-    // kept unbroken regardless of `bracketSameLine`.
-    // jsxBracketSameLine is deprecated in favour of bracketSameLine,
-    // but is still needed for backwards compatibility.
-    (node.attributes.length === 0 && !nameHasComments) ||
-    ((options.bracketSameLine || options.jsxBracketSameLine) &&
-      // We should print the bracket in a new line for the following cases:
-      // <div
-      //   // comment
-      // >
-      // <div
-      //   attr // comment
-      // >
-      (!nameHasComments || node.attributes.length > 0) &&
-      !lastAttrHasTrailingComments);
-
   // We should print the opening element expanded if any prop value is a
   // string literal with newlines
   const shouldBreak =
@@ -617,10 +596,47 @@ function printJsxOpeningElement(path, options, print) {
       print("name"),
       print("typeParameters"),
       indent(path.map(() => [attributeLine, print()], "attributes")),
-      node.selfClosing ? line : bracketSameLine ? ">" : softline,
-      node.selfClosing ? "/>" : bracketSameLine ? "" : ">",
+      ...printClosing(node, options, nameHasComments),
     ],
     { shouldBreak }
+  );
+}
+
+function printClosing(node, options, nameHasComments) {
+  if (node.selfClosing) {
+    return [line, "/>"];
+  }
+  const bracketSameLine = shouldPrintBracketSameline(
+    node,
+    options,
+    nameHasComments
+  );
+  if (bracketSameLine) {
+    return [">"];
+  }
+  return [softline, ">"];
+}
+
+function shouldPrintBracketSameline(node, options, nameHasComments) {
+  const lastAttrHasTrailingComments =
+    node.attributes.length > 0 &&
+    hasComment(getLast(node.attributes), CommentCheckFlags.Trailing);
+  return (
+    // Simple tags (no attributes and no comment in tag name) should be
+    // kept unbroken regardless of `bracketSameLine`.
+    // jsxBracketSameLine is deprecated in favour of bracketSameLine,
+    // but is still needed for backwards compatibility.
+    (node.attributes.length === 0 && !nameHasComments) ||
+    ((options.bracketSameLine || options.jsxBracketSameLine) &&
+      // We should print the bracket in a new line for the following cases:
+      // <div
+      //   // comment
+      // >
+      // <div
+      //   attr // comment
+      // >
+      (!nameHasComments || node.attributes.length > 0) &&
+      !lastAttrHasTrailingComments)
   );
 }
 

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -606,7 +606,7 @@ function printEndOfOpeningTag(node, options, nameHasComments) {
   if (node.selfClosing) {
     return [line, "/>"];
   }
-  const bracketSameLine = shouldPrintBracketSameline(
+  const bracketSameLine = shouldPrintBracketSameLine(
     node,
     options,
     nameHasComments
@@ -617,7 +617,7 @@ function printEndOfOpeningTag(node, options, nameHasComments) {
   return [softline, ">"];
 }
 
-function shouldPrintBracketSameline(node, options, nameHasComments) {
+function shouldPrintBracketSameLine(node, options, nameHasComments) {
   const lastAttrHasTrailingComments =
     node.attributes.length > 0 &&
     hasComment(getLast(node.attributes), CommentCheckFlags.Trailing);

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -596,13 +596,13 @@ function printJsxOpeningElement(path, options, print) {
       print("name"),
       print("typeParameters"),
       indent(path.map(() => [attributeLine, print()], "attributes")),
-      ...printClosing(node, options, nameHasComments),
+      ...printEndOfOpeningTag(node, options, nameHasComments),
     ],
     { shouldBreak }
   );
 }
 
-function printClosing(node, options, nameHasComments) {
+function printEndOfOpeningTag(node, options, nameHasComments) {
   if (node.selfClosing) {
     return [line, "/>"];
   }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
