### PR TITLE
Migrate third-party.js to ES Module

### DIFF
--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -343,8 +343,7 @@ const coreBundles = [
     replaceModule: [replaceDiffPackageEntry("lib/patch/create.js")],
   },
   {
-    input: "src/common/third-party.cjs",
-    output: "third-party.js",
+    input: "src/common/third-party.js",
     replaceModule: [
       // cosmiconfig@6 -> import-fresh can't find parentModule, since module is bundled
       {

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -2,7 +2,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import chalk from "chalk";
 import * as prettier from "../index.js";
-import thirdParty from "../common/third-party.cjs";
+import thirdParty from "../common/third-party.js";
 import { createIgnorer, errors } from "./prettier-internal.js";
 import { expandPatterns, fixWindowsSlashes } from "./expand-patterns.js";
 import getOptionsForFile from "./options/get-options-for-file.js";

--- a/src/cli/is-tty.js
+++ b/src/cli/is-tty.js
@@ -1,4 +1,4 @@
-import thirdParty from "../common/third-party.cjs";
+import thirdParty from "../common/third-party.js";
 
 // Some CI pipelines incorrectly report process.stdout.isTTY status,
 // which causes unwanted lines in the output. An additional check for isCI() helps.

--- a/src/common/load-plugins.js
+++ b/src/common/load-plugins.js
@@ -6,7 +6,7 @@ import fastGlob from "fast-glob";
 import mem, { memClear } from "mem";
 import partition from "../utils/partition.js";
 import uniqByKey from "../utils/uniq-by-key.js";
-import thirdParty from "./third-party.cjs";
+import thirdParty from "./third-party.js";
 import resolve from "./resolve.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/src/common/third-party.cjs
+++ b/src/common/third-party.cjs
@@ -1,8 +1,0 @@
-"use strict";
-
-module.exports = {
-  cosmiconfig: require("cosmiconfig").cosmiconfig,
-  findParentDir: require("find-parent-dir").sync,
-  getStdin: require("get-stdin"),
-  isCI: () => require("ci-info").isCI,
-};

--- a/src/common/third-party.js
+++ b/src/common/third-party.js
@@ -1,0 +1,13 @@
+import { cosmiconfig } from "cosmiconfig";
+import { sync as findParentDir } from "find-parent-dir";
+import getStdin from "get-stdin";
+import { isCI } from "ci-info";
+
+const thirdParty = {
+  cosmiconfig,
+  findParentDir,
+  getStdin,
+  isCI: () => isCI,
+};
+
+export default thirdParty;

--- a/src/config/resolve-config.js
+++ b/src/config/resolve-config.js
@@ -2,7 +2,7 @@ import { createRequire } from "node:module";
 import path from "node:path";
 import micromatch from "micromatch";
 import mem, { memClear } from "mem";
-import thirdParty from "../common/third-party.cjs";
+import thirdParty from "../common/third-party.js";
 import loadToml from "../utils/load-toml.js";
 import loadJson5 from "../utils/load-json5.js";
 import resolve from "../common/resolve.js";

--- a/tests/integration/__tests__/third-party.js
+++ b/tests/integration/__tests__/third-party.js
@@ -3,14 +3,18 @@ import createEsmUtils from "esm-utils";
 import { thirdParty } from "../env.js";
 import jestPathSerializer from "../path-serializer.js";
 
-const { require, __dirname } = createEsmUtils(import.meta);
-const { cosmiconfig, isCI } = require(thirdParty);
+const {  __dirname, importModule } = createEsmUtils(import.meta);
 
 expect.addSnapshotSerializer(jestPathSerializer);
 
 // This don't has to be the same result as `prettier.resolveConfig`,
 // Because we are testing with default `cosmiconfigOptions`
 describe("cosmiconfig", () => {
+let cosmiconfig
+   beforeAll(async () => {
+      ({ cosmiconfig } = await importModule(thirdParty));
+    })
+
   const configs = [
     {
       title: "prettier.config.cjs",
@@ -59,6 +63,7 @@ describe("cosmiconfig", () => {
   });
 });
 
-test("isCI", () => {
+test("isCI", async () => {
+const {isCI} =  await importModule(thirdParty)
   expect(typeof isCI()).toBe("boolean");
 });

--- a/tests/integration/__tests__/third-party.js
+++ b/tests/integration/__tests__/third-party.js
@@ -1,19 +1,22 @@
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import createEsmUtils from "esm-utils";
 import { thirdParty } from "../env.js";
 import jestPathSerializer from "../path-serializer.js";
 
-const {  __dirname, importModule } = createEsmUtils(import.meta);
+const { __dirname } = createEsmUtils(import.meta);
 
 expect.addSnapshotSerializer(jestPathSerializer);
 
 // This don't has to be the same result as `prettier.resolveConfig`,
 // Because we are testing with default `cosmiconfigOptions`
 describe("cosmiconfig", () => {
-let cosmiconfig
-   beforeAll(async () => {
-      ({ cosmiconfig } = await importModule(thirdParty));
-    })
+  let cosmiconfig;
+  beforeAll(async () => {
+    ({
+      default: { cosmiconfig },
+    } = await import(pathToFileURL(thirdParty)));
+  });
 
   const configs = [
     {
@@ -64,6 +67,8 @@ let cosmiconfig
 });
 
 test("isCI", async () => {
-const {isCI} =  await importModule(thirdParty)
+  const {
+    default: { isCI },
+  } = await import(pathToFileURL(thirdParty));
   expect(typeof isCI()).toBe("boolean");
 });

--- a/tests/integration/cli-worker.js
+++ b/tests/integration/cli-worker.js
@@ -37,7 +37,9 @@ async function run() {
   process.stdin.isTTY = Boolean(options.isTTY);
   process.stdout.isTTY = Boolean(options.stdoutIsTTY);
 
-  const {default: thirdParty} = await import(url.pathToFileURL(thirdPartyModuleFile));
+  const { default: thirdParty } = await import(
+    url.pathToFileURL(thirdPartyModuleFile)
+  );
 
   // We cannot use `jest.setMock("get-stream", impl)` here, because in the
   // production build everything is bundled into one file so there is no

--- a/tests/integration/cli-worker.js
+++ b/tests/integration/cli-worker.js
@@ -37,7 +37,7 @@ async function run() {
   process.stdin.isTTY = Boolean(options.isTTY);
   process.stdout.isTTY = Boolean(options.stdoutIsTTY);
 
-  const thirdParty = require(thirdPartyModuleFile);
+  const {default: thirdParty} = await import(url.pathToFileURL(thirdPartyModuleFile));
 
   // We cannot use `jest.setMock("get-stream", impl)` here, because in the
   // production build everything is bundled into one file so there is no

--- a/tests/integration/env.js
+++ b/tests/integration/env.js
@@ -12,8 +12,8 @@ const prettierCli = path.join(
 );
 
 const thirdParty = isProduction
-  ? path.join(PRETTIER_DIR, "./third-party")
-  : path.join(PRETTIER_DIR, "./src/common/third-party");
+  ? path.join(PRETTIER_DIR, "./third-party.js")
+  : path.join(PRETTIER_DIR, "./src/common/third-party.js");
 
 const projectRoot = path.join(__dirname, "../..");
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Part of #12356

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
