### PR TITLE
Use appropriate chalk instance for stderr output

### DIFF
--- a/src/cli/logger.js
+++ b/src/cli/logger.js
@@ -6,7 +6,7 @@ const wcwidth = require("wcwidth");
 // eslint-disable-next-line no-restricted-modules
 const { default: stripAnsi } = require("../../vendors/strip-ansi.js");
 // eslint-disable-next-line no-restricted-modules
-const { default: chalk } = require("../../vendors/chalk.js");
+const { default: chalk, chalkStderr } = require("../../vendors/chalk.js");
 
 const countLines = (stream, text) => {
   const columns = stream.columns || 80;
@@ -45,8 +45,9 @@ function createLogger(logLevel = "log") {
       return () => emptyLogResult;
     }
 
-    const prefix = color ? `[${chalk[color](loggerName)}] ` : "";
     const stream = process[loggerName === "log" ? "stdout" : "stderr"];
+    const chalkInstance = loggerName === "log" ? chalk : chalkStderr;
+    const prefix = color ? `[${chalkInstance[color](loggerName)}] ` : "";
 
     return (message, options) => {
       options = {


### PR DESCRIPTION
Chalk auto-detects whether the output channel supports colors, but does that for stderr.  Consequently, colors appear inconsistently (and wrongly) depending on whether stdout or stderr have been redirected.

Issue: #13097

## Description

This change corrects the instance of chalk used, according to the employed output channel (stdout or stderr).

## Checklist

- [ ] I manually tested the result. I also tried adding tests to confirm my change works in three ways, but none is viable. Specifically, I tried the following:
  - via changes to `run-pretties.js` (its existing `process.stdin.isTTY` code is bogus, because `chalk` calls directly `isatty()`),
  - via mocking (it doesn't work, because `chalk` sets the values at the module level), and 
  - by modifying the `chalk` object with `Object.defineProperty` (it doesn't work, because the `configurable` is set to false).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
