### PR TITLE
Migrate parsers to async

### DIFF
--- a/src/language-handlebars/parser-glimmer.js
+++ b/src/language-handlebars/parser-glimmer.js
@@ -1,9 +1,6 @@
-import { createRequire } from "node:module";
 import { LinesAndColumns } from "lines-and-columns";
 import createError from "../common/parser-create-error.js";
 import { locStart, locEnd } from "./loc.js";
-
-const require = createRequire(import.meta.url);
 
 /* from the following template: `non-escaped mustache \\{{helper}}`
  * glimmer parser will produce an AST missing a backslash
@@ -50,8 +47,12 @@ function addOffset(text) {
   });
 }
 
-function parse(text) {
-  const { preprocess: glimmer } = require("@glimmer/syntax");
+let glimmer;
+async function parse(text) {
+  if (!glimmer) {
+    ({ preprocess: glimmer } = await import("@glimmer/syntax"));
+  }
+
   let ast;
   try {
     ast = glimmer(text, {

--- a/src/language-js/parse/acorn.js
+++ b/src/language-js/parse/acorn.js
@@ -66,7 +66,7 @@ function parseWithOptions(text, sourceType) {
 }
 
 function parse(text, parsers, options = {}) {
-  const { result: ast, error: moduleParseError } = tryCombinations(
+  const { result: ast, error: moduleParseError } = tryCombinations.sync(
     () => parseWithOptions(text, /* sourceType */ "module"),
     () => parseWithOptions(text, /* sourceType */ "script")
   );

--- a/src/language-js/parse/acorn.js
+++ b/src/language-js/parse/acorn.js
@@ -38,6 +38,7 @@ function createParseError(error) {
 let parser;
 const getParser = () => {
   if (!parser) {
+    // We can't use `import()` here, https://github.com/acornjs/acorn-jsx/issues/133
     const { Parser: AcornParser } = require("acorn");
     const acornJsx = require("acorn-jsx");
     parser = AcornParser.extend(acornJsx());

--- a/src/language-js/parse/angular.js
+++ b/src/language-js/parse/angular.js
@@ -1,21 +1,24 @@
-import { createRequire } from "node:module";
 import { locStart, locEnd } from "../loc.js";
 
-const require = createRequire(import.meta.url);
-
+let ngEstreeParser;
 function createParser(_parse) {
-  const parse = (text, parsers, options) => {
-    const ngEstreeParser = require("angular-estree-parser");
-    const node = _parse(text, ngEstreeParser);
-    return {
-      type: "NGRoot",
-      node:
-        options.parser === "__ng_action" && node.type !== "NGChainedExpression"
-          ? { ...node, type: "NGChainedExpression", expressions: [node] }
-          : node,
-    };
+  return {
+    astFormat: "estree",
+    async parse(text, parsers, options) {
+      ngEstreeParser ??= await import("angular-estree-parser");
+      const node = _parse(text, ngEstreeParser);
+      return {
+        type: "NGRoot",
+        node:
+          options.parser === "__ng_action" &&
+          node.type !== "NGChainedExpression"
+            ? { ...node, type: "NGChainedExpression", expressions: [node] }
+            : node,
+      };
+    },
+    locStart,
+    locEnd,
   };
-  return { astFormat: "estree", parse, locStart, locEnd };
 }
 
 const parser = {

--- a/src/language-js/parse/espree.js
+++ b/src/language-js/parse/espree.js
@@ -33,11 +33,14 @@ function createParseError(error) {
   return createError(message, { start: { line: lineNumber, column } });
 }
 
-function parse(originalText, parsers, options = {}) {
-  const { parse: espreeParse } = require("espree");
+let espreeParse;
+async function parse(originalText, parsers, options = {}) {
+  if (!espreeParse) {
+    ({ parse: espreeParse } = await import("espree"));
+  }
 
   const textToParse = replaceHashbang(originalText);
-  const { result: ast, error: moduleParseError } = tryCombinations(
+  const { result: ast, error: moduleParseError } = await tryCombinations(
     () => espreeParse(textToParse, { ...parseOptions, sourceType: "module" }),
     () => espreeParse(textToParse, { ...parseOptions, sourceType: "script" })
   );

--- a/src/language-js/parse/espree.js
+++ b/src/language-js/parse/espree.js
@@ -33,14 +33,11 @@ function createParseError(error) {
   return createError(message, { start: { line: lineNumber, column } });
 }
 
-let espreeParse;
-async function parse(originalText, parsers, options = {}) {
-  if (!espreeParse) {
-    ({ parse: espreeParse } = await import("espree"));
-  }
+function parse(originalText, parsers, options = {}) {
+  const { parse: espreeParse } = require("espree");
 
   const textToParse = replaceHashbang(originalText);
-  const { result: ast, error: moduleParseError } = await tryCombinations(
+  const { result: ast, error: moduleParseError } = tryCombinations(
     () => espreeParse(textToParse, { ...parseOptions, sourceType: "module" }),
     () => espreeParse(textToParse, { ...parseOptions, sourceType: "script" })
   );

--- a/src/language-js/parse/json.js
+++ b/src/language-js/parse/json.js
@@ -1,19 +1,17 @@
-import { createRequire } from "node:module";
 import isNonEmptyArray from "../../utils/is-non-empty-array.js";
 import createError from "../../common/parser-create-error.js";
 import createParser from "./utils/create-parser.js";
 import createBabelParseError from "./utils/create-babel-parse-error.js";
 
-const require = createRequire(import.meta.url);
-
+let babelParser;
 function createJsonParse(options = {}) {
   const { allowComments = true } = options;
 
-  return function parse(text /*, parsers, options*/) {
-    const { parseExpression } = require("@babel/parser");
+  return async function parse(text /*, parsers, options*/) {
+    babelParser ??= await import("@babel/parser");
     let ast;
     try {
-      ast = parseExpression(text, {
+      ast = babelParser.parseExpression(text, {
         tokens: true,
         ranges: true,
       });

--- a/src/language-js/parse/meriyah.js
+++ b/src/language-js/parse/meriyah.js
@@ -42,8 +42,11 @@ const parseOptions = {
   uniqueKeyInPattern: false,
 };
 
-function parseWithOptions(text, module) {
-  const { parse: meriyahParse } = require("meriyah");
+let meriyahParse;
+async function parseWithOptions(text, module) {
+  if (!meriyahParse) {
+    ({ parse: meriyahParse } = await import("meriyah"));
+  }
   const comments = [];
   const tokens = [];
 
@@ -85,8 +88,8 @@ function createParseError(error) {
   return createError(message, { start: { line, column } });
 }
 
-function parse(text, parsers, options = {}) {
-  const { result: ast, error: moduleParseError } = tryCombinations(
+async function parse(text, parsers, options = {}) {
+  const { result: ast, error: moduleParseError } = await tryCombinations(
     () => parseWithOptions(text, /* module */ true),
     () => parseWithOptions(text, /* module */ false)
   );

--- a/src/language-js/parse/typescript.js
+++ b/src/language-js/parse/typescript.js
@@ -33,12 +33,14 @@ function createParseError(error) {
   });
 }
 
-function parse(text, parsers, options = {}) {
+let typescriptEstree;
+async function parse(text, parsers, options = {}) {
   const textToParse = replaceHashbang(text);
   const jsx = isProbablyJsx(text);
 
-  const { parseWithNodeMaps } = require("@typescript-eslint/typescript-estree");
-  const { result, error: firstError } = tryCombinations(
+  typescriptEstree ??= await import("@typescript-eslint/typescript-estree");
+  const { parseWithNodeMaps } = typescriptEstree;
+  const { result, error: firstError } = await tryCombinations(
     // Try passing with our best guess first.
     () => parseWithNodeMaps(textToParse, { ...parseOptions, jsx }),
     // But if we get it wrong, try the opposite.

--- a/src/language-yaml/parser-yaml.js
+++ b/src/language-yaml/parser-yaml.js
@@ -1,12 +1,9 @@
-import { createRequire } from "node:module";
 import createError from "../common/parser-create-error.js";
 import { hasPragma } from "./pragma.js";
 import { locStart, locEnd } from "./loc.js";
 
-const require = createRequire(import.meta.url);
-
-function parse(text) {
-  const { parse: parseYaml } = require("yaml-unist-parser");
+async function parse(text) {
+  const { parse: parseYaml } = await import("yaml-unist-parser");
 
   try {
     const root = parseYaml(text);

--- a/src/utils/try-combinations.js
+++ b/src/utils/try-combinations.js
@@ -1,8 +1,8 @@
-function tryCombinations(...combinations) {
+async function tryCombinations(...combinations) {
   let firstError;
   for (const [index, fn] of combinations.entries()) {
     try {
-      return { result: fn() };
+      return { result: await fn() };
     } catch (error) {
       if (index === 0) {
         firstError = error;

--- a/src/utils/try-combinations.js
+++ b/src/utils/try-combinations.js
@@ -12,4 +12,18 @@ async function tryCombinations(...combinations) {
   return { error: firstError };
 }
 
+tryCombinations.sync = function (...combinations) {
+  let firstError;
+  for (const [index, fn] of combinations.entries()) {
+    try {
+      return { result: fn() };
+    } catch (error) {
+      if (index === 0) {
+        firstError = error;
+      }
+    }
+  }
+  return { error: firstError };
+};
+
 export default tryCombinations;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Avoid to use `require()`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
