### PR TITLE
Fix comments formatting in if/else statement

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -17,6 +17,7 @@ const skipInlineComment = require("../utils/text/skip-inline-comment.js");
 const skipTrailingComment = require("../utils/text/skip-trailing-comment.js");
 const skipNewline = require("../utils/text/skip-newline.js");
 const getNextNonSpaceNonCommentCharacterIndexWithStartIndex = require("../utils/text/get-next-non-space-non-comment-character-index-with-start-index.js");
+const getPreviousNonSpaceNonCommentCharacterIndexWithStartIndex = require("../utils/text/get-previous-non-space-non-comment-character-index-with-start-index.js");
 
 const getPenultimate = (arr) => arr[arr.length - 2];
 
@@ -167,6 +168,34 @@ function getNextNonSpaceNonCommentCharacter(text, node, locEnd) {
   return text.charAt(
     // @ts-expect-error => TBD: can return false, should we define a fallback?
     getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd)
+  );
+}
+
+/**
+ * @template N
+ * @param {string} text
+ * @param {N} node
+ * @param {(node: N) => number} locEnd
+ * @returns {number | false}
+ */
+function getPreviousNonSpaceNonCommentCharacterIndex(text, node, locEnd) {
+  return getPreviousNonSpaceNonCommentCharacterIndexWithStartIndex(
+    text,
+    locEnd(node)
+  );
+}
+
+/**
+ * @template N
+ * @param {string} text
+ * @param {N} node
+ * @param {(node: N) => number} locEnd
+ * @returns {string}
+ */
+function getPreviousNonSpaceNonCommentCharacter(text, node, locEnd) {
+  return text.charAt(
+    // @ts-expect-error => TBD: can return false, should we define a fallback?
+    getPreviousNonSpaceNonCommentCharacterIndex(text, node, locEnd)
   );
 }
 
@@ -491,6 +520,9 @@ module.exports = {
   getNextNonSpaceNonCommentCharacterIndexWithStartIndex,
   getNextNonSpaceNonCommentCharacterIndex,
   getNextNonSpaceNonCommentCharacter,
+  getPreviousNonSpaceNonCommentCharacterIndexWithStartIndex,
+  getPreviousNonSpaceNonCommentCharacterIndex,
+  getPreviousNonSpaceNonCommentCharacter,
   skip,
   skipWhitespace,
   skipSpaces,

--- a/src/language-js/print/misc.js
+++ b/src/language-js/print/misc.js
@@ -78,7 +78,7 @@ function printTypeScriptModifiers(path, options, print) {
 }
 
 function adjustClause(node, clause, forceSpace) {
-  if (node.type === "EmptyStatement") {
+  if (node.type === "EmptyStatement" && clause === ";") {
     return ";";
   }
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -210,8 +210,14 @@ function printPathNoParens(path, options, print, args) {
     case "Program":
       return printBlockBody(path, options, print);
     // Babel extension.
-    case "EmptyStatement":
-      return "";
+    case "EmptyStatement": {
+      const danglingComment = printDanglingComments(
+        path,
+        options,
+        true
+      );
+      return danglingComment ? [danglingComment, ";"] : ";";
+    }
     case "ExpressionStatement": {
       // Detect Flow and TypeScript directives
       if (node.directive) {

--- a/src/utils/text/get-closest-non-space-non-comment-character-index-with-start-index.js
+++ b/src/utils/text/get-closest-non-space-non-comment-character-index-with-start-index.js
@@ -1,0 +1,31 @@
+"use strict";
+
+/** @typedef {import("./skip").SkipOptions} SkipOptions */
+
+const skipInlineComment = require("./skip-inline-comment.js");
+const skipNewline = require("./skip-newline.js");
+const skipTrailingComment = require("./skip-trailing-comment.js");
+const { skipSpaces } = require("./skip.js");
+
+/**
+ * @param {string} text
+ * @param {number} idx
+ * @param {SkipOptions=} opts
+ * @returns {number | false}
+ */
+function getClosestNonSpaceNonCommentCharacterIndexWithStartIndex(text, idx, opts) {
+  /** @type {number | false} */
+  let oldIdx = null;
+  /** @type {number | false} */
+  let nextIdx = idx;
+  while (nextIdx !== oldIdx) {
+    oldIdx = nextIdx;
+    nextIdx = skipSpaces(text, nextIdx, opts);
+    nextIdx = skipInlineComment(text, nextIdx, opts);
+    nextIdx = skipTrailingComment(text, nextIdx, opts);
+    nextIdx = skipNewline(text, nextIdx, opts);
+  }
+  return nextIdx;
+}
+
+module.exports = getClosestNonSpaceNonCommentCharacterIndexWithStartIndex;

--- a/src/utils/text/get-next-non-space-non-comment-character-index-with-start-index.js
+++ b/src/utils/text/get-next-non-space-non-comment-character-index-with-start-index.js
@@ -1,9 +1,6 @@
 "use strict";
 
-const skipInlineComment = require("./skip-inline-comment.js");
-const skipNewline = require("./skip-newline.js");
-const skipTrailingComment = require("./skip-trailing-comment.js");
-const { skipSpaces } = require("./skip.js");
+const getClosestNonSpaceNonCommentCharacterIndexWithStartIndex = require("./get-closest-non-space-non-comment-character-index-with-start-index.js");
 
 /**
  * @param {string} text
@@ -11,18 +8,7 @@ const { skipSpaces } = require("./skip.js");
  * @returns {number | false}
  */
 function getNextNonSpaceNonCommentCharacterIndexWithStartIndex(text, idx) {
-  /** @type {number | false} */
-  let oldIdx = null;
-  /** @type {number | false} */
-  let nextIdx = idx;
-  while (nextIdx !== oldIdx) {
-    oldIdx = nextIdx;
-    nextIdx = skipSpaces(text, nextIdx);
-    nextIdx = skipInlineComment(text, nextIdx);
-    nextIdx = skipTrailingComment(text, nextIdx);
-    nextIdx = skipNewline(text, nextIdx);
-  }
-  return nextIdx;
+  return getClosestNonSpaceNonCommentCharacterIndexWithStartIndex(text, idx, { backwards: false });
 }
 
 module.exports = getNextNonSpaceNonCommentCharacterIndexWithStartIndex;

--- a/src/utils/text/get-previous-non-space-non-comment-character-index-with-start-index.js
+++ b/src/utils/text/get-previous-non-space-non-comment-character-index-with-start-index.js
@@ -1,0 +1,14 @@
+"use strict";
+
+const getClosestNonSpaceNonCommentCharacterIndexWithStartIndex = require("./get-closest-non-space-non-comment-character-index-with-start-index.js");
+
+/**
+ * @param {string} text
+ * @param {number} idx
+ * @returns {number | false}
+ */
+function getPreviousNonSpaceNonCommentCharacterIndexWithStartIndex(text, idx) {
+  return getClosestNonSpaceNonCommentCharacterIndexWithStartIndex(text, idx, { backwards: true });
+}
+
+module.exports = getPreviousNonSpaceNonCommentCharacterIndexWithStartIndex;

--- a/src/utils/text/skip-inline-comment.js
+++ b/src/utils/text/skip-inline-comment.js
@@ -1,23 +1,38 @@
 "use strict";
 
+/** @typedef {import("./skip").SkipOptions} SkipOptions */
+
 /**
  * @param {string} text
  * @param {number | false} index
+ * @param {SkipOptions=} opts
  * @returns {number | false}
  */
-function skipInlineComment(text, index) {
+function skipInlineComment(text, index, opts) {
+  const backwards = opts && opts.backwards;
   /* istanbul ignore next */
   if (index === false) {
     return false;
   }
 
-  if (text.charAt(index) === "/" && text.charAt(index + 1) === "*") {
-    for (let i = index + 2; i < text.length; ++i) {
-      if (text.charAt(i) === "*" && text.charAt(i + 1) === "/") {
-        return i + 2;
+  if (backwards) {
+    if (text.charAt(index) === "/" && text.charAt(index - 1) === "*") {
+      for (let i = index - 2; i >= 0; --i) {
+        if (text.charAt(i) === "*" && text.charAt(i - 1) === "/") {
+          return i - 2;
+        }
+      }
+    }
+  } else {
+    if (text.charAt(index) === "/" && text.charAt(index + 1) === "*") {
+      for (let i = index + 2; i < text.length; ++i) {
+        if (text.charAt(i) === "*" && text.charAt(i + 1) === "/") {
+          return i + 2;
+        }
       }
     }
   }
+
   return index;
 }
 

--- a/src/utils/text/skip-trailing-comment.js
+++ b/src/utils/text/skip-trailing-comment.js
@@ -1,19 +1,23 @@
 "use strict";
 
+/** @typedef {import("./skip").SkipOptions} SkipOptions */
+
 const { skipEverythingButNewLine } = require("./skip.js");
 
 /**
  * @param {string} text
  * @param {number | false} index
+ * @param {SkipOptions=} opts
  * @returns {number | false}
  */
-function skipTrailingComment(text, index) {
+function skipTrailingComment(text, index, opts) {
+  const backwards = opts && opts.backwards;
   /* istanbul ignore next */
   if (index === false) {
     return false;
   }
 
-  if (text.charAt(index) === "/" && text.charAt(index + 1) === "/") {
+  if (text.charAt(index) === "/" && text.charAt(index + (backwards ? -1 : 1)) === "/") {
     return skipEverythingButNewLine(text, index);
   }
   return index;

--- a/tests/format/js/if/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/if/__snapshots__/jsfmt.spec.js.snap
@@ -38,6 +38,32 @@ else stuff;
 ================================================================================
 `;
 
+exports[`comment_before_empty_statement.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+if (cond) /** comment 1 */;
+else /** comment 2 */;
+
+if (cond);
+else /** comment */;
+
+if (cond) /** comment */;
+
+=====================================output=====================================
+if (cond) /** comment 1 */;
+else /** comment 2 */;
+
+if (cond);
+else /** comment */;
+
+if (cond) /** comment */;
+
+================================================================================
+`;
+
 exports[`else.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/format/js/if/comment_before_empty_statement.js
+++ b/tests/format/js/if/comment_before_empty_statement.js
@@ -1,0 +1,7 @@
+if (cond) /** comment 1 */;
+else /** comment 2 */;
+
+if (cond);
+else /** comment */;
+
+if (cond) /** comment */;


### PR DESCRIPTION
## Description
Fixed formfitting of the comments before empty statement inside if/else instruction. Related issue #13079.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
