### PR TITLE
Refactor: simplify `fits`

### DIFF
--- a/src/document/doc-printer.js
+++ b/src/document/doc-printer.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-sparse-arrays */
 "use strict";
 
 const { convertEndOfLineToChars } = require("../common/end-of-line.js");
@@ -7,11 +6,16 @@ const getStringWidth = require("../utils/get-string-width.js");
 const { fill, cursor, indent } = require("./doc-builders.js");
 const { isConcat, getDocParts } = require("./doc-utils.js");
 
-/** @type {Record<symbol, typeof MODE_BREAK | typeof MODE_FLAT>} */
+/** @typedef {typeof MODE_BREAK | typeof MODE_FLAT} Mode */
+/** @typedef {{ ind: any, doc: any, mode: Mode }} Command */
+
+/** @type {Record<symbol, Mode>} */
 let groupModeMap;
 
-const MODE_BREAK = 1;
-const MODE_FLAT = 2;
+// prettier-ignore
+const MODE_BREAK = /** @type {const} */ (1);
+// prettier-ignore
+const MODE_FLAT = /** @type {const} */ (2);
 
 function rootIndent() {
   return { value: "", length: 0, queue: [] };
@@ -147,8 +151,17 @@ function trim(out) {
   return trimCount;
 }
 
+/**
+ * @param {Command} next
+ * @param {Command[]} restCommands
+ * @param {number} width
+ * @param {boolean} hasLineSuffix
+ * @param {boolean} [mustBeFlat]
+ * @returns {boolean}
+ */
 function fits(next, restCommands, width, hasLineSuffix, mustBeFlat) {
   let restIdx = restCommands.length;
+  /** @type {Array<Omit<Command, 'ind'>>} */
   const cmds = [next];
   // `out` is only used for width counting because `trim` requires to look
   // backwards for space characters.
@@ -162,7 +175,7 @@ function fits(next, restCommands, width, hasLineSuffix, mustBeFlat) {
       continue;
     }
 
-    const [, mode, doc] = cmds.pop();
+    const { mode, doc } = cmds.pop();
 
     if (typeof doc === "string") {
       out.push(doc);
@@ -170,7 +183,7 @@ function fits(next, restCommands, width, hasLineSuffix, mustBeFlat) {
     } else if (isConcat(doc) || doc.type === "fill") {
       const parts = getDocParts(doc);
       for (let i = parts.length - 1; i >= 0; i--) {
-        cmds.push([, mode, parts[i]]);
+        cmds.push({ mode, doc: parts[i] });
       }
     } else {
       switch (doc.type) {
@@ -178,7 +191,7 @@ function fits(next, restCommands, width, hasLineSuffix, mustBeFlat) {
         case "align":
         case "indent-if-break":
         case "label":
-          cmds.push([, mode, doc.contents]);
+          cmds.push({ mode, doc: doc.contents });
           break;
 
         case "trim":
@@ -195,7 +208,7 @@ function fits(next, restCommands, width, hasLineSuffix, mustBeFlat) {
             doc.expandedStates && groupMode === MODE_BREAK
               ? getLast(doc.expandedStates)
               : doc.contents;
-          cmds.push([, groupMode, contents]);
+          cmds.push({ mode: groupMode, doc: contents });
           break;
         }
 
@@ -206,7 +219,7 @@ function fits(next, restCommands, width, hasLineSuffix, mustBeFlat) {
           const contents =
             groupMode === MODE_BREAK ? doc.breakContents : doc.flatContents;
           if (contents) {
-            cmds.push([, mode, contents]);
+            cmds.push({ mode, doc: contents });
           }
           break;
         }
@@ -245,13 +258,15 @@ function printDocToString(doc, options) {
   // cmds is basically a stack. We've turned a recursive call into a
   // while loop which is much faster. The while loop below adds new
   // cmds to the array instead of recursively calling `print`.
-  const cmds = [[rootIndent(), MODE_BREAK, doc]];
+  /** @type Command[] */
+  const cmds = [{ ind: rootIndent(), mode: MODE_BREAK, doc }];
   const out = [];
   let shouldRemeasure = false;
-  let lineSuffix = [];
+  /** @type Command[] */
+  const lineSuffix = [];
 
   while (cmds.length > 0) {
-    const [ind, mode, doc] = cmds.pop();
+    const { ind, mode, doc } = cmds.pop();
 
     if (typeof doc === "string") {
       const formatted = newLine !== "\n" ? doc.replace(/\n/g, newLine) : doc;
@@ -260,7 +275,7 @@ function printDocToString(doc, options) {
     } else if (isConcat(doc)) {
       const parts = getDocParts(doc);
       for (let i = parts.length - 1; i >= 0; i--) {
-        cmds.push([ind, mode, parts[i]]);
+        cmds.push({ ind, mode, doc: parts[i] });
       }
     } else {
       switch (doc.type) {
@@ -269,11 +284,15 @@ function printDocToString(doc, options) {
 
           break;
         case "indent":
-          cmds.push([makeIndent(ind, options), mode, doc.contents]);
+          cmds.push({ ind: makeIndent(ind, options), mode, doc: doc.contents });
 
           break;
         case "align":
-          cmds.push([makeAlign(ind, doc.n, options), mode, doc.contents]);
+          cmds.push({
+            ind: makeAlign(ind, doc.n, options),
+            mode,
+            doc: doc.contents,
+          });
 
           break;
         case "trim":
@@ -284,11 +303,11 @@ function printDocToString(doc, options) {
           switch (mode) {
             case MODE_FLAT:
               if (!shouldRemeasure) {
-                cmds.push([
+                cmds.push({
                   ind,
-                  doc.break ? MODE_BREAK : MODE_FLAT,
-                  doc.contents,
-                ]);
+                  mode: doc.break ? MODE_BREAK : MODE_FLAT,
+                  doc: doc.contents,
+                });
 
                 break;
               }
@@ -297,7 +316,7 @@ function printDocToString(doc, options) {
             case MODE_BREAK: {
               shouldRemeasure = false;
 
-              const next = [ind, MODE_FLAT, doc.contents];
+              const next = { ind, mode: MODE_FLAT, doc: doc.contents };
               const rem = width - pos;
               const hasLineSuffix = lineSuffix.length > 0;
 
@@ -315,18 +334,18 @@ function printDocToString(doc, options) {
                   const mostExpanded = getLast(doc.expandedStates);
 
                   if (doc.break) {
-                    cmds.push([ind, MODE_BREAK, mostExpanded]);
+                    cmds.push({ ind, mode: MODE_BREAK, doc: mostExpanded });
 
                     break;
                   } else {
                     for (let i = 1; i < doc.expandedStates.length + 1; i++) {
                       if (i >= doc.expandedStates.length) {
-                        cmds.push([ind, MODE_BREAK, mostExpanded]);
+                        cmds.push({ ind, mode: MODE_BREAK, doc: mostExpanded });
 
                         break;
                       } else {
                         const state = doc.expandedStates[i];
-                        const cmd = [ind, MODE_FLAT, state];
+                        const cmd = { ind, mode: MODE_FLAT, doc: state };
 
                         if (fits(cmd, cmds, rem, hasLineSuffix)) {
                           cmds.push(cmd);
@@ -337,7 +356,7 @@ function printDocToString(doc, options) {
                     }
                   }
                 } else {
-                  cmds.push([ind, MODE_BREAK, doc.contents]);
+                  cmds.push({ ind, mode: MODE_BREAK, doc: doc.contents });
                 }
               }
 
@@ -346,7 +365,7 @@ function printDocToString(doc, options) {
           }
 
           if (doc.id) {
-            groupModeMap[doc.id] = getLast(cmds)[1];
+            groupModeMap[doc.id] = getLast(cmds).mode;
           }
           break;
         // Fills each line with as much code as possible before moving to a new
@@ -378,8 +397,8 @@ function printDocToString(doc, options) {
           }
 
           const [content, whitespace] = parts;
-          const contentFlatCmd = [ind, MODE_FLAT, content];
-          const contentBreakCmd = [ind, MODE_BREAK, content];
+          const contentFlatCmd = { ind, mode: MODE_FLAT, doc: content };
+          const contentBreakCmd = { ind, mode: MODE_BREAK, doc: content };
           const contentFits = fits(
             contentFlatCmd,
             [],
@@ -397,8 +416,8 @@ function printDocToString(doc, options) {
             break;
           }
 
-          const whitespaceFlatCmd = [ind, MODE_FLAT, whitespace];
-          const whitespaceBreakCmd = [ind, MODE_BREAK, whitespace];
+          const whitespaceFlatCmd = { ind, mode: MODE_FLAT, doc: whitespace };
+          const whitespaceBreakCmd = { ind, mode: MODE_BREAK, doc: whitespace };
 
           if (parts.length === 2) {
             if (contentFits) {
@@ -415,15 +434,15 @@ function printDocToString(doc, options) {
           // elements to a new array would make this algorithm quadratic,
           // which is unusable for large arrays (e.g. large texts in JSX).
           parts.splice(0, 2);
-          const remainingCmd = [ind, mode, fill(parts)];
+          const remainingCmd = { ind, mode, doc: fill(parts) };
 
           const secondContent = parts[0];
 
-          const firstAndSecondContentFlatCmd = [
+          const firstAndSecondContentFlatCmd = {
             ind,
-            MODE_FLAT,
-            [content, whitespace, secondContent],
-          ];
+            mode: MODE_FLAT,
+            doc: [content, whitespace, secondContent],
+          };
           const firstAndSecondContentFits = fits(
             firstAndSecondContentFlatCmd,
             [],
@@ -452,7 +471,7 @@ function printDocToString(doc, options) {
                 ? doc.contents
                 : indent(doc.contents);
             if (breakContents) {
-              cmds.push([ind, mode, breakContents]);
+              cmds.push({ ind, mode, doc: breakContents });
             }
           }
           if (groupMode === MODE_FLAT) {
@@ -463,18 +482,18 @@ function printDocToString(doc, options) {
                 ? indent(doc.contents)
                 : doc.contents;
             if (flatContents) {
-              cmds.push([ind, mode, flatContents]);
+              cmds.push({ ind, mode, doc: flatContents });
             }
           }
 
           break;
         }
         case "line-suffix":
-          lineSuffix.push([ind, mode, doc.contents]);
+          lineSuffix.push({ ind, mode, doc: doc.contents });
           break;
         case "line-suffix-boundary":
           if (lineSuffix.length > 0) {
-            cmds.push([ind, mode, { type: "line", hard: true }]);
+            cmds.push({ ind, mode, doc: { type: "line", hard: true } });
           }
           break;
         case "line":
@@ -501,8 +520,8 @@ function printDocToString(doc, options) {
 
             case MODE_BREAK:
               if (lineSuffix.length > 0) {
-                cmds.push([ind, mode, doc], ...lineSuffix.reverse());
-                lineSuffix = [];
+                cmds.push({ ind, mode, doc }, ...lineSuffix.reverse());
+                lineSuffix.length = 0;
                 break;
               }
 
@@ -523,7 +542,7 @@ function printDocToString(doc, options) {
           }
           break;
         case "label":
-          cmds.push([ind, mode, doc.contents]);
+          cmds.push({ ind, mode, doc: doc.contents });
           break;
         default:
       }
@@ -533,7 +552,7 @@ function printDocToString(doc, options) {
     // there is no new line after the line-suffix.
     if (cmds.length === 0 && lineSuffix.length > 0) {
       cmds.push(...lineSuffix.reverse());
-      lineSuffix = [];
+      lineSuffix.length = 0;
     }
   }
 


### PR DESCRIPTION
## Description

`fits` currently contains indentation-related logic, but it's not needed. `fits` deals with the remainder of the line when the indentation has been already printed.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
