### PR TITLE
docs: Mention `code-tag` helper in Embedded Language Formatting

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -440,7 +440,7 @@ _First available in v2.1.0_
 
 Control whether Prettier formats quoted code embedded in the file.
 
-When Prettier identifies cases where it looks like you've placed some code it knows how to format within a string in another file, like in a tagged template in JavaScript with a tag named `html` or in code blocks in Markdown, it will by default try to format that code.
+When Prettier identifies cases where it looks like you've placed some code it knows how to format within a string in another file, like in a tagged template in JavaScript with a [tag named `html`](https://github.com/fregante/code-tag#readme) or in code blocks in Markdown, it will by default try to format that code.
 
 Sometimes this behavior is undesirable, particularly in cases where you might not have intended the string to be interpreted as code. This option allows you to switch between the default behavior (`auto`) and disabling this feature entirely (`off`).
 


### PR DESCRIPTION
## Description

Template literal functions appear simple, but are deceiving:

```js
const html = ([string]) => string;

html`<title>${document.title}</title>`;
// -> '<title>', not '<title>The document title</title>'
```

So I published [`code-tag`](https://github.com/fregante/code-tag/blob/main/index.ts) to safely mark embedded code.

I'd like to extend Prettier’s documentation to mention the existence of this helper and I'm open suggestions to extending the helper’s own readme to document this obscure _platform_ feature:

- https://github.com/fregante/code-tag/pull/5

Prettier’s own docs only mention this feature in the options page I think, so I avoided adding examples because the sentence is already quite long.

## Checklist

None applicable

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
