### PR TITLE
Update some tests

### DIFF
--- a/tests/config/format-test.js
+++ b/tests/config/format-test.js
@@ -52,8 +52,6 @@ const espreeDisabledTests = new Set(
   [
     // These tests only work for `babel`
     "comments-closure-typecast",
-    // Unknown reason https://github.com/babel/babel/pull/14779#discussion_r928137651
-    "strings",
   ].map((directory) => path.join(__dirname, "../format/js", directory))
 );
 const acornDisabledTests = espreeDisabledTests;

--- a/tests/format/js/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/strings/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`non-octal-eight-and-nine.js [acorn] format 1`] = `
+"Invalid escape sequence (3:3)
+  1 | // https://github.com/babel/babel/pull/11852
+  2 |
+> 3 | "\\8","\\9";
+    |   ^
+  4 | () => {
+  5 |   "use strict";
+  6 |   "\\8", "\\9";"
+`;
+
+exports[`non-octal-eight-and-nine.js [espree] format 1`] = `
+"Invalid escape sequence (3:3)
+  1 | // https://github.com/babel/babel/pull/11852
+  2 |
+> 3 | "\\8","\\9";
+    |   ^
+  4 | () => {
+  5 |   "use strict";
+  6 |   "\\8", "\\9";"
+`;
+
+exports[`non-octal-eight-and-nine.js - {"trailingComma":"all"} [acorn] format 1`] = `
+"Invalid escape sequence (3:3)
+  1 | // https://github.com/babel/babel/pull/11852
+  2 |
+> 3 | "\\8","\\9";
+    |   ^
+  4 | () => {
+  5 |   "use strict";
+  6 |   "\\8", "\\9";"
+`;
+
+exports[`non-octal-eight-and-nine.js - {"trailingComma":"all"} [espree] format 1`] = `
+"Invalid escape sequence (3:3)
+  1 | // https://github.com/babel/babel/pull/11852
+  2 |
+> 3 | "\\8","\\9";
+    |   ^
+  4 | () => {
+  5 |   "use strict";
+  6 |   "\\8", "\\9";"
+`;
+
 exports[`non-octal-eight-and-nine.js - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow"]

--- a/tests/format/js/strings/jsfmt.spec.js
+++ b/tests/format/js/strings/jsfmt.spec.js
@@ -1,2 +1,13 @@
-run_spec(import.meta, ["babel", "flow"]);
-run_spec(import.meta, ["babel", "flow"], { trailingComma: "all" });
+run_spec(import.meta, ["babel", "flow"], {
+  errors: {
+    acorn: ["non-octal-eight-and-nine.js"],
+    espree: ["non-octal-eight-and-nine.js"],
+  },
+});
+run_spec(import.meta, ["babel", "flow"], {
+  trailingComma: "all",
+  errors: {
+    acorn: ["non-octal-eight-and-nine.js"],
+    espree: ["non-octal-eight-and-nine.js"],
+  },
+});

--- a/tests/format/typescript/optional-variance/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/optional-variance/__snapshots__/jsfmt.spec.js.snap
@@ -140,9 +140,6 @@ parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-// valid JSX
-<in T>() => {}</in>;
-
 type Covariant<out T> = {
     x: T;
 }
@@ -206,9 +203,6 @@ declare class StateNode<TContext, in out TEvent extends { type: string }> {
 }
 
 =====================================output=====================================
-// valid JSX
-<in T>() => {}</in>;
-
 type Covariant<out T> = {
   x: T;
 };
@@ -282,4 +276,138 @@ exports[`with-jsx.tsx [typescript] format 1`] = `
   3 |
   4 | type Covariant<out T> = {
   5 |     x: T;"
+`;
+
+exports[`with-jsx.tsx format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type Covariant<out T> = {
+    x: T;
+}
+type Contravariant<in T> = {
+    f: (x: T) => void;
+}
+type Invariant<in out T> = {
+    f: (x: T) => T;
+}
+type T10<out T> = T;
+type T11<in T> = keyof T;
+type T12<out T, out K extends keyof T> = T[K];
+type T13<in out T> = T[keyof T];
+
+type Covariant1<in T> = {
+    x: T;
+}
+
+type Contravariant1<out T> = keyof T;
+
+type Contravariant2<out T> = {
+    f: (x: T) => void;
+}
+
+type Invariant1<in T> = {
+    f: (x: T) => T;
+}
+
+type Invariant2<out T> = {
+    f: (x: T) => T;
+}
+type Foo1<in T> = {
+    x: T;
+    f: FooFn1<T>;
+}
+
+type Foo2<out T> = {
+    x: T;
+    f: FooFn2<T>;
+}
+
+type Foo3<in out T> = {
+    x: T;
+    f: FooFn3<T>;
+}
+
+type T21<in out T> = T;
+
+interface Baz<out T> {}
+interface Baz<in T> {}
+
+interface Parent<out A> {
+    child: Child<A> | null;
+    parent: Parent<A> | null;
+}
+
+declare class StateNode<TContext, in out TEvent extends { type: string }> {
+    _storedEvent: TEvent;
+    _action: ActionObject<TEvent>;
+    _state: StateNode<TContext, any>;
+}
+
+=====================================output=====================================
+type Covariant<out T> = {
+  x: T;
+};
+type Contravariant<in T> = {
+  f: (x: T) => void;
+};
+type Invariant<in out T> = {
+  f: (x: T) => T;
+};
+type T10<out T> = T;
+type T11<in T> = keyof T;
+type T12<out T, out K extends keyof T> = T[K];
+type T13<in out T> = T[keyof T];
+
+type Covariant1<in T> = {
+  x: T;
+};
+
+type Contravariant1<out T> = keyof T;
+
+type Contravariant2<out T> = {
+  f: (x: T) => void;
+};
+
+type Invariant1<in T> = {
+  f: (x: T) => T;
+};
+
+type Invariant2<out T> = {
+  f: (x: T) => T;
+};
+type Foo1<in T> = {
+  x: T;
+  f: FooFn1<T>;
+};
+
+type Foo2<out T> = {
+  x: T;
+  f: FooFn2<T>;
+};
+
+type Foo3<in out T> = {
+  x: T;
+  f: FooFn3<T>;
+};
+
+type T21<in out T> = T;
+
+interface Baz<out T> {}
+interface Baz<in T> {}
+
+interface Parent<out A> {
+  child: Child<A> | null;
+  parent: Parent<A> | null;
+}
+
+declare class StateNode<TContext, in out TEvent extends { type: string }> {
+  _storedEvent: TEvent;
+  _action: ActionObject<TEvent>;
+  _state: StateNode<TContext, any>;
+}
+
+================================================================================
 `;

--- a/tests/format/typescript/optional-variance/jsfmt.spec.js
+++ b/tests/format/typescript/optional-variance/jsfmt.spec.js
@@ -1,3 +1,1 @@
-run_spec(import.meta, ["typescript"], {
-  errors: { typescript: ["with-jsx.tsx"] },
-});
+run_spec(import.meta, ["typescript"]);

--- a/tests/format/typescript/optional-variance/with-jsx.tsx
+++ b/tests/format/typescript/optional-variance/with-jsx.tsx
@@ -1,6 +1,3 @@
-// valid JSX
-<in T>() => {}</in>;
-
 type Covariant<out T> = {
     x: T;
 }


### PR DESCRIPTION
I reverted #13159.
And removed `<in T>() => {}</in>;` as it was not legal.
https://www.typescriptlang.org/play?noImplicitAny=false&ts=4.8.0-beta#code/DwSwdgBAKgfAFASggXhhA3gX2AenDAbiA

Ref: https://github.com/babel/babel/pull/14779#discussion_r928144602

cc @fisker 

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
