### PR TITLE
Remove `parser.preprocess`

### DIFF
--- a/src/main/core.js
+++ b/src/main/core.js
@@ -32,12 +32,12 @@ function attachComments(text, ast, opts) {
   return astComments;
 }
 
-async function coreFormat(originalText, opts, addAlignmentSize = 0) {
-  if (!originalText || originalText.trim().length === 0) {
+async function coreFormat(text, opts, addAlignmentSize = 0) {
+  if (!text || text.trim().length === 0) {
     return { formatted: "", cursorOffset: -1, comments: [] };
   }
 
-  const { ast, text } = await parse(originalText, opts);
+  const ast = await parse(text, opts);
 
   if (opts.cursorOffset >= 0) {
     const nodeResult = findNodeAtOffset(ast, opts.cursorOffset, opts);
@@ -140,8 +140,8 @@ async function coreFormat(originalText, opts, addAlignmentSize = 0) {
   };
 }
 
-async function formatRange(originalText, opts) {
-  const { ast, text } = await parse(originalText, opts);
+async function formatRange(text, opts) {
+  const ast = await parse(text, opts);
   const { rangeStart, rangeEnd } = calculateRange(text, opts, ast);
   const rangeString = text.slice(rangeStart, rangeEnd);
 
@@ -327,11 +327,11 @@ const prettier = {
       originalText,
       normalizeOptions(originalOptions)
     );
-    const parsed = await parse(text, options);
+    let ast = await parse(text, options);
     if (massage) {
-      parsed.ast = massageAST(parsed.ast, options);
+      ast = massageAST(ast, options);
     }
-    return parsed;
+    return {ast, text};
   },
 
   formatAST(ast, options) {
@@ -351,9 +351,9 @@ const prettier = {
     return formatted;
   },
 
-  async printToDoc(originalText, options) {
+  async printToDoc(text, options) {
     options = normalizeOptions(options);
-    const { ast, text } = await parse(originalText, options);
+    const ast = await parse(text, options);
     attachComments(text, ast, options);
     return printAstToDoc(ast, options);
   },

--- a/src/main/multiparser.js
+++ b/src/main/multiparser.js
@@ -39,14 +39,11 @@ function textToDoc(
     { passThrough: true }
   );
 
-  const result = parseSync(text, nextOptions);
-  const { ast } = result;
+  const ast = parseSync(text, nextOptions);
 
   if (typeof ast?.then === "function") {
     throw new TypeError("async parse is not supported in embed");
   }
-
-  text = result.text;
 
   const astComments = ast.comments;
   delete ast.comments;

--- a/src/main/parser.js
+++ b/src/main/parser.js
@@ -53,7 +53,7 @@ function resolveParser(opts, parsers = getParsers(opts)) {
   }
 }
 
-async function parse(originalText, opts) {
+async function parse(text, opts) {
   const parsers = getParsers(opts);
 
   // Create a new object {parserName: parseFn}. Uses defineProperty() to only call
@@ -74,18 +74,12 @@ async function parse(originalText, opts) {
   );
 
   const parser = resolveParser(opts, parsers);
-  const text = parser.preprocess
-    ? parser.preprocess(originalText, opts)
-    : originalText;
 
-  let ast;
   try {
-    ast = await parser.parse(text, parsersForCustomParserApi, opts);
+    return await parser.parse(text, parsersForCustomParserApi, opts);
   } catch (error) {
-    handleParseError(error, originalText);
+    handleParseError(error, text);
   }
-
-  return { text, ast };
 }
 
 function handleParseError(error, text) {
@@ -103,7 +97,7 @@ function handleParseError(error, text) {
 }
 
 // TODO: Remove this when we allow async parser in embed
-function parseSync(originalText, opts) {
+function parseSync(text, opts) {
   const parsers = getParsers(opts);
 
   // Create a new object {parserName: parseFn}. Uses defineProperty() to only call
@@ -124,18 +118,12 @@ function parseSync(originalText, opts) {
   );
 
   const parser = resolveParser(opts, parsers);
-  const text = parser.preprocess
-    ? parser.preprocess(originalText, opts)
-    : originalText;
 
-  let ast;
   try {
-    ast = parser.parse(text, parsersForCustomParserApi, opts);
+    return parser.parse(text, parsersForCustomParserApi, opts);
   } catch (error) {
-    handleParseError(error, originalText);
+    handleParseError(error, text);
   }
-
-  return { text, ast };
 }
 
 export { parse, parseSync, resolveParser };


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

`parse` function is called immediately after this function, if plugin want do something before parse, it should be done inside `parse`.

The only case I can image is that parser need change originalText for options, or print errors, but I don't think any plugin need that.

Core plugins not using it.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
