### PR TITLE
Playground: "Rethrow embed errors" checkbox

### DIFF
--- a/changelog_unreleased/api/13227.md
+++ b/changelog_unreleased/api/13227.md
@@ -1,0 +1,3 @@
+#### "Rethrow embed errors" checkbox on the Playground (#13227 by @thorn0)
+
+Previously, the behavior of the Playground was confusingly inconsistent with the local behavior of Prettier in that it surfaced parsing errors in embedded languages for debug purposes. Now this behavior is controlled by a checkbox and disabled by default.

--- a/website/playground/EditorState.js
+++ b/website/playground/EditorState.js
@@ -14,6 +14,7 @@ export default class EditorState extends React.Component {
       showSecondFormat: false,
       showInput: true,
       showOutput: true,
+      rethrowEmbedErrors: true,
       toggleSidebar: () => this.setState(stateToggler("showSidebar")),
       toggleAst: () => this.setState(stateToggler("showAst")),
       toggleDoc: () => this.setState(stateToggler("showDoc")),
@@ -21,6 +22,8 @@ export default class EditorState extends React.Component {
       toggleSecondFormat: () => this.setState(stateToggler("showSecondFormat")),
       toggleInput: () => this.setState(stateToggler("showInput")),
       toggleOutput: () => this.setState(stateToggler("showOutput")),
+      toggleEmbedErrors: () =>
+        this.setState(stateToggler("rethrowEmbedErrors")),
       ...storage.get("editor_state"),
     };
   }

--- a/website/playground/EditorState.js
+++ b/website/playground/EditorState.js
@@ -6,6 +6,7 @@ import * as storage from "./storage.js";
 export default class EditorState extends React.Component {
   constructor() {
     super();
+    const loadedState = storage.get("editor_state");
     this.state = {
       showSidebar: window.innerWidth > window.innerHeight,
       showAst: false,
@@ -14,7 +15,8 @@ export default class EditorState extends React.Component {
       showSecondFormat: false,
       showInput: true,
       showOutput: true,
-      rethrowEmbedErrors: true,
+      // false by default, but true if the state was saved by an older version of playground
+      rethrowEmbedErrors: loadedState !== undefined,
       toggleSidebar: () => this.setState(stateToggler("showSidebar")),
       toggleAst: () => this.setState(stateToggler("showAst")),
       toggleDoc: () => this.setState(stateToggler("showDoc")),
@@ -24,7 +26,7 @@ export default class EditorState extends React.Component {
       toggleOutput: () => this.setState(stateToggler("showOutput")),
       toggleEmbedErrors: () =>
         this.setState(stateToggler("rethrowEmbedErrors")),
-      ...storage.get("editor_state"),
+      ...loadedState,
     };
   }
 

--- a/website/playground/EditorState.js
+++ b/website/playground/EditorState.js
@@ -6,7 +6,6 @@ import * as storage from "./storage.js";
 export default class EditorState extends React.Component {
   constructor() {
     super();
-    const loadedState = storage.get("editor_state");
     this.state = {
       showSidebar: window.innerWidth > window.innerHeight,
       showAst: false,
@@ -15,8 +14,7 @@ export default class EditorState extends React.Component {
       showSecondFormat: false,
       showInput: true,
       showOutput: true,
-      // false by default, but true if the state was saved by an older version of playground
-      rethrowEmbedErrors: loadedState !== undefined,
+      rethrowEmbedErrors: false,
       toggleSidebar: () => this.setState(stateToggler("showSidebar")),
       toggleAst: () => this.setState(stateToggler("showAst")),
       toggleDoc: () => this.setState(stateToggler("showDoc")),
@@ -26,7 +24,7 @@ export default class EditorState extends React.Component {
       toggleOutput: () => this.setState(stateToggler("showOutput")),
       toggleEmbedErrors: () =>
         this.setState(stateToggler("rethrowEmbedErrors")),
-      ...loadedState,
+      ...storage.get("editor_state"),
     };
   }
 

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -208,6 +208,7 @@ class Playground extends React.Component {
             debugDoc={editorState.showDoc}
             debugComments={showShowComments && editorState.showComments}
             reformat={editorState.showSecondFormat}
+            rethrowEmbedErrors={editorState.rethrowEmbedErrors}
           >
             {({ formatted, debug }) => {
               const fullReport = this.getMarkdown({
@@ -288,6 +289,11 @@ class Playground extends React.Component {
                           label="show second format"
                           checked={editorState.showSecondFormat}
                           onChange={editorState.toggleSecondFormat}
+                        />
+                        <Checkbox
+                          label="rethrow embed errors"
+                          checked={editorState.rethrowEmbedErrors}
+                          onChange={editorState.toggleEmbedErrors}
                         />
                         {editorState.showDoc && (
                           <ClipboardButton

--- a/website/playground/PrettierFormat.js
+++ b/website/playground/PrettierFormat.js
@@ -19,6 +19,7 @@ export default class PrettierFormat extends React.Component {
       "debugDoc",
       "debugComments",
       "reformat",
+      "rethrowEmbedErrors",
     ]) {
       if (prevProps[key] !== this.props[key]) {
         this.format();
@@ -37,6 +38,7 @@ export default class PrettierFormat extends React.Component {
       debugDoc: doc,
       debugComments: comments,
       reformat,
+      rethrowEmbedErrors,
     } = this.props;
 
     if (!enabled) {
@@ -44,7 +46,13 @@ export default class PrettierFormat extends React.Component {
     }
 
     worker
-      .format(code, options, { ast, doc, comments, reformat })
+      .format(code, options, {
+        ast,
+        doc,
+        comments,
+        reformat,
+        rethrowEmbedErrors,
+      })
       .then((result) => this.setState(result));
   }
 

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -2,8 +2,6 @@
 
 "use strict";
 
-self.PRETTIER_DEBUG = true;
-
 const imported = Object.create(null);
 function importScriptOnce(url) {
   if (!imported[url]) {
@@ -72,96 +70,106 @@ function serializeAst(ast) {
 }
 
 function handleMessage(message) {
-  if (message.type === "meta") {
-    return {
-      type: "meta",
-      supportInfo: JSON.parse(
-        JSON.stringify(
-          prettier.getSupportInfo({
-            showUnreleased: true,
-            plugins: [docExplorerPlugin],
-          })
-        )
-      ),
-      version: prettier.version,
-    };
-  }
-
-  if (message.type === "format") {
-    const options = message.options || {};
-
-    delete options.ast;
-    delete options.doc;
-    delete options.output2;
-
-    const plugins = [{ parsers }, docExplorerPlugin];
-    options.plugins = plugins;
-
-    const formatResult = formatCode(message.code, options);
-
-    const response = {
-      formatted: formatResult.formatted,
-      cursorOffset: formatResult.cursorOffset,
-      error: formatResult.error,
-      debug: {
-        ast: null,
-        doc: null,
-        comments: null,
-        reformatted: null,
-      },
-    };
-
-    if (message.debug.ast) {
-      let ast;
-      let errored = false;
-      try {
-        ast = serializeAst(prettier.__debug.parse(message.code, options).ast);
-      } catch (e) {
-        errored = true;
-        ast = String(e);
-      }
-
-      if (!errored) {
-        try {
-          ast = formatCode(ast, { parser: "json", plugins }).formatted;
-        } catch {
-          ast = serializeAst(ast);
-        }
-      }
-      response.debug.ast = ast;
-    }
-
-    if (message.debug.doc) {
-      try {
-        response.debug.doc = prettier.__debug.formatDoc(
-          prettier.__debug.printToDoc(message.code, options),
-          { plugins }
-        );
-      } catch {
-        response.debug.doc = "";
-      }
-    }
-
-    if (message.debug.comments) {
-      response.debug.comments = formatCode(
-        JSON.stringify(formatResult.comments || []),
-        { parser: "json", plugins }
-      ).formatted;
-    }
-
-    if (message.debug.reformat) {
-      response.debug.reformatted = formatCode(
-        response.formatted,
-        options
-      ).formatted;
-    }
-
-    return response;
+  switch (message.type) {
+    case "meta":
+      return handleMetaMessage();
+    case "format":
+      return handleFormatMessage(message);
   }
 }
 
-function formatCode(text, options) {
+function handleMetaMessage() {
+  return {
+    type: "meta",
+    supportInfo: JSON.parse(
+      JSON.stringify(
+        prettier.getSupportInfo({
+          showUnreleased: true,
+          plugins: [docExplorerPlugin],
+        })
+      )
+    ),
+    version: prettier.version,
+  };
+}
+
+function handleFormatMessage(message) {
+  const plugins = [{ parsers }, docExplorerPlugin];
+  const options = { ...message.options, plugins };
+
+  delete options.ast;
+  delete options.doc;
+  delete options.output2;
+
+  const formatResult = formatCode(
+    message.code,
+    options,
+    message.debug.rethrowEmbedErrors
+  );
+
+  const response = {
+    formatted: formatResult.formatted,
+    cursorOffset: formatResult.cursorOffset,
+    error: formatResult.error,
+    debug: {
+      ast: null,
+      doc: null,
+      comments: null,
+      reformatted: null,
+    },
+  };
+
+  if (message.debug.ast) {
+    let ast;
+    let errored = false;
+    try {
+      ast = serializeAst(prettier.__debug.parse(message.code, options).ast);
+    } catch (e) {
+      errored = true;
+      ast = String(e);
+    }
+
+    if (!errored) {
+      try {
+        ast = formatCode(ast, { parser: "json", plugins }).formatted;
+      } catch {
+        ast = serializeAst(ast);
+      }
+    }
+    response.debug.ast = ast;
+  }
+
+  if (message.debug.doc) {
+    try {
+      response.debug.doc = prettier.__debug.formatDoc(
+        prettier.__debug.printToDoc(message.code, options),
+        { plugins }
+      );
+    } catch {
+      response.debug.doc = "";
+    }
+  }
+
+  if (message.debug.comments) {
+    response.debug.comments = formatCode(
+      JSON.stringify(formatResult.comments || []),
+      { parser: "json", plugins }
+    ).formatted;
+  }
+
+  if (message.debug.reformat) {
+    response.debug.reformatted = formatCode(
+      response.formatted,
+      options
+    ).formatted;
+  }
+
+  return response;
+}
+
+function formatCode(text, options, rethrowEmbedErrors) {
   try {
+    self.PRETTIER_DEBUG = rethrowEmbedErrors;
     return prettier.formatWithCursor(text, options);
   } catch (e) {
     if (e.constructor && e.constructor.name === "SyntaxError") {
@@ -171,6 +179,8 @@ function formatCode(text, options) {
     // Likely a bug in Prettier
     // Provide the whole stack for debugging
     return { formatted: stringifyError(e), error: true };
+  } finally {
+    self.PRETTIER_DEBUG = undefined;
   }
 }
 


### PR DESCRIPTION
## Description

I'm going to make this checkbox unchecked by default. Reason: https://github.com/prettier/prettier/issues/10602#issuecomment-808602535

fixes https://github.com/prettier/prettier/issues/10602

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
