### PR TITLE
Sort plugin default values when create usage

### DIFF
--- a/src/cli/usage.js
+++ b/src/cli/usage.js
@@ -1,6 +1,6 @@
 import camelCase from "camelcase";
 import * as constant from "./constant.js";
-import { groupBy, isNonEmptyArray } from "./utils.js";
+import { groupBy } from "./utils.js";
 import { optionsHiddenDefaults } from "./prettier-internal.js";
 
 const OPTION_USAGE_THRESHOLD = 25;
@@ -161,10 +161,11 @@ function createPluginDefaults(pluginDefaults) {
       pluginNameA.localeCompare(pluginNameB)
     )
     .map(
-      ([plugin, value]) => `\n* ${plugin}: ${createDefaultValueDisplay(value)}`
-    );
+      ([plugin, value]) => `* ${plugin}: ${createDefaultValueDisplay(value)}`
+    )
+    .join("\n");
 
-  return `\nPlugin defaults:${defaults}`;
+  return `\nPlugin defaults:\n${defaults}`;
 }
 
 function createDetailedUsage(context, flag) {

--- a/src/cli/usage.js
+++ b/src/cli/usage.js
@@ -1,6 +1,6 @@
 import camelCase from "camelcase";
 import * as constant from "./constant.js";
-import { groupBy } from "./utils.js";
+import { groupBy, isNonEmptyArray } from "./utils.js";
 import { optionsHiddenDefaults } from "./prettier-internal.js";
 
 const OPTION_USAGE_THRESHOLD = 25;
@@ -151,6 +151,22 @@ function createUsage(context) {
   return [constant.usageSummary, ...optionsUsage, ""].join("\n\n");
 }
 
+function createPluginDefaults(pluginDefaults) {
+  if (!pluginDefaults || Object.keys(pluginDefaults).length === 0) {
+    return "";
+  }
+
+  const defaults = Object.entries(pluginDefaults)
+    .sort(([pluginNameA], [pluginNameB]) =>
+      pluginNameA.localeCompare(pluginNameB)
+    )
+    .map(
+      ([plugin, value]) => `\n* ${plugin}: ${createDefaultValueDisplay(value)}`
+    );
+
+  return `\nPlugin defaults:${defaults}`;
+}
+
 function createDetailedUsage(context, flag) {
   const option = getOptionsWithOpposites(context.detailedOptions).find(
     (option) => option.name === flag || option.alias === flag
@@ -174,12 +190,7 @@ function createDetailedUsage(context, flag) {
       ? `\n\nDefault: ${createDefaultValueDisplay(optionDefaultValue)}`
       : "";
 
-  const pluginDefaults =
-    option.pluginDefaults && Object.keys(option.pluginDefaults).length > 0
-      ? `\nPlugin defaults:${Object.entries(option.pluginDefaults).map(
-          ([key, value]) => `\n* ${key}: ${createDefaultValueDisplay(value)}`
-        )}`
-      : "";
+  const pluginDefaults = createPluginDefaults(option.pluginDefaults);
   return `${header}${description}${choices}${defaults}${pluginDefaults}`;
 }
 

--- a/tests/integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests/integration/__tests__/__snapshots__/early-exit.js.snap
@@ -20,7 +20,7 @@ exports[`show detailed usage with plugin options (automatic resolution) (stdout)
 
 Default: 2
 Plugin defaults:
-* prettier-plugin-bar: 4,
+* prettier-plugin-bar: 4
 * prettier-plugin-baz.js: 4
 "
 `;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Unstable orders seem to cause random failure on tests. https://github.com/prettier/prettier/runs/7702032774?check_suite_focus=true#step:6:56

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
