### PR TITLE
Use `import()` to load `@babel/code-frame`

### DIFF
--- a/src/main/parser.js
+++ b/src/main/parser.js
@@ -1,9 +1,6 @@
-import { createRequire } from "node:module";
 import { ConfigError } from "../common/errors.js";
 import { locStart, locEnd } from "../language-js/loc.js";
 import loadParser from "./load-parser.js";
-
-const require = createRequire(import.meta.url);
 
 // Use defineProperties()/getOwnPropertyDescriptor() to prevent
 // triggering the parsers getters.
@@ -82,17 +79,17 @@ async function parse(originalText, opts) {
   try {
     ast = await parser.parse(text, parsersForCustomParserApi, opts);
   } catch (error) {
-    handleParseError(error, originalText);
+    await handleParseError(error, originalText);
   }
 
   return { text, ast };
 }
 
-function handleParseError(error, text) {
+async function handleParseError(error, text) {
   const { loc } = error;
 
   if (loc) {
-    const { codeFrameColumns } = require("@babel/code-frame");
+    const { codeFrameColumns } = await import("@babel/code-frame");
     error.codeFrame = codeFrameColumns(text, loc, { highlightCode: true });
     error.message += "\n" + error.codeFrame;
     throw error;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Get rid of `require()`

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
