### PR TITLE
docs: removal of the Custom parser API

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -156,6 +156,7 @@
         "Joar",
         "josephfrazier",
         "jscodefmt",
+        "jscodeshift",
         "jsesc",
         "jsfmt",
         "jsonata",

--- a/docs/api.md
+++ b/docs/api.md
@@ -126,13 +126,15 @@ The support information looks like this:
 }
 ```
 
-## Custom Parser API
+<a name="custom-parser-api"></a>
+
+## Custom Parser API (removed)
 
 _Removed in v3.0.0 (superseded by the Plugin API)_
 
 Before [plugins](plugins.md) were a thing, Prettier had a similar but more limited feature called custom parsers. It’s been removed in v3.0.0 as its functionality was a subset of what the Plugin API did. If you used it, please check the example below on how to migrate.
 
-Custom parser API:
+❌ Custom parser API (removed):
 
 ```js
 import { format } from "prettier";
@@ -147,7 +149,7 @@ format("lodash ( )", {
 // -> "_();\n"
 ```
 
-Plugin API:
+✔️ Plugin API:
 
 ```js
 import { format } from "prettier";
@@ -173,6 +175,6 @@ format("lodash ( )", {
 // -> "_();\n"
 ```
 
-> Note: It’s just an example. Overall, doing codemods this way isn’t recommended. Prettier uses the location data of AST nodes for many things like preserving blank lines and attaching comments. When the AST is modified after the parsing, the location data can get out of sync, which may lead to unpredictable results. Consider using [jscodeshift](https://github.com/facebook/jscodeshift) if you need codemods.
+> Note: Overall, doing codemods this way isn’t recommended. Prettier uses the location data of AST nodes for many things like preserving blank lines and attaching comments. When the AST is modified after the parsing, the location data often gets out of sync, which may lead to unpredictable results. Consider using [jscodeshift](https://github.com/facebook/jscodeshift) if you need codemods.
 
 As part of the removed Custom parser API, it was previously possible to pass a path to a module exporting a `parse` function via the `--parser` option. Use the `--plugin` CLI option or the `plugins` API option instead to [load plugins](plugins.md#using-plugins).

--- a/docs/api.md
+++ b/docs/api.md
@@ -128,16 +128,16 @@ The support information looks like this:
 
 ## Custom Parser API
 
-If you need to make modifications to the AST (such as codemods), or you want to provide an alternate parser, you can do so by setting the `parser` option to a function. The function signature of the parser function is:
+_Removed in v3.0.0 (superseded by the Plugin API)_
+
+Before [plugins](plugins.md) were a thing, Prettier had a similar but more limited feature called custom parsers. It’s been removed in v3.0.0 as its functionality was a subset of what the Plugin API did. If you used it, please check the example below on how to migrate.
+
+Custom parser API:
 
 ```js
-(text: string, parsers: object, options: object) => AST;
-```
+import { format } from "prettier";
 
-Prettier’s built-in parsers are exposed as properties on the `parsers` argument.
-
-```js
-prettier.format("lodash ( )", {
+format("lodash ( )", {
   parser(text, { babel }) {
     const ast = babel(text);
     ast.program.body[0].expression.callee.name = "_";
@@ -147,4 +147,32 @@ prettier.format("lodash ( )", {
 // -> "_();\n"
 ```
 
-The `--parser` CLI option may be a path to a node.js module exporting a parse function.
+Plugin API:
+
+```js
+import { format } from "prettier";
+import parserBabel from "prettier/parser-babel.js";
+
+const myCustomPlugin = {
+  parsers: {
+    "my-custom-parser": {
+      parse(text) {
+        const ast = parserBabel.parsers.babel.parse(text);
+        ast.program.body[0].expression.callee.name = "_";
+        return ast;
+      },
+      astFormat: "estree",
+    },
+  },
+};
+
+format("lodash ( )", {
+  parser: "my-custom-parser",
+  plugins: [myCustomPlugin],
+});
+// -> "_();\n"
+```
+
+> Note: It’s just an example. Overall, doing codemods this way isn’t recommended. Prettier uses the location data of AST nodes for many things like preserving blank lines and attaching comments. When the AST is modified after the parsing, the location data can get out of sync, which may lead to unpredictable results. Consider using [jscodeshift](https://github.com/facebook/jscodeshift) if you need codemods.
+
+As part of the removed Custom parser API, it was previously possible to pass a path to a module exporting a `parse` function via the `--parser` option. Use the `--plugin` CLI option or the `plugins` API option instead to [load plugins](plugins.md#using-plugins).

--- a/docs/options.md
+++ b/docs/options.md
@@ -281,13 +281,13 @@ Valid options:
 - `"lwc"` (same parser as `"html"`, but also formats LWC-specific syntax for unquoted template attributes) _First available in 1.17.0_
 - `"yaml"` (via [yaml](https://github.com/eemeli/yaml) and [yaml-unist-parser](https://github.com/ikatyang/yaml-unist-parser)) _First available in 1.14.0_
 
-[Custom parsers](api.md#custom-parser-api) are also supported. _First available in v1.5.0_
-
-| Default | CLI Override                                    | API Override                                               |
-| ------- | ----------------------------------------------- | ---------------------------------------------------------- |
-| None    | `--parser <string>`<br />`--parser ./my-parser` | `parser: "<string>"`<br />`parser: require("./my-parser")` |
+| Default | CLI Override        | API Override         |
+| ------- | ------------------- | -------------------- |
+| None    | `--parser <string>` | `parser: "<string>"` |
 
 Note: the default value was `"babylon"` until v1.13.0.
+
+Note: the Custom parser API has been removed in v3.0.0. Use [plugins](plugins.md) instead ([how to migrate](api.md#custom-parser-api)).
 
 <a name="filepath"></a>
 


### PR DESCRIPTION
## Description

https://github.com/prettier/prettier/issues/13232

https://deploy-preview-13249--prettier.netlify.app/docs/en/next/api.html#custom-parser-api

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
