### PR TITLE
Remove unnecessary spreading `options` in `textToDoc`

### DIFF
--- a/src/language-yaml/embed.js
+++ b/src/language-yaml/embed.js
@@ -10,10 +10,7 @@ function embed(path, options) {
     /(?:[/\\]|^)\.(?:prettier|stylelint|lintstaged)rc$/.test(options.filepath)
   ) {
     return async (textToDoc) => {
-      const doc = await textToDoc(options.originalText, {
-        ...options,
-        parser: "json",
-      });
+      const doc = await textToDoc(options.originalText, { parser: "json" });
       return doc ? [doc, hardline] : undefined;
     };
   }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Found this during other PRs, I thought there are more, but this seems the only one left.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
