### PR TITLE
Switch `jest-light-runner` back to npm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "esm-utils": "4.0.0",
     "execa": "6.1.0",
     "jest": "28.1.0",
-    "jest-light-runner": "fisker/jest-light-runner#b5e893d3a7d301bfb5d68ed81eebadbe2bb0577d",
+    "jest-light-runner": "0.3.0",
     "jest-snapshot-serializer-ansi": "1.0.0",
     "jest-snapshot-serializer-raw": "1.2.0",
     "jest-watch-typeahead": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5169,9 +5169,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-light-runner@fisker/jest-light-runner#b5e893d3a7d301bfb5d68ed81eebadbe2bb0577d":
-  version: 0.2.2
-  resolution: "jest-light-runner@https://github.com/fisker/jest-light-runner.git#commit=b5e893d3a7d301bfb5d68ed81eebadbe2bb0577d"
+"jest-light-runner@npm:0.3.0":
+  version: 0.3.0
+  resolution: "jest-light-runner@npm:0.3.0"
   dependencies:
     "@jest/expect": ^28.0.2
     jest-circus: ^28.0.0
@@ -5182,7 +5182,7 @@ __metadata:
     supports-color: ^9.2.1
   peerDependencies:
     jest: ^27.0.0 || ^28.0.0
-  checksum: 9eb43cacaad844853d1e53bf3205c5729fef6569e45407dd51cd39c18fa8491cfe981245dec49b0bbf4965cbd2e77730d41fba4836baf98b00b843a1b307e986
+  checksum: afd963071ef8058f5a04c6f30fe25e0a32a003ab301ac3bed5083e4bb30fe9d9d5d831e61091105a700b67566d4fed1149b863b15f29a238e072556b27c5cf76
   languageName: node
   linkType: hard
 
@@ -6961,7 +6961,7 @@ __metadata:
     import-meta-resolve: 2.0.3
     jest: 28.1.0
     jest-docblock: 28.1.1
-    jest-light-runner: "fisker/jest-light-runner#b5e893d3a7d301bfb5d68ed81eebadbe2bb0577d"
+    jest-light-runner: 0.3.0
     jest-snapshot-serializer-ansi: 1.0.0
     jest-snapshot-serializer-raw: 1.2.0
     jest-watch-typeahead: 2.0.0


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

This feature we need already merged https://github.com/nicolo-ribaudo/jest-light-runner/pull/47

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
