### PR TITLE
Always wrap certain CSS prop values (box-shadow, text-shadow, etc)

### DIFF
--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -37,6 +37,7 @@ const {
   insideAtRuleNode,
   insideURLFunctionInImportAtRuleNode,
   isKeyframeAtRuleKeywords,
+  isWrappedProp,
   isWideKeywords,
   isLastNode,
   isSCSSControlDirectiveNode,
@@ -874,10 +875,16 @@ function genericPrint(path, options, print) {
       if (!node.open) {
         const printed = path.map(print, "groups");
         const res = [];
+        const declAncestor = getAncestorNode(path, "css-decl");
+        const splitLines = declAncestor && isWrappedProp(declAncestor.prop);
+
+        if (splitLines && printed.length > 1) {
+          res.push(hardline);
+        }
 
         for (let i = 0; i < printed.length; i++) {
           if (i !== 0) {
-            res.push([",", line]);
+            res.push([",", splitLines ? hardline : line]);
           }
           res.push(printed[i]);
         }

--- a/src/language-css/utils/index.js
+++ b/src/language-css/utils/index.js
@@ -54,6 +54,17 @@ function getPropOfDeclNode(path) {
   return declAncestorNode?.prop?.toLowerCase();
 }
 
+const wrappedProps = new Set([
+  "box-shadow",
+  "transition",
+  "background-image",
+  "text-shadow",
+  "background",
+]);
+function isWrappedProp(value) {
+  return wrappedProps.has(value.toLowerCase());
+}
+
 const wideKeywords = new Set(["initial", "inherit", "unset", "revert"]);
 function isWideKeywords(value) {
   return wideKeywords.has(value.toLowerCase());
@@ -402,6 +413,7 @@ module.exports = {
   insideAtRuleNode,
   insideURLFunctionInImportAtRuleNode,
   isKeyframeAtRuleKeywords,
+  isWrappedProp,
   isWideKeywords,
   isLastNode,
   isSCSSControlDirectiveNode,

--- a/tests/format/css/indent/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/css/indent/__snapshots__/jsfmt.spec.js.snap
@@ -16,7 +16,8 @@ div {
 div {
   background: var(fig-light-02) url(/images/inset-shadow-east-ltr.png) 100% 0
     repeat-y;
-  box-shadow: 0 0 1px 2px rgba(88, 144, 255, 0.75),
+  box-shadow:
+    0 0 1px 2px rgba(88, 144, 255, 0.75),
     0 1px 1px rgba(0, 0, 0, 0.15);
   padding-bottom: calc(
     var(ads-help-tray-footer-with-support-link-height) +


### PR DESCRIPTION
## Description

Always wrap specific CSS property values (box-shadow, transition, background-image, text-shadow, background). Fixes #6024

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
