### PR TITLE
Use `startColumn: 1` in babel parse

### DIFF
--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -44,6 +44,7 @@ const parseOptions = {
   ],
   tokens: true,
   ranges: true,
+  startColumn: 1,
 };
 
 /** @type {ParserPlugin} */

--- a/src/language-js/parse/json.js
+++ b/src/language-js/parse/json.js
@@ -16,6 +16,7 @@ function createJsonParse(options = {}) {
       ast = parseExpression(text, {
         tokens: true,
         ranges: true,
+        startColumn: 1,
       });
     } catch (error) {
       throw createBabelParseError(error);
@@ -34,13 +35,7 @@ function createJsonParse(options = {}) {
 }
 
 function createJsonError(node, description) {
-  const [start, end] = [node.loc.start, node.loc.end].map(
-    ({ line, column }) => ({
-      line,
-      column: column + 1,
-    })
-  );
-  return createError(`${description} is not allowed in JSON.`, { start, end });
+  return createError(`${description} is not allowed in JSON.`, node.loc);
 }
 
 function assertJsonNode(node) {

--- a/src/language-js/parse/utils/create-babel-parse-error.js
+++ b/src/language-js/parse/utils/create-babel-parse-error.js
@@ -7,8 +7,8 @@ function createBabelParseError(error) {
 
   return createError(message.replace(/ \(.*\)/, ""), {
     start: {
-      line: loc ? loc.line : 0,
-      column: loc ? loc.column + 1 : 0,
+      line: loc?.line ?? 0,
+      column: loc?.column ?? 0,
     },
   });
 }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Easier to throw error. Local test didn't pass, should be bugs in babel.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
