### PR TITLE
Make `prettier.clearConfigCache` async

### DIFF
--- a/changelog_unreleased/api/12574.md
+++ b/changelog_unreleased/api/12574.md
@@ -1,4 +1,4 @@
-#### [BREAKING] Change public APIs to asynchronous (#12574, #12788, #12790 by @fisker)
+#### [BREAKING] Change public APIs to asynchronous (#12574, #12788, #12790, #13265 by @fisker)
 
 - `prettier.format()` returns `Promise<string>`
 - `prettier.formatWithCursor()` returns `Promise<{formatted: string, cursorOffset: number}>`

--- a/changelog_unreleased/api/12574.md
+++ b/changelog_unreleased/api/12574.md
@@ -5,6 +5,7 @@
 - `prettier.formatAST()` returns `Promise<string>`
 - `prettier.check()` returns `Promise<boolean>`
 - `prettier.getSupportInfo()` returns `Promise`
+- `prettier.clearConfigCache()` returns `Promise<void>`
 - `prettier.resolveConfig.sync` is removed
 - `prettier.resolveConfigFile.sync` is removed
 - `prettier.getFileInfo.sync` is removed

--- a/docs/api.md
+++ b/docs/api.md
@@ -45,10 +45,9 @@ The promise will be rejected if there was an error parsing the configuration fil
 If `options.useCache` is `false`, all caching will be bypassed.
 
 ```js
-const text = fs.readFileSync(filePath, "utf8");
-prettier.resolveConfig(filePath).then((options) => {
-  const formatted = prettier.format(text, options);
-});
+const text = await fs.readFile(filePath, "utf8");
+const options = await prettier.resolveConfig(filePath)
+const formatted = await prettier.format(text, options);
 ```
 
 If `options.editorconfig` is `true` and an [`.editorconfig` file](https://editorconfig.org/) is in your project, Prettier will parse it and convert its properties to the corresponding Prettier configuration. This configuration will be overridden by `.prettierrc`, etc. Currently, the following EditorConfig properties are supported:
@@ -70,9 +69,8 @@ The promise will be rejected if there was an error parsing the configuration fil
 The search starts at `process.cwd()`, or at `filePath` if provided. Please see the [cosmiconfig docs](https://github.com/davidtheclark/cosmiconfig#explorersearch) for details on how the resolving works.
 
 ```js
-prettier.resolveConfigFile(filePath).then((configFile) => {
-  // you got the path of the configuration file
-});
+const configFile = await prettier.resolveConfigFile(filePath);
+// you got the path of the configuration file
 ```
 
 ## `prettier.clearConfigCache()`

--- a/docs/api.md
+++ b/docs/api.md
@@ -46,7 +46,7 @@ If `options.useCache` is `false`, all caching will be bypassed.
 
 ```js
 const text = await fs.readFile(filePath, "utf8");
-const options = await prettier.resolveConfig(filePath)
+const options = await prettier.resolveConfig(filePath);
 const formatted = await prettier.format(text, options);
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,8 @@ async function check(text, options) {
   return (await format(text, options)) === text;
 }
 
-function clearCache() {
+// eslint-disable-next-line require-await
+async function clearCache() {
   clearConfigCache();
   clearPluginCache();
 }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Reason https://github.com/prettier/prettier/issues/8772#issuecomment-1209163206

All public APIs are async now.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
