### PR TITLE
fix: extra space between '#' and '{'

### DIFF
--- a/changelog_unreleased/scss/13286.md
+++ b/changelog_unreleased/scss/13286.md
@@ -1,0 +1,15 @@
+#### fix: extra space between '#' and '{' (#13286 by @jspereiramoura)
+
+<!-- Optional description if it makes sense. -->
+
+<!-- prettier-ignore -->
+```scss
+// Input
+padding: var(--spacer#{(1) + 2});
+
+// Prettier stable
+padding: var(--spacer# {(1) + 2});
+
+// Prettier main
+padding: var(--spacer#{(1) + 2});
+```

--- a/changelog_unreleased/scss/13286.md
+++ b/changelog_unreleased/scss/13286.md
@@ -1,7 +1,5 @@
 #### fix: extra space between '#' and '{' (#13286 by @jspereiramoura)
 
-<!-- Optional description if it makes sense. -->
-
 <!-- prettier-ignore -->
 ```scss
 // Input

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -825,6 +825,14 @@ function genericPrint(path, options, print) {
           continue;
         }
 
+        if (
+          iNode.value?.slice(-1) === "#" &&
+          iNextNode.value === "{" &&
+          isParenGroupNode(iNextNode.group)
+        ) {
+          continue;
+        }
+
         // Be default all values go through `line`
         parts.push(line);
       }

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -826,7 +826,7 @@ function genericPrint(path, options, print) {
         }
 
         if (
-          iNode.value?.slice(-1) === "#" &&
+          iNode.value?.endsWith("#") &&
           iNextNode.value === "{" &&
           isParenGroupNode(iNextNode.group)
         ) {

--- a/tests/format/scss/variables/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/scss/variables/__snapshots__/jsfmt.spec.js.snap
@@ -12,6 +12,7 @@ printWidth: 80
   prop1: var(--#{$var});
   prop2: var(#{$var}, --my-#{$var}, pink);
   prop3: calc(var(--#{$var}) * 1px);
+  prop4: var(--spacer#{(1) + 2});
 }
 
 @supports (--#{$prop}: green) {
@@ -27,6 +28,7 @@ printWidth: 80
   prop1: var(--#{$var});
   prop2: var(#{$var}, --my-#{$var}, pink);
   prop3: calc(var(--#{$var}) * 1px);
+  prop4: var(--spacer#{(1) + 2});
 }
 
 @supports (--#{$prop}: green) {

--- a/tests/format/scss/variables/variables.scss
+++ b/tests/format/scss/variables/variables.scss
@@ -4,6 +4,7 @@
   prop1: var(--#{$var});
   prop2: var(#{$var}, --my-#{$var}, pink);
   prop3: calc(var(--#{$var}) * 1px);
+  prop4: var(--spacer#{(1) + 2});
 }
 
 @supports (--#{$prop}: green) {


### PR DESCRIPTION
## Description
**fix:** https://github.com/prettier/prettier/issues/13185

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
