### PR TITLE
fix: paren shouldn't be removed from infer func 

### DIFF
--- a/changelog_unreleased/typescript/13289.md
+++ b/changelog_unreleased/typescript/13289.md
@@ -1,7 +1,7 @@
-#### Fix range format for function bodies (#13289 by @GlebDolzhikov )
+#### Fix parens in inferred function return types with `extends` (#13289 by @GlebDolzhikov)
 
 <!-- prettier-ignore -->
-```jsx
+```ts
 // Input
 type Foo<T> = T extends (...a: any[]) => (infer R extends string) ? R : never;
 
@@ -9,5 +9,5 @@ type Foo<T> = T extends (...a: any[]) => (infer R extends string) ? R : never;
 type Foo<T> = T extends (...a: any[]) => infer R extends string ? R : never;
 
 // Prettier main
-type Foo<T> = T extends (...a: any[]) => (infer R extends string) ? R : never;
+type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;
 ```

--- a/changelog_unreleased/typescript/13289.md
+++ b/changelog_unreleased/typescript/13289.md
@@ -1,0 +1,13 @@
+#### Fix range format for function bodies (#13289 by @GlebDolzhikov )
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+type Foo<T> = T extends (...a: any[]) => (infer R extends string) ? R : never;
+
+// Prettier stable
+type Foo<T> = T extends (...a: any[]) => infer R extends string ? R : never;
+
+// Prettier main
+type Foo<T> = T extends (...a: any[]) => (infer R extends string) ? R : never;
+```

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -412,6 +412,16 @@ function needsParens(path, options) {
     // fallthrough
     case "TSFunctionType":
     case "TSConstructorType":
+      if (parent.type === "TSConditionalType" && name === "extendsType") {
+        const returnTypeAnnotation = (node.returnType || node.typeAnnotation)
+          .typeAnnotation;
+        if (
+          returnTypeAnnotation.type === "TSInferType" &&
+          returnTypeAnnotation.typeParameter.constraint
+        ) {
+          return true;
+        }
+      }
       if (name === "checkType" && parent.type === "TSConditionalType") {
         return true;
       }
@@ -428,9 +438,6 @@ function needsParens(path, options) {
       }
     // fallthrough
     case "TSInferType":
-      if (node.type === "TSInferType" && parent.type === "TSTypeAnnotation") {
-        return true;
-      }
       if (node.type === "TSInferType" && parent.type === "TSRestType") {
         return false;
       }

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -412,7 +412,7 @@ function needsParens(path, options) {
     // fallthrough
     case "TSFunctionType":
     case "TSConstructorType":
-      if (parent.type === "TSConditionalType" && name === "extendsType") {
+      if (name === "extendsType" && parent.type === "TSConditionalType") {
         const returnTypeAnnotation = (node.returnType || node.typeAnnotation)
           .typeAnnotation;
         if (

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -428,6 +428,9 @@ function needsParens(path, options) {
       }
     // fallthrough
     case "TSInferType":
+      if (node.type === "TSInferType" && parent.type === "TSTypeAnnotation") {
+        return true;
+      }
       if (node.type === "TSInferType" && parent.type === "TSRestType") {
         return false;
       }

--- a/tests/format/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
@@ -263,13 +263,13 @@ type Unpacked<T> =
 =====================================output=====================================
 type TestReturnType<T extends (...args: any[]) => any> = T extends (
   ...args: any[]
-) => infer R
+) => (infer R)
   ? R
   : any;
 
 type Unpacked<T> = T extends (infer U)[]
   ? U
-  : T extends (...args: any[]) => infer U
+  : T extends (...args: any[]) => (infer U)
   ? U
   : T extends Promise<infer U>
   ? U

--- a/tests/format/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
@@ -263,17 +263,31 @@ type Unpacked<T> =
 =====================================output=====================================
 type TestReturnType<T extends (...args: any[]) => any> = T extends (
   ...args: any[]
-) => (infer R)
+) => infer R
   ? R
   : any;
 
 type Unpacked<T> = T extends (infer U)[]
   ? U
-  : T extends (...args: any[]) => (infer U)
+  : T extends (...args: any[]) => infer U
   ? U
   : T extends Promise<infer U>
   ? U
   : T;
+
+================================================================================
+`;
+
+exports[`issue-13275.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;
+
+=====================================output=====================================
+type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;
 
 ================================================================================
 `;

--- a/tests/format/typescript/conditional-types/issue-13275.ts
+++ b/tests/format/typescript/conditional-types/issue-13275.ts
@@ -1,0 +1,1 @@
+type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;


### PR DESCRIPTION
## Description

Parentheses shouldn't be removed from inferred function return types with extends constraints
fix for https://github.com/prettier/prettier/issues/13275
## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
