### PR TITLE
Forbid pass non-node object to `print()`

### DIFF
--- a/src/language-js/print/type-parameters.js
+++ b/src/language-js/print/type-parameters.js
@@ -112,8 +112,11 @@ function printTypeParameter(path, options, print) {
   const node = path.getValue();
   const parts = [];
   const parent = path.getParentNode();
+
+  const name = node.type === "TSTypeParameter" ? print("name") : node.name;
+
   if (parent.type === "TSMappedType") {
-    parts.push("[", print("name"));
+    parts.push("[", name);
     if (node.constraint) {
       parts.push(" in ", print("constraint"));
     }
@@ -139,7 +142,7 @@ function printTypeParameter(path, options, print) {
     parts.push("out ");
   }
 
-  parts.push(print("name"));
+  parts.push(name);
 
   if (node.bound) {
     parts.push(": ", print("bound"));

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -88,32 +88,6 @@ import { printComment } from "./print/comment.js";
 import { printLiteral } from "./print/literal.js";
 import { printDecorators } from "./print/decorators.js";
 
-const ensurePrintingNode = function (path) {
-  const parent = path.getParentNode();
-
-  if (!parent) {
-    return;
-  }
-
-  let name = path.getName();
-  if (typeof name === "number") {
-    name = path.stack[path.stack.length - 4];
-  }
-
-  const visitorKeys = getVisitorKeys(parent);
-  if (visitorKeys.includes(name)) {
-    return;
-  }
-
-  /* istanbul ignore next */
-  throw Object.assign(new Error("Calling `print()` on non-node object."), {
-    parentNode: parent,
-    allowedProperties: visitorKeys,
-    printingProperty: name,
-    printingValue: path.getValue(),
-  });
-};
-
 function genericPrint(path, options, print, args) {
   const node = path.getValue();
 
@@ -871,6 +845,32 @@ function canAttachComment(node) {
     // `babel-ts` don't have similar node for `class Foo { bar() /* bat */; }`
     node.type !== "TSEmptyBodyFunctionExpression"
   );
+}
+
+function ensurePrintingNode(path) {
+  const parent = path.getParentNode();
+
+  if (!parent) {
+    return;
+  }
+
+  let name = path.getName();
+  if (typeof name === "number") {
+    name = path.stack[path.stack.length - 4];
+  }
+
+  const visitorKeys = getVisitorKeys(parent);
+  if (visitorKeys.includes(name)) {
+    return;
+  }
+
+  /* istanbul ignore next */
+  throw Object.assign(new Error("Calling `print()` on non-node object."), {
+    parentNode: parent,
+    allowedProperties: visitorKeys,
+    printingProperty: name,
+    printingValue: path.getValue(),
+  });
 }
 
 const printer = {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -848,17 +848,31 @@ function canAttachComment(node) {
 }
 
 function ensurePrintingNode(path) {
-  const parent = path.getParentNode();
+  let name = path.getName();
 
-  if (!parent) {
+  // AST root
+  if (name === null) {
     return;
   }
 
-  let name = path.getName();
   if (typeof name === "number") {
+    /*
+    Nodes in array are stored in path.stack like
+
+    ```js
+    [
+      parentNode,
+      property, // <-
+      array,
+      index,
+      node,
+    ]
+    ```
+    */
     name = path.stack[path.stack.length - 4];
   }
 
+  const parent = path.getParentNode();
   const visitorKeys = getVisitorKeys(parent);
   if (visitorKeys.includes(name)) {
     return;

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -269,7 +269,7 @@ function printPathNoParens(path, options, print, args) {
         path,
         options,
         /** sameIndent */ true,
-        ({ marker }) => marker === markerForIfWithoutBlockAndSameLineComment,
+        ({ marker }) => marker === markerForIfWithoutBlockAndSameLineComment
       );
 
       // Do not append semicolon after the only JSX element in a program
@@ -317,8 +317,8 @@ function printPathNoParens(path, options, print, args) {
 
       parts.push(
         group(
-          indent([softline, printBindExpressionCallee(path, options, print)]),
-        ),
+          indent([softline, printBindExpressionCallee(path, options, print)])
+        )
       );
 
       return parts;
@@ -366,7 +366,7 @@ function printPathNoParens(path, options, print, args) {
           parts = [indent([softline, ...parts]), softline];
           const parentAwaitOrBlock = path.findAncestor(
             (node) =>
-              node.type === "AwaitExpression" || node.type === "BlockStatement",
+              node.type === "AwaitExpression" || node.type === "BlockStatement"
           );
           if (
             !parentAwaitOrBlock ||
@@ -467,7 +467,7 @@ function printPathNoParens(path, options, print, args) {
 
       if (hasComment(node.argument)) {
         parts.push(
-          group(["(", indent([softline, print("argument")]), softline, ")"]),
+          group(["(", indent([softline, print("argument")]), softline, ")"])
         );
       } else {
         parts.push(print("argument"));
@@ -517,7 +517,7 @@ function printPathNoParens(path, options, print, args) {
               ",",
               hasValue && !isParentForLoop ? hardline : line,
               p,
-            ]),
+            ])
         ),
       ];
 
@@ -549,7 +549,7 @@ function printPathNoParens(path, options, print, args) {
         const commentOnOwnLine =
           hasComment(
             node.consequent,
-            CommentCheckFlags.Trailing | CommentCheckFlags.Line,
+            CommentCheckFlags.Trailing | CommentCheckFlags.Line
           ) || needsHardlineAfterDanglingComment(node);
         const elseOnSameLine =
           node.consequent.type === "BlockStatement" && !commentOnOwnLine;
@@ -558,7 +558,7 @@ function printPathNoParens(path, options, print, args) {
         if (hasComment(node, CommentCheckFlags.Dangling)) {
           parts.push(
             printDanglingComments(path, options, true),
-            commentOnOwnLine ? hardline : " ",
+            commentOnOwnLine ? hardline : " "
           );
         }
 
@@ -568,9 +568,9 @@ function printPathNoParens(path, options, print, args) {
             adjustClause(
               node.alternate,
               print("alternate"),
-              node.alternate.type === "IfStatement",
-            ),
-          ),
+              node.alternate.type === "IfStatement"
+            )
+          )
         );
       }
 
@@ -585,7 +585,7 @@ function printPathNoParens(path, options, print, args) {
       const dangling = printDanglingComments(
         path,
         options,
-        /* sameLine */ true,
+        /* sameLine */ true
       );
       const printedComments = dangling ? [dangling, softline] : "";
 
@@ -658,7 +658,7 @@ function printPathNoParens(path, options, print, args) {
         "while (",
         group([indent([softline, print("test")]), softline]),
         ")",
-        semi,
+        semi
       );
 
       return parts;
@@ -709,7 +709,7 @@ function printPathNoParens(path, options, print, args) {
             (comment.trailing &&
               hasNewline(options.originalText, locStart(comment), {
                 backwards: true,
-              })),
+              }))
         );
         const param = print("param");
 
@@ -747,7 +747,7 @@ function printPathNoParens(path, options, print, args) {
                       ? hardline
                       : "",
                   ];
-                }, "cases"),
+                }, "cases")
               ),
             ])
           : "",
@@ -766,7 +766,7 @@ function printPathNoParens(path, options, print, args) {
       }
 
       const consequent = node.consequent.filter(
-        (node) => node.type !== "EmptyStatement",
+        (node) => node.type !== "EmptyStatement"
       );
 
       if (consequent.length > 0) {
@@ -775,7 +775,7 @@ function printPathNoParens(path, options, print, args) {
         parts.push(
           consequent.length === 1 && consequent[0].type === "BlockStatement"
             ? [" ", cons]
-            : indent([hardline, cons]),
+            : indent([hardline, cons])
         );
       }
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -107,8 +107,9 @@ const ensurePrintingNode = function (path) {
 
   throw Object.assign(new Error("Calling `print()` on non-node object."), {
     parentNode: parent,
-    printingProperty: name,
     allowedProperties: visitorKeys,
+    printingProperty: name,
+    printingValue: path.getValue(),
   });
 };
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -89,9 +89,9 @@ import { printLiteral } from "./print/literal.js";
 import { printDecorators } from "./print/decorators.js";
 
 const ensurePrintingNode = function (path) {
-  const parentNode = path.getParentNode();
+  const parent = path.getParentNode();
 
-  if (!parentNode) {
+  if (!parent) {
     return;
   }
 
@@ -100,31 +100,27 @@ const ensurePrintingNode = function (path) {
     name = path.stack[path.stack.length - 4];
   }
 
-  const visitorKeys = getVisitorKeys(parentNode);
+  const visitorKeys = getVisitorKeys(parent);
   if (visitorKeys.includes(name)) {
     return;
   }
 
   throw Object.assign(new Error("Calling `print()` on non-node object."), {
-    parentNode,
-    printingKey: name,
-    allowed: visitorKeys,
+    parentNode: parent,
+    printingProperty: name,
+    allowedProperties: visitorKeys,
   });
 };
 
 function genericPrint(path, options, print, args) {
   const node = path.getValue();
 
-  if (!node) {
+  if (node === undefined || node === null) {
     return "";
   }
 
   if (process.env.NODE_ENV !== "production") {
     ensurePrintingNode(path);
-  }
-
-  if (typeof node === "string") {
-    return node;
   }
 
   const printed = printPathNoParens(path, options, print, args);
@@ -807,7 +803,7 @@ function printPathNoParens(path, options, print, args) {
     case "TaggedTemplateExpression":
       return [print("tag"), print("typeParameters"), print("quasi")];
     case "PrivateIdentifier":
-      return ["#", print("name")];
+      return ["#", node.name];
     case "PrivateName":
       return ["#", print("id")];
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -105,6 +105,7 @@ const ensurePrintingNode = function (path) {
     return;
   }
 
+  /* istanbul ignore next */
   throw Object.assign(new Error("Calling `print()` on non-node object."), {
     parentNode: parent,
     allowedProperties: visitorKeys,

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -89,12 +89,21 @@ import { printLiteral } from "./print/literal.js";
 import { printDecorators } from "./print/decorators.js";
 
 function genericPrint(path, options, print, args) {
+  const node = path.getValue();
+
+  if (!node) {
+    return "";
+  }
+
+  if (typeof node === "string") {
+    return node;
+  }
+
   const printed = printPathNoParens(path, options, print, args);
   if (!printed) {
     return "";
   }
 
-  const node = path.getValue();
   const { type } = node;
   // Their decorators are handled themselves, and they can't have parentheses
   if (
@@ -169,14 +178,6 @@ function genericPrint(path, options, print, args) {
 function printPathNoParens(path, options, print, args) {
   const node = path.getValue();
   const semi = options.semi ? ";" : "";
-
-  if (!node) {
-    return "";
-  }
-
-  if (typeof node === "string") {
-    return node;
-  }
 
   for (const printer of [
     printLiteral,

--- a/src/language-js/traverse/visitor-keys.evaluate.js
+++ b/src/language-js/traverse/visitor-keys.evaluate.js
@@ -46,6 +46,9 @@ const additionalVisitorKeys = {
   ArrowFunctionExpression: ["predicate"],
   DeclareFunction: ["predicate"],
   FunctionDeclaration: ["predicate"],
+  ClassProperty: ["variance"],
+  ClassPrivateProperty: ["variance"],
+  EnumBooleanMember: ["init"],
 
   Property: ["decorators"],
 };

--- a/src/language-js/traverse/visitor-keys.evaluate.js
+++ b/src/language-js/traverse/visitor-keys.evaluate.js
@@ -46,6 +46,8 @@ const additionalVisitorKeys = {
   ArrowFunctionExpression: ["predicate"],
   DeclareFunction: ["predicate"],
   FunctionDeclaration: ["predicate"],
+
+  Property: ["decorators"],
 };
 
 export default unionVisitorKeys([

--- a/src/language-js/traverse/visitor-keys.evaluate.js
+++ b/src/language-js/traverse/visitor-keys.evaluate.js
@@ -10,7 +10,7 @@ const angularVisitorKeys = {
   NGQuotedExpression: [],
   NGMicrosyntax: ["body"],
   NGMicrosyntaxKey: [],
-  NGMicrosyntaxExpression: ["expression", "name"],
+  NGMicrosyntaxExpression: ["expression", "alias"],
   NGMicrosyntaxKeyedExpression: ["key", "expression"],
   NGMicrosyntaxLet: ["key", "value"],
   NGMicrosyntaxAs: ["key", "alias"],

--- a/tests/unit/__snapshots__/visitor-keys.js.snap
+++ b/tests/unit/__snapshots__/visitor-keys.js.snap
@@ -471,7 +471,7 @@ exports[`visitor keys estree 1`] = `
   ],
   "NGMicrosyntaxExpression": [
     "expression",
-    "name",
+    "alias",
   ],
   "NGMicrosyntaxKey": [],
   "NGMicrosyntaxKeyedExpression": [

--- a/tests/unit/__snapshots__/visitor-keys.js.snap
+++ b/tests/unit/__snapshots__/visitor-keys.js.snap
@@ -123,12 +123,14 @@ exports[`visitor keys estree 1`] = `
     "value",
     "decorators",
     "typeAnnotation",
+    "variance",
   ],
   "ClassProperty": [
     "key",
     "value",
     "typeAnnotation",
     "decorators",
+    "variance",
   ],
   "ConditionalExpression": [
     "test",
@@ -212,6 +214,7 @@ exports[`visitor keys estree 1`] = `
   ],
   "EnumBooleanMember": [
     "id",
+    "init",
   ],
   "EnumDeclaration": [
     "id",

--- a/tests/unit/__snapshots__/visitor-keys.js.snap
+++ b/tests/unit/__snapshots__/visitor-keys.js.snap
@@ -597,6 +597,7 @@ exports[`visitor keys estree 1`] = `
   "Property": [
     "key",
     "value",
+    "decorators",
   ],
   "PropertyDefinition": [
     "decorators",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
