### PR TITLE
Fix row break in arrow func with default argument value

### DIFF
--- a/changelog_unreleased/javascript/13300.md
+++ b/changelog_unreleased/javascript/13300.md
@@ -1,0 +1,17 @@
+#### Fix row break in the arrow func with default argument value (#13300 by @GlebDolzhikov)
+
+<!-- prettier-ignore -->
+```js
+
+// Input
+const fn = (a = 1) => () => 0;
+
+// Prettier stable
+const fn =
+  (a = 1) =>
+  () =>
+    0;
+
+// Prettier main
+const fn = (a = 1) => () => 0;
+```

--- a/src/language-js/print/function.js
+++ b/src/language-js/print/function.js
@@ -305,7 +305,10 @@ function printArrowFunction(path, options, print, args) {
       // Always break the chain if:
       (node.returnType && getFunctionParameters(node).length > 0) ||
       node.typeParameters ||
-      getFunctionParameters(node).some((param) => param.type !== "Identifier");
+      getFunctionParameters(node).some(
+        (param) =>
+          param.type !== "Identifier" && param.type !== "AssignmentPattern"
+      );
 
     if (
       node.body.type !== "ArrowFunctionExpression" ||

--- a/tests/format/js/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -2233,6 +2233,14 @@ const fn12 = a => b => c => d => e => ({ foo: bar, bar: baz, baz: foo });
 const fn13 = a => b => c => d => e => g => ({ foo: bar, bar: baz, baz: foo });
 const fn14 = a => b => c => d => e => g => f => ({ foo: bar, bar: baz, baz: foo });
 
+const fn15= (a = 2) => 0;
+const fn16 = (a =1) => (b) => 3;
+const fn17 = (a = 2) => (b) => (c) => 3;
+const fn18 = (a) => (b) => (c) => (d) => 3;
+const fn19 = (a) => (b= 1) => (c) => (d) => (e) => 3;
+const fn20 = (a) => (b) => (c=3) => (d) => (e) => (g) => 3;
+const fn21 = (a) => (b) => (c) => (d=3) => (e) => (g) => (f) => 3;
+
 const curryTest =
     (argument1) =>
     (argument2) =>
@@ -2455,6 +2463,14 @@ const fn14 = (a) => (b) => (c) => (d) => (e) => (g) => (f) => ({
   baz: foo,
 });
 
+const fn15 = (a = 2) => 0;
+const fn16 = (a = 1) => (b) => 3;
+const fn17 = (a = 2) => (b) => (c) => 3;
+const fn18 = (a) => (b) => (c) => (d) => 3;
+const fn19 = (a) => (b = 1) => (c) => (d) => (e) => 3;
+const fn20 = (a) => (b) => (c = 3) => (d) => (e) => (g) => 3;
+const fn21 = (a) => (b) => (c) => (d = 3) => (e) => (g) => (f) => 3;
+
 const curryTest =
   (argument1) =>
   (argument2) =>
@@ -2675,6 +2691,14 @@ const fn12 = a => b => c => d => e => ({ foo: bar, bar: baz, baz: foo });
 const fn13 = a => b => c => d => e => g => ({ foo: bar, bar: baz, baz: foo });
 const fn14 = a => b => c => d => e => g => f => ({ foo: bar, bar: baz, baz: foo });
 
+const fn15= (a = 2) => 0;
+const fn16 = (a =1) => (b) => 3;
+const fn17 = (a = 2) => (b) => (c) => 3;
+const fn18 = (a) => (b) => (c) => (d) => 3;
+const fn19 = (a) => (b= 1) => (c) => (d) => (e) => 3;
+const fn20 = (a) => (b) => (c=3) => (d) => (e) => (g) => 3;
+const fn21 = (a) => (b) => (c) => (d=3) => (e) => (g) => (f) => 3;
+
 const curryTest =
     (argument1) =>
     (argument2) =>
@@ -2888,6 +2912,14 @@ const fn14 = a => b => c => d => e => g => f => ({
   bar: baz,
   baz: foo,
 });
+
+const fn15 = (a = 2) => 0;
+const fn16 = (a = 1) => b => 3;
+const fn17 = (a = 2) => b => c => 3;
+const fn18 = a => b => c => d => 3;
+const fn19 = a => (b = 1) => c => d => e => 3;
+const fn20 = a => b => (c = 3) => d => e => g => 3;
+const fn21 = a => b => c => (d = 3) => e => g => f => 3;
 
 const curryTest =
   argument1 =>
@@ -3474,10 +3506,8 @@ const foobaz =
     return "baz";
   };
 
-const makeSomeFunction =
-  (services = { logger: null }) =>
-  (a, b, c) =>
-    services.logger(a, b, c);
+const makeSomeFunction = (services = { logger: null }) => (a, b, c) =>
+  services.logger(a, b, c);
 
 const makeSomeFunction2 =
   (
@@ -3533,10 +3563,8 @@ const foobaz =
     return "baz";
   };
 
-const makeSomeFunction =
-  (services = { logger: null }) =>
-  (a, b, c) =>
-    services.logger(a, b, c);
+const makeSomeFunction = (services = { logger: null }) => (a, b, c) =>
+  services.logger(a, b, c);
 
 const makeSomeFunction2 =
   (

--- a/tests/format/js/arrows/curried.js
+++ b/tests/format/js/arrows/curried.js
@@ -14,6 +14,14 @@ const fn12 = a => b => c => d => e => ({ foo: bar, bar: baz, baz: foo });
 const fn13 = a => b => c => d => e => g => ({ foo: bar, bar: baz, baz: foo });
 const fn14 = a => b => c => d => e => g => f => ({ foo: bar, bar: baz, baz: foo });
 
+const fn15= (a = 2) => 0;
+const fn16 = (a =1) => (b) => 3;
+const fn17 = (a = 2) => (b) => (c) => 3;
+const fn18 = (a) => (b) => (c) => (d) => 3;
+const fn19 = (a) => (b= 1) => (c) => (d) => (e) => 3;
+const fn20 = (a) => (b) => (c=3) => (d) => (e) => (g) => 3;
+const fn21 = (a) => (b) => (c) => (d=3) => (e) => (g) => (f) => 3;
+
 const curryTest =
     (argument1) =>
     (argument2) =>


### PR DESCRIPTION
## Description

fixes https://github.com/prettier/prettier/issues/12597

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [X] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
