### PR TITLE
Remove `placeholder` from `doc.builders.cursor`

### DIFF
--- a/src/document/builders.js
+++ b/src/document/builders.js
@@ -208,7 +208,7 @@ const softline = { type: DOC_TYPE_LINE, soft: true };
 const hardline = [hardlineWithoutBreakParent, breakParent];
 const literalline = [literallineWithoutBreakParent, breakParent];
 
-const cursor = { type: DOC_TYPE_CURSOR, placeholder: Symbol("cursor") };
+const cursor = { type: DOC_TYPE_CURSOR };
 
 /**
  * @param {Doc} sep

--- a/src/document/printer.js
+++ b/src/document/printer.js
@@ -18,11 +18,7 @@ import {
   DOC_TYPE_LABEL,
   DOC_TYPE_BREAK_PARENT,
 } from "./constants.js";
-import {
-  fill,
-  indent,
-  hardlineWithoutBreakParent,
-} from "./builders.js";
+import { fill, indent, hardlineWithoutBreakParent } from "./builders.js";
 import { getDocParts, getDocType } from "./utils.js";
 import InvalidDocError from "./invalid-doc-error.js";
 
@@ -37,7 +33,7 @@ const MODE_BREAK = /** @type {const} */ (1);
 // prettier-ignore
 const MODE_FLAT = /** @type {const} */ (2);
 
-const CURSOR_PLACEHOLDER = Symbol("cursor")
+const CURSOR_PLACEHOLDER = Symbol("cursor");
 
 function rootIndent() {
   return { value: "", length: 0, queue: [] };

--- a/src/document/printer.js
+++ b/src/document/printer.js
@@ -20,7 +20,6 @@ import {
 } from "./constants.js";
 import {
   fill,
-  cursor,
   indent,
   hardlineWithoutBreakParent,
 } from "./builders.js";
@@ -37,6 +36,8 @@ let groupModeMap;
 const MODE_BREAK = /** @type {const} */ (1);
 // prettier-ignore
 const MODE_FLAT = /** @type {const} */ (2);
+
+const CURSOR_PLACEHOLDER = Symbol("cursor")
 
 function rootIndent() {
   return { value: "", length: 0, queue: [] };
@@ -309,7 +310,7 @@ function printDocToString(doc, options) {
       }
 
       case DOC_TYPE_CURSOR:
-        out.push(cursor.placeholder);
+        out.push(CURSOR_PLACEHOLDER);
         break;
 
       case DOC_TYPE_INDENT:
@@ -593,10 +594,10 @@ function printDocToString(doc, options) {
     }
   }
 
-  const cursorPlaceholderIndex = out.indexOf(cursor.placeholder);
+  const cursorPlaceholderIndex = out.indexOf(CURSOR_PLACEHOLDER);
   if (cursorPlaceholderIndex !== -1) {
     const otherCursorPlaceholderIndex = out.indexOf(
-      cursor.placeholder,
+      CURSOR_PLACEHOLDER,
       cursorPlaceholderIndex + 1
     );
     const beforeCursor = out.slice(0, cursorPlaceholderIndex).join("");


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

The symbol don't need be in the doc, if printer use different `doc.js` to build doc, even will cause problems. (edge case, but possible.)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
