### PR TITLE
Use `symbol` for doc print mode

### DIFF
--- a/src/document/printer.js
+++ b/src/document/printer.js
@@ -33,10 +33,10 @@ import InvalidDocError from "./invalid-doc-error.js";
 /** @type {Record<symbol, Mode>} */
 let groupModeMap;
 
-// prettier-ignore
-const MODE_BREAK = /** @type {const} */ (Symbol("MODE_BREAK"));
-// prettier-ignore
-const MODE_FLAT = /** @type {const} */ (Symbol("MODE_FLAT"));
+/** @type {unique symbol} */
+const MODE_BREAK = Symbol("MODE_BREAK");
+/** @type {unique symbol} */
+const MODE_FLAT = Symbol("MODE_FLAT");
 
 function rootIndent() {
   return { value: "", length: 0, queue: [] };

--- a/src/document/printer.js
+++ b/src/document/printer.js
@@ -34,9 +34,9 @@ import InvalidDocError from "./invalid-doc-error.js";
 let groupModeMap;
 
 // prettier-ignore
-const MODE_BREAK = /** @type {const} */ (1);
+const MODE_BREAK = /** @type {const} */ (Symbol("MODE_BREAK"));
 // prettier-ignore
-const MODE_FLAT = /** @type {const} */ (2);
+const MODE_FLAT = /** @type {const} */ (Symbol("MODE_FLAT"));
 
 function rootIndent() {
   return { value: "", length: 0, queue: [] };


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Easier to inspect `Command`, especially it was an array before #13154, very unidentifiable.


```text
{
  ind: { value: '', length: 0, queue: [] },
  mode: Symbol(MODE_FLAT),
  doc: [
    '{',
    { type: 'indent', contents: [Array] },
    {
      type: 'if-break',
      breakContents: ',',
      flatContents: undefined,
      groupId: undefined
    },
    { type: 'line' },
    '}'
  ]
}
```

VS

```text
{
  ind: { value: '', length: 0, queue: [] },
  mode: 2,
  doc: [
    '{',
    { type: 'indent', contents: [Array] },
    {
      type: 'if-break',
      breakContents: ',',
      flatContents: undefined,
      groupId: undefined
    },
    { type: 'line' },
    '}'
  ]
}
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
