### PR TITLE
Stop mutate `doc.parts` when printing `fill`

### DIFF
--- a/changelog_unreleased/api/13315.md
+++ b/changelog_unreleased/api/13315.md
@@ -1,0 +1,3 @@
+#### Stop mutate doc in `prettier.doc.printDocToString` (#13315 by @fisker)
+
+For performance reason, `prettier.doc.printDocToString` mutates `.parts` of the [`fill`](https://github.com/prettier/prettier/blob/main/commands.md#fill) command during print, it's now [pure function](https://en.wikipedia.org/wiki/Pure_function) since Prettier main.

--- a/changelog_unreleased/api/13315.md
+++ b/changelog_unreleased/api/13315.md
@@ -1,3 +1,3 @@
-#### Stop mutate doc in `prettier.doc.printDocToString` (#13315 by @fisker)
+#### Stop doc mutation in `prettier.doc.printDocToString` (#13315 by @fisker)
 
-For performance reason, `prettier.doc.printDocToString` mutates `.parts` of the [`fill`](https://github.com/prettier/prettier/blob/main/commands.md#fill) command during print, it's now [pure function](https://en.wikipedia.org/wiki/Pure_function) since Prettier main.
+For performance reason, `prettier.doc.printDocToString` used to mutate `.parts` of the [`fill`](https://github.com/prettier/prettier/blob/main/commands.md#fill) command during print. It was converted to a [pure function](https://en.wikipedia.org/wiki/Pure_function) to ensure output correctness.

--- a/changelog_unreleased/javascript/13315-2.md
+++ b/changelog_unreleased/javascript/13315-2.md
@@ -1,0 +1,19 @@
+#### Fix template literal print with array (#13315 by @fisker, @syi0808)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+const string = `${[[1, 2], [3, 4]]}`
+
+// Prettier stable
+const string = `${[
+  [1, 2],
+  [3, 4],
+]}`;
+
+// Prettier main
+const string = `${[
+  [1, 2],
+  [3, 4],
+]}`;
+```

--- a/src/document/printer.js
+++ b/src/document/printer.js
@@ -32,7 +32,7 @@ const MODE_FLAT = Symbol("MODE_FLAT");
 
 const CURSOR_PLACEHOLDER = Symbol("cursor");
 
-const DOC_FILL_IS_MUTABLE = Symbol("DOC_FILL_IS_MUTABLE");
+const IS_MUTABLE_FILL = Symbol("IS_MUTABLE_FILL");
 
 function rootIndent() {
   return { value: "", length: 0, queue: [] };
@@ -507,21 +507,25 @@ function printDocToString(doc, options) {
 
         const secondContent = parts[2];
 
+        parts.splice(0, 2);
+
         // At this point we've handled the first pair (context, separator)
         // and will create a new *mutable* fill doc for the rest of the content.
         // Copying all the elements to a new array would make this algorithm quadratic,
         // which is unusable for large arrays (e.g. large texts in JSX).
         // https://github.com/prettier/prettier/issues/3263#issuecomment-344275152
         let remainingDoc = doc;
-        if (doc[DOC_FILL_IS_MUTABLE]) {
+        if (doc[IS_MUTABLE_FILL]) {
           parts.splice(0, 2);
         } else {
           remainingDoc = {
             ...doc,
             parts: parts.slice(2),
-            [DOC_FILL_IS_MUTABLE]: true,
+            [IS_MUTABLE_FILL]: true,
           };
         }
+
+        /** @type {Command} */
         const remainingCmd = { ind, mode, doc: remainingDoc };
 
         /** @type {Command} */

--- a/src/document/printer.js
+++ b/src/document/printer.js
@@ -507,8 +507,6 @@ function printDocToString(doc, options) {
 
         const secondContent = parts[2];
 
-        parts.splice(0, 2);
-
         // At this point we've handled the first pair (context, separator)
         // and will create a new *mutable* fill doc for the rest of the content.
         // Copying all the elements to a new array would make this algorithm quadratic,

--- a/src/document/printer.js
+++ b/src/document/printer.js
@@ -1,6 +1,6 @@
 import { convertEndOfLineToChars } from "../common/end-of-line.js";
 import getStringWidth from "../utils/get-string-width.js";
-import { fill, hardlineWithoutBreakParent, indent } from "./builders.js";
+import { hardlineWithoutBreakParent, indent } from "./builders.js";
 import {
   DOC_TYPE_ALIGN,
   DOC_TYPE_ARRAY,
@@ -31,6 +31,8 @@ const MODE_BREAK = Symbol("MODE_BREAK");
 const MODE_FLAT = Symbol("MODE_FLAT");
 
 const CURSOR_PLACEHOLDER = Symbol("cursor");
+
+const DOC_FILL_IS_MUTABLE = Symbol("DOC_FILL_IS_MUTABLE");
 
 function rootIndent() {
   return { value: "", length: 0, queue: [] };
@@ -503,16 +505,24 @@ function printDocToString(doc, options) {
           break;
         }
 
-        // At this point we've handled the first pair (context, separator)
-        // and will create a new fill doc for the rest of the content.
-        // Ideally we wouldn't mutate the array here but copying all the
-        // elements to a new array would make this algorithm quadratic,
-        // which is unusable for large arrays (e.g. large texts in JSX).
-        parts.splice(0, 2);
-        /** @type {Command} */
-        const remainingCmd = { ind, mode, doc: fill(parts) };
+        const secondContent = parts[2];
 
-        const secondContent = parts[0];
+        // At this point we've handled the first pair (context, separator)
+        // and will create a new *mutable* fill doc for the rest of the content.
+        // Copying all the elements to a new array would make this algorithm quadratic,
+        // which is unusable for large arrays (e.g. large texts in JSX).
+        // https://github.com/prettier/prettier/issues/3263#issuecomment-344275152
+        let remainingDoc = doc;
+        if (doc[DOC_FILL_IS_MUTABLE]) {
+          parts.splice(0, 2);
+        } else {
+          remainingDoc = {
+            ...doc,
+            parts: parts.slice(2),
+            [DOC_FILL_IS_MUTABLE]: true,
+          };
+        }
+        const remainingCmd = { ind, mode, doc: remainingDoc };
 
         /** @type {Command} */
         const firstAndSecondContentFlatCmd = {

--- a/tests/format/js/template-literals/__snapshots__/format.test.js.snap
+++ b/tests/format/js/template-literals/__snapshots__/format.test.js.snap
@@ -164,7 +164,7 @@ descirbe('something', () => {
 
 throw new Error(\`pretty-format: Option "theme" has a key "\${key}" whose value "\${value}" is undefined in ansi-styles.\`,)
 
-\`\${[[1, 2, 3], [4, 5, 6]]}\`
+a = \`\${[[1, 2, 3], [4, 5, 6]]}\`
 
 =====================================output=====================================
 const long1 = \`long \${
@@ -224,7 +224,9 @@ descirbe("something", () => {
 
 throw new Error(
   \`pretty-format: Option "theme" has a key "\${key}" whose value "\${value}" is undefined in ansi-styles.\`,
-)\`\${[
+);
+
+a = \`\${[
   [1, 2, 3],
   [4, 5, 6],
 ]}\`;

--- a/tests/format/js/template-literals/__snapshots__/format.test.js.snap
+++ b/tests/format/js/template-literals/__snapshots__/format.test.js.snap
@@ -164,6 +164,8 @@ descirbe('something', () => {
 
 throw new Error(\`pretty-format: Option "theme" has a key "\${key}" whose value "\${value}" is undefined in ansi-styles.\`,)
 
+\`\${[[1, 2, 3], [4, 5, 6]]}\`
+
 =====================================output=====================================
 const long1 = \`long \${
   a.b //comment
@@ -222,7 +224,10 @@ descirbe("something", () => {
 
 throw new Error(
   \`pretty-format: Option "theme" has a key "\${key}" whose value "\${value}" is undefined in ansi-styles.\`,
-);
+)\`\${[
+  [1, 2, 3],
+  [4, 5, 6],
+]}\`;
 
 ================================================================================
 `;

--- a/tests/format/js/template-literals/expressions.js
+++ b/tests/format/js/template-literals/expressions.js
@@ -45,4 +45,4 @@ descirbe('something', () => {
 
 throw new Error(`pretty-format: Option "theme" has a key "${key}" whose value "${value}" is undefined in ansi-styles.`,)
 
-`${[[1, 2, 3], [4, 5, 6]]}`
+a = `${[[1, 2, 3], [4, 5, 6]]}`

--- a/tests/format/js/template-literals/expressions.js
+++ b/tests/format/js/template-literals/expressions.js
@@ -44,3 +44,5 @@ descirbe('something', () => {
 })
 
 throw new Error(`pretty-format: Option "theme" has a key "${key}" whose value "${value}" is undefined in ansi-styles.`,)
+
+`${[[1, 2, 3], [4, 5, 6]]}`

--- a/tests/unit/doc-printer.js
+++ b/tests/unit/doc-printer.js
@@ -1,3 +1,4 @@
+// TODO: Find a better way to test the performance
 import { fill, join, line } from "../../src/document/builders.js";
 import { printDocToString } from "../../src/document/printer.js";
 

--- a/tests/unit/doc-printer.js
+++ b/tests/unit/doc-printer.js
@@ -1,0 +1,44 @@
+import { fill, join, line } from "../../src/document/builders.js";
+import { printDocToString } from "../../src/document/printer.js";
+
+test("`printDocToString` should not manipulate docs", () => {
+  const printOptions = { printWidth: 40, tabWidth: 2 };
+  const doc = fill(
+    join(
+      line,
+      Array.from({ length: 255 }, (_, index) => String(index + 1))
+    )
+  );
+
+  expect(doc.parts.length).toBe(255 + 254);
+
+  const { formatted: firstPrint } = printDocToString(doc, printOptions);
+
+  expect(doc.parts.length).toBe(255 + 254);
+
+  const { formatted: secondPrint } = printDocToString(doc, printOptions);
+
+  expect(firstPrint).toBe(secondPrint);
+
+  {
+    // About 1000 lines, #3263
+    const WORD = "word";
+    const hugeParts = join(
+      line,
+      Array.from(
+        { length: 1000 * Math.ceil(printOptions.printWidth / WORD.length) },
+        () => WORD
+      )
+    );
+    const orignalLength = hugeParts.length;
+
+    const startTime = performance.now();
+    const { formatted } = printDocToString(fill(hugeParts), printOptions);
+    const endTime = performance.now();
+    expect(hugeParts.length).toBe(orignalLength);
+
+    const lines = formatted.split("\n");
+    expect(lines.length).toBeGreaterThan(1000);
+    expect(endTime - startTime).toBeLessThan(1000);
+  }
+});

--- a/tests/unit/doc-printer.js
+++ b/tests/unit/doc-printer.js
@@ -6,8 +6,8 @@ test("`printDocToString` should not manipulate docs", () => {
   const doc = fill(
     join(
       line,
-      Array.from({ length: 255 }, (_, index) => String(index + 1))
-    )
+      Array.from({ length: 255 }, (_, index) => String(index + 1)),
+    ),
   );
 
   expect(doc.parts.length).toBe(255 + 254);
@@ -27,8 +27,8 @@ test("`printDocToString` should not manipulate docs", () => {
       line,
       Array.from(
         { length: 1000 * Math.ceil(printOptions.printWidth / WORD.length) },
-        () => WORD
-      )
+        () => WORD,
+      ),
     );
     const orignalLength = hugeParts.length;
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Stop mutate the parts, by only copy it once to a mutable `fill`.

The playground link in #3263 is broken, I can't test the original case.

//cc @duailibe It will be great if you can review, since you bring this in #3273

Fixes #16493

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
