### PR TITLE
Playground: fix 'show doc', add folding for doc-explorer

### DIFF
--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -188,13 +188,8 @@ class Playground extends React.Component {
   }
 
   render() {
-    const { worker, version } = this.props;
+    const { worker } = this.props;
     const { content, options } = this.state;
-
-    // TODO: remove this when v2.3.0 is released
-    const [major, minor] = version.split(".", 2).map(Number);
-    const showShowComments =
-      Number.isNaN(major) || (major === 2 && minor >= 3) || major > 2;
 
     return (
       <EditorState>
@@ -206,7 +201,7 @@ class Playground extends React.Component {
             options={options}
             debugAst={editorState.showAst}
             debugDoc={editorState.showDoc}
-            debugComments={showShowComments && editorState.showComments}
+            debugComments={editorState.showComments}
             reformat={editorState.showSecondFormat}
             rethrowEmbedErrors={editorState.rethrowEmbedErrors}
           >
@@ -273,13 +268,11 @@ class Playground extends React.Component {
                           checked={editorState.showDoc}
                           onChange={editorState.toggleDoc}
                         />
-                        {showShowComments && (
-                          <Checkbox
-                            label="show comments"
-                            checked={editorState.showComments}
-                            onChange={editorState.toggleComments}
-                          />
-                        )}
+                        <Checkbox
+                          label="show comments"
+                          checked={editorState.showComments}
+                          onChange={editorState.toggleComments}
+                        />
                         <Checkbox
                           label="show output"
                           checked={editorState.showOutput}
@@ -322,6 +315,7 @@ class Playground extends React.Component {
                           onChange={this.setContent}
                           onSelectionChange={this.setSelection}
                           onFormat={this.handleInputPanelFormat}
+                          foldGutter={options.parser === "doc-explorer"}
                         />
                       ) : null}
                       {editorState.showAst ? (
@@ -333,7 +327,7 @@ class Playground extends React.Component {
                       {editorState.showDoc ? (
                         <DebugPanel value={debug.doc || ""} />
                       ) : null}
-                      {showShowComments && editorState.showComments ? (
+                      {editorState.showComments ? (
                         <DebugPanel
                           value={debug.comments || ""}
                           autoFold={util.getAstAutoFold(options.parser)}

--- a/website/playground/panels.js
+++ b/website/playground/panels.js
@@ -68,6 +68,14 @@ class CodeMirrorPanel extends React.Component {
     if (this.props.ruler !== prevProps.ruler) {
       this._codeMirror.setOption("rulers", [makeRuler(this.props)]);
     }
+    if (this.props.foldGutter !== prevProps.foldGutter) {
+      this._codeMirror.setOption(
+        "gutters",
+        this.props.foldGutter
+          ? ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
+          : []
+      );
+    }
   }
 
   updateValue(value) {

--- a/website/playground/panels.js
+++ b/website/playground/panels.js
@@ -22,10 +22,7 @@ class CodeMirrorPanel extends React.Component {
     delete options.onFormat;
 
     options.rulers = [makeRuler(this.props)];
-
-    if (options.foldGutter) {
-      options.gutters = ["CodeMirror-linenumbers", "CodeMirror-foldgutter"];
-    }
+    options.gutters = makeGutters(this.props);
 
     if (this.props.onFormat) {
       options.extraKeys = {
@@ -69,12 +66,7 @@ class CodeMirrorPanel extends React.Component {
       this._codeMirror.setOption("rulers", [makeRuler(this.props)]);
     }
     if (this.props.foldGutter !== prevProps.foldGutter) {
-      this._codeMirror.setOption(
-        "gutters",
-        this.props.foldGutter
-          ? ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
-          : []
-      );
+      this._codeMirror.setOption("gutters", makeGutters(this.props));
     }
   }
 
@@ -196,6 +188,12 @@ function createOverlay(start, end) {
 
 function makeRuler(props) {
   return { column: props.ruler, color: props.rulerColor };
+}
+
+function makeGutters(props) {
+  return props.foldGutter
+    ? ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
+    : [];
 }
 
 export function InputPanel(props) {

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -141,8 +141,8 @@ async function handleFormatMessage(message) {
 
   if (message.debug.doc) {
     try {
-      response.debug.doc = prettier.__debug.formatDoc(
-        prettier.__debug.printToDoc(message.code, options),
+      response.debug.doc = await prettier.__debug.formatDoc(
+        await prettier.__debug.printToDoc(message.code, options),
         { plugins }
       );
     } catch {


### PR DESCRIPTION
## Description


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
