### PR TITLE
Replace `replaceTextEndOfLine` with `replaceEndOfLine`

### DIFF
--- a/src/document/utils.js
+++ b/src/document/utils.js
@@ -390,16 +390,12 @@ function normalizeDoc(doc) {
   });
 }
 
-function replaceEndOfLine(doc) {
+function replaceEndOfLine(doc, replacement = literalline) {
   return mapDoc(doc, (currentDoc) =>
-    typeof currentDoc === "string" && currentDoc.includes("\n")
-      ? replaceTextEndOfLine(currentDoc)
+    typeof currentDoc === "string"
+      ? join(replacement, currentDoc.split("\n"))
       : currentDoc
   );
-}
-
-function replaceTextEndOfLine(text, replacement = literalline) {
-  return join(replacement, text.split("\n"));
 }
 
 function canBreakFn(doc) {
@@ -424,7 +420,6 @@ export {
   normalizeParts,
   normalizeDoc,
   cleanDoc,
-  replaceTextEndOfLine,
   replaceEndOfLine,
   canBreak,
   getDocType,

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -9,7 +9,7 @@ import {
   line,
   softline,
 } from "../document/builders.js";
-import { replaceTextEndOfLine } from "../document/utils.js";
+import { replaceEndOfLine } from "../document/utils.js";
 import { getPreferredQuote, isNonEmptyArray } from "../common/util.js";
 import createGetVisitorKeys from "../utils/create-get-visitor-keys.js";
 import { locStart, locEnd } from "./loc.js";
@@ -224,7 +224,7 @@ function print(path, options, print) {
           ];
         }
 
-        return replaceTextEndOfLine(text);
+        return replaceEndOfLine(text);
       }
 
       const whitespacesOnlyRE = /^[\t\n\f\r ]*$/;

--- a/src/language-html/embed.js
+++ b/src/language-html/embed.js
@@ -7,7 +7,7 @@ import {
   fill,
   softline,
 } from "../document/builders.js";
-import { mapDoc, replaceTextEndOfLine } from "../document/utils.js";
+import { mapDoc, replaceEndOfLine } from "../document/utils.js";
 import printFrontMatter from "../utils/front-matter/print.js";
 import {
   printClosingTag,
@@ -216,7 +216,7 @@ async function printEmbeddedAttributeValue(node, htmlTextToDoc, options) {
       const parts = [];
       for (const [index, part] of value.split(interpolationRegex).entries()) {
         if (index % 2 === 0) {
-          parts.push(replaceTextEndOfLine(part));
+          parts.push(replaceEndOfLine(part));
         } else {
           try {
             parts.push(
@@ -234,7 +234,7 @@ async function printEmbeddedAttributeValue(node, htmlTextToDoc, options) {
               ])
             );
           } catch {
-            parts.push("{{", replaceTextEndOfLine(part), "}}");
+            parts.push("{{", replaceEndOfLine(part), "}}");
           }
         }
       }

--- a/src/language-html/print/children.js
+++ b/src/language-html/print/children.js
@@ -6,7 +6,7 @@ import {
   softline,
   hardline,
 } from "../../document/builders.js";
-import { replaceTextEndOfLine } from "../../document/utils.js";
+import { replaceEndOfLine } from "../../document/utils.js";
 import { locStart, locEnd } from "../loc.js";
 import {
   forceBreakChildren,
@@ -31,7 +31,7 @@ function printChild(childPath, options, print) {
   if (hasPrettierIgnore(child)) {
     return [
       printOpeningTagPrefix(child, options),
-      ...replaceTextEndOfLine(
+      replaceEndOfLine(
         options.originalText.slice(
           locStart(child) +
             (child.prev && needsToBorrowNextOpeningTagStartMarker(child.prev)

--- a/src/language-html/print/element.js
+++ b/src/language-html/print/element.js
@@ -8,7 +8,7 @@ import {
   line,
   softline,
 } from "../../document/builders.js";
-import { replaceTextEndOfLine } from "../../document/utils.js";
+import { replaceEndOfLine } from "../../document/utils.js";
 import getNodeContent from "../get-node-content.js";
 import {
   shouldPreserveContent,
@@ -34,7 +34,7 @@ function printElement(path, options, print) {
     return [
       printOpeningTagPrefix(node, options),
       group(printOpeningTag(path, options, print)),
-      ...replaceTextEndOfLine(getNodeContent(node, options)),
+      replaceEndOfLine(getNodeContent(node, options)),
       ...printClosingTag(node, options),
       printClosingTagSuffix(node, options),
     ];

--- a/src/language-html/print/tag.js
+++ b/src/language-html/print/tag.js
@@ -11,7 +11,7 @@ import {
   softline,
   hardline,
 } from "../../document/builders.js";
-import { replaceTextEndOfLine } from "../../document/utils.js";
+import { replaceEndOfLine } from "../../document/utils.js";
 import { locStart, locEnd } from "../loc.js";
 import {
   isTextLikeNode,
@@ -241,7 +241,7 @@ function printAttributes(path, options, print) {
   const printedAttributes = path.map((attributePath) => {
     const attribute = attributePath.getValue();
     return hasPrettierIgnoreAttribute(attribute)
-      ? replaceTextEndOfLine(
+      ? replaceEndOfLine(
           options.originalText.slice(locStart(attribute), locEnd(attribute))
         )
       : print();

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -3,7 +3,7 @@
  */
 
 import { fill, group, hardline } from "../document/builders.js";
-import { cleanDoc, replaceTextEndOfLine } from "../document/utils.js";
+import { cleanDoc, replaceEndOfLine } from "../document/utils.js";
 import createGetVisitorKeys from "../utils/create-get-visitor-keys.js";
 import clean from "./clean.js";
 import {
@@ -30,7 +30,7 @@ function genericPrint(path, options, print) {
 
   switch (node.type) {
     case "front-matter":
-      return replaceTextEndOfLine(node.raw);
+      return replaceEndOfLine(node.raw);
     case "root":
       if (options.__onHtmlRoot) {
         options.__onHtmlRoot(node);
@@ -57,10 +57,7 @@ function genericPrint(path, options, print) {
         const value = hasTrailingNewline
           ? node.value.replace(trailingNewlineRegex, "")
           : node.value;
-        return [
-          ...replaceTextEndOfLine(value),
-          hasTrailingNewline ? hardline : "",
-        ];
+        return [replaceEndOfLine(value), hasTrailingNewline ? hardline : ""];
       }
 
       const printed = cleanDoc([
@@ -87,7 +84,7 @@ function genericPrint(path, options, print) {
     case "comment": {
       return [
         printOpeningTagPrefix(node, options),
-        ...replaceTextEndOfLine(
+        replaceEndOfLine(
           options.originalText.slice(locStart(node), locEnd(node))
         ),
         printClosingTagSuffix(node, options),
@@ -103,11 +100,9 @@ function genericPrint(path, options, print) {
       const quote = singleQuoteCount < doubleQuoteCount ? "'" : '"';
       return [
         node.rawName,
-
         "=",
         quote,
-
-        ...replaceTextEndOfLine(
+        replaceEndOfLine(
           quote === '"'
             ? value.replace(/"/g, "&quot;")
             : value.replace(/'/g, "&apos;")

--- a/src/language-html/utils/index.js
+++ b/src/language-html/utils/index.js
@@ -4,7 +4,7 @@
 
 import { inferParserByLanguage, isFrontMatterNode } from "../../common/util.js";
 import { line, hardline, join } from "../../document/builders.js";
-import { replaceTextEndOfLine } from "../../document/utils.js";
+import { replaceEndOfLine } from "../../document/utils.js";
 import {
   CSS_DISPLAY_TAGS,
   CSS_DISPLAY_DEFAULT,
@@ -633,8 +633,8 @@ function isVueSfcBindingsAttribute(attribute, options) {
 function getTextValueParts(node, value = node.value) {
   return node.parent.isWhitespaceSensitive
     ? node.parent.isIndentationSensitive
-      ? replaceTextEndOfLine(value)
-      : replaceTextEndOfLine(
+      ? replaceEndOfLine(value)
+      : replaceEndOfLine(
           dedentString(htmlTrimPreserveIndentation(value)),
           hardline
         )

--- a/src/language-js/print/comment.js
+++ b/src/language-js/print/comment.js
@@ -1,6 +1,6 @@
 import { hasNewline } from "../../common/util.js";
 import { join, hardline } from "../../document/builders.js";
-import { replaceTextEndOfLine } from "../../document/utils.js";
+import { replaceEndOfLine } from "../../document/utils.js";
 
 import { isLineComment } from "../utils/index.js";
 import { locStart, locEnd } from "../loc.js";
@@ -38,7 +38,7 @@ function printComment(commentPath, options) {
       options.originalText.slice(commentEnd - 3, commentEnd) === "*-/";
     return [
       "/*",
-      replaceTextEndOfLine(comment.value),
+      replaceEndOfLine(comment.value),
       isInsideFlowComment ? "*-/" : "*/",
     ];
   }

--- a/src/language-js/print/flow.js
+++ b/src/language-js/print/flow.js
@@ -4,7 +4,7 @@ import assert from "node:assert";
 import { printDanglingComments } from "../../main/comments.js";
 import { printString, printNumber } from "../../common/util.js";
 import { hardline, softline, group, indent } from "../../document/builders.js";
-import { replaceTextEndOfLine } from "../../document/utils.js";
+import { replaceEndOfLine } from "../../document/utils.js";
 import {
   getParentExportDeclaration,
   isFunctionNotation,
@@ -269,7 +269,7 @@ function printFlow(path, options, print) {
     case "QualifiedTypeIdentifier":
       return [print("qualification"), ".", print("id")];
     case "StringLiteralTypeAnnotation":
-      return replaceTextEndOfLine(printString(rawText(node), options));
+      return replaceEndOfLine(printString(rawText(node), options));
     case "NumberLiteralTypeAnnotation":
       assert.strictEqual(typeof node.value, "number");
     // fall through

--- a/src/language-js/print/literal.js
+++ b/src/language-js/print/literal.js
@@ -1,5 +1,5 @@
 import { printString, printNumber } from "../../common/util.js";
-import { replaceTextEndOfLine } from "../../document/utils.js";
+import { replaceEndOfLine } from "../../document/utils.js";
 
 function printLiteral(path, options /*, print*/) {
   const node = path.getNode();
@@ -13,7 +13,7 @@ function printLiteral(path, options /*, print*/) {
     case "NumericLiteral": // Babel 6 Literal split
       return printNumber(node.extra.raw);
     case "StringLiteral": // Babel 6 Literal split
-      return replaceTextEndOfLine(printString(node.extra.raw, options));
+      return replaceEndOfLine(printString(node.extra.raw, options));
     case "NullLiteral": // Babel 6 Literal split
       return "null";
     case "BooleanLiteral": // Babel 6 Literal split
@@ -40,7 +40,7 @@ function printLiteral(path, options /*, print*/) {
       }
 
       if (typeof value === "string") {
-        return replaceTextEndOfLine(printString(node.raw, options));
+        return replaceEndOfLine(printString(node.raw, options));
       }
 
       return String(value);

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -11,7 +11,7 @@ import {
   group,
   indent,
 } from "../document/builders.js";
-import { replaceTextEndOfLine } from "../document/utils.js";
+import { replaceEndOfLine } from "../document/utils.js";
 import embed from "./embed.js";
 import clean from "./clean.js";
 import { insertPragma } from "./pragma.js";
@@ -761,7 +761,7 @@ function printPathNoParens(path, options, print, args) {
     case "ClassAccessorProperty":
       return printClassProperty(path, options, print);
     case "TemplateElement":
-      return replaceTextEndOfLine(node.value.raw);
+      return replaceEndOfLine(node.value.raw);
     case "TemplateLiteral":
       return printTemplateLiteral(path, print, options);
     case "TaggedTemplateExpression":

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -20,7 +20,7 @@ import {
   group,
   hardlineWithoutBreakParent,
 } from "../document/builders.js";
-import { normalizeDoc, replaceTextEndOfLine } from "../document/utils.js";
+import { normalizeDoc, replaceEndOfLine } from "../document/utils.js";
 import { printDocToString } from "../document/printer.js";
 import createGetVisitorKeys from "../utils/create-get-visitor-keys.js";
 import embed from "./embed.js";
@@ -243,7 +243,7 @@ function genericPrint(path, options, print) {
         const alignment = " ".repeat(4);
         return align(alignment, [
           alignment,
-          ...replaceTextEndOfLine(node.value, hardline),
+          replaceEndOfLine(node.value, hardline),
         ]);
       }
 
@@ -257,8 +257,7 @@ function genericPrint(path, options, print) {
         node.lang || "",
         node.meta ? " " + node.meta : "",
         hardline,
-
-        ...replaceTextEndOfLine(
+        replaceEndOfLine(
           getFencedCodeBlockValue(node, options.originalText),
           hardline
         ),
@@ -274,7 +273,7 @@ function genericPrint(path, options, print) {
           : node.value;
       const isHtmlComment = /^<!--.*-->$/s.test(value);
 
-      return replaceTextEndOfLine(
+      return replaceEndOfLine(
         value,
         // @ts-expect-error
         isHtmlComment ? hardline : markAsRoot(literalline)
@@ -427,7 +426,7 @@ function genericPrint(path, options, print) {
         ? ["  ", markAsRoot(literalline)]
         : ["\\", hardline];
     case "liquidNode":
-      return replaceTextEndOfLine(node.value, hardline);
+      return replaceEndOfLine(node.value, hardline);
     // MDX
     // fallback to the original text if multiparser failed
     // or `embeddedLanguageFormatting: "off"`
@@ -441,9 +440,7 @@ function genericPrint(path, options, print) {
       return [
         "$$",
         hardline,
-        node.value
-          ? [...replaceTextEndOfLine(node.value, hardline), hardline]
-          : "",
+        node.value ? [replaceEndOfLine(node.value, hardline), hardline] : "",
         "$$",
       ];
     case "inlineMath": {

--- a/src/language-yaml/printer-yaml.js
+++ b/src/language-yaml/printer-yaml.js
@@ -9,7 +9,7 @@ import {
   line,
   lineSuffix,
 } from "../document/builders.js";
-import { replaceTextEndOfLine } from "../document/utils.js";
+import { replaceEndOfLine } from "../document/utils.js";
 import { isPreviousLineEmpty } from "../common/util.js";
 import createGetVisitorKeys from "../utils/create-get-visitor-keys.js";
 import { insertPragma, isPragma } from "./pragma.js";
@@ -97,7 +97,7 @@ function genericPrint(path, options, print) {
   const parentNode = path.getParentNode();
   if (hasPrettierIgnore(path)) {
     parts.push(
-      replaceTextEndOfLine(
+      replaceEndOfLine(
         options.originalText
           .slice(node.position.start.offset, node.position.end.offset)
           .trimEnd()


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
