### PR TITLE
Forbid pass non-node object to graphql printer

### DIFF
--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -422,7 +422,7 @@ function genericPrint(path, options, print) {
     }
 
     case "OperationTypeDefinition": {
-      return [print("operation"), ": ", print("type")];
+      return [node.operation, ": ", print("type")];
     }
 
     case "InterfaceTypeExtension":

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -598,7 +598,7 @@ clean.ignoredProperties = new Set(["loc", "comments"]);
 
 function hasPrettierIgnore(path) {
   const node = path.getValue();
-  return node.comments?.some(
+  return node?.comments?.some(
     (comment) => comment.value.trim() === "prettier-ignore"
   );
 }

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -321,7 +321,6 @@ function genericPrint(path, options, print) {
         "enum ",
         print("name"),
         printDirectives(path, print, node),
-
         node.values.length > 0
           ? [
               " {",
@@ -551,7 +550,7 @@ function printSequence(path, options, print, property) {
 }
 
 function canAttachComment(node) {
-  return node.kind && node.kind !== "Comment";
+  return node.kind !== "Comment";
 }
 
 function printComment(commentPath) {
@@ -568,7 +567,7 @@ function printInterfaces(path, options, print) {
   const node = path.getNode();
   const parts = [];
   const { interfaces } = node;
-  const printed = path.map((node) => print(node), "interfaces");
+  const printed = path.map(print, "interfaces");
 
   for (let index = 0; index < interfaces.length; index++) {
     const interfaceNode = interfaces[index];
@@ -599,7 +598,7 @@ clean.ignoredProperties = new Set(["loc", "comments"]);
 
 function hasPrettierIgnore(path) {
   const node = path.getValue();
-  return node?.comments?.some(
+  return node.comments?.some(
     (comment) => comment.value.trim() === "prettier-ignore"
   );
 }

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -512,7 +512,7 @@ function genericPrint(path, options, print) {
     default:
       /* istanbul ignore next */
       throw Object.assign(
-        new Error("Unknown node type: " + JSON.stringify(node.kind)),
+        new Error("Unknown node kind: " + JSON.stringify(node.kind)),
         { node }
       );
   }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -803,7 +803,7 @@ function printPathNoParens(path, options, print, args) {
     default:
       /* istanbul ignore next */
       throw Object.assign(
-        new Error("Unknown node type: " + JSON.stringify(node.type)),
+        new Error("Unknown node kind: " + JSON.stringify(node.type)),
         { node }
       );
   }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -803,7 +803,7 @@ function printPathNoParens(path, options, print, args) {
     default:
       /* istanbul ignore next */
       throw Object.assign(
-        new Error("Unknown node kind: " + JSON.stringify(node.type)),
+        new Error("Unknown node type: " + JSON.stringify(node.type)),
         { node }
       );
   }

--- a/src/utils/create-print-pre-check-function.js
+++ b/src/utils/create-print-pre-check-function.js
@@ -1,0 +1,44 @@
+// TODO: Move this check to `../main/ast-to-doc.js` after all languages pass this
+function createPrintPreCheckFunction(getVisitorKeys) {
+  return function (path) {
+    let name = path.getName();
+
+    // AST root
+    if (name === null) {
+      return;
+    }
+
+    if (typeof name === "number") {
+      /*
+    Nodes in array are stored in path.stack like
+
+    ```js
+    [
+      parentNode,
+      property, // <-
+      array,
+      index,
+      node,
+    ]
+    ```
+    */
+      name = path.stack[path.stack.length - 4];
+    }
+
+    const parent = path.getParentNode();
+    const visitorKeys = getVisitorKeys(parent);
+    if (visitorKeys.includes(name)) {
+      return;
+    }
+
+    /* istanbul ignore next */
+    throw Object.assign(new Error("Calling `print()` on non-node object."), {
+      parentNode: parent,
+      allowedProperties: visitorKeys,
+      printingProperty: name,
+      printingValue: path.getValue(),
+    });
+  };
+}
+
+export default createPrintPreCheckFunction;

--- a/src/utils/create-print-pre-check-function.js
+++ b/src/utils/create-print-pre-check-function.js
@@ -1,4 +1,4 @@
-// TODO: Move this check to `../main/ast-to-doc.js` after all languages pass this
+// TODO: Move this check to `../main/ast-to-doc.js` after all languages pass it
 function createPrintPreCheckFunction(getVisitorKeys) {
   return function (path) {
     let name = path.getName();

--- a/src/utils/create-print-pre-check-function.js
+++ b/src/utils/create-print-pre-check-function.js
@@ -10,18 +10,18 @@ function createPrintPreCheckFunction(getVisitorKeys) {
 
     if (typeof name === "number") {
       /*
-    Nodes in array are stored in path.stack like
+      Nodes in array are stored in path.stack like
 
-    ```js
-    [
-      parentNode,
-      property, // <-
-      array,
-      index,
-      node,
-    ]
-    ```
-    */
+      ```js
+      [
+        parentNode,
+        property, // <-
+        array,
+        index,
+        node,
+      ]
+      ```
+      */
       name = path.stack[path.stack.length - 4];
     }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
