### PR TITLE
Stop passing `undefine` and `null` to printer

### DIFF
--- a/changelog_unreleased/api/13397.md
+++ b/changelog_unreleased/api/13397.md
@@ -1,0 +1,19 @@
+#### [BREAKING] `undefined` and `null` are not passing to plugin's `print` function (#13397 by @fisker)
+
+If your plugin happened use `print` to print them before, please check them in the parent node.
+
+```diff
+function print(path, print) {
+-  const value = path.getValue();
+-  if (!value?.type) {
+-    return String(value);
+-  }
+
+-  return path.map(print, "values");
+
++  return path.map((childPath) => {
++    const value = childPath.getValue();
++    return value?.type ? print() : String(value);
++  }, "values");
+}
+```

--- a/changelog_unreleased/api/13397.md
+++ b/changelog_unreleased/api/13397.md
@@ -1,6 +1,6 @@
-#### [BREAKING] `undefined` and `null` are not passing to plugin's `print` function (#13397 by @fisker)
+#### [BREAKING] `undefined` and `null` are not passed to plugin's `print` function (#13397 by @fisker)
 
-If your plugin happened use `print` to print them before, please check them in the parent node.
+If your plugin happened to use `print` to print them, please check them in the parent node instead.
 
 ```diff
 function print(path, print) {

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -83,11 +83,6 @@ function shouldPrintComma(options) {
 function genericPrint(path, options, print) {
   const node = path.getValue();
 
-  /* istanbul ignore if */
-  if (!node) {
-    return "";
-  }
-
   if (typeof node === "string") {
     return node;
   }

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -21,10 +21,6 @@ const ensurePrintingNode = createPrintPreCheckFunction(getVisitorKeys);
 function genericPrint(path, options, print) {
   const node = path.getValue();
 
-  if (node === undefined || node === null) {
-    return "";
-  }
-
   if (process.env.NODE_ENV !== "production") {
     ensurePrintingNode(path);
   }

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -41,10 +41,6 @@ const NEWLINES_TO_PRESERVE_MAX = 2;
 function print(path, options, print) {
   const node = path.getValue();
 
-  if (node === undefined || node === null) {
-    return "";
-  }
-
   if (process.env.NODE_ENV !== "production") {
     ensurePrintingNode(path);
   }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -95,10 +95,6 @@ const ensurePrintingNode = createPrintPreCheckFunction(getVisitorKeys);
 function genericPrint(path, options, print, args) {
   const node = path.getValue();
 
-  if (node === undefined || node === null) {
-    return "";
-  }
-
   if (process.env.NODE_ENV !== "production") {
     ensurePrintingNode(path);
   }

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -73,7 +73,7 @@ async function printAstToDoc(ast, options, alignmentSize = 0) {
   function mainPrintInternal(args) {
     const value = path.getValue();
 
-    if (!value) {
+    if (value === undefined || value === null) {
       return "";
     }
 

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -73,6 +73,10 @@ async function printAstToDoc(ast, options, alignmentSize = 0) {
   function mainPrintInternal(args) {
     const value = path.getValue();
 
+    if (!value) {
+      return "";
+    }
+
     const shouldCache =
       value && typeof value === "object" && args === undefined;
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Should be safe, things like hole in array should checked by printer like [we did](https://github.com/prettier/prettier/blob/5a627651ff648edd38bd0b5e667210a8a1f4e4a1/src/language-js/printer-estree-json.js#L19)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
