### PR TITLE
Don't break signature of hugged function expression if parameters are identifiers without types

### DIFF
--- a/changelog_unreleased/javascript/13410.md
+++ b/changelog_unreleased/javascript/13410.md
@@ -1,0 +1,19 @@
+#### Don't break signature of hugged function expression if parameters are identifiers without types (#13410 by @thorn0)
+
+<!-- prettier-ignore -->
+```tsx
+// Prettier stable
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
+  props,
+  ref
+) {
+  return <ThemeUILink ref={ref} variant="default" {...props} />;
+});
+
+// Prettier main
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
+  function Link(props, ref) {
+    return <ThemeUILink ref={ref} variant="default" {...props} />;
+  },
+);
+```

--- a/src/language-js/print/function.js
+++ b/src/language-js/print/function.js
@@ -57,7 +57,13 @@ function printFunction(path, print, options, args) {
     args?.expandLastArg
   ) {
     const parent = path.getParentNode();
-    if (isCallExpression(parent) && getCallArguments(parent).length > 1) {
+    if (
+      isCallExpression(parent) &&
+      (getCallArguments(parent).length > 1 ||
+        getFunctionParameters(node).every(
+          (param) => param.type === "Identifier" && !param.typeAnnotation
+        ))
+    ) {
       expandArg = true;
     }
   }

--- a/tests/format/typescript/last-argument-expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/last-argument-expansion/__snapshots__/jsfmt.spec.js.snap
@@ -226,6 +226,12 @@ export const ArrowWithLongName = forwardRef<HTMLAnchorElement, LinkProps>(
   }
 );
 
+const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
+  function Link(props, ref) {
+    return <ThemeUILink ref={ref} variant="default" {...props} />;
+  },
+);
+
 =====================================output=====================================
 export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
   function Link(props, ref) {
@@ -245,6 +251,12 @@ export const Arrow = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
 
 export const ArrowWithLongName = forwardRef<HTMLAnchorElement, LinkProps>(
   (props, ref) => {
+    return <ThemeUILink ref={ref} variant="default" {...props} />;
+  },
+);
+
+const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
+  function Link(props, ref) {
     return <ThemeUILink ref={ref} variant="default" {...props} />;
   },
 );

--- a/tests/format/typescript/last-argument-expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/last-argument-expansion/__snapshots__/jsfmt.spec.js.snap
@@ -197,3 +197,57 @@ var listener = DOM.listen(
 
 ================================================================================
 `;
+
+exports[`forward-ref.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
+  function Link(props, ref) {
+    return <ThemeUILink ref={ref} variant="default" {...props} />;
+  }
+);
+
+export const LinkWithLongName = forwardRef<HTMLAnchorElement, LinkProps>(
+  function Link(props, ref) {
+    return <ThemeUILink ref={ref} variant="default" {...props} />;
+  }
+);
+
+export const Arrow = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
+  return <ThemeUILink ref={ref} variant="default" {...props} />;
+});
+
+export const ArrowWithLongName = forwardRef<HTMLAnchorElement, LinkProps>(
+  (props, ref) => {
+    return <ThemeUILink ref={ref} variant="default" {...props} />;
+  }
+);
+
+=====================================output=====================================
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
+  function Link(props, ref) {
+    return <ThemeUILink ref={ref} variant="default" {...props} />;
+  },
+);
+
+export const LinkWithLongName = forwardRef<HTMLAnchorElement, LinkProps>(
+  function Link(props, ref) {
+    return <ThemeUILink ref={ref} variant="default" {...props} />;
+  },
+);
+
+export const Arrow = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
+  return <ThemeUILink ref={ref} variant="default" {...props} />;
+});
+
+export const ArrowWithLongName = forwardRef<HTMLAnchorElement, LinkProps>(
+  (props, ref) => {
+    return <ThemeUILink ref={ref} variant="default" {...props} />;
+  },
+);
+
+================================================================================
+`;

--- a/tests/format/typescript/last-argument-expansion/forward-ref.ts
+++ b/tests/format/typescript/last-argument-expansion/forward-ref.ts
@@ -1,0 +1,21 @@
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
+  function Link(props, ref) {
+    return <ThemeUILink ref={ref} variant="default" {...props} />;
+  }
+);
+
+export const LinkWithLongName = forwardRef<HTMLAnchorElement, LinkProps>(
+  function Link(props, ref) {
+    return <ThemeUILink ref={ref} variant="default" {...props} />;
+  }
+);
+
+export const Arrow = forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
+  return <ThemeUILink ref={ref} variant="default" {...props} />;
+});
+
+export const ArrowWithLongName = forwardRef<HTMLAnchorElement, LinkProps>(
+  (props, ref) => {
+    return <ThemeUILink ref={ref} variant="default" {...props} />;
+  }
+);

--- a/tests/format/typescript/last-argument-expansion/forward-ref.ts
+++ b/tests/format/typescript/last-argument-expansion/forward-ref.ts
@@ -19,3 +19,9 @@ export const ArrowWithLongName = forwardRef<HTMLAnchorElement, LinkProps>(
     return <ThemeUILink ref={ref} variant="default" {...props} />;
   }
 );
+
+const Link = React.forwardRef<HTMLAnchorElement, LinkProps>(
+  function Link(props, ref) {
+    return <ThemeUILink ref={ref} variant="default" {...props} />;
+  },
+);


### PR DESCRIPTION
## Description

fixes #11794

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
