### PR TITLE
Override version for the trim package to fix Markdown perf

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,9 @@
     "snapshot-diff": "0.9.0",
     "tempy": "3.0.0"
   },
+  "resolutions": {
+    "trim": "1.0.1"
+  },
   "scripts": {
     "prepublishOnly": "echo \"Error: must publish from dist/\" && exit 1",
     "test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --runInBand",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8231,10 +8231,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"trim@npm:0.0.1":
-  version: 0.0.1
-  resolution: "trim@npm:0.0.1"
-  checksum: 2b4646dff99a222e8e1526edd4e3a43bbd925af0b8e837c340455d250157e7deefaa4da49bb891ab841e5c27b1afc5e9e32d4b57afb875d2dfcabf4e319b8f7f
+"trim@npm:1.0.1":
+  version: 1.0.1
+  resolution: "trim@npm:1.0.1"
+  checksum: d7593f72edc1738218e94deeff54a9b81cb52b6448ef8a4d20015bd4581dadc3a636553fb06b1ab36d14e3803fd3138bd2b6da555de926abed33b0ae24f92879
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

fixes #13217

```console
# before (2.7.1)
$ time prettier test-slow.md -c
Checking formatting...
All matched files use Prettier code style!

real    0m18.831s
user    0m18.844s
sys     0m0.141s

# after
$ time prettier test-slow.md -c
Checking formatting...
All matched files use Prettier code style!

real    0m1.664s
user    0m1.359s
sys     0m0.375s
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
