### PR TITLE
Get rid of regexp and handle cursor in trim in doc printer

### DIFF
--- a/src/document/printer.js
+++ b/src/document/printer.js
@@ -160,6 +160,8 @@ function trim(out) {
       throw new Error(`Unexpected value in trim: '${typeof last}'`);
     }
 
+    // Not using a regexp here because regexps for trimming off trailing
+    // characters are known to have performance issues.
     for (let charIndex = last.length - 1; charIndex >= 0; charIndex--) {
       const char = last[charIndex];
       if (char === " " || char === "\t") {

--- a/tests/unit/print-doc-to-string.js
+++ b/tests/unit/print-doc-to-string.js
@@ -20,6 +20,10 @@ test("Should properly trim with cursor", () => {
     printDocToString(
       [cursor, "Prettier  \t", cursor, "\t \t", hardline],
       options
-    ).formatted
-  ).toBe("Prettier\n");
+    )
+  ).toEqual({
+    formatted: "Prettier\n",
+    cursorNodeStart: 0,
+    cursorNodeText: "Prettier",
+  });
 });

--- a/tests/unit/print-doc-to-string.js
+++ b/tests/unit/print-doc-to-string.js
@@ -1,8 +1,25 @@
-import { cursor } from "../../src/document/builders.js";
+import { cursor, hardline } from "../../src/document/builders.js";
 import { printDocToString } from "../../src/document/printer.js";
+
+const options = { printWidth: 80, tabWidth: 2 };
 
 test("Should reject if too many cursor in doc", () => {
   expect(() => {
-    printDocToString([cursor, cursor, cursor], { printWidth: 80, tabWidth: 2 });
+    printDocToString([cursor, cursor, cursor], options);
   }).toThrow({ message: "There are too many 'cursor' in doc." });
+});
+
+test("Should trim blank first line", () => {
+  expect(
+    printDocToString(["   ", hardline, "Prettier", hardline], options).formatted
+  ).toBe("\nPrettier\n");
+});
+
+test("Should properly trim with cursor", () => {
+  expect(
+    printDocToString(
+      [cursor, "Prettier  \t", cursor, "\t \t", hardline],
+      options
+    ).formatted
+  ).toBe("Prettier\n");
 });


### PR DESCRIPTION
## Description

see https://github.com/prettier/prettier/pull/13415#issuecomment-1236294897

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
