### PR TITLE
Fix leading comments in mapped types with `readonly`

### DIFF
--- a/changelog_unreleased/typescript/13427.md
+++ b/changelog_unreleased/typescript/13427.md
@@ -1,0 +1,22 @@
+#### Fix leading comments in mapped types with `readonly` (#13427 by @thorn0, @sosukesuzuki)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+type Type = {
+  // comment
+  readonly [key in Foo];
+};
+
+// Prettier stable
+type Type = {
+  readonly // comment
+  [key in Foo];
+};
+
+// Prettier main
+type Type = {
+  // comment
+  readonly [key in Foo];
+};
+```

--- a/src/language-js/print/type-parameters.js
+++ b/src/language-js/print/type-parameters.js
@@ -16,6 +16,7 @@ import {
   shouldPrintComma,
   getFunctionParameters,
   isObjectType,
+  getTypeScriptMappedTypeModifier,
 } from "../utils/index.js";
 import { createGroupIdMapper } from "../../common/util.js";
 import { shouldHugType } from "./type-annotation.js";
@@ -116,6 +117,12 @@ function printTypeParameter(path, options, print) {
   const name = node.type === "TSTypeParameter" ? print("name") : node.name;
 
   if (parent.type === "TSMappedType") {
+    if (parent.readonly) {
+      parts.push(
+        getTypeScriptMappedTypeModifier(parent.readonly, "readonly"),
+        " "
+      );
+    }
     parts.push("[", name);
     if (node.constraint) {
       parts.push(" in ", print("constraint"));

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -298,13 +298,6 @@ function printTypescript(path, options, print) {
           "{",
           indent([
             options.bracketSpacing ? line : softline,
-            node.readonly
-              ? [
-                  getTypeScriptMappedTypeModifier(node.readonly, "readonly"),
-                  " ",
-                ]
-              : "",
-            printTypeScriptModifiers(path, options, print),
             print("typeParameter"),
             node.optional
               ? getTypeScriptMappedTypeModifier(node.optional, "?")

--- a/tests/format/typescript/mapped-type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/mapped-type/__snapshots__/jsfmt.spec.js.snap
@@ -69,6 +69,17 @@ type Type = {
   [T in number];
 };
 
+type Type = {
+  readonly
+  // comment
+  [T in number];
+};
+
+type Type = {
+  readonly // foo
+  /* bar */ [T in number];
+};
+
 =====================================output=====================================
 type Type = {
   // comment
@@ -109,6 +120,16 @@ type Type = {
 type Type = {
   // comment
   [T in number];
+};
+
+type Type = {
+  // comment
+  readonly [T in number];
+};
+
+type Type = {
+  // foo
+  /* bar */ readonly [T in number];
 };
 
 ================================================================================

--- a/tests/format/typescript/mapped-type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/mapped-type/__snapshots__/jsfmt.spec.js.snap
@@ -22,6 +22,98 @@ type Example = {
 ================================================================================
 `;
 
+exports[`issue-11098.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type Type = {
+  // comment
+  readonly [T in number];
+};
+
+type Type = {
+  // comment1
+  // comment2
+  readonly [T in number];
+};
+
+type Type = {
+  // comment
+  +readonly [T in number];
+};
+
+type Type = {
+  // comment
+  -readonly [T in number];
+};
+
+type Type = {
+  // comment
+  +    readonly [T in number];
+};
+
+type Type = {
+  // comment
+  +readonly     [T in number];
+};
+
+type Type = {
+  // comment
+  readonly       [T in number];
+};
+
+type Type = {
+  // comment
+  [T in number];
+};
+
+=====================================output=====================================
+type Type = {
+  // comment
+  readonly [T in number];
+};
+
+type Type = {
+  // comment1
+  // comment2
+  readonly [T in number];
+};
+
+type Type = {
+  // comment
+  +readonly [T in number];
+};
+
+type Type = {
+  // comment
+  -readonly [T in number];
+};
+
+type Type = {
+  // comment
+  +readonly [T in number];
+};
+
+type Type = {
+  // comment
+  +readonly [T in number];
+};
+
+type Type = {
+  // comment
+  readonly [T in number];
+};
+
+type Type = {
+  // comment
+  [T in number];
+};
+
+================================================================================
+`;
+
 exports[`mapped-type.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/mapped-type/issue-11098.ts
+++ b/tests/format/typescript/mapped-type/issue-11098.ts
@@ -1,0 +1,40 @@
+type Type = {
+  // comment
+  readonly [T in number];
+};
+
+type Type = {
+  // comment1
+  // comment2
+  readonly [T in number];
+};
+
+type Type = {
+  // comment
+  +readonly [T in number];
+};
+
+type Type = {
+  // comment
+  -readonly [T in number];
+};
+
+type Type = {
+  // comment
+  +    readonly [T in number];
+};
+
+type Type = {
+  // comment
+  +readonly     [T in number];
+};
+
+type Type = {
+  // comment
+  readonly       [T in number];
+};
+
+type Type = {
+  // comment
+  [T in number];
+};

--- a/tests/format/typescript/mapped-type/issue-11098.ts
+++ b/tests/format/typescript/mapped-type/issue-11098.ts
@@ -38,3 +38,14 @@ type Type = {
   // comment
   [T in number];
 };
+
+type Type = {
+  readonly
+  // comment
+  [T in number];
+};
+
+type Type = {
+  readonly // foo
+  /* bar */ [T in number];
+};


### PR DESCRIPTION
## Description

Fixes https://github.com/prettier/prettier/issues/11098

@sosukesuzuki I believe this is a more optimal fix than #11190. There is no need to support comments between the modifier and identifier. I used the tests from your PR.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
