### PR TITLE
Remove outdated hack for `flow` parser

### DIFF
--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -44,14 +44,6 @@ const parsers = [
   },
   {
     input: "src/language-js/parse/flow.js",
-    replaceModule: [
-      // `flow-parser` use this for `globalThis`, can't work in strictMode
-      {
-        module: require.resolve("flow-parser"),
-        find: "(function(){return this}())",
-        replacement: "(globalThis)",
-      },
-    ],
   },
   {
     input: "src/language-js/parse/typescript.js",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

It use `globalThis` now. Since v0.181.0

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
