### PR TITLE
Refactor: use path.getValue() everywhere instead of getNode()

### DIFF
--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -521,7 +521,7 @@ function printComment(commentPath) {
 }
 
 function printInterfaces(path, options, print) {
-  const node = path.getNode();
+  const node = path.getValue();
   const parts = [];
   const { interfaces } = node;
   const printed = path.map(print, "interfaces");

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -22,7 +22,7 @@ function needsParens(path, options) {
   }
 
   const name = path.getName();
-  const node = path.getNode();
+  const node = path.getValue();
 
   // to avoid unexpected `}}` in HTML interpolations
   if (

--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -58,7 +58,7 @@ function printCallArguments(path, options, print) {
   const lastArgIndex = args.length - 1;
   const printedArguments = [];
   iterateCallArgumentsPath(path, (argPath, index) => {
-    const arg = argPath.getNode();
+    const arg = argPath.getValue();
     const parts = [print()];
 
     if (index === lastArgIndex) {

--- a/src/language-js/print/function.js
+++ b/src/language-js/print/function.js
@@ -120,7 +120,7 @@ function printFunction(path, print, options, args) {
 }
 
 function printMethod(path, options, print) {
-  const node = path.getNode();
+  const node = path.getValue();
   const { kind } = node;
   const value = node.value || node;
   const parts = [];
@@ -159,7 +159,7 @@ function printMethod(path, options, print) {
 }
 
 function printMethodInternal(path, options, print) {
-  const node = path.getNode();
+  const node = path.getValue();
   const parametersDoc = printFunctionParameters(path, print, options);
   const returnTypeDoc = printReturnType(path, print, options);
   const shouldGroupParameters = shouldGroupFunctionParameters(

--- a/src/language-js/print/literal.js
+++ b/src/language-js/print/literal.js
@@ -2,7 +2,7 @@ import { printString, printNumber } from "../../common/util.js";
 import { replaceEndOfLine } from "../../document/utils.js";
 
 function printLiteral(path, options /*, print*/) {
-  const node = path.getNode();
+  const node = path.getValue();
 
   switch (node.type) {
     case "RegExpLiteral": // Babel 6 Literal split

--- a/src/language-js/print/module.js
+++ b/src/language-js/print/module.js
@@ -269,7 +269,7 @@ function shouldNotPrintSpecifiers(node, options) {
 }
 
 function printImportAssertions(path, options, print) {
-  const node = path.getNode();
+  const node = path.getValue();
   if (isNonEmptyArray(node.assertions)) {
     return [
       " assert {",
@@ -283,7 +283,7 @@ function printImportAssertions(path, options, print) {
 }
 
 function printModuleSpecifier(path, options, print) {
-  const node = path.getNode();
+  const node = path.getValue();
 
   const { type } = node;
 

--- a/src/language-js/print/property.js
+++ b/src/language-js/print/property.js
@@ -12,7 +12,7 @@ import { printAssignment } from "./assignment.js";
 const needsQuoteProps = new WeakMap();
 
 function printPropertyKey(path, options, print) {
-  const node = path.getNode();
+  const node = path.getValue();
 
   if (node.computed) {
     return ["[", print("key"), "]"];

--- a/src/language-js/print/statement.js
+++ b/src/language-js/print/statement.js
@@ -83,7 +83,7 @@ function getLastStatement(statements) {
 }
 
 function statementNeedsASIProtection(path, options) {
-  const node = path.getNode();
+  const node = path.getValue();
 
   if (node.type !== "ExpressionStatement") {
     return false;

--- a/src/language-js/print/template-literal.js
+++ b/src/language-js/print/template-literal.js
@@ -114,7 +114,7 @@ function printJestEachTemplateLiteral(path, options, print) {
    * ${1} | ${2} | ${3}
    * ${2} | ${1} | ${3}
    */
-  const node = path.getNode();
+  const node = path.getValue();
   const headerNames = node.quasis[0].value.raw.trim().split(/\s*\|\s*/);
   if (
     headerNames.length > 1 ||

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -317,7 +317,7 @@ function isTheOnlyJsxElementInMarkdown(options, path) {
     return false;
   }
 
-  const node = path.getNode();
+  const node = path.getValue();
 
   if (!node.expression || !isJsxNode(node.expression)) {
     return false;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
