### PR TITLE
Add getters to path object

### DIFF
--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -1,6 +1,5 @@
 import assert from "node:assert";
 import getLast from "../utils/get-last.js";
-import { getPenultimate } from "./util.js";
 
 function getNodeHelper(path, count) {
   const stackIndex = getNodeStackIndexHelper(path.stack, count);
@@ -23,7 +22,21 @@ class AstPath {
   }
 
   get key() {
-    return getPenultimate(this.stack) || null;
+    const { stack } = this;
+    const { length } = stack;
+    let key = stack[length - 2];
+    if (typeof key === "number") {
+      assert(Array.isArray(stack[length - 3]));
+      key = stack[length - 4];
+    }
+    return key;
+  }
+
+  get index() {
+    const { stack } = this;
+    const { length } = stack;
+    const index = stack[length - 2];
+    return typeof index === "number" ? index : null;
   }
 
   get node() {
@@ -44,6 +57,14 @@ class AstPath {
 
   get previous() {
     return this.#getSiblingNode(-1);
+  }
+
+  get siblings() {
+    const { stack } = this;
+    const { length } = stack;
+    const array = stack[length - 3];
+    assert(Array.isArray(array));
+    return array;
   }
 
   // The name of the current property is always the penultimate element of

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -1,4 +1,5 @@
 import getLast from "../utils/get-last.js";
+import { getPenultimate } from "./util.js";
 
 function getNodeHelper(path, count) {
   const stackIndex = getNodeStackIndexHelper(path.stack, count);
@@ -18,6 +19,30 @@ function getNodeStackIndexHelper(stack, count) {
 class AstPath {
   constructor(value) {
     this.stack = [value];
+  }
+
+  get name() {
+    return getPenultimate(this.stack) || null;
+  }
+
+  get node() {
+    return getLast(this.stack);
+  }
+
+  get parent() {
+    return this.getNode(1);
+  }
+
+  get grandparent() {
+    return this.getNode(2);
+  }
+
+  get next() {
+    return this.#getSiblingNode(1);
+  }
+
+  get previous() {
+    return this.#getSiblingNode(-1);
   }
 
   // The name of the current property is always the penultimate element of
@@ -46,6 +71,23 @@ class AstPath {
 
   getParentNode(count = 0) {
     return getNodeHelper(this, count + 1);
+  }
+
+  #getSiblingNode(offset) {
+    const { stack } = this;
+    const { length } = stack;
+    if (length < 3) {
+      return null;
+    }
+    const number = stack[length - 2];
+    if (typeof number !== "number") {
+      return null;
+    }
+    const array = stack[length - 3];
+    if (!Array.isArray(array)) {
+      return null;
+    }
+    return array[number + offset];
   }
 
   // Temporarily push properties named by string arguments given after the

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -77,7 +77,7 @@ class AstPath {
   #getSiblingNode(offset) {
     const { stack } = this;
     const { length } = stack;
-    assert(length < 3);
+    assert(length >= 5);
     const index = stack[length - 2];
     assert(typeof index === "number");
     const array = stack[length - 3];

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -1,5 +1,6 @@
 import assert from "node:assert";
 import getLast from "../utils/get-last.js";
+import { getPenultimate } from "./util.js";
 
 class AstPath {
   constructor(value) {
@@ -8,14 +9,11 @@ class AstPath {
 
   get key() {
     const { stack } = this;
-    const { length } = stack;
-    return stack[length - (this.isInArray ? 4 : 2)] ?? null;
+    return stack[stack.length - (this.isInArray ? 4 : 2)] ?? null;
   }
 
   get index() {
-    const { stack } = this;
-    const { length } = stack;
-    return this.isInArray ? stack[length - 2] : null;
+    return this.isInArray ? getPenultimate(this.stack) : null;
   }
 
   get node() {
@@ -41,14 +39,12 @@ class AstPath {
   get siblings() {
     assert(this.isInArray);
     const { stack } = this;
-    const { length } = stack;
-    return stack[length - 3];
+    return stack[stack.length - 3];
   }
 
   get isInArray() {
     const { stack } = this;
-    const { length } = stack;
-    return Array.isArray(stack[length - 3]);
+    return Array.isArray(stack[stack.length - 3]);
   }
 
   get isFirst() {

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -52,6 +52,18 @@ class AstPath {
     return array;
   }
 
+  get isInArray() {
+    return this.index !== null;
+  }
+
+  get isFirst() {
+    return this.index === 0;
+  }
+
+  get isLast() {
+    return this.index === this.siblings.length - 1;
+  }
+
   // The name of the current property is always the penultimate element of
   // this.stack, and always a String.
   getName() {

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -52,7 +52,7 @@ class AstPath {
   }
 
   get isInArray() {
-    return Array.isArray[this.stack.length - 3];
+    return Array.isArray(this.stack.length - 3);
   }
 
   get isFirst() {

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -18,6 +18,7 @@ class AstPath {
   }
 
   get index() {
+    assert(this.isInArray);
     return this.isInArray ? getPenultimate(this.stack) : null;
   }
 
@@ -48,12 +49,10 @@ class AstPath {
   }
 
   get isFirst() {
-    assert(this.isInArray);
     return this.index === 0;
   }
 
   get isLast() {
-    assert(this.isInArray);
     return this.index === this.siblings.length - 1;
   }
 

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -7,9 +7,14 @@ class AstPath {
     this.stack = [value];
   }
 
-  get key() {
+  get isInArray() {
     const { stack } = this;
-    return stack[stack.length - (this.isInArray ? 4 : 2)] ?? null;
+    return Array.isArray(stack[stack.length - 3]);
+  }
+
+  get key() {
+    const { stack, isInArray } = this;
+    return stack[stack.length - (isInArray ? 4 : 2)] ?? null;
   }
 
   get index() {
@@ -28,23 +33,18 @@ class AstPath {
     return this.getNode(2);
   }
 
-  get next() {
-    return this.siblings[this.index + 1];
-  }
-
-  get previous() {
-    return this.siblings[this.index - 1];
-  }
-
   get siblings() {
     assert(this.isInArray);
     const { stack } = this;
     return stack[stack.length - 3];
   }
 
-  get isInArray() {
-    const { stack } = this;
-    return Array.isArray(stack[stack.length - 3]);
+  get next() {
+    return this.siblings[this.index + 1];
+  }
+
+  get previous() {
+    return this.siblings[this.index - 1];
   }
 
   get isFirst() {

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -9,19 +9,13 @@ class AstPath {
   get key() {
     const { stack } = this;
     const { length } = stack;
-    let key = stack[length - 2];
-    if (typeof key === "number") {
-      assert(this.isInArray);
-      key = stack[length - 4];
-    }
-    return key ?? null;
+    return stack[length - (this.isInArray ? 4 : 2)] ?? null;
   }
 
   get index() {
     const { stack } = this;
     const { length } = stack;
-    const index = stack[length - 2];
-    return typeof index === "number" ? index : null;
+    return this.isInArray ? stack[length - 2] : null;
   }
 
   get node() {

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -18,7 +18,6 @@ class AstPath {
   }
 
   get index() {
-    assert(this.isInArray);
     return this.isInArray ? getPenultimate(this.stack) : null;
   }
 
@@ -49,10 +48,12 @@ class AstPath {
   }
 
   get isFirst() {
+    assert(this.isInArray);
     return this.index === 0;
   }
 
   get isLast() {
+    assert(this.isInArray);
     return this.index === this.siblings.length - 1;
   }
 

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -78,11 +78,11 @@ class AstPath {
     const { stack } = this;
     const { length } = stack;
     assert(length < 3);
-    const number = stack[length - 2];
-    assert(typeof number === "number");
+    const index = stack[length - 2];
+    assert(typeof index === "number");
     const array = stack[length - 3];
     assert(Array.isArray(array));
-    return array[number + offset];
+    return array[index + offset];
   }
 
   // Temporarily push properties named by string arguments given after the

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -1,4 +1,3 @@
-import assert from "node:assert";
 import getLast from "../utils/get-last.js";
 import { getPenultimate } from "./util.js";
 
@@ -7,18 +6,13 @@ class AstPath {
     this.stack = [value];
   }
 
-  get isInArray() {
-    const { stack } = this;
-    return Array.isArray(stack[stack.length - 3]);
-  }
-
   get key() {
-    const { stack, isInArray } = this;
-    return stack[stack.length - (isInArray ? 4 : 2)] ?? null;
+    const { stack, siblings } = this;
+    return stack[stack.length - (siblings === null ? 4 : 2)] ?? null;
   }
 
   get index() {
-    return this.isInArray ? getPenultimate(this.stack) : null;
+    return this.siblings === null ? null : getPenultimate(this.stack);
   }
 
   get node() {
@@ -33,10 +27,14 @@ class AstPath {
     return this.getNode(2);
   }
 
+  get isInArray() {
+    return this.siblings !== null;
+  }
+
   get siblings() {
-    assert(this.isInArray);
     const { stack } = this;
-    return stack[stack.length - 3];
+    const maybeArray = stack[stack.length - 3];
+    return Array.isArray(maybeArray) ? maybeArray : null;
   }
 
   get next() {
@@ -48,13 +46,12 @@ class AstPath {
   }
 
   get isFirst() {
-    assert(this.isInArray);
     return this.index === 0;
   }
 
   get isLast() {
-    assert(this.isInArray);
-    return this.index === this.siblings.length - 1;
+    const { siblings, index } = this;
+    return siblings !== null && index === siblings.length - 1;
   }
 
   get isRoot() {

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -52,7 +52,9 @@ class AstPath {
   }
 
   get isInArray() {
-    return Array.isArray(this.stack.length - 3);
+    const { stack } = this;
+    const { length } = stack;
+    return Array.isArray(stack[length - 3]);
   }
 
   get isFirst() {

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -84,8 +84,7 @@ class AstPath {
   #getNodeStackIndex(count) {
     const { stack } = this;
     for (let i = stack.length - 1; i >= 0; i -= 2) {
-      const value = stack[i];
-      if (value && !Array.isArray(value) && --count < 0) {
+      if (!Array.isArray(stack[i]) && --count < 0) {
         return i;
       }
     }

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -14,7 +14,7 @@ class AstPath {
       assert(Array.isArray(stack[length - 3]));
       key = stack[length - 4];
     }
-    return key;
+    return key ?? null;
   }
 
   get index() {
@@ -65,15 +65,15 @@ class AstPath {
   }
 
   // The name of the current property is always the penultimate element of
-  // this.stack, and always a String.
+  // this.stack, and always a string/number/symbol.
   getName() {
     const { stack } = this;
     const { length } = stack;
     if (length > 1) {
       return stack[length - 2];
     }
-    // Since the name is always a string, null is a safe sentinel value to
-    // return if we do not know the name of the (root) value.
+    // Since the name is a string/number/symbol, null is a safe sentinel value
+    // to return if we do not know the name of the (root) value.
     /* istanbul ignore next */
     return null;
   }

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -1,3 +1,4 @@
+import assert from "node:assert";
 import getLast from "../utils/get-last.js";
 import { getPenultimate } from "./util.js";
 
@@ -21,7 +22,7 @@ class AstPath {
     this.stack = [value];
   }
 
-  get name() {
+  get key() {
     return getPenultimate(this.stack) || null;
   }
 
@@ -76,17 +77,11 @@ class AstPath {
   #getSiblingNode(offset) {
     const { stack } = this;
     const { length } = stack;
-    if (length < 3) {
-      return null;
-    }
+    assert(length < 3);
     const number = stack[length - 2];
-    if (typeof number !== "number") {
-      return null;
-    }
+    assert(typeof number === "number");
     const array = stack[length - 3];
-    if (!Array.isArray(array)) {
-      return null;
-    }
+    assert(Array.isArray(array));
     return array[number + offset];
   }
 

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -11,7 +11,7 @@ class AstPath {
     const { length } = stack;
     let key = stack[length - 2];
     if (typeof key === "number") {
-      assert(Array.isArray(stack[length - 3]));
+      assert(this.isInArray);
       key = stack[length - 4];
     }
     return key ?? null;
@@ -45,22 +45,23 @@ class AstPath {
   }
 
   get siblings() {
+    assert(this.isInArray);
     const { stack } = this;
     const { length } = stack;
-    const array = stack[length - 3];
-    assert(Array.isArray(array));
-    return array;
+    return stack[length - 3];
   }
 
   get isInArray() {
-    return this.index !== null;
+    return Array.isArray[this.stack.length - 3];
   }
 
   get isFirst() {
+    assert(this.isInArray);
     return this.index === 0;
   }
 
   get isLast() {
+    assert(this.isInArray);
     return this.index === this.siblings.length - 1;
   }
 

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -57,6 +57,10 @@ class AstPath {
     return this.index === this.siblings.length - 1;
   }
 
+  get isRoot() {
+    return this.stack.length === 1;
+  }
+
   // The name of the current property is always the penultimate element of
   // this.stack, and always a string/number/symbol.
   getName() {

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -889,7 +889,7 @@ function clamp(value, min, max) {
 }
 
 function hasPrettierIgnore(path) {
-  return path.name > 0 && isPrettierIgnore(path.previous) === "next";
+  return path.key > 0 && isPrettierIgnore(path.previous) === "next";
 }
 
 const printer = {

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -154,15 +154,11 @@ function genericPrint(path, options, print) {
       } else {
         const { previous, next } = path;
         const hasPrevOrNextWord = // `1*2*3` is considered emphasis but `1_2_3` is not
-          (previous &&
-            previous.type === "sentence" &&
-            previous.children.length > 0 &&
-            getLast(previous.children).type === "word" &&
+          (previous?.type === "sentence" &&
+            getLast(previous.children)?.type === "word" &&
             !getLast(previous.children).hasTrailingPunctuation) ||
-          (next &&
-            next.type === "sentence" &&
-            next.children.length > 0 &&
-            next.children[0].type === "word" &&
+          (next?.type === "sentence" &&
+            next.children[0]?.type === "word" &&
             !next.children[0].hasLeadingPunctuation);
         style =
           hasPrevOrNextWord || getAncestorNode(path, "emphasis") ? "*" : "_";
@@ -384,7 +380,6 @@ function genericPrint(path, options, print) {
     case "footnoteReference":
       return ["[^", node.identifier, "]"];
     case "footnoteDefinition": {
-      const { next } = path;
       const shouldInlineFootnote =
         node.children.length === 1 &&
         node.children[0].type === "paragraph" &&
@@ -406,7 +401,7 @@ function genericPrint(path, options, print) {
                     index === 0 ? group([softline, print()]) : print(),
                 })
               ),
-              next && next.type === "footnoteDefinition" ? softline : "",
+              path.next?.type === "footnoteDefinition" ? softline : "",
             ]),
       ];
     }
@@ -823,7 +818,7 @@ function shouldPrePrintDoubleHardline(node, data) {
 }
 
 function shouldPrePrintTripleHardline(node, data) {
-  const isPrevNodeList = data.prevNode && data.prevNode.type === "list";
+  const isPrevNodeList = data.prevNode?.type === "list";
   const isIndentedCode = node.type === "code" && node.isIndented;
 
   return isPrevNodeList && isIndentedCode;

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -889,7 +889,7 @@ function clamp(value, min, max) {
 }
 
 function hasPrettierIgnore(path) {
-  return path.key > 0 && isPrettierIgnore(path.previous) === "next";
+  return path.index > 0 && isPrettierIgnore(path.previous) === "next";
 }
 
 const printer = {

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -55,7 +55,7 @@ const SIBLING_NODE_TYPES = new Set([
 ]);
 
 function genericPrint(path, options, print) {
-  const node = path.getValue();
+  const { node } = path;
 
   if (shouldRemainTheSameContent(path)) {
     return splitText(
@@ -137,13 +137,11 @@ function genericPrint(path, options, print) {
       return escapedValue;
     }
     case "whitespace": {
-      const parentNode = path.getParentNode();
-      const index = parentNode.children.indexOf(node);
-      const nextNode = parentNode.children[index + 1];
+      const { next } = path;
 
       const proseWrap =
         // leading char that may cause different syntax
-        nextNode && /^>|^(?:[*+-]|#{1,6}|\d+[).])$/.test(nextNode.value)
+        next && /^>|^(?:[*+-]|#{1,6}|\d+[).])$/.test(next.value)
           ? "never"
           : options.proseWrap;
 
@@ -154,21 +152,18 @@ function genericPrint(path, options, print) {
       if (isAutolink(node.children[0])) {
         style = options.originalText[node.position.start.offset];
       } else {
-        const parentNode = path.getParentNode();
-        const index = parentNode.children.indexOf(node);
-        const prevNode = parentNode.children[index - 1];
-        const nextNode = parentNode.children[index + 1];
+        const { previous, next } = path;
         const hasPrevOrNextWord = // `1*2*3` is considered emphasis but `1_2_3` is not
-          (prevNode &&
-            prevNode.type === "sentence" &&
-            prevNode.children.length > 0 &&
-            getLast(prevNode.children).type === "word" &&
-            !getLast(prevNode.children).hasTrailingPunctuation) ||
-          (nextNode &&
-            nextNode.type === "sentence" &&
-            nextNode.children.length > 0 &&
-            nextNode.children[0].type === "word" &&
-            !nextNode.children[0].hasLeadingPunctuation);
+          (previous &&
+            previous.type === "sentence" &&
+            previous.children.length > 0 &&
+            getLast(previous.children).type === "word" &&
+            !getLast(previous.children).hasTrailingPunctuation) ||
+          (next &&
+            next.type === "sentence" &&
+            next.children.length > 0 &&
+            next.children[0].type === "word" &&
+            !next.children[0].hasLeadingPunctuation);
         style =
           hasPrevOrNextWord || getAncestorNode(path, "emphasis") ? "*" : "_";
       }
@@ -269,9 +264,9 @@ function genericPrint(path, options, print) {
       ];
     }
     case "html": {
-      const parentNode = path.getParentNode();
+      const { parent } = path;
       const value =
-        parentNode.type === "root" && getLast(parentNode.children) === node
+        parent.type === "root" && getLast(parent.children) === node
           ? node.value.trimEnd()
           : node.value;
       const isHtmlComment = /^<!--.*-->$/s.test(value);
@@ -283,10 +278,7 @@ function genericPrint(path, options, print) {
       );
     }
     case "list": {
-      const nthSiblingIndex = getNthListSiblingIndex(
-        node,
-        path.getParentNode()
-      );
+      const nthSiblingIndex = getNthListSiblingIndex(node, path.parent);
 
       const isGitDiffFriendlyOrderedList = hasGitDiffFriendlyOrderedList(
         node,
@@ -296,7 +288,7 @@ function genericPrint(path, options, print) {
       return printChildren(path, options, print, {
         processor: (childPath, index) => {
           const prefix = getPrefix();
-          const childNode = childPath.getValue();
+          const childNode = childPath.node;
 
           if (
             childNode.children.length === 2 &&
@@ -392,7 +384,7 @@ function genericPrint(path, options, print) {
     case "footnoteReference":
       return ["[^", node.identifier, "]"];
     case "footnoteDefinition": {
-      const nextNode = path.getParentNode().children[path.getName() + 1];
+      const { next } = path;
       const shouldInlineFootnote =
         node.children.length === 1 &&
         node.children[0].type === "paragraph" &&
@@ -414,9 +406,7 @@ function genericPrint(path, options, print) {
                     index === 0 ? group([softline, print()]) : print(),
                 })
               ),
-              nextNode && nextNode.type === "footnoteDefinition"
-                ? softline
-                : "",
+              next && next.type === "footnoteDefinition" ? softline : "",
             ]),
       ];
     }
@@ -464,13 +454,13 @@ function genericPrint(path, options, print) {
 }
 
 function printListItem(path, options, print, listPrefix) {
-  const node = path.getValue();
+  const { node } = path;
   const prefix = node.checked === null ? "" : node.checked ? "[x] " : "[ ] ";
   return [
     prefix,
     printChildren(path, options, print, {
       processor: (childPath, index) => {
-        if (index === 0 && childPath.getValue().type !== "list") {
+        if (index === 0 && childPath.node.type !== "list") {
           return align(" ".repeat(prefix.length), print());
         }
 
@@ -560,7 +550,7 @@ function printLine(path, value, options) {
 }
 
 function printTable(path, options, print) {
-  const node = path.getValue();
+  const { node } = path;
 
   const columnMaxWidths = [];
   // { [rowIndex: number]: { [columnIndex: number]: {text: string, width: number} } }
@@ -644,7 +634,7 @@ function printRoot(path, options, print) {
   /** @type {IgnorePosition | null} */
   let ignoreStart = null;
 
-  const { children } = path.getValue();
+  const { children } = path.node;
   for (const [index, childNode] of children.entries()) {
     switch (isPrettierIgnore(childNode)) {
       case "start":
@@ -702,13 +692,13 @@ function printChildren(path, options, print, events = {}) {
   const { postprocessor } = events;
   const processor = events.processor || (() => print());
 
-  const node = path.getValue();
+  const { node } = path;
   const parts = [];
 
   let lastChildNode;
 
   path.each((childPath, index) => {
-    const childNode = childPath.getValue();
+    const childNode = childPath.node;
 
     const result = processor(childPath, index);
     if (result !== false) {
@@ -904,14 +894,7 @@ function clamp(value, min, max) {
 }
 
 function hasPrettierIgnore(path) {
-  const index = Number(path.getName());
-
-  if (index === 0) {
-    return false;
-  }
-
-  const prevNode = path.getParentNode().children[index - 1];
-  return isPrettierIgnore(prevNode) === "next";
+  return path.name > 0 && isPrettierIgnore(path.previous) === "next";
 }
 
 const printer = {


### PR DESCRIPTION
## Description

This PR adds getters to the path object that can be used, in particular, for convenient destructuring. See https://github.com/prettier/prettier/pull/10565#issuecomment-1231520272. Also, this PR uses the added getters in the Markdown printer.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
