### PR TITLE
Move comment-related printer methods to separate directory

### DIFF
--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -9,32 +9,25 @@ import {
   addDanglingComment,
   getNextNonSpaceNonCommentCharacterIndex,
   isNonEmptyArray,
-} from "../common/util.js";
+} from "../../common/util.js";
 import {
   getFunctionParameters,
   isPrettierIgnoreComment,
-  isJsxNode,
-  hasFlowShorthandAnnotationComment,
-  hasFlowAnnotationComment,
-  hasIgnoreComment,
   isCallLikeExpression,
   getCallArguments,
   isCallExpression,
   isMemberExpression,
   isObjectProperty,
   isLineComment,
-  getComments,
-  CommentCheckFlags,
   markerForIfWithoutBlockAndSameLineComment,
-} from "./utils/index.js";
-import { locStart, locEnd } from "./loc.js";
-import isBlockComment from "./utils/is-block-comment.js";
-import isTypeCastComment from "./utils/is-type-cast-comment.js";
+} from "../utils/index.js";
+import { locStart, locEnd } from "../loc.js";
+import isBlockComment from "../utils/is-block-comment.js";
+import isTypeCastComment from "../utils/is-type-cast-comment.js";
 
 /**
- * @typedef {import("./types/estree").Node} Node
- * @typedef {import("./types/estree").Comment} Comment
- * @typedef {import("../common/ast-path.js").default} AstPath
+ * @typedef {import("../types/estree").Node} Node
+ * @typedef {import("../types/estree").Comment} Comment
  *
  * @typedef {Object} CommentContext
  * @property {Comment} comment
@@ -918,72 +911,12 @@ function isRealFunctionLikeNode(node) {
   );
 }
 
-/**
- * @param {any} node
- * @returns {Node[] | void}
- */
-function getCommentChildNodes(node, options) {
-  // Prevent attaching comments to FunctionExpression in this case:
-  //     class Foo {
-  //       bar() // comment
-  //       {
-  //         baz();
-  //       }
-  //     }
-  if (
-    (options.parser === "typescript" ||
-      options.parser === "flow" ||
-      options.parser === "acorn" ||
-      options.parser === "espree" ||
-      options.parser === "meriyah" ||
-      options.parser === "__babel_estree") &&
-    node.type === "MethodDefinition" &&
-    node.value &&
-    node.value.type === "FunctionExpression" &&
-    getFunctionParameters(node.value).length === 0 &&
-    !node.value.returnType &&
-    !isNonEmptyArray(node.value.typeParameters) &&
-    node.value.body
-  ) {
-    return [...(node.decorators || []), node.key, node.value.body];
-  }
-}
-
-/**
- * @param {AstPath} path
- * @returns {boolean}
- */
-function willPrintOwnComments(path /*, options */) {
-  const { node } = path;
-  const parent = path.getParentNode();
-
-  const hasFlowAnnotations = (node) =>
-    hasFlowAnnotationComment(getComments(node, CommentCheckFlags.Leading)) ||
-    hasFlowAnnotationComment(getComments(node, CommentCheckFlags.Trailing));
-
-  return (
-    ((node &&
-      (isJsxNode(node) ||
-        hasFlowShorthandAnnotationComment(node) ||
-        (isCallExpression(parent) && hasFlowAnnotations(node)))) ||
-      (parent &&
-        (parent.type === "JSXSpreadAttribute" ||
-          parent.type === "JSXSpreadChild" ||
-          parent.type === "UnionTypeAnnotation" ||
-          parent.type === "TSUnionType" ||
-          ((parent.type === "ClassDeclaration" ||
-            parent.type === "ClassExpression") &&
-            parent.superClass === node)))) &&
-    (!hasIgnoreComment(path) ||
-      parent.type === "UnionTypeAnnotation" ||
-      parent.type === "TSUnionType")
-  );
-}
+// TODO: Make this default behavior
+const avoidAstMutation = true;
 
 export {
-  handleOwnLineComment,
-  handleEndOfLineComment,
-  handleRemainingComment,
-  getCommentChildNodes,
-  willPrintOwnComments,
+  handleOwnLineComment as ownLine,
+  handleEndOfLineComment as endOfLine,
+  handleRemainingComment as remaining,
+  avoidAstMutation,
 };

--- a/src/language-js/comments/printer-methods.js
+++ b/src/language-js/comments/printer-methods.js
@@ -1,0 +1,105 @@
+import isNonEmptyArray from "../../utils/is-non-empty-array.js";
+import { hasJsxIgnoreComment } from "../print/jsx.js";
+import {
+  CommentCheckFlags,
+  getComments,
+  getFunctionParameters,
+  hasFlowAnnotationComment,
+  hasFlowShorthandAnnotationComment,
+  hasNodeIgnoreComment,
+  isCallExpression,
+  isJsxNode,
+  isLineComment,
+} from "../utils/index.js";
+import isBlockComment from "../utils/is-block-comment.js";
+
+/**
+ * @typedef {import("../types/estree").Node} Node
+ * @typedef {import("../../common/ast-path.js").default} AstPath
+ */
+
+function canAttachComment(node) {
+  return (
+    node.type &&
+    !isBlockComment(node) &&
+    !isLineComment(node) &&
+    node.type !== "EmptyStatement" &&
+    node.type !== "TemplateElement" &&
+    node.type !== "Import" &&
+    // `babel-ts` doesn't have similar node for `class Foo { bar() /* bat */; }`
+    node.type !== "TSEmptyBodyFunctionExpression"
+  );
+}
+
+/**
+ * @param {any} node
+ * @returns {Node[] | void}
+ */
+function getCommentChildNodes(node, options) {
+  // Prevent attaching comments to FunctionExpression in this case:
+  //     class Foo {
+  //       bar() // comment
+  //       {
+  //         baz();
+  //       }
+  //     }
+  if (
+    (options.parser === "typescript" ||
+      options.parser === "flow" ||
+      options.parser === "acorn" ||
+      options.parser === "espree" ||
+      options.parser === "meriyah" ||
+      options.parser === "__babel_estree") &&
+    node.type === "MethodDefinition" &&
+    node.value &&
+    node.value.type === "FunctionExpression" &&
+    getFunctionParameters(node.value).length === 0 &&
+    !node.value.returnType &&
+    !isNonEmptyArray(node.value.typeParameters) &&
+    node.value.body
+  ) {
+    return [...(node.decorators || []), node.key, node.value.body];
+  }
+}
+
+function hasPrettierIgnore(path) {
+  return hasNodeIgnoreComment(path.node) || hasJsxIgnoreComment(path);
+}
+
+/**
+ * @param {AstPath} path
+ * @returns {boolean}
+ */
+function willPrintOwnComments({ node, parent }) {
+  const hasFlowAnnotations = (node) =>
+    hasFlowAnnotationComment(getComments(node, CommentCheckFlags.Leading)) ||
+    hasFlowAnnotationComment(getComments(node, CommentCheckFlags.Trailing));
+
+  return (
+    ((node &&
+      (isJsxNode(node) ||
+        hasFlowShorthandAnnotationComment(node) ||
+        (isCallExpression(parent) && hasFlowAnnotations(node)))) ||
+      (parent &&
+        (parent.type === "JSXSpreadAttribute" ||
+          parent.type === "JSXSpreadChild" ||
+          parent.type === "UnionTypeAnnotation" ||
+          parent.type === "TSUnionType" ||
+          ((parent.type === "ClassDeclaration" ||
+            parent.type === "ClassExpression") &&
+            parent.superClass === node)))) &&
+    (!hasNodeIgnoreComment(node) ||
+      parent.type === "UnionTypeAnnotation" ||
+      parent.type === "TSUnionType")
+  );
+}
+
+export * as handleComments from "./handle-comments.js";
+export { printComment } from "../print/comment.js";
+export {
+  canAttachComment,
+  getCommentChildNodes,
+  hasPrettierIgnore,
+  isBlockComment,
+  willPrintOwnComments,
+};

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -27,7 +27,7 @@ import {
   hasNodeIgnoreComment,
 } from "../utils/index.js";
 import pathNeedsParens from "../needs-parens.js";
-import { willPrintOwnComments } from "../comments.js";
+import { willPrintOwnComments } from "../comments/printer-methods.js";
 
 const isEmptyStringOrAnyLine = (doc) =>
   doc === "" || doc === line || doc === hardline || doc === softline;
@@ -833,14 +833,13 @@ function isJsxWhitespaceExpression(node) {
  * @returns {boolean}
  */
 function hasJsxIgnoreComment(path) {
-  const { node } = path;
-  const parent = path.getParentNode();
+  const { node, parent } = path;
   if (!parent || !node || !isJsxNode(node) || !isJsxNode(parent)) {
     return false;
   }
 
   // Lookup the previous sibling, ignoring any empty JSXText elements
-  const index = parent.children.indexOf(node);
+  const { index } = path;
   let prevSibling = null;
   for (let i = index; i > 0; i--) {
     const candidate = parent.children[i - 1];
@@ -852,8 +851,7 @@ function hasJsxIgnoreComment(path) {
   }
 
   return (
-    prevSibling &&
-    prevSibling.type === "JSXExpressionContainer" &&
+    prevSibling?.type === "JSXExpressionContainer" &&
     prevSibling.expression.type === "JSXEmptyExpression" &&
     hasNodeIgnoreComment(prevSibling.expression)
   );

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -16,7 +16,7 @@ import UnexpectedNodeError from "../utils/unexpected-node-error.js";
 import embed from "./embed.js";
 import clean from "./clean.js";
 import { insertPragma } from "./pragma.js";
-import * as handleComments from "./comments.js";
+import * as commentsRelatedPrinterMethods from "./comments/printer-methods.js";
 import pathNeedsParens from "./needs-parens.js";
 import preprocess from "./print-preprocess.js";
 import {
@@ -24,11 +24,9 @@ import {
   hasComment,
   CommentCheckFlags,
   isTheOnlyJsxElementInMarkdown,
-  isLineComment,
   isNextLineEmpty,
   needsHardlineAfterDanglingComment,
   rawText,
-  hasIgnoreComment,
   isCallExpression,
   isMemberExpression,
   markerForIfWithoutBlockAndSameLineComment,
@@ -42,7 +40,7 @@ import {
   isVueEventBindingExpression,
 } from "./print/html-binding.js";
 import { printAngular } from "./print/angular.js";
-import { printJsx, hasJsxIgnoreComment } from "./print/jsx.js";
+import { printJsx } from "./print/jsx.js";
 import { printFlow } from "./print/flow.js";
 import { printTypescript } from "./print/typescript.js";
 import {
@@ -85,7 +83,6 @@ import { printBinaryishExpression } from "./print/binaryish.js";
 import { printSwitchCaseConsequent } from "./print/statement.js";
 import { printMemberExpression } from "./print/member.js";
 import { printBlock, printBlockBody } from "./print/block.js";
-import { printComment } from "./print/comment.js";
 import { printLiteral } from "./print/literal.js";
 import { printDecorators } from "./print/decorators.js";
 
@@ -815,41 +812,14 @@ function printDirective(node, options) {
   return enclosingQuote + rawContent + enclosingQuote;
 }
 
-function canAttachComment(node) {
-  return (
-    node.type &&
-    !isBlockComment(node) &&
-    !isLineComment(node) &&
-    node.type !== "EmptyStatement" &&
-    node.type !== "TemplateElement" &&
-    node.type !== "Import" &&
-    // `babel-ts` don't have similar node for `class Foo { bar() /* bat */; }`
-    node.type !== "TSEmptyBodyFunctionExpression"
-  );
-}
-
 const printer = {
   preprocess,
   print: genericPrint,
   embed,
   insertPragma,
   massageAstNode: clean,
-  hasPrettierIgnore(path) {
-    return hasIgnoreComment(path) || hasJsxIgnoreComment(path);
-  },
-  willPrintOwnComments: handleComments.willPrintOwnComments,
-  canAttachComment,
-  printComment,
-  isBlockComment,
-  handleComments: {
-    // TODO: Make this as default behavior
-    avoidAstMutation: true,
-    ownLine: handleComments.handleOwnLineComment,
-    endOfLine: handleComments.handleEndOfLineComment,
-    remaining: handleComments.handleRemainingComment,
-  },
-  getCommentChildNodes: handleComments.getCommentChildNodes,
   getVisitorKeys,
+  ...commentsRelatedPrinterMethods,
 };
 
 export default printer;

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -1210,11 +1210,6 @@ function hasNodeIgnoreComment(node) {
   );
 }
 
-function hasIgnoreComment(path) {
-  const { node } = path;
-  return hasNodeIgnoreComment(node);
-}
-
 const CommentCheckFlags = {
   /** Check comment is a leading comment */
   Leading: 1 << 1,
@@ -1334,7 +1329,6 @@ export {
   hasLeadingOwnLineComment,
   hasNakedLeftSide,
   hasNode,
-  hasIgnoreComment,
   hasNodeIgnoreComment,
   identity,
   isBinaryish,


### PR DESCRIPTION
## Description

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
