### PR TITLE
SCSS: Fix formatting string value that includes escape `\`

### DIFF
--- a/changelog_unreleased/scss/13487.md
+++ b/changelog_unreleased/scss/13487.md
@@ -1,0 +1,16 @@
+#### Fix formatting string value that includes escape `\` (#13487 by @sosukesuzuki)
+
+<!-- prettier-ignore -->
+```scss
+/* Input */
+$description: "Lorem ipsum dolor sit \"amet\", consectetur adipiscing elit, " +
+  "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+
+/* Prettier stable */
+$description: 'Lorem ipsum dolor sit "amet", consectetur adipiscing elit, '+ "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+
+/* Prettier main */
+$description: 'Lorem ipsum dolor sit "amet", consectetur adipiscing elit, ' +
+  "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+
+```

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -590,7 +590,6 @@ function genericPrint(path, options, print) {
           insideSCSSInterpolationInString &&
           iNextNode.type === "value-string" &&
           iNextNode.value.endsWith("}");
-
         if (
           isStartSCSSInterpolationInString ||
           isEndingSCSSInterpolationInString
@@ -621,6 +620,7 @@ function genericPrint(path, options, print) {
 
         // Ignore escape `\`
         if (
+          iNode.type !== "value-string" &&
           iNode.value &&
           iNode.value.includes("\\") &&
           iNextNode &&

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -590,6 +590,7 @@ function genericPrint(path, options, print) {
           insideSCSSInterpolationInString &&
           iNextNode.type === "value-string" &&
           iNextNode.value.endsWith("}");
+
         if (
           isStartSCSSInterpolationInString ||
           isEndingSCSSInterpolationInString

--- a/tests/format/scss/quotes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/scss/quotes/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`escape-in-string.scss - {"singleQuote":true} format 1`] = `
+====================================options=====================================
+parsers: ["scss"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+$description: "Lorem ipsum dolor sit \\"amet\\", consectetur adipiscing elit, " +
+  "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+
+=====================================output=====================================
+$description: 'Lorem ipsum dolor sit "amet", consectetur adipiscing elit, ' +
+  'sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.';
+
+================================================================================
+`;
+
+exports[`escape-in-string.scss format 1`] = `
+====================================options=====================================
+parsers: ["scss"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+$description: "Lorem ipsum dolor sit \\"amet\\", consectetur adipiscing elit, " +
+  "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+
+=====================================output=====================================
+$description: 'Lorem ipsum dolor sit "amet", consectetur adipiscing elit, ' +
+  "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";
+
+================================================================================
+`;
+
 exports[`forward-with.scss - {"singleQuote":true} format 1`] = `
 ====================================options=====================================
 parsers: ["scss"]

--- a/tests/format/scss/quotes/escape-in-string.scss
+++ b/tests/format/scss/quotes/escape-in-string.scss
@@ -1,0 +1,2 @@
+$description: "Lorem ipsum dolor sit \"amet\", consectetur adipiscing elit, " +
+  "sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.";


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #12889

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
