### PR TITLE
Use `Object.hasOwn` instead of `Reflect.has` in build script

### DIFF
--- a/scripts/build/esbuild-plugins/replace-module.mjs
+++ b/scripts/build/esbuild-plugins/replace-module.mjs
@@ -37,8 +37,8 @@ function processReplacements(replacements) {
     }
 
     if (
-      Reflect.has(replacement, "external") ||
-      Reflect.has(replacement, "path")
+      Object.hasOwn(replacement, "external") ||
+      Object.hasOwn(replacement, "path")
     ) {
       if (module === "*") {
         throw new Error("Can not replace all modules with the same path.");
@@ -48,7 +48,7 @@ function processReplacements(replacements) {
 
       onResolveReplacements.set(
         module,
-        Reflect.has(replacement, "external")
+        Object.hasOwn(replacement, "external")
           ? { external: true, path: replacement.external }
           : { path: replacement.path }
       );
@@ -56,7 +56,7 @@ function processReplacements(replacements) {
       continue;
     }
 
-    if (Reflect.has(replacement, "text")) {
+    if (Object.hasOwn(replacement, "text")) {
       if (module === "*") {
         throw new Error("Can not replace all modules with the same content.");
       }
@@ -81,7 +81,7 @@ function processReplacements(replacements) {
 
     const processFunctions = onLoadProcessors.get(module);
 
-    if (Reflect.has(replacement, "process")) {
+    if (Object.hasOwn(replacement, "process")) {
       const { process } = replacement;
       if (typeof process !== "function") {
         throw new TypeError("'process' option should be a function.");
@@ -92,8 +92,8 @@ function processReplacements(replacements) {
     }
 
     if (
-      Reflect.has(replacement, "find") &&
-      Reflect.has(replacement, "replacement")
+      Object.hasOwn(replacement, "find") &&
+      Object.hasOwn(replacement, "replacement")
     ) {
       processFunctions.push((text) =>
         text.replaceAll(replacement.find, replacement.replacement)


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

If we don't need to consider about prototypes here, we can use `Object.hasOwn` instead of `Reflect.has`. What do you think? @fisker 

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
