### PR TITLE
[handlebars] correctly format custom "else if" blocks

### DIFF
--- a/changelog_unreleased/handlebars/13507.md
+++ b/changelog_unreleased/handlebars/13507.md
@@ -1,0 +1,33 @@
+#### [handlebars] correctly format custom "else if" blocks (#13507 by @jamescdavis)
+
+A template transform can be used to create custom block keywords that behave similar to `if`. This updates printer-glimmer to correctly recognize and format the "else if" case when "if" is a custom keyword.
+
+<!-- prettier-ignore -->
+```hbs
+{{! Input }}
+{{#when isAtWork}}
+  Ship that code!
+{{else when isReading}}
+  You can finish War and Peace eventually...
+{{else}}
+  Go to bed!
+{{/when}}
+
+{{! Prettier stable }}
+{{#when isAtWork}}
+  Ship that code!
+{{else}}{{#when isReading}}
+    You can finish War and Peace eventually...
+  {{else}}
+    Go to bed!
+  {{/when}}{{/when}}
+
+{{! Prettier main }}
+{{#when isAtWork}}
+  Ship that code!
+{{else when isReading}}
+  You can finish War and Peace eventually...
+{{else}}
+  Go to bed!
+{{/when}}
+```

--- a/changelog_unreleased/handlebars/13507.md
+++ b/changelog_unreleased/handlebars/13507.md
@@ -1,4 +1,4 @@
-#### [handlebars] correctly format custom "else if" blocks (#13507 by @jamescdavis)
+#### Correctly format custom "else if" blocks (#13507 by @jamescdavis)
 
 A template transform can be used to create custom block keywords that behave similar to `if`. This updates printer-glimmer to correctly recognize and format the "else if" case when "if" is a custom keyword.
 

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -96,16 +96,16 @@ function print(path, options, print) {
     case "BlockStatement": {
       const pp = path.getParentNode(1);
 
-      const isElseIf =
+      const isElseIfish =
         pp &&
         pp.inverse &&
         pp.inverse.body.length === 1 &&
         pp.inverse.body[0] === node &&
-        pp.inverse.body[0].path.parts[0] === "if";
+        pp.inverse.body[0].path.parts[0] === pp.path.parts[0];
 
-      if (isElseIf) {
+      if (isElseIfish) {
         return [
-          printElseIfBlock(path, print),
+          printElseIfishBlock(path, print, pp.inverse.body[0].path.parts[0]),
           printProgram(path, print, options),
           printInverse(path, print, options),
         ];
@@ -562,12 +562,14 @@ function printElseBlock(node, options) {
   ];
 }
 
-function printElseIfBlock(path, print) {
+function printElseIfishBlock(path, print, ifish) {
   const parentNode = path.getParentNode(1);
 
   return [
     printInverseBlockOpeningMustache(parentNode),
-    "else if ",
+    "else ",
+    ifish,
+    " ",
     printParams(path, print),
     printInverseBlockClosingMustache(parentNode),
   ];
@@ -603,12 +605,12 @@ function blockStatementHasOnlyWhitespaceInProgram(node) {
   );
 }
 
-function blockStatementHasElseIf(node) {
+function blockStatementHasElseIfish(node) {
   return (
     blockStatementHasElse(node) &&
     node.inverse.body.length === 1 &&
     isNodeOfSomeType(node.inverse.body[0], ["BlockStatement"]) &&
-    node.inverse.body[0].path.parts[0] === "if"
+    node.inverse.body[0].path.parts[0] === node.path.parts[0]
   );
 }
 
@@ -641,7 +643,7 @@ function printInverse(path, print, options) {
       ? [hardline, inverse]
       : inverse;
 
-  if (blockStatementHasElseIf(node)) {
+  if (blockStatementHasElseIfish(node)) {
     return printed;
   }
 

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -96,16 +96,16 @@ function print(path, options, print) {
     case "BlockStatement": {
       const pp = path.getParentNode(1);
 
-      const isElseIfish =
+      const isElseIfLike =
         pp &&
         pp.inverse &&
         pp.inverse.body.length === 1 &&
         pp.inverse.body[0] === node &&
         pp.inverse.body[0].path.parts[0] === pp.path.parts[0];
 
-      if (isElseIfish) {
+      if (isElseIfLike) {
         return [
-          printElseIfishBlock(path, print, pp.inverse.body[0].path.parts[0]),
+          printElseIfLikeBlock(path, print, pp.inverse.body[0].path.parts[0]),
           printProgram(path, print, options),
           printInverse(path, print, options),
         ];
@@ -562,13 +562,13 @@ function printElseBlock(node, options) {
   ];
 }
 
-function printElseIfishBlock(path, print, ifish) {
+function printElseIfLikeBlock(path, print, ifLikeKeyword) {
   const parentNode = path.getParentNode(1);
 
   return [
     printInverseBlockOpeningMustache(parentNode),
     "else ",
-    ifish,
+    ifLikeKeyword,
     " ",
     printParams(path, print),
     printInverseBlockClosingMustache(parentNode),
@@ -605,7 +605,7 @@ function blockStatementHasOnlyWhitespaceInProgram(node) {
   );
 }
 
-function blockStatementHasElseIfish(node) {
+function blockStatementHasElseIfLike(node) {
   return (
     blockStatementHasElse(node) &&
     node.inverse.body.length === 1 &&
@@ -643,7 +643,7 @@ function printInverse(path, print, options) {
       ? [hardline, inverse]
       : inverse;
 
-  if (blockStatementHasElseIfish(node)) {
+  if (blockStatementHasElseIfLike(node)) {
     return printed;
   }
 

--- a/tests/format/handlebars/block-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/handlebars/block-statement/__snapshots__/jsfmt.spec.js.snap
@@ -159,6 +159,231 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`custom-else.hbs format 1`] = `
+====================================options=====================================
+parsers: ["glimmer"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<h1>
+{{#when isAtWork}}
+  Ship that code!
+{{else when isReading}}
+  You can finish War and Peace eventually...
+{{else}}
+  Go to bed!
+{{/when}}
+</h1>
+
+<h2>
+{{#when a}}
+  A
+{{else}}
+  B
+{{/when}}
+</h2>
+
+{{#when a}}
+  b
+{{else when c}}
+  d
+{{else}}
+  e
+{{/when}}
+
+{{#when a}}
+  b
+{{else when c}}
+  d
+{{else}}
+  hello
+  {{#when f}}
+    g
+  {{/when}}
+  e
+{{/when}}
+
+{{#when a}}
+  b
+{{else when c}}
+  d
+{{else when e}}
+  f
+{{else when g}}
+  h
+{{else}}
+  j
+{{/when}}
+
+<div>
+  {{#when a}}
+    b
+  {{else when c}}
+    d
+  {{else}}
+    e
+  {{/when}}
+</div>
+
+<div>
+  <div>
+    {{#when a}}
+      b
+    {{else when c}}
+      d
+    {{else}}
+      e
+    {{/when}}
+  </div>
+</div>
+
+{{#when a}}
+  b
+{{else}}
+  {{#each c as |d|}}
+    e
+  {{/each}}
+{{/when}}
+
+{{#when a}}
+  {{#when b}}
+    ab
+  {{else when c}}
+    ac
+  {{/when}}
+{{/when}}
+
+{{#when a}}
+  a
+  <div>b</div>
+  c
+{{else}}
+  {{#when c}}
+    a
+    b
+    <div>c</div>
+  {{/when}}
+  <div>a</div>
+  b
+  c
+{{/when}}
+
+{{~#when someCondition~}}
+  One thing
+{{~else when anotherCondition~}}
+  Another thing
+{{~/when~}}
+
+=====================================output=====================================
+<h1>
+  {{#when isAtWork}}
+    Ship that code!
+  {{else when isReading}}
+    You can finish War and Peace eventually...
+  {{else}}
+    Go to bed!
+  {{/when}}
+</h1>
+
+<h2>
+  {{#when a}}
+    A
+  {{else}}
+    B
+  {{/when}}
+</h2>
+
+{{#when a}}
+  b
+{{else when c}}
+  d
+{{else}}
+  e
+{{/when}}
+
+{{#when a}}
+  b
+{{else when c}}
+  d
+{{else}}
+  hello
+  {{#when f}}
+    g
+  {{/when}}
+  e
+{{/when}}
+
+{{#when a}}
+  b
+{{else when c}}
+  d
+{{else when e}}
+  f
+{{else when g}}
+  h
+{{else}}
+  j
+{{/when}}
+
+<div>
+  {{#when a}}
+    b
+  {{else when c}}
+    d
+  {{else}}
+    e
+  {{/when}}
+</div>
+
+<div>
+  <div>
+    {{#when a}}
+      b
+    {{else when c}}
+      d
+    {{else}}
+      e
+    {{/when}}
+  </div>
+</div>
+
+{{#when a}}
+  b
+{{else}}
+  {{#each c as |d|}}
+    e
+  {{/each}}
+{{/when}}
+
+{{#when a}}
+  {{#when b}}
+    ab
+  {{else when c}}
+    ac
+  {{/when}}
+{{/when}}
+
+{{#when a}}
+  a
+  <div>b</div>
+  c
+{{else}}
+  {{#when c}}
+    a b
+    <div>c</div>
+  {{/when}}
+  <div>a</div>
+  b c
+{{/when}}
+
+{{~#when someCondition~}}
+  One thing
+{{~else when anotherCondition~}}
+  Another thing
+{{~/when~}}
+================================================================================
+`;
+
 exports[`each.hbs format 1`] = `
 ====================================options=====================================
 parsers: ["glimmer"]

--- a/tests/format/handlebars/block-statement/custom-else.hbs
+++ b/tests/format/handlebars/block-statement/custom-else.hbs
@@ -1,0 +1,108 @@
+<h1>
+{{#when isAtWork}}
+  Ship that code!
+{{else when isReading}}
+  You can finish War and Peace eventually...
+{{else}}
+  Go to bed!
+{{/when}}
+</h1>
+
+<h2>
+{{#when a}}
+  A
+{{else}}
+  B
+{{/when}}
+</h2>
+
+{{#when a}}
+  b
+{{else when c}}
+  d
+{{else}}
+  e
+{{/when}}
+
+{{#when a}}
+  b
+{{else when c}}
+  d
+{{else}}
+  hello
+  {{#when f}}
+    g
+  {{/when}}
+  e
+{{/when}}
+
+{{#when a}}
+  b
+{{else when c}}
+  d
+{{else when e}}
+  f
+{{else when g}}
+  h
+{{else}}
+  j
+{{/when}}
+
+<div>
+  {{#when a}}
+    b
+  {{else when c}}
+    d
+  {{else}}
+    e
+  {{/when}}
+</div>
+
+<div>
+  <div>
+    {{#when a}}
+      b
+    {{else when c}}
+      d
+    {{else}}
+      e
+    {{/when}}
+  </div>
+</div>
+
+{{#when a}}
+  b
+{{else}}
+  {{#each c as |d|}}
+    e
+  {{/each}}
+{{/when}}
+
+{{#when a}}
+  {{#when b}}
+    ab
+  {{else when c}}
+    ac
+  {{/when}}
+{{/when}}
+
+{{#when a}}
+  a
+  <div>b</div>
+  c
+{{else}}
+  {{#when c}}
+    a
+    b
+    <div>c</div>
+  {{/when}}
+  <div>a</div>
+  b
+  c
+{{/when}}
+
+{{~#when someCondition~}}
+  One thing
+{{~else when anotherCondition~}}
+  Another thing
+{{~/when~}}


### PR DESCRIPTION
## Description

A template transform can be used to create custom block keywords that behave similar to `if`. This updates printer-glimmer to correctly recognize and format the "else if" case when "if" is a custom keyword.

```hbs
{{! Input }}
{{#when isAtWork}}
  Ship that code!
{{else when isReading}}
  You can finish War and Peace eventually...
{{else}}
  Go to bed!
{{/when}}

{{! Prettier stable }}
{{#when isAtWork}}
  Ship that code!
{{else}}{{#when isReading}}
    You can finish War and Peace eventually...
  {{else}}
    Go to bed!
  {{/when}}{{/when}}

{{! Prettier main }}
{{#when isAtWork}}
  Ship that code!
{{else when isReading}}
  You can finish War and Peace eventually...
{{else}}
  Go to bed!
{{/when}}
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~~
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
