### PR TITLE
Rename `bin-prettier.js` bundle to `bin-prettier.cjs`

### DIFF
--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -133,4 +133,4 @@ jobs:
         run: node -v | grep "v0.10.48" || exit 1
 
       - name: Run CLI on Node.js v0.10.48
-        run: node dist/bin-prettier --version 2>&1 >/dev/null | grep "prettier requires at least version 14 of Node, please upgrade" || exit 1
+        run: node dist/bin-prettier.cjs --version 2>&1 >/dev/null | grep "prettier requires at least version 14 of Node, please upgrade" || exit 1

--- a/scripts/build/build.mjs
+++ b/scripts/build/build.mjs
@@ -132,6 +132,7 @@ async function createBundle(bundleConfig, options) {
 
 async function preparePackage() {
   const packageJson = await readJson(path.join(PROJECT_ROOT, "package.json"));
+  packageJson.bin = "./bin-prettier.cjs";
   packageJson.main = "./index.cjs";
   // TODO: Add `exports`
 

--- a/scripts/build/build.mjs
+++ b/scripts/build/build.mjs
@@ -132,7 +132,6 @@ async function createBundle(bundleConfig, options) {
 
 async function preparePackage() {
   const packageJson = await readJson(path.join(PROJECT_ROOT, "package.json"));
-  packageJson.bin = "./bin-prettier.js";
   packageJson.main = "./index.cjs";
   // TODO: Add `exports`
 

--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -265,7 +265,7 @@ const coreBundles = [
   },
   {
     input: "bin/prettier.cjs",
-    output: "bin-prettier.js",
+    output: "bin-prettier.cjs",
     esbuildTarget: ["node0.10"],
     replaceModule: [
       {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

My idea is to use 
- `.cjs` for CommonJS modules, `bin-prettier.cjs` `index.cjs`
- `.mjs` for ESM modules, `cli.mjs` `index.mjs` `third-party.mjs`(#13509) `esm/*`
- `.js` for UMD modules, `standalone.js`, `parser-*.js`

FYI:
I'm planning to 

- move `esm/parser-*` and `parser-*` to `plugins/`
- move `third-party.mjs*`  to `interal/`

So there will be

`babel.js` and `babel.mjs` in `plugins/`, should we use `.common.cjs` / `.esm.mjs` / `.umd.js` to be more clear?

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
