### PR TITLE
Fix `parse-srcset` checksum in `yarn.lock`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6376,7 +6376,7 @@ __metadata:
 "parse-srcset@ikatyang/parse-srcset#54eb9c1cb21db5c62b4d0e275d7249516df6f0ee":
   version: 1.0.2
   resolution: "parse-srcset@https://github.com/ikatyang/parse-srcset.git#commit=54eb9c1cb21db5c62b4d0e275d7249516df6f0ee"
-  checksum: 4f3325a79e8d881d1d29ae4d2857a40b1d9d8d98f093b865a04a4e18ba5b136e7e1d37a317a8fc2ed10a8f473951c396f7c1b0904fe10de430e44811698ce0f1
+  checksum: 1f4b1e48977ed0c47a357e8f484792ca71007c87df33dc3b9c806c1b096162e9e7ba41f5517ba16c2fddce7c6754016692f4b673b4c0960241508671ac8dcebe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

When trying to install dependencies on the `next` branch, Yarn fails with an error related to one of its dependencies' remote archive not matching the expected checksum in `yarn.lock`. This behaviour occurs because the default for `checksumBehavior` is set to [`throw`](https://yarnpkg.com/configuration/yarnrc#checksumBehavior). Doing a one-time update fixes that (as I don't believe continuous updates should be a thing).

This is equivalent to running `YARN_CHECKSUM_BEHAVIOR=update yarn`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
