### PR TITLE
Move `third-party.mjs` to `internal/`

### DIFF
--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -332,6 +332,7 @@ const nodejsFiles = [
   },
   {
     input: "src/common/third-party.js",
+    outputBaseName: "internal/third-party",
     replaceModule: [
       // cosmiconfig@6 -> import-fresh can't find parentModule, since module is bundled
       {

--- a/src/common/third-party.js
+++ b/src/common/third-party.js
@@ -1,3 +1,7 @@
+/*
+Add these modules here, so we can mock during test
+*/
+
 import { cosmiconfig } from "cosmiconfig";
 import { sync as findParentDir } from "find-parent-dir";
 import getStdin from "get-stdin";

--- a/tests/integration/env.js
+++ b/tests/integration/env.js
@@ -12,7 +12,7 @@ const prettierCli = path.join(
 );
 
 const thirdParty = isProduction
-  ? path.join(PRETTIER_DIR, "./third-party.mjs")
+  ? path.join(PRETTIER_DIR, "./internal/third-party.mjs")
   : path.join(PRETTIER_DIR, "./src/common/third-party.js");
 
 const projectRoot = path.join(__dirname, "../..");


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

This file exists only because we need mock modules during tests. The modules in this file don't have to be third-party modules.

[#13428 may need to mock an internal module](https://github.com/prettier/prettier/pull/13428#discussion_r973700020), we should give it a better name.

`internal-modules.js`? `internal-modules-to-mock.js`? `mockable-modules.js`? Can't think of a good name.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
