### PR TITLE
Replace `esutils` with `@prettier/is-es5-identifier-name`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@babel/types": "7.19.4",
     "@glimmer/syntax": "0.84.2",
     "@iarna/toml": "2.2.5",
+    "@prettier/is-es5-identifier-name": "0.0.2",
     "@prettier/parse-srcset": "2.0.2",
     "@typescript-eslint/typescript-estree": "5.40.0",
     "@typescript-eslint/visitor-keys": "5.40.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "editorconfig-to-prettier": "0.2.0",
     "escape-string-regexp": "5.0.0",
     "espree": "9.4.0",
-    "esutils": "2.0.3",
     "fast-glob": "3.2.12",
     "fast-json-stable-stringify": "2.1.0",
     "file-entry-cache": "6.0.1",

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -1,4 +1,3 @@
-import esutils from "esutils";
 import {
   hasNewline,
   skipWhitespace,
@@ -8,10 +7,9 @@ import {
 } from "../../common/util.js";
 import { locStart, locEnd, hasSameLocStart } from "../loc.js";
 import getVisitorKeys from "../traverse/get-visitor-keys.js";
+import isEs5IdentifierName from "./is-es5-identifier-name.js";
 import isBlockComment from "./is-block-comment.js";
 import isNodeMatches from "./is-node-matches.js";
-
-const isIdentifierName = esutils.keyword.isIdentifierNameES5;
 
 /**
  * @typedef {import("../types/estree.js").Node} Node
@@ -680,7 +678,7 @@ function isStringPropSafeToUnquote(node, options) {
     options.parser !== "json" &&
     isStringLiteral(node.key) &&
     rawText(node.key).slice(1, -1) === node.key.value &&
-    ((isIdentifierName(node.key.value) &&
+    ((isEs5IdentifierName(node.key.value) &&
       // With `--strictPropertyInitialization`, TS treats properties with quoted names differently than unquoted ones.
       // See https://github.com/microsoft/TypeScript/pull/20075
       !(

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -1,3 +1,5 @@
+
+import isEs5IdentifierName from "@prettier/is-es5-identifier-name";
 import {
   hasNewline,
   skipWhitespace,
@@ -7,7 +9,6 @@ import {
 } from "../../common/util.js";
 import { locStart, locEnd, hasSameLocStart } from "../loc.js";
 import getVisitorKeys from "../traverse/get-visitor-keys.js";
-import isEs5IdentifierName from "./is-es5-identifier-name.js";
 import isBlockComment from "./is-block-comment.js";
 import isNodeMatches from "./is-node-matches.js";
 

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -1,4 +1,3 @@
-
 import isEs5IdentifierName from "@prettier/is-es5-identifier-name";
 import {
   hasNewline,

--- a/src/language-js/utils/is-es5-identifier-name.js
+++ b/src/language-js/utils/is-es5-identifier-name.js
@@ -1,6 +1,0 @@
-// https://github.com/tc39/proposal-regexp-unicode-property-escapes#other-examples
-function isEs5IdentifierName(id) {
-  return /^(?:[$_\p{ID_Start}])(?:[$_\u200C\u200D\p{ID_Continue}])*$/u.test(id)
-}
-
-export default isEs5IdentifierName

--- a/src/language-js/utils/is-es5-identifier-name.js
+++ b/src/language-js/utils/is-es5-identifier-name.js
@@ -1,0 +1,6 @@
+// https://github.com/tc39/proposal-regexp-unicode-property-escapes#other-examples
+function isEs5IdentifierName(id) {
+  return /^(?:[$_\p{ID_Start}])(?:[$_\u200C\u200D\p{ID_Continue}])*$/u.test(id)
+}
+
+export default isEs5IdentifierName

--- a/yarn.lock
+++ b/yarn.lock
@@ -3659,7 +3659,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esutils@npm:2.0.3, esutils@npm:^2.0.2":
+"esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
   checksum: 22b5b08f74737379a840b8ed2036a5fb35826c709ab000683b092d9054e5c2a82c27818f12604bfc2a9a76b90b6834ef081edbc1c7ae30d1627012e067c6ec87
@@ -6639,7 +6639,6 @@ __metadata:
     eslint-plugin-unicorn: 44.0.2
     esm-utils: 4.1.0
     espree: 9.4.0
-    esutils: 2.0.3
     execa: 6.1.0
     fast-glob: 3.2.12
     fast-json-stable-stringify: 2.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -1326,6 +1326,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@prettier/is-es5-identifier-name@npm:0.0.2":
+  version: 0.0.2
+  resolution: "@prettier/is-es5-identifier-name@npm:0.0.2"
+  checksum: f7b3490ad7d7764099cf6803b0acac167bac1833553cc3841249ae9b7a34c0504db6a3b6ddfa56436be4d3bf9d234930c502762e6e4e1c53e7ffbb43b4b0860d
+  languageName: node
+  linkType: hard
+
 "@prettier/parse-srcset@npm:2.0.2":
   version: 2.0.2
   resolution: "@prettier/parse-srcset@npm:2.0.2"
@@ -6595,6 +6602,7 @@ __metadata:
     "@glimmer/reference": 0.84.2
     "@glimmer/syntax": 0.84.2
     "@iarna/toml": 2.2.5
+    "@prettier/is-es5-identifier-name": 0.0.2
     "@prettier/parse-srcset": 2.0.2
     "@types/estree": 1.0.0
     "@types/file-entry-cache": 5.0.2


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Ref https://github.com/prettier/prettier/issues/12144#issuecomment-1023251590

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
