### PR TITLE
Format pseudo-selector args like a function call

### DIFF
--- a/changelog_unreleased/css/13577.md
+++ b/changelog_unreleased/css/13577.md
@@ -1,0 +1,32 @@
+#### Fix formatting of long `:is`, `:where`, and `:not` selectors (#13577 by @j-f1)
+
+Pseudo-selectors like `:is`, `:where`, and `:not` that can take multiple selectors as arguments are now formatted like function calls are in other languages. Previously, no special significance was attached to the commas between their “arguments,” leading to confusing wrapping behavior. There are likely still improvements to be made here — please open an issue with some example code if you find something that doesn’t look as expected.
+
+<!-- prettier-ignore -->
+```css
+/* Input */
+:where(
+  label > input:valid,
+  label > textarea:not(:empty),
+  label > button[disabled]
+) ~ .errors > .error { display: none; }
+
+/* Prettier stable */
+:where(label > input:valid, label > textarea:not(:empty), label
+    > button[disabled])
+  ~ .errors
+  > .error {
+  display: none;
+}
+
+/* Prettier main */
+:where(
+    label > input:valid,
+    label > textarea:not(:empty),
+    label > button[disabled]
+  )
+  ~ .errors
+  > .error {
+  display: none;
+}
+```

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -461,7 +461,12 @@ function genericPrint(path, options, print) {
       return [
         maybeToLowerCase(node.value),
         isNonEmptyArray(node.nodes)
-          ? ["(", join(", ", path.map(print, "nodes")), ")"]
+          ? group([
+              "(",
+              indent([softline, join([",", line], path.map(print, "nodes"))]),
+              softline,
+              ")",
+            ])
           : "",
       ];
     }

--- a/tests/format/css/indent/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/css/indent/__snapshots__/jsfmt.spec.js.snap
@@ -42,7 +42,9 @@ a {
 
 =====================================output=====================================
 a {
-  ~ .Pagination-itemWrapper:not(.is-separator):not([data-priority^="#{$priority}"])
+  ~ .Pagination-itemWrapper:not(.is-separator):not(
+      [data-priority^="#{$priority}"]
+    )
     ~ .Pagination-itemWrapper.is-separator[data-priority^="#{$priority}"] {
     display: flex;
   }

--- a/tests/format/css/pseudo-call/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/css/pseudo-call/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,86 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`is.css format 1`] = `
+====================================options=====================================
+parsers: ["css"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+:is(ol, ul, menu:unsupported) :is(ol, ul) {
+    color: green;
+}
+
+:is(ol, ul) :is(ol, ul) ol {
+    list-style-type: lower-greek;
+    color: chocolate;
+}
+
+:is(ol, ul, menu, dir) :is(ol, ul, menu, dir) :is(ul, menu, dir) {
+  list-style-type: square;
+}
+
+/* Level 0 */
+h1 {
+  font-size: 30px;
+}
+/* Level 1 */
+:is(section, article, aside, nav) h1 {
+  font-size: 25px;
+}
+/* Level 2 */
+:is(section, article, aside, nav) :is(section, article, aside, nav) h1 {
+  font-size: 20px;
+}
+/* Level 3 */
+:is(section, article, aside, nav)  :is(section, article, aside, nav)  :is(section, article, aside, nav)  h1 {
+  font-size: 15px;
+}
+
+some-element:is(::before, ::after) {
+  display: block;
+}
+
+=====================================output=====================================
+:is(ol, ul, menu:unsupported) :is(ol, ul) {
+  color: green;
+}
+
+:is(ol, ul) :is(ol, ul) ol {
+  list-style-type: lower-greek;
+  color: chocolate;
+}
+
+:is(ol, ul, menu, dir) :is(ol, ul, menu, dir) :is(ul, menu, dir) {
+  list-style-type: square;
+}
+
+/* Level 0 */
+h1 {
+  font-size: 30px;
+}
+/* Level 1 */
+:is(section, article, aside, nav) h1 {
+  font-size: 25px;
+}
+/* Level 2 */
+:is(section, article, aside, nav) :is(section, article, aside, nav) h1 {
+  font-size: 20px;
+}
+/* Level 3 */
+:is(section, article, aside, nav)
+  :is(section, article, aside, nav)
+  :is(section, article, aside, nav)
+  h1 {
+  font-size: 15px;
+}
+
+some-element:is(::before, ::after) {
+  display: block;
+}
+
+================================================================================
+`;
+
 exports[`pseudo_call.css format 1`] = `
 ====================================options=====================================
 parsers: ["css"]
@@ -11,6 +92,63 @@ div:not(:last-child) {
 
 =====================================output=====================================
 div:not(:last-child) {
+}
+
+================================================================================
+`;
+
+exports[`where.css format 1`] = `
+====================================options=====================================
+parsers: ["css"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+:where(#p0:checked ~ #play:checked ~ #c1:checked, #p1:checked ~ #play:checked ~ #c2:checked, #p2:checked ~ #play:checked ~ #cO:checked) ~ #result >
+#c { display: block; }
+
+:where(ol, ul, menu:unsupported) :where(ol, ul) {
+    color: green;
+}
+
+:where(ol, ul) :where(ol, ul) ol {
+    list-style-type: lower-greek;
+    color: chocolate;
+}
+
+:is(section.is-styling, aside.is-styling, footer.is-styling) a {
+  color: red;
+}
+
+:where(section.where-styling, aside.where-styling, footer.where-styling) a {
+  color: orange;
+}
+
+=====================================output=====================================
+:where(
+    #p0:checked ~ #play:checked ~ #c1:checked,
+    #p1:checked ~ #play:checked ~ #c2:checked,
+    #p2:checked ~ #play:checked ~ #cO:checked
+  )
+  ~ #result
+  > #c {
+  display: block;
+}
+
+:where(ol, ul, menu:unsupported) :where(ol, ul) {
+  color: green;
+}
+
+:where(ol, ul) :where(ol, ul) ol {
+  list-style-type: lower-greek;
+  color: chocolate;
+}
+
+:is(section.is-styling, aside.is-styling, footer.is-styling) a {
+  color: red;
+}
+
+:where(section.where-styling, aside.where-styling, footer.where-styling) a {
+  color: orange;
 }
 
 ================================================================================

--- a/tests/format/css/pseudo-call/is.css
+++ b/tests/format/css/pseudo-call/is.css
@@ -1,0 +1,33 @@
+:is(ol, ul, menu:unsupported) :is(ol, ul) {
+    color: green;
+}
+
+:is(ol, ul) :is(ol, ul) ol {
+    list-style-type: lower-greek;
+    color: chocolate;
+}
+
+:is(ol, ul, menu, dir) :is(ol, ul, menu, dir) :is(ul, menu, dir) {
+  list-style-type: square;
+}
+
+/* Level 0 */
+h1 {
+  font-size: 30px;
+}
+/* Level 1 */
+:is(section, article, aside, nav) h1 {
+  font-size: 25px;
+}
+/* Level 2 */
+:is(section, article, aside, nav) :is(section, article, aside, nav) h1 {
+  font-size: 20px;
+}
+/* Level 3 */
+:is(section, article, aside, nav)  :is(section, article, aside, nav)  :is(section, article, aside, nav)  h1 {
+  font-size: 15px;
+}
+
+some-element:is(::before, ::after) {
+  display: block;
+}

--- a/tests/format/css/pseudo-call/where.css
+++ b/tests/format/css/pseudo-call/where.css
@@ -1,0 +1,19 @@
+:where(#p0:checked ~ #play:checked ~ #c1:checked, #p1:checked ~ #play:checked ~ #c2:checked, #p2:checked ~ #play:checked ~ #cO:checked) ~ #result >
+#c { display: block; }
+
+:where(ol, ul, menu:unsupported) :where(ol, ul) {
+    color: green;
+}
+
+:where(ol, ul) :where(ol, ul) ol {
+    list-style-type: lower-greek;
+    color: chocolate;
+}
+
+:is(section.is-styling, aside.is-styling, footer.is-styling) a {
+  color: red;
+}
+
+:where(section.where-styling, aside.where-styling, footer.where-styling) a {
+  color: orange;
+}


### PR DESCRIPTION
## Description

Currently, pseudo-selector arguments are formatted all on one line (using `", "` as a separator. This results in [undesirable formatting](https://twitter.com/scriptraccoon/status/1576320682245267456):

```css
:where(#p0:checked ~ #play:checked ~ #c1:checked, #p1:checked
    ~ #play:checked
    ~ #c2:checked, #p2:checked ~ #play:checked ~ #cO:checked)
  ~ #result
  > #c {
  display: block;
}
```

My change formats them more like function arguments in other languages (using the `group`/`indent` primitives).

Additionally, tests for `:where`/`:is` were missing from the codebase, so this issue was not apparent in the tests. I’ve added the above code, as well as some examples from MDN to make sure we don’t regress in the future.

The current logic was implemented in #1792 back in 2017, which I believe is before these newer selectors were proposed, and since they didn’t introduce any syntax changes on our end, it seems like nobody ever thought to update the implementation

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
