### PR TITLE
Add '--single-attribute-per-line' option to Playground

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@
 
 [build.environment]
   NODE_VERSION = "lts/*"
-  YARN_VERSION = "1.22.15"
+  YARN_VERSION = "1.22.19"
 [[headers]]
   for = "/worker.js"
   [headers.values]

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -47,6 +47,7 @@ const ENABLED_OPTIONS = [
   "vueIndentScriptAndStyle",
   "embeddedLanguageFormatting",
   "bracketSameLine",
+  "singleAttributePerLine",
 ];
 
 class Playground extends React.Component {


### PR DESCRIPTION
## Description

Just adds the new [`--single-attribute-per-line`](https://prettier.io/docs/en/options.html#single-attribute-per-line) option to the Playground.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
   (_I presumed this step wouldn't be necessary for such a minor update as this — apologies if I'm mistaken_)
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
