### PR TITLE
Playground: show preprocessed AST

### DIFF
--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -142,10 +142,10 @@ async function format(context, input, opt) {
     } else {
       const stringify = (obj) => JSON.stringify(obj, null, 2);
       const ast = stringify(
-        (await prettier.__debug.parse(input, opt, /* massage */ true)).ast
+        (await prettier.__debug.parse(input, opt, { massage: true })).ast
       );
       const past = stringify(
-        (await prettier.__debug.parse(pp, opt, /* massage */ true)).ast
+        (await prettier.__debug.parse(pp, opt, { massage: true })).ast
       );
 
       /* istanbul ignore next */

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -336,9 +336,9 @@ const prettier = {
       }
       if (devOptions.preprocessForPrint) {
         attachComments(parsed.text, parsed.ast, options);
-        parsed.ast = options.printer.preprocess
-          ? await options.printer.preprocess(parsed.ast, options)
-          : parsed.ast;
+        if (options.printer.preprocess) {
+          parsed.ast = await options.printer.preprocess(parsed.ast, options);
+        }
       }
     }
     return parsed;

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -334,6 +334,7 @@ const prettier = {
       parsed.ast = massageAST(parsed.ast, options);
     }
     if (preprocessForPrint && options.printer.preprocess) {
+      attachComments(parsed.text, parsed.ast, options);
       parsed.ast = options.printer.preprocess(parsed.ast, options);
     }
     return parsed;

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -337,7 +337,7 @@ const prettier = {
       if (devOptions.preprocessForPrint) {
         attachComments(parsed.text, parsed.ast, options);
         parsed.ast = options.printer.preprocess
-          ? options.printer.preprocess(parsed.ast, options)
+          ? await options.printer.preprocess(parsed.ast, options)
           : parsed.ast;
       }
     }

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -333,9 +333,11 @@ const prettier = {
     if (massage) {
       parsed.ast = massageAST(parsed.ast, options);
     }
-    if (preprocessForPrint && options.printer.preprocess) {
+    if (preprocessForPrint) {
       attachComments(parsed.text, parsed.ast, options);
-      parsed.ast = options.printer.preprocess(parsed.ast, options);
+      parsed.ast = options.printer.preprocess
+        ? options.printer.preprocess(parsed.ast, options)
+        : parsed.ast;
     }
     return parsed;
   },

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -324,24 +324,22 @@ async function formatWithCursor(originalText, originalOptions) {
 const prettier = {
   formatWithCursor,
 
-  async parse(
-    originalText,
-    originalOptions,
-    { massage = false, preprocessForPrint = false } = {}
-  ) {
+  async parse(originalText, originalOptions, devOptions) {
     const { text, options } = normalizeInputAndOptions(
       originalText,
       await normalizeOptions(originalOptions)
     );
     const parsed = await parse(text, options);
-    if (massage) {
-      parsed.ast = massageAST(parsed.ast, options);
-    }
-    if (preprocessForPrint) {
-      attachComments(parsed.text, parsed.ast, options);
-      parsed.ast = options.printer.preprocess
-        ? options.printer.preprocess(parsed.ast, options)
-        : parsed.ast;
+    if (devOptions) {
+      if (devOptions.massage) {
+        parsed.ast = massageAST(parsed.ast, options);
+      }
+      if (devOptions.preprocessForPrint) {
+        attachComments(parsed.text, parsed.ast, options);
+        parsed.ast = options.printer.preprocess
+          ? options.printer.preprocess(parsed.ast, options)
+          : parsed.ast;
+      }
     }
     return parsed;
   },

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -324,7 +324,7 @@ async function formatWithCursor(originalText, originalOptions) {
 const prettier = {
   formatWithCursor,
 
-  async parse(originalText, originalOptions, massage) {
+  async parse(originalText, originalOptions, massage, preprocessForPrint) {
     const { text, options } = normalizeInputAndOptions(
       originalText,
       await normalizeOptions(originalOptions)
@@ -332,6 +332,9 @@ const prettier = {
     const parsed = await parse(text, options);
     if (massage) {
       parsed.ast = massageAST(parsed.ast, options);
+    }
+    if (preprocessForPrint && options.printer.preprocess) {
+      parsed.ast = options.printer.preprocess(parsed.ast, options);
     }
     return parsed;
   },

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -324,16 +324,16 @@ async function formatWithCursor(originalText, originalOptions) {
 const prettier = {
   formatWithCursor,
 
-  async parse(originalText, originalOptions, massage, preprocessForPrint) {
+  async parse(originalText, originalOptions, devOptions) {
     const { text, options } = normalizeInputAndOptions(
       originalText,
       await normalizeOptions(originalOptions)
     );
     const parsed = await parse(text, options);
-    if (massage) {
+    if (devOptions.massage) {
       parsed.ast = massageAST(parsed.ast, options);
     }
-    if (preprocessForPrint) {
+    if (devOptions.preprocessForPrint) {
       attachComments(parsed.text, parsed.ast, options);
       parsed.ast = options.printer.preprocess
         ? options.printer.preprocess(parsed.ast, options)

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -324,16 +324,20 @@ async function formatWithCursor(originalText, originalOptions) {
 const prettier = {
   formatWithCursor,
 
-  async parse(originalText, originalOptions, devOptions) {
+  async parse(
+    originalText,
+    originalOptions,
+    { massage = false, preprocessForPrint = false } = {}
+  ) {
     const { text, options } = normalizeInputAndOptions(
       originalText,
       await normalizeOptions(originalOptions)
     );
     const parsed = await parse(text, options);
-    if (devOptions.massage) {
+    if (massage) {
       parsed.ast = massageAST(parsed.ast, options);
     }
-    if (devOptions.preprocessForPrint) {
+    if (preprocessForPrint) {
       attachComments(parsed.text, parsed.ast, options);
       parsed.ast = options.printer.preprocess
         ? options.printer.preprocess(parsed.ast, options)

--- a/tests/config/format-test.js
+++ b/tests/config/format-test.js
@@ -435,11 +435,9 @@ function shouldSkipEolTest(code, options) {
 
 async function parse(source, options) {
   const prettier = await getPrettier();
-  const { ast } = await prettier.__debug.parse(
-    source,
-    options,
-    /* massage */ true
-  );
+  const { ast } = await prettier.__debug.parse(source, options, {
+    massage: true,
+  });
   return ast;
 }
 

--- a/tests/config/require-standalone.cjs
+++ b/tests/config/require-standalone.cjs
@@ -56,11 +56,14 @@ module.exports = {
               ...($$$options.plugins || []),
             ],
           };
-          prettier.__debug.parse($$$input, options, ${JSON.stringify(
-            devOptions
-          )});
+          prettier.__debug.parse($$$input, options, $$$devOptions);
         `,
-        { $$$input: input, $$$options: options, ...sandbox }
+        {
+          $$$input: input,
+          $$$options: options,
+          $$$devOptions: devOptions,
+          ...sandbox,
+        }
       );
     },
   },

--- a/tests/config/require-standalone.cjs
+++ b/tests/config/require-standalone.cjs
@@ -46,7 +46,7 @@ module.exports = {
   },
 
   __debug: {
-    parse(input, options, massage) {
+    parse(input, options, devOptions) {
       return vm.runInNewContext(
         `
           const options = {
@@ -56,7 +56,9 @@ module.exports = {
               ...($$$options.plugins || []),
             ],
           };
-          prettier.__debug.parse($$$input, options, ${JSON.stringify(massage)});
+          prettier.__debug.parse($$$input, options, ${JSON.stringify(
+            devOptions
+          )});
         `,
         { $$$input: input, $$$options: options, ...sandbox }
       );

--- a/website/playground/EditorState.js
+++ b/website/playground/EditorState.js
@@ -9,7 +9,7 @@ export default class EditorState extends React.Component {
     this.state = {
       showSidebar: window.innerWidth > window.innerHeight,
       showAst: false,
-      showPreprintAst: false,
+      showPreprocessedAst: false,
       showDoc: false,
       showComments: false,
       showSecondFormat: false,
@@ -18,7 +18,8 @@ export default class EditorState extends React.Component {
       rethrowEmbedErrors: false,
       toggleSidebar: () => this.setState(stateToggler("showSidebar")),
       toggleAst: () => this.setState(stateToggler("showAst")),
-      togglePreprintAst: () => this.setState(stateToggler("showPreprintAst")),
+      togglePreprocessedAst: () =>
+        this.setState(stateToggler("showPreprocessedAst")),
       toggleDoc: () => this.setState(stateToggler("showDoc")),
       toggleComments: () => this.setState(stateToggler("showComments")),
       toggleSecondFormat: () => this.setState(stateToggler("showSecondFormat")),

--- a/website/playground/EditorState.js
+++ b/website/playground/EditorState.js
@@ -9,6 +9,7 @@ export default class EditorState extends React.Component {
     this.state = {
       showSidebar: window.innerWidth > window.innerHeight,
       showAst: false,
+      showPreprintAst: false,
       showDoc: false,
       showComments: false,
       showSecondFormat: false,
@@ -17,6 +18,7 @@ export default class EditorState extends React.Component {
       rethrowEmbedErrors: false,
       toggleSidebar: () => this.setState(stateToggler("showSidebar")),
       toggleAst: () => this.setState(stateToggler("showAst")),
+      togglePreprintAst: () => this.setState(stateToggler("showPreprintAst")),
       toggleDoc: () => this.setState(stateToggler("showDoc")),
       toggleComments: () => this.setState(stateToggler("showComments")),
       toggleSecondFormat: () => this.setState(stateToggler("showSecondFormat")),

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -218,7 +218,7 @@ class Playground extends React.Component {
             code={content}
             options={options}
             debugAst={editorState.showAst}
-            debugPreprintAst={editorState.showPreprintAst}
+            debugPreprocessedAst={editorState.showPreprocessedAst}
             debugDoc={editorState.showDoc}
             debugComments={editorState.showComments}
             reformat={editorState.showSecondFormat}
@@ -284,8 +284,8 @@ class Playground extends React.Component {
                         />
                         <Checkbox
                           label="show preprint AST"
-                          checked={editorState.showPreprintAst}
-                          onChange={editorState.togglePreprintAst}
+                          checked={editorState.showPreprocessedAst}
+                          onChange={editorState.togglePreprocessedAst}
                         />
                         <Checkbox
                           label="show doc"
@@ -352,9 +352,9 @@ class Playground extends React.Component {
                           autoFold={util.getAstAutoFold(options.parser)}
                         />
                       ) : null}
-                      {editorState.showPreprintAst ? (
+                      {editorState.showPreprocessedAst ? (
                         <DebugPanel
-                          value={debug.preprintAst || ""}
+                          value={debug.preprocessedAst || ""}
                           autoFold={util.getAstAutoFold(options.parser)}
                         />
                       ) : null}

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -283,7 +283,7 @@ class Playground extends React.Component {
                           onChange={editorState.toggleAst}
                         />
                         <Checkbox
-                          label="show preprint AST"
+                          label="show preprocessed AST"
                           checked={editorState.showPreprocessedAst}
                           onChange={editorState.togglePreprocessedAst}
                         />

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -218,6 +218,7 @@ class Playground extends React.Component {
             code={content}
             options={options}
             debugAst={editorState.showAst}
+            debugPreprintAst={editorState.showPreprintAst}
             debugDoc={editorState.showDoc}
             debugComments={editorState.showComments}
             reformat={editorState.showSecondFormat}
@@ -282,6 +283,11 @@ class Playground extends React.Component {
                           onChange={editorState.toggleAst}
                         />
                         <Checkbox
+                          label="show preprint AST"
+                          checked={editorState.showPreprintAst}
+                          onChange={editorState.togglePreprintAst}
+                        />
+                        <Checkbox
                           label="show doc"
                           checked={editorState.showDoc}
                           onChange={editorState.toggleDoc}
@@ -343,6 +349,12 @@ class Playground extends React.Component {
                       {editorState.showAst ? (
                         <DebugPanel
                           value={debug.ast || ""}
+                          autoFold={util.getAstAutoFold(options.parser)}
+                        />
+                      ) : null}
+                      {editorState.showPreprintAst ? (
+                        <DebugPanel
+                          value={debug.preprintAst || ""}
                           autoFold={util.getAstAutoFold(options.parser)}
                         />
                       ) : null}

--- a/website/playground/PrettierFormat.js
+++ b/website/playground/PrettierFormat.js
@@ -16,7 +16,7 @@ export default class PrettierFormat extends React.Component {
       "code",
       "options",
       "debugAst",
-      "debugPreprintAst",
+      "debugPreprocessedAst",
       "debugDoc",
       "debugComments",
       "reformat",
@@ -36,7 +36,7 @@ export default class PrettierFormat extends React.Component {
       code,
       options,
       debugAst: ast,
-      debugPreprintAst: preprintAst,
+      debugPreprocessedAst: preprocessedAst,
       debugDoc: doc,
       debugComments: comments,
       reformat,
@@ -49,7 +49,7 @@ export default class PrettierFormat extends React.Component {
 
     const result = await worker.format(code, options, {
       ast,
-      preprintAst,
+      preprocessedAst,
       doc,
       comments,
       reformat,

--- a/website/playground/PrettierFormat.js
+++ b/website/playground/PrettierFormat.js
@@ -16,6 +16,7 @@ export default class PrettierFormat extends React.Component {
       "code",
       "options",
       "debugAst",
+      "debugPreprintAst",
       "debugDoc",
       "debugComments",
       "reformat",
@@ -35,6 +36,7 @@ export default class PrettierFormat extends React.Component {
       code,
       options,
       debugAst: ast,
+      debugPreprintAst: preprintAst,
       debugDoc: doc,
       debugComments: comments,
       reformat,
@@ -47,6 +49,7 @@ export default class PrettierFormat extends React.Component {
 
     const result = await worker.format(code, options, {
       ast,
+      preprintAst,
       doc,
       comments,
       reformat,

--- a/website/playground/util.js
+++ b/website/playground/util.js
@@ -53,8 +53,7 @@ export function getCodemirrorMode(parser) {
 }
 
 const astAutoFold = {
-  estree:
-    /^\s*"(loc|start|end|tokens|leadingComments|trailingComments|innerComments)":/,
+  estree: /^\s*"(loc|start|end|tokens|\w+Comments|comments)":/,
   postcss: /^\s*"(source|input|raws|file)":/,
   html: /^\s*"(\w+Span|valueTokens|tokens|file|tagDefinition)":/,
   mdast: /^\s*"position":/,

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -116,12 +116,22 @@ async function handleFormatMessage(message) {
     },
   };
 
-  if (message.debug.ast) {
+  for (const key of ["ast", "preprintAst"]) {
+    if (!message.debug[key]) {
+      continue;
+    }
     let ast;
     let errored = false;
     try {
       ast = serializeAst(
-        (await prettier.__debug.parse(message.code, options)).ast
+        (
+          await prettier.__debug.parse(
+            message.code,
+            options,
+            false,
+            key === "preprintAst"
+          )
+        ).ast
       );
     } catch (e) {
       errored = true;
@@ -135,7 +145,7 @@ async function handleFormatMessage(message) {
         ast = serializeAst(ast);
       }
     }
-    response.debug.ast = ast;
+    response.debug[key] = ast;
   }
 
   if (message.debug.doc) {

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -116,7 +116,7 @@ async function handleFormatMessage(message) {
     },
   };
 
-  for (const key of ["ast", "preprintAst"]) {
+  for (const key of ["ast", "preprocessedAst"]) {
     if (!message.debug[key]) {
       continue;
     }
@@ -129,7 +129,7 @@ async function handleFormatMessage(message) {
             message.code,
             options,
             false,
-            key === "preprintAst"
+            key === "preprocessedAst"
           )
         ).ast
       );

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -120,32 +120,31 @@ async function handleFormatMessage(message) {
     if (!message.debug[key]) {
       continue;
     }
-    let ast;
+    let serializedAst;
     let errored = false;
     try {
-      ast = serializeAst(
-        (
-          await prettier.__debug.parse(
-            message.code,
-            options,
-            false,
-            key === "preprocessedAst"
-          )
-        ).ast
+      const { ast } = await prettier.__debug.parse(
+        message.code,
+        options,
+        false,
+        key === "preprocessedAst"
       );
+      serializedAst = serializeAst(ast);
     } catch (e) {
       errored = true;
-      ast = String(e);
+      serializedAst = String(e);
     }
 
     if (!errored) {
       try {
-        ast = (await formatCode(ast, { parser: "json", plugins })).formatted;
+        serializedAst = (
+          await formatCode(serializedAst, { parser: "json", plugins })
+        ).formatted;
       } catch {
-        ast = serializeAst(ast);
+        serializedAst = serializeAst(serializedAst);
       }
     }
-    response.debug[key] = ast;
+    response.debug[key] = serializedAst;
   }
 
   if (message.debug.doc) {

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -123,12 +123,9 @@ async function handleFormatMessage(message) {
     let serializedAst;
     let errored = false;
     try {
-      const { ast } = await prettier.__debug.parse(
-        message.code,
-        options,
-        false,
-        key === "preprocessedAst"
-      );
+      const { ast } = await prettier.__debug.parse(message.code, options, {
+        preprocessForPrint: key === "preprocessedAst",
+      });
       serializedAst = serializeAst(ast);
     } catch (e) {
       errored = true;

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -120,28 +120,26 @@ async function handleFormatMessage(message) {
     if (!message.debug[key]) {
       continue;
     }
-    let serializedAst;
+    let ast;
     let errored = false;
     try {
-      const { ast } = await prettier.__debug.parse(message.code, options, {
+      const parsed = await prettier.__debug.parse(message.code, options, {
         preprocessForPrint: key === "preprocessedAst",
       });
-      serializedAst = serializeAst(ast);
+      ast = serializeAst(parsed.ast);
     } catch (e) {
       errored = true;
-      serializedAst = String(e);
+      ast = String(e);
     }
 
     if (!errored) {
       try {
-        serializedAst = (
-          await formatCode(serializedAst, { parser: "json", plugins })
-        ).formatted;
+        ast = (await formatCode(ast, { parser: "json", plugins })).formatted;
       } catch {
-        serializedAst = serializeAst(serializedAst);
+        ast = serializeAst(ast);
       }
     }
-    response.debug[key] = serializedAst;
+    response.debug[key] = ast;
   }
 
   if (message.debug.doc) {


### PR DESCRIPTION
## Description

This can be especially useful for the Markdown printer as its preprocessing is really complex. HTML is interesting too.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
