### PR TITLE
Consistent dangling comments formatting for tuple and array

### DIFF
--- a/changelog_unreleased/typescript/13608.md
+++ b/changelog_unreleased/typescript/13608.md
@@ -1,0 +1,27 @@
+#### Consistent dangling comments formatting for tuple types and arrays (#13608 by @sosukesuzuki)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+type Foo = [
+   // comment
+];
+const bar = [
+   // comment
+];
+
+// Prettier stable
+type Foo = [// comment];
+type Bar = [
+   // comment
+];
+
+// Prettier main
+type Foo = [
+   // comment
+];
+type Bar = [
+   // comment
+];
+
+```

--- a/changelog_unreleased/typescript/13608.md
+++ b/changelog_unreleased/typescript/13608.md
@@ -12,7 +12,7 @@ const bar = [
 
 // Prettier stable
 type Foo = [// comment];
-type Bar = [
+const bar = [
    // comment
 ];
 
@@ -20,7 +20,7 @@ type Bar = [
 type Foo = [
    // comment
 ];
-type Bar = [
+const bar = [
    // comment
 ];
 

--- a/src/language-js/print/array.js
+++ b/src/language-js/print/array.js
@@ -23,6 +23,19 @@ import { printOptionalToken, printTypeAnnotation } from "./misc.js";
 
 /** @typedef {import("../../document/builders.js").Doc} Doc */
 
+function printEmptyArrayLike(path, openBracket, closeBracket, options) {
+  const { node } = path;
+  if (!hasComment(node, CommentCheckFlags.Dangling)) {
+    return [openBracket, closeBracket];
+  }
+  return group([
+    openBracket,
+    printDanglingComments(path, options),
+    softline,
+    closeBracket,
+  ]);
+}
+
 function printArray(path, options, print) {
   const { node } = path;
   /** @type{Doc[]} */
@@ -31,18 +44,7 @@ function printArray(path, options, print) {
   const openBracket = node.type === "TupleExpression" ? "#[" : "[";
   const closeBracket = "]";
   if (node.elements.length === 0) {
-    if (!hasComment(node, CommentCheckFlags.Dangling)) {
-      parts.push(openBracket, closeBracket);
-    } else {
-      parts.push(
-        group([
-          openBracket,
-          printDanglingComments(path, options),
-          softline,
-          closeBracket,
-        ])
-      );
-    }
+    parts.push(printEmptyArrayLike(path, openBracket, closeBracket, options));
   } else {
     const lastElem = node.elements.at(-1);
     const canHaveTrailingComma = !(lastElem && lastElem.type === "RestElement");
@@ -187,4 +189,9 @@ function printArrayItemsConcisely(path, options, print, trailingComma) {
   return fill(parts);
 }
 
-export { printArray, printArrayItems, isConciselyPrintedArray };
+export {
+  printArray,
+  printArrayItems,
+  isConciselyPrintedArray,
+  printEmptyArrayLike,
+};

--- a/src/language-js/print/array.js
+++ b/src/language-js/print/array.js
@@ -23,7 +23,7 @@ import { printOptionalToken, printTypeAnnotation } from "./misc.js";
 
 /** @typedef {import("../../document/builders.js").Doc} Doc */
 
-function printEmptyArrayLike(path, openBracket, closeBracket, options) {
+function printEmptyArray(path, openBracket, closeBracket, options) {
   const { node } = path;
   if (!hasComment(node, CommentCheckFlags.Dangling)) {
     return [openBracket, closeBracket];
@@ -44,7 +44,7 @@ function printArray(path, options, print) {
   const openBracket = node.type === "TupleExpression" ? "#[" : "[";
   const closeBracket = "]";
   if (node.elements.length === 0) {
-    parts.push(printEmptyArrayLike(path, openBracket, closeBracket, options));
+    parts.push(printEmptyArray(path, openBracket, closeBracket, options));
   } else {
     const lastElem = node.elements.at(-1);
     const canHaveTrailingComma = !(lastElem && lastElem.type === "RestElement");
@@ -193,5 +193,5 @@ export {
   printArray,
   printArrayItems,
   isConciselyPrintedArray,
-  printEmptyArrayLike,
+  printEmptyArray,
 };

--- a/src/language-js/print/type-annotation.js
+++ b/src/language-js/print/type-annotation.js
@@ -23,7 +23,7 @@ import {
   printFunctionParameters,
   shouldGroupFunctionParameters,
 } from "./function-parameters.js";
-import { printArrayItems } from "./array.js";
+import { printArrayItems, printEmptyArrayLike } from "./array.js";
 
 function shouldHugType(node) {
   if (isSimpleType(node) || isObjectType(node)) {
@@ -291,8 +291,13 @@ function printTupleType(path, options, print) {
   const types = node[typesField];
   const isNonEmptyTuple = isNonEmptyArray(types);
   const bracketsDelimiterLine = isNonEmptyTuple ? softline : "";
+  const openBracket = "[";
+  const closeBracket = "]";
+  if (!isNonEmptyTuple) {
+    return printEmptyArrayLike(path, openBracket, closeBracket, options);
+  }
   return group([
-    "[",
+    openBracket,
     indent([
       bracketsDelimiterLine,
       printArrayItems(path, options, typesField, print),
@@ -300,7 +305,7 @@ function printTupleType(path, options, print) {
     ifBreak(isNonEmptyTuple && shouldPrintComma(options, "all") ? "," : ""),
     printDanglingComments(path, options, /* sameIndent */ true),
     bracketsDelimiterLine,
-    "]",
+    closeBracket,
   ]);
 }
 

--- a/src/language-js/print/type-annotation.js
+++ b/src/language-js/print/type-annotation.js
@@ -1,5 +1,4 @@
-import { printComments, printDanglingComments } from "../../main/comments.js";
-import { isNonEmptyArray } from "../../common/util.js";
+import { printComments } from "../../main/comments.js";
 import {
   group,
   join,
@@ -23,7 +22,7 @@ import {
   printFunctionParameters,
   shouldGroupFunctionParameters,
 } from "./function-parameters.js";
-import { printArrayItems, printEmptyArrayLike } from "./array.js";
+import { printArrayItems, printEmptyArray } from "./array.js";
 
 function shouldHugType(node) {
   if (isSimpleType(node) || isObjectType(node)) {
@@ -289,12 +288,12 @@ function printTupleType(path, options, print) {
   const { node } = path;
   const typesField = node.type === "TSTupleType" ? "elementTypes" : "types";
   const types = node[typesField];
-  const isNonEmptyTuple = isNonEmptyArray(types);
-  const bracketsDelimiterLine = isNonEmptyTuple ? softline : "";
+  const isEmptyTuple = types.length === 0;
+  const bracketsDelimiterLine = isEmptyTuple ? softline : "";
   const openBracket = "[";
   const closeBracket = "]";
-  if (!isNonEmptyTuple) {
-    return printEmptyArrayLike(path, openBracket, closeBracket, options);
+  if (isEmptyTuple) {
+    return printEmptyArray(path, openBracket, closeBracket, options);
   }
   return group([
     openBracket,
@@ -302,8 +301,7 @@ function printTupleType(path, options, print) {
       bracketsDelimiterLine,
       printArrayItems(path, options, typesField, print),
     ]),
-    ifBreak(isNonEmptyTuple && shouldPrintComma(options, "all") ? "," : ""),
-    printDanglingComments(path, options, /* sameIndent */ true),
+    ifBreak(shouldPrintComma(options, "all") ? "," : ""),
     bracketsDelimiterLine,
     closeBracket,
   ]);

--- a/src/language-js/print/type-annotation.js
+++ b/src/language-js/print/type-annotation.js
@@ -289,7 +289,6 @@ function printTupleType(path, options, print) {
   const typesField = node.type === "TSTupleType" ? "elementTypes" : "types";
   const types = node[typesField];
   const isEmptyTuple = types.length === 0;
-  const bracketsDelimiterLine = isEmptyTuple ? "" : softline;
   const openBracket = "[";
   const closeBracket = "]";
   if (isEmptyTuple) {
@@ -297,12 +296,9 @@ function printTupleType(path, options, print) {
   }
   return group([
     openBracket,
-    indent([
-      bracketsDelimiterLine,
-      printArrayItems(path, options, typesField, print),
-    ]),
+    indent([softline, printArrayItems(path, options, typesField, print)]),
     ifBreak(shouldPrintComma(options, "all") ? "," : ""),
-    bracketsDelimiterLine,
+    softline,
     closeBracket,
   ]);
 }

--- a/src/language-js/print/type-annotation.js
+++ b/src/language-js/print/type-annotation.js
@@ -289,7 +289,7 @@ function printTupleType(path, options, print) {
   const typesField = node.type === "TSTupleType" ? "elementTypes" : "types";
   const types = node[typesField];
   const isEmptyTuple = types.length === 0;
-  const bracketsDelimiterLine = isEmptyTuple ? softline : "";
+  const bracketsDelimiterLine = isEmptyTuple ? "" : softline;
   const openBracket = "[";
   const closeBracket = "]";
   if (isEmptyTuple) {

--- a/tests/format/typescript/tuple/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/tuple/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,203 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`dangling-comments.ts - {"trailingComma":"all"} format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+type Foo1 = [/* comment */];
+
+type Foo2 = [
+    // comment
+];
+
+type Foo3 = [
+    // comment1
+    // comment2
+];
+
+type Foo4 = [
+    // comment1
+
+    // comment2
+];
+
+type Foo5 = [
+    /* comment1 */
+];
+
+type Foo6 = [
+    /* comment1 */
+
+    /* comment2 */
+];
+
+
+=====================================output=====================================
+type Foo1 = [
+  /* comment */
+];
+
+type Foo2 = [
+  // comment
+];
+
+type Foo3 = [
+  // comment1
+  // comment2
+];
+
+type Foo4 = [
+  // comment1
+  // comment2
+];
+
+type Foo5 = [
+  /* comment1 */
+];
+
+type Foo6 = [
+  /* comment1 */
+  /* comment2 */
+];
+
+================================================================================
+`;
+
+exports[`dangling-comments.ts - {"trailingComma":"es5"} format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+trailingComma: "es5"
+                                                                                | printWidth
+=====================================input======================================
+type Foo1 = [/* comment */];
+
+type Foo2 = [
+    // comment
+];
+
+type Foo3 = [
+    // comment1
+    // comment2
+];
+
+type Foo4 = [
+    // comment1
+
+    // comment2
+];
+
+type Foo5 = [
+    /* comment1 */
+];
+
+type Foo6 = [
+    /* comment1 */
+
+    /* comment2 */
+];
+
+
+=====================================output=====================================
+type Foo1 = [
+  /* comment */
+];
+
+type Foo2 = [
+  // comment
+];
+
+type Foo3 = [
+  // comment1
+  // comment2
+];
+
+type Foo4 = [
+  // comment1
+  // comment2
+];
+
+type Foo5 = [
+  /* comment1 */
+];
+
+type Foo6 = [
+  /* comment1 */
+  /* comment2 */
+];
+
+================================================================================
+`;
+
+exports[`dangling-comments.ts - {"trailingComma":"none"} format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+trailingComma: "none"
+                                                                                | printWidth
+=====================================input======================================
+type Foo1 = [/* comment */];
+
+type Foo2 = [
+    // comment
+];
+
+type Foo3 = [
+    // comment1
+    // comment2
+];
+
+type Foo4 = [
+    // comment1
+
+    // comment2
+];
+
+type Foo5 = [
+    /* comment1 */
+];
+
+type Foo6 = [
+    /* comment1 */
+
+    /* comment2 */
+];
+
+
+=====================================output=====================================
+type Foo1 = [
+  /* comment */
+];
+
+type Foo2 = [
+  // comment
+];
+
+type Foo3 = [
+  // comment1
+  // comment2
+];
+
+type Foo4 = [
+  // comment1
+  // comment2
+];
+
+type Foo5 = [
+  /* comment1 */
+];
+
+type Foo6 = [
+  /* comment1 */
+  /* comment2 */
+];
+
+================================================================================
+`;
+
 exports[`trailing-comma.ts - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/tuple/dangling-comments.ts
+++ b/tests/format/typescript/tuple/dangling-comments.ts
@@ -1,0 +1,27 @@
+type Foo1 = [/* comment */];
+
+type Foo2 = [
+    // comment
+];
+
+type Foo3 = [
+    // comment1
+    // comment2
+];
+
+type Foo4 = [
+    // comment1
+
+    // comment2
+];
+
+type Foo5 = [
+    /* comment1 */
+];
+
+type Foo6 = [
+    /* comment1 */
+
+    /* comment2 */
+];
+


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #13588

This is not a refactoring of the dangling comments format that thorn0 was mention to, just a consistent formatting of the dangling comments in arrays and tuple types.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
