### PR TITLE
Refactor template literal print

### DIFF
--- a/src/language-js/print/template-literal.js
+++ b/src/language-js/print/template-literal.js
@@ -14,7 +14,6 @@ import { printDocToString } from "../../document/printer.js";
 import { mapDoc } from "../../document/utils.js";
 import {
   isBinaryish,
-  isJestEachTemplateLiteral,
   isSimpleTemplateLiteral,
   hasComment,
   isMemberExpression,
@@ -26,7 +25,7 @@ function printTemplateLiteral(path, print, options) {
 
   if (
     isTemplateLiteral &&
-    isJestEachTemplateLiteral(node, path.getParentNode())
+    isJestEachTemplateLiteral(path)
   ) {
     const printed = printJestEachTemplateLiteral(path, options, print);
     if (printed) {
@@ -39,11 +38,11 @@ function printTemplateLiteral(path, print, options) {
   }
   const parts = [];
 
-  let expressions = path.map(print, expressionsKey);
+  let expressionDocs = path.map(print, expressionsKey);
   const isSimple = isSimpleTemplateLiteral(node);
 
   if (isSimple) {
-    expressions = expressions.map(
+    expressionDocs = expressionDocs.map(
       (doc) =>
         printDocToString(doc, {
           ...options,
@@ -54,52 +53,51 @@ function printTemplateLiteral(path, print, options) {
 
   parts.push(lineSuffixBoundary, "`");
 
-  path.each((childPath) => {
-    const i = childPath.getName();
-
+  path.each(({ index, node: quasi }) => {
     parts.push(print());
 
-    if (i < expressions.length) {
-      // For a template literal of the following form:
-      //   `someQuery {
-      //     ${call({
-      //       a,
-      //       b,
-      //     })}
-      //   }`
-      // the expression is on its own line (there is a \n in the previous
-      // quasi literal), therefore we want to indent the JavaScript
-      // expression inside at the beginning of ${ instead of the beginning
-      // of the `.
-      const { tabWidth } = options;
-      const quasi = childPath.node;
-      const indentSize = getIndentSize(quasi.value.raw, tabWidth);
-
-      let printed = expressions[i];
-
-      if (!isSimple) {
-        const expression = node[expressionsKey][i];
-        // Breaks at the template element boundaries (${ and }) are preferred to breaking
-        // in the middle of a MemberExpression
-        if (
-          hasComment(expression) ||
-          isMemberExpression(expression) ||
-          expression.type === "ConditionalExpression" ||
-          expression.type === "SequenceExpression" ||
-          expression.type === "TSAsExpression" ||
-          isBinaryish(expression)
-        ) {
-          printed = [indent([softline, printed]), softline];
-        }
-      }
-
-      const aligned =
-        indentSize === 0 && quasi.value.raw.endsWith("\n")
-          ? align(Number.NEGATIVE_INFINITY, printed)
-          : addAlignmentToDoc(printed, indentSize, tabWidth);
-
-      parts.push(group(["${", aligned, lineSuffixBoundary, "}"]));
+    if (quasi.tail) {
+      return;
     }
+
+    // For a template literal of the following form:
+    //   `someQuery {
+    //     ${call({
+    //       a,
+    //       b,
+    //     })}
+    //   }`
+    // the expression is on its own line (there is a \n in the previous
+    // quasi literal), therefore we want to indent the JavaScript
+    // expression inside at the beginning of ${ instead of the beginning
+    // of the `.
+    const { tabWidth } = options;
+    const indentSize = getIndentSize(quasi.value.raw, tabWidth);
+
+    let expressionDoc = expressionDocs[index];
+
+    if (!isSimple) {
+      const expression = node[expressionsKey][index];
+      // Breaks at the template element boundaries (${ and }) are preferred to breaking
+      // in the middle of a MemberExpression
+      if (
+        hasComment(expression) ||
+        isMemberExpression(expression) ||
+        expression.type === "ConditionalExpression" ||
+        expression.type === "SequenceExpression" ||
+        expression.type === "TSAsExpression" ||
+        isBinaryish(expression)
+      ) {
+        expressionDoc = [indent([softline, expressionDoc]), softline];
+      }
+    }
+
+    const aligned =
+      indentSize === 0 && quasi.value.raw.endsWith("\n")
+        ? align(Number.NEGATIVE_INFINITY, expressionDoc)
+        : addAlignmentToDoc(expressionDoc, indentSize, tabWidth);
+
+    parts.push(group(["${", aligned, lineSuffixBoundary, "}"]));
   }, "quasis");
 
   parts.push("`");
@@ -236,6 +234,35 @@ function escapeTemplateCharacters(doc, raw) {
 
 function uncookTemplateElementValue(cookedValue) {
   return cookedValue.replace(/([\\`]|\${)/g, "\\$1");
+}
+
+function isJestEachTemplateLiteral({node, parent}) {
+  /**
+   * describe.each`table`(name, fn)
+   * describe.only.each`table`(name, fn)
+   * describe.skip.each`table`(name, fn)
+   * test.each`table`(name, fn)
+   * test.only.each`table`(name, fn)
+   * test.skip.each`table`(name, fn)
+   *
+   * Ref: https://github.com/facebook/jest/pull/6102
+   */
+  const jestEachTriggerRegex = /^[fx]?(?:describe|it|test)$/;
+  return (
+    parent.type === "TaggedTemplateExpression" &&
+    parent.quasi === node &&
+    parent.tag.type === "MemberExpression" &&
+    parent.tag.property.type === "Identifier" &&
+    parent.tag.property.name === "each" &&
+    ((parent.tag.object.type === "Identifier" &&
+      jestEachTriggerRegex.test(parent.tag.object.name)) ||
+      (parent.tag.object.type === "MemberExpression" &&
+        parent.tag.object.property.type === "Identifier" &&
+        (parent.tag.object.property.name === "only" ||
+          parent.tag.object.property.name === "skip") &&
+        parent.tag.object.object.type === "Identifier" &&
+        jestEachTriggerRegex.test(parent.tag.object.object.name)))
+  );
 }
 
 export {

--- a/src/language-js/print/template-literal.js
+++ b/src/language-js/print/template-literal.js
@@ -23,10 +23,7 @@ function printTemplateLiteral(path, print, options) {
   const { node } = path;
   const isTemplateLiteral = node.type === "TemplateLiteral";
 
-  if (
-    isTemplateLiteral &&
-    isJestEachTemplateLiteral(path)
-  ) {
+  if (isTemplateLiteral && isJestEachTemplateLiteral(path)) {
     const printed = printJestEachTemplateLiteral(path, options, print);
     if (printed) {
       return printed;
@@ -236,7 +233,7 @@ function uncookTemplateElementValue(cookedValue) {
   return cookedValue.replace(/([\\`]|\${)/g, "\\$1");
 }
 
-function isJestEachTemplateLiteral({node, parent}) {
+function isJestEachTemplateLiteral({ node, parent }) {
   /**
    * describe.each`table`(name, fn)
    * describe.only.each`table`(name, fn)

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -703,40 +703,6 @@ function isSimpleNumber(numberString) {
 }
 
 /**
- * @param {Node} node
- * @param {Node} parentNode
- * @returns {boolean}
- */
-function isJestEachTemplateLiteral(node, parentNode) {
-  /**
-   * describe.each`table`(name, fn)
-   * describe.only.each`table`(name, fn)
-   * describe.skip.each`table`(name, fn)
-   * test.each`table`(name, fn)
-   * test.only.each`table`(name, fn)
-   * test.skip.each`table`(name, fn)
-   *
-   * Ref: https://github.com/facebook/jest/pull/6102
-   */
-  const jestEachTriggerRegex = /^[fx]?(?:describe|it|test)$/;
-  return (
-    parentNode.type === "TaggedTemplateExpression" &&
-    parentNode.quasi === node &&
-    parentNode.tag.type === "MemberExpression" &&
-    parentNode.tag.property.type === "Identifier" &&
-    parentNode.tag.property.name === "each" &&
-    ((parentNode.tag.object.type === "Identifier" &&
-      jestEachTriggerRegex.test(parentNode.tag.object.name)) ||
-      (parentNode.tag.object.type === "MemberExpression" &&
-        parentNode.tag.object.property.type === "Identifier" &&
-        (parentNode.tag.object.property.name === "only" ||
-          parentNode.tag.object.property.name === "skip") &&
-        parentNode.tag.object.object.type === "Identifier" &&
-        jestEachTriggerRegex.test(parentNode.tag.object.object.name)))
-  );
-}
-
-/**
  * @param {TemplateLiteral} template
  * @returns {boolean}
  */
@@ -1342,7 +1308,6 @@ export {
   isFunctionNotation,
   isFunctionOrArrowExpression,
   isGetterOrSetter,
-  isJestEachTemplateLiteral,
   isJsxNode,
   isLiteral,
   isLongCurriedCallExpression,


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

- Move `isJestEachTemplateLiteral` from `utils/index.js` into `print/template-literal.js`
- Use `AstPath` getters
- Rename variables https://github.com/prettier/prettier/pull/13621#discussion_r993334531
- Use `quasi.tail`
- Earlier return

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
