### PR TITLE
Fix package.json `exports` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "require": "./src/index.cjs",
       "default": "./src/index.js"
     },
-    "./*": "./"
+    "./*": "./*"
   },
   "engines": {
     "node": ">=16"

--- a/scripts/build/build-package-json.js
+++ b/scripts/build/build-package-json.js
@@ -22,7 +22,7 @@ async function buildPackageJson({ files }) {
       require: "./index.cjs",
       default: "./index.mjs",
     },
-    "./*": "./",
+    "./*": "./*",
     ...Object.fromEntries(
       files
         .filter((file) => file.output.format === "umd")


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

It seems

```
{
	"./*": "./"
}
```

is incorrect.

https://github.com/prettier/yaml-unist-parser/pull/289

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
