### PR TITLE
Fix codecov status check

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,4 +1,4 @@
-comment: off
+comment: false
 
 coverage:
   status:

--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -72,3 +72,4 @@ jobs:
         if: ${{ matrix.ENABLE_CODE_COVERAGE }}
         with:
           fail_ci_if_error: true
+          files: coverage/lcov.info

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -4,7 +4,8 @@ import installPrettier from "./tests/config/install-prettier.js";
 
 const { dirname: PROJECT_ROOT } = createEsmUtils(import.meta);
 const isProduction = process.env.NODE_ENV === "production";
-const ENABLE_CODE_COVERAGE = Boolean(process.env.ENABLE_CODE_COVERAGE);
+// Disabled https://github.com/nicolo-ribaudo/jest-light-runner/pull/13
+// const ENABLE_CODE_COVERAGE = Boolean(process.env.ENABLE_CODE_COVERAGE);
 const TEST_STANDALONE = Boolean(process.env.TEST_STANDALONE);
 const INSTALL_PACKAGE = Boolean(process.env.INSTALL_PACKAGE);
 // When debugging production test, this flag can skip installing package
@@ -58,7 +59,7 @@ const config = {
     "<rootDir>/tests/unit/**/*.js",
   ],
   testPathIgnorePatterns,
-  collectCoverage: ENABLE_CODE_COVERAGE,
+  // collectCoverage: ENABLE_CODE_COVERAGE,
   collectCoverageFrom: ["<rootDir>/src/**/*.js", "<rootDir>/bin/**/*.js"],
   coveragePathIgnorePatterns: [
     "<rootDir>/src/standalone.js",

--- a/package.json
+++ b/package.json
@@ -181,6 +181,14 @@
     "reporter": [
       "lcov",
       "text"
+    ],
+    "include": [
+      "src/**",
+      "bin/**"
+    ],
+    "exclude": [
+      "src/standalone.js",
+      "src/document/debug.js"
     ]
   },
   "browserslist": [


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

https://github.com/prettier/prettier/pull/11597#issuecomment-1279336969

As tested in #13643, the check is missing because there are too many files generate by `c8`, add `files` config should fix it.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
