### PR TITLE
Remove `prefer-ast-path-node` and add `prefer-ast-path-getters`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -344,7 +344,7 @@ module.exports = {
         "prettier-internal-rules/prefer-indent-if-break": "error",
         "prettier-internal-rules/prefer-is-non-empty-array": "error",
         "prettier-internal-rules/prefer-fs-promises-submodule": "error",
-        "prettier-internal-rules/prefer-ast-path-node": "error",
+        "prettier-internal-rules/prefer-ast-path-getters": "error",
       },
     },
     {

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/index.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/index.js
@@ -18,6 +18,6 @@ module.exports = {
     "prefer-indent-if-break": require("./prefer-indent-if-break.js"),
     "prefer-is-non-empty-array": require("./prefer-is-non-empty-array.js"),
     "prefer-fs-promises-submodule": require("./prefer-fs-promises-submodule.js"),
-    "prefer-ast-path-node": require("./prefer-ast-path-node.js"),
+    "prefer-ast-path-getters": require("./prefer-ast-path-getters.js"),
   },
 };

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-getters.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-getters.js
@@ -28,15 +28,15 @@ module.exports = {
   create(context) {
     const report = (node, argumentsLength, getterName) => {
       const getterMethodMap = new Map([
-        ["`node`", "`path.getValue()` or `path.getNode()`"],
-        ["`parent`", "`path.getParent()`"],
-        ["`grandparent`", "`path.getParent(1)"],
+        ["node", "`path.getValue()`` or `path.getNode()`"],
+        ["parent", "`path.getParentNode()` or `path.getParentNode(0)`"],
+        ["grandparent", "`path.getParentNode(1)`"],
       ]);
       context.report({
         node,
         messageId,
         data: {
-          getter: getterName,
+          getter: "`" + getterName + "`",
           method: getterMethodMap.get(getterName),
         },
         fix: (fixer) => [

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-getters.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-getters.js
@@ -22,22 +22,17 @@ module.exports = {
     },
     fixable: "code",
     messages: {
-      [messageId]: "Prefer {{ getter }} instead of {{ method }}.",
+      [messageId]: "Prefer `AstPath#{{ getter }}` over `AstPath#{{ method }}`.",
     },
   },
   create(context) {
     const report = (node, argumentsLength, getterName) => {
-      const getterMethodMap = new Map([
-        ["node", "`path.getValue()` or `path.getNode()`"],
-        ["parent", "`path.getParentNode()` or `path.getParentNode(0)`"],
-        ["grandparent", "`path.getParentNode(1)`"],
-      ]);
       context.report({
         node,
         messageId,
         data: {
-          getter: `\`path.${getterName}\``,
-          method: getterMethodMap.get(getterName),
+          getter: getterName,
+          method: node.property.name,
         },
         fix: (fixer) => [
           fixer.replaceTextRange(
@@ -57,7 +52,7 @@ module.exports = {
           return;
         }
 
-        const propertyName = node.property?.name;
+        const propertyName = node.property.name;
         const callExprArguments = node.parent.arguments;
 
         if (
@@ -69,11 +64,13 @@ module.exports = {
         }
 
         if (propertyName === getParentNodeFunctionName) {
-          if (callExprArguments.length === 0) {
+          if (
             // path.getParentNode()
-            report(node, callExprArguments.length, "parent");
-          } else if (callExprArguments[0].value === 0) {
+            callExprArguments.length === 0 ||
             // path.getParentNode(0)
+            callExprArguments[0].value === 0
+          ) {
+            // path.getParentNode()
             report(node, callExprArguments.length, "parent");
           } else if (callExprArguments[0].value === 1) {
             // path.getParentNode(1)

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-getters.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-getters.js
@@ -28,7 +28,7 @@ module.exports = {
   create(context) {
     const report = (node, argumentsLength, getterName) => {
       const getterMethodMap = new Map([
-        ["node", "`path.getValue()`` or `path.getNode()`"],
+        ["node", "`path.getValue()` or `path.getNode()`"],
         ["parent", "`path.getParentNode()` or `path.getParentNode(0)`"],
         ["grandparent", "`path.getParentNode(1)`"],
       ]);
@@ -36,7 +36,7 @@ module.exports = {
         node,
         messageId,
         data: {
-          getter: "`" + getterName + "`",
+          getter: `\`path.${getterName}\``,
           method: getterMethodMap.get(getterName),
         },
         fix: (fixer) => [

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-getters.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-getters.js
@@ -7,10 +7,9 @@ const selector = [
   '[callee.type="MemberExpression"]',
   "[callee.computed=false]",
   "[callee.optional=false]",
-  '[callee.property.type="Identifier"]',
-  '[callee.type="MemberExpression"]',
   '[callee.object.type="Identifier"]',
   "[callee.object.name=/[pP]ath$/]",
+  '[callee.property.type="Identifier"]',
 ].join("");
 
 const messageId = "prefer-ast-path-getters";

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-getters.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-getters.js
@@ -5,7 +5,7 @@ const selector = [
   "> MemberExpression",
 ].join("");
 
-const messageId = "prefer-ast-path-node";
+const messageId = "prefer-ast-path-getters";
 
 const getNodeFunctionNames = new Set(["getValue", "getNode"]);
 const getParentNodeFunctionName = "getParentNode";
@@ -18,19 +18,19 @@ module.exports = {
   meta: {
     type: "suggestion",
     docs: {
-      url: "https://github.com/prettier/prettier/blob/main/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-node.js",
+      url: "https://github.com/prettier/prettier/blob/main/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-getters.js",
     },
     fixable: "code",
     messages: {
-      [messageId]: "Prefer {{ getter }} instead of {{ method }} for path.",
+      [messageId]: "Prefer {{ getter }} instead of {{ method }}.",
     },
   },
   create(context) {
     const report = (node, argumentsLength, getterName) => {
       const getterMethodMap = new Map([
-        ["node", "`path.getValue()` or `path.getNode()`"],
-        ["parent", "`path.getParent()`"],
-        ["grandparent", "`path.getParent(1)"],
+        ["`node`", "`path.getValue()` or `path.getNode()`"],
+        ["`parent`", "`path.getParent()`"],
+        ["`grandparent`", "`path.getParent(1)"],
       ]);
       context.report({
         node,

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-node.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-node.js
@@ -1,13 +1,18 @@
 "use strict";
 
 const selector = [
-  "CallExpression[arguments.length=0]",
+  "CallExpression[arguments.length<2]",
   "> MemberExpression",
 ].join("");
 
 const messageId = "prefer-ast-path-node";
 
 const getNodeFunctionNames = new Set(["getValue", "getNode"]);
+const getParentNodeFunctionName = "getParentNode";
+
+function isPathMemberExpression(node) {
+  return node.object?.name?.toLowerCase().endsWith("path");
+}
 
 module.exports = {
   meta: {
@@ -17,33 +22,77 @@ module.exports = {
     },
     fixable: "code",
     messages: {
-      [messageId]:
-        "Prefer `path.node` instead of `path.getValue()` and `path.getNode()`",
+      [messageId]: "Prefer {{ getter }} instead of {{ method }} for path.",
     },
   },
   create(context) {
+    const report = (node, argumentsLength, getterName) => {
+      const data =
+        getterName === "node"
+          ? {
+              getter: "`path.node`",
+              method: "`path.getValue()` or `path.getNode()`",
+            }
+          : getterName === "parent"
+          ? {
+              getter: "`path.parent`",
+              method: "`path.getParent()`",
+            }
+          : getterName === "grandparent"
+          ? {
+              getter: "`path.grandparent`",
+              method: "`path.getParent(1)`",
+            }
+          : null;
+      context.report({
+        node,
+        messageId,
+        data,
+        fix: (fixer) => [
+          fixer.replaceTextRange(
+            [
+              node.property.range[0],
+              // remove `()` for CallExpression
+              node.property.range[1] + 2 + argumentsLength,
+            ],
+            getterName
+          ),
+        ],
+      });
+    };
     return {
       [selector](node) {
-        if (!node.object?.name?.toLowerCase().endsWith("path")) {
+        if (!isPathMemberExpression(node)) {
           return;
         }
-        if (!getNodeFunctionNames.has(node.property?.name)) {
+
+        const propertyName = node.property?.name;
+        const callExprArguments = node.parent.arguments;
+
+        // path.getNode() or path.getValue()
+        if (
+          getNodeFunctionNames.has(propertyName) &&
+          callExprArguments.length === 0
+        ) {
+          report(node, callExprArguments.length, "node");
           return;
         }
-        context.report({
-          node,
-          messageId,
-          fix: (fixer) => [
-            fixer.replaceTextRange(
-              [
-                node.property.range[0],
-                // remove `()` for CallExpression
-                node.property.range[1] + 2,
-              ],
-              "node"
-            ),
-          ],
-        });
+
+        if (propertyName === getParentNodeFunctionName) {
+          // path.getParentNode()
+          if (callExprArguments.length === 0) {
+            report(node, callExprArguments.length, "parent");
+            return;
+          }
+          // path.getParentNode(0)
+          if (callExprArguments[0].value === 0) {
+            report(node, callExprArguments.arguments, "parent");
+          }
+          // path.getParentNode(1)
+          if (callExprArguments[0].value === 1) {
+            report(node, callExprArguments.length, "grandparent");
+          }
+        }
       },
     };
   },

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-node.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-node.js
@@ -83,7 +83,7 @@ module.exports = {
             report(node, callExprArguments.length, "parent");
           } else if (callExprArguments[0].value === 0) {
             // path.getParentNode(0)
-            report(node, callExprArguments.arguments, "parent");
+            report(node, callExprArguments.length, "parent");
           } else if (callExprArguments[0].value === 1) {
             // path.getParentNode(1)
             report(node, callExprArguments.length, "grandparent");

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-node.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-node.js
@@ -69,27 +69,23 @@ module.exports = {
         const propertyName = node.property?.name;
         const callExprArguments = node.parent.arguments;
 
-        // path.getNode() or path.getValue()
         if (
           getNodeFunctionNames.has(propertyName) &&
           callExprArguments.length === 0
         ) {
+          // path.getNode() or path.getValue()
           report(node, callExprArguments.length, "node");
-          return;
         }
 
         if (propertyName === getParentNodeFunctionName) {
-          // path.getParentNode()
           if (callExprArguments.length === 0) {
+            // path.getParentNode()
             report(node, callExprArguments.length, "parent");
-            return;
-          }
-          // path.getParentNode(0)
-          if (callExprArguments[0].value === 0) {
+          } else if (callExprArguments[0].value === 0) {
+            // path.getParentNode(0)
             report(node, callExprArguments.arguments, "parent");
-          }
-          // path.getParentNode(1)
-          if (callExprArguments[0].value === 1) {
+          } else if (callExprArguments[0].value === 1) {
+            // path.getParentNode(1)
             report(node, callExprArguments.length, "grandparent");
           }
         }

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-node.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/prefer-ast-path-node.js
@@ -27,27 +27,18 @@ module.exports = {
   },
   create(context) {
     const report = (node, argumentsLength, getterName) => {
-      const data =
-        getterName === "node"
-          ? {
-              getter: "`path.node`",
-              method: "`path.getValue()` or `path.getNode()`",
-            }
-          : getterName === "parent"
-          ? {
-              getter: "`path.parent`",
-              method: "`path.getParent()`",
-            }
-          : getterName === "grandparent"
-          ? {
-              getter: "`path.grandparent`",
-              method: "`path.getParent(1)`",
-            }
-          : null;
+      const getterMethodMap = new Map([
+        ["node", "`path.getValue()` or `path.getNode()`"],
+        ["parent", "`path.getParent()`"],
+        ["grandparent", "`path.getParent(1)"],
+      ]);
       context.report({
         node,
         messageId,
-        data,
+        data: {
+          getter: getterName,
+          method: getterMethodMap.get(getterName),
+        },
         fix: (fixer) => [
           fixer.replaceTextRange(
             [

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
@@ -518,8 +518,7 @@ test("prefer-ast-path-getters", {
       output: "path.node",
       errors: [
         {
-          message:
-            "Prefer `path.node` instead of `path.getValue()` or `path.getNode()`.",
+          message: "Prefer `AstPath#node` over `AstPath#getNode()`.",
         },
       ],
     },
@@ -528,8 +527,7 @@ test("prefer-ast-path-getters", {
       output: "const node = path.node",
       errors: [
         {
-          message:
-            "Prefer `path.node` instead of `path.getValue()` or `path.getNode()`.",
+          message: "Prefer `AstPath#node` over `AstPath#getNode()`.",
         },
       ],
     },
@@ -538,8 +536,7 @@ test("prefer-ast-path-getters", {
       output: "fooPath.node",
       errors: [
         {
-          message:
-            "Prefer `path.node` instead of `path.getValue()` or `path.getNode()`.",
+          message: "Prefer `AstPath#node` over `AstPath#getNode()`.",
         },
       ],
     },
@@ -550,8 +547,7 @@ test("prefer-ast-path-getters", {
       output: "path.node",
       errors: [
         {
-          message:
-            "Prefer `path.node` instead of `path.getValue()` or `path.getNode()`.",
+          message: "Prefer `AstPath#node` over `AstPath#getValue()`.",
         },
       ],
     },
@@ -560,8 +556,7 @@ test("prefer-ast-path-getters", {
       output: "const node = path.node",
       errors: [
         {
-          message:
-            "Prefer `path.node` instead of `path.getValue()` or `path.getNode()`.",
+          message: "Prefer `AstPath#node` over `AstPath#getValue()`.",
         },
       ],
     },
@@ -570,8 +565,7 @@ test("prefer-ast-path-getters", {
       output: "fooPath.node",
       errors: [
         {
-          message:
-            "Prefer `path.node` instead of `path.getValue()` or `path.getNode()`.",
+          message: "Prefer `AstPath#node` over `AstPath#getValue()`.",
         },
       ],
     },
@@ -582,8 +576,7 @@ test("prefer-ast-path-getters", {
       output: "path.parent",
       errors: [
         {
-          message:
-            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+          message: "Prefer `AstPath#parent` over `AstPath#getParentNode()`.",
         },
       ],
     },
@@ -592,8 +585,7 @@ test("prefer-ast-path-getters", {
       output: "const node = path.parent",
       errors: [
         {
-          message:
-            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+          message: "Prefer `AstPath#parent` over `AstPath#getParentNode()`.",
         },
       ],
     },
@@ -602,8 +594,7 @@ test("prefer-ast-path-getters", {
       output: "path.parent",
       errors: [
         {
-          message:
-            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+          message: "Prefer `AstPath#parent` over `AstPath#getParentNode()`.",
         },
       ],
     },
@@ -612,8 +603,7 @@ test("prefer-ast-path-getters", {
       output: "const node = path.parent",
       errors: [
         {
-          message:
-            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+          message: "Prefer `AstPath#parent` over `AstPath#getParentNode()`.",
         },
       ],
     },
@@ -622,8 +612,7 @@ test("prefer-ast-path-getters", {
       output: "fooPath.parent",
       errors: [
         {
-          message:
-            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+          message: "Prefer `AstPath#parent` over `AstPath#getParentNode()`.",
         },
       ],
     },
@@ -634,8 +623,7 @@ test("prefer-ast-path-getters", {
       output: "path.parent",
       errors: [
         {
-          message:
-            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+          message: "Prefer `AstPath#parent` over `AstPath#getParentNode(0)`.",
         },
       ],
     },
@@ -644,8 +632,7 @@ test("prefer-ast-path-getters", {
       output: "const node = path.parent",
       errors: [
         {
-          message:
-            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+          message: "Prefer `AstPath#parent` over `AstPath#getParentNode(0)`.",
         },
       ],
     },
@@ -654,8 +641,7 @@ test("prefer-ast-path-getters", {
       output: "path.parent",
       errors: [
         {
-          message:
-            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+          message: "Prefer `AstPath#parent` over `AstPath#getParentNode(0)`.",
         },
       ],
     },
@@ -664,8 +650,7 @@ test("prefer-ast-path-getters", {
       output: "const node = path.parent",
       errors: [
         {
-          message:
-            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+          message: "Prefer `AstPath#parent` over `AstPath#getParentNode(0)`.",
         },
       ],
     },
@@ -674,8 +659,7 @@ test("prefer-ast-path-getters", {
       output: "fooPath.parent",
       errors: [
         {
-          message:
-            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+          message: "Prefer `AstPath#parent` over `AstPath#getParentNode(0)`.",
         },
       ],
     },
@@ -687,7 +671,7 @@ test("prefer-ast-path-getters", {
       errors: [
         {
           message:
-            "Prefer `path.grandparent` instead of `path.getParentNode(1)`.",
+            "Prefer `AstPath#grandparent` over `AstPath#getParentNode(1)`.",
         },
       ],
     },
@@ -697,7 +681,7 @@ test("prefer-ast-path-getters", {
       errors: [
         {
           message:
-            "Prefer `path.grandparent` instead of `path.getParentNode(1)`.",
+            "Prefer `AstPath#grandparent` over `AstPath#getParentNode(1)`.",
         },
       ],
     },
@@ -707,7 +691,7 @@ test("prefer-ast-path-getters", {
       errors: [
         {
           message:
-            "Prefer `path.grandparent` instead of `path.getParentNode(1)`.",
+            "Prefer `AstPath#grandparent` over `AstPath#getParentNode(1)`.",
         },
       ],
     },
@@ -717,7 +701,7 @@ test("prefer-ast-path-getters", {
       errors: [
         {
           message:
-            "Prefer `path.grandparent` instead of `path.getParentNode(1)`.",
+            "Prefer `AstPath#grandparent` over `AstPath#getParentNode(1)`.",
         },
       ],
     },
@@ -727,7 +711,7 @@ test("prefer-ast-path-getters", {
       errors: [
         {
           message:
-            "Prefer `path.grandparent` instead of `path.getParentNode(1)`.",
+            "Prefer `AstPath#grandparent` over `AstPath#getParentNode(1)`.",
         },
       ],
     },

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
@@ -497,15 +497,22 @@ test("prefer-fs-promises-submodule", {
   })),
 });
 
-test("prefer-ast-path-node", {
+test("prefer-ast-path-getters", {
   valid: [
     "path.getNode(2)",
     "path.getNode",
     "getNode",
     "this.getNode()",
     "path.node",
+    "path.getParentNode(2)",
+    "path.getParentNode",
+    "getParentNode",
+    "this.getParentNode()",
+    "path.parent",
+    "path.grandparent",
   ],
   invalid: [
+    // path.getNode
     {
       code: "path.getNode()",
       output: "path.node",
@@ -516,6 +523,13 @@ test("prefer-ast-path-node", {
       output: "const node = path.node",
       errors: 1,
     },
+    {
+      code: "fooPath.getNode()",
+      output: "fooPath.node",
+      errors: 1,
+    },
+
+    // path.getValue()
     {
       code: "path.getValue()",
       output: "path.node",
@@ -531,9 +545,85 @@ test("prefer-ast-path-node", {
       output: "fooPath.node",
       errors: 1,
     },
+
+    // path.getParentNode()
     {
-      code: "fooPath.getNode()",
-      output: "fooPath.node",
+      code: "path.getParentNode()",
+      output: "path.parent",
+      errors: 1,
+    },
+    {
+      code: "const node = path.getParentNode()",
+      output: "const node = path.parent",
+      errors: 1,
+    },
+    {
+      code: "path.getParentNode()",
+      output: "path.parent",
+      errors: 1,
+    },
+    {
+      code: "const node = path.getParentNode()",
+      output: "const node = path.parent",
+      errors: 1,
+    },
+    {
+      code: "fooPath.getParentNode()",
+      output: "fooPath.parent",
+      errors: 1,
+    },
+
+    // path.getParentNode(0)
+    {
+      code: "path.getParentNode(0)",
+      output: "path.parent",
+      errors: 1,
+    },
+    {
+      code: "const node = path.getParentNode(0)",
+      output: "const node = path.parent",
+      errors: 1,
+    },
+    {
+      code: "path.getParentNode(0)",
+      output: "path.parent",
+      errors: 1,
+    },
+    {
+      code: "const node = path.getParentNode(0)",
+      output: "const node = path.parent",
+      errors: 1,
+    },
+    {
+      code: "fooPath.getParentNode(0)",
+      output: "fooPath.parent",
+      errors: 1,
+    },
+
+    // path.getParentNode(1)
+    {
+      code: "path.getParentNode(1)",
+      output: "path.grandparent",
+      errors: 1,
+    },
+    {
+      code: "const node = path.getParentNode(1)",
+      output: "const node = path.grandparent",
+      errors: 1,
+    },
+    {
+      code: "path.getParentNode(1)",
+      output: "path.grandparent",
+      errors: 1,
+    },
+    {
+      code: "const node = path.getParentNode(1)",
+      output: "const node = path.grandparent",
+      errors: 1,
+    },
+    {
+      code: "fooPath.getParentNode(1)",
+      output: "fooPath.grandparent",
       errors: 1,
     },
   ],

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
@@ -516,115 +516,220 @@ test("prefer-ast-path-getters", {
     {
       code: "path.getNode()",
       output: "path.node",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.node` instead of `path.getValue()` or `path.getNode()`.",
+        },
+      ],
     },
     {
       code: "const node = path.getNode()",
       output: "const node = path.node",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.node` instead of `path.getValue()` or `path.getNode()`.",
+        },
+      ],
     },
     {
       code: "fooPath.getNode()",
       output: "fooPath.node",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.node` instead of `path.getValue()` or `path.getNode()`.",
+        },
+      ],
     },
 
     // path.getValue()
     {
       code: "path.getValue()",
       output: "path.node",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.node` instead of `path.getValue()` or `path.getNode()`.",
+        },
+      ],
     },
     {
       code: "const node = path.getValue()",
       output: "const node = path.node",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.node` instead of `path.getValue()` or `path.getNode()`.",
+        },
+      ],
     },
     {
       code: "fooPath.getValue()",
       output: "fooPath.node",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.node` instead of `path.getValue()` or `path.getNode()`.",
+        },
+      ],
     },
 
     // path.getParentNode()
     {
       code: "path.getParentNode()",
       output: "path.parent",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+        },
+      ],
     },
     {
       code: "const node = path.getParentNode()",
       output: "const node = path.parent",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+        },
+      ],
     },
     {
       code: "path.getParentNode()",
       output: "path.parent",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+        },
+      ],
     },
     {
       code: "const node = path.getParentNode()",
       output: "const node = path.parent",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+        },
+      ],
     },
     {
       code: "fooPath.getParentNode()",
       output: "fooPath.parent",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+        },
+      ],
     },
 
     // path.getParentNode(0)
     {
       code: "path.getParentNode(0)",
       output: "path.parent",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+        },
+      ],
     },
     {
       code: "const node = path.getParentNode(0)",
       output: "const node = path.parent",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+        },
+      ],
     },
     {
       code: "path.getParentNode(0)",
       output: "path.parent",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+        },
+      ],
     },
     {
       code: "const node = path.getParentNode(0)",
       output: "const node = path.parent",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+        },
+      ],
     },
     {
       code: "fooPath.getParentNode(0)",
       output: "fooPath.parent",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.parent` instead of `path.getParentNode()` or `path.getParentNode(0)`.",
+        },
+      ],
     },
 
     // path.getParentNode(1)
     {
       code: "path.getParentNode(1)",
       output: "path.grandparent",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.grandparent` instead of `path.getParentNode(1)`.",
+        },
+      ],
     },
     {
       code: "const node = path.getParentNode(1)",
       output: "const node = path.grandparent",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.grandparent` instead of `path.getParentNode(1)`.",
+        },
+      ],
     },
     {
       code: "path.getParentNode(1)",
       output: "path.grandparent",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.grandparent` instead of `path.getParentNode(1)`.",
+        },
+      ],
     },
     {
       code: "const node = path.getParentNode(1)",
       output: "const node = path.grandparent",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.grandparent` instead of `path.getParentNode(1)`.",
+        },
+      ],
     },
     {
       code: "fooPath.getParentNode(1)",
       output: "fooPath.grandparent",
-      errors: 1,
+      errors: [
+        {
+          message:
+            "Prefer `path.grandparent` instead of `path.getParentNode(1)`.",
+        },
+      ],
     },
   ],
 });

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -132,7 +132,7 @@ function genericPrint(path, options, print) {
       ];
 
     case "css-decl": {
-      const parentNode = path.getParentNode();
+      const parentNode = path.parent;
 
       const { between: rawBetween } = node.raws;
       const trimmedBetween = rawBetween.trim();
@@ -189,7 +189,7 @@ function genericPrint(path, options, print) {
       ];
     }
     case "css-atrule": {
-      const parentNode = path.getParentNode();
+      const parentNode = path.parent;
       const isTemplatePlaceholderNodeWithoutSemiColon =
         isTemplatePlaceholderNode(node) &&
         !parentNode.raws.semicolon &&
@@ -385,7 +385,7 @@ function genericPrint(path, options, print) {
       return adjustStrings(node.value, options);
 
     case "selector-tag": {
-      const parentNode = path.getParentNode();
+      const parentNode = path.parent;
       const index = parentNode && parentNode.nodes.indexOf(node);
       const prevNode = index && parentNode.nodes[index - 1];
 
@@ -433,7 +433,7 @@ function genericPrint(path, options, print) {
         node.value === "~" ||
         node.value === ">>>"
       ) {
-        const parentNode = path.getParentNode();
+        const parentNode = path.parent;
         const leading =
           parentNode.type === "selector-selector" &&
           parentNode.nodes[0] === node
@@ -484,7 +484,7 @@ function genericPrint(path, options, print) {
       }
 
       // originalText has to be used for Less, see replaceQuotesInInlineComments in loc.js
-      const parentNode = path.getParentNode();
+      const parentNode = path.parent;
       if (parentNode.raws && parentNode.raws.selector) {
         const start = locStart(parentNode);
         const end = start + parentNode.raws.selector.length;
@@ -492,7 +492,7 @@ function genericPrint(path, options, print) {
       }
 
       // Same reason above
-      const grandParent = path.getParentNode(1);
+      const grandParent = path.grandparent;
       if (
         parentNode.type === "value-paren_group" &&
         grandParent &&
@@ -519,8 +519,8 @@ function genericPrint(path, options, print) {
       return options.originalText.slice(locStart(node), locEnd(node));
 
     case "value-comma_group": {
-      const parentNode = path.getParentNode();
-      const parentParentNode = path.getParentNode(1);
+      const parentNode = path.parent;
+      const parentParentNode = path.grandparent;
       const declAncestorProp = getPropOfDeclNode(path);
       const isGridValue =
         declAncestorProp &&
@@ -867,7 +867,7 @@ function genericPrint(path, options, print) {
       return group(indent(fill(parts)));
     }
     case "value-paren_group": {
-      const parentNode = path.getParentNode();
+      const parentNode = path.parent;
       const printedGroups = path.map(() => {
         const child = path.node;
         return typeof child === "string" ? child : print();
@@ -1004,7 +1004,7 @@ function genericPrint(path, options, print) {
       return node.value;
 
     case "value-colon": {
-      const parentNode = path.getParentNode();
+      const parentNode = path.parent;
       const index = parentNode && parentNode.groups.indexOf(node);
       const prevNode = index && parentNode.groups[index - 1];
       return [

--- a/src/language-css/utils/index.js
+++ b/src/language-css/utils/index.js
@@ -109,7 +109,7 @@ function isVarFunctionNode(node) {
 }
 
 function isLastNode(path, node) {
-  const nodes = path.getParentNode()?.nodes;
+  const nodes = path.parent?.nodes;
   return nodes && nodes.indexOf(node) === nodes.length - 1;
 }
 
@@ -262,7 +262,7 @@ function isSCSSMapItemNode(path, options) {
     return false;
   }
 
-  const parentParentNode = path.getParentNode(1);
+  const parentParentNode = path.grandparent;
 
   // Check open parens contain key/value pair (i.e. `(key: value)` and `(key: (value, other-value)`)
   if (

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -85,7 +85,7 @@ function print(path, options, print) {
     }
 
     case "BlockStatement": {
-      const pp = path.getParentNode(1);
+      const pp = path.grandparent;
 
       const isElseIfLike =
         pp &&
@@ -550,7 +550,7 @@ function printElseBlock(node, options) {
 }
 
 function printElseIfLikeBlock(path, print, ifLikeKeyword) {
-  const parentNode = path.getParentNode(1);
+  const parentNode = path.grandparent;
 
   return [
     printInverseBlockOpeningMustache(parentNode),

--- a/src/language-handlebars/utils.js
+++ b/src/language-handlebars/utils.js
@@ -2,7 +2,7 @@ import { htmlVoidElements } from "html-void-elements";
 
 function isLastNodeOfSiblings(path) {
   const { node } = path;
-  const parentNode = path.getParentNode(0);
+  const parentNode = path.parent;
 
   if (
     isParentOfSomeType(path, ["ElementNode"]) &&
@@ -49,7 +49,7 @@ function isNodeOfSomeType(node, types) {
 }
 
 function isParentOfSomeType(path, types) {
-  const parentNode = path.getParentNode(0);
+  const parentNode = path.parent;
   return isNodeOfSomeType(parentNode, types);
 }
 
@@ -65,7 +65,7 @@ function isNextNodeOfSomeType(path, types) {
 
 function getSiblingNode(path, offset) {
   const { node } = path;
-  const parentNode = path.getParentNode(0) ?? {};
+  const parentNode = path.parent ?? {};
   const children =
     parentNode.children ?? parentNode.body ?? parentNode.parts ?? [];
   const index = children.indexOf(node);

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -226,7 +226,7 @@ function needsParens(path, options) {
         return true;
       }
       if (node.operator === "|>" && node.extra && node.extra.parenthesized) {
-        const grandParent = path.getParentNode(1);
+        const grandParent = path.grandparent;
         if (
           grandParent.type === "BinaryExpression" &&
           grandParent.operator === "|>"
@@ -443,7 +443,7 @@ function needsParens(path, options) {
         (key === "objectType" && parent.type === "TSIndexedAccessType") ||
         parent.type === "TSTypeOperator" ||
         (parent.type === "TSTypeAnnotation" &&
-          path.getParentNode(1).type.startsWith("TSJSDoc"))
+          path.grandparent.type.startsWith("TSJSDoc"))
       );
 
     case "ArrayTypeAnnotation":
@@ -472,7 +472,7 @@ function needsParens(path, options) {
     case "FunctionTypeAnnotation": {
       const ancestor =
         parent.type === "NullableTypeAnnotation"
-          ? path.getParentNode(1)
+          ? path.grandparent
           : parent;
 
       return (
@@ -516,7 +516,7 @@ function needsParens(path, options) {
         !parent.directive
       ) {
         // To avoid becoming a directive
-        const grandParent = path.getParentNode(1);
+        const grandParent = path.grandparent;
 
         return (
           grandParent.type === "Program" ||
@@ -531,7 +531,7 @@ function needsParens(path, options) {
       );
 
     case "AssignmentExpression": {
-      const grandParent = path.getParentNode(1);
+      const grandParent = path.grandparent;
 
       if (key === "body" && parent.type === "ArrowFunctionExpression") {
         return true;
@@ -684,7 +684,7 @@ function needsParens(path, options) {
 
     case "OptionalMemberExpression":
     case "OptionalCallExpression": {
-      const parentParent = path.getParentNode(1);
+      const parentParent = path.grandparent;
       if (
         (key === "object" && parent.type === "MemberExpression") ||
         (key === "callee" &&

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -471,9 +471,7 @@ function needsParens(path, options) {
 
     case "FunctionTypeAnnotation": {
       const ancestor =
-        parent.type === "NullableTypeAnnotation"
-          ? path.grandparent
-          : parent;
+        parent.type === "NullableTypeAnnotation" ? path.grandparent : parent;
 
       return (
         ancestor.type === "UnionTypeAnnotation" ||

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -28,8 +28,8 @@ import {
 let uid = 0;
 function printBinaryishExpression(path, options, print) {
   const { node } = path;
-  const parent = path.getParentNode();
-  const parentParent = path.getParentNode(1);
+  const {parent} = path;
+  const parentParent = path.grandparent;
   const isInsideParenthesis =
     node !== parent.body &&
     (parent.type === "IfStatement" ||
@@ -278,7 +278,7 @@ function printBinaryishExpressions(
 
   // If there's only a single binary expression, we want to create a group
   // in order to avoid having a small right part like -1 be on its own line.
-  const parent = path.getParentNode();
+  const {parent} = path;
   const shouldBreak = hasComment(
     node.left,
     CommentCheckFlags.Trailing | CommentCheckFlags.Line

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -28,7 +28,7 @@ import {
 let uid = 0;
 function printBinaryishExpression(path, options, print) {
   const { node } = path;
-  const {parent} = path;
+  const { parent } = path;
   const parentParent = path.grandparent;
   const isInsideParenthesis =
     node !== parent.body &&
@@ -278,7 +278,7 @@ function printBinaryishExpressions(
 
   // If there's only a single binary expression, we want to create a group
   // in order to avoid having a small right part like -1 be on its own line.
-  const {parent} = path;
+  const { parent } = path;
   const shouldBreak = hasComment(
     node.left,
     CommentCheckFlags.Trailing | CommentCheckFlags.Line

--- a/src/language-js/print/block.js
+++ b/src/language-js/print/block.js
@@ -21,7 +21,7 @@ function printBlock(path, options, print) {
   }
 
   if (node.type === "ClassBody" && isNonEmptyArray(node.body)) {
-    const parent = path.getParentNode();
+    const {parent} = path;
     parts.push(printHardlineAfterHeritage(parent));
   }
 
@@ -30,8 +30,8 @@ function printBlock(path, options, print) {
   if (printed) {
     parts.push(indent([hardline, printed]), hardline);
   } else {
-    const parent = path.getParentNode();
-    const parentParent = path.getParentNode(1);
+    const {parent} = path;
+    const parentParent = path.grandparent;
     if (
       !(
         parent.type === "ArrowFunctionExpression" ||
@@ -94,7 +94,7 @@ function printBlockBody(path, options, print) {
   }
 
   if (node.type === "Program") {
-    const parent = path.getParentNode();
+    const {parent} = path;
     if (!parent || parent.type !== "ModuleExpression") {
       parts.push(hardline);
     }

--- a/src/language-js/print/block.js
+++ b/src/language-js/print/block.js
@@ -21,7 +21,7 @@ function printBlock(path, options, print) {
   }
 
   if (node.type === "ClassBody" && isNonEmptyArray(node.body)) {
-    const {parent} = path;
+    const { parent } = path;
     parts.push(printHardlineAfterHeritage(parent));
   }
 
@@ -30,7 +30,7 @@ function printBlock(path, options, print) {
   if (printed) {
     parts.push(indent([hardline, printed]), hardline);
   } else {
-    const {parent} = path;
+    const { parent } = path;
     const parentParent = path.grandparent;
     if (
       !(
@@ -94,7 +94,7 @@ function printBlockBody(path, options, print) {
   }
 
   if (node.type === "Program") {
-    const {parent} = path;
+    const { parent } = path;
     if (!parent || parent.type !== "ModuleExpression") {
       parts.push(hardline);
     }

--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -86,7 +86,7 @@ function printCallArguments(path, options, print) {
 
   if (
     anyArgEmptyLine ||
-    (path.getParentNode().type !== "Decorator" &&
+    (path.parent.type !== "Decorator" &&
       isFunctionCompositionArgs(args))
   ) {
     return allArgsBrokenOut();

--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -86,8 +86,7 @@ function printCallArguments(path, options, print) {
 
   if (
     anyArgEmptyLine ||
-    (path.parent.type !== "Decorator" &&
-      isFunctionCompositionArgs(args))
+    (path.parent.type !== "Decorator" && isFunctionCompositionArgs(args))
   ) {
     return allArgsBrokenOut();
   }

--- a/src/language-js/print/class.js
+++ b/src/language-js/print/class.js
@@ -147,7 +147,7 @@ function printList(path, options, print, listName) {
 
 function printSuperClass(path, options, print) {
   const printed = print("superClass");
-  const parent = path.getParentNode();
+  const {parent} = path;
   if (parent.type === "AssignmentExpression") {
     return group(
       ifBreak(["(", indent([softline, printed]), softline, ")"], printed)

--- a/src/language-js/print/class.js
+++ b/src/language-js/print/class.js
@@ -147,7 +147,7 @@ function printList(path, options, print, listName) {
 
 function printSuperClass(path, options, print) {
   const printed = print("superClass");
-  const {parent} = path;
+  const { parent } = path;
   if (parent.type === "AssignmentExpression") {
     return group(
       ifBreak(["(", indent([softline, printed]), softline, ")"], printed)

--- a/src/language-js/print/decorators.js
+++ b/src/language-js/print/decorators.js
@@ -35,7 +35,7 @@ function printDecorators(path, options, print) {
     // If the parent node is an export declaration and the decorator
     // was written before the export, the export will be responsible
     // for printing the decorators.
-    hasDecoratorsBeforeExport(path.getParentNode())
+    hasDecoratorsBeforeExport(path.parent)
   ) {
     return;
   }

--- a/src/language-js/print/flow.js
+++ b/src/language-js/print/flow.js
@@ -187,7 +187,7 @@ function printFlow(path, options, print) {
     case "FunctionTypeParam": {
       const name = node.name
         ? print("name")
-        : path.getParentNode().this === node
+        : path.parent.this === node
         ? "this"
         : "";
       return [

--- a/src/language-js/print/function-parameters.js
+++ b/src/language-js/print/function-parameters.js
@@ -60,7 +60,7 @@ function printFunctionParameters(
     ];
   }
 
-  const {parent} = path;
+  const { parent } = path;
   const isParametersInTestCall = isTestCall(parent);
   const shouldHugParameters = shouldHugTheOnlyFunctionParameter(functionNode);
   const printed = [];

--- a/src/language-js/print/function-parameters.js
+++ b/src/language-js/print/function-parameters.js
@@ -60,7 +60,7 @@ function printFunctionParameters(
     ];
   }
 
-  const parent = path.getParentNode();
+  const {parent} = path;
   const isParametersInTestCall = isTestCall(parent);
   const shouldHugParameters = shouldHugTheOnlyFunctionParameter(functionNode);
   const printed = [];

--- a/src/language-js/print/function.js
+++ b/src/language-js/print/function.js
@@ -55,7 +55,7 @@ function printFunction(path, print, options, args) {
       node.type === "FunctionExpression") &&
     args?.expandLastArg
   ) {
-    const {parent} = path;
+    const { parent } = path;
     if (
       isCallExpression(parent) &&
       (getCallArguments(parent).length > 1 ||
@@ -246,7 +246,7 @@ function printArrowChain(
   tailNode
 ) {
   const name = path.getName();
-  const {parent} = path;
+  const { parent } = path;
   const isCallee = isCallLikeExpression(parent) && name === "callee";
   const isAssignmentRhs = Boolean(args && args.assignmentLayout);
   const shouldPutBodyOnSeparateLine =
@@ -363,8 +363,7 @@ function printArrowFunction(path, options, print, args) {
   // with the opening (, or if it's inside a JSXExpression (e.g. an attribute)
   // we should align the expression's closing } with the line with the opening {.
   const shouldAddSoftLine =
-    (args?.expandLastArg ||
-      path.parent.type === "JSXExpressionContainer") &&
+    (args?.expandLastArg || path.parent.type === "JSXExpressionContainer") &&
     !hasComment(node);
 
   const printTrailingComma =

--- a/src/language-js/print/function.js
+++ b/src/language-js/print/function.js
@@ -55,7 +55,7 @@ function printFunction(path, print, options, args) {
       node.type === "FunctionExpression") &&
     args?.expandLastArg
   ) {
-    const parent = path.getParentNode();
+    const {parent} = path;
     if (
       isCallExpression(parent) &&
       (getCallArguments(parent).length > 1 ||
@@ -246,7 +246,7 @@ function printArrowChain(
   tailNode
 ) {
   const name = path.getName();
-  const parent = path.getParentNode();
+  const {parent} = path;
   const isCallee = isCallLikeExpression(parent) && name === "callee";
   const isAssignmentRhs = Boolean(args && args.assignmentLayout);
   const shouldPutBodyOnSeparateLine =
@@ -364,7 +364,7 @@ function printArrowFunction(path, options, print, args) {
   // we should align the expression's closing } with the line with the opening {.
   const shouldAddSoftLine =
     (args?.expandLastArg ||
-      path.getParentNode().type === "JSXExpressionContainer") &&
+      path.parent.type === "JSXExpressionContainer") &&
     !hasComment(node);
 
   const printTrailingComma =

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -422,7 +422,7 @@ function separatorWithWhitespace(
 }
 
 function maybeWrapJsxElementInParens(path, elem, options) {
-  const {parent} = path;
+  const { parent } = path;
   /* istanbul ignore next */
   if (!parent) {
     return elem;

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -106,7 +106,7 @@ function printJsxElementInternal(path, options, print) {
     containsMultipleAttributes ||
     containsMultipleExpressions;
 
-  const isMdxBlock = path.getParentNode().rootMarker === "mdx";
+  const isMdxBlock = path.parent.rootMarker === "mdx";
 
   const rawJsxWhitespace = options.singleQuote ? "{' '}" : '{" "}';
   const jsxWhitespace = isMdxBlock
@@ -422,7 +422,7 @@ function separatorWithWhitespace(
 }
 
 function maybeWrapJsxElementInParens(path, elem, options) {
-  const parent = path.getParentNode();
+  const {parent} = path;
   /* istanbul ignore next */
   if (!parent) {
     return elem;
@@ -514,7 +514,7 @@ function printJsxExpressionContainer(path, options, print) {
         (isJsxNode(parent) &&
           (node.type === "ConditionalExpression" || isBinaryish(node)))));
 
-  if (shouldInline(node.expression, path.getParentNode(0))) {
+  if (shouldInline(node.expression, path.parent)) {
     return group(["{", print("expression"), lineSuffixBoundary, "}"]);
   }
 

--- a/src/language-js/print/member-chain.js
+++ b/src/language-js/print/member-chain.js
@@ -48,7 +48,7 @@ import {
 // MemberExpression and CallExpression. We need to traverse the AST
 // and make groups out of it to print it in the desired way.
 function printMemberChain(path, options, print) {
-  const parent = path.getParentNode();
+  const {parent} = path;
   const isExpressionStatement =
     !parent || parent.type === "ExpressionStatement";
 

--- a/src/language-js/print/member-chain.js
+++ b/src/language-js/print/member-chain.js
@@ -48,7 +48,7 @@ import {
 // MemberExpression and CallExpression. We need to traverse the AST
 // and make groups out of it to print it in the desired way.
 function printMemberChain(path, options, print) {
-  const {parent} = path;
+  const { parent } = path;
   const isExpressionStatement =
     !parent || parent.type === "ExpressionStatement";
 

--- a/src/language-js/print/member.js
+++ b/src/language-js/print/member.js
@@ -9,7 +9,7 @@ import { printOptionalToken } from "./misc.js";
 function printMemberExpression(path, options, print) {
   const { node } = path;
 
-  const parent = path.getParentNode();
+  const {parent} = path;
   let firstNonMemberParent;
   let i = 0;
   do {

--- a/src/language-js/print/member.js
+++ b/src/language-js/print/member.js
@@ -9,7 +9,7 @@ import { printOptionalToken } from "./misc.js";
 function printMemberExpression(path, options, print) {
   const { node } = path;
 
-  const {parent} = path;
+  const { parent } = path;
   let firstNonMemberParent;
   let i = 0;
   do {

--- a/src/language-js/print/misc.js
+++ b/src/language-js/print/misc.js
@@ -8,7 +8,7 @@ function printOptionalToken(path) {
     !node.optional ||
     // It's an optional computed method parsed by typescript-estree.
     // "?" is printed in `printMethod`.
-    (node.type === "Identifier" && node === path.getParentNode().key)
+    (node.type === "Identifier" && node === path.parent.key)
   ) {
     return "";
   }
@@ -49,7 +49,7 @@ function printTypeAnnotation(path, options, print) {
     return "";
   }
 
-  const parentNode = path.getParentNode();
+  const parentNode = path.parent;
 
   const isFunctionDeclarationIdentifier =
     parentNode.type === "DeclareFunction" && parentNode.id === node;

--- a/src/language-js/print/object.js
+++ b/src/language-js/print/object.js
@@ -62,7 +62,7 @@ function printObject(path, options, print) {
     propsAndLoc.sort((a, b) => a.loc - b.loc);
   }
 
-  const {parent} = path;
+  const { parent } = path;
   const isFlowInterfaceLikeBody =
     isTypeAnnotation &&
     parent &&

--- a/src/language-js/print/object.js
+++ b/src/language-js/print/object.js
@@ -62,7 +62,7 @@ function printObject(path, options, print) {
     propsAndLoc.sort((a, b) => a.loc - b.loc);
   }
 
-  const parent = path.getParentNode(0);
+  const {parent} = path;
   const isFlowInterfaceLikeBody =
     isTypeAnnotation &&
     parent &&

--- a/src/language-js/print/property.js
+++ b/src/language-js/print/property.js
@@ -18,7 +18,7 @@ function printPropertyKey(path, options, print) {
     return ["[", print("key"), "]"];
   }
 
-  const {parent} = path;
+  const { parent } = path;
   const { key } = node;
 
   // flow has `Identifier` key, other parsers use `PrivateIdentifier` (ESTree) or `PrivateName`

--- a/src/language-js/print/property.js
+++ b/src/language-js/print/property.js
@@ -18,7 +18,7 @@ function printPropertyKey(path, options, print) {
     return ["[", print("key"), "]"];
   }
 
-  const parent = path.getParentNode();
+  const {parent} = path;
   const { key } = node;
 
   // flow has `Identifier` key, other parsers use `PrivateIdentifier` (ESTree) or `PrivateName`

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -108,7 +108,7 @@ function printTernaryTest(path, options, print) {
     ? "alternate"
     : "falseType";
 
-  const parent = path.getParentNode();
+  const {parent} = path;
 
   const printed = isConditionalExpression
     ? print("test")
@@ -206,7 +206,7 @@ function printTernary(path, options, print) {
   // We print a ConditionalExpression in either "JSX mode" or "normal mode".
   // See `tests/format/jsx/conditional-expression.js` for more info.
   let jsxMode = false;
-  const parent = path.getParentNode();
+  const {parent} = path;
   const isParentTest =
     parent.type === node.type &&
     testNodePropertyNames.some((prop) => parent[prop] === node);

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -108,7 +108,7 @@ function printTernaryTest(path, options, print) {
     ? "alternate"
     : "falseType";
 
-  const {parent} = path;
+  const { parent } = path;
 
   const printed = isConditionalExpression
     ? print("test")
@@ -206,7 +206,7 @@ function printTernary(path, options, print) {
   // We print a ConditionalExpression in either "JSX mode" or "normal mode".
   // See `tests/format/jsx/conditional-expression.js` for more info.
   let jsxMode = false;
-  const {parent} = path;
+  const { parent } = path;
   const isParentTest =
     parent.type === node.type &&
     testNodePropertyNames.some((prop) => parent[prop] === node);

--- a/src/language-js/print/type-annotation.js
+++ b/src/language-js/print/type-annotation.js
@@ -130,7 +130,7 @@ function printUnionType(path, options, print) {
   // | B
   // | C
 
-  const parent = path.getParentNode();
+  const {parent} = path;
 
   // If there's a leading comment, the parent is doing the indentation
   const shouldIndent =
@@ -144,7 +144,7 @@ function printUnionType(path, options, print) {
     !(
       parent.type === "FunctionTypeParam" &&
       !parent.name &&
-      path.getParentNode(1).this !== parent
+      path.grandparent.this !== parent
     ) &&
     !(
       (parent.type === "TypeAlias" ||
@@ -208,8 +208,8 @@ function printFunctionType(path, options, print) {
   // FunctionTypeAnnotation is ambiguous:
   // declare function foo(a: B): void; OR
   // var A: (a: B) => void;
-  const parent = path.getParentNode(0);
-  const parentParent = path.getParentNode(1);
+  const {parent} = path;
+  const parentParent = path.grandparent;
   const parentParentParent = path.getParentNode(2);
   let isArrowFunctionTypeAnnotation =
     node.type === "TSFunctionType" ||

--- a/src/language-js/print/type-annotation.js
+++ b/src/language-js/print/type-annotation.js
@@ -130,7 +130,7 @@ function printUnionType(path, options, print) {
   // | B
   // | C
 
-  const {parent} = path;
+  const { parent } = path;
 
   // If there's a leading comment, the parent is doing the indentation
   const shouldIndent =
@@ -208,7 +208,7 @@ function printFunctionType(path, options, print) {
   // FunctionTypeAnnotation is ambiguous:
   // declare function foo(a: B): void; OR
   // var A: (a: B) => void;
-  const {parent} = path;
+  const { parent } = path;
   const parentParent = path.grandparent;
   const parentParentParent = path.getParentNode(2);
   let isArrowFunctionTypeAnnotation =

--- a/src/language-js/print/type-parameters.js
+++ b/src/language-js/print/type-parameters.js
@@ -112,7 +112,7 @@ function printDanglingCommentsForInline(path, options) {
 function printTypeParameter(path, options, print) {
   const { node } = path;
   const parts = [];
-  const {parent} = path;
+  const { parent } = path;
 
   const name = node.type === "TSTypeParameter" ? print("name") : node.name;
 

--- a/src/language-js/print/type-parameters.js
+++ b/src/language-js/print/type-parameters.js
@@ -74,7 +74,7 @@ function printTypeParameters(path, options, print, paramsKey) {
       : getFunctionParameters(node).length === 1 &&
         isTSXFile(options) &&
         !node[paramsKey][0].constraint &&
-        path.getParentNode().type === "ArrowFunctionExpression"
+        path.parent.type === "ArrowFunctionExpression"
       ? ","
       : shouldPrintComma(options, "all")
       ? ifBreak(",")
@@ -112,7 +112,7 @@ function printDanglingCommentsForInline(path, options) {
 function printTypeParameter(path, options, print) {
   const { node } = path;
   const parts = [];
-  const parent = path.getParentNode();
+  const {parent} = path;
 
   const name = node.type === "TSTypeParameter" ? print("name") : node.name;
 

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -144,7 +144,7 @@ function printTypescript(path, options, print) {
       return printTypeParameter(path, options, print);
     case "TSAsExpression": {
       parts.push(print("expression"), " as ", print("typeAnnotation"));
-      const {parent} = path;
+      const { parent } = path;
       if (
         (isCallExpression(parent) && parent.callee === node) ||
         (isMemberExpression(parent) && parent.object === node)
@@ -199,7 +199,7 @@ function printTypescript(path, options, print) {
     case "TSTypeQuery":
       return ["typeof ", print("exprName"), print("typeParameters")];
     case "TSIndexSignature": {
-      const {parent} = path;
+      const { parent } = path;
 
       // The typescript parser accepts multiple parameters here. If you're
       // using them, it makes sense to have a trailing comma. But if you
@@ -432,7 +432,7 @@ function printTypescript(path, options, print) {
     case "TSExternalModuleReference":
       return ["require(", print("expression"), ")"];
     case "TSModuleDeclaration": {
-      const {parent} = path;
+      const { parent } = path;
       const isExternalModule = isLiteral(node.id);
       const parentIsDeclaration = parent.type === "TSModuleDeclaration";
       const bodyIsDeclaration =

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -144,7 +144,7 @@ function printTypescript(path, options, print) {
       return printTypeParameter(path, options, print);
     case "TSAsExpression": {
       parts.push(print("expression"), " as ", print("typeAnnotation"));
-      const parent = path.getParentNode();
+      const {parent} = path;
       if (
         (isCallExpression(parent) && parent.callee === node) ||
         (isMemberExpression(parent) && parent.object === node)
@@ -199,7 +199,7 @@ function printTypescript(path, options, print) {
     case "TSTypeQuery":
       return ["typeof ", print("exprName"), print("typeParameters")];
     case "TSIndexSignature": {
-      const parent = path.getParentNode();
+      const {parent} = path;
 
       // The typescript parser accepts multiple parameters here. If you're
       // using them, it makes sense to have a trailing comma. But if you
@@ -432,7 +432,7 @@ function printTypescript(path, options, print) {
     case "TSExternalModuleReference":
       return ["require(", print("expression"), ")"];
     case "TSModuleDeclaration": {
-      const parent = path.getParentNode();
+      const {parent} = path;
       const isExternalModule = isLiteral(node.id);
       const parentIsDeclaration = parent.type === "TSModuleDeclaration";
       const bodyIsDeclaration =

--- a/src/language-js/printer-estree-json.js
+++ b/src/language-js/printer-estree-json.js
@@ -49,7 +49,7 @@ function genericPrint(path, options, print) {
     case "NumericLiteral":
       return JSON.stringify(node.value);
     case "Identifier": {
-      const parent = path.getParentNode();
+      const {parent} = path;
       if (parent && parent.type === "ObjectProperty" && parent.key === node) {
         return JSON.stringify(node.name);
       }

--- a/src/language-js/printer-estree-json.js
+++ b/src/language-js/printer-estree-json.js
@@ -49,7 +49,7 @@ function genericPrint(path, options, print) {
     case "NumericLiteral":
       return JSON.stringify(node.value);
     case "Identifier": {
-      const {parent} = path;
+      const { parent } = path;
       if (parent && parent.type === "ObjectProperty" && parent.key === node) {
         return JSON.stringify(node.name);
       }

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -220,7 +220,7 @@ function printPathNoParens(path, options, print, args) {
         options.parser === "__vue_event_binding" ||
         options.parser === "__vue_ts_event_binding"
       ) {
-        const parent = path.getParentNode();
+        const {parent} = path;
         if (
           parent.type === "Program" &&
           parent.body.length === 1 &&
@@ -326,7 +326,7 @@ function printPathNoParens(path, options, print, args) {
       parts.push("await");
       if (node.argument) {
         parts.push(" ", print("argument"));
-        const parent = path.getParentNode();
+        const {parent} = path;
         if (
           (isCallExpression(parent) && parent.callee === node) ||
           (isMemberExpression(parent) && parent.object === node)
@@ -395,7 +395,7 @@ function printPathNoParens(path, options, print, args) {
     case "TupleExpression":
       return printArray(path, options, print);
     case "SequenceExpression": {
-      const parent = path.getParentNode();
+      const {parent} = path;
       if (
         parent.type === "ExpressionStatement" ||
         parent.type === "ForStatement"
@@ -454,7 +454,7 @@ function printPathNoParens(path, options, print, args) {
 
       // We generally want to terminate all variable declarations with a
       // semicolon, except when they in the () part of for loops.
-      const parentNode = path.getParentNode();
+      const parentNode = path.parent;
 
       const isParentForLoop =
         parentNode.type === "ForStatement" ||

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -220,7 +220,7 @@ function printPathNoParens(path, options, print, args) {
         options.parser === "__vue_event_binding" ||
         options.parser === "__vue_ts_event_binding"
       ) {
-        const {parent} = path;
+        const { parent } = path;
         if (
           parent.type === "Program" &&
           parent.body.length === 1 &&
@@ -326,7 +326,7 @@ function printPathNoParens(path, options, print, args) {
       parts.push("await");
       if (node.argument) {
         parts.push(" ", print("argument"));
-        const {parent} = path;
+        const { parent } = path;
         if (
           (isCallExpression(parent) && parent.callee === node) ||
           (isMemberExpression(parent) && parent.object === node)
@@ -395,7 +395,7 @@ function printPathNoParens(path, options, print, args) {
     case "TupleExpression":
       return printArray(path, options, print);
     case "SequenceExpression": {
-      const {parent} = path;
+      const { parent } = path;
       if (
         parent.type === "ExpressionStatement" ||
         parent.type === "ForStatement"

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -322,7 +322,7 @@ function isTheOnlyJsxElementInMarkdown(options, path) {
     return false;
   }
 
-  const {parent} = path;
+  const { parent } = path;
 
   return parent.type === "Program" && parent.body.length === 1;
 }
@@ -775,7 +775,7 @@ function isFunctionCompositionArgs(args) {
  */
 function isLongCurriedCallExpression(path) {
   const { node } = path;
-  const {parent} = path;
+  const { parent } = path;
   return (
     isCallExpression(node) &&
     isCallExpression(parent) &&

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -192,7 +192,7 @@ const isExportDeclaration = createTypeCheckFunction([
  * @returns {Node | null}
  */
 function getParentExportDeclaration(path) {
-  const parentNode = path.getParentNode();
+  const parentNode = path.parent;
   if (path.getName() === "declaration" && isExportDeclaration(parentNode)) {
     return parentNode;
   }
@@ -322,7 +322,7 @@ function isTheOnlyJsxElementInMarkdown(options, path) {
     return false;
   }
 
-  const parent = path.getParentNode();
+  const {parent} = path;
 
   return parent.type === "Program" && parent.body.length === 1;
 }
@@ -775,7 +775,7 @@ function isFunctionCompositionArgs(args) {
  */
 function isLongCurriedCallExpression(path) {
   const { node } = path;
-  const parent = path.getParentNode();
+  const {parent} = path;
   return (
     isCallExpression(node) &&
     isCallExpression(parent) &&

--- a/src/language-yaml/print/misc.js
+++ b/src/language-yaml/print/misc.js
@@ -17,7 +17,7 @@ function printNextEmptyLine(path, originalText) {
     isNextEmptyLinePrintedSet.add(node.position.end.line);
     if (
       isNextLineEmpty(node, originalText) &&
-      !shouldPrintEndComments(path.getParentNode())
+      !shouldPrintEndComments(path.parent)
     ) {
       return softline;
     }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Removes `prefer-ast-path-node` internal ESLint rule.
Adds `prefer-ast-path-getters` that supports `path.node`, `path.parent` and `path.grandparent`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
