### PR TITLE
Add `meta.schema` to internal ESLint rules for removing warnings

### DIFF
--- a/scripts/tools/eslint-plugin-prettier-internal-rules/jsx-identifier-case.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/jsx-identifier-case.js
@@ -15,6 +15,10 @@ module.exports = {
       [MESSAGE_ID]: "Please rename '{{name}}' to '{{fixed}}'.",
     },
     fixable: "code",
+    schema: {
+      type: "array",
+      uniqueItems: true,
+    },
   },
   create(context) {
     const ignored = new Set(context.options);
@@ -37,9 +41,5 @@ module.exports = {
         });
       },
     };
-  },
-  schema: {
-    type: "array",
-    uniqueItems: true,
   },
 };

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/no-node-comments.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/no-node-comments.js
@@ -34,8 +34,9 @@ module.exports = {
     messages: {
       [messageId]: "Do not access node.comments.",
     },
-    schema: [
-      {
+    schema: {
+      type: "array",
+      items: {
         anyOf: [
           { type: "string" },
           {
@@ -50,7 +51,7 @@ module.exports = {
           },
         ],
       },
-    ],
+    },
   },
   create(context) {
     const fileName = context.getFilename();

--- a/scripts/tools/eslint-plugin-prettier-internal-rules/no-node-comments.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/no-node-comments.js
@@ -34,6 +34,23 @@ module.exports = {
     messages: {
       [messageId]: "Do not access node.comments.",
     },
+    schema: [
+      {
+        anyOf: [
+          { type: "string" },
+          {
+            type: "object",
+            properties: {
+              file: { type: "string" },
+              functions: {
+                type: "array",
+                items: { type: "string" },
+              },
+            },
+          },
+        ],
+      },
+    ],
   },
   create(context) {
     const fileName = context.getFilename();


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Adds `meta.schema` for `jsx-identifier-case` and `no-node-comments` rule to remove the below warnings:

```
$ node ./scripts/tools/eslint-plugin-prettier-internal-rules/test.js
(node:81036) DeprecationWarning: "jsx-identifier-case" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/developer-guide/working-with-rules#options-schemas
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:81036) DeprecationWarning: "no-node-comments" rule has options but is missing the "meta.schema" property and will stop working in ESLint v9. Please add a schema: https://eslint.org/docs/developer-guide/working-with-rules#options-schemas
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
