### PR TITLE
Reduce size of `typescript` plugin

### DIFF
--- a/scripts/build/modify-typescript-module.mjs
+++ b/scripts/build/modify-typescript-module.mjs
@@ -157,7 +157,8 @@ function modifyTypescriptModule(text) {
     text.includes("ts.TypeScriptServicesFactory = TypeScriptServicesFactory;")
   );
   source.replaceAlignedCode({
-    start: "function createLanguageService(host, documentRegistry, syntaxOnlyOrLanguageServiceMode) {",
+    start:
+      "function createLanguageService(host, documentRegistry, syntaxOnlyOrLanguageServiceMode) {",
     end: "}",
     replacement: "function createLanguageService() {}",
   });

--- a/scripts/build/modify-typescript-module.mjs
+++ b/scripts/build/modify-typescript-module.mjs
@@ -156,6 +156,11 @@ function modifyTypescriptModule(text) {
   source.removeSubmodule((text) =>
     text.includes("ts.TypeScriptServicesFactory = TypeScriptServicesFactory;")
   );
+  source.replaceAlignedCode({
+    start: "function createLanguageService(host, documentRegistry, syntaxOnlyOrLanguageServiceMode) {",
+    end: "}",
+    replacement: "function createLanguageService() {}",
+  });
 
   // `ts.Version`
   source.removeSubmodule((text) => text.includes("ts.Version = Version;"));


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

**Size Change:** -52.9 kB (-1%) 

**Total Size:** 10.5 MB

| Filename | Size | Change |
| :--- | :---: | :---: |
| `./dist/plugins/typescript.js` | 1.35 MB | -26.4 kB (-2%) |
| `./dist/plugins/typescript.mjs` | 1.35 MB | -26.4 kB (-2%) |

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
