### PR TITLE
fix: Print dangling comments for `break|continue|debugger`

### DIFF
--- a/changelog_unreleased/javascript/13677-2.md
+++ b/changelog_unreleased/javascript/13677-2.md
@@ -1,20 +1,18 @@
 #### Fix Idempotence for `break|continue|debugger` (#13677 by @liuxingbaoyu)
 
-<!-- Optional description if it makes sense. -->
-
 <!-- prettier-ignore -->
 ```js
 // Input
-
 for (const f in {}) break// comment
 ;
 
 // Prettier stable
-
 for (const f in {})
   break; // comment
 
-// Prettier main
+// Prettier stable (second format)
+for (const f in {}) break; // comment
 
+// Prettier main
 for (const f in {}) break; // comment
 ```

--- a/changelog_unreleased/javascript/13677-2.md
+++ b/changelog_unreleased/javascript/13677-2.md
@@ -1,0 +1,20 @@
+#### Fix Idempotence for `break|continue|debugger` (#13677 by @liuxingbaoyu)
+
+<!-- Optional description if it makes sense. -->
+
+<!-- prettier-ignore -->
+```js
+// Input
+
+for (const f in {}) break// comment
+;
+
+// Prettier stable
+
+for (const f in {})
+  break; // comment
+
+// Prettier main
+
+for (const f in {}) break; // comment
+```

--- a/changelog_unreleased/javascript/13677.md
+++ b/changelog_unreleased/javascript/13677.md
@@ -1,11 +1,8 @@
 #### Fix printing dangling comments for `break|continue|debugger` (#13677 by @liuxingbaoyu)
 
-<!-- Optional description if it makes sense. -->
-
 <!-- prettier-ignore -->
 ```js
 // Input
-
 for (;;) {
   if (a) break; // comment
   else foo();
@@ -16,11 +13,9 @@ for (;;) {
 }
 
 // Prettier stable
-
 Error
 
 // Prettier main
-
 for (;;) {
   if (a) break; // comment
   else foo();

--- a/changelog_unreleased/javascript/13677.md
+++ b/changelog_unreleased/javascript/13677.md
@@ -1,0 +1,32 @@
+#### Fix printing dangling comments for `break|continue|debugger` (#13677 by @liuxingbaoyu)
+
+<!-- Optional description if it makes sense. -->
+
+<!-- prettier-ignore -->
+```js
+// Input
+
+for (;;) {
+  if (a) break; // comment
+  else foo();
+  if(a) continue; // comment
+  else foo();
+  if(a) debugger; // comment
+  else foo();
+}
+
+// Prettier stable
+
+Error
+
+// Prettier main
+
+for (;;) {
+  if (a) break; // comment
+  else foo();
+  if(a) continue; // comment
+  else foo();
+  if(a) debugger; // comment
+  else foo();
+}
+```

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -193,7 +193,12 @@ function handleIfStatementComments({
     precedingNode === enclosingNode.consequent &&
     followingNode === enclosingNode.alternate
   ) {
-    if (precedingNode.type === "BlockStatement") {
+    if (
+      precedingNode.type === "BlockStatement" ||
+      precedingNode.type === "BreakStatement" ||
+      precedingNode.type === "ContinueStatement" ||
+      precedingNode.type === "DebuggerStatement"
+    ) {
       addTrailingComment(precedingNode, comment);
     } else {
       const isSingleLineComment =

--- a/src/language-js/print/misc.js
+++ b/src/language-js/print/misc.js
@@ -78,7 +78,13 @@ function adjustClause(node, clause, forceSpace) {
     return ";";
   }
 
-  if (node.type === "BlockStatement" || forceSpace) {
+  if (
+    node.type === "BlockStatement" ||
+    node.type === "BreakStatement" ||
+    node.type === "ContinueStatement" ||
+    node.type === "DebuggerStatement" ||
+    forceSpace
+  ) {
     return [" ", clause];
   }
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -640,10 +640,6 @@ function printPathNoParens(path, options, print, args) {
 
       parts.push(semi);
 
-      if (hasComment(node, CommentCheckFlags.Dangling)) {
-        parts.push(" ", printDanglingComments(path, options, true));
-      }
-
       return parts;
     case "LabeledStatement":
       if (node.body.type === "EmptyStatement") {
@@ -743,13 +739,7 @@ function printPathNoParens(path, options, print, args) {
     }
     // JSX extensions below.
     case "DebuggerStatement":
-      parts.push("debugger", semi);
-
-      if (hasComment(node, CommentCheckFlags.Dangling)) {
-        parts.push(" ", printDanglingComments(path, options, true));
-      }
-
-      return parts;
+      return ["debugger", semi];
 
     case "ClassDeclaration":
     case "ClassExpression":

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -186,7 +186,7 @@ function printPathNoParens(path, options, print, args) {
 
   const { node } = path;
   const semi = options.semi ? ";" : "";
-  /** @type{Doc[]} */
+  /** @type {Doc[]} */
   let parts = [];
 
   switch (node.type) {

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -640,6 +640,10 @@ function printPathNoParens(path, options, print, args) {
 
       parts.push(semi);
 
+      if (hasComment(node, CommentCheckFlags.Dangling)) {
+        parts.push(" ", printDanglingComments(path, options, true));
+      }
+
       return parts;
     case "LabeledStatement":
       if (node.body.type === "EmptyStatement") {
@@ -739,7 +743,13 @@ function printPathNoParens(path, options, print, args) {
     }
     // JSX extensions below.
     case "DebuggerStatement":
-      return ["debugger", semi];
+      parts.push("debugger", semi);
+
+      if (hasComment(node, CommentCheckFlags.Dangling)) {
+        parts.push(" ", printDanglingComments(path, options, true));
+      }
+
+      return parts;
 
     case "ClassDeclaration":
     case "ClassExpression":

--- a/tests/config/format-test.js
+++ b/tests/config/format-test.js
@@ -369,8 +369,9 @@ async function runTest({
       try {
         expect(secondOutput).not.toEqual(firstOutput);
       } catch {
+        /** @see unstableTests */
         throw new Error(
-          `There is an unstable test that is now becoming stable, please remove it.\n${filename}`
+          `There is an unstable test that is now becoming stable, please remove it in \`unstableTests\`.\n${filename}`
         );
       }
     } else {

--- a/tests/config/format-test.js
+++ b/tests/config/format-test.js
@@ -36,7 +36,6 @@ const unstableTests = new Map(
     ["flow/no-semi/comments.js", (options) => options.semi === false],
     "typescript/prettier-ignore/mapped-types.ts",
     "js/comments/html-like/comment.js",
-    "js/for/continue-and-break-comment-without-blocks.js",
   ].map((fixture) => {
     const [file, isUnstable = () => true] = Array.isArray(fixture)
       ? fixture
@@ -367,7 +366,13 @@ async function runTest({
     if (isUnstableTest) {
       // To keep eye on failed tests, this assert never supposed to pass,
       // if it fails, just remove the file from `unstableTests`
-      expect(secondOutput).not.toEqual(firstOutput);
+      try {
+        expect(secondOutput).not.toEqual(firstOutput);
+      } catch (error) {
+        throw new Error(
+          `There is an unstable test that is now becoming stable, please remove it.\n${filename}`
+        );
+      }
     } else {
       expect(secondOutput).toEqual(firstOutput);
     }

--- a/tests/config/format-test.js
+++ b/tests/config/format-test.js
@@ -368,7 +368,7 @@ async function runTest({
       // if it fails, just remove the file from `unstableTests`
       try {
         expect(secondOutput).not.toEqual(firstOutput);
-      } catch (error) {
+      } catch {
         throw new Error(
           `There is an unstable test that is now becoming stable, please remove it.\n${filename}`
         );

--- a/tests/format/js/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1324,6 +1324,20 @@ for (;;) {
   else foo();
 }
 
+for (;;) {
+
+  if (true) break // comment
+;
+  else foo();
+
+}
+
+for (;;) {
+  if (true)
+    break; // comment
+  else foo();
+}
+
 =====================================output=====================================
 for (;;) {
   if (a) break // comment
@@ -1333,6 +1347,16 @@ for (;;) {
   else foo()
 
   if (a) debugger // comment
+  else foo()
+}
+
+for (;;) {
+  if (true) break // comment
+  else foo()
+}
+
+for (;;) {
+  if (true) break // comment
   else foo()
 }
 
@@ -1356,6 +1380,20 @@ for (;;) {
   else foo();
 }
 
+for (;;) {
+
+  if (true) break // comment
+;
+  else foo();
+
+}
+
+for (;;) {
+  if (true)
+    break; // comment
+  else foo();
+}
+
 =====================================output=====================================
 for (;;) {
   if (a) break; // comment
@@ -1365,6 +1403,16 @@ for (;;) {
   else foo();
 
   if (a) debugger; // comment
+  else foo();
+}
+
+for (;;) {
+  if (true) break; // comment
+  else foo();
+}
+
+for (;;) {
+  if (true) break; // comment
   else foo();
 }
 

--- a/tests/format/js/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1306,6 +1306,71 @@ for (;;);
 ================================================================================
 `;
 
+exports[`dangling-debugger-continue-break.js - {"semi":false} format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+for (;;) {
+  if (a) break; // comment
+  else foo();
+
+  if(a) continue; // comment
+  else foo();
+
+  if(a) debugger; // comment
+  else foo();
+}
+
+=====================================output=====================================
+for (;;) {
+  if (a) break // comment
+  else foo()
+
+  if (a) continue // comment
+  else foo()
+
+  if (a) debugger // comment
+  else foo()
+}
+
+================================================================================
+`;
+
+exports[`dangling-debugger-continue-break.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+for (;;) {
+  if (a) break; // comment
+  else foo();
+
+  if(a) continue; // comment
+  else foo();
+
+  if(a) debugger; // comment
+  else foo();
+}
+
+=====================================output=====================================
+for (;;) {
+  if (a) break; // comment
+  else foo();
+
+  if (a) continue; // comment
+  else foo();
+
+  if (a) debugger; // comment
+  else foo();
+}
+
+================================================================================
+`;
+
 exports[`dynamic_imports.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/format/js/comments/dangling-debugger-continue-break.js
+++ b/tests/format/js/comments/dangling-debugger-continue-break.js
@@ -1,0 +1,10 @@
+for (;;) {
+  if (a) break; // comment
+  else foo();
+
+  if(a) continue; // comment
+  else foo();
+
+  if(a) debugger; // comment
+  else foo();
+}

--- a/tests/format/js/comments/dangling-debugger-continue-break.js
+++ b/tests/format/js/comments/dangling-debugger-continue-break.js
@@ -8,3 +8,17 @@ for (;;) {
   if(a) debugger; // comment
   else foo();
 }
+
+for (;;) {
+
+  if (true) break // comment
+;
+  else foo();
+
+}
+
+for (;;) {
+  if (true)
+    break; // comment
+  else foo();
+}

--- a/tests/format/js/for/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/for/__snapshots__/jsfmt.spec.js.snap
@@ -683,47 +683,35 @@ label1: for (;;) continue label1
 ;
 
 =====================================output=====================================
-for (;;)
-  continue;
-  // comment
+for (;;) continue;
+// comment
 
-for (;;)
-  break;
-  // comment
+for (;;) break;
+// comment
 
-for (const f of [])
-  continue;
-  // comment
+for (const f of []) continue;
+// comment
 
-for (const f of [])
-  break;
-  // comment
+for (const f of []) break;
+// comment
 
-for (const f in {})
-  continue;
-  // comment
+for (const f in {}) continue;
+// comment
 
-for (const f in {})
-  break;
-  // comment
+for (const f in {}) break;
+// comment
 
-for (;;)
-  continue; // comment
+for (;;) continue; // comment
 
-for (;;)
-  break; // comment
+for (;;) break; // comment
 
-for (const f of [])
-  continue; // comment
+for (const f of []) continue; // comment
 
-for (const f of [])
-  break; // comment
+for (const f of []) break; // comment
 
-for (const f in {})
-  continue; // comment
+for (const f in {}) continue; // comment
 
-for (const f in {})
-  break; // comment
+for (const f in {}) break; // comment
 
 for (;;) continue; /* comment */
 
@@ -737,42 +725,33 @@ for (const f in {}) continue; /* comment */
 
 for (const f in {}) break; /* comment */
 
-for (;;)
-  continue;
-  /* comment */
+for (;;) continue;
+/* comment */
 
-for (;;)
-  break;
-  /* comment */
+for (;;) break;
+/* comment */
 
-for (const f of [])
-  continue;
-  /* comment */
+for (const f of []) continue;
+/* comment */
 
-for (const f of [])
-  break;
-  /* comment */
+for (const f of []) break;
+/* comment */
 
-for (const f in {})
-  continue;
-  /* comment */
+for (const f in {}) continue;
+/* comment */
 
-for (const f in {})
-  break;
-  /* comment */
+for (const f in {}) break;
+/* comment */
 
 label1: for (;;) continue label1 /* comment */;
 
-label1: for (;;)
-  continue label1;
-  /* comment */
+label1: for (;;) continue label1;
+/* comment */
 
-label1: for (;;)
-  continue label1; // comment
+label1: for (;;) continue label1; // comment
 
-label1: for (;;)
-  continue label1;
-  // comment
+label1: for (;;) continue label1;
+// comment
 
 ================================================================================
 `;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Some comments after `break|continue|debugger` cannot be printed.

Fixes #12655

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
