### PR TITLE
handlebars: Stricter `prettier-ignore` check in

### DIFF
--- a/tests/format/handlebars/prettier-ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/handlebars/prettier-ignore/__snapshots__/jsfmt.spec.js.snap
@@ -77,3 +77,66 @@ printWidth: 80
 </div>
 ================================================================================
 `;
+
+exports[`prettier-ignore2.hbs format 1`] = `
+====================================options=====================================
+parsers: ["glimmer"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+{{! prettier-ignore }}
+<ignored>{{     ugly }}</ignored>
+<not-ignored>{{     ugly }}</not-ignored>
+
+<div>
+  {{! prettier-ignore }}
+  <ignored>{{     ugly }}</ignored>
+  <not-ignored>{{     ugly }}</not-ignored>
+</div>
+
+{{! prettier-ignore }}text
+<not-ignored>{{     ugly }}</not-ignored>
+<not-ignored>{{     ugly }}</not-ignored>
+
+{{! prettier-ignore }}<ignored>{{     ugly }}</ignored><not-ignored>{{     ugly }}</not-ignored>
+
+{{! prettier-ignore }} <not-ignored>{{     ugly }}</not-ignored><not-ignored>{{     ugly }}</not-ignored>
+{{! prettier-ignore }}text<not-ignored>{{     ugly }}</not-ignored><not-ignored>{{     ugly }}</not-ignored>
+
+
+{{!                prettier-ignore }}
+<div>
+  \`prettier-ignore\` comment self should not be ignored.
+  {{     ugly }}
+</div>
+
+=====================================output=====================================
+{{! prettier-ignore }}
+<ignored>{{     ugly }}</ignored>
+<not-ignored>{{ugly}}</not-ignored>
+
+<div>
+  {{! prettier-ignore }}
+  <ignored>{{     ugly }}</ignored>
+  <not-ignored>{{ugly}}</not-ignored>
+</div>
+
+{{! prettier-ignore }}text
+<not-ignored>{{ugly}}</not-ignored>
+<not-ignored>{{ugly}}</not-ignored>
+
+{{! prettier-ignore }}<ignored>{{     ugly }}</ignored><not-ignored
+>{{ugly}}</not-ignored>
+
+{{! prettier-ignore }}
+<not-ignored>{{ugly}}</not-ignored><not-ignored>{{ugly}}</not-ignored>
+{{! prettier-ignore }}text<not-ignored>{{ugly}}</not-ignored><not-ignored
+>{{ugly}}</not-ignored>
+
+{{!                prettier-ignore }}
+<div>
+  \`prettier-ignore\` comment self should not be ignored.
+  {{     ugly }}
+</div>
+================================================================================
+`;

--- a/tests/format/handlebars/prettier-ignore/prettier-ignore2.hbs
+++ b/tests/format/handlebars/prettier-ignore/prettier-ignore2.hbs
@@ -1,0 +1,25 @@
+{{! prettier-ignore }}
+<ignored>{{     ugly }}</ignored>
+<not-ignored>{{     ugly }}</not-ignored>
+
+<div>
+  {{! prettier-ignore }}
+  <ignored>{{     ugly }}</ignored>
+  <not-ignored>{{     ugly }}</not-ignored>
+</div>
+
+{{! prettier-ignore }}text
+<not-ignored>{{     ugly }}</not-ignored>
+<not-ignored>{{     ugly }}</not-ignored>
+
+{{! prettier-ignore }}<ignored>{{     ugly }}</ignored><not-ignored>{{     ugly }}</not-ignored>
+
+{{! prettier-ignore }} <not-ignored>{{     ugly }}</not-ignored><not-ignored>{{     ugly }}</not-ignored>
+{{! prettier-ignore }}text<not-ignored>{{     ugly }}</not-ignored><not-ignored>{{     ugly }}</not-ignored>
+
+
+{{!                prettier-ignore }}
+<div>
+  `prettier-ignore` comment self should not be ignored.
+  {{     ugly }}
+</div>


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
It seems we only mean to ignore elements, the previous check is too lossy. I think only elements next to or under the comment should be ignored.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
