### PR TITLE
Handlebars: Add tests for `{{! prettier-ignore}}`

### DIFF
--- a/tests/format/handlebars/prettier-ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/handlebars/prettier-ignore/__snapshots__/jsfmt.spec.js.snap
@@ -7,6 +7,19 @@ printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
 {{! prettier-ignore }}
+{{        ugly}}
+
+{{! prettier-ignore }}
+        ugly
+
+{{! prettier-ignore }}
+{{#        ugly}}
+{{/        ugly}}
+
+{{! prettier-ignore }}
+{{!        ugly}}
+
+{{! prettier-ignore }}
 <div>
   "hello! my parent was ignored"
   {{#my-crazy-component     "shall"     be="preserved"}}
@@ -41,6 +54,19 @@ printWidth: 80
   {{/another-sibling}}
 </div>
 =====================================output=====================================
+{{! prettier-ignore }}
+{{        ugly}}
+
+{{! prettier-ignore }}
+ugly
+
+{{! prettier-ignore }}
+{{#        ugly}}
+{{/        ugly}}
+
+{{! prettier-ignore }}
+{{!        ugly}}
+
 {{! prettier-ignore }}
 <div>
   "hello! my parent was ignored"

--- a/tests/format/handlebars/prettier-ignore/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/handlebars/prettier-ignore/__snapshots__/jsfmt.spec.js.snap
@@ -9,15 +9,23 @@ printWidth: 80
 {{! prettier-ignore }}
 {{        ugly}}
 
+{{! prettier-ignore }}{{        ugly}}
+
 {{! prettier-ignore }}
         ugly
+
+{{! prettier-ignore }}          ugly
 
 {{! prettier-ignore }}
 {{#        ugly}}
 {{/        ugly}}
 
+{{! prettier-ignore }}{{#        ugly}}{{/        ugly}}
+
 {{! prettier-ignore }}
 {{!        ugly}}
+
+{{! prettier-ignore }}{{!        ugly}}
 
 {{! prettier-ignore }}
 <div>
@@ -53,9 +61,15 @@ printWidth: 80
 
   {{/another-sibling}}
 </div>
+
 =====================================output=====================================
 {{! prettier-ignore }}
 {{        ugly}}
+
+{{! prettier-ignore }}{{ugly}}
+
+{{! prettier-ignore }}
+ugly
 
 {{! prettier-ignore }}
 ugly
@@ -64,8 +78,12 @@ ugly
 {{#        ugly}}
 {{/        ugly}}
 
+{{! prettier-ignore }}{{#ugly}}{{/ugly}}
+
 {{! prettier-ignore }}
 {{!        ugly}}
+
+{{! prettier-ignore }}{{!        ugly}}
 
 {{! prettier-ignore }}
 <div>

--- a/tests/format/handlebars/prettier-ignore/prettier-ignore.hbs
+++ b/tests/format/handlebars/prettier-ignore/prettier-ignore.hbs
@@ -1,4 +1,17 @@
 {{! prettier-ignore }}
+{{        ugly}}
+
+{{! prettier-ignore }}
+        ugly
+
+{{! prettier-ignore }}
+{{#        ugly}}
+{{/        ugly}}
+
+{{! prettier-ignore }}
+{{!        ugly}}
+
+{{! prettier-ignore }}
 <div>
   "hello! my parent was ignored"
   {{#my-crazy-component     "shall"     be="preserved"}}

--- a/tests/format/handlebars/prettier-ignore/prettier-ignore.hbs
+++ b/tests/format/handlebars/prettier-ignore/prettier-ignore.hbs
@@ -1,15 +1,23 @@
 {{! prettier-ignore }}
 {{        ugly}}
 
+{{! prettier-ignore }}{{        ugly}}
+
 {{! prettier-ignore }}
         ugly
+
+{{! prettier-ignore }}          ugly
 
 {{! prettier-ignore }}
 {{#        ugly}}
 {{/        ugly}}
 
+{{! prettier-ignore }}{{#        ugly}}{{/        ugly}}
+
 {{! prettier-ignore }}
 {{!        ugly}}
+
+{{! prettier-ignore }}{{!        ugly}}
 
 {{! prettier-ignore }}
 <div>


### PR DESCRIPTION
## Description

This PR adds test cases for {{! prettier-ignore}} when it is above or before:
- a text element
- a mustache element
- a block element
- a comment element

@fisker it should help with https://github.com/prettier/prettier/pull/13690

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
