### PR TITLE
Reduce size of `typescript` plugin

### DIFF
--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -115,11 +115,7 @@ const pluginFiles = [
         module: require.resolve(
           "@typescript-eslint/typescript-estree/dist/ast-converter.js"
         ),
-        process: (text) =>
-          text.replace(
-            'require("./simple-traverse")',
-            "{}"
-          ),
+        process: (text) => text.replace('require("./simple-traverse")', "{}"),
       },
       {
         module: require.resolve("debug/src/browser.js"),

--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -110,6 +110,17 @@ const pluginFiles = [
         ),
         text: "module.exports.typescriptVersionIsAtLeast = new Proxy({}, {get: () => true})",
       },
+      // Only needed if `range`/`loc` in parse options is `false`
+      {
+        module: require.resolve(
+          "@typescript-eslint/typescript-estree/dist/ast-converter.js"
+        ),
+        process: (text) =>
+          text.replace(
+            'require("./simple-traverse")',
+            "{}"
+          ),
+      },
       {
         module: require.resolve("debug/src/browser.js"),
         path: path.join(dirname, "./shims/debug.js"),

--- a/src/language-js/parse/typescript.js
+++ b/src/language-js/parse/typescript.js
@@ -8,6 +8,8 @@ import postprocess from "./postprocess/index.js";
 const parseOptions = {
   // `jest@<=26.4.2` rely on `loc`
   // https://github.com/facebook/jest/issues/10444
+  // Set `loc` and `range` to `true` also prevent AST traverse
+  // https://github.com/typescript-eslint/typescript-eslint/blob/733b3598c17d3a712cf6f043115587f724dbe3ef/packages/typescript-estree/src/ast-converter.ts#L38
   loc: true,
   range: true,
   comment: true,


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

**Size Change:** -32.7 kB (0%) 

**Total Size:** 10.4 MB

| Filename | Size | Change |  |
| :--- | :---: | :---: | :---: |
| `./dist/LICENSE` | 227 kB | -13.1 kB (-5%) | ✅ |
| `./dist/plugins/typescript.js` | 1.34 MB | -9.81 kB (-1%) |  |
| `./dist/plugins/typescript.mjs` | 1.34 MB | -9.81 kB (-1%) |  |

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
