### PR TITLE
Reduce size of `glimmer` plugin

### DIFF
--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -211,7 +211,8 @@ const pluginFiles = [
         module: require.resolve(
           "@glimmer/syntax/dist/modules/es2017/lib/parser/tokenizer-event-handlers.js"
         ),
-        process: text => text.replace(/\nconst syntax = \{.*?\n\};/su, "\nconst syntax = {};")
+        process: (text) =>
+          text.replace(/\nconst syntax = \{.*?\n\};/su, "\nconst syntax = {};"),
       },
     ],
   },

--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -214,6 +214,16 @@ const pluginFiles = [
         process: (text) =>
           text.replace(/\nconst syntax = \{.*?\n\};/su, "\nconst syntax = {};"),
       },
+      {
+        module: path.join(
+          path.dirname(require.resolve("@handlebars/parser/package.json")),
+          "dist/esm/index.js"
+        ),
+        path: path.join(
+          path.dirname(require.resolve("@handlebars/parser/package.json")),
+          "dist/esm/parse.js"
+        ),
+      },
     ],
   },
   "src/language-html/parser-html.js",

--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -206,6 +206,13 @@ const pluginFiles = [
           "@glimmer/syntax/dist/modules/es2017/lib/parser/tokenizer-event-handlers.js"
         ),
       },
+      // This passed to plugins, our plugin don't need access to the options
+      {
+        module: require.resolve(
+          "@glimmer/syntax/dist/modules/es2017/lib/parser/tokenizer-event-handlers.js"
+        ),
+        process: text => text.replace(/\nconst syntax = \{.*?\n\};/su, "\nconst syntax = {};")
+      },
     ],
   },
   "src/language-html/parser-html.js",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

**Size Change:** -20 kB (0%) 

**Total Size:** 10.4 MB

| Filename | Size | Change |  |
| :--- | :---: | :---: | :---: |
| `./dist/plugins/glimmer.js` | 120 kB | -10 kB (-8%) | ✅ |
| `./dist/plugins/glimmer.mjs` | 119 kB | -10 kB (-8%) | ✅ |

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
