### PR TITLE
Remove `since` from options and languages

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -108,7 +108,6 @@ The support information looks like this:
 {
   languages: Array<{
     name: string;
-    since?: string;
     parsers: string[];
     group?: string;
     tmScope?: string;

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "remark-math": "3.0.1",
     "remark-parse": "8.0.3",
     "sdbm": "2.0.0",
-    "semver": "7.3.7",
     "string-width": "5.0.1",
     "strip-ansi": "7.0.1",
     "to-fast-properties": "4.0.0",
@@ -147,6 +146,7 @@
     "pretty-bytes": "6.0.0",
     "rimraf": "3.0.2",
     "rollup-plugin-license": "2.8.2",
+    "semver": "7.3.8",
     "snapshot-diff": "0.10.0",
     "tempy": "3.0.0"
   },

--- a/scripts/generate-schema.mjs
+++ b/scripts/generate-schema.mjs
@@ -1,10 +1,11 @@
 #!/usr/bin/env node
 
-import { format, getSupportInfo } from "../index.js";
+import { format } from "../index.js";
+import { getSupportInfo } from "../src/main/support.js";
 import generateSchema from "./utils/generate-schema.mjs";
 
 console.log(
-  format(JSON.stringify(generateSchema(getSupportInfo().options)), {
+  await format(JSON.stringify(generateSchema(getSupportInfo().options)), {
     parser: "json",
   })
 );

--- a/src/cli/options/get-context-options.js
+++ b/src/cli/options/get-context-options.js
@@ -66,7 +66,6 @@ function supportInfoToContextOptions({ options: supportOptions, languages }) {
 async function getContextOptions(plugins, pluginSearchDirs) {
   const supportInfo = await getSupportInfo({
     showDeprecated: true,
-    showUnreleased: true,
     showInternal: true,
     plugins,
     pluginSearchDirs,

--- a/src/cli/usage.js
+++ b/src/cli/usage.js
@@ -60,7 +60,7 @@ function createOptionUsageType(option) {
       return null;
     case "choice":
       return `<${option.choices
-        .filter((choice) => !choice.deprecated && choice.since !== null)
+        .filter((choice) => !choice.deprecated)
         .map((choice) => choice.value)
         .join("|")}>`;
     default:
@@ -69,9 +69,7 @@ function createOptionUsageType(option) {
 }
 
 function createChoiceUsages(choices, margin, indentation) {
-  const activeChoices = choices.filter(
-    (choice) => !choice.deprecated && choice.since !== null
-  );
+  const activeChoices = choices.filter((choice) => !choice.deprecated);
   const threshold =
     Math.max(0, ...activeChoices.map((choice) => choice.value.length)) + margin;
   return activeChoices.map((choice) =>

--- a/src/common/common-options.js
+++ b/src/common/common-options.js
@@ -3,7 +3,6 @@ const CATEGORY_COMMON = "Common";
 // format based on https://github.com/prettier/prettier/blob/main/src/main/core-options.js
 const options = {
   bracketSpacing: {
-    since: "0.0.0",
     category: CATEGORY_COMMON,
     type: "boolean",
     default: true,
@@ -11,41 +10,32 @@ const options = {
     oppositeDescription: "Do not print spaces between brackets.",
   },
   singleQuote: {
-    since: "0.0.0",
     category: CATEGORY_COMMON,
     type: "boolean",
     default: false,
     description: "Use single quotes instead of double quotes.",
   },
   proseWrap: {
-    since: "1.8.2",
     category: CATEGORY_COMMON,
     type: "choice",
-    default: [
-      { since: "1.8.2", value: true },
-      { since: "1.9.0", value: "preserve" },
-    ],
+    default: "preserve",
     description: "How to wrap prose.",
     choices: [
       {
-        since: "1.9.0",
         value: "always",
         description: "Wrap prose if it exceeds the print width.",
       },
       {
-        since: "1.9.0",
         value: "never",
         description: "Do not wrap prose.",
       },
       {
-        since: "1.9.0",
         value: "preserve",
         description: "Wrap prose as-is.",
       },
     ],
   },
   bracketSameLine: {
-    since: "2.4.0",
     category: CATEGORY_COMMON,
     type: "boolean",
     default: false,
@@ -53,7 +43,6 @@ const options = {
       "Put > of opening tags on the last line instead of on a new line.",
   },
   singleAttributePerLine: {
-    since: "2.6.0",
     category: CATEGORY_COMMON,
     type: "boolean",
     default: false,

--- a/src/language-css/languages.evaluate.js
+++ b/src/language-css/languages.evaluate.js
@@ -3,7 +3,6 @@ import createLanguage from "../utils/create-language.js";
 
 const languages = [
   createLanguage(linguistLanguages.CSS, (data) => ({
-    since: "1.4.0",
     parsers: ["css"],
     vscodeLanguageIds: ["css"],
     extensions: [
@@ -14,17 +13,14 @@ const languages = [
     ],
   })),
   createLanguage(linguistLanguages.PostCSS, () => ({
-    since: "1.4.0",
     parsers: ["css"],
     vscodeLanguageIds: ["postcss"],
   })),
   createLanguage(linguistLanguages.Less, () => ({
-    since: "1.4.0",
     parsers: ["less"],
     vscodeLanguageIds: ["less"],
   })),
   createLanguage(linguistLanguages.SCSS, () => ({
-    since: "1.4.0",
     parsers: ["scss"],
     vscodeLanguageIds: ["scss"],
   })),

--- a/src/language-graphql/languages.evaluate.js
+++ b/src/language-graphql/languages.evaluate.js
@@ -3,7 +3,6 @@ import createLanguage from "../utils/create-language.js";
 
 const languages = [
   createLanguage(linguistLanguages.GraphQL, () => ({
-    since: "1.5.0",
     parsers: ["graphql"],
     vscodeLanguageIds: ["graphql"],
   })),

--- a/src/language-handlebars/languages.evaluate.js
+++ b/src/language-handlebars/languages.evaluate.js
@@ -3,7 +3,6 @@ import createLanguage from "../utils/create-language.js";
 
 const languages = [
   createLanguage(linguistLanguages.Handlebars, () => ({
-    since: "2.3.0",
     parsers: ["glimmer"],
     vscodeLanguageIds: ["handlebars"],
   })),

--- a/src/language-html/languages.evaluate.js
+++ b/src/language-html/languages.evaluate.js
@@ -4,14 +4,12 @@ import createLanguage from "../utils/create-language.js";
 const languages = [
   createLanguage(linguistLanguages.HTML, () => ({
     name: "Angular",
-    since: "1.15.0",
     parsers: ["angular"],
     vscodeLanguageIds: ["html"],
     extensions: [".component.html"],
     filenames: [],
   })),
   createLanguage(linguistLanguages.HTML, (data) => ({
-    since: "1.15.0",
     parsers: ["html"],
     vscodeLanguageIds: ["html"],
     extensions: [
@@ -21,14 +19,12 @@ const languages = [
   })),
   createLanguage(linguistLanguages.HTML, () => ({
     name: "Lightning Web Components",
-    since: "1.17.0",
     parsers: ["lwc"],
     vscodeLanguageIds: ["html"],
     extensions: [],
     filenames: [],
   })),
   createLanguage(linguistLanguages.Vue, () => ({
-    since: "1.10.0",
     parsers: ["vue"],
     vscodeLanguageIds: ["vue"],
   })),

--- a/src/language-html/options.js
+++ b/src/language-html/options.js
@@ -6,7 +6,6 @@ const CATEGORY_HTML = "HTML";
 const options = {
   bracketSameLine: commonOptions.bracketSameLine,
   htmlWhitespaceSensitivity: {
-    since: "1.15.0",
     category: CATEGORY_HTML,
     type: "choice",
     default: "css",
@@ -28,7 +27,6 @@ const options = {
   },
   singleAttributePerLine: commonOptions.singleAttributePerLine,
   vueIndentScriptAndStyle: {
-    since: "1.19.0",
     category: CATEGORY_HTML,
     type: "boolean",
     default: false,

--- a/src/language-js/languages.evaluate.js
+++ b/src/language-js/languages.evaluate.js
@@ -3,7 +3,6 @@ import createLanguage from "../utils/create-language.js";
 
 const languages = [
   createLanguage(linguistLanguages.JavaScript, (data) => ({
-    since: "0.0.0",
     parsers: [
       "babel",
       "acorn",
@@ -29,7 +28,6 @@ const languages = [
   })),
   createLanguage(linguistLanguages.JavaScript, () => ({
     name: "Flow",
-    since: "0.0.0",
     parsers: ["flow", "babel-flow"],
     vscodeLanguageIds: ["javascript"],
     aliases: [],
@@ -38,7 +36,6 @@ const languages = [
   })),
   createLanguage(linguistLanguages.JavaScript, () => ({
     name: "JSX",
-    since: "0.0.0",
     parsers: [
       "babel",
       "babel-flow",
@@ -61,37 +58,31 @@ const languages = [
     color: undefined,
   })),
   createLanguage(linguistLanguages.TypeScript, () => ({
-    since: "1.4.0",
     parsers: ["typescript", "babel-ts"],
     vscodeLanguageIds: ["typescript"],
   })),
   createLanguage(linguistLanguages.TSX, () => ({
-    since: "1.4.0",
     parsers: ["typescript", "babel-ts"],
     vscodeLanguageIds: ["typescriptreact"],
   })),
   createLanguage(linguistLanguages.JSON, () => ({
     name: "JSON.stringify",
-    since: "1.13.0",
     parsers: ["json-stringify"],
     vscodeLanguageIds: ["json"],
     extensions: [".importmap"], // .json file defaults to json instead of json-stringify
     filenames: ["package.json", "package-lock.json", "composer.json"],
   })),
   createLanguage(linguistLanguages.JSON, (data) => ({
-    since: "1.5.0",
     parsers: ["json"],
     vscodeLanguageIds: ["json"],
     extensions: data.extensions.filter((extension) => extension !== ".jsonl"),
   })),
   createLanguage(linguistLanguages["JSON with Comments"], (data) => ({
-    since: "1.5.0",
     parsers: ["json"],
     vscodeLanguageIds: ["jsonc"],
     filenames: [...data.filenames, ".eslintrc", ".swcrc"],
   })),
   createLanguage(linguistLanguages.JSON5, () => ({
-    since: "1.13.0",
     parsers: ["json5"],
     vscodeLanguageIds: ["json5"],
   })),

--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -5,13 +5,9 @@ const CATEGORY_JAVASCRIPT = "JavaScript";
 // format based on https://github.com/prettier/prettier/blob/main/src/main/core-options.js
 const options = {
   arrowParens: {
-    since: "1.9.0",
     category: CATEGORY_JAVASCRIPT,
     type: "choice",
-    default: [
-      { since: "1.9.0", value: "avoid" },
-      { since: "2.0.0", value: "always" },
-    ],
+    default: "always",
     description: "Include parentheses around a sole arrow function parameter.",
     choices: [
       {
@@ -27,14 +23,12 @@ const options = {
   bracketSameLine: commonOptions.bracketSameLine,
   bracketSpacing: commonOptions.bracketSpacing,
   jsxBracketSameLine: {
-    since: "0.17.0",
     category: CATEGORY_JAVASCRIPT,
     type: "boolean",
     description: "Put > on the last line instead of at a new line.",
     deprecated: "2.4.0",
   },
   semi: {
-    since: "1.0.0",
     category: CATEGORY_JAVASCRIPT,
     type: "boolean",
     default: true,
@@ -44,14 +38,12 @@ const options = {
   },
   singleQuote: commonOptions.singleQuote,
   jsxSingleQuote: {
-    since: "1.15.0",
     category: CATEGORY_JAVASCRIPT,
     type: "boolean",
     default: false,
     description: "Use single quotes in JSX.",
   },
   quoteProps: {
-    since: "1.17.0",
     category: CATEGORY_JAVASCRIPT,
     type: "choice",
     default: "as-needed",
@@ -73,15 +65,9 @@ const options = {
     ],
   },
   trailingComma: {
-    since: "0.0.0",
     category: CATEGORY_JAVASCRIPT,
     type: "choice",
-    default: [
-      { since: "0.0.0", value: false },
-      { since: "0.19.0", value: "none" },
-      { since: "2.0.0", value: "es5" },
-      { since: "3.0.0", value: "all" },
-    ],
+    default: "all",
     description: "Print trailing commas wherever possible when multi-line.",
     choices: [
       {

--- a/src/language-markdown/languages.evaluate.js
+++ b/src/language-markdown/languages.evaluate.js
@@ -3,7 +3,6 @@ import createLanguage from "../utils/create-language.js";
 
 const languages = [
   createLanguage(linguistLanguages.Markdown, (data) => ({
-    since: "1.8.0",
     parsers: ["markdown"],
     vscodeLanguageIds: ["markdown"],
     filenames: [...data.filenames, "README"],
@@ -11,7 +10,6 @@ const languages = [
   })),
   createLanguage(linguistLanguages.Markdown, () => ({
     name: "MDX",
-    since: "1.15.0",
     parsers: ["mdx"],
     vscodeLanguageIds: ["mdx"],
     filenames: [],

--- a/src/language-yaml/languages.evaluate.js
+++ b/src/language-yaml/languages.evaluate.js
@@ -3,7 +3,6 @@ import createLanguage from "../utils/create-language.js";
 
 const languages = [
   createLanguage(linguistLanguages.YAML, (data) => ({
-    since: "1.14.0",
     parsers: ["yaml"],
     vscodeLanguageIds: ["yaml", "ansible", "home-assistant"],
     // yarn.lock is not YAML: https://github.com/yarnpkg/yarn/issues/5629

--- a/src/main/core-options.js
+++ b/src/main/core-options.js
@@ -137,7 +137,7 @@ const options = {
   plugins: {
     type: "path",
     array: true,
-    default: [{ value: [] }],
+    default: [],
     category: CATEGORY_GLOBAL,
     description:
       "Add a plugin. Multiple plugins can be passed as separate `--plugin`s.",
@@ -149,7 +149,7 @@ const options = {
   pluginSearchDirs: {
     type: "path",
     array: true,
-    default: [{ value: [] }],
+    default: [],
     category: CATEGORY_GLOBAL,
     description: outdent`
       Custom directory that contains prettier plugins in node_modules subdirectory.

--- a/src/main/core-options.js
+++ b/src/main/core-options.js
@@ -24,8 +24,8 @@ const CATEGORY_SPECIAL = "Special";
  * @property {string} [cliCategory]
  * @property {string} [cliDescription]
  *
- * @typedef {number | boolean | string} OptionValue
- * @typedef {OptionValue | [{ value: OptionValue[] }] | Array<{ since: string, value: OptionValue}>} OptionValueInfo
+ * @typedef {number | boolean | string | []} OptionValue
+ * @typedef {OptionValue | [{ value: OptionValue }] | (() => OptionValue)} OptionValueInfo
  *
  * @typedef {Object} OptionRedirectInfo
  * @property {string} option

--- a/src/main/core-options.js
+++ b/src/main/core-options.js
@@ -137,7 +137,7 @@ const options = {
   plugins: {
     type: "path",
     array: true,
-    default: [],
+    default: () => [],
     category: CATEGORY_GLOBAL,
     description:
       "Add a plugin. Multiple plugins can be passed as separate `--plugin`s.",
@@ -149,7 +149,7 @@ const options = {
   pluginSearchDirs: {
     type: "path",
     array: true,
-    default: [],
+    default: () => [],
     category: CATEGORY_GLOBAL,
     description: outdent`
       Custom directory that contains prettier plugins in node_modules subdirectory.

--- a/src/main/core-options.js
+++ b/src/main/core-options.js
@@ -10,7 +10,6 @@ const CATEGORY_SPECIAL = "Special";
 
 /**
  * @typedef {Object} OptionInfo
- * @property {string} [since] - available since version
  * @property {string} category
  * @property {'int' | 'boolean' | 'choice' | 'path' | 'string' | 'flag'} type
  * @property {boolean} [array] - indicate it's an array of the specified type
@@ -40,7 +39,6 @@ const CATEGORY_SPECIAL = "Special";
  * @typedef {Object} OptionChoiceInfo
  * @property {boolean | string} value - boolean for the option that is originally boolean type
  * @property {string} description
- * @property {string} [since] - undefined if available since the first version of the option
  * @property {string} [deprecated] - deprecated since version
  * @property {OptionValueInfo} [redirect] - redirect deprecated value
  */
@@ -48,7 +46,6 @@ const CATEGORY_SPECIAL = "Special";
 /** @type {{ [name: string]: OptionInfo }} */
 const options = {
   cursorOffset: {
-    since: "1.4.0",
     category: CATEGORY_SPECIAL,
     type: "int",
     default: -1,
@@ -60,13 +57,9 @@ const options = {
     cliCategory: CATEGORY_EDITOR,
   },
   endOfLine: {
-    since: "1.15.0",
     category: CATEGORY_GLOBAL,
     type: "choice",
-    default: [
-      { since: "1.15.0", value: "auto" },
-      { since: "2.0.0", value: "lf" },
-    ],
+    default: "lf",
     description: "Which end of line characters to apply.",
     choices: [
       {
@@ -93,7 +86,6 @@ const options = {
     ],
   },
   filepath: {
-    since: "1.4.0",
     category: CATEGORY_SPECIAL,
     type: "path",
     description:
@@ -103,7 +95,6 @@ const options = {
     cliDescription: "Path to the file to pretend that stdin comes from.",
   },
   insertPragma: {
-    since: "1.8.0",
     category: CATEGORY_SPECIAL,
     type: "boolean",
     default: false,
@@ -111,52 +102,39 @@ const options = {
     cliCategory: CATEGORY_OTHER,
   },
   parser: {
-    since: "0.0.10",
     category: CATEGORY_GLOBAL,
     type: "choice",
-    default: [
-      { since: "0.0.10", value: "babylon" },
-      { since: "1.13.0", value: undefined },
-    ],
+    default: undefined,
     description: "Which parser to use.",
     exception: (value) =>
       typeof value === "string" || typeof value === "function",
     choices: [
       { value: "flow", description: "Flow" },
-      { value: "babel", since: "1.16.0", description: "JavaScript" },
-      { value: "babel-flow", since: "1.16.0", description: "Flow" },
-      { value: "babel-ts", since: "2.0.0", description: "TypeScript" },
-      { value: "typescript", since: "1.4.0", description: "TypeScript" },
-      { value: "acorn", since: "2.6.0", description: "JavaScript" },
-      { value: "espree", since: "2.2.0", description: "JavaScript" },
-      { value: "meriyah", since: "2.2.0", description: "JavaScript" },
-      { value: "css", since: "1.7.1", description: "CSS" },
-      { value: "less", since: "1.7.1", description: "Less" },
-      { value: "scss", since: "1.7.1", description: "SCSS" },
-      { value: "json", since: "1.5.0", description: "JSON" },
-      { value: "json5", since: "1.13.0", description: "JSON5" },
-      {
-        value: "json-stringify",
-        since: "1.13.0",
-        description: "JSON.stringify",
-      },
-      { value: "graphql", since: "1.5.0", description: "GraphQL" },
-      { value: "markdown", since: "1.8.0", description: "Markdown" },
-      { value: "mdx", since: "1.15.0", description: "MDX" },
-      { value: "vue", since: "1.10.0", description: "Vue" },
-      { value: "yaml", since: "1.14.0", description: "YAML" },
-      { value: "glimmer", since: "2.3.0", description: "Ember / Handlebars" },
-      { value: "html", since: "1.15.0", description: "HTML" },
-      { value: "angular", since: "1.15.0", description: "Angular" },
-      {
-        value: "lwc",
-        since: "1.17.0",
-        description: "Lightning Web Components",
-      },
+      { value: "babel", description: "JavaScript" },
+      { value: "babel-flow", description: "Flow" },
+      { value: "babel-ts", description: "TypeScript" },
+      { value: "typescript", description: "TypeScript" },
+      { value: "acorn", description: "JavaScript" },
+      { value: "espree", description: "JavaScript" },
+      { value: "meriyah", description: "JavaScript" },
+      { value: "css", description: "CSS" },
+      { value: "less", description: "Less" },
+      { value: "scss", description: "SCSS" },
+      { value: "json", description: "JSON" },
+      { value: "json5", description: "JSON5" },
+      { value: "json-stringify", description: "JSON.stringify" },
+      { value: "graphql", description: "GraphQL" },
+      { value: "markdown", description: "Markdown" },
+      { value: "mdx", description: "MDX" },
+      { value: "vue", description: "Vue" },
+      { value: "yaml", description: "YAML" },
+      { value: "glimmer", description: "Ember / Handlebars" },
+      { value: "html", description: "HTML" },
+      { value: "angular", description: "Angular" },
+      { value: "lwc", description: "Lightning Web Components" },
     ],
   },
   plugins: {
-    since: "1.10.0",
     type: "path",
     array: true,
     default: [{ value: [] }],
@@ -169,7 +147,6 @@ const options = {
     cliCategory: CATEGORY_CONFIG,
   },
   pluginSearchDirs: {
-    since: "1.13.0",
     type: "path",
     array: true,
     default: [{ value: [] }],
@@ -185,7 +162,6 @@ const options = {
     cliCategory: CATEGORY_CONFIG,
   },
   printWidth: {
-    since: "0.0.0",
     category: CATEGORY_GLOBAL,
     type: "int",
     default: 80,
@@ -193,7 +169,6 @@ const options = {
     range: { start: 0, end: Number.POSITIVE_INFINITY, step: 1 },
   },
   rangeEnd: {
-    since: "1.4.0",
     category: CATEGORY_SPECIAL,
     type: "int",
     default: Number.POSITIVE_INFINITY,
@@ -206,7 +181,6 @@ const options = {
     cliCategory: CATEGORY_EDITOR,
   },
   rangeStart: {
-    since: "1.4.0",
     category: CATEGORY_SPECIAL,
     type: "int",
     default: 0,
@@ -219,7 +193,6 @@ const options = {
     cliCategory: CATEGORY_EDITOR,
   },
   requirePragma: {
-    since: "1.7.0",
     category: CATEGORY_SPECIAL,
     type: "boolean",
     default: false,
@@ -237,17 +210,15 @@ const options = {
     range: { start: 0, end: Number.POSITIVE_INFINITY, step: 1 },
   },
   useTabs: {
-    since: "1.0.0",
     category: CATEGORY_GLOBAL,
     type: "boolean",
     default: false,
     description: "Indent with tabs instead of spaces.",
   },
   embeddedLanguageFormatting: {
-    since: "2.1.0",
     category: CATEGORY_GLOBAL,
     type: "choice",
-    default: [{ since: "2.1.0", value: "auto" }],
+    default: "auto",
     description:
       "Control how Prettier formats quoted code embedded in the file.",
     choices: [

--- a/src/main/core-options.js
+++ b/src/main/core-options.js
@@ -25,7 +25,7 @@ const CATEGORY_SPECIAL = "Special";
  * @property {string} [cliDescription]
  *
  * @typedef {number | boolean | string | []} OptionValue
- * @typedef {OptionValue | [{ value: OptionValue }] | (() => OptionValue)} OptionValueInfo
+ * @typedef {OptionValue | [{ value: OptionValue }]} OptionValueInfo
  *
  * @typedef {Object} OptionRedirectInfo
  * @property {string} option
@@ -137,7 +137,7 @@ const options = {
   plugins: {
     type: "path",
     array: true,
-    default: () => [],
+    default: [{ value: [] }],
     category: CATEGORY_GLOBAL,
     description:
       "Add a plugin. Multiple plugins can be passed as separate `--plugin`s.",
@@ -149,7 +149,7 @@ const options = {
   pluginSearchDirs: {
     type: "path",
     array: true,
-    default: () => [],
+    default: [{ value: [] }],
     category: CATEGORY_GLOBAL,
     description: outdent`
       Custom directory that contains prettier plugins in node_modules subdirectory.

--- a/src/main/options.js
+++ b/src/main/options.js
@@ -19,7 +19,6 @@ async function normalize(options, opts = {}) {
 
   const supportOptions = getSupportInfo({
     plugins: options.plugins,
-    showUnreleased: true,
     showDeprecated: true,
   }).options;
 
@@ -118,9 +117,7 @@ function getPlugin(options) {
 
 function inferParser(filepath, plugins) {
   const filename = path.basename(filepath).toLowerCase();
-  const languages = getSupportInfo({ plugins }).languages.filter(
-    (language) => language.since !== null
-  );
+  const { languages } = getSupportInfo({ plugins });
 
   // If the file has no extension, we can try to infer the language from the
   // interpreter in the shebang line, if any; but since this requires FS access,

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -59,7 +59,7 @@ function getSupportInfo({
   return { languages, options };
 
   function filterDeprecated(object) {
-    return showDeprecated || !("deprecated" in object) || object.deprecated;
+    return showDeprecated || !object.deprecated;
   }
 
   function mapInternal(object) {

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -35,7 +35,9 @@ function getSupportInfo({
 
       if (Array.isArray(option.default)) {
         // eslint-disable-next-line no-console
-        console.warn("the default value of option should be a primitive value or a function.")
+        console.warn(
+          "the default value of option should be a primitive value or a function."
+        );
         option.default = option.default[0].value;
       } else if (typeof option.default === "function") {
         option.default = option.default();

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -33,6 +33,14 @@ function getSupportInfo({
     .map((option) => {
       option = { ...option };
 
+      if (Array.isArray(option.default)) {
+        // eslint-disable-next-line no-console
+        console.warn("the default value of option should be a primitive value or a function.")
+        option.default = option.default[0].value;
+      } else if (typeof option.default === "function") {
+        option.default = option.default();
+      }
+
       if (Array.isArray(option.choices)) {
         option.choices = option.choices.filter((option) =>
           filterDeprecated(option)

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -1,6 +1,3 @@
-import semverCompare from "semver/functions/compare.js";
-import semverGte from "semver/functions/gte.js";
-import semverLt from "semver/functions/lt.js";
 import arrayify from "../utils/arrayify.js";
 import { options as coreOptions } from "./core-options.js";
 import currentVersion from "./version.evaluate.cjs";
@@ -16,14 +13,12 @@ import currentVersion from "./version.evaluate.cjs";
  * @param {object} param0
  * @param {(string | object)[]=} param0.plugins Strings are resolved by `withPlugins`.
  * @param {string[]=} param0.pluginSearchDirs Added by `withPlugins`.
- * @param {boolean=} param0.showUnreleased
  * @param {boolean=} param0.showDeprecated
  * @param {boolean=} param0.showInternal
  * @return {{ languages: Array<any>, options: Array<NamedOptionInfo> }}
  */
 function getSupportInfo({
   plugins = [],
-  showUnreleased = false,
   showDeprecated = false,
   showInternal = false,
 } = {}) {
@@ -31,34 +26,21 @@ function getSupportInfo({
   // we need to treat it as the normal one so as to test new features.
   const version = currentVersion.split("-", 1)[0];
 
-  const languages = plugins
-    .flatMap((plugin) => plugin.languages || [])
-    .filter(filterSince);
+  const languages = plugins.flatMap((plugin) => plugin.languages || []);
 
   const options = arrayify(
     Object.assign({}, ...plugins.map(({ options }) => options), coreOptions),
     "name"
   )
-    .filter((option) => filterSince(option) && filterDeprecated(option))
+    .filter((option) => filterDeprecated(option))
     .sort((a, b) => (a.name === b.name ? 0 : a.name < b.name ? -1 : 1))
     .map(mapInternal)
     .map((option) => {
       option = { ...option };
 
-      if (Array.isArray(option.default)) {
-        option.default =
-          option.default.length === 1
-            ? option.default[0].value
-            : option.default
-                .filter(filterSince)
-                .sort((info1, info2) =>
-                  semverCompare(info2.since, info1.since)
-                )[0].value;
-      }
-
       if (Array.isArray(option.choices)) {
-        option.choices = option.choices.filter(
-          (option) => filterSince(option) && filterDeprecated(option)
+        option.choices = option.choices.filter((option) =>
+          filterDeprecated(option)
         );
 
         if (option.name === "parser") {
@@ -81,20 +63,8 @@ function getSupportInfo({
 
   return { languages, options };
 
-  function filterSince(object) {
-    return (
-      showUnreleased ||
-      !("since" in object) ||
-      (object.since && semverGte(version, object.since))
-    );
-  }
-
   function filterDeprecated(object) {
-    return (
-      showDeprecated ||
-      !("deprecated" in object) ||
-      (object.deprecated && semverLt(version, object.deprecated))
-    );
+    return showDeprecated || !("deprecated" in object) || object.deprecated;
   }
 
   function mapInternal(object) {

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -1,6 +1,5 @@
 import arrayify from "../utils/arrayify.js";
 import { options as coreOptions } from "./core-options.js";
-import currentVersion from "./version.evaluate.cjs";
 
 /**
  * @typedef {import("./core-options.js").OptionInfo} OptionInfo
@@ -22,10 +21,6 @@ function getSupportInfo({
   showDeprecated = false,
   showInternal = false,
 } = {}) {
-  // pre-release version is smaller than the normal version in semver,
-  // we need to treat it as the normal one so as to test new features.
-  const version = currentVersion.split("-", 1)[0];
-
   const languages = plugins.flatMap((plugin) => plugin.languages || []);
 
   const options = arrayify(

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -33,14 +33,9 @@ function getSupportInfo({
     .map((option) => {
       option = { ...option };
 
+      // This work this way because we used support `[{value: [], since: '0.0.0'}]`
       if (Array.isArray(option.default)) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          "the default value of option should be a primitive value or a function."
-        );
-        option.default = option.default[0].value;
-      } else if (typeof option.default === "function") {
-        option.default = option.default();
+        option.default = option.default.at(-1).value;
       }
 
       if (Array.isArray(option.choices)) {

--- a/tests/integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests/integration/__tests__/__snapshots__/schema.js.snap
@@ -123,6 +123,11 @@ This option cannot be used with --range-start and --range-end.",
           "description": "Insert @format pragma into file's first docblock comment.",
           "type": "boolean",
         },
+        "jsxBracketSameLine": {
+          "default": undefined,
+          "description": "Put > on the last line instead of at a new line.",
+          "type": "boolean",
+        },
         "jsxSingleQuote": {
           "default": false,
           "description": "Use single quotes in JSX.",

--- a/tests/integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests/integration/__tests__/__snapshots__/schema.js.snap
@@ -123,11 +123,6 @@ This option cannot be used with --range-start and --range-end.",
           "description": "Insert @format pragma into file's first docblock comment.",
           "type": "boolean",
         },
-        "jsxBracketSameLine": {
-          "default": undefined,
-          "description": "Put > on the last line instead of at a new line.",
-          "type": "boolean",
-        },
         "jsxSingleQuote": {
           "default": false,
           "description": "Use single quotes in JSX.",

--- a/tests/integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests/integration/__tests__/__snapshots__/support-info.js.snap
@@ -147,10 +147,6 @@ exports[`API getSupportInfo() 1`] = `
       "default": false,
       "type": "boolean",
     },
-    "jsxBracketSameLine": {
-      "default": undefined,
-      "type": "boolean",
-    },
     "jsxSingleQuote": {
       "default": false,
       "type": "boolean",
@@ -891,14 +887,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "default": false,
       "description": "Insert @format pragma into file's first docblock comment.",
       "name": "insertPragma",
-      "pluginDefaults": {},
-      "type": "boolean"
-    },
-    {
-      "category": "JavaScript",
-      "deprecated": "2.4.0",
-      "description": "Put > on the last line instead of at a new line.",
-      "name": "jsxBracketSameLine",
       "pluginDefaults": {},
       "type": "boolean"
     },

--- a/tests/integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests/integration/__tests__/__snapshots__/support-info.js.snap
@@ -147,6 +147,10 @@ exports[`API getSupportInfo() 1`] = `
       "default": false,
       "type": "boolean",
     },
+    "jsxBracketSameLine": {
+      "default": undefined,
+      "type": "boolean",
+    },
     "jsxSingleQuote": {
       "default": false,
       "type": "boolean",
@@ -295,7 +299,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 146,
       "name": "Angular",
       "parsers": ["angular"],
-      "since": "1.15.0",
       "tmScope": "text.html.basic",
       "type": "markup",
       "vscodeLanguageIds": ["html"]
@@ -309,7 +312,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 50,
       "name": "CSS",
       "parsers": ["css"],
-      "since": "1.4.0",
       "tmScope": "source.css",
       "type": "markup",
       "vscodeLanguageIds": ["css"]
@@ -337,7 +339,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 183,
       "name": "Flow",
       "parsers": ["flow", "babel-flow"],
-      "since": "0.0.0",
       "tmScope": "source.js",
       "type": "programming",
       "vscodeLanguageIds": ["javascript"]
@@ -349,7 +350,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 139,
       "name": "GraphQL",
       "parsers": ["graphql"],
-      "since": "1.5.0",
       "tmScope": "source.graphql",
       "type": "data",
       "vscodeLanguageIds": ["graphql"]
@@ -362,7 +362,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 155,
       "name": "Handlebars",
       "parsers": ["glimmer"],
-      "since": "2.3.0",
       "tmScope": "text.html.handlebars",
       "type": "markup",
       "vscodeLanguageIds": ["handlebars"]
@@ -386,7 +385,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 146,
       "name": "HTML",
       "parsers": ["html"],
-      "since": "1.15.0",
       "tmScope": "text.html.basic",
       "type": "markup",
       "vscodeLanguageIds": ["html"]
@@ -450,7 +448,6 @@ exports[`CLI --support-info (stdout) 1`] = `
         "flow",
         "typescript"
       ],
-      "since": "0.0.0",
       "tmScope": "source.js",
       "type": "programming",
       "vscodeLanguageIds": ["javascript", "mongo"]
@@ -497,7 +494,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 174,
       "name": "JSON",
       "parsers": ["json"],
-      "since": "1.5.0",
       "tmScope": "source.json",
       "type": "data",
       "vscodeLanguageIds": ["json"]
@@ -545,7 +541,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 423,
       "name": "JSON with Comments",
       "parsers": ["json"],
-      "since": "1.5.0",
       "tmScope": "source.js",
       "type": "data",
       "vscodeLanguageIds": ["jsonc"]
@@ -561,7 +556,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 174,
       "name": "JSON.stringify",
       "parsers": ["json-stringify"],
-      "since": "1.13.0",
       "tmScope": "source.json",
       "type": "data",
       "vscodeLanguageIds": ["json"]
@@ -575,7 +569,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 175,
       "name": "JSON5",
       "parsers": ["json5"],
-      "since": "1.13.0",
       "tmScope": "source.js",
       "type": "data",
       "vscodeLanguageIds": ["json5"]
@@ -597,7 +590,6 @@ exports[`CLI --support-info (stdout) 1`] = `
         "espree",
         "meriyah"
       ],
-      "since": "0.0.0",
       "tmScope": "source.js.jsx",
       "type": "programming",
       "vscodeLanguageIds": ["javascriptreact"]
@@ -612,7 +604,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 198,
       "name": "Less",
       "parsers": ["less"],
-      "since": "1.4.0",
       "tmScope": "source.css.less",
       "type": "markup",
       "vscodeLanguageIds": ["less"]
@@ -628,7 +619,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 146,
       "name": "Lightning Web Components",
       "parsers": ["lwc"],
-      "since": "1.17.0",
       "tmScope": "text.html.basic",
       "type": "markup",
       "vscodeLanguageIds": ["html"]
@@ -656,7 +646,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 222,
       "name": "Markdown",
       "parsers": ["markdown"],
-      "since": "1.8.0",
       "tmScope": "source.gfm",
       "type": "prose",
       "vscodeLanguageIds": ["markdown"],
@@ -673,7 +662,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 222,
       "name": "MDX",
       "parsers": ["mdx"],
-      "since": "1.15.0",
       "tmScope": "source.gfm",
       "type": "prose",
       "vscodeLanguageIds": ["mdx"],
@@ -687,7 +675,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 262764437,
       "name": "PostCSS",
       "parsers": ["css"],
-      "since": "1.4.0",
       "tmScope": "source.postcss",
       "type": "markup",
       "vscodeLanguageIds": ["postcss"]
@@ -701,7 +688,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 329,
       "name": "SCSS",
       "parsers": ["scss"],
-      "since": "1.4.0",
       "tmScope": "source.css.scss",
       "type": "markup",
       "vscodeLanguageIds": ["scss"]
@@ -716,7 +702,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 94901924,
       "name": "TSX",
       "parsers": ["typescript", "babel-ts"],
-      "since": "1.4.0",
       "tmScope": "source.tsx",
       "type": "programming",
       "vscodeLanguageIds": ["typescriptreact"]
@@ -732,7 +717,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 378,
       "name": "TypeScript",
       "parsers": ["typescript", "babel-ts"],
-      "since": "1.4.0",
       "tmScope": "source.ts",
       "type": "programming",
       "vscodeLanguageIds": ["typescript"]
@@ -744,7 +728,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 391,
       "name": "Vue",
       "parsers": ["vue"],
-      "since": "1.10.0",
       "tmScope": "text.html.vue",
       "type": "markup",
       "vscodeLanguageIds": ["vue"]
@@ -780,7 +763,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "linguistLanguageId": 407,
       "name": "YAML",
       "parsers": ["yaml"],
-      "since": "1.14.0",
       "tmScope": "source.yaml",
       "type": "data",
       "vscodeLanguageIds": ["yaml", "ansible", "home-assistant"]
@@ -803,7 +785,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "description": "Include parentheses around a sole arrow function parameter.",
       "name": "arrowParens",
       "pluginDefaults": {},
-      "since": "1.9.0",
       "type": "choice"
     },
     {
@@ -812,7 +793,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "description": "Put > of opening tags on the last line instead of on a new line.",
       "name": "bracketSameLine",
       "pluginDefaults": {},
-      "since": "2.4.0",
       "type": "boolean"
     },
     {
@@ -822,7 +802,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "name": "bracketSpacing",
       "oppositeDescription": "Do not print spaces between brackets.",
       "pluginDefaults": {},
-      "since": "0.0.0",
       "type": "boolean"
     },
     {
@@ -832,7 +811,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "name": "cursorOffset",
       "pluginDefaults": {},
       "range": { "end": null, "start": -1, "step": 1 },
-      "since": "1.4.0",
       "type": "int"
     },
     {
@@ -851,7 +829,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "description": "Control how Prettier formats quoted code embedded in the file.",
       "name": "embeddedLanguageFormatting",
       "pluginDefaults": {},
-      "since": "2.1.0",
       "type": "choice"
     },
     {
@@ -878,7 +855,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "description": "Which end of line characters to apply.",
       "name": "endOfLine",
       "pluginDefaults": {},
-      "since": "1.15.0",
       "type": "choice"
     },
     {
@@ -886,7 +862,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "description": "Specify the input filepath. This will be used to do parser inference.",
       "name": "filepath",
       "pluginDefaults": {},
-      "since": "1.4.0",
       "type": "path"
     },
     {
@@ -909,7 +884,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "description": "How to handle whitespaces in HTML.",
       "name": "htmlWhitespaceSensitivity",
       "pluginDefaults": {},
-      "since": "1.15.0",
       "type": "choice"
     },
     {
@@ -918,7 +892,14 @@ exports[`CLI --support-info (stdout) 1`] = `
       "description": "Insert @format pragma into file's first docblock comment.",
       "name": "insertPragma",
       "pluginDefaults": {},
-      "since": "1.8.0",
+      "type": "boolean"
+    },
+    {
+      "category": "JavaScript",
+      "deprecated": "2.4.0",
+      "description": "Put > on the last line instead of at a new line.",
+      "name": "jsxBracketSameLine",
+      "pluginDefaults": {},
       "type": "boolean"
     },
     {
@@ -927,56 +908,38 @@ exports[`CLI --support-info (stdout) 1`] = `
       "description": "Use single quotes in JSX.",
       "name": "jsxSingleQuote",
       "pluginDefaults": {},
-      "since": "1.15.0",
       "type": "boolean"
     },
     {
       "category": "Global",
       "choices": [
         { "description": "Flow", "value": "flow" },
-        { "description": "JavaScript", "since": "1.16.0", "value": "babel" },
-        { "description": "Flow", "since": "1.16.0", "value": "babel-flow" },
-        { "description": "TypeScript", "since": "2.0.0", "value": "babel-ts" },
-        {
-          "description": "TypeScript",
-          "since": "1.4.0",
-          "value": "typescript"
-        },
-        { "description": "JavaScript", "since": "2.6.0", "value": "acorn" },
-        { "description": "JavaScript", "since": "2.2.0", "value": "espree" },
-        { "description": "JavaScript", "since": "2.2.0", "value": "meriyah" },
-        { "description": "CSS", "since": "1.7.1", "value": "css" },
-        { "description": "Less", "since": "1.7.1", "value": "less" },
-        { "description": "SCSS", "since": "1.7.1", "value": "scss" },
-        { "description": "JSON", "since": "1.5.0", "value": "json" },
-        { "description": "JSON5", "since": "1.13.0", "value": "json5" },
-        {
-          "description": "JSON.stringify",
-          "since": "1.13.0",
-          "value": "json-stringify"
-        },
-        { "description": "GraphQL", "since": "1.5.0", "value": "graphql" },
-        { "description": "Markdown", "since": "1.8.0", "value": "markdown" },
-        { "description": "MDX", "since": "1.15.0", "value": "mdx" },
-        { "description": "Vue", "since": "1.10.0", "value": "vue" },
-        { "description": "YAML", "since": "1.14.0", "value": "yaml" },
-        {
-          "description": "Ember / Handlebars",
-          "since": "2.3.0",
-          "value": "glimmer"
-        },
-        { "description": "HTML", "since": "1.15.0", "value": "html" },
-        { "description": "Angular", "since": "1.15.0", "value": "angular" },
-        {
-          "description": "Lightning Web Components",
-          "since": "1.17.0",
-          "value": "lwc"
-        }
+        { "description": "JavaScript", "value": "babel" },
+        { "description": "Flow", "value": "babel-flow" },
+        { "description": "TypeScript", "value": "babel-ts" },
+        { "description": "TypeScript", "value": "typescript" },
+        { "description": "JavaScript", "value": "acorn" },
+        { "description": "JavaScript", "value": "espree" },
+        { "description": "JavaScript", "value": "meriyah" },
+        { "description": "CSS", "value": "css" },
+        { "description": "Less", "value": "less" },
+        { "description": "SCSS", "value": "scss" },
+        { "description": "JSON", "value": "json" },
+        { "description": "JSON5", "value": "json5" },
+        { "description": "JSON.stringify", "value": "json-stringify" },
+        { "description": "GraphQL", "value": "graphql" },
+        { "description": "Markdown", "value": "markdown" },
+        { "description": "MDX", "value": "mdx" },
+        { "description": "Vue", "value": "vue" },
+        { "description": "YAML", "value": "yaml" },
+        { "description": "Ember / Handlebars", "value": "glimmer" },
+        { "description": "HTML", "value": "html" },
+        { "description": "Angular", "value": "angular" },
+        { "description": "Lightning Web Components", "value": "lwc" }
       ],
       "description": "Which parser to use.",
       "name": "parser",
       "pluginDefaults": {},
-      "since": "0.0.10",
       "type": "choice"
     },
     {
@@ -986,7 +949,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "description": "Custom directory that contains prettier plugins in node_modules subdirectory.\\nOverrides default behavior when plugins are searched relatively to the location of Prettier.\\nMultiple values are accepted.",
       "name": "pluginSearchDirs",
       "pluginDefaults": {},
-      "since": "1.13.0",
       "type": "path"
     },
     {
@@ -996,7 +958,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "description": "Add a plugin. Multiple plugins can be passed as separate \`--plugin\`s.",
       "name": "plugins",
       "pluginDefaults": {},
-      "since": "1.10.0",
       "type": "path"
     },
     {
@@ -1006,7 +967,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "name": "printWidth",
       "pluginDefaults": {},
       "range": { "end": null, "start": 0, "step": 1 },
-      "since": "0.0.0",
       "type": "int"
     },
     {
@@ -1014,25 +974,15 @@ exports[`CLI --support-info (stdout) 1`] = `
       "choices": [
         {
           "description": "Wrap prose if it exceeds the print width.",
-          "since": "1.9.0",
           "value": "always"
         },
-        {
-          "description": "Do not wrap prose.",
-          "since": "1.9.0",
-          "value": "never"
-        },
-        {
-          "description": "Wrap prose as-is.",
-          "since": "1.9.0",
-          "value": "preserve"
-        }
+        { "description": "Do not wrap prose.", "value": "never" },
+        { "description": "Wrap prose as-is.", "value": "preserve" }
       ],
       "default": "preserve",
       "description": "How to wrap prose.",
       "name": "proseWrap",
       "pluginDefaults": {},
-      "since": "1.8.2",
       "type": "choice"
     },
     {
@@ -1055,7 +1005,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "description": "Change when properties in objects are quoted.",
       "name": "quoteProps",
       "pluginDefaults": {},
-      "since": "1.17.0",
       "type": "choice"
     },
     {
@@ -1065,7 +1014,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "name": "rangeEnd",
       "pluginDefaults": {},
       "range": { "end": null, "start": 0, "step": 1 },
-      "since": "1.4.0",
       "type": "int"
     },
     {
@@ -1075,7 +1023,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "name": "rangeStart",
       "pluginDefaults": {},
       "range": { "end": null, "start": 0, "step": 1 },
-      "since": "1.4.0",
       "type": "int"
     },
     {
@@ -1084,7 +1031,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "description": "Require either '@prettier' or '@format' to be present in the file's first docblock comment\\nin order for it to be formatted.",
       "name": "requirePragma",
       "pluginDefaults": {},
-      "since": "1.7.0",
       "type": "boolean"
     },
     {
@@ -1094,7 +1040,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "name": "semi",
       "oppositeDescription": "Do not print semicolons, except at the beginning of lines which may need them.",
       "pluginDefaults": {},
-      "since": "1.0.0",
       "type": "boolean"
     },
     {
@@ -1103,7 +1048,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "description": "Enforce single attribute per line in HTML, Vue and JSX.",
       "name": "singleAttributePerLine",
       "pluginDefaults": {},
-      "since": "2.6.0",
       "type": "boolean"
     },
     {
@@ -1112,7 +1056,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "description": "Use single quotes instead of double quotes.",
       "name": "singleQuote",
       "pluginDefaults": {},
-      "since": "0.0.0",
       "type": "boolean"
     },
     {
@@ -1141,7 +1084,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "description": "Print trailing commas wherever possible when multi-line.",
       "name": "trailingComma",
       "pluginDefaults": {},
-      "since": "0.0.0",
       "type": "choice"
     },
     {
@@ -1150,7 +1092,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "description": "Indent with tabs instead of spaces.",
       "name": "useTabs",
       "pluginDefaults": {},
-      "since": "1.0.0",
       "type": "boolean"
     },
     {
@@ -1159,7 +1100,6 @@ exports[`CLI --support-info (stdout) 1`] = `
       "description": "Indent script and style tags in Vue files.",
       "name": "vueIndentScriptAndStyle",
       "pluginDefaults": {},
-      "since": "1.19.0",
       "type": "boolean"
     }
   ]

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -70,7 +70,7 @@ class Playground extends React.Component {
 
     // 1.8.2 ~ 1.9.0
     if (typeof options.proseWrap === "boolean") {
-      options.proseWrap = options.proseWrap ? "preserve" : "never";
+      options.proseWrap = options.proseWrap ? "always" : "never";
     }
 
     // 0.0.0 ~ 1.9.0

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -63,7 +63,7 @@ class Playground extends React.Component {
 
     const options = Object.assign(defaultOptions, original.options);
 
-    // 0.0.10 ~ 0.0.10
+    // 0.0.0 ~ 0.0.10
     if (options.parser === "babylon") {
       options.parser = "babel";
     }

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -68,6 +68,11 @@ class Playground extends React.Component {
       options.parser = "babel";
     }
 
+    // 0.0.0 ~ 0.0.10
+    if (options.useFlowParser) {
+      options.parser ??= "flow";
+    }
+
     // 1.8.2 ~ 1.9.0
     if (typeof options.proseWrap === "boolean") {
       options.proseWrap = options.proseWrap ? "always" : "never";

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -63,9 +63,25 @@ class Playground extends React.Component {
 
     const options = Object.assign(defaultOptions, original.options);
 
-    // backwards support for old parser `babylon`
+    // 0.0.10 ~ 0.0.10
     if (options.parser === "babylon") {
       options.parser = "babel";
+    }
+
+    // 1.8.2 ~ 1.9.0
+    if (typeof options.proseWrap === "boolean") {
+      options.proseWrap = options.proseWrap ? "preserve" : "never";
+    }
+
+    // 0.0.0 ~ 1.9.0
+    if (typeof options.trailingComma === "boolean") {
+      options.trailingComma = options.trailingComma ? "es5" : "none";
+    }
+
+    // 0.17.0 ~ 2.4.0
+    if (options.jsxBracketSameLine) {
+      delete options.jsxBracketSameLine;
+      options.bracketSameLine ??= options.jsxBracketSameLine;
     }
 
     const codeSample = getCodeSample(options.parser);

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -79,7 +79,6 @@ function handleMessage(message) {
 
 async function handleMetaMessage() {
   const supportInfo = await prettier.getSupportInfo({
-    showUnreleased: true,
     plugins: [docExplorerPlugin],
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6692,7 +6692,7 @@ __metadata:
     rimraf: 3.0.2
     rollup-plugin-license: 2.8.2
     sdbm: 2.0.0
-    semver: 7.3.7
+    semver: 7.3.8
     snapshot-diff: 0.10.0
     string-width: 5.0.1
     strip-ansi: 7.0.1
@@ -7210,14 +7210,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.3.7, semver@npm:^7.0.0, semver@npm:^7.3.5, semver@npm:^7.3.7":
-  version: 7.3.7
-  resolution: "semver@npm:7.3.7"
+"semver@npm:7.3.8":
+  version: 7.3.8
+  resolution: "semver@npm:7.3.8"
   dependencies:
     lru-cache: ^6.0.0
   bin:
     semver: bin/semver.js
-  checksum: 2fa3e877568cd6ce769c75c211beaed1f9fce80b28338cadd9d0b6c40f2e2862bafd62c19a6cff42f3d54292b7c623277bcab8816a2b5521cf15210d43e75232
+  checksum: ba9c7cbbf2b7884696523450a61fee1a09930d888b7a8d7579025ad93d459b2d1949ee5bbfeb188b2be5f4ac163544c5e98491ad6152df34154feebc2cc337c1
   languageName: node
   linkType: hard
 
@@ -7227,6 +7227,17 @@ __metadata:
   bin:
     semver: ./bin/semver.js
   checksum: 1b26ecf6db9e8292dd90df4e781d91875c0dcc1b1909e70f5d12959a23c7eebb8f01ea581c00783bbee72ceeaad9505797c381756326073850dc36ed284b21b9
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.0.0, semver@npm:^7.3.5, semver@npm:^7.3.7":
+  version: 7.3.7
+  resolution: "semver@npm:7.3.7"
+  dependencies:
+    lru-cache: ^6.0.0
+  bin:
+    semver: bin/semver.js
+  checksum: 2fa3e877568cd6ce769c75c211beaed1f9fce80b28338cadd9d0b6c40f2e2862bafd62c19a6cff42f3d54292b7c623277bcab8816a2b5521cf15210d43e75232
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7210,7 +7210,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.3.8":
+"semver@npm:7.3.8, semver@npm:^7.0.0, semver@npm:^7.3.5, semver@npm:^7.3.7":
   version: 7.3.8
   resolution: "semver@npm:7.3.8"
   dependencies:
@@ -7227,17 +7227,6 @@ __metadata:
   bin:
     semver: ./bin/semver.js
   checksum: 1b26ecf6db9e8292dd90df4e781d91875c0dcc1b1909e70f5d12959a23c7eebb8f01ea581c00783bbee72ceeaad9505797c381756326073850dc36ed284b21b9
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.0.0, semver@npm:^7.3.5, semver@npm:^7.3.7":
-  version: 7.3.7
-  resolution: "semver@npm:7.3.7"
-  dependencies:
-    lru-cache: ^6.0.0
-  bin:
-    semver: bin/semver.js
-  checksum: 2fa3e877568cd6ce769c75c211beaed1f9fce80b28338cadd9d0b6c40f2e2862bafd62c19a6cff42f3d54292b7c623277bcab8816a2b5521cf15210d43e75232
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Since v2.0.0, we removed `version` option from `getSupportInfo` #7620, `since` became useless, let's remove it.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
