### PR TITLE
Make `flatContents` in `ifBreak` default to `""`

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -83,8 +83,8 @@ Expects the `docs` argument to be an array of alternating content and line break
 
 ```ts
 declare function ifBreak(
-  ifBreak: Doc,
-  noBreak?: Doc,
+  breakContents: Doc,
+  flatContents?: Doc,
   options?: { groupId?: symbol }
 ): Doc;
 ```

--- a/src/document/builders.js
+++ b/src/document/builders.js
@@ -143,12 +143,12 @@ function fill(parts) {
 }
 
 /**
- * @param {Doc} [breakContents]
+ * @param {Doc} breakContents
  * @param {Doc} [flatContents]
  * @param {object} [opts] - TBD ???
  * @returns Doc
  */
-function ifBreak(breakContents, flatContents, opts = {}) {
+function ifBreak(breakContents, flatContents = "", opts = {}) {
   if (process.env.NODE_ENV !== "production") {
     if (breakContents) {
       assertDoc(breakContents);

--- a/src/document/debug.js
+++ b/src/document/debug.js
@@ -46,7 +46,7 @@ function flattenDoc(doc) {
     return {
       ...doc,
       contents: flattenDoc(doc.contents),
-      expandedStates: doc.expandedStates && doc.expandedStates.map(flattenDoc),
+      expandedStates: doc.expandedStates?.map(flattenDoc),
     };
   }
 

--- a/src/document/utils.js
+++ b/src/document/utils.js
@@ -65,12 +65,12 @@ function mapDoc(doc, cb) {
       case DOC_TYPE_FILL:
         return cb({ ...doc, parts: doc.parts.map(rec) });
 
-      case DOC_TYPE_IF_BREAK: {
-        let { breakContents, flatContents } = doc;
-        breakContents &&= rec(breakContents);
-        flatContents &&= rec(flatContents);
-        return cb({ ...doc, breakContents, flatContents });
-      }
+      case DOC_TYPE_IF_BREAK:
+        return cb({
+          ...doc,
+          breakContents: rec(doc.breakContents),
+          flatContents: rec(doc.flatContents),
+        });
 
       case DOC_TYPE_GROUP: {
         let { expandedStates, contents } = doc;
@@ -193,7 +193,7 @@ function removeLinesFn(doc) {
   }
 
   if (doc.type === DOC_TYPE_IF_BREAK) {
-    return doc.flatContents || "";
+    return doc.flatContents;
   }
 
   return doc;
@@ -234,12 +234,12 @@ function stripTrailingHardlineFromDoc(doc) {
       return { ...doc, contents };
     }
 
-    case DOC_TYPE_IF_BREAK: {
-      let { breakContents, flatContents } = doc;
-      breakContents &&= stripTrailingHardlineFromDoc(breakContents);
-      flatContents &&= stripTrailingHardlineFromDoc(flatContents);
-      return { ...doc, breakContents, flatContents };
-    }
+    case DOC_TYPE_IF_BREAK:
+      return {
+        ...doc,
+        breakContents: stripTrailingHardlineFromDoc(doc.breakContents),
+        flatContents: stripTrailingHardlineFromDoc(doc.flatContents),
+      };
 
     case DOC_TYPE_FILL:
       return { ...doc, parts: stripTrailingHardlineFromParts(doc.parts) };

--- a/src/document/utils/traverse-doc.js
+++ b/src/document/utils/traverse-doc.js
@@ -58,12 +58,7 @@ function traverseDoc(doc, onEnter, onExit, shouldTraverseConditionalGroups) {
       }
 
       case DOC_TYPE_IF_BREAK:
-        if (doc.flatContents) {
-          docsStack.push(doc.flatContents);
-        }
-        if (doc.breakContents) {
-          docsStack.push(doc.breakContents);
-        }
+        docsStack.push(doc.flatContents, doc.breakContents);
         break;
 
       case DOC_TYPE_GROUP:


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

So it will always be a valid doc, we don't need do `if (flatContents);`. This shouldn't breaking things, unless plugin use old version of doc to build.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
