### PR TITLE
Move `normalizeDoc` back to markdown (revert #8496)

### DIFF
--- a/src/document/utils.js
+++ b/src/document/utils.js
@@ -356,52 +356,6 @@ function cleanDoc(doc) {
   return mapDoc(doc, (currentDoc) => cleanDocFn(currentDoc));
 }
 
-function normalizeParts(parts) {
-  const newParts = [];
-
-  const restParts = parts.filter(Boolean);
-  while (restParts.length > 0) {
-    const part = restParts.shift();
-
-    if (!part) {
-      continue;
-    }
-
-    if (Array.isArray(part)) {
-      restParts.unshift(...part);
-      continue;
-    }
-
-    if (
-      newParts.length > 0 &&
-      typeof newParts.at(-1) === "string" &&
-      typeof part === "string"
-    ) {
-      newParts[newParts.length - 1] += part;
-      continue;
-    }
-
-    newParts.push(part);
-  }
-
-  return newParts;
-}
-
-function normalizeDoc(doc) {
-  return mapDoc(doc, (currentDoc) => {
-    if (Array.isArray(currentDoc)) {
-      return normalizeParts(currentDoc);
-    }
-    if (!currentDoc.parts) {
-      return currentDoc;
-    }
-    return {
-      ...currentDoc,
-      parts: normalizeParts(currentDoc.parts),
-    };
-  });
-}
-
 function replaceEndOfLine(doc, replacement = literalline) {
   return mapDoc(doc, (currentDoc) =>
     typeof currentDoc === "string"
@@ -429,8 +383,6 @@ export {
   propagateBreaks,
   removeLines,
   stripTrailingHardline,
-  normalizeParts,
-  normalizeDoc,
   cleanDoc,
   replaceEndOfLine,
   canBreak,


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Change logic back to old version.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
