### PR TITLE
Remove `rimraf` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,6 @@
     "path-browserify": "1.0.1",
     "prettier": "2.7.1",
     "pretty-bytes": "6.0.0",
-    "rimraf": "3.0.2",
     "rollup-plugin-license": "2.8.2",
     "snapshot-diff": "0.10.0",
     "tempy": "3.0.0"

--- a/scripts/draft-blog-post.mjs
+++ b/scripts/draft-blog-post.mjs
@@ -2,8 +2,8 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import rimraf from "rimraf";
 import createEsmUtils from "esm-utils";
+import fg from "fast-glob";
 import {
   getEntries,
   replaceVersions,
@@ -67,7 +67,9 @@ for (const dir of changelogUnreleasedDirs) {
   category.entries = getEntries(dirPath);
 }
 
-rimraf.sync(postGlob);
+for (const filePath of fg.sync(postGlob)) {
+  fs.rmSync(filePath);
+}
 
 const introFileData = fs.readFileSync(introFile, "utf8").trim();
 

--- a/scripts/sync-flow-tests.cjs
+++ b/scripts/sync-flow-tests.cjs
@@ -4,7 +4,6 @@ const fs = require("fs");
 const path = require("path");
 const flowParser = require("flow-parser");
 const fastGlob = require("fast-glob");
-const rimraf = require("rimraf");
 
 const DEFAULT_SPEC_CONTENT = "run_spec(__dirname);\n";
 const SPEC_FILE_NAME = "jsfmt.spec.js";
@@ -50,7 +49,7 @@ function syncTests(syncDir) {
 
   const skipped = [];
 
-  rimraf.sync(FLOW_TESTS_DIR);
+  fs.rmSync(FLOW_TESTS_DIR);
 
   for (const file of filesToCopy) {
     const content = fs.readFileSync(file, "utf8");

--- a/tests/integration/__tests__/cache.js
+++ b/tests/integration/__tests__/cache.js
@@ -1,7 +1,6 @@
 import path from "node:path";
 import { promises as fs } from "node:fs";
 import { fileURLToPath } from "node:url";
-import rimraf from "rimraf";
 
 function resolveDir(dir) {
   return fileURLToPath(new URL(`../${dir}/`, import.meta.url));
@@ -26,8 +25,11 @@ describe("--cache option", () => {
   });
 
   afterEach(async () => {
-    rimraf.sync(path.join(dir, "node_modules"));
-    rimraf.sync(nonDefaultCacheFilePath);
+    await fs.rm(path.join(dir, "node_modules"), {
+      force: true,
+      recursive: true,
+    });
+    await fs.rm(nonDefaultCacheFilePath, { force: true });
     await fs.writeFile(path.join(dir, "a.js"), contentA);
     await fs.writeFile(path.join(dir, "b.js"), contentB);
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6696,7 +6696,6 @@ __metadata:
     remark-footnotes: 2.0.0
     remark-math: 3.0.1
     remark-parse: 8.0.3
-    rimraf: 3.0.2
     rollup-plugin-license: 2.8.2
     sdbm: 2.0.0
     semver: 7.3.7
@@ -7074,7 +7073,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rimraf@npm:3.0.2, rimraf@npm:^3.0.2":
+"rimraf@npm:^3.0.2":
   version: 3.0.2
   resolution: "rimraf@npm:3.0.2"
   dependencies:


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Prettier v3 supports only Node.js >= 14 that support [`fs.rm`](https://nodejs.org/api/fs.html#fsrmpath-options-callback) and [`fs.rmSync`](https://nodejs.org/api/fs.html#fsrmsyncpath-options).

So we can remove `rimraf`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
