### PR TITLE
Enable `prettier-internal-rules/prefer-fs-promises-submodule` for all files

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -115,6 +115,7 @@ module.exports = {
     // Internal rules
     "prettier-internal-rules/jsx-identifier-case": "error",
     "prettier-internal-rules/no-identifier-n": "error",
+    "prettier-internal-rules/prefer-fs-promises-submodule": "error",
 
     // @typescript-eslint/eslint-plugin
     "@typescript-eslint/prefer-ts-expect-error": "error",
@@ -343,7 +344,6 @@ module.exports = {
         "prettier-internal-rules/prefer-ast-path-each": "error",
         "prettier-internal-rules/prefer-indent-if-break": "error",
         "prettier-internal-rules/prefer-is-non-empty-array": "error",
-        "prettier-internal-rules/prefer-fs-promises-submodule": "error",
         "prettier-internal-rules/prefer-ast-path-getters": "error",
       },
     },

--- a/scripts/build/build-license.js
+++ b/scripts/build/build-license.js
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { promises as fs } from "node:fs";
+import fs from "node:fs/promises";
 import { outdent } from "outdent";
 import { DIST_DIR, PROJECT_ROOT } from "../utils/index.mjs";
 

--- a/tests/integration/__tests__/cache.js
+++ b/tests/integration/__tests__/cache.js
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { promises as fs } from "node:fs";
+import fs from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import rimraf from "rimraf";
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
`prettier-internal-rules/prefer-fs-promises-submodule` should be applied to all JS files.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
