### PR TITLE
Reduce size of `typescript` plugin

### DIFF
--- a/scripts/build/modify-typescript-module.mjs
+++ b/scripts/build/modify-typescript-module.mjs
@@ -173,6 +173,7 @@ function modifyTypescriptModule(text) {
     })
     .replace("ts.createLanguageService = createLanguageService;", "");
 
+  /* spell-checker: disable */
   // `ts.createParenthesizerRules`
   source
     .replaceAlignedCode({
@@ -183,6 +184,7 @@ function modifyTypescriptModule(text) {
       "ts.createParenthesizerRules = createParenthesizerRules;",
       "ts.createParenthesizerRules = () => ts.nullParenthesizerRules;"
     );
+  /* spell-checker: enable */
 
   // `ts.createNodeConverters`
   source


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

**Size Change:** -85.7 kB (-1%) 

**Total Size:** 10.2 MB

| Filename | Size | Change |
| :--- | :---: | :---: |
| `./dist/plugins/typescript.js` | 1.3 MB | -42.9 kB (-3%) |
| `./dist/plugins/typescript.mjs` | 1.3 MB | -42.9 kB (-3%) |

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
