### PR TITLE
Build: improve use of `define` option

### DIFF
--- a/scripts/build/build-javascript-module.js
+++ b/scripts/build/build-javascript-module.js
@@ -113,7 +113,7 @@ function getEsbuildOptions({ file, files, shouldCollectLicenses, cliOptions }) {
     define.process = undefined;
     // @babel/code-frame/lib/index.js
     define["process.emitWarning"] = undefined;
-    // @babel/code-frame/lib/index.js
+    // postcss/lib/postcss.js
     define["process.env.LANG"] = "";
 
     // Replace `__dirname` and `__filename` with a fake value

--- a/scripts/build/build-javascript-module.js
+++ b/scripts/build/build-javascript-module.js
@@ -14,6 +14,7 @@ import esbuildPluginVisualizer from "./esbuild-plugins/visualizer.mjs";
 import esbuildPluginStripNodeProtocol from "./esbuild-plugins/strip-node-protocol.mjs";
 import esbuildPluginThrowWarnings from "./esbuild-plugins/throw-warnings.mjs";
 import esbuildPluginShimCommonjsObjects from "./esbuild-plugins/shim-commonjs-objects.mjs";
+import esbuildPluginPrimitiveDefine from "./esbuild-plugins/primitive-define.mjs";
 import transform from "./transform/index.js";
 
 const { dirname, readJsonSync, require } = createEsmUtils(import.meta);
@@ -96,8 +97,8 @@ function getEsbuildOptions({ file, files, shouldCollectLicenses, cliOptions }) {
   ];
 
   const define = {
-    "process.env.PRETTIER_TARGET": JSON.stringify(file.platform),
-    "process.env.NODE_ENV": JSON.stringify("production"),
+    "process.env.PRETTIER_TARGET": file.platform,
+    "process.env.NODE_ENV": "production",
   };
 
   if (file.platform === "universal") {
@@ -109,15 +110,17 @@ function getEsbuildOptions({ file, files, shouldCollectLicenses, cliOptions }) {
       replacement: "globalThis.PRETTIER_DEBUG",
     });
 
-    define.process = JSON.stringify({ env: {}, argv: [] });
+    define.process = undefined;
+    // @babel/code-frame/lib/index.js
+    define["process.emitWarning"] = undefined;
+    // @babel/code-frame/lib/index.js
+    define["process.env.LANG"] = "";
 
     // Replace `__dirname` and `__filename` with a fake value
     // So `parser-typescript.js` won't contain a path of working directory
     // See #8268
-    define.__filename = JSON.stringify(
-      "/prettier-security-filename-placeholder.js"
-    );
-    define.__dirname = JSON.stringify("/prettier-security-dirname-placeholder");
+    define.__filename = "/prettier-security-filename-placeholder.js";
+    define.__dirname = "/prettier-security-dirname-placeholder";
   }
 
   if (file.platform === "node") {
@@ -198,10 +201,10 @@ function getEsbuildOptions({ file, files, shouldCollectLicenses, cliOptions }) {
 
   const esbuildOptions = {
     entryPoints: [path.join(PROJECT_ROOT, file.input)],
-    define,
     bundle: true,
     metafile: true,
     plugins: [
+      esbuildPluginPrimitiveDefine(define),
       esbuildPluginEvaluate(),
       esbuildPluginStripNodeProtocol(),
       esbuildPluginReplaceModule({

--- a/scripts/build/esbuild-plugins/primitive-define.mjs
+++ b/scripts/build/esbuild-plugins/primitive-define.mjs
@@ -3,7 +3,7 @@ function stringify(value) {
     value !== null &&
     !["boolean", "number", "string", "undefined"].includes(typeof value)
   ) {
-    throw Object.assign(new TypeError("value not allowed"), {value});
+    throw Object.assign(new TypeError("value not allowed"), { value });
   }
 
   return JSON.stringify(value);

--- a/scripts/build/esbuild-plugins/primitive-define.mjs
+++ b/scripts/build/esbuild-plugins/primitive-define.mjs
@@ -1,0 +1,32 @@
+function stringify(value) {
+  if (
+    value !== null &&
+    !["boolean", "number", "string", "undefined"].includes(typeof value)
+  ) {
+    throw Object.assign(new TypeError("value not allowed"), {value});
+  }
+
+  return JSON.stringify(value);
+}
+
+/*
+Non-primitive value will cause esbuild inject a function call in every file
+only primitive values are allowed to use.
+*/
+export default function esbuildPluginPrimitiveDefine(define) {
+  return {
+    name: "primitive-define",
+    setup(build) {
+      const esbuildConfig = build.initialOptions;
+      if (esbuildConfig.define) {
+        throw new Error(
+          "Use `esbuildPluginPrimitiveDefine(define)` instead of 'define' option"
+        );
+      }
+
+      esbuildConfig.define = Object.fromEntries(
+        Object.entries(define).map(([key, value]) => [key, stringify(value)])
+      );
+    },
+  };
+}


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Non-primitive value will cause esbuild inject a function call in every file

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
