### PR TITLE
Make `resolveParser` work like v2

### DIFF
--- a/src/main/parser.js
+++ b/src/main/parser.js
@@ -1,7 +1,13 @@
 import { ConfigError } from "../common/errors.js";
 
 function resolveParser({ plugins, parser }) {
-  for (const { parsers } of plugins) {
+  /*
+  Loop from end to allow plugins override builtin plugins,
+  this is how `resolveParser` works in v2.
+  This is a temporarily solution, see #13729
+  */
+  for (let index = plugins.length - 1; index >= 0; index--) {
+    const { parsers } = plugins[index];
     if (parsers && Object.hasOwn(parsers, parser)) {
       const parserOrParserInitFunction = parsers[parser];
 

--- a/tests/integration/__tests__/plugin-override-buitin-plugins.js
+++ b/tests/integration/__tests__/plugin-override-buitin-plugins.js
@@ -1,0 +1,17 @@
+import prettier from "../../config/prettier-entry.js";
+import createPlugin from "../../config/utils/create-plugin.cjs";
+
+test("plugins can override builtin plugins", async () => {
+  const outputWithoutPlugin = await prettier.format("foo()", {
+    parser: "babel",
+  });
+  const outputWithPlugin = await prettier.format("foo()", {
+    parser: "babel",
+    plugins: [
+      createPlugin({ name: "babel", print: () => "fake-babel-output" }),
+    ],
+  });
+
+  expect(outputWithoutPlugin).not.toBe(outputWithPlugin);
+  expect(outputWithPlugin).toBe("fake-babel-output\n");
+});


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Since I'm going to release a fix for #13731, so I'm going to temporarily restore the behavior of this function until we find a better solution.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
