### PR TITLE
Reduce size of `typescript` plugin

### DIFF
--- a/scripts/build/modify-typescript-module.mjs
+++ b/scripts/build/modify-typescript-module.mjs
@@ -173,6 +173,26 @@ function modifyTypescriptModule(text) {
     })
     .replace("ts.createLanguageService = createLanguageService;", "");
 
+  // `ts.scanner`
+  // This is a big module, most code except `ts.scanner` is not used
+  source.replaceSubmodule(
+    (text) => text.includes("ts.findPackageJson = findPackageJson;"),
+    "ts.scanner = ts.createScanner(99 /* ScriptTarget.Latest */, /*skipTrivia*/ true);"
+  );
+
+  // `ts.visitNode`
+  source.removeSubmodule((text) => text.includes("ts.visitNode = visitNode;"));
+
+  // `ts.createGetSymbolWalker`
+  source.removeSubmodule((text) =>
+    text.includes("ts.createGetSymbolWalker = createGetSymbolWalker;")
+  );
+
+  // `ts.getModuleInstanceState `
+  source.removeSubmodule((text) =>
+    text.includes("ts.getModuleInstanceState = getModuleInstanceState;")
+  );
+
   /* spell-checker: disable */
   // `ts.createParenthesizerRules`
   source
@@ -199,7 +219,9 @@ function modifyTypescriptModule(text) {
 
   // `ts.classifier`
   source.removeSubmodule((text) => text.includes("classifier = ts.classifier"));
-  source.removeSubmodule((text) => text.includes("ts.createClassifier = createClassifier;"));
+  source.removeSubmodule((text) =>
+    text.includes("ts.createClassifier = createClassifier;")
+  );
 
   // `ts.getScriptTargetFeatures`
   source

--- a/scripts/build/modify-typescript-module.mjs
+++ b/scripts/build/modify-typescript-module.mjs
@@ -197,6 +197,10 @@ function modifyTypescriptModule(text) {
       "ts.createNodeConverters = () => ts.nullNodeConverters;"
     );
 
+  // `ts.classifier`
+  source.removeSubmodule((text) => text.includes("classifier = ts.classifier"));
+  source.removeSubmodule((text) => text.includes("ts.createClassifier = createClassifier;"));
+
   // `ts.getScriptTargetFeatures`
   source
     .replaceAlignedCode({


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

**Size Change:** -274 kB (-3%) 

**Total Size:** 9.77 MB

| Filename | Size | Change |  |
| :--- | :---: | :---: | :---: |
| `./dist/plugins/typescript.js` | 1.16 MB | -137 kB (-11%) | 👏 |
| `./dist/plugins/typescript.mjs` | 1.16 MB | -137 kB (-11%) | 👏 |

Bundle coverage can be found on https://github.com/fisker/prettier-dist-coverage

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
