### PR TITLE
Update `getInterpreter` to use builtin modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "meriyah": "4.3.2",
     "micromatch": "4.0.5",
     "minimist": "1.2.7",
-    "n-readlines": "1.0.1",
     "outdent": "0.8.0",
     "please-upgrade-node": "3.2.0",
     "postcss": "8.4.18",

--- a/src/main/options.js
+++ b/src/main/options.js
@@ -40,7 +40,10 @@ async function normalize(options, opts = {}) {
       );
       rawOptions.parser = "babel";
     } else {
-      rawOptions.parser = inferParser(rawOptions.filepath, rawOptions.plugins);
+      rawOptions.parser = await inferParser(
+        rawOptions.filepath,
+        rawOptions.plugins
+      );
       if (!rawOptions.parser) {
         throw new UndefinedParserError(
           `No parser could be inferred for file: ${rawOptions.filepath}`
@@ -115,7 +118,7 @@ function getPlugin(options) {
   return printerPlugin;
 }
 
-function inferParser(filepath, plugins) {
+async function inferParser(filepath, plugins) {
   const filename = path.basename(filepath).toLowerCase();
   const { languages } = getSupportInfo({ plugins });
 
@@ -137,11 +140,13 @@ function inferParser(filepath, plugins) {
     !language &&
     !filename.includes(".")
   ) {
-    const interpreter = getInterpreter(filepath);
-    language = languages.find(
-      (language) =>
-        language.interpreters && language.interpreters.includes(interpreter)
-    );
+    const interpreter = await getInterpreter(filepath);
+    if (interpreter) {
+      language = languages.find(
+        (language) =>
+          language.interpreters && language.interpreters.includes(interpreter)
+      );
+    }
   }
 
   return language && language.parsers[0];

--- a/src/utils/get-interpreter.js
+++ b/src/utils/get-interpreter.js
@@ -1,50 +1,40 @@
 import fs from "node:fs";
-import readlines from "n-readlines";
+import readline from "node:readline/promises";
 
-function getInterpreter(filepath) {
+async function readFirstLine(filepath) {
+  const rl = readline.createInterface({
+    input: fs.createReadStream(filepath),
+    crlfDelay: Number.POSITIVE_INFINITY,
+  });
+  const { value: firstLine } = await rl[Symbol.asyncIterator]().next();
+
+  return firstLine;
+}
+
+async function getInterpreter(filepath) {
   /* c8 ignore next 3 */
   if (typeof filepath !== "string") {
-    return "";
+    return;
   }
 
-  let fd;
+  let firstLine;
   try {
-    fd = fs.openSync(filepath, "r");
+    firstLine = await readFirstLine(filepath);
   } catch {
-    /* c8 ignore next */
-    return "";
+    // No op
   }
 
-  try {
-    const liner = new readlines(fd);
-    const firstLine = liner.next().toString("utf8");
+  if (!firstLine) {
+    return;
+  }
 
+  const match =
     // #!/bin/env node, #!/usr/bin/env node
-    const m1 = firstLine.match(/^#!\/(?:usr\/)?bin\/env\s+(\S+)/);
-    if (m1) {
-      return m1[1];
-    }
-
+    firstLine.match(/^#!\/(?:usr\/)?bin\/env\s+(?<interpreter>\S+)/) ??
     // #!/bin/node, #!/usr/bin/node, #!/usr/local/bin/node
-    const m2 = firstLine.match(/^#!\/(?:usr\/(?:local\/)?)?bin\/(\S+)/);
-    if (m2) {
-      return m2[1];
-    }
-    return "";
-  } catch {
-    // There are some weird cases where paths are missing, causing Jest
-    // failures. It's unclear what these correspond to in the real world.
-    /* c8 ignore next */
-    return "";
-  } finally {
-    try {
-      // There are some weird cases where paths are missing, causing Jest
-      // failures. It's unclear what these correspond to in the real world.
-      fs.closeSync(fd);
-    } catch {
-      // nop
-    }
-  }
+    firstLine.match(/^#!\/(?:usr\/(?:local\/)?)?bin\/(?<interpreter>\S+)/);
+
+  return match?.groups.interpreter;
 }
 
 export default getInterpreter;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5906,13 +5906,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"n-readlines@npm:1.0.1":
-  version: 1.0.1
-  resolution: "n-readlines@npm:1.0.1"
-  checksum: 3dd0c762793aa8a7dae258a593f8d10f44824545aef84ddd994ac387fb99672c48f77d3c97f06683802b6424b43fb4b61c5b37b174b22b0c9f071fef01323ef5
-  languageName: node
-  linkType: hard
-
 "nanoid@npm:^3.1.22, nanoid@npm:^3.3.4":
   version: 3.3.4
   resolution: "nanoid@npm:3.3.4"
@@ -6694,7 +6687,6 @@ __metadata:
     meriyah: 4.3.2
     micromatch: 4.0.5
     minimist: 1.2.7
-    n-readlines: 1.0.1
     node-fetch: 3.2.10
     npm-run-all: 4.1.5
     outdent: 0.8.0


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
