### PR TITLE
Reduce size of `postcss` plugin

### DIFF
--- a/scripts/build/config.mjs
+++ b/scripts/build/config.mjs
@@ -189,6 +189,26 @@ const pluginFiles = [
         module: path.join(require.resolve("postcss"), "../map-generator.js"),
         text: "module.exports = class { generate() {} };",
       },
+      // Prevent `node:util`, `node:utl`, and `node:path` shim
+      {
+        module: require.resolve("postcss-values-parser/lib/tokenize.js"),
+        process: (text) =>
+          text
+            .replace("require('util')", "{}")
+            .replace(
+              "let message = util.format('Unclosed %s at line: %d, column: %d, token: %d', what, line, pos - offset, pos);",
+              "let message = `Unclosed ${what} at line: ${line}, column: ${pos - offset}, token: ${pos}`;"
+            )
+            .replace(
+              "let message = util.format('Syntax error at line: %d, column: %d, token: %d', line, pos - offset, pos);",
+              "let message = `Syntax error at line: ${line}, column: ${pos - offset}, token: ${pos}`;"
+            ),
+      },
+      {
+        module: path.join(require.resolve("postcss"), "../input.js"),
+        process: (text) =>
+          text.replace("require('url')", "{}").replace("require('path')", "{}"),
+      },
     ],
   },
   "src/language-graphql/parser-graphql.js",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

**Size Change:** -45.5 kB (0%) 

**Total Size:** 9.72 MB

| Filename | Size | Change |  |
| :--- | :---: | :---: | :---: |
| `./dist/LICENSE` | 226 kB | -1.26 kB (-1%) |  |
| `./dist/plugins/postcss.js` | 124 kB | -22.1 kB (-15%) | 👏 |
| `./dist/plugins/postcss.mjs` | 124 kB | -22.2 kB (-15%) | 👏 |

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
