### PR TITLE
Minor tweak to bundled dependencies license

### DIFF
--- a/scripts/build/build-license.js
+++ b/scripts/build/build-license.js
@@ -7,6 +7,14 @@ const PROJECT_LICENSE_FILE = path.join(PROJECT_ROOT, "LICENSE");
 const LICENSE_FILE = path.join(DIST_DIR, "LICENSE");
 const separator = `\n${"-".repeat(40)}\n\n`;
 
+function toBlockQuote(text) {
+  return text
+    .trim()
+    .split("\n")
+    .map((line) => (line ? `> ${line}` : ">"))
+    .join("\n");
+}
+
 async function getLicenseText(files) {
   let dependencies = files.flatMap((file) => file.dependencies);
 
@@ -66,14 +74,28 @@ async function getLicenseText(files) {
 
       const meta = [];
 
+      if (dependency.description) {
+        meta.push(toBlockQuote(dependency.description) + "\n");
+      }
+
       if (dependency.license) {
         meta.push(`License: ${dependency.license}`);
       }
-      if (dependency.author?.name) {
-        meta.push(`By: ${dependency.author.name}`);
+      if (dependency.homepage) {
+        meta.push(`Homepage: <${dependency.homepage}>`);
       }
       if (dependency.repository?.url) {
         meta.push(`Repository: <${dependency.repository.url}>`);
+      }
+      if (dependency.author) {
+        meta.push(`Author: ${dependency.author.text()}`);
+      }
+      if (dependency.contributors?.length > 0) {
+        const contributors = dependency.contributors
+          .map((contributor) => ` - ${contributor.text()}`)
+          .join("\n");
+
+        meta.push(`Contributors:\n${contributors}`);
       }
 
       if (meta.length > 0) {
@@ -81,14 +103,7 @@ async function getLicenseText(files) {
       }
 
       if (dependency.licenseText) {
-        text +=
-          "\n" +
-          dependency.licenseText
-            .trim()
-            .split("\n")
-            .map((line) => (line ? `> ${line}` : ">"))
-            .join("\n") +
-          "\n";
+        text += "\n" + toBlockQuote(dependency.licenseText) + "\n";
       }
       return text;
     })


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Add description, homepage & contributors

<details>
<summary>Details</summary>

```patch
@@ -19,17 +19,22 @@ MIT, ISC, BSD-2-Clause, BSD-3-Clause, 0BSD, Apache-2.0
 
 ### @angular/compiler@v14.2.7
 
+> Angular - the compiler library
+
 License: MIT
-By: angular
 Repository: <https://github.com/angular/angular.git>
+Author: angular
 
 ----------------------------------------
 
 ### @babel/code-frame@v7.18.6
 
+> Generate errors that contain a code frame that point to source locations.
+
 License: MIT
-By: The Babel Team
+Homepage: <https://babel.dev/docs/en/next/babel-code-frame>
 Repository: <https://github.com/babel/babel.git>
+Author: The Babel Team (https://babel.dev/team)
 
 > MIT License
 >
@@ -58,9 +63,11 @@ Repository: <https://github.com/babel/babel.git>
 
 ### @babel/helper-validator-identifier@v7.19.1
 
+> Validate identifier/keywords name
+
 License: MIT
-By: The Babel Team
 Repository: <https://github.com/babel/babel.git>
+Author: The Babel Team (https://babel.dev/team)
 
 > MIT License
 >
@@ -89,9 +96,12 @@ Repository: <https://github.com/babel/babel.git>
 
 ### @babel/highlight@v7.18.6
 
+> Syntax highlight JavaScript strings for output in terminals.
+
 License: MIT
-By: The Babel Team
+Homepage: <https://babel.dev/docs/en/next/babel-highlight>
 Repository: <https://github.com/babel/babel.git>
+Author: The Babel Team (https://babel.dev/team)
 
 > MIT License
 >
@@ -120,9 +130,12 @@ Repository: <https://github.com/babel/babel.git>
 
 ### @babel/parser@v7.19.6
 
+> A JavaScript parser
+
 License: MIT
-By: The Babel Team
+Homepage: <https://babel.dev/docs/en/next/babel-parser>
 Repository: <https://github.com/babel/babel.git>
+Author: The Babel Team (https://babel.dev/team)
 
 > Copyright (C) 2012-2014 by various contributors (see AUTHORS)
 >
@@ -148,6 +161,8 @@ Repository: <https://github.com/babel/babel.git>
 
 ### @glimmer/env@v0.1.7
 
+> Glimmer application environment variables stub
+
 License: MIT
 
 > Copyright (c) 2017 Martin Muñoz and contributors.
@@ -200,6 +215,8 @@ License: MIT
 
 ### @glimmer/util@v0.84.2
 
+> Common utilities used in Glimmer
+
 License: MIT
 
 > Copyright (c) 2015 Tilde, Inc.
@@ -226,16 +243,22 @@ License: MIT
 
 ### @handlebars/parser@v2.0.0
 
+> The parser for the Handlebars language
+
 License: ISC
+Homepage: <https://github.com/handlebars-lang/handlebars-parser#readme>
 Repository: <git+https://github.com/handlebars-lang/handlebars-parser.git>
 
 ----------------------------------------
 
 ### @iarna/toml@v2.2.5
 
+> Better TOML parsing and stringifying all in that familiar JSON interface.
+
 License: ISC
-By: Rebecca Turner
+Homepage: <https://github.com/iarna/iarna-toml#readme>
 Repository: <git+https://github.com/iarna/iarna-toml.git>
+Author: Rebecca Turner <me@re-becca.org> (http://re-becca.org/)
 
 > Copyright (c) 2016, Rebecca Turner <me@re-becca.org>
 >
@@ -255,6 +278,8 @@ Repository: <git+https://github.com/iarna/iarna-toml.git>
 
 ### @nodelib/fs.scandir@v2.1.5
 
+> List files and directories inside the specified directory
+
 License: MIT
 
 > The MIT License (MIT)
@@ -283,6 +308,8 @@ License: MIT
 
 ### @nodelib/fs.stat@v2.0.5
 
+> Get the status of a file with some features
+
 License: MIT
 
 > The MIT License (MIT)
@@ -311,6 +338,8 @@ License: MIT
 
 ### @nodelib/fs.walk@v1.2.8
 
+> A library for efficiently walking a directory recursively
+
 License: MIT
 
 > The MIT License (MIT)
@@ -339,8 +368,10 @@ License: MIT
 
 ### @prettier/is-es5-identifier-name@v0.0.2
 
+> Check if provided string is an `IdentifierName` as specified in ECMA262 edition 5.1 section 7.6.
+
 License: MIT
-By: fisker Cheung
+Author: fisker Cheung <lionkay@gmail.com>
 
 > MIT License
 >
@@ -368,8 +399,11 @@ By: fisker Cheung
 
 ### @prettier/parse-srcset@v2.0.2
 
+> A spec-conformant JavaScript parser for the HTML5 srcset attribute
+
 License: MIT
-By: Alex Bell
+Homepage: <https://github.com/prettier/parse-srcset#readme>
+Author: Alex Bell <alex@bellandwhistle.net>
 
 > The MIT License (MIT)
 >
@@ -397,6 +431,8 @@ By: Alex Bell
 
 ### @typescript-eslint/types@v5.40.1
 
+> Types for the TypeScript-ESTree AST spec
+
 License: MIT
 Repository: <https://github.com/typescript-eslint/typescript-eslint.git>
 
@@ -426,6 +462,8 @@ Repository: <https://github.com/typescript-eslint/typescript-eslint.git>
 
 ### @typescript-eslint/typescript-estree@v5.40.1
 
+> A parser that converts TypeScript source code into an ESTree compatible form
+
 License: BSD-2-Clause
 Repository: <https://github.com/typescript-eslint/typescript-eslint.git>
 
@@ -460,7 +498,10 @@ Repository: <https://github.com/typescript-eslint/typescript-eslint.git>
 
 ### acorn@v8.8.0
 
+> ECMAScript parser
+
 License: MIT
+Homepage: <https://github.com/acornjs/acorn>
 Repository: <https://github.com/acornjs/acorn.git>
 
 > MIT License
@@ -489,7 +530,10 @@ Repository: <https://github.com/acornjs/acorn.git>
 
 ### acorn-jsx@v5.3.2
 
+> Modern, fast React.js JSX parser
+
 License: MIT
+Homepage: <https://github.com/acornjs/acorn-jsx>
 Repository: <https://github.com/acornjs/acorn-jsx>
 
 > Copyright (C) 2012-2017 by Ingvar Stepanyan
@@ -516,8 +560,11 @@ Repository: <https://github.com/acornjs/acorn-jsx>
 
 ### angular-estree-parser@v4.0.1
 
+> A parser that converts Angular source code into an ESTree-compatible form
+
 License: MIT
-By: Ika
+Homepage: <https://github.com/prettier/angular-estree-parser#readme>
+Author: Ika <ikatyang@gmail.com> (https://github.com/ikatyang)
 
 > MIT License
 >
@@ -545,8 +592,11 @@ By: Ika
 
 ### angular-html-parser@v2.1.0
 
+> A HTML parser extracted from Angular with some modifications
+
 License: MIT
-By: Ika
+Homepage: <https://github.com/prettier/angular-html-parser/blob/master/packages/angular-html-parser#readme>
+Author: Ika <ikatyang@gmail.com> (https://github.com/ikatyang)
 
 > MIT License
 > 
@@ -574,8 +624,10 @@ By: Ika
 
 ### ansi-regex@v6.0.1
 
+> Regular expression for matching ANSI escape codes
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 
 > MIT License
 >
@@ -591,8 +643,10 @@ By: Sindre Sorhus
 
 ### ansi-styles@v3.2.1
 
+> ANSI escape codes for styling strings in the terminal
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
 > MIT License
 >
@@ -608,8 +662,12 @@ By: Sindre Sorhus
 
 ### bail@v1.0.5
 
+> Throw a given error
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -638,9 +696,12 @@ By: Titus Wormer
 
 ### balanced-match@v1.0.2
 
+> Match balanced character pairs, like "{" and "}"
+
 License: MIT
-By: Julian Gruber
+Homepage: <https://github.com/juliangruber/balanced-match>
 Repository: <git://github.com/juliangruber/balanced-match.git>
+Author: Julian Gruber <mail@juliangruber.com> (http://juliangruber.com)
 
 > (MIT)
 >
@@ -668,9 +729,12 @@ Repository: <git://github.com/juliangruber/balanced-match.git>
 
 ### brace-expansion@v1.1.11
 
+> Brace expansion as known from sh/bash
+
 License: MIT
-By: Julian Gruber
+Homepage: <https://github.com/juliangruber/brace-expansion>
 Repository: <git://github.com/juliangruber/brace-expansion.git>
+Author: Julian Gruber <mail@juliangruber.com> (http://juliangruber.com)
 
 > MIT License
 >
@@ -698,8 +762,17 @@ Repository: <git://github.com/juliangruber/brace-expansion.git>
 
 ### braces@v3.0.2
 
+> Bash-like brace expansion, implemented in JavaScript. Safer than other brace expansion libs, with complete support for the Bash 4.3 braces specification, without sacrificing speed.
+
 License: MIT
-By: Jon Schlinkert
+Homepage: <https://github.com/micromatch/braces>
+Author: Jon Schlinkert (https://github.com/jonschlinkert)
+Contributors:
+ - Brian Woodward (https://twitter.com/doowb)
+ - Elan Shanker (https://github.com/es128)
+ - Eugene Sharygin (https://github.com/eush77)
+ - hemanth.hm (http://h3manth.com)
+ - Jon Schlinkert (http://twitter.com/jonschlinkert)
 
 > The MIT License (MIT)
 >
@@ -727,8 +800,10 @@ By: Jon Schlinkert
 
 ### camelcase@v7.0.0
 
+> Convert a dash/dot/underscore/space separated string to camelCase or PascalCase: `foo-bar` → `fooBar`
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 
 > MIT License
 >
@@ -744,8 +819,12 @@ By: Sindre Sorhus
 
 ### ccount@v1.1.0
 
+> Count characters
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -774,6 +853,8 @@ By: Titus Wormer
 
 ### chalk@v2.4.2
 
+> Terminal string styling done right
+
 License: MIT
 
 > MIT License
@@ -790,6 +871,8 @@ License: MIT
 
 ### chalk@v5.1.2
 
+> Terminal string styling done right
+
 License: MIT
 
 > MIT License
@@ -806,8 +889,12 @@ License: MIT
 
 ### character-entities@v1.2.4
 
+> HTML character entity information
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -836,8 +923,12 @@ By: Titus Wormer
 
 ### character-entities-legacy@v1.1.4
 
+> HTML legacy character entity information
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -866,8 +957,12 @@ By: Titus Wormer
 
 ### character-reference-invalid@v1.1.4
 
+> HTML invalid numeric character reference information
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -896,8 +991,11 @@ By: Titus Wormer
 
 ### ci-info@v3.5.0
 
+> Get details about the current Continuous Integration environment
+
 License: MIT
-By: Thomas Watson Steen
+Homepage: <https://github.com/watson/ci-info>
+Author: Thomas Watson Steen <w@tson.dk> (https://twitter.com/wa7son)
 
 > The MIT License (MIT)
 >
@@ -925,9 +1023,28 @@ By: Thomas Watson Steen
 
 ### clone@v1.0.4
 
+> deep cloning of objects and arrays
+
 License: MIT
-By: Paul Vorbach
 Repository: <git://github.com/pvorb/node-clone.git>
+Author: Paul Vorbach <paul@vorba.ch> (http://paul.vorba.ch/)
+Contributors:
+ - Blake Miner <miner.blake@gmail.com> (http://www.blakeminer.com/)
+ - Tian You <axqd001@gmail.com> (http://blog.axqd.net/)
+ - George Stagas <gstagas@gmail.com> (http://stagas.com/)
+ - Tobiasz Cudnik <tobiasz.cudnik@gmail.com> (https://github.com/TobiaszCudnik)
+ - Pavel Lang <langpavel@phpskelet.org> (https://github.com/langpavel)
+ - Dan MacTough (http://yabfog.com/)
+ - w1nk (https://github.com/w1nk)
+ - Hugh Kennedy (http://twitter.com/hughskennedy)
+ - Dustin Diaz (http://dustindiaz.com)
+ - Ilya Shaisultanov (https://github.com/diversario)
+ - Nathan MacInnes <nathan@macinn.es> (http://macinn.es/)
+ - Benjamin E. Coe <ben@npmjs.com> (https://twitter.com/benjamincoe)
+ - Nathan Zadoks (https://github.com/nathan7)
+ - Róbert Oroszi <robert+gh@oroszi.net> (https://github.com/oroce)
+ - Aurélio A. Heckert (http://softwarelivre.org/aurium)
+ - Guy Ellis (http://www.guyellisrocks.com/)
 
 > Copyright © 2011-2015 Paul Vorbach <paul@vorba.ch>
 >
@@ -952,8 +1069,12 @@ Repository: <git://github.com/pvorb/node-clone.git>
 
 ### collapse-white-space@v1.0.6
 
+> Replace multiple white-space characters with a single space
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -982,8 +1103,10 @@ By: Titus Wormer
 
 ### color-convert@v1.9.3
 
+> Plain color conversion functions
+
 License: MIT
-By: Heather Arthur
+Author: Heather Arthur <fayearthur@gmail.com>
 
 > Copyright (c) 2011-2016 Heather Arthur <fayearthur@gmail.com>
 >
@@ -1010,9 +1133,12 @@ By: Heather Arthur
 
 ### color-name@v1.1.3
 
+> A list of color names and its values
+
 License: MIT
-By: DY
+Homepage: <https://github.com/dfcreative/color-name>
 Repository: <git@github.com:dfcreative/color-name.git>
+Author: DY <dfcreative@gmail.com>
 
 > The MIT License (MIT)
 > Copyright (c) 2015 Dmitry Ivanov
@@ -1027,9 +1153,11 @@ Repository: <git@github.com:dfcreative/color-name.git>
 
 ### commondir@v1.0.1
 
+> compute the closest common parent for file paths
+
 License: MIT
-By: James Halliday
 Repository: <http://github.com/substack/node-commondir.git>
+Author: James Halliday <mail@substack.net> (http://substack.net)
 
 > The MIT License
 >
@@ -1060,9 +1188,11 @@ Repository: <http://github.com/substack/node-commondir.git>
 
 ### concat-map@v0.0.1
 
+> concatenative mapdashery
+
 License: MIT
-By: James Halliday
 Repository: <git://github.com/substack/node-concat-map.git>
+Author: James Halliday <mail@substack.net> (http://substack.net)
 
 > This software is released under the MIT license:
 >
@@ -1087,9 +1217,15 @@ Repository: <git://github.com/substack/node-concat-map.git>
 
 ### cosmiconfig@v7.0.1
 
+> Find and load configuration from a package.json property, rc file, or CommonJS module
+
 License: MIT
-By: David Clark
+Homepage: <https://github.com/davidtheclark/cosmiconfig#readme>
 Repository: <git+https://github.com/davidtheclark/cosmiconfig.git>
+Author: David Clark <david.dave.clark@gmail.com>
+Contributors:
+ - Bogdan Chadkin <trysound@yandex.ru>
+ - Suhas Karanth <sudo.suhas@gmail.com>
 
 > The MIT License (MIT)
 >
@@ -1117,8 +1253,15 @@ Repository: <git+https://github.com/davidtheclark/cosmiconfig.git>
 
 ### dashify@v2.0.0
 
+> Convert a camelcase or space-separated string to a dash-separated string. ~12 sloc, fast, supports diacritics.
+
 License: MIT
-By: Jon Schlinkert
+Homepage: <https://github.com/jonschlinkert/dashify>
+Author: Jon Schlinkert (https://github.com/jonschlinkert)
+Contributors:
+ - Jeffrey Priebe (https://github.com/jeffreypriebe)
+ - Jon Schlinkert (http://twitter.com/jonschlinkert)
+ - Ondrej Brinkel (https://www.anzui.de)
 
 > The MIT License (MIT)
 >
@@ -1146,9 +1289,11 @@ By: Jon Schlinkert
 
 ### defaults@v1.0.3
 
+> merge single level defaults over a config object
+
 License: MIT
-By: Elijah Insua
 Repository: <git://github.com/tmpvar/defaults.git>
+Author: Elijah Insua <tmpvar@gmail.com>
 
 > The MIT License (MIT)
 >
@@ -1176,6 +1321,8 @@ Repository: <git://github.com/tmpvar/defaults.git>
 
 ### diff@v5.1.0
 
+> A javascript text diff implementation.
+
 License: BSD-3-Clause
 Repository: <git://github.com/kpdecker/jsdiff.git>
 
@@ -1215,9 +1362,15 @@ Repository: <git://github.com/kpdecker/jsdiff.git>
 
 ### editorconfig@v0.15.3
 
+> EditorConfig File Locator and Interpreter for Node.js
+
 License: MIT
-By: EditorConfig Team
 Repository: <git://github.com/editorconfig/editorconfig-core-js.git>
+Author: EditorConfig Team
+Contributors:
+ - Hong Xu (topbug.net)
+ - Jed Mao (https://github.com/jedmao/)
+ - Trey Hunner (http://treyhunner.com)
 
 > Copyright © 2012 EditorConfig Team
 >
@@ -1243,17 +1396,23 @@ Repository: <git://github.com/editorconfig/editorconfig-core-js.git>
 
 ### editorconfig-to-prettier@v0.2.0
 
+> Converts an `editorconfig`-parsed object to a `prettier` configuration
+
 License: ISC
-By: Joseph Frazier
+Homepage: <https://github.com/josephfrazier/editorconfig-to-prettier#readme>
 Repository: <git+https://github.com/josephfrazier/editorconfig-to-prettier.git>
+Author: Joseph Frazier <1212jtraceur@gmail.com>
 
 ----------------------------------------
 
 ### emoji-regex@v9.2.2
 
+> A regular expression to match all Emoji-only symbols as per the Unicode Standard.
+
 License: MIT
-By: Mathias Bynens
+Homepage: <https://mths.be/emoji-regex>
 Repository: <https://github.com/mathiasbynens/emoji-regex.git>
+Author: Mathias Bynens (https://mathiasbynens.be/)
 
 > Copyright Mathias Bynens <https://mathiasbynens.be/>
 >
@@ -1280,6 +1439,8 @@ Repository: <https://github.com/mathiasbynens/emoji-regex.git>
 
 ### error-ex@v1.3.2
 
+> Easy error subclassing and stack customization
+
 License: MIT
 
 > The MIT License (MIT)
@@ -1308,8 +1469,10 @@ License: MIT
 
 ### escape-string-regexp@v1.0.5
 
+> Escape RegExp special characters
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
 > The MIT License (MIT)
 >
@@ -1337,8 +1500,10 @@ By: Sindre Sorhus
 
 ### escape-string-regexp@v5.0.0
 
+> Escape RegExp special characters
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 
 > MIT License
 >
@@ -1354,8 +1519,11 @@ By: Sindre Sorhus
 
 ### espree@v9.4.0
 
+> An Esprima-compatible JavaScript parser built on Acorn
+
 License: BSD-2-Clause
-By: Nicholas C. Zakas
+Homepage: <https://github.com/eslint/espree>
+Author: Nicholas C. Zakas <nicholas+npm@nczconsulting.com>
 
 > BSD 2-Clause License
 >
@@ -1387,9 +1555,13 @@ By: Nicholas C. Zakas
 
 ### extend@v3.0.2
 
+> Port of jQuery.extend for node.js and the browser
+
 License: MIT
-By: Stefan Thomas
 Repository: <https://github.com/justmoon/node-extend.git>
+Author: Stefan Thomas <justmoon@members.fsf.org> (http://www.justmoon.net)
+Contributors:
+ - Jordan Harband (https://github.com/ljharb)
 
 > The MIT License (MIT)
 >
@@ -1418,8 +1590,10 @@ Repository: <https://github.com/justmoon/node-extend.git>
 
 ### fast-glob@v3.2.12
 
+> It's a very fast and efficient glob library for Node.js
+
 License: MIT
-By: Denis Malinochkin
+Author: Denis Malinochkin (https://mrmlnc.com)
 
 > The MIT License (MIT)
 >
@@ -1447,9 +1621,12 @@ By: Denis Malinochkin
 
 ### fast-json-stable-stringify@v2.1.0
 
+> deterministic `JSON.stringify()` - a faster version of substack's json-stable-strigify without jsonify
+
 License: MIT
-By: James Halliday
+Homepage: <https://github.com/epoberezkin/fast-json-stable-stringify>
 Repository: <git://github.com/epoberezkin/fast-json-stable-stringify.git>
+Author: James Halliday <mail@substack.net> (http://substack.net)
 
 > This software is released under the MIT license:
 >
@@ -1477,9 +1654,12 @@ Repository: <git://github.com/epoberezkin/fast-json-stable-stringify.git>
 
 ### fastq@v1.13.0
 
+> Fast, in memory work queue
+
 License: ISC
-By: Matteo Collina
+Homepage: <https://github.com/mcollina/fastq#readme>
 Repository: <git+https://github.com/mcollina/fastq.git>
+Author: Matteo Collina <hello@matteocollina.com>
 
 > Copyright (c) 2015-2020, Matteo Collina <matteo.collina@gmail.com>
 >
@@ -1499,8 +1679,10 @@ Repository: <git+https://github.com/mcollina/fastq.git>
 
 ### file-entry-cache@v6.0.1
 
+> Super simple cache for file metadata, useful for process that work o a given series of files and that only need to repeat the job on the changed ones since the previous run of the process
+
 License: MIT
-By: Roy Riojas
+Author: Roy Riojas (http://royriojas.com)
 
 > The MIT License (MIT)
 >
@@ -1528,8 +1710,17 @@ By: Roy Riojas
 
 ### fill-range@v7.0.1
 
+> Fill in a range of numbers or letters, optionally passing an increment or `step` to use, or create a regex-compatible range with `options.toRegex`
+
 License: MIT
-By: Jon Schlinkert
+Homepage: <https://github.com/jonschlinkert/fill-range>
+Author: Jon Schlinkert (https://github.com/jonschlinkert)
+Contributors:
+ - Edo Rivai (edo.rivai.nl)
+ - Jon Schlinkert (http://twitter.com/jonschlinkert)
+ - Paul Miller (paulmillr.com)
+ - Rouven Weßling (www.rouvenwessling.de)
+ - null (https://github.com/wtgtybhertgeghgtwtg)
 
 > The MIT License (MIT)
 >
@@ -1557,6 +1748,8 @@ By: Jon Schlinkert
 
 ### find-cache-dir@v3.3.2
 
+> Finds the common standard cache directory
+
 License: MIT
 
 > MIT License
@@ -1573,9 +1766,12 @@ License: MIT
 
 ### find-parent-dir@v0.3.1
 
+> Finds the first parent directory that contains a given file or directory.
+
 License: MIT
-By: Thorsten Lorenz
+Homepage: <https://github.com/thlorenz/find-parent-dir>
 Repository: <git://github.com/thlorenz/find-parent-dir.git>
+Author: Thorsten Lorenz <thlorenz@gmx.de> (http://thlorenz.com)
 
 > Copyright 2013 Thorsten Lorenz. 
 > All rights reserved.
@@ -1605,8 +1801,10 @@ Repository: <git://github.com/thlorenz/find-parent-dir.git>
 
 ### find-up@v4.1.0
 
+> Find a file or directory by walking up parent directories
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
 > MIT License
 >
@@ -1622,8 +1820,10 @@ By: Sindre Sorhus
 
 ### flat-cache@v3.0.4
 
+> A stupidly simple key/value storage using files to persist some data
+
 License: MIT
-By: Roy Riojas
+Author: Roy Riojas (http://royriojas.com)
 
 > The MIT License (MIT)
 >
@@ -1651,9 +1851,12 @@ By: Roy Riojas
 
 ### flatted@v3.2.7
 
+> A super light and fast circular JSON parser.
+
 License: ISC
-By: Andrea Giammarchi
+Homepage: <https://github.com/WebReflection/flatted#readme>
 Repository: <git+https://github.com/WebReflection/flatted.git>
+Author: Andrea Giammarchi
 
 > ISC License
 >
@@ -1675,9 +1878,14 @@ Repository: <git+https://github.com/WebReflection/flatted.git>
 
 ### flatten@v1.0.3
 
+> Flatten arbitrarily nested arrays into a non-nested list of non-array items. Maintained for legacy compatibility.
+
 License: MIT
-By: Joshua Holbrook
+Homepage: <https://github.com/mk-pmb/flatten-js/#readme>
 Repository: <git+https://github.com/mk-pmb/flatten-js.git>
+Author: Joshua Holbrook <josh.holbrook@gmail.com> (http://jesusabdullah.net)
+Contributors:
+ - M.K. (https://github.com/mk-pmb)
 
 > The MIT License (MIT)
 >
@@ -1705,17 +1913,22 @@ Repository: <git+https://github.com/mk-pmb/flatten-js.git>
 
 ### flow-parser@v0.190.1
 
+> JavaScript parser written in OCaml. Produces ESTree AST
+
 License: MIT
-By: Flow Team
+Homepage: <https://flow.org>
 Repository: <https://github.com/facebook/flow.git>
+Author: Flow Team <flow@fb.com>
 
 ----------------------------------------
 
 ### fs.realpath@v1.0.0
 
+> Use node's fs.realpath, but fall back to the JS implementation if the native one fails
+
 License: ISC
-By: Isaac Z. Schlueter
 Repository: <git+https://github.com/isaacs/fs.realpath.git>
+Author: Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
 
 > The ISC License
 >
@@ -1765,8 +1978,10 @@ Repository: <git+https://github.com/isaacs/fs.realpath.git>
 
 ### get-stdin@v9.0.0
 
+> Get stdin as a string or buffer
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 
 > MIT License
 >
@@ -1782,9 +1997,11 @@ By: Sindre Sorhus
 
 ### glob@v7.2.3
 
+> a little globber
+
 License: ISC
-By: Isaac Z. Schlueter
 Repository: <git://github.com/isaacs/node-glob.git>
+Author: Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
 
 > The ISC License
 >
@@ -1812,8 +2029,13 @@ Repository: <git://github.com/isaacs/node-glob.git>
 
 ### glob-parent@v5.1.2
 
+> Extract the non-magic parent path from a glob string.
+
 License: ISC
-By: Gulp Team
+Author: Gulp Team <team@gulpjs.com> (https://gulpjs.com/)
+Contributors:
+ - Elan Shanker (https://github.com/es128)
+ - Blaine Bublitz <blaine.bublitz@gmail.com>
 
 > The ISC License
 >
@@ -1835,7 +2057,10 @@ By: Gulp Team
 
 ### graphql@v16.6.0
 
+> A Query Language and Runtime which can target any service.
+
 License: MIT
+Homepage: <https://github.com/graphql/graphql-js>
 Repository: <https://github.com/graphql/graphql-js.git>
 
 > MIT License
@@ -1864,8 +2089,10 @@ Repository: <https://github.com/graphql/graphql-js.git>
 
 ### has-flag@v3.0.0
 
+> Check if argv has a specific flag
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
 > MIT License
 >
@@ -1881,8 +2108,12 @@ By: Sindre Sorhus
 
 ### html-element-attributes@v3.1.0
 
+> Map of HTML elements to allowed attributes
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -1911,8 +2142,13 @@ By: Titus Wormer
 
 ### html-tag-names@v2.0.1
 
+> List of known HTML tag names
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+ - Valerio Coltrè <mister.gamer@gmail.com>
 
 > (The MIT License)
 >
@@ -1941,8 +2177,12 @@ By: Titus Wormer
 
 ### html-void-elements@v2.0.1
 
+> List of HTML void tag names
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -1971,9 +2211,11 @@ By: Titus Wormer
 
 ### ignore@v5.2.0
 
+> Ignore is a manager and filter for .gitignore rules, the one used by eslint, gitbook and many others.
+
 License: MIT
-By: kael
 Repository: <git@github.com:kaelzhang/node-ignore.git>
+Author: kael
 
 > Copyright (c) 2013 Kael Zhang <i@kael.me>, contributors
 > http://kael.me/
@@ -2001,8 +2243,10 @@ Repository: <git@github.com:kaelzhang/node-ignore.git>
 
 ### import-fresh@v3.3.0
 
+> Import a module while bypassing the cache
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 
 > MIT License
 >
@@ -2018,8 +2262,12 @@ By: Sindre Sorhus
 
 ### import-meta-resolve@v2.1.0
 
+> Resolve things like Node.js — ponyfill for `import.meta.resolve`
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -2100,9 +2348,12 @@ By: Titus Wormer
 
 ### indexes-of@v1.0.1
 
+> line String/Array#indexOf but return all the indexes in an array
+
 License: MIT
-By: Dominic Tarr
+Homepage: <https://github.com/dominictarr/indexes-of>
 Repository: <git://github.com/dominictarr/indexes-of.git>
+Author: Dominic Tarr <dominic.tarr@gmail.com> (dominictarr.com)
 
 > Copyright (c) 2013 Dominic Tarr
 >
@@ -2131,9 +2382,12 @@ Repository: <git://github.com/dominictarr/indexes-of.git>
 
 ### inflight@v1.0.6
 
+> Add callbacks to requests in flight to avoid async duplication
+
 License: ISC
-By: Isaac Z. Schlueter
+Homepage: <https://github.com/isaacs/inflight>
 Repository: <https://github.com/npm/inflight.git>
+Author: Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
 
 > The ISC License
 >
@@ -2155,6 +2409,8 @@ Repository: <https://github.com/npm/inflight.git>
 
 ### inherits@v2.0.4
 
+> Browser-friendly inheritance fully compatible with standard node.js inherits()
+
 License: ISC
 
 > The ISC License
@@ -2177,8 +2433,12 @@ License: ISC
 
 ### is-alphabetical@v1.0.4
 
+> Check if a character is alphabetical
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -2207,8 +2467,12 @@ By: Titus Wormer
 
 ### is-alphanumerical@v1.0.4
 
+> Check if a character is alphanumerical
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -2237,9 +2501,11 @@ By: Titus Wormer
 
 ### is-arrayish@v0.2.1
 
+> Determines if an object can be used as an array
+
 License: MIT
-By: Qix
 Repository: <https://github.com/qix-/node-is-arrayish.git>
+Author: Qix (http://github.com/qix-)
 
 > The MIT License (MIT)
 >
@@ -2267,9 +2533,11 @@ Repository: <https://github.com/qix-/node-is-arrayish.git>
 
 ### is-buffer@v2.0.5
 
+> Determine if an object is a Buffer
+
 License: MIT
-By: Feross Aboukhadijeh
 Repository: <git://github.com/feross/is-buffer.git>
+Author: Feross Aboukhadijeh <feross@feross.org> (https://feross.org)
 
 > The MIT License (MIT)
 >
@@ -2297,8 +2565,12 @@ Repository: <git://github.com/feross/is-buffer.git>
 
 ### is-decimal@v1.0.4
 
+> Check if a character is decimal
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -2327,8 +2599,11 @@ By: Titus Wormer
 
 ### is-extglob@v2.1.1
 
+> Returns true if a string has an extglob.
+
 License: MIT
-By: Jon Schlinkert
+Homepage: <https://github.com/jonschlinkert/is-extglob>
+Author: Jon Schlinkert (https://github.com/jonschlinkert)
 
 > The MIT License (MIT)
 >
@@ -2356,8 +2631,10 @@ By: Jon Schlinkert
 
 ### is-fullwidth-code-point@v4.0.0
 
+> Check if the character represented by a given Unicode code point is fullwidth
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 
 > MIT License
 >
@@ -2373,8 +2650,15 @@ By: Sindre Sorhus
 
 ### is-glob@v4.0.3
 
+> Returns `true` if the given string looks like a glob pattern or an extglob pattern. This makes it easy to create code that only uses external modules like node-glob when necessary, resulting in much faster code execution and initialization time, and a better user experience.
+
 License: MIT
-By: Jon Schlinkert
+Homepage: <https://github.com/micromatch/is-glob>
+Author: Jon Schlinkert (https://github.com/jonschlinkert)
+Contributors:
+ - Brian Woodward (https://twitter.com/doowb)
+ - Daniel Perez (https://tuvistavie.com)
+ - Jon Schlinkert (http://twitter.com/jonschlinkert)
 
 > The MIT License (MIT)
 >
@@ -2402,8 +2686,12 @@ By: Jon Schlinkert
 
 ### is-hexadecimal@v1.0.4
 
+> Check if a character is hexadecimal
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -2432,8 +2720,15 @@ By: Titus Wormer
 
 ### is-number@v7.0.0
 
+> Returns true if a number or string value is a finite number. Useful for regex matches, parsing, user input, etc.
+
 License: MIT
-By: Jon Schlinkert
+Homepage: <https://github.com/jonschlinkert/is-number>
+Author: Jon Schlinkert (https://github.com/jonschlinkert)
+Contributors:
+ - Jon Schlinkert (http://twitter.com/jonschlinkert)
+ - Olsten Larck (https://i.am.charlike.online)
+ - Rouven Weßling (www.rouvenwessling.de)
 
 > The MIT License (MIT)
 >
@@ -2461,8 +2756,10 @@ By: Jon Schlinkert
 
 ### is-plain-obj@v2.1.0
 
+> Check if a value is a plain object
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
 > MIT License
 >
@@ -2478,8 +2775,12 @@ By: Sindre Sorhus
 
 ### is-whitespace-character@v1.0.4
 
+> Check if a character is a whitespace character
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -2508,8 +2809,12 @@ By: Titus Wormer
 
 ### is-word-character@v1.0.4
 
+> Check if a character is a word character
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -2567,8 +2872,10 @@ Repository: <https://github.com/facebook/jest.git>
 
 ### js-tokens@v4.0.0
 
+> A regex that tokenizes JavaScript.
+
 License: MIT
-By: Simon Lydell
+Author: Simon Lydell
 
 > The MIT License (MIT)
 >
@@ -2596,8 +2903,10 @@ By: Simon Lydell
 
 ### json-parse-even-better-errors@v2.3.1
 
+> JSON.parse with context information on error
+
 License: MIT
-By: Kat Marchán
+Author: Kat Marchán <kzm@zkat.tech>
 
 > Copyright 2017 Kat Marchán
 > Copyright npm, Inc.
@@ -2629,9 +2938,16 @@ By: Kat Marchán
 
 ### json5@v2.2.1
 
+> JSON for humans.
+
 License: MIT
-By: Aseem Kishore
+Homepage: <http://json5.org/>
 Repository: <git+https://github.com/json5/json5.git>
+Author: Aseem Kishore <aseem.kishore@gmail.com>
+Contributors:
+ - Max Nanasy <max.nanasy@gmail.com>
+ - Andrew Eisenberg <andrew@eisenberg.as>
+ - Jordan Tucker <jordanbtucker@gmail.com>
 
 > MIT License
 >
@@ -2661,8 +2977,10 @@ Repository: <git+https://github.com/json5/json5.git>
 
 ### leven@v2.1.0
 
+> Measure the difference between two strings using the fastest JS implementation of the Levenshtein distance algorithm
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
 > The MIT License (MIT)
 >
@@ -2690,8 +3008,10 @@ By: Sindre Sorhus
 
 ### leven@v4.0.0
 
+> Measure the difference between two strings using the Levenshtein distance algorithm
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 
 > MIT License
 >
@@ -2707,9 +3027,12 @@ By: Sindre Sorhus
 
 ### lines-and-columns@v1.2.4
 
+> Maps lines and columns to character offsets and back.
+
 License: MIT
-By: Brian Donovan
+Homepage: <https://github.com/eventualbuddha/lines-and-columns#readme>
 Repository: <https://github.com/eventualbuddha/lines-and-columns.git>
+Author: Brian Donovan <brian@donovans.cc>
 
 > The MIT License (MIT)
 >
@@ -2737,9 +3060,12 @@ Repository: <https://github.com/eventualbuddha/lines-and-columns.git>
 
 ### lines-and-columns@v2.0.3
 
+> Maps lines and columns to character offsets and back.
+
 License: MIT
-By: Brian Donovan
+Homepage: <https://github.com/eventualbuddha/lines-and-columns#readme>
 Repository: <https://github.com/eventualbuddha/lines-and-columns.git>
+Author: Brian Donovan <brian@donovans.cc>
 
 > The MIT License (MIT)
 >
@@ -2767,8 +3093,10 @@ Repository: <https://github.com/eventualbuddha/lines-and-columns.git>
 
 ### locate-path@v5.0.0
 
+> Get the first path that exists on disk of multiple paths
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
 > MIT License
 >
@@ -2784,8 +3112,10 @@ By: Sindre Sorhus
 
 ### lru-cache@v4.1.5
 
+> A cache object that deletes the least-recently-used items.
+
 License: ISC
-By: Isaac Z. Schlueter
+Author: Isaac Z. Schlueter <i@izs.me>
 
 > The ISC License
 >
@@ -2807,8 +3137,10 @@ By: Isaac Z. Schlueter
 
 ### make-dir@v3.1.0
 
+> Make a directory and its parents if needed - Think `mkdir -p`
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
 > MIT License
 >
@@ -2824,8 +3156,10 @@ By: Sindre Sorhus
 
 ### map-age-cleaner@v0.1.3
 
+> Automatically cleanup expired items in a Map
+
 License: MIT
-By: Sam Verschueren
+Author: Sam Verschueren <sam.verschueren@gmail.com> (github.com/SamVerschueren)
 
 > MIT License
 >
@@ -2841,8 +3175,12 @@ By: Sam Verschueren
 
 ### markdown-escapes@v1.0.4
 
+> List of escapable characters in markdown
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -2871,8 +3209,10 @@ By: Titus Wormer
 
 ### mem@v9.0.2
 
+> Memoize functions - An optimization used to speed up consecutive function calls by caching the result of calls with identical input
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 
 > MIT License
 >
@@ -2888,7 +3228,10 @@ By: Sindre Sorhus
 
 ### merge2@v1.4.1
 
+> Merge multiple streams into one stream in sequence or parallel.
+
 License: MIT
+Homepage: <https://github.com/teambition/merge2>
 Repository: <git@github.com:teambition/merge2.git>
 
 > The MIT License (MIT)
@@ -2917,9 +3260,14 @@ Repository: <git@github.com:teambition/merge2.git>
 
 ### meriyah@v4.3.2
 
+> A 100% compliant, self-hosted javascript parser with high focus on both performance and stability
+
 License: ISC
-By: Kenny F.
+Homepage: <https://github.com/meriyah/meriyah>
 Repository: <https://github.com/meriyah/meriyah>
+Author: Kenny F. (https://github.com/KFlash)
+Contributors:
+ - Chunpeng Huo (https://github.com/3cp)
 
 > ISC License
 >
@@ -2933,8 +3281,27 @@ Repository: <https://github.com/meriyah/meriyah>
 
 ### micromatch@v4.0.5
 
-License: MIT
-By: Jon Schlinkert
+> Glob matching for javascript/node.js. A replacement and faster alternative to minimatch and multimatch.
+
+License: MIT
+Homepage: <https://github.com/micromatch/micromatch>
+Author: Jon Schlinkert (https://github.com/jonschlinkert)
+Contributors:
+ - null (https://github.com/DianeLooney)
+ - Amila Welihinda (amilajack.com)
+ - Bogdan Chadkin (https://github.com/TrySound)
+ - Brian Woodward (https://twitter.com/doowb)
+ - Devon Govett (http://badassjs.com)
+ - Elan Shanker (https://github.com/es128)
+ - Fabrício Matté (https://ultcombo.js.org)
+ - Jon Schlinkert (http://twitter.com/jonschlinkert)
+ - Martin Kolárik (https://kolarik.sk)
+ - Olsten Larck (https://i.am.charlike.online)
+ - Paul Miller (paulmillr.com)
+ - Tom Byrer (https://github.com/tomByrer)
+ - Tyler Akins (http://rumkin.com)
+ - Peter Bright <drpizza@quiscalusmexicanus.org> (https://github.com/drpizza)
+ - Kuba Juszczyk (https://github.com/ku8ar)
 
 > The MIT License (MIT)
 >
@@ -2962,8 +3329,10 @@ By: Jon Schlinkert
 
 ### mimic-fn@v4.0.0
 
+> Make a function mimic another one
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 
 > MIT License
 >
@@ -2979,9 +3348,11 @@ By: Sindre Sorhus
 
 ### minimatch@v3.1.2
 
+> a glob matcher in javascript
+
 License: ISC
-By: Isaac Z. Schlueter
 Repository: <git://github.com/isaacs/minimatch.git>
+Author: Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me)
 
 > The ISC License
 >
@@ -3003,9 +3374,12 @@ Repository: <git://github.com/isaacs/minimatch.git>
 
 ### minimist@v1.2.7
 
+> parse argument options
+
 License: MIT
-By: James Halliday
+Homepage: <https://github.com/minimistjs/minimist>
 Repository: <git://github.com/minimistjs/minimist.git>
+Author: James Halliday <mail@substack.net> (http://substack.net)
 
 > This software is released under the MIT license:
 >
@@ -3030,9 +3404,11 @@ Repository: <git://github.com/minimistjs/minimist.git>
 
 ### n-readlines@v1.0.1
 
+> Read file line by line without buffering the whole file in memory.
+
 License: MIT
-By: Yoan Arnaudov
 Repository: <http://github.com/nacholibre/node-readlines.git>
+Author: Yoan Arnaudov <jonidev@gmail.com>
 
 > The MIT License (MIT)
 >
@@ -3059,8 +3435,10 @@ Repository: <http://github.com/nacholibre/node-readlines.git>
 
 ### nanoid@v3.3.4
 
+> A tiny (116 bytes), secure URL-friendly unique string ID generator
+
 License: MIT
-By: Andrey Sitnik
+Author: Andrey Sitnik <andrey@sitnik.ru>
 
 > The MIT License (MIT)
 >
@@ -3087,9 +3465,11 @@ By: Andrey Sitnik
 
 ### once@v1.4.0
 
+> Run a function exactly one time
+
 License: ISC
-By: Isaac Z. Schlueter
 Repository: <git://github.com/isaacs/once>
+Author: Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
 
 > The ISC License
 >
@@ -3111,9 +3491,12 @@ Repository: <git://github.com/isaacs/once>
 
 ### outdent@v0.8.0
 
+> Remove leading indentation from ES6 template literals.
+
 License: MIT
-By: Andrew Bradley
+Homepage: <https://github.com/cspotcode/outdent#readme>
 Repository: <git+https://github.com/cspotcode/outdent.git>
+Author: Andrew Bradley <cspotcode@gmail.com>
 
 > The MIT License (MIT)
 >
@@ -3141,8 +3524,10 @@ Repository: <git+https://github.com/cspotcode/outdent.git>
 
 ### p-defer@v1.0.0
 
+> Create a deferred promise
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
 > The MIT License (MIT)
 >
@@ -3170,8 +3555,10 @@ By: Sindre Sorhus
 
 ### p-limit@v2.3.0
 
+> Run multiple promise-returning & async functions with limited concurrency
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
 > MIT License
 >
@@ -3187,8 +3574,10 @@ By: Sindre Sorhus
 
 ### p-locate@v4.1.0
 
+> Get the first fulfilled promise that satisfies the provided testing function
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
 > MIT License
 >
@@ -3204,8 +3593,10 @@ By: Sindre Sorhus
 
 ### p-try@v2.2.0
 
+> `Start a promise chain
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
 > MIT License
 >
@@ -3221,8 +3612,12 @@ By: Sindre Sorhus
 
 ### parse-entities@v2.0.0
 
+> Parse HTML character references: fast, spec-compliant, positional information
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -3251,8 +3646,10 @@ By: Titus Wormer
 
 ### parse-json@v5.2.0
 
+> Parse JSON with more helpful errors
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 
 > MIT License
 >
@@ -3268,8 +3665,10 @@ By: Sindre Sorhus
 
 ### path-exists@v4.0.0
 
+> Check if a path exists
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
 > MIT License
 >
@@ -3285,8 +3684,10 @@ By: Sindre Sorhus
 
 ### path-is-absolute@v1.0.1
 
+> Node.js 0.12 path.isAbsolute() ponyfill
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
 > The MIT License (MIT)
 >
@@ -3314,8 +3715,10 @@ By: Sindre Sorhus
 
 ### path-type@v4.0.0
 
+> Check if a path is a file, directory, or symlink
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
 > MIT License
 >
@@ -3331,8 +3734,10 @@ By: Sindre Sorhus
 
 ### picocolors@v1.0.0
 
+> The tiniest and the fastest library for terminal output formatting with ANSI colors
+
 License: ISC
-By: Alexey Raspopov
+Author: Alexey Raspopov
 
 > ISC License
 >
@@ -3354,8 +3759,11 @@ By: Alexey Raspopov
 
 ### picomatch@v2.3.1
 
+> Blazing fast and accurate glob matcher written in JavaScript, with no dependencies and full support for standard and extended Bash glob features, including braces, extglobs, POSIX brackets, and regular expressions.
+
 License: MIT
-By: Jon Schlinkert
+Homepage: <https://github.com/micromatch/picomatch>
+Author: Jon Schlinkert (https://github.com/jonschlinkert)
 
 > The MIT License (MIT)
 >
@@ -3383,8 +3791,10 @@ By: Jon Schlinkert
 
 ### pkg-dir@v4.2.0
 
+> Find the root directory of a Node.js project or npm package
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
 > MIT License
 >
@@ -3400,9 +3810,12 @@ By: Sindre Sorhus
 
 ### please-upgrade-node@v3.2.0
 
+> Displays a beginner-friendly message telling your user to upgrade their version of Node
+
 License: MIT
-By: typicode
+Homepage: <https://github.com/typicode/please-upgrade-node#readme>
 Repository: <git+https://github.com/typicode/please-upgrade-node.git>
+Author: typicode
 
 > MIT License
 >
@@ -3430,8 +3843,11 @@ Repository: <git+https://github.com/typicode/please-upgrade-node.git>
 
 ### postcss@v8.4.18
 
+> Tool for transforming styles with JS plugins
+
 License: MIT
-By: Andrey Sitnik
+Homepage: <https://postcss.org/>
+Author: Andrey Sitnik <andrey@sitnik.ru>
 
 > The MIT License (MIT)
 >
@@ -3458,8 +3874,11 @@ By: Andrey Sitnik
 
 ### postcss-less@v6.0.0
 
+> LESS parser for PostCSS
+
 License: MIT
-By: Denys Kniazevych
+Homepage: <https://github.com/shellscape/postcss-less>
+Author: Denys Kniazevych <webschik@gmail.com>
 
 > The MIT License (MIT)
 >
@@ -3490,16 +3909,21 @@ By: Denys Kniazevych
 
 ### postcss-media-query-parser@v0.2.3
 
+> A tool for parsing media query lists.
+
 License: MIT
-By: dryoma
+Homepage: <https://github.com/dryoma/postcss-media-query-parser>
 Repository: <git+https://github.com/dryoma/postcss-media-query-parser.git>
+Author: dryoma
 
 ----------------------------------------
 
 ### postcss-scss@v4.0.5
 
+> SCSS parser for PostCSS
+
 License: MIT
-By: Andrey Sitnik
+Author: Andrey Sitnik <andrey@sitnik.ru>
 
 > The MIT License (MIT)
 >
@@ -3527,7 +3951,8 @@ By: Andrey Sitnik
 ### postcss-selector-parser@v2.2.3
 
 License: MIT
-By: Ben Briggs
+Homepage: <https://github.com/postcss/postcss-selector-parser>
+Author: Ben Briggs <beneb.info@gmail.com> (http://beneb.info)
 
 > Copyright (c) Ben Briggs <beneb.info@gmail.com> (http://beneb.info)
 >
@@ -3556,8 +3981,10 @@ By: Ben Briggs
 
 ### postcss-values-parser@v2.0.1
 
+> A CSS property value parser for use with PostCSS
+
 License: MIT
-By: Andrew Powell (shellscape)
+Author: Andrew Powell (shellscape) <andrew@shellscape.org> (http://shellscape.org)
 
 > Copyright (c) Andrew Powell <andrew@shellscape.org>
 >
@@ -3586,9 +4013,12 @@ By: Andrew Powell (shellscape)
 
 ### pseudomap@v1.0.2
 
+> A thing that is a lot like ES6 `Map`, but without iterators, for use in environments where `for..of` syntax and `Map` are not available.
+
 License: ISC
-By: Isaac Z. Schlueter
+Homepage: <https://github.com/isaacs/pseudomap#readme>
 Repository: <git+https://github.com/isaacs/pseudomap.git>
+Author: Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
 
 > The ISC License
 >
@@ -3610,9 +4040,12 @@ Repository: <git+https://github.com/isaacs/pseudomap.git>
 
 ### queue-microtask@v1.2.3
 
+> fast, tiny `queueMicrotask` shim for modern engines
+
 License: MIT
-By: Feross Aboukhadijeh
+Homepage: <https://github.com/feross/queue-microtask>
 Repository: <git://github.com/feross/queue-microtask.git>
+Author: Feross Aboukhadijeh <feross@feross.org> (https://feross.org)
 
 > The MIT License (MIT)
 >
@@ -3639,8 +4072,12 @@ Repository: <git://github.com/feross/queue-microtask.git>
 
 ### remark-footnotes@v2.0.0
 
+> remark plugin to add support for pandoc footnotes
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -3669,22 +4106,45 @@ By: Titus Wormer
 
 ### remark-math@v3.0.1
 
+> remark plugin to parse and stringify math
+
 License: MIT
-By: Junyoung Choi
+Author: Junyoung Choi <fluke8259@gmail.com> (https://rokt33r.github.io)
+Contributors:
+ - Junyoung Choi <fluke8259@gmail.com> (https://rokt33r.github.io)
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 ----------------------------------------
 
 ### remark-parse@v8.0.3
 
+> remark plugin to parse Markdown
+
 License: MIT
-By: Titus Wormer
+Homepage: <https://remark.js.org>
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+ - Eugene Sharygin <eush77@gmail.com>
+ - Junyoung Choi <fluke8259@gmail.com>
+ - Elijah Hamovitz <elijahhamovitz@gmail.com>
+ - Ika <ikatyang@gmail.com>
 
 ----------------------------------------
 
 ### repeat-string@v1.6.1
 
+> Repeat the given string n times. Fastest implementation for repeating a string.
+
 License: MIT
-By: Jon Schlinkert
+Homepage: <https://github.com/jonschlinkert/repeat-string>
+Author: Jon Schlinkert (http://github.com/jonschlinkert)
+Contributors:
+ - Brian Woodward <brian.woodward@gmail.com> (https://github.com/doowb)
+ - Jon Schlinkert <jon.schlinkert@sellside.com> (http://twitter.com/jonschlinkert)
+ - Linus Unnebäck <linus@folkdatorn.se> (http://linus.unnebäck.se)
+ - Thijs Busser <tbusser@gmail.com> (http://tbusser.net)
+ - Titus <tituswormer@gmail.com> (wooorm.com)
 
 > The MIT License (MIT)
 >
@@ -3712,8 +4172,10 @@ By: Jon Schlinkert
 
 ### resolve-from@v4.0.0
 
+> Resolve the path of a module like `require.resolve()` but from a given path
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
 > MIT License
 >
@@ -3729,9 +4191,12 @@ By: Sindre Sorhus
 
 ### reusify@v1.0.4
 
+> Reuse objects and functions with style
+
 License: MIT
-By: Matteo Collina
+Homepage: <https://github.com/mcollina/reusify#readme>
 Repository: <git+https://github.com/mcollina/reusify.git>
+Author: Matteo Collina <hello@matteocollina.com>
 
 > The MIT License (MIT)
 >
@@ -3759,8 +4224,10 @@ Repository: <git+https://github.com/mcollina/reusify.git>
 
 ### rimraf@v3.0.2
 
+> A deep deletion module for node (like `rm -rf`)
+
 License: ISC
-By: Isaac Z. Schlueter
+Author: Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
 
 > The ISC License
 >
@@ -3799,9 +4266,12 @@ Repository: <git@github.com:ionic-team/rollup-plugin-node-polyfills.git>
 
 ### run-parallel@v1.2.0
 
+> Run an array of functions in parallel
+
 License: MIT
-By: Feross Aboukhadijeh
+Homepage: <https://github.com/feross/run-parallel>
 Repository: <git://github.com/feross/run-parallel.git>
+Author: Feross Aboukhadijeh <feross@feross.org> (https://feross.org)
 
 > The MIT License (MIT)
 >
@@ -3828,8 +4298,10 @@ Repository: <git://github.com/feross/run-parallel.git>
 
 ### sdbm@v2.0.0
 
+> SDBM non-cryptographic hash function
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 
 > MIT License
 >
@@ -3845,6 +4317,8 @@ By: Sindre Sorhus
 
 ### semver@v6.3.0
 
+> The semantic version parser used by npm.
+
 License: ISC
 
 > The ISC License
@@ -3867,9 +4341,11 @@ License: ISC
 
 ### semver@v7.3.8
 
+> The semantic version parser used by npm.
+
 License: ISC
-By: GitHub Inc.
 Repository: <https://github.com/npm/node-semver.git>
+Author: GitHub Inc.
 
 > The ISC License
 >
@@ -3891,9 +4367,12 @@ Repository: <https://github.com/npm/node-semver.git>
 
 ### semver-compare@v1.0.0
 
+> compare two semver version strings, returning -1, 0, or 1
+
 License: MIT
-By: James Halliday
+Homepage: <https://github.com/substack/semver-compare>
 Repository: <git://github.com/substack/semver-compare.git>
+Author: James Halliday <mail@substack.net> (http://substack.net)
 
 > This software is released under the MIT license:
 >
@@ -3918,9 +4397,11 @@ Repository: <git://github.com/substack/semver-compare.git>
 
 ### sigmund@v1.0.1
 
+> Quick and dirty signatures for Objects.
+
 License: ISC
-By: Isaac Z. Schlueter
 Repository: <git://github.com/isaacs/sigmund>
+Author: Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
 
 > The ISC License
 >
@@ -3942,6 +4423,8 @@ Repository: <git://github.com/isaacs/sigmund>
 
 ### simple-html-tokenizer@v0.5.11
 
+> Simple HTML Tokenizer is a lightweight JavaScript library that can be used to tokenize the kind of HTML normally found in templates.
+
 License: MIT
 Repository: <https://github.com/tildeio/simple-html-tokenizer.git>
 
@@ -3969,8 +4452,12 @@ Repository: <https://github.com/tildeio/simple-html-tokenizer.git>
 
 ### state-toggle@v1.0.3
 
+> Enter/exit a state
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -3999,8 +4486,10 @@ By: Titus Wormer
 
 ### string-width@v5.0.1
 
+> Get the visual width of a string - the number of columns required to display it
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 
 > MIT License
 >
@@ -4016,8 +4505,10 @@ By: Sindre Sorhus
 
 ### strip-ansi@v7.0.1
 
+> Strip ANSI escape codes from a string
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (https://sindresorhus.com)
 
 > MIT License
 >
@@ -4033,8 +4524,10 @@ By: Sindre Sorhus
 
 ### supports-color@v5.5.0
 
+> Detect whether a terminal supports color
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 
 > MIT License
 >
@@ -4050,8 +4543,10 @@ By: Sindre Sorhus
 
 ### to-fast-properties@v4.0.0
 
+> Force V8 to use fast properties for an object
+
 License: MIT
-By: Sindre Sorhus
+Author: Sindre Sorhus <sindresorhus@gmail.com> (https:/sindresorhus.com)
 
 > MIT License
 >
@@ -4070,8 +4565,14 @@ By: Sindre Sorhus
 
 ### to-regex-range@v5.0.1
 
+> Pass two numbers, get a regex-compatible source string for matching ranges. Validated against more than 2.78 million test assertions.
+
 License: MIT
-By: Jon Schlinkert
+Homepage: <https://github.com/micromatch/to-regex-range>
+Author: Jon Schlinkert (https://github.com/jonschlinkert)
+Contributors:
+ - Jon Schlinkert (http://twitter.com/jonschlinkert)
+ - Rouven Weßling (www.rouvenwessling.de)
 
 > The MIT License (MIT)
 >
@@ -4099,16 +4600,22 @@ By: Jon Schlinkert
 
 ### trim@v1.0.1
 
+> Trim string whitespace
+
 License: MIT
-By: TJ Holowaychuk
 Repository: <https://github.com/Trott/trim.git>
+Author: TJ Holowaychuk <tj@vision-media.ca>
 
 ----------------------------------------
 
 ### trim-trailing-lines@v1.1.4
 
+> Remove final line feeds from a string
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -4137,8 +4644,12 @@ By: Titus Wormer
 
 ### trough@v1.0.5
 
+> Middleware: a channel used to convey a liquid
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -4166,9 +4677,12 @@ By: Titus Wormer
 
 ### tslib@v1.14.1
 
+> Runtime library for TypeScript helper functions
+
 License: 0BSD
-By: Microsoft Corp.
+Homepage: <https://www.typescriptlang.org/>
 Repository: <https://github.com/Microsoft/tslib.git>
+Author: Microsoft Corp.
 
 > Copyright (c) Microsoft Corporation.
 > 
@@ -4187,9 +4701,11 @@ Repository: <https://github.com/Microsoft/tslib.git>
 
 ### tsutils@v3.21.0
 
+> utilities for working with typescript's AST
+
 License: MIT
-By: Klaus Meinhardt
 Repository: <https://github.com/ajafff/tsutils>
+Author: Klaus Meinhardt
 
 > The MIT License (MIT)
 > 
@@ -4217,9 +4733,12 @@ Repository: <https://github.com/ajafff/tsutils>
 
 ### typescript@v4.8.4
 
+> TypeScript is a language for application scale JavaScript development
+
 License: Apache-2.0
-By: Microsoft Corp.
+Homepage: <https://www.typescriptlang.org/>
 Repository: <https://github.com/Microsoft/TypeScript.git>
+Author: Microsoft Corp.
 
 > Apache License
 > 
@@ -4281,8 +4800,12 @@ Repository: <https://github.com/Microsoft/TypeScript.git>
 
 ### unherit@v1.1.3
 
+> Clone a constructor without affecting the super-class
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -4310,8 +4833,18 @@ By: Titus Wormer
 
 ### unified@v9.2.2
 
+> Interface for parsing, inspecting, transforming, and serializing content through syntax trees
+
 License: MIT
-By: Titus Wormer
+Homepage: <https://unifiedjs.com>
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+ - Junyoung Choi <fluke8259@gmail.com>
+ - Hernan Rajchert <hrajchert@gmail.com>
+ - Christian Murphy <christian.murphy.42@gmail.com>
+ - Vse Mozhet Byt <vsemozhetbyt@gmail.com>
+ - Richard Littauer <richard.littauer@gmail.com>
 
 > (The MIT License)
 >
@@ -4339,9 +4872,11 @@ By: Titus Wormer
 
 ### uniq@v1.0.1
 
+> Removes duplicates from a sorted array in place
+
 License: MIT
-By: Mikola Lysenko
 Repository: <git://github.com/mikolalysenko/uniq.git>
+Author: Mikola Lysenko
 
 > The MIT License (MIT)
 >
@@ -4369,8 +4904,14 @@ Repository: <git://github.com/mikolalysenko/uniq.git>
 
 ### unist-util-is@v4.1.0
 
+> unist utility to check if a node passes a test
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+ - Christian Murphy <christian.murphy.42@gmail.com>
+ - Lucas Brandstaetter <lucas@brandstaetter.tech> (https://github.com/Roang-zero1)
 
 > (The MIT license)
 >
@@ -4399,8 +4940,12 @@ By: Titus Wormer
 
 ### unist-util-remove-position@v2.0.1
 
+> unist utility to remove positions from a tree
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -4429,8 +4974,12 @@ By: Titus Wormer
 
 ### unist-util-stringify-position@v2.0.3
 
+> unist utility to serialize a node, position, or point as a human readable location
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -4459,8 +5008,14 @@ By: Titus Wormer
 
 ### unist-util-visit@v2.0.3
 
+> unist utility to visit nodes
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+ - Eugene Sharygin <eush77@gmail.com>
+ - Richard Gibson <richard.gibson@gmail.com>
 
 > (The MIT License)
 >
@@ -4489,8 +5044,12 @@ By: Titus Wormer
 
 ### unist-util-visit-parents@v3.1.1
 
+> unist utility to recursively walk over nodes, with ancestral information
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -4519,8 +5078,17 @@ By: Titus Wormer
 
 ### vfile@v4.2.1
 
+> Virtual file format for text processing
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+ - Brendan Abbott <brendan.abbott@temando.com>
+ - Denys Dovhan <email@denysdovhan.com>
+ - Kyle Mathews <mathews.kyle@gmail.com>
+ - Shinnosuke Watanabe <snnskwtnb@gmail.com>
+ - Sindre Sorhus <sindresorhus@gmail.com>
 
 > (The MIT License)
 >
@@ -4548,8 +5116,13 @@ By: Titus Wormer
 
 ### vfile-location@v3.2.0
 
+> vfile utility to convert between positional (line and column-based) and offset (range-based) locations
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+ - Christian Murphy <christian.murphy.42@gmail.com>
 
 > (The MIT License)
 >
@@ -4578,8 +5151,12 @@ By: Titus Wormer
 
 ### vfile-message@v2.0.4
 
+> vfile utility to create a virtual message
+
 License: MIT
-By: Titus Wormer
+Author: Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
+Contributors:
+ - Titus Wormer <tituswormer@gmail.com> (https://wooorm.com)
 
 > (The MIT License)
 >
@@ -4608,8 +5185,11 @@ By: Titus Wormer
 
 ### vnopts@v1.0.2
 
+> validate and normalize options
+
 License: MIT
-By: Ika
+Homepage: <https://github.com/ikatyang/vnopts#readme>
+Author: Ika <ikatyang@gmail.com> (https://github.com/ikatyang)
 
 > MIT License
 >
@@ -4637,9 +5217,14 @@ By: Ika
 
 ### wcwidth@v1.0.1
 
+> Port of C's wcwidth() and wcswidth()
+
 License: MIT
-By: Tim Oxley
+Homepage: <https://github.com/timoxley/wcwidth#readme>
 Repository: <git+https://github.com/timoxley/wcwidth.git>
+Author: Tim Oxley
+Contributors:
+ - Woong Jun <woong.jun@gmail.com> (http://code.woong.org/)
 
 > wcwidth.js: JavaScript Portng of Markus Kuhn's wcwidth() Implementation
 > =======================================================================
@@ -4675,9 +5260,12 @@ Repository: <git+https://github.com/timoxley/wcwidth.git>
 
 ### wrappy@v1.0.2
 
+> Callback wrapping utility
+
 License: ISC
-By: Isaac Z. Schlueter
+Homepage: <https://github.com/npm/wrappy>
 Repository: <https://github.com/npm/wrappy>
+Author: Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
 
 > The ISC License
 >
@@ -4699,8 +5287,14 @@ Repository: <https://github.com/npm/wrappy>
 
 ### xtend@v4.0.2
 
+> extend like a boss
+
 License: MIT
-By: Raynos
+Homepage: <https://github.com/Raynos/xtend>
+Author: Raynos <raynos2@gmail.com>
+Contributors:
+ - Jake Verbaten
+ - Matt Esch
 
 > The MIT License (MIT)
 > Copyright (c) 2012-2014 Raynos.
@@ -4727,9 +5321,11 @@ By: Raynos
 
 ### yallist@v2.1.2
 
+> Yet Another Linked List
+
 License: ISC
-By: Isaac Z. Schlueter
 Repository: <git+https://github.com/isaacs/yallist.git>
+Author: Isaac Z. Schlueter <i@izs.me> (http://blog.izs.me/)
 
 > The ISC License
 >
@@ -4751,8 +5347,11 @@ Repository: <git+https://github.com/isaacs/yallist.git>
 
 ### yaml@v1.10.2
 
+> JavaScript parser and stringifier for YAML
+
 License: ISC
-By: Eemeli Aro
+Homepage: <https://eemeli.org/yaml/v1/>
+Author: Eemeli Aro <eemeli@gmail.com>
 
 > Copyright 2018 Eemeli Aro <eemeli@gmail.com>
 >
@@ -4772,8 +5371,11 @@ By: Eemeli Aro
 
 ### yaml-unist-parser@v2.0.1
 
+> A YAML parser that produces output compatible with unist
+
 License: MIT
-By: Ika
+Homepage: <https://github.com/prettier/yaml-unist-parser#readme>
+Author: Ika <ikatyang@gmail.com> (https://github.com/ikatyang)
 
 > MIT License
 >
```

</details>

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
