### PR TITLE
Add gql() call expression support

### DIFF
--- a/src/language-js/clean.js
+++ b/src/language-js/clean.js
@@ -186,7 +186,8 @@ function clean(ast, newObj, parent) {
     );
     if (
       hasLanguageComment ||
-      (parent.type === "CallExpression" && parent.callee.name === "graphql") ||
+      (parent.type === "CallExpression" &&
+        (parent.callee.name === "gql" || parent.callee.name === "graphql")) ||
       // TODO: check parser
       // `flow` and `typescript` don't have `leadingComments`
       !ast.leadingComments

--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -263,7 +263,7 @@ function isGraphQL(path) {
             (parent.tag.name === "gql" || parent.tag.name === "graphql")))) ||
         (parent.type === "CallExpression" &&
           parent.callee.type === "Identifier" &&
-          parent.callee.name === "graphql")))
+          (parent.callee.name === "gql" || parent.callee.name === "graphql"))))
   );
 }
 

--- a/tests/format/js/multiparser-graphql/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/multiparser-graphql/__snapshots__/jsfmt.spec.js.snap
@@ -399,6 +399,18 @@ query User {
 fragment another on User { name
 }\${ fragment }\`
 
+// Using CallExpression
+
+gql(\`
+      {
+    user(   id :   5  )  {
+      firstName
+
+      lastName
+    }
+  }
+\`);
+
 =====================================output=====================================
 import gql from "graphql-tag";
 
@@ -563,6 +575,18 @@ gql\`
   }
   \${fragment}
 \`;
+
+// Using CallExpression
+
+gql(\`
+  {
+    user(id: 5) {
+      firstName
+
+      lastName
+    }
+  }
+\`);
 
 ================================================================================
 `;

--- a/tests/format/js/multiparser-graphql/graphql-tag.js
+++ b/tests/format/js/multiparser-graphql/graphql-tag.js
@@ -156,3 +156,15 @@ ${fragment}#comment
 
 fragment another on User { name
 }${ fragment }`
+
+// Using CallExpression
+
+gql(`
+      {
+    user(   id :   5  )  {
+      firstName
+
+      lastName
+    }
+  }
+`);


### PR DESCRIPTION
## Description

Add `gql()` call expression support. Example:
```js
gql(`
...
`);
```

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
