### PR TITLE
Enable `regexp/no-useless-non-capturing-group` rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -167,6 +167,7 @@ module.exports = {
       },
     ],
     "regexp/no-useless-lazy": "error",
+    "regexp/no-useless-non-capturing-group": "error",
 
     // eslint-plugin-unicorn
     "unicorn/better-regex": "error",

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -770,11 +770,11 @@ const containsNonJsxWhitespaceRegex = new RegExp(
 const trimJsxWhitespace = (text) =>
   text.replace(
     new RegExp(
-      "(?:^" +
+      "^" +
         matchJsxWhitespaceRegex.source +
         "|" +
         matchJsxWhitespaceRegex.source +
-        "$)"
+        "$"
     ),
     ""
   );


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-non-capturing-group.html

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
