### PR TITLE
Remove needless conditions for `YeildExpression` in `needs-parens`

### DIFF
--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -349,12 +349,7 @@ function needsParens(path, options) {
       }
 
     case "YieldExpression":
-      if (
-        parent.type === "UnaryExpression" ||
-        parent.type === "AwaitExpression" ||
-        parent.type === "TSAsExpression" ||
-        parent.type === "TSNonNullExpression"
-      ) {
+      if (parent.type === "AwaitExpression") {
         return true;
       }
     // else fallthrough


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
I tried to address https://github.com/prettier/prettier/pull/13783#issuecomment-1302942619.
Then I noticed some conditions are not actually used.

I'll backport this PR  to `main` after merge this into `next`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
