### PR TITLE
Remove needless conditions for `YeildExpression` in `needs-parens` (backporting #13790)

### DIFF
--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -363,12 +363,7 @@ function needsParens(path, options) {
       }
 
     case "YieldExpression":
-      if (
-        parent.type === "UnaryExpression" ||
-        parent.type === "AwaitExpression" ||
-        isTSTypeExpression(parent) ||
-        parent.type === "TSNonNullExpression"
-      ) {
+      if (parent.type === "AwaitExpression") {
         return true;
       }
     // else fallthrough


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Backport https://github.com/prettier/prettier/pull/13790

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
