### PR TITLE
Add clarification notes about EditorConfig

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -176,7 +176,11 @@ If you’d like a JSON schema to validate your configuration, one is available h
 
 ## EditorConfig
 
-If `options.editorconfig` is `true` and an [`.editorconfig` file](https://editorconfig.org/) is in your project, Prettier will parse it and convert its properties to the corresponding Prettier configuration. This configuration will be overridden by `.prettierrc`, etc.
+The `prettier` CLI respects `.editorconfig` by default, but you can opt out with `--no-editorconfig`.
+
+However, the API _doesn't_ respect `.editorconfig` by default, in order to avoid potential editor integration issues. To opt in, add `editorconfig: true` to the [`prettier.resolveConfig`](https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath--options) options.
+
+> Note: Rules that are set in `.editorconfig` can be overridden by their corresponding rules from `.prettierrc.js`, therefore rules from `.editorconfig` can be used as a fallback for files that Prettier doesn't support. See the languages list supported by Prettier [here](https://prettier.io/docs/en/index.html)
 
 Here’s an annotated description of how different properties map to Prettier’s behavior:
 

--- a/website/versioned_docs/version-stable/configuration.md
+++ b/website/versioned_docs/version-stable/configuration.md
@@ -177,7 +177,11 @@ If you’d like a JSON schema to validate your configuration, one is available h
 
 ## EditorConfig
 
-If `options.editorconfig` is `true` and an [`.editorconfig` file](https://editorconfig.org/) is in your project, Prettier will parse it and convert its properties to the corresponding Prettier configuration. This configuration will be overridden by `.prettierrc`, etc.
+The `prettier` CLI respects `.editorconfig` by default, but you can opt out with `--no-editorconfig`.
+
+However, the API _doesn't_ respect `.editorconfig` by default, in order to avoid potential editor integration issues. To opt in, add `editorconfig: true` to the [`prettier.resolveConfig`](https://prettier.io/docs/en/api.html#prettierresolveconfigfilepath--options) options.
+
+> Note: Rules that are set in `.editorconfig` can be overridden by their corresponding rules from `.prettierrc.js`, therefore rules from `.editorconfig` can be used as a fallback for files that Prettier doesn't support. See the languages list supported by Prettier [here](https://prettier.io/docs/en/index.html)
 
 Here’s an annotated description of how different properties map to Prettier’s behavior:
 


### PR DESCRIPTION
```
## Description

Although I'm not a Prettier expert, IMHO the section about the EditorConfig integration is not super clear, to be honest. So I'd add some more words about the relationships between Prettier and EditorConfig.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**

```