### PR TITLE
TypeScript: Throw errors for invalid modifier on type parameter

### DIFF
--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -210,7 +210,6 @@ const allowedMessageCodes = new Set([
   "ReadonlyForMethodSignature",
   "ClassMethodHasDeclare",
   "ClassMethodHasReadonly",
-  "InvalidModifierOnTypeMember",
   "DuplicateAccessibilityModifier",
   "IndexSignatureHasDeclare",
 

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -207,7 +207,6 @@ const allowedMessageCodes = new Set([
   "InvalidTupleMemberLabel",
 
   "NonClassMethodPropertyHasAbstractModifer",
-  "ReadonlyForMethodSignature",
   "ClassMethodHasDeclare",
   "ClassMethodHasReadonly",
   "DuplicateAccessibilityModifier",

--- a/src/language-js/parse/postprocess/typescript.js
+++ b/src/language-js/parse/postprocess/typescript.js
@@ -104,7 +104,7 @@ function throwErrorForInvalidModifierOnTypeParameter(tsNode, esTreeNode) {
     return;
   }
 
-  const invalidModifier = tsNode.modifiers.find(
+  const invalidModifier = tsNode.modifiers?.find(
     (modifier) =>
       !(
         modifier.kind === SyntaxKind.InKeyword ||

--- a/src/language-js/parse/postprocess/typescript.js
+++ b/src/language-js/parse/postprocess/typescript.js
@@ -97,7 +97,10 @@ function throwErrorForInvalidDeclare(tsNode, esTreeNode) {
 }
 
 function throwErrorForInvalidModifierOnTypeParameter(tsNode, esTreeNode) {
-  if (esTreeNode.type !== "TSMethodSignature" || tsNode.kind !== SyntaxKind.TypeParameter) {
+  if (
+    esTreeNode.type !== "TSMethodSignature" ||
+    tsNode.kind !== SyntaxKind.TypeParameter
+  ) {
     return;
   }
 

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -320,13 +320,6 @@ function printTypescript(path, options, print) {
       parts.push(
         node.accessibility ? [node.accessibility, " "] : "",
         kind,
-        node.export ? "export " : "",
-        node.static ? "static " : "",
-        node.readonly ? "readonly " : "",
-        // "abstract" and "declare" are supported by only "babel-ts"
-        // https://github.com/prettier/prettier/issues/9760
-        node.abstract ? "abstract " : "",
-        node.declare ? "declare " : "",
         node.computed ? "[" : "",
         print("key"),
         node.computed ? "]" : "",

--- a/tests/config/format-test.js
+++ b/tests/config/format-test.js
@@ -166,6 +166,11 @@ function runSpec(fixtures, parsers, options) {
 
   snippets = snippets.map((test, index) => {
     test = typeof test === "string" ? { code: test } : test;
+
+    if (typeof test.code !== "string") {
+      throw Object.assign(new Error("Invalid test"), {test});
+    }
+
     return {
       ...test,
       name: `snippet: ${test.name || `#${index}`}`,

--- a/tests/config/format-test.js
+++ b/tests/config/format-test.js
@@ -168,7 +168,7 @@ function runSpec(fixtures, parsers, options) {
     test = typeof test === "string" ? { code: test } : test;
 
     if (typeof test.code !== "string") {
-      throw Object.assign(new Error("Invalid test"), {test});
+      throw Object.assign(new Error("Invalid test"), { test });
     }
 
     return {

--- a/tests/format/misc/errors/typescript/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/typescript/__snapshots__/jsfmt.spec.js.snap
@@ -94,7 +94,50 @@ exports[`snippet: #5 [typescript] format 1`] = `
     |               ^"
 `;
 
-exports[`snippet: #6 [typescript] format 1`] = `"Cannot read properties of undefined (reading 'indexOf')"`;
+exports[`snippet: #6 [typescript] format 1`] = `
+"This modifier cannot appear on a type member (1:16)
+> 1 | interface Foo {
+    |                ^
+> 2 |   export e();
+    | ^^^^^^^^^
+  3 | }"
+`;
+
+exports[`snippet: #7 [typescript] format 1`] = `
+"This modifier cannot appear on a type member (1:16)
+> 1 | interface Foo {
+    |                ^
+> 2 |   static e();
+    | ^^^^^^^^^
+  3 | }"
+`;
+
+exports[`snippet: #8 [typescript] format 1`] = `
+"This modifier cannot appear on a type member (1:16)
+> 1 | interface Foo {
+    |                ^
+> 2 |   readonly e();
+    | ^^^^^^^^^^^
+  3 | }"
+`;
+
+exports[`snippet: #9 [typescript] format 1`] = `
+"This modifier cannot appear on a type member (1:16)
+> 1 | interface Foo {
+    |                ^
+> 2 |   abstract e();
+    | ^^^^^^^^^^^
+  3 | }"
+`;
+
+exports[`snippet: #10 [typescript] format 1`] = `
+"This modifier cannot appear on a type member (1:16)
+> 1 | interface Foo {
+    |                ^
+> 2 |   declare e();
+    | ^^^^^^^^^^
+  3 | }"
+`;
 
 exports[`value-of-abstract-property.ts [typescript] format 1`] = `
 "Abstract property cannot have an initializer (2:3)

--- a/tests/format/misc/errors/typescript/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/typescript/__snapshots__/jsfmt.spec.js.snap
@@ -94,6 +94,8 @@ exports[`snippet: #5 [typescript] format 1`] = `
     |               ^"
 `;
 
+exports[`snippet: #6 [typescript] format 1`] = `"Cannot read properties of undefined (reading 'indexOf')"`;
+
 exports[`value-of-abstract-property.ts [typescript] format 1`] = `
 "Abstract property cannot have an initializer (2:3)
   1 | abstract class Foo {

--- a/tests/format/misc/errors/typescript/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/typescript/__snapshots__/jsfmt.spec.js.snap
@@ -98,12 +98,30 @@ exports[`snippet: #6 [typescript] format 1`] = `
 "This modifier cannot appear on a type member (1:16)
 > 1 | interface Foo {
     |                ^
+> 2 |   abstract e();
+    | ^^^^^^^^^^^
+  3 | }"
+`;
+
+exports[`snippet: #7 [typescript] format 1`] = `
+"This modifier cannot appear on a type member (1:16)
+> 1 | interface Foo {
+    |                ^
+> 2 |   declare e();
+    | ^^^^^^^^^^
+  3 | }"
+`;
+
+exports[`snippet: #8 [typescript] format 1`] = `
+"This modifier cannot appear on a type member (1:16)
+> 1 | interface Foo {
+    |                ^
 > 2 |   export e();
     | ^^^^^^^^^
   3 | }"
 `;
 
-exports[`snippet: #7 [typescript] format 1`] = `
+exports[`snippet: #9 [typescript] format 1`] = `
 "This modifier cannot appear on a type member (1:16)
 > 1 | interface Foo {
     |                ^
@@ -112,30 +130,39 @@ exports[`snippet: #7 [typescript] format 1`] = `
   3 | }"
 `;
 
-exports[`snippet: #8 [typescript] format 1`] = `
+exports[`snippet: #10 [typescript] format 1`] = `
+"This modifier cannot appear on a type member (1:16)
+> 1 | interface Foo {
+    |                ^
+> 2 |   private e();
+    | ^^^^^^^^^^
+  3 | }"
+`;
+
+exports[`snippet: #11 [typescript] format 1`] = `
+"This modifier cannot appear on a type member (1:16)
+> 1 | interface Foo {
+    |                ^
+> 2 |   protected e();
+    | ^^^^^^^^^^^^
+  3 | }"
+`;
+
+exports[`snippet: #12 [typescript] format 1`] = `
+"This modifier cannot appear on a type member (1:16)
+> 1 | interface Foo {
+    |                ^
+> 2 |   public e();
+    | ^^^^^^^^^
+  3 | }"
+`;
+
+exports[`snippet: #13 [typescript] format 1`] = `
 "This modifier cannot appear on a type member (1:16)
 > 1 | interface Foo {
     |                ^
 > 2 |   readonly e();
     | ^^^^^^^^^^^
-  3 | }"
-`;
-
-exports[`snippet: #9 [typescript] format 1`] = `
-"This modifier cannot appear on a type member (1:16)
-> 1 | interface Foo {
-    |                ^
-> 2 |   abstract e();
-    | ^^^^^^^^^^^
-  3 | }"
-`;
-
-exports[`snippet: #10 [typescript] format 1`] = `
-"This modifier cannot appear on a type member (1:16)
-> 1 | interface Foo {
-    |                ^
-> 2 |   declare e();
-    | ^^^^^^^^^^
   3 | }"
 `;
 

--- a/tests/format/misc/errors/typescript/babel-ts/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/typescript/babel-ts/__snapshots__/jsfmt.spec.js.snap
@@ -60,6 +60,14 @@ exports[`snippet: #4 [babel-ts] format 1`] = `
   3 | }"
 `;
 
+exports[`snippet: #5 [babel-ts] format 1`] = `
+"'readonly' modifier can only appear on a property declaration or index signature. (2:3)
+  1 | interface Foo {
+> 2 |   readonly e();
+    |   ^
+  3 | }"
+`;
+
 exports[`snippet: #6 [babel-ts] format 1`] = `
 "'abstract' modifier cannot appear on a type member. (2:3)
   1 | interface Foo {

--- a/tests/format/misc/errors/typescript/babel-ts/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/typescript/babel-ts/__snapshots__/jsfmt.spec.js.snap
@@ -43,3 +43,5 @@ exports[`snippet: #2 [babel-ts] format 1`] = `
 > 1 | <string>foo = '100';
     |         ^"
 `;
+
+exports[`snippet: #3 [babel-ts] format 1`] = `"Cannot read properties of undefined (reading 'indexOf')"`;

--- a/tests/format/misc/errors/typescript/babel-ts/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/typescript/babel-ts/__snapshots__/jsfmt.spec.js.snap
@@ -44,4 +44,34 @@ exports[`snippet: #2 [babel-ts] format 1`] = `
     |         ^"
 `;
 
-exports[`snippet: #3 [babel-ts] format 1`] = `"Cannot read properties of undefined (reading 'indexOf')"`;
+exports[`snippet: #3 [babel-ts] format 1`] = `
+"Unexpected token, expected ";" (2:10)
+  1 | interface Foo {
+> 2 |   export e();
+    |          ^
+  3 | }"
+`;
+
+exports[`snippet: #4 [babel-ts] format 1`] = `
+"'static' modifier cannot appear on a type member. (2:3)
+  1 | interface Foo {
+> 2 |   static e();
+    |   ^
+  3 | }"
+`;
+
+exports[`snippet: #6 [babel-ts] format 1`] = `
+"'abstract' modifier cannot appear on a type member. (2:3)
+  1 | interface Foo {
+> 2 |   abstract e();
+    |   ^
+  3 | }"
+`;
+
+exports[`snippet: #7 [babel-ts] format 1`] = `
+"'declare' modifier cannot appear on a type member. (2:3)
+  1 | interface Foo {
+> 2 |   declare e();
+    |   ^
+  3 | }"
+`;

--- a/tests/format/misc/errors/typescript/babel-ts/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/typescript/babel-ts/__snapshots__/jsfmt.spec.js.snap
@@ -45,30 +45,6 @@ exports[`snippet: #2 [babel-ts] format 1`] = `
 `;
 
 exports[`snippet: #3 [babel-ts] format 1`] = `
-"Unexpected token, expected ";" (2:10)
-  1 | interface Foo {
-> 2 |   export e();
-    |          ^
-  3 | }"
-`;
-
-exports[`snippet: #4 [babel-ts] format 1`] = `
-"'static' modifier cannot appear on a type member. (2:3)
-  1 | interface Foo {
-> 2 |   static e();
-    |   ^
-  3 | }"
-`;
-
-exports[`snippet: #5 [babel-ts] format 1`] = `
-"'readonly' modifier can only appear on a property declaration or index signature. (2:3)
-  1 | interface Foo {
-> 2 |   readonly e();
-    |   ^
-  3 | }"
-`;
-
-exports[`snippet: #6 [babel-ts] format 1`] = `
 "'abstract' modifier cannot appear on a type member. (2:3)
   1 | interface Foo {
 > 2 |   abstract e();
@@ -76,10 +52,58 @@ exports[`snippet: #6 [babel-ts] format 1`] = `
   3 | }"
 `;
 
-exports[`snippet: #7 [babel-ts] format 1`] = `
+exports[`snippet: #4 [babel-ts] format 1`] = `
 "'declare' modifier cannot appear on a type member. (2:3)
   1 | interface Foo {
 > 2 |   declare e();
+    |   ^
+  3 | }"
+`;
+
+exports[`snippet: #5 [babel-ts] format 1`] = `
+"Unexpected token, expected ";" (2:10)
+  1 | interface Foo {
+> 2 |   export e();
+    |          ^
+  3 | }"
+`;
+
+exports[`snippet: #6 [babel-ts] format 1`] = `
+"'static' modifier cannot appear on a type member. (2:3)
+  1 | interface Foo {
+> 2 |   static e();
+    |   ^
+  3 | }"
+`;
+
+exports[`snippet: #7 [babel-ts] format 1`] = `
+"'private' modifier cannot appear on a type member. (2:3)
+  1 | interface Foo {
+> 2 |   private e();
+    |   ^
+  3 | }"
+`;
+
+exports[`snippet: #8 [babel-ts] format 1`] = `
+"'protected' modifier cannot appear on a type member. (2:3)
+  1 | interface Foo {
+> 2 |   protected e();
+    |   ^
+  3 | }"
+`;
+
+exports[`snippet: #9 [babel-ts] format 1`] = `
+"'public' modifier cannot appear on a type member. (2:3)
+  1 | interface Foo {
+> 2 |   public e();
+    |   ^
+  3 | }"
+`;
+
+exports[`snippet: #10 [babel-ts] format 1`] = `
+"'readonly' modifier can only appear on a property declaration or index signature. (2:3)
+  1 | interface Foo {
+> 2 |   readonly e();
     |   ^
   3 | }"
 `;

--- a/tests/format/misc/errors/typescript/babel-ts/jsfmt.spec.js
+++ b/tests/format/misc/errors/typescript/babel-ts/jsfmt.spec.js
@@ -1,3 +1,5 @@
+import {outdent} from "outdent";
+
 run_spec(
   {
     importMeta: import.meta,
@@ -5,6 +7,17 @@ run_spec(
       "foo as any = 10;",
       "({ a: b as any = 2000 } = x);",
       "<string>foo = '100';",
+      [
+        "export",
+        "static",
+        "readonly",
+        "abstract",
+        "declare",
+      ].map(modifier => outdent`
+        interface Foo {
+          ${modifier} e();
+        }
+      `),
     ],
   },
   ["babel-ts"]

--- a/tests/format/misc/errors/typescript/babel-ts/jsfmt.spec.js
+++ b/tests/format/misc/errors/typescript/babel-ts/jsfmt.spec.js
@@ -7,7 +7,7 @@ run_spec(
       "foo as any = 10;",
       "({ a: b as any = 2000 } = x);",
       "<string>foo = '100';",
-      [
+      ...[
         "export",
         "static",
         "readonly",

--- a/tests/format/misc/errors/typescript/babel-ts/jsfmt.spec.js
+++ b/tests/format/misc/errors/typescript/babel-ts/jsfmt.spec.js
@@ -7,12 +7,21 @@ run_spec(
       "foo as any = 10;",
       "({ a: b as any = 2000 } = x);",
       "<string>foo = '100';",
-      ...["export", "static", "readonly", "abstract", "declare"].map(
+      ...[
+        "abstract",
+        "declare",
+        "export",
+        "static",
+        "private",
+        "protected",
+        "public",
+        "readonly",
+      ].map(
         (modifier) => outdent`
-        interface Foo {
-          ${modifier} e();
-        }
-      `
+          interface Foo {
+            ${modifier} e();
+          }
+        `
       ),
     ],
   },

--- a/tests/format/misc/errors/typescript/babel-ts/jsfmt.spec.js
+++ b/tests/format/misc/errors/typescript/babel-ts/jsfmt.spec.js
@@ -1,4 +1,4 @@
-import {outdent} from "outdent";
+import { outdent } from "outdent";
 
 run_spec(
   {
@@ -7,17 +7,13 @@ run_spec(
       "foo as any = 10;",
       "({ a: b as any = 2000 } = x);",
       "<string>foo = '100';",
-      ...[
-        "export",
-        "static",
-        "readonly",
-        "abstract",
-        "declare",
-      ].map(modifier => outdent`
+      ...["export", "static", "readonly", "abstract", "declare"].map(
+        (modifier) => outdent`
         interface Foo {
           ${modifier} e();
         }
-      `),
+      `
+      ),
     ],
   },
   ["babel-ts"]

--- a/tests/format/misc/errors/typescript/jsfmt.spec.js
+++ b/tests/format/misc/errors/typescript/jsfmt.spec.js
@@ -1,4 +1,4 @@
-import {outdent} from "outdent";
+import { outdent } from "outdent";
 
 run_spec(
   {
@@ -10,17 +10,13 @@ run_spec(
       'let x4 = <div>{"foo"}></div>;',
       'let x5 = <div>}{"foo"}</div>;',
       'let x6 = <div>>{"foo"}</div>;',
-      ...[
-        "export",
-        "static",
-        "readonly",
-        "abstract",
-        "declare",
-      ].map(modifier => outdent`
+      ...["export", "static", "readonly", "abstract", "declare"].map(
+        (modifier) => outdent`
         interface Foo {
           ${modifier} e();
         }
-      `),
+      `
+      ),
     ],
   },
   ["typescript"]

--- a/tests/format/misc/errors/typescript/jsfmt.spec.js
+++ b/tests/format/misc/errors/typescript/jsfmt.spec.js
@@ -1,3 +1,5 @@
+import {outdent} from "outdent";
+
 run_spec(
   {
     importMeta: import.meta,
@@ -8,6 +10,17 @@ run_spec(
       'let x4 = <div>{"foo"}></div>;',
       'let x5 = <div>}{"foo"}</div>;',
       'let x6 = <div>>{"foo"}</div>;',
+      [
+        "export",
+        "static",
+        "readonly",
+        "abstract",
+        "declare",
+      ].map(modifier => outdent`
+        interface Foo {
+          ${modifier} e();
+        }
+      `),
     ],
   },
   ["typescript"]

--- a/tests/format/misc/errors/typescript/jsfmt.spec.js
+++ b/tests/format/misc/errors/typescript/jsfmt.spec.js
@@ -10,7 +10,7 @@ run_spec(
       'let x4 = <div>{"foo"}></div>;',
       'let x5 = <div>}{"foo"}</div>;',
       'let x6 = <div>>{"foo"}</div>;',
-      [
+      ...[
         "export",
         "static",
         "readonly",

--- a/tests/format/misc/errors/typescript/jsfmt.spec.js
+++ b/tests/format/misc/errors/typescript/jsfmt.spec.js
@@ -10,12 +10,21 @@ run_spec(
       'let x4 = <div>{"foo"}></div>;',
       'let x5 = <div>}{"foo"}</div>;',
       'let x6 = <div>>{"foo"}</div>;',
-      ...["export", "static", "readonly", "abstract", "declare"].map(
+      ...[
+        "abstract",
+        "declare",
+        "export",
+        "static",
+        "private",
+        "protected",
+        "public",
+        "readonly",
+      ].map(
         (modifier) => outdent`
-        interface Foo {
-          ${modifier} e();
-        }
-      `
+          interface Foo {
+            ${modifier} e();
+          }
+        `
       ),
     ],
   },

--- a/tests/format/misc/typescript-babel-only/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/typescript-babel-only/__snapshots__/jsfmt.spec.js.snap
@@ -26,32 +26,12 @@ parsers: ["babel-ts"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-interface Foo {
-  private a();
-  public b();
-  protected c();
-  static d();
-  declare e();
-  abstract f();
-  readonly g();
-}
-
 class Bar {
   declare e() {};
   readonly g() {};
 }
 
 =====================================output=====================================
-interface Foo {
-  private a();
-  public b();
-  protected c();
-  static d();
-  declare e();
-  abstract f();
-  readonly g();
-}
-
 class Bar {
   declare e() {}
   readonly g() {}

--- a/tests/format/misc/typescript-babel-only/invalid-modifiers.ts
+++ b/tests/format/misc/typescript-babel-only/invalid-modifiers.ts
@@ -1,13 +1,3 @@
-interface Foo {
-  private a();
-  public b();
-  protected c();
-  static d();
-  declare e();
-  abstract f();
-  readonly g();
-}
-
 class Bar {
   declare e() {};
   readonly g() {};

--- a/tests/format/misc/typescript-only/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/typescript-only/__snapshots__/jsfmt.spec.js.snap
@@ -57,16 +57,6 @@ parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-interface Foo {
-  private a();
-  public b();
-  protected c();
-  static d();
-  declare e();
-  abstract f();
-  readonly g();
-}
-
 class Bar {
   declare e() {};
   abstract f() {};
@@ -74,16 +64,6 @@ class Bar {
 }
 
 =====================================output=====================================
-interface Foo {
-  private a();
-  public b();
-  protected c();
-  static d();
-  e();
-  f();
-  readonly g();
-}
-
 class Bar {
   e() {}
   abstract f() {}

--- a/tests/format/misc/typescript-only/invalid-modifiers.ts
+++ b/tests/format/misc/typescript-only/invalid-modifiers.ts
@@ -1,13 +1,3 @@
-interface Foo {
-  private a();
-  public b();
-  protected c();
-  static d();
-  declare e();
-  abstract f();
-  readonly g();
-}
-
 class Bar {
   declare e() {};
   abstract f() {};

--- a/tests/format/typescript/class/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/class/__snapshots__/jsfmt.spec.js.snap
@@ -402,6 +402,10 @@ class X {
     optionalMethod?() {}
 }
 
+interface Iterable<T> {
+  [Symbol.iterator](): Iterator<T>;
+}
+
 export class Check {
   private static property = 'test';
 }
@@ -409,6 +413,10 @@ export class Check {
 =====================================output=====================================
 class X {
   optionalMethod?() {}
+}
+
+interface Iterable<T> {
+  [Symbol.iterator](): Iterator<T>;
 }
 
 export class Check {

--- a/tests/format/typescript/class/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/class/__snapshots__/jsfmt.spec.js.snap
@@ -392,17 +392,6 @@ interface AudioBufferList {
 ================================================================================
 `;
 
-exports[`methods.ts [babel-ts] format 1`] = `
-"Unexpected token, expected ";" (6:10)
-  4 |
-  5 | interface Iterable<T> {
-> 6 |   export [Symbol.iterator](): Iterator<T>;
-    |          ^
-  7 | }
-  8 |
-  9 | export class Check {"
-`;
-
 exports[`methods.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -413,10 +402,6 @@ class X {
     optionalMethod?() {}
 }
 
-interface Iterable<T> {
-  export [Symbol.iterator](): Iterator<T>;
-}
-
 export class Check {
   private static property = 'test';
 }
@@ -424,10 +409,6 @@ export class Check {
 =====================================output=====================================
 class X {
   optionalMethod?() {}
-}
-
-interface Iterable<T> {
-  export [Symbol.iterator](): Iterator<T>;
 }
 
 export class Check {

--- a/tests/format/typescript/class/jsfmt.spec.js
+++ b/tests/format/typescript/class/jsfmt.spec.js
@@ -1,3 +1,3 @@
 run_spec(import.meta, ["typescript"], {
-  errors: { "babel-ts": ["constructor.ts", "generics.ts", "methods.ts"] },
+  errors: { "babel-ts": ["constructor.ts", "generics.ts"] },
 });

--- a/tests/format/typescript/class/methods.ts
+++ b/tests/format/typescript/class/methods.ts
@@ -2,10 +2,6 @@ class X {
     optionalMethod?() {}
 }
 
-interface Iterable<T> {
-  export [Symbol.iterator](): Iterator<T>;
-}
-
 export class Check {
   private static property = 'test';
 }

--- a/tests/format/typescript/class/methods.ts
+++ b/tests/format/typescript/class/methods.ts
@@ -2,6 +2,10 @@ class X {
     optionalMethod?() {}
 }
 
+interface Iterable<T> {
+  [Symbol.iterator](): Iterator<T>;
+}
+
 export class Check {
   private static property = 'test';
 }

--- a/tests/format/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
@@ -661,23 +661,6 @@ const shouldFail: { important: boolean } = output.x.children;
 ================================================================================
 `;
 
-exports[`modifiersOnInterfaceIndexSignature1.ts format 1`] = `
-====================================options=====================================
-parsers: ["typescript"]
-printWidth: 80
-                                                                                | printWidth
-=====================================input======================================
-interface I {
-  public [a: string]: number;
-}
-=====================================output=====================================
-interface I {
-  public [a: string]: number;
-}
-
-================================================================================
-`;
-
 exports[`privacyGloImport.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
@@ -661,6 +661,24 @@ const shouldFail: { important: boolean } = output.x.children;
 ================================================================================
 `;
 
+exports[`modifiersOnInterfaceIndexSignature1.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+interface I {
+  [a: string]: number;
+}
+
+=====================================output=====================================
+interface I {
+  [a: string]: number;
+}
+
+================================================================================
+`;
+
 exports[`privacyGloImport.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/compiler/modifiersOnInterfaceIndexSignature1.ts
+++ b/tests/format/typescript/compiler/modifiersOnInterfaceIndexSignature1.ts
@@ -1,3 +1,0 @@
-interface I {
-  public [a: string]: number;
-}

--- a/tests/format/typescript/compiler/modifiersOnInterfaceIndexSignature1.ts
+++ b/tests/format/typescript/compiler/modifiersOnInterfaceIndexSignature1.ts
@@ -1,0 +1,3 @@
+interface I {
+  [a: string]: number;
+}


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

#9760

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
