### PR TITLE
Enable `regexp/prefer-lookaround` rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -169,6 +169,7 @@ module.exports = {
     ],
     "regexp/no-useless-lazy": "error",
     "regexp/no-useless-non-capturing-group": "error",
+    /* cspell:disable-next-line */
     "regexp/prefer-lookaround": [
       "error",
       {

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -169,6 +169,12 @@ module.exports = {
     ],
     "regexp/no-useless-lazy": "error",
     "regexp/no-useless-non-capturing-group": "error",
+    "regexp/prefer-lookaround": [
+      "error",
+      {
+        strictTypes: false,
+      },
+    ],
 
     // eslint-plugin-unicorn
     "unicorn/better-regex": "error",

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -295,7 +295,7 @@ function printNumber(rawNumber) {
     rawNumber
       .toLowerCase()
       // Remove unnecessary plus and zeroes from scientific notation.
-      .replace(/^([+-]?[\d.]+e)(?:\+|(-))?0*(\d)/, "$1$2$3")
+      .replace(/^([+-]?[\d.]+e)(?:\+|(-))?0*(?=\d)/, "$1$2")
       // Remove unnecessary scientific notation (1e0).
       .replace(/^([+-]?[\d.]+)e[+-]?0+$/, "$1")
       // Make sure numbers always start with a digit.

--- a/src/language-markdown/clean.js
+++ b/src/language-markdown/clean.js
@@ -53,7 +53,7 @@ function clean(ast, newObj, parent) {
       ast.type === "image") &&
     ast.title
   ) {
-    newObj.title = ast.title.replace(/\\(["')])/g, "$1");
+    newObj.title = ast.title.replace(/\\(?=["')])/g, "");
   }
 
   // for insert pragma

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -820,7 +820,7 @@ function printTitle(title, options, printSpace = true) {
   }
 
   // title is escaped after `remark-parse` v7
-  title = title.replace(/\\(["')])/g, "$1");
+  title = title.replace(/\\(?=["')])/g, "");
 
   if (title.includes('"') && title.includes("'") && !title.includes(")")) {
     return `(${title})`; // avoid escaped quotes

--- a/website/playground/index.js
+++ b/website/playground/index.js
@@ -53,7 +53,7 @@ function augmentOption(option) {
   option.cliName =
     "--" +
     (option.inverted ? "no-" : "") +
-    option.name.replace(/([a-z])([A-Z])/g, "$1-$2").toLowerCase();
+    option.name.replace(/(?<=[a-z])(?=[A-Z])/g, "-").toLowerCase();
 
   return option;
 }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

https://ota-meshi.github.io/eslint-plugin-regexp/rules/prefer-lookaround.html

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
