### PR TITLE
Fix union type should be printed in the multi-line variant when there are comments

### DIFF
--- a/changelog_unreleased/typescript/13860.md
+++ b/changelog_unreleased/typescript/13860.md
@@ -3,18 +3,15 @@
 <!-- prettier-ignore -->
 ```tsx
 // Input
-// BUG: everything gets shoved onto one line, including comments
 type FooBar = 
   | Number // this documents the first option
   | void // this documents the second option
   ;
 
 // Prettier stable
-// BUG: everything gets shoved onto one line, including comments
 type FooBar = Number | void; // this documents the first option // this documents the second option
 
 // Prettier main
-// BUG: everything gets shoved onto one line, including comments
 type FooBar =
   | Number // this documents the first option
   | void; // this documents the second option

--- a/changelog_unreleased/typescript/13860.md
+++ b/changelog_unreleased/typescript/13860.md
@@ -1,0 +1,21 @@
+#### Fix union type should be printed in the multi-line variant when there are comments (#13860 by @PerfectPan)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+// BUG: everything gets shoved onto one line, including comments
+type FooBar = 
+  | Number // this documents the first option
+  | void // this documents the second option
+  ;
+
+// Prettier stable
+// BUG: everything gets shoved onto one line, including comments
+type FooBar = Number | void; // this documents the first option // this documents the second option
+
+// Prettier main
+// BUG: everything gets shoved onto one line, including comments
+type FooBar =
+  | Number // this documents the first option
+  | void; // this documents the second option
+```

--- a/src/language-js/print/type-annotation.js
+++ b/src/language-js/print/type-annotation.js
@@ -16,6 +16,7 @@ import {
   hasLeadingOwnLineComment,
   isObjectTypePropertyAFunction,
   shouldPrintComma,
+  hasComment,
 } from "../utils/index.js";
 import { printAssignment } from "./assignment.js";
 import {
@@ -47,7 +48,9 @@ function shouldHugType(node) {
         node.type === "TSTypeReference"
     );
 
-    if (node.types.length - 1 === voidCount && hasObject) {
+    const hasComments = node.types.some((node) => hasComment(node));
+
+    if (node.types.length - 1 === voidCount && hasObject && !hasComments) {
       return true;
     }
   }

--- a/tests/format/typescript/union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/union/__snapshots__/jsfmt.spec.js.snap
@@ -50,12 +50,12 @@ interface RelayProps {
 interface RelayProps {
   articles: Array<{
     __id: string,
-  } | null> 
-  | null // articles type may be null 
+  } | null>
+  | null // articles type may be null
   | void, // articles type may be void
 }
 
-type FooBar = null // null 
+type FooBar = null // null
 | { /** x **/
   y: number;
   z: string;
@@ -69,6 +69,11 @@ type FooBarWithoutComment = null
   z: string;
 }
   | void
+  ;
+
+type FooBar2 =
+  | Number // this documents the first option
+  | void // this documents the second option
   ;
 
 type UploadState<E, EM, D>
@@ -135,6 +140,10 @@ type FooBarWithoutComment = null | {
   y: number;
   z: string;
 } | void;
+
+type FooBar2 =
+  | Number // this documents the first option
+  | void; // this documents the second option
 
 type UploadState<E, EM, D> =
   // The upload hasnt begun yet

--- a/tests/format/typescript/union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/union/__snapshots__/jsfmt.spec.js.snap
@@ -47,6 +47,30 @@ interface RelayProps {
   } | null> | null | void,
 }
 
+interface RelayProps {
+  articles: Array<{
+    __id: string,
+  } | null> 
+  | null // articles type may be null 
+  | void, // articles type may be void
+}
+
+type FooBar = null // null 
+| { /** x **/
+  y: number;
+  z: string;
+} // this documents the first option
+  | void // this documents the second option
+  ;
+
+type FooBarWithoutComment = null
+  | {
+  y: number;
+  z: string;
+}
+  | void
+  ;
+
 type UploadState<E, EM, D>
   // The upload hasnt begun yet
   = {type: "Not_begun"}
@@ -89,6 +113,28 @@ interface RelayProps {
     __id: string;
   } | null> | null | void;
 }
+
+interface RelayProps {
+  articles:
+    | Array<{
+        __id: string;
+      } | null>
+    | null // articles type may be null
+    | void; // articles type may be void
+}
+
+type FooBar =
+  | null // null
+  | {
+      /** x **/ y: number;
+      z: string;
+    } // this documents the first option
+  | void; // this documents the second option
+
+type FooBarWithoutComment = null | {
+  y: number;
+  z: string;
+} | void;
 
 type UploadState<E, EM, D> =
   // The upload hasnt begun yet

--- a/tests/format/typescript/union/inlining.ts
+++ b/tests/format/typescript/union/inlining.ts
@@ -10,12 +10,12 @@ interface RelayProps {
 interface RelayProps {
   articles: Array<{
     __id: string,
-  } | null> 
-  | null // articles type may be null 
+  } | null>
+  | null // articles type may be null
   | void, // articles type may be void
 }
 
-type FooBar = null // null 
+type FooBar = null // null
 | { /** x **/
   y: number;
   z: string;
@@ -29,6 +29,11 @@ type FooBarWithoutComment = null
   z: string;
 }
   | void
+  ;
+
+type FooBar2 =
+  | Number // this documents the first option
+  | void // this documents the second option
   ;
 
 type UploadState<E, EM, D>

--- a/tests/format/typescript/union/inlining.ts
+++ b/tests/format/typescript/union/inlining.ts
@@ -7,6 +7,30 @@ interface RelayProps {
   } | null> | null | void,
 }
 
+interface RelayProps {
+  articles: Array<{
+    __id: string,
+  } | null> 
+  | null // articles type may be null 
+  | void, // articles type may be void
+}
+
+type FooBar = null // null 
+| { /** x **/
+  y: number;
+  z: string;
+} // this documents the first option
+  | void // this documents the second option
+  ;
+
+type FooBarWithoutComment = null
+  | {
+  y: number;
+  z: string;
+}
+  | void
+  ;
+
 type UploadState<E, EM, D>
   // The upload hasnt begun yet
   = {type: "Not_begun"}


### PR DESCRIPTION
## Description

Fix the problem that type should not be considered as hug type when there are comments (#13858)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
