### PR TITLE
Update eslint-plugin-regexp to v1.11.0

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -159,6 +159,7 @@ module.exports = {
         allows: ["dotAll"],
       },
     ],
+    /* cspell:disable-next-line */
     "regexp/no-extra-lookaround-assertions": "error",
     "regexp/no-missing-g-flag": "error",
     "regexp/no-unused-capturing-group": "error",

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -159,8 +159,10 @@ module.exports = {
         allows: ["dotAll"],
       },
     ],
+    "regexp/no-extra-lookaround-assertions": "error",
     "regexp/no-missing-g-flag": "error",
     "regexp/no-unused-capturing-group": "error",
+    "regexp/no-useless-assertions": "error",
     "regexp/no-useless-flag": [
       "error",
       {

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "eslint-plugin-n": "15.5.1",
     "eslint-plugin-prettier-internal-rules": "2.0.1",
     "eslint-plugin-react": "7.31.11",
-    "eslint-plugin-regexp": "1.10.0",
+    "eslint-plugin-regexp": "1.11.0",
     "eslint-plugin-unicorn": "45.0.0",
     "esm-utils": "4.1.0",
     "execa": "6.1.0",

--- a/src/language-js/embed/html.js
+++ b/src/language-js/embed/html.js
@@ -55,7 +55,7 @@ async function embedHtmlLike(parser, textToDoc, print, path, options) {
         if (component) {
           component = uncookTemplateElementValue(component);
           if (options.__embeddedInHtml) {
-            component = component.replaceAll(/<\/(script)\b/gi, "<\\/$1");
+            component = component.replaceAll(/<\/(?=script\b)/gi, "<\\/");
           }
           parts.push(component);
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3489,9 +3489,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-regexp@npm:1.10.0":
-  version: 1.10.0
-  resolution: "eslint-plugin-regexp@npm:1.10.0"
+"eslint-plugin-regexp@npm:1.11.0":
+  version: 1.11.0
+  resolution: "eslint-plugin-regexp@npm:1.11.0"
   dependencies:
     comment-parser: ^1.1.2
     eslint-utils: ^3.0.0
@@ -3503,7 +3503,7 @@ __metadata:
     scslre: ^0.1.6
   peerDependencies:
     eslint: ">=6.0.0"
-  checksum: 27bb500e3135d749b794cceed238092777036c959e597a7872274792ce0bfa3d320e79ad33c744464e714d0827a83155e611455f8ef1c9c94d889f7ee945bf74
+  checksum: 8165a2beca4d4dc276e297fd4e93e6db25ec0044c2e09766281bd5fdbf0e5bc858521d40761e53f90198f709a739a0b7818441402a81010bb3886c2f6582b50b
   languageName: node
   linkType: hard
 
@@ -6737,7 +6737,7 @@ __metadata:
     eslint-plugin-n: 15.5.1
     eslint-plugin-prettier-internal-rules: 2.0.1
     eslint-plugin-react: 7.31.11
-    eslint-plugin-regexp: 1.10.0
+    eslint-plugin-regexp: 1.11.0
     eslint-plugin-unicorn: 45.0.0
     esm-utils: 4.1.0
     espree: 9.4.1


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

https://github.com/ota-meshi/eslint-plugin-regexp/releases/tag/v1.11.0
[regexp/no-extra-lookaround-assertions](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-extra-lookaround-assertions.html)
[regexp/no-useless-assertions](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-assertions.html)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
