### PR TITLE
Remove an empty `String#replace` call

### DIFF
--- a/src/language-css/clean.js
+++ b/src/language-css/clean.js
@@ -74,7 +74,7 @@ function clean(ast, newObj, parent) {
     (ast.type === "value-word" &&
       ((ast.isColor && ast.isHex) ||
         ["initial", "inherit", "unset", "revert"].includes(
-          newObj.value.replace().toLowerCase()
+          newObj.value.toLowerCase()
         ))) ||
     ast.type === "media-feature" ||
     ast.type === "selector-root-invalid" ||


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
