### PR TITLE
Skip measure width of last string in `printDocToString`

### DIFF
--- a/src/document/printer.js
+++ b/src/document/printer.js
@@ -320,6 +320,7 @@ function printDocToString(doc, options) {
         const formatted =
           newLine !== "\n" ? doc.replaceAll("\n", newLine) : doc;
         out.push(formatted);
+        // Plugins may print single string, should skip measure the width
         if (cmds.length > 0) {
           pos += getStringWidth(formatted);
         }

--- a/src/document/printer.js
+++ b/src/document/printer.js
@@ -320,7 +320,9 @@ function printDocToString(doc, options) {
         const formatted =
           newLine !== "\n" ? doc.replaceAll("\n", newLine) : doc;
         out.push(formatted);
-        pos += getStringWidth(formatted);
+        if (cmds.length > 0) {
+          pos += getStringWidth(formatted);
+        }
         break;
       }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Plugins like `@prettier/plugin-pug` prints a big string instead of doc commands, it cost time when measuring width.
Ideally it should only measure the last line, or even better should measure from `out` when use the `pos`, we should improve it in future.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
