### PR TITLE
test: format instantiation expr in logical expr

### DIFF
--- a/tests/format/typescript/instantiation-expression/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/instantiation-expression/__snapshots__/jsfmt.spec.js.snap
@@ -54,6 +54,39 @@ interface Example {
 ================================================================================
 `;
 
+exports[`logical-expr.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export class Foo<T> {
+  message: string;
+}
+
+function sample(error: unknown) {
+  if (!(error instanceof Foo<'some-type'> || error instanceof Error) || !error.message) {
+    return 'something';
+  }
+}
+
+=====================================output=====================================
+export class Foo<T> {
+  message: string;
+}
+
+function sample(error: unknown) {
+  if (
+    !(error instanceof Foo<"some-type"> || error instanceof Error) ||
+    !error.message
+  ) {
+    return "something";
+  }
+}
+
+================================================================================
+`;
+
 exports[`new.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/instantiation-expression/logical-expr.ts
+++ b/tests/format/typescript/instantiation-expression/logical-expr.ts
@@ -1,0 +1,9 @@
+export class Foo<T> {
+  message: string;
+}
+
+function sample(error: unknown) {
+  if (!(error instanceof Foo<'some-type'> || error instanceof Error) || !error.message) {
+    return 'something';
+  }
+}


### PR DESCRIPTION
## Description

- added test for formating logical expression with instantiation expression (#13856)

Close #13856

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
