### PR TITLE
Move cursor tracking from `printComments` to `printAstToDoc`

### DIFF
--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -1,5 +1,10 @@
 import AstPath from "../common/ast-path.js";
-import { hardline, addAlignmentToDoc } from "../document/builders.js";
+import {
+  hardline,
+  addAlignmentToDoc,
+  cursor,
+  label,
+} from "../document/builders.js";
 import { propagateBreaks } from "../document/utils.js";
 import { printComments } from "./comments.js";
 import { printEmbeddedLanguages } from "./multiparser.js";
@@ -146,6 +151,15 @@ function callPluginPrintFunction(path, options, printPath, args, embeds) {
     // printComments will call the plugin print function and check for
     // comments to print
     doc = printComments(path, doc, options, printedComments);
+  }
+
+  if (node === options.cursorNode) {
+    doc = label(
+      // Propagate object labels so that the printing logic for ancestor nodes
+      // could easily check them.
+      typeof doc.label === "object" && { commented: true, ...doc.label },
+      [cursor, doc, cursor]
+    );
   }
 
   return doc;

--- a/src/main/comments.js
+++ b/src/main/comments.js
@@ -6,7 +6,6 @@ import {
   indent,
   lineSuffix,
   join,
-  cursor,
   label,
 } from "../document/builders.js";
 import {
@@ -539,11 +538,9 @@ function printCommentsSeparately(path, options, ignored) {
   if (ignored) {
     comments = comments.filter((comment) => !ignored.has(comment));
   }
-  const isCursorNode = value === options.cursorNode;
 
   if (comments.length === 0) {
-    const maybeCursor = isCursorNode ? cursor : "";
-    return { leading: maybeCursor, trailing: maybeCursor };
+    return { leading: "", trailing: "" };
   }
 
   const leadingParts = [];
@@ -567,11 +564,6 @@ function printCommentsSeparately(path, options, ignored) {
       trailingParts.push(printedTrailingComment.doc);
     }
   }, "comments");
-
-  if (isCursorNode) {
-    leadingParts.unshift(cursor);
-    trailingParts.push(cursor);
-  }
 
   return { leading: leadingParts, trailing: trailingParts };
 }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

So we can still track cursorOffset even node `willPrintOwnComments`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
