### PR TITLE
Improve `cursorNode` find logic

### DIFF
--- a/src/language-css/loc.js
+++ b/src/language-css/loc.js
@@ -232,11 +232,11 @@ function replaceQuotesInInlineComments(text) {
 }
 
 function locStart(node) {
-  return node.source.startOffset;
+  return node.source?.startOffset;
 }
 
 function locEnd(node) {
-  return node.source.endOffset;
+  return node.source?.endOffset;
 }
 
 export { locStart, locEnd, calculateLoc, replaceQuotesInInlineComments };

--- a/src/language-js/parse/postprocess/index.js
+++ b/src/language-js/parse/postprocess/index.js
@@ -150,6 +150,11 @@ function postprocess(ast, options) {
     }
   }
 
+  // In `typescript`/`espree`/`flow`, `Program` doesn't count whitespace and comments
+  // See https://github.com/eslint/espree/issues/488
+  if (ast.type === "Program") {
+    ast.range = [0, options.originalText.length];
+  }
   return ast;
 
   /**

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -14,7 +14,8 @@ import massageAst from "./massage-ast.js";
 import { ensureAllCommentsPrinted, attach } from "./comments.js";
 import { parse, resolveParser } from "./parser.js";
 import printAstToDoc from "./ast-to-doc.js";
-import { calculateRange, findNodeAtOffset } from "./range-util.js";
+import { calculateRange } from "./range-util.js";
+import getCursorNode from "./get-cursor-node.js";
 
 const BOM = "\uFEFF";
 
@@ -40,10 +41,7 @@ async function coreFormat(originalText, opts, addAlignmentSize = 0) {
   const { ast, text } = await parse(originalText, opts);
 
   if (opts.cursorOffset >= 0) {
-    const nodeResult = findNodeAtOffset(ast, opts.cursorOffset, opts);
-    if (nodeResult?.node) {
-      opts.cursorNode = nodeResult.node;
-    }
+    opts.cursorNode = getCursorNode(ast, opts);
   }
 
   const astComments = attachComments(text, ast, opts);

--- a/src/main/get-cursor-node.js
+++ b/src/main/get-cursor-node.js
@@ -1,0 +1,41 @@
+import createGetVisitorKeysFunction from "./create-get-visitor-keys-function.js";
+
+function getCursorNode(ast, options) {
+  const { cursorOffset, locStart, locEnd } = options;
+
+  const getVisitorKeys = createGetVisitorKeysFunction(
+    options.printer.getVisitorKeys
+  );
+
+  const nodes = getChildren(ast, {
+    getVisitorKeys,
+    comparator(nodeA, nodeB) {
+      const lengthA = locEnd(nodeA) - locStart(nodeA);
+      const lengthB = locEnd(nodeB) - locStart(nodeB);
+      return lengthA - lengthB;
+    },
+    containsCursor(node) {
+      return locStart(node) <= cursorOffset && locEnd(node) >= cursorOffset;
+    },
+  });
+
+  return nodes[0] ?? ast;
+}
+
+function getChildren(node, options) {
+  if (
+    !(node !== null && typeof node === "object" && options.containsCursor(node))
+  ) {
+    return [];
+  }
+
+  return [
+    ...options
+      .getVisitorKeys(node)
+      .flatMap((key) => node[key])
+      .flatMap((node) => getChildren(node, options)),
+    node,
+  ].sort(options.comparator);
+}
+
+export default getCursorNode;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Before this change, it use `findNodeAtOffset` it checkes `canAttachComment` and `isSourceElement`, cursorNode should not care.
After this change, the `cursorNode` can be the most inside node, will make the "cursorNodeText" smaller and easier to locate new cursor.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
