### PR TITLE
[handlebars] allow custom "else if"-like with block params

### DIFF
--- a/changelog_unreleased/handlebars/13930.md
+++ b/changelog_unreleased/handlebars/13930.md
@@ -1,0 +1,42 @@
+#### Allow custom "else if"-like blocks with block params (#13930 by @jamescdavis)
+
+#13507 added support for custom block keywords used with `else`, but failed to allow block params. This updates printer-glimmer to allow block params with custom "else if"-like blocks.
+
+<!-- prettier-ignore -->
+```hbs
+{{! Input }}
+{#when isAtWork as |work|}}
+  Ship that
+  {{work}}!
+{{else when isReading as |book|}}
+  You can finish
+  {{book}}
+  eventually...
+{{else}}
+  Go to bed!
+{{/when}}
+
+{{! Prettier stable }}
+{{#when isAtWork as |work|}}
+  Ship that
+  {{work}}!
+{{else when isReading}}
+  You can finish
+  {{book}}
+  eventually...
+{{else}}
+  Go to bed!
+{{/when}}
+
+{{! Prettier main }}
+{#when isAtWork as |work|}}
+  Ship that
+  {{work}}!
+{{else when isReading as |book|}}
+  You can finish
+  {{book}}
+  eventually...
+{{else}}
+  Go to bed!
+{{/when}}
+```

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -567,20 +567,24 @@ function printElseIfLikeBlock(path, print, ifLikeKeyword) {
   let blockParams = [];
 
   if (isNonEmptyArray(node.program.blockParams)) {
-    blockParams = [" ", ...printBlockParams(node.program)];
+    blockParams = [line, printBlockParams(node.program)];
   }
 
   const parentNode = path.getParentNode(1);
 
-  return [
+  return group([
     printInverseBlockOpeningMustache(parentNode),
-    "else ",
-    ifLikeKeyword,
-    " ",
-    printParams(path, print),
-    ...blockParams,
+    indent(
+      group([
+        group(["else", line, ifLikeKeyword]),
+        line,
+        printParams(path, print),
+      ])
+    ),
+    indent(blockParams),
+    softline,
     printInverseBlockClosingMustache(parentNode),
-  ];
+  ]);
 }
 
 function printCloseBlock(path, print, options) {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -563,6 +563,13 @@ function printElseBlock(node, options) {
 }
 
 function printElseIfLikeBlock(path, print, ifLikeKeyword) {
+  const node = path.getValue();
+  let blockParams = [];
+
+  if (isNonEmptyArray(node.program.blockParams)) {
+    blockParams = [" ", ...printBlockParams(node.program)];
+  }
+
   const parentNode = path.getParentNode(1);
 
   return [
@@ -571,6 +578,7 @@ function printElseIfLikeBlock(path, print, ifLikeKeyword) {
     ifLikeKeyword,
     " ",
     printParams(path, print),
+    ...blockParams,
     printInverseBlockClosingMustache(parentNode),
   ];
 }

--- a/tests/format/handlebars/block-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/handlebars/block-statement/__snapshots__/jsfmt.spec.js.snap
@@ -286,6 +286,14 @@ printWidth: 80
   j
 {{/when}}
 
+{{#when abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst as |b|}}
+  {{b}}
+{{else when abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnop as |d|}}
+  {{d}}
+{{else when abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz as |f|}}
+  {{f}}
+{{/when}}
+
 =====================================output=====================================
 <h1>
   {{#when isAtWork}}
@@ -404,6 +412,22 @@ printWidth: 80
   {{h}}
 {{else}}
   j
+{{/when}}
+
+{{#when
+  abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst
+  as |b|
+}}
+  {{b}}
+{{else when abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnop
+  as |d|
+}}
+  {{d}}
+{{else when
+  abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz
+  as |f|
+}}
+  {{f}}
 {{/when}}
 ================================================================================
 `;

--- a/tests/format/handlebars/block-statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/handlebars/block-statement/__snapshots__/jsfmt.spec.js.snap
@@ -274,6 +274,18 @@ printWidth: 80
   Another thing
 {{~/when~}}
 
+{{#when a as |b|}}
+  {{b}}
+{{else when c as |d|}}
+  {{d}}
+{{else when e as |f|}}
+  {{f}}
+{{else when g as |h|}}
+  {{h}}
+{{else}}
+  j
+{{/when}}
+
 =====================================output=====================================
 <h1>
   {{#when isAtWork}}
@@ -381,6 +393,18 @@ printWidth: 80
 {{~else when anotherCondition~}}
   Another thing
 {{~/when~}}
+
+{{#when a as |b|}}
+  {{b}}
+{{else when c as |d|}}
+  {{d}}
+{{else when e as |f|}}
+  {{f}}
+{{else when g as |h|}}
+  {{h}}
+{{else}}
+  j
+{{/when}}
 ================================================================================
 `;
 

--- a/tests/format/handlebars/block-statement/custom-else.hbs
+++ b/tests/format/handlebars/block-statement/custom-else.hbs
@@ -118,3 +118,11 @@
 {{else}}
   j
 {{/when}}
+
+{{#when abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrst as |b|}}
+  {{b}}
+{{else when abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnop as |d|}}
+  {{d}}
+{{else when abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz as |f|}}
+  {{f}}
+{{/when}}

--- a/tests/format/handlebars/block-statement/custom-else.hbs
+++ b/tests/format/handlebars/block-statement/custom-else.hbs
@@ -106,3 +106,15 @@
 {{~else when anotherCondition~}}
   Another thing
 {{~/when~}}
+
+{{#when a as |b|}}
+  {{b}}
+{{else when c as |d|}}
+  {{d}}
+{{else when e as |f|}}
+  {{f}}
+{{else when g as |h|}}
+  {{h}}
+{{else}}
+  j
+{{/when}}


### PR DESCRIPTION
## Description

This is a follow-up to #13507 to allow block params in custom "else if"-like blocks.

```hbs
{{! Input }}
{{#when isAtWork as |work|}}
  Ship that
  {{work}}!
{{else when isReading as |book|}}
  You can finish
  {{book}}
  eventually...
{{else}}
  Go to bed!
{{/when}}

{{! Prettier stable }}
{{#when isAtWork as |work|}}
  Ship that
  {{work}}!
{{else when isReading}}
  You can finish
  {{book}}
  eventually...
{{else}}
  Go to bed!
{{/when}}

{{! Prettier main }}
{{#when isAtWork as |work|}}
  Ship that
  {{work}}!
{{else when isReading as |book|}}
  You can finish
  {{book}}
  eventually...
{{else}}
  Go to bed!
{{/when}}
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~~
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**

```
--parser glimmer
```

CC: @dcyriller