### PR TITLE
fix: preserve empty lines between nested SCSS maps

### DIFF
--- a/changelog_unreleased/scss/13931.md
+++ b/changelog_unreleased/scss/13931.md
@@ -1,4 +1,4 @@
-#### fix: preserve empty lines between scss nested maps (#13931 by @jneander)
+#### Preserve empty lines between scss nested maps (#13931 by @jneander)
 
 <!-- prettier-ignore -->
 ```scss

--- a/changelog_unreleased/scss/13931.md
+++ b/changelog_unreleased/scss/13931.md
@@ -1,0 +1,36 @@
+#### fix: preserve empty lines between scss nested maps (#13931 by @jneander)
+
+<!-- prettier-ignore -->
+```scss
+/* Input */
+$map: (
+  'one': (
+     'key': 'value',
+  ),
+
+  'two': (
+     'key': 'value',
+  ),
+)
+
+/* Prettier stable */
+$map: (
+  'one': (
+     'key': 'value',
+  ),
+  'two': (
+     'key': 'value',
+  ),
+)
+
+/* Prettier main */
+$map: (
+  'one': (
+     'key': 'value',
+  ),
+
+  'two': (
+     'key': 'value',
+  ),
+)
+```

--- a/changelog_unreleased/scss/13931.md
+++ b/changelog_unreleased/scss/13931.md
@@ -1,4 +1,4 @@
-#### Preserve empty lines between scss nested maps (#13931 by @jneander)
+#### Preserve empty lines between nested SCSS maps (#13931 by @jneander)
 
 <!-- prettier-ignore -->
 ```scss

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -918,7 +918,8 @@ function genericPrint(path, options, print) {
               path.map((childPath, index) => {
                 const child = childPath.getValue();
                 const isLast = index === node.groups.length - 1;
-                const printed = [print(), isLast ? "" : ","];
+
+                let printed = [print(), isLast ? "" : ","];
 
                 // Key/Value pair in open paren already indented
                 if (
@@ -931,7 +932,7 @@ function genericPrint(path, options, print) {
                 ) {
                   const parts = getDocParts(printed[0].contents.contents);
                   parts[1] = group(parts[1]);
-                  return group(dedent(printed));
+                  printed = [group(dedent(printed))];
                 }
 
                 if (
@@ -939,9 +940,14 @@ function genericPrint(path, options, print) {
                   child.type === "value-comma_group" &&
                   isNonEmptyArray(child.groups)
                 ) {
-                  const last = getLast(child.groups);
+                  let last = getLast(child.groups);
+
+                  // `value-paren_group` does not have location info, but its closing parenthesis does.
+                  if (!last.source && last.close) {
+                    last = last.close;
+                  }
+
                   if (
-                    // `value-paren_group` missing location info
                     last.source &&
                     isNextLineEmpty(options.originalText, last, locEnd)
                   ) {

--- a/tests/format/scss/parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/scss/parens/__snapshots__/jsfmt.spec.js.snap
@@ -28,6 +28,7 @@ $icons: (
     left: 253,
     top: 73,
   ),
+
   /* Should preserve empty lines */ cal-week-group:
     (
       left: 1,


### PR DESCRIPTION
## Description

Empty lines between SCSS maps nested within other maps are not being preserved by prettier. This resolves that.

No issue was found for this particular bug. As a reference, it relates to #12536, which mentioned the issue via code comment and in the pull request.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
