### PR TITLE
Add type checking to Prettier JS config example

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,13 +33,17 @@ JSON:
 JS:
 
 ```js
-// prettier.config.js or .prettierrc.js
-module.exports = {
+// prettier.config.js or .prettierrc.js - install @types/prettier if you want type checking
+
+/** @type {import('prettier').Options} */
+const config = {
   trailingComma: "es5",
   tabWidth: 4,
   semi: false,
   singleQuote: true,
 };
+
+module.exports = config;
 ```
 
 YAML:


### PR DESCRIPTION
Hi, long time no see Prettier team! As always, thanks for your continued effort here 🙌

## Description

The config example using JS does not include types, nor an example of where to get those types (see also https://github.com/prettier/prettier/pull/13896#discussion_r1032830756)

This unfortunately does not work with `module.exports = <object>`, because of https://github.com/microsoft/TypeScript/issues/51819:

<img width="342" alt="Screenshot 2022-12-08 at 13 18 36" src="https://user-images.githubusercontent.com/1935696/206445974-01e3dd52-d311-48f4-bc6e-303badfcd80f.png">

So using the common pattern of setting a `config` constant to enable this checking:

<img width="380" alt="Screenshot 2022-12-08 at 13 18 54" src="https://user-images.githubusercontent.com/1935696/206446059-e902774b-bfda-4e66-bbb2-6afba08a638d.png">

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**

cc @kachkaev @fisker 