### PR TITLE
fix(markdown): mark unordered lists as unaligned.

### DIFF
--- a/src/language-markdown/print-preprocess.js
+++ b/src/language-markdown/print-preprocess.js
@@ -192,7 +192,7 @@ function markAlignedList(ast, options) {
        * - 123
        * - 123
        */
-      return true;
+      return false;
     }
 
     const [firstItem, secondItem] = list.children;


### PR DESCRIPTION
## Description

Marking all unordered and task lists as aligned is causing unsightly behavior with the Markdown printer. With the Prettier default tab size of 2, everything looks normal and unchanged, but as soon as the tab size is set larger than that, excessive space is added between the list marker and the text:

```Markdown
-   Extra space
    -   lining up these bulleted lists with the tabs does more:
        -   harm
        -   than
        -   good
-   [ ] TODO
    -   [ ] Fix this by setting non-ordered lists to unaligned
-   [x] Do an example where you mix the two.
    -   oh yeah
    -   that's better

```

By marking all unordered lists as unaligned, they will retain one space between the marker and the text, staying closer to the Markdown spec and restoring just a bit of my sanity. I've also seen a few cases where lists formatted with extra spaces being improperly indented or losing their list-iness all together.

PS. I hope I got the commit msg format right. I'm new to conventional commits.

## Checklist

- [x] Does not affect any tests or documentation as far as I can tell.

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**

Edit: ran code example through Prettier Playground to ensure it is properly broken.
