### PR TITLE
Fix no space after unary minus when followed by opening parenthesis in LESS

### DIFF
--- a/changelog_unreleased/less/14008.md
+++ b/changelog_unreleased/less/14008.md
@@ -1,0 +1,43 @@
+#### Fix no space after unary minus when followed by opening parenthesis in LESS (#14008 by @mvorisek)
+
+<!-- prettier-ignore -->
+```less
+// Input
+.unary_minus_single {
+  margin: -(@a);
+}
+
+.unary_minus_multi {
+  margin: 0 -(@a);
+}
+
+.binary_minus {
+  margin: 0 - (@a);
+}
+
+// Prettier stable
+.unary_minus_single {
+  margin: - (@a);
+}
+
+.unary_minus_multi {
+  margin: 0 - (@a);
+}
+
+.binary_minus {
+  margin: 0 - (@a);
+}
+
+// Prettier main
+.unary_minus_single {
+  margin: -(@a);
+}
+
+.unary_minus_multi {
+  margin: 0 -(@a);
+}
+
+.binary_minus {
+  margin: 0 - (@a);
+}
+```

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -744,6 +744,18 @@ function genericPrint(path, options, print) {
           continue;
         }
 
+        // No space before unary minus followed by an opening parenthesis `-(`
+        if (
+          (options.parser === "scss" || options.parser === "less") &&
+          isMathOperator &&
+          iNode.value === "-" &&
+          isParenGroupNode(iNextNode) &&
+          locEnd(iNode) === locStart(iNextNode.open) &&
+          iNextNode.open.value === "("
+        ) {
+          continue;
+        }
+
         // Add `hardline` after inline comment (i.e. `// comment\n foo: bar;`)
         if (isInlineValueCommentNode(iNode)) {
           if (parentNode.type === "value-paren_group") {

--- a/tests/format/less/parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/less/parens/__snapshots__/jsfmt.spec.js.snap
@@ -302,6 +302,23 @@ a {
     unicode-range: U+0025-00FF, U+4??; /* multiple values */
 }
 
+// no space after unary minus when followed by opening parenthesis, #13998
+.unary_minus_single {
+  margin: -(@a);
+}
+
+.unary_minus_multi_1 {
+  margin: 0 -(@a);
+}
+
+.unary_minus_multi_2 {
+  margin: 0  -( @a + @b );
+}
+
+.binary_minus {
+  margin: 0 - (@a);
+}
+
 =====================================output=====================================
 a {
   prop1: func(1px, 1px, 1px, func(1px, 1px, 1px, func(1px, 1px, 1px)));
@@ -365,7 +382,7 @@ a {
   background: element(#css-source);
   padding-top: var(--paddingC);
   margin: 1 * 1 (1) * 1 1 * (1) (1) * (1);
-  prop: -1 * -1 - (-1) * -1 -1 * -(-1) - (-1) * -(-1);
+  prop: -1 * -1 -(-1) * -1 -1 * -(-1) -(-1) * -(-1);
   prop4: +1;
   prop5: -1;
   prop6: word + 1; /* word1 */
@@ -396,7 +413,7 @@ a {
   prop41: --(1);
   prop42: 1px+1px+1px+1px;
   prop43: 1px + 1px + 1px + 1px;
-  prop44: -1+-1 - (-1)+-1 -1+-(-1) - (-1)+-(-1);
+  prop44: -1+-1 -(-1)+-1 -1+-(-1) -(-1)+-(-1);
   prop45: round(1.5) * 2 round(1.5) * 2 round(1.5) * 2 round(1.5) * 2;
   prop46: 2 * round(1.5) 2 * round(1.5) 2 * round(1.5) 2 * round(1.5);
   prop47: (round(1.5) * 2) (round(1.5) * 2) (round(1.5) * 2) (round(1.5) * 2);
@@ -470,6 +487,23 @@ a {
   unicode-range: U+0025-00FF; /* codepoint range */
   unicode-range: U+4??; /* wildcard range */
   unicode-range: U+0025-00FF, U+4??; /* multiple values */
+}
+
+// no space after unary minus when followed by opening parenthesis, #13998
+.unary_minus_single {
+  margin: -(@a);
+}
+
+.unary_minus_multi_1 {
+  margin: 0 -(@a);
+}
+
+.unary_minus_multi_2 {
+  margin: 0 -(@a + @b);
+}
+
+.binary_minus {
+  margin: 0 - (@a);
 }
 
 ================================================================================

--- a/tests/format/less/parens/parens.less
+++ b/tests/format/less/parens/parens.less
@@ -259,3 +259,20 @@ a {
     unicode-range: U+4??;              /* wildcard range */
     unicode-range: U+0025-00FF, U+4??; /* multiple values */
 }
+
+// no space after unary minus when followed by opening parenthesis, #13998
+.unary_minus_single {
+  margin: -(@a);
+}
+
+.unary_minus_multi_1 {
+  margin: 0 -(@a);
+}
+
+.unary_minus_multi_2 {
+  margin: 0  -( @a + @b );
+}
+
+.binary_minus {
+  margin: 0 - (@a);
+}

--- a/tests/format/scss/parens/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/scss/parens/__snapshots__/jsfmt.spec.js.snap
@@ -418,10 +418,10 @@ a {
   );
   padding-top: var(--paddingC);
   margin: 1 * 1 (1) * 1 1 * (1) (1) * (1);
-  prop: -1 * -1 - (-1) * -1 -1 * -(-1) - (-1) * -(-1);
+  prop: -1 * -1 -(-1) * -1 -1 * -(-1) -(-1) * -(-1);
   prop1: #{($m) * (10)};
   prop2: #{$m * 10};
-  prop3: #{- (-$m) * -(-10)};
+  prop3: #{-(-$m) * -(-10)};
   prop4: +1;
   prop5: -1;
   prop6: word + 1; /* word1 */
@@ -469,7 +469,7 @@ a {
   prop41: --(1);
   prop42: 1px+1px+1px+1px;
   prop43: 1px + 1px + 1px + 1px;
-  prop44: -1+-1 - (-1)+-1 -1+-(-1) - (-1)+-(-1);
+  prop44: -1+-1 -(-1)+-1 -1+-(-1) -(-1)+-(-1);
   prop45: round(1.5) * 2 round(1.5) * 2 round(1.5) * 2 round(1.5) * 2;
   prop46: 2 * round(1.5) 2 * round(1.5) 2 * round(1.5) 2 * round(1.5);
   prop47: (round(1.5) * 2) (round(1.5) * 2) (round(1.5) * 2) (round(1.5) * 2);


### PR DESCRIPTION
## Description

Fix #13998.

Less online compiler https://lesscss.org/less-preview/ can be used to verify, added space can change the meaning of the data.

The problem is solely with `-`, `+` is not supported by less before `(`.

Also solely for LESS/SCSS, as regular CSS supports calculations only inside `calc()` where space has no special meaning.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [X] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**