### PR TITLE
Do not change case of property name if inside a variable declaration in LESS

### DIFF
--- a/changelog_unreleased/less/14034.md
+++ b/changelog_unreleased/less/14034.md
@@ -1,0 +1,19 @@
+#### Do not change case of property name if inside a variable declaration in LESS (#14034 by @mvorisek)
+
+<!-- prettier-ignore -->
+```less
+// Input
+@var: {
+  preserveCase: 0;
+};
+
+// Prettier stable
+@var: {
+  preservecase: 0;
+};
+
+// Prettier main
+@var: {
+  preserveCase: 0;
+};
+```

--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -492,13 +492,21 @@ function parseNestedCSS(node, options) {
           node.params[0] === ":"
         ) {
           node.variable = true;
-          node.value = parseValue(node.params.slice(1), options);
+          const text = node.params.slice(1);
+          if (text) {
+            node.value = parseValue(text, options);
+          }
           node.raws.afterName += ":";
         }
 
         // Less variable
         if (node.variable) {
           delete node.params;
+
+          if (!node.value) {
+            delete node.value;
+          }
+
           return node;
         }
       }

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -155,7 +155,12 @@ function genericPrint(path, options, print) {
 
       return [
         node.raws.before.replace(/[\s;]/g, ""),
-        insideICSSRuleNode(path) ? node.prop : maybeToLowerCase(node.prop),
+        (parentNode.type === "css-atrule" &&
+          typeof parentNode.raws.params === "string" &&
+          parentNode.raws.params.startsWith(":")) ||
+        insideICSSRuleNode(path)
+          ? node.prop
+          : maybeToLowerCase(node.prop),
         trimmedBetween.startsWith("//") ? " " : "",
         trimmedBetween,
         node.extend ? "" : " ",

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -155,9 +155,8 @@ function genericPrint(path, options, print) {
 
       return [
         node.raws.before.replace(/[\s;]/g, ""),
-        (parentNode.type === "css-atrule" &&
-          typeof parentNode.raws.params === "string" &&
-          parentNode.raws.params.startsWith(":")) ||
+        // Less variable
+        (parentNode.type === "css-atrule" && parentNode.variable) ||
         insideICSSRuleNode(path)
           ? node.prop
           : maybeToLowerCase(node.prop),

--- a/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
@@ -416,7 +416,7 @@ printWidth: 80
 };
 
 @var: /* comment */ {
-  preservecase: 5;
+  preserveCase: 5;
 };
 
 @var: /* comment */ {
@@ -424,7 +424,7 @@ printWidth: 80
 };
 
 @var: {
-  preservecase: 5;
+  preserveCase: 5;
 };
 
 @var // comment

--- a/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
@@ -380,8 +380,12 @@ printWidth: 80
 };
 
 @not-var {
-  notVar: @var[@notVarNested][notVar];
-  notVar2: @var[notVar];
+  shouldNotChangeCase: @var[@notVarNested][notVar];
+  shouldNotChangeCase: @var[    @notVarNested][notVar];
+  shouldNotChangeCase: @var[@notVarNested    ][notVar];
+  shouldNotChangeCase: @var[@notVarNested][    notVar];
+  shouldNotChangeCase: @var[@notVarNested][notVar    ];
+  shouldNotChangeCase: @var[notVar];
 }
 
 =====================================output=====================================
@@ -435,8 +439,12 @@ printWidth: 80
 }
 
 @not-var {
-  notvar: @var[ @notVarNested][notVar];
-  notvar2: @var[notVar];
+  shouldnotchangecase: @var[ @notVarNested][notVar];
+  shouldnotchangecase: @var[ @notVarNested][notVar];
+  shouldnotchangecase: @var[ @notVarNested ][notVar];
+  shouldnotchangecase: @var[ @notVarNested][ notVar];
+  shouldnotchangecase: @var[ @notVarNested][notVar ];
+  shouldnotchangecase: @var[notVar];
 }
 
 ================================================================================

--- a/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
@@ -328,9 +328,8 @@ parsers: ["less"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
+// Do not change case of property name if inside a variable declaration
 
-
-// do not change case of property name if inside a variable declaration
 @var: {
   notVar: 0;
   @notVarNested: {
@@ -389,7 +388,8 @@ printWidth: 80
 }
 
 =====================================output=====================================
-// do not change case of property name if inside a variable declaration
+// Do not change case of property name if inside a variable declaration
+
 @var: {
   notVar: 0;
   @notVarNested: {

--- a/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
@@ -342,7 +342,7 @@ TABLE {
 };
 
 @not-var {
-  notvar: @var[ @notVarNested][notVar];
+  notvar: @var[@notVarNested][notVar];
 }
 
 ================================================================================

--- a/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
@@ -154,24 +154,6 @@ TABLE {}
 
 .foo { &-KeepSelector {} &-KeepSelector & .KeepClassSelector {} &-100\\.200 {} }
 
-// do not change case of property name if inside a variable declaration
-@var: {
-  notVar: 0;
-  @notVarNested: {
-    notVar: 1;
-    notVar2: 2;
-  };
-};
-
-@var2 : {
-  notVar: 5;
-};
-
-@not-var {
-  notVar: @var[@notVarNested][notVar];
-  notVar2: @var2[notVar];
-}
-
 =====================================output=====================================
 // Convention in this test file:
 // - The case should be preserved for things prefixed with "Keep".
@@ -337,6 +319,17 @@ TABLE {
   }
 }
 
+================================================================================
+`;
+
+exports[`variable.less format 1`] = `
+====================================options=====================================
+parsers: ["less"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+
+
 // do not change case of property name if inside a variable declaration
 @var: {
   notVar: 0;
@@ -346,13 +339,104 @@ TABLE {
   };
 };
 
-@var2: {
-  notVar: 5;
+@var    :    {
+  shouldNotChangeCase: 5;
+};
+
+@var:    {
+  shouldNotChangeCase: 5;
+};
+
+@var    :{
+  shouldNotChangeCase: 5;
+};
+
+@var /* comment */ : /* comment */ {
+  shouldNotChangeCase: 5;
+};
+
+@var: /* comment */ {
+  shouldNotChangeCase: 5;
+};
+
+@var /* comment */ :{
+  shouldNotChangeCase: 5;
+};
+
+@var // comment
+: // comment
+{
+  shouldNotChangeCase: 5;
+};
+
+@var: // comment
+{
+  shouldNotChangeCase: 5;
+};
+
+@var // comment
+:{
+  shouldNotChangeCase: 5;
 };
 
 @not-var {
+  notVar: @var[@notVarNested][notVar];
+  notVar2: @var[notVar];
+}
+
+=====================================output=====================================
+// do not change case of property name if inside a variable declaration
+@var: {
+  notVar: 0;
+  @notVarNested: {
+    notVar: 1;
+    notVar2: 2;
+  };
+};
+
+@var: {
+  shouldNotChangeCase: 5;
+};
+
+@var: {
+  shouldNotChangeCase: 5;
+};
+
+@var: {
+  shouldNotChangeCase: 5;
+};
+
+@var: /* comment */ {
+  shouldnotchangecase: 5;
+};
+
+@var: /* comment */ {
+  shouldNotChangeCase: 5;
+};
+
+@var: {
+  shouldnotchangecase: 5;
+};
+
+@var // comment
+: // comment
+{
+  shouldnotchangecase: 5;
+}
+
+@var: // comment
+{
+  shouldNotChangeCase: 5;
+};
+
+@var // comment
+: {
+  shouldnotchangecase: 5;
+}
+
+@not-var {
   notvar: @var[ @notVarNested][notVar];
-  notvar2: @var2[notVar];
+  notvar2: @var[notVar];
 }
 
 ================================================================================

--- a/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
@@ -158,13 +158,18 @@ TABLE {}
 @var: {
   notVar: 0;
   @notVarNested: {
-    notVar: 0;
-    notVar2: 0;
+    notVar: 1;
+    notVar2: 2;
   };
+};
+
+@var2 : {
+  notVar: 5;
 };
 
 @not-var {
   notVar: @var[@notVarNested][notVar];
+  notVar2: @var2[notVar];
 }
 
 =====================================output=====================================
@@ -336,13 +341,18 @@ TABLE {
 @var: {
   notVar: 0;
   @notVarNested: {
-    notVar: 0;
-    notVar2: 0;
+    notVar: 1;
+    notVar2: 2;
   };
+};
+
+@var2: {
+  notVar: 5;
 };
 
 @not-var {
   notvar: @var[@notVarNested][notVar];
+  notvar2: @var2[notVar];
 }
 
 ================================================================================

--- a/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
@@ -339,52 +339,52 @@ printWidth: 80
 };
 
 @var    :    {
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var:    {
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var    :{
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var /* comment */ : /* comment */ {
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var: /* comment */ {
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var /* comment */ :{
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var // comment
 : // comment
 {
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var: // comment
 {
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var // comment
 :{
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @not-var {
-  shouldNotChangeCase: @var[@notVarNested][notVar];
-  shouldNotChangeCase: @var[    @notVarNested][notVar];
-  shouldNotChangeCase: @var[@notVarNested    ][notVar];
-  shouldNotChangeCase: @var[@notVarNested][    notVar];
-  shouldNotChangeCase: @var[@notVarNested][notVar    ];
-  shouldNotChangeCase: @var[notVar];
+  preserveCase: @var[@notVarNested][notVar];
+  preserveCase: @var[    @notVarNested][notVar];
+  preserveCase: @var[@notVarNested    ][notVar];
+  preserveCase: @var[@notVarNested][    notVar];
+  preserveCase: @var[@notVarNested][notVar    ];
+  preserveCase: @var[notVar];
 }
 
 =====================================output=====================================
@@ -399,52 +399,52 @@ printWidth: 80
 };
 
 @var: {
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var: {
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var: {
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var: /* comment */ {
-  shouldnotchangecase: 5;
+  preservecase: 5;
 };
 
 @var: /* comment */ {
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var: {
-  shouldnotchangecase: 5;
+  preservecase: 5;
 };
 
 @var // comment
 : // comment
 {
-  shouldnotchangecase: 5;
+  preservecase: 5;
 }
 
 @var: // comment
 {
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var // comment
 : {
-  shouldnotchangecase: 5;
+  preservecase: 5;
 }
 
 @not-var {
-  shouldnotchangecase: @var[ @notVarNested][notVar];
-  shouldnotchangecase: @var[ @notVarNested][notVar];
-  shouldnotchangecase: @var[ @notVarNested ][notVar];
-  shouldnotchangecase: @var[ @notVarNested][ notVar];
-  shouldnotchangecase: @var[ @notVarNested][notVar ];
-  shouldnotchangecase: @var[notVar];
+  preservecase: @var[ @notVarNested][notVar];
+  preservecase: @var[ @notVarNested][notVar];
+  preservecase: @var[ @notVarNested ][notVar];
+  preservecase: @var[ @notVarNested][ notVar];
+  preservecase: @var[ @notVarNested][notVar ];
+  preservecase: @var[notVar];
 }
 
 ================================================================================

--- a/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
@@ -378,6 +378,11 @@ printWidth: 80
   preserveCase: 5;
 };
 
+// Known css properties
+@var: {
+  COLoR: RED;
+};
+
 @not-var {
   preserveCase: @var[@notVarNested][notVar];
   preserveCase: @var[    @notVarNested][notVar];
@@ -437,6 +442,11 @@ printWidth: 80
 : {
   preservecase: 5;
 }
+
+// Known css properties
+@var: {
+  COLoR: RED;
+};
 
 @not-var {
   preservecase: @var[ @notVarNested][notVar];

--- a/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
@@ -154,6 +154,19 @@ TABLE {}
 
 .foo { &-KeepSelector {} &-KeepSelector & .KeepClassSelector {} &-100\\.200 {} }
 
+// do not change case of property name if inside a variable declaration
+@var: {
+  notVar: 0;
+  @notVarNested: {
+    notVar: 0;
+    notVar2: 0;
+  };
+};
+
+@not-var {
+  notVar: @var[@notVarNested][notVar];
+}
+
 =====================================output=====================================
 // Convention in this test file:
 // - The case should be preserved for things prefixed with "Keep".
@@ -204,7 +217,7 @@ svg[viewBox] linearGradient,
 }
 
 @KeepDetachedRuleset: /*:*/ {
-  background: RED;
+  BACKGROUND: RED;
 };
 
 %KeepScssPlaceholderSelector {
@@ -317,6 +330,19 @@ TABLE {
   }
   &-100\\.200 {
   }
+}
+
+// do not change case of property name if inside a variable declaration
+@var: {
+  notVar: 0;
+  @notVarNested: {
+    notVar: 0;
+    notVar2: 0;
+  };
+};
+
+@not-var {
+  notvar: @var[ @notVarNested][notVar];
 }
 
 ================================================================================

--- a/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
@@ -365,6 +365,7 @@ printWidth: 80
 @var // comment
 : // comment
 {
+  /* FIXME: should not change case */
   preserveCase: 5;
 };
 
@@ -375,6 +376,7 @@ printWidth: 80
 
 @var // comment
 :{
+  /* FIXME: should not change case */
   preserveCase: 5;
 };
 
@@ -430,6 +432,7 @@ printWidth: 80
 @var // comment
 : // comment
 {
+  /* FIXME: should not change case */
   preservecase: 5;
 }
 
@@ -440,6 +443,7 @@ printWidth: 80
 
 @var // comment
 : {
+  /* FIXME: should not change case */
   preservecase: 5;
 }
 

--- a/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
@@ -386,12 +386,12 @@ printWidth: 80
 };
 
 @not-var {
-  preserveCase: @var[@notVarNested][notVar];
-  preserveCase: @var[    @notVarNested][notVar];
-  preserveCase: @var[@notVarNested    ][notVar];
-  preserveCase: @var[@notVarNested][    notVar];
-  preserveCase: @var[@notVarNested][notVar    ];
-  preserveCase: @var[notVar];
+  canChangeCase: @var[@notVarNested][notVar];
+  canChangeCase: @var[    @notVarNested][notVar];
+  canChangeCase: @var[@notVarNested    ][notVar];
+  canChangeCase: @var[@notVarNested][    notVar];
+  canChangeCase: @var[@notVarNested][notVar    ];
+  canChangeCase: @var[notVar];
 }
 
 =====================================output=====================================
@@ -453,12 +453,12 @@ printWidth: 80
 };
 
 @not-var {
-  preservecase: @var[ @notVarNested][notVar];
-  preservecase: @var[ @notVarNested][notVar];
-  preservecase: @var[ @notVarNested ][notVar];
-  preservecase: @var[ @notVarNested][ notVar];
-  preservecase: @var[ @notVarNested][notVar ];
-  preservecase: @var[notVar];
+  canchangecase: @var[ @notVarNested][notVar];
+  canchangecase: @var[ @notVarNested][notVar];
+  canchangecase: @var[ @notVarNested ][notVar];
+  canchangecase: @var[ @notVarNested][ notVar];
+  canchangecase: @var[ @notVarNested][notVar ];
+  canchangecase: @var[notVar];
 }
 
 ================================================================================

--- a/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/less/case/__snapshots__/jsfmt.spec.js.snap
@@ -351,7 +351,7 @@ TABLE {
 };
 
 @not-var {
-  notvar: @var[@notVarNested][notVar];
+  notvar: @var[ @notVarNested][notVar];
   notvar2: @var2[notVar];
 }
 

--- a/tests/format/less/case/case.less
+++ b/tests/format/less/case/case.less
@@ -145,3 +145,16 @@ a:AFTER {
 TABLE {}
 
 .foo { &-KeepSelector {} &-KeepSelector & .KeepClassSelector {} &-100\.200 {} }
+
+// do not change case of property name if inside a variable declaration
+@var: {
+  notVar: 0;
+  @notVarNested: {
+    notVar: 0;
+    notVar2: 0;
+  };
+};
+
+@not-var {
+  notVar: @var[@notVarNested][notVar];
+}

--- a/tests/format/less/case/case.less
+++ b/tests/format/less/case/case.less
@@ -145,21 +145,3 @@ a:AFTER {
 TABLE {}
 
 .foo { &-KeepSelector {} &-KeepSelector & .KeepClassSelector {} &-100\.200 {} }
-
-// do not change case of property name if inside a variable declaration
-@var: {
-  notVar: 0;
-  @notVarNested: {
-    notVar: 1;
-    notVar2: 2;
-  };
-};
-
-@var2 : {
-  notVar: 5;
-};
-
-@not-var {
-  notVar: @var[@notVarNested][notVar];
-  notVar2: @var2[notVar];
-}

--- a/tests/format/less/case/case.less
+++ b/tests/format/less/case/case.less
@@ -150,11 +150,16 @@ TABLE {}
 @var: {
   notVar: 0;
   @notVarNested: {
-    notVar: 0;
-    notVar2: 0;
+    notVar: 1;
+    notVar2: 2;
   };
+};
+
+@var2 : {
+  notVar: 5;
 };
 
 @not-var {
   notVar: @var[@notVarNested][notVar];
+  notVar2: @var2[notVar];
 }

--- a/tests/format/less/case/variable.less
+++ b/tests/format/less/case/variable.less
@@ -9,50 +9,50 @@
 };
 
 @var    :    {
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var:    {
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var    :{
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var /* comment */ : /* comment */ {
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var: /* comment */ {
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var /* comment */ :{
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var // comment
 : // comment
 {
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var: // comment
 {
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @var // comment
 :{
-  shouldNotChangeCase: 5;
+  preserveCase: 5;
 };
 
 @not-var {
-  shouldNotChangeCase: @var[@notVarNested][notVar];
-  shouldNotChangeCase: @var[    @notVarNested][notVar];
-  shouldNotChangeCase: @var[@notVarNested    ][notVar];
-  shouldNotChangeCase: @var[@notVarNested][    notVar];
-  shouldNotChangeCase: @var[@notVarNested][notVar    ];
-  shouldNotChangeCase: @var[notVar];
+  preserveCase: @var[@notVarNested][notVar];
+  preserveCase: @var[    @notVarNested][notVar];
+  preserveCase: @var[@notVarNested    ][notVar];
+  preserveCase: @var[@notVarNested][    notVar];
+  preserveCase: @var[@notVarNested][notVar    ];
+  preserveCase: @var[notVar];
 }

--- a/tests/format/less/case/variable.less
+++ b/tests/format/less/case/variable.less
@@ -1,6 +1,5 @@
+// Do not change case of property name if inside a variable declaration
 
-
-// do not change case of property name if inside a variable declaration
 @var: {
   notVar: 0;
   @notVarNested: {

--- a/tests/format/less/case/variable.less
+++ b/tests/format/less/case/variable.less
@@ -56,10 +56,10 @@
 };
 
 @not-var {
-  preserveCase: @var[@notVarNested][notVar];
-  preserveCase: @var[    @notVarNested][notVar];
-  preserveCase: @var[@notVarNested    ][notVar];
-  preserveCase: @var[@notVarNested][    notVar];
-  preserveCase: @var[@notVarNested][notVar    ];
-  preserveCase: @var[notVar];
+  canChangeCase: @var[@notVarNested][notVar];
+  canChangeCase: @var[    @notVarNested][notVar];
+  canChangeCase: @var[@notVarNested    ][notVar];
+  canChangeCase: @var[@notVarNested][    notVar];
+  canChangeCase: @var[@notVarNested][notVar    ];
+  canChangeCase: @var[notVar];
 }

--- a/tests/format/less/case/variable.less
+++ b/tests/format/less/case/variable.less
@@ -48,6 +48,11 @@
   preserveCase: 5;
 };
 
+// Known css properties
+@var: {
+  COLoR: RED;
+};
+
 @not-var {
   preserveCase: @var[@notVarNested][notVar];
   preserveCase: @var[    @notVarNested][notVar];

--- a/tests/format/less/case/variable.less
+++ b/tests/format/less/case/variable.less
@@ -1,0 +1,55 @@
+
+
+// do not change case of property name if inside a variable declaration
+@var: {
+  notVar: 0;
+  @notVarNested: {
+    notVar: 1;
+    notVar2: 2;
+  };
+};
+
+@var    :    {
+  shouldNotChangeCase: 5;
+};
+
+@var:    {
+  shouldNotChangeCase: 5;
+};
+
+@var    :{
+  shouldNotChangeCase: 5;
+};
+
+@var /* comment */ : /* comment */ {
+  shouldNotChangeCase: 5;
+};
+
+@var: /* comment */ {
+  shouldNotChangeCase: 5;
+};
+
+@var /* comment */ :{
+  shouldNotChangeCase: 5;
+};
+
+@var // comment
+: // comment
+{
+  shouldNotChangeCase: 5;
+};
+
+@var: // comment
+{
+  shouldNotChangeCase: 5;
+};
+
+@var // comment
+:{
+  shouldNotChangeCase: 5;
+};
+
+@not-var {
+  notVar: @var[@notVarNested][notVar];
+  notVar2: @var[notVar];
+}

--- a/tests/format/less/case/variable.less
+++ b/tests/format/less/case/variable.less
@@ -35,6 +35,7 @@
 @var // comment
 : // comment
 {
+  /* FIXME: should not change case */
   preserveCase: 5;
 };
 
@@ -45,6 +46,7 @@
 
 @var // comment
 :{
+  /* FIXME: should not change case */
   preserveCase: 5;
 };
 

--- a/tests/format/less/case/variable.less
+++ b/tests/format/less/case/variable.less
@@ -50,6 +50,10 @@
 };
 
 @not-var {
-  notVar: @var[@notVarNested][notVar];
-  notVar2: @var[notVar];
+  shouldNotChangeCase: @var[@notVarNested][notVar];
+  shouldNotChangeCase: @var[    @notVarNested][notVar];
+  shouldNotChangeCase: @var[@notVarNested    ][notVar];
+  shouldNotChangeCase: @var[@notVarNested][    notVar];
+  shouldNotChangeCase: @var[@notVarNested][notVar    ];
+  shouldNotChangeCase: @var[notVar];
 }


### PR DESCRIPTION
## Description

Simple example:
```
@var: {
  camelCase: 0;
};

div {
  margin: @var[camelCase];
};
```

when `preserveCase` is changed to `preservecase`, LESS compilation fails.

This PR fixes such problem and handles also variable declaration with nested ruleset correctly.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
