### PR TITLE
Add missing parentheses to `let` in `for..of` loop

### DIFF
--- a/changelog_unreleased/javascript/14000.md
+++ b/changelog_unreleased/javascript/14000.md
@@ -1,4 +1,4 @@
-#### Fix missing parentheses when an expression statement starts with `let[` (#14000 by @fisker, @thorn0)
+#### Fix missing parentheses when an expression statement starts with `let[` (#14000, #14044 by @fisker, @thorn0)
 
 <!-- prettier-ignore -->
 ```jsx

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -105,8 +105,7 @@ function needsParens(path, options) {
         (node) =>
           node.type === "ExpressionStatement" ||
           node.type === "ForStatement" ||
-          node.type === "ForInStatement" ||
-          node.type === "ForOfStatement"
+          node.type === "ForInStatement"
       );
       const expression = !statement
         ? undefined

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -78,11 +78,7 @@ function needsParens(path, options) {
     }
 
     // `for ((let.a) of []);`
-    if (
-      name === "object" &&
-      node.name === "let" &&
-      parent.type === "MemberExpression"
-    ) {
+    if (node.name === "let") {
       const expression = path.findAncestor(
         (node) => node.type === "ForOfStatement"
       )?.left;

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -67,14 +67,31 @@ function needsParens(path, options) {
       return true;
     }
 
-    // `for (async of []);` is invalid
+    // `for ((async) of []);` and `for ((let) of []);`
     if (
       name === "left" &&
-      node.name === "async" &&
+      (node.name === "async" || node.name === "let") &&
       parent.type === "ForOfStatement" &&
       !parent.await
     ) {
       return true;
+    }
+
+    // `for ((let.a) of []);`
+    if (name === "object" && node.name === "let") {
+      const statement = path.findAncestor(
+        (node) => node.type === "ForOfStatement"
+      );
+      const expression = statement.left;
+      if (
+        expression &&
+        startsWithNoLookaheadToken(
+          expression,
+          (leftmostNode) => leftmostNode === node
+        )
+      ) {
+        return true;
+      }
     }
 
     // `(let)[a] = 1`

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -79,10 +79,9 @@ function needsParens(path, options) {
 
     // `for ((let.a) of []);`
     if (name === "object" && node.name === "let") {
-      const statement = path.findAncestor(
+      const expression = path.findAncestor(
         (node) => node.type === "ForOfStatement"
-      );
-      const expression = statement.left;
+      )?.left
       if (
         expression &&
         startsWithNoLookaheadToken(

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -78,7 +78,11 @@ function needsParens(path, options) {
     }
 
     // `for ((let.a) of []);`
-    if (name === "object" && node.name === "let") {
+    if (
+      name === "object" &&
+      node.name === "let" &&
+      parent.type === "MemberExpression"
+    ) {
       const expression = path.findAncestor(
         (node) => node.type === "ForOfStatement"
       )?.left;

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -81,7 +81,7 @@ function needsParens(path, options) {
     if (name === "object" && node.name === "let") {
       const expression = path.findAncestor(
         (node) => node.type === "ForOfStatement"
-      )?.left
+      )?.left;
       if (
         expression &&
         startsWithNoLookaheadToken(

--- a/tests/format/js/identifier/for-of/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/identifier/for-of/__snapshots__/jsfmt.spec.js.snap
@@ -14,11 +14,11 @@ for ((let.a) of foo);
 for ((let[a]) of foo);
 
 =====================================output=====================================
-for (let of foo);
+for ((let) of foo);
 for (foo of let);
 for (foo of let.a);
 for (foo of let[a]);
-for (let.a of foo);
+for ((let).a of foo);
 for ((let)[a] of foo);
 
 ================================================================================

--- a/tests/format/js/identifier/for-of/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/identifier/for-of/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`let.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+for ((let) of foo);
+for (foo of let);
+for (foo of let.a);
+for (foo of let[a]);
+for ((let.a) of foo);
+for ((let[a]) of foo);
+
+=====================================output=====================================
+for (let of foo);
+for (foo of let);
+for (foo of let.a);
+for (foo of let[a]);
+for (let.a of foo);
+for ((let)[a] of foo);
+
+================================================================================
+`;

--- a/tests/format/js/identifier/for-of/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/identifier/for-of/__snapshots__/jsfmt.spec.js.snap
@@ -8,17 +8,15 @@ printWidth: 80
 =====================================input======================================
 async function a() {
   for await((let).a of foo);
-}
-async function b() {
   for await((let)[a] of foo);
+  for await((let)()[a] of foo);
 }
 
 =====================================output=====================================
 async function a() {
   for await ((let).a of foo);
-}
-async function b() {
   for await ((let)[a] of foo);
+  for await ((let)()[a] of foo);
 }
 
 ================================================================================
@@ -37,6 +35,7 @@ for (foo of let[a]);
 for ((let.a) of foo);
 for ((let[a]) of foo);
 for ((let)().a of foo);
+for (letFoo of foo);
 
 for ((let.a) in foo);
 for ((let[a]) in foo);
@@ -49,6 +48,7 @@ for (foo of let[a]);
 for ((let).a of foo);
 for ((let)[a] of foo);
 for ((let)().a of foo);
+for (letFoo of foo);
 
 for (let.a in foo);
 for ((let)[a] in foo);

--- a/tests/format/js/identifier/for-of/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/identifier/for-of/__snapshots__/jsfmt.spec.js.snap
@@ -37,6 +37,9 @@ for (foo of let[a]);
 for ((let.a) of foo);
 for ((let[a]) of foo);
 
+for ((let.a) in foo);
+for ((let[a]) in foo);
+
 =====================================output=====================================
 for ((let) of foo);
 for (foo of let);
@@ -44,6 +47,9 @@ for (foo of let.a);
 for (foo of let[a]);
 for ((let).a of foo);
 for ((let)[a] of foo);
+
+for (let.a in foo);
+for ((let)[a] in foo);
 
 ================================================================================
 `;

--- a/tests/format/js/identifier/for-of/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/identifier/for-of/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`await.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+async function a() {
+  for await((let).a of foo);
+}
+async function b() {
+  for await((let)[a] of foo);
+}
+
+=====================================output=====================================
+async function a() {
+  for await ((let).a of foo);
+}
+async function b() {
+  for await ((let)[a] of foo);
+}
+
+================================================================================
+`;
+
 exports[`let.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript"]

--- a/tests/format/js/identifier/for-of/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/identifier/for-of/__snapshots__/jsfmt.spec.js.snap
@@ -36,6 +36,7 @@ for (foo of let.a);
 for (foo of let[a]);
 for ((let.a) of foo);
 for ((let[a]) of foo);
+for ((let)().a of foo);
 
 for ((let.a) in foo);
 for ((let[a]) in foo);
@@ -47,6 +48,7 @@ for (foo of let.a);
 for (foo of let[a]);
 for ((let).a of foo);
 for ((let)[a] of foo);
+for ((let)().a of foo);
 
 for (let.a in foo);
 for ((let)[a] in foo);

--- a/tests/format/js/identifier/for-of/await.js
+++ b/tests/format/js/identifier/for-of/await.js
@@ -1,0 +1,6 @@
+async function a() {
+  for await((let).a of foo);
+}
+async function b() {
+  for await((let)[a] of foo);
+}

--- a/tests/format/js/identifier/for-of/await.js
+++ b/tests/format/js/identifier/for-of/await.js
@@ -1,6 +1,5 @@
 async function a() {
   for await((let).a of foo);
-}
-async function b() {
   for await((let)[a] of foo);
+  for await((let)()[a] of foo);
 }

--- a/tests/format/js/identifier/for-of/jsfmt.spec.js
+++ b/tests/format/js/identifier/for-of/jsfmt.spec.js
@@ -1,0 +1,5 @@
+run_spec(__dirname, [
+  "babel",
+  // "flow",
+  "typescript",
+]);

--- a/tests/format/js/identifier/for-of/let.js
+++ b/tests/format/js/identifier/for-of/let.js
@@ -5,6 +5,7 @@ for (foo of let[a]);
 for ((let.a) of foo);
 for ((let[a]) of foo);
 for ((let)().a of foo);
+for (letFoo of foo);
 
 for ((let.a) in foo);
 for ((let[a]) in foo);

--- a/tests/format/js/identifier/for-of/let.js
+++ b/tests/format/js/identifier/for-of/let.js
@@ -4,6 +4,7 @@ for (foo of let.a);
 for (foo of let[a]);
 for ((let.a) of foo);
 for ((let[a]) of foo);
+for ((let)().a of foo);
 
 for ((let.a) in foo);
 for ((let[a]) in foo);

--- a/tests/format/js/identifier/for-of/let.js
+++ b/tests/format/js/identifier/for-of/let.js
@@ -4,3 +4,6 @@ for (foo of let.a);
 for (foo of let[a]);
 for ((let.a) of foo);
 for ((let[a]) of foo);
+
+for ((let.a) in foo);
+for ((let[a]) in foo);

--- a/tests/format/js/identifier/for-of/let.js
+++ b/tests/format/js/identifier/for-of/let.js
@@ -1,0 +1,6 @@
+for ((let) of foo);
+for (foo of let);
+for (foo of let.a);
+for (foo of let[a]);
+for ((let.a) of foo);
+for ((let[a]) of foo);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #10828

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
