### PR TITLE
Refactor Enum print

### DIFF
--- a/src/language-js/print/array.js
+++ b/src/language-js/print/array.js
@@ -209,4 +209,4 @@ function printArrayItemsConcisely(path, options, print, trailingComma) {
   return fill(parts);
 }
 
-export { printArray, printArrayItems, isConciselyPrintedArray };
+export { printArray, isConciselyPrintedArray };

--- a/src/language-js/print/enum.js
+++ b/src/language-js/print/enum.js
@@ -1,36 +1,8 @@
-import { hardline, softline, group, indent } from "../../document/builders.js";
-import { printDanglingComments } from "../../main/comments.js";
-import { shouldPrintComma } from "../utils/index.js";
-import { printArrayItems } from "./array.js";
 import { printTypeScriptModifiers } from "./misc.js";
-
-function printEnumMemberList(path, print, options) {
-  const {
-    node: { members, hasUnknownMembers },
-  } = path;
-
-  if (members.length === 0 && !hasUnknownMembers) {
-    return [printDanglingComments(path, options), softline];
-  }
-
-  return [
-    indent([
-      ...(members.length > 0
-        ? [
-            hardline,
-            printArrayItems(path, options, "members", print),
-            hasUnknownMembers || shouldPrintComma(options) ? "," : "",
-          ]
-        : []),
-      ...(hasUnknownMembers ? [hardline, "..."] : []),
-    ]),
-    printDanglingComments(path, options, /* sameIndent */ true),
-    hardline,
-  ];
-}
+import { printObject } from "./object.js";
 
 function printEnumMembers(path, print, options) {
-  return group(["{", printEnumMemberList(path, print, options), "}"]);
+  return printObject(path, options, print);
 }
 
 /*

--- a/src/language-js/print/object.js
+++ b/src/language-js/print/object.js
@@ -33,8 +33,14 @@ function printObject(path, options, print) {
   const { node } = path;
 
   const isTypeAnnotation = node.type === "ObjectTypeAnnotation";
+  const isEnumBody =
+    node.type === "TSEnumDeclaration" ||
+    node.type === "EnumBooleanBody" ||
+    node.type === "EnumNumberBody" ||
+    node.type === "EnumStringBody" ||
+    node.type === "EnumSymbolBody";
   const fields = [
-    node.type === "TSTypeLiteral"
+    node.type === "TSTypeLiteral" || isEnumBody
       ? "members"
       : node.type === "TSInterfaceBody"
       ? "body"
@@ -72,6 +78,7 @@ function printObject(path, options, print) {
     path.getName() === "body";
   const shouldBreak =
     node.type === "TSInterfaceBody" ||
+    isEnumBody ||
     isFlowInterfaceLikeBody ||
     (node.type === "ObjectPattern" &&
       parent.type !== "FunctionDeclaration" &&
@@ -124,7 +131,7 @@ function printObject(path, options, print) {
     return result;
   });
 
-  if (node.inexact) {
+  if (node.inexact || node.hasUnknownMembers) {
     let printed;
     if (hasComment(node, CommentCheckFlags.Dangling)) {
       const hasLineComments = hasComment(node, CommentCheckFlags.Line);
@@ -151,6 +158,7 @@ function printObject(path, options, print) {
 
   const canHaveTrailingSeparator = !(
     node.inexact ||
+    node.hasUnknownMembers ||
     (lastElem &&
       (lastElem.type === "RestElement" ||
         ((lastElem.type === "TSPropertySignature" ||


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

It's more reasonable to use `printObject` instead of `printArrayItems` to print members.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
