### PR TITLE
Fix displacing of comments in default switch case

### DIFF
--- a/changelog_unreleased/javascript/14047.md
+++ b/changelog_unreleased/javascript/14047.md
@@ -1,0 +1,27 @@
+#### Fix displacing of comments in default switch case (#14047 by @thorn0)
+
+It was a regression in Prettier 2.6.0.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+switch (state) {
+  default:
+    result = state; // no change
+    break;
+}
+
+// Prettier stable
+switch (state) {
+  default: // no change
+    result = state;
+    break;
+}
+
+// Prettier main
+switch (state) {
+  default:
+    result = state; // no change
+    break;
+}
+```

--- a/src/language-js/comments.js
+++ b/src/language-js/comments.js
@@ -884,7 +884,9 @@ function handleSwitchDefaultCaseComments({
   if (
     !enclosingNode ||
     enclosingNode.type !== "SwitchCase" ||
-    enclosingNode.test
+    enclosingNode.test ||
+    !followingNode ||
+    followingNode !== enclosingNode.consequent[0]
   ) {
     return false;
   }

--- a/tests/format/js/switch/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/switch/__snapshots__/jsfmt.spec.js.snap
@@ -136,6 +136,66 @@ switch (x) {
 ================================================================================
 `;
 
+exports[`comments2.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+switch(1){default: // comment1
+}
+
+switch(2){default: // comment2
+//comment2a
+}
+
+switch(3){default: // comment3
+break;// comment3a
+}
+
+switch(4){default: // comment4
+// comment4a
+break;// comment4b
+}
+
+switch(5){default: // comment5
+// comment5a
+foo();bar();//comment5b
+break;// comment5c
+}
+
+=====================================output=====================================
+switch (1) {
+  default: // comment1
+}
+
+switch (2) {
+  default: // comment2
+  //comment2a
+}
+
+switch (3) {
+  default: // comment3
+    break; // comment3a
+}
+
+switch (4) {
+  default: // comment4
+    // comment4a
+    break; // comment4b
+}
+
+switch (5) {
+  default: // comment5
+    // comment5a
+    foo();
+    bar(); //comment5b
+    break; // comment5c
+}
+
+================================================================================
+`;
+
 exports[`empty_lines.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/format/js/switch/comments2.js
+++ b/tests/format/js/switch/comments2.js
@@ -1,0 +1,21 @@
+switch(1){default: // comment1
+}
+
+switch(2){default: // comment2
+//comment2a
+}
+
+switch(3){default: // comment3
+break;// comment3a
+}
+
+switch(4){default: // comment4
+// comment4a
+break;// comment4b
+}
+
+switch(5){default: // comment5
+// comment5a
+foo();bar();//comment5b
+break;// comment5c
+}


### PR DESCRIPTION
## Description

fixes https://github.com/prettier/prettier/issues/12481

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
