### PR TITLE
Fix `isExportDeclaration`

### DIFF
--- a/src/language-js/print/decorators.js
+++ b/src/language-js/print/decorators.js
@@ -7,7 +7,7 @@ import {
   group,
 } from "../../document/builders.js";
 import { locEnd, hasSameLocStart } from "../loc.js";
-import { getParentExportDeclaration } from "../utils/index.js";
+import { isExportDeclaration } from "../utils/index.js";
 
 function printClassMemberDecorators(path, options, print) {
   const { node } = path;
@@ -27,7 +27,7 @@ function printDecoratorsBeforeExport(path, options, print) {
 }
 
 function printDecorators(path, options, print) {
-  const { node } = path;
+  const { node, parent } = path;
   const { decorators } = node;
 
   if (
@@ -35,7 +35,7 @@ function printDecorators(path, options, print) {
     // If the parent node is an export declaration and the decorator
     // was written before the export, the export will be responsible
     // for printing the decorators.
-    hasDecoratorsBeforeExport(path.parent)
+    hasDecoratorsBeforeExport(parent)
   ) {
     return;
   }
@@ -46,7 +46,7 @@ function printDecorators(path, options, print) {
     hasNewlineBetweenOrAfterDecorators(node, options);
 
   return [
-    getParentExportDeclaration(path)
+    path.key === "declaration" && isExportDeclaration(parent)
       ? hardline
       : shouldBreak
       ? breakParent
@@ -63,11 +63,7 @@ function hasNewlineBetweenOrAfterDecorators(node, options) {
 }
 
 function hasDecoratorsBeforeExport(node) {
-  if (
-    node.type !== "ExportDefaultDeclaration" &&
-    node.type !== "ExportNamedDeclaration" &&
-    node.type !== "DeclareExportDeclaration"
-  ) {
+  if (!isExportDeclaration(node)) {
     return false;
   }
 

--- a/src/language-js/print/decorators.js
+++ b/src/language-js/print/decorators.js
@@ -63,7 +63,11 @@ function hasNewlineBetweenOrAfterDecorators(node, options) {
 }
 
 function hasDecoratorsBeforeExport(node) {
-  if (!isExportDeclaration(node)) {
+  if (
+    node.type !== "ExportDefaultDeclaration" &&
+    node.type !== "ExportNamedDeclaration" &&
+    node.type !== "DeclareExportDeclaration"
+  ) {
     return false;
   }
 

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -140,6 +140,7 @@ const isExportDeclaration = createTypeCheckFunction([
   "DeclareExportDeclaration",
   "ExportNamedDeclaration",
   "ExportAllDeclaration",
+  "DeclareExportAllDeclaration",
 ]);
 
 /**

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -137,24 +137,10 @@ const isLineComment = createTypeCheckFunction([
  */
 const isExportDeclaration = createTypeCheckFunction([
   "ExportDefaultDeclaration",
-  "ExportDefaultSpecifier",
   "DeclareExportDeclaration",
   "ExportNamedDeclaration",
   "ExportAllDeclaration",
 ]);
-
-/**
- * @param {AstPath} path
- * @returns {Node | null}
- */
-function getParentExportDeclaration(path) {
-  const parentNode = path.parent;
-  if (path.getName() === "declaration" && isExportDeclaration(parentNode)) {
-    return parentNode;
-  }
-
-  return null;
-}
 
 /**
  * @param {Node} node
@@ -1212,7 +1198,6 @@ export {
   hasRestParameter,
   getLeftSide,
   getLeftSidePathName,
-  getParentExportDeclaration,
   getTypeScriptMappedTypeModifier,
   hasLeadingOwnLineComment,
   hasNakedLeftSide,


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

`ExportDefaultSpecifier` was there since [the first commit](https://github.com/prettier/prettier/commit/9b4535e9f8a7040f2fbc65b22c9713632f3731be#diff-9c0ec1b0a889e599f3ff81590864dd9dc65684a86b41f1da75acc53fafed12e3R276), but I don't think it should be considered export declaration.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
