### PR TITLE
Fix formatting of empty type parameters

### DIFF
--- a/changelog_unreleased/flow/14073.md
+++ b/changelog_unreleased/flow/14073.md
@@ -2,21 +2,12 @@
 
 <!-- prettier-ignore -->
 ```jsx
-/*
-Options:
---arrow-parens avoid
---trailing-comma all
-*/
 // Input
-const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx<> =
-  arg => null;
+const foo: bar</* comment */> = () => baz;
 
 // Prettier stable
-const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx<
-  ,
-> = arg => null;
+Error: Comment "comment" was not printed. Please report this error!
 
 // Prettier main
-const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx<> =
-  arg => null;
+const foo: bar</* comment */> = () => baz;
 ```

--- a/changelog_unreleased/flow/14073.md
+++ b/changelog_unreleased/flow/14073.md
@@ -1,0 +1,22 @@
+#### Fix formatting of empty type parameters (#14073 by @fisker)
+
+<!-- prettier-ignore -->
+```jsx
+/*
+Options:
+--arrow-parens avoid
+--trailing-comma all
+*/
+// Input
+const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx<> =
+  arg => null;
+
+// Prettier stable
+const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx<
+  ,
+> = arg => null;
+
+// Prettier main
+const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx<> =
+  arg => null;
+```

--- a/src/language-js/print/type-parameters.js
+++ b/src/language-js/print/type-parameters.js
@@ -44,12 +44,12 @@ function printTypeParameters(path, options, print, paramsKey) {
   );
 
   const shouldInline =
-    !isArrowFunctionVariable &&
-    (isParameterInTestCall ||
-      node[paramsKey].length === 0 ||
-      (node[paramsKey].length === 1 &&
-        (node[paramsKey][0].type === "NullableTypeAnnotation" ||
-          shouldHugType(node[paramsKey][0]))));
+    node[paramsKey].length === 0 ||
+    (!isArrowFunctionVariable &&
+      (isParameterInTestCall ||
+        (node[paramsKey].length === 1 &&
+          (node[paramsKey][0].type === "NullableTypeAnnotation" ||
+            shouldHugType(node[paramsKey][0])))));
 
   if (shouldInline) {
     return [

--- a/src/language-js/print/type-parameters.js
+++ b/src/language-js/print/type-parameters.js
@@ -39,17 +39,17 @@ function printTypeParameters(path, options, print, paramsKey) {
       !(node[paramsKey].length === 1 && isObjectType(node[paramsKey][0])),
     undefined,
     (node, name) => name === "typeAnnotation",
-    (node, name) => node.type === "Identifier" && name === "id",
+    (node) => node.type === "Identifier",
     isArrowFunctionVariableDeclarator
   );
 
   const shouldInline =
-    !isArrowFunctionVariable &&
-    (isParameterInTestCall ||
-      node[paramsKey].length === 0 ||
-      (node[paramsKey].length === 1 &&
-        (node[paramsKey][0].type === "NullableTypeAnnotation" ||
-          shouldHugType(node[paramsKey][0]))));
+    node[paramsKey].length === 0 ||
+    (!isArrowFunctionVariable &&
+      (isParameterInTestCall ||
+        (node[paramsKey].length === 1 &&
+          (node[paramsKey][0].type === "NullableTypeAnnotation" ||
+            shouldHugType(node[paramsKey][0])))));
 
   if (shouldInline) {
     return [

--- a/src/language-js/print/type-parameters.js
+++ b/src/language-js/print/type-parameters.js
@@ -39,17 +39,17 @@ function printTypeParameters(path, options, print, paramsKey) {
       !(node[paramsKey].length === 1 && isObjectType(node[paramsKey][0])),
     undefined,
     (node, name) => name === "typeAnnotation",
-    (node) => node.type === "Identifier",
+    (node, name) => node.type === "Identifier" && name === "id",
     isArrowFunctionVariableDeclarator
   );
 
   const shouldInline =
-    node[paramsKey].length === 0 ||
-    (!isArrowFunctionVariable &&
-      (isParameterInTestCall ||
-        (node[paramsKey].length === 1 &&
-          (node[paramsKey][0].type === "NullableTypeAnnotation" ||
-            shouldHugType(node[paramsKey][0])))));
+    !isArrowFunctionVariable &&
+    (isParameterInTestCall ||
+      node[paramsKey].length === 0 ||
+      (node[paramsKey].length === 1 &&
+        (node[paramsKey][0].type === "NullableTypeAnnotation" ||
+          shouldHugType(node[paramsKey][0]))));
 
   if (shouldInline) {
     return [

--- a/tests/format/typescript/assignment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/assignment/__snapshots__/jsfmt.spec.js.snap
@@ -340,32 +340,34 @@ const MyComponent2: React.VoidFunctionComponent<MyComponent2Props> = ({
   );
 };
 
-const MyComponentWithLongName1: React.VoidFunctionComponent<MyComponentWithLongNameProps> =
-  ({ x, y }) => {
-    const a = useA();
-    return (
-      <div>
-        x = {x}; y = {y}; a = {a}
-      </div>
-    );
-  };
+const MyComponentWithLongName1: React.VoidFunctionComponent<
+  MyComponentWithLongNameProps
+> = ({ x, y }) => {
+  const a = useA();
+  return (
+    <div>
+      x = {x}; y = {y}; a = {a}
+    </div>
+  );
+};
 
-const MyComponentWithLongName2: React.VoidFunctionComponent<MyComponentWithLongNameProps> =
-  ({
-    x,
-    y,
-    anotherPropWithLongName1,
-    anotherPropWithLongName2,
-    anotherPropWithLongName3,
-    anotherPropWithLongName4,
-  }) => {
-    const a = useA();
-    return (
-      <div>
-        x = {x}; y = {y}; a = {a}
-      </div>
-    );
-  };
+const MyComponentWithLongName2: React.VoidFunctionComponent<
+  MyComponentWithLongNameProps
+> = ({
+  x,
+  y,
+  anotherPropWithLongName1,
+  anotherPropWithLongName2,
+  anotherPropWithLongName3,
+  anotherPropWithLongName4,
+}) => {
+  const a = useA();
+  return (
+    <div>
+      x = {x}; y = {y}; a = {a}
+    </div>
+  );
+};
 
 const MyGenericComponent: React.VoidFunctionComponent<
   MyGenericComponentProps<number>

--- a/tests/format/typescript/assignment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/assignment/__snapshots__/jsfmt.spec.js.snap
@@ -340,34 +340,32 @@ const MyComponent2: React.VoidFunctionComponent<MyComponent2Props> = ({
   );
 };
 
-const MyComponentWithLongName1: React.VoidFunctionComponent<
-  MyComponentWithLongNameProps
-> = ({ x, y }) => {
-  const a = useA();
-  return (
-    <div>
-      x = {x}; y = {y}; a = {a}
-    </div>
-  );
-};
+const MyComponentWithLongName1: React.VoidFunctionComponent<MyComponentWithLongNameProps> =
+  ({ x, y }) => {
+    const a = useA();
+    return (
+      <div>
+        x = {x}; y = {y}; a = {a}
+      </div>
+    );
+  };
 
-const MyComponentWithLongName2: React.VoidFunctionComponent<
-  MyComponentWithLongNameProps
-> = ({
-  x,
-  y,
-  anotherPropWithLongName1,
-  anotherPropWithLongName2,
-  anotherPropWithLongName3,
-  anotherPropWithLongName4,
-}) => {
-  const a = useA();
-  return (
-    <div>
-      x = {x}; y = {y}; a = {a}
-    </div>
-  );
-};
+const MyComponentWithLongName2: React.VoidFunctionComponent<MyComponentWithLongNameProps> =
+  ({
+    x,
+    y,
+    anotherPropWithLongName1,
+    anotherPropWithLongName2,
+    anotherPropWithLongName3,
+    anotherPropWithLongName4,
+  }) => {
+    const a = useA();
+    return (
+      <div>
+        x = {x}; y = {y}; a = {a}
+      </div>
+    );
+  };
 
 const MyGenericComponent: React.VoidFunctionComponent<
   MyGenericComponentProps<number>

--- a/tests/format/typescript/typeparams/empty-parameters-with-arrow-function/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/typeparams/empty-parameters-with-arrow-function/__snapshots__/jsfmt.spec.js.snap
@@ -11,9 +11,25 @@ trailingComma: "all"
 const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx<> =
   arg => null;
 
+const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx</* comment */> =
+  arg => null;
+
+
+const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx<
+  // comment
+> =
+  arg => null;
+
 =====================================output=====================================
 const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx<> =
   arg => null;
+
+const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx</* comment */> =
+  arg => null;
+
+const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx<
+  // comment
+> = arg => null;
 
 ================================================================================
 `;

--- a/tests/format/typescript/typeparams/empty-parameters-with-arrow-function/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/typeparams/empty-parameters-with-arrow-function/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`issue-13817.ts - {"arrowParens":"avoid","trailingComma":"all"} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+parsers: ["typescript", "flow", "babel-flow"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx<> =
+  arg => null;
+
+=====================================output=====================================
+const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx<
+
+> = arg => null;
+
+================================================================================
+`;

--- a/tests/format/typescript/typeparams/empty-parameters-with-arrow-function/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/typeparams/empty-parameters-with-arrow-function/__snapshots__/jsfmt.spec.js.snap
@@ -12,9 +12,8 @@ const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx<> =
   arg => null;
 
 =====================================output=====================================
-const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx<
-
-> = arg => null;
+const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx<> =
+  arg => null;
 
 ================================================================================
 `;

--- a/tests/format/typescript/typeparams/empty-parameters-with-arrow-function/issue-13817.ts
+++ b/tests/format/typescript/typeparams/empty-parameters-with-arrow-function/issue-13817.ts
@@ -1,2 +1,11 @@
 const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx<> =
   arg => null;
+
+const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx</* comment */> =
+  arg => null;
+
+
+const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx<
+  // comment
+> =
+  arg => null;

--- a/tests/format/typescript/typeparams/empty-parameters-with-arrow-function/issue-13817.ts
+++ b/tests/format/typescript/typeparams/empty-parameters-with-arrow-function/issue-13817.ts
@@ -1,0 +1,2 @@
+const xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx: xxxxxxxxxxxxxxxxxxxxxx<> =
+  arg => null;

--- a/tests/format/typescript/typeparams/empty-parameters-with-arrow-function/jsfmt.spec.js
+++ b/tests/format/typescript/typeparams/empty-parameters-with-arrow-function/jsfmt.spec.js
@@ -1,0 +1,6 @@
+run_spec(
+  __dirname,
+  ["typescript", "flow", "babel-flow"],
+  // #13817 require those options to reproduce
+  { arrowParens: "avoid", trailingComma: "all" }
+);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #13817

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
