### PR TITLE
Improve `let` check in `for..of`

### DIFF
--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -70,7 +70,7 @@ function needsParens(path, options) {
     // `for ((async) of []);` and `for ((let) of []);`
     if (
       name === "left" &&
-      ((node.name === "async" && !parent.await) || node.name === "left") &&
+      ((node.name === "async" && !parent.await) || node.name === "let") &&
       parent.type === "ForOfStatement"
     ) {
       return true;

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -70,9 +70,8 @@ function needsParens(path, options) {
     // `for ((async) of []);` and `for ((let) of []);`
     if (
       name === "left" &&
-      (node.name === "async" || node.name === "let") &&
-      parent.type === "ForOfStatement" &&
-      !parent.await
+      ((node.name === "async" && !parent.await) || node.name === "left") &&
+      parent.type === "ForOfStatement"
     ) {
       return true;
     }

--- a/tests/format/js/identifier/for-of/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/identifier/for-of/__snapshots__/jsfmt.spec.js.snap
@@ -7,6 +7,7 @@ printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
 async function a() {
+  for await((let) of foo);
   for await((let).a of foo);
   for await((let)[a] of foo);
   for await((let)()[a] of foo);
@@ -14,6 +15,7 @@ async function a() {
 
 =====================================output=====================================
 async function a() {
+  for await ((let) of foo);
   for await ((let).a of foo);
   for await ((let)[a] of foo);
   for await ((let)()[a] of foo);

--- a/tests/format/js/identifier/for-of/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/identifier/for-of/__snapshots__/jsfmt.spec.js.snap
@@ -42,6 +42,8 @@ for (letFoo of foo);
 for ((let.a) in foo);
 for ((let[a]) in foo);
 
+for (let of of let);
+
 =====================================output=====================================
 for ((let) of foo);
 for (foo of let);
@@ -54,6 +56,8 @@ for (letFoo of foo);
 
 for (let.a in foo);
 for ((let)[a] in foo);
+
+for (let of of let);
 
 ================================================================================
 `;

--- a/tests/format/js/identifier/for-of/await.js
+++ b/tests/format/js/identifier/for-of/await.js
@@ -1,4 +1,5 @@
 async function a() {
+  for await((let) of foo);
   for await((let).a of foo);
   for await((let)[a] of foo);
   for await((let)()[a] of foo);

--- a/tests/format/js/identifier/for-of/let.js
+++ b/tests/format/js/identifier/for-of/let.js
@@ -9,3 +9,5 @@ for (letFoo of foo);
 
 for ((let.a) in foo);
 for ((let[a]) in foo);
+
+for (let of of let);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

I forgot to test 

```js
for await((let) of foo);
```

in #14044, but it's handled by `if` bellow.

Minor tweak to the logic, to avoid `findAncestor` call.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
