### PR TITLE
Treat `--trailing-comma=es5` as `all` when printing tuple types

### DIFF
--- a/src/language-js/print/array.js
+++ b/src/language-js/print/array.js
@@ -106,12 +106,7 @@ function printArray(path, options, print) {
       ? ""
       : needsForcedTrailingComma
       ? ","
-      : !shouldPrintComma(
-          options,
-          node.type === "TSTupleType" || node.type === "TupleTypeAnnotation"
-            ? "all"
-            : "es5"
-        )
+      : !shouldPrintComma(options)
       ? ""
       : shouldUseConciseFormatting
       ? ifBreak(",", "", { groupId })

--- a/tests/format/flow/tuple-types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/tuple-types/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,124 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`trailing-comma.js - {"trailingComma":"all"} format 1`] = `
+====================================options=====================================
+parsers: ["flow", "babel-flow"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+export interface ShopQueryResult {
+  chic: boolean;
+  location: number[];
+  menus: Menu[];
+  openingDays: number[];
+  closingDays: [
+    {
+      from: string,
+      to: string,
+    }, // <== this one
+  ];
+  shop: string;
+  distance: number;
+}
+
+=====================================output=====================================
+export interface ShopQueryResult {
+  chic: boolean;
+  location: number[];
+  menus: Menu[];
+  openingDays: number[];
+  closingDays: [
+    {
+      from: string,
+      to: string,
+    }, // <== this one
+  ];
+  shop: string;
+  distance: number;
+}
+
+================================================================================
+`;
+
+exports[`trailing-comma.js - {"trailingComma":"es5"} format 1`] = `
+====================================options=====================================
+parsers: ["flow", "babel-flow"]
+printWidth: 80
+trailingComma: "es5"
+                                                                                | printWidth
+=====================================input======================================
+export interface ShopQueryResult {
+  chic: boolean;
+  location: number[];
+  menus: Menu[];
+  openingDays: number[];
+  closingDays: [
+    {
+      from: string,
+      to: string,
+    }, // <== this one
+  ];
+  shop: string;
+  distance: number;
+}
+
+=====================================output=====================================
+export interface ShopQueryResult {
+  chic: boolean;
+  location: number[];
+  menus: Menu[];
+  openingDays: number[];
+  closingDays: [
+    {
+      from: string,
+      to: string,
+    }, // <== this one
+  ];
+  shop: string;
+  distance: number;
+}
+
+================================================================================
+`;
+
+exports[`trailing-comma.js - {"trailingComma":"none"} format 1`] = `
+====================================options=====================================
+parsers: ["flow", "babel-flow"]
+printWidth: 80
+trailingComma: "none"
+                                                                                | printWidth
+=====================================input======================================
+export interface ShopQueryResult {
+  chic: boolean;
+  location: number[];
+  menus: Menu[];
+  openingDays: number[];
+  closingDays: [
+    {
+      from: string,
+      to: string,
+    }, // <== this one
+  ];
+  shop: string;
+  distance: number;
+}
+
+=====================================output=====================================
+export interface ShopQueryResult {
+  chic: boolean;
+  location: number[];
+  menus: Menu[];
+  openingDays: number[];
+  closingDays: [
+    {
+      from: string,
+      to: string
+    } // <== this one
+  ];
+  shop: string;
+  distance: number;
+}
+
+================================================================================
+`;

--- a/tests/format/flow/tuple-types/jsfmt.spec.js
+++ b/tests/format/flow/tuple-types/jsfmt.spec.js
@@ -1,0 +1,3 @@
+run_spec(import.meta, ["flow", "babel-flow"], { trailingComma: "none" });
+run_spec(import.meta, ["flow", "babel-flow"], { trailingComma: "es5" });
+run_spec(import.meta, ["flow", "babel-flow"], { trailingComma: "all" });

--- a/tests/format/flow/tuple-types/trailing-comma.js
+++ b/tests/format/flow/tuple-types/trailing-comma.js
@@ -1,0 +1,14 @@
+export interface ShopQueryResult {
+  chic: boolean;
+  location: number[];
+  menus: Menu[];
+  openingDays: number[];
+  closingDays: [
+    {
+      from: string,
+      to: string,
+    }, // <== this one
+  ];
+  shop: string;
+  distance: number;
+}

--- a/tests/format/typescript/tuple/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/tuple/__snapshots__/jsfmt.spec.js.snap
@@ -271,7 +271,7 @@ export interface ShopQueryResult {
     {
       from: string;
       to: string;
-    } // <== this one
+    }, // <== this one
   ];
   shop: string;
   distance: number;
@@ -439,7 +439,7 @@ type ValidateArgs = [
   },
   string,
   string,
-  ...string[]
+  ...string[],
 ];
 
 ================================================================================
@@ -528,7 +528,7 @@ export type SCMRawResource = [
   modes.Command /*command*/,
   string[] /*icons: light, dark*/,
   boolean /*strike through*/,
-  boolean /*faded*/
+  boolean /*faded*/,
 ];
 
 ================================================================================


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
