### PR TITLE
Forbid `AstPath.getName()`

### DIFF
--- a/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
+++ b/scripts/tools/eslint-plugin-prettier-internal-rules/test.js
@@ -922,5 +922,19 @@ test("prefer-ast-path-getters", {
         },
       ],
     },
+    {
+      code: "path.getName()",
+      output: "path.getName()",
+      errors: [
+        {
+          message:
+            "Prefer `AstPath#key` or `AstPath#index` over `AstPath#getName()`.",
+          suggestions: [
+            { desc: "Use `AstPath#key`.", output: "path.key" },
+            { desc: "Use `AstPath#index`.", output: "path.index" },
+          ],
+        },
+      ],
+    },
   ],
 });


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
