### PR TITLE
Skip parsing inline JavaScript code in Less

### DIFF
--- a/changelog_unreleased/less/14109.md
+++ b/changelog_unreleased/less/14109.md
@@ -1,0 +1,27 @@
+#### Keep inline javascript as it is (#14109 by @fisker)
+
+<!-- prettier-ignore -->
+```less
+// Input
+.calcPxMixin() {
+  @functions: ~`(function() {
+    const designWidth = 3840
+    const actualWidth = 5760
+    this.calcPx = function(_) {
+      return _ * actualWidth / designWidth + 'px'
+    }
+  })()`;
+}
+
+// Prettier stable
+.calcPxMixin() {
+  @functions: ~`(
+      function() {const designWidth = 3840 const actualWidth = 5760 this.calcPx =
+        function(_) {return _ * actualWidth / designWidth + "px"}}
+    )
+    () `;
+}
+
+// Prettier main
+<Same as input>
+```

--- a/changelog_unreleased/less/14109.md
+++ b/changelog_unreleased/less/14109.md
@@ -1,4 +1,4 @@
-#### Keep inline javascript as it is (#14109 by @fisker)
+#### Keep inline JavaScript code as it is (#14109 by @fisker)
 
 <!-- prettier-ignore -->
 ```less

--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -220,6 +220,11 @@ async function parseNestedValue(node, options) {
 }
 
 async function parseValue(value, options) {
+  // Inline javascript in Less
+  if (options.parser === "less" && value.startsWith("~`")) {
+    return { type: "value-unknown", value };
+  }
+
   const Parser = await import("postcss-values-parser/lib/parser.js").then(
     (m) => m.default
   );

--- a/tests/format/less/inline-javascript/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/less/inline-javascript/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`inline-javascript.less format 1`] = `
+====================================options=====================================
+parsers: ["less"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// Deprecated feature https://lesscss.org/usage/#less-options-enable-inline-javascript-deprecated-
+
+.calcPxMixin() {
+  @functions: ~\`(function() {
+    const designWidth = 3840
+    const actualWidth = 5760
+    this.calcPx = function(_) {
+      return _ * actualWidth / designWidth + 'px'
+    }
+  })()\`
+}
+
+=====================================output=====================================
+// Deprecated feature https://lesscss.org/usage/#less-options-enable-inline-javascript-deprecated-
+
+.calcPxMixin() {
+  @functions: ~\`(
+      function() {const designWidth = 3840 const actualWidth = 5760 this.calcPx =
+        function(_) {return _ * actualWidth / designWidth + "px"}}
+    )
+    () \`;
+}
+
+================================================================================
+`;

--- a/tests/format/less/inline-javascript/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/less/inline-javascript/__snapshots__/jsfmt.spec.js.snap
@@ -22,11 +22,13 @@ printWidth: 80
 // Deprecated feature https://lesscss.org/usage/#less-options-enable-inline-javascript-deprecated-
 
 .calcPxMixin() {
-  @functions: ~\`(
-      function() {const designWidth = 3840 const actualWidth = 5760 this.calcPx =
-        function(_) {return _ * actualWidth / designWidth + "px"}}
-    )
-    () \`;
+  @functions: ~\`(function() {
+    const designWidth = 3840
+    const actualWidth = 5760
+    this.calcPx = function(_) {
+      return _ * actualWidth / designWidth + 'px'
+    }
+  })()\`;
 }
 
 ================================================================================

--- a/tests/format/less/inline-javascript/inline-javascript.less
+++ b/tests/format/less/inline-javascript/inline-javascript.less
@@ -1,0 +1,11 @@
+// Deprecated feature https://lesscss.org/usage/#less-options-enable-inline-javascript-deprecated-
+
+.calcPxMixin() {
+  @functions: ~`(function() {
+    const designWidth = 3840
+    const actualWidth = 5760
+    this.calcPx = function(_) {
+      return _ * actualWidth / designWidth + 'px'
+    }
+  })()`
+}

--- a/tests/format/less/inline-javascript/jsfmt.spec.js
+++ b/tests/format/less/inline-javascript/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(import.meta, ["less"]);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Closes #11340, since this feature already deprecated, I don't think changelog is necessary.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
