### PR TITLE
Minor refactor to `TSModuleDeclaration` print

### DIFF
--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -402,22 +402,14 @@ function printTypescript(path, options, print) {
         }
         parts.push(printTypeScriptModifiers(path, options, print));
 
-        const textBetweenNodeAndItsId = options.originalText.slice(
-          locStart(node),
-          locStart(node.id)
-        );
-
         // Global declaration looks like this:
         // (declare)? global { ... }
-        const isGlobalDeclaration =
-          node.id.type === "Identifier" &&
-          node.id.name === "global" &&
-          !/namespace|module/.test(textBetweenNodeAndItsId);
-
-        if (!isGlobalDeclaration) {
+        if (!node.global) {
           parts.push(
             isExternalModule ||
-              /(?:^|\s)module(?:\s|$)/.test(textBetweenNodeAndItsId)
+              /(?:^|\s)module(?:\s|$)/.test(
+                options.originalText.slice(locStart(node), locStart(node.id))
+              )
               ? "module "
               : "namespace "
           );

--- a/tests/format/typescript/module/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/module/__snapshots__/jsfmt.spec.js.snap
@@ -24,12 +24,20 @@ namespace global {}
 module global {}
 global {}
 declare global {}
+declare /* module */ global {}
+declare /* namespace */ global {}
+declare module  global {}
+declare namespace global {}
 
 =====================================output=====================================
 namespace global {}
 module global {}
 global {}
 declare global {}
+declare /* module */ global {}
+declare /* namespace */ global {}
+declare module global {}
+declare namespace global {}
 
 ================================================================================
 `;

--- a/tests/format/typescript/module/global.ts
+++ b/tests/format/typescript/module/global.ts
@@ -2,3 +2,7 @@ namespace global {}
 module global {}
 global {}
 declare global {}
+declare /* module */ global {}
+declare /* namespace */ global {}
+declare module  global {}
+declare namespace global {}


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Use `node.global` instead of checking originalText.

```ts
declare /* module */ global {}
```

was printed as

```ts
declare module /* module */ global {}
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
