### PR TITLE
feat: add copy to clipboard in code blocks

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -63,7 +63,6 @@ const siteConfig = {
   ],
   stylesheets: [
     "//unpkg.com/@sandhose/prettier-animated-logo@1.0.3/dist/wide.css",
-    "/css/code-block-buttons.css",
   ],
   algolia: {
     apiKey: process.env.ALGOLIA_PRETTIER_API_KEY,

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -56,9 +56,14 @@ const siteConfig = {
   },
   usePrism: ["javascript", "jsx", "typescript", "ts", "js", "html", "css"],
   useEnglishUrl: true,
-  scripts: ["https://buttons.github.io/buttons.js"],
+  scripts: [
+    "https://buttons.github.io/buttons.js",
+    "https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.0/clipboard.min.js",
+    "/js/code-block-buttons.js",
+  ],
   stylesheets: [
     "//unpkg.com/@sandhose/prettier-animated-logo@1.0.3/dist/wide.css",
+    "/css/code-block-buttons.css",
   ],
   algolia: {
     apiKey: process.env.ALGOLIA_PRETTIER_API_KEY,

--- a/website/static/css/code-block-buttons.css
+++ b/website/static/css/code-block-buttons.css
@@ -1,42 +1,63 @@
-/* "Copy" code block button */
-pre {
+/* "Copy" code block button, style from docusaurus v2 */
+
+.code-block-with-actions {
   position: relative;
 }
 
-pre .btnIcon {
+.code-block-actions {
   position: absolute;
-  top: -5px;
-  right: 16px;
-  z-index: 2;
-  cursor: pointer;
-  border: 1px solid transparent;
-  padding: 0;
-  background-color: transparent;
-  height: 30px;
-  transition: all 0.25s ease-out;
-  display: none;
+  top: 10px;
+  right: 10px;
 }
 
-pre .btnIcon:hover {
-  text-decoration: none;
-  display: block;
-}
-
-pre code[class*="language-"]:hover + .btnIcon {
-  display: block;
-}
-
-.btnIcon__body {
-  align-items: center;
+.code-block-copy-button {
+  width: 32px;
+  height: 32px;
+  border: 1px solid #dadde1;
+  border-radius: 6px;
   display: flex;
-  color: #535b64;
+  transition: opacity .2s ease-in-out;
+  opacity: 0;
+  position: relative;
+  cursor: pointer;
+  color: #393A34;
+  background-color: #f6f8fa;
 }
 
-.btnIcon svg {
+.code-block-with-actions:hover .code-block-copy-button {
+  opacity: 0.4;
+}
+
+.code-block-with-actions:hover .code-block-copy-button:hover {
+  opacity: 1;
+}
+
+.code-block-copy-button__icon {
   fill: currentColor;
-  margin-right: 0.4em;
+  position: absolute;
+  width: 18px;
+  height: 18px;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  margin: auto;
+  transition: .15s;
 }
 
-.btnIcon__label {
-  font-size: 11px;
+.code-block-copy-button__icon--copied {
+  color: #00d600;
+  opacity: 0;
+  transform: scale(.33);
+}
+
+.code-block-copy-button--copied .code-block-copy-button__icon--copy {
+  opacity: 0;
+  transform: scale(.33);
+}
+
+.code-block-copy-button--copied .code-block-copy-button__icon--copied {
+  transition-delay: 75ms;
+  transform: scale(1);
+  opacity: 1;
 }

--- a/website/static/css/code-block-buttons.css
+++ b/website/static/css/code-block-buttons.css
@@ -1,0 +1,42 @@
+/* "Copy" code block button */
+pre {
+  position: relative;
+}
+
+pre .btnIcon {
+  position: absolute;
+  top: -5px;
+  right: 16px;
+  z-index: 2;
+  cursor: pointer;
+  border: 1px solid transparent;
+  padding: 0;
+  background-color: transparent;
+  height: 30px;
+  transition: all 0.25s ease-out;
+  display: none;
+}
+
+pre .btnIcon:hover {
+  text-decoration: none;
+  display: block;
+}
+
+pre code[class*="language-"]:hover + .btnIcon {
+  display: block;
+}
+
+.btnIcon__body {
+  align-items: center;
+  display: flex;
+  color: #535b64;
+}
+
+.btnIcon svg {
+  fill: currentColor;
+  margin-right: 0.4em;
+}
+
+.btnIcon__label {
+  font-size: 11px;
+}

--- a/website/static/css/code-block-buttons.css
+++ b/website/static/css/code-block-buttons.css
@@ -16,11 +16,11 @@
   border: 1px solid #dadde1;
   border-radius: 6px;
   display: flex;
-  transition: opacity .2s ease-in-out;
+  transition: opacity 0.2s ease-in-out;
   opacity: 0;
   position: relative;
   cursor: pointer;
-  color: #393A34;
+  color: #393a34;
   background-color: #f6f8fa;
 }
 
@@ -42,18 +42,18 @@
   top: 0;
   bottom: 0;
   margin: auto;
-  transition: .15s;
+  transition: 0.15s;
 }
 
 .code-block-copy-button__icon--copied {
   color: #00d600;
   opacity: 0;
-  transform: scale(.33);
+  transform: scale(0.33);
 }
 
 .code-block-copy-button--copied .code-block-copy-button__icon--copy {
   opacity: 0;
-  transform: scale(.33);
+  transform: scale(0.33);
 }
 
 .code-block-copy-button--copied .code-block-copy-button__icon--copied {

--- a/website/static/js/code-block-buttons.js
+++ b/website/static/js/code-block-buttons.js
@@ -1,47 +1,55 @@
+/* global ClipboardJS */
+
 "use strict";
 
-window.addEventListener("load", () => {
-  function button(label, ariaLabel, icon, className) {
-    const btn = document.createElement("button");
-    btn.classList.add("btnIcon", className);
-    btn.setAttribute("type", "button");
-    btn.setAttribute("aria-label", ariaLabel);
-    btn.innerHTML =
-      '<div class="btnIcon__body">' +
-      icon +
-      '<strong class="btnIcon__label">' +
-      label +
-      "</strong>" +
-      "</div>";
-    return btn;
+(function () {
+  const CONTAINER_CLASS_NAME = "code-block-with-actions";
+  const ACTIONS_CONATINER_CLASS_NAME = "code-block-actions";
+  const COPY_BUTTON_CLASS_NAME = "code-block-copy-button";
+  const COPY_BUTTON_COPIED_CLASS_NAME = `${COPY_BUTTON_CLASS_NAME}--copied`;
+  const COPY_BUTTON_ICON_CLASS_NAME = `${COPY_BUTTON_CLASS_NAME}__icon`;
+  const COPY_BUTTON_COPY_ICON_CLASS_NAME = `${COPY_BUTTON_ICON_CLASS_NAME}--copy`;
+  const COPY_BUTTON_COPIED_ICON_CLASS_NAME = `${COPY_BUTTON_ICON_CLASS_NAME}--copied`;
+  const ATIA_LABEL = "Copy code to clipboard";
+  const ATIA_LABEL_COPIED = "Copied";
+
+  function init(codeBlock) {
+    const container = codeBlock.parentNode;
+    container.classList.add(CONTAINER_CLASS_NAME);
+
+    const actionsContainer = Object.assign(document.createElement("div"), {
+      className: ACTIONS_CONATINER_CLASS_NAME,
+    });
+    const copyButton = Object.assign(document.createElement("button"), {
+      className: COPY_BUTTON_CLASS_NAME,
+      type: "button",
+      innerHTML:
+        `<svg class="${COPY_BUTTON_ICON_CLASS_NAME} ${COPY_BUTTON_COPY_ICON_CLASS_NAME}" viewBox="0 0 24 24"><path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"></path></svg>` +
+        `<svg class="${COPY_BUTTON_ICON_CLASS_NAME} ${COPY_BUTTON_COPIED_ICON_CLASS_NAME}" viewBox="0 0 24 24"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg>`,
+    });
+    copyButton.setAttribute("aria-label", ATIA_LABEL);
+
+    new ClipboardJS(copyButton, { target: () => codeBlock }).on(
+      "success",
+      (event) => {
+        event.clearSelection();
+        copyButton.classList.add(COPY_BUTTON_COPIED_CLASS_NAME);
+        copyButton.setAttribute("aria-label", ATIA_LABEL_COPIED);
+
+        setTimeout(() => {
+          copyButton.classList.remove(COPY_BUTTON_COPIED_CLASS_NAME);
+          copyButton.setAttribute("aria-label", ATIA_LABEL);
+        }, 2000);
+      }
+    );
+
+    actionsContainer.appendChild(copyButton);
+    container.appendChild(actionsContainer);
   }
 
-  function addButtons(codeBlockSelector, btn) {
-    for (const code of document.querySelectorAll(codeBlockSelector)) {
-      code.parentNode.appendChild(btn.cloneNode(true));
+  window.addEventListener("load", () => {
+    for (const codeBlock of document.querySelectorAll("pre > code.hljs")) {
+      init(codeBlock);
     }
-  }
-
-  const copyIcon =
-    '<svg width="12" height="12" viewBox="340 364 14 15" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M342 375.974h4v.998h-4v-.998zm5-5.987h-5v.998h5v-.998zm2 2.994v-1.995l-3 2.993 3 2.994v-1.996h5v-1.995h-5zm-4.5-.997H342v.998h2.5v-.997zm-2.5 2.993h2.5v-.998H342v.998zm9 .998h1v1.996c-.016.28-.11.514-.297.702-.187.187-.422.28-.703.296h-10c-.547 0-1-.452-1-.998v-10.976c0-.546.453-.998 1-.998h3c0-1.107.89-1.996 2-1.996 1.11 0 2 .89 2 1.996h3c.547 0 1 .452 1 .998v4.99h-1v-2.995h-10v8.98h10v-1.996zm-9-7.983h8c0-.544-.453-.996-1-.996h-1c-.547 0-1-.453-1-.998 0-.546-.453-.998-1-.998-.547 0-1 .452-1 .998 0 .545-.453.998-1 .998h-1c-.547 0-1 .452-1 .997z" fill-rule="evenodd"/></svg>';
-
-  addButtons(
-    ".hljs",
-    button("Copy", "Copy code to clipboard", copyIcon, "btnClipboard")
-  );
-  // eslint-disable-next-line no-undef
-  const clipboard = new ClipboardJS(".btnClipboard", {
-    target(trigger) {
-      return trigger.parentNode.querySelector("code");
-    },
   });
-
-  clipboard.on("success", (event) => {
-    event.clearSelection();
-    const textEl = event.trigger.querySelector(".btnIcon__label");
-    textEl.textContent = "Copied";
-    setTimeout(() => {
-      textEl.textContent = "Copy";
-    }, 2000);
-  });
-});
+})();

--- a/website/static/js/code-block-buttons.js
+++ b/website/static/js/code-block-buttons.js
@@ -4,21 +4,21 @@
 
 (function () {
   const CONTAINER_CLASS_NAME = "code-block-with-actions";
-  const ACTIONS_CONATINER_CLASS_NAME = "code-block-actions";
+  const ACTIONS_CONTAINER_CLASS_NAME = "code-block-actions";
   const COPY_BUTTON_CLASS_NAME = "code-block-copy-button";
   const COPY_BUTTON_COPIED_CLASS_NAME = `${COPY_BUTTON_CLASS_NAME}--copied`;
   const COPY_BUTTON_ICON_CLASS_NAME = `${COPY_BUTTON_CLASS_NAME}__icon`;
   const COPY_BUTTON_COPY_ICON_CLASS_NAME = `${COPY_BUTTON_ICON_CLASS_NAME}--copy`;
   const COPY_BUTTON_COPIED_ICON_CLASS_NAME = `${COPY_BUTTON_ICON_CLASS_NAME}--copied`;
-  const ATIA_LABEL = "Copy code to clipboard";
-  const ATIA_LABEL_COPIED = "Copied";
+  const ARIA_LABEL = "Copy code to clipboard";
+  const ARIA_LABEL_COPIED = "Copied";
 
   function init(codeBlock) {
     const container = codeBlock.parentNode;
     container.classList.add(CONTAINER_CLASS_NAME);
 
     const actionsContainer = Object.assign(document.createElement("div"), {
-      className: ACTIONS_CONATINER_CLASS_NAME,
+      className: ACTIONS_CONTAINER_CLASS_NAME,
     });
     const copyButton = Object.assign(document.createElement("button"), {
       className: COPY_BUTTON_CLASS_NAME,
@@ -27,18 +27,18 @@
         `<svg class="${COPY_BUTTON_ICON_CLASS_NAME} ${COPY_BUTTON_COPY_ICON_CLASS_NAME}" viewBox="0 0 24 24"><path d="M19,21H8V7H19M19,5H8A2,2 0 0,0 6,7V21A2,2 0 0,0 8,23H19A2,2 0 0,0 21,21V7A2,2 0 0,0 19,5M16,1H4A2,2 0 0,0 2,3V17H4V3H16V1Z"></path></svg>` +
         `<svg class="${COPY_BUTTON_ICON_CLASS_NAME} ${COPY_BUTTON_COPIED_ICON_CLASS_NAME}" viewBox="0 0 24 24"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"></path></svg>`,
     });
-    copyButton.setAttribute("aria-label", ATIA_LABEL);
+    copyButton.setAttribute("aria-label", ARIA_LABEL);
 
     new ClipboardJS(copyButton, { target: () => codeBlock }).on(
       "success",
       (event) => {
         event.clearSelection();
         copyButton.classList.add(COPY_BUTTON_COPIED_CLASS_NAME);
-        copyButton.setAttribute("aria-label", ATIA_LABEL_COPIED);
+        copyButton.setAttribute("aria-label", ARIA_LABEL_COPIED);
 
         setTimeout(() => {
           copyButton.classList.remove(COPY_BUTTON_COPIED_CLASS_NAME);
-          copyButton.setAttribute("aria-label", ATIA_LABEL);
+          copyButton.setAttribute("aria-label", ARIA_LABEL);
         }, 2000);
       }
     );

--- a/website/static/js/code-block-buttons.js
+++ b/website/static/js/code-block-buttons.js
@@ -35,10 +35,12 @@
         event.clearSelection();
         copyButton.classList.add(COPY_BUTTON_COPIED_CLASS_NAME);
         copyButton.setAttribute("aria-label", ARIA_LABEL_COPIED);
+        copyButton.disabled = true;
 
         setTimeout(() => {
           copyButton.classList.remove(COPY_BUTTON_COPIED_CLASS_NAME);
           copyButton.setAttribute("aria-label", ARIA_LABEL);
+          copyButton.disabled = false;
         }, 2000);
       }
     );

--- a/website/static/js/code-block-buttons.js
+++ b/website/static/js/code-block-buttons.js
@@ -1,0 +1,47 @@
+"use strict";
+
+window.addEventListener("load", () => {
+  function button(label, ariaLabel, icon, className) {
+    const btn = document.createElement("button");
+    btn.classList.add("btnIcon", className);
+    btn.setAttribute("type", "button");
+    btn.setAttribute("aria-label", ariaLabel);
+    btn.innerHTML =
+      '<div class="btnIcon__body">' +
+      icon +
+      '<strong class="btnIcon__label">' +
+      label +
+      "</strong>" +
+      "</div>";
+    return btn;
+  }
+
+  function addButtons(codeBlockSelector, btn) {
+    for (const code of document.querySelectorAll(codeBlockSelector)) {
+      code.parentNode.appendChild(btn.cloneNode(true));
+    }
+  }
+
+  const copyIcon =
+    '<svg width="12" height="12" viewBox="340 364 14 15" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M342 375.974h4v.998h-4v-.998zm5-5.987h-5v.998h5v-.998zm2 2.994v-1.995l-3 2.993 3 2.994v-1.996h5v-1.995h-5zm-4.5-.997H342v.998h2.5v-.997zm-2.5 2.993h2.5v-.998H342v.998zm9 .998h1v1.996c-.016.28-.11.514-.297.702-.187.187-.422.28-.703.296h-10c-.547 0-1-.452-1-.998v-10.976c0-.546.453-.998 1-.998h3c0-1.107.89-1.996 2-1.996 1.11 0 2 .89 2 1.996h3c.547 0 1 .452 1 .998v4.99h-1v-2.995h-10v8.98h10v-1.996zm-9-7.983h8c0-.544-.453-.996-1-.996h-1c-.547 0-1-.453-1-.998 0-.546-.453-.998-1-.998-.547 0-1 .452-1 .998 0 .545-.453.998-1 .998h-1c-.547 0-1 .452-1 .997z" fill-rule="evenodd"/></svg>';
+
+  addButtons(
+    ".hljs",
+    button("Copy", "Copy code to clipboard", copyIcon, "btnClipboard")
+  );
+  // eslint-disable-next-line no-undef
+  const clipboard = new ClipboardJS(".btnClipboard", {
+    target(trigger) {
+      return trigger.parentNode.querySelector("code");
+    },
+  });
+
+  clipboard.on("success", (event) => {
+    event.clearSelection();
+    const textEl = event.trigger.querySelector(".btnIcon__label");
+    textEl.textContent = "Copied";
+    setTimeout(() => {
+      textEl.textContent = "Copy";
+    }, 2000);
+  });
+});

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2558,9 +2558,9 @@ dashdash@^1.12.0:
     assert-plus "^1.0.0"
 
 date-fns@^2.16.1:
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.28.0.tgz#9570d656f5fc13143e50c975a3b6bbeb46cd08b2"
-  integrity sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==
+  version "2.29.3"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.29.3.tgz#27402d2fc67eb442b511b70bbdf98e6411cd68a8"
+  integrity sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0:
   version "2.6.9"


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
This PR adds a copy to clipboard button to code blocks as part of #14006 

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**

<img width="644" alt="image" src="https://user-images.githubusercontent.com/34857453/211604689-c80a372b-55b4-49af-9c81-442e721c298a.png">


