### PR TITLE
Reuse `printFunctionType`

### DIFF
--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -258,37 +258,6 @@ function printTypescript(path, options, print) {
       return print("literal");
     case "TSIndexedAccessType":
       return printIndexedAccessType(path, options, print);
-    case "TSConstructSignatureDeclaration":
-    case "TSCallSignatureDeclaration":
-    case "TSConstructorType":
-      if (node.type === "TSConstructorType" && node.abstract) {
-        parts.push("abstract ");
-      }
-      if (node.type !== "TSCallSignatureDeclaration") {
-        parts.push("new ");
-      }
-
-      parts.push(
-        group(
-          printFunctionParameters(
-            path,
-            print,
-            options,
-            /* expandArg */ false,
-            /* printTypeParams */ true
-          )
-        )
-      );
-
-      if (node.returnType || node.typeAnnotation) {
-        const isType = node.type === "TSConstructorType";
-        parts.push(
-          isType ? " => " : ": ",
-          print("returnType"),
-          print("typeAnnotation")
-        );
-      }
-      return parts;
 
     case "TSTypeOperator":
       return [node.operator, " ", print("typeAnnotation")];
@@ -440,6 +409,9 @@ function printTypescript(path, options, print) {
     case "TSUnionType":
       return printUnionType(path, options, print);
     case "TSFunctionType":
+    case "TSCallSignatureDeclaration":
+    case "TSConstructorType":
+    case "TSConstructSignatureDeclaration":
       return printFunctionType(path, options, print);
     case "TSTupleType":
       return printArray(path, options, print);

--- a/tests/format/typescript/function-type/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/function-type/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,67 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`consistent.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// TSFunctionType
+type A = (
+  tpl: TemplateStringsArray,
+  ...args: Array<unknown>
+) => (replacements?: PublicReplacements) => T;
+
+// TSConstructorType
+type B = new (
+  tpl: TemplateStringsArray,
+  ...args: Array<unknown>
+) => (replacements?: PublicReplacements) => T;
+
+type X = {
+  // TSCallSignatureDeclaration
+  (
+    tpl: TemplateStringsArray,
+    ...args: Array<unknown>
+  ): (replacements?: PublicReplacements) => T;
+
+  // TSConstructSignatureDeclaration
+  new (
+    tpl: TemplateStringsArray,
+    ...args: Array<unknown>
+  ): (replacements?: PublicReplacements) => T;
+};
+
+=====================================output=====================================
+// TSFunctionType
+type A = (
+  tpl: TemplateStringsArray,
+  ...args: Array<unknown>
+) => (replacements?: PublicReplacements) => T;
+
+// TSConstructorType
+type B = new (
+  tpl: TemplateStringsArray,
+  ...args: Array<unknown>
+) => (replacements?: PublicReplacements) => T;
+
+type X = {
+  // TSCallSignatureDeclaration
+  (
+    tpl: TemplateStringsArray,
+    ...args: Array<unknown>
+  ): (replacements?: PublicReplacements) => T;
+
+  // TSConstructSignatureDeclaration
+  new (
+    tpl: TemplateStringsArray,
+    ...args: Array<unknown>
+  ): (replacements?: PublicReplacements) => T;
+};
+
+================================================================================
+`;
+
 exports[`single-parameter.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/function-type/consistent.ts
+++ b/tests/format/typescript/function-type/consistent.ts
@@ -1,0 +1,25 @@
+// TSFunctionType
+type A = (
+  tpl: TemplateStringsArray,
+  ...args: Array<unknown>
+) => (replacements?: PublicReplacements) => T;
+
+// TSConstructorType
+type B = new (
+  tpl: TemplateStringsArray,
+  ...args: Array<unknown>
+) => (replacements?: PublicReplacements) => T;
+
+type X = {
+  // TSCallSignatureDeclaration
+  (
+    tpl: TemplateStringsArray,
+    ...args: Array<unknown>
+  ): (replacements?: PublicReplacements) => T;
+
+  // TSConstructSignatureDeclaration
+  new (
+    tpl: TemplateStringsArray,
+    ...args: Array<unknown>
+  ): (replacements?: PublicReplacements) => T;
+};


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
