### PR TITLE
Refactor method value print

### DIFF
--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -34,7 +34,7 @@ import { printObject } from "./object.js";
 import { printClassProperty, printClassMethod } from "./class.js";
 import { printTypeParameter, printTypeParameters } from "./type-parameters.js";
 import { printPropertyKey } from "./property.js";
-import { printFunction, printMethodInternal } from "./function.js";
+import { printFunction, printMethodValue } from "./function.js";
 import { printInterface } from "./interface.js";
 import { printBlock } from "./block.js";
 import {
@@ -451,7 +451,7 @@ function printTypescript(path, options, print) {
     case "TSTypeAnnotation":
       return print("typeAnnotation");
     case "TSEmptyBodyFunctionExpression":
-      return printMethodInternal(path, options, print);
+      return printMethodValue(path, options, print);
 
     // These are not valid TypeScript. Printing them just for the sake of error recovery.
     case "TSJSDocAllType":


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Print `value` node of method through `print`, I'm not sure if there are comment/cursor related issue there, but I think it's better to print node through `print`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
