### PR TITLE
Extract `printClassBody`

### DIFF
--- a/src/language-js/print/block.js
+++ b/src/language-js/print/block.js
@@ -6,9 +6,7 @@ import {
   CommentCheckFlags,
   isNextLineEmpty,
 } from "../utils/index.js";
-import { printHardlineAfterHeritage } from "./class.js";
-
-import { printBody } from "./statement.js";
+import { printStatementSequence } from "./statement.js";
 
 /** @typedef {import("../../document/builders.js").Doc} Doc */
 
@@ -18,11 +16,6 @@ function printBlock(path, options, print) {
 
   if (node.type === "StaticBlock") {
     parts.push("static ");
-  }
-
-  if (node.type === "ClassBody" && isNonEmptyArray(node.body)) {
-    const { parent } = path;
-    parts.push(printHardlineAfterHeritage(parent));
   }
 
   parts.push("{");
@@ -47,8 +40,7 @@ function printBlock(path, options, print) {
         (parent.type === "CatchClause" && !parentParent.finalizer) ||
         parent.type === "TSModuleDeclaration" ||
         parent.type === "TSDeclareFunction" ||
-        node.type === "StaticBlock" ||
-        node.type === "ClassBody"
+        node.type === "StaticBlock"
       )
     ) {
       parts.push(hardline);
@@ -86,7 +78,7 @@ function printBlockBody(path, options, print) {
   }
 
   if (nodeHasBody) {
-    parts.push(printBody(path, options, print));
+    parts.push(printStatementSequence(path, options, print));
   }
 
   if (nodeHasComment) {

--- a/src/language-js/print/class.js
+++ b/src/language-js/print/class.js
@@ -9,7 +9,12 @@ import {
   indent,
   ifBreak,
 } from "../../document/builders.js";
-import { hasComment, CommentCheckFlags } from "../utils/index.js";
+import {
+  hasComment,
+  CommentCheckFlags,
+  createTypeCheckFunction,
+  isNextLineEmpty,
+} from "../utils/index.js";
 import { getTypeParametersGroupId } from "./type-parameters.js";
 import { printMethod } from "./function.js";
 import {
@@ -25,6 +30,16 @@ import { printClassMemberDecorators } from "./decorators.js";
 /**
  * @typedef {import("../../document/builders.js").Doc} Doc
  */
+
+const isClassProperty = createTypeCheckFunction([
+  "ClassProperty",
+  "PropertyDefinition",
+  "ClassPrivateProperty",
+  "ClassAccessorProperty",
+  "AccessorProperty",
+  "TSAbstractPropertyDefinition",
+  "TSAbstractAccessorProperty",
+]);
 
 /*
 - `ClassDeclaration`
@@ -250,9 +265,129 @@ function printClassProperty(path, options, print) {
   ];
 }
 
+function printClassBody(path, options, print) {
+  const { node } = path;
+  const parts = [];
+
+  path.each(({ node, next, isLast }) => {
+    parts.push(print());
+
+    if (
+      !options.semi &&
+      isClassProperty(node) &&
+      // `ClassBody` don't allow `EmptyStatement`,
+      // so we can use `statements` to get next node
+      shouldPrintSemicolonAfterClassProperty(node, next)
+    ) {
+      parts.push(";");
+    }
+
+    if (!isLast) {
+      parts.push(hardline);
+
+      if (isNextLineEmpty(node, options)) {
+        parts.push(hardline);
+      }
+    }
+  }, "body");
+
+  if (hasComment(node, CommentCheckFlags.Dangling)) {
+    parts.push(printDanglingComments(path, options, /* sameIndent */ true));
+  }
+
+  return [
+    isNonEmptyArray(node.body) ? printHardlineAfterHeritage(path.parent) : "",
+    "{",
+    parts.length > 0 ? [indent([hardline, parts]), hardline] : "",
+    "}",
+  ];
+}
+
+/**
+ * @returns {boolean}
+ */
+function shouldPrintSemicolonAfterClassProperty(node, nextNode) {
+  const { type, name } = node.key;
+  if (
+    !node.computed &&
+    type === "Identifier" &&
+    (name === "static" ||
+      name === "get" ||
+      name === "set" ||
+      // TODO: Remove this https://github.com/microsoft/TypeScript/issues/51707 is fixed
+      name === "accessor") &&
+    !node.value &&
+    !node.typeAnnotation
+  ) {
+    return true;
+  }
+
+  if (!nextNode) {
+    return false;
+  }
+
+  if (
+    nextNode.static ||
+    nextNode.accessibility // TypeScript
+  ) {
+    return false;
+  }
+
+  if (!nextNode.computed) {
+    const name = nextNode.key?.name;
+    if (name === "in" || name === "instanceof") {
+      return true;
+    }
+  }
+
+  // Flow variance sigil +/- requires semi if there's no
+  // "declare" or "static" keyword before it.
+  if (
+    isClassProperty(nextNode) &&
+    nextNode.variance &&
+    !nextNode.static &&
+    !nextNode.declare
+  ) {
+    return true;
+  }
+
+  switch (nextNode.type) {
+    case "ClassProperty":
+    case "PropertyDefinition":
+    case "TSAbstractPropertyDefinition":
+      return nextNode.computed;
+    case "MethodDefinition": // Flow
+    case "TSAbstractMethodDefinition": // TypeScript
+    case "ClassMethod":
+    case "ClassPrivateMethod": {
+      // Babel
+      const isAsync = nextNode.value ? nextNode.value.async : nextNode.async;
+      if (isAsync || nextNode.kind === "get" || nextNode.kind === "set") {
+        return false;
+      }
+
+      const isGenerator = nextNode.value
+        ? nextNode.value.generator
+        : nextNode.generator;
+      if (nextNode.computed || isGenerator) {
+        return true;
+      }
+
+      return false;
+    }
+
+    case "TSIndexSignature":
+      return true;
+  }
+
+  /* c8 ignore next */
+  return false;
+}
+
 export {
   printClass,
   printClassMethod,
   printClassProperty,
   printHardlineAfterHeritage,
+  printClassBody,
 };

--- a/src/language-js/print/class.js
+++ b/src/language-js/print/class.js
@@ -275,8 +275,6 @@ function printClassBody(path, options, print) {
     if (
       !options.semi &&
       isClassProperty(node) &&
-      // `ClassBody` don't allow `EmptyStatement`,
-      // so we can use `statements` to get next node
       shouldPrintSemicolonAfterClassProperty(node, next)
     ) {
       parts.push(";");
@@ -356,8 +354,8 @@ function shouldPrintSemicolonAfterClassProperty(node, nextNode) {
     case "PropertyDefinition":
     case "TSAbstractPropertyDefinition":
       return nextNode.computed;
-    case "MethodDefinition": // Flow
-    case "TSAbstractMethodDefinition": // TypeScript
+    case "MethodDefinition":
+    case "TSAbstractMethodDefinition":
     case "ClassMethod":
     case "ClassPrivateMethod": {
       // Babel

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -69,6 +69,7 @@ import {
   printClass,
   printClassMethod,
   printClassProperty,
+  printClassBody,
 } from "./print/class.js";
 import { printProperty } from "./print/property.js";
 import {
@@ -84,7 +85,7 @@ import {
   printAssignmentExpression,
 } from "./print/assignment.js";
 import { printBinaryishExpression } from "./print/binaryish.js";
-import { printSwitchCaseConsequent } from "./print/statement.js";
+import { printStatementSequence } from "./print/statement.js";
 import { printMemberExpression } from "./print/member.js";
 import { printBlock, printBlockBody } from "./print/block.js";
 import { printLiteral } from "./print/literal.js";
@@ -355,8 +356,9 @@ function printPathNoParens(path, options, print, args) {
       return "import";
     case "BlockStatement":
     case "StaticBlock":
-    case "ClassBody":
       return printBlock(path, options, print);
+    case "ClassBody":
+      return printClassBody(path, options, print);
     case "ThrowStatement":
       return printThrowStatement(path, options, print);
     case "ReturnStatement":
@@ -715,7 +717,7 @@ function printPathNoParens(path, options, print, args) {
       );
 
       if (consequent.length > 0) {
-        const cons = printSwitchCaseConsequent(path, options, print);
+        const cons = printStatementSequence(path, options, print);
 
         parts.push(
           consequent.length === 1 && consequent[0].type === "BlockStatement"


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

The `ClassBody` is different than normal statement sequence,

It can't have `directives` and `EmptyStatement` , it have different logic in no-semi mode.

Let's split it.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
