### PR TITLE
[TEST]: Ignore leading space of cursorNodeText

### DIFF
--- a/src/main/core.js
+++ b/src/main/core.js
@@ -82,8 +82,12 @@ async function coreFormat(originalText, opts, addAlignmentSize = 0) {
       cursorOffsetRelativeToOldCursorNode =
         opts.cursorOffset - oldCursorNodeStart;
 
-      newCursorNodeStart = result.cursorNodeStart;
-      newCursorNodeText = result.cursorNodeText;
+      const { cursorNodeText, cursorNodeStart } = result;
+      const trimmedCursorNodeText = cursorNodeText.trimStart();
+      newCursorNodeText = trimmedCursorNodeText;
+      newCursorNodeStart =
+        cursorNodeStart +
+        (cursorNodeText.length - trimmedCursorNodeText.length);
     } else {
       oldCursorNodeStart = 0;
       oldCursorNodeText = text;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

A possible problem in `formatWithCursor`,

This code,

```js
class A {}
//     ^
```

The cursor node is `ClassBody`.

Currently we print doc like 

```js
["class", " ", "A", " ", cursor, "{", "}", cursor, hardline]
```

But if we change doc to 

```js
["class", " ", "A", cursor, " ", "{", "}", cursor, hardline]
```

The cursor will became `8 -> 7`, is shouldn't matter we print space in `ClassDeclaration` or `ClassBody`.

Originally found here https://github.com/prettier/prettier/pull/14171#discussion_r1071129701

Don't know how to test yest.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
