### PR TITLE
Add `onParsed` to `textToDoc` option

### DIFF
--- a/src/language-html/embed.js
+++ b/src/language-html/embed.js
@@ -42,17 +42,17 @@ async function printEmbeddedAttributeValue(node, htmlTextToDoc, options) {
 
   let shouldHug = false;
 
-  const __onHtmlBindingRoot = (root, options) => {
+  const onAttributeValueParsed = (ast, options) => {
     const rootNode =
-      root.type === "NGRoot"
-        ? root.node.type === "NGMicrosyntax" &&
-          root.node.body.length === 1 &&
-          root.node.body[0].type === "NGMicrosyntaxExpression"
-          ? root.node.body[0].expression
-          : root.node
-        : root.type === "JsExpressionRoot"
-        ? root.node
-        : root;
+      ast.type === "NGRoot"
+        ? ast.node.type === "NGMicrosyntax" &&
+          ast.node.body.length === 1 &&
+          ast.node.body[0].type === "NGMicrosyntaxExpression"
+          ? ast.node.body[0].expression
+          : ast.node
+        : ast.type === "JsExpressionRoot"
+        ? ast.node
+        : ast;
     if (
       rootNode &&
       (rootNode.type === "ObjectExpression" ||
@@ -72,7 +72,7 @@ async function printEmbeddedAttributeValue(node, htmlTextToDoc, options) {
 
   const attributeTextToDoc = (code, opts) =>
     htmlTextToDoc(code, {
-      __onHtmlBindingRoot,
+      onParsed: onAttributeValueParsed,
       __embeddedInHtml: true,
       ...opts,
     });

--- a/src/language-js/parse/utils/wrap-babel-expression.js
+++ b/src/language-js/parse/utils/wrap-babel-expression.js
@@ -9,7 +9,6 @@ function wrapBabelExpression(node, options, type = "JsExpressionRoot") {
     type,
     node,
     range: [0, options.originalText.length],
-    rootMarker: options.rootMarker,
   };
 }
 

--- a/src/language-js/print/html-binding.js
+++ b/src/language-js/print/html-binding.js
@@ -7,17 +7,12 @@ import {
 } from "../../document/builders.js";
 
 function printHtmlBinding(path, options, print) {
-  const { node, isRoot } = path;
+  const { node } = path;
 
-  if (isRoot) {
-    options.__onHtmlBindingRoot?.(node, options);
-  }
-
-  if (node.type !== "File") {
-    return;
-  }
-
-  if (options.__isVueBindings || options.__isVueForBindingLeft) {
+  if (
+    node.type === "File" &&
+    (options.__isVueBindings || options.__isVueForBindingLeft)
+  ) {
     const parameterDocs = path.map(print, "program", "body", 0, "params");
 
     if (parameterDocs.length === 1) {

--- a/src/language-markdown/embed.js
+++ b/src/language-markdown/embed.js
@@ -51,7 +51,9 @@ function embed(path, options) {
       return (textToDoc) =>
         textToDoc(`<$>${node.value}</$>`, {
           parser: "__js_expression",
-          rootMarker: "mdx",
+          onParsed(ast) {
+            ast.rootMarker = "mdx";
+          },
         });
   }
 

--- a/src/main/multiparser.js
+++ b/src/main/multiparser.js
@@ -112,6 +112,7 @@ async function textToDoc(
   const nextOptions = await normalize(
     {
       ...parentOptions,
+      onParsed: undefined,
       ...partialNextOptions,
       parentParser: parentOptions.parser,
       originalText: text,
@@ -131,6 +132,8 @@ async function textToDoc(
   nextOptions[Symbol.for("comments")] = astComments || [];
   // @ts-expect-error -- Casting to `unique symbol` isn't allowed in JSDoc comment
   nextOptions[Symbol.for("tokens")] = ast.tokens || [];
+
+  nextOptions.onParsed?.(ast, nextOptions);
 
   const doc = await printAstToDoc(ast, nextOptions);
   ensureAllCommentsPrinted(astComments);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Provide a way to get embed AST.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
