### PR TITLE
Support for CSS language comments; less strict HTML language comments

### DIFF
--- a/src/language-js/clean.js
+++ b/src/language-js/clean.js
@@ -180,9 +180,7 @@ function clean(ast, newObj, parent) {
     const hasLanguageComment = ast.leadingComments?.some(
       (comment) =>
         isBlockComment(comment) &&
-        ["GraphQL", "HTML"].some(
-          (languageName) => comment.value === ` ${languageName} `
-        )
+        comment.value === " GraphQL " || ~["html", "css"].indexOf(comment.value.toLowerCase().trim())
     );
     if (
       hasLanguageComment ||

--- a/src/language-js/embed.js
+++ b/src/language-js/embed.js
@@ -15,7 +15,8 @@ function getLanguage(path) {
     isStyledJsx(path) ||
     isStyledComponents(path) ||
     isCssProp(path) ||
-    isAngularComponentStyles(path)
+    isAngularComponentStyles(path) ||
+    hasLanguageComment(path.getValue(), "CSS")
   ) {
     return "css";
   }
@@ -273,10 +274,13 @@ function hasLanguageComment(node, languageName) {
   // we will not trim the comment value and we will expect exactly one space on
   // either side of the GraphQL string
   // Also see ./clean.js
+
+  const strict = languageName === "GraphQL";
+
   return hasComment(
     node,
     CommentCheckFlags.Block | CommentCheckFlags.Leading,
-    ({ value }) => value === ` ${languageName} `
+    ({ value }) => strict ? value === ` ${languageName} ` : value.trim().toLowerCase() === languageName.toLowerCase()
   );
 }
 

--- a/tests/format/misc/embedded_language_formatting/in-javascript/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/embedded_language_formatting/in-javascript/__snapshots__/jsfmt.spec.js.snap
@@ -9,11 +9,15 @@ printWidth: 80
 =====================================input======================================
 css\`a { }\`
 
+const foo = /*css*/\`a{}\`;
+
 md\`\`
 
 graphql(\`{id}\`)
 
 html\`<a>\`
+
+const bar = /*html*/\`<a>\`;
 
 @Component({
   template: \`<a>\`,
@@ -24,11 +28,15 @@ class TestComponent {}
 =====================================output=====================================
 css\`a { }\`;
 
+const foo = /*css*/ \`a{}\`;
+
 md\`\`;
 
 graphql(\`{id}\`);
 
 html\`<a>\`;
+
+const bar = /*html*/ \`<a>\`;
 
 @Component({
   template: \`<a>\`,
@@ -47,11 +55,15 @@ printWidth: 80
 =====================================input======================================
 css\`a { }\`
 
+const foo = /*css*/\`a{}\`;
+
 md\`\`
 
 graphql(\`{id}\`)
 
 html\`<a>\`
+
+const bar = /*html*/\`<a>\`;
 
 @Component({
   template: \`<a>\`,
@@ -61,6 +73,11 @@ class TestComponent {}
 
 =====================================output=====================================
 css\`
+  a {
+  }
+\`;
+
+const foo = /*css*/ \`
   a {
   }
 \`;
@@ -78,6 +95,8 @@ graphql(
 );
 
 html\`<a></a>\`;
+
+const bar = /*html*/ \`<a></a>\`;
 
 @Component({
   template: \`<a></a>\`,

--- a/tests/format/misc/embedded_language_formatting/in-javascript/test.js
+++ b/tests/format/misc/embedded_language_formatting/in-javascript/test.js
@@ -1,10 +1,14 @@
 css`a { }`
 
+const foo = /*css*/`a{}`;
+
 md``
 
 graphql(`{id}`)
 
 html`<a>`
+
+const bar = /*html*/`<a>`;
 
 @Component({
   template: `<a>`,


### PR DESCRIPTION
## Description

The main objective of this pull request is to add support for CSS language comments for embedded language formatting, e.g.

```javascript
const styleSheet = /* css */`.foo { }`;
```

This builds upon existing support for HTML language comments, e.g.

```javascript
const tmpl = /* HTML */`<button>submit</button>`;
```

> **Note**
> The existing implementation for HTML and GraphQL is case-sensitive and requires leading and trailing spaces. For better compatibility with other tools, CSS language comments are case-insensitive and allow leading/trailing whitespace. I followed suit for HTML; but I left the strict requirements in place for GraphQL because I don't fully understand why they were implemented that way in the first place.

## Motivation/Justification

While the language-comment pattern is undoubtedly less common than using a tag function, it is still a pattern people want to use. Here are a few bits of evidence:
* VS Code extensions
  * [Inline HTML](https://marketplace.visualstudio.com/items?itemName=pushqrdx.inline-html) (~69k downloads)
  * [es6-string-css](https://marketplace.visualstudio.com/items?itemName=bashmish.es6-string-css) (~20k downloads)
* @jaydenseric's [comment](https://github.com/prettier/prettier/issues/4360#issuecomment-383826369) on a Prettier issue
* No-op tagging libraries
  * [jaydenseric/fake-tag](https://github.com/jaydenseric/fake-tag)
  * [lleaff/tagged-template-noop](https://github.com/lleaff/tagged-template-noop)
  * [fabiospampinato/noop-tag](https://github.com/fabiospampinato/noop-tag)
  * [WebReflection/plain-tag](https://github.com/WebReflection/plain-tag)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~~ N/A
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
