### PR TITLE
Support --ignore-pattern as a command line option

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -114,6 +114,14 @@ If you don’t have a configuration file, or want to ignore it if it does exist,
 
 Path to a file containing patterns that describe files to ignore. By default, Prettier looks for `./.prettierignore`.
 
+## `--ignore-pattern`
+
+This allows you to specify patterns of files to ignore (in addition to those in .prettierignore).
+
+```bash
+prettier --ignore-pattern "./ignore**.js" --check .
+```
+
 ## `--list-different`
 
 Another useful flag is `--list-different` (or `-l`) which prints the filenames of files that are different from Prettier formatting. If there are differences the script errors out, which is useful in a CI scenario.

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -233,7 +233,8 @@ async function createIgnorerFromContextOrDie(context) {
   try {
     return await createIgnorer(
       context.argv.ignorePath,
-      context.argv.withNodeModules
+      context.argv.withNodeModules,
+      context.argv.ignorePatterns
     );
   } catch (e) {
     context.logger.error(e.message);

--- a/src/common/create-ignorer.js
+++ b/src/common/create-ignorer.js
@@ -7,32 +7,40 @@ const getFileContentOrNull = require("../utils/get-file-content-or-null.js");
 /**
  * @param {string?} ignorePath
  * @param {boolean?} withNodeModules
+ * @param {Array<string>?} ignorePatterns
  */
-async function createIgnorer(ignorePath, withNodeModules) {
+async function createIgnorer(ignorePath, withNodeModules, ignorePatterns = []) {
   const ignoreContent = ignorePath
     ? await getFileContentOrNull(path.resolve(ignorePath))
     : null;
 
-  return _createIgnorer(ignoreContent, withNodeModules);
+  return _createIgnorer(ignoreContent, withNodeModules, ignorePatterns);
 }
 
 /**
  * @param {string?} ignorePath
  * @param {boolean?} withNodeModules
  */
-createIgnorer.sync = function (ignorePath, withNodeModules) {
+createIgnorer.sync = function (
+  ignorePath,
+  withNodeModules,
+  ignorePatterns = []
+) {
   const ignoreContent = !ignorePath
     ? null
     : getFileContentOrNull.sync(path.resolve(ignorePath));
-  return _createIgnorer(ignoreContent, withNodeModules);
+  return _createIgnorer(ignoreContent, withNodeModules, ignorePatterns);
 };
 
 /**
  * @param {null | string} ignoreContent
  * @param {boolean?} withNodeModules
+ * @param {Array<string>} ignorePatterns
  */
-function _createIgnorer(ignoreContent, withNodeModules) {
+function _createIgnorer(ignoreContent, withNodeModules, ignorePatterns) {
   const ignorer = ignore({ allowRelativePaths: true }).add(ignoreContent || "");
+  ignorer.add(ignorePatterns);
+
   if (!withNodeModules) {
     ignorer.add("node_modules");
   }

--- a/src/main/core-options.js
+++ b/src/main/core-options.js
@@ -104,6 +104,21 @@ const options = {
     cliCategory: CATEGORY_OTHER,
     cliDescription: "Path to the file to pretend that stdin comes from.",
   },
+  ignorePatterns: {
+    since: "2.9.0",
+    type: "path",
+    array: true,
+    default: [{ value: [] }],
+    category: CATEGORY_GLOBAL,
+    description: outdent`
+      Specify the patterns of files to ignore, in addition to those in the
+      configuration.
+    `,
+    exception: (value) =>
+      typeof value === "string" || typeof value === "object",
+    cliName: "ignore-pattern",
+    cliCategory: CATEGORY_CONFIG,
+  },
   insertPragma: {
     since: "1.8.0",
     category: CATEGORY_SPECIAL,

--- a/tests/integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests/integration/__tests__/__snapshots__/early-exit.js.snap
@@ -114,6 +114,9 @@ Config options:
                            Find and print the path to a configuration file for the given input file.
   --ignore-path <path>     Path to a file with patterns describing files to ignore.
                            Defaults to .prettierignore.
+  --ignore-pattern <path>  Specify the patterns of files to ignore, in addition to those in the
+                           configuration.
+                           Defaults to [].
   --plugin <path>          Add a plugin. Multiple plugins can be passed as separate \`--plugin\`s.
                            Defaults to [].
   --plugin-search-dir <path>
@@ -289,6 +292,9 @@ Config options:
                            Find and print the path to a configuration file for the given input file.
   --ignore-path <path>     Path to a file with patterns describing files to ignore.
                            Defaults to .prettierignore.
+  --ignore-pattern <path>  Specify the patterns of files to ignore, in addition to those in the
+                           configuration.
+                           Defaults to [].
   --plugin <path>          Add a plugin. Multiple plugins can be passed as separate \`--plugin\`s.
                            Defaults to [].
   --plugin-search-dir <path>

--- a/tests/integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/help-options.js.snap
@@ -274,6 +274,20 @@ Default: .prettierignore
 
 exports[`show detailed usage with --help ignore-path (write) 1`] = `[]`;
 
+exports[`show detailed usage with --help ignore-pattern (stderr) 1`] = `""`;
+
+exports[`show detailed usage with --help ignore-pattern (stdout) 1`] = `
+"--ignore-pattern <path>
+
+  Specify the patterns of files to ignore, in addition to those in the
+  configuration.
+
+Default: []
+"
+`;
+
+exports[`show detailed usage with --help ignore-pattern (write) 1`] = `[]`;
+
 exports[`show detailed usage with --help ignore-unknown (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help ignore-unknown (stdout) 1`] = `

--- a/tests/integration/__tests__/__snapshots__/ignore-patterns.js.snap
+++ b/tests/integration/__tests__/__snapshots__/ignore-patterns.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ignore patterns (stderr) 1`] = `""`;
+
+exports[`ignore patterns (stdout) 1`] = `
+"regular-module.js
+"
+`;
+
+exports[`ignore patterns (write) 1`] = `[]`;
+
+exports[`ignore patterns with multiple arguments (stderr) 1`] = `""`;
+
+exports[`ignore patterns with multiple arguments (stdout) 1`] = `""`;
+
+exports[`ignore patterns with multiple arguments (write) 1`] = `[]`;
+
+exports[`outputs files as-is if no --write (stderr) 1`] = `""`;
+
+exports[`outputs files as-is if no --write (stdout) 1`] = `
+"'use strict';
+"
+`;
+
+exports[`outputs files as-is if no --write (write) 1`] = `[]`;

--- a/tests/integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests/integration/__tests__/__snapshots__/schema.js.snap
@@ -118,6 +118,15 @@ This option cannot be used with --range-start and --range-end.",
             },
           ],
         },
+        "ignorePatterns": {
+          "default": [],
+          "description": "Specify the patterns of files to ignore, in addition to those in the
+configuration.",
+          "items": {
+            "type": "string",
+          },
+          "type": "array",
+        },
         "insertPragma": {
           "default": false,
           "description": "Insert @format pragma into file's first docblock comment.",

--- a/tests/integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests/integration/__tests__/__snapshots__/support-info.js.snap
@@ -143,6 +143,10 @@ exports[`API getSupportInfo() 1`] = `
       "default": "css",
       "type": "choice",
     },
+    "ignorePatterns": {
+      "default": [],
+      "type": "path",
+    },
     "insertPragma": {
       "default": false,
       "type": "boolean",
@@ -911,6 +915,16 @@ exports[`CLI --support-info (stdout) 1`] = `
       "pluginDefaults": {},
       "since": "1.15.0",
       "type": "choice"
+    },
+    {
+      "array": true,
+      "category": "Global",
+      "default": [],
+      "description": "Specify the patterns of files to ignore, in addition to those in the\\nconfiguration.",
+      "name": "ignorePatterns",
+      "pluginDefaults": {},
+      "since": "2.9.0",
+      "type": "path"
     },
     {
       "category": "Special",

--- a/tests/integration/__tests__/ignore-patterns.js
+++ b/tests/integration/__tests__/ignore-patterns.js
@@ -1,0 +1,39 @@
+"use strict";
+
+const runPrettier = require("../run-prettier.js");
+
+describe("ignore patterns", () => {
+  runPrettier("cli/ignore-patterns", [
+    "**/*.js",
+    "--ignore-pattern",
+    "**/other-regular-module.js",
+    "-l",
+  ]).test({
+    status: 1,
+  });
+});
+
+describe("ignore patterns with multiple arguments", () => {
+  runPrettier("cli/ignore-patterns", [
+    "**/*.js",
+    "--ignore-pattern",
+    "**/other-regular-module.js",
+    "--ignore-pattern",
+    "**/regular-module.js",
+    "-l",
+  ]).test({
+    status: 0,
+  });
+});
+
+describe("outputs files as-is if no --write", () => {
+  runPrettier(
+    "cli/ignore-patterns",
+    ["--ignore-pattern", "**/regular-module.js", "regular-module.js"],
+    {
+      ignoreLineEndings: true,
+    }
+  ).test({
+    status: 0,
+  });
+});

--- a/tests/integration/cli/ignore-patterns/other-regular-module.js
+++ b/tests/integration/cli/ignore-patterns/other-regular-module.js
@@ -1,0 +1,1 @@
+'use strict';

--- a/tests/integration/cli/ignore-patterns/regular-module.js
+++ b/tests/integration/cli/ignore-patterns/regular-module.js
@@ -1,0 +1,1 @@
+'use strict';


### PR DESCRIPTION
## Description

This adds `--ignore-pattern` as a command line option, allowing multiple patterns for ignoring files to be specified on the command line. This echos the [ESLint command line option](https://eslint.org/docs/latest/use/command-line-interface#--ignore-pattern)

This is part of the work for #3460. Related work and discussion is in #12672, however that PR appears to have stalled out.

I'm planning to also add an `ignores` to the configuration, but I'm still figuring out how the structure fits together, as this appears to the first time that option of this type would be added.

I'm happy to do the configuration addition in either this PR or a follow-up, whatever makes most sense - but I thought I'd post this as this part works fine on its own.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [X] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
