### PR TITLE
docs(install): update lint-staged note

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -130,7 +130,7 @@ For example, you can do the following to have Prettier run before each commit:
 }
 ```
 
-> Note: If you use ESLint, make sure lint-staged runs it before Prettier, not after.
+> Note: If you also use ESLint, pay attention to the [task concurrency](https://github.com/okonet/lint-staged#task-concurrency) of lint-staged.
 
 See [Pre-commit Hook](precommit.md) for more information.
 


### PR DESCRIPTION
## Description

I don't think the current documentation is clear enough on why the order has an impact when using lint-staged. So I've added a link to the lint-staged documentation. In the case of ESLint with `eslint-plugin-prettier`, running ESLint first will output errors before Prettier works. Therefore, I think it should just hint the risk and let the user decide the order of commands by themselves.

## Checklist

- [x] (It's document-only) I’ve tested the website in localhost to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
