### PR TITLE
Add ability to dynamically create AstPath

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -14,6 +14,7 @@
         "arrayify",
         "Artem",
         "Ascher",
+        "astpath",
         "astro",
         "atrule",
         "atrules",

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -53,17 +53,22 @@ function printAstToDoc(ast, options, alignmentSize = 0) {
 
   function mainPrint(selector, args) {
     if (selector === undefined || selector === path) {
-      return mainPrintInternal(args);
+      return mainPrintInternal(args, path);
+    }
+
+    if (selector instanceof AstPath) {
+      // An AstPath that doesn't match `path` should be propagated.
+      return mainPrintInternal(args, selector);
     }
 
     if (Array.isArray(selector)) {
-      return path.call(() => mainPrintInternal(args), ...selector);
+      return path.call(() => mainPrintInternal(args, path), ...selector);
     }
 
-    return path.call(() => mainPrintInternal(args), selector);
+    return path.call(() => mainPrintInternal(args, path), selector);
   }
 
-  function mainPrintInternal(args) {
+  function mainPrintInternal(args, path) {
     const value = path.getValue();
 
     const shouldCache =

--- a/tests/integration/__tests__/plugin-dynamic-astpath.js
+++ b/tests/integration/__tests__/plugin-dynamic-astpath.js
@@ -1,0 +1,15 @@
+"use strict";
+
+const runPrettier = require("../run-prettier.js");
+const EOL = "\n";
+
+describe("an dynamically-generated AstPath can be used for printing", () => {
+  runPrettier("plugins/dynamic-astpath", ["*.foo", "--plugin=./plugin"], {
+    ignoreLineEndings: true,
+  }).test({
+    stdout: "<foo>\n  <bar>\n    the,bar,string\n  </bar>\n  <baz>the; baz; string</baz>\n</foo>" + EOL,
+    stderr: "",
+    status: 0,
+    write: [],
+  });
+});

--- a/tests/integration/plugins/dynamic-astpath/file.foo
+++ b/tests/integration/plugins/dynamic-astpath/file.foo
@@ -1,0 +1,16 @@
+{
+  "type": "element",
+  "name": "foo",
+  "children": [
+    {
+      "type": "element",
+      "name": "bar",
+      "children": [{ "type": "string", "value": "the,bar,string" }]
+    },
+    {
+      "type": "element",
+      "name": "baz",
+      "children": [{ "type": "string", "value": "the,baz,string" }]
+    }
+  ]
+}

--- a/tests/integration/plugins/dynamic-astpath/plugin.js
+++ b/tests/integration/plugins/dynamic-astpath/plugin.js
@@ -1,0 +1,57 @@
+"use strict";
+
+const prettier = require("prettier-local");
+const { group, hardline, indent, softline } = prettier.doc.builders;
+
+/**
+ * This plugin tests whether a dynamically-created AstPath can be used
+ * in the printing process.
+ */
+module.exports = {
+  languages: [
+    {
+      name: "foo",
+      parsers: ["foo-parser"],
+      extensions: [".foo"],
+    },
+  ],
+  parsers: {
+    "foo-parser": {
+      parse: (text) => JSON.parse(text),
+      astFormat: "foo-ast",
+    },
+  },
+  printers: {
+    "foo-ast": {
+      print: (path, options, print) => {
+        const node = path.getNode();
+
+        // If we encounter a `baz` element, we want to reparse its content and
+        // print it specially.
+        if (node.type === "element" && node.name === "baz") {
+          const newAst = {
+            type: "list",
+            content: node.children[0].value.split(","),
+          };
+          const newPath = new path.constructor(newAst);
+          return ["<baz>", print(newPath), "</baz>"];
+        }
+
+        switch (node.type) {
+          case "element":
+            return [
+              `<${node.name}>`,
+              indent([hardline, group(path.map(print, "children"))]),
+              hardline,
+              `</${node.name}>`,
+              softline,
+            ];
+          case "string":
+            return node.value;
+          case "list":
+            return node.content.join("; ");
+        }
+      },
+    },
+  },
+};


### PR DESCRIPTION
## Description

This PR resolves the issue in #14230 It should be fully compatible with existing code.

It adds the ability to pass in an `AstPath` other than the path that was initially created when the printing processes starts. This means that a plugin can perform dynamic re-parsing/manipulation of the AST during printing and pass the new AST fragments to `print` by means of a new `AstPath` object.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
