### PR TITLE
Forbid `initializer` of `TSPropertySignature`

### DIFF
--- a/src/language-js/parse/postprocess/index.js
+++ b/src/language-js/parse/postprocess/index.js
@@ -104,6 +104,14 @@ function postprocess(ast, options) {
           }
         }
         break;
+      case "TSPropertySignature":
+        if (node.initializer) {
+          throwSyntaxError(
+            node.initializer,
+            "An interface property cannot have an initializer."
+          );
+        }
+        break;
 
       // For hack-style pipeline
       case "TopicReference":

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -160,22 +160,12 @@ function printTypescript(path, options, print) {
     case "TSArrayType":
       return [print("elementType"), "[]"];
     case "TSPropertySignature":
-      if (node.readonly) {
-        parts.push("readonly ");
-      }
-
-      parts.push(
+      return [
+        node.readonly ? "readonly " : "",
         printPropertyKey(path, options, print),
         printOptionalToken(path),
-        printTypeAnnotationProperty(path, print)
-      );
-
-      // This isn't valid semantically, but it's in the AST so we can print it.
-      if (node.initializer) {
-        parts.push(" = ", print("initializer"));
-      }
-
-      return parts;
+        printTypeAnnotationProperty(path, print),
+      ];
 
     case "TSParameterProperty":
       if (node.accessibility) {

--- a/src/language-js/traverse/visitor-keys.evaluate.js
+++ b/src/language-js/traverse/visitor-keys.evaluate.js
@@ -59,6 +59,9 @@ const excludeKeys = {
   // TODO: Remove `types` when babel changes AST of `TupleTypeAnnotation`
   // Flow parser changed `.types` to `.elementTypes` https://github.com/facebook/flow/commit/5b60e6a81dc277dfab2e88fa3737a4dc9aafdcab
   // TupleTypeAnnotation: ["types"],
+
+  // TypeScript
+  TSPropertySignature: ["initializer"],
 };
 
 const visitorKeys = Object.fromEntries(

--- a/tests/format/misc/errors/typescript/interface/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/typescript/interface/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snippet: #0 [babel-ts] format 1`] = `
+"Unexpected token, expected ";" (1:25)
+> 1 | interface I { x: number = 1;}
+    |                         ^"
+`;
+
+exports[`snippet: #0 [typescript] format 1`] = `
+"An interface property cannot have an initializer. (1:27)
+> 1 | interface I { x: number = 1;}
+    |                           ^"
+`;

--- a/tests/format/misc/errors/typescript/interface/jsfmt.spec.js
+++ b/tests/format/misc/errors/typescript/interface/jsfmt.spec.js
@@ -1,0 +1,10 @@
+run_spec(
+  {
+    importMeta: import.meta,
+    snippets: [
+      // Invalid initializer
+      "interface I { x: number = 1;}",
+    ],
+  },
+  ["babel-ts", "typescript"]
+);

--- a/tests/format/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/compiler/__snapshots__/jsfmt.spec.js.snap
@@ -441,33 +441,6 @@ const;
 ================================================================================
 `;
 
-exports[`errorOnInitializerInInterfaceProperty.ts [babel-ts] format 1`] = `
-"Unexpected token, expected ";" (2:17)
-  1 | interface Foo {
-> 2 |     bar: number = 5;
-    |                 ^
-  3 | }
-  4 |"
-`;
-
-exports[`errorOnInitializerInInterfaceProperty.ts format 1`] = `
-====================================options=====================================
-parsers: ["typescript"]
-printWidth: 80
-                                                                                | printWidth
-=====================================input======================================
-interface Foo {
-    bar: number = 5;
-}
-
-=====================================output=====================================
-interface Foo {
-  bar: number = 5;
-}
-
-================================================================================
-`;
-
 exports[`es5ExportDefaultClassDeclaration4.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/compiler/errorOnInitializerInInterfaceProperty.ts
+++ b/tests/format/typescript/compiler/errorOnInitializerInInterfaceProperty.ts
@@ -1,3 +1,0 @@
-interface Foo {
-    bar: number = 5;
-}

--- a/tests/format/typescript/compiler/jsfmt.spec.js
+++ b/tests/format/typescript/compiler/jsfmt.spec.js
@@ -1,9 +1,5 @@
 run_spec(import.meta, ["typescript"], {
   errors: {
-    "babel-ts": [
-      "downlevelLetConst1.ts",
-      "errorOnInitializerInInterfaceProperty.ts",
-      "decrementAndIncrementOperators.ts",
-    ],
+    "babel-ts": ["downlevelLetConst1.ts", "decrementAndIncrementOperators.ts"],
   },
 });

--- a/tests/unit/__snapshots__/visitor-keys.js.snap
+++ b/tests/unit/__snapshots__/visitor-keys.js.snap
@@ -869,7 +869,6 @@ exports[`visitor keys estree 1`] = `
   "TSPropertySignature": [
     "key",
     "typeAnnotation",
-    "initializer",
   ],
   "TSProtectedKeyword": [],
   "TSPublicKeyword": [],


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Ref: https://github.com/typescript-eslint/typescript-eslint/pull/6243#discussion_r1090246389

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
