### PR TITLE
Remove printing `modifiers` of `TSModuleDeclaration`

### DIFF
--- a/src/language-js/parse/postprocess/typescript.js
+++ b/src/language-js/parse/postprocess/typescript.js
@@ -175,9 +175,7 @@ function throwErrorForInvalidModifier(node) {
     ) {
       throwErrorOnTsNode(
         modifier,
-        `'${ts.tokenToString(
-          modifier.kind
-        )}' modifier cannot appear on a module or namespace element.`
+        "'accessor' modifier can only appear on a property declaration."
       );
     }
 

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -22,7 +22,7 @@ import {
 import isTsKeywordType from "../utils/is-ts-keyword-type.js";
 import { locStart, locEnd } from "../loc.js";
 
-import { printOptionalToken, printTypeScriptModifiers } from "./misc.js";
+import { printOptionalToken } from "./misc.js";
 import { printTernary } from "./ternary.js";
 import {
   printFunctionParameters,
@@ -367,10 +367,7 @@ function printTypescript(path, options, print) {
       if (parentIsDeclaration) {
         parts.push(".");
       } else {
-        parts.push(
-          printDeclareToken(path),
-          printTypeScriptModifiers(path, options, print)
-        );
+        parts.push(printDeclareToken(path));
 
         // Global declaration looks like this:
         // (declare)? global { ... }

--- a/src/language-js/traverse/visitor-keys.evaluate.js
+++ b/src/language-js/traverse/visitor-keys.evaluate.js
@@ -31,7 +31,6 @@ const additionalVisitorKeys = {
   TSJSDocNonNullableType: ["typeAnnotation"],
   // This one maybe invalid, need investigate
   TSAbstractMethodDefinition: ["decorators"],
-  TSModuleDeclaration: ["modifiers"],
   TSEnumDeclaration: ["modifiers"],
 
   // Flow

--- a/tests/format/misc/errors/typescript/modifiers/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/typescript/modifiers/__snapshots__/jsfmt.spec.js.snap
@@ -1091,7 +1091,7 @@ exports[`snippet: #68 [babel-ts] format 1`] = `
 `;
 
 exports[`snippet: #68 [typescript] format 1`] = `
-"'accessor' modifier cannot appear on a module or namespace element. (1:1)
+"'accessor' modifier can only appear on a property declaration. (1:1)
 > 1 | accessor interface Foo {}
     | ^^^^^^^^"
 `;
@@ -1446,4 +1446,316 @@ exports[`snippet: #96 [typescript] format 1`] = `
 > 2 |   declare set setter(v) {}
     |   ^^^^^^^
   3 | }"
+`;
+
+exports[`snippet: #97 [babel-ts] format 1`] = `
+"Unexpected token, expected "class" (1:10)
+> 1 | abstract module Foo {}
+    |          ^"
+`;
+
+exports[`snippet: #97 [typescript] format 1`] = `
+"'abstract' modifier can only appear on a class, method, or property declaration. (1:1)
+> 1 | abstract module Foo {}
+    | ^^^^^^^^"
+`;
+
+exports[`snippet: #98 [babel-ts] format 1`] = `
+"Unexpected token, expected "class" (1:10)
+> 1 | abstract namespace Foo {}
+    |          ^"
+`;
+
+exports[`snippet: #98 [typescript] format 1`] = `
+"'abstract' modifier can only appear on a class, method, or property declaration. (1:1)
+> 1 | abstract namespace Foo {}
+    | ^^^^^^^^"
+`;
+
+exports[`snippet: #99 [babel-ts] format 1`] = `
+"Missing semicolon. (1:9)
+> 1 | accessor module Foo {}
+    |         ^"
+`;
+
+exports[`snippet: #99 [typescript] format 1`] = `
+"'accessor' modifier can only appear on a property declaration. (1:1)
+> 1 | accessor module Foo {}
+    | ^^^^^^^^"
+`;
+
+exports[`snippet: #100 [babel-ts] format 1`] = `
+"Missing semicolon. (1:9)
+> 1 | accessor namespace Foo {}
+    |         ^"
+`;
+
+exports[`snippet: #100 [typescript] format 1`] = `
+"'accessor' modifier can only appear on a property declaration. (1:1)
+> 1 | accessor namespace Foo {}
+    | ^^^^^^^^"
+`;
+
+exports[`snippet: #101 [babel-ts] format 1`] = `
+"Missing semicolon. (1:6)
+> 1 | async module Foo {}
+    |      ^"
+`;
+
+exports[`snippet: #101 [typescript] format 1`] = `
+"'async' modifier cannot be used here. (1:1)
+> 1 | async module Foo {}
+    | ^^^^^"
+`;
+
+exports[`snippet: #102 [babel-ts] format 1`] = `
+"Missing semicolon. (1:6)
+> 1 | async namespace Foo {}
+    |      ^"
+`;
+
+exports[`snippet: #102 [typescript] format 1`] = `
+"'async' modifier cannot be used here. (1:1)
+> 1 | async namespace Foo {}
+    | ^^^^^"
+`;
+
+exports[`snippet: #103 [babel-ts] format 1`] = `
+"Missing initializer in const declaration. (1:13)
+> 1 | const module Foo {}
+    |             ^"
+`;
+
+exports[`snippet: #103 [typescript] format 1`] = `
+"',' expected. (1:14)
+> 1 | const module Foo {}
+    |              ^"
+`;
+
+exports[`snippet: #104 [babel-ts] format 1`] = `
+"Missing initializer in const declaration. (1:16)
+> 1 | const namespace Foo {}
+    |                ^"
+`;
+
+exports[`snippet: #104 [typescript] format 1`] = `
+"',' expected. (1:17)
+> 1 | const namespace Foo {}
+    |                 ^"
+`;
+
+exports[`snippet: #105 [babel-ts] format 1`] = `
+"Unexpected token (1:1)
+> 1 | default module Foo {}
+    | ^"
+`;
+
+exports[`snippet: #105 [typescript] format 1`] = `
+"'export' expected. (1:1)
+> 1 | default module Foo {}
+    | ^"
+`;
+
+exports[`snippet: #106 [babel-ts] format 1`] = `
+"Unexpected token (1:1)
+> 1 | default namespace Foo {}
+    | ^"
+`;
+
+exports[`snippet: #106 [typescript] format 1`] = `
+"'export' expected. (1:1)
+> 1 | default namespace Foo {}
+    | ^"
+`;
+
+exports[`snippet: #107 [babel-ts] format 1`] = `
+"Unexpected token (1:1)
+> 1 | in module Foo {}
+    | ^"
+`;
+
+exports[`snippet: #107 [typescript] format 1`] = `
+"Expression expected. (1:1)
+> 1 | in module Foo {}
+    | ^"
+`;
+
+exports[`snippet: #108 [babel-ts] format 1`] = `
+"Unexpected token (1:1)
+> 1 | in namespace Foo {}
+    | ^"
+`;
+
+exports[`snippet: #108 [typescript] format 1`] = `
+"Expression expected. (1:1)
+> 1 | in namespace Foo {}
+    | ^"
+`;
+
+exports[`snippet: #109 [babel-ts] format 1`] = `
+"Missing semicolon. (1:4)
+> 1 | out module Foo {}
+    |    ^"
+`;
+
+exports[`snippet: #109 [typescript] format 1`] = `
+"Unexpected keyword or identifier. (1:1)
+> 1 | out module Foo {}
+    | ^"
+`;
+
+exports[`snippet: #110 [babel-ts] format 1`] = `
+"Missing semicolon. (1:4)
+> 1 | out namespace Foo {}
+    |    ^"
+`;
+
+exports[`snippet: #110 [typescript] format 1`] = `
+"Unexpected keyword or identifier. (1:1)
+> 1 | out namespace Foo {}
+    | ^"
+`;
+
+exports[`snippet: #111 [babel-ts] format 1`] = `
+"Missing semicolon. (1:9)
+> 1 | override module Foo {}
+    |         ^"
+`;
+
+exports[`snippet: #111 [typescript] format 1`] = `
+"Unexpected keyword or identifier. (1:1)
+> 1 | override module Foo {}
+    | ^"
+`;
+
+exports[`snippet: #112 [babel-ts] format 1`] = `
+"Missing semicolon. (1:9)
+> 1 | override namespace Foo {}
+    |         ^"
+`;
+
+exports[`snippet: #112 [typescript] format 1`] = `
+"Unexpected keyword or identifier. (1:1)
+> 1 | override namespace Foo {}
+    | ^"
+`;
+
+exports[`snippet: #113 [babel-ts] format 1`] = `
+"Missing semicolon. (1:8)
+> 1 | private module Foo {}
+    |        ^"
+`;
+
+exports[`snippet: #113 [typescript] format 1`] = `
+"'private' modifier cannot appear on a module or namespace element. (1:1)
+> 1 | private module Foo {}
+    | ^^^^^^^"
+`;
+
+exports[`snippet: #114 [babel-ts] format 1`] = `
+"Missing semicolon. (1:8)
+> 1 | private namespace Foo {}
+    |        ^"
+`;
+
+exports[`snippet: #114 [typescript] format 1`] = `
+"'private' modifier cannot appear on a module or namespace element. (1:1)
+> 1 | private namespace Foo {}
+    | ^^^^^^^"
+`;
+
+exports[`snippet: #115 [babel-ts] format 1`] = `
+"Missing semicolon. (1:10)
+> 1 | protected module Foo {}
+    |          ^"
+`;
+
+exports[`snippet: #115 [typescript] format 1`] = `
+"'protected' modifier cannot appear on a module or namespace element. (1:1)
+> 1 | protected module Foo {}
+    | ^^^^^^^^^"
+`;
+
+exports[`snippet: #116 [babel-ts] format 1`] = `
+"Missing semicolon. (1:10)
+> 1 | protected namespace Foo {}
+    |          ^"
+`;
+
+exports[`snippet: #116 [typescript] format 1`] = `
+"'protected' modifier cannot appear on a module or namespace element. (1:1)
+> 1 | protected namespace Foo {}
+    | ^^^^^^^^^"
+`;
+
+exports[`snippet: #117 [babel-ts] format 1`] = `
+"Missing semicolon. (1:7)
+> 1 | public module Foo {}
+    |       ^"
+`;
+
+exports[`snippet: #117 [typescript] format 1`] = `
+"'public' modifier cannot appear on a module or namespace element. (1:1)
+> 1 | public module Foo {}
+    | ^^^^^^"
+`;
+
+exports[`snippet: #118 [babel-ts] format 1`] = `
+"Missing semicolon. (1:7)
+> 1 | public namespace Foo {}
+    |       ^"
+`;
+
+exports[`snippet: #118 [typescript] format 1`] = `
+"'public' modifier cannot appear on a module or namespace element. (1:1)
+> 1 | public namespace Foo {}
+    | ^^^^^^"
+`;
+
+exports[`snippet: #119 [babel-ts] format 1`] = `
+"Missing semicolon. (1:9)
+> 1 | readonly module Foo {}
+    |         ^"
+`;
+
+exports[`snippet: #119 [typescript] format 1`] = `
+"'readonly' modifier can only appear on a property declaration or index signature. (1:1)
+> 1 | readonly module Foo {}
+    | ^^^^^^^^"
+`;
+
+exports[`snippet: #120 [babel-ts] format 1`] = `
+"Missing semicolon. (1:9)
+> 1 | readonly namespace Foo {}
+    |         ^"
+`;
+
+exports[`snippet: #120 [typescript] format 1`] = `
+"'readonly' modifier can only appear on a property declaration or index signature. (1:1)
+> 1 | readonly namespace Foo {}
+    | ^^^^^^^^"
+`;
+
+exports[`snippet: #121 [babel-ts] format 1`] = `
+"Missing semicolon. (1:7)
+> 1 | static module Foo {}
+    |       ^"
+`;
+
+exports[`snippet: #121 [typescript] format 1`] = `
+"'static' modifier cannot appear on a module or namespace element. (1:1)
+> 1 | static module Foo {}
+    | ^^^^^^"
+`;
+
+exports[`snippet: #122 [babel-ts] format 1`] = `
+"Missing semicolon. (1:7)
+> 1 | static namespace Foo {}
+    |       ^"
+`;
+
+exports[`snippet: #122 [typescript] format 1`] = `
+"'static' modifier cannot appear on a module or namespace element. (1:1)
+> 1 | static namespace Foo {}
+    | ^^^^^^"
 `;

--- a/tests/format/misc/errors/typescript/modifiers/jsfmt.spec.js
+++ b/tests/format/misc/errors/typescript/modifiers/jsfmt.spec.js
@@ -85,6 +85,14 @@ run_spec(
           declare set setter(v) {}
         }
       `,
+
+      // `TSModuleDeclaration`
+      ...POSSIBLE_MODIFIERS.filter(
+        (modifier) => modifier !== "declare" && modifier !== "export"
+      ).flatMap((modifier) => [
+        `${modifier} module Foo {}`,
+        `${modifier} namespace Foo {}`,
+      ]),
     ],
   },
   ["babel-ts", "typescript"]

--- a/tests/unit/__snapshots__/visitor-keys.js.snap
+++ b/tests/unit/__snapshots__/visitor-keys.js.snap
@@ -839,7 +839,6 @@ exports[`visitor keys estree 1`] = `
   "TSModuleDeclaration": [
     "id",
     "body",
-    "modifiers",
   ],
   "TSNamedTupleMember": [
     "label",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

`TSModuleDeclaration` can't have `modifiers`.

https://github.com/typescript-eslint/typescript-eslint/pull/4863

Related #14265

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
