### PR TITLE
Allow babel e2e test to ignore tests

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,6 +1,7 @@
 import path from "node:path";
 import createEsmUtils from "esm-utils";
 import installPrettier from "./tests/config/install-prettier.js";
+import parseForeignTestIgnorePatterns from "./tests/config/parse-foreign-test-ignore-patterns.js";
 
 const { dirname: PROJECT_ROOT } = createEsmUtils(import.meta);
 const isProduction = process.env.NODE_ENV === "production";
@@ -27,9 +28,21 @@ process.env.PRETTIER_INSTALLED_DIR = PRETTIER_INSTALLED_DIR;
 process.env.PRETTIER_DIR = PRETTIER_DIR;
 
 const testPathIgnorePatterns = [];
+
+// For babel e2e test to ignore specific tests
+// See https://github.com/babel/babel/pull/15385#issuecomment-1409800413
+if (process.env.FOREIGN_TEST === "babel") {
+  testPathIgnorePatterns.push(
+    ...parseForeignTestIgnorePatterns(
+      path.join(PROJECT_ROOT, ".babel-e2e-test-ignore")
+    )
+  );
+}
+
 if (TEST_STANDALONE) {
   testPathIgnorePatterns.push("<rootDir>/tests/integration/");
 }
+
 if (isProduction) {
   // Only run unit test for development
   testPathIgnorePatterns.push("<rootDir>/tests/unit/");

--- a/tests/config/parse-foreign-test-ignore-patterns.js
+++ b/tests/config/parse-foreign-test-ignore-patterns.js
@@ -1,0 +1,32 @@
+import fs from "node:fs";
+
+const ROOT_DIR_PREFIX = "<rootDir>/";
+
+function* parseForeignTestIgnorePatterns(file) {
+  if (!fs.existsSync(file)) {
+    return;
+  }
+
+  let content = "";
+  try {
+    content = fs.readFileSync(file, "utf8");
+  } catch {
+    return;
+  }
+
+  for (let pattern of content.split("\n")) {
+    pattern = pattern.trim();
+
+    if (pattern.startsWith("/")) {
+      pattern = pattern.slice(1);
+    }
+
+    if (!pattern.startsWith("tests/")) {
+      continue;
+    }
+
+    yield ROOT_DIR_PREFIX + pattern;
+  }
+}
+
+export default parseForeignTestIgnorePatterns;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

https://github.com/babel/babel/pull/15385#issuecomment-1409800413

cc @JLHwung 

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
