### PR TITLE
Fix incorrect removal of parentheses when using an `infer` with a constraint in a function predicate

### DIFF
--- a/changelog_unreleased/typescript/14279.md
+++ b/changelog_unreleased/typescript/14279.md
@@ -1,0 +1,16 @@
+#### Fix parens in inferred function return types with `extends` (#14279 by @fisker)
+
+<!-- prettier-ignore -->
+```ts
+// Input
+type Foo<T> = T extends ((a) => a is infer R extends string) ? R : never;
+
+// Prettier stable (First format)
+type Foo<T> = T extends (a) => a is infer R extends string ? R : never;
+
+// Prettier stable (Second format)
+SyntaxError: '?' expected. 
+
+// Prettier main
+type Foo<T> = T extends ((a) => a is infer R extends string) ? R : never;
+```

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -466,13 +466,13 @@ function needsParens(path, options) {
       }
 
     case "TSConditionalType":
-      if (name === "extendsType" && parent.type === "TSConditionalType") {
-        return true;
-      }
-    // fallthrough
     case "TSFunctionType":
     case "TSConstructorType":
       if (name === "extendsType" && parent.type === "TSConditionalType") {
+        if (node.type === "TSConditionalType") {
+          return true;
+        }
+
         let { typeAnnotation } = node.returnType || node.typeAnnotation;
 
         if (

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -473,15 +473,23 @@ function needsParens(path, options) {
     case "TSFunctionType":
     case "TSConstructorType":
       if (name === "extendsType" && parent.type === "TSConditionalType") {
-        const returnTypeAnnotation = (node.returnType || node.typeAnnotation)
-          .typeAnnotation;
+        let { typeAnnotation } = node.returnType || node.typeAnnotation;
+
         if (
-          returnTypeAnnotation.type === "TSInferType" &&
-          returnTypeAnnotation.typeParameter.constraint
+          typeAnnotation.type === "TSTypePredicate" &&
+          typeAnnotation.typeAnnotation
+        ) {
+          typeAnnotation = typeAnnotation.typeAnnotation.typeAnnotation;
+        }
+
+        if (
+          typeAnnotation.type === "TSInferType" &&
+          typeAnnotation.typeParameter.constraint
         ) {
           return true;
         }
       }
+
       if (name === "checkType" && parent.type === "TSConditionalType") {
         return true;
       }

--- a/tests/format/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
@@ -278,20 +278,6 @@ type Unpacked<T> = T extends (infer U)[]
 ================================================================================
 `;
 
-exports[`issue-13275.ts format 1`] = `
-====================================options=====================================
-parsers: ["typescript"]
-printWidth: 80
-                                                                                | printWidth
-=====================================input======================================
-type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;
-
-=====================================output=====================================
-type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;
-
-================================================================================
-`;
-
 exports[`nested-in-condition.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -428,6 +414,46 @@ type Unpacked<T> = T extends (infer U)[]
   : T extends Promise<infer U>
   ? U
   : T;
+
+================================================================================
+`;
+
+exports[`parentheses.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// #13275
+type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;
+
+// #14275
+type Test<T> = T extends ((
+  token: TSESTree.Token
+) => token is infer U extends TSESTree.Token)
+  ? U
+  : TSESTree.Token;
+type Test<T> = T extends ((
+  token: TSESTree.Token
+) => asserts token is infer U extends TSESTree.Token)
+  ? U
+  : TSESTree.Token;
+
+=====================================output=====================================
+// #13275
+type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;
+
+// #14275
+type Test<T> = T extends ((
+  token: TSESTree.Token
+) => token is infer U extends TSESTree.Token)
+  ? U
+  : TSESTree.Token;
+type Test<T> = T extends ((
+  token: TSESTree.Token
+) => asserts token is infer U extends TSESTree.Token)
+  ? U
+  : TSESTree.Token;
 
 ================================================================================
 `;

--- a/tests/format/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
@@ -428,6 +428,13 @@ printWidth: 80
 type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;
 type Foo<T> = T extends (new (...a: any[]) => infer R extends string) ? R : never;
 
+// Nest
+type Foo<T> = T extends (
+  (...a: any[]) => infer R extends (
+    T extends ((...a: any[]) => infer R extends string) ? R : never
+  )
+) ? R : never;
+
 // #14275
 type Test<T> = T extends ((
   token: TSESTree.Token
@@ -449,6 +456,15 @@ type Test<T> = T extends (new (
 // #13275
 type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;
 type Foo<T> = T extends (new (...a: any[]) => infer R extends string)
+  ? R
+  : never;
+
+// Nest
+type Foo<T> = T extends ((
+  ...a: any[]
+) => infer R extends T extends ((...a: any[]) => infer R extends string)
+  ? R
+  : never)
   ? R
   : never;
 

--- a/tests/format/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
@@ -426,6 +426,7 @@ printWidth: 80
 =====================================input======================================
 // #13275
 type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;
+type Foo<T> = T extends (new (...a: any[]) => infer R extends string) ? R : never;
 
 // #14275
 type Test<T> = T extends ((
@@ -436,12 +437,20 @@ type Test<T> = T extends ((
 type Test<T> = T extends ((
   token: TSESTree.Token
 ) => asserts token is infer U extends TSESTree.Token)
+  ? U
+  : TSESTree.Token;
+type Test<T> = T extends (new (
+  token: TSESTree.Token
+) => token is infer U extends TSESTree.Token)
   ? U
   : TSESTree.Token;
 
 =====================================output=====================================
 // #13275
 type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;
+type Foo<T> = T extends (new (...a: any[]) => infer R extends string)
+  ? R
+  : never;
 
 // #14275
 type Test<T> = T extends ((
@@ -452,6 +461,11 @@ type Test<T> = T extends ((
 type Test<T> = T extends ((
   token: TSESTree.Token
 ) => asserts token is infer U extends TSESTree.Token)
+  ? U
+  : TSESTree.Token;
+type Test<T> = T extends (new (
+  token: TSESTree.Token
+) => token is infer U extends TSESTree.Token)
   ? U
   : TSESTree.Token;
 

--- a/tests/format/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/conditional-types/__snapshots__/jsfmt.spec.js.snap
@@ -428,13 +428,6 @@ printWidth: 80
 type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;
 type Foo<T> = T extends (new (...a: any[]) => infer R extends string) ? R : never;
 
-// Nest
-type Foo<T> = T extends (
-  (...a: any[]) => infer R extends (
-    T extends ((...a: any[]) => infer R extends string) ? R : never
-  )
-) ? R : never;
-
 // #14275
 type Test<T> = T extends ((
   token: TSESTree.Token
@@ -456,15 +449,6 @@ type Test<T> = T extends (new (
 // #13275
 type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;
 type Foo<T> = T extends (new (...a: any[]) => infer R extends string)
-  ? R
-  : never;
-
-// Nest
-type Foo<T> = T extends ((
-  ...a: any[]
-) => infer R extends T extends ((...a: any[]) => infer R extends string)
-  ? R
-  : never)
   ? R
   : never;
 

--- a/tests/format/typescript/conditional-types/issue-13275.ts
+++ b/tests/format/typescript/conditional-types/issue-13275.ts
@@ -1,1 +1,0 @@
-type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;

--- a/tests/format/typescript/conditional-types/parentheses.ts
+++ b/tests/format/typescript/conditional-types/parentheses.ts
@@ -2,6 +2,13 @@
 type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;
 type Foo<T> = T extends (new (...a: any[]) => infer R extends string) ? R : never;
 
+// Nest
+type Foo<T> = T extends (
+  (...a: any[]) => infer R extends (
+    T extends ((...a: any[]) => infer R extends string) ? R : never
+  )
+) ? R : never;
+
 // #14275
 type Test<T> = T extends ((
   token: TSESTree.Token

--- a/tests/format/typescript/conditional-types/parentheses.ts
+++ b/tests/format/typescript/conditional-types/parentheses.ts
@@ -2,13 +2,6 @@
 type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;
 type Foo<T> = T extends (new (...a: any[]) => infer R extends string) ? R : never;
 
-// Nest
-type Foo<T> = T extends (
-  (...a: any[]) => infer R extends (
-    T extends ((...a: any[]) => infer R extends string) ? R : never
-  )
-) ? R : never;
-
 // #14275
 type Test<T> = T extends ((
   token: TSESTree.Token

--- a/tests/format/typescript/conditional-types/parentheses.ts
+++ b/tests/format/typescript/conditional-types/parentheses.ts
@@ -1,5 +1,6 @@
 // #13275
 type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;
+type Foo<T> = T extends (new (...a: any[]) => infer R extends string) ? R : never;
 
 // #14275
 type Test<T> = T extends ((
@@ -10,5 +11,10 @@ type Test<T> = T extends ((
 type Test<T> = T extends ((
   token: TSESTree.Token
 ) => asserts token is infer U extends TSESTree.Token)
+  ? U
+  : TSESTree.Token;
+type Test<T> = T extends (new (
+  token: TSESTree.Token
+) => token is infer U extends TSESTree.Token)
   ? U
   : TSESTree.Token;

--- a/tests/format/typescript/conditional-types/parentheses.ts
+++ b/tests/format/typescript/conditional-types/parentheses.ts
@@ -1,0 +1,14 @@
+// #13275
+type Foo<T> = T extends ((...a: any[]) => infer R extends string) ? R : never;
+
+// #14275
+type Test<T> = T extends ((
+  token: TSESTree.Token
+) => token is infer U extends TSESTree.Token)
+  ? U
+  : TSESTree.Token;
+type Test<T> = T extends ((
+  token: TSESTree.Token
+) => asserts token is infer U extends TSESTree.Token)
+  ? U
+  : TSESTree.Token;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #14275

Related #13289

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
