### PR TITLE
Forbid test `babel` parser in `typescript/`

### DIFF
--- a/tests/config/utils/check-parsers.js
+++ b/tests/config/utils/check-parsers.js
@@ -111,7 +111,7 @@ const categoryParsers = new Map([
     "typescript",
     {
       parsers: ["typescript", "babel-ts"],
-      verifyParsers: ["babel", "flow", "babel-flow", "typescript", "babel-ts"],
+      verifyParsers: ["typescript", "babel-ts", "flow", "babel-flow"],
       extensions: [".ts", ".tsx", ".cts", ".mts"],
     },
   ],

--- a/tests/format/typescript/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`arrow_function_expression.ts - {"arrowParens":"always"} format 1`] = `
 ====================================options=====================================
 arrowParens: "always"
-parsers: ["typescript", "babel"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -18,7 +18,7 @@ a = (b?) => c;
 exports[`arrow_function_expression.ts - {"arrowParens":"avoid"} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-parsers: ["typescript", "babel"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -33,7 +33,7 @@ a = (b?) => c;
 exports[`short_body.ts - {"arrowParens":"always"} format 1`] = `
 ====================================options=====================================
 arrowParens: "always"
-parsers: ["typescript", "babel"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -58,7 +58,7 @@ const initializeSnapshotState = (
 exports[`short_body.ts - {"arrowParens":"avoid"} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-parsers: ["typescript", "babel"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -83,7 +83,7 @@ const initializeSnapshotState = (
 exports[`type_params.ts - {"arrowParens":"always"} format 1`] = `
 ====================================options=====================================
 arrowParens: "always"
-parsers: ["typescript", "babel"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -98,7 +98,7 @@ printWidth: 80
 exports[`type_params.ts - {"arrowParens":"avoid"} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-parsers: ["typescript", "babel"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/typescript/arrows/jsfmt.spec.js
+++ b/tests/format/typescript/arrows/jsfmt.spec.js
@@ -1,2 +1,2 @@
-run_spec(import.meta, ["typescript", "babel"], { arrowParens: "always" });
-run_spec(import.meta, ["typescript", "babel"], { arrowParens: "avoid" });
+run_spec(import.meta, ["typescript", "flow"], { arrowParens: "always" });
+run_spec(import.meta, ["typescript", "flow"], { arrowParens: "avoid" });

--- a/tests/format/typescript/class-comment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/class-comment/__snapshots__/jsfmt.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`class-implements.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -177,7 +177,7 @@ class a9
 
 exports[`declare.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -213,7 +213,7 @@ declare class A1<T> // 1
 
 exports[`generic.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -268,7 +268,7 @@ class G4<
 
 exports[`misc.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/typescript/class-comment/jsfmt.spec.js
+++ b/tests/format/typescript/class-comment/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(import.meta, ["typescript", "babel", "flow"]);
+run_spec(import.meta, ["typescript", "flow"]);

--- a/tests/format/typescript/classes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/classes/__snapshots__/jsfmt.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`break.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -93,7 +93,7 @@ export class VisTimelineComponent2
 
 exports[`break-heritage.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/typescript/classes/jsfmt.spec.js
+++ b/tests/format/typescript/classes/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(import.meta, ["typescript", "babel", "flow"]);
+run_spec(import.meta, ["typescript", "flow"]);

--- a/tests/format/typescript/comments-2/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/comments-2/__snapshots__/jsfmt.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`dangling.ts - {"semi":false} format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
 semi: false
                                                                                 | printWidth
@@ -22,7 +22,7 @@ declare class Foo extends Qux<string> {
 
 exports[`dangling.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -41,7 +41,7 @@ declare class Foo extends Qux<string> {
 
 exports[`issues.ts - {"semi":false} format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
 semi: false
                                                                                 | printWidth
@@ -65,7 +65,7 @@ function f(
 
 exports[`issues.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -88,7 +88,7 @@ function f(
 
 exports[`last-arg.ts - {"semi":false} format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
 semi: false
                                                                                 | printWidth
@@ -205,7 +205,7 @@ class X2 {
 
 exports[`last-arg.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/typescript/comments-2/jsfmt.spec.js
+++ b/tests/format/typescript/comments-2/jsfmt.spec.js
@@ -1,2 +1,2 @@
-run_spec(import.meta, ["typescript", "babel", "flow"]);
-run_spec(import.meta, ["typescript", "babel", "flow"], { semi: false });
+run_spec(import.meta, ["typescript", "flow"]);
+run_spec(import.meta, ["typescript", "flow"], { semi: false });

--- a/tests/format/typescript/end-of-line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/end-of-line/__snapshots__/jsfmt.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`multiline.ts - {"endOfLine":"cr"} format 1`] = `
 ====================================options=====================================
 endOfLine: "cr"
-parsers: ["typescript", "babel"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -62,7 +62,7 @@ export const IAmIncredibleLongFunctionName = IAmAnotherFunctionName(<CR>
 exports[`multiline.ts - {"endOfLine":"crlf"} format 1`] = `
 ====================================options=====================================
 endOfLine: "crlf"
-parsers: ["typescript", "babel"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -121,7 +121,7 @@ export const IAmIncredibleLongFunctionName = IAmAnotherFunctionName(<CRLF>
 exports[`multiline.ts - {"endOfLine":"lf"} format 1`] = `
 ====================================options=====================================
 endOfLine: "lf"
-parsers: ["typescript", "babel"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/typescript/end-of-line/jsfmt.spec.js
+++ b/tests/format/typescript/end-of-line/jsfmt.spec.js
@@ -1,3 +1,3 @@
-run_spec(import.meta, ["typescript", "babel"], { endOfLine: "lf" });
-run_spec(import.meta, ["typescript", "babel"], { endOfLine: "cr" });
-run_spec(import.meta, ["typescript", "babel"], { endOfLine: "crlf" });
+run_spec(import.meta, ["typescript", "flow"], { endOfLine: "lf" });
+run_spec(import.meta, ["typescript", "flow"], { endOfLine: "cr" });
+run_spec(import.meta, ["typescript", "flow"], { endOfLine: "crlf" });

--- a/tests/format/typescript/function/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/function/__snapshots__/jsfmt.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`single_expand.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/typescript/function/jsfmt.spec.js
+++ b/tests/format/typescript/function/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(import.meta, ["typescript", "babel", "flow"]);
+run_spec(import.meta, ["typescript", "flow"]);

--- a/tests/format/typescript/functional-composition/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/functional-composition/__snapshots__/jsfmt.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`pipe-function-calls.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -49,7 +49,7 @@ printWidth: 80
 
 exports[`pipe-function-calls-with-comments.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/typescript/functional-composition/jsfmt.spec.js
+++ b/tests/format/typescript/functional-composition/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(import.meta, ["typescript", "babel", "flow"]);
+run_spec(import.meta, ["typescript", "flow"]);

--- a/tests/format/typescript/interface2/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/interface2/__snapshots__/jsfmt.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`break.ts - {"trailingComma":"es5"} format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
 trailingComma: "es5"
                                                                                 | printWidth
@@ -183,7 +183,7 @@ export interface ExtendsLongOneWithGenerics
 
 exports[`comments.ts - {"trailingComma":"es5"} format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
 trailingComma: "es5"
                                                                                 | printWidth
@@ -262,7 +262,7 @@ interface A6 // comment1
 
 exports[`comments-declare.ts - {"trailingComma":"es5"} format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
 trailingComma: "es5"
                                                                                 | printWidth
@@ -283,7 +283,7 @@ declare interface a // 1
 
 exports[`module.ts - {"trailingComma":"es5"} format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
 trailingComma: "es5"
                                                                                 | printWidth

--- a/tests/format/typescript/interface2/jsfmt.spec.js
+++ b/tests/format/typescript/interface2/jsfmt.spec.js
@@ -1,3 +1,3 @@
-run_spec(import.meta, ["typescript", "babel", "flow"], {
+run_spec(import.meta, ["typescript", "flow"], {
   trailingComma: "es5",
 });

--- a/tests/format/typescript/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`comment.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/typescript/method-chain/jsfmt.spec.js
+++ b/tests/format/typescript/method-chain/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(import.meta, ["typescript", "babel", "flow"]);
+run_spec(import.meta, ["typescript", "flow"]);

--- a/tests/format/typescript/multiparser-css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/multiparser-css/__snapshots__/jsfmt.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`issue-6259.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/typescript/multiparser-css/jsfmt.spec.js
+++ b/tests/format/typescript/multiparser-css/jsfmt.spec.js
@@ -1,1 +1,1 @@
-run_spec(import.meta, ["typescript", "babel", "flow"]);
+run_spec(import.meta, ["typescript", "flow"]);

--- a/tests/format/typescript/test-declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/test-declarations/__snapshots__/jsfmt.spec.js.snap
@@ -3,7 +3,7 @@
 exports[`test_declarations.ts - {"arrowParens":"avoid"} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
@@ -21,7 +21,7 @@ test("does something really long and complicated so I have to write a very long 
 
 exports[`test_declarations.ts format 1`] = `
 ====================================options=====================================
-parsers: ["typescript", "babel", "flow"]
+parsers: ["typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================

--- a/tests/format/typescript/test-declarations/jsfmt.spec.js
+++ b/tests/format/typescript/test-declarations/jsfmt.spec.js
@@ -1,4 +1,4 @@
-run_spec(import.meta, ["typescript", "babel", "flow"]);
-run_spec(import.meta, ["typescript", "babel", "flow"], {
+run_spec(import.meta, ["typescript", "flow"]);
+run_spec(import.meta, ["typescript", "flow"], {
   arrowParens: "avoid",
 });


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

All those places mean to test with `flow`. (`babel-flow` auto tested #14245)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
