### PR TITLE
Fix `hasMultipleHeritage` logic

### DIFF
--- a/src/language-js/print/class.js
+++ b/src/language-js/print/class.js
@@ -123,9 +123,10 @@ function printHardlineAfterHeritage(node) {
 
 function hasMultipleHeritage(node) {
   return (
-    ["superClass", "extends", "mixins", "implements"].filter((key) =>
-      Boolean(node[key])
-    ).length > 1
+    ["extends", "mixins", "implements"].reduce(
+      (count, key) => count + (Array.isArray(node[key]) ? node[key].length : 0),
+      node.superClass ? 1 : 0
+    ) > 1
   );
 }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

The old one consider empty array as one heritage, found this when working on #14259, we haven't decide what to do with #14259, [ts parser is making some changes may effect this part](https://github.com/typescript-eslint/typescript-eslint/pull/6274).

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
