### PR TITLE
Rename `isJsxNode` as `isJsxElement`

### DIFF
--- a/src/language-js/comments/printer-methods.js
+++ b/src/language-js/comments/printer-methods.js
@@ -3,7 +3,7 @@ import { hasJsxIgnoreComment } from "../print/jsx.js";
 import {
   getFunctionParameters,
   hasNodeIgnoreComment,
-  isJsxNode,
+  isJsxElement,
   isLineComment,
 } from "../utils/index.js";
 import isBlockComment from "../utils/is-block-comment.js";
@@ -66,7 +66,7 @@ function hasPrettierIgnore(path) {
  */
 function willPrintOwnComments({ node, parent }) {
   return (
-    (isJsxNode(node) ||
+    (isJsxElement(node) ||
       (parent &&
         (parent.type === "JSXSpreadAttribute" ||
           parent.type === "JSXSpreadChild" ||

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -13,7 +13,7 @@ import { cleanDoc, getDocParts } from "../../document/utils.js";
 import {
   hasLeadingOwnLineComment,
   isBinaryish,
-  isJsxNode,
+  isJsxElement,
   shouldFlatten,
   hasComment,
   CommentCheckFlags,
@@ -135,7 +135,7 @@ function printBinaryishExpression(path, options, print) {
   //     </Foo>
   //   )
 
-  const hasJsx = isJsxNode(node.right);
+  const hasJsx = isJsxElement(node.right);
 
   const firstGroupIndex = parts.findIndex(
     (part) =>
@@ -327,7 +327,7 @@ function shouldInlineLogicalExpression(node) {
     return true;
   }
 
-  if (isJsxNode(node.right)) {
+  if (isJsxElement(node.right)) {
     return true;
   }
 

--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -4,7 +4,7 @@ import {
   hasComment,
   CommentCheckFlags,
   isFunctionCompositionArgs,
-  isJsxNode,
+  isJsxElement,
   isLongCurriedCallExpression,
   shouldPrintComma,
   getCallArguments,
@@ -212,7 +212,7 @@ function couldExpandArg(arg, arrowChainRecursion = false) {
         (!arrowChainRecursion &&
           (isCallExpression(arg.body) ||
             arg.body.type === "ConditionalExpression")) ||
-        isJsxNode(arg.body))) ||
+        isJsxElement(arg.body))) ||
     arg.type === "DoExpression" ||
     arg.type === "ModuleExpression"
   );

--- a/src/language-js/print/function.js
+++ b/src/language-js/print/function.js
@@ -22,7 +22,7 @@ import { ArgExpansionBailout } from "../../common/errors.js";
 import {
   getFunctionParameters,
   hasLeadingOwnLineComment,
-  isJsxNode,
+  isJsxElement,
   isTemplateOnItsOwnLine,
   shouldPrintComma,
   startsWithNoLookaheadToken,
@@ -345,7 +345,7 @@ function printArrowFunction(path, options, print, args) {
     (isArrayOrTupleExpression(node.body) ||
       isObjectOrRecordExpression(node.body) ||
       node.body.type === "BlockStatement" ||
-      isJsxNode(node.body) ||
+      isJsxElement(node.body) ||
       (body[0].label?.hug !== false &&
         (body[0].label?.embed ||
           isTemplateOnItsOwnLine(node.body, options.originalText))) ||

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -16,7 +16,7 @@ import UnexpectedNodeError from "../../utils/unexpected-node-error.js";
 
 import { getPreferredQuote } from "../../common/util.js";
 import {
-  isJsxNode,
+  isJsxElement,
   rawText,
   isCallExpression,
   isStringLiteral,
@@ -93,7 +93,7 @@ function printJsxElementInternal(path, options, print) {
     return child;
   });
 
-  const containsTag = node.children.some(isJsxNode);
+  const containsTag = node.children.some(isJsxElement);
   const containsMultipleExpressions =
     node.children.filter((child) => child.type === "JSXExpressionContainer")
       .length > 1;
@@ -500,7 +500,7 @@ function printJsxExpressionContainer(path, options, print) {
         node.type === "TemplateLiteral" ||
         node.type === "TaggedTemplateExpression" ||
         node.type === "DoExpression" ||
-        (isJsxNode(parent) &&
+        (isJsxElement(parent) &&
           (node.type === "ConditionalExpression" || isBinaryish(node)))));
 
   if (shouldInline(node.expression, path.parent)) {
@@ -814,7 +814,7 @@ function isJsxWhitespaceExpression(node) {
  */
 function hasJsxIgnoreComment(path) {
   const { node, parent } = path;
-  if (!isJsxNode(node) || !isJsxNode(parent)) {
+  if (!isJsxElement(node) || !isJsxElement(parent)) {
     return false;
   }
 

--- a/src/language-js/print/statement.js
+++ b/src/language-js/print/statement.js
@@ -3,7 +3,7 @@ import pathNeedsParens from "../needs-parens.js";
 import {
   getLeftSidePathName,
   hasNakedLeftSide,
-  isJsxNode,
+  isJsxElement,
   isTheOnlyJsxElementInMarkdown,
   hasComment,
   CommentCheckFlags,
@@ -116,7 +116,7 @@ function expressionNeedsASIProtection(path, options) {
       break;
 
     default:
-      if (isJsxNode(node)) {
+      if (isJsxElement(node)) {
         return true;
       }
   }

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -1,6 +1,6 @@
 import { hasNewlineInRange } from "../../common/util.js";
 import {
-  isJsxNode,
+  isJsxElement,
   isCallExpression,
   isMemberExpression,
   isTSTypeExpression,
@@ -89,7 +89,7 @@ function conditionalExpressionChainContainsJsx(node) {
     for (const property of ["test", "consequent", "alternate"]) {
       const node = conditionalExpression[property];
 
-      if (isJsxNode(node)) {
+      if (isJsxElement(node)) {
         return true;
       }
 
@@ -235,9 +235,9 @@ function printTernary(path, options, print) {
 
   if (
     isConditionalExpression &&
-    (isJsxNode(node[testNodePropertyNames[0]]) ||
-      isJsxNode(consequentNode) ||
-      isJsxNode(alternateNode) ||
+    (isJsxElement(node[testNodePropertyNames[0]]) ||
+      isJsxElement(consequentNode) ||
+      isJsxElement(alternateNode) ||
       conditionalExpressionChainContainsJsx(lastConditionalParent))
   ) {
     jsxMode = true;

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -270,7 +270,7 @@ function isAngularTestWrapper(node) {
  * @param {Node} node
  * @returns {boolean}
  */
-const isJsxNode = createTypeCheckFunction(["JSXElement", "JSXFragment"]);
+const isJsxElement = createTypeCheckFunction(["JSXElement", "JSXFragment"]);
 
 function isTheOnlyJsxElementInMarkdown(options, path) {
   if (options.parentParser !== "markdown" && options.parentParser !== "mdx") {
@@ -279,7 +279,7 @@ function isTheOnlyJsxElementInMarkdown(options, path) {
 
   const { node } = path;
 
-  if (!node.expression || !isJsxNode(node.expression)) {
+  if (!node.expression || !isJsxElement(node.expression)) {
     return false;
   }
 
@@ -592,7 +592,7 @@ function getTypeScriptMappedTypeModifier(tokenNode, keyword) {
  * @returns {boolean}
  */
 function hasLeadingOwnLineComment(text, node) {
-  if (isJsxNode(node)) {
+  if (isJsxElement(node)) {
     return hasNodeIgnoreComment(node);
   }
 
@@ -1240,7 +1240,7 @@ export {
   isFunctionNotation,
   isFunctionOrArrowExpression,
   isGetterOrSetter,
-  isJsxNode,
+  isJsxElement,
   isLiteral,
   isLongCurriedCallExpression,
   isSimpleCallArgument,


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

The old one feels like it includes any `JSX*` node.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
