### PR TITLE
Refactor literal related code

### DIFF
--- a/src/language-js/print/assignment.js
+++ b/src/language-js/print/assignment.js
@@ -11,7 +11,6 @@ import {
   hasLeadingOwnLineComment,
   isBinaryish,
   isStringLiteral,
-  isLiteral,
   isNumericLiteral,
   isCallExpression,
   isMemberExpression,
@@ -24,6 +23,7 @@ import {
 } from "../utils/index.js";
 import { shouldInlineLogicalExpression } from "./binaryish.js";
 import { printCallExpression } from "./call-expression.js";
+import { isLiteral } from "./literal.js";
 
 function printAssignment(
   path,

--- a/src/language-js/print/literal.js
+++ b/src/language-js/print/literal.js
@@ -97,14 +97,15 @@ function printDirective(rawText, options) {
  */
 const isLiteral = createTypeCheckFunction([
   "Literal",
-  "BooleanLiteral",
+  // Babel, flow uses `BigIntLiteral` too
   "BigIntLiteral",
+  "BooleanLiteral",
+  "DecimalLiteral",
+  "DirectiveLiteral",
   "NullLiteral",
   "NumericLiteral",
-  "DecimalLiteral",
   "RegExpLiteral",
   "StringLiteral",
-  "DirectiveLiteral",
 ]);
 
 export { printLiteral, printBigInt, isLiteral };

--- a/src/language-js/print/literal.js
+++ b/src/language-js/print/literal.js
@@ -1,6 +1,11 @@
 import { printString, printNumber } from "../../common/util.js";
 import { replaceEndOfLine } from "../../document/utils.js";
+import { createTypeCheckFunction } from "../utils/index.js";
 import { printDirective } from "./misc.js";
+
+/**
+ * @typedef {import("../types/estree.js").Node} Node
+ */
 
 function printLiteral(path, options /*, print*/) {
   const { node } = path;
@@ -67,4 +72,19 @@ function printRegex({ pattern, flags }) {
   return `/${pattern}/${flags}`;
 }
 
-export { printLiteral, printBigInt };
+/**
+ * @param {Node} node
+ * @returns {boolean}
+ */
+const isLiteral = createTypeCheckFunction([
+  "Literal",
+  "BooleanLiteral",
+  "BigIntLiteral",
+  "NullLiteral",
+  "NumericLiteral",
+  "DecimalLiteral",
+  "RegExpLiteral",
+  "StringLiteral",
+]);
+
+export { printLiteral, printBigInt, isLiteral };

--- a/src/language-js/print/misc.js
+++ b/src/language-js/print/misc.js
@@ -118,24 +118,6 @@ function printRestSpread(path, print) {
   return ["...", print("argument"), printTypeAnnotationProperty(path, print)];
 }
 
-function printDirective(rawText, options) {
-  const rawContent = rawText.slice(1, -1);
-
-  // Check for the alternate quote, to determine if we're allowed to swap
-  // the quotes on a DirectiveLiteral.
-  if (rawContent.includes('"') || rawContent.includes("'")) {
-    return rawText;
-  }
-
-  const enclosingQuote = options.singleQuote ? "'" : '"';
-
-  // Directives are exact code unit sequences, which means that you can't
-  // change the escape sequences they use.
-  // See https://github.com/prettier/prettier/issues/1555
-  // and https://tc39.github.io/ecma262/#directive-prologue
-  return enclosingQuote + rawContent + enclosingQuote;
-}
-
 function printTypeScriptAccessibilityToken(node) {
   return node.accessibility ? node.accessibility + " " : "";
 }
@@ -149,6 +131,5 @@ export {
   printBindExpressionCallee,
   printRestSpread,
   adjustClause,
-  printDirective,
   printTypeScriptAccessibilityToken,
 };

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -428,8 +428,6 @@ function printPathNoParens(path, options, print, args) {
       return "super";
     case "Directive":
       return [print("value"), semi]; // Babel 6
-    case "DirectiveLiteral":
-      return printDirective(node.extra.raw, options);
     case "UnaryExpression":
       parts.push(node.operator);
 

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -47,7 +47,6 @@ import {
   adjustClause,
   printRestSpread,
   printDefiniteToken,
-  printDirective,
   printDeclareToken,
 } from "./print/misc.js";
 import {

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -149,25 +149,6 @@ const isExportDeclaration = createTypeCheckFunction([
  * @param {Node} node
  * @returns {boolean}
  */
-const isLiteral = createTypeCheckFunction([
-  "BooleanLiteral",
-  "DirectiveLiteral",
-  "Literal",
-  "NullLiteral",
-  "NumericLiteral",
-  "BigIntLiteral",
-  "DecimalLiteral",
-  "RegExpLiteral",
-  "StringLiteral",
-  "TemplateLiteral",
-  "TSTypeLiteral",
-  "JSXText",
-]);
-
-/**
- * @param {Node} node
- * @returns {boolean}
- */
 const isArrayOrTupleExpression = createTypeCheckFunction([
   "ArrayExpression",
   "TupleExpression",
@@ -1243,7 +1224,6 @@ export {
   isFunctionOrArrowExpression,
   isGetterOrSetter,
   isJsxElement,
-  isLiteral,
   isLongCurriedCallExpression,
   isSimpleCallArgument,
   isMemberish,


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Remove `TemplateLiteral`, `TSTypeLiteral`, and `JSXText` from `isLiteral`
They are not Literal in ESTree, only used [here](https://github.com/prettier/prettier/blob/be84156d43805a281369c934ae28148065d6316e/src/language-js/print/assignment.js#L404), they can't be an argument or handled above.

Move `DirectiveLiteral` into `literal.js`, since the same Node represent as `Literal` in ESTree.


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
