### PR TITLE
Refactor leading semicolon print

### DIFF
--- a/src/language-js/print/print-semicolon.js
+++ b/src/language-js/print/print-semicolon.js
@@ -1,0 +1,91 @@
+import pathNeedsParens from "../needs-parens.js";
+import {
+  getLeftSidePathName,
+  hasNakedLeftSide,
+  isJsxElement,
+  isTheOnlyJsxElementInMarkdown,
+} from "../utils/index.js";
+import { shouldPrintParamsWithoutParens } from "./function.js";
+
+function shouldPrintLeadingSemicolon(path, options) {
+  if (options.semi || isTheOnlyJsxElementInMarkdown(options, path)) {
+    return false;
+  }
+
+  const { node } = path;
+  if (
+    node.type === "ExpressionStatement" &&
+    [
+      (node, key) =>
+        key === "body" &&
+        (node.type === "Program" ||
+          node.type === "BlockStatement" ||
+          node.type === "StaticBlock" ||
+          node.type === "TSModuleBlock"),
+      (node, key) => key === "consequent" && node.type === "SwitchCase",
+    ].some((predicate) => path.match(undefined, predicate)) &&
+    path.call(() => expressionNeedsASIProtection(path, options), "expression")
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function expressionNeedsASIProtection(path, options) {
+  const { node } = path;
+  switch (node.type) {
+    case "ParenthesizedExpression":
+    case "TypeCastExpression":
+    case "ArrayExpression":
+    case "ArrayPattern":
+    case "TemplateLiteral":
+    case "TemplateElement":
+    case "RegExpLiteral":
+      return true;
+    case "ArrowFunctionExpression":
+      if (!shouldPrintParamsWithoutParens(path, options)) {
+        return true;
+      }
+      break;
+
+    case "UnaryExpression": {
+      const { prefix, operator } = node;
+      if (prefix && (operator === "+" || operator === "-")) {
+        return true;
+      }
+      break;
+    }
+    case "BindExpression":
+      if (!node.object) {
+        return true;
+      }
+      break;
+
+    case "Literal":
+      if (node.regex) {
+        return true;
+      }
+      break;
+
+    default:
+      if (isJsxElement(node)) {
+        return true;
+      }
+  }
+
+  if (pathNeedsParens(path, options)) {
+    return true;
+  }
+
+  if (!hasNakedLeftSide(node)) {
+    return false;
+  }
+
+  return path.call(
+    () => expressionNeedsASIProtection(path, options),
+    ...getLeftSidePathName(node)
+  );
+}
+
+export { shouldPrintLeadingSemicolon };

--- a/src/language-js/print/semicolon.js
+++ b/src/language-js/print/semicolon.js
@@ -12,18 +12,16 @@ function shouldPrintLeadingSemicolon(path, options) {
     return false;
   }
 
-  const { node } = path;
+  const { node, key, parent } = path;
   if (
     node.type === "ExpressionStatement" &&
-    [
-      (node, key) =>
-        key === "body" &&
-        (node.type === "Program" ||
-          node.type === "BlockStatement" ||
-          node.type === "StaticBlock" ||
-          node.type === "TSModuleBlock"),
-      (node, key) => key === "consequent" && node.type === "SwitchCase",
-    ].some((predicate) => path.match(undefined, predicate)) &&
+    // `Program.directives` don't need leading semicolon
+    ((key === "body" &&
+      (parent.type === "Program" ||
+        parent.type === "BlockStatement" ||
+        parent.type === "StaticBlock" ||
+        parent.type === "TSModuleBlock")) ||
+      (key === "consequent" && parent.type === "SwitchCase")) &&
     path.call(() => expressionNeedsASIProtection(path, options), "expression")
   ) {
     return true;

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -89,7 +89,7 @@ import { printBlock, printBlockBody } from "./print/block.js";
 import { printLiteral } from "./print/literal.js";
 import { printDecorators } from "./print/decorators.js";
 import { printTypeAnnotationProperty } from "./print/type-annotation.js";
-import { shouldPrintLeadingSemicolon } from "./print/print-semicolon.js";
+import { shouldPrintLeadingSemicolon } from "./print/semicolon.js";
 
 /**
  * @typedef {import("../common/ast-path.js").default} AstPath

--- a/src/language-js/printer-estree.js
+++ b/src/language-js/printer-estree.js
@@ -89,6 +89,7 @@ import { printBlock, printBlockBody } from "./print/block.js";
 import { printLiteral } from "./print/literal.js";
 import { printDecorators } from "./print/decorators.js";
 import { printTypeAnnotationProperty } from "./print/type-annotation.js";
+import { shouldPrintLeadingSemicolon } from "./print/print-semicolon.js";
 
 /**
  * @typedef {import("../common/ast-path.js").default} AstPath
@@ -144,7 +145,7 @@ function genericPrint(path, options, print, args) {
   }
 
   const needsParens = pathNeedsParens(path, options);
-  const needsSemi = args?.needsSemi;
+  const needsSemi = shouldPrintLeadingSemicolon(path, options);
 
   if (!needsParens) {
     if (needsSemi) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Move the leading semicolon check from `printStatementSequence` to `genericPrint`, so we don't need pass `args.needsSemi` (which breaks print cache)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
