### PR TITLE
Add `getNextNonSpaceNonCommentCharacter` to `prettier.util`

### DIFF
--- a/changelog_unreleased/api/14317.md
+++ b/changelog_unreleased/api/14317.md
@@ -1,3 +1,25 @@
-#### Added `prettier.util.getNextNonSpaceNonCommentCharacter` (#14317 by @fisker)
+#### Update `prettier.util` (#14317 by @fisker)
 
-See the [documentation](https://prettier.io/docs/en/plugins.html#utility-functions).
+- Added `prettier.util.getNextNonSpaceNonCommentCharacter`
+- Changed `prettier.util.getNextNonSpaceNonCommentCharacter`
+
+  Signature changed from
+
+  ```ts
+  function getNextNonSpaceNonCommentCharacterIndex<N>(
+    text: string,
+    node: N,
+    locEnd: (node: N) => number
+  ): number | false;
+  ```
+
+  to
+
+  ```ts
+  function getNextNonSpaceNonCommentCharacterIndex(
+    text: string,
+    startIndex: number
+  ): number | false;
+  ```
+
+See the [documentation](https://prettier.io/docs/en/plugins.html#utility-functions) for details.

--- a/changelog_unreleased/api/14317.md
+++ b/changelog_unreleased/api/14317.md
@@ -1,0 +1,3 @@
+#### Added `prettier.util.getNextNonSpaceNonCommentCharacter` (#14317 by @fisker)
+
+See the [documentation](https://prettier.io/docs/en/plugins.html#utility-functions).

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -585,16 +585,14 @@ function makeString(
   unescapeUnnecessaryEscapes?: boolean
 ): string;
 
-function getNextNonSpaceNonCommentCharacter<N>(
+function getNextNonSpaceNonCommentCharacter(
   text: string,
-  node: N,
-  locEnd: (node: N) => number
+  startIndex: number
 ): string;
 
-function getNextNonSpaceNonCommentCharacterIndex<N>(
+function getNextNonSpaceNonCommentCharacterIndex(
   text: string,
-  node: N,
-  locEnd: (node: N) => number
+  startIndex: number
 ): number | false;
 
 function isNextLineEmptyAfterIndex(text: string, index: number): boolean;

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -585,6 +585,12 @@ function makeString(
   unescapeUnnecessaryEscapes?: boolean
 ): string;
 
+function getNextNonSpaceNonCommentCharacter<N>(
+  text: string,
+  node: N,
+  locEnd: (node: N) => number
+): string;
+
 function getNextNonSpaceNonCommentCharacterIndex<N>(
   text: string,
   node: N,

--- a/src/common/util-shared.js
+++ b/src/common/util-shared.js
@@ -16,10 +16,17 @@ function legacyGetNextNonSpaceNonCommentCharacterIndex(text, node, locEnd) {
 }
 
 // TODO: export `getNextNonSpaceNonCommentCharacterIndex` directly in v4
-export function getNextNonSpaceNonCommentCharacterIndex(...args) {
-  return args.length === 3
-    ? legacyGetNextNonSpaceNonCommentCharacterIndex(...args)
-    : getNextNonSpaceNonCommentCharacterIndexWithStartIndex(...args);
+/**
+ * @param {string} text
+ * @param {number} startIndex
+ * @returns {number | false}
+ */
+export function getNextNonSpaceNonCommentCharacterIndex(text, startIndex) {
+  return arguments.length === 2 || typeof startIndex === "number"
+    ? getNextNonSpaceNonCommentCharacterIndexWithStartIndex(text, startIndex)
+    // @ts-expect-error -- expected
+    // eslint-disable-next-line prefer-rest-params
+    : legacyGetNextNonSpaceNonCommentCharacterIndex(...arguments);
 }
 
 export {

--- a/src/common/util-shared.js
+++ b/src/common/util-shared.js
@@ -34,6 +34,7 @@ export {
   isNextLineEmpty,
   isNextLineEmptyAfterIndex,
   isPreviousLineEmpty,
+  getNextNonSpaceNonCommentCharacter,
   makeString,
   addLeadingComment,
   addDanglingComment,

--- a/src/common/util-shared.js
+++ b/src/common/util-shared.js
@@ -24,9 +24,9 @@ function legacyGetNextNonSpaceNonCommentCharacterIndex(text, node, locEnd) {
 export function getNextNonSpaceNonCommentCharacterIndex(text, startIndex) {
   return arguments.length === 2 || typeof startIndex === "number"
     ? getNextNonSpaceNonCommentCharacterIndexWithStartIndex(text, startIndex)
-    // @ts-expect-error -- expected
-    // eslint-disable-next-line prefer-rest-params
-    : legacyGetNextNonSpaceNonCommentCharacterIndex(...arguments);
+    : // @ts-expect-error -- expected
+      // eslint-disable-next-line prefer-rest-params
+      legacyGetNextNonSpaceNonCommentCharacterIndex(...arguments);
 }
 
 export {

--- a/src/common/util-shared.js
+++ b/src/common/util-shared.js
@@ -1,6 +1,6 @@
 import { getNextNonSpaceNonCommentCharacterIndex as getNextNonSpaceNonCommentCharacterIndexWithStartIndex } from "./util.js";
 
-// Legacy way of `getNextNonSpaceNonCommentCharacterIndex`
+// Legacy version of `getNextNonSpaceNonCommentCharacterIndex`
 /**
  * @template N
  * @param {string} text
@@ -8,11 +8,18 @@ import { getNextNonSpaceNonCommentCharacterIndex as getNextNonSpaceNonCommentCha
  * @param {(node: N) => number} locEnd
  * @returns {number | false}
  */
-export function getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd) {
+function legacyGetNextNonSpaceNonCommentCharacterIndex(text, node, locEnd) {
   return getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
     text,
     locEnd(node)
   );
+}
+
+// TODO: export `getNextNonSpaceNonCommentCharacterIndex` directly in v4
+export function getNextNonSpaceNonCommentCharacterIndex(...args) {
+  return args.length === 3
+    ? legacyGetNextNonSpaceNonCommentCharacterIndex(...args)
+    : getNextNonSpaceNonCommentCharacterIndexWithStartIndex(...args);
 }
 
 export {

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -99,7 +99,6 @@ function isNextLineEmpty(text, node, locEnd) {
  */
 function getNextNonSpaceNonCommentCharacter(text, startIndex) {
   const index = getNextNonSpaceNonCommentCharacterIndex(text, startIndex);
-
   return index === false ? "" : text.charAt(index);
 }
 

--- a/tests/integration/__tests__/util-shared.js
+++ b/tests/integration/__tests__/util-shared.js
@@ -103,41 +103,51 @@ test("sharedUtil.getNextNonSpaceNonCommentCharacter and sharedUtil.getNextNonSpa
     getNextNonSpaceNonCommentCharacter,
     getNextNonSpaceNonCommentCharacterIndex,
   } = sharedUtil;
+  const FAKE_NODE = { type: "Identifier", name: "a" };
 
   {
-    const text = "/* comment 1 */ a /* comment 1 */ b";
-    const indexOfIdentifierA = text.indexOf("a");
+    const text = "/* comment 1 */ a /* comment 2 */ b";
+    const endOfIdentifierA = text.indexOf("a") + 1;
     const indexOfIdentifierB = text.indexOf("b");
-    const node = {};
-    const locEnd = () => indexOfIdentifierA + 1;
+    const locEnd = () => endOfIdentifierA;
 
-    expect(getNextNonSpaceNonCommentCharacter(text, node, locEnd)).toBe("b");
-    expect(getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd)).toBe(
-      indexOfIdentifierB
+    expect(getNextNonSpaceNonCommentCharacter(text, endOfIdentifierA)).toBe(
+      "b"
     );
+    expect(
+      getNextNonSpaceNonCommentCharacterIndex(text, endOfIdentifierA)
+    ).toBe(indexOfIdentifierB);
+    expect(
+      getNextNonSpaceNonCommentCharacterIndex(text, FAKE_NODE, locEnd)
+    ).toBe(indexOfIdentifierB);
   }
 
   {
-    const text = "/* comment 1 */ a /* comment 1 */";
-    const indexOfIdentifierA = text.indexOf("a");
-    const node = {};
-    const locEnd = () => indexOfIdentifierA + 1;
+    const text = "/* comment 1 */ a /* comment 2 */";
+    const endOfIdentifierA = text.indexOf("a") + 1;
+    const locEnd = () => endOfIdentifierA;
 
-    expect(getNextNonSpaceNonCommentCharacter(text, node, locEnd)).toBe("");
-    expect(getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd)).toBe(
-      text.length
-    );
+    expect(getNextNonSpaceNonCommentCharacter(text, endOfIdentifierA)).toBe("");
+    expect(
+      getNextNonSpaceNonCommentCharacterIndex(text, endOfIdentifierA)
+    ).toBe(text.length);
+    expect(
+      getNextNonSpaceNonCommentCharacterIndex(text, FAKE_NODE, locEnd)
+    ).toBe(text.length);
   }
 
   {
-    const text = "/* comment 1 */ a /* comment 1 */";
-    const node = {};
-    const locEnd = () => false;
+    const text = "/* comment 1 */ a /* comment 2 */";
+    const startIndex = false;
+    const locEnd = () => startIndex;
 
-    expect(getNextNonSpaceNonCommentCharacter(text, node, locEnd)).toBe("");
-    expect(getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd)).toBe(
+    expect(getNextNonSpaceNonCommentCharacter(text, startIndex)).toBe("");
+    expect(getNextNonSpaceNonCommentCharacterIndex(text, startIndex)).toBe(
       false
     );
+    expect(
+      getNextNonSpaceNonCommentCharacterIndex(text, FAKE_NODE, locEnd)
+    ).toBe(false);
   }
 });
 

--- a/tests/integration/__tests__/util-shared.js
+++ b/tests/integration/__tests__/util-shared.js
@@ -21,6 +21,7 @@ test("shared util has correct structure", () => {
   expect(typeof sharedUtil.isNextLineEmpty).toBe("function");
   expect(typeof sharedUtil.isNextLineEmptyAfterIndex).toBe("function");
   expect(typeof sharedUtil.isPreviousLineEmpty).toBe("function");
+  expect(typeof sharedUtil.getNextNonSpaceNonCommentCharacter).toBe("function");
   expect(typeof sharedUtil.getNextNonSpaceNonCommentCharacterIndex).toBe(
     "function"
   );
@@ -95,6 +96,49 @@ test("sharedUtil.getIndentSize", () => {
   expect(getIndentSize("\n\t\n\t\t", /* tabWidth */ 2)).toBe(4);
   expect(getIndentSize("\n \n  ", /* tabWidth */ 2)).toBe(2);
   expect(getIndentSize("   \n\t\t\n", /* tabWidth */ 2)).toBe(0);
+});
+
+test("sharedUtil.getNextNonSpaceNonCommentCharacter and sharedUtil.getNextNonSpaceNonCommentCharacterIndex", () => {
+  const {
+    getNextNonSpaceNonCommentCharacter,
+    getNextNonSpaceNonCommentCharacterIndex,
+  } = sharedUtil;
+
+  {
+    const text = "/* comment 1 */ a /* comment 1 */ b";
+    const indexOfIdentifierA = text.indexOf("a");
+    const indexOfIdentifierB = text.indexOf("b");
+    const node = {};
+    const locEnd = () => indexOfIdentifierA + 1;
+
+    expect(getNextNonSpaceNonCommentCharacter(text, node, locEnd)).toBe("b");
+    expect(getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd)).toBe(
+      indexOfIdentifierB
+    );
+  }
+
+  {
+    const text = "/* comment 1 */ a /* comment 1 */";
+    const indexOfIdentifierA = text.indexOf("a");
+    const node = {};
+    const locEnd = () => indexOfIdentifierA + 1;
+
+    expect(getNextNonSpaceNonCommentCharacter(text, node, locEnd)).toBe("");
+    expect(getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd)).toBe(
+      text.length
+    );
+  }
+
+  {
+    const text = "/* comment 1 */ a /* comment 1 */";
+    const node = {};
+    const locEnd = () => false;
+
+    expect(getNextNonSpaceNonCommentCharacter(text, node, locEnd)).toBe("");
+    expect(getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd)).toBe(
+      false
+    );
+  }
 });
 
 test("sharedUtil.makeString", () => {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #14035

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
