### PR TITLE
Simplify `getNextNonSpaceNonCommentCharacter`

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -107,7 +107,6 @@ function getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd) {
 }
 
 /**
- * @template N
  * @param {string} text
  * @param {number} startIndex
  * @returns {string}

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -109,15 +109,16 @@ function getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd) {
 /**
  * @template N
  * @param {string} text
- * @param {N} node
- * @param {(node: N) => number} locEnd
+ * @param {number} startIndex
  * @returns {string}
  */
-function getNextNonSpaceNonCommentCharacter(text, node, locEnd) {
-  return text.charAt(
-    // @ts-expect-error => TBD: can return false, should we define a fallback?
-    getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd)
+function getNextNonSpaceNonCommentCharacter(text, startIndex) {
+  const index = getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
+    text,
+    startIndex
   );
+
+  return index === false ? "" : text.charAt(index);
 }
 
 // Not using, but it's public utils

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -179,8 +179,7 @@ function handleIfStatementComments({
   // it is a ).
   const nextCharacter = getNextNonSpaceNonCommentCharacter(
     text,
-    comment,
-    locEnd
+    locEnd(comment)
   );
   if (nextCharacter === ")") {
     addTrailingComment(precedingNode, comment);
@@ -260,8 +259,7 @@ function handleWhileComments({
   // it is a ).
   const nextCharacter = getNextNonSpaceNonCommentCharacter(
     text,
-    comment,
-    locEnd
+    locEnd(comment)
   );
   if (nextCharacter === ")") {
     addTrailingComment(precedingNode, comment);
@@ -461,7 +459,7 @@ function handleMethodNameComments({
   if (
     enclosingNode &&
     precedingNode &&
-    getNextNonSpaceNonCommentCharacter(text, comment, locEnd) === "(" &&
+    getNextNonSpaceNonCommentCharacter(text, locEnd(comment)) === "(" &&
     // "MethodDefinition" is handled in getCommentChildNodes
     (enclosingNode.type === "Property" ||
       enclosingNode.type === "TSDeclareMethod" ||
@@ -470,7 +468,7 @@ function handleMethodNameComments({
     enclosingNode.key === precedingNode &&
     // special Property case: { key: /*comment*/(value) };
     // comment should be attached to value instead of key
-    getNextNonSpaceNonCommentCharacter(text, precedingNode, locEnd) !== ":"
+    getNextNonSpaceNonCommentCharacter(text, locEnd(precedingNode)) !== ":"
   ) {
     addTrailingComment(precedingNode, comment);
     return true;
@@ -502,7 +500,7 @@ function handleFunctionNameComments({
   enclosingNode,
   text,
 }) {
-  if (getNextNonSpaceNonCommentCharacter(text, comment, locEnd) !== "(") {
+  if (getNextNonSpaceNonCommentCharacter(text, locEnd(comment)) !== "(") {
     return false;
   }
   if (precedingNode && functionLikeNodeTypes.has(enclosingNode?.type)) {
@@ -527,7 +525,7 @@ function handleCommentAfterArrowParams({ comment, enclosingNode, text }) {
 }
 
 function handleCommentInEmptyParens({ comment, enclosingNode, text }) {
-  if (getNextNonSpaceNonCommentCharacter(text, comment, locEnd) !== ")") {
+  if (getNextNonSpaceNonCommentCharacter(text, locEnd(comment)) !== ")") {
     return false;
   }
 
@@ -577,7 +575,7 @@ function handleLastFunctionArgComments({
       precedingNode?.type === "AssignmentPattern") &&
     enclosingNode &&
     isRealFunctionLikeNode(enclosingNode) &&
-    getNextNonSpaceNonCommentCharacter(text, comment, locEnd) === ")"
+    getNextNonSpaceNonCommentCharacter(text, locEnd(comment)) === ")"
   ) {
     addTrailingComment(precedingNode, comment);
     return true;
@@ -829,7 +827,7 @@ function handleTSFunctionTrailingComments({
     (enclosingNode?.type === "TSMethodSignature" ||
       enclosingNode?.type === "TSDeclareFunction" ||
       enclosingNode?.type === "TSAbstractMethodDefinition") &&
-    getNextNonSpaceNonCommentCharacter(text, comment, locEnd) === ";"
+    getNextNonSpaceNonCommentCharacter(text, locEnd(comment)) === ";"
   ) {
     addTrailingComment(enclosingNode, comment);
     return true;

--- a/src/language-js/print/function-parameters.js
+++ b/src/language-js/print/function-parameters.js
@@ -51,8 +51,7 @@ function printFunctionParameters(
         filter: (comment) =>
           getNextNonSpaceNonCommentCharacter(
             options.originalText,
-            comment,
-            locEnd
+            locEnd(comment)
           ) === ")",
       }),
       ")",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Accept `startIndex` instead of `node` + `locEnd`

Prepare for #14317

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
