### PR TITLE
Replace `getNextNonSpaceNonCommentCharacterIndex` with `getNextNonSpaceNonCommentCharacterIndexWithStartIndex` internally

### DIFF
--- a/src/common/util-shared.js
+++ b/src/common/util-shared.js
@@ -1,3 +1,20 @@
+import {getNextNonSpaceNonCommentCharacterIndexWithStartIndex} from "./util.js"
+
+// Legacy way of `getNextNonSpaceNonCommentCharacterIndex`
+/**
+ * @template N
+ * @param {string} text
+ * @param {N} node
+ * @param {(node: N) => number} locEnd
+ * @returns {number | false}
+ */
+export function getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd) {
+  return getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
+    text,
+    locEnd(node)
+  );
+}
+
 export {
   getMaxContinuousCount,
   getStringWidth,

--- a/src/common/util-shared.js
+++ b/src/common/util-shared.js
@@ -1,4 +1,4 @@
-import { getNextNonSpaceNonCommentCharacterIndexWithStartIndex } from "./util.js";
+import { getNextNonSpaceNonCommentCharacterIndex as getNextNonSpaceNonCommentCharacterIndexWithStartIndex } from "./util.js";
 
 // Legacy way of `getNextNonSpaceNonCommentCharacterIndex`
 /**
@@ -34,7 +34,6 @@ export {
   isNextLineEmpty,
   isNextLineEmptyAfterIndex,
   isPreviousLineEmpty,
-  getNextNonSpaceNonCommentCharacterIndex,
   makeString,
   addLeadingComment,
   addDanglingComment,

--- a/src/common/util-shared.js
+++ b/src/common/util-shared.js
@@ -1,4 +1,4 @@
-import {getNextNonSpaceNonCommentCharacterIndexWithStartIndex} from "./util.js"
+import { getNextNonSpaceNonCommentCharacterIndexWithStartIndex } from "./util.js";
 
 // Legacy way of `getNextNonSpaceNonCommentCharacterIndex`
 /**

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -93,20 +93,6 @@ function isNextLineEmpty(text, node, locEnd) {
 }
 
 /**
- * @template N
- * @param {string} text
- * @param {N} node
- * @param {(node: N) => number} locEnd
- * @returns {number | false}
- */
-function getNextNonSpaceNonCommentCharacterIndex(text, node, locEnd) {
-  return getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
-    text,
-    locEnd(node)
-  );
-}
-
-/**
  * @param {string} text
  * @param {number} startIndex
  * @returns {string}
@@ -423,7 +409,6 @@ export {
   getMaxContinuousCount,
   getMinNotPresentContinuousCount,
   getNextNonSpaceNonCommentCharacterIndexWithStartIndex,
-  getNextNonSpaceNonCommentCharacterIndex,
   getNextNonSpaceNonCommentCharacter,
   skip,
   skipWhitespace,

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -9,7 +9,7 @@ import {
 import skipInlineComment from "../utils/text/skip-inline-comment.js";
 import skipTrailingComment from "../utils/text/skip-trailing-comment.js";
 import skipNewline from "../utils/text/skip-newline.js";
-import getNextNonSpaceNonCommentCharacterIndexWithStartIndex from "../utils/text/get-next-non-space-non-comment-character-index-with-start-index.js";
+import getNextNonSpaceNonCommentCharacterIndex from "../utils/text/get-next-non-space-non-comment-character-index.js";
 
 /**
  * @typedef {{backwards?: boolean}} SkipOptions
@@ -98,10 +98,7 @@ function isNextLineEmpty(text, node, locEnd) {
  * @returns {string}
  */
 function getNextNonSpaceNonCommentCharacter(text, startIndex) {
-  const index = getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
-    text,
-    startIndex
-  );
+  const index = getNextNonSpaceNonCommentCharacterIndex(text, startIndex);
 
   return index === false ? "" : text.charAt(index);
 }
@@ -408,7 +405,7 @@ function describeNodeForDebugging(node) {
 export {
   getMaxContinuousCount,
   getMinNotPresentContinuousCount,
-  getNextNonSpaceNonCommentCharacterIndexWithStartIndex,
+  getNextNonSpaceNonCommentCharacterIndex,
   getNextNonSpaceNonCommentCharacter,
   skip,
   skipWhitespace,

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -1,6 +1,6 @@
 import {
   hasNewline,
-  getNextNonSpaceNonCommentCharacterIndexWithStartIndex,
+  getNextNonSpaceNonCommentCharacterIndex,
   getNextNonSpaceNonCommentCharacter,
   hasNewlineInRange,
   addLeadingComment,
@@ -514,10 +514,7 @@ function handleCommentAfterArrowParams({ comment, enclosingNode, text }) {
     return false;
   }
 
-  const index = getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
-    text,
-    locEnd(comment)
-  );
+  const index = getNextNonSpaceNonCommentCharacterIndex(text, locEnd(comment));
   if (index !== false && text.slice(index, index + 2) === "=>") {
     addDanglingComment(enclosingNode, comment);
     return true;
@@ -590,19 +587,16 @@ function handleLastFunctionArgComments({
     const functionParamRightParenIndex = (() => {
       const parameters = getFunctionParameters(enclosingNode);
       if (parameters.length > 0) {
-        return getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
+        return getNextNonSpaceNonCommentCharacterIndex(
           text,
           locEnd(parameters.at(-1))
         );
       }
       const functionParamLeftParenIndex =
-        getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
-          text,
-          locEnd(enclosingNode.id)
-        );
+        getNextNonSpaceNonCommentCharacterIndex(text, locEnd(enclosingNode.id));
       return (
         functionParamLeftParenIndex !== false &&
-        getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
+        getNextNonSpaceNonCommentCharacterIndex(
           text,
           functionParamLeftParenIndex + 1
         )

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -6,7 +6,6 @@ import {
   addLeadingComment,
   addTrailingComment,
   addDanglingComment,
-  getNextNonSpaceNonCommentCharacterIndex,
   isNonEmptyArray,
 } from "../../common/util.js";
 import {
@@ -515,7 +514,10 @@ function handleCommentAfterArrowParams({ comment, enclosingNode, text }) {
     return false;
   }
 
-  const index = getNextNonSpaceNonCommentCharacterIndex(text, comment, locEnd);
+  const index = getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
+    text,
+    locEnd(comment)
+  );
   if (index !== false && text.slice(index, index + 2) === "=>") {
     addDanglingComment(enclosingNode, comment);
     return true;

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -1,6 +1,6 @@
 import tryCombinations from "../../utils/try-combinations.js";
 import getShebang from "../utils/get-shebang.js";
-import getNextNonSpaceNonCommentCharacterIndexWithStartIndex from "../../utils/text/get-next-non-space-non-comment-character-index-with-start-index.js";
+import getNextNonSpaceNonCommentCharacterIndex from "../../utils/text/get-next-non-space-non-comment-character-index-with-start-index.js";
 // JSON parsers are bundled here so we can reduce package size
 import jsonParsers from "../../language-json/parser-json.js";
 import createParser from "./utils/create-parser.js";
@@ -81,7 +81,7 @@ function isFlowFile(text, options) {
   }
 
   const firstNonSpaceNonCommentCharacterIndex =
-    getNextNonSpaceNonCommentCharacterIndexWithStartIndex(text, 0);
+    getNextNonSpaceNonCommentCharacterIndex(text, 0);
 
   if (firstNonSpaceNonCommentCharacterIndex !== false) {
     text = text.slice(0, firstNonSpaceNonCommentCharacterIndex);

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -1,6 +1,6 @@
 import tryCombinations from "../../utils/try-combinations.js";
 import getShebang from "../utils/get-shebang.js";
-import getNextNonSpaceNonCommentCharacterIndex from "../../utils/text/get-next-non-space-non-comment-character-index-with-start-index.js";
+import getNextNonSpaceNonCommentCharacterIndex from "../../utils/text/get-next-non-space-non-comment-character-index.js";
 // JSON parsers are bundled here so we can reduce package size
 import jsonParsers from "../../language-json/parser-json.js";
 import createParser from "./utils/create-parser.js";

--- a/src/language-js/print/function.js
+++ b/src/language-js/print/function.js
@@ -5,7 +5,7 @@ import {
   printDanglingComments,
   printCommentsSeparately,
 } from "../../main/comments.js";
-import { getNextNonSpaceNonCommentCharacterIndex } from "../../common/util.js";
+import { getNextNonSpaceNonCommentCharacterIndexWithStartIndex } from "../../common/util.js";
 import {
   line,
   softline,
@@ -227,11 +227,11 @@ function printArrowFunctionSignature(path, options, print, args) {
 
   const dangling = printDanglingComments(path, options, {
     filter(comment) {
-      const nextCharacter = getNextNonSpaceNonCommentCharacterIndex(
-        options.originalText,
-        comment,
-        locEnd
-      );
+      const nextCharacter =
+        getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
+          options.originalText,
+          locEnd(comment)
+        );
       return (
         nextCharacter !== false &&
         options.originalText.slice(nextCharacter, nextCharacter + 2) === "=>"

--- a/src/language-js/print/function.js
+++ b/src/language-js/print/function.js
@@ -5,7 +5,7 @@ import {
   printDanglingComments,
   printCommentsSeparately,
 } from "../../main/comments.js";
-import { getNextNonSpaceNonCommentCharacterIndexWithStartIndex } from "../../common/util.js";
+import { getNextNonSpaceNonCommentCharacterIndex } from "../../common/util.js";
 import {
   line,
   softline,
@@ -227,11 +227,10 @@ function printArrowFunctionSignature(path, options, print, args) {
 
   const dangling = printDanglingComments(path, options, {
     filter(comment) {
-      const nextCharacter =
-        getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
-          options.originalText,
-          locEnd(comment)
-        );
+      const nextCharacter = getNextNonSpaceNonCommentCharacterIndex(
+        options.originalText,
+        locEnd(comment)
+      );
       return (
         nextCharacter !== false &&
         options.originalText.slice(nextCharacter, nextCharacter + 2) === "=>"

--- a/src/language-js/print/member-chain.js
+++ b/src/language-js/print/member-chain.js
@@ -1,7 +1,7 @@
 import { printComments } from "../../main/comments.js";
 import {
   isNextLineEmptyAfterIndex,
-  getNextNonSpaceNonCommentCharacterIndex,
+  getNextNonSpaceNonCommentCharacterIndexWithStartIndex,
 } from "../../common/util.js";
 import pathNeedsParens from "../needs-parens.js";
 import {
@@ -65,10 +65,9 @@ function printMemberChain(path, options, print) {
   // the first group whether it is in parentheses or not
   function shouldInsertEmptyLineAfter(node) {
     const { originalText } = options;
-    const nextCharIndex = getNextNonSpaceNonCommentCharacterIndex(
+    const nextCharIndex = getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
       originalText,
-      node,
-      locEnd
+      locEnd(node)
     );
     const nextChar = originalText.charAt(nextCharIndex);
 

--- a/src/language-js/print/member-chain.js
+++ b/src/language-js/print/member-chain.js
@@ -1,7 +1,7 @@
 import { printComments } from "../../main/comments.js";
 import {
   isNextLineEmptyAfterIndex,
-  getNextNonSpaceNonCommentCharacterIndexWithStartIndex,
+  getNextNonSpaceNonCommentCharacterIndex,
 } from "../../common/util.js";
 import pathNeedsParens from "../needs-parens.js";
 import {
@@ -65,7 +65,7 @@ function printMemberChain(path, options, print) {
   // the first group whether it is in parentheses or not
   function shouldInsertEmptyLineAfter(node) {
     const { originalText } = options;
-    const nextCharIndex = getNextNonSpaceNonCommentCharacterIndexWithStartIndex(
+    const nextCharIndex = getNextNonSpaceNonCommentCharacterIndex(
       originalText,
       locEnd(node)
     );

--- a/src/utils/text/get-next-non-space-non-comment-character-index.js
+++ b/src/utils/text/get-next-non-space-non-comment-character-index.js
@@ -5,14 +5,14 @@ import { skipSpaces } from "./skip.js";
 
 /**
  * @param {string} text
- * @param {number} idx
+ * @param {number} startIndex
  * @returns {number | false}
  */
-function getNextNonSpaceNonCommentCharacterIndexWithStartIndex(text, idx) {
+function getNextNonSpaceNonCommentCharacterIndex(text, startIndex) {
   /** @type {number | false} */
   let oldIdx = null;
   /** @type {number | false} */
-  let nextIdx = idx;
+  let nextIdx = startIndex;
   while (nextIdx !== oldIdx) {
     oldIdx = nextIdx;
     nextIdx = skipSpaces(text, nextIdx);
@@ -23,4 +23,4 @@ function getNextNonSpaceNonCommentCharacterIndexWithStartIndex(text, idx) {
   return nextIdx;
 }
 
-export default getNextNonSpaceNonCommentCharacterIndexWithStartIndex;
+export default getNextNonSpaceNonCommentCharacterIndex;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
