### PR TITLE
CLI: Display posix style paths on Windows

### DIFF
--- a/changelog_unreleased/cli/14333.md
+++ b/changelog_unreleased/cli/14333.md
@@ -1,0 +1,18 @@
+#### Display posix style paths on Windows (#14333 by @fisker)
+
+Align with other tools like ESLint and Stylelint.
+
+<!-- prettier-ignore -->
+```jsx
+// Prettier stable
+Checking formatting...
+[warn] src\utils\create-get-visitor-keys.js
+[warn] src\utils\unexpected-node-error.js
+[warn] Code style issues found in 2 files. Forgot to run Prettier?
+
+// Prettier main
+Checking formatting...
+[warn] src/utils/create-get-visitor-keys.js
+[warn] src/utils/unexpected-node-error.js
+[warn] Code style issues found in 2 files. Forgot to run Prettier?
+```

--- a/cspell.json
+++ b/cspell.json
@@ -250,6 +250,7 @@
         "Pieter",
         "pnpapi",
         "pnpm",
+        "posix",
         "postprocessor",
         "prebuilds",
         "precache",

--- a/src/cli/expand-patterns.js
+++ b/src/cli/expand-patterns.js
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { statSafe } from "./utils.js";
+import { statSafe, normalizeToPosix } from "./utils.js";
 import { fastGlob } from "./prettier-internal.js";
 
 /** @typedef {import('./context').Context} Context */
@@ -186,17 +186,12 @@ function escapePathForGlob(path) {
     .replaceAll("\0", "@(\\\\)"); // Workaround for fast-glob#262 (part 2)
 }
 
-const isWindows = path.sep === "\\";
-
 /**
  * Using backslashes in globs is probably not okay, but not accepting
  * backslashes as path separators on Windows is even more not okay.
  * https://github.com/prettier/prettier/pull/6776#discussion_r380723717
  * https://github.com/mrmlnc/fast-glob#how-to-write-patterns-on-windows
- * @param {string} pattern
  */
-function fixWindowsSlashes(pattern) {
-  return isWindows ? pattern.replaceAll("\\", "/") : pattern;
-}
+const fixWindowsSlashes = normalizeToPosix;
 
 export { expandPatterns };

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -9,7 +9,7 @@ import getOptionsForFile from "./options/get-options-for-file.js";
 import isTTY from "./is-tty.js";
 import findCacheFile from "./find-cache-file.js";
 import FormatResultsCache from "./format-results-cache.js";
-import { statSafe } from "./utils.js";
+import { statSafe, normalizeToPosix } from "./utils.js";
 
 const { getStdin } = thirdParty;
 
@@ -351,7 +351,7 @@ async function formatFiles(context) {
 
     let printedFilename;
     if (isTTY()) {
-      printedFilename = context.logger.log(filename, {
+      printedFilename = context.logger.log(normalizeToPosix(filename), {
         newline: false,
         clearable: true,
       });
@@ -423,7 +423,9 @@ async function formatFiles(context) {
       // mtime based caches.
       if (isDifferent) {
         if (!context.argv.check && !context.argv.listDifferent) {
-          context.logger.log(`${filename} ${Date.now() - start}ms`);
+          context.logger.log(
+            `${normalizeToPosix(filename)} ${Date.now() - start}ms`
+          );
         }
 
         try {
@@ -440,7 +442,9 @@ async function formatFiles(context) {
           process.exitCode = 2;
         }
       } else if (!context.argv.check && !context.argv.listDifferent) {
-        const message = `${chalk.grey(filename)} ${Date.now() - start}ms`;
+        const message = `${chalk.grey(normalizeToPosix(filename))} ${
+          Date.now() - start
+        }ms`;
         if (isCacheExists) {
           context.logger.log(`${message} (cached)`);
         } else {
@@ -449,7 +453,7 @@ async function formatFiles(context) {
       }
     } else if (context.argv.debugCheck) {
       if (result.filepath) {
-        context.logger.log(result.filepath);
+        context.logger.log(normalizeToPosix(result.filepath));
       } else {
         /* c8 ignore next */
         process.exitCode = 2;
@@ -466,9 +470,9 @@ async function formatFiles(context) {
 
     if (isDifferent) {
       if (context.argv.check) {
-        context.logger.warn(filename);
+        context.logger.warn(normalizeToPosix(filename));
       } else if (context.argv.listDifferent) {
-        context.logger.log(filename);
+        context.logger.log(normalizeToPosix(filename));
       }
       numberOfUnformattedFilesFound += 1;
     }

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import path from "node:path";
 import sdbm from "sdbm";
 import { __internal as sharedWithCli } from "../index.js";
 
@@ -79,6 +80,16 @@ function isJson(value) {
   }
 }
 
+/**
+ * Replace `\` with `/` on Windows
+ * @param {string} filepath
+ * @returns {string}
+ */
+const normalizeToPosix =
+  path.sep === "\\"
+    ? (filepath) => filepath.replaceAll("\\", "/")
+    : (filepath) => filepath;
+
 export {
   arrayify,
   isNonEmptyArray,
@@ -89,4 +100,5 @@ export {
   createHash,
   statSafe,
   isJson,
+  normalizeToPosix,
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Before:

```console
Checking formatting...
[warn] src\utils\create-get-visitor-keys.js
[warn] src\utils\unexpected-node-error.js
[warn] Code style issues found in 2 files. Forgot to run Prettier?
```

After:

```console
Checking formatting...
[warn] src/utils/create-get-visitor-keys.js
[warn] src/utils/unexpected-node-error.js
[warn] Code style issues found in 2 files. Forgot to run Prettier?
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
