### PR TITLE
Add `.originalText` before calling `parse`

### DIFF
--- a/src/language-css/parser-postcss.js
+++ b/src/language-css/parser-postcss.js
@@ -673,7 +673,6 @@ async function parseWithParser(parse, text, options) {
     });
   }
 
-  options.originalText = text;
   result = await parseNestedCSS(addTypePrefix(result, "css-"), options);
 
   calculateLoc(result, text);

--- a/src/language-js/parse/acorn.js
+++ b/src/language-js/parse/acorn.js
@@ -78,7 +78,6 @@ function parse(text, options = {}) {
     throw createParseError(error);
   }
 
-  options.originalText = text;
   return postprocess(ast, options);
 }
 

--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -158,8 +158,6 @@ function createParse({ isExpression = false, optionsCombinations }) {
       throw createBabelParseError(error);
     }
 
-    opts.originalText = text;
-
     if (isExpression) {
       ast = wrapBabelExpression(ast, opts);
     }

--- a/src/language-js/parse/espree.js
+++ b/src/language-js/parse/espree.js
@@ -51,7 +51,6 @@ function parse(text, options = {}) {
     throw createParseError(error);
   }
 
-  options.originalText = text;
   return postprocess(ast, options);
 }
 

--- a/src/language-js/parse/flow.js
+++ b/src/language-js/parse/flow.js
@@ -50,7 +50,6 @@ async function parse(text, options = {}) {
     throw createParseError(error);
   }
 
-  options.originalText = text;
   return postprocess(ast, options);
 }
 

--- a/src/language-js/parse/meriyah.js
+++ b/src/language-js/parse/meriyah.js
@@ -98,7 +98,6 @@ async function parse(text, options = {}) {
     throw createParseError(error);
   }
 
-  options.originalText = text;
   return postprocess(ast, options);
 }
 

--- a/src/language-js/parse/typescript.js
+++ b/src/language-js/parse/typescript.js
@@ -55,8 +55,6 @@ async function parse(text, options = {}) {
     throw createParseError(error);
   }
 
-  options.originalText = text;
-
   await throwErrorForInvalidNodes(result, options);
 
   return postprocess(result.ast, options);

--- a/src/language-json/parser-json.js
+++ b/src/language-json/parser-json.js
@@ -27,7 +27,6 @@ function createJsonParse(options = {}) {
 
     assertJsonNode(ast);
 
-    options.originalText = text;
     return wrapBabelExpression(ast, options, "JsonRoot");
   };
 }

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -29,7 +29,6 @@ function attachComments(text, ast, opts) {
   }
   opts[Symbol.for("comments")] = astComments || [];
   opts[Symbol.for("tokens")] = ast.tokens || [];
-  opts.originalText = text;
   return astComments;
 }
 

--- a/src/main/parser.js
+++ b/src/main/parser.js
@@ -30,6 +30,7 @@ async function parse(originalText, options) {
   const text = parser.preprocess
     ? parser.preprocess(originalText, options)
     : originalText;
+  options.originalText = text;
 
   let ast;
   try {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
