### PR TITLE
docs: mention to add a line break

### DIFF
--- a/docs/ignore.md
+++ b/docs/ignore.md
@@ -5,7 +5,7 @@ title: Ignoring Code
 
 Use `.prettierignore` to ignore (i.e. not reformat) certain files and folders completely.
 
-Use “prettier-ignore” comments to ignore parts of files.
+Use “prettier-ignore” comments, followed by a line break, to ignore parts of files.
 
 ## Ignoring Files: .prettierignore
 


### PR DESCRIPTION
## Description

I noticed that pragmas like `<!-- prettier-ignore-start -->` don't work when there is no line break afterwards. The following code for example gets formatted:

````md
<!-- prettier-ignore-start --> <!-- SOMETHING AUTO-GENERATED BY TOOLS - START -->

| MY | AWESOME | AUTO-GENERATED | TABLE |
|-|-|-|-|
| a | b | c | d |

<!-- SOMETHING AUTO-GENERATED BY TOOLS - END --> <!-- prettier-ignore-end -->
````

That's why I find it important to mention this detail of adding a line break.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
