### PR TITLE
Perf: Array#at is slow for a hot function like `AstPath.node`

### DIFF
--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -16,7 +16,8 @@ class AstPath {
 
   /** @type {object} */
   get node() {
-    return this.stack.at(-1);
+    // eslint-disable-next-line unicorn/prefer-at
+    return this.stack[this.stack.length - 1];
   }
 
   /** @type {object | null} */

--- a/src/common/ast-path.js
+++ b/src/common/ast-path.js
@@ -16,7 +16,7 @@ class AstPath {
 
   /** @type {object} */
   get node() {
-    // eslint-disable-next-line unicorn/prefer-at
+    // eslint-disable-next-line unicorn/prefer-at -- `Array#at` is slow on Node.js v16 and v18
     return this.stack[this.stack.length - 1];
   }
 


### PR DESCRIPTION
## Description
Hi, I hope this drive by PR is okay. 

I was profiling some of the the tools I use at $work looking for some easy performance gains, and out of curiosity I tried the "next" branch hoping that it would be faster than main. When I was profiling on my own app I saw that `AstPath.node` was a very hot function taking about 2% of the time. I saw that the implementation was using `Array#at(-1)`, and I switched it back to using the `stack[stack.length - 1]` pattern that is used in the main branch, and after running the benchmark script a few time I'm seeing a ~10% performance improvement.

I also took into account [the comments made about the benchmark script about i/o caching](https://github.com/prettier/prettier/pull/13224#issuecomment-1228161394) and adjusted the benchmark script locally to copy the test file for each branch.

```
Benchmark 1: node ./bench.mjs next serial prettier/scripts/benchmark/next/test-file.js
  Time (mean ± σ):     50.935 s ±  1.101 s    [User: 75.290 s, System: 1.240 s]
  Range (min … max):   49.818 s … 53.261 s    10 runs
 
Benchmark 2: node ./bench.mjs next parallel prettier/scripts/benchmark/next/test-file.js
  Time (mean ± σ):     49.321 s ±  1.119 s    [User: 70.245 s, System: 1.542 s]
  Range (min … max):   48.315 s … 51.809 s    10 runs
 
Benchmark 3: node ./bench.mjs feature/last-index serial prettier/scripts/benchmark/feature/last-index/test-file.js
  Time (mean ± σ):     46.425 s ±  0.602 s    [User: 70.303 s, System: 1.183 s]
  Range (min … max):   45.724 s … 47.428 s    10 runs
 
Benchmark 4: node ./bench.mjs feature/last-index parallel prettier/scripts/benchmark/feature/last-index/test-file.js
  Time (mean ± σ):     45.060 s ±  1.100 s    [User: 65.943 s, System: 1.524 s]
  Range (min … max):   43.483 s … 47.047 s    10 runs
 
Summary
  'node ./bench.mjs feature/last-index parallel prettier/scripts/benchmark/feature/last-index/test-file.js' ran
    1.03 ± 0.03 times faster than 'node ./bench.mjs feature/last-index serial prettier/scripts/benchmark/feature/last-index/test-file.js'
    1.09 ± 0.04 times faster than 'node ./bench.mjs next parallel prettier/scripts/benchmark/next/test-file.js'
    1.13 ± 0.04 times faster than 'node ./bench.mjs next serial prettier/scripts/benchmark/next/test-file.js'
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
