### PR TITLE
Simplify `canAttachComment`

### DIFF
--- a/src/language-js/comments/printer-methods.js
+++ b/src/language-js/comments/printer-methods.js
@@ -4,28 +4,31 @@ import {
   getFunctionParameters,
   hasNodeIgnoreComment,
   isJsxElement,
-  isLineComment,
 } from "../utils/index.js";
-import isBlockComment from "../utils/is-block-comment.js";
 
 /**
  * @typedef {import("../types/estree.js").Node} Node
  * @typedef {import("../../common/ast-path.js").default} AstPath
  */
 
+const nodeTypesCanNotAttachComment = new Set([
+  "EmptyStatement",
+  "TemplateElement",
+  // In ESTree `import` is a token, `import("foo")`
+  "Import",
+  // There is no similar node in Babel AST
+  // ```ts
+  // class Foo {
+  //   bar();
+  //      ^^^ TSEmptyBodyFunctionExpression
+  // }
+  // ```
+  "TSEmptyBodyFunctionExpression",
+  // There is no similar node in Babel AST, `a?.b`
+  "ChainExpression",
+]);
 function canAttachComment(node) {
-  return (
-    node.type &&
-    !isBlockComment(node) &&
-    !isLineComment(node) &&
-    node.type !== "EmptyStatement" &&
-    node.type !== "TemplateElement" &&
-    node.type !== "Import" &&
-    // `babel-ts` doesn't have similar node for `class Foo { bar() /* bat */; }`
-    node.type !== "TSEmptyBodyFunctionExpression" &&
-    // `babel` doesn't have similar node to attach comments
-    node.type !== "ChainExpression"
-  );
+  return !nodeTypesCanNotAttachComment.has(node.type);
 }
 
 /**
@@ -94,11 +97,11 @@ function isGap(text, { parser }) {
 
 export * as handleComments from "./handle-comments.js";
 export { printComment } from "../print/comment.js";
+export { default as isBlockComment } from "../utils/is-block-comment.js";
 export {
   canAttachComment,
   getCommentChildNodes,
   hasPrettierIgnore,
-  isBlockComment,
   willPrintOwnComments,
   isGap,
 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

We have full vistorKeys, so this function can't receive comments or other non-node objects.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
