### PR TITLE
Include prettier-plugin-sql-cst to community plugins list

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -72,6 +72,7 @@ To turn off plugin autoloading, use `--no-plugin-search` when using Prettier CLI
 - [`prettier-plugin-properties`](https://github.com/eemeli/prettier-plugin-properties) by [**@eemeli**](https://github.com/eemeli)
 - [`prettier-plugin-sh`](https://github.com/un-ts/prettier/tree/master/packages/sh) by [**@JounQin**](https://github.com/JounQin)
 - [`prettier-plugin-sql`](https://github.com/un-ts/prettier/tree/master/packages/sql) by [**@JounQin**](https://github.com/JounQin)
+- [`prettier-plugin-sql-cst`](https://github.com/nene/prettier-plugin-sql-cst) by [**@nene**](https://github.com/nene)
 - [`prettier-plugin-solidity`](https://github.com/prettier-solidity/prettier-plugin-solidity) by [**@mattiaerre**](https://github.com/mattiaerre)
 - [`prettier-plugin-svelte`](https://github.com/UnwrittenFun/prettier-plugin-svelte) by [**@UnwrittenFun**](https://github.com/UnwrittenFun)
 - [`prettier-plugin-toml`](https://github.com/bd82/toml-tools/tree/master/packages/prettier-plugin-toml) by [**@bd82**](https://github.com/bd82)


### PR DESCRIPTION
## Description

This PR adds link to [prettier-plugin-sql-cst](https://github.com/nene/prettier-plugin-sql-cst) to the list of community plugins.

Admittedly, this is an attempt to promote an SQL-formatting plugin that I have written. There already exists an SQL-plugin in this list, so why do I suggest adding another one?

The existing SQL plugin simply wraps an existing [sql-formatter](https://github.com/sql-formatter-org/sql-formatter) library, which doesn't really format the code in the way Prettier itself does. I know its limitations quite well, as I'm actually the author of that library.

The new plugin uses the actual Prettier formatting algorithm to lay out the code and is also much more in line with the philosophy of Prettier, by providing almost no configuration options and having a very opinionated approach to SQL code style.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
