### PR TITLE
Use `export default` in `.d.ts` files

### DIFF
--- a/src/language-css/parser-postcss.d.ts
+++ b/src/language-css/parser-postcss.d.ts
@@ -1,10 +1,11 @@
 import { Parser } from "../index.js";
 
-declare const parser: {
+declare const plugin: {
   parsers: {
     css: Parser;
     less: Parser;
     scss: Parser;
   };
 };
-export = parser;
+
+export default plugin;

--- a/src/language-graphql/parser-graphql.d.ts
+++ b/src/language-graphql/parser-graphql.d.ts
@@ -1,8 +1,9 @@
 import { Parser } from "../index.js";
 
-declare const parser: {
+declare const plugin: {
   parsers: {
     graphql: Parser;
   };
 };
-export = parser;
+
+export default plugin;

--- a/src/language-handlebars/parser-glimmer.d.ts
+++ b/src/language-handlebars/parser-glimmer.d.ts
@@ -1,8 +1,9 @@
 import { Parser } from "../index.js";
 
-declare const parser: {
+declare const plugin: {
   parsers: {
     glimmer: Parser;
   };
 };
-export = parser;
+
+export default plugin;

--- a/src/language-html/parser-html.d.ts
+++ b/src/language-html/parser-html.d.ts
@@ -1,6 +1,6 @@
 import { Parser } from "../index.js";
 
-declare const parser: {
+declare const plugin: {
   parsers: {
     html: Parser;
     angular: Parser;
@@ -8,4 +8,5 @@ declare const parser: {
     lwc: Parser;
   };
 };
-export = parser;
+
+export default plugin;

--- a/src/language-js/parse/acorn-and-espree.d.ts
+++ b/src/language-js/parse/acorn-and-espree.d.ts
@@ -1,10 +1,10 @@
 import { Parser } from "../../index.js";
 
-declare const parser: {
+declare const plugin: {
   parsers: {
     acorn: Parser;
     espree: Parser;
   };
 };
 
-export = parser;
+export default plugin;

--- a/src/language-js/parse/angular.d.ts
+++ b/src/language-js/parse/angular.d.ts
@@ -1,6 +1,6 @@
 import { Parser } from "../../index.js";
 
-declare const parser: {
+declare const plugin: {
   parsers: {
     __ng_action: Parser;
     __ng_binding: Parser;
@@ -8,4 +8,5 @@ declare const parser: {
     __ng_directive: Parser;
   };
 };
-export = parser;
+
+export default plugin;

--- a/src/language-js/parse/babel.d.ts
+++ b/src/language-js/parse/babel.d.ts
@@ -1,6 +1,6 @@
 import { Parser } from "../../index.js";
 
-declare const parser: {
+declare const plugin: {
   parsers: {
     babel: Parser;
     "babel-flow": Parser;
@@ -13,4 +13,5 @@ declare const parser: {
     __vue_event_binding: Parser;
   };
 };
-export = parser;
+
+export default plugin;

--- a/src/language-js/parse/flow.d.ts
+++ b/src/language-js/parse/flow.d.ts
@@ -1,8 +1,9 @@
 import { Parser } from "../../index.js";
 
-declare const parser: {
+declare const plugin: {
   parsers: {
     flow: Parser;
   };
 };
-export = parser;
+
+export default plugin;

--- a/src/language-js/parse/meriyah.d.ts
+++ b/src/language-js/parse/meriyah.d.ts
@@ -1,8 +1,9 @@
 import { Parser } from "../../index.js";
 
-declare const parser: {
+declare const plugin: {
   parsers: {
     meriyah: Parser;
   };
 };
-export = parser;
+
+export default plugin;

--- a/src/language-js/parse/typescript.d.ts
+++ b/src/language-js/parse/typescript.d.ts
@@ -1,8 +1,9 @@
 import { Parser } from "../../index.js";
 
-declare const parser: {
+declare const plugin: {
   parsers: {
     typescript: Parser;
   };
 };
-export = parser;
+
+export default plugin;

--- a/src/language-markdown/parser-markdown.d.ts
+++ b/src/language-markdown/parser-markdown.d.ts
@@ -1,10 +1,11 @@
 import { Parser } from "../index.js";
 
-declare const parser: {
+declare const plugin: {
   parsers: {
     remark: Parser;
     markdown: Parser;
     mdx: Parser;
   };
 };
-export = parser;
+
+export default plugin;

--- a/src/language-yaml/parser-yaml.d.ts
+++ b/src/language-yaml/parser-yaml.d.ts
@@ -1,8 +1,9 @@
 import { Parser } from "../index.js";
 
-declare const parser: {
+declare const plugin: {
   parsers: {
     yaml: Parser;
   };
 };
-export = parser;
+
+export default plugin;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

TS5 seems not allow use `export =`, [CI log](https://github.com/prettier/prettier/actions/runs/4311945857/jobs/7521900909#step:6:5)

I've tested locally, it works.

Also, these modules are prettier plugins, not parsers, so renamed `parser` -> `plugin`.

cc @sosukesuzuki 

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
