### PR TITLE
Simplify `inferParserByLanguage`

### DIFF
--- a/src/language-html/parser-html.js
+++ b/src/language-html/parser-html.js
@@ -87,7 +87,7 @@ function ngHtmlParser(
           return false;
         }
         const language = node.attrs.find((attr) => attr.name === "lang")?.value;
-        return !language || inferParserByLanguage(language, options) === "html";
+        return !language || inferParserByLanguage(options, language) === "html";
       };
       if (rootNodes.some(shouldParseAsHTML)) {
         /** @type {ParserTreeResult | undefined} */

--- a/src/language-html/utils/index.js
+++ b/src/language-html/utils/index.js
@@ -386,7 +386,7 @@ function inferStyleParser(node, options) {
   // But, we need to handle `"stylus"` here for printing a style block in Vue SFC as stylus code by external plugin.
   // https://github.com/prettier/prettier/pull/12707
   if (lang === "stylus") {
-    return inferParserByLanguage("stylus", options);
+    return inferParserByLanguage(options, "stylus");
   }
 }
 
@@ -406,7 +406,7 @@ function inferScriptParser(node, options) {
     return (
       _inferScriptParser(node) ||
       (!("src" in node.attrMap) &&
-        inferParserByLanguage(node.attrMap.lang, options))
+        inferParserByLanguage(options, node.attrMap.lang))
     );
   }
 }

--- a/src/language-markdown/embed.js
+++ b/src/language-markdown/embed.js
@@ -9,7 +9,7 @@ function embed(path, options) {
   const { node } = path;
 
   if (node.type === "code" && node.lang !== null) {
-    const parser = inferParserByLanguage(node.lang, options);
+    const parser = inferParserByLanguage(options, node.lang);
     if (parser) {
       return async (textToDoc) => {
         const styleUnit = options.__inJsTemplate ? "~" : "`";

--- a/src/utils/infer-parser-by-language.js
+++ b/src/utils/infer-parser-by-language.js
@@ -1,7 +1,10 @@
-import { getSupportInfo } from "../main/support.js";
+function inferParserByLanguage(options, language) {
+  if (!language) {
+    return;
+  }
 
-function inferParserByLanguage(language, options) {
-  const { languages } = getSupportInfo({ plugins: options.plugins });
+  const languages = options.plugins.flatMap((plugin) => plugin.languages ?? []);
+
   const matched =
     languages.find(({ name }) => name.toLowerCase() === language) ??
     languages.find(({ aliases }) => aliases?.includes(language)) ??


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Remove use of `getSupportInfo`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
