### PR TITLE
Move `propagateBreaks` to `printDocToString`

### DIFF
--- a/src/document/printer.js
+++ b/src/document/printer.js
@@ -18,7 +18,7 @@ import {
   DOC_TYPE_BREAK_PARENT,
 } from "./constants.js";
 import { fill, indent, hardlineWithoutBreakParent } from "./builders.js";
-import { getDocParts, getDocType } from "./utils.js";
+import { getDocParts, getDocType, propagateBreaks } from "./utils.js";
 import InvalidDocError from "./invalid-doc-error.js";
 
 /** @typedef {typeof MODE_BREAK | typeof MODE_FLAT} Mode */
@@ -296,6 +296,8 @@ function fits(
 }
 
 function printDocToString(doc, options) {
+  propagateBreaks(doc);
+
   /** @type GroupModeMap */
   const groupModeMap = {};
 

--- a/src/document/printer.js
+++ b/src/document/printer.js
@@ -296,8 +296,6 @@ function fits(
 }
 
 function printDocToString(doc, options) {
-  propagateBreaks(doc);
-
   /** @type GroupModeMap */
   const groupModeMap = {};
 
@@ -314,6 +312,8 @@ function printDocToString(doc, options) {
   /** @type Command[] */
   const lineSuffix = [];
   let printedCursorCount = 0;
+
+  propagateBreaks(doc);
 
   while (cmds.length > 0) {
     const { ind, mode, doc } = cmds.pop();

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -5,7 +5,6 @@ import {
   cursor,
   label,
 } from "../document/builders.js";
-import { propagateBreaks } from "../document/utils.js";
 import { printComments } from "./comments/print.js";
 import { printEmbeddedLanguages } from "./multiparser.js";
 import createPrintPreCheckFunction from "./create-print-pre-check-function.js";
@@ -65,8 +64,6 @@ async function printAstToDoc(ast, options, alignmentSize = 0) {
     // It should be removed in index.js format()
     doc = addAlignmentToDoc([hardline, doc], alignmentSize, options.tabWidth);
   }
-
-  propagateBreaks(doc);
 
   return doc;
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

`printAstToDoc` should not do it.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
