### PR TITLE
feat: add config option to place operators at the beginning of line

### DIFF
--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -222,10 +222,11 @@ function printBinaryishExpressions(
 
   const shouldInline = shouldInlineLogicalExpression(node);
   const lineBeforeOperator =
-    (node.operator === "|>" ||
+    options.operatorPosition === "beginning" ||
+    ((node.operator === "|>" ||
       node.type === "NGPipeExpression" ||
       (node.operator === "|" && options.parser === "__vue_expression")) &&
-    !hasLeadingOwnLineComment(options.originalText, node.right);
+      !hasLeadingOwnLineComment(options.originalText, node.right));
 
   const operator = node.type === "NGPipeExpression" ? "|" : node.operator;
   const rightSuffix =

--- a/src/main/core-options.js
+++ b/src/main/core-options.js
@@ -264,6 +264,22 @@ const options = {
       },
     ],
   },
+  operatorPosition: {
+    category: CATEGORY_GLOBAL,
+    type: "choice",
+    default: "end",
+    description: "Placement of operators.",
+    choices: [
+      {
+        value: "end",
+        description: "Places operators at the end of line (default).",
+      },
+      {
+        value: "beginning",
+        description: "Places operators at the beginning of line.",
+      },
+    ],
+  },
 };
 
 module.exports = {


### PR DESCRIPTION
## Description

Added config option to place operators at the beginning of line #3806 .

Defaut option is at the end of line for backward compatibility. User can place `operatorPosition: "beginning"` to place operators at the beginning of line.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
