### PR TITLE
Simplify `getPreferredQuote`

### DIFF
--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -31,8 +31,6 @@ const NEWLINES_TO_PRESERVE_MAX = 2;
 function print(path, options, print) {
   const { node } = path;
 
-  const favoriteQuote = options.singleQuote ? "'" : '"';
-
   switch (node.type) {
     case "Block":
     case "Program":
@@ -378,11 +376,7 @@ function print(path, options, print) {
       return ["<!--", node.value, "-->"];
 
     case "StringLiteral":
-      if (needsOppositeQuote(path)) {
-        const printFavoriteQuote = !options.singleQuote ? "'" : '"';
-        return printStringLiteral(node.value, printFavoriteQuote);
-      }
-      return printStringLiteral(node.value, favoriteQuote);
+      return printStringLiteral(path, options);
 
     case "NumberLiteral":
       return String(node.value);
@@ -693,12 +687,18 @@ function generateHardlines(number = 0) {
  * the string literal. This function is the glimmer equivalent of `printString`
  * in `common/util`, but has differences because of the way escaped characters
  * are treated in hbs string literals.
- * @param {string} stringLiteral - the string literal value
- * @param {Quote} favoriteQuote - the user's preferred quote: `'` or `"`
  */
-function printStringLiteral(stringLiteral, favoriteQuote) {
-  const quote = getPreferredQuote(stringLiteral, favoriteQuote);
-  return [quote, stringLiteral.replaceAll(quote, `\\${quote}`), quote];
+function printStringLiteral(path, options) {
+  const {
+    node: { value },
+  } = path;
+
+  const quote = getPreferredQuote(
+    value,
+    needsOppositeQuote(path) ? !options.singleQuote : options.singleQuote
+  );
+
+  return [quote, value.replaceAll(quote, `\\${quote}`), quote];
 }
 
 function needsOppositeQuote(path) {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -129,8 +129,7 @@ function print(path, options, print) {
         : value.type === "ConcatStatement"
         ? getPreferredQuote(
             value.parts
-              .filter((part) => part.type === "TextNode")
-              .map((part) => part.chars)
+              .map((part) => (part.type === "TextNode" ? part.chars : ""))
               .join(""),
             options.singleQuote
           )

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -127,14 +127,14 @@ function print(path, options, print) {
       // Let's assume quotes inside the content of text nodes are already
       // properly escaped with entities, otherwise the parse wouldn't have parsed them.
       const quote = isText
-        ? getPreferredQuote(value.chars, favoriteQuote)
+        ? getPreferredQuote(value.chars, options.singleQuote)
         : value.type === "ConcatStatement"
         ? getPreferredQuote(
             value.parts
               .filter((part) => part.type === "TextNode")
               .map((part) => part.chars)
               .join(""),
-            favoriteQuote
+            options.singleQuote
           )
         : "";
 

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -127,7 +127,7 @@ function print(path, options, print) {
       // Let's assume quotes inside the content of text nodes are already
       // properly escaped with entities, otherwise the parse wouldn't have parsed them.
       const quote = isText
-        ? getPreferredQuote(value.chars, favoriteQuote).quote
+        ? getPreferredQuote(value.chars, favoriteQuote)
         : value.type === "ConcatStatement"
         ? getPreferredQuote(
             value.parts
@@ -135,7 +135,7 @@ function print(path, options, print) {
               .map((part) => part.chars)
               .join(""),
             favoriteQuote
-          ).quote
+          )
         : "";
 
       const valueDoc = print("value");
@@ -697,8 +697,8 @@ function generateHardlines(number = 0) {
  * @param {Quote} favoriteQuote - the user's preferred quote: `'` or `"`
  */
 function printStringLiteral(stringLiteral, favoriteQuote) {
-  const { quote, regex } = getPreferredQuote(stringLiteral, favoriteQuote);
-  return [quote, stringLiteral.replace(regex, `\\${quote}`), quote];
+  const quote = getPreferredQuote(stringLiteral, favoriteQuote);
+  return [quote, stringLiteral.replaceAll(quote, `\\${quote}`), quote];
 }
 
 function needsOppositeQuote(path) {

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -92,7 +92,7 @@ function genericPrint(path, options, print) {
         return node.rawName;
       }
       const value = unescapeQuoteEntities(node.value);
-      const { quote } = getPreferredQuote(value, '"');
+      const quote = getPreferredQuote(value, '"');
       return [
         node.rawName,
         "=",

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -479,10 +479,7 @@ function printJsxAttribute(path, options, print) {
         .slice(1, -1)
         .replaceAll("&apos;", "'")
         .replaceAll("&quot;", '"');
-      const quote = getPreferredQuote(
-        final,
-        options.jsxSingleQuote ? "'" : '"'
-      );
+      const quote = getPreferredQuote(final, options.jsxSingleQuote);
       final =
         quote === '"'
           ? final.replaceAll('"', "&quot;")

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -479,11 +479,14 @@ function printJsxAttribute(path, options, print) {
         .slice(1, -1)
         .replaceAll("&apos;", "'")
         .replaceAll("&quot;", '"');
-      const { escaped, quote, regex } = getPreferredQuote(
+      const quote = getPreferredQuote(
         final,
         options.jsxSingleQuote ? "'" : '"'
       );
-      final = final.replace(regex, escaped);
+      final =
+        quote === '"'
+          ? final.replaceAll('"', "&quot;")
+          : final.replaceAll("'", "&apos;");
       res = path.call(
         () =>
           printComments(path, replaceEndOfLine(quote + final + quote), options),

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -809,9 +809,9 @@ function printTitle(title, options, printSpace = true) {
   if (title.includes('"') && title.includes("'") && !title.includes(")")) {
     return `(${title})`; // avoid escaped quotes
   }
-  const { quote } = getPreferredQuote(title, options.singleQuote ? "'" : '"');
+  const quote = getPreferredQuote(title, options.singleQuote ? "'" : '"');
   title = title.replaceAll("\\", "\\\\");
-  title = title.replaceAll(new RegExp(`(${quote})`, "g"), "\\$1");
+  title = title.replaceAll(quote, `\\${quote}`);
   return `${quote}${title}${quote}`;
 }
 

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -809,7 +809,7 @@ function printTitle(title, options, printSpace = true) {
   if (title.includes('"') && title.includes("'") && !title.includes(")")) {
     return `(${title})`; // avoid escaped quotes
   }
-  const quote = getPreferredQuote(title, options.singleQuote ? "'" : '"');
+  const quote = getPreferredQuote(title, options.singleQuote);
   title = title.replaceAll("\\", "\\\\");
   title = title.replaceAll(quote, `\\${quote}`);
   return `${quote}${title}${quote}`;

--- a/src/utils/get-preferred-quote.js
+++ b/src/utils/get-preferred-quote.js
@@ -8,13 +8,13 @@ const DOUBLE_QUOTE = '"';
 /**
  *
  * @param {string} rawContent
- * @param {Quote | boolean} quoteOrPreferSingleQuote
+ * @param {Quote | boolean} preferredQuoteOrPreferSingleQuote
  * @returns {Quote}
  */
-function getPreferredQuote(rawContent, quoteOrPreferSingleQuote) {
+function getPreferredQuote(rawContent, preferredQuoteOrPreferSingleQuote) {
   const preferred =
-    quoteOrPreferSingleQuote === true ||
-    quoteOrPreferSingleQuote === SINGLE_QUOTE
+    preferredQuoteOrPreferSingleQuote === true ||
+    preferredQuoteOrPreferSingleQuote === SINGLE_QUOTE
       ? SINGLE_QUOTE
       : DOUBLE_QUOTE;
   const alternate = preferred === SINGLE_QUOTE ? DOUBLE_QUOTE : SINGLE_QUOTE;

--- a/src/utils/get-preferred-quote.js
+++ b/src/utils/get-preferred-quote.js
@@ -1,39 +1,35 @@
 /**
- * @typedef {'"' | "'"} Quote
+ * @typedef {SINGLE_QUOTE | DOUBLE_QUOTE} Quote
  */
+
+const SINGLE_QUOTE = "'";
+const DOUBLE_QUOTE = '"';
 
 /**
  *
  * @param {string} rawContent
- * @param {Quote} preferredQuote
- * @returns {{ quote: Quote, regex: RegExp, escaped: string }}
+ * @param {Quote | boolean} quoteOrPreferSingleQuote
+ * @returns {Quote}
  */
+function getPreferredQuote(rawContent, quoteOrPreferSingleQuote) {
+  const preferred =
+    quoteOrPreferSingleQuote === true ||
+    quoteOrPreferSingleQuote === SINGLE_QUOTE
+      ? SINGLE_QUOTE
+      : DOUBLE_QUOTE;
+  const alternate = preferred === SINGLE_QUOTE ? DOUBLE_QUOTE : SINGLE_QUOTE;
 
-function getPreferredQuote(rawContent, preferredQuote) {
-  /** @type {{ quote: '"', regex: RegExp, escaped: "&quot;" }} */
-  const double = { quote: '"', regex: /"/g, escaped: "&quot;" };
-  /** @type {{ quote: "'", regex: RegExp, escaped: "&apos;" }} */
-  const single = { quote: "'", regex: /'/g, escaped: "&apos;" };
-
-  const preferred = preferredQuote === "'" ? single : double;
-  const alternate = preferred === single ? double : single;
-
-  let result = preferred;
-
-  // If `rawContent` contains at least one of the quote preferred for enclosing
-  // the string, we might want to enclose with the alternate quote instead, to
-  // minimize the number of escaped quotes.
-  if (
-    rawContent.includes(preferred.quote) ||
-    rawContent.includes(alternate.quote)
-  ) {
-    const numPreferredQuotes = (rawContent.match(preferred.regex) || []).length;
-    const numAlternateQuotes = (rawContent.match(alternate.regex) || []).length;
-
-    result = numPreferredQuotes > numAlternateQuotes ? alternate : preferred;
+  let preferredQuoteCount = 0;
+  let alternateQuoteCount = 0;
+  for (const character of rawContent) {
+    if (character === preferred) {
+      preferredQuoteCount++;
+    } else if (character === alternate) {
+      alternateQuoteCount++;
+    }
   }
 
-  return result;
+  return preferredQuoteCount > alternateQuoteCount ? alternate : preferred;
 }
 
 export default getPreferredQuote;

--- a/src/utils/print-string.js
+++ b/src/utils/print-string.js
@@ -17,7 +17,7 @@ function printString(raw, options) {
       ? '"'
       : options.__isInHtmlAttribute
       ? "'"
-      : getPreferredQuote(rawContent, options.singleQuote ? "'" : '"');
+      : getPreferredQuote(rawContent, options.singleQuote);
 
   // It might sound unnecessary to use `makeString` even if the string already
   // is enclosed with `enclosingQuote`, but it isn't. The string could contain

--- a/src/utils/print-string.js
+++ b/src/utils/print-string.js
@@ -17,7 +17,7 @@ function printString(raw, options) {
       ? '"'
       : options.__isInHtmlAttribute
       ? "'"
-      : getPreferredQuote(rawContent, options.singleQuote ? "'" : '"').quote;
+      : getPreferredQuote(rawContent, options.singleQuote ? "'" : '"');
 
   // It might sound unnecessary to use `makeString` even if the string already
   // is enclosed with `enclosingQuote`, but it isn't. The string could contain


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

We can use `String#replaceAll` now, unnecessary to return an object.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
