### PR TITLE
Support `max_line_length=off` when parsing `.editorconfig`

### DIFF
--- a/changelog_unreleased/misc/14516.md
+++ b/changelog_unreleased/misc/14516.md
@@ -1,0 +1,21 @@
+#### Support `max_line_length=off` when parsing `.editorconfig` (#14516 by @josephfrazier)
+
+If an .editorconfig file is in your project and it sets `max_line_length=off` for the file you're formatting,
+it will be interpreted as a `printWidth` of `Infinity` rather than being ignored
+(which previously resulted in the default `printWidth` of 80 being applied, if not overridden by Prettier-specific configuration).
+
+<!-- prettier-ignore -->
+```html
+<!-- Input -->
+<div className='HelloWorld' title={`You are visitor number ${ num }`} onMouseOver={onMouseOver}/>
+
+<!-- Prettier stable -->
+<div
+  className="HelloWorld"
+  title={`You are visitor number ${num}`}
+  onMouseOver={onMouseOver}
+/>;
+
+<!-- Prettier main -->
+<div className="HelloWorld" title={`You are visitor number ${num}`} onMouseOver={onMouseOver} />;
+```

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "dashify": "2.0.0",
     "diff": "5.0.0",
     "editorconfig": "0.15.3",
-    "editorconfig-to-prettier": "0.2.0",
+    "editorconfig-to-prettier": "1.0.0",
     "escape-string-regexp": "5.0.0",
     "espree": "9.4.1",
     "esutils": "2.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2917,10 +2917,10 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
-editorconfig-to-prettier@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/editorconfig-to-prettier/-/editorconfig-to-prettier-0.2.0.tgz#db4f4e96796c746673c863ccac881377ea83dbe8"
-  integrity sha512-tOcbAuPyYE9zOA1HF2xI9Xqm2TW7BE9E2lhwbz69ngtaJrBWQwL6akzyWA+UPx8jRss91KXMChyjHNpqaYFWuQ==
+editorconfig-to-prettier@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/editorconfig-to-prettier/-/editorconfig-to-prettier-1.0.0.tgz#f2bccca5877be9dea8a8022b93bcc6aba582a31c"
+  integrity sha512-WkBQRWxQOat9zBBhrnV0eoCRRMj0fMc/OIwTs+R3pvjsBD2fhTjGLLToGwalUwug3L5K4NvTTMfVRRHT6Hmorg==
 
 editorconfig@0.15.3:
   version "0.15.3"


### PR DESCRIPTION
## Description

This fixes https://github.com/prettier/prettier/issues/14514 by upgrading `editorconfig-to-prettier` with the fix from https://github.com/josephfrazier/editorconfig-to-prettier/pull/10

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
