### PR TITLE
Add `experimentalOperatorPosition` for breaking lines before binary operators 

### DIFF
--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -85,7 +85,7 @@ const options = {
     ],
   },
   singleAttributePerLine: commonOptions.singleAttributePerLine,
-  experimentalOperatorLocation: {
+  experimentalOperatorPosition: {
     category: coreOptions.CATEGORY_EXPERIMENTAL,
     type: "boolean",
     default: false,

--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -1,3 +1,4 @@
+import * as coreOptions from "../main/core-options.evaluate.js";
 import commonOptions from "../common/common-options.js";
 
 const CATEGORY_JAVASCRIPT = "JavaScript";
@@ -84,6 +85,13 @@ const options = {
     ],
   },
   singleAttributePerLine: commonOptions.singleAttributePerLine,
+  experimentalOperatorLocation: {
+    category: coreOptions.CATEGORY_EXPERIMENTAL,
+    type: "boolean",
+    default: false,
+    description:
+      "Use experimental formatting for breaking lines before binary operators",
+  },
 };
 
 export default options;

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -233,11 +233,11 @@ function printBinaryishExpressions(
     (comment) => isTypeCastComment(comment)
   );
   const commentBeforeOperator =
-    options.experimentalOperatorLocation &&
+    options.experimentalOperatorPosition &&
     !hasTypeCastComment &&
     hasLeadingOwnLineComment(options.originalText, node.right);
   const lineBeforeOperator =
-    options.experimentalOperatorLocation ||
+    options.experimentalOperatorPosition ||
     ((node.operator === "|>" ||
       node.type === "NGPipeExpression" ||
       (node.operator === "|" && options.parser === "__vue_expression")) &&

--- a/src/main/core-options.evaluate.js
+++ b/src/main/core-options.evaluate.js
@@ -7,6 +7,7 @@ const CATEGORY_OTHER = "Other";
 const CATEGORY_OUTPUT = "Output";
 const CATEGORY_GLOBAL = "Global";
 const CATEGORY_SPECIAL = "Special";
+const CATEGORY_EXPERIMENTAL = "Experimental";
 
 /**
  * @typedef {Object} OptionInfo
@@ -243,5 +244,6 @@ export {
   CATEGORY_OUTPUT,
   CATEGORY_GLOBAL,
   CATEGORY_SPECIAL,
+  CATEGORY_EXPERIMENTAL,
   options,
 };

--- a/tests/format/angular/angular/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/angular/angular/__snapshots__/jsfmt.spec.js.snap
@@ -41,6 +41,47 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`angularjs.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["angular"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<div ng-if="$ctrl .shouldShowWarning&&!$ctrl.loading">Warning!</div>
+
+<div
+	class="common--error-message"
+	test-hook="upper-error-message"
+	ng-if="!$ctrl.showsFormBelowPlain() && !!$ctrl.error.message && !($ctrl.error.kind === 'validator' && $ctrl.form.$valid && $ctrl.error.form === $ctrl.form)"
+>
+	<div ng-if="$ctrl.error.html" ng-bind-html="$ctrl.error.message"></div>
+	<div ng-if="!$ctrl.error.html" ng-bind="$ctrl.error.message"></div>
+</div>
+
+=====================================output=====================================
+<div ng-if="$ctrl.shouldShowWarning && !$ctrl.loading">Warning!</div>
+
+<div
+  class="common--error-message"
+  test-hook="upper-error-message"
+  ng-if="
+    !$ctrl.showsFormBelowPlain()
+    && !!$ctrl.error.message
+    && !(
+      $ctrl.error.kind === 'validator'
+      && $ctrl.form.$valid
+      && $ctrl.error.form === $ctrl.form
+    )
+  "
+>
+  <div ng-if="$ctrl.error.html" ng-bind-html="$ctrl.error.message"></div>
+  <div ng-if="!$ctrl.error.html" ng-bind="$ctrl.error.message"></div>
+</div>
+
+================================================================================
+`;
+
 exports[`angularjs.html - {"htmlWhitespaceSensitivity":"ignore"} format 1`] = `
 ====================================options=====================================
 htmlWhitespaceSensitivity: "ignore"
@@ -238,6 +279,21 @@ trailingComma: "none"
 exports[`attr-name.component.html - {"bracketSpacing":false} format 1`] = `
 ====================================options=====================================
 bracketSpacing: false
+parsers: ["angular"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<div someDirective itemType="x"></div>
+
+=====================================output=====================================
+<div someDirective itemType="x"></div>
+
+================================================================================
+`;
+
+exports[`attr-name.component.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
 parsers: ["angular"]
 printWidth: 80
                                                                                 | printWidth
@@ -530,6 +586,277 @@ printWidth: 80
     listRow.NextScheduledSendStatus == 1 ||
     listRow.NextScheduledSendStatus == 2 ||
     listRow.NextScheduledSendStatus == 3
+  "
+  [target]="{
+    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true
+  }"
+  [error]="'We couldn\\\\\\'t find anything with that name.'"
+  *ngIf="form.controls.details?.controls.amount?.errors.min"
+  [ngClass]="{
+    'btn-success': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
+    'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
+    'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER
+  }"
+  [stickout]="+toolAssembly.stickoutMm"
+  test="{{ 'test' | translate }}"
+  test="foo {{       invalid invalid       }} bar {{ valid }} baz"
+  test="foo
+    
+    {{       invalid
+             invalid       }} 
+    
+    bar 
+    
+          {{ valid }} 
+    
+    baz"
+  i18n="Normal i18n text"
+  i18n="
+    This is a very long internationalization description text, exceeding the
+    configured print width, but could easily be formatted
+  "
+  i18n-test="Attribute i18n text"
+  i18n-test="
+    This is a very long internationalization description text, exceeding the
+    configured print width, but could easily be formatted
+  "
+  i18n="
+    This is a very long internationalization description text, exceeding the
+    configured print width, but could easily be formatted
+  "
+  i18n="
+    This is yet another very long internationalization description text,
+    exceeding the configured print width, but could easily be formatted
+  "
+  i18n="@@customId"
+  i18n="Some description@@customIdWithDescription"
+  i18n="some meaning|Some description@@customIdWithDescription"
+  i18n="
+    some meaning|Some very long internationalization description text exceeding
+    the configured print width@@customIdWithDescription"
+></div>
+
+================================================================================
+`;
+
+exports[`attributes.component.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["angular"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<div
+    bindon-target=" a | b : c "
+    [(target)]=" a | b : c "
+    bind-target=" a | b : c "
+    [target]=" a | b : c "
+    [target]=" a | pipe   "
+    [target]=" 0 - 1 "
+    [target]=" - 1 "
+    [target]=" a ? 1 : 2 "
+    [target]=" "
+    [target]=" a ( 1 ) ( 2 ) "
+    [target]=" a [ b ] "
+    [target]=" [ 1 ] "
+    [target]=" { 'a' : 1 } "
+    [target]=" { a : 1 } "
+    [target]=" { 
+      trailingComma : 'notAllowed'
+    }"
+    [target]=" [ 
+      longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+    ]"
+    [target]=" true "
+    [target]=" undefined "
+    [target]=" null "
+    [target]=" ( 1 ) "
+    [target]=" 1 "
+    [target]="  'hello' "
+    [target]=" a ( 1 , 2 ) "
+    [target]=" a . b ( 1 , 2 ) "
+    [target]=" x ! "
+    [target]=" ! x "
+    [target]=" ( ( a ) ) "
+    [target]=" a "
+    [target]=" a // hello "
+    [target]=" a . b "
+    [target]=" javascript : 'hello world' "
+    [target]=" a ?. b ( ) "
+    [target]=" a ?. b "
+    [target]=" this . a "
+    on-target=" a = 1 "
+    (target)=" a = 1 "
+    (target)=" a . b = 1 "
+    (target)=" a [ b ] = 1 "
+    (target)=" a // hello "
+    (target)=" a ; b "
+    (event)="  0  "
+    (event)="  a.b  "
+    (event)="  hello  "
+    (event)="  hello()  "
+    (event)="  a && b  "
+    (event)="  a && b()  "
+    (event)="  foo = $event  "
+    (event)="  foo == $event  "
+    *ngIf=" something?true:false    "
+    *ngIf=" a | pipe   "
+    *ngFor="  let     hero     of     heroes"
+    *ngFor="  let    hero     of[1,2,3,666666666666666666666666666666666666]; let i=index"
+    *ngFor="     let hero     of     heroes;     trackBy    :    trackByHeroes     "
+    *ngFor=" let     item   of   items   ;    index    as   i  ; trackBy  :     trackByFn"
+    *ngFor="  let    hero     of heroes; let i  =  index"
+    *ngFor="  let    hero     of heroes; value     myValue"
+    *ngIf=" condition  ;  else  elseBlock "
+    *ngIf=" condition  ;  then  thenBlock  else  elseBlock "
+    *ngIf=" condition  as  value  ;  else  elseBlock "
+    *directive=" let hero "
+    *directive=" let hero = hello "
+    *directive=" let hero of heroes "
+    *directive=" let hero ; of : heroes "
+    *directive=" a "
+    *directive=" a as b "
+    *directive=" a , b "
+    *directive=" a ; b "
+    *directive=" a ; b c "
+    *directive=" a ; b : c "
+    *directive=" a ; b : c as d "
+    *directive=" a ; b as c "
+    *ngIf="listRow.NextScheduledSendStatus == 1 || listRow.NextScheduledSendStatus == 2 || listRow.NextScheduledSendStatus == 3"
+    *ngIf="listRow.NextScheduledSendStatus == 1 || listRow.NextScheduledSendStatus == 2 || listRow.NextScheduledSendStatus == 3; else hello"
+    (target)="listRow.NextScheduledSendStatus == 1 || listRow.NextScheduledSendStatus == 2 || listRow.NextScheduledSendStatus == 3"
+    [target]="listRow.NextScheduledSendStatus == 1 || listRow.NextScheduledSendStatus == 2 || listRow.NextScheduledSendStatus == 3"
+    [target]="{ longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true }"
+    [error]="'We couldn\\\\\\'t find anything with that name.'"
+    *ngIf="form.controls.details?.controls.amount?.errors.min"
+    [ngClass]="
+    {'btn-success': (dialog$ | async).level === dialogLevelEnum.SUCCESS,
+      'btn-warning': (dialog$ | async).level === dialogLevelEnum.WARNING,
+      'btn-svg': (dialog$ | async).level === dialogLevelEnum.DANGER}"
+    [stickout]="+toolAssembly.stickoutMm"
+    test='{{ "test" | translate }}'
+    test='foo {{       invalid invalid       }} bar {{       valid       }} baz'
+    test='foo
+    
+    {{       invalid
+             invalid       }} 
+    
+    bar 
+    
+          {{       valid       }} 
+    
+    baz'
+    i18n="Normal i18n text"
+    i18n="This is a very long internationalization description text, exceeding the configured print width, but could easily be formatted"
+    i18n-test="Attribute i18n text"
+    i18n-test="This is a very long internationalization description text, exceeding the configured print width, but could easily be formatted"
+    i18n="This is a very long internationalization description text, exceeding the configured print width, but could easily be formatted" i18n="This is yet another very long internationalization description text, exceeding the configured print width, but could easily be formatted"
+    i18n="@@customId"
+    i18n="Some description@@customIdWithDescription"
+    i18n="some meaning|Some description@@customIdWithDescription"
+    i18n="some meaning|Some very long internationalization description text exceeding the configured print width@@customIdWithDescription"
+></div>
+
+=====================================output=====================================
+<div
+  bindon-target="a | b : c"
+  [(target)]="a | b : c"
+  bind-target="a | b : c"
+  [target]="a | b : c"
+  [target]="a | pipe"
+  [target]="0 - 1"
+  [target]="-1"
+  [target]="a ? 1 : 2"
+  [target]=""
+  [target]="a(1)(2)"
+  [target]="a[b]"
+  [target]="[1]"
+  [target]="{ a: 1 }"
+  [target]="{ a: 1 }"
+  [target]="{
+    trailingComma: 'notAllowed'
+  }"
+  [target]="[
+    longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong
+  ]"
+  [target]="true"
+  [target]="undefined"
+  [target]="null"
+  [target]="1"
+  [target]="1"
+  [target]="'hello'"
+  [target]="a(1, 2)"
+  [target]="a.b(1, 2)"
+  [target]="x!"
+  [target]="!x"
+  [target]="a"
+  [target]="a"
+  [target]="a // hello"
+  [target]="a.b"
+  [target]=" javascript : 'hello world' "
+  [target]="a?.b()"
+  [target]="a?.b"
+  [target]="this.a"
+  on-target="a = 1"
+  (target)="a = 1"
+  (target)="a.b = 1"
+  (target)="a[b] = 1"
+  (target)="(a) // hello"
+  (target)="(a); (b)"
+  (event)="(0)"
+  (event)="(a.b)"
+  (event)="(hello)"
+  (event)="hello()"
+  (event)="(a && b)"
+  (event)="a && b()"
+  (event)="foo = $event"
+  (event)="(foo == $event)"
+  *ngIf="something ? true : false"
+  *ngIf="a | pipe"
+  *ngFor="let hero of heroes"
+  *ngFor="
+    let hero of [1, 2, 3, 666666666666666666666666666666666666];
+    let i = index
+  "
+  *ngFor="let hero of heroes; trackBy: trackByHeroes"
+  *ngFor="let item of items; index as i; trackBy: trackByFn"
+  *ngFor="let hero of heroes; let i = index"
+  *ngFor="let hero of heroes; value: myValue"
+  *ngIf="condition; else elseBlock"
+  *ngIf="condition; then thenBlock; else elseBlock"
+  *ngIf="condition as value; else elseBlock"
+  *directive="let hero"
+  *directive="let hero = hello"
+  *directive="let hero of heroes"
+  *directive="let hero of heroes"
+  *directive="a"
+  *directive="a as b"
+  *directive="a; b"
+  *directive="a; b"
+  *directive="a; b: c"
+  *directive="a; b: c"
+  *directive="a; b: c as d"
+  *directive="a; b as c"
+  *ngIf="
+    listRow.NextScheduledSendStatus == 1
+    || listRow.NextScheduledSendStatus == 2
+    || listRow.NextScheduledSendStatus == 3
+  "
+  *ngIf="
+    listRow.NextScheduledSendStatus == 1
+      || listRow.NextScheduledSendStatus == 2
+      || listRow.NextScheduledSendStatus == 3;
+    else hello
+  "
+  (target)="
+    (listRow.NextScheduledSendStatus == 1
+      || listRow.NextScheduledSendStatus == 2
+      || listRow.NextScheduledSendStatus == 3)
+  "
+  [target]="
+    listRow.NextScheduledSendStatus == 1
+    || listRow.NextScheduledSendStatus == 2
+    || listRow.NextScheduledSendStatus == 3
   "
   [target]="{
     longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true
@@ -2087,6 +2414,99 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`first-lf.component.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["angular"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<textarea>{{ generatedDiscountCodes }}</textarea>
+<textarea>
+{{ generatedDiscountCodes }}</textarea>
+<textarea>
+    {{ generatedDiscountCodes }}</textarea>
+<textarea>  
+{{ generatedDiscountCodes }}</textarea>
+<textarea>  
+    {{ generatedDiscountCodes }}</textarea>
+<textarea>{{ generatedDiscountCodes }}123</textarea>
+<textarea>
+{{ generatedDiscountCodes }}123</textarea>
+<textarea>
+    {{ generatedDiscountCodes }}123</textarea>
+<textarea>  
+{{ generatedDiscountCodes }}123</textarea>
+<textarea>  
+    {{ generatedDiscountCodes }}123</textarea>
+<textarea type="text">{{ generatedDiscountCodes }}</textarea>
+<textarea type="text">
+{{ generatedDiscountCodes }}</textarea>
+<textarea type="text">
+    {{ generatedDiscountCodes }}</textarea>
+<textarea type="text">  
+{{ generatedDiscountCodes }}</textarea>
+<textarea type="text">  
+    {{ generatedDiscountCodes }}</textarea>
+<textarea type="text">{{ generatedDiscountCodes }}123</textarea>
+<textarea type="text">
+{{ generatedDiscountCodes }}123</textarea>
+<textarea type="text">
+    {{ generatedDiscountCodes }}123</textarea>
+<textarea type="text">  
+{{ generatedDiscountCodes }}123</textarea>
+<textarea type="text">  
+    {{ generatedDiscountCodes }}123</textarea>
+
+=====================================output=====================================
+<textarea>{{ generatedDiscountCodes }}</textarea>
+<textarea>{{ generatedDiscountCodes }}</textarea>
+<textarea>    {{ generatedDiscountCodes }}</textarea>
+<textarea>
+  
+{{ generatedDiscountCodes }}</textarea
+>
+<textarea>
+  
+    {{ generatedDiscountCodes }}</textarea
+>
+<textarea>{{ generatedDiscountCodes }}123</textarea>
+<textarea>{{ generatedDiscountCodes }}123</textarea>
+<textarea>    {{ generatedDiscountCodes }}123</textarea>
+<textarea>
+  
+{{ generatedDiscountCodes }}123</textarea
+>
+<textarea>
+  
+    {{ generatedDiscountCodes }}123</textarea
+>
+<textarea type="text">{{ generatedDiscountCodes }}</textarea>
+<textarea type="text">{{ generatedDiscountCodes }}</textarea>
+<textarea type="text">    {{ generatedDiscountCodes }}</textarea>
+<textarea type="text">
+  
+{{ generatedDiscountCodes }}</textarea
+>
+<textarea type="text">
+  
+    {{ generatedDiscountCodes }}</textarea
+>
+<textarea type="text">{{ generatedDiscountCodes }}123</textarea>
+<textarea type="text">{{ generatedDiscountCodes }}123</textarea>
+<textarea type="text">    {{ generatedDiscountCodes }}123</textarea>
+<textarea type="text">
+  
+{{ generatedDiscountCodes }}123</textarea
+>
+<textarea type="text">
+  
+    {{ generatedDiscountCodes }}123</textarea
+>
+
+================================================================================
+`;
+
 exports[`first-lf.component.html - {"htmlWhitespaceSensitivity":"ignore"} format 1`] = `
 ====================================options=====================================
 htmlWhitespaceSensitivity: "ignore"
@@ -2597,6 +3017,65 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`ignore-attribute.component.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["angular"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<div
+    bindon-target=" a | b : c "
+    [(target)]=" a | b : c "
+    bind-target=" a | b : c "
+></div>
+<!--  prettier-ignore-attribute -->
+<div
+    bindon-target=" a | b : c "
+    [(target)]=" a | b : c "
+    bind-target=" a | b : c "
+></div>
+<!--  prettier-ignore-attribute bind-target -->
+<div
+    bindon-target=" a | b : c "
+    [(target)]=" a | b : c "
+    bind-target=" a | b : c "
+></div>
+<!--  prettier-ignore-attribute [(target)] bind-target -->
+<div
+    bindon-target=" a | b : c "
+    [(target)]=" a | b : c "
+    bind-target=" a | b : c "
+></div>
+
+=====================================output=====================================
+<div
+  bindon-target="a | b : c"
+  [(target)]="a | b : c"
+  bind-target="a | b : c"
+></div>
+<!--  prettier-ignore-attribute -->
+<div
+  bindon-target=" a | b : c "
+  [(target)]=" a | b : c "
+  bind-target=" a | b : c "
+></div>
+<!--  prettier-ignore-attribute bind-target -->
+<div
+  bindon-target="a | b : c"
+  [(target)]="a | b : c"
+  bind-target=" a | b : c "
+></div>
+<!--  prettier-ignore-attribute [(target)] bind-target -->
+<div
+  bindon-target="a | b : c"
+  [(target)]=" a | b : c "
+  bind-target=" a | b : c "
+></div>
+
+================================================================================
+`;
+
 exports[`ignore-attribute.component.html - {"htmlWhitespaceSensitivity":"ignore"} format 1`] = `
 ====================================options=====================================
 htmlWhitespaceSensitivity: "ignore"
@@ -3019,6 +3498,173 @@ printWidth: 80
 <p>{{ {a: a === ({})} }}</p>
 <p>{{ {a: !({})} }}</p>
 <p>{{ {a: a ? b : ({})} }}</p>
+
+================================================================================
+`;
+
+exports[`interpolation.component.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["angular"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<div>{{ a | b : c }}</div>
+<div>{{  a | pipe    }}</div>
+<div>{{ 0 - 1 }}</div>
+<div>{{ - 1 }}</div>
+<div>{{ a ? 1 : 2 }}</div>
+<div>{{ a ( 1 ) ( 2 ) }}</div>
+<div>{{ a [ b ] }}</div>
+<div>{{ [ 1 ] }}</div>
+<div>{{ { 'a' : 1 } }}</div>
+<div>{{ { a : 1 } }}</div>
+<div>{{ true }}</div>
+<div>{{ undefined }}</div>
+<div>{{ null }}</div>
+<div>{{ ( 1 ) }}</div>
+<div>{{ 1 }}</div>
+<div>{{  'hello' }}</div>
+<div>{{ a ( 1 , 2 ) }}</div>
+<div>{{ a . b ( 1 , 2 ) }}</div>
+<div>{{ x ! }}</div>
+<div>{{ ! x }}</div>
+<div>{{ ( ( a ) ) }}</div>
+<div>{{ a }}</div>
+<div>{{ a // hello }}</div>
+<div>{{ a . b }}</div>
+<div>{{ a ?. b ( ) }}</div>
+<div>{{ a ?. b }}</div>
+<div>{{  a // hello  }}</div>
+<label for="transmissionLayoutRadioButton">{{
+"SearchSelection.transmissionLayoutRadioButton" | localize:localizationSection
+}}</label>
+<label for="transmissionLayoutRadioButtontransmissionLayoutRadioButtontransmissionLayoutRadioButtontransmissionLayoutRadioButton">{{
+"SearchSelection.transmissionLayoutRadioButton" | localize:localizationSection
+}}</label>
+<label for="transmissionLayoutRadioButton">{{
+"SearchSelection.transmissionLayoutRadioButton" | localize:localizationSection
+}} </label>
+<label for="transmissionLayoutRadioButton"> {{
+"SearchSelection.transmissionLayoutRadioButton" | localize:localizationSection
+}}</label>
+<label for="transmissionLayoutRadioButton"> {{
+"SearchSelection.transmissionLayoutRadioButton" | localize:localizationSection
+}} </label>
+<div class="Nemo possimus non voluptates dicta accusamus id quia">{{copyTypes[options.copyType]}}</div>
+{{listRow.NextScheduledSendStatus == 1 || listRow.NextScheduledSendStatus == 2 || listRow.NextScheduledSendStatus == 3}}
+<span
+><!--
+--><span
+  >{{a}}</span
+><!--
+--><span
+  >{{b}}</span
+><!--
+--></span>
+<span>
+  {{ aNormalValue | aPipe }}:
+  <strong>{{ aReallyReallySuperLongValue | andASuperLongPipeJustToBreakThis }}</strong>
+</span>
+<p>
+  {{
+      'delete'
+          | translate: {what: ('entities' | translate: {count: array.length})}
+  }}
+</p>
+<p>{{ {a:1+{} } }}</p>
+<p>{{ {a:a==={} } }}</p>
+<p>{{ {a:!{} } }}</p>
+<p>{{ {a:a?b:{} } }}</p>
+
+=====================================output=====================================
+<div>{{ a | b : c }}</div>
+<div>{{ a | pipe }}</div>
+<div>{{ 0 - 1 }}</div>
+<div>{{ -1 }}</div>
+<div>{{ a ? 1 : 2 }}</div>
+<div>{{ a(1)(2) }}</div>
+<div>{{ a[b] }}</div>
+<div>{{ [1] }}</div>
+<div>{{ { a: 1 } }}</div>
+<div>{{ { a: 1 } }}</div>
+<div>{{ true }}</div>
+<div>{{ undefined }}</div>
+<div>{{ null }}</div>
+<div>{{ 1 }}</div>
+<div>{{ 1 }}</div>
+<div>{{ "hello" }}</div>
+<div>{{ a(1, 2) }}</div>
+<div>{{ a.b(1, 2) }}</div>
+<div>{{ x! }}</div>
+<div>{{ !x }}</div>
+<div>{{ a }}</div>
+<div>{{ a }}</div>
+<div>{{ a // hello }}</div>
+<div>{{ a.b }}</div>
+<div>{{ a?.b() }}</div>
+<div>{{ a?.b }}</div>
+<div>{{ a // hello }}</div>
+<label for="transmissionLayoutRadioButton">{{
+  "SearchSelection.transmissionLayoutRadioButton"
+    | localize : localizationSection
+}}</label>
+<label
+  for="transmissionLayoutRadioButtontransmissionLayoutRadioButtontransmissionLayoutRadioButtontransmissionLayoutRadioButton"
+  >{{
+    "SearchSelection.transmissionLayoutRadioButton"
+      | localize : localizationSection
+  }}</label
+>
+<label for="transmissionLayoutRadioButton"
+  >{{
+    "SearchSelection.transmissionLayoutRadioButton"
+      | localize : localizationSection
+  }}
+</label>
+<label for="transmissionLayoutRadioButton">
+  {{
+    "SearchSelection.transmissionLayoutRadioButton"
+      | localize : localizationSection
+  }}</label
+>
+<label for="transmissionLayoutRadioButton">
+  {{
+    "SearchSelection.transmissionLayoutRadioButton"
+      | localize : localizationSection
+  }}
+</label>
+<div class="Nemo possimus non voluptates dicta accusamus id quia">
+  {{ copyTypes[options.copyType] }}
+</div>
+{{
+  listRow.NextScheduledSendStatus == 1
+    || listRow.NextScheduledSendStatus == 2
+    || listRow.NextScheduledSendStatus == 3
+}}
+<span
+  ><!--
+--><span>{{ a }}</span
+  ><!--
+--><span>{{ b }}</span
+  ><!--
+--></span>
+<span>
+  {{ aNormalValue | aPipe }}:
+  <strong>{{
+    aReallyReallySuperLongValue | andASuperLongPipeJustToBreakThis
+  }}</strong>
+</span>
+<p>
+  {{
+    "delete"
+      | translate : { what: ("entities" | translate : { count: array.length }) }
+  }}
+</p>
+<p>{{ { a: 1 + {} } }}</p>
+<p>{{ { a: a === {} } }}</p>
+<p>{{ { a: !{} } }}</p>
+<p>{{ { a: a ? b : {} } }}</p>
 
 ================================================================================
 `;
@@ -5067,6 +5713,1533 @@ bindon-ngModel
 
 <div class="bad curly special">Bad curly special</div>
 <div [ngClass]="{bad: false, curly: true, special: true}">Curly special</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- NgStyle binding -->
+<hr />
+<h2 id="ngStyle">NgStyle Binding</h2>
+
+<div [style.font-size]="isSpecial ? 'x-large' : 'smaller'">
+  This div is x-large or smaller.
+</div>
+
+<h3>[ngStyle] binding to currentStyles - CSS property names</h3>
+<p>currentStyles is {{ currentStyles | json }}</p>
+<div [ngStyle]="currentStyles">
+  This div is initially italic, normal weight, and extra large (24px).
+</div>
+
+<!-- not used in chapter -->
+<br />
+<label>italic: <input type="checkbox" [(ngModel)]="canSave" /></label> |
+<label>normal: <input type="checkbox" [(ngModel)]="isUnchanged" /></label> |
+<label>xlarge: <input type="checkbox" [(ngModel)]="isSpecial" /></label>
+<button (click)="setCurrentStyles()">Refresh currentStyles</button>
+<br /><br />
+<div [ngStyle]="currentStyles">
+  This div should be {{ canSave ? "italic" : "plain" }},
+  {{ isUnchanged ? "normal weight" : "bold" }} and,
+  {{ isSpecial ? "extra large" : "normal size" }} after clicking "Refresh".
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- NgIf binding -->
+<hr />
+<h2 id="ngIf">NgIf Binding</h2>
+
+<app-hero-detail *ngIf="isActive"></app-hero-detail>
+
+<div *ngIf="currentHero">Hello, {{ currentHero.name }}</div>
+<div *ngIf="nullHero">Hello, {{ nullHero.name }}</div>
+
+<!-- NgIf binding with template (no *) -->
+
+<ng-template [ngIf]="currentHero"
+  >Add {{ currentHero.name }} with template</ng-template
+>
+
+<!-- Does not show because isActive is false! -->
+<div>Hero Detail removed from DOM (via template) because isActive is false</div>
+<ng-template [ngIf]="isActive">
+  <app-hero-detail></app-hero-detail>
+</ng-template>
+
+<!-- isSpecial is true -->
+<div [class.hidden]="!isSpecial">Show with class</div>
+<div [class.hidden]="isSpecial">Hide with class</div>
+
+<!-- HeroDetail is in the DOM but hidden -->
+<app-hero-detail [class.hidden]="isSpecial"></app-hero-detail>
+
+<div [style.display]="isSpecial ? 'block' : 'none'">Show with style</div>
+<div [style.display]="isSpecial ? 'none' : 'block'">Hide with style</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- NgFor binding -->
+<hr />
+<h2 id="ngFor">NgFor Binding</h2>
+
+<div class="box">
+  <div *ngFor="let hero of heroes">{{ hero.name }}</div>
+</div>
+<br />
+
+<div class="box">
+  <!-- *ngFor w/ hero-detail Component -->
+  <app-hero-detail *ngFor="let hero of heroes" [hero]="hero"></app-hero-detail>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<h4 id="ngFor-index">*ngFor with index</h4>
+<p>with <i>semi-colon</i> separator</p>
+<div class="box">
+  <div *ngFor="let hero of heroes; let i = index">
+    {{ i + 1 }} - {{ hero.name }}
+  </div>
+</div>
+
+<p>with <i>comma</i> separator</p>
+<div class="box">
+  <!-- Ex: "1 - Hercules" -->
+  <div *ngFor="let hero of heroes; let i = index">
+    {{ i + 1 }} - {{ hero.name }}
+  </div>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<h4 id="ngFor-trackBy">*ngFor trackBy</h4>
+<button (click)="resetHeroes()">Reset heroes</button>
+<button (click)="changeIds()">Change ids</button>
+<button (click)="clearTrackByCounts()">Clear counts</button>
+
+<p><i>without</i> trackBy</p>
+<div class="box">
+  <div #noTrackBy *ngFor="let hero of heroes">
+    ({{ hero.id }}) {{ hero.name }}
+  </div>
+
+  <div id="noTrackByCnt" *ngIf="heroesNoTrackByCount">
+    Hero DOM elements change #{{ heroesNoTrackByCount }} without trackBy
+  </div>
+</div>
+
+<p>with trackBy</p>
+<div class="box">
+  <div #withTrackBy *ngFor="let hero of heroes; trackBy: trackByHeroes">
+    ({{ hero.id }}) {{ hero.name }}
+  </div>
+
+  <div id="withTrackByCnt" *ngIf="heroesWithTrackByCount">
+    Hero DOM elements change #{{ heroesWithTrackByCount }} with trackBy
+  </div>
+</div>
+
+<br /><br /><br />
+
+<p>with trackBy and <i>semi-colon</i> separator</p>
+<div class="box">
+  <div *ngFor="let hero of heroes; trackBy: trackByHeroes">
+    ({{ hero.id }}) {{ hero.name }}
+  </div>
+</div>
+
+<p>with trackBy and <i>comma</i> separator</p>
+<div class="box">
+  <div *ngFor="let hero of heroes; trackBy: trackByHeroes">
+    ({{ hero.id }}) {{ hero.name }}
+  </div>
+</div>
+
+<p>with trackBy and <i>space</i> separator</p>
+<div class="box">
+  <div *ngFor="let hero of heroes; trackBy: trackByHeroes">
+    ({{ hero.id }}) {{ hero.name }}
+  </div>
+</div>
+
+<p>with <i>generic</i> trackById function</p>
+<div class="box">
+  <div *ngFor="let hero of heroes; trackBy: trackById">
+    ({{ hero.id }}) {{ hero.name }}
+  </div>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- NgSwitch binding -->
+<hr />
+<h2 id="ngSwitch">NgSwitch Binding</h2>
+
+<p>Pick your favorite hero</p>
+<div>
+  <label *ngFor="let h of heroes">
+    <input type="radio" name="heroes" [(ngModel)]="currentHero" [value]="h" />{{
+      h.name
+    }}
+  </label>
+</div>
+
+<div [ngSwitch]="currentHero.emotion">
+  <app-happy-hero *ngSwitchCase="'happy'" [hero]="currentHero"></app-happy-hero>
+  <app-sad-hero *ngSwitchCase="'sad'" [hero]="currentHero"></app-sad-hero>
+  <app-confused-hero
+    *ngSwitchCase="'confused'"
+    [hero]="currentHero"
+  ></app-confused-hero>
+  <div *ngSwitchCase="'confused'">
+    Are you as confused as {{ currentHero.name }}?
+  </div>
+  <app-unknown-hero *ngSwitchDefault [hero]="currentHero"></app-unknown-hero>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- template reference variable -->
+<hr />
+<h2 id="ref-vars">Template reference variables</h2>
+
+<input #phone placeholder="phone number" />
+
+<!-- lots of other elements -->
+
+<!-- phone refers to the input element; pass its \`value\` to an event handler -->
+<button (click)="callPhone(phone.value)">Call</button>
+
+<input ref-fax placeholder="fax number" />
+<button (click)="callFax(fax.value)">Fax</button>
+
+<!-- btn refers to the button element; show its disabled state -->
+<button
+  #btn
+  disabled
+  [innerHTML]="'disabled by attribute: ' + btn.disabled"
+></button>
+
+<h4>Example Form</h4>
+<app-hero-form [hero]="currentHero"></app-hero-form>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- inputs and output -->
+<hr />
+<h2 id="inputs-and-outputs">Inputs and Outputs</h2>
+
+<img [src]="iconUrl" />
+<button (click)="onSave()">Save</button>
+
+<app-hero-detail [hero]="currentHero" (deleteRequest)="deleteHero($event)">
+</app-hero-detail>
+
+<div (myClick)="clickMessage2 = $event" clickable>myClick2</div>
+{{ clickMessage2 }}
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- Pipes -->
+<hr />
+<h2 id="pipes">Pipes</h2>
+
+<div>Title through uppercase pipe: {{ title | uppercase }}</div>
+
+<!-- Pipe chaining: convert title to uppercase, then to lowercase -->
+<div>
+  Title through a pipe chain:
+  {{ title | uppercase | lowercase }}
+</div>
+
+<!-- pipe with configuration argument => "February 25, 1970" -->
+<div>Birthdate: {{ currentHero?.birthdate | date : "longDate" }}</div>
+
+<div>{{ currentHero | json }}</div>
+
+<div>
+  Birthdate: {{ currentHero?.birthdate | date : "longDate" | uppercase }}
+</div>
+
+<div>
+  <!-- pipe price to USD and display the $ symbol -->
+  <label>Price: </label>{{ product.price | currency : "USD" : true }}
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- Null values and the safe navigation operator -->
+<hr />
+<h2 id="safe-navigation-operator">Safe navigation operator <i>?.</i></h2>
+
+<div>The title is {{ title }}</div>
+
+<div>The current hero's name is {{ currentHero?.name }}</div>
+
+<div>The current hero's name is {{ currentHero.name }}</div>
+
+<!--
+The null hero's name is {{nullHero.name}}
+
+See console log:
+  TypeError: Cannot read property 'name' of null in [null]
+-->
+
+<!--No hero, div not displayed, no error -->
+<div *ngIf="nullHero">The null hero's name is {{ nullHero.name }}</div>
+
+<div>The null hero's name is {{ nullHero && nullHero.name }}</div>
+
+<div>
+  <!-- No hero, no problem! -->
+  The null hero's name is {{ nullHero?.name }}
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- non-null assertion operator -->
+<hr />
+<h2 id="non-null-assertion-operator">Non-null assertion operator <i>!.</i></h2>
+
+<div>
+  <!--No hero, no text -->
+  <div *ngIf="hero">The hero's name is {{ hero!.name }}</div>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- non-null assertion operator -->
+<hr />
+<h2 id="any-type-cast-function">$any type cast function <i>$any( )</i>.</h2>
+
+<div>
+  <!-- Accessing an undeclared member -->
+  <div>The hero's marker is {{ $any(hero).marker }}</div>
+</div>
+
+<div>
+  <!-- Accessing an undeclared member -->
+  <div>Undeclared members is {{ $any(this).member }}</div>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- TODO: discuss this in the Style binding section -->
+<!-- enums in bindings -->
+<hr />
+<h2 id="enums">Enums in binding</h2>
+
+<p>
+  The name of the Color.Red enum is {{ Color[Color.Red] }}.<br />
+  The current color is {{ Color[color] }} and its number is {{ color }}.<br />
+  <button [style.color]="Color[color]" (click)="colorToggle()">
+    Enum Toggle
+  </button>
+</p>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- 
+Copyright 2017-2018 Google Inc. All Rights Reserved.
+Use of this source code is governed by an MIT-style license that
+can be found in the LICENSE file at http://angular.io/license
+-->
+
+<div id="heroForm">
+  <form (ngSubmit)="onSubmit(heroForm)" #heroForm="ngForm">
+    <div class="form-group">
+      <label for="name"
+        >Name
+        <input
+          class="form-control"
+          name="name"
+          required
+          [(ngModel)]="hero.name"
+        />
+      </label>
+    </div>
+    <button type="submit" [disabled]="!heroForm.form.valid">Submit</button>
+  </form>
+  <div [hidden]="!heroForm.form.valid">
+    {{ submitMessage }}
+  </div>
+</div>
+
+<!-- 
+Copyright 2017-2018 Google Inc. All Rights Reserved.
+Use of this source code is governed by an MIT-style license that
+can be found in the LICENSE file at http://angular.io/license
+-->
+
+================================================================================
+`;
+
+exports[`real-world.component.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["angular"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<!-- copied from: https://stackblitz.com/angular/ymdjlgmlavo -->
+
+<a id="toc"></a>
+<h1>Template Syntax</h1>
+<a href="#interpolation">Interpolation</a><br>
+<a href="#expression-context">Expression context</a><br>
+<a href="#statement-context">Statement context</a><br>
+<a href="#mental-model">Mental Model</a><br>
+<a href="#buttons">Buttons</a><br>
+<a href="#prop-vs-attrib">Properties vs. Attributes</a><br>
+<br>
+<a href="#property-binding">Property Binding</a><br>
+<div style="margin-left:8px">
+  <a href="#attribute-binding">Attribute Binding</a><br>
+  <a href="#class-binding">Class Binding</a><br>
+  <a href="#style-binding">Style Binding</a><br>
+</div>
+<br>
+<a href="#event-binding">Event Binding</a><br>
+<a href="#two-way">Two-way Binding</a><br>
+<br>
+<div>Directives</div>
+<div style="margin-left:8px">
+  <a href="#ngModel">NgModel (two-way) Binding</a><br>
+  <a href="#ngClass">NgClass Binding</a><br>
+  <a href="#ngStyle">NgStyle Binding</a><br>
+  <a href="#ngIf">NgIf</a><br>
+  <a href="#ngFor">NgFor</a><br>
+  <div style="margin-left:8px">
+    <a href="#ngFor-index">NgFor with index</a><br>
+    <a href="#ngFor-trackBy">NgFor with trackBy</a><br>
+  </div>
+  <a href="#ngSwitch">NgSwitch</a><br>
+</div>
+<br>
+<a href="#ref-vars">Template reference variables</a><br>
+<a href="#inputs-and-outputs">Inputs and outputs</a><br>
+<a href="#pipes">Pipes</a><br>
+<a href="#safe-navigation-operator">Safe navigation operator <i>?.</i></a><br>
+<a href="#non-null-assertion-operator">Non-null assertion operator <i>!.</i></a><br>
+<a href="#enums">Enums</a><br>
+
+<!-- Interpolation and expressions -->
+<hr><h2 id="interpolation">Interpolation</h2>
+
+<p>My current hero is {{currentHero.name}}</p>
+
+<h3>
+  {{title}}
+  <img src="{{heroImageUrl}}" style="height:30px">
+</h3>
+
+<!-- "The sum of 1 + 1 is 2" -->
+<p>The sum of 1 + 1 is {{1 + 1}}</p>
+
+<!-- "The sum of 1 + 1 is not 4" -->
+<p>The sum of 1 + 1 is not {{1 + 1 + getVal()}}</p>
+
+<a class="to-toc" href="#toc">top</a>
+
+<hr><h2 id="expression-context">Expression context</h2>
+
+<p>Component expression context (&#123;&#123;title&#125;&#125;, [hidden]="isUnchanged")</p>
+<div class="context">
+  {{title}}
+  <span [hidden]="isUnchanged">changed</span>
+</div>
+
+
+<p>Template input variable expression context (let hero)</p>
+<!-- template hides the following; plenty of examples later -->
+<ng-template>
+  <div *ngFor="let hero of heroes">{{hero.name}}</div>
+</ng-template>
+
+<p>Template reference variable expression context (#heroInput)</p>
+<div (keyup)="0" class="context">
+  Type something:
+  <input #heroInput> {{heroInput.value}}
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<hr><h2 id="statement-context">Statement context</h2>
+
+<p>Component statement context ( (click)="onSave() )
+<div class="context">
+  <button (click)="deleteHero()">Delete hero</button>
+</div>
+
+<p>Template $event statement context</p>
+<div class="context">
+  <button (click)="onSave($event)">Save</button>
+</div>
+
+<p>Template input variable statement context (let hero)</p>
+<!-- template hides the following; plenty of examples later -->
+<div class="context">
+  <button *ngFor="let hero of heroes" (click)="deleteHero(hero)">{{hero.name}}</button>
+</div>
+
+<p>Template reference variable statement context (#heroForm)</p>
+<div class="context">
+  <form #heroForm (ngSubmit)="onSubmit(heroForm)"> ... </form>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- New Mental Model -->
+<hr><h2 id="mental-model">New Mental Model</h2>
+
+<!--<img src="http://www.wpclipart.com/cartoon/people/hero/hero_silhoutte_T.png">-->
+<!-- Public Domain terms of use: http://www.wpclipart.com/terms.html -->
+<div class="special">Mental Model</div>
+<img src="assets/images/hero.png">
+<button disabled>Save</button>
+<br><br>
+
+<div>
+  <!-- Normal HTML -->
+  <div class="special">Mental Model</div>
+  <!-- Wow! A new element! -->
+  <app-hero-detail></app-hero-detail>
+</div>
+<br><br>
+
+<div>
+  <!-- Bind button disabled state to \`isUnchanged\` property -->
+  <button [disabled]="isUnchanged">Save</button>
+</div>
+<br><br>
+
+<div>
+  <img [src]="heroImageUrl">
+  <app-hero-detail [hero]="currentHero"></app-hero-detail>
+  <div [ngClass]="{'special': isSpecial}"></div>
+</div>
+<br><br>
+
+<button (click)="onSave()">Save</button>
+<app-hero-detail (deleteRequest)="deleteHero()"></app-hero-detail>
+<div (myClick)="clicked=$event" clickable>click me</div>
+{{clicked}}
+<br><br>
+
+<div>
+  Hero Name:
+  <input [(ngModel)]="name">
+  {{name}}
+</div>
+<br><br>
+
+<button [attr.aria-label]="help">help</button>
+<br><br>
+
+<div [class.special]="isSpecial">Special</div>
+<br><br>
+
+<button [style.color]="isSpecial ? 'red' : 'green'">
+button</button>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- property vs. attribute -->
+<hr><h2 id="prop-vs-attrib">Property vs. Attribute (img examples)</h2>
+<!-- examine the following <img> tag in the browser tools -->
+<img src="images/ng-logo.png"
+    [src]="heroImageUrl">
+
+<br><br>
+
+<img [src]="iconUrl"/>
+<img bind-src="heroImageUrl"/>
+<img [attr.src]="villainImageUrl"/>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- buttons -->
+<hr><h2 id="buttons">Buttons</h2>
+
+<button>Enabled (but does nothing)</button>
+<button disabled>Disabled</button>
+<button disabled=false>Still disabled</button>
+<br><br>
+<button disabled>disabled by attribute</button>
+<button [disabled]="isUnchanged">disabled by property binding</button>
+<br><br>
+<button bind-disabled="isUnchanged" on-click="onSave($event)">Disabled Cancel</button>
+<button [disabled]="!canSave" (click)="onSave($event)">Enabled Save</button>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- property binding -->
+<hr><h2 id="property-binding">Property Binding</h2>
+
+<img [src]="heroImageUrl">
+<button [disabled]="isUnchanged">Cancel is disabled</button>
+<div [ngClass]="classes">[ngClass] binding to the classes property</div>
+<app-hero-detail [hero]="currentHero"></app-hero-detail>
+<img bind-src="heroImageUrl">
+
+<!-- ERROR: HeroDetailComponent.hero expects a
+     Hero object, not the string "currentHero" -->
+<div *ngIf="false">
+  <app-hero-detail hero="currentHero"></app-hero-detail>
+</div>
+<app-hero-detail prefix="You are my" [hero]="currentHero"></app-hero-detail>
+
+<p><img src="{{heroImageUrl}}"> is the <i>interpolated</i> image.</p>
+<p><img [src]="heroImageUrl"> is the <i>property bound</i> image.</p>
+
+<p><span>"{{title}}" is the <i>interpolated</i> title.</span></p>
+<p>"<span [innerHTML]="title"></span>" is the <i>property bound</i> title.</p>
+
+<!--
+  Angular generates warnings for these two lines as it sanitizes them
+  WARNING: sanitizing HTML stripped some content (see http://g.co/ng/security#xss).
+ -->
+<p><span>"{{evilTitle}}" is the <i>interpolated</i> evil title.</span></p>
+<p>"<span [innerHTML]="evilTitle"></span>" is the <i>property bound</i> evil title.</p>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- attribute binding -->
+<hr><h2 id="attribute-binding">Attribute Binding</h2>
+
+<!--  create and set a colspan attribute -->
+<table border=1>
+  <!--  expression calculates colspan=2 -->
+  <tr><td [attr.colspan]="1 + 1">One-Two</td></tr>
+
+  <!-- ERROR: There is no \`colspan\` property to set!
+    <tr><td colspan="{{1 + 1}}">Three-Four</td></tr>
+  -->
+
+  <tr><td>Five</td><td>Six</td></tr>
+</table>
+
+<br>
+<!-- create and set an aria attribute for assistive technology -->
+<button [attr.aria-label]="actionName">{{actionName}} with Aria</button>
+<br><br>
+
+<!-- The following effects are not discussed in the chapter -->
+<div>
+  <!-- any use of [attr.disabled] creates the disabled attribute -->
+  <button [attr.disabled]="isUnchanged">Disabled</button>
+
+  <button [attr.disabled]="!isUnchanged">Disabled as well</button>
+
+  <!-- we'd have to remove it with property binding -->
+  <button disabled [disabled]="false">Enabled (but inert)</button>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- class binding -->
+<hr><h2 id="class-binding">Class Binding</h2>
+
+<!-- standard class attribute setting  -->
+<div class="bad curly special">Bad curly special</div>
+
+<!-- reset/override all class names with a binding  -->
+<div class="bad curly special"
+     [class]="badCurly">Bad curly</div>
+
+<!-- toggle the "special" class on/off with a property -->
+<div [class.special]="isSpecial">The class binding is special</div>
+
+<!-- binding to \`class.special\` trumps the class attribute -->
+<div class="special"
+     [class.special]="!isSpecial">This one is not so special</div>
+
+<div bind-class.special="isSpecial">This class binding is special too</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!--style binding -->
+<hr><h2 id="style-binding">Style Binding</h2>
+
+<button [style.color]="isSpecial ? 'red': 'green'">Red</button>
+<button [style.background-color]="canSave ? 'cyan': 'grey'" >Save</button>
+
+<button [style.font-size.em]="isSpecial ? 3 : 1" >Big</button>
+<button [style.font-size.%]="!isSpecial ? 150 : 50" >Small</button>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- event binding -->
+<hr><h2 id="event-binding">Event Binding</h2>
+
+<button (click)="onSave()">Save</button>
+
+<button on-click="onSave()">On Save</button>
+
+<div>
+<!-- \`myClick\` is an event on the custom \`ClickDirective\` -->
+<div (myClick)="clickMessage=$event" clickable>click with myClick</div>
+{{clickMessage}}
+</div>
+
+
+<!-- binding to a nested component -->
+<app-hero-detail (deleteRequest)="deleteHero($event)" [hero]="currentHero"></app-hero-detail>
+<br>
+
+<app-big-hero-detail
+    (deleteRequest)="deleteHero($event)"
+    [hero]="currentHero">
+</app-big-hero-detail>
+
+<div class="parent-div" (click)="onClickMe($event)" clickable>Click me
+  <div class="child-div">Click me too!</div>
+</div>
+
+<!-- Will save only once -->
+<div (click)="onSave()" clickable>
+  <button (click)="onSave($event)">Save, no propagation</button>
+</div>
+
+<!-- Will save twice -->
+<div (click)="onSave()" clickable>
+  <button (click)="onSave()">Save w/ propagation</button>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<hr><h2 id="two-way">Two-way Binding</h2>
+<div id="two-way-1">
+  <app-sizer [(size)]="fontSizePx"></app-sizer>
+  <div [style.font-size.px]="fontSizePx">Resizable Text</div>
+  <label>FontSize (px): <input [(ngModel)]="fontSizePx"></label>
+</div>
+<br>
+<div id="two-way-2">
+  <h3>De-sugared two-way binding</h3>
+  <app-sizer [size]="fontSizePx" (sizeChange)="fontSizePx=$event"></app-sizer>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- Two way data binding unwound;
+    passing the changed display value to the event handler via \`$event\` -->
+<hr><h2 id="ngModel">NgModel (two-way) Binding</h2>
+
+<h3>Result: {{currentHero.name}}</h3>
+
+<input [value]="currentHero.name"
+       (input)="currentHero.name=$event.target.value" >
+without NgModel
+<br>
+<input [(ngModel)]="currentHero.name">
+[(ngModel)]
+<br>
+<input bindon-ngModel="currentHero.name">
+bindon-ngModel
+<br>
+<input
+  [ngModel]="currentHero.name"
+  (ngModelChange)="currentHero.name=$event">
+(ngModelChange)="...name=$event"
+<br>
+<input
+  [ngModel]="currentHero.name"
+  (ngModelChange)="setUppercaseName($event)">
+(ngModelChange)="setUppercaseName($event)"
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- NgClass binding -->
+<hr><h2 id="ngClass">NgClass Binding</h2>
+
+<p>currentClasses is {{currentClasses | json}}</p>
+<div [ngClass]="currentClasses">This div is initially saveable, unchanged, and special</div>
+
+<!-- not used in chapter -->
+<br>
+<label>saveable   <input type="checkbox" [(ngModel)]="canSave"></label> |
+<label>modified:  <input type="checkbox" [value]="!isUnchanged" (change)="isUnchanged=!isUnchanged"></label> |
+<label>special:   <input type="checkbox" [(ngModel)]="isSpecial"></label>
+<button (click)="setCurrentClasses()">Refresh currentClasses</button>
+<br><br>
+<div [ngClass]="currentClasses">
+  This div should be {{ canSave ? "": "not"}} saveable,
+                  {{ isUnchanged ? "unchanged" : "modified" }} and,
+                  {{ isSpecial ? "": "not"}} special after clicking "Refresh".</div>
+<br><br>
+
+<div [ngClass]="isSpecial ? 'special' : ''">This div is special</div>
+
+<div class="bad curly special">Bad curly special</div>
+<div [ngClass]="{'bad':false, 'curly':true, 'special':true}">Curly special</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- NgStyle binding -->
+<hr><h2 id="ngStyle">NgStyle Binding</h2>
+
+<div [style.font-size]="isSpecial ? 'x-large' : 'smaller'" >
+  This div is x-large or smaller.
+</div>
+
+<h3>[ngStyle] binding to currentStyles - CSS property names</h3>
+<p>currentStyles is {{currentStyles | json}}</p>
+<div [ngStyle]="currentStyles">
+  This div is initially italic, normal weight, and extra large (24px).
+</div>
+
+<!-- not used in chapter -->
+<br>
+<label>italic: <input type="checkbox" [(ngModel)]="canSave"></label> |
+<label>normal: <input type="checkbox" [(ngModel)]="isUnchanged"></label> |
+<label>xlarge: <input type="checkbox" [(ngModel)]="isSpecial"></label>
+<button (click)="setCurrentStyles()">Refresh currentStyles</button>
+<br><br>
+<div [ngStyle]="currentStyles">
+  This div should be {{ canSave ? "italic": "plain"}},
+                  {{ isUnchanged ? "normal weight" : "bold" }} and,
+                  {{ isSpecial ? "extra large": "normal size"}} after clicking "Refresh".</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- NgIf binding -->
+<hr><h2 id="ngIf">NgIf Binding</h2>
+
+<app-hero-detail *ngIf="isActive"></app-hero-detail>
+
+<div *ngIf="currentHero">Hello, {{currentHero.name}}</div>
+<div *ngIf="nullHero">Hello, {{nullHero.name}}</div>
+
+<!-- NgIf binding with template (no *) -->
+
+<ng-template [ngIf]="currentHero">Add {{currentHero.name}} with template</ng-template>
+
+<!-- Does not show because isActive is false! -->
+<div>Hero Detail removed from DOM (via template) because isActive is false</div>
+<ng-template [ngIf]="isActive">
+  <app-hero-detail></app-hero-detail>
+</ng-template>
+
+<!-- isSpecial is true -->
+<div [class.hidden]="!isSpecial">Show with class</div>
+<div [class.hidden]="isSpecial">Hide with class</div>
+
+<!-- HeroDetail is in the DOM but hidden -->
+<app-hero-detail [class.hidden]="isSpecial"></app-hero-detail>
+
+<div [style.display]="isSpecial ? 'block' : 'none'">Show with style</div>
+<div [style.display]="isSpecial ? 'none'  : 'block'">Hide with style</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- NgFor binding -->
+<hr><h2 id="ngFor">NgFor Binding</h2>
+
+<div class="box">
+  <div *ngFor="let hero of heroes">{{hero.name}}</div>
+</div>
+<br>
+
+<div class="box">
+  <!-- *ngFor w/ hero-detail Component -->
+  <app-hero-detail *ngFor="let hero of heroes" [hero]="hero"></app-hero-detail>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<h4 id="ngFor-index">*ngFor with index</h4>
+<p>with <i>semi-colon</i> separator</p>
+<div class="box">
+  <div *ngFor="let hero of heroes; let i=index">{{i + 1}} - {{hero.name}}</div>
+</div>
+
+<p>with <i>comma</i> separator</p>
+<div class="box">
+  <!-- Ex: "1 - Hercules" -->
+  <div *ngFor="let hero of heroes, let i=index">{{i + 1}} - {{hero.name}}</div>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<h4 id="ngFor-trackBy">*ngFor trackBy</h4>
+<button (click)="resetHeroes()">Reset heroes</button>
+<button (click)="changeIds()">Change ids</button>
+<button (click)="clearTrackByCounts()">Clear counts</button>
+
+<p><i>without</i> trackBy</p>
+<div class="box">
+  <div #noTrackBy *ngFor="let hero of heroes">({{hero.id}}) {{hero.name}}</div>
+
+  <div id="noTrackByCnt" *ngIf="heroesNoTrackByCount" >
+    Hero DOM elements change #{{heroesNoTrackByCount}} without trackBy
+  </div>
+</div>
+
+<p>with trackBy</p>
+<div class="box">
+  <div #withTrackBy *ngFor="let hero of heroes; trackBy: trackByHeroes">({{hero.id}}) {{hero.name}}</div>
+
+  <div id="withTrackByCnt" *ngIf="heroesWithTrackByCount">
+    Hero DOM elements change #{{heroesWithTrackByCount}} with trackBy
+  </div>
+</div>
+
+<br><br><br>
+
+<p>with trackBy and <i>semi-colon</i> separator</p>
+<div class="box">
+  <div *ngFor="let hero of heroes; trackBy: trackByHeroes">
+    ({{hero.id}}) {{hero.name}}
+  </div>
+</div>
+
+<p>with trackBy and <i>comma</i> separator</p>
+<div class="box">
+  <div *ngFor="let hero of heroes, trackBy: trackByHeroes">({{hero.id}}) {{hero.name}}</div>
+</div>
+
+<p>with trackBy and <i>space</i> separator</p>
+<div class="box">
+  <div *ngFor="let hero of heroes trackBy: trackByHeroes">({{hero.id}}) {{hero.name}}</div>
+</div>
+
+<p>with <i>generic</i> trackById function</p>
+<div class="box">
+  <div *ngFor="let hero of heroes, trackBy: trackById">({{hero.id}}) {{hero.name}}</div>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- NgSwitch binding -->
+<hr><h2 id="ngSwitch">NgSwitch Binding</h2>
+
+<p>Pick your favorite hero</p>
+<div>
+  <label *ngFor="let h of heroes">
+    <input type="radio" name="heroes" [(ngModel)]="currentHero" [value]="h">{{h.name}}
+  </label>
+</div>
+
+<div [ngSwitch]="currentHero.emotion">
+  <app-happy-hero    *ngSwitchCase="'happy'"    [hero]="currentHero"></app-happy-hero>
+  <app-sad-hero      *ngSwitchCase="'sad'"      [hero]="currentHero"></app-sad-hero>
+  <app-confused-hero *ngSwitchCase="'confused'" [hero]="currentHero"></app-confused-hero>
+  <div *ngSwitchCase="'confused'">Are you as confused as {{currentHero.name}}?</div>
+  <app-unknown-hero  *ngSwitchDefault           [hero]="currentHero"></app-unknown-hero>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- template reference variable -->
+<hr><h2 id="ref-vars">Template reference variables</h2>
+
+<input #phone placeholder="phone number">
+
+<!-- lots of other elements -->
+
+<!-- phone refers to the input element; pass its \`value\` to an event handler -->
+<button (click)="callPhone(phone.value)">Call</button>
+
+<input ref-fax placeholder="fax number">
+<button (click)="callFax(fax.value)">Fax</button>
+
+<!-- btn refers to the button element; show its disabled state -->
+<button #btn disabled [innerHTML]="'disabled by attribute: '+btn.disabled"></button>
+
+<h4>Example Form</h4>
+<app-hero-form [hero]="currentHero"></app-hero-form>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- inputs and output -->
+<hr><h2 id="inputs-and-outputs">Inputs and Outputs</h2>
+
+<img [src]="iconUrl"/>
+<button (click)="onSave()">Save</button>
+
+<app-hero-detail [hero]="currentHero" (deleteRequest)="deleteHero($event)">
+</app-hero-detail>
+
+<div (myClick)="clickMessage2=$event" clickable>myClick2</div>
+{{clickMessage2}}
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- Pipes -->
+<hr><h2 id="pipes">Pipes</h2>
+
+<div>Title through uppercase pipe: {{title | uppercase}}</div>
+
+<!-- Pipe chaining: convert title to uppercase, then to lowercase -->
+<div>
+  Title through a pipe chain:
+  {{title | uppercase | lowercase}}
+</div>
+
+<!-- pipe with configuration argument => "February 25, 1970" -->
+<div>Birthdate: {{currentHero?.birthdate | date:'longDate'}}</div>
+
+<div>{{currentHero | json}}</div>
+
+<div>Birthdate: {{(currentHero?.birthdate | date:'longDate') | uppercase}}</div>
+
+<div>
+  <!-- pipe price to USD and display the $ symbol -->
+  <label>Price: </label>{{product.price | currency:'USD':true}}
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- Null values and the safe navigation operator -->
+<hr><h2 id="safe-navigation-operator">Safe navigation operator <i>?.</i></h2>
+
+<div>
+  The title is {{title}}
+</div>
+
+<div>
+  The current hero's name is {{currentHero?.name}}
+</div>
+
+<div>
+  The current hero's name is {{currentHero.name}}
+</div>
+
+
+<!--
+The null hero's name is {{nullHero.name}}
+
+See console log:
+  TypeError: Cannot read property 'name' of null in [null]
+-->
+
+<!--No hero, div not displayed, no error -->
+<div *ngIf="nullHero">The null hero's name is {{nullHero.name}}</div>
+
+<div>
+The null hero's name is {{nullHero && nullHero.name}}
+</div>
+
+<div>
+  <!-- No hero, no problem! -->
+  The null hero's name is {{nullHero?.name}}
+</div>
+
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- non-null assertion operator -->
+<hr><h2 id="non-null-assertion-operator">Non-null assertion operator <i>!.</i></h2>
+
+<div>
+  <!--No hero, no text -->
+  <div *ngIf="hero">
+    The hero's name is {{hero!.name}}
+  </div>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- non-null assertion operator -->
+<hr><h2 id="any-type-cast-function">$any type cast function <i>$any( )</i>.</h2>
+
+<div>
+  <!-- Accessing an undeclared member -->
+  <div>
+    The hero's marker is {{$any(hero).marker}}
+  </div>
+</div>
+
+<div>
+  <!-- Accessing an undeclared member -->
+  <div>
+    Undeclared members is {{$any(this).member}}
+  </div>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- TODO: discuss this in the Style binding section -->
+<!-- enums in bindings -->
+<hr><h2 id="enums">Enums in binding</h2>
+
+<p>
+  The name of the Color.Red enum is {{Color[Color.Red]}}.<br>
+  The current color is {{Color[color]}} and its number is {{color}}.<br>
+  <button [style.color]="Color[color]" (click)="colorToggle()">Enum Toggle</button>
+</p>
+
+<a class="to-toc" href="#toc">top</a>
+
+
+<!-- 
+Copyright 2017-2018 Google Inc. All Rights Reserved.
+Use of this source code is governed by an MIT-style license that
+can be found in the LICENSE file at http://angular.io/license
+-->
+
+<div id="heroForm">
+  <form (ngSubmit)="onSubmit(heroForm)" #heroForm="ngForm">
+    <div class="form-group">
+      <label for="name">Name
+        <input class="form-control" name="name" required [(ngModel)]="hero.name">
+      </label>
+    </div>
+    <button type="submit" [disabled]="!heroForm.form.valid">Submit</button>
+  </form>
+  <div [hidden]="!heroForm.form.valid">
+    {{submitMessage}}
+  </div>
+</div>
+
+
+<!-- 
+Copyright 2017-2018 Google Inc. All Rights Reserved.
+Use of this source code is governed by an MIT-style license that
+can be found in the LICENSE file at http://angular.io/license
+-->
+
+=====================================output=====================================
+<!-- copied from: https://stackblitz.com/angular/ymdjlgmlavo -->
+
+<a id="toc"></a>
+<h1>Template Syntax</h1>
+<a href="#interpolation">Interpolation</a><br />
+<a href="#expression-context">Expression context</a><br />
+<a href="#statement-context">Statement context</a><br />
+<a href="#mental-model">Mental Model</a><br />
+<a href="#buttons">Buttons</a><br />
+<a href="#prop-vs-attrib">Properties vs. Attributes</a><br />
+<br />
+<a href="#property-binding">Property Binding</a><br />
+<div style="margin-left: 8px">
+  <a href="#attribute-binding">Attribute Binding</a><br />
+  <a href="#class-binding">Class Binding</a><br />
+  <a href="#style-binding">Style Binding</a><br />
+</div>
+<br />
+<a href="#event-binding">Event Binding</a><br />
+<a href="#two-way">Two-way Binding</a><br />
+<br />
+<div>Directives</div>
+<div style="margin-left: 8px">
+  <a href="#ngModel">NgModel (two-way) Binding</a><br />
+  <a href="#ngClass">NgClass Binding</a><br />
+  <a href="#ngStyle">NgStyle Binding</a><br />
+  <a href="#ngIf">NgIf</a><br />
+  <a href="#ngFor">NgFor</a><br />
+  <div style="margin-left: 8px">
+    <a href="#ngFor-index">NgFor with index</a><br />
+    <a href="#ngFor-trackBy">NgFor with trackBy</a><br />
+  </div>
+  <a href="#ngSwitch">NgSwitch</a><br />
+</div>
+<br />
+<a href="#ref-vars">Template reference variables</a><br />
+<a href="#inputs-and-outputs">Inputs and outputs</a><br />
+<a href="#pipes">Pipes</a><br />
+<a href="#safe-navigation-operator">Safe navigation operator <i>?.</i></a
+><br />
+<a href="#non-null-assertion-operator">Non-null assertion operator <i>!.</i></a
+><br />
+<a href="#enums">Enums</a><br />
+
+<!-- Interpolation and expressions -->
+<hr />
+<h2 id="interpolation">Interpolation</h2>
+
+<p>My current hero is {{ currentHero.name }}</p>
+
+<h3>
+  {{ title }}
+  <img src="{{ heroImageUrl }}" style="height: 30px" />
+</h3>
+
+<!-- "The sum of 1 + 1 is 2" -->
+<p>The sum of 1 + 1 is {{ 1 + 1 }}</p>
+
+<!-- "The sum of 1 + 1 is not 4" -->
+<p>The sum of 1 + 1 is not {{ 1 + 1 + getVal() }}</p>
+
+<a class="to-toc" href="#toc">top</a>
+
+<hr />
+<h2 id="expression-context">Expression context</h2>
+
+<p>
+  Component expression context (&#123;&#123;title&#125;&#125;,
+  [hidden]="isUnchanged")
+</p>
+<div class="context">
+  {{ title }}
+  <span [hidden]="isUnchanged">changed</span>
+</div>
+
+<p>Template input variable expression context (let hero)</p>
+<!-- template hides the following; plenty of examples later -->
+<ng-template>
+  <div *ngFor="let hero of heroes">{{ hero.name }}</div>
+</ng-template>
+
+<p>Template reference variable expression context (#heroInput)</p>
+<div (keyup)="(0)" class="context">
+  Type something:
+  <input #heroInput /> {{ heroInput.value }}
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<hr />
+<h2 id="statement-context">Statement context</h2>
+
+<p>Component statement context ( (click)="onSave() )</p>
+<div class="context">
+  <button (click)="deleteHero()">Delete hero</button>
+</div>
+
+<p>Template $event statement context</p>
+<div class="context">
+  <button (click)="onSave($event)">Save</button>
+</div>
+
+<p>Template input variable statement context (let hero)</p>
+<!-- template hides the following; plenty of examples later -->
+<div class="context">
+  <button *ngFor="let hero of heroes" (click)="deleteHero(hero)">
+    {{ hero.name }}
+  </button>
+</div>
+
+<p>Template reference variable statement context (#heroForm)</p>
+<div class="context">
+  <form #heroForm (ngSubmit)="onSubmit(heroForm)">...</form>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- New Mental Model -->
+<hr />
+<h2 id="mental-model">New Mental Model</h2>
+
+<!--<img src="http://www.wpclipart.com/cartoon/people/hero/hero_silhoutte_T.png">-->
+<!-- Public Domain terms of use: http://www.wpclipart.com/terms.html -->
+<div class="special">Mental Model</div>
+<img src="assets/images/hero.png" />
+<button disabled>Save</button>
+<br /><br />
+
+<div>
+  <!-- Normal HTML -->
+  <div class="special">Mental Model</div>
+  <!-- Wow! A new element! -->
+  <app-hero-detail></app-hero-detail>
+</div>
+<br /><br />
+
+<div>
+  <!-- Bind button disabled state to \`isUnchanged\` property -->
+  <button [disabled]="isUnchanged">Save</button>
+</div>
+<br /><br />
+
+<div>
+  <img [src]="heroImageUrl" />
+  <app-hero-detail [hero]="currentHero"></app-hero-detail>
+  <div [ngClass]="{ special: isSpecial }"></div>
+</div>
+<br /><br />
+
+<button (click)="onSave()">Save</button>
+<app-hero-detail (deleteRequest)="deleteHero()"></app-hero-detail>
+<div (myClick)="clicked = $event" clickable>click me</div>
+{{ clicked }}
+<br /><br />
+
+<div>
+  Hero Name:
+  <input [(ngModel)]="name" />
+  {{ name }}
+</div>
+<br /><br />
+
+<button [attr.aria-label]="help">help</button>
+<br /><br />
+
+<div [class.special]="isSpecial">Special</div>
+<br /><br />
+
+<button [style.color]="isSpecial ? 'red' : 'green'">button</button>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- property vs. attribute -->
+<hr />
+<h2 id="prop-vs-attrib">Property vs. Attribute (img examples)</h2>
+<!-- examine the following <img> tag in the browser tools -->
+<img src="images/ng-logo.png" [src]="heroImageUrl" />
+
+<br /><br />
+
+<img [src]="iconUrl" />
+<img bind-src="heroImageUrl" />
+<img [attr.src]="villainImageUrl" />
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- buttons -->
+<hr />
+<h2 id="buttons">Buttons</h2>
+
+<button>Enabled (but does nothing)</button>
+<button disabled>Disabled</button>
+<button disabled="false">Still disabled</button>
+<br /><br />
+<button disabled>disabled by attribute</button>
+<button [disabled]="isUnchanged">disabled by property binding</button>
+<br /><br />
+<button bind-disabled="isUnchanged" on-click="onSave($event)">
+  Disabled Cancel
+</button>
+<button [disabled]="!canSave" (click)="onSave($event)">Enabled Save</button>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- property binding -->
+<hr />
+<h2 id="property-binding">Property Binding</h2>
+
+<img [src]="heroImageUrl" />
+<button [disabled]="isUnchanged">Cancel is disabled</button>
+<div [ngClass]="classes">[ngClass] binding to the classes property</div>
+<app-hero-detail [hero]="currentHero"></app-hero-detail>
+<img bind-src="heroImageUrl" />
+
+<!-- ERROR: HeroDetailComponent.hero expects a
+     Hero object, not the string "currentHero" -->
+<div *ngIf="false">
+  <app-hero-detail hero="currentHero"></app-hero-detail>
+</div>
+<app-hero-detail prefix="You are my" [hero]="currentHero"></app-hero-detail>
+
+<p><img src="{{ heroImageUrl }}" /> is the <i>interpolated</i> image.</p>
+<p><img [src]="heroImageUrl" /> is the <i>property bound</i> image.</p>
+
+<p>
+  <span>"{{ title }}" is the <i>interpolated</i> title.</span>
+</p>
+<p>"<span [innerHTML]="title"></span>" is the <i>property bound</i> title.</p>
+
+<!--
+  Angular generates warnings for these two lines as it sanitizes them
+  WARNING: sanitizing HTML stripped some content (see http://g.co/ng/security#xss).
+ -->
+<p>
+  <span>"{{ evilTitle }}" is the <i>interpolated</i> evil title.</span>
+</p>
+<p>
+  "<span [innerHTML]="evilTitle"></span>" is the <i>property bound</i> evil
+  title.
+</p>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- attribute binding -->
+<hr />
+<h2 id="attribute-binding">Attribute Binding</h2>
+
+<!--  create and set a colspan attribute -->
+<table border="1">
+  <!--  expression calculates colspan=2 -->
+  <tr>
+    <td [attr.colspan]="1 + 1">One-Two</td>
+  </tr>
+
+  <!-- ERROR: There is no \`colspan\` property to set!
+    <tr><td colspan="{{1 + 1}}">Three-Four</td></tr>
+  -->
+
+  <tr>
+    <td>Five</td>
+    <td>Six</td>
+  </tr>
+</table>
+
+<br />
+<!-- create and set an aria attribute for assistive technology -->
+<button [attr.aria-label]="actionName">{{ actionName }} with Aria</button>
+<br /><br />
+
+<!-- The following effects are not discussed in the chapter -->
+<div>
+  <!-- any use of [attr.disabled] creates the disabled attribute -->
+  <button [attr.disabled]="isUnchanged">Disabled</button>
+
+  <button [attr.disabled]="!isUnchanged">Disabled as well</button>
+
+  <!-- we'd have to remove it with property binding -->
+  <button disabled [disabled]="false">Enabled (but inert)</button>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- class binding -->
+<hr />
+<h2 id="class-binding">Class Binding</h2>
+
+<!-- standard class attribute setting  -->
+<div class="bad curly special">Bad curly special</div>
+
+<!-- reset/override all class names with a binding  -->
+<div class="bad curly special" [class]="badCurly">Bad curly</div>
+
+<!-- toggle the "special" class on/off with a property -->
+<div [class.special]="isSpecial">The class binding is special</div>
+
+<!-- binding to \`class.special\` trumps the class attribute -->
+<div class="special" [class.special]="!isSpecial">
+  This one is not so special
+</div>
+
+<div bind-class.special="isSpecial">This class binding is special too</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!--style binding -->
+<hr />
+<h2 id="style-binding">Style Binding</h2>
+
+<button [style.color]="isSpecial ? 'red' : 'green'">Red</button>
+<button [style.background-color]="canSave ? 'cyan' : 'grey'">Save</button>
+
+<button [style.font-size.em]="isSpecial ? 3 : 1">Big</button>
+<button [style.font-size.%]="!isSpecial ? 150 : 50">Small</button>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- event binding -->
+<hr />
+<h2 id="event-binding">Event Binding</h2>
+
+<button (click)="onSave()">Save</button>
+
+<button on-click="onSave()">On Save</button>
+
+<div>
+  <!-- \`myClick\` is an event on the custom \`ClickDirective\` -->
+  <div (myClick)="clickMessage = $event" clickable>click with myClick</div>
+  {{ clickMessage }}
+</div>
+
+<!-- binding to a nested component -->
+<app-hero-detail
+  (deleteRequest)="deleteHero($event)"
+  [hero]="currentHero"
+></app-hero-detail>
+<br />
+
+<app-big-hero-detail (deleteRequest)="deleteHero($event)" [hero]="currentHero">
+</app-big-hero-detail>
+
+<div class="parent-div" (click)="onClickMe($event)" clickable>
+  Click me
+  <div class="child-div">Click me too!</div>
+</div>
+
+<!-- Will save only once -->
+<div (click)="onSave()" clickable>
+  <button (click)="onSave($event)">Save, no propagation</button>
+</div>
+
+<!-- Will save twice -->
+<div (click)="onSave()" clickable>
+  <button (click)="onSave()">Save w/ propagation</button>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<hr />
+<h2 id="two-way">Two-way Binding</h2>
+<div id="two-way-1">
+  <app-sizer [(size)]="fontSizePx"></app-sizer>
+  <div [style.font-size.px]="fontSizePx">Resizable Text</div>
+  <label>FontSize (px): <input [(ngModel)]="fontSizePx" /></label>
+</div>
+<br />
+<div id="two-way-2">
+  <h3>De-sugared two-way binding</h3>
+  <app-sizer [size]="fontSizePx" (sizeChange)="fontSizePx = $event"></app-sizer>
+</div>
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- Two way data binding unwound;
+    passing the changed display value to the event handler via \`$event\` -->
+<hr />
+<h2 id="ngModel">NgModel (two-way) Binding</h2>
+
+<h3>Result: {{ currentHero.name }}</h3>
+
+<input
+  [value]="currentHero.name"
+  (input)="currentHero.name = $event.target.value"
+/>
+without NgModel
+<br />
+<input [(ngModel)]="currentHero.name" />
+[(ngModel)]
+<br />
+<input bindon-ngModel="currentHero.name" />
+bindon-ngModel
+<br />
+<input
+  [ngModel]="currentHero.name"
+  (ngModelChange)="currentHero.name = $event"
+/>
+(ngModelChange)="...name=$event"
+<br />
+<input
+  [ngModel]="currentHero.name"
+  (ngModelChange)="setUppercaseName($event)"
+/>
+(ngModelChange)="setUppercaseName($event)"
+
+<a class="to-toc" href="#toc">top</a>
+
+<!-- NgClass binding -->
+<hr />
+<h2 id="ngClass">NgClass Binding</h2>
+
+<p>currentClasses is {{ currentClasses | json }}</p>
+<div [ngClass]="currentClasses">
+  This div is initially saveable, unchanged, and special
+</div>
+
+<!-- not used in chapter -->
+<br />
+<label>saveable <input type="checkbox" [(ngModel)]="canSave" /></label> |
+<label
+  >modified:
+  <input
+    type="checkbox"
+    [value]="!isUnchanged"
+    (change)="isUnchanged = !isUnchanged"
+/></label>
+|
+<label>special: <input type="checkbox" [(ngModel)]="isSpecial" /></label>
+<button (click)="setCurrentClasses()">Refresh currentClasses</button>
+<br /><br />
+<div [ngClass]="currentClasses">
+  This div should be {{ canSave ? "" : "not" }} saveable,
+  {{ isUnchanged ? "unchanged" : "modified" }} and,
+  {{ isSpecial ? "" : "not" }} special after clicking "Refresh".
+</div>
+<br /><br />
+
+<div [ngClass]="isSpecial ? 'special' : ''">This div is special</div>
+
+<div class="bad curly special">Bad curly special</div>
+<div [ngClass]="{ bad: false, curly: true, special: true }">Curly special</div>
 
 <a class="to-toc" href="#toc">top</a>
 
@@ -13573,6 +15746,21 @@ can be found in the LICENSE file at http://angular.io/license
 exports[`tag-name.component.html - {"bracketSpacing":false} format 1`] = `
 ====================================options=====================================
 bracketSpacing: false
+parsers: ["angular"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<Table></Table>
+
+=====================================output=====================================
+<Table></Table>
+
+================================================================================
+`;
+
+exports[`tag-name.component.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
 parsers: ["angular"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/angular/angular/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/angular/angular/__snapshots__/jsfmt.spec.js.snap
@@ -41,9 +41,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`angularjs.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`angularjs.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["angular"]
 printWidth: 80
                                                                                 | printWidth
@@ -291,9 +291,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`attr-name.component.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`attr-name.component.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["angular"]
 printWidth: 80
                                                                                 | printWidth
@@ -639,9 +639,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`attributes.component.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`attributes.component.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["angular"]
 printWidth: 80
                                                                                 | printWidth
@@ -2414,9 +2414,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`first-lf.component.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`first-lf.component.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["angular"]
 printWidth: 80
                                                                                 | printWidth
@@ -3017,9 +3017,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`ignore-attribute.component.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`ignore-attribute.component.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["angular"]
 printWidth: 80
                                                                                 | printWidth
@@ -3502,9 +3502,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`interpolation.component.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`interpolation.component.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["angular"]
 printWidth: 80
                                                                                 | printWidth
@@ -6074,9 +6074,9 @@ can be found in the LICENSE file at http://angular.io/license
 ================================================================================
 `;
 
-exports[`real-world.component.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`real-world.component.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["angular"]
 printWidth: 80
                                                                                 | printWidth
@@ -15758,9 +15758,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`tag-name.component.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`tag-name.component.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["angular"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/angular/angular/jsfmt.spec.js
+++ b/tests/format/angular/angular/jsfmt.spec.js
@@ -3,4 +3,4 @@ run_spec(import.meta, ["angular"], { trailingComma: "es5" });
 run_spec(import.meta, ["angular"], { printWidth: 1 });
 run_spec(import.meta, ["angular"], { htmlWhitespaceSensitivity: "ignore" });
 run_spec(import.meta, ["angular"], { bracketSpacing: false });
-run_spec(import.meta, ["angular"], { experimentalOperatorLocation: true });
+run_spec(import.meta, ["angular"], { experimentalOperatorPosition: true });

--- a/tests/format/angular/angular/jsfmt.spec.js
+++ b/tests/format/angular/angular/jsfmt.spec.js
@@ -3,3 +3,4 @@ run_spec(import.meta, ["angular"], { trailingComma: "es5" });
 run_spec(import.meta, ["angular"], { printWidth: 1 });
 run_spec(import.meta, ["angular"], { htmlWhitespaceSensitivity: "ignore" });
 run_spec(import.meta, ["angular"], { bracketSpacing: false });
+run_spec(import.meta, ["angular"], { experimentalOperatorLocation: true });

--- a/tests/format/angular/interpolation/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/angular/interpolation/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`logical-expression.ng - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`logical-expression.ng - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["__ng_interpolation"]
 printWidth: 80
                                                                                 | printWidth
@@ -46,9 +46,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`optional-chaining.ng - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`optional-chaining.ng - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["__ng_interpolation"]
 printWidth: 80
                                                                                 | printWidth
@@ -74,9 +74,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`pipe-expression.ng - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`pipe-expression.ng - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["__ng_interpolation"]
 printWidth: 80
                                                                                 | printWidth
@@ -208,9 +208,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`pipe-in-object.ng - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`pipe-in-object.ng - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["__ng_interpolation"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/angular/interpolation/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/angular/interpolation/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`logical-expression.ng - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["__ng_interpolation"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+[
+    advancedSearchService.patientInformationFieldsRow2 && advancedSearchService.patientInformationFieldsRow2.indexOf(advancedSearchService.formElementData.customFieldList[i].customFieldType) !== -1,
+  (x && y) ?? z
+]
+
+=====================================output=====================================
+[
+  advancedSearchService.patientInformationFieldsRow2
+    && advancedSearchService.patientInformationFieldsRow2.indexOf(
+      advancedSearchService.formElementData.customFieldList[i].customFieldType,
+    ) !== -1,
+  (x && y) ?? z,
+]
+================================================================================
+`;
+
 exports[`logical-expression.ng - {"trailingComma":"none"} format 1`] = `
 ====================================options=====================================
 parsers: ["__ng_interpolation"]
@@ -23,6 +46,20 @@ trailingComma: "none"
 ================================================================================
 `;
 
+exports[`optional-chaining.ng - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["__ng_interpolation"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+[  a?.b[c], (a?.b)[c]  ]
+
+=====================================output=====================================
+[a?.b[c], (a?.b)[c]]
+================================================================================
+`;
+
 exports[`optional-chaining.ng - {"trailingComma":"none"} format 1`] = `
 ====================================options=====================================
 parsers: ["__ng_interpolation"]
@@ -34,6 +71,73 @@ trailingComma: "none"
 
 =====================================output=====================================
 [a?.b[c], (a?.b)[c]]
+================================================================================
+`;
+
+exports[`pipe-expression.ng - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["__ng_interpolation"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+[
+    a ? (b | c : d) : (e | f : g),
+    a | b | c | d,
+    ((a | b) | c) | d,
+    a | b:(c | d),
+    { a: b | c },
+    (a + b) | c,
+    (a | b) + c,
+    fn(a | b),
+    a?.b(c | d),
+    a[b | c],
+    ($students | async).items,
+    ($students | async)(),
+    myData | myPipe:'arg1':'arg2':'arg3',
+    value
+      | pipeA: {
+        keyA: reallySuperLongValue,
+        keyB: shortValue | pipeB | pipeC: valueToPipeC
+      } : {
+        keyA: reallySuperLongValue,
+        keyB: shortValue | pipeB | pipeC: valueToPipeC
+      }
+      | aaa,
+   (hideLinqPanel ? "ReportSelection.HideShowLabel_Show.String" : "ReportSelection.HideShowLabel_Hide.String") | localize:(localizationSection) 
+]
+
+=====================================output=====================================
+[
+  a ? (b | c : d) : (e | f : g),
+  a | b | c | d,
+  a | b | c | d,
+  a | b : (c | d),
+  { a: b | c },
+  a + b | c,
+  (a | b) + c,
+  fn(a | b),
+  a?.b(c | d),
+  a[b | c],
+  ($students | async).items,
+  ($students | async)(),
+  myData | myPipe : "arg1" : "arg2" : "arg3",
+  value
+    | pipeA
+      : {
+          keyA: reallySuperLongValue,
+          keyB: shortValue | pipeB | pipeC : valueToPipeC,
+        }
+      : {
+          keyA: reallySuperLongValue,
+          keyB: shortValue | pipeB | pipeC : valueToPipeC,
+        }
+    | aaa,
+  (hideLinqPanel
+    ? "ReportSelection.HideShowLabel_Show.String"
+    : "ReportSelection.HideShowLabel_Hide.String"
+  ) | localize : localizationSection,
+]
 ================================================================================
 `;
 
@@ -101,6 +205,20 @@ trailingComma: "none"
     : "ReportSelection.HideShowLabel_Hide.String"
   ) | localize : localizationSection
 ]
+================================================================================
+`;
+
+exports[`pipe-in-object.ng - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["__ng_interpolation"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+[{ AngularJS: '1.x', 'color': ('#222' | darken)}]
+
+=====================================output=====================================
+[{ AngularJS: "1.x", color: ("#222" | darken) }]
 ================================================================================
 `;
 

--- a/tests/format/angular/interpolation/jsfmt.spec.js
+++ b/tests/format/angular/interpolation/jsfmt.spec.js
@@ -1,5 +1,5 @@
 // We always pass {trailingComma: "none"} when printing
 run_spec(import.meta, ["__ng_interpolation"], { trailingComma: "none" });
 run_spec(import.meta, ["__ng_interpolation"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/angular/interpolation/jsfmt.spec.js
+++ b/tests/format/angular/interpolation/jsfmt.spec.js
@@ -1,2 +1,5 @@
 // We always pass {trailingComma: "none"} when printing
 run_spec(import.meta, ["__ng_interpolation"], { trailingComma: "none" });
+run_spec(import.meta, ["__ng_interpolation"], {
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/flow-repo/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow-repo/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`advanced_arrows.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`advanced_arrows.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -69,9 +69,9 @@ var ident = <T>(x: T): T => x;
 ================================================================================
 `;
 
-exports[`arrows.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`arrows.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["flow"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/flow-repo/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow-repo/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`advanced_arrows.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+/**
+ * @flow
+ */
+
+var add = (x: number, y: number): number => x + y;
+
+var bad = (x: number): string => x; // Error!
+
+var ident = <T>(x: T): T => x;
+(ident(1): number);
+(ident("hi"): number); // Error
+
+=====================================output=====================================
+/**
+ * @flow
+ */
+
+var add = (x: number, y: number): number => x + y;
+
+var bad = (x: number): string => x; // Error!
+
+var ident = <T>(x: T): T => x;
+(ident(1): number);
+(ident("hi"): number); // Error
+
+================================================================================
+`;
+
 exports[`advanced_arrows.js format 1`] = `
 ====================================options=====================================
 parsers: ["flow"]
@@ -30,6 +65,41 @@ var bad = (x: number): string => x; // Error!
 var ident = <T>(x: T): T => x;
 (ident(1): number);
 (ident("hi"): number); // Error
+
+================================================================================
+`;
+
+exports[`arrows.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function selectBestEffortImageForWidth(
+    maxWidth: number,
+    images: Array<Image>
+): Image {
+    var maxPixelWidth = maxWidth;
+    //images = images.sort(function (a, b) { return a.width - b.width });
+    images = images.sort((a, b) => (a.width - b.width) + "");
+    return images.find(image => image.width >= maxPixelWidth) ||
+        images[images.length - 1];
+}
+
+=====================================output=====================================
+function selectBestEffortImageForWidth(
+  maxWidth: number,
+  images: Array<Image>,
+): Image {
+  var maxPixelWidth = maxWidth;
+  //images = images.sort(function (a, b) { return a.width - b.width });
+  images = images.sort((a, b) => a.width - b.width + "");
+  return (
+    images.find((image) => image.width >= maxPixelWidth)
+    || images[images.length - 1]
+  );
+}
 
 ================================================================================
 `;

--- a/tests/format/flow-repo/arrows/jsfmt.spec.js
+++ b/tests/format/flow-repo/arrows/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(import.meta, ["flow"]);
+run_spec(import.meta, ["flow"], { experimentalOperatorLocation: true });

--- a/tests/format/flow-repo/arrows/jsfmt.spec.js
+++ b/tests/format/flow-repo/arrows/jsfmt.spec.js
@@ -1,2 +1,2 @@
 run_spec(import.meta, ["flow"]);
-run_spec(import.meta, ["flow"], { experimentalOperatorLocation: true });
+run_spec(import.meta, ["flow"], { experimentalOperatorPosition: true });

--- a/tests/format/flow-repo/intersection/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow-repo/intersection/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`intersection.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`intersection.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -53,9 +53,9 @@ function bar(x: Error & { type: number }): number {
 ================================================================================
 `;
 
-exports[`objassign.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`objassign.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -122,9 +122,9 @@ let y: ObjAssignT = { ...x }; // should be fine
 ================================================================================
 `;
 
-exports[`pred.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`pred.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -253,9 +253,9 @@ function hasObjectMode_ok(options: DuplexStreamOptions): boolean {
 ================================================================================
 `;
 
-exports[`test_fun.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`test_fun.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -402,9 +402,9 @@ var g: (_: number | string) => void = f;
 ================================================================================
 `;
 
-exports[`test_obj.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`test_obj.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["flow"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/flow-repo/intersection/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow-repo/intersection/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`intersection.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function foo(x: $All<Error,{type:number}>): number {
+    return x.type;
+}
+
+function bar(x: Error & {type:number}): number {
+    return x.type;
+}
+
+=====================================output=====================================
+function foo(x: $All<Error, { type: number }>): number {
+  return x.type;
+}
+
+function bar(x: Error & { type: number }): number {
+  return x.type;
+}
+
+================================================================================
+`;
+
 exports[`intersection.js format 1`] = `
 ====================================options=====================================
 parsers: ["flow"]
@@ -22,6 +49,41 @@ function foo(x: $All<Error, { type: number }>): number {
 function bar(x: Error & { type: number }): number {
   return x.type;
 }
+
+================================================================================
+`;
+
+exports[`objassign.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+/**
+ * Test intersection of objects flowing to spread assignment.
+ *
+ * Definitions in lib/lib.js
+ *
+ * @noflow
+ */
+
+declare var x: ObjAssignT;
+
+let y: ObjAssignT = { ...x }; // should be fine
+
+=====================================output=====================================
+/**
+ * Test intersection of objects flowing to spread assignment.
+ *
+ * Definitions in lib/lib.js
+ *
+ * @noflow
+ */
+
+declare var x: ObjAssignT;
+
+let y: ObjAssignT = { ...x }; // should be fine
 
 ================================================================================
 `;
@@ -56,6 +118,72 @@ let y: ObjAssignT = { ...x }; // should be fine
 declare var x: ObjAssignT;
 
 let y: ObjAssignT = { ...x }; // should be fine
+
+================================================================================
+`;
+
+exports[`pred.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+/**
+ * Test interaction of object intersections and predicates.
+ * Definitions in lib/lib.js
+ *
+ * @flow
+ */
+
+type DuplexStreamOptions = ReadableStreamOptions & WritableStreamOptions & {
+  allowHalfOpen? : boolean,
+  readableObjectMode? : boolean,
+  writableObjectMode? : boolean
+};
+
+function hasObjectMode_bad(options: DuplexStreamOptions): boolean {
+  return options.objectMode
+    || options.readableObjectMode
+    || options.writableObjectMode; // error, undefined ~> boolean
+}
+
+function hasObjectMode_ok(options: DuplexStreamOptions): boolean {
+  return !!(options.objectMode
+    || options.readableObjectMode
+    || options.writableObjectMode);
+}
+
+=====================================output=====================================
+/**
+ * Test interaction of object intersections and predicates.
+ * Definitions in lib/lib.js
+ *
+ * @flow
+ */
+
+type DuplexStreamOptions = ReadableStreamOptions &
+  WritableStreamOptions & {
+    allowHalfOpen?: boolean,
+    readableObjectMode?: boolean,
+    writableObjectMode?: boolean,
+  };
+
+function hasObjectMode_bad(options: DuplexStreamOptions): boolean {
+  return (
+    options.objectMode
+    || options.readableObjectMode
+    || options.writableObjectMode
+  ); // error, undefined ~> boolean
+}
+
+function hasObjectMode_ok(options: DuplexStreamOptions): boolean {
+  return !!(
+    options.objectMode
+    || options.readableObjectMode
+    || options.writableObjectMode
+  );
+}
 
 ================================================================================
 `;
@@ -121,6 +249,81 @@ function hasObjectMode_ok(options: DuplexStreamOptions): boolean {
     options.writableObjectMode
   );
 }
+
+================================================================================
+`;
+
+exports[`test_fun.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+/**
+ * Tests for intersections of function types.
+ *
+ * Note: Flow abuses intersection types to model
+ * function overloading, which precludes using a
+ * correct intersection of return types in the result.
+ *
+ * Here we test the special case where return types
+ * are equal. Tests of the overloading behavior can
+ * be found in tests/overload
+ *
+ * Definitions lin lib/lib.js
+ *
+ * @noflow
+ */
+
+// intersection of function types satisfies union of param types
+
+type F = (_: ObjA) => void;
+type G = (_: ObjB) => void;
+type FG = (_: ObjA | ObjB) => void;
+
+declare var fun1 : F & G;
+
+(fun1 : FG);
+
+var fun2 : FG = fun1;
+
+// simpler variation
+declare var f : ((_: number) => void) & ((_: string) => void);
+var g: (_: number | string) => void = f;
+
+=====================================output=====================================
+/**
+ * Tests for intersections of function types.
+ *
+ * Note: Flow abuses intersection types to model
+ * function overloading, which precludes using a
+ * correct intersection of return types in the result.
+ *
+ * Here we test the special case where return types
+ * are equal. Tests of the overloading behavior can
+ * be found in tests/overload
+ *
+ * Definitions lin lib/lib.js
+ *
+ * @noflow
+ */
+
+// intersection of function types satisfies union of param types
+
+type F = (_: ObjA) => void;
+type G = (_: ObjB) => void;
+type FG = (_: ObjA | ObjB) => void;
+
+declare var fun1: F & G;
+
+(fun1: FG);
+
+var fun2: FG = fun1;
+
+// simpler variation
+declare var f: ((_: number) => void) & ((_: string) => void);
+var g: (_: number | string) => void = f;
 
 ================================================================================
 `;
@@ -195,6 +398,77 @@ var fun2: FG = fun1;
 // simpler variation
 declare var f: ((_: number) => void) & ((_: string) => void);
 var g: (_: number | string) => void = f;
+
+================================================================================
+`;
+
+exports[`test_obj.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+/**
+ * Tests for intersections of object types
+ *
+ * @noflow
+ */
+
+// TODO we should give explicit errors for incompatibilities
+// which make an intersection uninhabitable:
+// - shared mutable properties with different types
+// - different dictionary types
+//
+// Currently we give no such errors. Instead, we rely on
+// the impossibility of providing a value for such a type
+// to produce errors on value inflows. This is clearly
+// suboptimal, since eg declared vars require no explicit
+// provision of values. This leaves the impossible types
+// free to flow downstream and satisfy impossible constraints.
+
+// intersection of object types satisfies union of properties
+declare var a: A;
+var b: B = a;
+
+// intersection of dictionary types:
+declare var c: C;
+var d: D = c; // ok
+
+// dict type mismatch
+type E = { [key: string]: string };
+var e: E = c; // error
+
+=====================================output=====================================
+/**
+ * Tests for intersections of object types
+ *
+ * @noflow
+ */
+
+// TODO we should give explicit errors for incompatibilities
+// which make an intersection uninhabitable:
+// - shared mutable properties with different types
+// - different dictionary types
+//
+// Currently we give no such errors. Instead, we rely on
+// the impossibility of providing a value for such a type
+// to produce errors on value inflows. This is clearly
+// suboptimal, since eg declared vars require no explicit
+// provision of values. This leaves the impossible types
+// free to flow downstream and satisfy impossible constraints.
+
+// intersection of object types satisfies union of properties
+declare var a: A;
+var b: B = a;
+
+// intersection of dictionary types:
+declare var c: C;
+var d: D = c; // ok
+
+// dict type mismatch
+type E = { [key: string]: string };
+var e: E = c; // error
 
 ================================================================================
 `;

--- a/tests/format/flow-repo/intersection/jsfmt.spec.js
+++ b/tests/format/flow-repo/intersection/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(import.meta, ["flow"]);
+run_spec(import.meta, ["flow"], { experimentalOperatorLocation: true });

--- a/tests/format/flow-repo/intersection/jsfmt.spec.js
+++ b/tests/format/flow-repo/intersection/jsfmt.spec.js
@@ -1,2 +1,2 @@
 run_spec(import.meta, ["flow"]);
-run_spec(import.meta, ["flow"], { experimentalOperatorLocation: true });
+run_spec(import.meta, ["flow"], { experimentalOperatorPosition: true });

--- a/tests/format/html/basics/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/html/basics/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,40 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`broken-html.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<!-- 
+#7241, 
+reproduction:
+two different element,
+linebreak
+\`<\`
+extra space(s)
+-->
+<div><span>
+
+
+
+<                                           
+
+=====================================output=====================================
+<!-- 
+#7241, 
+reproduction:
+two different element,
+linebreak
+\`<\`
+extra space(s)
+-->
+<div><span> < </span></div>
+
+================================================================================
+`;
+
 exports[`broken-html.html format 1`] = `
 ====================================options=====================================
 parsers: ["html"]
@@ -34,6 +69,21 @@ extra space(s)
 ================================================================================
 `;
 
+exports[`comment.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<!--hello world-->
+
+=====================================output=====================================
+<!--hello world-->
+
+================================================================================
+`;
+
 exports[`comment.html format 1`] = `
 ====================================options=====================================
 parsers: ["html"]
@@ -48,6 +98,19 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`empty.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+
+=====================================output=====================================
+
+================================================================================
+`;
+
 exports[`empty.html format 1`] = `
 ====================================options=====================================
 parsers: ["html"]
@@ -56,6 +119,29 @@ printWidth: 80
 =====================================input======================================
 
 =====================================output=====================================
+
+================================================================================
+`;
+
+exports[`empty-doc.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<!doctype html>
+<html>
+<head></head>
+<body></body>
+</html>
+
+=====================================output=====================================
+<!doctype html>
+<html>
+  <head></head>
+  <body></body>
+</html>
 
 ================================================================================
 `;
@@ -78,6 +164,197 @@ printWidth: 80
   <head></head>
   <body></body>
 </html>
+
+================================================================================
+`;
+
+exports[`form.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<form>
+  <div class="form-group">
+    <label for="exampleInputEmail1">Email address</label>
+    <input type="email" class="form-control" id="exampleInputEmail1" aria-describedby="emailHelp" placeholder="Enter email">
+    <small id="emailHelp" class="form-text text-muted">We'll never share your email with anyone else.</small>
+  </div>
+  <div class="form-group">
+    <label for="exampleInputPassword1">Password</label>
+    <input type="password" class="form-control" id="exampleInputPassword1" placeholder="Password">
+  </div>
+  <div class="form-group">
+    <label for="exampleSelect1">Example select</label>
+    <select class="form-control" id="exampleSelect1">
+      <option>1</option>
+      <option>2</option>
+      <option>3</option>
+      <option>4</option>
+      <option>5</option>
+    </select>
+  </div>
+  <div class="form-group">
+    <label for="exampleSelect2">Example multiple select</label>
+    <select multiple class="form-control" id="exampleSelect2">
+      <option>1</option>
+      <option>2</option>
+      <option>3</option>
+      <option>4</option>
+      <option>5</option>
+    </select>
+  </div>
+  <div class="form-group">
+    <label for="exampleTextarea">Example textarea</label>
+    <textarea class="form-control" id="exampleTextarea" rows="3"></textarea>
+  </div>
+  <div class="form-group">
+    <label for="exampleInputFile">File input</label>
+    <input type="file" class="form-control-file" id="exampleInputFile" aria-describedby="fileHelp">
+    <small id="fileHelp" class="form-text text-muted">This is some placeholder block-level help text for the above input. It's a bit lighter and easily wraps to a new line.</small>
+  </div>
+  <fieldset class="form-group">
+    <legend>Radio buttons</legend>
+    <div class="form-check">
+      <label class="form-check-label">
+        <input type="radio" class="form-check-input" name="optionsRadios" id="optionsRadios1" value="option1" checked>
+        Option one is this and that&mdash;be sure to include why it's great
+      </label>
+    </div>
+    <div class="form-check">
+      <label class="form-check-label">
+        <input type="radio" class="form-check-input" name="optionsRadios" id="optionsRadios2" value="option2">
+        Option two can be something else and selecting it will deselect option one
+      </label>
+    </div>
+    <div class="form-check disabled">
+      <label class="form-check-label">
+        <input type="radio" class="form-check-input" name="optionsRadios" id="optionsRadios3" value="option3" disabled>
+        Option three is disabled
+      </label>
+    </div>
+  </fieldset>
+  <div class="form-check">
+    <label class="form-check-label">
+      <input type="checkbox" class="form-check-input">
+      Check me out
+    </label>
+  </div>
+  <button type="submit" class="btn btn-primary">Submit</button>
+</form>
+
+=====================================output=====================================
+<form>
+  <div class="form-group">
+    <label for="exampleInputEmail1">Email address</label>
+    <input
+      type="email"
+      class="form-control"
+      id="exampleInputEmail1"
+      aria-describedby="emailHelp"
+      placeholder="Enter email"
+    />
+    <small id="emailHelp" class="form-text text-muted"
+      >We'll never share your email with anyone else.</small
+    >
+  </div>
+  <div class="form-group">
+    <label for="exampleInputPassword1">Password</label>
+    <input
+      type="password"
+      class="form-control"
+      id="exampleInputPassword1"
+      placeholder="Password"
+    />
+  </div>
+  <div class="form-group">
+    <label for="exampleSelect1">Example select</label>
+    <select class="form-control" id="exampleSelect1">
+      <option>1</option>
+      <option>2</option>
+      <option>3</option>
+      <option>4</option>
+      <option>5</option>
+    </select>
+  </div>
+  <div class="form-group">
+    <label for="exampleSelect2">Example multiple select</label>
+    <select multiple class="form-control" id="exampleSelect2">
+      <option>1</option>
+      <option>2</option>
+      <option>3</option>
+      <option>4</option>
+      <option>5</option>
+    </select>
+  </div>
+  <div class="form-group">
+    <label for="exampleTextarea">Example textarea</label>
+    <textarea class="form-control" id="exampleTextarea" rows="3"></textarea>
+  </div>
+  <div class="form-group">
+    <label for="exampleInputFile">File input</label>
+    <input
+      type="file"
+      class="form-control-file"
+      id="exampleInputFile"
+      aria-describedby="fileHelp"
+    />
+    <small id="fileHelp" class="form-text text-muted"
+      >This is some placeholder block-level help text for the above input. It's
+      a bit lighter and easily wraps to a new line.</small
+    >
+  </div>
+  <fieldset class="form-group">
+    <legend>Radio buttons</legend>
+    <div class="form-check">
+      <label class="form-check-label">
+        <input
+          type="radio"
+          class="form-check-input"
+          name="optionsRadios"
+          id="optionsRadios1"
+          value="option1"
+          checked
+        />
+        Option one is this and that&mdash;be sure to include why it's great
+      </label>
+    </div>
+    <div class="form-check">
+      <label class="form-check-label">
+        <input
+          type="radio"
+          class="form-check-input"
+          name="optionsRadios"
+          id="optionsRadios2"
+          value="option2"
+        />
+        Option two can be something else and selecting it will deselect option
+        one
+      </label>
+    </div>
+    <div class="form-check disabled">
+      <label class="form-check-label">
+        <input
+          type="radio"
+          class="form-check-input"
+          name="optionsRadios"
+          id="optionsRadios3"
+          value="option3"
+          disabled
+        />
+        Option three is disabled
+      </label>
+    </div>
+  </fieldset>
+  <div class="form-check">
+    <label class="form-check-label">
+      <input type="checkbox" class="form-check-input" />
+      Check me out
+    </label>
+  </div>
+  <button type="submit" class="btn btn-primary">Submit</button>
+</form>
 
 ================================================================================
 `;
@@ -272,6 +549,46 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`hello-world.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="ie=edge">
+    <title>Document</title>
+</head>
+<body>
+    <!-- A comment -->
+    <h1>Hello World</h1>
+</body>
+</html>
+
+
+=====================================output=====================================
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta http-equiv="X-UA-Compatible" content="ie=edge" />
+    <title>Document</title>
+  </head>
+  <body>
+    <!-- A comment -->
+    <h1>Hello World</h1>
+  </body>
+</html>
+
+================================================================================
+`;
+
 exports[`hello-world.html format 1`] = `
 ====================================options=====================================
 parsers: ["html"]
@@ -311,6 +628,33 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`html-comments.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<!-- htmlhint attr-lowercase: false -->
+<html>
+  <body>
+    <a href="#">Anchor</a>
+    <div hidden class="foo" id=bar></div>
+  </body>
+</html>
+
+=====================================output=====================================
+<!-- htmlhint attr-lowercase: false -->
+<html>
+  <body>
+    <a href="#">Anchor</a>
+    <div hidden class="foo" id="bar"></div>
+  </body>
+</html>
+
+================================================================================
+`;
+
 exports[`html-comments.html format 1`] = `
 ====================================options=====================================
 parsers: ["html"]
@@ -331,6 +675,122 @@ printWidth: 80
   <body>
     <a href="#">Anchor</a>
     <div hidden class="foo" id="bar"></div>
+  </body>
+</html>
+
+================================================================================
+`;
+
+exports[`html5-boilerplate.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<!doctype html>
+<html class="no-js" lang="">
+
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <title></title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <link rel="manifest" href="site.webmanifest">
+    <link rel="apple-touch-icon" href="icon.png">
+    <!-- Place favicon.ico in the root directory -->
+
+    <link rel="stylesheet" href="css/normalize.css">
+    <link rel="stylesheet" href="css/main.css">
+  </head>
+
+  <body>
+    <!--[if lte IE 9]>
+    <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="https://browsehappy.com/">upgrade your browser</a> to improve your experience and security.</p>
+    <![endif]-->
+
+    <!-- Add your site or application content here -->
+    <p>Hello world! This is HTML5 Boilerplate.</p>
+    <script src="js/vendor/modernizr-3.6.0.min.js"></script>
+    <script src="https://code.jquery.com/jquery-3.3.1.min.js" integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8=" crossorigin="anonymous"></script>
+    <script>window.jQuery || document.write('<script src="js/vendor/jquery-3.3.1.min.js"><\\/script>')</script>
+    <script src="js/plugins.js"></script>
+    <script src="js/main.js"></script>
+
+    <!-- Google Analytics: change UA-XXXXX-Y to be your site's ID. -->
+    <script>
+      window.ga = function () { ga.q.push(arguments) }; ga.q = []; ga.l = +new Date;
+      ga('create', 'UA-XXXXX-Y', 'auto'); ga('send', 'pageview')
+    </script>
+    <script src="https://www.google-analytics.com/analytics.js" async defer></script>
+  </body>
+
+</html>
+
+=====================================output=====================================
+<!doctype html>
+<html class="no-js" lang="">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="x-ua-compatible" content="ie=edge" />
+    <title></title>
+    <meta name="description" content="" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+
+    <link rel="manifest" href="site.webmanifest" />
+    <link rel="apple-touch-icon" href="icon.png" />
+    <!-- Place favicon.ico in the root directory -->
+
+    <link rel="stylesheet" href="css/normalize.css" />
+    <link rel="stylesheet" href="css/main.css" />
+  </head>
+
+  <body>
+    <!--[if lte IE 9]>
+      <p class="browserupgrade">
+        You are using an <strong>outdated</strong> browser. Please
+        <a href="https://browsehappy.com/">upgrade your browser</a> to improve
+        your experience and security.
+      </p>
+    <![endif]-->
+
+    <!-- Add your site or application content here -->
+    <p>Hello world! This is HTML5 Boilerplate.</p>
+    <script src="js/vendor/modernizr-3.6.0.min.js"></script>
+    <script
+      src="https://code.jquery.com/jquery-3.3.1.min.js"
+      integrity="sha256-FgpCb/KJQlLNfOu91ta32o/NMZxltwRo8QtmkMRdAu8="
+      crossorigin="anonymous"
+    ></script>
+    <script>
+      window.jQuery
+        || document.write(
+          '<script src="js/vendor/jquery-3.3.1.min.js"><\\/script>',
+        );
+    </script>
+    <script src="js/plugins.js"></script>
+    <script src="js/main.js"></script>
+
+    <!-- Google Analytics: change UA-XXXXX-Y to be your site's ID. -->
+    <script>
+      window.ga = function () {
+        ga.q.push(arguments);
+      };
+      ga.q = [];
+      ga.l = +new Date();
+      ga("create", "UA-XXXXX-Y", "auto");
+      ga("send", "pageview");
+    </script>
+    <script
+      src="https://www.google-analytics.com/analytics.js"
+      async
+      defer
+    ></script>
   </body>
 </html>
 
@@ -452,6 +912,21 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`issue-9368.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<strong>a</strong>-&gt;<strong>b</strong>-&gt;
+
+=====================================output=====================================
+<strong>a</strong>-&gt;<strong>b</strong>-&gt;
+
+================================================================================
+`;
+
 exports[`issue-9368.html format 1`] = `
 ====================================options=====================================
 parsers: ["html"]
@@ -462,6 +937,21 @@ printWidth: 80
 
 =====================================output=====================================
 <strong>a</strong>-&gt;<strong>b</strong>-&gt;
+
+================================================================================
+`;
+
+exports[`issue-9368-2.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<strong>a</strong>-<strong>b</strong>-
+
+=====================================output=====================================
+<strong>a</strong>-<strong>b</strong>-
 
 ================================================================================
 `;
@@ -480,6 +970,21 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`issue-9368-3.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+a track<strong>pad</strong>, or a <strong>gyro</strong>scope.
+
+=====================================output=====================================
+a track<strong>pad</strong>, or a <strong>gyro</strong>scope.
+
+================================================================================
+`;
+
 exports[`issue-9368-3.html format 1`] = `
 ====================================options=====================================
 parsers: ["html"]
@@ -490,6 +995,33 @@ a track<strong>pad</strong>, or a <strong>gyro</strong>scope.
 
 =====================================output=====================================
 a track<strong>pad</strong>, or a <strong>gyro</strong>scope.
+
+================================================================================
+`;
+
+exports[`more-html.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<html>
+<head></head>
+<body>
+    <a href="#">Anchor</a>
+    <div hidden class="foo" id=bar></div>
+</body>
+</html>
+
+=====================================output=====================================
+<html>
+  <head></head>
+  <body>
+    <a href="#">Anchor</a>
+    <div hidden class="foo" id="bar"></div>
+  </body>
+</html>
 
 ================================================================================
 `;
@@ -520,6 +1052,33 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`void-elements.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<html>
+<head>
+  <meta charset="UTF-8">
+  <link rel="stylesheet" href="code-guide.css">
+</head>
+<body></body>
+</html>
+
+=====================================output=====================================
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="stylesheet" href="code-guide.css" />
+  </head>
+  <body></body>
+</html>
+
+================================================================================
+`;
+
 exports[`void-elements.html format 1`] = `
 ====================================options=====================================
 parsers: ["html"]
@@ -542,6 +1101,46 @@ printWidth: 80
   </head>
   <body></body>
 </html>
+
+================================================================================
+`;
+
+exports[`void-elements-2.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<video controls width="250">
+    <source src="/media/examples/flower.webm"
+            type="video/webm">
+    <source src="/media/examples/flower.mp4"
+            type="video/mp4"
+></video>text after
+
+<!-- #8626 -->
+<object data="horse.wav"><param name="autoplay" value="true"
+><param name="autoplay" value="true"
+></object>1
+
+<span><img  src="1.png"
+><img src="1.png"
+></span>1
+
+=====================================output=====================================
+<video controls width="250">
+  <source src="/media/examples/flower.webm" type="video/webm" />
+  <source src="/media/examples/flower.mp4" type="video/mp4" /></video
+>text after
+
+<!-- #8626 -->
+<object data="horse.wav">
+  <param name="autoplay" value="true" />
+  <param name="autoplay" value="true" /></object
+>1
+
+<span><img src="1.png" /><img src="1.png" /></span>1
 
 ================================================================================
 `;
@@ -581,6 +1180,404 @@ printWidth: 80
 >1
 
 <span><img src="1.png" /><img src="1.png" /></span>1
+
+================================================================================
+`;
+
+exports[`with-colon.html - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<!-- unknown tag with colon -->
+<div>
+<foo:bar>
+<div> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block </div>
+<div> block </div><DIV> BLOCK </DIV> <div> block </div><div> block </div><div> block </div>
+<pre> pre pr
+e</pre>
+<textarea> pre-wrap pr
+e-wrap </textarea>
+<span> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline </span>
+<span> inline </span><span> inline </span> <span> inline </span><span> inline </span>
+<html:div> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block </html:div>
+<html:DIV> block </html:DIV><HTML:DIV> BLOCK </HTML:DIV> <html:div> block </html:div><html:div> block </html:div><html:div> block </html:div>
+<html:pre> pre pr
+e</html:pre>
+<html:textarea> pre-wrap pr
+e-wrap </html:textarea>
+<html:span> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline </html:span>
+<html:span> inline </html:span><html:span> inline </html:span> <html:span> inline </html:span><html:span> inline </html:span></foo:bar>
+</div>
+
+<!-- block tag with colon -->
+<div>
+<foo:div>
+<div> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block </div>
+<div> block </div><DIV> BLOCK </DIV> <div> block </div><div> block </div><div> block </div>
+<pre> pre pr
+e</pre>
+<textarea> pre-wrap pr
+e-wrap </textarea>
+<span> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline </span>
+<span> inline </span><span> inline </span> <span> inline </span><span> inline </span>
+<html:div> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block </html:div>
+<html:DIV> block </html:DIV><HTML:DIV> BLOCK </HTML:DIV> <html:div> block </html:div><html:div> block </html:div><html:div> block </html:div>
+<html:pre> pre pr
+e</html:pre>
+<html:textarea> pre-wrap pr
+e-wrap </html:textarea>
+<html:span> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline </html:span>
+<html:span> inline </html:span><html:span> inline </html:span> <html:span> inline </html:span><html:span> inline </html:span></foo:div>
+</div>
+
+<!-- inline tag with colon -->
+<div>
+<foo:span>
+<div> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block </div>
+<div> block </div><DIV> BLOCK </DIV> <div> block </div><div> block </div><div> block </div>
+<pre> pre pr
+e</pre>
+<textarea> pre-wrap pr
+e-wrap </textarea>
+<span> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline </span>
+<span> inline </span><span> inline </span> <span> inline </span><span> inline </span>
+<html:div> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block </html:div>
+<html:DIV> block </html:DIV><HTML:DIV> BLOCK </HTML:DIV> <html:div> block </html:div><html:div> block </html:div><html:div> block </html:div>
+<html:pre> pre pr
+e</html:pre>
+<html:textarea> pre-wrap pr
+e-wrap </html:textarea>
+<html:span> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline </html:span>
+<html:span> inline </html:span><html:span> inline </html:span> <html:span> inline </html:span><html:span> inline </html:span></foo:span>
+</div>
+
+<!-- unknown -->
+<div>
+<foo-bar>
+<div> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block </div>
+<div> block </div><DIV> BLOCK </DIV> <div> block </div><div> block </div><div> block </div>
+<pre> pre pr
+e</pre>
+<textarea> pre-wrap pr
+e-wrap </textarea>
+<span> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline </span>
+<span> inline </span><span> inline </span> <span> inline </span><span> inline </span>
+<html:div> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block </html:div>
+<html:DIV> block </html:DIV><HTML:DIV> BLOCK </HTML:DIV> <html:div> block </html:div><html:div> block </html:div><html:div> block </html:div>
+<html:pre> pre pr
+e</html:pre>
+<html:textarea> pre-wrap pr
+e-wrap </html:textarea>
+<html:span> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline </html:span>
+<html:span> inline </html:span><html:span> inline </html:span> <html:span> inline </html:span><html:span> inline </html:span></foo-bar>
+</div>
+
+<!-- without colon -->
+<div>
+<div>
+<div> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block </div>
+<div> block </div><DIV> BLOCK </DIV> <div> block </div><div> block </div><div> block </div>
+<pre> pre pr
+e</pre>
+<textarea> pre-wrap pr
+e-wrap </textarea>
+<span> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline </span>
+<span> inline </span><span> inline </span> <span> inline </span><span> inline </span>
+<html:div> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block </html:div>
+<html:DIV> block </html:DIV><HTML:DIV> BLOCK </HTML:DIV> <html:div> block </html:div><html:div> block </html:div><html:div> block </html:div>
+<html:pre> pre pr
+e</html:pre>
+<html:textarea> pre-wrap pr
+e-wrap </html:textarea>
+<html:span> looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline </html:span>
+<html:span> inline </html:span><html:span> inline </html:span> <html:span> inline </html:span><html:span> inline </html:span></div>
+</div>
+
+<!-- #7236 -->
+<with:colon>
+  <div><h1> text  text  text  text  text  text  text  text  text  text  text  text  text  text </h1></div>
+  <script>
+  const func = function() { console.log('Hello, there');}
+  </script>
+  </with:colon>
+
+<!-- script like -->
+<with:colon>
+<style>.a{color:#f00}</style>
+  <SCRIPT>
+  const func = function() { console.log('Hello, there');}
+  </SCRIPT>
+<STYLE>.A{COLOR:#F00}</STYLE>
+<html:script>const func = function() { console.log('Hello, there');}</html:script>
+<html:style>.a{color:#f00}</html:style>
+<svg><style>.a{color:#f00}</style></svg>
+<svg><style>.a{color:#f00}</style></svg>
+</with:colon>
+<html:script>const func = function() { console.log('Hello, there');}</html:script>
+<html:style>.a{color:#f00}</html:style>
+
+=====================================output=====================================
+<!-- unknown tag with colon -->
+<div>
+  <foo:bar>
+    <div>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block
+    </div>
+    <div>block</div>
+    <div>BLOCK</div>
+    <div>block</div>
+    <div>block</div>
+    <div>block</div>
+    <pre>
+ pre pr
+e</pre
+    >
+    <textarea>
+ pre-wrap pr
+e-wrap </textarea
+    >
+    <span>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline
+    </span>
+    <span> inline </span><span> inline </span> <span> inline </span
+    ><span> inline </span>
+    <html:div>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block
+    </html:div>
+    <html:DIV> block </html:DIV><HTML:DIV> BLOCK </HTML:DIV>
+    <html:div> block </html:div><html:div> block </html:div
+    ><html:div> block </html:div>
+    <html:pre> pre pr e</html:pre>
+    <html:textarea> pre-wrap pr e-wrap </html:textarea>
+    <html:span>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline
+    </html:span>
+    <html:span> inline </html:span><html:span> inline </html:span>
+    <html:span> inline </html:span><html:span> inline </html:span></foo:bar
+  >
+</div>
+
+<!-- block tag with colon -->
+<div>
+  <foo:div>
+    <div>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block
+    </div>
+    <div>block</div>
+    <div>BLOCK</div>
+    <div>block</div>
+    <div>block</div>
+    <div>block</div>
+    <pre>
+ pre pr
+e</pre
+    >
+    <textarea>
+ pre-wrap pr
+e-wrap </textarea
+    >
+    <span>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline
+    </span>
+    <span> inline </span><span> inline </span> <span> inline </span
+    ><span> inline </span>
+    <html:div>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block
+    </html:div>
+    <html:DIV> block </html:DIV><HTML:DIV> BLOCK </HTML:DIV>
+    <html:div> block </html:div><html:div> block </html:div
+    ><html:div> block </html:div>
+    <html:pre> pre pr e</html:pre>
+    <html:textarea> pre-wrap pr e-wrap </html:textarea>
+    <html:span>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline
+    </html:span>
+    <html:span> inline </html:span><html:span> inline </html:span>
+    <html:span> inline </html:span><html:span> inline </html:span></foo:div
+  >
+</div>
+
+<!-- inline tag with colon -->
+<div>
+  <foo:span>
+    <div>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block
+    </div>
+    <div>block</div>
+    <div>BLOCK</div>
+    <div>block</div>
+    <div>block</div>
+    <div>block</div>
+    <pre>
+ pre pr
+e</pre
+    >
+    <textarea>
+ pre-wrap pr
+e-wrap </textarea
+    >
+    <span>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline
+    </span>
+    <span> inline </span><span> inline </span> <span> inline </span
+    ><span> inline </span>
+    <html:div>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block
+    </html:div>
+    <html:DIV> block </html:DIV><HTML:DIV> BLOCK </HTML:DIV>
+    <html:div> block </html:div><html:div> block </html:div
+    ><html:div> block </html:div>
+    <html:pre> pre pr e</html:pre>
+    <html:textarea> pre-wrap pr e-wrap </html:textarea>
+    <html:span>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline
+    </html:span>
+    <html:span> inline </html:span><html:span> inline </html:span>
+    <html:span> inline </html:span><html:span> inline </html:span></foo:span
+  >
+</div>
+
+<!-- unknown -->
+<div>
+  <foo-bar>
+    <div>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block
+    </div>
+    <div>block</div>
+    <div>BLOCK</div>
+    <div>block</div>
+    <div>block</div>
+    <div>block</div>
+    <pre>
+ pre pr
+e</pre
+    >
+    <textarea>
+ pre-wrap pr
+e-wrap </textarea
+    >
+    <span>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline
+    </span>
+    <span> inline </span><span> inline </span> <span> inline </span
+    ><span> inline </span>
+    <html:div>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block
+    </html:div>
+    <html:DIV> block </html:DIV><HTML:DIV> BLOCK </HTML:DIV>
+    <html:div> block </html:div><html:div> block </html:div
+    ><html:div> block </html:div>
+    <html:pre> pre pr e</html:pre>
+    <html:textarea> pre-wrap pr e-wrap </html:textarea>
+    <html:span>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline
+    </html:span>
+    <html:span> inline </html:span><html:span> inline </html:span>
+    <html:span> inline </html:span><html:span> inline </html:span></foo-bar
+  >
+</div>
+
+<!-- without colon -->
+<div>
+  <div>
+    <div>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block
+    </div>
+    <div>block</div>
+    <div>BLOCK</div>
+    <div>block</div>
+    <div>block</div>
+    <div>block</div>
+    <pre>
+ pre pr
+e</pre
+    >
+    <textarea>
+ pre-wrap pr
+e-wrap </textarea
+    >
+    <span>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline
+    </span>
+    <span> inline </span><span> inline </span> <span> inline </span
+    ><span> inline </span>
+    <html:div>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog block
+    </html:div>
+    <html:DIV> block </html:DIV><HTML:DIV> BLOCK </HTML:DIV>
+    <html:div> block </html:div><html:div> block </html:div
+    ><html:div> block </html:div>
+    <html:pre> pre pr e</html:pre>
+    <html:textarea> pre-wrap pr e-wrap </html:textarea>
+    <html:span>
+      looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline
+    </html:span>
+    <html:span> inline </html:span><html:span> inline </html:span>
+    <html:span> inline </html:span><html:span> inline </html:span>
+  </div>
+</div>
+
+<!-- #7236 -->
+<with:colon>
+  <div>
+    <h1>
+      text text text text text text text text text text text text text text
+    </h1>
+  </div>
+  <script>
+    const func = function () {
+      console.log("Hello, there");
+    };
+  </script>
+</with:colon>
+
+<!-- script like -->
+<with:colon>
+  <style>
+    .a {
+      color: #f00;
+    }
+  </style>
+  <script>
+    const func = function () {
+      console.log("Hello, there");
+    };
+  </script>
+  <style>
+    .A {
+      color: #f00;
+    }
+  </style>
+  <html:script
+    >const func = function() { console.log('Hello, there');}</html:script
+  >
+  <html:style
+    >.a{color:#f00}</html:style
+  >
+  <svg>
+    <style>
+      .a {
+        color: #f00;
+      }
+    </style>
+  </svg>
+  <svg>
+    <style>
+      .a {
+        color: #f00;
+      }
+    </style>
+  </svg>
+</with:colon>
+<html:script
+  >const func = function() { console.log('Hello, there');}</html:script
+>
+<html:style
+  >.a{color:#f00}</html:style
+>
 
 ================================================================================
 `;

--- a/tests/format/html/basics/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/html/basics/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`broken-html.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`broken-html.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["html"]
 printWidth: 80
                                                                                 | printWidth
@@ -69,9 +69,9 @@ extra space(s)
 ================================================================================
 `;
 
-exports[`comment.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`comment.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["html"]
 printWidth: 80
                                                                                 | printWidth
@@ -98,9 +98,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`empty.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`empty.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["html"]
 printWidth: 80
                                                                                 | printWidth
@@ -123,9 +123,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`empty-doc.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`empty-doc.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["html"]
 printWidth: 80
                                                                                 | printWidth
@@ -168,9 +168,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`form.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`form.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["html"]
 printWidth: 80
                                                                                 | printWidth
@@ -549,9 +549,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`hello-world.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`hello-world.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["html"]
 printWidth: 80
                                                                                 | printWidth
@@ -628,9 +628,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`html-comments.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`html-comments.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["html"]
 printWidth: 80
                                                                                 | printWidth
@@ -681,9 +681,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`html5-boilerplate.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`html5-boilerplate.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["html"]
 printWidth: 80
                                                                                 | printWidth
@@ -912,9 +912,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`issue-9368.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-9368.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["html"]
 printWidth: 80
                                                                                 | printWidth
@@ -941,9 +941,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`issue-9368-2.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-9368-2.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["html"]
 printWidth: 80
                                                                                 | printWidth
@@ -970,9 +970,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`issue-9368-3.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-9368-3.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["html"]
 printWidth: 80
                                                                                 | printWidth
@@ -999,9 +999,9 @@ a track<strong>pad</strong>, or a <strong>gyro</strong>scope.
 ================================================================================
 `;
 
-exports[`more-html.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`more-html.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["html"]
 printWidth: 80
                                                                                 | printWidth
@@ -1052,9 +1052,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`void-elements.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`void-elements.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["html"]
 printWidth: 80
                                                                                 | printWidth
@@ -1105,9 +1105,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`void-elements-2.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`void-elements-2.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["html"]
 printWidth: 80
                                                                                 | printWidth
@@ -1184,9 +1184,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`with-colon.html - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`with-colon.html - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["html"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/html/basics/jsfmt.spec.js
+++ b/tests/format/html/basics/jsfmt.spec.js
@@ -1,2 +1,2 @@
 run_spec(import.meta, ["html"]);
-run_spec(import.meta, ["html"], { experimentalOperatorLocation: true });
+run_spec(import.meta, ["html"], { experimentalOperatorPosition: true });

--- a/tests/format/html/basics/jsfmt.spec.js
+++ b/tests/format/html/basics/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(import.meta, ["html"]);
+run_spec(import.meta, ["html"], { experimentalOperatorLocation: true });

--- a/tests/format/js/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -82,6 +82,89 @@ a = (b) => {
 ================================================================================
 `;
 
+exports[`arrow_function_expression.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+(a => {}).length
+typeof (() => {});
+export default (() => {})();
+(() => {})()\`\`;
+(() => {})\`\`;
+new (() => {});
+if ((() => {}) ? 1 : 0) {}
+let f = () => ({}())
+let a = () => ({} instanceof a);
+a = () => ({} && a);
+a = () => ({}() && a);
+a = () => ({} && a && b);
+a = () => ({} + a);
+a = () => ({}()() && a);
+a = () => ({}.b && a);
+a = () => ({}[b] && a);
+a = () => ({}\`\` && a);
+a = () => ({} = 0);
+a = () => ({}, a);
+a => a instanceof {};
+a => ({}().b && 0)
+a => ({}().c = 0)
+x => ({}()())
+x => ({}()\`\`)
+x => ({}().b);
+a = b => c;
+x => (y = z);
+x => (y += z);
+f(a => ({})) + 1;
+(a => ({})) || 0;
+a = b => c;
+a = b => {
+  return c
+};
+
+=====================================output=====================================
+(a => {}).length;
+typeof (() => {});
+export default (() => {})();
+(() => {})()\`\`;
+(() => {})\`\`;
+new (() => {})();
+if ((() => {}) ? 1 : 0) {
+}
+let f = () => ({}());
+let a = () => ({} instanceof a);
+a = () => ({} && a);
+a = () => ({}() && a);
+a = () => ({} && a && b);
+a = () => ({} + a);
+a = () => ({}()() && a);
+a = () => ({}.b && a);
+a = () => ({}[b] && a);
+a = () => ({}\`\` && a);
+a = () => ({} = 0);
+a = () => ({}, a);
+a => a instanceof {};
+a => ({}().b && 0);
+a => ({}().c = 0);
+x => ({}()());
+x => ({}()\`\`);
+x => ({}().b);
+a = b => c;
+x => (y = z);
+x => (y += z);
+f(a => ({})) + 1;
+(a => ({})) || 0;
+a = b => c;
+a = b => {
+  return c;
+};
+
+================================================================================
+`;
+
 exports[`arrow_function_expression.js - {"arrowParens":"avoid"} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
@@ -191,6 +274,45 @@ x =
 
 x2 =
   (a) =>
+  (
+    askTrovenaBeenaDependsRowans1,
+    askTrovenaBeenaDependsRowans2,
+    askTrovenaBeenaDependsRowans3,
+  ) => {
+    c();
+  } /* ! */; // KABOOM
+
+================================================================================
+`;
+
+exports[`arrow-chain-with-trailing-comments.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+x = (bifornCringerMoshedPerplexSawder) => ((askTrovenaBeenaDependsRowans, glimseGlyphsHazardNoopsTieTie) => (f00) => {
+  averredBathersBoxroomBuggyNurl();
+} // BOOM
+)
+
+x2 = (a) => ((askTrovenaBeenaDependsRowans1, askTrovenaBeenaDependsRowans2, askTrovenaBeenaDependsRowans3) => {
+  c();
+} /* ! */ // KABOOM
+)
+
+=====================================output=====================================
+x =
+  bifornCringerMoshedPerplexSawder =>
+  (askTrovenaBeenaDependsRowans, glimseGlyphsHazardNoopsTieTie) =>
+  f00 => {
+    averredBathersBoxroomBuggyNurl();
+  }; // BOOM
+
+x2 =
+  a =>
   (
     askTrovenaBeenaDependsRowans1,
     askTrovenaBeenaDependsRowans2,
@@ -340,6 +462,105 @@ const bifornCringer3 =
 ================================================================================
 `;
 
+exports[`assignment-chain-with-arrow-chain.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+bifornCringer = askTrovenaBeenaDepends = glimseGlyphs = (
+  argumentOne,
+  argumentTwo,
+) => restOfTheArguments12345678 => {
+  return "baz";
+};
+
+bifornCringer = askTrovenaBeenaDepends = glimseGlyphs = (
+  argumentOne,
+  argumentTwo,
+  argumentThree
+) => restOfTheArguments12345678 => {
+  return "baz";
+};
+
+bifornCringer = askTrovenaBeenaDepends = glimseGlyphs = (
+  argumentOne,
+  argumentTwo,
+  argumentThree
+) => {
+  return "baz";
+};
+
+const bifornCringer1 =
+  askTrovenaBeenaDepends =
+  glimseGlyphs =
+    (argumentOne, argumentTwo) => (restOfTheArguments12345678) => {
+      return "baz";
+    };
+
+const bifornCringer2 =
+  askTrovenaBeenaDepends =
+  glimseGlyphs =
+    (argumentOne, argumentTwo, argumentThree) =>
+    (restOfTheArguments12345678) => {
+      return "baz";
+    };
+
+const bifornCringer3 =
+  askTrovenaBeenaDepends =
+  glimseGlyphs =
+    (argumentOne, argumentTwo, argumentThree) => {
+      return "baz";
+    };
+
+=====================================output=====================================
+bifornCringer =
+  askTrovenaBeenaDepends =
+  glimseGlyphs =
+    (argumentOne, argumentTwo) => restOfTheArguments12345678 => {
+      return "baz";
+    };
+
+bifornCringer =
+  askTrovenaBeenaDepends =
+  glimseGlyphs =
+    (argumentOne, argumentTwo, argumentThree) => restOfTheArguments12345678 => {
+      return "baz";
+    };
+
+bifornCringer =
+  askTrovenaBeenaDepends =
+  glimseGlyphs =
+    (argumentOne, argumentTwo, argumentThree) => {
+      return "baz";
+    };
+
+const bifornCringer1 =
+  (askTrovenaBeenaDepends =
+  glimseGlyphs =
+    (argumentOne, argumentTwo) => restOfTheArguments12345678 => {
+      return "baz";
+    });
+
+const bifornCringer2 =
+  (askTrovenaBeenaDepends =
+  glimseGlyphs =
+    (argumentOne, argumentTwo, argumentThree) => restOfTheArguments12345678 => {
+      return "baz";
+    });
+
+const bifornCringer3 =
+  (askTrovenaBeenaDepends =
+  glimseGlyphs =
+    (argumentOne, argumentTwo, argumentThree) => {
+      return "baz";
+    });
+
+================================================================================
+`;
+
 exports[`assignment-chain-with-arrow-chain.js - {"arrowParens":"avoid"} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
@@ -441,6 +662,22 @@ const bifornCringer3 =
 exports[`block_like.js - {"arrowParens":"always"} format 1`] = `
 ====================================options=====================================
 arrowParens: "always"
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+a = () => ({} = this);
+
+=====================================output=====================================
+a = () => ({} = this);
+
+================================================================================
+`;
+
+exports[`block_like.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+experimentalOperatorLocation: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1255,6 +1492,804 @@ foo(
   (
     a = 1 +
       f({
+        a,
+
+        b,
+      }),
+  ) => {},
+);
+
+================================================================================
+`;
+
+exports[`call.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+Seq(typeDef.interface.groups).forEach(group =>
+  Seq(group.members).forEach((member, memberName) =>
+    markdownDoc(
+      member.doc,
+      { typePath: typePath.concat(memberName.slice(1)),
+       signatures: member.signatures }
+    )
+  )
+)
+
+const promiseFromCallback = fn =>
+  new Promise((resolve, reject) =>
+    fn((err, result) => {
+      if (err) return reject(err);
+      return resolve(result);
+    })
+  );
+
+runtimeAgent.getProperties(
+  objectId,
+  false, // ownProperties
+  false, // accessorPropertiesOnly
+  false, // generatePreview
+  (error, properties, internalProperties) => {
+    return 1
+  },
+);
+
+function render() {
+  return (
+    <View>
+      <Image
+        onProgress={(e) => this.setState({progress: Math.round(100 * e.nativeEvent.loaded / e.nativeEvent.total)})}
+      />
+    </View>
+  );
+}
+
+function render() {
+  return (
+    <View>
+      <Image
+        onProgress={e =>
+          this.setState({
+            progress: Math.round(
+              100 * e.nativeEvent.loaded / e.nativeEvent.total,
+            ),
+          })}
+      />
+    </View>
+  );
+}
+
+function render() {
+  return (
+    <View>
+      <Image
+        onProgress={e =>
+          this.setState({
+            progress: Math.round(
+              100 * e.nativeEvent.loaded / e.nativeEvent.total,
+            ),
+          })}
+      />
+    </View>
+  );
+}
+
+jest.mock(
+  '../SearchSource',
+  () => class {
+    findMatchingTests(pattern) {
+      return {paths: []};
+    }
+  },
+);
+
+fooooooooooooooooooooooooooooooooooooooooooooooooooo(action => next =>
+    dispatch(action),
+);
+
+foo(
+  ({
+    a,
+
+    b
+  }) => {}
+);
+
+foo(
+  ({
+    a,
+    b
+
+  }) => {}
+);
+
+foo(
+  ({
+    a,
+    b
+  }) => {}
+);
+
+foo(
+  a,
+  ({
+    a,
+
+    b
+  }) => {}
+)
+
+foo(
+  ({
+    a,
+
+    b
+  }) => a
+);
+
+foo(
+  ({
+    a,
+    b
+  }) => a
+);
+
+foo(
+  ({
+    a,
+    b
+
+  }) => a
+);
+
+foo(
+  ({
+    a: {
+      a,
+
+      b
+    }
+  }) => {}
+);
+
+foo(
+  ({
+    a: {
+      b: {
+        c,
+
+        d
+      }
+    }
+  }) => {}
+);
+
+foo(
+  ({
+    a: {
+      b: {
+        c: {
+          d,
+
+          e
+        }
+      }
+    }
+  }) => {}
+);
+
+foo(
+  ({
+    a: {
+      a,
+
+      b
+    }
+  }) => a
+);
+
+foo(
+  ({
+    a: {
+      b: {
+        c,
+
+        d
+      }
+    }
+  }) => a
+);
+
+foo(
+  ({
+    a: {
+      b: {
+        c: {
+          d,
+
+          e
+        }
+      }
+    }
+  }) => a
+);
+
+foo(
+  ([
+    {
+      a: {
+        b: {
+          c: {
+            d,
+
+            e
+          }
+        }
+      }
+    }
+  ]) => {}
+);
+
+foo(
+  ([
+    ...{
+      a: {
+        b: {
+          c: {
+            d,
+
+            e
+          }
+        }
+      }
+    }
+  ]) => {}
+);
+
+foo(
+  (
+    n = {
+      a: {
+        b: {
+          c: {
+            d,
+
+            e
+          }
+        }
+      }
+    }
+  ) => {}
+);
+
+foo(
+  ({
+    x: [
+      {
+        a,
+
+        b
+      }
+    ]
+  }) => {}
+);
+
+foo(
+  (
+    a = [
+      {
+        a,
+
+        b
+      }
+    ]
+  ) => a
+);
+
+foo(
+  ([
+    [
+      {
+        a,
+
+        b
+      }
+    ]
+  ]) => {}
+);
+
+foo(
+  ([
+    [
+      [
+        [
+          {
+            a,
+            b: {
+              c,
+              d: {
+                e,
+
+                f
+              }
+            }
+          }
+        ]
+      ]
+    ]
+  ]) => {}
+);
+
+foo(
+  (
+    ...{
+      a,
+
+      b
+    }
+  ) => {}
+);
+
+foo(
+  (
+    ...[
+      {
+        a,
+
+        b
+      }
+    ]
+  ) => {}
+);
+
+foo(
+  ([
+    ...[
+      {
+        a,
+
+        b
+      }
+    ]
+  ]) => {}
+);
+
+foo(
+  (
+    a = [{
+      a,
+
+      b
+    }]
+  ) => {}
+);
+
+foo(
+  (
+    a = (({
+      a,
+
+      b
+    }) => {})()
+  ) => {}
+);
+
+foo(
+  (
+    a = f({
+      a,
+
+      b
+    })
+  ) => {}
+);
+
+foo(
+  (
+    a = ({
+      a,
+
+      b
+    }) => {}
+  ) => {}
+);
+
+foo(
+  (
+    a = 1 +
+      f({
+        a,
+
+        b
+      })
+  ) => {}
+);
+
+=====================================output=====================================
+Seq(typeDef.interface.groups).forEach(group =>
+  Seq(group.members).forEach((member, memberName) =>
+    markdownDoc(member.doc, {
+      typePath: typePath.concat(memberName.slice(1)),
+      signatures: member.signatures,
+    }),
+  ),
+);
+
+const promiseFromCallback = fn =>
+  new Promise((resolve, reject) =>
+    fn((err, result) => {
+      if (err) return reject(err);
+      return resolve(result);
+    }),
+  );
+
+runtimeAgent.getProperties(
+  objectId,
+  false, // ownProperties
+  false, // accessorPropertiesOnly
+  false, // generatePreview
+  (error, properties, internalProperties) => {
+    return 1;
+  },
+);
+
+function render() {
+  return (
+    <View>
+      <Image
+        onProgress={e =>
+          this.setState({
+            progress: Math.round(
+              (100 * e.nativeEvent.loaded) / e.nativeEvent.total,
+            ),
+          })
+        }
+      />
+    </View>
+  );
+}
+
+function render() {
+  return (
+    <View>
+      <Image
+        onProgress={e =>
+          this.setState({
+            progress: Math.round(
+              (100 * e.nativeEvent.loaded) / e.nativeEvent.total,
+            ),
+          })
+        }
+      />
+    </View>
+  );
+}
+
+function render() {
+  return (
+    <View>
+      <Image
+        onProgress={e =>
+          this.setState({
+            progress: Math.round(
+              (100 * e.nativeEvent.loaded) / e.nativeEvent.total,
+            ),
+          })
+        }
+      />
+    </View>
+  );
+}
+
+jest.mock(
+  "../SearchSource",
+  () =>
+    class {
+      findMatchingTests(pattern) {
+        return { paths: [] };
+      }
+    },
+);
+
+fooooooooooooooooooooooooooooooooooooooooooooooooooo(
+  action => next => dispatch(action),
+);
+
+foo(
+  ({
+    a,
+
+    b,
+  }) => {},
+);
+
+foo(({ a, b }) => {});
+
+foo(({ a, b }) => {});
+
+foo(
+  a,
+  ({
+    a,
+
+    b,
+  }) => {},
+);
+
+foo(
+  ({
+    a,
+
+    b,
+  }) => a,
+);
+
+foo(({ a, b }) => a);
+
+foo(({ a, b }) => a);
+
+foo(
+  ({
+    a: {
+      a,
+
+      b,
+    },
+  }) => {},
+);
+
+foo(
+  ({
+    a: {
+      b: {
+        c,
+
+        d,
+      },
+    },
+  }) => {},
+);
+
+foo(
+  ({
+    a: {
+      b: {
+        c: {
+          d,
+
+          e,
+        },
+      },
+    },
+  }) => {},
+);
+
+foo(
+  ({
+    a: {
+      a,
+
+      b,
+    },
+  }) => a,
+);
+
+foo(
+  ({
+    a: {
+      b: {
+        c,
+
+        d,
+      },
+    },
+  }) => a,
+);
+
+foo(
+  ({
+    a: {
+      b: {
+        c: {
+          d,
+
+          e,
+        },
+      },
+    },
+  }) => a,
+);
+
+foo(
+  ([
+    {
+      a: {
+        b: {
+          c: {
+            d,
+
+            e,
+          },
+        },
+      },
+    },
+  ]) => {},
+);
+
+foo(
+  ([
+    ...{
+      a: {
+        b: {
+          c: {
+            d,
+
+            e,
+          },
+        },
+      },
+    }
+  ]) => {},
+);
+
+foo(
+  (
+    n = {
+      a: {
+        b: {
+          c: {
+            d,
+
+            e,
+          },
+        },
+      },
+    },
+  ) => {},
+);
+
+foo(
+  ({
+    x: [
+      {
+        a,
+
+        b,
+      },
+    ],
+  }) => {},
+);
+
+foo(
+  (
+    a = [
+      {
+        a,
+
+        b,
+      },
+    ],
+  ) => a,
+);
+
+foo(
+  ([
+    [
+      {
+        a,
+
+        b,
+      },
+    ],
+  ]) => {},
+);
+
+foo(
+  ([
+    [
+      [
+        [
+          {
+            a,
+            b: {
+              c,
+              d: {
+                e,
+
+                f,
+              },
+            },
+          },
+        ],
+      ],
+    ],
+  ]) => {},
+);
+
+foo(
+  (
+    ...{
+      a,
+
+      b,
+    }
+  ) => {},
+);
+
+foo(
+  (
+    ...[
+      {
+        a,
+
+        b,
+      },
+    ]
+  ) => {},
+);
+
+foo(
+  ([
+    ...[
+      {
+        a,
+
+        b,
+      },
+    ]
+  ]) => {},
+);
+
+foo(
+  (
+    a = [
+      {
+        a,
+
+        b,
+      },
+    ],
+  ) => {},
+);
+
+foo(
+  (
+    a = (({
+      a,
+
+      b,
+    }) => {})(),
+  ) => {},
+);
+
+foo(
+  (
+    a = f({
+      a,
+
+      b,
+    }),
+  ) => {},
+);
+
+foo(
+  (
+    a = ({
+      a,
+
+      b,
+    }) => {},
+  ) => {},
+);
+
+foo(
+  (
+    a = 1
+      + f({
         a,
 
         b,
@@ -2150,6 +3185,95 @@ const z = a.b(
 ================================================================================
 `;
 
+exports[`chain-as-arg.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const w = a.b(
+  (
+    c = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+    d = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef"
+  ) =>
+  (e) =>
+    0
+);
+
+const x = a.b(
+  (
+    c = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+    d = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef"
+  ) =>
+  (e) =>
+    0
+)(x);
+
+const y = a.b(
+  1,
+  (
+    c = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+    d = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef"
+  ) =>
+  (e) =>
+    0
+)(x);
+
+const z = a.b(
+  (
+    c = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+    d = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef"
+  ) =>
+  (e) =>
+    0,
+  2
+)(x);
+
+
+=====================================output=====================================
+const w = a.b(
+  (
+    c = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+    d = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+  ) =>
+    e =>
+      0,
+);
+
+const x = a.b(
+  (
+    c = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+    d = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+  ) =>
+    e =>
+      0,
+)(x);
+
+const y = a.b(
+  1,
+  (
+    c = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+    d = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+  ) =>
+    e =>
+      0,
+)(x);
+
+const z = a.b(
+  (
+    c = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+    d = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+  ) =>
+    e =>
+      0,
+  2,
+)(x);
+
+================================================================================
+`;
+
 exports[`chain-as-arg.js - {"arrowParens":"avoid"} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
@@ -2267,6 +3391,36 @@ const x =
 ================================================================================
 `;
 
+exports[`chain-in-logical-expression.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const x = a.b ?? (
+  (
+    c = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+    d = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef"
+  ) =>
+  (e) =>
+    0
+);
+
+=====================================output=====================================
+const x =
+  a.b
+  ?? ((
+    c = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+    d = "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdef",
+  ) =>
+    e =>
+      0);
+
+================================================================================
+`;
+
 exports[`chain-in-logical-expression.js - {"arrowParens":"avoid"} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
@@ -2353,6 +3507,81 @@ export const bem =
    * @returns {String}
    */
   (modifier) =>
+    [
+      ".",
+      css(block),
+      element ? \`__\${css(element)}\` : "",
+      modifier ? \`--\${css(modifier)}\` : "",
+    ].join("");
+
+<FlatList
+  renderItem={(
+    info, // $FlowExpectedError - bad widgetCount type 6, should be Object
+  ) => <span>{info.item.widget.missingProp}</span>}
+  data={data}
+/>;
+
+================================================================================
+`;
+
+exports[`comment.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+/**
+ * Curried function that ends with a BEM CSS Selector
+ *
+ * @param {String} block - the BEM Block you'd like to select.
+ * @returns {Function}
+ */
+export const bem = block =>
+  /**
+   * @param {String} [element] - the BEM Element within that block; if undefined, selects the block itself.
+   * @returns {Function}
+   */
+  element =>
+    /**
+     * @param {?String} [modifier] - the BEM Modifier for the Block or Element; if undefined, selects the Block or Element unmodified.
+     * @returns {String}
+     */
+    modifier =>
+      [
+        ".",
+        css(block),
+        element ? \`__\${css(element)}\` : "",
+        modifier ? \`--\${css(modifier)}\` : ""
+      ].join("");
+
+<FlatList
+  renderItem={(
+    info, // $FlowExpectedError - bad widgetCount type 6, should be Object
+  ) => <span>{info.item.widget.missingProp}</span>}
+  data={data}
+/>
+
+=====================================output=====================================
+/**
+ * Curried function that ends with a BEM CSS Selector
+ *
+ * @param {String} block - the BEM Block you'd like to select.
+ * @returns {Function}
+ */
+export const bem =
+  block =>
+  /**
+   * @param {String} [element] - the BEM Element within that block; if undefined, selects the block itself.
+   * @returns {Function}
+   */
+  element =>
+  /**
+   * @param {?String} [modifier] - the BEM Modifier for the Block or Element; if undefined, selects the Block or Element unmodified.
+   * @returns {String}
+   */
+  modifier =>
     [
       ".",
       css(block),
@@ -2886,6 +4115,439 @@ import(
 ================================================================================
 `;
 
+exports[`curried.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const fn1 = a => 3;
+const fn2 = a => b => 3;
+const fn3 = a => b => c => 3;
+const fn4 = a => b => c => d => 3;
+const fn5 = a => b => c => d => e => 3;
+const fn6 = a => b => c => d => e => g => 3;
+const fn7 = a => b => c => d => e => g => f => 3;
+
+const fn8 = a => ({ foo: bar, bar: baz, baz: foo });
+const fn9 = a => b => ({ foo: bar, bar: baz, baz: foo });
+const fn10 = a => b => c => ({ foo: bar, bar: baz, baz: foo });
+const fn11 = a => b => c => d => ({ foo: bar, bar: baz, baz: foo });
+const fn12 = a => b => c => d => e => ({ foo: bar, bar: baz, baz: foo });
+const fn13 = a => b => c => d => e => g => ({ foo: bar, bar: baz, baz: foo });
+const fn14 = a => b => c => d => e => g => f => ({ foo: bar, bar: baz, baz: foo });
+
+const curryTest =
+    (argument1) =>
+    (argument2) =>
+    (argument3) =>
+    (argument4) =>
+    (argument5) =>
+    (argument6) =>
+    (argument7) =>
+    (argument8) =>
+    (argument9) =>
+    (argument10) =>
+    (argument11) =>
+    (argument12) =>
+      ({
+        foo: argument1,
+        bar: argument2,
+      });
+
+let curryTest2 =
+    (argument1) =>
+    (argument2) =>
+    (argument3) =>
+    (argument4) =>
+    (argument5) =>
+    (argument6) =>
+    (argument7) =>
+    (argument8) =>
+    (argument9) =>
+    (argument10) =>
+    (argument11) =>
+    (argument12) => {
+      const foo = "foo";
+      return foo + "bar";
+    };
+
+curryTest2 =
+    (argument1) =>
+    (argument2) =>
+    (argument3) =>
+    (argument4) =>
+    (argument5) =>
+    (argument6) =>
+    (argument7) =>
+    (argument8) =>
+    (argument9) =>
+    (argument10) =>
+    (argument11) =>
+    (argument12) => {
+      const foo = "foo";
+      return foo + "bar";
+    };
+
+throw (argument1) =>
+(argument2) =>
+(argument3) =>
+(argument4) =>
+(argument5) =>
+(argument6) =>
+(argument7) =>
+(argument8) =>
+(argument9) =>
+(argument10) =>
+(argument11) =>
+(argument12) => {
+  const foo = "foo";
+  return foo + "bar";
+};
+
+foo((argument1) =>
+    (argument2) =>
+    (argument3) =>
+    (argument4) =>
+    (argument5) =>
+    (argument6) =>
+    (argument7) =>
+    (argument8) =>
+    (argument9) =>
+    (argument10) =>
+    (argument11) =>
+    (argument12) => 3);
+
+foo((argument1) =>
+    (argument2) =>
+    (argument3) =>
+    (argument4) =>
+    (argument5) =>
+    (argument6) =>
+    (argument7) =>
+    (argument8) =>
+    (argument9) =>
+    (argument10) =>
+    (argument11) =>
+    (argument12) => ({
+        foo: bar,
+        bar: baz,
+        baz: foo
+    }));
+
+foo(
+    (argument1) =>
+    (argument2) =>
+    (argument3) =>
+    (argument4) =>
+    (argument5) =>
+    (argument6) =>
+    (argument7) =>
+    (argument8) =>
+    (argument9) =>
+    (argument10) =>
+    (argument11) =>
+    (argument12) => {
+      const foo = "foo";
+      return foo + "bar";
+    }
+);
+
+((argument1) =>
+    (argument2) =>
+    (argument3) =>
+    (argument4) =>
+    (argument5) =>
+    (argument6) =>
+    (argument7) =>
+    (argument8) =>
+    (argument9) =>
+    (argument10) =>
+    (argument11) =>
+    (argument12) => 3)(3);
+
+bar(
+  foo(
+    (argument1) =>
+    (argument2) =>
+    (argument3) =>
+    (argument4) =>
+    (argument5) =>
+    (argument6) =>
+    (argument7) =>
+    (argument8) =>
+    (argument9) =>
+    (argument10) =>
+    (argument11) =>
+    (argument12) => ({
+      foo: bar,
+      bar: baz,
+    })
+  )
+);
+
+const baaaz = (aaaaa1, bbbbb1) => (aaaaa2, bbbbb2) => (aaaaa3, bbbbb3) => (aaaaa4, bbbbb4) => ({
+  foo: bar
+});
+
+new Fooooooooooooooooooooooooooooooooooooooooooooooooooo(
+  (action) =>
+    (next) =>
+    (next) =>
+    (next) =>
+    (next) =>
+    (next) =>
+    (next) =>
+    dispatch(action)
+);
+
+foo?.Fooooooooooooooooooooooooooooooooooooooooooooooooooo(
+  (action) =>
+    (next) =>
+    (next) =>
+    (next) =>
+    (next) =>
+    (next) =>
+    (next) =>
+    dispatch(action)
+);
+
+foo(action => action => action);
+
+import( (argument1) =>
+    (argument2) =>
+    (argument3) =>
+    (argument4) =>
+    (argument5) =>
+    (argument6) =>
+    (argument7) =>
+    (argument8) =>
+    (argument9) =>
+    (argument10) =>
+    (argument11) =>
+    (argument12) => {
+      const foo = "foo";
+      return foo + "bar";
+    });
+
+=====================================output=====================================
+const fn1 = a => 3;
+const fn2 = a => b => 3;
+const fn3 = a => b => c => 3;
+const fn4 = a => b => c => d => 3;
+const fn5 = a => b => c => d => e => 3;
+const fn6 = a => b => c => d => e => g => 3;
+const fn7 = a => b => c => d => e => g => f => 3;
+
+const fn8 = a => ({ foo: bar, bar: baz, baz: foo });
+const fn9 = a => b => ({ foo: bar, bar: baz, baz: foo });
+const fn10 = a => b => c => ({ foo: bar, bar: baz, baz: foo });
+const fn11 = a => b => c => d => ({ foo: bar, bar: baz, baz: foo });
+const fn12 = a => b => c => d => e => ({ foo: bar, bar: baz, baz: foo });
+const fn13 = a => b => c => d => e => g => ({ foo: bar, bar: baz, baz: foo });
+const fn14 = a => b => c => d => e => g => f => ({
+  foo: bar,
+  bar: baz,
+  baz: foo,
+});
+
+const curryTest =
+  argument1 =>
+  argument2 =>
+  argument3 =>
+  argument4 =>
+  argument5 =>
+  argument6 =>
+  argument7 =>
+  argument8 =>
+  argument9 =>
+  argument10 =>
+  argument11 =>
+  argument12 => ({
+    foo: argument1,
+    bar: argument2,
+  });
+
+let curryTest2 =
+  argument1 =>
+  argument2 =>
+  argument3 =>
+  argument4 =>
+  argument5 =>
+  argument6 =>
+  argument7 =>
+  argument8 =>
+  argument9 =>
+  argument10 =>
+  argument11 =>
+  argument12 => {
+    const foo = "foo";
+    return foo + "bar";
+  };
+
+curryTest2 =
+  argument1 =>
+  argument2 =>
+  argument3 =>
+  argument4 =>
+  argument5 =>
+  argument6 =>
+  argument7 =>
+  argument8 =>
+  argument9 =>
+  argument10 =>
+  argument11 =>
+  argument12 => {
+    const foo = "foo";
+    return foo + "bar";
+  };
+
+throw argument1 =>
+  argument2 =>
+  argument3 =>
+  argument4 =>
+  argument5 =>
+  argument6 =>
+  argument7 =>
+  argument8 =>
+  argument9 =>
+  argument10 =>
+  argument11 =>
+  argument12 => {
+    const foo = "foo";
+    return foo + "bar";
+  };
+
+foo(
+  argument1 =>
+    argument2 =>
+    argument3 =>
+    argument4 =>
+    argument5 =>
+    argument6 =>
+    argument7 =>
+    argument8 =>
+    argument9 =>
+    argument10 =>
+    argument11 =>
+    argument12 =>
+      3,
+);
+
+foo(
+  argument1 =>
+    argument2 =>
+    argument3 =>
+    argument4 =>
+    argument5 =>
+    argument6 =>
+    argument7 =>
+    argument8 =>
+    argument9 =>
+    argument10 =>
+    argument11 =>
+    argument12 => ({
+      foo: bar,
+      bar: baz,
+      baz: foo,
+    }),
+);
+
+foo(
+  argument1 =>
+    argument2 =>
+    argument3 =>
+    argument4 =>
+    argument5 =>
+    argument6 =>
+    argument7 =>
+    argument8 =>
+    argument9 =>
+    argument10 =>
+    argument11 =>
+    argument12 => {
+      const foo = "foo";
+      return foo + "bar";
+    },
+);
+
+(
+  argument1 =>
+  argument2 =>
+  argument3 =>
+  argument4 =>
+  argument5 =>
+  argument6 =>
+  argument7 =>
+  argument8 =>
+  argument9 =>
+  argument10 =>
+  argument11 =>
+  argument12 =>
+    3
+)(3);
+
+bar(
+  foo(
+    argument1 =>
+      argument2 =>
+      argument3 =>
+      argument4 =>
+      argument5 =>
+      argument6 =>
+      argument7 =>
+      argument8 =>
+      argument9 =>
+      argument10 =>
+      argument11 =>
+      argument12 => ({
+        foo: bar,
+        bar: baz,
+      }),
+  ),
+);
+
+const baaaz =
+  (aaaaa1, bbbbb1) =>
+  (aaaaa2, bbbbb2) =>
+  (aaaaa3, bbbbb3) =>
+  (aaaaa4, bbbbb4) => ({
+    foo: bar,
+  });
+
+new Fooooooooooooooooooooooooooooooooooooooooooooooooooo(
+  action => next => next => next => next => next => next => dispatch(action),
+);
+
+foo?.Fooooooooooooooooooooooooooooooooooooooooooooooooooo(
+  action => next => next => next => next => next => next => dispatch(action),
+);
+
+foo(action => action => action);
+
+import(
+  argument1 =>
+    argument2 =>
+    argument3 =>
+    argument4 =>
+    argument5 =>
+    argument6 =>
+    argument7 =>
+    argument8 =>
+    argument9 =>
+    argument10 =>
+    argument11 =>
+    argument12 => {
+      const foo = "foo";
+      return foo + "bar";
+    }
+);
+
+================================================================================
+`;
+
 exports[`curried.js - {"arrowParens":"avoid"} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
@@ -3365,6 +5027,54 @@ const middleware = (options) => (req, res, next) => {
 ================================================================================
 `;
 
+exports[`currying.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const fn = b => c => d => {
+  return 3;
+};
+
+const foo = (a, b) => c => d => {
+  return 3;
+};
+
+const bar = a => b => c => a + b + c
+
+const mw = store => next => action => {
+  return next(action)
+}
+
+const middleware = options => (req, res, next) => {
+  // ...
+};
+
+=====================================output=====================================
+const fn = b => c => d => {
+  return 3;
+};
+
+const foo = (a, b) => c => d => {
+  return 3;
+};
+
+const bar = a => b => c => a + b + c;
+
+const mw = store => next => action => {
+  return next(action);
+};
+
+const middleware = options => (req, res, next) => {
+  // ...
+};
+
+================================================================================
+`;
+
 exports[`currying.js - {"arrowParens":"avoid"} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
@@ -3456,6 +5166,54 @@ request.get(
     (modyLoremIpsumDolorAbstractProviderFactoryServiceModule) => {
       console.log(head, body);
     },
+);
+
+================================================================================
+`;
+
+exports[`currying-2.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const a =
+  (x) => (y) => (z) =>
+    x / 0.123456789 + (y * calculateSomething(z)) / Math.PI;
+
+request.get('https://preview-9992--prettier.netlify.app', head => body => {
+  console.log(head, body);
+});
+
+request.get('https://preview-9992--prettier.netlify.app', head => body => mody => {
+  console.log(head, body);
+});
+
+request.get('https://preview-9992--prettier.netlify.app', head => body => modyLoremIpsumDolorAbstractProviderFactoryServiceModule => {
+  console.log(head, body);
+});
+=====================================output=====================================
+const a = x => y => z =>
+  x / 0.123456789 + (y * calculateSomething(z)) / Math.PI;
+
+request.get("https://preview-9992--prettier.netlify.app", head => body => {
+  console.log(head, body);
+});
+
+request.get(
+  "https://preview-9992--prettier.netlify.app",
+  head => body => mody => {
+    console.log(head, body);
+  },
+);
+
+request.get(
+  "https://preview-9992--prettier.netlify.app",
+  head => body => modyLoremIpsumDolorAbstractProviderFactoryServiceModule => {
+    console.log(head, body);
+  },
 );
 
 ================================================================================
@@ -3582,6 +5340,85 @@ function f(
   (fooLoremIpsumFactory) =>
   (bazLoremIpsumFactory) =>
   (barLoremIpsumServiceFactory) =>
+    b + fooLoremIpsumFactory(c) - bazLoremIpsumFactory(b + d)
+)(x);
+
+================================================================================
+`;
+
+exports[`currying-3.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+((b) => (c) => (d) => {
+  return 3;
+})(x);
+
+function f(
+  a = (fooLorem) => (bazIpsum) => (barLorem) => {
+    return 3;
+  }
+) {}
+
+(
+  (fooLoremIpsumFactory) =>
+  (bazLoremIpsumFactory) =>
+  (barLoremIpsumServiceFactory) => {
+    return 3;
+  }
+)(x);
+
+(
+  (b) => (c) => (d) =>
+    b + fooLoremIpsumFactory(c) - bazLoremIpsumFactory(b + d)
+)(x, fooLoremIpsumFactory, fooLoremIpsumFactory);
+
+(
+  (fooLorem) => (bazIpsum) => (barLorem) =>
+    b + fooLoremIpsumFactory(c) - bazLoremIpsumFactory(b + d)
+)(boo);
+
+(
+  (fooLoremIpsumFactory) =>
+  (bazLoremIpsumFactory) =>
+  (barLoremIpsumServiceFactory) =>
+    b + fooLoremIpsumFactory(c) - bazLoremIpsumFactory(b + d)
+)(x);
+=====================================output=====================================
+(b => c => d => {
+  return 3;
+})(x);
+
+function f(
+  a = fooLorem => bazIpsum => barLorem => {
+    return 3;
+  },
+) {}
+
+(
+  fooLoremIpsumFactory =>
+  bazLoremIpsumFactory =>
+  barLoremIpsumServiceFactory => {
+    return 3;
+  }
+)(x);
+
+(
+  b => c => d =>
+    b + fooLoremIpsumFactory(c) - bazLoremIpsumFactory(b + d)
+)(x, fooLoremIpsumFactory, fooLoremIpsumFactory);
+
+(
+  fooLorem => bazIpsum => barLorem =>
+    b + fooLoremIpsumFactory(c) - bazLoremIpsumFactory(b + d)
+)(boo);
+
+(
+  fooLoremIpsumFactory => bazLoremIpsumFactory => barLoremIpsumServiceFactory =>
     b + fooLoremIpsumFactory(c) - bazLoremIpsumFactory(b + d)
 )(x);
 
@@ -3725,6 +5562,66 @@ const makeSomeFunction2 =
 ================================================================================
 `;
 
+exports[`issue-1389-curry.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const foobar = (argumentOne, argumentTwo, argumentThree) =>
+  (...restOfTheArguments) => {
+    return "baz";
+  };
+
+const foobaz = (argumentOne, argumentTwo, argumentThree) =>
+  (restOfTheArguments123, j) => {
+    return "baz";
+  };
+
+
+const makeSomeFunction =
+  (services = {logger:null}) =>
+    (a, b, c) =>
+      services.logger(a,b,c)
+
+const makeSomeFunction2 =
+  (services = {
+    logger: null
+  }) =>
+    (a, b, c) =>
+      services.logger(a, b, c)
+
+=====================================output=====================================
+const foobar =
+  (argumentOne, argumentTwo, argumentThree) =>
+  (...restOfTheArguments) => {
+    return "baz";
+  };
+
+const foobaz =
+  (argumentOne, argumentTwo, argumentThree) => (restOfTheArguments123, j) => {
+    return "baz";
+  };
+
+const makeSomeFunction =
+  (services = { logger: null }) =>
+  (a, b, c) =>
+    services.logger(a, b, c);
+
+const makeSomeFunction2 =
+  (
+    services = {
+      logger: null,
+    },
+  ) =>
+  (a, b, c) =>
+    services.logger(a, b, c);
+
+================================================================================
+`;
+
 exports[`issue-1389-curry.js - {"arrowParens":"avoid"} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
@@ -3801,6 +5698,24 @@ const myCurriedFn = (arg1) => (arg2) => (arg3) => arg1 + arg2 + arg3;
 ================================================================================
 `;
 
+exports[`issue-4166-curry.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const myCurriedFn = arg1 =>
+  arg2 =>
+    arg3 => arg1 + arg2 + arg3;
+
+=====================================output=====================================
+const myCurriedFn = arg1 => arg2 => arg3 => arg1 + arg2 + arg3;
+
+================================================================================
+`;
+
 exports[`issue-4166-curry.js - {"arrowParens":"avoid"} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
@@ -3821,6 +5736,25 @@ const myCurriedFn = arg1 => arg2 => arg3 => arg1 + arg2 + arg3;
 exports[`long-call-no-args.js - {"arrowParens":"always"} format 1`] = `
 ====================================options=====================================
 arrowParens: "always"
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+veryLongCall(VERY_VERY_VERY_VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_CONSTANT, () => {})
+
+=====================================output=====================================
+veryLongCall(
+  VERY_VERY_VERY_VERY_VERY_VERY_VERY_VERY_VERY_VERY_LONG_CONSTANT,
+  () => {},
+);
+
+================================================================================
+`;
+
+exports[`long-call-no-args.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+experimentalOperatorLocation: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -3857,6 +5791,31 @@ veryLongCall(
 exports[`long-contents.js - {"arrowParens":"always"} format 1`] = `
 ====================================options=====================================
 arrowParens: "always"
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const foo = () => {
+  expect(arg1, arg2, arg3).toEqual({message: 'test', messageType: 'SMS', status: 'Unknown', created: '11/01/2017 13:36'});
+};
+
+=====================================output=====================================
+const foo = () => {
+  expect(arg1, arg2, arg3).toEqual({
+    message: "test",
+    messageType: "SMS",
+    status: "Unknown",
+    created: "11/01/2017 13:36",
+  });
+};
+
+================================================================================
+`;
+
+exports[`long-contents.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+experimentalOperatorLocation: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -3955,6 +5914,64 @@ foo((a) => b, d);
 
 foo((a) => (0, 1));
 foo((a) => (b) => (0, 1));
+
+================================================================================
+`;
+
+exports[`parens.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+promise.then(
+  (result) => result,
+  (err) => err
+)
+
+promise.then(
+  (result) => { f(); return result },
+  (err) => { f(); return err }
+)
+
+foo(a => b)
+foo(a => { return b })
+foo(c, a => b)
+foo(c, a => b, d)
+foo(a => b, d)
+
+foo(a => (0, 1));
+foo(a => b => (0, 1));
+
+=====================================output=====================================
+promise.then(
+  result => result,
+  err => err,
+);
+
+promise.then(
+  result => {
+    f();
+    return result;
+  },
+  err => {
+    f();
+    return err;
+  },
+);
+
+foo(a => b);
+foo(a => {
+  return b;
+});
+foo(c, a => b);
+foo(c, a => b, d);
+foo(a => b, d);
+
+foo(a => (0, 1));
+foo(a => b => (0, 1));
 
 ================================================================================
 `;
@@ -4105,6 +6122,112 @@ const fn12 = (a) => (b) => (c) => (d) => (e) => #{
   bar: baz,
   baz: foo,
 };
+
+map(() => [
+  // comment
+  foo,
+]);
+
+map(() => #[
+  // comment
+  foo,
+]);
+
+map(() => ({
+  // comment
+  foo,
+}));
+
+map(() => #{
+  // comment
+  foo,
+});
+
+================================================================================
+`;
+
+exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} [acorn] format 1`] = `
+"Identifier 'fn12' has already been declared (4:7)
+  2 |   ({ foo: bar, bar: baz, baz: foo });
+  3 |
+> 4 | const fn12 = (a) => (b) => (c) => (d) => (e) =>
+    |       ^
+  5 |   (#{ foo: bar, bar: baz, baz: foo });
+  6 |
+  7 | map(() => (["
+`;
+
+exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} [espree] format 1`] = `
+"Identifier 'fn12' has already been declared (4:7)
+  2 |   ({ foo: bar, bar: baz, baz: foo });
+  3 |
+> 4 | const fn12 = (a) => (b) => (c) => (d) => (e) =>
+    |       ^
+  5 |   (#{ foo: bar, bar: baz, baz: foo });
+  6 |
+  7 | map(() => (["
+`;
+
+exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} [meriyah] format 1`] = `
+"'#' not followed by identifier (5:4)
+  3 |
+  4 | const fn12 = (a) => (b) => (c) => (d) => (e) =>
+> 5 |   (#{ foo: bar, bar: baz, baz: foo });
+    |    ^
+  6 |
+  7 | map(() => ([
+  8 |   // comment"
+`;
+
+exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} [typescript] format 1`] = `
+"Invalid character. (5:4)
+  3 |
+  4 | const fn12 = (a) => (b) => (c) => (d) => (e) =>
+> 5 |   (#{ foo: bar, bar: baz, baz: foo });
+    |    ^
+  6 |
+  7 | map(() => ([
+  8 |   // comment"
+`;
+
+exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const fn12 = (a) => (b) => (c) => (d) => (e) =>
+  ({ foo: bar, bar: baz, baz: foo });
+
+const fn12 = (a) => (b) => (c) => (d) => (e) =>
+  (#{ foo: bar, bar: baz, baz: foo });
+
+map(() => ([
+  // comment
+  foo
+]));
+
+map(() => (#[
+  // comment
+  foo
+]));
+
+map(() => ({
+  // comment
+  foo
+}));
+
+map(() => (#{
+  // comment
+  foo
+}));
+
+=====================================output=====================================
+const fn12 = a => b => c => d => e => ({ foo: bar, bar: baz, baz: foo });
+
+const fn12 = a => b => c => d => e => #{ foo: bar, bar: baz, baz: foo };
 
 map(() => [
   // comment

--- a/tests/format/js/arrows/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/arrows/__snapshots__/jsfmt.spec.js.snap
@@ -82,10 +82,10 @@ a = (b) => {
 ================================================================================
 `;
 
-exports[`arrow_function_expression.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+exports[`arrow_function_expression.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -285,10 +285,10 @@ x2 =
 ================================================================================
 `;
 
-exports[`arrow-chain-with-trailing-comments.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+exports[`arrow-chain-with-trailing-comments.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -462,10 +462,10 @@ const bifornCringer3 =
 ================================================================================
 `;
 
-exports[`assignment-chain-with-arrow-chain.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+exports[`assignment-chain-with-arrow-chain.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -674,10 +674,10 @@ a = () => ({} = this);
 ================================================================================
 `;
 
-exports[`block_like.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+exports[`block_like.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1502,10 +1502,10 @@ foo(
 ================================================================================
 `;
 
-exports[`call.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+exports[`call.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -3185,10 +3185,10 @@ const z = a.b(
 ================================================================================
 `;
 
-exports[`chain-as-arg.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+exports[`chain-as-arg.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -3391,10 +3391,10 @@ const x =
 ================================================================================
 `;
 
-exports[`chain-in-logical-expression.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+exports[`chain-in-logical-expression.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -3524,10 +3524,10 @@ export const bem =
 ================================================================================
 `;
 
-exports[`comment.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+exports[`comment.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -4115,10 +4115,10 @@ import(
 ================================================================================
 `;
 
-exports[`curried.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+exports[`curried.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -5027,10 +5027,10 @@ const middleware = (options) => (req, res, next) => {
 ================================================================================
 `;
 
-exports[`currying.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+exports[`currying.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -5171,10 +5171,10 @@ request.get(
 ================================================================================
 `;
 
-exports[`currying-2.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+exports[`currying-2.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -5346,10 +5346,10 @@ function f(
 ================================================================================
 `;
 
-exports[`currying-3.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+exports[`currying-3.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -5562,10 +5562,10 @@ const makeSomeFunction2 =
 ================================================================================
 `;
 
-exports[`issue-1389-curry.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-1389-curry.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -5698,10 +5698,10 @@ const myCurriedFn = (arg1) => (arg2) => (arg3) => arg1 + arg2 + arg3;
 ================================================================================
 `;
 
-exports[`issue-4166-curry.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-4166-curry.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -5751,10 +5751,10 @@ veryLongCall(
 ================================================================================
 `;
 
-exports[`long-call-no-args.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+exports[`long-call-no-args.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -5812,10 +5812,10 @@ const foo = () => {
 ================================================================================
 `;
 
-exports[`long-contents.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+exports[`long-contents.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -5918,10 +5918,10 @@ foo((a) => (b) => (0, 1));
 ================================================================================
 `;
 
-exports[`parens.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+exports[`parens.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -6146,7 +6146,7 @@ map(() => #{
 ================================================================================
 `;
 
-exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} [acorn] format 1`] = `
+exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} [acorn] format 1`] = `
 "Identifier 'fn12' has already been declared (4:7)
   2 |   ({ foo: bar, bar: baz, baz: foo });
   3 |
@@ -6157,7 +6157,7 @@ exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorLocat
   7 | map(() => (["
 `;
 
-exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} [espree] format 1`] = `
+exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} [espree] format 1`] = `
 "Identifier 'fn12' has already been declared (4:7)
   2 |   ({ foo: bar, bar: baz, baz: foo });
   3 |
@@ -6168,7 +6168,7 @@ exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorLocat
   7 | map(() => (["
 `;
 
-exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} [meriyah] format 1`] = `
+exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} [meriyah] format 1`] = `
 "'#' not followed by identifier (5:4)
   3 |
   4 | const fn12 = (a) => (b) => (c) => (d) => (e) =>
@@ -6179,7 +6179,7 @@ exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorLocat
   8 |   // comment"
 `;
 
-exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} [typescript] format 1`] = `
+exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} [typescript] format 1`] = `
 "Invalid character. (5:4)
   3 |
   4 | const fn12 = (a) => (b) => (c) => (d) => (e) =>
@@ -6190,10 +6190,10 @@ exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorLocat
   8 |   // comment"
 `;
 
-exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorLocation":true} format 1`] = `
+exports[`tuple-and-record.js - {"arrowParens":"avoid","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/arrows/jsfmt.spec.js
+++ b/tests/format/js/arrows/jsfmt.spec.js
@@ -13,3 +13,8 @@ run_spec(import.meta, ["babel", "typescript"], {
   arrowParens: "avoid",
   errors,
 });
+run_spec(import.meta, ["babel", "typescript"], {
+  arrowParens: "avoid",
+  experimentalOperatorLocation: true,
+  errors,
+});

--- a/tests/format/js/arrows/jsfmt.spec.js
+++ b/tests/format/js/arrows/jsfmt.spec.js
@@ -15,6 +15,6 @@ run_spec(import.meta, ["babel", "typescript"], {
 });
 run_spec(import.meta, ["babel", "typescript"], {
   arrowParens: "avoid",
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
   errors,
 });

--- a/tests/format/js/assignment-comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/assignment-comments/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`call.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`call.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -53,9 +53,9 @@ if (true)
 ================================================================================
 `;
 
-exports[`call2.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`call2.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -86,9 +86,9 @@ const kochabCooieGameOnOboleUnweave = // ???
 ================================================================================
 `;
 
-exports[`function.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`function.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -343,9 +343,9 @@ let f6 =
 ================================================================================
 `;
 
-exports[`identifier.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`identifier.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -396,9 +396,9 @@ const bifornCringerMoshedPerplexSawder = // !!!
 ================================================================================
 `;
 
-exports[`number.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`number.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -589,9 +589,9 @@ var fnNumber =
 ================================================================================
 `;
 
-exports[`string.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`string.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/assignment-comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/assignment-comments/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`call.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+if (true)
+  if (true)
+    if (true)
+      if (true)
+        if (true)
+          longVariableName1 = // @ts-ignore
+          (variable01 + veryLongVariableNameNumber2).method();
+
+=====================================output=====================================
+if (true)
+  if (true)
+    if (true)
+      if (true)
+        if (true)
+          longVariableName1 = // @ts-ignore
+            (variable01 + veryLongVariableNameNumber2).method();
+
+================================================================================
+`;
+
 exports[`call.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -26,6 +53,23 @@ if (true)
 ================================================================================
 `;
 
+exports[`call2.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const kochabCooieGameOnOboleUnweave = // ???
+      rhubarbRhubarb(annularCooeedSplicesWalksWayWay);
+
+=====================================output=====================================
+const kochabCooieGameOnOboleUnweave = // ???
+  rhubarbRhubarb(annularCooeedSplicesWalksWayWay);
+
+================================================================================
+`;
+
 exports[`call2.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -38,6 +82,135 @@ const kochabCooieGameOnOboleUnweave = // ???
 =====================================output=====================================
 const kochabCooieGameOnOboleUnweave = // ???
   rhubarbRhubarb(annularCooeedSplicesWalksWayWay);
+
+================================================================================
+`;
+
+exports[`function.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+f1 = (
+  a =
+  //comment
+  b
+) => {};
+  
+f2 = (
+  a = //comment
+  b
+) => {};
+  
+f3 = (
+  a =
+  b //comment
+) => {};
+  
+f4 = // Comment
+  () => {};
+
+f5 =
+  
+  // Comment
+  
+ () => {}
+  
+f6 = /* comment */
+  
+  // Comment
+  
+  () => {}
+  
+let f1 = (
+  a =
+  //comment
+  b
+) => {};
+  
+let f2 = (
+  a = //comment
+  b
+) => {};
+  
+let f3 = (
+  a =
+  b //comment
+) => {};
+  
+let f4 = // Comment
+  () => {};
+  
+let f5 =
+  
+  // Comment
+  
+  () => {}
+  
+let f6 = /* comment */
+  
+  // Comment
+  
+  () => {}
+
+=====================================output=====================================
+f1 = (
+  //comment
+  a = b,
+) => {};
+
+f2 = (
+  a = b, //comment
+) => {};
+
+f3 = (
+  a = b, //comment
+) => {};
+
+f4 = // Comment
+  () => {};
+
+f5 =
+  // Comment
+
+  () => {};
+
+f6 =
+  /* comment */
+
+  // Comment
+
+  () => {};
+
+let f1 = (
+  //comment
+  a = b,
+) => {};
+
+let f2 = (
+  a = b, //comment
+) => {};
+
+let f3 = (
+  a = b, //comment
+) => {};
+
+let f4 = // Comment
+  () => {};
+
+let f5 =
+  // Comment
+
+  () => {};
+
+let f6 =
+  /* comment */
+
+  // Comment
+
+  () => {};
 
 ================================================================================
 `;
@@ -170,6 +343,33 @@ let f6 =
 ================================================================================
 `;
 
+exports[`identifier.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const kochabCooieGameOnOboleUnweave = // ???
+      annularCooeedSplicesWalksWayWay;
+
+const bifornCringerMoshedPerplexSawder = // !!!
+  glimseGlyphsHazardNoopsTieTie +
+  averredBathersBoxroomBuggyNurl -
+  anodyneCondosMalateOverateRetinol;
+
+=====================================output=====================================
+const kochabCooieGameOnOboleUnweave = // ???
+  annularCooeedSplicesWalksWayWay;
+
+const bifornCringerMoshedPerplexSawder = // !!!
+  glimseGlyphsHazardNoopsTieTie
+  + averredBathersBoxroomBuggyNurl
+  - anodyneCondosMalateOverateRetinol;
+
+================================================================================
+`;
+
 exports[`identifier.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -192,6 +392,103 @@ const bifornCringerMoshedPerplexSawder = // !!!
   glimseGlyphsHazardNoopsTieTie +
   averredBathersBoxroomBuggyNurl -
   anodyneCondosMalateOverateRetinol;
+
+================================================================================
+`;
+
+exports[`number.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+fnNumber =
+  // Comment
+  3;
+
+fnNumber =
+
+  // Comment
+
+  3;
+
+fnNumber =
+  // Comment0
+  // Comment1
+  3;
+
+fnNumber = /* comment */
+  3;
+
+fnNumber = /* comments0 */
+  /* comments1 */
+  3;
+
+fnNumber =
+  // Comment
+  3;
+
+var fnNumber =
+
+  // Comment
+
+  3;
+
+var fnNumber =
+  // Comment0
+  // Comment1
+  3;
+
+var fnNumber = /* comment */
+  3;
+
+var fnNumber = /* comments0 */
+  /* comments1 */
+  3;
+
+=====================================output=====================================
+fnNumber =
+  // Comment
+  3;
+
+fnNumber =
+  // Comment
+
+  3;
+
+fnNumber =
+  // Comment0
+  // Comment1
+  3;
+
+fnNumber = /* comment */ 3;
+
+fnNumber =
+  /* comments0 */
+  /* comments1 */
+  3;
+
+fnNumber =
+  // Comment
+  3;
+
+var fnNumber =
+  // Comment
+
+  3;
+
+var fnNumber =
+  // Comment0
+  // Comment1
+  3;
+
+var fnNumber = /* comment */ 3;
+
+var fnNumber =
+  /* comments0 */
+  /* comments1 */
+  3;
 
 ================================================================================
 `;
@@ -288,6 +585,175 @@ var fnNumber =
   /* comments0 */
   /* comments1 */
   3;
+
+================================================================================
+`;
+
+exports[`string.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+fnString =
+  // Comment
+  'some' + 'long' + 'string';
+
+fnString =
+  // Comment
+
+  'some' + 'long' + 'string';
+
+fnString =
+
+  // Comment
+
+  'some' + 'long' + 'string';
+
+fnString =
+  /* comment */
+  'some' + 'long' + 'string';
+
+fnString =
+  /**
+   * multi-line
+   */
+  'some' + 'long' + 'string';
+
+fnString =
+  /* inline */ 'some' + 'long' + 'string' + 'some' + 'long' + 'string' + 'some' + 'long' + 'string' + 'some' + 'long' + 'string';
+
+fnString = // Comment0
+  // Comment1
+  'some' + 'long' + 'string';
+
+fnString = // Comment
+  'some' + 'long' + 'string';
+
+fnString =
+  // Comment
+  'some' + 'long' + 'string';
+
+var fnString =
+  // Comment
+
+  'some' + 'long' + 'string';
+
+var fnString =
+
+  // Comment
+
+  'some' + 'long' + 'string';
+
+var fnString =
+  /* comment */
+  'some' + 'long' + 'string';
+
+var fnString =
+  /**
+   * multi-line
+   */
+  'some' + 'long' + 'string';
+
+var fnString =
+  /* inline */ 'some' + 'long' + 'string' + 'some' + 'long' + 'string' + 'some' + 'long' + 'string' + 'some' + 'long' + 'string';
+
+var fnString = // Comment0
+  // Comment1
+  'some' + 'long' + 'string';
+
+var fnString = // Comment
+  'some' + 'long' + 'string';
+
+=====================================output=====================================
+fnString =
+  // Comment
+  "some" + "long" + "string";
+
+fnString =
+  // Comment
+
+  "some" + "long" + "string";
+
+fnString =
+  // Comment
+
+  "some" + "long" + "string";
+
+fnString =
+  /* comment */
+  "some" + "long" + "string";
+
+fnString =
+  /**
+   * multi-line
+   */
+  "some" + "long" + "string";
+
+fnString =
+  /* inline */ "some"
+  + "long"
+  + "string"
+  + "some"
+  + "long"
+  + "string"
+  + "some"
+  + "long"
+  + "string"
+  + "some"
+  + "long"
+  + "string";
+
+fnString = // Comment0
+  // Comment1
+  "some" + "long" + "string";
+
+fnString = "some" + "long" + "string"; // Comment
+
+fnString =
+  // Comment
+  "some" + "long" + "string";
+
+var fnString =
+  // Comment
+
+  "some" + "long" + "string";
+
+var fnString =
+  // Comment
+
+  "some" + "long" + "string";
+
+var fnString =
+  /* comment */
+  "some" + "long" + "string";
+
+var fnString =
+  /**
+   * multi-line
+   */
+  "some" + "long" + "string";
+
+var fnString =
+  /* inline */ "some"
+  + "long"
+  + "string"
+  + "some"
+  + "long"
+  + "string"
+  + "some"
+  + "long"
+  + "string"
+  + "some"
+  + "long"
+  + "string";
+
+var fnString = // Comment0
+  // Comment1
+  "some" + "long" + "string";
+
+var fnString = "some" + "long" + "string"; // Comment
 
 ================================================================================
 `;

--- a/tests/format/js/assignment-comments/jsfmt.spec.js
+++ b/tests/format/js/assignment-comments/jsfmt.spec.js
@@ -1,1 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
+run_spec(import.meta, ["babel", "flow", "typescript"], {
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/assignment-comments/jsfmt.spec.js
+++ b/tests/format/js/assignment-comments/jsfmt.spec.js
@@ -1,4 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
 run_spec(import.meta, ["babel", "flow", "typescript"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/js/assignment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/assignment/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`binaryish.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const computedDescriptionLines = (showConfirm &&
+  descriptionLinesConfirming) ||
+  (focused && !loading && descriptionLinesFocused) ||
+  descriptionLines;
+
+computedDescriptionLines = (focused &&
+  !loading &&
+  descriptionLinesFocused) ||
+  descriptionLines;
+
+=====================================output=====================================
+const computedDescriptionLines =
+  (showConfirm && descriptionLinesConfirming)
+  || (focused && !loading && descriptionLinesFocused)
+  || descriptionLines;
+
+computedDescriptionLines =
+  (focused && !loading && descriptionLinesFocused) || descriptionLines;
+
+================================================================================
+`;
+
 exports[`binaryish.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -24,6 +53,38 @@ const computedDescriptionLines =
 
 computedDescriptionLines =
   (focused && !loading && descriptionLinesFocused) || descriptionLines;
+
+================================================================================
+`;
+
+exports[`call-with-template.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const result = template(\`
+  if (SOME_VAR === "") {}
+\`)({
+  SOME_VAR: value,
+});
+
+const output =
+ template(\`function f() %%A%%\`)({
+   A: t.blockStatement([]),
+ });
+
+=====================================output=====================================
+const result = template(\`
+  if (SOME_VAR === "") {}
+\`)({
+  SOME_VAR: value,
+});
+
+const output = template(\`function f() %%A%%\`)({
+  A: t.blockStatement([]),
+});
 
 ================================================================================
 `;
@@ -55,6 +116,81 @@ const result = template(\`
 const output = template(\`function f() %%A%%\`)({
   A: t.blockStatement([]),
 });
+
+================================================================================
+`;
+
+exports[`chain.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+let bifornCringerMoshedPerplexSawder=
+askTrovenaBeenaDependsRowans=
+glimseGlyphsHazardNoopsTieTie=
+averredBathersBoxroomBuggyNurl=
+anodyneCondosMalateOverateRetinol=
+annularCooeedSplicesWalksWayWay=
+kochabCooieGameOnOboleUnweave;
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans =
+  glimseGlyphsHazardNoopsTieTie =
+  x =
+  averredBathersBoxroomBuggyNurl =
+  anodyneCondosMal(sdsadsa,dasdas,asd(()=>sdf)).ateOverateRetinol =
+  annularCooeedSplicesWalksWayWay =
+    kochabCooieGameOnOboleUnweave;
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans =
+  glimseGlyphsHazardNoopsTieTie =
+  x =
+  averredBathersBoxroomBuggyNurl =
+  anodyneCondosMal(sdsadsa,dasdas,asd(()=>sdf)).ateOverateRetinol =
+  annularCooeedSplicesWalksWayWay =
+    kochabCooieGameOnOboleUnweave+kochabCooieGameOnOboleUnweave;
+
+a=b=c;
+
+=====================================output=====================================
+let bifornCringerMoshedPerplexSawder =
+  (askTrovenaBeenaDependsRowans =
+  glimseGlyphsHazardNoopsTieTie =
+  averredBathersBoxroomBuggyNurl =
+  anodyneCondosMalateOverateRetinol =
+  annularCooeedSplicesWalksWayWay =
+    kochabCooieGameOnOboleUnweave);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans =
+  glimseGlyphsHazardNoopsTieTie =
+  x =
+  averredBathersBoxroomBuggyNurl =
+  anodyneCondosMal(
+    sdsadsa,
+    dasdas,
+    asd(() => sdf),
+  ).ateOverateRetinol =
+  annularCooeedSplicesWalksWayWay =
+    kochabCooieGameOnOboleUnweave;
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans =
+  glimseGlyphsHazardNoopsTieTie =
+  x =
+  averredBathersBoxroomBuggyNurl =
+  anodyneCondosMal(
+    sdsadsa,
+    dasdas,
+    asd(() => sdf),
+  ).ateOverateRetinol =
+  annularCooeedSplicesWalksWayWay =
+    kochabCooieGameOnOboleUnweave + kochabCooieGameOnOboleUnweave;
+
+a = b = c;
 
 ================================================================================
 `;
@@ -133,6 +269,29 @@ a = b = c;
 ================================================================================
 `;
 
+exports[`chain-two-segments.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+tt.parenR.updateContext = tt.braceR.updateContext = function () {
+  if (this.state.context.length === 1) {
+    return;
+  }
+}
+
+=====================================output=====================================
+tt.parenR.updateContext = tt.braceR.updateContext = function () {
+  if (this.state.context.length === 1) {
+    return;
+  }
+};
+
+================================================================================
+`;
+
 exports[`chain-two-segments.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -151,6 +310,45 @@ tt.parenR.updateContext = tt.braceR.updateContext = function () {
     return;
   }
 };
+
+================================================================================
+`;
+
+exports[`destructuring.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+let {
+  bottom: offsetBottom,
+  left: offsetLeft,
+  right: offsetRight,
+  top: offsetTop,
+} = getPressRectOffset == null ? DEFAULT_PRESS_RECT : getPressRectOffset();
+
+const { accessibilityModule: FooAccessibilityModule, accessibilityModule: FooAccessibilityModule2, accessibilityModule: FooAccessibilityModule3, accessibilityModule: FooAccessibilityModule4,
+      } = foo || {};
+
+({ prop: toAssign = "default" } = { prop: "propval" });
+
+=====================================output=====================================
+let {
+  bottom: offsetBottom,
+  left: offsetLeft,
+  right: offsetRight,
+  top: offsetTop,
+} = getPressRectOffset == null ? DEFAULT_PRESS_RECT : getPressRectOffset();
+
+const {
+  accessibilityModule: FooAccessibilityModule,
+  accessibilityModule: FooAccessibilityModule2,
+  accessibilityModule: FooAccessibilityModule3,
+  accessibilityModule: FooAccessibilityModule4,
+} = foo || {};
+
+({ prop: toAssign = "default" } = { prop: "propval" });
 
 ================================================================================
 `;
@@ -193,6 +391,26 @@ const {
 ================================================================================
 `;
 
+exports[`destructuring-array.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const [
+  width= nextWidth,
+  height= nextHeight,
+  baseline= nextBaseline,
+] = measureText(nextText, getFontString(element));
+
+=====================================output=====================================
+const [width = nextWidth, height = nextHeight, baseline = nextBaseline] =
+  measureText(nextText, getFontString(element));
+
+================================================================================
+`;
+
 exports[`destructuring-array.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -208,6 +426,73 @@ const [
 =====================================output=====================================
 const [width = nextWidth, height = nextHeight, baseline = nextBaseline] =
   measureText(nextText, getFontString(element));
+
+================================================================================
+`;
+
+exports[`destructuring-heuristic.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+{{
+  const {
+    id,
+    static: isStatic,
+    method: isMethod,
+    methodId,
+    getId,
+    setId,
+  } = privateNamesMap.get(name);
+
+  const {
+    id1,
+    method: isMethod1,
+    methodId1
+  } = privateNamesMap.get(name);
+
+  const {
+    id2,
+    method: isMethod2,
+    methodId2
+  } = privateNamesMap.get(bifornCringerMoshedPerplexSawder);
+
+  const {
+    id3,
+    method: isMethod3,
+    methodId3
+  } = anodyneCondosMalateOverateRetinol.get(bifornCringerMoshedPerplexSawder);
+}}
+
+=====================================output=====================================
+{
+  {
+    const {
+      id,
+      static: isStatic,
+      method: isMethod,
+      methodId,
+      getId,
+      setId,
+    } = privateNamesMap.get(name);
+
+    const { id1, method: isMethod1, methodId1 } = privateNamesMap.get(name);
+
+    const {
+      id2,
+      method: isMethod2,
+      methodId2,
+    } = privateNamesMap.get(bifornCringerMoshedPerplexSawder);
+
+    const {
+      id3,
+      method: isMethod3,
+      methodId3,
+    } = anodyneCondosMalateOverateRetinol.get(bifornCringerMoshedPerplexSawder);
+  }
+}
 
 ================================================================================
 `;
@@ -278,6 +563,27 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`issue-1419.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+someReallyLongThingStoredInAMapWithAReallyBigName[pageletID] =
+  _someVariableThatWeAreCheckingForFalsiness
+    ? Date.now() - _someVariableThatWeAreCheckingForFalsiness
+    : 0;
+
+=====================================output=====================================
+someReallyLongThingStoredInAMapWithAReallyBigName[pageletID] =
+  _someVariableThatWeAreCheckingForFalsiness
+    ? Date.now() - _someVariableThatWeAreCheckingForFalsiness
+    : 0;
+
+================================================================================
+`;
+
 exports[`issue-1419.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -294,6 +600,32 @@ someReallyLongThingStoredInAMapWithAReallyBigName[pageletID] =
   _someVariableThatWeAreCheckingForFalsiness
     ? Date.now() - _someVariableThatWeAreCheckingForFalsiness
     : 0;
+
+================================================================================
+`;
+
+exports[`issue-1966.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const aVeryLongNameThatGoesOnAndOn = this.someOtherObject.someOtherNestedObject.someLongFunctionName();
+
+this.someObject.someOtherNestedObject = this.someOtherObject.whyNotNestAnotherOne.someLongFunctionName();
+
+this.isaverylongmethodexpression.withmultiplelevels = this.isanotherverylongexpression.thatisalsoassigned = 0;
+
+=====================================output=====================================
+const aVeryLongNameThatGoesOnAndOn =
+  this.someOtherObject.someOtherNestedObject.someLongFunctionName();
+
+this.someObject.someOtherNestedObject =
+  this.someOtherObject.whyNotNestAnotherOne.someLongFunctionName();
+
+this.isaverylongmethodexpression.withmultiplelevels =
+  this.isanotherverylongexpression.thatisalsoassigned = 0;
 
 ================================================================================
 `;
@@ -323,6 +655,27 @@ this.isaverylongmethodexpression.withmultiplelevels =
 ================================================================================
 `;
 
+exports[`issue-2184.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const areaPercentageDiff = (
+    topRankedZoneFit.areaPercentageRemaining
+  - previousZoneFitNow.areaPercentageRemaining
+).toFixed(2)
+
+=====================================output=====================================
+const areaPercentageDiff = (
+  topRankedZoneFit.areaPercentageRemaining
+  - previousZoneFitNow.areaPercentageRemaining
+).toFixed(2);
+
+================================================================================
+`;
+
 exports[`issue-2184.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -339,6 +692,48 @@ const areaPercentageDiff = (
   topRankedZoneFit.areaPercentageRemaining -
   previousZoneFitNow.areaPercentageRemaining
 ).toFixed(2);
+
+================================================================================
+`;
+
+exports[`issue-2482-1.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+  anotherVeryLongNameForIllustrativePurposes;
+
+aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+  'a very long string for illustrative purposes'.length;
+
+aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+  anotherVeryLongNameForIllustrativePurposes();
+
+aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+  anotherVeryLongNameForIllustrativePurposes.length;
+
+aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+  anotherVeryLongNameForIllustrativePurposes + 1;
+
+
+=====================================output=====================================
+aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+  anotherVeryLongNameForIllustrativePurposes;
+
+aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+  "a very long string for illustrative purposes".length;
+
+aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+  anotherVeryLongNameForIllustrativePurposes();
+
+aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+  anotherVeryLongNameForIllustrativePurposes.length;
+
+aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
+  anotherVeryLongNameForIllustrativePurposes + 1;
 
 ================================================================================
 `;
@@ -384,6 +779,34 @@ aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
 ================================================================================
 `;
 
+exports[`issue-2482-2.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+class foo {
+    bar() {
+        const median = dates.length % 2
+            ? dates[half].getTime()
+            : (dates[half - 1].getTime() + dates[half].getTime()) / 2.0;
+    }
+}
+
+=====================================output=====================================
+class foo {
+  bar() {
+    const median =
+      dates.length % 2
+        ? dates[half].getTime()
+        : (dates[half - 1].getTime() + dates[half].getTime()) / 2.0;
+  }
+}
+
+================================================================================
+`;
+
 exports[`issue-2482-2.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -411,6 +834,24 @@ class foo {
 ================================================================================
 `;
 
+exports[`issue-2540.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+manifestCache[templateId] = readFileSync(\`\${MANIFESTS_PATH}/\${templateId}.json\`, { encoding: 'utf-8' });
+
+=====================================output=====================================
+manifestCache[templateId] = readFileSync(
+  \`\${MANIFESTS_PATH}/\${templateId}.json\`,
+  { encoding: "utf-8" },
+);
+
+================================================================================
+`;
+
 exports[`issue-2540.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -424,6 +865,41 @@ manifestCache[templateId] = readFileSync(
   \`\${MANIFESTS_PATH}/\${templateId}.json\`,
   { encoding: "utf-8" },
 );
+
+================================================================================
+`;
+
+exports[`issue-3819.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+this.dummy.type1.dummyPropertyFunction
+      = this.dummy.type2.dummyPropertyFunction
+      = this.dummy.type3.dummyPropertyFunction
+      = this.dummy.type4.dummyPropertyFunction
+      = this.dummy.type5.dummyPropertyFunction
+      = this.dummy.type6.dummyPropertyFunction
+      = this.dummy.type7.dummyPropertyFunction
+      = this.dummy.type8.dummyPropertyFunction
+      = () => {
+        return 'dummy';
+      };
+
+=====================================output=====================================
+this.dummy.type1.dummyPropertyFunction =
+  this.dummy.type2.dummyPropertyFunction =
+  this.dummy.type3.dummyPropertyFunction =
+  this.dummy.type4.dummyPropertyFunction =
+  this.dummy.type5.dummyPropertyFunction =
+  this.dummy.type6.dummyPropertyFunction =
+  this.dummy.type7.dummyPropertyFunction =
+  this.dummy.type8.dummyPropertyFunction =
+    () => {
+      return "dummy";
+    };
 
 ================================================================================
 `;
@@ -462,6 +938,27 @@ this.dummy.type1.dummyPropertyFunction =
 ================================================================================
 `;
 
+exports[`issue-4094.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+if (something) {
+  const otherBrandsWithThisAdjacencyCount123 = Object.values(edge.to.edges).length
+}
+
+=====================================output=====================================
+if (something) {
+  const otherBrandsWithThisAdjacencyCount123 = Object.values(
+    edge.to.edges,
+  ).length;
+}
+
+================================================================================
+`;
+
 exports[`issue-4094.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -478,6 +975,32 @@ if (something) {
     edge.to.edges,
   ).length;
 }
+
+================================================================================
+`;
+
+exports[`issue-5610.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// Function call wrapping is not optimal for readability:
+// Function names tend to get pushed to the right, whereas arguments end up on the left,
+// creating a wide gap that the eyes have to cross in order to read the call.
+const {qfwvfkwjdqgz, bctsyljqucgz, xuodxhmgwwpw} =
+  qbhtcuzxwedz(yrwimwkjeeiu, njwvozigdkfi, alvvjgkmnmhd);
+
+=====================================output=====================================
+// Function call wrapping is not optimal for readability:
+// Function names tend to get pushed to the right, whereas arguments end up on the left,
+// creating a wide gap that the eyes have to cross in order to read the call.
+const { qfwvfkwjdqgz, bctsyljqucgz, xuodxhmgwwpw } = qbhtcuzxwedz(
+  yrwimwkjeeiu,
+  njwvozigdkfi,
+  alvvjgkmnmhd,
+);
 
 ================================================================================
 `;
@@ -502,6 +1025,72 @@ const { qfwvfkwjdqgz, bctsyljqucgz, xuodxhmgwwpw } = qbhtcuzxwedz(
   yrwimwkjeeiu,
   njwvozigdkfi,
   alvvjgkmnmhd,
+);
+
+================================================================================
+`;
+
+exports[`issue-6922.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+async function f() {
+  const { data, status } = await request.delete(
+    \`/account/\${accountId}/documents/\${type}/\${documentNumber}\`,
+    { validateStatus: () => true }
+  );
+  return { data, status };
+}
+
+const data1 = request.delete(
+  '----------------------------------------------',
+  { validateStatus: () => true }
+);
+
+const data2 = request.delete(
+  '----------------------------------------------x',
+  { validateStatus: () => true }
+);
+
+const data3 = request.delete(
+  '----------------------------------------------xx',
+  { validateStatus: () => true }
+);
+
+const data4 = request.delete(
+  '----------------------------------------------xxx',
+  { validateStatus: () => true }
+);
+
+=====================================output=====================================
+async function f() {
+  const { data, status } = await request.delete(
+    \`/account/\${accountId}/documents/\${type}/\${documentNumber}\`,
+    { validateStatus: () => true },
+  );
+  return { data, status };
+}
+
+const data1 = request.delete("----------------------------------------------", {
+  validateStatus: () => true,
+});
+
+const data2 = request.delete(
+  "----------------------------------------------x",
+  { validateStatus: () => true },
+);
+
+const data3 = request.delete(
+  "----------------------------------------------xx",
+  { validateStatus: () => true },
+);
+
+const data4 = request.delete(
+  "----------------------------------------------xxx",
+  { validateStatus: () => true },
 );
 
 ================================================================================
@@ -572,6 +1161,24 @@ const data4 = request.delete(
 ================================================================================
 `;
 
+exports[`issue-7091.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const {
+  imStore, showChat, customerServiceAccount
+} = store[config.reduxStoreName]
+
+=====================================output=====================================
+const { imStore, showChat, customerServiceAccount } =
+  store[config.reduxStoreName];
+
+================================================================================
+`;
+
 exports[`issue-7091.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -585,6 +1192,31 @@ const {
 =====================================output=====================================
 const { imStore, showChat, customerServiceAccount } =
   store[config.reduxStoreName];
+
+================================================================================
+`;
+
+exports[`issue-7572.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const t = {
+  "hello": world(),
+  'this-is-a-very-long-key-and-the-assignment-should-be-put-on-the-next-line':
+  	orMaybeIAmMisunderstandingAndIHaveSetSomethingWrongInMyConfig(),
+  "can-someone-explain": this()
+};
+
+=====================================output=====================================
+const t = {
+  hello: world(),
+  "this-is-a-very-long-key-and-the-assignment-should-be-put-on-the-next-line":
+    orMaybeIAmMisunderstandingAndIHaveSetSomethingWrongInMyConfig(),
+  "can-someone-explain": this(),
+};
 
 ================================================================================
 `;
@@ -613,6 +1245,31 @@ const t = {
 ================================================================================
 `;
 
+exports[`issue-7961.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// works as expected
+something.veeeeeery.looooooooooooooooooooooooooong = some.other.rather.long.chain;
+
+// does not work if it ends with a function call
+something.veeeeeery.looooooooooooooooooooooooooong = some.other.rather.long.chain.functionCall();
+
+=====================================output=====================================
+// works as expected
+something.veeeeeery.looooooooooooooooooooooooooong =
+  some.other.rather.long.chain;
+
+// does not work if it ends with a function call
+something.veeeeeery.looooooooooooooooooooooooooong =
+  some.other.rather.long.chain.functionCall();
+
+================================================================================
+`;
+
 exports[`issue-7961.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -637,6 +1294,28 @@ something.veeeeeery.looooooooooooooooooooooooooong =
 ================================================================================
 `;
 
+exports[`issue-8218.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const pendingIndicators = shield.alarmGeneratorConfiguration.getPendingVersionColumnValues;
+
+const pendingIndicatorz =
+  shield.alarmGeneratorConfiguration.getPendingVersionColumnValues();
+
+=====================================output=====================================
+const pendingIndicators =
+  shield.alarmGeneratorConfiguration.getPendingVersionColumnValues;
+
+const pendingIndicatorz =
+  shield.alarmGeneratorConfiguration.getPendingVersionColumnValues();
+
+================================================================================
+`;
+
 exports[`issue-8218.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -654,6 +1333,35 @@ const pendingIndicators =
 
 const pendingIndicatorz =
   shield.alarmGeneratorConfiguration.getPendingVersionColumnValues();
+
+================================================================================
+`;
+
+exports[`issue-10218.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const _id1 = data.createTestMessageWithAReallyLongName.someVeryLongProperty.thisIsAlsoALongProperty._id;
+
+const {_id2} = data.createTestMessageWithAReallyLongName.someVeryLongProperty.thisIsAlsoALongProperty;
+
+const {_id:id3} = data.createTestMessageWithAReallyLongName.someVeryLongProperty.thisIsAlsoALongProperty;
+
+=====================================output=====================================
+const _id1 =
+  data.createTestMessageWithAReallyLongName.someVeryLongProperty
+    .thisIsAlsoALongProperty._id;
+
+const { _id2 } =
+  data.createTestMessageWithAReallyLongName.someVeryLongProperty
+    .thisIsAlsoALongProperty;
+
+const { _id: id3 } =
+  data.createTestMessageWithAReallyLongName.someVeryLongProperty
+    .thisIsAlsoALongProperty;
 
 ================================================================================
 `;
@@ -682,6 +1390,58 @@ const { _id2 } =
 const { _id: id3 } =
   data.createTestMessageWithAReallyLongName.someVeryLongProperty
     .thisIsAlsoALongProperty;
+
+================================================================================
+`;
+
+exports[`lone-arg.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+let vgChannel = pointPositionDefaultRef({
+  model,
+  defaultPos,
+  channel,
+})()
+
+let vgChannel2 = pointPositionDefaultRef({ model,
+  defaultPos,
+  channel,
+})()
+
+const bifornCringerMoshedPerplexSawderGlyphsHa =
+  someBigFunctionName("foo")("bar");
+
+if (true) {
+  node.id = this.flowParseTypeAnnotatableIdentifier(/*allowPrimitiveOverride*/ true);
+}
+
+const bifornCringerMoshedPerplexSawderGlyphsHb = someBigFunctionName(\`foo
+\`)("bar");
+
+=====================================output=====================================
+let vgChannel = pointPositionDefaultRef({
+  model,
+  defaultPos,
+  channel,
+})();
+
+let vgChannel2 = pointPositionDefaultRef({ model, defaultPos, channel })();
+
+const bifornCringerMoshedPerplexSawderGlyphsHa =
+  someBigFunctionName("foo")("bar");
+
+if (true) {
+  node.id = this.flowParseTypeAnnotatableIdentifier(
+    /*allowPrimitiveOverride*/ true,
+  );
+}
+
+const bifornCringerMoshedPerplexSawderGlyphsHb = someBigFunctionName(\`foo
+\`)("bar");
 
 ================================================================================
 `;
@@ -737,6 +1497,33 @@ const bifornCringerMoshedPerplexSawderGlyphsHb = someBigFunctionName(\`foo
 ================================================================================
 `;
 
+exports[`sequence.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+for ((i = 0), (len = arr.length); i < len; i++) {
+  console.log(arr[i])
+}
+
+for (i = 0, len = arr.length; i < len; i++) {
+  console.log(arr[i])
+}
+
+=====================================output=====================================
+for (i = 0, len = arr.length; i < len; i++) {
+  console.log(arr[i]);
+}
+
+for (i = 0, len = arr.length; i < len; i++) {
+  console.log(arr[i]);
+}
+
+================================================================================
+`;
+
 exports[`sequence.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -759,6 +1546,43 @@ for (i = 0, len = arr.length; i < len; i++) {
 for (i = 0, len = arr.length; i < len; i++) {
   console.log(arr[i]);
 }
+
+================================================================================
+`;
+
+exports[`unary.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const loooooooooooooooooooooooooong1 = void looooooooooooooong.looooooooooooooong.loooooong;
+const loooooooooooooooooooooooooong2 = void "looooooooooooooooooooooooooooooooooooooooooog";
+const loooooooooooooooooooooooooong3 = !looooooooooooooong.looooooooooooooong.loooooong;
+const loooooooooooooooooooooooooong4 = !"looooooooooooooooooooooooooooooooooooooooooog";
+const loooooooooooooooooooooooooong5 = void void looooooooooooooong.looooooooooooooong.loooooong;
+const loooooooooooooooooooooooooong6 = void void "looooooooooooooooooooooooooooooooooooooooooog";
+const loooooooooooooooooooooooooong7 = !!looooooooooooooong.looooooooooooooong.loooooong;
+const loooooooooooooooooooooooooong8 = !!"looooooooooooooooooooooooooooooooooooooooooog";
+
+=====================================output=====================================
+const loooooooooooooooooooooooooong1 =
+  void looooooooooooooong.looooooooooooooong.loooooong;
+const loooooooooooooooooooooooooong2 =
+  void "looooooooooooooooooooooooooooooooooooooooooog";
+const loooooooooooooooooooooooooong3 =
+  !looooooooooooooong.looooooooooooooong.loooooong;
+const loooooooooooooooooooooooooong4 =
+  !"looooooooooooooooooooooooooooooooooooooooooog";
+const loooooooooooooooooooooooooong5 =
+  void void looooooooooooooong.looooooooooooooong.loooooong;
+const loooooooooooooooooooooooooong6 =
+  void void "looooooooooooooooooooooooooooooooooooooooooog";
+const loooooooooooooooooooooooooong7 =
+  !!looooooooooooooong.looooooooooooooong.loooooong;
+const loooooooooooooooooooooooooong8 =
+  !!"looooooooooooooooooooooooooooooooooooooooooog";
 
 ================================================================================
 `;

--- a/tests/format/js/assignment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/assignment/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`binaryish.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`binaryish.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -57,9 +57,9 @@ computedDescriptionLines =
 ================================================================================
 `;
 
-exports[`call-with-template.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`call-with-template.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -120,9 +120,9 @@ const output = template(\`function f() %%A%%\`)({
 ================================================================================
 `;
 
-exports[`chain.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`chain.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -269,9 +269,9 @@ a = b = c;
 ================================================================================
 `;
 
-exports[`chain-two-segments.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`chain-two-segments.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -314,9 +314,9 @@ tt.parenR.updateContext = tt.braceR.updateContext = function () {
 ================================================================================
 `;
 
-exports[`destructuring.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`destructuring.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -391,9 +391,9 @@ const {
 ================================================================================
 `;
 
-exports[`destructuring-array.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`destructuring-array.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -430,9 +430,9 @@ const [width = nextWidth, height = nextHeight, baseline = nextBaseline] =
 ================================================================================
 `;
 
-exports[`destructuring-heuristic.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`destructuring-heuristic.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -563,9 +563,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`issue-1419.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-1419.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -604,9 +604,9 @@ someReallyLongThingStoredInAMapWithAReallyBigName[pageletID] =
 ================================================================================
 `;
 
-exports[`issue-1966.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-1966.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -655,9 +655,9 @@ this.isaverylongmethodexpression.withmultiplelevels =
 ================================================================================
 `;
 
-exports[`issue-2184.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-2184.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -696,9 +696,9 @@ const areaPercentageDiff = (
 ================================================================================
 `;
 
-exports[`issue-2482-1.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-2482-1.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -779,9 +779,9 @@ aParticularlyLongAndObnoxiousNameForIllustrativePurposes =
 ================================================================================
 `;
 
-exports[`issue-2482-2.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-2482-2.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -834,9 +834,9 @@ class foo {
 ================================================================================
 `;
 
-exports[`issue-2540.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-2540.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -869,9 +869,9 @@ manifestCache[templateId] = readFileSync(
 ================================================================================
 `;
 
-exports[`issue-3819.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-3819.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -938,9 +938,9 @@ this.dummy.type1.dummyPropertyFunction =
 ================================================================================
 `;
 
-exports[`issue-4094.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-4094.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -979,9 +979,9 @@ if (something) {
 ================================================================================
 `;
 
-exports[`issue-5610.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-5610.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1030,9 +1030,9 @@ const { qfwvfkwjdqgz, bctsyljqucgz, xuodxhmgwwpw } = qbhtcuzxwedz(
 ================================================================================
 `;
 
-exports[`issue-6922.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-6922.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1161,9 +1161,9 @@ const data4 = request.delete(
 ================================================================================
 `;
 
-exports[`issue-7091.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-7091.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1196,9 +1196,9 @@ const { imStore, showChat, customerServiceAccount } =
 ================================================================================
 `;
 
-exports[`issue-7572.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-7572.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1245,9 +1245,9 @@ const t = {
 ================================================================================
 `;
 
-exports[`issue-7961.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-7961.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1294,9 +1294,9 @@ something.veeeeeery.looooooooooooooooooooooooooong =
 ================================================================================
 `;
 
-exports[`issue-8218.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-8218.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1337,9 +1337,9 @@ const pendingIndicatorz =
 ================================================================================
 `;
 
-exports[`issue-10218.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-10218.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1394,9 +1394,9 @@ const { _id: id3 } =
 ================================================================================
 `;
 
-exports[`lone-arg.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`lone-arg.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1497,9 +1497,9 @@ const bifornCringerMoshedPerplexSawderGlyphsHb = someBigFunctionName(\`foo
 ================================================================================
 `;
 
-exports[`sequence.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`sequence.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1550,9 +1550,9 @@ for (i = 0, len = arr.length; i < len; i++) {
 ================================================================================
 `;
 
-exports[`unary.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`unary.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/assignment/jsfmt.spec.js
+++ b/tests/format/js/assignment/jsfmt.spec.js
@@ -1,1 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
+run_spec(import.meta, ["babel", "flow", "typescript"], {
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/assignment/jsfmt.spec.js
+++ b/tests/format/js/assignment/jsfmt.spec.js
@@ -1,4 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
 run_spec(import.meta, ["babel", "flow", "typescript"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/js/break-calls/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/break-calls/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`break.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`break.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -205,9 +205,9 @@ expect(
 ================================================================================
 `;
 
-exports[`parent.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`parent.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -266,9 +266,9 @@ runtimeAgent.getProperties(
 ================================================================================
 `;
 
-exports[`react.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`react.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -631,9 +631,9 @@ function Comp5() {
 ================================================================================
 `;
 
-exports[`reduce.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`reduce.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/break-calls/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/break-calls/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,108 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`break.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+h(f(g(() => {
+  a
+})))
+
+deepCopyAndAsyncMapLeavesA(
+  { source: sourceValue, destination: destination[sourceKey] },
+  { valueMapper, overwriteExistingKeys }
+)
+
+deepCopyAndAsyncMapLeavesB(
+  1337,
+  { source: sourceValue, destination: destination[sourceKey] },
+  { valueMapper, overwriteExistingKeys }
+)
+
+deepCopyAndAsyncMapLeavesC(
+  { source: sourceValue, destination: destination[sourceKey] },
+  1337,
+  { valueMapper, overwriteExistingKeys }
+)
+
+function someFunction(url) {
+  return get(url)
+    .then(
+      json => dispatch(success(json)),
+      error => dispatch(failed(error))
+    );
+}
+
+const mapChargeItems = fp.flow(
+  l => l < 10 ? l: 1,
+  l => Immutable.Range(l).toMap()
+);
+
+expect(new LongLongLongLongLongRange([0, 0], [0, 0])).toEqualAtomLongLongLongLongRange(new LongLongLongRange([0, 0], [0, 0]));
+
+["red", "white", "blue", "black", "hotpink", "rebeccapurple"].reduce(
+  (allColors, color) => {
+    return allColors.concat(color);
+  },
+  []
+);
+
+
+=====================================output=====================================
+h(
+  f(
+    g(() => {
+      a;
+    }),
+  ),
+);
+
+deepCopyAndAsyncMapLeavesA(
+  { source: sourceValue, destination: destination[sourceKey] },
+  { valueMapper, overwriteExistingKeys },
+);
+
+deepCopyAndAsyncMapLeavesB(
+  1337,
+  { source: sourceValue, destination: destination[sourceKey] },
+  { valueMapper, overwriteExistingKeys },
+);
+
+deepCopyAndAsyncMapLeavesC(
+  { source: sourceValue, destination: destination[sourceKey] },
+  1337,
+  { valueMapper, overwriteExistingKeys },
+);
+
+function someFunction(url) {
+  return get(url).then(
+    (json) => dispatch(success(json)),
+    (error) => dispatch(failed(error)),
+  );
+}
+
+const mapChargeItems = fp.flow(
+  (l) => (l < 10 ? l : 1),
+  (l) => Immutable.Range(l).toMap(),
+);
+
+expect(
+  new LongLongLongLongLongRange([0, 0], [0, 0]),
+).toEqualAtomLongLongLongLongRange(new LongLongLongRange([0, 0], [0, 0]));
+
+["red", "white", "blue", "black", "hotpink", "rebeccapurple"].reduce(
+  (allColors, color) => {
+    return allColors.concat(color);
+  },
+  [],
+);
+
+================================================================================
+`;
+
 exports[`break.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -102,6 +205,37 @@ expect(
 ================================================================================
 `;
 
+exports[`parent.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+runtimeAgent.getProperties(
+  objectId,
+  false, // ownProperties
+  false, // accessorPropertiesOnly
+  false, // generatePreview
+  (error, properties, internalProperties) => {
+    return 1
+  },
+);
+
+=====================================output=====================================
+runtimeAgent.getProperties(
+  objectId,
+  false, // ownProperties
+  false, // accessorPropertiesOnly
+  false, // generatePreview
+  (error, properties, internalProperties) => {
+    return 1;
+  },
+);
+
+================================================================================
+`;
+
 exports[`parent.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -128,6 +262,189 @@ runtimeAgent.getProperties(
     return 1;
   },
 );
+
+================================================================================
+`;
+
+exports[`react.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function helloWorld() {
+  useEffect(() => {
+    // do something
+  }, [props.value])
+  useEffect(() => {
+    // do something
+  }, [props.value, props.value, props.value, props.value, props.value, props.value, props.value, props.value, props.value, props.value, props.value])
+}
+
+function helloWorldWithReact() {
+  React.useEffect(() => {
+    // do something
+  }, [props.value])
+  React.useEffect(() => {
+    // do something
+  }, [props.value, props.value, props.value, props.value, props.value, props.value, props.value, props.value, props.value, props.value, props.value])
+}
+
+function MyComponent(props) {
+  useEffect(
+    () => {
+      console.log("some code", props.foo);
+    },
+
+    // We need to disable the eslint warning here,
+    // because of some complicated reason.
+    // eslint-disable line react-hooks/exhaustive-deps
+    []
+  );
+
+  return null;
+}
+
+function Comp1() {
+  const { firstName, lastName } = useMemo(
+    () => parseFullName(fullName),
+    [fullName],
+  );
+}
+
+function Comp2() {
+  const { firstName, lastName } = useMemo(
+    () => func(),
+    [props.value, props.value, props.value, props.value, props.value, props.value, props.value, props.value, props.value, props.value, props.value]
+  )
+}
+
+function Comp3() {
+  const { firstName, lastName } = useMemo(
+    (aaa, bbb, ccc, ddd, eee, fff, ggg, hhh, iii, jjj, kkk) => func(aaa, bbb, ccc, ddd, eee, fff, ggg, hhh, iii, jjj, kkk),
+    [foo, bar, baz]
+  );
+}
+
+function Comp4() {
+  const { firstName, lastName } = useMemo(
+    () => foo && bar && baz || baz || foo && baz(foo) + bar(foo) + foo && bar && baz || baz || foo && baz(foo) + bar(foo),
+    [foo, bar, baz]
+  )
+}
+
+function Comp5() {
+  const { firstName, lastName } = useMemo(() => func(), [foo]);
+}
+
+=====================================output=====================================
+function helloWorld() {
+  useEffect(() => {
+    // do something
+  }, [props.value]);
+  useEffect(() => {
+    // do something
+  }, [
+    props.value,
+    props.value,
+    props.value,
+    props.value,
+    props.value,
+    props.value,
+    props.value,
+    props.value,
+    props.value,
+    props.value,
+    props.value,
+  ]);
+}
+
+function helloWorldWithReact() {
+  React.useEffect(() => {
+    // do something
+  }, [props.value]);
+  React.useEffect(() => {
+    // do something
+  }, [
+    props.value,
+    props.value,
+    props.value,
+    props.value,
+    props.value,
+    props.value,
+    props.value,
+    props.value,
+    props.value,
+    props.value,
+    props.value,
+  ]);
+}
+
+function MyComponent(props) {
+  useEffect(
+    () => {
+      console.log("some code", props.foo);
+    },
+
+    // We need to disable the eslint warning here,
+    // because of some complicated reason.
+    // eslint-disable line react-hooks/exhaustive-deps
+    [],
+  );
+
+  return null;
+}
+
+function Comp1() {
+  const { firstName, lastName } = useMemo(
+    () => parseFullName(fullName),
+    [fullName],
+  );
+}
+
+function Comp2() {
+  const { firstName, lastName } = useMemo(
+    () => func(),
+    [
+      props.value,
+      props.value,
+      props.value,
+      props.value,
+      props.value,
+      props.value,
+      props.value,
+      props.value,
+      props.value,
+      props.value,
+      props.value,
+    ],
+  );
+}
+
+function Comp3() {
+  const { firstName, lastName } = useMemo(
+    (aaa, bbb, ccc, ddd, eee, fff, ggg, hhh, iii, jjj, kkk) =>
+      func(aaa, bbb, ccc, ddd, eee, fff, ggg, hhh, iii, jjj, kkk),
+    [foo, bar, baz],
+  );
+}
+
+function Comp4() {
+  const { firstName, lastName } = useMemo(
+    () =>
+      (foo && bar && baz)
+      || baz
+      || (foo && baz(foo) + bar(foo) + foo && bar && baz)
+      || baz
+      || (foo && baz(foo) + bar(foo)),
+    [foo, bar, baz],
+  );
+}
+
+function Comp5() {
+  const { firstName, lastName } = useMemo(() => func(), [foo]);
+}
 
 ================================================================================
 `;
@@ -310,6 +627,37 @@ function Comp4() {
 function Comp5() {
   const { firstName, lastName } = useMemo(() => func(), [foo]);
 }
+
+================================================================================
+`;
+
+exports[`reduce.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const [ first1 ] = array.reduce(
+  () => [accumulator, element, accumulator, element],
+  [fullName]
+);
+
+const [ first2 ] = array.reduce(
+  (accumulator, element, ) => [accumulator, element],
+  [fullName]
+);
+
+=====================================output=====================================
+const [first1] = array.reduce(
+  () => [accumulator, element, accumulator, element],
+  [fullName],
+);
+
+const [first2] = array.reduce(
+  (accumulator, element) => [accumulator, element],
+  [fullName],
+);
 
 ================================================================================
 `;

--- a/tests/format/js/break-calls/jsfmt.spec.js
+++ b/tests/format/js/break-calls/jsfmt.spec.js
@@ -1,1 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
+run_spec(import.meta, ["babel", "flow", "typescript"], {
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/break-calls/jsfmt.spec.js
+++ b/tests/format/js/break-calls/jsfmt.spec.js
@@ -1,4 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
 run_spec(import.meta, ["babel", "flow", "typescript"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/js/call/first-argument-expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/call/first-argument-expansion/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`expression-2nd-arg.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`expression-2nd-arg.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -103,9 +103,9 @@ call(
 ================================================================================
 `;
 
-exports[`issue-2456.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-2456.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -158,9 +158,9 @@ f(
 ================================================================================
 `;
 
-exports[`issue-4401.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-4401.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -211,9 +211,9 @@ export function test() {
 ================================================================================
 `;
 
-exports[`issue-5172.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-5172.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -302,9 +302,9 @@ call(
 ================================================================================
 `;
 
-exports[`issue-12892.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-12892.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -365,9 +365,9 @@ setTimeout(
 ================================================================================
 `;
 
-exports[`issue-13237.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-13237.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -466,9 +466,9 @@ exportDefaultWhatever(function (
 ================================================================================
 `;
 
-exports[`issue-14454.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-14454.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -501,9 +501,9 @@ f(
 ================================================================================
 `;
 
-exports[`jsx.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`jsx.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -542,9 +542,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`test.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`test.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/call/first-argument-expansion/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/call/first-argument-expansion/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,57 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`expression-2nd-arg.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+call(
+  function() {
+    return 1;
+  },
+  200_000_000_000n * askTrovenaBeenaDependsRowans
+);
+
+call(
+  function() {
+    return 1;
+  },
+  200_000_000_000n * askTrovenaBeenaDependsRowans / glimseGlyphsHazardNoopsTieTie
+);
+
+call(
+  function() {
+    return 1;
+  },
+  askTrovenaBeenaDependsRowans = glimseGlyphsHazardNoopsTieTie = 200_000_000_000n
+);
+
+=====================================output=====================================
+call(function () {
+  return 1;
+}, 200_000_000_000n * askTrovenaBeenaDependsRowans);
+
+call(
+  function () {
+    return 1;
+  },
+  (200_000_000_000n * askTrovenaBeenaDependsRowans)
+    / glimseGlyphsHazardNoopsTieTie,
+);
+
+call(
+  function () {
+    return 1;
+  },
+  (askTrovenaBeenaDependsRowans = glimseGlyphsHazardNoopsTieTie =
+    200_000_000_000n),
+);
+
+================================================================================
+`;
+
 exports[`expression-2nd-arg.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -51,6 +103,34 @@ call(
 ================================================================================
 `;
 
+exports[`issue-2456.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+f(x => { y }, err.message.includes("asd") && err.message.includes("id") &&
+  err.message.includes('"1"') && err.message.includes("Model") &&
+  err.message.includes("/id") && err.message.includes("identifier(number)")
+)
+
+=====================================output=====================================
+f(
+  (x) => {
+    y;
+  },
+  err.message.includes("asd")
+    && err.message.includes("id")
+    && err.message.includes('"1"')
+    && err.message.includes("Model")
+    && err.message.includes("/id")
+    && err.message.includes("identifier(number)"),
+);
+
+================================================================================
+`;
+
 exports[`issue-2456.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -78,6 +158,33 @@ f(
 ================================================================================
 `;
 
+exports[`issue-4401.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export function test() {
+  setTimeout(
+    () => { console.warn({}, 'Lambda approaching timeout.') },
+    Math.max(context.getRemainingTimeInMillis() - WARN_TIMEOUT_MS, 0),
+  );
+}
+
+=====================================output=====================================
+export function test() {
+  setTimeout(
+    () => {
+      console.warn({}, "Lambda approaching timeout.");
+    },
+    Math.max(context.getRemainingTimeInMillis() - WARN_TIMEOUT_MS, 0),
+  );
+}
+
+================================================================================
+`;
+
 exports[`issue-4401.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -100,6 +207,52 @@ export function test() {
     Math.max(context.getRemainingTimeInMillis() - WARN_TIMEOUT_MS, 0),
   );
 }
+
+================================================================================
+`;
+
+exports[`issue-5172.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+call(
+    function() {
+        return 1;
+    },
+    $var ?? $var ?? $var ?? $var ?? $var ?? $var ?? $var ?? $var ?? $var ?? 'test'
+);
+
+call(function () {
+  return 1;
+}, $var || ($var ?? $var ?? $var ?? $var ?? $var ?? $var ?? $var ?? $var ?? "test"));
+
+=====================================output=====================================
+call(
+  function () {
+    return 1;
+  },
+  $var
+    ?? $var
+    ?? $var
+    ?? $var
+    ?? $var
+    ?? $var
+    ?? $var
+    ?? $var
+    ?? $var
+    ?? "test",
+);
+
+call(
+  function () {
+    return 1;
+  },
+  $var
+    || ($var ?? $var ?? $var ?? $var ?? $var ?? $var ?? $var ?? $var ?? "test"),
+);
 
 ================================================================================
 `;
@@ -149,6 +302,38 @@ call(
 ================================================================================
 `;
 
+exports[`issue-12892.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+setTimeout(() => {
+  console.log('test');
+}, someFunctionCall(
+  veryLongParameterName1,
+  veryLongParameterName2,
+  veryLongParameterName3,
+  veryLongParameterName4,
+));
+
+=====================================output=====================================
+setTimeout(
+  () => {
+    console.log("test");
+  },
+  someFunctionCall(
+    veryLongParameterName1,
+    veryLongParameterName2,
+    veryLongParameterName3,
+    veryLongParameterName4,
+  ),
+);
+
+================================================================================
+`;
+
 exports[`issue-12892.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -176,6 +361,57 @@ setTimeout(
     veryLongParameterName4,
   ),
 );
+
+================================================================================
+`;
+
+exports[`issue-13237.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+/* version 1 */
+
+exportDefaultWhatever(function (
+  aaaaaaaaaaaString,
+  bbbbbbbbbbbString,
+  cccccccccccString,
+) {
+  return null;
+}, "xyz");
+
+/* version 2 (only difference is that \`//\`) */
+
+exportDefaultWhatever(function (
+  aaaaaaaaaaaString,  //
+  bbbbbbbbbbbString,
+  cccccccccccString,
+) {
+  return null;
+}, "xyz");
+
+=====================================output=====================================
+/* version 1 */
+
+exportDefaultWhatever(function (
+  aaaaaaaaaaaString,
+  bbbbbbbbbbbString,
+  cccccccccccString,
+) {
+  return null;
+}, "xyz");
+
+/* version 2 (only difference is that \`//\`) */
+
+exportDefaultWhatever(function (
+  aaaaaaaaaaaString, //
+  bbbbbbbbbbbString,
+  cccccccccccString,
+) {
+  return null;
+}, "xyz");
 
 ================================================================================
 `;
@@ -230,6 +466,24 @@ exportDefaultWhatever(function (
 ================================================================================
 `;
 
+exports[`issue-14454.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+f(() => {}, scroller.qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq)
+
+=====================================output=====================================
+f(
+  () => {},
+  scroller.qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq,
+);
+
+================================================================================
+`;
+
 exports[`issue-14454.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -243,6 +497,27 @@ f(
   () => {},
   scroller.qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq,
 );
+
+================================================================================
+`;
+
+exports[`jsx.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<elem onFlip={wrap(function () {flop('!'); }, arg2)}>content</elem>
+
+=====================================output=====================================
+<elem
+  onFlip={wrap(function () {
+    flop("!");
+  }, arg2)}
+>
+  content
+</elem>;
 
 ================================================================================
 `;
@@ -263,6 +538,293 @@ printWidth: 80
 >
   content
 </elem>;
+
+================================================================================
+`;
+
+exports[`test.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+setTimeout(function() {
+  thing();
+}, 500);
+
+["a","b","c"].reduce(function(item, thing) {
+  return thing + " " + item;
+}, "letters:")
+
+func(() => {
+  thing();
+}, identifier);
+
+func(function() {
+  thing();
+}, this.props.timeout * 1000);
+
+func((that) => {
+  thing();
+}, this.props.getTimeout());
+
+func(() => {
+  thing();
+}, true);
+
+func(() => {
+  thing();
+}, null);
+
+func(() => {
+  thing();
+}, undefined);
+
+func(() => {
+  thing();
+}, /regex.*?/);
+
+func(() => {
+  thing();
+}, 1 ? 2 : 3);
+
+func(function() {
+  return thing()
+}, 1 ? 2 : 3);
+
+func(() => {
+  thing();
+}, something() ? someOtherThing() : somethingElse(true, 0));
+
+
+func(() => {
+  thing();
+}, something(longArgumentName, anotherLongArgumentName) ? someOtherThing() : somethingElse(true, 0));
+
+
+func(() => {
+  thing();
+}, something(longArgumentName, anotherLongArgumentName, anotherLongArgumentName, anotherLongArgumentName) ? someOtherThing() : somethingElse(true, 0));
+
+compose((a) => {
+  return a.thing;
+}, b => b * b);
+
+somthing.reduce(function(item, thing) {
+  return thing.blah =  item;
+}, {})
+
+somthing.reduce(function(item, thing) {
+  return thing.push(item);
+}, [])
+
+reallyLongLongLongLongLongLongLongLongLongLongLongLongLongLongMethod((f, g, h) => {
+  return f.pop();
+}, true);
+
+// Don't do the rest of these
+
+func(function() {
+  thing();
+}, true, false);
+
+func(() => {
+  thing();
+}, {yes: true, cats: 5});
+
+compose((a) => {
+  return a.thing;
+}, b => {
+  return b + "";
+});
+
+compose((a) => {
+  return a.thing;
+}, b => [1, 2, 3, 4, 5]);
+
+renderThing(a =>
+  <div>Content. So much to say. Oh my. Are we done yet?</div>
+,args);
+
+setTimeout(
+  // Something
+  function() {
+    thing();
+  },
+  500
+);
+
+setTimeout(/* blip */ function() {
+  thing();
+}, 500);
+
+func((args) => {
+  execute(args);
+}, result => result && console.log("success"))
+
+=====================================output=====================================
+setTimeout(function () {
+  thing();
+}, 500);
+
+["a", "b", "c"].reduce(function (item, thing) {
+  return thing + " " + item;
+}, "letters:");
+
+func(() => {
+  thing();
+}, identifier);
+
+func(function () {
+  thing();
+}, this.props.timeout * 1000);
+
+func((that) => {
+  thing();
+}, this.props.getTimeout());
+
+func(() => {
+  thing();
+}, true);
+
+func(() => {
+  thing();
+}, null);
+
+func(() => {
+  thing();
+}, undefined);
+
+func(() => {
+  thing();
+}, /regex.*?/);
+
+func(
+  () => {
+    thing();
+  },
+  1 ? 2 : 3,
+);
+
+func(
+  function () {
+    return thing();
+  },
+  1 ? 2 : 3,
+);
+
+func(
+  () => {
+    thing();
+  },
+  something() ? someOtherThing() : somethingElse(true, 0),
+);
+
+func(
+  () => {
+    thing();
+  },
+  something(longArgumentName, anotherLongArgumentName)
+    ? someOtherThing()
+    : somethingElse(true, 0),
+);
+
+func(
+  () => {
+    thing();
+  },
+  something(
+    longArgumentName,
+    anotherLongArgumentName,
+    anotherLongArgumentName,
+    anotherLongArgumentName,
+  )
+    ? someOtherThing()
+    : somethingElse(true, 0),
+);
+
+compose(
+  (a) => {
+    return a.thing;
+  },
+  (b) => b * b,
+);
+
+somthing.reduce(function (item, thing) {
+  return (thing.blah = item);
+}, {});
+
+somthing.reduce(function (item, thing) {
+  return thing.push(item);
+}, []);
+
+reallyLongLongLongLongLongLongLongLongLongLongLongLongLongLongMethod(
+  (f, g, h) => {
+    return f.pop();
+  },
+  true,
+);
+
+// Don't do the rest of these
+
+func(
+  function () {
+    thing();
+  },
+  true,
+  false,
+);
+
+func(
+  () => {
+    thing();
+  },
+  { yes: true, cats: 5 },
+);
+
+compose(
+  (a) => {
+    return a.thing;
+  },
+  (b) => {
+    return b + "";
+  },
+);
+
+compose(
+  (a) => {
+    return a.thing;
+  },
+  (b) => [1, 2, 3, 4, 5],
+);
+
+renderThing(
+  (a) => <div>Content. So much to say. Oh my. Are we done yet?</div>,
+  args,
+);
+
+setTimeout(
+  // Something
+  function () {
+    thing();
+  },
+  500,
+);
+
+setTimeout(
+  /* blip */ function () {
+    thing();
+  },
+  500,
+);
+
+func(
+  (args) => {
+    execute(args);
+  },
+  (result) => result && console.log("success"),
+);
 
 ================================================================================
 `;

--- a/tests/format/js/call/first-argument-expansion/jsfmt.spec.js
+++ b/tests/format/js/call/first-argument-expansion/jsfmt.spec.js
@@ -1,1 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
+run_spec(import.meta, ["babel", "flow", "typescript"], {
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/call/first-argument-expansion/jsfmt.spec.js
+++ b/tests/format/js/call/first-argument-expansion/jsfmt.spec.js
@@ -1,4 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
 run_spec(import.meta, ["babel", "flow", "typescript"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/js/class-comment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/class-comment/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`class-property.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`class-property.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -53,9 +53,9 @@ class X {
 ================================================================================
 `;
 
-exports[`misc.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`misc.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -100,9 +100,9 @@ class x {
 ================================================================================
 `;
 
-exports[`superclass.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`superclass.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/class-comment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/class-comment/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`class-property.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+class X {
+  TEMPLATE =
+    // tab index is needed so we can focus, which is needed for keyboard events
+    '<div class="ag-large-text" tabindex="0">' +
+    '<div class="ag-large-textarea"></div>' +
+    '</div>';
+}
+
+=====================================output=====================================
+class X {
+  TEMPLATE =
+    // tab index is needed so we can focus, which is needed for keyboard events
+    '<div class="ag-large-text" tabindex="0">'
+    + '<div class="ag-large-textarea"></div>'
+    + "</div>";
+}
+
+================================================================================
+`;
+
 exports[`class-property.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -26,6 +53,30 @@ class X {
 ================================================================================
 `;
 
+exports[`misc.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+class x {
+  focus() // comment 1
+  {
+    // comment 2
+  }
+}
+
+=====================================output=====================================
+class x {
+  focus() { // comment 1
+    // comment 2
+  }
+}
+
+================================================================================
+`;
+
 exports[`misc.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -44,6 +95,102 @@ class x {
   focus() { // comment 1
     // comment 2
   }
+}
+
+================================================================================
+`;
+
+exports[`superclass.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+class A // comment 1
+  // comment 2
+  extends B {}
+
+class A1 extends B // comment1
+// comment2
+// comment3
+{}
+
+class A2 /* a */ extends B {}
+class A3 extends B /* a */ {}
+class A4 extends /* a */ B {}
+
+(class A5 // comment 1
+  // comment 2
+  extends B {});
+
+(class A6 extends B // comment1
+// comment2
+// comment3
+{});
+
+(class A7 /* a */ extends B {});
+(class A8 extends B /* a */ {});
+(class A9 extends /* a */ B {});
+
+class a extends b // comment
+{
+  constructor() {}
+}
+
+class c extends d
+// comment2
+{
+  constructor() {}
+}
+
+class C2  // comment
+extends Base
+{  foo(){} }
+
+=====================================output=====================================
+class A // comment 1
+  // comment 2
+  extends B {}
+
+class A1 extends B {
+  // comment1
+  // comment2
+  // comment3
+}
+
+class A2 /* a */ extends B {}
+class A3 extends B /* a */ {}
+class A4 extends /* a */ B {}
+
+(class A5 // comment 1
+  // comment 2
+  extends B {});
+
+(class A6 extends B {
+  // comment1
+  // comment2
+  // comment3
+});
+
+(class A7 /* a */ extends B {});
+(class A8 extends B /* a */ {});
+(class A9 extends /* a */ B {});
+
+class a extends b {
+  // comment
+  constructor() {}
+}
+
+class c extends d {
+  // comment2
+  constructor() {}
+}
+
+class C2 // comment
+  extends Base
+{
+  foo() {}
 }
 
 ================================================================================

--- a/tests/format/js/class-comment/jsfmt.spec.js
+++ b/tests/format/js/class-comment/jsfmt.spec.js
@@ -1,1 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
+run_spec(import.meta, ["babel", "flow", "typescript"], {
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/class-comment/jsfmt.spec.js
+++ b/tests/format/js/class-comment/jsfmt.spec.js
@@ -1,4 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
 run_spec(import.meta, ["babel", "flow", "typescript"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/js/classes-private-fields/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/classes-private-fields/__snapshots__/jsfmt.spec.js.snap
@@ -27,6 +27,52 @@ exports[`optional-chaining.js [meriyah] format 1`] = `
   4 |"
 `;
 
+exports[`optional-chaining.js - {"experimentalOperatorLocation":true} [acorn] format 1`] = `
+"Private field '#x' must be declared in an enclosing class (3:13)
+  1 | // https://github.com/babel/babel/pull/11669
+  2 |
+> 3 | delete obj?.#x.a
+    |             ^
+  4 |"
+`;
+
+exports[`optional-chaining.js - {"experimentalOperatorLocation":true} [espree] format 1`] = `
+"Private field '#x' must be declared in an enclosing class (3:13)
+  1 | // https://github.com/babel/babel/pull/11669
+  2 |
+> 3 | delete obj?.#x.a
+    |             ^
+  4 |"
+`;
+
+exports[`optional-chaining.js - {"experimentalOperatorLocation":true} [meriyah] format 1`] = `
+"Dot property must be an identifier (3:13)
+  1 | // https://github.com/babel/babel/pull/11669
+  2 |
+> 3 | delete obj?.#x.a
+    |             ^
+  4 |"
+`;
+
+exports[`optional-chaining.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// https://github.com/babel/babel/pull/11669
+
+delete obj?.#x.a
+
+=====================================output=====================================
+// https://github.com/babel/babel/pull/11669
+
+delete obj?.#x.a;
+
+================================================================================
+`;
+
 exports[`optional-chaining.js - {"semi":false} [acorn] format 1`] = `
 "Private field '#x' must be declared in an enclosing class (3:13)
   1 | // https://github.com/babel/babel/pull/11669
@@ -87,6 +133,135 @@ delete obj?.#x.a
 // https://github.com/babel/babel/pull/11669
 
 delete obj?.#x.a;
+
+================================================================================
+`;
+
+exports[`private_fields.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+class A { #x; #y; }
+class B { #x = 0; #y = 1; }
+
+class C {
+  static #x;
+  static #y = 1;
+}
+
+class D {
+  #x
+  #y
+}
+
+class Point {
+  #x = 1;
+  #y = 2;
+
+  constructor(x = 0, y = 0) {
+    this.#x = +x;
+    this.#y = +y;
+  }
+
+  get x() { return this.#x }
+  set x(value) { this.#x = +value }
+
+  get y() { return this.#y }
+  set y(value) { this.#y = +value }
+
+  equals(p) { return this.#x === p.#x && this.#y === p.#y }
+
+  toString() { return \`Point<\${ this.#x },\${ this.#y }>\` }
+}
+
+class E {
+  async #a() {}
+  #b() {}
+  get #c() {}
+  set #c(bar) {}
+  *#d() {}
+  async *#e() {}
+  get #f() {}
+  set #f(taz) {}
+}
+
+class F {
+  #func(id, { blog: { title } }) {
+    return id + title;
+  }
+}
+
+=====================================output=====================================
+class A {
+  #x;
+  #y;
+}
+class B {
+  #x = 0;
+  #y = 1;
+}
+
+class C {
+  static #x;
+  static #y = 1;
+}
+
+class D {
+  #x;
+  #y;
+}
+
+class Point {
+  #x = 1;
+  #y = 2;
+
+  constructor(x = 0, y = 0) {
+    this.#x = +x;
+    this.#y = +y;
+  }
+
+  get x() {
+    return this.#x;
+  }
+  set x(value) {
+    this.#x = +value;
+  }
+
+  get y() {
+    return this.#y;
+  }
+  set y(value) {
+    this.#y = +value;
+  }
+
+  equals(p) {
+    return this.#x === p.#x && this.#y === p.#y;
+  }
+
+  toString() {
+    return \`Point<\${this.#x},\${this.#y}>\`;
+  }
+}
+
+class E {
+  async #a() {}
+  #b() {}
+  get #c() {}
+  set #c(bar) {}
+  *#d() {}
+  async *#e() {}
+  get #f() {}
+  set #f(taz) {}
+}
+
+class F {
+  #func(id, { blog: { title } }) {
+    return id + title;
+  }
+}
 
 ================================================================================
 `;
@@ -343,6 +518,33 @@ class F {
   #func(id, { blog: { title } }) {
     return id + title;
   }
+}
+
+================================================================================
+`;
+
+exports[`with_comments.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+class A {
+  #foobar =
+    // comment to break
+    1 +
+    // comment to break again
+    2;
+}
+
+=====================================output=====================================
+class A {
+  #foobar =
+    // comment to break
+    1
+    // comment to break again
+    + 2;
 }
 
 ================================================================================

--- a/tests/format/js/classes-private-fields/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/classes-private-fields/__snapshots__/jsfmt.spec.js.snap
@@ -27,7 +27,7 @@ exports[`optional-chaining.js [meriyah] format 1`] = `
   4 |"
 `;
 
-exports[`optional-chaining.js - {"experimentalOperatorLocation":true} [acorn] format 1`] = `
+exports[`optional-chaining.js - {"experimentalOperatorPosition":true} [acorn] format 1`] = `
 "Private field '#x' must be declared in an enclosing class (3:13)
   1 | // https://github.com/babel/babel/pull/11669
   2 |
@@ -36,7 +36,7 @@ exports[`optional-chaining.js - {"experimentalOperatorLocation":true} [acorn] fo
   4 |"
 `;
 
-exports[`optional-chaining.js - {"experimentalOperatorLocation":true} [espree] format 1`] = `
+exports[`optional-chaining.js - {"experimentalOperatorPosition":true} [espree] format 1`] = `
 "Private field '#x' must be declared in an enclosing class (3:13)
   1 | // https://github.com/babel/babel/pull/11669
   2 |
@@ -45,7 +45,7 @@ exports[`optional-chaining.js - {"experimentalOperatorLocation":true} [espree] f
   4 |"
 `;
 
-exports[`optional-chaining.js - {"experimentalOperatorLocation":true} [meriyah] format 1`] = `
+exports[`optional-chaining.js - {"experimentalOperatorPosition":true} [meriyah] format 1`] = `
 "Dot property must be an identifier (3:13)
   1 | // https://github.com/babel/babel/pull/11669
   2 |
@@ -54,9 +54,9 @@ exports[`optional-chaining.js - {"experimentalOperatorLocation":true} [meriyah] 
   4 |"
 `;
 
-exports[`optional-chaining.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`optional-chaining.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel"]
 printWidth: 80
                                                                                 | printWidth
@@ -137,9 +137,9 @@ delete obj?.#x.a;
 ================================================================================
 `;
 
-exports[`private_fields.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`private_fields.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel"]
 printWidth: 80
                                                                                 | printWidth
@@ -523,9 +523,9 @@ class F {
 ================================================================================
 `;
 
-exports[`with_comments.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`with_comments.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/classes-private-fields/jsfmt.spec.js
+++ b/tests/format/js/classes-private-fields/jsfmt.spec.js
@@ -10,3 +10,7 @@ run_spec(import.meta, ["babel"], {
   semi: false,
   errors,
 });
+run_spec(import.meta, ["babel"], {
+  experimentalOperatorLocation: true,
+  errors,
+});

--- a/tests/format/js/classes-private-fields/jsfmt.spec.js
+++ b/tests/format/js/classes-private-fields/jsfmt.spec.js
@@ -11,6 +11,6 @@ run_spec(import.meta, ["babel"], {
   errors,
 });
 run_spec(import.meta, ["babel"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
   errors,
 });

--- a/tests/format/js/classes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/classes/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`asi.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// https://github.com/facebook/flow/commit/78f657e8da014e16ff509ad34f8178b158c47af7
+class C {
+  foo
+    () {}
+}
+
+=====================================output=====================================
+// https://github.com/facebook/flow/commit/78f657e8da014e16ff509ad34f8178b158c47af7
+class C {
+  foo() {}
+}
+
+================================================================================
+`;
+
 exports[`asi.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -17,6 +39,85 @@ class C {
 class C {
   foo() {}
 }
+
+================================================================================
+`;
+
+exports[`assignment.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends (
+  aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg1
+) {
+  method () {
+    console.log("foo");
+  }
+};
+
+foo = class extends bar {
+  method() {
+    console.log("foo");
+  }
+};
+
+aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends bar {
+  method() {
+    console.log("foo");
+  }
+};
+
+foo = class extends aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 {
+  method() {
+    console.log("foo");
+  }
+};
+
+module.exports = class A extends B {
+  method () {
+    console.log("foo");
+  }
+};
+
+=====================================output=====================================
+aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends (
+  aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg1
+) {
+  method() {
+    console.log("foo");
+  }
+};
+
+foo = class extends bar {
+  method() {
+    console.log("foo");
+  }
+};
+
+aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2 = class extends (
+  bar
+) {
+  method() {
+    console.log("foo");
+  }
+};
+
+foo = class extends (
+  aaaaaaaa.bbbbbbbb.cccccccc.dddddddd.eeeeeeee.ffffffff.gggggggg2
+) {
+  method() {
+    console.log("foo");
+  }
+};
+
+module.exports = class A extends B {
+  method() {
+    console.log("foo");
+  }
+};
 
 ================================================================================
 `;
@@ -99,6 +200,27 @@ module.exports = class A extends B {
 ================================================================================
 `;
 
+exports[`binary.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+(class {}) + 1;
+(class a {}) + 1;
+(class extends b {}) + 1;
+(class a extends b {}) + 1;
+
+=====================================output=====================================
+(class {}) + 1;
+(class a {}) + 1;
+(class extends b {}) + 1;
+(class a extends b {}) + 1;
+
+================================================================================
+`;
+
 exports[`binary.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -119,6 +241,21 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`call.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+(class {})(class {});
+
+=====================================output=====================================
+(class {})(class {});
+
+================================================================================
+`;
+
 exports[`call.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -129,6 +266,51 @@ printWidth: 80
 
 =====================================output=====================================
 (class {})(class {});
+
+================================================================================
+`;
+
+exports[`class-fields-features.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+class Foo {
+  static epoch = new CustomDate(0);
+  #xValue = 0;
+  get #x() { return this.#xValue; }
+  set #x(value) {
+    this.#xValue = value;
+    window.requestAnimationFrame(this.#render.bind(this));
+  }
+  #clicked() {
+    this.#x++;
+  }
+  #render() {
+    this.textContent = this.#x.toString();
+  }
+}
+
+=====================================output=====================================
+class Foo {
+  static epoch = new CustomDate(0);
+  #xValue = 0;
+  get #x() {
+    return this.#xValue;
+  }
+  set #x(value) {
+    this.#xValue = value;
+    window.requestAnimationFrame(this.#render.bind(this));
+  }
+  #clicked() {
+    this.#x++;
+  }
+  #render() {
+    this.textContent = this.#x.toString();
+  }
+}
 
 ================================================================================
 `;
@@ -177,6 +359,45 @@ class Foo {
 ================================================================================
 `;
 
+exports[`empty.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+class A1 {
+  // comment
+}
+
+class A2 { // comment
+}
+
+class A3 {
+}
+
+class A4 {
+  m() {}
+}
+
+=====================================output=====================================
+class A1 {
+  // comment
+}
+
+class A2 {
+  // comment
+}
+
+class A3 {}
+
+class A4 {
+  m() {}
+}
+
+================================================================================
+`;
+
 exports[`empty.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -215,6 +436,23 @@ class A4 {
 ================================================================================
 `;
 
+exports[`member.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+(class {})[1];
+(class {}).a;
+
+=====================================output=====================================
+(class {})[1];
+(class {}).a;
+
+================================================================================
+`;
+
 exports[`member.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -227,6 +465,37 @@ printWidth: 80
 =====================================output=====================================
 (class {})[1];
 (class {}).a;
+
+================================================================================
+`;
+
+exports[`method.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+
+class C {
+  name/*comment*/() {
+  }
+};
+
+
+({
+  name/*comment*/() {
+  }
+});
+
+=====================================output=====================================
+class C {
+  name /*comment*/() {}
+}
+
+({
+  name /*comment*/() {},
+});
 
 ================================================================================
 `;
@@ -261,6 +530,23 @@ class C {
 ================================================================================
 `;
 
+exports[`new.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+new class {};
+new Ctor(class {});
+
+=====================================output=====================================
+new (class {})();
+new Ctor(class {});
+
+================================================================================
+`;
+
 exports[`new.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -273,6 +559,55 @@ new Ctor(class {});
 =====================================output=====================================
 new (class {})();
 new Ctor(class {});
+
+================================================================================
+`;
+
+exports[`property.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+class A {
+  foobar =
+    // comment to break
+    1 +
+    // comment to break again
+    2;
+}
+
+class B {
+  someInstanceProperty = this.props.foofoofoofoofoofoo &&
+    this.props.barbarbarbar;
+  
+  someInstanceProperty2 = { foo: this.props.foofoofoofoofoofoo &&
+    this.props.barbarbarbar };
+  
+    someInstanceProperty3 =
+  "foo";
+}
+
+=====================================output=====================================
+class A {
+  foobar =
+    // comment to break
+    1
+    // comment to break again
+    + 2;
+}
+
+class B {
+  someInstanceProperty =
+    this.props.foofoofoofoofoofoo && this.props.barbarbarbar;
+
+  someInstanceProperty2 = {
+    foo: this.props.foofoofoofoofoofoo && this.props.barbarbarbar,
+  };
+
+  someInstanceProperty3 = "foo";
+}
 
 ================================================================================
 `;
@@ -325,6 +660,29 @@ class B {
 ================================================================================
 `;
 
+exports[`super.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+class A extends B {
+    #a() {
+        super.x();
+    }
+}
+
+=====================================output=====================================
+class A extends B {
+  #a() {
+    super.x();
+  }
+}
+
+================================================================================
+`;
+
 exports[`super.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -343,6 +701,21 @@ class A extends B {
     super.x();
   }
 }
+
+================================================================================
+`;
+
+exports[`ternary.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+if (1) (class {}) ? 1 : 2;
+
+=====================================output=====================================
+if (1) (class {}) ? 1 : 2;
 
 ================================================================================
 `;

--- a/tests/format/js/classes/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/classes/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`asi.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`asi.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -43,9 +43,9 @@ class C {
 ================================================================================
 `;
 
-exports[`assignment.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`assignment.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -200,9 +200,9 @@ module.exports = class A extends B {
 ================================================================================
 `;
 
-exports[`binary.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`binary.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -241,9 +241,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`call.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`call.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -270,9 +270,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`class-fields-features.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`class-fields-features.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -359,9 +359,9 @@ class Foo {
 ================================================================================
 `;
 
-exports[`empty.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`empty.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -436,9 +436,9 @@ class A4 {
 ================================================================================
 `;
 
-exports[`member.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`member.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -469,9 +469,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`method.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`method.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -530,9 +530,9 @@ class C {
 ================================================================================
 `;
 
-exports[`new.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`new.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -563,9 +563,9 @@ new Ctor(class {});
 ================================================================================
 `;
 
-exports[`property.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`property.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -660,9 +660,9 @@ class B {
 ================================================================================
 `;
 
-exports[`super.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`super.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -705,9 +705,9 @@ class A extends B {
 ================================================================================
 `;
 
-exports[`ternary.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`ternary.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/classes/jsfmt.spec.js
+++ b/tests/format/js/classes/jsfmt.spec.js
@@ -1,1 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
+run_spec(import.meta, ["babel", "flow", "typescript"], {
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/classes/jsfmt.spec.js
+++ b/tests/format/js/classes/jsfmt.spec.js
@@ -1,4 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
 run_spec(import.meta, ["babel", "flow", "typescript"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/js/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,24 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`arrow.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const fn = (/*event, data*/) => doSomething();
+
+const fn2 = (/*event, data*/) => doSomething(anything);
+
+=====================================output=====================================
+const fn = (/*event, data*/) => doSomething();
+
+const fn2 = (/*event, data*/) => doSomething(anything);
+
+================================================================================
+`;
+
 exports[`arrow.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -33,6 +52,32 @@ const fn2 = (/*event, data*/) => doSomething(anything);
 const fn = (/*event, data*/) => doSomething();
 
 const fn2 = (/*event, data*/) => doSomething(anything);
+
+================================================================================
+`;
+
+exports[`assignment-pattern.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const { a /* comment */ = 1 } = b;
+
+const { c = 1 /* comment */ } = d;
+
+let {d //comment
+= b} = c
+
+=====================================output=====================================
+const { a /* comment */ = 1 } = b;
+
+const { c = 1 /* comment */ } = d;
+
+let {
+  d = b, //comment
+} = c;
 
 ================================================================================
 `;
@@ -88,6 +133,31 @@ let {
 ================================================================================
 `;
 
+exports[`before-comma.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const foo = {
+  a: 'a' /* comment for this line */,
+
+  /* Section B */
+  b: 'b',
+};
+
+=====================================output=====================================
+const foo = {
+  a: "a" /* comment for this line */,
+
+  /* Section B */
+  b: "b",
+};
+
+================================================================================
+`;
+
 exports[`before-comma.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -133,6 +203,161 @@ const foo = {
   /* Section B */
   b: "b",
 };
+
+================================================================================
+`;
+
+exports[`binary-expressions.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function addition() {
+	0
+	// Comment
+	+ x
+}
+
+function multiplication() {
+	0
+	// Comment
+	* x
+}
+
+function division() {
+	0
+	// Comment
+	/ x
+}
+
+function substraction() {
+	0
+	// Comment
+	- x
+}
+
+function remainder() {
+	0
+	// Comment
+	% x
+}
+
+function exponentiation() {
+	0
+	// Comment
+	** x
+}
+
+function leftShift() {
+	0
+	// Comment
+	<< x
+}
+
+function rightShift() {
+	0
+	// Comment
+	>> x
+}
+
+function unsignedRightShift() {
+	0
+	// Comment
+	>>> x
+}
+
+function bitwiseAnd() {
+	0
+	// Comment
+	& x
+}
+
+function bitwiseOr() {
+	0
+	// Comment
+	| x
+}
+
+function bitwiseXor() {
+	0
+	// Comment
+	^ x
+}
+
+=====================================output=====================================
+function addition() {
+  0
+    // Comment
+    + x;
+}
+
+function multiplication() {
+  0
+    // Comment
+    * x;
+}
+
+function division() {
+  0
+    // Comment
+    / x;
+}
+
+function substraction() {
+  0
+    // Comment
+    - x;
+}
+
+function remainder() {
+  0
+    // Comment
+    % x;
+}
+
+function exponentiation() {
+  0
+    // Comment
+    ** x;
+}
+
+function leftShift() {
+  0
+    // Comment
+    << x;
+}
+
+function rightShift() {
+  0
+    // Comment
+    >> x;
+}
+
+function unsignedRightShift() {
+  0
+    // Comment
+    >>> x;
+}
+
+function bitwiseAnd() {
+  0
+    // Comment
+    & x;
+}
+
+function bitwiseOr() {
+  0
+    // Comment
+    | x;
+}
+
+function bitwiseXor() {
+  0
+    // Comment
+    ^ x;
+}
 
 ================================================================================
 `;
@@ -446,6 +671,106 @@ function bitwiseXor() {
 ================================================================================
 `;
 
+exports[`binary-expressions-block-comments.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+a = b || /** Comment */
+c;
+
+a = b /** Comment */ ||
+c;
+
+a = b || /** TODO this is a very very very very long comment that makes it go > 80 columns */
+c;
+
+a = b /** TODO this is a very very very very long comment that makes it go > 80 columns */ ||
+c;
+
+a = b || /** TODO this is a very very very very long comment that makes it go > 80 columns */ c;
+
+a = b && /** Comment */
+c;
+
+a = b /** Comment */ &&
+c;
+
+a = b && /** TODO this is a very very very very long comment that makes it go > 80 columns */
+c;
+
+a = b /** TODO this is a very very very very long comment that makes it go > 80 columns */ &&
+c;
+
+a = b && /** TODO this is a very very very very long comment that makes it go > 80 columns */ c;
+
+a = b + /** Comment */
+c;
+
+a = b /** Comment */ +
+c;
+
+a = b + /** TODO this is a very very very very long comment that makes it go > 80 columns */
+c;
+
+a = b /** TODO this is a very very very very long comment that makes it go > 80 columns */ +
+c;
+
+a = b + /** TODO this is a very very very very long comment that makes it go > 80 columns */ c;
+=====================================output=====================================
+a = b /** Comment */ || c;
+
+a = b /** Comment */ || c;
+
+a =
+  b /** TODO this is a very very very very long comment that makes it go > 80 columns */
+  || c;
+
+a =
+  b /** TODO this is a very very very very long comment that makes it go > 80 columns */
+  || c;
+
+a =
+  b
+  || /** TODO this is a very very very very long comment that makes it go > 80 columns */ c;
+
+a = b /** Comment */ && c;
+
+a = b /** Comment */ && c;
+
+a =
+  b /** TODO this is a very very very very long comment that makes it go > 80 columns */
+  && c;
+
+a =
+  b /** TODO this is a very very very very long comment that makes it go > 80 columns */
+  && c;
+
+a =
+  b
+  && /** TODO this is a very very very very long comment that makes it go > 80 columns */ c;
+
+a = b /** Comment */ + c;
+
+a = b /** Comment */ + c;
+
+a =
+  b /** TODO this is a very very very very long comment that makes it go > 80 columns */
+  + c;
+
+a =
+  b /** TODO this is a very very very very long comment that makes it go > 80 columns */
+  + c;
+
+a =
+  b
+  + /** TODO this is a very very very very long comment that makes it go > 80 columns */ c;
+
+================================================================================
+`;
+
 exports[`binary-expressions-block-comments.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -645,6 +970,38 @@ a =
 ================================================================================
 `;
 
+exports[`binary-expressions-parens.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+Math.min(
+  (
+    /* $FlowFixMe(>=0.38.0 site=www) - Flow error detected during the
+     * deployment of v0.38.0. To see the error, remove this comment and
+     * run flow */
+    document.body.scrollHeight -
+    (window.scrollY + window.innerHeight)
+  ) - devsite_footer_height,
+  0,
+)
+
+=====================================output=====================================
+Math.min(
+  /* $FlowFixMe(>=0.38.0 site=www) - Flow error detected during the
+   * deployment of v0.38.0. To see the error, remove this comment and
+   * run flow */
+  document.body.scrollHeight
+    - (window.scrollY + window.innerHeight)
+    - devsite_footer_height,
+  0,
+);
+
+================================================================================
+`;
+
 exports[`binary-expressions-parens.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -704,6 +1061,58 @@ Math.min(
     devsite_footer_height,
   0,
 );
+
+================================================================================
+`;
+
+exports[`binary-expressions-single-comments.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+a = b || // Comment
+c;
+
+a = b || // TODO this is a very very very very long comment that makes it go > 80 columns
+c;
+
+a = b && // Comment
+c;
+
+a = b && // TODO this is a very very very very long comment that makes it go > 80 columns
+c;
+
+a = b + // Comment
+c;
+
+a = b + // TODO this is a very very very very long comment that makes it go > 80 columns
+c;
+=====================================output=====================================
+a =
+  b // Comment
+  || c;
+
+a =
+  b // TODO this is a very very very very long comment that makes it go > 80 columns
+  || c;
+
+a =
+  b // Comment
+  && c;
+
+a =
+  b // TODO this is a very very very very long comment that makes it go > 80 columns
+  && c;
+
+a =
+  b // Comment
+  + c;
+
+a =
+  b // TODO this is a very very very very long comment that makes it go > 80 columns
+  + c;
 
 ================================================================================
 `;
@@ -807,6 +1216,61 @@ a =
 a =
   b + // TODO this is a very very very very long comment that makes it go > 80 columns
   c;
+
+================================================================================
+`;
+
+exports[`blank.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// This file only
+// has comments. This comment
+// should still exist
+//
+// when printed.
+
+/**
+ * @typedef {DataDrivenMapping|ConstantMapping} Mapping
+ */
+/**
+ * @typedef {Object.<String, Mapping>} ConfigurationMapping
+ */
+
+/**
+ * @typedef {Function} D3Scale - a D3 scale
+ * @property {Function} ticks
+ * @property {Function} tickFormat
+ */
+// comment
+
+// comment
+
+=====================================output=====================================
+// This file only
+// has comments. This comment
+// should still exist
+//
+// when printed.
+
+/**
+ * @typedef {DataDrivenMapping|ConstantMapping} Mapping
+ */
+/**
+ * @typedef {Object.<String, Mapping>} ConfigurationMapping
+ */
+
+/**
+ * @typedef {Function} D3Scale - a D3 scale
+ * @property {Function} ticks
+ * @property {Function} tickFormat
+ */
+// comment
+
+// comment
 
 ================================================================================
 `;
@@ -920,6 +1384,41 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`break-continue-statements.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+for (;;) {
+  break /* comment */;
+  continue /* comment */;
+}
+
+loop: for (;;) {
+  break /* comment */ loop;
+  break loop /* comment */;
+  continue /* comment */ loop;
+  continue loop /* comment */;
+}
+
+=====================================output=====================================
+for (;;) {
+  break; /* comment */
+  continue; /* comment */
+}
+
+loop: for (;;) {
+  break /* comment */ loop;
+  break loop /* comment */;
+  continue /* comment */ loop;
+  continue loop /* comment */;
+}
+
+================================================================================
+`;
+
 exports[`break-continue-statements.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -985,6 +1484,50 @@ loop: for (;;) {
   continue /* comment */ loop;
   continue loop /* comment */;
 }
+
+================================================================================
+`;
+
+exports[`call_comment.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+render( // Warm any cache
+  <ChildUpdates renderAnchor={true} anchorClassOn={true} />,
+  container
+);
+
+React.render( // Warm any cache
+  <ChildUpdates renderAnchor={true} anchorClassOn={true} />,
+  container
+);
+
+render?.( // Warm any cache
+  <ChildUpdates renderAnchor={true} anchorClassOn={true} />,
+  container
+);
+
+=====================================output=====================================
+render(
+  // Warm any cache
+  <ChildUpdates renderAnchor={true} anchorClassOn={true} />,
+  container,
+);
+
+React.render(
+  // Warm any cache
+  <ChildUpdates renderAnchor={true} anchorClassOn={true} />,
+  container,
+);
+
+render?.(
+  // Warm any cache
+  <ChildUpdates renderAnchor={true} anchorClassOn={true} />,
+  container,
+);
 
 ================================================================================
 `;
@@ -1076,6 +1619,39 @@ render?.(
 ================================================================================
 `;
 
+exports[`class.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// #8718
+class C {
+    ma() {} /* D */ /* E */
+    mb() {}
+}
+
+class D {
+    ma() {} /* D */ /* E */ /* F */
+    mb() {}
+}
+
+=====================================output=====================================
+// #8718
+class C {
+  ma() {} /* D */ /* E */
+  mb() {}
+}
+
+class D {
+  ma() {} /* D */ /* E */ /* F */
+  mb() {}
+}
+
+================================================================================
+`;
+
 exports[`class.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -1137,6 +1713,45 @@ class D {
   ma() {} /* D */ /* E */ /* F */
   mb() {}
 }
+
+================================================================================
+`;
+
+exports[`dangling.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+var a = {/* dangling */};
+var b = {
+  // dangling
+};
+var b = [/* dangling */];
+function d() {
+  /* dangling */
+}
+new Thing(/* dangling */);
+Thing(/* dangling */);
+export /* dangling */{};
+
+=====================================output=====================================
+var a = {
+  /* dangling */
+};
+var b = {
+  // dangling
+};
+var b = [
+  /* dangling */
+];
+function d() {
+  /* dangling */
+}
+new Thing(/* dangling */);
+Thing(/* dangling */);
+export /* dangling */ {};
 
 ================================================================================
 `;
@@ -1218,6 +1833,29 @@ export /* dangling */ {};
 ================================================================================
 `;
 
+exports[`dangling_array.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+expect(() => {}).toTriggerReadyStateChanges([
+  // Nothing.
+]);
+
+[1 /* first comment */, 2 /* second comment */, 3];
+
+=====================================output=====================================
+expect(() => {}).toTriggerReadyStateChanges([
+  // Nothing.
+]);
+
+[1 /* first comment */, 2 /* second comment */, 3];
+
+================================================================================
+`;
+
 exports[`dangling_array.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -1263,6 +1901,28 @@ expect(() => {}).toTriggerReadyStateChanges([
 ================================================================================
 `;
 
+exports[`dangling_for.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+for // comment
+(;;);
+
+for /* comment */(;;);
+
+=====================================output=====================================
+// comment
+for (;;);
+
+/* comment */
+for (;;);
+
+================================================================================
+`;
+
 exports[`dangling_for.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -1302,6 +1962,53 @@ for (;;);
 
 /* comment */
 for (;;);
+
+================================================================================
+`;
+
+exports[`dynamic_imports.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+import(/* Hello */ 'something')
+
+import('something' /* Hello */)
+
+import(/* Hello */ 'something' /* Hello */)
+
+import('something' /* Hello */ + 'else')
+
+import(
+  /* Hello */
+  'something'
+  /* Hello */
+)
+
+wrap(
+  import(/* Hello */
+    'something'
+  )
+)
+
+=====================================output=====================================
+import(/* Hello */ "something");
+
+import("something" /* Hello */);
+
+import(/* Hello */ "something" /* Hello */);
+
+import("something" /* Hello */ + "else");
+
+import(
+  /* Hello */
+  "something"
+  /* Hello */
+);
+
+wrap(import(/* Hello */ "something"));
 
 ================================================================================
 `;
@@ -1399,6 +2106,29 @@ wrap(import(/* Hello */ "something"));
 ================================================================================
 `;
 
+exports[`emoji.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+/* #2091 */
+
+const test = '💖'
+// This comment
+// should not get collapsed
+
+=====================================output=====================================
+/* #2091 */
+
+const test = "💖";
+// This comment
+// should not get collapsed
+
+================================================================================
+`;
+
 exports[`emoji.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -1440,6 +2170,54 @@ const test = '💖'
 const test = "💖";
 // This comment
 // should not get collapsed
+
+================================================================================
+`;
+
+exports[`empty-statements.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+a; /* a */ // b
+; /* c */
+
+foo; // first
+;// second
+;// third
+
+function x() {
+} // first
+; // second
+
+a = (
+  b // 1
+  + // 2
+  c // 3
+  + // 4
+  d // 5
+  + /* 6 */
+  e // 7
+);
+
+=====================================output=====================================
+a; /* a */ // b
+/* c */
+foo; // first
+// second
+// third
+function x() {} // first
+// second
+a =
+  b // 1
+  // 2
+  + c // 3
+  // 4
+  + d // 5
+  /* 6 */
+  + e; // 7
 
 ================================================================================
 `;
@@ -1535,6 +2313,97 @@ a =
   d + // 5
   /* 6 */
   e; // 7
+
+================================================================================
+`;
+
+exports[`export.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export //comment
+{}
+
+export /* comment */ {};
+
+const foo = ''
+export {
+  foo // comment
+}
+
+const bar = ''
+export {
+  // comment
+  bar
+}
+
+const fooo = ''
+const barr = ''
+export {
+  fooo, // comment
+  barr, // comment
+}
+
+const foooo = ''
+const barrr = ''
+export {
+  foooo,
+
+  barrr as  // comment
+		 baz,
+} from 'foo'
+
+const fooooo = ''
+const barrrr = ''
+export {
+  fooooo,
+
+  barrrr as  // comment
+		 bazz,
+}
+
+=====================================output=====================================
+export //comment
+ {};
+
+export /* comment */ {};
+
+const foo = "";
+export {
+  foo, // comment
+};
+
+const bar = "";
+export {
+  // comment
+  bar,
+};
+
+const fooo = "";
+const barr = "";
+export {
+  fooo, // comment
+  barr, // comment
+};
+
+const foooo = "";
+const barrr = "";
+export {
+  foooo,
+  // comment
+  barrr as baz,
+} from "foo";
+
+const fooooo = "";
+const barrrr = "";
+export {
+  fooooo,
+  // comment
+  barrrr as bazz,
+};
 
 ================================================================================
 `;
@@ -1720,6 +2589,66 @@ export {
 ================================================================================
 `;
 
+exports[`export-and-import.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// These are tests to compare comment formats in \`export\` and \`import\`.
+
+export {
+  foo,
+
+  bar as  // comment
+		 baz,
+} from 'foo'
+
+const fooo = ""
+const barr = ""
+
+export {
+  fooo,
+
+  barr as  // comment
+		 bazz,
+}
+
+import {
+  foo,
+
+  bar as  // comment
+		 baz,
+} from 'foo'
+
+=====================================output=====================================
+// These are tests to compare comment formats in \`export\` and \`import\`.
+
+export {
+  foo,
+  // comment
+  bar as baz,
+} from "foo";
+
+const fooo = "";
+const barr = "";
+
+export {
+  fooo,
+  // comment
+  barr as bazz,
+};
+
+import {
+  foo,
+  // comment
+  bar as baz,
+} from "foo";
+
+================================================================================
+`;
+
 exports[`export-and-import.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -1839,6 +2768,23 @@ import {
 ================================================================================
 `;
 
+exports[`first-line.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+a // comment
+b
+
+=====================================output=====================================
+a; // comment
+b;
+
+================================================================================
+`;
+
 exports[`first-line.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -1868,6 +2814,143 @@ b
 =====================================output=====================================
 a; // comment
 b;
+
+================================================================================
+`;
+
+exports[`function-declaration.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function a(/* comment */) {} // comment
+function b() {} // comment
+function c(/* comment */ argA, argB, argC) {} // comment
+call((/*object*/ row) => {});
+KEYPAD_NUMBERS.map(num => ( // Buttons 0-9
+  <div />
+));
+
+function f1 /* f */() {}
+function f2 (/* args */) {}
+function f3 () /* returns */ {}
+function f4 /* f */(/* args */) /* returns */ {}
+
+function f5 /* f */(/* a */ a) {}
+function f6 /* f */(a /* a */) {}
+function f7 /* f */(/* a */ a) /* returns */ {}
+
+const obj = {
+  f1 /* f */() {},
+  f2 (/* args */) {},
+  f3 () /* returns */ {},
+  f4 /* f */(/* args */) /* returns */ {},
+};
+
+(function f /* f */() {})();
+(function f (/* args */) {})();
+(function f () /* returns */ {})();
+(function f /* f */(/* args */) /* returns */ {})();
+
+class C1 {
+  f/* f */() {}
+}
+class C2 {
+  f(/* args */) {}
+}
+class C3 {
+  f() /* returns */ {}
+}
+class C4 {
+  f/* f */(/* args */) /* returns */ {}
+}
+
+function foo1() 
+// this is a function
+{
+  return 42
+}
+
+function foo2() // this is a function
+{
+  return 42
+}
+
+function foo3() { // this is a function
+  return 42
+}
+
+function foo4() {
+  // this is a function
+  return 42;
+}
+
+=====================================output=====================================
+function a(/* comment */) {} // comment
+function b() {} // comment
+function c(/* comment */ argA, argB, argC) {} // comment
+call((/*object*/ row) => {});
+KEYPAD_NUMBERS.map(
+  (
+    num, // Buttons 0-9
+  ) => <div />,
+);
+
+function f1 /* f */() {}
+function f2(/* args */) {}
+function f3() /* returns */ {}
+function f4 /* f */(/* args */) /* returns */ {}
+
+function f5 /* f */(/* a */ a) {}
+function f6 /* f */(a /* a */) {}
+function f7 /* f */(/* a */ a) /* returns */ {}
+
+const obj = {
+  f1 /* f */() {},
+  f2(/* args */) {},
+  f3() /* returns */ {},
+  f4 /* f */(/* args */) /* returns */ {},
+};
+
+(function f /* f */() {})();
+(function f(/* args */) {})();
+(function f() /* returns */ {})();
+(function f /* f */(/* args */) /* returns */ {})();
+
+class C1 {
+  f /* f */() {}
+}
+class C2 {
+  f(/* args */) {}
+}
+class C3 {
+  f() /* returns */ {}
+}
+class C4 {
+  f /* f */(/* args */) /* returns */ {}
+}
+
+function foo1() {
+  // this is a function
+  return 42;
+}
+
+function foo2() {
+  // this is a function
+  return 42;
+}
+
+function foo3() {
+  // this is a function
+  return 42;
+}
+
+function foo4() {
+  // this is a function
+  return 42;
+}
 
 ================================================================================
 `;
@@ -2141,6 +3224,153 @@ function foo4() {
   // this is a function
   return 42;
 }
+
+================================================================================
+`;
+
+exports[`if.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+if (1)
+// comment
+{
+  false
+}
+// comment
+else if (2)
+  true
+// multi
+// ple
+// lines
+else if (3)
+  // existing comment
+  true
+// okay?
+else if (4) {
+  // empty with existing comment
+}
+// comment
+else {
+}
+
+if (5) // comment
+true
+
+if (6) // comment
+{true}
+else if (7) // comment
+true
+else // comment
+{true}
+
+if (8) // comment
+// comment
+{true}
+else if (9) // comment
+// comment
+true
+else // comment
+// comment
+{true}
+
+if (10) /* comment */ // comment
+{true}
+else if (11) /* comment */
+true
+else if (12) // comment /* comment */ // comment
+true
+else if (13) /* comment */ /* comment */ // comment
+true
+else /* comment */
+{true}
+
+if (14) // comment
+/* comment */
+// comment
+{true}
+else if (15) // comment
+/* comment */
+/* comment */ // comment
+true
+
+=====================================output=====================================
+if (1) {
+  // comment
+  false;
+}
+// comment
+else if (2) true;
+// multi
+// ple
+// lines
+else if (3)
+  // existing comment
+  true;
+// okay?
+else if (4) {
+  // empty with existing comment
+}
+// comment
+else {
+}
+
+if (5)
+  // comment
+  true;
+
+if (6) {
+  // comment
+  true;
+} else if (7)
+  // comment
+  true;
+// comment
+else {
+  true;
+}
+
+if (8) {
+  // comment
+  // comment
+  true;
+} else if (9)
+  // comment
+  // comment
+  true;
+// comment
+// comment
+else {
+  true;
+}
+
+if (10) {
+  /* comment */ // comment
+  true;
+} else if (11) /* comment */ true;
+else if (12)
+  // comment /* comment */ // comment
+  true;
+else if (13)
+  /* comment */ /* comment */ // comment
+  true;
+/* comment */ else {
+  true;
+}
+
+if (14) {
+  // comment
+  /* comment */
+  // comment
+  true;
+} else if (15)
+  // comment
+  /* comment */
+  /* comment */ // comment
+  true;
 
 ================================================================================
 `;
@@ -2438,6 +3668,97 @@ if (14) {
 ================================================================================
 `;
 
+exports[`issue-3532.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+import React from 'react';
+
+/*
+import styled from 'react-emotion';
+
+const AspectRatioBox = styled.div\`
+  &::before {
+    content: '';
+    width: 1px;
+    margin-left: -1px;
+    float: left;
+    height: 0;
+    padding-top: \${props => 100 / props.aspectRatio}%;
+  }
+
+  &::after {
+    /* To clear float *//*
+    content: '';
+    display: table;
+    clear: both;
+  }
+\`;
+*/
+
+const AspectRatioBox = ({
+  aspectRatio,
+  children,
+  ...props
+}) => (
+  <div
+    className={\`height: 0;
+  overflow: hidden;
+  padding-top: \${props => 100 / props.aspectRatio}%;
+  background: white;
+  position: relative;\`}
+  >
+    <div>{children}</div>
+  </div>
+);
+
+export default AspectRatioBox;
+
+=====================================output=====================================
+import React from "react";
+
+/*
+import styled from 'react-emotion';
+
+const AspectRatioBox = styled.div\`
+  &::before {
+    content: '';
+    width: 1px;
+    margin-left: -1px;
+    float: left;
+    height: 0;
+    padding-top: \${props => 100 / props.aspectRatio}%;
+  }
+
+  &::after {
+    /* To clear float */ /*
+    content: '';
+    display: table;
+    clear: both;
+  }
+\`;
+*/
+
+const AspectRatioBox = ({ aspectRatio, children, ...props }) => (
+  <div
+    className={\`height: 0;
+  overflow: hidden;
+  padding-top: \${(props) => 100 / props.aspectRatio}%;
+  background: white;
+  position: relative;\`}
+  >
+    <div>{children}</div>
+  </div>
+);
+
+export default AspectRatioBox;
+
+================================================================================
+`;
+
 exports[`issue-3532.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -2615,6 +3936,158 @@ const AspectRatioBox = ({ aspectRatio, children, ...props }) => (
 );
 
 export default AspectRatioBox;
+
+================================================================================
+`;
+
+exports[`issues.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// Does not need to break as it fits in 80 columns
+this.call(a, /* comment */ b);
+
+// Comments should either stay at the end of the line or always before, but
+// not one before and one after.
+throw new ProcessSystemError({
+  code: acc.error.code, // Alias of errno
+  originalError: acc.error, // Just in case.
+});
+
+// Missing one level of indentation because of the comment
+const rootEpic = (actions, store) => (
+  combineEpics(...epics)(actions, store)
+    // Log errors and continue.
+    .catch((err, stream) => {
+      getLogger().error(err);
+      return stream;
+    })
+);
+
+// optional trailing comma gets moved all the way to the beginning
+const regex = new RegExp(
+  '^\\\\s*' + // beginning of the line
+  'name\\\\s*=\\\\s*' + // name =
+  '[\\'"]' + // opening quotation mark
+  escapeStringRegExp(target.name) + // target name
+  '[\\'"]' + // closing quotation mark
+  ',?$', // optional trailing comma
+);
+
+// The comment is moved and doesn't trigger the eslint rule anymore
+import path from 'path'; // eslint-disable-line nuclide-internal/prefer-nuclide-uri
+
+// Comments disappear in-between MemberExpressions
+Observable.of(process)
+  // Don't complete until we say so!
+  .merge(Observable.never())
+  // Get the errors.
+  .takeUntil(throwOnError ? errors.flatMap(Observable.throw) : errors)
+  .takeUntil(exit);
+
+// Comments disappear inside of JSX
+<div>
+  {/* Some comment */}
+</div>;
+
+// Comments in JSX tag are placed in a non optimal way
+<div
+  // comment
+/>;
+
+// Comments disappear in empty blocks
+if (1) {
+  // Comment
+}
+
+// Comments trigger invalid JavaScript in-between else if
+if (1) {
+}
+// Comment
+else {
+
+}
+
+// The comment makes the line break in a weird way
+const result = asyncExecute('non_existing_command', /* args */ []);
+
+// The closing paren is printed on the same line as the comment
+foo({}
+  // Hi
+);
+
+=====================================output=====================================
+// Does not need to break as it fits in 80 columns
+this.call(a, /* comment */ b);
+
+// Comments should either stay at the end of the line or always before, but
+// not one before and one after.
+throw new ProcessSystemError({
+  code: acc.error.code, // Alias of errno
+  originalError: acc.error, // Just in case.
+});
+
+// Missing one level of indentation because of the comment
+const rootEpic = (actions, store) =>
+  combineEpics(...epics)(actions, store)
+    // Log errors and continue.
+    .catch((err, stream) => {
+      getLogger().error(err);
+      return stream;
+    });
+
+// optional trailing comma gets moved all the way to the beginning
+const regex = new RegExp(
+  "^\\\\s*" // beginning of the line
+    + "name\\\\s*=\\\\s*" // name =
+    + "['\\"]" // opening quotation mark
+    + escapeStringRegExp(target.name) // target name
+    + "['\\"]" // closing quotation mark
+    + ",?$", // optional trailing comma
+);
+
+// The comment is moved and doesn't trigger the eslint rule anymore
+import path from "path"; // eslint-disable-line nuclide-internal/prefer-nuclide-uri
+
+// Comments disappear in-between MemberExpressions
+Observable.of(process)
+  // Don't complete until we say so!
+  .merge(Observable.never())
+  // Get the errors.
+  .takeUntil(throwOnError ? errors.flatMap(Observable.throw) : errors)
+  .takeUntil(exit);
+
+// Comments disappear inside of JSX
+<div>{/* Some comment */}</div>;
+
+// Comments in JSX tag are placed in a non optimal way
+<div
+// comment
+/>;
+
+// Comments disappear in empty blocks
+if (1) {
+  // Comment
+}
+
+// Comments trigger invalid JavaScript in-between else if
+if (1) {
+}
+// Comment
+else {
+}
+
+// The comment makes the line break in a weird way
+const result = asyncExecute("non_existing_command", /* args */ []);
+
+// The closing paren is printed on the same line as the comment
+foo(
+  {},
+  // Hi
+);
 
 ================================================================================
 `;
@@ -2922,6 +4395,70 @@ foo(
 ================================================================================
 `;
 
+exports[`jsdoc.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+/** @type {any} */
+const x = (
+    <div>
+        <div />
+    </div>
+);
+
+/**
+ * @type {object}
+ */
+() => (
+    <div>
+        sajdfpoiasdjfpoiasdjfpoiasdjfpoiadsjfpaoisdjfapsdiofjapioisadfaskfaspiofjp
+    </div>
+);
+
+/**
+ * @type {object}
+ */
+function HelloWorld() {
+    return (
+        <div>
+           <span>Test</span>
+        </div>
+    );
+}
+=====================================output=====================================
+/** @type {any} */
+const x = (
+  <div>
+    <div />
+  </div>
+);
+
+/**
+ * @type {object}
+ */
+() => (
+  <div>
+    sajdfpoiasdjfpoiasdjfpoiasdjfpoiadsjfpaoisdjfapsdiofjapioisadfaskfaspiofjp
+  </div>
+);
+
+/**
+ * @type {object}
+ */
+function HelloWorld() {
+  return (
+    <div>
+      <span>Test</span>
+    </div>
+  );
+}
+
+================================================================================
+`;
+
 exports[`jsdoc.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -3045,6 +4582,75 @@ function HelloWorld() {
     </div>
   );
 }
+
+================================================================================
+`;
+
+exports[`jsdoc-nestled.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const issues = {
+  see: "#7724 and #12653"
+  /** Trailing comment 1 (not nestled as both comments should be multiline for that) *//**
+  * Trailing comment 2
+  */
+};
+
+/**
+ * @template T
+ * @param {Type} type
+ * @param {T} value
+ * @return {Value}
+ *//**
+ * @param {Type} type
+ * @return {Value}
+ */
+function value(type, value) {
+  if (arguments.length === 2) {
+    return new ConcreteValue(type, value);
+  } else {
+    return new Value(type);
+  }
+}
+
+/** Trailing nestled comment 1
+ *//** Trailing nestled comment 2
+ *//** Trailing nestled comment 3
+ */
+
+=====================================output=====================================
+const issues = {
+  see: "#7724 and #12653",
+  /** Trailing comment 1 (not nestled as both comments should be multiline for that) */ /**
+   * Trailing comment 2
+   */
+};
+
+/**
+ * @template T
+ * @param {Type} type
+ * @param {T} value
+ * @return {Value}
+ *//**
+ * @param {Type} type
+ * @return {Value}
+ */
+function value(type, value) {
+  if (arguments.length === 2) {
+    return new ConcreteValue(type, value);
+  } else {
+    return new Value(type);
+  }
+}
+
+/** Trailing nestled comment 1
+ *//** Trailing nestled comment 2
+ *//** Trailing nestled comment 3
+ */
 
 ================================================================================
 `;
@@ -3186,6 +4792,50 @@ function value(type, value) {
 ================================================================================
 `;
 
+exports[`jsdoc-nestled-dangling.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+{{{{{{{
+o={
+  /**
+   * A
+   *//**
+   * B
+   */
+
+}
+}}}}}}}
+
+=====================================output=====================================
+{
+  {
+    {
+      {
+        {
+          {
+            {
+              o = {
+                /**
+                 * A
+                 *//**
+                 * B
+                 */
+              };
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+================================================================================
+`;
+
 exports[`jsdoc-nestled-dangling.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -3269,6 +4919,247 @@ o={
     }
   }
 }
+
+================================================================================
+`;
+
+exports[`jsx.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<div>
+  {
+    /* comment */
+  }
+</div>;
+
+<div>
+  {/* comment */
+  }
+</div>;
+
+<div>
+  {/* comment
+*/
+  }
+</div>;
+
+<div>
+  {a/* comment
+*/
+  }
+</div>;
+
+<div>
+  {/* comment
+*/
+  a
+  }
+</div>;
+
+<div>
+  {/* comment */
+  }
+</div>;
+
+<div>
+  {/* comment */}
+</div>;
+
+<div>
+  {
+    // single line comment
+  }
+</div>;
+
+<div>
+  {
+    // multiple line comments 1
+    // multiple line comments 2
+  }
+</div>;
+
+<div>
+  {
+    // multiple mixed comments 1
+    /* multiple mixed comments 2 */
+    /* multiple mixed comments 3 */
+    // multiple mixed comments 4
+  }
+</div>;
+
+<div>
+  {
+    // Some very v  ery very very merry (xmas) very very long line to break line width limit
+  }
+</div>;
+
+<div>{/*<div>  Some very v  ery very very long line to break line width limit </div>*/}</div>;
+
+<div>
+  {/**
+   * JSDoc-y comment in JSX. I wonder what will happen to it?
+  */}
+</div>;
+
+<div>
+  {
+    /**
+   * Another JSDoc comment in JSX.
+  */
+  }
+</div>;
+
+<div
+  /**
+ * Handles clicks.
+*/
+onClick={() => {}}>
+
+</div>;
+
+<div
+  // comment
+>
+  {foo}
+</div>;
+
+<div
+  className="foo" // comment
+>
+  {foo}
+</div>;
+
+<div
+  className="foo"
+  // comment
+>
+  {foo}
+</div>;
+
+<div // comment
+  id="foo"
+>
+  {children}
+</div>;
+
+<Wrapper>
+  {}
+  <Component />
+</Wrapper>
+
+=====================================output=====================================
+<div>{/* comment */}</div>;
+
+<div>{/* comment */}</div>;
+
+<div>
+  {/* comment
+   */}
+</div>;
+
+<div>
+  {
+    a /* comment
+     */
+  }
+</div>;
+
+<div>
+  {
+    /* comment
+     */
+    a
+  }
+</div>;
+
+<div>{/* comment */}</div>;
+
+<div>{/* comment */}</div>;
+
+<div>
+  {
+    // single line comment
+  }
+</div>;
+
+<div>
+  {
+    // multiple line comments 1
+    // multiple line comments 2
+  }
+</div>;
+
+<div>
+  {
+    // multiple mixed comments 1
+    /* multiple mixed comments 2 */
+    /* multiple mixed comments 3 */
+    // multiple mixed comments 4
+  }
+</div>;
+
+<div>
+  {
+    // Some very v  ery very very merry (xmas) very very long line to break line width limit
+  }
+</div>;
+
+<div>
+  {/*<div>  Some very v  ery very very long line to break line width limit </div>*/}
+</div>;
+
+<div>
+  {/**
+   * JSDoc-y comment in JSX. I wonder what will happen to it?
+   */}
+</div>;
+
+<div>
+  {/**
+   * Another JSDoc comment in JSX.
+   */}
+</div>;
+
+<div
+  /**
+   * Handles clicks.
+   */
+  onClick={() => {}}
+></div>;
+
+<div
+// comment
+>
+  {foo}
+</div>;
+
+<div
+  className="foo" // comment
+>
+  {foo}
+</div>;
+
+<div
+  className="foo"
+  // comment
+>
+  {foo}
+</div>;
+
+<div // comment
+  id="foo"
+>
+  {children}
+</div>;
+
+<Wrapper>
+  {}
+  <Component />
+</Wrapper>;
 
 ================================================================================
 `;
@@ -3754,6 +5645,94 @@ onClick={() => {}}>
 ================================================================================
 `;
 
+exports[`last-arg.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+
+class Foo {
+  a(lol /*string*/) {}
+
+  b(lol /*string*/
+  ) {}
+
+  d(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) {}
+
+  d(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) /*string*/ {}
+
+  // prettier-ignore
+  c(lol /*string*/
+  ) {}
+
+  // prettier-ignore
+  d(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) {}
+
+  // prettier-ignore
+  e(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) {} /* string*/
+}
+
+=====================================output=====================================
+class Foo {
+  a(lol /*string*/) {}
+
+  b(lol /*string*/) {}
+
+  d(lol /*string*/, lol2 /*string*/, lol3 /*string*/, lol4 /*string*/) {}
+
+  d(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/,
+  ) /*string*/ {}
+
+  // prettier-ignore
+  c(lol /*string*/
+  ) {}
+
+  // prettier-ignore
+  d(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) {}
+
+  // prettier-ignore
+  e(
+    lol /*string*/,
+    lol2 /*string*/,
+    lol3 /*string*/,
+    lol4 /*string*/
+  ) {} /* string*/
+}
+
+================================================================================
+`;
+
 exports[`last-arg.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -3929,6 +5908,57 @@ class Foo {
 ================================================================================
 `;
 
+exports[`multi-comments.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// #8323
+
+import { MapViewProps } from 'react-native-maps'; /*
+comment 14
+*/ /* comment1
+10
+*/ /*/ comment 13 */
+/*
+ comment 9
+ ****/
+import * as ts from 'typescript';
+
+x; /*
+1 */ /* 2 */
+
+y
+
+x; /*1*//*2*/
+y;
+
+=====================================output=====================================
+// #8323
+
+import { MapViewProps } from "react-native-maps"; /*
+comment 14
+*/ /* comment1
+10
+*/ /*/ comment 13 */
+/*
+ comment 9
+ ****/
+import * as ts from "typescript";
+
+x; /*
+1 */ /* 2 */
+
+y;
+
+x; /*1*/ /*2*/
+y;
+
+================================================================================
+`;
+
 exports[`multi-comments.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -4030,6 +6060,31 @@ y;
 ================================================================================
 `;
 
+exports[`multi-comments-2.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+  const x = 0;
+  
+  /* istanbul ignore if */ // debug case currently not triggered
+  if (true) {
+    x;
+  }
+
+=====================================output=====================================
+const x = 0;
+
+/* istanbul ignore if */ // debug case currently not triggered
+if (true) {
+  x;
+}
+
+================================================================================
+`;
+
 exports[`multi-comments-2.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -4075,6 +6130,198 @@ const x = 0;
 if (true) {
   x;
 }
+
+================================================================================
+`;
+
+exports[`multi-comments-on-same-line.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+/*========= All on same line =========*/
+a;
+/*1*//*2*//*3*/
+b;
+
+a;/*1*//*2*//*3*/
+b;
+
+a;
+/*1*//*2*//*3*/b;
+
+a;
+/*
+1*//*2*//*3
+*/
+b;
+
+a;/*
+1*//*2*//*3
+*/
+b;
+
+a;/*
+1*//*2*//*3
+*/b;
+
+/*========= First two on same line =========*/
+a;
+/*1*//*2*/
+/*3*/
+b;
+
+a;/*1*//*2*/
+/*3*/
+b;
+
+a;
+/*1*//*2*/
+/*3*/b;
+
+a;
+/*
+1*//*2*/
+/*3
+*/
+b;
+
+a;/*
+1*//*2*/
+/*3
+*/
+b;
+
+a;/*
+1*//*2*/
+/*3
+*/b;
+
+/*========= Last two on same line =========*/
+a;
+/*1*/
+/*2*//*3*/
+b;
+
+a;/*1*/
+/*2*//*3*/
+b;
+
+a;
+/*1*/
+/*2*//*3*/b;
+
+a;
+/*
+1*/
+/*2*//*3
+*/
+b;
+
+a;/*
+1*/
+/*2*//*3
+*/
+b;
+
+a;/*
+1*/
+/*2*//*3
+*/b;
+
+=====================================output=====================================
+/*========= All on same line =========*/
+a;
+/*1*/ /*2*/ /*3*/
+b;
+
+a; /*1*/ /*2*/ /*3*/
+b;
+
+a;
+/*1*/ /*2*/ /*3*/ b;
+
+a;
+/*
+1*/ /*2*/ /*3
+ */
+b;
+
+a; /*
+1*/ /*2*/ /*3
+ */
+b;
+
+a;
+/*
+1*/ /*2*/ /*3
+ */ b;
+
+/*========= First two on same line =========*/
+a;
+/*1*/ /*2*/
+/*3*/
+b;
+
+a; /*1*/ /*2*/
+/*3*/
+b;
+
+a;
+/*1*/ /*2*/
+/*3*/ b;
+
+a;
+/*
+1*/ /*2*/
+/*3
+ */
+b;
+
+a; /*
+1*/ /*2*/
+/*3
+ */
+b;
+
+a; /*
+1*/ /*2*/
+/*3
+ */ b;
+
+/*========= Last two on same line =========*/
+a;
+/*1*/
+/*2*/ /*3*/
+b;
+
+a; /*1*/
+/*2*/ /*3*/
+b;
+
+a;
+/*1*/
+/*2*/ /*3*/ b;
+
+a;
+/*
+1*/
+/*2*/ /*3
+ */
+b;
+
+a; /*
+1*/
+/*2*/ /*3
+ */
+b;
+
+a; /*
+1*/
+/*2*/ /*3
+ */ b;
 
 ================================================================================
 `;
@@ -4462,6 +6709,23 @@ a; /*
 ================================================================================
 `;
 
+exports[`multi-comments-on-same-line-2.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+/* 1 */ /* 2 */ /* 3 */ a;
+a; /* 4 */ /* 5 */ /* 6 */
+
+=====================================output=====================================
+/* 1 */ /* 2 */ /* 3 */ a;
+a; /* 4 */ /* 5 */ /* 6 */
+
+================================================================================
+`;
+
 exports[`multi-comments-on-same-line-2.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -4491,6 +6755,61 @@ a; /* 4 */ /* 5 */ /* 6 */
 =====================================output=====================================
 /* 1 */ /* 2 */ /* 3 */ a;
 a; /* 4 */ /* 5 */ /* 6 */
+
+================================================================================
+`;
+
+exports[`preserve-new-line-last.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function f() {
+  a
+  /* eslint-disable */
+}
+
+function f() {
+  a
+
+  /* eslint-disable */
+}
+
+function name() {
+  // comment1
+  func1()
+
+  // comment2
+  func2()
+
+  // comment3 why func3 commented
+  // func3()
+}
+
+=====================================output=====================================
+function f() {
+  a;
+  /* eslint-disable */
+}
+
+function f() {
+  a;
+
+  /* eslint-disable */
+}
+
+function name() {
+  // comment1
+  func1();
+
+  // comment2
+  func2();
+
+  // comment3 why func3 commented
+  // func3()
+}
 
 ================================================================================
 `;
@@ -4599,6 +6918,269 @@ function name() {
 
   // comment3 why func3 commented
   // func3()
+}
+
+================================================================================
+`;
+
+exports[`return-statement.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function jsx() {
+  return (
+    // Comment
+    <div />
+  );
+}
+
+function unary() {
+  return (
+    // Comment
+    !!x
+  );
+}
+
+function numericLiteralNoParen() {
+  return 1337; // Comment
+}
+
+function logical() {
+  return (
+    // Reason for 42
+    42
+  ) && 84
+}
+
+function binary() {
+  return (
+    // Reason for 42
+    42
+  ) * 84
+}
+
+function binaryInBinaryLeft() {
+  return (
+    // Reason for 42
+    42
+  ) * 84 + 2
+}
+
+function binaryInBinaryRight() {
+  return (
+    // Reason for 42
+    42
+  ) + 84 * 2
+}
+
+function conditional() {
+  return (
+    // Reason for 42
+    42
+  ) ? 1 : 2
+}
+
+function binaryInConditional() {
+  return (
+    // Reason for 42
+    42
+  ) * 3 ? 1 : 2
+}
+
+function call() {
+  return (
+    // Reason for a
+    a
+  )()
+}
+
+function memberInside() {
+  return (
+    // Reason for a.b
+    a.b
+  ).c
+}
+
+function memberOutside() {
+  return (
+    // Reason for a
+    a
+  ).b.c
+}
+
+function memberInAndOutWithCalls() {
+  return (
+    // Reason for a
+    aFunction.b()
+  ).c.d()
+}
+
+function excessiveEverything() {
+  return (
+    // Reason for stuff
+    a.b() * 3 + 4 ? (a\`hi\`, 1) ? 1 : 1 : 1
+  )
+}
+
+// See https://github.com/prettier/prettier/issues/2392
+// function sequenceExpression() {
+//   return (
+//     // Reason for a
+//     a
+//   ), b
+// }
+
+function sequenceExpressionInside() {
+  return ( // Reason for a
+    a, b
+  );
+}
+
+function taggedTemplate() {
+  return (
+    // Reason for a
+    a
+  )\`b\`
+}
+
+function inlineComment() {
+  return (
+    /* hi */ 42
+  ) || 42
+}
+
+=====================================output=====================================
+function jsx() {
+  return (
+    // Comment
+    <div />
+  );
+}
+
+function unary() {
+  return (
+    // Comment
+    !!x
+  );
+}
+
+function numericLiteralNoParen() {
+  return 1337; // Comment
+}
+
+function logical() {
+  return (
+    // Reason for 42
+    42 && 84
+  );
+}
+
+function binary() {
+  return (
+    // Reason for 42
+    42 * 84
+  );
+}
+
+function binaryInBinaryLeft() {
+  return (
+    // Reason for 42
+    42
+      * 84
+    + 2
+  );
+}
+
+function binaryInBinaryRight() {
+  return (
+    // Reason for 42
+    42
+    + 84 * 2
+  );
+}
+
+function conditional() {
+  return (
+    // Reason for 42
+    42
+      ? 1
+      : 2
+  );
+}
+
+function binaryInConditional() {
+  return (
+    // Reason for 42
+    42 * 3
+      ? 1
+      : 2
+  );
+}
+
+function call() {
+  return (
+    // Reason for a
+    a()
+  );
+}
+
+function memberInside() {
+  return (
+    // Reason for a.b
+    a.b.c
+  );
+}
+
+function memberOutside() {
+  return (
+    // Reason for a
+    a.b.c
+  );
+}
+
+function memberInAndOutWithCalls() {
+  return (
+    aFunction
+      .b// Reason for a
+      ()
+      .c.d()
+  );
+}
+
+function excessiveEverything() {
+  return (
+    // Reason for stuff
+    a.b() * 3 + 4 ? ((a\`hi\`, 1) ? 1 : 1) : 1
+  );
+}
+
+// See https://github.com/prettier/prettier/issues/2392
+// function sequenceExpression() {
+//   return (
+//     // Reason for a
+//     a
+//   ), b
+// }
+
+function sequenceExpressionInside() {
+  return (
+    // Reason for a
+    a, b
+  );
+}
+
+function taggedTemplate() {
+  return (
+    // Reason for a
+    a\`b\`
+  );
+}
+
+function inlineComment() {
+  return /* hi */ 42 || 42;
 }
 
 ================================================================================
@@ -5129,6 +7711,79 @@ function inlineComment() {
 ================================================================================
 `;
 
+exports[`single-star-jsdoc.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+/*
+ * Looking good!
+ */
+
+if(true) {
+    /*
+     * Oh no
+     */
+}
+
+  /** first line
+* second line
+   * third line */
+
+  /* first line
+* second line
+   * third line */
+
+  /*! first line
+*second line
+   *  third line */
+
+/*!
+* Extracted from vue codebase
+* https://github.com/vuejs/vue/blob/cfd73c2386623341fdbb3ac636c4baf84ea89c2c/src/compiler/parser/html-parser.js
+* HTML Parser By John Resig (ejohn.org)
+* Modified by Juriy "kangax" Zaytsev
+* Original code by Erik Arvidsson, Mozilla Public License
+* http://erik.eae.net/simplehtmlparser/simplehtmlparser.js
+*/
+
+=====================================output=====================================
+/*
+ * Looking good!
+ */
+
+if (true) {
+  /*
+   * Oh no
+   */
+}
+
+/** first line
+ * second line
+ * third line */
+
+/* first line
+ * second line
+ * third line */
+
+/*! first line
+ *second line
+ *  third line */
+
+/*!
+ * Extracted from vue codebase
+ * https://github.com/vuejs/vue/blob/cfd73c2386623341fdbb3ac636c4baf84ea89c2c/src/compiler/parser/html-parser.js
+ * HTML Parser By John Resig (ejohn.org)
+ * Modified by Juriy "kangax" Zaytsev
+ * Original code by Erik Arvidsson, Mozilla Public License
+ * http://erik.eae.net/simplehtmlparser/simplehtmlparser.js
+ */
+
+================================================================================
+`;
+
 exports[`single-star-jsdoc.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -5274,6 +7929,23 @@ if (true) {
 ================================================================================
 `;
 
+exports[`snippet: #0 - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+var a = { /* comment */      
+b };
+=====================================output=====================================
+var a = {
+  /* comment */ b,
+};
+
+================================================================================
+`;
+
 exports[`snippet: #0 - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -5298,6 +7970,23 @@ printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
 var a = { /* comment */      
+b };
+=====================================output=====================================
+var a = {
+  /* comment */ b,
+};
+
+================================================================================
+`;
+
+exports[`snippet: #1 - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+var a = { /* comment */
 b };
 =====================================output=====================================
 var a = {
@@ -5336,6 +8025,94 @@ b };
 var a = {
   /* comment */ b,
 };
+
+================================================================================
+`;
+
+exports[`switch.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+switch (node && node.type) {
+  case "Property":
+  case "MethodDefinition":
+    prop = node.key;
+    break;
+
+  case "MemberExpression":
+    prop = node.property;
+    break;
+
+  // no default
+}
+
+switch (foo) {
+  case "bar":
+    doThing()
+
+  // no default
+}
+
+switch (foo) {
+  case "bar": //comment
+    doThing(); //comment
+
+  case "baz":
+    doOtherThing(); //comment
+
+}
+
+switch (foo) {
+  case "bar": {
+    doThing();
+  } //comment
+
+  case "baz": {
+    doThing();
+  } //comment
+}
+
+=====================================output=====================================
+switch (node && node.type) {
+  case "Property":
+  case "MethodDefinition":
+    prop = node.key;
+    break;
+
+  case "MemberExpression":
+    prop = node.property;
+    break;
+
+  // no default
+}
+
+switch (foo) {
+  case "bar":
+    doThing();
+
+  // no default
+}
+
+switch (foo) {
+  case "bar": //comment
+    doThing(); //comment
+
+  case "baz":
+    doOtherThing(); //comment
+}
+
+switch (foo) {
+  case "bar": {
+    doThing();
+  } //comment
+
+  case "baz": {
+    doThing();
+  } //comment
+}
 
 ================================================================================
 `;
@@ -5515,6 +8292,48 @@ switch (foo) {
 ================================================================================
 `;
 
+exports[`tagged-template-literal.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+foo\`\`; // comment
+
+foo // comment
+\`\`;
+
+foo // comment
+\`
+\`;
+
+foo /* comment */\`
+\`;
+
+foo /* comment */
+\`
+\`;
+
+=====================================output=====================================
+foo\`\`; // comment
+
+foo // comment
+\`\`;
+
+foo // comment
+\`
+\`;
+
+foo/* comment */ \`
+\`;
+
+foo /* comment */\`
+\`;
+
+================================================================================
+`;
+
 exports[`tagged-template-literal.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -5598,6 +8417,45 @@ foo /* comment */\`
 ================================================================================
 `;
 
+exports[`template-literal.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+\`
+\${a // comment
+}
+
+\${b /* comment */}
+
+\${/* comment */ c /* comment */}
+
+\${// comment
+d //comment
+};
+\`
+
+=====================================output=====================================
+\`
+\${
+  a // comment
+}
+
+\${b /* comment */}
+
+\${/* comment */ c /* comment */}
+
+\${
+  // comment
+  d //comment
+};
+\`;
+
+================================================================================
+`;
+
 exports[`template-literal.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -5675,6 +8533,29 @@ d //comment
 ================================================================================
 `;
 
+exports[`trailing_space.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+#!/there/is-space-here->         
+
+// Do not trim trailing whitespace from this source file!
+
+// There is some space here ->                        
+
+=====================================output=====================================
+#!/there/is-space-here->
+
+// Do not trim trailing whitespace from this source file!
+
+// There is some space here ->
+
+================================================================================
+`;
+
 exports[`trailing_space.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -5716,6 +8597,64 @@ printWidth: 80
 // Do not trim trailing whitespace from this source file!
 
 // There is some space here ->
+
+================================================================================
+`;
+
+exports[`trailing-jsdocs.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const CONNECTION_STATUS = exports.CONNECTION_STATUS = {
+  CLOSED: Object.freeze({ kind: 'CLOSED' }),
+  CONNECTED: Object.freeze({ kind: 'CONNECTED' }),
+  CONNECTING: Object.freeze({ kind: 'CONNECTING' }),
+  NOT_CONNECTED: Object.freeze({ kind: 'NOT_CONNECTED' }) };
+
+/* A comment */ /**
+* A type that can be written to a buffer.
+*/ /**
+* Describes the connection status of a ReactiveSocket/DuplexConnection.
+* - NOT_CONNECTED: no connection established or pending.
+* - CONNECTING: when \`connect()\` has been called but a connection is not yet
+*   established.
+* - CONNECTED: when a connection is established.
+* - CLOSED: when the connection has been explicitly closed via \`close()\`.
+* - ERROR: when the connection has been closed for any other reason.
+*/ /**
+* A contract providing different interaction models per the [ReactiveSocket protocol]
+* (https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md).
+*/ /**
+* A single unit of data exchanged between the peers of a \`ReactiveSocket\`.
+*/
+
+=====================================output=====================================
+const CONNECTION_STATUS = (exports.CONNECTION_STATUS = {
+  CLOSED: Object.freeze({ kind: "CLOSED" }),
+  CONNECTED: Object.freeze({ kind: "CONNECTED" }),
+  CONNECTING: Object.freeze({ kind: "CONNECTING" }),
+  NOT_CONNECTED: Object.freeze({ kind: "NOT_CONNECTED" }),
+});
+
+/* A comment */ /**
+ * A type that can be written to a buffer.
+ */ /**
+ * Describes the connection status of a ReactiveSocket/DuplexConnection.
+ * - NOT_CONNECTED: no connection established or pending.
+ * - CONNECTING: when \`connect()\` has been called but a connection is not yet
+ *   established.
+ * - CONNECTED: when a connection is established.
+ * - CLOSED: when the connection has been explicitly closed via \`close()\`.
+ * - ERROR: when the connection has been closed for any other reason.
+ */ /**
+ * A contract providing different interaction models per the [ReactiveSocket protocol]
+ * (https://github.com/ReactiveSocket/reactivesocket/blob/master/Protocol.md).
+ */ /**
+ * A single unit of data exchanged between the peers of a \`ReactiveSocket\`.
+ */
 
 ================================================================================
 `;
@@ -5831,6 +8770,46 @@ const CONNECTION_STATUS = (exports.CONNECTION_STATUS = {
  */ /**
  * A single unit of data exchanged between the peers of a \`ReactiveSocket\`.
  */
+
+================================================================================
+`;
+
+exports[`try.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// Comment 1
+try { // Comment 2
+  // Comment 3
+}
+// Comment 4
+catch(e) { // Comment 5
+  // Comment 6
+}
+// Comment 7
+finally { // Comment 8
+  // Comment 9
+}
+// Comment 10
+
+=====================================output=====================================
+// Comment 1
+try {
+  // Comment 2
+  // Comment 3
+} catch (e) {
+  // Comment 4
+  // Comment 5
+  // Comment 6
+} finally {
+  // Comment 7
+  // Comment 8
+  // Comment 9
+}
+// Comment 10
 
 ================================================================================
 `;
@@ -5967,6 +8946,112 @@ exports[`tuple-and-record.js [typescript] format 1`] = `
    8 |   key: 'value'
    9 | }
   10 |"
+`;
+
+exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [acorn] format 1`] = `
+"Unexpected character '{' (7:2)
+   5 |
+   6 | let record = // Comment
+>  7 | #{
+     |  ^
+   8 |   key: 'value'
+   9 | }
+  10 |"
+`;
+
+exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [espree] format 1`] = `
+"Unexpected character '{' (7:2)
+   5 |
+   6 | let record = // Comment
+>  7 | #{
+     |  ^
+   8 |   key: 'value'
+   9 | }
+  10 |"
+`;
+
+exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [flow] format 1`] = `
+"Unexpected token \`#\`, expected an identifier (7:1)
+   5 |
+   6 | let record = // Comment
+>  7 | #{
+     | ^
+   8 |   key: 'value'
+   9 | }
+  10 |"
+`;
+
+exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [meriyah] format 1`] = `
+"'#' not followed by identifier (7:1)
+   5 |
+   6 | let record = // Comment
+>  7 | #{
+     | ^
+   8 |   key: 'value'
+   9 | }
+  10 |"
+`;
+
+exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [typescript] format 1`] = `
+"Invalid character. (7:1)
+   5 |
+   6 | let record = // Comment
+>  7 | #{
+     | ^
+   8 |   key: 'value'
+   9 | }
+  10 |"
+`;
+
+exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+let object = // Comment
+{
+  key: 'value'
+}
+
+let record = // Comment
+#{
+  key: 'value'
+}
+
+let array = // Comment
+[
+  'value'
+]
+
+let tuple = // Comment
+#[
+  'value'
+]
+
+=====================================output=====================================
+let object =
+  // Comment
+  {
+    key: "value",
+  };
+
+let record =
+  // Comment
+  #{
+    key: "value",
+  };
+
+let array =
+  // Comment
+  ["value"];
+
+let tuple =
+  // Comment
+  #["value"];
+
+================================================================================
 `;
 
 exports[`tuple-and-record.js - {"semi":false} [acorn] format 1`] = `
@@ -6121,6 +9206,157 @@ let array =
 let tuple =
   // Comment
   #["value"];
+
+================================================================================
+`;
+
+exports[`variable_declarator.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+let obj1 = // Comment
+{
+  key: 'val'
+}
+
+let obj2 // Comment
+= {
+  key: 'val'
+}
+
+let obj3 = { // Comment
+  key: 'val'
+}
+
+let obj4 = {
+  // Comment
+  key: 'val'
+}
+
+let obj5 = // Comment
+[
+  'val'
+]
+
+let obj6 // Comment
+= [
+  'val'
+]
+
+let obj7 = [ // Comment
+  'val'
+]
+
+let obj8 = [
+  // Comment
+  'val'
+]
+
+let obj9 = // Comment
+\`val\`;
+
+let obj10 = // Comment
+\`
+val
+val
+\`;
+
+let obj11 = // Comment
+tag\`val\`;
+
+let obj12 = // Comment
+tag\`
+val
+val
+\`;
+
+let // Comment
+  foo1 = 'val';
+
+let // Comment
+  foo2 = 'val',
+  bar = 'val';
+
+const foo3 = 123
+// Nothing to see here.
+;["2", "3"].forEach(x => console.log(x))
+
+=====================================output=====================================
+let obj1 =
+  // Comment
+  {
+    key: "val",
+  };
+
+let obj2 =
+  // Comment
+  {
+    key: "val",
+  };
+
+let obj3 = {
+  // Comment
+  key: "val",
+};
+
+let obj4 = {
+  // Comment
+  key: "val",
+};
+
+let obj5 =
+  // Comment
+  ["val"];
+
+let obj6 =
+  // Comment
+  ["val"];
+
+let obj7 = [
+  // Comment
+  "val",
+];
+
+let obj8 = [
+  // Comment
+  "val",
+];
+
+let obj9 =
+  // Comment
+  \`val\`;
+
+let obj10 =
+  // Comment
+  \`
+val
+val
+\`;
+
+let obj11 =
+  // Comment
+  tag\`val\`;
+
+let obj12 =
+  // Comment
+  tag\`
+val
+val
+\`;
+
+let // Comment
+  foo1 = "val";
+
+let // Comment
+  foo2 = "val",
+  bar = "val";
+
+const foo3 = 123;
+// Nothing to see here.
+["2", "3"].forEach((x) => console.log(x));
 
 ================================================================================
 `;
@@ -6422,6 +9658,69 @@ let // Comment
 const foo3 = 123;
 // Nothing to see here.
 ["2", "3"].forEach((x) => console.log(x));
+
+================================================================================
+`;
+
+exports[`while.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+while(
+    true
+    // Comment
+  ) {}
+
+while(true)// Comment
+{}
+
+while(true){}// Comment
+
+while(true)/*Comment*/{}
+
+while(
+  true // Comment
+  && true // Comment
+  ){}
+
+while(true) {} // comment
+
+while(true) /* comment */ ++x; 
+
+while(1) // Comment
+  foo();
+
+=====================================output=====================================
+while (
+  true
+  // Comment
+) {}
+
+while (true) {
+  // Comment
+}
+
+while (true) {} // Comment
+
+while (true) {
+  /*Comment*/
+}
+
+while (
+  true // Comment
+  && true // Comment
+) {}
+
+while (true) {} // comment
+
+while (true) /* comment */ ++x;
+
+while (1)
+  // Comment
+  foo();
 
 ================================================================================
 `;

--- a/tests/format/js/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`arrow.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`arrow.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -56,9 +56,9 @@ const fn2 = (/*event, data*/) => doSomething(anything);
 ================================================================================
 `;
 
-exports[`assignment-pattern.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`assignment-pattern.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -133,9 +133,9 @@ let {
 ================================================================================
 `;
 
-exports[`before-comma.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`before-comma.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -207,9 +207,9 @@ const foo = {
 ================================================================================
 `;
 
-exports[`binary-expressions.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`binary-expressions.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -671,9 +671,9 @@ function bitwiseXor() {
 ================================================================================
 `;
 
-exports[`binary-expressions-block-comments.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`binary-expressions-block-comments.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -970,9 +970,9 @@ a =
 ================================================================================
 `;
 
-exports[`binary-expressions-parens.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`binary-expressions-parens.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1065,9 +1065,9 @@ Math.min(
 ================================================================================
 `;
 
-exports[`binary-expressions-single-comments.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`binary-expressions-single-comments.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1220,9 +1220,9 @@ a =
 ================================================================================
 `;
 
-exports[`blank.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`blank.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1384,9 +1384,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`break-continue-statements.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`break-continue-statements.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1488,9 +1488,9 @@ loop: for (;;) {
 ================================================================================
 `;
 
-exports[`call_comment.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`call_comment.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1619,9 +1619,9 @@ render?.(
 ================================================================================
 `;
 
-exports[`class.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`class.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1717,9 +1717,9 @@ class D {
 ================================================================================
 `;
 
-exports[`dangling.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`dangling.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1833,9 +1833,9 @@ export /* dangling */ {};
 ================================================================================
 `;
 
-exports[`dangling_array.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`dangling_array.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1901,9 +1901,9 @@ expect(() => {}).toTriggerReadyStateChanges([
 ================================================================================
 `;
 
-exports[`dangling_for.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`dangling_for.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1966,9 +1966,9 @@ for (;;);
 ================================================================================
 `;
 
-exports[`dynamic_imports.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`dynamic_imports.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -2106,9 +2106,9 @@ wrap(import(/* Hello */ "something"));
 ================================================================================
 `;
 
-exports[`emoji.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`emoji.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -2174,9 +2174,9 @@ const test = "💖";
 ================================================================================
 `;
 
-exports[`empty-statements.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`empty-statements.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -2317,9 +2317,9 @@ a =
 ================================================================================
 `;
 
-exports[`export.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`export.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -2589,9 +2589,9 @@ export {
 ================================================================================
 `;
 
-exports[`export-and-import.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`export-and-import.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -2768,9 +2768,9 @@ import {
 ================================================================================
 `;
 
-exports[`first-line.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`first-line.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -2818,9 +2818,9 @@ b;
 ================================================================================
 `;
 
-exports[`function-declaration.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`function-declaration.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -3228,9 +3228,9 @@ function foo4() {
 ================================================================================
 `;
 
-exports[`if.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`if.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -3668,9 +3668,9 @@ if (14) {
 ================================================================================
 `;
 
-exports[`issue-3532.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-3532.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -3940,9 +3940,9 @@ export default AspectRatioBox;
 ================================================================================
 `;
 
-exports[`issues.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issues.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -4395,9 +4395,9 @@ foo(
 ================================================================================
 `;
 
-exports[`jsdoc.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`jsdoc.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -4586,9 +4586,9 @@ function HelloWorld() {
 ================================================================================
 `;
 
-exports[`jsdoc-nestled.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`jsdoc-nestled.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -4792,9 +4792,9 @@ function value(type, value) {
 ================================================================================
 `;
 
-exports[`jsdoc-nestled-dangling.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`jsdoc-nestled-dangling.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -4923,9 +4923,9 @@ o={
 ================================================================================
 `;
 
-exports[`jsx.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`jsx.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -5645,9 +5645,9 @@ onClick={() => {}}>
 ================================================================================
 `;
 
-exports[`last-arg.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`last-arg.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -5908,9 +5908,9 @@ class Foo {
 ================================================================================
 `;
 
-exports[`multi-comments.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`multi-comments.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -6060,9 +6060,9 @@ y;
 ================================================================================
 `;
 
-exports[`multi-comments-2.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`multi-comments-2.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -6134,9 +6134,9 @@ if (true) {
 ================================================================================
 `;
 
-exports[`multi-comments-on-same-line.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`multi-comments-on-same-line.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -6709,9 +6709,9 @@ a; /*
 ================================================================================
 `;
 
-exports[`multi-comments-on-same-line-2.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`multi-comments-on-same-line-2.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -6759,9 +6759,9 @@ a; /* 4 */ /* 5 */ /* 6 */
 ================================================================================
 `;
 
-exports[`preserve-new-line-last.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`preserve-new-line-last.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -6923,9 +6923,9 @@ function name() {
 ================================================================================
 `;
 
-exports[`return-statement.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`return-statement.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -7711,9 +7711,9 @@ function inlineComment() {
 ================================================================================
 `;
 
-exports[`single-star-jsdoc.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`single-star-jsdoc.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -7929,9 +7929,9 @@ if (true) {
 ================================================================================
 `;
 
-exports[`snippet: #0 - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`snippet: #0 - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -7979,9 +7979,9 @@ var a = {
 ================================================================================
 `;
 
-exports[`snippet: #1 - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`snippet: #1 - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -8029,9 +8029,9 @@ var a = {
 ================================================================================
 `;
 
-exports[`switch.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`switch.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -8292,9 +8292,9 @@ switch (foo) {
 ================================================================================
 `;
 
-exports[`tagged-template-literal.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`tagged-template-literal.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -8417,9 +8417,9 @@ foo /* comment */\`
 ================================================================================
 `;
 
-exports[`template-literal.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`template-literal.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -8533,9 +8533,9 @@ d //comment
 ================================================================================
 `;
 
-exports[`trailing_space.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`trailing_space.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -8601,9 +8601,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`trailing-jsdocs.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`trailing-jsdocs.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -8774,9 +8774,9 @@ const CONNECTION_STATUS = (exports.CONNECTION_STATUS = {
 ================================================================================
 `;
 
-exports[`try.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`try.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -8948,7 +8948,7 @@ exports[`tuple-and-record.js [typescript] format 1`] = `
   10 |"
 `;
 
-exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [acorn] format 1`] = `
+exports[`tuple-and-record.js - {"experimentalOperatorPosition":true} [acorn] format 1`] = `
 "Unexpected character '{' (7:2)
    5 |
    6 | let record = // Comment
@@ -8959,7 +8959,7 @@ exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [acorn] for
   10 |"
 `;
 
-exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [espree] format 1`] = `
+exports[`tuple-and-record.js - {"experimentalOperatorPosition":true} [espree] format 1`] = `
 "Unexpected character '{' (7:2)
    5 |
    6 | let record = // Comment
@@ -8970,7 +8970,7 @@ exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [espree] fo
   10 |"
 `;
 
-exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [flow] format 1`] = `
+exports[`tuple-and-record.js - {"experimentalOperatorPosition":true} [flow] format 1`] = `
 "Unexpected token \`#\`, expected an identifier (7:1)
    5 |
    6 | let record = // Comment
@@ -8981,7 +8981,7 @@ exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [flow] form
   10 |"
 `;
 
-exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [meriyah] format 1`] = `
+exports[`tuple-and-record.js - {"experimentalOperatorPosition":true} [meriyah] format 1`] = `
 "'#' not followed by identifier (7:1)
    5 |
    6 | let record = // Comment
@@ -8992,7 +8992,7 @@ exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [meriyah] f
   10 |"
 `;
 
-exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [typescript] format 1`] = `
+exports[`tuple-and-record.js - {"experimentalOperatorPosition":true} [typescript] format 1`] = `
 "Invalid character. (7:1)
    5 |
    6 | let record = // Comment
@@ -9003,9 +9003,9 @@ exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [typescript
   10 |"
 `;
 
-exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`tuple-and-record.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -9210,9 +9210,9 @@ let tuple =
 ================================================================================
 `;
 
-exports[`variable_declarator.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`variable_declarator.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -9662,9 +9662,9 @@ const foo3 = 123;
 ================================================================================
 `;
 
-exports[`while.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`while.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/comments/jsfmt.spec.js
+++ b/tests/format/js/comments/jsfmt.spec.js
@@ -16,3 +16,7 @@ const errors = {
 
 run_spec(fixtures, ["babel", "flow", "typescript"], { errors });
 run_spec(fixtures, ["babel", "flow", "typescript"], { semi: false, errors });
+run_spec(fixtures, ["babel", "flow", "typescript"], {
+  errors,
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/comments/jsfmt.spec.js
+++ b/tests/format/js/comments/jsfmt.spec.js
@@ -18,5 +18,5 @@ run_spec(fixtures, ["babel", "flow", "typescript"], { errors });
 run_spec(fixtures, ["babel", "flow", "typescript"], { semi: false, errors });
 run_spec(fixtures, ["babel", "flow", "typescript"], {
   errors,
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/js/conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/conditional/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,262 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`comments.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+var inspect = 4 === util.inspect.length
+  ? // node <= 0.8.x
+    (function(v, colors) {
+      return util.inspect(v, void 0, void 0, colors);
+    })
+  : // node > 0.8.x
+    (function(v, colors) {
+      return util.inspect(v, { colors: colors });
+    });
+
+var inspect = 4 === util.inspect.length
+  ? // node <= 0.8.x
+    (function(v, colors) {
+      return util.inspect(v, void 0, void 0, colors);
+    })
+  : // node > 0.8.x
+    (function(v, colors) {
+      return util.inspect(v, { colors: colors });
+    });
+
+const extractTextPluginOptions = shouldUseRelativeAssetPaths
+  // Making sure that the publicPath goes back to to build folder.
+  ? { publicPath: Array(cssFilename.split('/').length).join('../') } :
+  {};
+
+const extractTextPluginOptions2 = shouldUseRelativeAssetPaths
+  ? // Making sure that the publicPath goes back to to build folder.
+    { publicPath: Array(cssFilename.split("/").length).join("../") }
+  : {};
+
+const extractTextPluginOptions3 = shouldUseRelativeAssetPaths // Making sure that the publicPath goes back to to build folder.
+  ? { publicPath: Array(cssFilename.split("/").length).join("../") }
+  : {};
+
+const { configureStore } = process.env.NODE_ENV === "production"
+  ? require("./configureProdStore") // a
+  : require("./configureDevStore"); // b
+
+test /* comment
+  comment
+      comment
+*/
+  ? foo
+  : bar;
+
+test
+  ? /* comment
+          comment
+    comment
+          comment
+  */
+    foo
+  : bar;
+
+test
+  ? /* comment
+       comment
+       comment
+       comment
+    */
+    foo
+  : test
+  ? /* comment
+  comment
+    comment */
+    foo
+  : bar;
+
+test
+  ? /* comment */
+    foo
+  : bar;
+
+test
+  ? foo
+  : /* comment
+         comment
+     comment
+           comment
+    */
+  bar;
+
+test
+  ? foo
+  : /* comment
+         comment
+     comment
+           comment
+      A newline will be added after this comment, unfortunately – but it can be removed manually, see next statement.
+    */
+  test
+  ? foo
+  : /* comment
+  comment
+    comment
+   */
+    bar;
+
+
+// It is at least possible to delete the extra newline that was
+// unfortunately added before the second condition above:
+test ?
+  foo :/* comment
+         comment
+     comment
+           comment
+    */
+test ?
+  foo :
+  /* comment
+  comment
+    comment
+   */
+  bar;
+
+test
+  ? foo
+  : /* comment */
+  bar;
+
+test ? test /* c
+c */? foo : bar : bar;
+
+=====================================output=====================================
+var inspect =
+  4 === util.inspect.length
+    ? // node <= 0.8.x
+      function (v, colors) {
+        return util.inspect(v, void 0, void 0, colors);
+      }
+    : // node > 0.8.x
+      function (v, colors) {
+        return util.inspect(v, { colors: colors });
+      };
+
+var inspect =
+  4 === util.inspect.length
+    ? // node <= 0.8.x
+      function (v, colors) {
+        return util.inspect(v, void 0, void 0, colors);
+      }
+    : // node > 0.8.x
+      function (v, colors) {
+        return util.inspect(v, { colors: colors });
+      };
+
+const extractTextPluginOptions = shouldUseRelativeAssetPaths
+  ? // Making sure that the publicPath goes back to to build folder.
+    { publicPath: Array(cssFilename.split("/").length).join("../") }
+  : {};
+
+const extractTextPluginOptions2 = shouldUseRelativeAssetPaths
+  ? // Making sure that the publicPath goes back to to build folder.
+    { publicPath: Array(cssFilename.split("/").length).join("../") }
+  : {};
+
+const extractTextPluginOptions3 = shouldUseRelativeAssetPaths // Making sure that the publicPath goes back to to build folder.
+  ? { publicPath: Array(cssFilename.split("/").length).join("../") }
+  : {};
+
+const { configureStore } =
+  process.env.NODE_ENV === "production"
+    ? require("./configureProdStore") // a
+    : require("./configureDevStore"); // b
+
+test /* comment
+  comment
+      comment
+*/
+  ? foo
+  : bar;
+
+test
+  ? /* comment
+          comment
+    comment
+          comment
+  */
+    foo
+  : bar;
+
+test
+  ? /* comment
+       comment
+       comment
+       comment
+    */
+    foo
+  : test
+  ? /* comment
+  comment
+    comment */
+    foo
+  : bar;
+
+test ? /* comment */ foo : bar;
+
+test
+  ? foo
+  : /* comment
+         comment
+     comment
+           comment
+    */
+    bar;
+
+test
+  ? foo
+  : /* comment
+         comment
+     comment
+           comment
+      A newline will be added after this comment, unfortunately – but it can be removed manually, see next statement.
+    */
+  test
+  ? foo
+  : /* comment
+  comment
+    comment
+   */
+    bar;
+
+// It is at least possible to delete the extra newline that was
+// unfortunately added before the second condition above:
+test
+  ? foo /* comment
+         comment
+     comment
+           comment
+    */
+  : test
+  ? foo
+  : /* comment
+  comment
+    comment
+   */
+    bar;
+
+test ? foo : /* comment */ bar;
+
+test
+  ? test /* c
+c */
+    ? foo
+    : bar
+  : bar;
+
+================================================================================
+`;
+
 exports[`comments.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -256,6 +513,25 @@ c */
 ================================================================================
 `;
 
+exports[`new-expression.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const testConsole = new TestConsole(
+  config.useStderr ? process.stderr : process.stdout
+);
+
+=====================================output=====================================
+const testConsole = new TestConsole(
+  config.useStderr ? process.stderr : process.stdout,
+);
+
+================================================================================
+`;
+
 exports[`new-expression.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -269,6 +545,307 @@ const testConsole = new TestConsole(
 =====================================output=====================================
 const testConsole = new TestConsole(
   config.useStderr ? process.stderr : process.stdout,
+);
+
+================================================================================
+`;
+
+exports[`new-ternary-examples.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// from https://gist.github.com/rattrayalex/dacbf5838571a47f22d0ae1f8b960268
+// Input and output should match (for 2-space indent formatting).
+// TypeScript is here: prettier/tests/format/typescript/conditional-types/new-ternary-spec.ts
+// EXAMPLES
+//  mostly taken from https://github.com/prettier/prettier/issues/9561
+
+const message =
+  i % 3 === 0 && i % 5 === 0 ? "fizzbuzz"
+  : i % 3 === 0 ? "fizz"
+  : i % 5 === 0 ? "buzz"
+  : String(i);
+
+const paymentMessageShort =
+  state == "success" ? "Payment completed successfully"
+  : state == "processing" ? "Payment processing"
+  : state == "invalid_cvc" ? "There was an issue with your CVC number"
+  : state == "invalid_expiry" ? "Expiry must be sometime in the past."
+  : "There was an issue with the payment.  Please contact support.";
+
+const paymentMessageWithABreak =
+  state == "success" ? "Payment completed successfully"
+  : state == "processing" ? "Payment processing"
+  : state == "invalid_cvc" ?
+    "There was an issue with your CVC number, and you need to take a prompt action on it."
+  : state == "invalid_expiry" ? "Expiry must be sometime in the past."
+  : "There was an issue with the payment.  Please contact support.";
+
+const typeofExample =
+  definition.encode ?
+    definition.encode(
+      typeof row[field] !== "undefined" ? row[field]
+      : typeof definition.default !== "undefined" ? definition.default
+      : null
+    )
+  : typeof row[field] !== "undefined" ? row[field]
+  : typeof definition.default !== "undefined" ? definition.default
+  : null
+
+// (the following is semantically equivalent to the above, but written in a more-confusing style – it'd be hard to grok no matter the formatting)
+const typeofExampleFlipped =
+  definition.encode ?
+    definition.encode(
+      typeof row[field] === "undefined" ?
+        typeof definition.default === "undefined" ? null
+        : definition.default
+      : row[field]
+    )
+  : typeof row[field] === "undefined" ?
+    typeof definition.default === "undefined" ? null
+    : definition.default
+  : row[field];
+
+
+// JSX Examples:
+
+const typicalLongConsequentWithNullAlternate = (
+  <div>
+    {children && !isEmptyChildren(children) ?
+      <FooComponent
+        className="a bunch of css classes might go here, wow so many"
+        foo={foo}
+        bar={includeBar ? bar : null}
+      />
+    : null}
+  </div>
+);
+
+const reactRouterExampleJSX = (
+  <div>
+    {children && !isEmptyChildren(children) ?
+      children
+    : props.match ?
+      component ? React.createElement(component, props)
+      : render ? render(props)
+      : null
+    : null}
+  </div>
+);
+
+const reactRouterExampleNonJSX =
+  children && !isEmptyChildren(children) ? children
+  : props.match ?
+    component ? React.createElement(component, props)
+    : render ? render(props)
+    : null
+  : null;
+
+inJSXExpressionContainer.withLongConditionals.example = (
+  <div>
+    {(
+      isACat() &&
+      (someReallyLongCondition ||
+        moreInThisLongCondition)
+    ) ?
+      someReallyLargeExpression
+        .toMakeMeowNoise()
+        .willCauseParens()
+    : (
+      someReallyLongCondition ||
+        moreInThisLongCondition
+    ) ?
+      bark()
+    : someReallyLargeExpression
+        .toMakeMeowNoise()
+        .willCauseParens()
+    }
+  </div>
+);
+
+inJSXExpressionContainer.withLoops.orBooleans.example = (
+  <div>
+    {items ?
+      items.map((item) => (
+        item.display ?
+          <Item item={item} attr="breaks ternary but not consequent" />
+        : <Blank />
+      ))
+    : null}
+
+    {showTheStuff && (
+      foo ?
+        <Thing thing={foooooooooooooooooooooooooo} bar="bazzzzzz" />
+      : <OtherThing />
+    )}
+  </div>
+);
+
+inJSXExpressionContainer.withNullConditional = (
+  <div>
+    {isACat() ? null : <Foo />}
+    {isACat() && (someReallyLongCondition || moreInThisLongCondition) ? null : (
+      <Foo />
+    )}
+    {isACat() && (someReallyLongCondition || moreInThisLongCondition || evenMoreInThisExtraLongConditional) ? null : (
+      <Foo />
+    )}
+  </div>
+);
+
+=====================================output=====================================
+// from https://gist.github.com/rattrayalex/dacbf5838571a47f22d0ae1f8b960268
+// Input and output should match (for 2-space indent formatting).
+// TypeScript is here: prettier/tests/format/typescript/conditional-types/new-ternary-spec.ts
+// EXAMPLES
+//  mostly taken from https://github.com/prettier/prettier/issues/9561
+
+const message =
+  i % 3 === 0 && i % 5 === 0
+    ? "fizzbuzz"
+    : i % 3 === 0
+    ? "fizz"
+    : i % 5 === 0
+    ? "buzz"
+    : String(i);
+
+const paymentMessageShort =
+  state == "success"
+    ? "Payment completed successfully"
+    : state == "processing"
+    ? "Payment processing"
+    : state == "invalid_cvc"
+    ? "There was an issue with your CVC number"
+    : state == "invalid_expiry"
+    ? "Expiry must be sometime in the past."
+    : "There was an issue with the payment.  Please contact support.";
+
+const paymentMessageWithABreak =
+  state == "success"
+    ? "Payment completed successfully"
+    : state == "processing"
+    ? "Payment processing"
+    : state == "invalid_cvc"
+    ? "There was an issue with your CVC number, and you need to take a prompt action on it."
+    : state == "invalid_expiry"
+    ? "Expiry must be sometime in the past."
+    : "There was an issue with the payment.  Please contact support.";
+
+const typeofExample = definition.encode
+  ? definition.encode(
+      typeof row[field] !== "undefined"
+        ? row[field]
+        : typeof definition.default !== "undefined"
+        ? definition.default
+        : null,
+    )
+  : typeof row[field] !== "undefined"
+  ? row[field]
+  : typeof definition.default !== "undefined"
+  ? definition.default
+  : null;
+
+// (the following is semantically equivalent to the above, but written in a more-confusing style – it'd be hard to grok no matter the formatting)
+const typeofExampleFlipped = definition.encode
+  ? definition.encode(
+      typeof row[field] === "undefined"
+        ? typeof definition.default === "undefined"
+          ? null
+          : definition.default
+        : row[field],
+    )
+  : typeof row[field] === "undefined"
+  ? typeof definition.default === "undefined"
+    ? null
+    : definition.default
+  : row[field];
+
+// JSX Examples:
+
+const typicalLongConsequentWithNullAlternate = (
+  <div>
+    {children && !isEmptyChildren(children) ? (
+      <FooComponent
+        className="a bunch of css classes might go here, wow so many"
+        foo={foo}
+        bar={includeBar ? bar : null}
+      />
+    ) : null}
+  </div>
+);
+
+const reactRouterExampleJSX = (
+  <div>
+    {children && !isEmptyChildren(children)
+      ? children
+      : props.match
+      ? component
+        ? React.createElement(component, props)
+        : render
+        ? render(props)
+        : null
+      : null}
+  </div>
+);
+
+const reactRouterExampleNonJSX =
+  children && !isEmptyChildren(children)
+    ? children
+    : props.match
+    ? component
+      ? React.createElement(component, props)
+      : render
+      ? render(props)
+      : null
+    : null;
+
+inJSXExpressionContainer.withLongConditionals.example = (
+  <div>
+    {isACat() && (someReallyLongCondition || moreInThisLongCondition)
+      ? someReallyLargeExpression.toMakeMeowNoise().willCauseParens()
+      : someReallyLongCondition || moreInThisLongCondition
+      ? bark()
+      : someReallyLargeExpression.toMakeMeowNoise().willCauseParens()}
+  </div>
+);
+
+inJSXExpressionContainer.withLoops.orBooleans.example = (
+  <div>
+    {items
+      ? items.map((item) =>
+          item.display ? (
+            <Item item={item} attr="breaks ternary but not consequent" />
+          ) : (
+            <Blank />
+          ),
+        )
+      : null}
+
+    {showTheStuff
+      && (foo ? (
+        <Thing thing={foooooooooooooooooooooooooo} bar="bazzzzzz" />
+      ) : (
+        <OtherThing />
+      ))}
+  </div>
+);
+
+inJSXExpressionContainer.withNullConditional = (
+  <div>
+    {isACat() ? null : <Foo />}
+    {isACat() && (someReallyLongCondition || moreInThisLongCondition) ? null : (
+      <Foo />
+    )}
+    {isACat()
+    && (someReallyLongCondition
+      || moreInThisLongCondition
+      || evenMoreInThisExtraLongConditional) ? null : (
+      <Foo />
+    )}
+  </div>
 );
 
 ================================================================================
@@ -569,6 +1146,400 @@ inJSXExpressionContainer.withNullConditional = (
       <Foo />
     )}
   </div>
+);
+
+================================================================================
+`;
+
+exports[`new-ternary-spec.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// from https://gist.github.com/rattrayalex/dacbf5838571a47f22d0ae1f8b960268
+// Input and output should match (for 2-space indent formatting).
+// TypeScript is here: prettier/tests/format/typescript/conditional-types/new-ternary-spec.ts
+
+// remain on one line if possible:
+const short = isLoud() ? makeNoise() : silent();
+
+// next, put everything after the =
+const lessShort =
+  isLoudReallyLoud() ? makeNoiseReallyLoudly.omgSoLoud() : silent();
+
+// next, indent the consequent:
+const andIndented = isLoudReallyReallyReallyReallyLoud() ?
+    makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+  : silent();
+
+// unless the consequent is short (less than ten characters long):
+const shortSoCase = isLoudReallyReallyReallyReallyLoud() ? silent()
+  : makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud();
+
+// if chained, always break and put after the =
+const chainedShort =
+  isCat() ? meow()
+  : isDog() ? bark()
+  : silent();
+
+// when a consequent breaks in a chain:
+const chainedWithLongConsequent =
+  isCat() ?
+    someReallyLargeExpression
+      .thatWouldCauseALineBreak()
+      .willCauseAnIndentButNotParens()
+  : isDog() ? bark()
+  : silent();
+
+// nested ternary in consequent always breaks:
+const chainedWithTernaryConsequent =
+  isCat() ?
+    aNestedCondition ? theResult()
+    : theAlternate()
+  : isDog() ? bark()
+  : silent();
+
+// consequent and terminal alternate break:
+const consequentAndTerminalAlternateBreak =
+  isCat() ?
+    someReallyLargeExpression
+      .thatWouldCauseALineBreak()
+      .willCauseAnIndentButNotParens()
+  : isDog() ? bark()
+  : someReallyLargeExpression
+      .thatWouldCauseALineBreak()
+      .willCauseAnIndentButNotParens();
+
+// multiline conditions and consequents/alternates:
+const multilineConditionsConsequentsAndAlternates =
+  (
+    isAnAdorableKittyCat() &&
+    (someReallyLongCondition || moreInThisLongCondition)
+  ) ?
+    someReallyLargeExpression
+      .thatWouldCauseALineBreak()
+      .willCauseAnIndentButNotParens()
+  : (
+    isNotAnAdorableKittyCat() &&
+    (someReallyLongCondition || moreInThisLongCondition)
+  ) ?
+    bark()
+  : shortCondition() ? shortConsequent()
+  : someReallyLargeExpression
+      .thatWouldCauseALineBreak()
+      .willCauseAnIndentButNotParens();
+
+// illustrating case of mostly short conditionals
+const mostlyShort =
+  x === 1 ? "one"
+  : x === 2 ? "two"
+  : x === 3 ? "three"
+  : (
+    x === 5 &&
+    y === 7 &&
+    someOtherThing.thatIsSoLong.thatItBreaksTheTestCondition()
+  ) ?
+    "four"
+  : x === 6 ? "six"
+  : "idk";
+
+// long conditional, short consequent/alternate, not chained - do indent after ?
+const longConditional = (
+    bifornCringerMoshedPerplexSawder === 2 / askTrovenaBeenaDependsRowans &&
+    glimseGlyphsHazardNoopsTieTie >=
+      averredBathersBoxroomBuggyNurl().anodyneCondosMalateOverateRetinol()
+  ) ?
+    "foo"
+  : "bar";
+
+// long conditional, short consequent/alternate, chained
+// (break on short consequents iff in chained ternary and its conditional broke)
+const longConditionalChained =
+  (
+    bifornCringerMoshedPerplexSawder === 2 / askTrovenaBeenaDependsRowans &&
+    glimseGlyphsHazardNoopsTieTie >=
+      averredBathersBoxroomBuggyNurl().anodyneCondosMalateOverateRetinol()
+  ) ?
+    "foo"
+  : anotherCondition ? "bar"
+  : "baz";
+
+// As a function parameter, don't add an extra indent:
+definition.encode(
+  typeof row[field] !== "undefined" ? row[field]
+  : typeof definition.default !== "undefined" ? definition.default
+  : null,
+  typeof row[field] === "undefined" ?
+    typeof definition.default === "undefined" ? null
+    : definition.default
+  : row[field]
+);
+
+// In a return, break and over-indent:
+const inReturn = () => {
+  if (short) {
+    return foo ? 1 : 2;
+  }
+  return typeof row[aVeryLongFieldName] !== "undefined" ?
+      row[aVeryLongFieldName]
+    : null;
+};
+
+// Remove current JSX Mode, and replace it with this algorithm:
+// When a ternary's parent is a JSXExpressionContainer which is not in a JSXAttribute,
+// force the consequent to break,
+// and if the alternate breaks,
+// add a newline before the closing curly brace.
+// Special case when the consequent is \`null\`:
+// do not add a line before or after it,
+// and wrap the alternate in parens.
+
+const someJSX = (
+  <div>
+    Typical jsx case:
+    {showFoo ?
+      <Foo attribute="such and such stuff here" />
+    : <Bar short />}
+    Nested, and with a non-jsx consequent is the same:
+    {component ?
+      React.createElement(component, props)
+    : render ?
+      <div>{render(props)}</div>
+    : <div>Nothing is here</div>}
+    As is a non-jsx consequent:
+    {showTheJSXElement ?
+      <div>the stuff</div>
+    : renderOtherStuff()}
+    But if the alternate breaks, add a newline before the closing curly brace:
+    {showTheThing || pleaseShowTheThing ?
+      <Foo attribute="such and such stuff here" />
+    : <Bar
+        attribute="such and such stuff here"
+        another="more stuff here"
+        third="and even more, hooray!"
+      />
+    }
+    When the consequent is \`null\` and the alternate breaks,
+    hug it with parens to match boolean behavior:
+    {!thing ? null : (
+      <TheThing
+        thing={thing}
+        someVeryLongPropertyThatBreaksTheAlternate="hello"
+      />
+    )}
+  </div>
+);
+
+ternaryWithJSXElements.hasNoSpecialCasing =
+  component ? <div>{React.createElement(component, props)}</div>
+  : render ? <div>{render(props)}</div>
+  : <div>Nothing is here</div>;
+
+jsxExpressionContainer.inJSXAttribute.hasNoSpecialCasing = (
+  <Foo
+    withJSX={isRed ? <RedColorThing /> : <GreenColorThing />}
+    withJSXBroken={
+      isRed || isSomeOtherLongCondition.thatBreaksTheLine() ?
+        <RedColorThing />
+      : <GreenColorThing />
+    }
+  />
+);
+
+=====================================output=====================================
+// from https://gist.github.com/rattrayalex/dacbf5838571a47f22d0ae1f8b960268
+// Input and output should match (for 2-space indent formatting).
+// TypeScript is here: prettier/tests/format/typescript/conditional-types/new-ternary-spec.ts
+
+// remain on one line if possible:
+const short = isLoud() ? makeNoise() : silent();
+
+// next, put everything after the =
+const lessShort = isLoudReallyLoud()
+  ? makeNoiseReallyLoudly.omgSoLoud()
+  : silent();
+
+// next, indent the consequent:
+const andIndented = isLoudReallyReallyReallyReallyLoud()
+  ? makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud()
+  : silent();
+
+// unless the consequent is short (less than ten characters long):
+const shortSoCase = isLoudReallyReallyReallyReallyLoud()
+  ? silent()
+  : makeNoiseReallyReallyReallyReallyReallyLoudly.omgSoLoud();
+
+// if chained, always break and put after the =
+const chainedShort = isCat() ? meow() : isDog() ? bark() : silent();
+
+// when a consequent breaks in a chain:
+const chainedWithLongConsequent = isCat()
+  ? someReallyLargeExpression
+      .thatWouldCauseALineBreak()
+      .willCauseAnIndentButNotParens()
+  : isDog()
+  ? bark()
+  : silent();
+
+// nested ternary in consequent always breaks:
+const chainedWithTernaryConsequent = isCat()
+  ? aNestedCondition
+    ? theResult()
+    : theAlternate()
+  : isDog()
+  ? bark()
+  : silent();
+
+// consequent and terminal alternate break:
+const consequentAndTerminalAlternateBreak = isCat()
+  ? someReallyLargeExpression
+      .thatWouldCauseALineBreak()
+      .willCauseAnIndentButNotParens()
+  : isDog()
+  ? bark()
+  : someReallyLargeExpression
+      .thatWouldCauseALineBreak()
+      .willCauseAnIndentButNotParens();
+
+// multiline conditions and consequents/alternates:
+const multilineConditionsConsequentsAndAlternates =
+  isAnAdorableKittyCat() && (someReallyLongCondition || moreInThisLongCondition)
+    ? someReallyLargeExpression
+        .thatWouldCauseALineBreak()
+        .willCauseAnIndentButNotParens()
+    : isNotAnAdorableKittyCat()
+      && (someReallyLongCondition || moreInThisLongCondition)
+    ? bark()
+    : shortCondition()
+    ? shortConsequent()
+    : someReallyLargeExpression
+        .thatWouldCauseALineBreak()
+        .willCauseAnIndentButNotParens();
+
+// illustrating case of mostly short conditionals
+const mostlyShort =
+  x === 1
+    ? "one"
+    : x === 2
+    ? "two"
+    : x === 3
+    ? "three"
+    : x === 5
+      && y === 7
+      && someOtherThing.thatIsSoLong.thatItBreaksTheTestCondition()
+    ? "four"
+    : x === 6
+    ? "six"
+    : "idk";
+
+// long conditional, short consequent/alternate, not chained - do indent after ?
+const longConditional =
+  bifornCringerMoshedPerplexSawder === 2 / askTrovenaBeenaDependsRowans
+  && glimseGlyphsHazardNoopsTieTie
+    >= averredBathersBoxroomBuggyNurl().anodyneCondosMalateOverateRetinol()
+    ? "foo"
+    : "bar";
+
+// long conditional, short consequent/alternate, chained
+// (break on short consequents iff in chained ternary and its conditional broke)
+const longConditionalChained =
+  bifornCringerMoshedPerplexSawder === 2 / askTrovenaBeenaDependsRowans
+  && glimseGlyphsHazardNoopsTieTie
+    >= averredBathersBoxroomBuggyNurl().anodyneCondosMalateOverateRetinol()
+    ? "foo"
+    : anotherCondition
+    ? "bar"
+    : "baz";
+
+// As a function parameter, don't add an extra indent:
+definition.encode(
+  typeof row[field] !== "undefined"
+    ? row[field]
+    : typeof definition.default !== "undefined"
+    ? definition.default
+    : null,
+  typeof row[field] === "undefined"
+    ? typeof definition.default === "undefined"
+      ? null
+      : definition.default
+    : row[field],
+);
+
+// In a return, break and over-indent:
+const inReturn = () => {
+  if (short) {
+    return foo ? 1 : 2;
+  }
+  return typeof row[aVeryLongFieldName] !== "undefined"
+    ? row[aVeryLongFieldName]
+    : null;
+};
+
+// Remove current JSX Mode, and replace it with this algorithm:
+// When a ternary's parent is a JSXExpressionContainer which is not in a JSXAttribute,
+// force the consequent to break,
+// and if the alternate breaks,
+// add a newline before the closing curly brace.
+// Special case when the consequent is \`null\`:
+// do not add a line before or after it,
+// and wrap the alternate in parens.
+
+const someJSX = (
+  <div>
+    Typical jsx case:
+    {showFoo ? <Foo attribute="such and such stuff here" /> : <Bar short />}
+    Nested, and with a non-jsx consequent is the same:
+    {component ? (
+      React.createElement(component, props)
+    ) : render ? (
+      <div>{render(props)}</div>
+    ) : (
+      <div>Nothing is here</div>
+    )}
+    As is a non-jsx consequent:
+    {showTheJSXElement ? <div>the stuff</div> : renderOtherStuff()}
+    But if the alternate breaks, add a newline before the closing curly brace:
+    {showTheThing || pleaseShowTheThing ? (
+      <Foo attribute="such and such stuff here" />
+    ) : (
+      <Bar
+        attribute="such and such stuff here"
+        another="more stuff here"
+        third="and even more, hooray!"
+      />
+    )}
+    When the consequent is \`null\` and the alternate breaks, hug it with parens
+    to match boolean behavior:
+    {!thing ? null : (
+      <TheThing
+        thing={thing}
+        someVeryLongPropertyThatBreaksTheAlternate="hello"
+      />
+    )}
+  </div>
+);
+
+ternaryWithJSXElements.hasNoSpecialCasing = component ? (
+  <div>{React.createElement(component, props)}</div>
+) : render ? (
+  <div>{render(props)}</div>
+) : (
+  <div>Nothing is here</div>
+);
+
+jsxExpressionContainer.inJSXAttribute.hasNoSpecialCasing = (
+  <Foo
+    withJSX={isRed ? <RedColorThing /> : <GreenColorThing />}
+    withJSXBroken={
+      isRed || isSomeOtherLongCondition.thatBreaksTheLine() ? (
+        <RedColorThing />
+      ) : (
+        <GreenColorThing />
+      )
+    }
+  />
 );
 
 ================================================================================
@@ -967,6 +1938,25 @@ jsxExpressionContainer.inJSXAttribute.hasNoSpecialCasing = (
 ================================================================================
 `;
 
+exports[`no-confusing-arrow.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// no-confusing-arrow
+var x = a => 1 ? 2 : 3;
+var x = a <= 1 ? 2 : 3;
+
+=====================================output=====================================
+// no-confusing-arrow
+var x = (a) => (1 ? 2 : 3);
+var x = a <= 1 ? 2 : 3;
+
+================================================================================
+`;
+
 exports[`no-confusing-arrow.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -981,6 +1971,309 @@ var x = a <= 1 ? 2 : 3;
 // no-confusing-arrow
 var x = (a) => (1 ? 2 : 3);
 var x = a <= 1 ? 2 : 3;
+
+================================================================================
+`;
+
+exports[`postfix-ternary-regressions.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+
+// concatened string in consequent should be visually distinguishable from alternate
+// … or maybe this is okay, because the colon is enough?
+const avatar = has_ordered ?
+    'https://marmelab.com/posters/avatar/longer-word-that-breaks-consequent-' +
+    numberOfCustomers +
+    '.jpeg'
+  : undefined;
+
+// Similarly, in the alternate:
+const redirectUrl = pathName ?
+    pathName
+  : nextPathName + nextSearch ||
+    defaultAuthParams.afterLoginUrl.makeThisLongerSoItBreaks;
+
+// And another, more pathological case of the above:
+const isEmpty = obj =>
+  obj instanceof Date ?
+    false
+  : obj === '' ||
+    obj === null ||
+    obj === undefined ||
+    obj === somethingThatIsLonger ||
+    shallowEqual(obj, {});
+
+
+// Again, this case is a bit hard to distinguish the alternate.
+const eventsFromOrders =
+  orderIds && orders ?
+    orderIds.map(id => ({
+        type: 'order',
+        date: orders[id].date,
+        data: orders[id],
+    }))
+  : [];
+
+// Kinda weird to have dedents to the level of "return" in a function.
+function foo() {
+  return !linkTo ?
+      false
+    : typeof linkTo === 'function'
+      ? linkTo(record, reference)
+      : linkToRecord(rootPath, sourceId, linkTo_as_string);
+}
+function foo2() {
+  return React.isValidElement(emptyText)
+    ? React.cloneElement(emptyText)
+    : emptyText === ''
+      ? ' ' // em space, forces the display of an empty line of normal height
+      : translate(emptyText, { _: emptyText });
+}
+
+// Function call ideally wouldnt break break
+const matchingReferencesError = isMatchingReferencesError(
+  matchingReferences
+)
+  ? translate(matchingReferences.error, {
+      _: matchingReferences.error,
+    })
+  : null;
+
+// This one is kinda confusing any way you slice it…
+const obj = {
+  error:
+    matchingReferencesError &&
+    (!input.value ||
+      (input.value &&
+        selectedReferencesDataStatus === REFERENCES_STATUS_EMPTY))
+      ? translate('ra.input.references.all_missing', {
+          _: 'ra.input.references.all_missing',
+        })
+      : null,
+}
+
+// I think we should indent after the inner || on this, and do better wtih the parens around the &&
+const obj2 = {
+  warning:
+    matchingReferencesError ||
+    (input.value && selectedReferencesDataStatus !== REFERENCES_STATUS_READY)
+      ? matchingReferencesError ||
+          translate('ra.input.references.many_missing', {
+              _: 'ra.input.references.many_missing',
+          })
+      : null,
+}
+
+// The boolean conditions in the test should look cohesive.
+const selectedReferencesDataStatus =
+  !isEmpty(value) && typeof value === 'string' && !pattern.test(value)
+      ? getMessage(message, { pattern }, value, values)
+      : undefined
+
+
+// Would be nice if these two nested ternaries didn't look like a single one.
+resolveRedirectTo(
+  redirectTo,
+  basePath,
+  payload
+    ? payload.id || (payload.data ? payload.data.id : null)
+    : requestPayload
+      ? requestPayload.id
+      : null,
+  payload && payload.data
+    ? payload.data
+    : requestPayload && requestPayload.data
+      ? requestPayload.data
+      : null
+)
+
+const delayedDataProvider = new Proxy(restProvider, {
+  get: (target, name, self) =>
+      name === 'then' ? // as we await for the dataProvider, JS calls then on it. We must trap that call or else the dataProvider will be called with the then method
+           self
+          : (
+          (resource, params) =>
+              new Promise(resolve =>
+                  setTimeout(
+                      () =>
+                          resolve(
+                              restProvider[name](resource, params)
+                          ),
+                      500
+                  )
+              )
+      ),
+});
+
+function foo4() {
+  return !match || match.length < 5 ? line : (
+    match[1] + match[2] + match[3] + match[4]
+  )
+}
+
+function foo5() {
+  return !match || match.length < 5 ? foo(line) : (
+    match[1] + match[2] + match[3] + match[4]
+  )
+}
+
+function foo6() {
+  return !match || match.length < 5 ? linethatisverylongandbreaksthelinehooray : (
+    match[1] + match[2] + match[3] + match[4]
+  )
+}
+
+function foo7() {
+  return !match || match.length < 5 ? linethatisverylongandbreaksthelinehoorayjustabitlonger : (
+    match[1] + match[2] + match[3] + match[4]
+  )
+}
+
+=====================================output=====================================
+// concatened string in consequent should be visually distinguishable from alternate
+// … or maybe this is okay, because the colon is enough?
+const avatar = has_ordered
+  ? "https://marmelab.com/posters/avatar/longer-word-that-breaks-consequent-"
+    + numberOfCustomers
+    + ".jpeg"
+  : undefined;
+
+// Similarly, in the alternate:
+const redirectUrl = pathName
+  ? pathName
+  : nextPathName + nextSearch
+    || defaultAuthParams.afterLoginUrl.makeThisLongerSoItBreaks;
+
+// And another, more pathological case of the above:
+const isEmpty = (obj) =>
+  obj instanceof Date
+    ? false
+    : obj === ""
+      || obj === null
+      || obj === undefined
+      || obj === somethingThatIsLonger
+      || shallowEqual(obj, {});
+
+// Again, this case is a bit hard to distinguish the alternate.
+const eventsFromOrders =
+  orderIds && orders
+    ? orderIds.map((id) => ({
+        type: "order",
+        date: orders[id].date,
+        data: orders[id],
+      }))
+    : [];
+
+// Kinda weird to have dedents to the level of "return" in a function.
+function foo() {
+  return !linkTo
+    ? false
+    : typeof linkTo === "function"
+    ? linkTo(record, reference)
+    : linkToRecord(rootPath, sourceId, linkTo_as_string);
+}
+function foo2() {
+  return React.isValidElement(emptyText)
+    ? React.cloneElement(emptyText)
+    : emptyText === ""
+    ? " " // em space, forces the display of an empty line of normal height
+    : translate(emptyText, { _: emptyText });
+}
+
+// Function call ideally wouldnt break break
+const matchingReferencesError = isMatchingReferencesError(matchingReferences)
+  ? translate(matchingReferences.error, {
+      _: matchingReferences.error,
+    })
+  : null;
+
+// This one is kinda confusing any way you slice it…
+const obj = {
+  error:
+    matchingReferencesError
+    && (!input.value
+      || (input.value
+        && selectedReferencesDataStatus === REFERENCES_STATUS_EMPTY))
+      ? translate("ra.input.references.all_missing", {
+          _: "ra.input.references.all_missing",
+        })
+      : null,
+};
+
+// I think we should indent after the inner || on this, and do better wtih the parens around the &&
+const obj2 = {
+  warning:
+    matchingReferencesError
+    || (input.value && selectedReferencesDataStatus !== REFERENCES_STATUS_READY)
+      ? matchingReferencesError
+        || translate("ra.input.references.many_missing", {
+          _: "ra.input.references.many_missing",
+        })
+      : null,
+};
+
+// The boolean conditions in the test should look cohesive.
+const selectedReferencesDataStatus =
+  !isEmpty(value) && typeof value === "string" && !pattern.test(value)
+    ? getMessage(message, { pattern }, value, values)
+    : undefined;
+
+// Would be nice if these two nested ternaries didn't look like a single one.
+resolveRedirectTo(
+  redirectTo,
+  basePath,
+  payload
+    ? payload.id || (payload.data ? payload.data.id : null)
+    : requestPayload
+    ? requestPayload.id
+    : null,
+  payload && payload.data
+    ? payload.data
+    : requestPayload && requestPayload.data
+    ? requestPayload.data
+    : null,
+);
+
+const delayedDataProvider = new Proxy(restProvider, {
+  get: (target, name, self) =>
+    name === "then" // as we await for the dataProvider, JS calls then on it. We must trap that call or else the dataProvider will be called with the then method
+      ? self
+      : (resource, params) =>
+          new Promise((resolve) =>
+            setTimeout(
+              () => resolve(restProvider[name](resource, params)),
+              500,
+            ),
+          ),
+});
+
+function foo4() {
+  return !match || match.length < 5
+    ? line
+    : match[1] + match[2] + match[3] + match[4];
+}
+
+function foo5() {
+  return !match || match.length < 5
+    ? foo(line)
+    : match[1] + match[2] + match[3] + match[4];
+}
+
+function foo6() {
+  return !match || match.length < 5
+    ? linethatisverylongandbreaksthelinehooray
+    : match[1] + match[2] + match[3] + match[4];
+}
+
+function foo7() {
+  return !match || match.length < 5
+    ? linethatisverylongandbreaksthelinehoorayjustabitlonger
+    : match[1] + match[2] + match[3] + match[4];
+}
 
 ================================================================================
 `;

--- a/tests/format/js/conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/conditional/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`comments.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`comments.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -513,9 +513,9 @@ c */
 ================================================================================
 `;
 
-exports[`new-expression.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`new-expression.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -550,9 +550,9 @@ const testConsole = new TestConsole(
 ================================================================================
 `;
 
-exports[`new-ternary-examples.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`new-ternary-examples.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1151,9 +1151,9 @@ inJSXExpressionContainer.withNullConditional = (
 ================================================================================
 `;
 
-exports[`new-ternary-spec.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`new-ternary-spec.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1938,9 +1938,9 @@ jsxExpressionContainer.inJSXAttribute.hasNoSpecialCasing = (
 ================================================================================
 `;
 
-exports[`no-confusing-arrow.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`no-confusing-arrow.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1975,9 +1975,9 @@ var x = a <= 1 ? 2 : 3;
 ================================================================================
 `;
 
-exports[`postfix-ternary-regressions.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`postfix-ternary-regressions.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/conditional/jsfmt.spec.js
+++ b/tests/format/js/conditional/jsfmt.spec.js
@@ -1,1 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
+run_spec(import.meta, ["babel", "flow", "typescript"], {
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/conditional/jsfmt.spec.js
+++ b/tests/format/js/conditional/jsfmt.spec.js
@@ -1,4 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
 run_spec(import.meta, ["babel", "flow", "typescript"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/js/logical_expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/logical_expressions/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`issue-7024.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const radioSelectedAttr =
+  (isAnyValueSelected &&
+    node.getAttribute(radioAttr.toLowerCase()) === radioValue) ||
+  ((!isAnyValueSelected && values[a].default === true) || a === 0);
+
+=====================================output=====================================
+const radioSelectedAttr =
+  (isAnyValueSelected
+    && node.getAttribute(radioAttr.toLowerCase()) === radioValue)
+  || (!isAnyValueSelected && values[a].default === true)
+  || a === 0;
+
+================================================================================
+`;
+
 exports[`issue-7024.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -17,6 +39,83 @@ const radioSelectedAttr =
     node.getAttribute(radioAttr.toLowerCase()) === radioValue) ||
   (!isAnyValueSelected && values[a].default === true) ||
   a === 0;
+
+================================================================================
+`;
+
+exports[`logical_expression_operators.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// Same operators do not require parens
+(foo && bar) && baz;
+foo && (bar && baz);
+foo && ((bar && baz) && qux);
+foo && (bar && (baz && qux));
+foo && (bar && ((baz && qux) && xyz));
+foo && (bar && (baz && (qux && xyz)));
+
+(foo || bar) || baz;
+foo || (bar || baz);
+foo || ((bar || baz) || qux);
+foo || (bar || (baz || qux));
+foo || (bar || ((baz || qux) || xyz));
+foo || (bar || (baz || (qux || xyz)));
+
+(foo ?? bar) ?? baz;
+foo ?? (bar ?? baz);
+foo ?? ((bar ?? baz) ?? qux);
+foo ?? (bar ?? (baz ?? qux));
+foo ?? (bar ?? ((baz ?? qux) ?? xyz));
+foo ?? (bar ?? (baz ?? (qux ?? xyz)));
+
+// Explicitly parenthesized && and || requires parens
+(foo && bar) || baz;
+(foo || bar) && baz;
+
+foo && (bar || baz);
+foo || (bar && baz);
+
+// Implicitly parenthesized && and || requires parens
+foo && bar || baz;
+foo || bar && baz;
+
+=====================================output=====================================
+// Same operators do not require parens
+foo && bar && baz;
+foo && bar && baz;
+foo && bar && baz && qux;
+foo && bar && baz && qux;
+foo && bar && baz && qux && xyz;
+foo && bar && baz && qux && xyz;
+
+foo || bar || baz;
+foo || bar || baz;
+foo || bar || baz || qux;
+foo || bar || baz || qux;
+foo || bar || baz || qux || xyz;
+foo || bar || baz || qux || xyz;
+
+foo ?? bar ?? baz;
+foo ?? bar ?? baz;
+foo ?? bar ?? baz ?? qux;
+foo ?? bar ?? baz ?? qux;
+foo ?? bar ?? baz ?? qux ?? xyz;
+foo ?? bar ?? baz ?? qux ?? xyz;
+
+// Explicitly parenthesized && and || requires parens
+(foo && bar) || baz;
+(foo || bar) && baz;
+
+foo && (bar || baz);
+foo || (bar && baz);
+
+// Implicitly parenthesized && and || requires parens
+(foo && bar) || baz;
+foo || (bar && baz);
 
 ================================================================================
 `;

--- a/tests/format/js/logical_expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/logical_expressions/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`issue-7024.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-7024.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -43,9 +43,9 @@ const radioSelectedAttr =
 ================================================================================
 `;
 
-exports[`logical_expression_operators.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`logical_expression_operators.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/logical_expressions/jsfmt.spec.js
+++ b/tests/format/js/logical_expressions/jsfmt.spec.js
@@ -1,1 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
+run_spec(import.meta, ["babel", "flow", "typescript"], {
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/logical_expressions/jsfmt.spec.js
+++ b/tests/format/js/logical_expressions/jsfmt.spec.js
@@ -1,4 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
 run_spec(import.meta, ["babel", "flow", "typescript"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/js/member/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/member/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,26 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`conditional.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(this.defaultUser))
+.prop;
+
+=====================================output=====================================
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(this.defaultUser)
+).prop;
+
+================================================================================
+`;
+
 exports[`conditional.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -16,6 +37,100 @@ printWidth: 80
   ? helper.responseBody(this.currentUser)
   : helper.responseBody(this.defaultUser)
 ).prop;
+
+================================================================================
+`;
+
+exports[`expand.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const veryVeryVeryVeryVeryVeryVeryLong = doc.expandedStates[doc.expandedStates.length - 1];
+const small = doc.expandedStates[doc.expandedStates.length - 1];
+
+const promises = [
+  promise.resolve().then(console.log).catch(err => {
+    console.log(err)
+    return null
+  }),
+  redis.fetch(),
+  other.fetch(),
+];
+
+const promises2 = [
+  promise.resolve().veryLongFunctionCall().veryLongFunctionCall().then(console.log).catch(err => {
+    console.log(err)
+    return null
+  }),
+  redis.fetch(),
+  other.fetch(),
+];
+
+window.FooClient.setVars({
+  locale: getFooLocale({ page }),
+  authorizationToken: data.token
+}).initVerify("foo_container");
+
+window.something.FooClient.setVars({
+  locale: getFooLocale({ page }),
+  authorizationToken: data.token
+}).initVerify("foo_container");
+
+window.FooClient.something.setVars({
+  locale: getFooLocale({ page }),
+  authorizationToken: data.token
+}).initVerify("foo_container");
+
+=====================================output=====================================
+const veryVeryVeryVeryVeryVeryVeryLong =
+  doc.expandedStates[doc.expandedStates.length - 1];
+const small = doc.expandedStates[doc.expandedStates.length - 1];
+
+const promises = [
+  promise
+    .resolve()
+    .then(console.log)
+    .catch((err) => {
+      console.log(err);
+      return null;
+    }),
+  redis.fetch(),
+  other.fetch(),
+];
+
+const promises2 = [
+  promise
+    .resolve()
+    .veryLongFunctionCall()
+    .veryLongFunctionCall()
+    .then(console.log)
+    .catch((err) => {
+      console.log(err);
+      return null;
+    }),
+  redis.fetch(),
+  other.fetch(),
+];
+
+window.FooClient.setVars({
+  locale: getFooLocale({ page }),
+  authorizationToken: data.token,
+}).initVerify("foo_container");
+
+window.something.FooClient.setVars({
+  locale: getFooLocale({ page }),
+  authorizationToken: data.token,
+}).initVerify("foo_container");
+
+window.FooClient.something
+  .setVars({
+    locale: getFooLocale({ page }),
+    authorizationToken: data.token,
+  })
+  .initVerify("foo_container");
 
 ================================================================================
 `;
@@ -109,6 +224,29 @@ window.FooClient.something
     authorizationToken: data.token,
   })
   .initVerify("foo_container");
+
+================================================================================
+`;
+
+exports[`logical.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+(veryLongVeryLongVeryLong || e).prop;
+
+(veryLongVeryLongVeryLong || anotherVeryLongVeryLongVeryLong || veryVeryVeryLongError).prop;
+
+=====================================output=====================================
+(veryLongVeryLongVeryLong || e).prop;
+
+(
+  veryLongVeryLongVeryLong
+  || anotherVeryLongVeryLongVeryLong
+  || veryVeryVeryLongError
+).prop;
 
 ================================================================================
 `;

--- a/tests/format/js/member/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/member/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`conditional.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`conditional.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -41,9 +41,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`expand.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`expand.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -228,9 +228,9 @@ window.FooClient.something
 ================================================================================
 `;
 
-exports[`logical.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`logical.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/member/jsfmt.spec.js
+++ b/tests/format/js/member/jsfmt.spec.js
@@ -1,1 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
+run_spec(import.meta, ["babel", "flow", "typescript"], {
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/member/jsfmt.spec.js
+++ b/tests/format/js/member/jsfmt.spec.js
@@ -1,4 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
 run_spec(import.meta, ["babel", "flow", "typescript"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/js/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`13018.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+foo(_a).bar().leet();
+foo(-a).bar().leet();
+foo(+a).bar().leet();
+foo(~a).bar().leet();
+foo(++a).bar().leet();
+foo(--a).bar().leet();
+foo(a++).bar().leet();
+foo(a--).bar().leet();
+
+=====================================output=====================================
+foo(_a).bar().leet();
+foo(-a).bar().leet();
+foo(+a).bar().leet();
+foo(~a).bar().leet();
+foo(++a).bar().leet();
+foo(--a).bar().leet();
+foo(a++).bar().leet();
+foo(a--).bar().leet();
+
+================================================================================
+`;
+
 exports[`13018.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -24,6 +53,38 @@ foo(++a).bar().leet();
 foo(--a).bar().leet();
 foo(a++).bar().leet();
 foo(a--).bar().leet();
+
+================================================================================
+`;
+
+exports[`bracket_0.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function a() {
+  function b() {
+	queryThenMutateDOM(
+      () => {
+        title = SomeThing.call(root, 'someLongStringThatPushesThisTextReallyFar')[0];
+      }
+    );
+  }
+}
+
+=====================================output=====================================
+function a() {
+  function b() {
+    queryThenMutateDOM(() => {
+      title = SomeThing.call(
+        root,
+        "someLongStringThatPushesThisTextReallyFar",
+      )[0];
+    });
+  }
+}
 
 ================================================================================
 `;
@@ -59,6 +120,24 @@ function a() {
 ================================================================================
 `;
 
+exports[`bracket_0-1.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const thingamabobMetaAlias =
+path.scope.getProgramParent().path.get("body")[0].node;
+
+=====================================output=====================================
+const thingamabobMetaAlias = path.scope
+  .getProgramParent()
+  .path.get("body")[0].node;
+
+================================================================================
+`;
+
 exports[`bracket_0-1.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -72,6 +151,133 @@ path.scope.getProgramParent().path.get("body")[0].node;
 const thingamabobMetaAlias = path.scope
   .getProgramParent()
   .path.get("body")[0].node;
+
+================================================================================
+`;
+
+exports[`break-last-call.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export default store => {
+  return callApi(endpoint, schema).then(
+    response => next(actionWith({
+      response,
+      type: successType
+    })),
+    error => next(actionWith({
+      type: failureType,
+      error: error.message || 'Something bad happened'
+    }))
+  )
+}
+
+it('should group messages with same created time', () => {
+  expect(
+    groupMessages(messages).toJS(),
+  ).toEqual({
+    '11/01/2017 13:36': [
+      {message: 'test', messageType: 'SMS', status: 'Unknown', created: '11/01/2017 13:36'},
+      {message: 'test', messageType: 'Email', status: 'Unknown', created: '11/01/2017 13:36'},
+    ],
+    '09/01/2017 17:25': [
+      {message: 'te', messageType: 'SMS', status: 'Unknown', created: '09/01/2017 17:25'},
+      {message: 'te', messageType: 'Email', status: 'Unknown', created: '09/01/2017 17:25'},
+    ],
+    '11/01/2017 13:33': [
+      {message: 'test', messageType: 'SMS', status: 'Unknown', created: '11/01/2017 13:33'},
+      {message: 'test', messageType: 'Email', status: 'Unknown', created: '11/01/2017 13:33'},
+    ],
+    '11/01/2017 13:37': [
+      {message: 'test', messageType: 'SMS', status: 'Unknown', created: '11/01/2017 13:37'},
+      {message: 'test', messageType: 'Email', status: 'Unknown', created: '11/01/2017 13:37'},
+    ],
+  });
+});
+
+=====================================output=====================================
+export default (store) => {
+  return callApi(endpoint, schema).then(
+    (response) =>
+      next(
+        actionWith({
+          response,
+          type: successType,
+        }),
+      ),
+    (error) =>
+      next(
+        actionWith({
+          type: failureType,
+          error: error.message || "Something bad happened",
+        }),
+      ),
+  );
+};
+
+it("should group messages with same created time", () => {
+  expect(groupMessages(messages).toJS()).toEqual({
+    "11/01/2017 13:36": [
+      {
+        message: "test",
+        messageType: "SMS",
+        status: "Unknown",
+        created: "11/01/2017 13:36",
+      },
+      {
+        message: "test",
+        messageType: "Email",
+        status: "Unknown",
+        created: "11/01/2017 13:36",
+      },
+    ],
+    "09/01/2017 17:25": [
+      {
+        message: "te",
+        messageType: "SMS",
+        status: "Unknown",
+        created: "09/01/2017 17:25",
+      },
+      {
+        message: "te",
+        messageType: "Email",
+        status: "Unknown",
+        created: "09/01/2017 17:25",
+      },
+    ],
+    "11/01/2017 13:33": [
+      {
+        message: "test",
+        messageType: "SMS",
+        status: "Unknown",
+        created: "11/01/2017 13:33",
+      },
+      {
+        message: "test",
+        messageType: "Email",
+        status: "Unknown",
+        created: "11/01/2017 13:33",
+      },
+    ],
+    "11/01/2017 13:37": [
+      {
+        message: "test",
+        messageType: "SMS",
+        status: "Unknown",
+        created: "11/01/2017 13:37",
+      },
+      {
+        message: "test",
+        messageType: "Email",
+        status: "Unknown",
+        created: "11/01/2017 13:37",
+      },
+    ],
+  });
+});
 
 ================================================================================
 `;
@@ -202,6 +408,76 @@ it("should group messages with same created time", () => {
 ================================================================================
 `;
 
+exports[`break-last-member.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+SomeVeryLongUpperCaseConstant.someVeryLongCallExpression().some_very_long_member_expression
+weNeedToReachTheEightyCharacterLimitXXXXXXXXXXXXXXXXX.someNode
+  .childrenInAnArray[0];
+superSupersuperSupersuperSupersuperSupersuperSuperLong.exampleOfOrderOfGetterAndSetterReordered;
+superSupersuperSupersuperSupersuperSupersuperSuperLong.exampleOfOrderOfGetterAndSetterReordered[0];
+
+expect(
+  findDOMNode(component.instance()).getElementsByClassName(styles.inner)[0].style.paddingRight
+).toBe('1000px');
+
+const { course, conflicts = [], index, scheduleId, studentId, something } = a.this.props;
+
+const { course2, conflicts2 = [], index2, scheduleId2, studentId2, something2 } = this.props;
+
+const {
+  updated,
+  author: { identifier: ownerId },
+  location,
+  category: categories,
+} = rawAd.entry;
+
+=====================================output=====================================
+SomeVeryLongUpperCaseConstant.someVeryLongCallExpression()
+  .some_very_long_member_expression;
+weNeedToReachTheEightyCharacterLimitXXXXXXXXXXXXXXXXX.someNode
+  .childrenInAnArray[0];
+superSupersuperSupersuperSupersuperSupersuperSuperLong.exampleOfOrderOfGetterAndSetterReordered;
+superSupersuperSupersuperSupersuperSupersuperSuperLong
+  .exampleOfOrderOfGetterAndSetterReordered[0];
+
+expect(
+  findDOMNode(component.instance()).getElementsByClassName(styles.inner)[0]
+    .style.paddingRight,
+).toBe("1000px");
+
+const {
+  course,
+  conflicts = [],
+  index,
+  scheduleId,
+  studentId,
+  something,
+} = a.this.props;
+
+const {
+  course2,
+  conflicts2 = [],
+  index2,
+  scheduleId2,
+  studentId2,
+  something2,
+} = this.props;
+
+const {
+  updated,
+  author: { identifier: ownerId },
+  location,
+  category: categories,
+} = rawAd.entry;
+
+================================================================================
+`;
+
 exports[`break-last-member.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -271,6 +547,29 @@ const {
 ================================================================================
 `;
 
+exports[`break-multiple.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+object.foo().bar().baz();
+
+foo().bar().baz();
+
+foo().bar.baz();
+
+=====================================output=====================================
+object.foo().bar().baz();
+
+foo().bar().baz();
+
+foo().bar.baz();
+
+================================================================================
+`;
+
 exports[`break-multiple.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -289,6 +588,134 @@ object.foo().bar().baz();
 foo().bar().baz();
 
 foo().bar.baz();
+
+================================================================================
+`;
+
+exports[`comment.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function f() {
+  return observableFromSubscribeFunction()
+    // Debounce manually rather than using editor.onDidStopChanging so that the debounce time is
+    // configurable.
+    .debounceTime(debounceInterval);
+}
+
+_.a(a)
+  /* very very very very very very very long such that it is longer than 80 columns */
+  .a()
+
+_.a(
+  a
+)/* very very very very very very very long such that it is longer than 80 columns */
+.a();
+
+_.a(
+  a
+) /* very very very very very very very long such that it is longer than 80 columns */.a();
+
+Something
+  // $FlowFixMe(>=0.41.0)
+  .getInstance(this.props.dao)
+  .getters()
+
+// Warm-up first
+measure()
+  .then(() => {
+    SomethingLong();
+  });
+
+measure() // Warm-up first
+  .then(() => {
+    SomethingLong();
+  });
+
+const configModel = this.baseConfigurationService.getCache().consolidated		// global/default values (do NOT modify)
+  .merge(this.cachedWorkspaceConfig);
+
+this.doWriteConfiguration(target, value, options) // queue up writes to prevent race conditions
+  .then(() => null,
+  error => {
+    return options.donotNotifyError ? TPromise.wrapError(error) : this.onError(error, target, value);
+  });
+
+ret = __DEV__ ?
+  // $FlowFixMe: this type differs according to the env
+vm.runInContext(source, ctx)
+: a
+
+angular.module('AngularAppModule')
+  // Hello, I am comment.
+  .constant('API_URL', 'http://localhost:8080/api');
+
+=====================================output=====================================
+function f() {
+  return (
+    observableFromSubscribeFunction()
+      // Debounce manually rather than using editor.onDidStopChanging so that the debounce time is
+      // configurable.
+      .debounceTime(debounceInterval)
+  );
+}
+
+_.a(a)
+  /* very very very very very very very long such that it is longer than 80 columns */
+  .a();
+
+_.a(
+  a,
+) /* very very very very very very very long such that it is longer than 80 columns */
+  .a();
+
+_.a(
+  a,
+) /* very very very very very very very long such that it is longer than 80 columns */
+  .a();
+
+Something
+  // $FlowFixMe(>=0.41.0)
+  .getInstance(this.props.dao)
+  .getters();
+
+// Warm-up first
+measure().then(() => {
+  SomethingLong();
+});
+
+measure() // Warm-up first
+  .then(() => {
+    SomethingLong();
+  });
+
+const configModel = this.baseConfigurationService
+  .getCache()
+  .consolidated // global/default values (do NOT modify)
+  .merge(this.cachedWorkspaceConfig);
+
+this.doWriteConfiguration(target, value, options) // queue up writes to prevent race conditions
+  .then(
+    () => null,
+    (error) => {
+      return options.donotNotifyError
+        ? TPromise.wrapError(error)
+        : this.onError(error, target, value);
+    },
+  );
+
+ret = __DEV__
+  ? // $FlowFixMe: this type differs according to the env
+    vm.runInContext(source, ctx)
+  : a;
+
+angular
+  .module("AngularAppModule")
+  // Hello, I am comment.
+  .constant("API_URL", "http://localhost:8080/api");
 
 ================================================================================
 `;
@@ -420,6 +847,27 @@ angular
 ================================================================================
 `;
 
+exports[`complex-args.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+client.execute(
+  Post.selectAll()
+    .where(Post.id.eq(42))
+    .where(Post.published.eq(true))
+);
+
+=====================================output=====================================
+client.execute(
+  Post.selectAll().where(Post.id.eq(42)).where(Post.published.eq(true)),
+);
+
+================================================================================
+`;
+
 exports[`complex-args.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -436,6 +884,31 @@ client.execute(
 client.execute(
   Post.selectAll().where(Post.id.eq(42)).where(Post.published.eq(true)),
 );
+
+================================================================================
+`;
+
+exports[`computed.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+nock(/test/)
+  .matchHeader('Accept', 'application/json')
+  [httpMethodNock(method)]('/foo')
+  .reply(200, {
+    foo: 'bar',
+  });
+
+=====================================output=====================================
+nock(/test/)
+  .matchHeader("Accept", "application/json")
+  [httpMethodNock(method)]("/foo")
+  .reply(200, {
+    foo: "bar",
+  });
 
 ================================================================================
 `;
@@ -460,6 +933,51 @@ nock(/test/)
   .reply(200, {
     foo: "bar",
   });
+
+================================================================================
+`;
+
+exports[`computed-merge.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+[].forEach(key => {
+  data[key]('foo')
+    .then(() => console.log('bar'))
+    .catch(() => console.log('baz'));
+});
+
+[].forEach(key => {
+  data('foo')
+    [key]('bar')
+    .then(() => console.log('bar'))
+    .catch(() => console.log('baz'));
+});
+
+window.Data[key]("foo")
+  .then(() => a)
+  .catch(() => b);
+
+=====================================output=====================================
+[].forEach((key) => {
+  data[key]("foo")
+    .then(() => console.log("bar"))
+    .catch(() => console.log("baz"));
+});
+
+[].forEach((key) => {
+  data("foo")
+    [key]("bar")
+    .then(() => console.log("bar"))
+    .catch(() => console.log("baz"));
+});
+
+window.Data[key]("foo")
+  .then(() => a)
+  .catch(() => b);
 
 ================================================================================
 `;
@@ -504,6 +1022,72 @@ window.Data[key]("foo")
 window.Data[key]("foo")
   .then(() => a)
   .catch(() => b);
+
+================================================================================
+`;
+
+exports[`conditional.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+(a ? b : c).d();
+
+(a ? b : c).d().e();
+
+(a ? b : c).d().e().f();
+
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(this.defaultUser))
+.map();
+
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(this.defaultUser))
+.map().filter();
+
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(defaultUser))
+.map();
+
+object[valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(defaultUser)]
+.map();
+
+=====================================output=====================================
+(a ? b : c).d();
+
+(a ? b : c).d().e();
+
+(a ? b : c).d().e().f();
+
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(this.defaultUser)
+).map();
+
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(this.defaultUser)
+)
+  .map()
+  .filter();
+
+(valid
+  ? helper.responseBody(this.currentUser)
+  : helper.responseBody(defaultUser)
+).map();
+
+object[
+  valid
+    ? helper.responseBody(this.currentUser)
+    : helper.responseBody(defaultUser)
+].map();
 
 ================================================================================
 `;
@@ -573,6 +1157,29 @@ object[
 ================================================================================
 `;
 
+exports[`cypress.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+cy.get('option:first')
+  .should('be.selected')
+  .and('have.value', 'Metallica')
+
+cy.get(".ready")
+  .should("have.text", "FOO")
+  .should("have.css", "color", "#aaa");
+
+=====================================output=====================================
+cy.get("option:first").should("be.selected").and("have.value", "Metallica");
+
+cy.get(".ready").should("have.text", "FOO").should("have.css", "color", "#aaa");
+
+================================================================================
+`;
+
 exports[`cypress.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -591,6 +1198,50 @@ cy.get(".ready")
 cy.get("option:first").should("be.selected").and("have.value", "Metallica");
 
 cy.get(".ready").should("have.text", "FOO").should("have.css", "color", "#aaa");
+
+================================================================================
+`;
+
+exports[`d3.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+d3.select('body')
+  .append('circle')
+  .at({ width: 30, fill: '#f0f' })
+  .st({ fontWeight: 600 })
+
+const myScale = d3.scaleLinear()
+  .domain([1950, 1980])
+  .range([0, width])
+
+not.d3.select('body')
+  .append('circle')
+  .at({ width: 30, fill: '#f0f' })
+  .st({ fontWeight: 600 })
+
+not.d3.scaleLinear()
+  .domain([1950, 1980])
+  .range([0, width])
+
+=====================================output=====================================
+d3.select("body")
+  .append("circle")
+  .at({ width: 30, fill: "#f0f" })
+  .st({ fontWeight: 600 });
+
+const myScale = d3.scaleLinear().domain([1950, 1980]).range([0, width]);
+
+not.d3
+  .select("body")
+  .append("circle")
+  .at({ width: 30, fill: "#f0f" })
+  .st({ fontWeight: 600 });
+
+not.d3.scaleLinear().domain([1950, 1980]).range([0, width]);
 
 ================================================================================
 `;
@@ -634,6 +1285,86 @@ not.d3
   .st({ fontWeight: 600 });
 
 not.d3.scaleLinear().domain([1950, 1980]).range([0, width]);
+
+================================================================================
+`;
+
+exports[`first_long.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export default function theFunction(action$, store) {
+  return action$.ofType(THE_ACTION).switchMap(action => Observable
+    .webSocket({
+      url: THE_URL,
+      more: stuff(),
+      evenMore: stuff({
+        value1: true,
+        value2: false,
+        value3: false
+      })
+    })
+    .filter(data => theFilter(data))
+    .map(({ theType, ...data }) => theMap(theType, data))
+    .retryWhen(errors => errors));
+}
+
+function f() {
+  return this._getWorker(workerOptions)({
+    filePath,
+    hasteImplModulePath: this._options.hasteImplModulePath,
+  }).then(
+    metadata => {
+      // \`1\` for truthy values instead of \`true\` to save cache space.
+      fileMetadata[H.VISITED] = 1;
+      const metadataId = metadata.id;
+      const metadataModule = metadata.module;
+      if (metadataId && metadataModule) {
+        fileMetadata[H.ID] = metadataId;
+        setModule(metadataId, metadataModule);
+      }
+      fileMetadata[H.DEPENDENCIES] = metadata.dependencies || [];
+    }
+  );
+}
+
+=====================================output=====================================
+export default function theFunction(action$, store) {
+  return action$.ofType(THE_ACTION).switchMap((action) =>
+    Observable.webSocket({
+      url: THE_URL,
+      more: stuff(),
+      evenMore: stuff({
+        value1: true,
+        value2: false,
+        value3: false,
+      }),
+    })
+      .filter((data) => theFilter(data))
+      .map(({ theType, ...data }) => theMap(theType, data))
+      .retryWhen((errors) => errors),
+  );
+}
+
+function f() {
+  return this._getWorker(workerOptions)({
+    filePath,
+    hasteImplModulePath: this._options.hasteImplModulePath,
+  }).then((metadata) => {
+    // \`1\` for truthy values instead of \`true\` to save cache space.
+    fileMetadata[H.VISITED] = 1;
+    const metadataId = metadata.id;
+    const metadataModule = metadata.module;
+    if (metadataId && metadataModule) {
+      fileMetadata[H.ID] = metadataId;
+      setModule(metadataId, metadataModule);
+    }
+    fileMetadata[H.DEPENDENCIES] = metadata.dependencies || [];
+  });
+}
 
 ================================================================================
 `;
@@ -717,6 +1448,46 @@ function f() {
 ================================================================================
 `;
 
+exports[`fluent-configuration.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+domain
+    .concept('Page')
+    .val('title', 'string')
+    .vals('widgets', 'Widget')
+domain
+    .concept('Widget')
+    .val('title', 'string')
+    .val('color', 'Color')
+    .val('foo', 'Foo')
+    .val('bar', 'Bar')
+domain
+    .concept('Widget')
+    .val('title', 'string')
+    .val('color', 'Color')
+domain
+    .concept(CONCEPT_NAME)
+    .val('title')
+    .vals()
+
+=====================================output=====================================
+domain.concept("Page").val("title", "string").vals("widgets", "Widget");
+domain
+  .concept("Widget")
+  .val("title", "string")
+  .val("color", "Color")
+  .val("foo", "Foo")
+  .val("bar", "Bar");
+domain.concept("Widget").val("title", "string").val("color", "Color");
+domain.concept(CONCEPT_NAME).val("title").vals();
+
+================================================================================
+`;
+
 exports[`fluent-configuration.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -752,6 +1523,52 @@ domain
   .val("bar", "Bar");
 domain.concept("Widget").val("title", "string").val("color", "Color");
 domain.concept(CONCEPT_NAME).val("title").vals();
+
+================================================================================
+`;
+
+exports[`inline_merge.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+Object.keys(
+  availableLocales({
+    test: true
+  })
+)
+.forEach(locale => {
+  // ...
+});
+
+this.layoutPartsToHide = this.utils.hashset(
+	_.flatMap(this.visibilityHandlers, fn => fn())
+		.concat(this.record.resolved_legacy_visrules)
+		.filter(Boolean)
+);
+
+var jqxhr = $.ajax("example.php")
+  .done(doneFn)
+  .fail(failFn);
+
+=====================================output=====================================
+Object.keys(
+  availableLocales({
+    test: true,
+  }),
+).forEach((locale) => {
+  // ...
+});
+
+this.layoutPartsToHide = this.utils.hashset(
+  _.flatMap(this.visibilityHandlers, (fn) => fn())
+    .concat(this.record.resolved_legacy_visrules)
+    .filter(Boolean),
+);
+
+var jqxhr = $.ajax("example.php").done(doneFn).fail(failFn);
 
 ================================================================================
 `;
@@ -801,6 +1618,33 @@ var jqxhr = $.ajax("example.php").done(doneFn).fail(failFn);
 ================================================================================
 `;
 
+exports[`issue-3594.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const fetched = fetch("/foo");
+fetched
+	.then(response => response.json())
+	.then(json => processThings(json.data.things));
+
+let column = new Column(null, conn)
+    .table(data.table)
+    .json(data.column);
+
+=====================================output=====================================
+const fetched = fetch("/foo");
+fetched
+  .then((response) => response.json())
+  .then((json) => processThings(json.data.things));
+
+let column = new Column(null, conn).table(data.table).json(data.column);
+
+================================================================================
+`;
+
 exports[`issue-3594.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -823,6 +1667,41 @@ fetched
   .then((json) => processThings(json.data.things));
 
 let column = new Column(null, conn).table(data.table).json(data.column);
+
+================================================================================
+`;
+
+exports[`issue-3621.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const palindrome = str => {
+  const s = str.toLowerCase().replace(/[\\W_]/g, '');
+  return s === s.split('').reverse().join('');
+};
+
+const apiCurrencies = api().currencies().all()
+
+expect(cells.at(1).render().text()).toBe('link text1')
+expect(cells.at(2).render().text()).toBe('link text2')
+expect(cells.at(3).render().text()).toBe('link text3')
+expect(cells.at(4).render().text()).toBe('link text4')
+
+=====================================output=====================================
+const palindrome = (str) => {
+  const s = str.toLowerCase().replace(/[\\W_]/g, "");
+  return s === s.split("").reverse().join("");
+};
+
+const apiCurrencies = api().currencies().all();
+
+expect(cells.at(1).render().text()).toBe("link text1");
+expect(cells.at(2).render().text()).toBe("link text2");
+expect(cells.at(3).render().text()).toBe("link text3");
+expect(cells.at(4).render().text()).toBe("link text4");
 
 ================================================================================
 `;
@@ -857,6 +1736,335 @@ expect(cells.at(1).render().text()).toBe("link text1");
 expect(cells.at(2).render().text()).toBe("link text2");
 expect(cells.at(3).render().text()).toBe("link text3");
 expect(cells.at(4).render().text()).toBe("link text4");
+
+================================================================================
+`;
+
+exports[`issue-4125.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// examples from https://github.com/prettier/prettier/issues/4125
+
+const sha256 = (data) => crypto.createHash("sha256").update(data).digest("hex");
+
+req.checkBody('id').isInt().optional();
+req.checkBody('name').notEmpty().optional();
+
+const x = moment().add(1, 'day').valueOf()
+
+// should stay on one line:
+const y = obj.foo(1).foo(2).foo(3);
+const z = obj.foo(-1).foo(import('2')).foo(!x).check(/[A-Z]/);
+
+// better on multiple lines:
+somePromise.then(format).then((val)=>doSomething(val)).catch((err)=>handleError(err))
+
+// you can still force multi-line chaining with a comment:
+const sha256_2 = (data) =>
+  crypto // breakme
+    .createHash("sha256")
+    .update(data)
+    .digest("hex");
+
+// examples from https://github.com/prettier/prettier/pull/4765
+
+if ($(el).attr("href").includes("/wiki/")) {
+}
+
+if ($(el).attr("href").includes("/wiki/")) {
+  if ($(el).attr("xyz").includes("/whatever/")) {
+    if ($(el).attr("hello").includes("/world/")) {
+    }
+  }
+}
+
+const parseNumbers = s => s.split('').map(Number).sort()
+
+function palindrome(a, b) {
+  return a.slice().reverse().join(',') === b.slice().sort().join(',');
+}
+
+// examples from https://github.com/prettier/prettier/issues/1565
+
+d3.select("body").selectAll("p").data([1, 2, 3]).enter().style("color", "white");
+
+Object.keys(props).filter(key => key in own === false).reduce((a, key) => {
+  a[key] = props[key];
+  return a;
+}, {})
+
+point().x(4).y(3).z(6).plot();
+
+assert.equal(this.$().text().trim(), '1000');
+
+something().then(() => doSomethingElse()).then(result => dontForgetThisAsWell(result))
+
+db.branch(
+  db.table('users').filter({ email }).count(),
+  db.table('users').filter({ email: 'a@b.com' }).count(),
+  db.table('users').insert({ email }),
+  db.table('users').filter({ email }),
+)
+
+sandbox.stub(config, 'get').withArgs('env').returns('dev')
+
+const date = moment.utc(userInput).hour(0).minute(0).second(0)
+
+fetchUser(id)
+  .then(fetchAccountForUser)
+  .catch(handleFetchError)
+
+fetchUser(id) //
+  .then(fetchAccountForUser)
+  .catch(handleFetchError)
+
+// examples from https://github.com/prettier/prettier/issues/3107
+
+function HelloWorld() {
+  window.FooClient.setVars({
+    locale: getFooLocale({ page }),
+    authorizationToken: data.token,
+  }).initVerify('foo_container');
+
+  fejax.ajax({
+    url: '/verification/',
+    dataType: 'json',
+  }).then(
+    (data) => {
+      this.setState({ isLoading: false });
+      this.initWidget(data);
+    },
+    (data) => {
+      this.logImpression('foo_fetch_error', data);
+      Flash.error(I18n.t('offline_identity.foo_issue'));
+    },
+  );
+}
+
+action$.ofType(ActionTypes.SEARCHED_USERS)
+  .map(action => action.payload.query)
+  .filter(q => !!q)
+  .switchMap(q =>
+    Observable.timer(800) // debounce
+      .takeUntil(action$.ofType(ActionTypes.CLEARED_SEARCH_RESULTS))
+      .mergeMap(() =>
+        Observable.merge(
+          Observable.of(replace(\`?q=\${q}\`)),
+          ajax
+            .getJSON(\`https://api.github.com/search/users?q=\${q}\`)
+            .map(res => res.items)
+            .map(receiveUsers)
+        )
+      )
+  );
+
+window.FooClient
+  .setVars({
+    locale: getFooLocale({ page }),
+    authorizationToken: data.token,
+  })
+  .initVerify('foo_container');
+
+it('gets triggered by mouseenter', () => {
+  const wrapper = shallow(<CalendarDay />);
+  wrapper.dive().find(Button).prop();
+});
+
+const a1 = x.a(true).b(null).c(123)
+const a2 = x.d('').e(\`\`).f(g)
+const a3 = x.d('').e(\`\${123}\`).f(g)
+const a4 = x.h(i.j).k(l()).m([n, o])
+class X {
+  y() {
+    const j = x.a(this).b(super.cde()).f(/g/).h(new i()).j();
+  }
+}
+
+// should break when call expressions get complex
+x.a().b([c, [d, [e]]]).f()
+x.a().b(c(d(e()))).f()
+x.a().b(\`\${c(d())}\`).f()
+
+xyz.a().b().c(a(a(b(c(d().p).p).p).p))
+
+var l = base
+    .replace(/^\\w*:\\/\\//, '')
+    .replace(/\\/$/, '')
+    .split('/').length
+
+
+=====================================output=====================================
+// examples from https://github.com/prettier/prettier/issues/4125
+
+const sha256 = (data) => crypto.createHash("sha256").update(data).digest("hex");
+
+req.checkBody("id").isInt().optional();
+req.checkBody("name").notEmpty().optional();
+
+const x = moment().add(1, "day").valueOf();
+
+// should stay on one line:
+const y = obj.foo(1).foo(2).foo(3);
+const z = obj.foo(-1).foo(import("2")).foo(!x).check(/[A-Z]/);
+
+// better on multiple lines:
+somePromise
+  .then(format)
+  .then((val) => doSomething(val))
+  .catch((err) => handleError(err));
+
+// you can still force multi-line chaining with a comment:
+const sha256_2 = (data) =>
+  crypto // breakme
+    .createHash("sha256")
+    .update(data)
+    .digest("hex");
+
+// examples from https://github.com/prettier/prettier/pull/4765
+
+if ($(el).attr("href").includes("/wiki/")) {
+}
+
+if ($(el).attr("href").includes("/wiki/")) {
+  if ($(el).attr("xyz").includes("/whatever/")) {
+    if ($(el).attr("hello").includes("/world/")) {
+    }
+  }
+}
+
+const parseNumbers = (s) => s.split("").map(Number).sort();
+
+function palindrome(a, b) {
+  return a.slice().reverse().join(",") === b.slice().sort().join(",");
+}
+
+// examples from https://github.com/prettier/prettier/issues/1565
+
+d3.select("body")
+  .selectAll("p")
+  .data([1, 2, 3])
+  .enter()
+  .style("color", "white");
+
+Object.keys(props)
+  .filter((key) => key in own === false)
+  .reduce((a, key) => {
+    a[key] = props[key];
+    return a;
+  }, {});
+
+point().x(4).y(3).z(6).plot();
+
+assert.equal(this.$().text().trim(), "1000");
+
+something()
+  .then(() => doSomethingElse())
+  .then((result) => dontForgetThisAsWell(result));
+
+db.branch(
+  db.table("users").filter({ email }).count(),
+  db.table("users").filter({ email: "a@b.com" }).count(),
+  db.table("users").insert({ email }),
+  db.table("users").filter({ email }),
+);
+
+sandbox.stub(config, "get").withArgs("env").returns("dev");
+
+const date = moment.utc(userInput).hour(0).minute(0).second(0);
+
+fetchUser(id).then(fetchAccountForUser).catch(handleFetchError);
+
+fetchUser(id) //
+  .then(fetchAccountForUser)
+  .catch(handleFetchError);
+
+// examples from https://github.com/prettier/prettier/issues/3107
+
+function HelloWorld() {
+  window.FooClient.setVars({
+    locale: getFooLocale({ page }),
+    authorizationToken: data.token,
+  }).initVerify("foo_container");
+
+  fejax
+    .ajax({
+      url: "/verification/",
+      dataType: "json",
+    })
+    .then(
+      (data) => {
+        this.setState({ isLoading: false });
+        this.initWidget(data);
+      },
+      (data) => {
+        this.logImpression("foo_fetch_error", data);
+        Flash.error(I18n.t("offline_identity.foo_issue"));
+      },
+    );
+}
+
+action$
+  .ofType(ActionTypes.SEARCHED_USERS)
+  .map((action) => action.payload.query)
+  .filter((q) => !!q)
+  .switchMap((q) =>
+    Observable.timer(800) // debounce
+      .takeUntil(action$.ofType(ActionTypes.CLEARED_SEARCH_RESULTS))
+      .mergeMap(() =>
+        Observable.merge(
+          Observable.of(replace(\`?q=\${q}\`)),
+          ajax
+            .getJSON(\`https://api.github.com/search/users?q=\${q}\`)
+            .map((res) => res.items)
+            .map(receiveUsers),
+        ),
+      ),
+  );
+
+window.FooClient.setVars({
+  locale: getFooLocale({ page }),
+  authorizationToken: data.token,
+}).initVerify("foo_container");
+
+it("gets triggered by mouseenter", () => {
+  const wrapper = shallow(<CalendarDay />);
+  wrapper.dive().find(Button).prop();
+});
+
+const a1 = x.a(true).b(null).c(123);
+const a2 = x.d("").e(\`\`).f(g);
+const a3 = x.d("").e(\`\${123}\`).f(g);
+const a4 = x.h(i.j).k(l()).m([n, o]);
+class X {
+  y() {
+    const j = x.a(this).b(super.cde()).f(/g/).h(new i()).j();
+  }
+}
+
+// should break when call expressions get complex
+x.a()
+  .b([c, [d, [e]]])
+  .f();
+x.a()
+  .b(c(d(e())))
+  .f();
+x.a()
+  .b(\`\${c(d())}\`)
+  .f();
+
+xyz
+  .a()
+  .b()
+  .c(a(a(b(c(d().p).p).p).p));
+
+var l = base
+  .replace(/^\\w*:\\/\\//, "")
+  .replace(/\\/$/, "")
+  .split("/").length;
 
 ================================================================================
 `;
@@ -1189,6 +2397,29 @@ var l = base
 ================================================================================
 `;
 
+exports[`issue-11298.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+foo1(/𠮟𠮟𠮟/).foo2(bar).foo3(baz);
+
+foo1(/叱叱叱/).foo2(bar).foo3(baz);
+
+=====================================output=====================================
+foo1(/𠮟𠮟𠮟/)
+  .foo2(bar)
+  .foo3(baz);
+
+foo1(/叱叱叱/)
+  .foo2(bar)
+  .foo3(baz);
+
+================================================================================
+`;
+
 exports[`issue-11298.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -1207,6 +2438,61 @@ foo1(/𠮟𠮟𠮟/)
 foo1(/叱叱叱/)
   .foo2(bar)
   .foo3(baz);
+
+================================================================================
+`;
+
+exports[`logical.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const someLongVariableName = (idx(
+  this.props,
+  props => props.someLongPropertyName
+) || []
+).map(edge => edge.node);
+
+(veryLongVeryLongVeryLong || e).map(tickets =>
+  TicketRecord.createFromSomeLongString());
+
+(veryLongVeryLongVeryLong || e).map(tickets =>
+  TicketRecord.createFromSomeLongString()).filter(obj => !!obj);
+
+(veryLongVeryLongVeryLong || anotherVeryLongVeryLongVeryLong || veryVeryVeryLongError).map(tickets =>
+  TicketRecord.createFromSomeLongString());
+
+(veryLongVeryLongVeryLong || anotherVeryLongVeryLongVeryLong || veryVeryVeryLongError).map(tickets =>
+  TicketRecord.createFromSomeLongString()).filter(obj => !!obj);
+
+=====================================output=====================================
+const someLongVariableName = (
+  idx(this.props, (props) => props.someLongPropertyName) || []
+).map((edge) => edge.node);
+
+(veryLongVeryLongVeryLong || e).map((tickets) =>
+  TicketRecord.createFromSomeLongString(),
+);
+
+(veryLongVeryLongVeryLong || e)
+  .map((tickets) => TicketRecord.createFromSomeLongString())
+  .filter((obj) => !!obj);
+
+(
+  veryLongVeryLongVeryLong
+  || anotherVeryLongVeryLongVeryLong
+  || veryVeryVeryLongError
+).map((tickets) => TicketRecord.createFromSomeLongString());
+
+(
+  veryLongVeryLongVeryLong
+  || anotherVeryLongVeryLongVeryLong
+  || veryVeryVeryLongError
+)
+  .map((tickets) => TicketRecord.createFromSomeLongString())
+  .filter((obj) => !!obj);
 
 ================================================================================
 `;
@@ -1261,6 +2547,101 @@ const someLongVariableName = (
 )
   .map((tickets) => TicketRecord.createFromSomeLongString())
   .filter((obj) => !!obj);
+
+================================================================================
+`;
+
+exports[`multiple-members.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+if (testConfig.ENABLE_ONLINE_TESTS === "true") {
+  describe("POST /users/me/pet", function() {
+    it("saves pet", function() {
+      function assert(pet) {
+        expect(pet).to.have.property("OwnerAddress").that.deep.equals({
+          AddressLine1: "Alexanderstrasse",
+          AddressLine2: "",
+          PostalCode: "10999",
+          Region: "Berlin",
+          City: "Berlin",
+          Country: "DE"
+        });
+      }
+    });
+  });
+}
+
+wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName')().then(function() {
+  doSomething();
+});
+
+wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName')('argument').then(function() {
+  doSomething();
+});
+
+wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName', 'second argument that pushes this group past 80 characters')('argument').then(function() {
+  doSomething();
+});
+
+wrapper.find('SomewhatLongNodeName').prop('longPropFunctionName')('argument', 'second argument that pushes this group past 80 characters').then(function() {
+  doSomething();
+});
+
+=====================================output=====================================
+if (testConfig.ENABLE_ONLINE_TESTS === "true") {
+  describe("POST /users/me/pet", function () {
+    it("saves pet", function () {
+      function assert(pet) {
+        expect(pet).to.have.property("OwnerAddress").that.deep.equals({
+          AddressLine1: "Alexanderstrasse",
+          AddressLine2: "",
+          PostalCode: "10999",
+          Region: "Berlin",
+          City: "Berlin",
+          Country: "DE",
+        });
+      }
+    });
+  });
+}
+
+wrapper
+  .find("SomewhatLongNodeName")
+  .prop("longPropFunctionName")()
+  .then(function () {
+    doSomething();
+  });
+
+wrapper
+  .find("SomewhatLongNodeName")
+  .prop("longPropFunctionName")("argument")
+  .then(function () {
+    doSomething();
+  });
+
+wrapper
+  .find("SomewhatLongNodeName")
+  .prop(
+    "longPropFunctionName",
+    "second argument that pushes this group past 80 characters",
+  )("argument")
+  .then(function () {
+    doSomething();
+  });
+
+wrapper
+  .find("SomewhatLongNodeName")
+  .prop("longPropFunctionName")(
+    "argument",
+    "second argument that pushes this group past 80 characters",
+  )
+  .then(function () {
+    doSomething();
+  });
 
 ================================================================================
 `;
@@ -1359,6 +2740,49 @@ wrapper
 ================================================================================
 `;
 
+exports[`object-literal.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+of("test")
+  .pipe(throwIfEmpty())
+  .subscribe({
+    error(err) {
+      thrown = err;
+    }
+  });
+
+of("test")
+  .pipe(throwIfEmpty())
+  .subscribe({
+    get foo() {
+      bar();
+    }
+  });
+
+=====================================output=====================================
+of("test")
+  .pipe(throwIfEmpty())
+  .subscribe({
+    error(err) {
+      thrown = err;
+    },
+  });
+
+of("test")
+  .pipe(throwIfEmpty())
+  .subscribe({
+    get foo() {
+      bar();
+    },
+  });
+
+================================================================================
+`;
+
 exports[`object-literal.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -1401,6 +2825,41 @@ of("test")
 ================================================================================
 `;
 
+exports[`pr-7889.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const Profile = view.with({ name: (state) => state.name }).as((props) => (
+  <div>
+    <h1>Hello, {props.name}</h1>
+  </div>
+))
+
+const Profile2 = view.with({ name }).as((props) => (
+  <div>
+    <h1>Hello, {props.name}</h1>
+  </div>
+))
+
+=====================================output=====================================
+const Profile = view.with({ name: (state) => state.name }).as((props) => (
+  <div>
+    <h1>Hello, {props.name}</h1>
+  </div>
+));
+
+const Profile2 = view.with({ name }).as((props) => (
+  <div>
+    <h1>Hello, {props.name}</h1>
+  </div>
+));
+
+================================================================================
+`;
+
 exports[`pr-7889.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -1435,6 +2894,27 @@ const Profile2 = view.with({ name }).as((props) => (
 ================================================================================
 `;
 
+exports[`short-names.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const svgJsFiles = fs
+  .readdirSync(svgDir)
+  .filter(f => svgJsFileExtRegex.test(f))
+  .map(f => path.join(svgDir, f));
+
+=====================================output=====================================
+const svgJsFiles = fs
+  .readdirSync(svgDir)
+  .filter((f) => svgJsFileExtRegex.test(f))
+  .map((f) => path.join(svgDir, f));
+
+================================================================================
+`;
+
 exports[`short-names.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -1455,6 +2935,25 @@ const svgJsFiles = fs
 ================================================================================
 `;
 
+exports[`simple-args.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const fieldsToSend = _(["id", extra]).without("transition").uniq();
+
+console.log(values.filter(isValid).map(extractId).slice(-5, -1));
+
+=====================================output=====================================
+const fieldsToSend = _(["id", extra]).without("transition").uniq();
+
+console.log(values.filter(isValid).map(extractId).slice(-5, -1));
+
+================================================================================
+`;
+
 exports[`simple-args.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -1469,6 +2968,37 @@ console.log(values.filter(isValid).map(extractId).slice(-5, -1));
 const fieldsToSend = _(["id", extra]).without("transition").uniq();
 
 console.log(values.filter(isValid).map(extractId).slice(-5, -1));
+
+================================================================================
+`;
+
+exports[`square_0.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const version = someLongString
+  .split('jest version =')
+  .pop()
+  .split(EOL)[0]
+  .trim();
+
+const component = find('.org-lclp-edit-copy-url-banner__link')[0]
+  .getAttribute('href')
+  .indexOf(this.landingPageLink);
+
+=====================================output=====================================
+const version = someLongString
+  .split("jest version =")
+  .pop()
+  .split(EOL)[0]
+  .trim();
+
+const component = find(".org-lclp-edit-copy-url-banner__link")[0]
+  .getAttribute("href")
+  .indexOf(this.landingPageLink);
 
 ================================================================================
 `;
@@ -1503,6 +3033,32 @@ const component = find(".org-lclp-edit-copy-url-banner__link")[0]
 ================================================================================
 `;
 
+exports[`test.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+method().then(x => x)
+  ["abc"](x => x)
+  [abc](x => x);
+
+({}.a().b());
+({}).a().b();
+
+=====================================output=====================================
+method()
+  .then((x) => x)
+  ["abc"]((x) => x)
+  [abc]((x) => x);
+
+({}).a().b();
+({}).a().b();
+
+================================================================================
+`;
+
 exports[`test.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -1524,6 +3080,25 @@ method()
 
 ({}).a().b();
 ({}).a().b();
+
+================================================================================
+`;
+
+exports[`this.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const sel = this.connections
+  .concat(this.activities.concat(this.operators))
+  .filter(x => x.selected);
+
+=====================================output=====================================
+const sel = this.connections
+  .concat(this.activities.concat(this.operators))
+  .filter((x) => x.selected);
 
 ================================================================================
 `;
@@ -1594,6 +3169,79 @@ exports[`tuple-and-record.js [typescript] format 1`] = `
   3 |
   4 | foo.a().b().c({n, o})
   5 | foo.a().b().c(#{n, o})"
+`;
+
+exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [acorn] format 1`] = `
+"Unexpected character '[' (2:16)
+  1 | foo.a().b().c([n, o])
+> 2 | foo.a().b().c(#[n, o])
+    |                ^
+  3 |
+  4 | foo.a().b().c({n, o})
+  5 | foo.a().b().c(#{n, o})"
+`;
+
+exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [espree] format 1`] = `
+"Unexpected character '[' (2:16)
+  1 | foo.a().b().c([n, o])
+> 2 | foo.a().b().c(#[n, o])
+    |                ^
+  3 |
+  4 | foo.a().b().c({n, o})
+  5 | foo.a().b().c(#{n, o})"
+`;
+
+exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [flow] format 1`] = `
+"Unexpected token \`#\`, expected an identifier (2:15)
+  1 | foo.a().b().c([n, o])
+> 2 | foo.a().b().c(#[n, o])
+    |               ^
+  3 |
+  4 | foo.a().b().c({n, o})
+  5 | foo.a().b().c(#{n, o})"
+`;
+
+exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [meriyah] format 1`] = `
+"'#' not followed by identifier (2:15)
+  1 | foo.a().b().c([n, o])
+> 2 | foo.a().b().c(#[n, o])
+    |               ^
+  3 |
+  4 | foo.a().b().c({n, o})
+  5 | foo.a().b().c(#{n, o})"
+`;
+
+exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [typescript] format 1`] = `
+"Invalid character. (2:15)
+  1 | foo.a().b().c([n, o])
+> 2 | foo.a().b().c(#[n, o])
+    |               ^
+  3 |
+  4 | foo.a().b().c({n, o})
+  5 | foo.a().b().c(#{n, o})"
+`;
+
+exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+foo.a().b().c([n, o])
+foo.a().b().c(#[n, o])
+
+foo.a().b().c({n, o})
+foo.a().b().c(#{n, o})
+
+=====================================output=====================================
+foo.a().b().c([n, o]);
+foo.a().b().c(#[n, o]);
+
+foo.a().b().c({ n, o });
+foo.a().b().c(#{ n, o });
+
+================================================================================
 `;
 
 exports[`tuple-and-record.js format 1`] = `

--- a/tests/format/js/method-chain/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/method-chain/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`13018.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`13018.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -57,9 +57,9 @@ foo(a--).bar().leet();
 ================================================================================
 `;
 
-exports[`bracket_0.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`bracket_0.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -120,9 +120,9 @@ function a() {
 ================================================================================
 `;
 
-exports[`bracket_0-1.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`bracket_0-1.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -155,9 +155,9 @@ const thingamabobMetaAlias = path.scope
 ================================================================================
 `;
 
-exports[`break-last-call.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`break-last-call.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -408,9 +408,9 @@ it("should group messages with same created time", () => {
 ================================================================================
 `;
 
-exports[`break-last-member.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`break-last-member.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -547,9 +547,9 @@ const {
 ================================================================================
 `;
 
-exports[`break-multiple.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`break-multiple.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -592,9 +592,9 @@ foo().bar.baz();
 ================================================================================
 `;
 
-exports[`comment.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`comment.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -847,9 +847,9 @@ angular
 ================================================================================
 `;
 
-exports[`complex-args.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`complex-args.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -888,9 +888,9 @@ client.execute(
 ================================================================================
 `;
 
-exports[`computed.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`computed.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -937,9 +937,9 @@ nock(/test/)
 ================================================================================
 `;
 
-exports[`computed-merge.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`computed-merge.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1026,9 +1026,9 @@ window.Data[key]("foo")
 ================================================================================
 `;
 
-exports[`conditional.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`conditional.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1157,9 +1157,9 @@ object[
 ================================================================================
 `;
 
-exports[`cypress.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`cypress.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1202,9 +1202,9 @@ cy.get(".ready").should("have.text", "FOO").should("have.css", "color", "#aaa");
 ================================================================================
 `;
 
-exports[`d3.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`d3.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1289,9 +1289,9 @@ not.d3.scaleLinear().domain([1950, 1980]).range([0, width]);
 ================================================================================
 `;
 
-exports[`first_long.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`first_long.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1448,9 +1448,9 @@ function f() {
 ================================================================================
 `;
 
-exports[`fluent-configuration.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`fluent-configuration.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1527,9 +1527,9 @@ domain.concept(CONCEPT_NAME).val("title").vals();
 ================================================================================
 `;
 
-exports[`inline_merge.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`inline_merge.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1618,9 +1618,9 @@ var jqxhr = $.ajax("example.php").done(doneFn).fail(failFn);
 ================================================================================
 `;
 
-exports[`issue-3594.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-3594.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1671,9 +1671,9 @@ let column = new Column(null, conn).table(data.table).json(data.column);
 ================================================================================
 `;
 
-exports[`issue-3621.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-3621.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1740,9 +1740,9 @@ expect(cells.at(4).render().text()).toBe("link text4");
 ================================================================================
 `;
 
-exports[`issue-4125.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-4125.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -2397,9 +2397,9 @@ var l = base
 ================================================================================
 `;
 
-exports[`issue-11298.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-11298.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -2442,9 +2442,9 @@ foo1(/叱叱叱/)
 ================================================================================
 `;
 
-exports[`logical.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`logical.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -2551,9 +2551,9 @@ const someLongVariableName = (
 ================================================================================
 `;
 
-exports[`multiple-members.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`multiple-members.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -2740,9 +2740,9 @@ wrapper
 ================================================================================
 `;
 
-exports[`object-literal.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`object-literal.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -2825,9 +2825,9 @@ of("test")
 ================================================================================
 `;
 
-exports[`pr-7889.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`pr-7889.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -2894,9 +2894,9 @@ const Profile2 = view.with({ name }).as((props) => (
 ================================================================================
 `;
 
-exports[`short-names.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`short-names.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -2935,9 +2935,9 @@ const svgJsFiles = fs
 ================================================================================
 `;
 
-exports[`simple-args.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`simple-args.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -2972,9 +2972,9 @@ console.log(values.filter(isValid).map(extractId).slice(-5, -1));
 ================================================================================
 `;
 
-exports[`square_0.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`square_0.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -3033,9 +3033,9 @@ const component = find(".org-lclp-edit-copy-url-banner__link")[0]
 ================================================================================
 `;
 
-exports[`test.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`test.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -3084,9 +3084,9 @@ method()
 ================================================================================
 `;
 
-exports[`this.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`this.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -3171,7 +3171,7 @@ exports[`tuple-and-record.js [typescript] format 1`] = `
   5 | foo.a().b().c(#{n, o})"
 `;
 
-exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [acorn] format 1`] = `
+exports[`tuple-and-record.js - {"experimentalOperatorPosition":true} [acorn] format 1`] = `
 "Unexpected character '[' (2:16)
   1 | foo.a().b().c([n, o])
 > 2 | foo.a().b().c(#[n, o])
@@ -3181,7 +3181,7 @@ exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [acorn] for
   5 | foo.a().b().c(#{n, o})"
 `;
 
-exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [espree] format 1`] = `
+exports[`tuple-and-record.js - {"experimentalOperatorPosition":true} [espree] format 1`] = `
 "Unexpected character '[' (2:16)
   1 | foo.a().b().c([n, o])
 > 2 | foo.a().b().c(#[n, o])
@@ -3191,7 +3191,7 @@ exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [espree] fo
   5 | foo.a().b().c(#{n, o})"
 `;
 
-exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [flow] format 1`] = `
+exports[`tuple-and-record.js - {"experimentalOperatorPosition":true} [flow] format 1`] = `
 "Unexpected token \`#\`, expected an identifier (2:15)
   1 | foo.a().b().c([n, o])
 > 2 | foo.a().b().c(#[n, o])
@@ -3201,7 +3201,7 @@ exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [flow] form
   5 | foo.a().b().c(#{n, o})"
 `;
 
-exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [meriyah] format 1`] = `
+exports[`tuple-and-record.js - {"experimentalOperatorPosition":true} [meriyah] format 1`] = `
 "'#' not followed by identifier (2:15)
   1 | foo.a().b().c([n, o])
 > 2 | foo.a().b().c(#[n, o])
@@ -3211,7 +3211,7 @@ exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [meriyah] f
   5 | foo.a().b().c(#{n, o})"
 `;
 
-exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [typescript] format 1`] = `
+exports[`tuple-and-record.js - {"experimentalOperatorPosition":true} [typescript] format 1`] = `
 "Invalid character. (2:15)
   1 | foo.a().b().c([n, o])
 > 2 | foo.a().b().c(#[n, o])
@@ -3221,9 +3221,9 @@ exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} [typescript
   5 | foo.a().b().c(#{n, o})"
 `;
 
-exports[`tuple-and-record.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`tuple-and-record.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/method-chain/jsfmt.spec.js
+++ b/tests/format/js/method-chain/jsfmt.spec.js
@@ -9,5 +9,5 @@ const errors = {
 run_spec(import.meta, ["babel", "flow", "typescript"], { errors });
 run_spec(import.meta, ["babel", "flow", "typescript"], {
   errors,
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/js/method-chain/jsfmt.spec.js
+++ b/tests/format/js/method-chain/jsfmt.spec.js
@@ -7,3 +7,7 @@ const errors = {
 };
 
 run_spec(import.meta, ["babel", "flow", "typescript"], { errors });
+run_spec(import.meta, ["babel", "flow", "typescript"], {
+  errors,
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/multiparser-css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/multiparser-css/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`colons-after-substitutions.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const Icon = styled.div\`
+  flex: none;
+  transition:    fill 0.25s;
+  width: 48px;
+  height: 48px;
+
+  \${Link}:hover {
+    fill:   rebeccapurple;
+  }
+
+  \${Link} :hover {
+    fill: yellow;
+  }
+
+  \${media.smallDown}::before {}
+\`
+
+=====================================output=====================================
+const Icon = styled.div\`
+  flex: none;
+  transition: fill 0.25s;
+  width: 48px;
+  height: 48px;
+
+  \${Link}:hover {
+    fill: rebeccapurple;
+  }
+
+  \${Link} :hover {
+    fill: yellow;
+  }
+
+  \${media.smallDown}::before {
+  }
+\`;
+
+================================================================================
+`;
+
 exports[`colons-after-substitutions.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -39,6 +85,65 @@ const Icon = styled.div\`
   }
 
   \${media.smallDown}::before {
+  }
+\`;
+
+================================================================================
+`;
+
+exports[`colons-after-substitutions2.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const Icon = styled.div\`
+  height: 48px;
+
+  \${Link}:nth-child(2) {
+    fill: rebeccapurple;
+  }
+\`;
+
+const Icon2 = styled.div\`
+  height: 48px;
+
+  \${Link}:empty:before{
+    fill: rebeccapurple;
+  }
+\`;
+
+const Icon3 = styled.div\`
+  height: 48px;
+
+  \${Link}:not(:first-child) {
+    fill: rebeccapurple;
+  }
+\`;
+
+=====================================output=====================================
+const Icon = styled.div\`
+  height: 48px;
+
+  \${Link}:nth-child(2) {
+    fill: rebeccapurple;
+  }
+\`;
+
+const Icon2 = styled.div\`
+  height: 48px;
+
+  \${Link}:empty:before {
+    fill: rebeccapurple;
+  }
+\`;
+
+const Icon3 = styled.div\`
+  height: 48px;
+
+  \${Link}:not(:first-child) {
+    fill: rebeccapurple;
   }
 \`;
 
@@ -103,6 +208,49 @@ const Icon3 = styled.div\`
 ================================================================================
 `;
 
+exports[`issue-2636.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export const ButtonWrapper = styled.button\`
+  \${base}
+  \${hover}
+  \${opaque}
+  \${block}
+  \${active}
+  \${disabled}
+  \${outline}
+  \${dashed}
+  \${spacing}
+\`;
+
+export const ButtonWrapper2 = styled.button\`
+  \${base} \${hover} \${opaque} \${block} \${active} \${disabled} \${outline} \${dashed} \${spacing}
+\`;
+
+=====================================output=====================================
+export const ButtonWrapper = styled.button\`
+  \${base}
+  \${hover}
+  \${opaque}
+  \${block}
+  \${active}
+  \${disabled}
+  \${outline}
+  \${dashed}
+  \${spacing}
+\`;
+
+export const ButtonWrapper2 = styled.button\`
+  \${base} \${hover} \${opaque} \${block} \${active} \${disabled} \${outline} \${dashed} \${spacing}
+\`;
+
+================================================================================
+`;
+
 exports[`issue-2636.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -140,6 +288,53 @@ export const ButtonWrapper = styled.button\`
 
 export const ButtonWrapper2 = styled.button\`
   \${base} \${hover} \${opaque} \${block} \${active} \${disabled} \${outline} \${dashed} \${spacing}
+\`;
+
+================================================================================
+`;
+
+exports[`issue-2883.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export const foo = css\`
+&.foo .\${bar}::before,&.foo[value="hello"] .\${bar}::before {
+	position: absolute;
+}
+\`;
+
+export const foo2 = css\`
+a.\${bar}:focus,a.\${bar}:hover {
+  color: red;
+}
+\`;
+
+export const global = css\`
+button.\${foo}.\${bar} {
+  color: #fff;
+}
+\`;
+
+=====================================output=====================================
+export const foo = css\`
+  &.foo .\${bar}::before,&.foo[value="hello"] .\${bar}::before {
+    position: absolute;
+  }
+\`;
+
+export const foo2 = css\`
+  a.\${bar}:focus,a.\${bar}:hover {
+    color: red;
+  }
+\`;
+
+export const global = css\`
+  button.\${foo}.\${bar} {
+    color: #fff;
+  }
 \`;
 
 ================================================================================
@@ -191,6 +386,54 @@ export const global = css\`
 ================================================================================
 `;
 
+exports[`issue-5697.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const StyledH1 = styled.div\`
+  font-size: 2.5em;
+  font-weight: \${(props) => (props.strong ? 500 : 100)};
+  font-family: \${constants.text.displayFont.fontFamily};
+  letter-spacing: \${(props) => (props.light ? '0.04em' : 0)};
+  color: \${(props) => props.textColor};
+  \${(props) =>
+    props.center
+      ? \` display: flex;
+                align-items: center;
+                justify-content: center;
+                text-align: center;\`
+      : ''}
+  @media (max-width: \${(props) => (props.noBreakPoint ? '0' : constants.layout.breakpoint.break1)}px) {
+    font-size: 2em;
+  }
+\`;
+
+=====================================output=====================================
+const StyledH1 = styled.div\`
+  font-size: 2.5em;
+  font-weight: \${(props) => (props.strong ? 500 : 100)};
+  font-family: \${constants.text.displayFont.fontFamily};
+  letter-spacing: \${(props) => (props.light ? "0.04em" : 0)};
+  color: \${(props) => props.textColor};
+  \${(props) =>
+    props.center
+      ? \` display: flex;
+                align-items: center;
+                justify-content: center;
+                text-align: center;\`
+      : ""}
+  @media (max-width: \${(props) =>
+    props.noBreakPoint ? "0" : constants.layout.breakpoint.break1}px) {
+    font-size: 2em;
+  }
+\`;
+
+================================================================================
+`;
+
 exports[`issue-5697.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -232,6 +475,90 @@ const StyledH1 = styled.div\`
   @media (max-width: \${(props) =>
     props.noBreakPoint ? "0" : constants.layout.breakpoint.break1}px) {
     font-size: 2em;
+  }
+\`;
+
+================================================================================
+`;
+
+exports[`issue-5961.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const Steps = styled.div\`
+  @media (min-width: 1px) {
+    \${Step}:nth-child(odd) {}
+  }
+\`;
+
+const Steps2 = styled.div\`
+  @media (min-width: \${breakpoints.lg}) {
+    \${Step} {
+      margin-bottom: 90px;
+    }
+
+    \${Step}:nth-child(odd) {
+      \${StepItemDescription} {
+        grid-row: 1;
+        grid-column: 3 / span 3;
+      }
+      \${Image} {
+        grid-row: 1;
+        grid-column: 7 / span 6;
+      }
+    }
+
+    \${Step}:nth-child(even) {
+      \${Image} {
+        grid-row: 1;
+        grid-column: 3 / span 6;
+      }
+      \${StepItemDescription} {
+        grid-row: 1;
+        grid-column: 10 / span 3;
+      }
+    }
+  }
+\`;
+
+=====================================output=====================================
+const Steps = styled.div\`
+  @media (min-width: 1px) {
+    \${Step}:nth-child(odd) {
+    }
+  }
+\`;
+
+const Steps2 = styled.div\`
+  @media (min-width: \${breakpoints.lg}) {
+    \${Step} {
+      margin-bottom: 90px;
+    }
+
+    \${Step}:nth-child(odd) {
+      \${StepItemDescription} {
+        grid-row: 1;
+        grid-column: 3 / span 3;
+      }
+      \${Image} {
+        grid-row: 1;
+        grid-column: 7 / span 6;
+      }
+    }
+
+    \${Step}:nth-child(even) {
+      \${Image} {
+        grid-row: 1;
+        grid-column: 3 / span 6;
+      }
+      \${StepItemDescription} {
+        grid-row: 1;
+        grid-column: 10 / span 3;
+      }
+    }
   }
 \`;
 
@@ -321,6 +648,49 @@ const Steps2 = styled.div\`
 ================================================================================
 `;
 
+exports[`issue-6259.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export const Group = styled.div\`
+  margin: 0;
+
+  .input {
+    margin: 0;
+  }
+
+  \${StyledInput}:not(:first-child) {
+    margin: 0;
+  }
+
+  & > :not(.\${inputWrap}):not(\${Button}) {
+    display: flex;
+  }
+\`
+
+=====================================output=====================================
+export const Group = styled.div\`
+  margin: 0;
+
+  .input {
+    margin: 0;
+  }
+
+  \${StyledInput}:not(:first-child) {
+    margin: 0;
+  }
+
+  & > :not(.\${inputWrap}):not(\${Button}) {
+    display: flex;
+  }
+\`;
+
+================================================================================
+`;
+
 exports[`issue-6259.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -358,6 +728,45 @@ export const Group = styled.div\`
   & > :not(.\${inputWrap}):not(\${Button}) {
     display: flex;
   }
+\`;
+
+================================================================================
+`;
+
+exports[`issue-9072.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const style1 = css\`
+  width:\${size+10}\${sizeUnit};
+  border:\${size/10} \${sizeUnit} solid \${color};
+\`;
+
+const style2 = css\`
+  width: \${size + 10}\${sizeUnit};
+  border: \${size / 10} \${sizeUnit} solid \${color};
+\`;
+
+const style3 = css\`
+  foo: \${foo}\${bar}       \${baz};
+\`;
+
+=====================================output=====================================
+const style1 = css\`
+  width: \${size + 10}\${sizeUnit};
+  border: \${size / 10} \${sizeUnit} solid \${color};
+\`;
+
+const style2 = css\`
+  width: \${size + 10}\${sizeUnit};
+  border: \${size / 10} \${sizeUnit} solid \${color};
+\`;
+
+const style3 = css\`
+  foo: \${foo}\${bar} \${baz};
 \`;
 
 ================================================================================
@@ -401,6 +810,44 @@ const style3 = css\`
 ================================================================================
 `;
 
+exports[`issue-11797.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const paragraph1 = css\`
+  font-size: 12px;
+  transform: \${vert ? 'translateY' : 'translateX'}(\${translation + handleOffset}px);
+\`;
+
+const paragraph2 = css\`
+  transform: \${expr}(30px);
+\`;
+
+const paragraph3 = css\`
+  transform: \${expr} (30px);
+\`;
+
+=====================================output=====================================
+const paragraph1 = css\`
+  font-size: 12px;
+  transform: \${vert ? "translateY" : "translateX"}
+    (\${translation + handleOffset}px);
+\`;
+
+const paragraph2 = css\`
+  transform: \${expr}(30px);
+\`;
+
+const paragraph3 = css\`
+  transform: \${expr} (30px);
+\`;
+
+================================================================================
+`;
+
 exports[`issue-11797.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -433,6 +880,544 @@ const paragraph2 = css\`
 
 const paragraph3 = css\`
   transform: \${expr} (30px);
+\`;
+
+================================================================================
+`;
+
+exports[`styled-components.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const ListItem1 = styled.li\`\`;
+
+const ListItem2 = styled.li\` \`;
+
+const Dropdown = styled.div\`position: relative;\`
+
+const Button = styled.button\`
+	  color:   palevioletred ;
+
+	font-size : 1em   ;
+\`;
+
+const TomatoButton = Button.extend\`
+	color  : tomato  ;
+
+border-color : tomato
+    ;
+
+\`;
+
+Button.extend.attr({})\`
+border-color : black;
+\`
+
+styled(ExistingComponent)\`
+       color : papayawhip ; background-color: firebrick\`;
+
+
+styled.button.attr({})\`
+border : rebeccapurple\`;
+
+styled(ExistingComponent).attr({})\`
+border : rebeccapurple\`;
+
+styled.div\`
+  color: \${props => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  \${props => props.small ? 'font-size: 0.8em;' : ''};
+\`
+
+styled.div\`
+  color: \${props => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  \${props => props.small ? 'font-size: 0.8em;' : ''}
+\`
+
+styled.div\`
+   /* prettier-ignore */
+  color: \${props => props.theme.colors.paragraph};
+  \${props => props.small ? 'font-size: 0.8em;' : ''};
+\`
+
+styled.div\`
+  color: \${props => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  \${props => props.small ? 'font-size: 0.8em;' : ''};
+  /* prettier-ignore */
+  \${props => props.red ? 'color: red;' : ''};
+\`
+
+styled.div\`
+  /* prettier-ignore */
+  color: \${props => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  \${props => props.small ? 'font-size: 0.8em;' : ''};
+  /* prettier-ignore */
+  \${props => props.red ? 'color: red;' : ''};
+  /* prettier-ignore */
+\`
+
+styled.div\`
+ \${sanitize} \${fonts}
+  html {
+    margin: 0;
+  }
+\`
+
+styled.div\`
+  \${bar}
+  baz
+\`
+
+styled.span\`
+  foo
+  \${bar}
+  baz
+\`
+
+styled.div\`
+  foo
+  \${bar}
+  \${baz}
+\`
+
+styled.span\`
+  \${foo}
+  \${bar}
+\`
+
+styled.div\`
+  \${foo} bar
+\`
+
+styled.span\`
+  \${foo} \${bar}
+  baz: \${foo}
+\`
+
+styled.span\`
+\${foo};
+\${bar};
+\`
+
+styled.span\`
+\${foo}: \${bar};
+\`
+
+styled.span\`
+\${foo}: \${bar}
+\`
+
+styled.span\`
+\${foo}:
+\${bar}
+\`
+
+styled.span\`
+\${foo}:
+\${bar};
+\`
+
+styled.a\`
+  \${feedbackCountBlockCss}
+  text-decoration: none;
+
+  \${FeedbackCount} {
+    margin: 0;
+  }
+\`
+
+const StyledComponent1 = styled.div\`
+  \${anInterpolation}
+  /* a comment */
+
+  .aRule {
+    color: red
+  }
+\`;
+
+const StyledComponent2 = styled.div\`
+  \${anInterpolation}
+
+  /* a comment */
+
+  .aRule {
+    color: red
+  }
+\`;
+
+const Direction = styled.span\`
+  \${({ up }) => up && \`color: \${color.positive};\`}
+  \${({ down }) => down && \`color: \${color.negative};\`}
+\`;
+
+const Direction2 = styled.span\`
+  \${({ up }) => up && \`color: \${color.positive}\`};
+  \${({ down }) => down && \`color: \${color.negative}\`};
+\`;
+
+const mixin = css\`
+  color: \${props => props.color};
+  \${props => props.otherProperty}: \${props => props.otherValue};
+\`;
+
+const foo = styled.div\`
+  display: flex;
+  \${props => props.useMixin && mixin}
+\`;
+
+const Single1 = styled.div\`
+  color: red
+\`;
+
+const Single2 = styled.div\`
+  color: red;
+\`;
+
+const Dropdown2 = styled.div\`
+  /* A comment to avoid the prettier issue: https://github.com/prettier/prettier/issues/2291 */
+  position: relative;
+\`;
+
+const bar = styled.div\`
+  border-radius: 50%;
+  border: 5px solid rgba(var(--green-rgb), 0);
+  display: inline-block;
+  height: 40px;
+  width: 40px;
+
+  \${props =>
+    (props.complete || props.inProgress) &&
+    css\`
+      border-color: rgba(var(--green-rgb), 0.15);
+    \`}
+
+  div {
+    background-color: var(--purpleTT);
+    border-radius: 50%;
+    border: 4px solid rgba(var(--purple-rgb), 0.2);
+    color: var(--purpleTT);
+    display: inline-flex;
+
+    \${props =>
+    props.complete &&
+    css\`
+        background-color: var(--green);
+        border-width: 7px;
+      \`}
+
+    \${props =>
+    (props.complete || props.inProgress) &&
+    css\`
+        border-color: var(--green);
+      \`}
+  }
+\`;
+
+const A = styled.a\`
+  display: inline-block;
+  color: #fff;
+  \${props => props.a &&css\`
+    display: none;
+  \`}
+   height: 30px;
+\`;
+
+const Foo = styled.p\`
+  max-width: 980px;
+  \${mediaBreakpointOnlyXs\`
+    && {
+      font-size: 0.8rem;
+    }
+  \`}
+
+  &.bottom {
+    margin-top: 3rem;
+  }
+\`;
+
+styled(A)\`
+  // prettier-ignore
+  @media (aaaaaaaaaaaaa) {
+	z-index: \${(props) => (props.isComplete ? '1' : '0')};
+  }
+\`;
+
+const StyledDiv = styled.div\`
+  \${props => getSize(props.$size.xs)}
+  \${props => getSize(props.$size.sm, 'sm')}
+  \${props => getSize(props.$size.md, 'md')}
+\`;
+
+=====================================output=====================================
+const ListItem1 = styled.li\`\`;
+
+const ListItem2 = styled.li\`\`;
+
+const Dropdown = styled.div\`
+  position: relative;
+\`;
+
+const Button = styled.button\`
+  color: palevioletred;
+
+  font-size: 1em;
+\`;
+
+const TomatoButton = Button.extend\`
+  color: tomato;
+
+  border-color: tomato;
+\`;
+
+Button.extend.attr({})\`
+  border-color: black;
+\`;
+
+styled(ExistingComponent)\`
+  color: papayawhip;
+  background-color: firebrick;
+\`;
+
+styled.button.attr({})\`
+  border: rebeccapurple;
+\`;
+
+styled(ExistingComponent).attr({})\`
+  border: rebeccapurple;
+\`;
+
+styled.div\`
+  color: \${(props) => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  \${(props) => (props.small ? "font-size: 0.8em;" : "")};
+\`;
+
+styled.div\`
+  color: \${(props) => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  \${(props) => (props.small ? "font-size: 0.8em;" : "")}
+\`;
+
+styled.div\`
+  /* prettier-ignore */
+  color: \${(props) => props.theme.colors.paragraph};
+  \${(props) => (props.small ? "font-size: 0.8em;" : "")};
+\`;
+
+styled.div\`
+  color: \${(props) => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  \${(props) => (props.small ? "font-size: 0.8em;" : "")};
+  /* prettier-ignore */
+  \${(props) => (props.red ? "color: red;" : "")};
+\`;
+
+styled.div\`
+  /* prettier-ignore */
+  color: \${(props) => props.theme.colors.paragraph};
+  /* prettier-ignore */
+  \${(props) => (props.small ? "font-size: 0.8em;" : "")};
+  /* prettier-ignore */
+  \${(props) => (props.red ? "color: red;" : "")};
+  /* prettier-ignore */
+\`;
+
+styled.div\`
+  \${sanitize} \${fonts}
+  html {
+    margin: 0;
+  }
+\`;
+
+styled.div\`
+  \${bar}
+  baz
+\`;
+
+styled.span\`
+  foo
+  \${bar}
+  baz
+\`;
+
+styled.div\`
+  foo
+  \${bar}
+  \${baz}
+\`;
+
+styled.span\`
+  \${foo}
+  \${bar}
+\`;
+
+styled.div\`
+  \${foo} bar
+\`;
+
+styled.span\`
+  \${foo} \${bar}
+  baz: \${foo}
+\`;
+
+styled.span\`
+  \${foo};
+  \${bar};
+\`;
+
+styled.span\`
+  \${foo}: \${bar};
+\`;
+
+styled.span\`
+  \${foo}: \${bar}
+\`;
+
+styled.span\`
+  \${foo}: \${bar}
+\`;
+
+styled.span\`
+  \${foo}: \${bar};
+\`;
+
+styled.a\`
+  \${feedbackCountBlockCss}
+  text-decoration: none;
+
+  \${FeedbackCount} {
+    margin: 0;
+  }
+\`;
+
+const StyledComponent1 = styled.div\`
+  \${anInterpolation}
+  /* a comment */
+
+  .aRule {
+    color: red;
+  }
+\`;
+
+const StyledComponent2 = styled.div\`
+  \${anInterpolation}
+
+  /* a comment */
+
+  .aRule {
+    color: red;
+  }
+\`;
+
+const Direction = styled.span\`
+  \${({ up }) => up && \`color: \${color.positive};\`}
+  \${({ down }) => down && \`color: \${color.negative};\`}
+\`;
+
+const Direction2 = styled.span\`
+  \${({ up }) => up && \`color: \${color.positive}\`};
+  \${({ down }) => down && \`color: \${color.negative}\`};
+\`;
+
+const mixin = css\`
+  color: \${(props) => props.color};
+  \${(props) => props.otherProperty}: \${(props) => props.otherValue};
+\`;
+
+const foo = styled.div\`
+  display: flex;
+  \${(props) => props.useMixin && mixin}
+\`;
+
+const Single1 = styled.div\`
+  color: red;
+\`;
+
+const Single2 = styled.div\`
+  color: red;
+\`;
+
+const Dropdown2 = styled.div\`
+  /* A comment to avoid the prettier issue: https://github.com/prettier/prettier/issues/2291 */
+  position: relative;
+\`;
+
+const bar = styled.div\`
+  border-radius: 50%;
+  border: 5px solid rgba(var(--green-rgb), 0);
+  display: inline-block;
+  height: 40px;
+  width: 40px;
+
+  \${(props) =>
+    (props.complete || props.inProgress)
+    && css\`
+      border-color: rgba(var(--green-rgb), 0.15);
+    \`}
+
+  div {
+    background-color: var(--purpleTT);
+    border-radius: 50%;
+    border: 4px solid rgba(var(--purple-rgb), 0.2);
+    color: var(--purpleTT);
+    display: inline-flex;
+
+    \${(props) =>
+      props.complete
+      && css\`
+        background-color: var(--green);
+        border-width: 7px;
+      \`}
+
+    \${(props) =>
+      (props.complete || props.inProgress)
+      && css\`
+        border-color: var(--green);
+      \`}
+  }
+\`;
+
+const A = styled.a\`
+  display: inline-block;
+  color: #fff;
+  \${(props) =>
+    props.a
+    && css\`
+      display: none;
+    \`}
+  height: 30px;
+\`;
+
+const Foo = styled.p\`
+  max-width: 980px;
+  \${mediaBreakpointOnlyXs\`
+    && {
+      font-size: 0.8rem;
+    }
+  \`}
+
+  &.bottom {
+    margin-top: 3rem;
+  }
+\`;
+
+styled(A)\`
+  // prettier-ignore
+  @media (aaaaaaaaaaaaa) {
+	z-index: \${(props) => (props.isComplete ? "1" : "0")};
+  }
+\`;
+
+const StyledDiv = styled.div\`
+  \${(props) => getSize(props.$size.xs)}
+  \${(props) => getSize(props.$size.sm, "sm")}
+  \${(props) => getSize(props.$size.md, "md")}
 \`;
 
 ================================================================================
@@ -975,6 +1960,67 @@ const StyledDiv = styled.div\`
 ================================================================================
 `;
 
+exports[`styled-components-multiple-expressions.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const Header = styled.div\`
+  \${something()}
+  & > \${Child}:not(:first-child) {
+margin-left:5px;
+}
+\`
+
+const Header2 = styled.div\`
+  \${something()}
+  & > \${Child}\${Child2}:not(:first-child) {
+margin-left:5px;
+}
+\`
+
+styled.div\`\${foo}-idle { }\`
+
+styled.div\`\${foo}-0-idle { }\`
+
+styled.div\`
+font-family: "\${a}", "\${b}";
+\`
+
+=====================================output=====================================
+const Header = styled.div\`
+  \${something()}
+  & > \${Child}:not(:first-child) {
+    margin-left: 5px;
+  }
+\`;
+
+const Header2 = styled.div\`
+  \${something()}
+  & > \${Child}\${Child2}:not(:first-child) {
+    margin-left: 5px;
+  }
+\`;
+
+styled.div\`
+  \${foo}-idle {
+  }
+\`;
+
+styled.div\`
+  \${foo}-0-idle {
+  }
+\`;
+
+styled.div\`
+  font-family: "\${a}", "\${b}";
+\`;
+
+================================================================================
+`;
+
 exports[`styled-components-multiple-expressions.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -1035,6 +2081,24 @@ styled.div\`
 ================================================================================
 `;
 
+exports[`url.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+styled.div\`color:red;background: url(http://example.com?q=\${foo})\`
+
+=====================================output=====================================
+styled.div\`
+  color: red;
+  background: url(http://example.com?q=\${foo});
+\`;
+
+================================================================================
+`;
+
 exports[`url.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -1047,6 +2111,71 @@ styled.div\`color:red;background: url(http://example.com?q=\${foo})\`
 styled.div\`
   color: red;
   background: url(http://example.com?q=\${foo});
+\`;
+
+================================================================================
+`;
+
+exports[`var.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const Something = styled.div\`
+  background: var(--\${one}); /* ... */
+  border: 1px solid var(--\${two}); /* ... */
+\`;
+
+const StyledPurchaseCard = styled(Card)\`
+  min-width: 200px;
+  background-color: var(--\${props => props.color});
+  color: #fff;
+\`;
+
+const v1 =  css\`
+prop: var(--global--color--\${props.variant});
+\`;
+
+const v2 = css\`
+        background-color: var(--global--color--\${props.variant});
+
+        &:hover {
+          background-color: var(--global--color--\${props.variant}__one);
+        }
+      \`
+
+export const StyledComponent = styled.div\`
+  grid-area:  area-\${props => props.propName};
+\`
+
+=====================================output=====================================
+const Something = styled.div\`
+  background: var(--\${one}); /* ... */
+  border: 1px solid var(--\${two}); /* ... */
+\`;
+
+const StyledPurchaseCard = styled(Card)\`
+  min-width: 200px;
+  background-color: var(--\${(props) => props.color});
+  color: #fff;
+\`;
+
+const v1 = css\`
+  prop: var(--global--color--\${props.variant});
+\`;
+
+const v2 = css\`
+  background-color: var(--global--color--\${props.variant});
+
+  &:hover {
+    background-color: var(--global--color--\${props.variant}__one);
+  }
+\`;
+
+export const StyledComponent = styled.div\`
+  grid-area: area-\${(props) => props.propName};
 \`;
 
 ================================================================================

--- a/tests/format/js/multiparser-css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/multiparser-css/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`colons-after-substitutions.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`colons-after-substitutions.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -91,9 +91,9 @@ const Icon = styled.div\`
 ================================================================================
 `;
 
-exports[`colons-after-substitutions2.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`colons-after-substitutions2.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -208,9 +208,9 @@ const Icon3 = styled.div\`
 ================================================================================
 `;
 
-exports[`issue-2636.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-2636.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -293,9 +293,9 @@ export const ButtonWrapper2 = styled.button\`
 ================================================================================
 `;
 
-exports[`issue-2883.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-2883.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -386,9 +386,9 @@ export const global = css\`
 ================================================================================
 `;
 
-exports[`issue-5697.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-5697.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -481,9 +481,9 @@ const StyledH1 = styled.div\`
 ================================================================================
 `;
 
-exports[`issue-5961.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-5961.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -648,9 +648,9 @@ const Steps2 = styled.div\`
 ================================================================================
 `;
 
-exports[`issue-6259.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-6259.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -733,9 +733,9 @@ export const Group = styled.div\`
 ================================================================================
 `;
 
-exports[`issue-9072.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-9072.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -810,9 +810,9 @@ const style3 = css\`
 ================================================================================
 `;
 
-exports[`issue-11797.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue-11797.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -885,9 +885,9 @@ const paragraph3 = css\`
 ================================================================================
 `;
 
-exports[`styled-components.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`styled-components.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -1960,9 +1960,9 @@ const StyledDiv = styled.div\`
 ================================================================================
 `;
 
-exports[`styled-components-multiple-expressions.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`styled-components-multiple-expressions.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -2081,9 +2081,9 @@ styled.div\`
 ================================================================================
 `;
 
-exports[`url.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`url.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -2116,9 +2116,9 @@ styled.div\`
 ================================================================================
 `;
 
-exports[`var.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`var.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/multiparser-css/jsfmt.spec.js
+++ b/tests/format/js/multiparser-css/jsfmt.spec.js
@@ -1,4 +1,4 @@
 run_spec(import.meta, ["babel", "typescript", "flow"]);
 run_spec(import.meta, ["babel", "typescript", "flow"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/js/multiparser-css/jsfmt.spec.js
+++ b/tests/format/js/multiparser-css/jsfmt.spec.js
@@ -1,1 +1,4 @@
 run_spec(import.meta, ["babel", "typescript", "flow"]);
+run_spec(import.meta, ["babel", "typescript", "flow"], {
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/no-semi/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/no-semi/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`class.js - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`class.js - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow"]
 printWidth: 80
 semi: false
@@ -741,9 +741,9 @@ class G4 {
 ================================================================================
 `;
 
-exports[`comments.js - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`comments.js - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow"]
 printWidth: 80
 semi: false
@@ -846,9 +846,9 @@ x;
 ================================================================================
 `;
 
-exports[`issue2006.js - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`issue2006.js - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow"]
 printWidth: 80
 semi: false
@@ -933,9 +933,9 @@ var c = a.e;
 ================================================================================
 `;
 
-exports[`no-semi.js - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`no-semi.js - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow"]
 printWidth: 80
 semi: false
@@ -1485,9 +1485,9 @@ aReallyLongLine012345678901234567890123456789012345678901234567890123456789 *
 ================================================================================
 `;
 
-exports[`private-field.js - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`private-field.js - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow"]
 printWidth: 80
 semi: false

--- a/tests/format/js/no-semi/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/no-semi/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,253 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`class.js - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+// TODO: upgrade parser
+// class A {
+//   async; // The semicolon is *not* necessary
+//   x(){}
+// }
+// class B {
+//   static; // The semicolon *is* necessary
+//   x(){}
+// }
+
+class C1 {
+  get; // The semicolon *is* necessary
+  x(){}
+}
+class C2 {
+  get = () => {}; // The semicolon is *not* necessary
+  x(){}
+}
+class C3 {
+  set; // The semicolon *is* necessary
+  x(){}
+}
+class C4 {
+  set = () => {}; // The semicolon is *not* necessary
+  x(){}
+}
+
+
+
+class A1 {
+  a = 0;
+  [b](){}
+
+  c = 0;
+  *d(){}
+
+  e = 0;
+  [f] = 0
+
+  // none of the semicolons above this comment can be omitted.
+  // none of the semicolons below this comment are necessary.
+
+  q() {};
+  [h](){}
+
+  p() {};
+  *i(){}
+
+  a = 1;
+  get ['y']() {}
+
+  a = 1;
+  static ['y']() {}
+
+  a = 1;
+  set ['z'](z) {}
+
+  a = 1;
+  async ['a']() {}
+
+  a = 1;
+  async *g() {}
+
+  a = 0;
+  b = 1;
+}
+
+class A2 {
+  a = 0;
+  [b](){}
+
+  c = 0;
+  *d(){}
+
+  e = 0;
+  [f] = 0
+
+  // none of the semicolons above this comment can be omitted.
+  // none of the semicolons below this comment are necessary.
+
+  q() {};
+  [h](){}
+
+  p() {};
+  *i(){}
+
+  a = 1;
+  get ['y']() {}
+
+  a = 1;
+  static ['y']() {}
+
+  a = 1;
+  set ['z'](z) {}
+
+  a = 1;
+  async ['a']() {}
+
+  a = 1;
+  async *g() {}
+
+  a = 0;
+  b = 1;
+}
+
+// being first/last shouldn't break things
+class G1 {
+  x = 1
+}
+class G2 {
+  x() {}
+}
+class G3 {
+  *x() {}
+}
+class G4 {
+  [x] = 1
+}
+
+=====================================output=====================================
+// TODO: upgrade parser
+// class A {
+//   async; // The semicolon is *not* necessary
+//   x(){}
+// }
+// class B {
+//   static; // The semicolon *is* necessary
+//   x(){}
+// }
+
+class C1 {
+  get; // The semicolon *is* necessary
+  x() {}
+}
+class C2 {
+  get = () => {} // The semicolon is *not* necessary
+  x() {}
+}
+class C3 {
+  set; // The semicolon *is* necessary
+  x() {}
+}
+class C4 {
+  set = () => {} // The semicolon is *not* necessary
+  x() {}
+}
+
+class A1 {
+  a = 0;
+  [b]() {}
+
+  c = 0;
+  *d() {}
+
+  e = 0;
+  [f] = 0
+
+  // none of the semicolons above this comment can be omitted.
+  // none of the semicolons below this comment are necessary.
+
+  q() {}
+  [h]() {}
+
+  p() {}
+  *i() {}
+
+  a = 1
+  get ["y"]() {}
+
+  a = 1
+  static ["y"]() {}
+
+  a = 1
+  set ["z"](z) {}
+
+  a = 1
+  async ["a"]() {}
+
+  a = 1
+  async *g() {}
+
+  a = 0
+  b = 1
+}
+
+class A2 {
+  a = 0;
+  [b]() {}
+
+  c = 0;
+  *d() {}
+
+  e = 0;
+  [f] = 0
+
+  // none of the semicolons above this comment can be omitted.
+  // none of the semicolons below this comment are necessary.
+
+  q() {}
+  [h]() {}
+
+  p() {}
+  *i() {}
+
+  a = 1
+  get ["y"]() {}
+
+  a = 1
+  static ["y"]() {}
+
+  a = 1
+  set ["z"](z) {}
+
+  a = 1
+  async ["a"]() {}
+
+  a = 1
+  async *g() {}
+
+  a = 0
+  b = 1
+}
+
+// being first/last shouldn't break things
+class G1 {
+  x = 1
+}
+class G2 {
+  x() {}
+}
+class G3 {
+  *x() {}
+}
+class G4 {
+  [x] = 1
+}
+
+================================================================================
+`;
+
 exports[`class.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow"]
@@ -493,6 +741,42 @@ class G4 {
 ================================================================================
 `;
 
+exports[`comments.js - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+let error = new Error(response.statusText);
+// comment
+[].response = response
+
+x;
+
+/* comment */ [].response = response
+
+x;
+
+[].response = response; /* comment */
+
+=====================================output=====================================
+let error = new Error(response.statusText)
+// comment
+;[].response = response
+
+x
+
+/* comment */ ;[].response = response
+
+x
+
+;[].response = response /* comment */
+
+================================================================================
+`;
+
 exports[`comments.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow"]
@@ -562,6 +846,36 @@ x;
 ================================================================================
 `;
 
+exports[`issue2006.js - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+switch (n) {
+  case 11:
+    var c = a.e;
+    (i.a += Ga(c.e)), F(i, c.i, 0);
+}
+
+var c = a.e;
+(i.a += Ga(c.e)), F(i, c.i, 0);
+
+=====================================output=====================================
+switch (n) {
+  case 11:
+    var c = a.e
+    ;(i.a += Ga(c.e)), F(i, c.i, 0)
+}
+
+var c = a.e
+;(i.a += Ga(c.e)), F(i, c.i, 0)
+
+================================================================================
+`;
+
 exports[`issue2006.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow"]
@@ -615,6 +929,191 @@ switch (n) {
 
 var c = a.e;
 (i.a += Ga(c.e)), F(i, c.i, 0);
+
+================================================================================
+`;
+
+exports[`no-semi.js - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+
+// with preexisting semi
+
+x; [1, 2, 3].forEach(fn)
+x; [a, b, ...c] = [1, 2]
+x; /r/i.test('r')
+x; +1
+x; - 1
+x; ('h' + 'i').repeat(10)
+x; (1, 2)
+x; (() => {})()
+x; ({ a: 1 }).entries()
+x; ({ a: 1 }).entries()
+x; <Hello />
+x; \`string\`
+x; (x, y) => x
+
+// doesn't have to be preceded by a semicolon
+
+class X {} [1, 2, 3].forEach(fn)
+
+
+// don't semicolon if it doesn't start statement
+
+if (true) (() => {})()
+
+
+// check indentation
+
+if (true) {
+  x; (() => {})()
+}
+
+// check statement clauses
+
+do break; while (false)
+if (true) do break; while (false)
+
+if (true) 1; else 2
+for (;;) ;
+for (x of y) ;
+
+debugger
+
+// check that it doesn't break non-ASI
+
+1
+- 1
+
+1
++ 1
+
+1
+/ 1
+
+arr
+[0]
+
+fn
+(x)
+
+!1
+
+1
+< 1
+
+tag
+\`string\`
+
+x; x => x
+
+x; (a || b).c++
+
+x; ++(a || b).c
+
+while (false)
+  (function(){}())
+
+aReallyLongLine012345678901234567890123456789012345678901234567890123456789 *
+  (b + c)
+
+=====================================output=====================================
+// with preexisting semi
+
+x
+;[1, 2, 3].forEach(fn)
+x
+;[a, b, ...c] = [1, 2]
+x
+;/r/i.test("r")
+x
+;+1
+x
+;-1
+x
+;("h" + "i").repeat(10)
+x
+1, 2
+x
+;(() => {})()
+x
+;({ a: 1 }).entries()
+x
+;({ a: 1 }).entries()
+x
+;<Hello />
+x
+;\`string\`
+x
+;(x, y) => x
+
+// doesn't have to be preceded by a semicolon
+
+class X {}
+;[1, 2, 3].forEach(fn)
+
+// don't semicolon if it doesn't start statement
+
+if (true) (() => {})()
+
+// check indentation
+
+if (true) {
+  x
+  ;(() => {})()
+}
+
+// check statement clauses
+
+do break
+while (false)
+if (true)
+  do break
+  while (false)
+
+if (true) 1
+else 2
+for (;;);
+for (x of y);
+
+debugger
+
+// check that it doesn't break non-ASI
+
+1 - 1
+
+1 + 1
+
+1 / 1
+
+arr[0]
+
+fn(x)
+
+!1
+
+1 < 1
+
+tag\`string\`
+
+x
+;(x) => x
+
+x
+;(a || b).c++
+
+x
+++(a || b).c
+
+while (false) (function () {})()
+
+aReallyLongLine012345678901234567890123456789012345678901234567890123456789
+  * (b + c)
 
 ================================================================================
 `;
@@ -982,6 +1481,28 @@ while (false) (function () {})();
 
 aReallyLongLine012345678901234567890123456789012345678901234567890123456789 *
   (b + c);
+
+================================================================================
+`;
+
+exports[`private-field.js - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+class C {
+  #field = 'value';
+  ["method"]() {}
+}
+
+=====================================output=====================================
+class C {
+  #field = "value";
+  ["method"]() {}
+}
 
 ================================================================================
 `;

--- a/tests/format/js/no-semi/jsfmt.spec.js
+++ b/tests/format/js/no-semi/jsfmt.spec.js
@@ -1,2 +1,6 @@
 run_spec(import.meta, ["babel", "flow"], {});
 run_spec(import.meta, ["babel", "flow"], { semi: false });
+run_spec(import.meta, ["babel", "flow"], {
+  semi: false,
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/no-semi/jsfmt.spec.js
+++ b/tests/format/js/no-semi/jsfmt.spec.js
@@ -2,5 +2,5 @@ run_spec(import.meta, ["babel", "flow"], {});
 run_spec(import.meta, ["babel", "flow"], { semi: false });
 run_spec(import.meta, ["babel", "flow"], {
   semi: false,
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/js/objects/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/objects/__snapshots__/jsfmt.spec.js.snap
@@ -9,6 +9,34 @@ exports[`bigint-key.js [typescript] format 1`] = `
   4 |"
 `;
 
+exports[`bigint-key.js - {"experimentalOperatorLocation":true} [typescript] format 1`] = `
+"Property assignment expected. (1:6)
+> 1 | a = {1n: ""}
+    |      ^
+  2 | a = {1n() {}}
+  3 | a = {get 1n() {}}
+  4 |"
+`;
+
+exports[`bigint-key.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+a = {1n: ""}
+a = {1n() {}}
+a = {get 1n() {}}
+
+=====================================output=====================================
+a = { 1n: "" };
+a = { 1n() {} };
+a = { get 1n() {} };
+
+================================================================================
+`;
+
 exports[`bigint-key.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -23,6 +51,35 @@ a = {get 1n() {}}
 a = { 1n: "" };
 a = { 1n() {} };
 a = { get 1n() {} };
+
+================================================================================
+`;
+
+exports[`escape-sequence-key.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// #6235
+const a = {
+  '\\u2139': 'why "\\\\u2139" is converted to "i"?',
+};
+
+const b = {
+  "\\x66\\x69\\x73\\x6b\\x65\\x72": "\\x66\\x69\\x73\\x6b\\x65\\x72",
+};
+
+=====================================output=====================================
+// #6235
+const a = {
+  "\\u2139": 'why "\\\\u2139" is converted to "i"?',
+};
+
+const b = {
+  "\\x66\\x69\\x73\\x6b\\x65\\x72": "\\x66\\x69\\x73\\x6b\\x65\\x72",
+};
 
 ================================================================================
 `;
@@ -51,6 +108,31 @@ const a = {
 const b = {
   "\\x66\\x69\\x73\\x6b\\x65\\x72": "\\x66\\x69\\x73\\x6b\\x65\\x72",
 };
+
+================================================================================
+`;
+
+exports[`expand.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const Component1 = ({ props }) => (
+  <Text>Test</Text>
+);
+
+const Component2 = ({
+  props
+}) => (
+  <Text>Test</Text>
+);
+
+=====================================output=====================================
+const Component1 = ({ props }) => <Text>Test</Text>;
+
+const Component2 = ({ props }) => <Text>Test</Text>;
 
 ================================================================================
 `;
@@ -134,6 +216,123 @@ exports[`expression.js [typescript] format 1`] = `
   8 | ({} = 0);"
 `;
 
+exports[`expression.js - {"experimentalOperatorLocation":true} [acorn] format 1`] = `
+"Unexpected token (5:4)
+  3 | a = () => ({}).x;
+  4 | ({} && a, b);
+> 5 | ({}::b, 0);
+    |    ^
+  6 | ({}::b()\`\`[''].c++ && 0 ? 0 : 0, 0);
+  7 | ({}(), 0);
+  8 | ({} = 0);"
+`;
+
+exports[`expression.js - {"experimentalOperatorLocation":true} [espree] format 1`] = `
+"Unexpected token : (5:4)
+  3 | a = () => ({}).x;
+  4 | ({} && a, b);
+> 5 | ({}::b, 0);
+    |    ^
+  6 | ({}::b()\`\`[''].c++ && 0 ? 0 : 0, 0);
+  7 | ({}(), 0);
+  8 | ({} = 0);"
+`;
+
+exports[`expression.js - {"experimentalOperatorLocation":true} [flow] format 1`] = `
+"Unexpected token \`:\`, expected a type (5:5)
+  3 | a = () => ({}).x;
+  4 | ({} && a, b);
+> 5 | ({}::b, 0);
+    |     ^
+  6 | ({}::b()\`\`[''].c++ && 0 ? 0 : 0, 0);
+  7 | ({}(), 0);
+  8 | ({} = 0);"
+`;
+
+exports[`expression.js - {"experimentalOperatorLocation":true} [meriyah] format 1`] = `
+"Expected ')' (5:4)
+  3 | a = () => ({}).x;
+  4 | ({} && a, b);
+> 5 | ({}::b, 0);
+    |    ^
+  6 | ({}::b()\`\`[''].c++ && 0 ? 0 : 0, 0);
+  7 | ({}(), 0);
+  8 | ({} = 0);"
+`;
+
+exports[`expression.js - {"experimentalOperatorLocation":true} [typescript] format 1`] = `
+"')' expected. (5:4)
+  3 | a = () => ({}).x;
+  4 | ({} && a, b);
+> 5 | ({}::b, 0);
+    |    ^
+  6 | ({}::b()\`\`[''].c++ && 0 ? 0 : 0, 0);
+  7 | ({}(), 0);
+  8 | ({} = 0);"
+`;
+
+exports[`expression.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+() => ({}\`\`);
+({})\`\`;
+a = () => ({}).x;
+({} && a, b);
+({}::b, 0);
+({}::b()\`\`[''].c++ && 0 ? 0 : 0, 0);
+({}(), 0);
+({} = 0);
+(({} = 0), 1);
+
+const a1 = {
+  someKey:
+    (shortName, shortName)
+};
+
+const a2 = {
+  someKey:
+    (longLongLongLongLongLongLongLongLongLongLongLongLongLongName, shortName)
+};
+
+const a3 = {
+  someKey:
+    (longLongLongLongLongLongLongLongLongLongLongLongLongLongName, longLongLongLongLongLongLongLongLongLongLongLongLongLongName, longLongLongLongLongLongLongLongLongLongLongLongLongLongName)
+};
+
+=====================================output=====================================
+() => ({}\`\`);
+({})\`\`;
+a = () => ({}.x);
+({}) && a, b;
+({})::b, 0;
+({})::b()\`\`[""].c++ && 0 ? 0 : 0, 0;
+({})(), 0;
+({} = 0);
+({} = 0), 1;
+
+const a1 = {
+  someKey: (shortName, shortName),
+};
+
+const a2 = {
+  someKey:
+    (longLongLongLongLongLongLongLongLongLongLongLongLongLongName, shortName),
+};
+
+const a3 = {
+  someKey:
+    (longLongLongLongLongLongLongLongLongLongLongLongLongLongName,
+    longLongLongLongLongLongLongLongLongLongLongLongLongLongName,
+    longLongLongLongLongLongLongLongLongLongLongLongLongLongName),
+};
+
+================================================================================
+`;
+
 exports[`expression.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -195,6 +394,31 @@ const a3 = {
 ================================================================================
 `;
 
+exports[`getter-setter.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+({ set x(foo) {} });
+({ get x() { return 1 } });
+({ set x(a) {} });
+({ get x() {} });
+
+=====================================output=====================================
+({ set x(foo) {} });
+({
+  get x() {
+    return 1;
+  },
+});
+({ set x(a) {} });
+({ get x() {} });
+
+================================================================================
+`;
+
 exports[`getter-setter.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -219,6 +443,21 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`method.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+a = { f() {} }
+
+=====================================output=====================================
+a = { f() {} };
+
+================================================================================
+`;
+
 exports[`method.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]
@@ -229,6 +468,45 @@ a = { f() {} }
 
 =====================================output=====================================
 a = { f() {} };
+
+================================================================================
+`;
+
+exports[`range.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+group(
+  concat([
+    "(",
+    indent(
+      options.tabWidth,
+      concat([line, join(concat([",", line]), printed)])
+    ),
+    options.trailingComma ? "," : "",
+    line,
+    ")"
+  ]),
+  {shouldBreak: true}
+)
+
+=====================================output=====================================
+group(
+  concat([
+    "(",
+    indent(
+      options.tabWidth,
+      concat([line, join(concat([",", line]), printed)]),
+    ),
+    options.trailingComma ? "," : "",
+    line,
+    ")",
+  ]),
+  { shouldBreak: true },
+);
 
 ================================================================================
 `;
@@ -267,6 +545,56 @@ group(
   ]),
   { shouldBreak: true },
 );
+
+================================================================================
+`;
+
+exports[`right-break.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const blablah =
+  "aldkfkladfskladklsfkladklfkaldfadfkdaf" +
+  "adlfasdklfkldsklfakldsfkladsfkadsfladsfa" +
+  "dflkadfkladsfklkadlfkladlfkadklfjadlfdfdaf";
+
+const k = {
+  blablah: "aldkfkladfskladklsfkladklfkaldfadfkdaf" +
+    "adlfasdklfkldsklfakldsfkladsfkadsfladsfa" +
+    "dflkadfkladsfklkadlfkladlfkadklfjadlfdfdaf"
+};
+
+somethingThatsAReallyLongPropName =
+  this.props.cardType === AwesomizerCardEnum.SEEFIRST;
+
+const o = {
+  somethingThatsAReallyLongPropName:
+    this.props.cardType === AwesomizerCardEnum.SEEFIRST,
+};
+
+=====================================output=====================================
+const blablah =
+  "aldkfkladfskladklsfkladklfkaldfadfkdaf"
+  + "adlfasdklfkldsklfakldsfkladsfkadsfladsfa"
+  + "dflkadfkladsfklkadlfkladlfkadklfjadlfdfdaf";
+
+const k = {
+  blablah:
+    "aldkfkladfskladklsfkladklfkaldfadfkdaf"
+    + "adlfasdklfkldsklfakldsfkladsfkadsfladsfa"
+    + "dflkadfkladsfklkadlfkladlfkadklfjadlfdfdaf",
+};
+
+somethingThatsAReallyLongPropName =
+  this.props.cardType === AwesomizerCardEnum.SEEFIRST;
+
+const o = {
+  somethingThatsAReallyLongPropName:
+    this.props.cardType === AwesomizerCardEnum.SEEFIRST,
+};
 
 ================================================================================
 `;

--- a/tests/format/js/objects/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/objects/__snapshots__/jsfmt.spec.js.snap
@@ -9,7 +9,7 @@ exports[`bigint-key.js [typescript] format 1`] = `
   4 |"
 `;
 
-exports[`bigint-key.js - {"experimentalOperatorLocation":true} [typescript] format 1`] = `
+exports[`bigint-key.js - {"experimentalOperatorPosition":true} [typescript] format 1`] = `
 "Property assignment expected. (1:6)
 > 1 | a = {1n: ""}
     |      ^
@@ -18,9 +18,9 @@ exports[`bigint-key.js - {"experimentalOperatorLocation":true} [typescript] form
   4 |"
 `;
 
-exports[`bigint-key.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`bigint-key.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -55,9 +55,9 @@ a = { get 1n() {} };
 ================================================================================
 `;
 
-exports[`escape-sequence-key.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`escape-sequence-key.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -112,9 +112,9 @@ const b = {
 ================================================================================
 `;
 
-exports[`expand.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`expand.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -216,7 +216,7 @@ exports[`expression.js [typescript] format 1`] = `
   8 | ({} = 0);"
 `;
 
-exports[`expression.js - {"experimentalOperatorLocation":true} [acorn] format 1`] = `
+exports[`expression.js - {"experimentalOperatorPosition":true} [acorn] format 1`] = `
 "Unexpected token (5:4)
   3 | a = () => ({}).x;
   4 | ({} && a, b);
@@ -227,7 +227,7 @@ exports[`expression.js - {"experimentalOperatorLocation":true} [acorn] format 1`
   8 | ({} = 0);"
 `;
 
-exports[`expression.js - {"experimentalOperatorLocation":true} [espree] format 1`] = `
+exports[`expression.js - {"experimentalOperatorPosition":true} [espree] format 1`] = `
 "Unexpected token : (5:4)
   3 | a = () => ({}).x;
   4 | ({} && a, b);
@@ -238,7 +238,7 @@ exports[`expression.js - {"experimentalOperatorLocation":true} [espree] format 1
   8 | ({} = 0);"
 `;
 
-exports[`expression.js - {"experimentalOperatorLocation":true} [flow] format 1`] = `
+exports[`expression.js - {"experimentalOperatorPosition":true} [flow] format 1`] = `
 "Unexpected token \`:\`, expected a type (5:5)
   3 | a = () => ({}).x;
   4 | ({} && a, b);
@@ -249,7 +249,7 @@ exports[`expression.js - {"experimentalOperatorLocation":true} [flow] format 1`]
   8 | ({} = 0);"
 `;
 
-exports[`expression.js - {"experimentalOperatorLocation":true} [meriyah] format 1`] = `
+exports[`expression.js - {"experimentalOperatorPosition":true} [meriyah] format 1`] = `
 "Expected ')' (5:4)
   3 | a = () => ({}).x;
   4 | ({} && a, b);
@@ -260,7 +260,7 @@ exports[`expression.js - {"experimentalOperatorLocation":true} [meriyah] format 
   8 | ({} = 0);"
 `;
 
-exports[`expression.js - {"experimentalOperatorLocation":true} [typescript] format 1`] = `
+exports[`expression.js - {"experimentalOperatorPosition":true} [typescript] format 1`] = `
 "')' expected. (5:4)
   3 | a = () => ({}).x;
   4 | ({} && a, b);
@@ -271,9 +271,9 @@ exports[`expression.js - {"experimentalOperatorLocation":true} [typescript] form
   8 | ({} = 0);"
 `;
 
-exports[`expression.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`expression.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -394,9 +394,9 @@ const a3 = {
 ================================================================================
 `;
 
-exports[`getter-setter.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`getter-setter.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -443,9 +443,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`method.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`method.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -472,9 +472,9 @@ a = { f() {} };
 ================================================================================
 `;
 
-exports[`range.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`range.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
@@ -549,9 +549,9 @@ group(
 ================================================================================
 `;
 
-exports[`right-break.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`right-break.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/objects/jsfmt.spec.js
+++ b/tests/format/js/objects/jsfmt.spec.js
@@ -8,6 +8,6 @@ const errors = {
 
 run_spec(import.meta, ["babel", "typescript", "flow"], { errors });
 run_spec(import.meta, ["babel", "typescript", "flow"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
   errors,
 });

--- a/tests/format/js/objects/jsfmt.spec.js
+++ b/tests/format/js/objects/jsfmt.spec.js
@@ -1,9 +1,13 @@
+const errors = {
+  acorn: ["expression.js"],
+  espree: ["expression.js"],
+  typescript: ["expression.js", "bigint-key.js"],
+  meriyah: ["expression.js"],
+  flow: ["expression.js"],
+};
+
+run_spec(import.meta, ["babel", "typescript", "flow"], { errors });
 run_spec(import.meta, ["babel", "typescript", "flow"], {
-  errors: {
-    acorn: ["expression.js"],
-    espree: ["expression.js"],
-    typescript: ["expression.js", "bigint-key.js"],
-    meriyah: ["expression.js"],
-    flow: ["expression.js"],
-  },
+  experimentalOperatorLocation: true,
+  errors,
 });

--- a/tests/format/js/optional-chaining/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/optional-chaining/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`chaining.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`chaining.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -365,9 +365,9 @@ new (foo?.())();
 ================================================================================
 `;
 
-exports[`comments.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`comments.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -578,9 +578,9 @@ foo.bar.baz
 ================================================================================
 `;
 
-exports[`eval.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`eval.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/optional-chaining/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/optional-chaining/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,188 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`chaining.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+var street = user.address?.street
+var fooValue = myForm.querySelector('input[name=foo]')?.value
+
+obj?.prop;
+obj?.[expr];
+func?.(...args);
+
+a?.();
+a?.[++x];
+a?.b.c(++x).d;
+a?.b[3].c?.(x).d;
+a?.b.c;
+(a?.b).c;
+a?.b?.c;
+delete a?.b;
+
+a?.b[3].c?.(x).d.e?.f[3].g?.(y).h;
+
+(a?.b).c();
+(a?.b[c]).c();
+
+(a?.b)?.c.d?.e;
+(a ? b : c)?.d;
+
+(list || list2)?.length;
+(list || list2)?.[(list || list2)];
+
+async function HelloWorld() {
+  var x = (await foo.bar.blah)?.hi;
+  a?.[await b];
+  (await x)?.();
+}
+
+a[b?.c].d();
+a?.[b?.c].d();
+a[b?.c]?.d();
+a?.[b?.c]?.d();
+
+(one?.fn());
+(one?.two).fn();
+(one?.two)();
+(one?.two())();
+(one.two?.fn());
+(one.two?.three).fn();
+(one.two?.three?.fn());
+
+(one?.());
+(one?.())();
+(one?.())?.();
+
+(one?.()).two;
+
+a?.[b ? c : d];
+
+(-1)?.toFixed();
+(void fn)?.();
+(a && b)?.();
+(a ? b : c)?.();
+(function(){})?.();
+(() => f)?.();
+(()=>f)?.x;
+(a?.(x)).x;
+(aaaaaaaaaaaaaaaaaaaaaaaa&&aaaaaaaaaaaaaaaaaaaaaaaa&&aaaaaaaaaaaaaaaaaaaaaaaa)?.();
+
+let f = () => ({}?.());
+let g = () => ({}?.b);
+a = () => ({}?.() && a);
+a = () => ({}?.()() && a);
+a = () => ({}?.().b && a);
+a = () => ({}?.b && a);
+a = () => ({}?.b() && a);
+(a) => ({}?.()?.b && 0);
+(a) => ({}?.b?.b && 0);
+(x) => ({}?.()());
+(x) => ({}?.().b);
+(x) => ({}?.b());
+(x) => ({}?.b.b);
+({}?.a().b());
+({ a: 1 }?.entries());
+
+new (foo?.bar)();
+new (foo?.bar())();
+new (foo?.())();
+
+=====================================output=====================================
+var street = user.address?.street;
+var fooValue = myForm.querySelector("input[name=foo]")?.value;
+
+obj?.prop;
+obj?.[expr];
+func?.(...args);
+
+a?.();
+a?.[++x];
+a?.b.c(++x).d;
+a?.b[3].c?.(x).d;
+a?.b.c;
+(a?.b).c;
+a?.b?.c;
+delete a?.b;
+
+a?.b[3].c?.(x).d.e?.f[3].g?.(y).h;
+
+(a?.b).c();
+(a?.b[c]).c();
+
+a?.b?.c.d?.e;
+(a ? b : c)?.d;
+
+(list || list2)?.length;
+(list || list2)?.[list || list2];
+
+async function HelloWorld() {
+  var x = (await foo.bar.blah)?.hi;
+  a?.[await b];
+  (await x)?.();
+}
+
+a[b?.c].d();
+a?.[b?.c].d();
+a[b?.c]?.d();
+a?.[b?.c]?.d();
+
+one?.fn();
+(one?.two).fn();
+(one?.two)();
+(one?.two())();
+one.two?.fn();
+(one.two?.three).fn();
+one.two?.three?.fn();
+
+one?.();
+(one?.())();
+one?.()?.();
+
+(one?.()).two;
+
+a?.[b ? c : d];
+
+(-1)?.toFixed();
+(void fn)?.();
+(a && b)?.();
+(a ? b : c)?.();
+(function () {})?.();
+(() => f)?.();
+(() => f)?.x;
+(a?.(x)).x;
+(
+  aaaaaaaaaaaaaaaaaaaaaaaa
+  && aaaaaaaaaaaaaaaaaaaaaaaa
+  && aaaaaaaaaaaaaaaaaaaaaaaa
+)?.();
+
+let f = () => ({}?.());
+let g = () => ({}?.b);
+a = () => ({}?.() && a);
+a = () => ({}?.()() && a);
+a = () => ({}?.().b && a);
+a = () => ({}?.b && a);
+a = () => ({}?.b() && a);
+(a) => ({}?.()?.b && 0);
+(a) => ({}?.b?.b && 0);
+(x) => ({}?.()());
+(x) => ({}?.().b);
+(x) => ({}?.b());
+(x) => ({}?.b.b);
+({})?.a().b();
+({ a: 1 })?.entries();
+
+new (foo?.bar)();
+new (foo?.bar())();
+new (foo?.())();
+
+================================================================================
+`;
+
 exports[`chaining.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -182,6 +365,113 @@ new (foo?.())();
 ================================================================================
 `;
 
+exports[`comments.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function foo() {
+  return a
+    .b()
+    .c()
+    // Comment
+    ?.d()
+}
+
+fooBar
+  .doSomething("Hello World")
+  .doAnotherThing("Foo", { foo: bar })
+
+  // App configuration.
+  .doOneMoreThing(config)
+
+  ?.run(() => console.log("Bar"));
+
+bigDeal
+
+  .doSomething("Hello World")
+
+  // Hello world
+  ?.doAnotherThing("Foo", { foo: bar })
+
+  // App configuration.
+  .doOneMoreThing(config)
+
+  ?.run(() => console.log("Bar"));
+
+foo.bar.baz
+
+  ?.doSomething("Hello World")
+
+  // Hello world
+  .foo.bar.doAnotherThing("Foo", { foo: bar })
+
+  .doOneMoreThing(config)
+  ?.bar.run(() => console.log("Bar"));
+
+(somethingGood ? thisIsIt : maybeNot)
+
+// Hello world
+.doSomething("Hello World")
+
+  ?.doAnotherThing("Foo", { foo: bar }) // Run this
+  .run(() => console.log("Bar")); // Do this
+
+=====================================output=====================================
+function foo() {
+  return (
+    a
+      .b()
+      .c()
+      // Comment
+      ?.d()
+  );
+}
+
+fooBar
+  .doSomething("Hello World")
+  .doAnotherThing("Foo", { foo: bar })
+
+  // App configuration.
+  .doOneMoreThing(config)
+
+  ?.run(() => console.log("Bar"));
+
+bigDeal
+
+  .doSomething("Hello World")
+
+  // Hello world
+  ?.doAnotherThing("Foo", { foo: bar })
+
+  // App configuration.
+  .doOneMoreThing(config)
+
+  ?.run(() => console.log("Bar"));
+
+foo.bar.baz
+
+  ?.doSomething("Hello World")
+
+  // Hello world
+  .foo.bar.doAnotherThing("Foo", { foo: bar })
+
+  .doOneMoreThing(config)
+  ?.bar.run(() => console.log("Bar"));
+
+(somethingGood ? thisIsIt : maybeNot)
+
+  // Hello world
+  .doSomething("Hello World")
+
+  ?.doAnotherThing("Foo", { foo: bar }) // Run this
+  .run(() => console.log("Bar")); // Do this
+
+================================================================================
+`;
+
 exports[`comments.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -284,6 +574,67 @@ foo.bar.baz
 
   ?.doAnotherThing("Foo", { foo: bar }) // Run this
   .run(() => console.log("Bar")); // Do this
+
+================================================================================
+`;
+
+exports[`eval.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// https://github.com/babel/babel/pull/11850
+
+let foo;
+
+/* indirect eval calls */
+eval?.(foo);
+
+(eval)?.(foo);
+
+eval?.()();
+
+eval?.().foo;
+
+/* direct eval calls */
+
+eval()?.();
+
+eval()?.foo;
+
+/* plain function calls */
+
+foo.eval?.(foo);
+
+eval.foo?.(foo);
+
+=====================================output=====================================
+// https://github.com/babel/babel/pull/11850
+
+let foo;
+
+/* indirect eval calls */
+eval?.(foo);
+
+eval?.(foo);
+
+eval?.()();
+
+eval?.().foo;
+
+/* direct eval calls */
+
+eval()?.();
+
+eval()?.foo;
+
+/* plain function calls */
+
+foo.eval?.(foo);
+
+eval.foo?.(foo);
 
 ================================================================================
 `;

--- a/tests/format/js/optional-chaining/jsfmt.spec.js
+++ b/tests/format/js/optional-chaining/jsfmt.spec.js
@@ -1,1 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
+run_spec(import.meta, ["babel", "flow", "typescript"], {
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/optional-chaining/jsfmt.spec.js
+++ b/tests/format/js/optional-chaining/jsfmt.spec.js
@@ -1,4 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
 run_spec(import.meta, ["babel", "flow", "typescript"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/js/preserve-line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/preserve-line/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`argument-list.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`argument-list.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -791,9 +791,9 @@ function foo(
 ================================================================================
 `;
 
-exports[`comments.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`comments.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -928,9 +928,9 @@ function a() {
 ================================================================================
 `;
 
-exports[`member-chain.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`member-chain.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1189,9 +1189,9 @@ const sel = this.connections
 ================================================================================
 `;
 
-exports[`parameter-list.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`parameter-list.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/preserve-line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/preserve-line/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,401 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`argument-list.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+longArgNamesWithComments(
+
+  // Hello World
+
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong1,
+
+  // Hello World
+
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong2,
+
+  /* Hello World */
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong3,
+
+
+);
+
+shortArgNames(
+
+
+  short,
+
+  short2,
+  short3,
+);
+
+comments(
+
+  // Comment
+
+  /* Some comments */
+  short,
+  /* Another comment */
+
+
+  short2, // Even more comments
+
+
+  /* Another comment */
+
+
+  // Long Long Long Long Long Comment
+
+
+
+  /* Long Long Long Long Long Comment */
+  // Long Long Long Long Long Comment
+
+  short3,
+  // More comments
+
+
+);
+
+differentArgTypes(
+
+  () => {
+    return true
+  },
+
+  isTrue ?
+    doSomething() : 12,
+
+);
+
+moreArgTypes(
+
+  [1, 2,
+    3],
+
+  {
+    name: 'Hello World',
+    age: 29
+  },
+
+  doSomething(
+
+    // Hello world
+
+
+    // Hello world again
+    { name: 'Hello World', age: 34 },
+
+
+    oneThing
+      + anotherThing,
+
+    // Comment
+
+  ),
+
+);
+
+evenMoreArgTypes(
+  doSomething(
+    { name: 'Hello World', age: 34 },
+
+
+    true
+
+  ),
+
+  14,
+
+  1 + 2
+    - 90/80,
+
+  !98 *
+    60 -
+    90,
+
+
+
+)
+
+foo.apply(null,
+
+// Array here
+[1, 2]);
+
+
+bar.on("readable",
+
+() => {
+  doStuff()
+});
+
+foo(['A, B'],
+
+/* function here */
+function doSomething() { return true; });
+
+doSomething.apply(null,
+
+// Comment
+
+[
+  'Hello world 1',
+  'Hello world 2',
+  'Hello world 3',
+]);
+
+
+doAnotherThing("node",
+
+{
+  solution_type,
+  time_frame
+});
+
+stuff.doThing(someStuff,
+
+  -1, {
+  accept: node => doSomething(node)
+});
+
+doThing(
+
+  someOtherStuff,
+
+  // This is important
+  true, {
+  decline: creditCard => takeMoney(creditCard)
+}
+
+);
+
+func(
+  () => {
+   thing();
+  },
+
+  { yes: true, no: 5 }
+);
+
+doSomething(
+
+   { tomorrow: maybe, today: never[always] },
+
+   1337,
+
+   /* Comment */
+
+   // This is important
+   { helloWorld, someImportantStuff }
+
+
+);
+
+function foo(
+  one,
+
+  two,
+  three,
+  four,
+
+
+  five,
+  six,
+  seven,
+  eight,
+  nine,
+  ten,
+
+  eleven
+
+) {}
+
+=====================================output=====================================
+longArgNamesWithComments(
+  // Hello World
+
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong1,
+
+  // Hello World
+
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong2,
+
+  /* Hello World */
+  longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong3,
+);
+
+shortArgNames(
+  short,
+
+  short2,
+  short3,
+);
+
+comments(
+  // Comment
+
+  /* Some comments */
+  short,
+  /* Another comment */
+
+  short2, // Even more comments
+
+  /* Another comment */
+
+  // Long Long Long Long Long Comment
+
+  /* Long Long Long Long Long Comment */
+  // Long Long Long Long Long Comment
+
+  short3,
+  // More comments
+);
+
+differentArgTypes(
+  () => {
+    return true;
+  },
+
+  isTrue ? doSomething() : 12,
+);
+
+moreArgTypes(
+  [1, 2, 3],
+
+  {
+    name: "Hello World",
+    age: 29,
+  },
+
+  doSomething(
+    // Hello world
+
+    // Hello world again
+    { name: "Hello World", age: 34 },
+
+    oneThing + anotherThing,
+
+    // Comment
+  ),
+);
+
+evenMoreArgTypes(
+  doSomething(
+    { name: "Hello World", age: 34 },
+
+    true,
+  ),
+
+  14,
+
+  1 + 2 - 90 / 80,
+
+  !98 * 60 - 90,
+);
+
+foo.apply(
+  null,
+
+  // Array here
+  [1, 2],
+);
+
+bar.on(
+  "readable",
+
+  () => {
+    doStuff();
+  },
+);
+
+foo(
+  ["A, B"],
+
+  /* function here */
+  function doSomething() {
+    return true;
+  },
+);
+
+doSomething.apply(
+  null,
+
+  // Comment
+
+  ["Hello world 1", "Hello world 2", "Hello world 3"],
+);
+
+doAnotherThing(
+  "node",
+
+  {
+    solution_type,
+    time_frame,
+  },
+);
+
+stuff.doThing(
+  someStuff,
+
+  -1,
+  {
+    accept: (node) => doSomething(node),
+  },
+);
+
+doThing(
+  someOtherStuff,
+
+  // This is important
+  true,
+  {
+    decline: (creditCard) => takeMoney(creditCard),
+  },
+);
+
+func(
+  () => {
+    thing();
+  },
+
+  { yes: true, no: 5 },
+);
+
+doSomething(
+  { tomorrow: maybe, today: never[always] },
+
+  1337,
+
+  /* Comment */
+
+  // This is important
+  { helloWorld, someImportantStuff },
+);
+
+function foo(
+  one,
+
+  two,
+  three,
+  four,
+
+  five,
+  six,
+  seven,
+  eight,
+  nine,
+  ten,
+
+  eleven,
+) {}
+
+================================================================================
+`;
+
 exports[`argument-list.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -395,6 +791,75 @@ function foo(
 ================================================================================
 `;
 
+exports[`comments.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function a() {
+  const a = 5; // comment
+
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */
+
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */ /* comment */
+
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */ /* comment */ // comment
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */ /* comment */ // comment
+
+  return a;
+}
+
+=====================================output=====================================
+function a() {
+  const a = 5; // comment
+
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */
+
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */ /* comment */
+
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */ /* comment */ // comment
+  return a;
+}
+
+function a() {
+  const a = 5; /* comment */ /* comment */ // comment
+
+  return a;
+}
+
+================================================================================
+`;
+
 exports[`comments.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -459,6 +924,137 @@ function a() {
 
   return a;
 }
+
+================================================================================
+`;
+
+exports[`member-chain.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+fooBar.doSomething('Hello World').doAnotherThing('Foo', { foo: bar })
+
+  // App configuration.
+  .doOneMoreThing(config)
+
+  .run(() => console.log('Bar'));
+
+bigDeal
+
+  .doSomething('Hello World')
+
+  // Hello world
+  .doAnotherThing('Foo', { foo: bar })
+
+  // App configuration.
+  .doOneMoreThing(config)
+
+  .run(() => console.log('Bar'));
+
+
+foo.bar.baz
+
+  .doSomething('Hello World')
+
+  // Hello world
+  .foo.bar.doAnotherThing('Foo', { foo: bar })
+
+  .doOneMoreThing(config)
+  .bar.run(() => console.log('Bar'));
+
+(
+  somethingGood ? thisIsIt : maybeNot
+)
+
+  // Hello world
+  .doSomething('Hello World')
+
+  .doAnotherThing('Foo', { foo: bar }) // Run this
+  .run(() => console.log('Bar')); // Do this
+
+helloWorld
+
+  .text()
+
+  .then(t => t);
+
+(veryLongVeryLongVeryLong ||
+ anotherVeryLongVeryLongVeryLong ||
+ veryVeryVeryLongError
+)
+
+  .map(tickets => TicketRecord.createFromSomeLongString())
+
+  .filter(obj => !!obj);
+
+const sel = this.connections
+
+  .concat(this.activities.concat(this.operators))
+  .filter(x => x.selected);
+
+=====================================output=====================================
+fooBar
+  .doSomething("Hello World")
+  .doAnotherThing("Foo", { foo: bar })
+
+  // App configuration.
+  .doOneMoreThing(config)
+
+  .run(() => console.log("Bar"));
+
+bigDeal
+
+  .doSomething("Hello World")
+
+  // Hello world
+  .doAnotherThing("Foo", { foo: bar })
+
+  // App configuration.
+  .doOneMoreThing(config)
+
+  .run(() => console.log("Bar"));
+
+foo.bar.baz
+
+  .doSomething("Hello World")
+
+  // Hello world
+  .foo.bar.doAnotherThing("Foo", { foo: bar })
+
+  .doOneMoreThing(config)
+  .bar.run(() => console.log("Bar"));
+
+(somethingGood ? thisIsIt : maybeNot)
+
+  // Hello world
+  .doSomething("Hello World")
+
+  .doAnotherThing("Foo", { foo: bar }) // Run this
+  .run(() => console.log("Bar")); // Do this
+
+helloWorld
+
+  .text()
+
+  .then((t) => t);
+
+(
+  veryLongVeryLongVeryLong
+  || anotherVeryLongVeryLongVeryLong
+  || veryVeryVeryLongError
+)
+
+  .map((tickets) => TicketRecord.createFromSomeLongString())
+
+  .filter((obj) => !!obj);
+
+const sel = this.connections
+
+  .concat(this.activities.concat(this.operators))
+  .filter((x) => x.selected);
 
 ================================================================================
 `;
@@ -589,6 +1185,282 @@ const sel = this.connections
 
   .concat(this.activities.concat(this.operators))
   .filter((x) => x.selected);
+
+================================================================================
+`;
+
+exports[`parameter-list.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+class Foo {
+  constructor(
+    one,
+
+    two,
+    three,
+    four,
+
+
+    five,
+    six,
+    seven,
+    eight,
+    nine,
+    ten,
+
+    eleven
+
+  ) {}
+}
+
+function foo(
+  one,
+
+  two,
+  three,
+  four,
+
+
+  five,
+  six,
+  seven,
+  eight,
+  nine,
+  ten,
+
+  eleven
+
+) {}
+
+call((a, b) => {});
+
+call((
+  one,
+  two,
+  three,
+  four,
+  five,
+  six,
+  seven,
+  eight,
+  nine,
+  ten,
+  eleven
+) => {});
+
+call((
+  one,
+
+  two,
+  three,
+  four,
+
+
+  five,
+  six,
+  seven,
+  eight,
+  nine,
+  ten,
+
+  eleven
+
+) => {});
+
+function test({
+  one,
+
+  two,
+  three,
+  four,
+
+
+  five,
+  six,
+  seven,
+  eight,
+  nine,
+  ten,
+
+  eleven
+
+}) {}
+
+function test({
+  one,
+  two,
+  three,
+  four,
+}) {}
+
+function test({
+  one,
+
+  two,
+  three,
+  four,
+
+}) {}
+
+function test({ one, two, three, four }, $a) {}
+
+
+function test(
+  { one, two, three, four },
+
+  $a
+) {}
+
+function foo(
+
+  ...rest
+
+) {}
+
+function foo(
+  one,
+
+  ...rest
+) {}
+
+function foo(one,...rest) {}
+
+f(
+  superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong,...args
+);
+
+it(
+
+  "does something really long and complicated so I have to write a very long name for the test",
+
+  function(
+
+    done,
+
+    foo
+  ) {
+
+    console.log("hello!");
+  }
+);
+
+=====================================output=====================================
+class Foo {
+  constructor(
+    one,
+
+    two,
+    three,
+    four,
+
+    five,
+    six,
+    seven,
+    eight,
+    nine,
+    ten,
+
+    eleven,
+  ) {}
+}
+
+function foo(
+  one,
+
+  two,
+  three,
+  four,
+
+  five,
+  six,
+  seven,
+  eight,
+  nine,
+  ten,
+
+  eleven,
+) {}
+
+call((a, b) => {});
+
+call((one, two, three, four, five, six, seven, eight, nine, ten, eleven) => {});
+
+call(
+  (
+    one,
+
+    two,
+    three,
+    four,
+
+    five,
+    six,
+    seven,
+    eight,
+    nine,
+    ten,
+
+    eleven,
+  ) => {},
+);
+
+function test({
+  one,
+
+  two,
+  three,
+  four,
+
+  five,
+  six,
+  seven,
+  eight,
+  nine,
+  ten,
+
+  eleven,
+}) {}
+
+function test({ one, two, three, four }) {}
+
+function test({
+  one,
+
+  two,
+  three,
+  four,
+}) {}
+
+function test({ one, two, three, four }, $a) {}
+
+function test(
+  { one, two, three, four },
+
+  $a,
+) {}
+
+function foo(...rest) {}
+
+function foo(
+  one,
+
+  ...rest
+) {}
+
+function foo(one, ...rest) {}
+
+f(
+  superSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperSuperLong,
+  ...args,
+);
+
+it("does something really long and complicated so I have to write a very long name for the test", function (done, foo) {
+  console.log("hello!");
+});
 
 ================================================================================
 `;

--- a/tests/format/js/preserve-line/jsfmt.spec.js
+++ b/tests/format/js/preserve-line/jsfmt.spec.js
@@ -1,1 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
+run_spec(import.meta, ["babel", "flow", "typescript"], {
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/preserve-line/jsfmt.spec.js
+++ b/tests/format/js/preserve-line/jsfmt.spec.js
@@ -1,4 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
 run_spec(import.meta, ["babel", "flow", "typescript"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/js/return/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/return/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`binaryish.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function f() {
+  return (
+    property.isIdentifier() &&
+     FUNCTIONS[property.node.name] &&
+     (object.isIdentifier(JEST_GLOBAL) ||
+       (callee.isMemberExpression() && shouldHoistExpression(object))) &&
+    FUNCTIONS[property.node.name](expr.get('arguments'))
+  );
+
+  return (
+    chalk.bold(
+      'No tests found related to files changed since last commit.\\n',
+    ) +
+    chalk.dim(
+      patternInfo.watch ?
+        'Press \`a\` to run all tests, or run Jest with \`--watchAll\`.' :
+        'Run Jest without \`-o\` to run all tests.',
+    )
+  );
+
+  return !filePath.includes(coverageDirectory) &&
+    !filePath.endsWith(\`.\${SNAPSHOT_EXTENSION}\`);
+}
+
+=====================================output=====================================
+function f() {
+  return (
+    property.isIdentifier()
+    && FUNCTIONS[property.node.name]
+    && (object.isIdentifier(JEST_GLOBAL)
+      || (callee.isMemberExpression() && shouldHoistExpression(object)))
+    && FUNCTIONS[property.node.name](expr.get("arguments"))
+  );
+
+  return (
+    chalk.bold("No tests found related to files changed since last commit.\\n")
+    + chalk.dim(
+      patternInfo.watch
+        ? "Press \`a\` to run all tests, or run Jest with \`--watchAll\`."
+        : "Run Jest without \`-o\` to run all tests.",
+    )
+  );
+
+  return (
+    !filePath.includes(coverageDirectory)
+    && !filePath.endsWith(\`.\${SNAPSHOT_EXTENSION}\`)
+  );
+}
+
+================================================================================
+`;
+
 exports[`binaryish.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -54,6 +113,101 @@ function f() {
     !filePath.endsWith(\`.\${SNAPSHOT_EXTENSION}\`)
   );
 }
+
+================================================================================
+`;
+
+exports[`comment.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function f() {
+  return /* a */;
+}
+
+function f() {
+  return // a
+  ;
+}
+
+function f() {
+  return // a
+  /* b */;
+}
+
+function f() {
+  return /* a */
+  // b
+  ;
+}
+
+function x() {
+  return func2
+      //comment
+      .bar();
+}
+
+function f() {
+  return (
+    foo
+      // comment
+      .bar()
+  );
+}
+
+fn(function f() {
+  return (
+    foo
+      // comment
+      .bar()
+  );
+});
+
+=====================================output=====================================
+function f() {
+  return /* a */;
+}
+
+function f() {
+  return; // a
+}
+
+function f() {
+  return // a
+  /* b */;
+}
+
+function f() {
+  return; /* a */
+  // b
+}
+
+function x() {
+  return (
+    func2
+      //comment
+      .bar()
+  );
+}
+
+function f() {
+  return (
+    foo
+      // comment
+      .bar()
+  );
+}
+
+fn(function f() {
+  return (
+    foo
+      // comment
+      .bar()
+  );
+});
 
 ================================================================================
 `;

--- a/tests/format/js/return/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/return/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`binaryish.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`binaryish.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -117,9 +117,9 @@ function f() {
 ================================================================================
 `;
 
-exports[`comment.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`comment.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/return/jsfmt.spec.js
+++ b/tests/format/js/return/jsfmt.spec.js
@@ -1,1 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
+run_spec(import.meta, ["babel", "flow", "typescript"], {
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/return/jsfmt.spec.js
+++ b/tests/format/js/return/jsfmt.spec.js
@@ -1,4 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
 run_spec(import.meta, ["babel", "flow", "typescript"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/js/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/strings/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`multiline-literal.js - {"trailingComma":"all","experimentalOperatorLocation":true} format 1`] = `
+exports[`multiline-literal.js - {"trailingComma":"all","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow"]
 printWidth: 80
 trailingComma: "all"
@@ -100,7 +100,7 @@ const loremIpsumFooBazBar2 =
 ================================================================================
 `;
 
-exports[`non-octal-eight-and-nine.js - {"trailingComma":"all","experimentalOperatorLocation":true} [acorn] format 1`] = `
+exports[`non-octal-eight-and-nine.js - {"trailingComma":"all","experimentalOperatorPosition":true} [acorn] format 1`] = `
 "Invalid escape sequence (3:3)
   1 | // https://github.com/babel/babel/pull/11852
   2 |
@@ -111,7 +111,7 @@ exports[`non-octal-eight-and-nine.js - {"trailingComma":"all","experimentalOpera
   6 |   "\\8", "\\9";"
 `;
 
-exports[`non-octal-eight-and-nine.js - {"trailingComma":"all","experimentalOperatorLocation":true} [espree] format 1`] = `
+exports[`non-octal-eight-and-nine.js - {"trailingComma":"all","experimentalOperatorPosition":true} [espree] format 1`] = `
 "Invalid escape sequence (3:3)
   1 | // https://github.com/babel/babel/pull/11852
   2 |
@@ -122,9 +122,9 @@ exports[`non-octal-eight-and-nine.js - {"trailingComma":"all","experimentalOpera
   6 |   "\\8", "\\9";"
 `;
 
-exports[`non-octal-eight-and-nine.js - {"trailingComma":"all","experimentalOperatorLocation":true} format 1`] = `
+exports[`non-octal-eight-and-nine.js - {"trailingComma":"all","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow"]
 printWidth: 80
 trailingComma: "all"
@@ -248,9 +248,9 @@ trailingComma: "es5"
 ================================================================================
 `;
 
-exports[`strings.js - {"trailingComma":"all","experimentalOperatorLocation":true} format 1`] = `
+exports[`strings.js - {"trailingComma":"all","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow"]
 printWidth: 80
 trailingComma: "all"
@@ -438,9 +438,9 @@ trailingComma: "es5"
 ================================================================================
 `;
 
-exports[`template-literals.js - {"trailingComma":"all","experimentalOperatorLocation":true} format 1`] = `
+exports[`template-literals.js - {"trailingComma":"all","experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow"]
 printWidth: 80
 trailingComma: "all"

--- a/tests/format/js/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/strings/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,39 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`multiline-literal.js - {"trailingComma":"all","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+// https://github.com/prettier/prettier/pull/13274
+
+const loremIpsumFooBazBar1 = 'Multiline string\\
+         Multiline string\\
+'
+
+const loremIpsumFooBazBar2 = 'Multiline string\\
+         Multiline string\\
+         Multiline string'
+
+=====================================output=====================================
+// https://github.com/prettier/prettier/pull/13274
+
+const loremIpsumFooBazBar1 =
+  "Multiline string\\
+         Multiline string\\
+";
+
+const loremIpsumFooBazBar2 =
+  "Multiline string\\
+         Multiline string\\
+         Multiline string";
+
+================================================================================
+`;
+
 exports[`multiline-literal.js - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow"]
@@ -62,6 +96,56 @@ const loremIpsumFooBazBar2 =
   "Multiline string\\
          Multiline string\\
          Multiline string";
+
+================================================================================
+`;
+
+exports[`non-octal-eight-and-nine.js - {"trailingComma":"all","experimentalOperatorLocation":true} [acorn] format 1`] = `
+"Invalid escape sequence (3:3)
+  1 | // https://github.com/babel/babel/pull/11852
+  2 |
+> 3 | "\\8","\\9";
+    |   ^
+  4 | () => {
+  5 |   "use strict";
+  6 |   "\\8", "\\9";"
+`;
+
+exports[`non-octal-eight-and-nine.js - {"trailingComma":"all","experimentalOperatorLocation":true} [espree] format 1`] = `
+"Invalid escape sequence (3:3)
+  1 | // https://github.com/babel/babel/pull/11852
+  2 |
+> 3 | "\\8","\\9";
+    |   ^
+  4 | () => {
+  5 |   "use strict";
+  6 |   "\\8", "\\9";"
+`;
+
+exports[`non-octal-eight-and-nine.js - {"trailingComma":"all","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+// https://github.com/babel/babel/pull/11852
+
+"\\8","\\9";
+() => {
+  "use strict";
+  "\\8", "\\9";
+}
+
+=====================================output=====================================
+// https://github.com/babel/babel/pull/11852
+
+"8", "9";
+() => {
+  "use strict";
+  "8", "9";
+};
 
 ================================================================================
 `;
@@ -160,6 +244,70 @@ trailingComma: "es5"
   "use strict";
   "8", "9";
 };
+
+================================================================================
+`;
+
+exports[`strings.js - {"trailingComma":"all","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+[
+  "abc",
+  'abc',
+
+  '\\'',
+
+  '"',
+  '\\"',
+  '\\\\"',
+
+  "'",
+  "\\'",
+  "\\\\'",
+
+  "'\\"",
+  '\\'"',
+
+  '\\\\',
+  "\\\\",
+
+  '\\0',
+  '🐶',
+
+  '\\uD801\\uDC28',
+];
+
+=====================================output=====================================
+[
+  "abc",
+  "abc",
+
+  "'",
+
+  '"',
+  '"',
+  '\\\\"',
+
+  "'",
+  "'",
+  "\\\\'",
+
+  "'\\"",
+  "'\\"",
+
+  "\\\\",
+  "\\\\",
+
+  "\\0",
+  "🐶",
+
+  "\\uD801\\uDC28",
+];
 
 ================================================================================
 `;
@@ -286,6 +434,191 @@ trailingComma: "es5"
 
   "\\uD801\\uDC28",
 ];
+
+================================================================================
+`;
+
+exports[`template-literals.js - {"trailingComma":"all","experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+foo(\`a long string \${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 } with expr\`);
+
+const x = \`a long string \${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + ( function() {return 3 })() + 3 + 2 + 3 + 2 + 3 } with expr\`;
+
+foo(\`a long string \${ 1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + ( function() {
+  const x = 5;
+
+  return x;
+ })() + 3 + 2 + 3 + 2 + 3 } with expr\`);
+
+pipe.write(
+  \`\\n  \${chalk.dim(\`\\u203A and \${more} more \${more} more \${more} more \${more}\`)}\`,
+);
+
+// https://github.com/prettier/prettier/issues/1662#issue-230406820
+const content = \`
+const env = \${ JSON.stringify({
+	assetsRootUrl: env.assetsRootUrl,
+	env: env.env,
+	role: "client",
+	adsfafa: "sdfsdff",
+	asdfasff: "wefwefw",
+  	fefef: "sf sdfs fdsfdsf s dfsfds"
+}, null, "\\t") });
+\`;
+
+// https://github.com/prettier/prettier/issues/821#issue-210557749
+f(\`\${{
+  a: 4,
+  b: 9,
+}}\`);
+
+// https://github.com/prettier/prettier/issues/1183#issue-220863505
+const makeBody = (store, assets, html) =>
+  \`<!doctype html>\${
+    ReactDOMServer.renderToStaticMarkup(
+      <Html
+        headScripts={compact([ assets.javascript.head ])}
+        headStyles={compact([ assets.styles.body, assets.styles.head ])}
+        bodyScripts={compact([ assets.javascript.body ])}
+        bodyStyles={[]}
+        stringScripts={[
+          \`window.__INITIAL_STATE__ = \${
+            JSON.stringify(store.getState(), null, 2)
+          };\`,
+        ]}
+        content={[
+          { id: 'app-container', dangerouslySetInnerHTML: { __html: html } },
+        ]}
+      />
+    )
+  }\`
+
+// https://github.com/prettier/prettier/issues/1626#issue-229655106
+const Bar = styled.div\`
+  color: \${props => (props.highlight.length > 0 ? palette(['text', 'dark', 'tertiary'])(props) : palette(['text', 'dark', 'primary'])(props))} !important;
+\`
+
+=====================================output=====================================
+foo(
+  \`a long string \${
+    1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3
+  } with expr\`,
+);
+
+const x = \`a long string \${
+  1
+  + 2
+  + 3
+  + 2
+  + 3
+  + 2
+  + 3
+  + 2
+  + 3
+  + 2
+  + 3
+  + 2
+  + (function () {
+    return 3;
+  })()
+  + 3
+  + 2
+  + 3
+  + 2
+  + 3
+} with expr\`;
+
+foo(
+  \`a long string \${
+    1
+    + 2
+    + 3
+    + 2
+    + 3
+    + 2
+    + 3
+    + 2
+    + 3
+    + 2
+    + 3
+    + 2
+    + (function () {
+      const x = 5;
+
+      return x;
+    })()
+    + 3
+    + 2
+    + 3
+    + 2
+    + 3
+  } with expr\`,
+);
+
+pipe.write(
+  \`\\n  \${chalk.dim(
+    \`\\u203A and \${more} more \${more} more \${more} more \${more}\`,
+  )}\`,
+);
+
+// https://github.com/prettier/prettier/issues/1662#issue-230406820
+const content = \`
+const env = \${JSON.stringify(
+  {
+    assetsRootUrl: env.assetsRootUrl,
+    env: env.env,
+    role: "client",
+    adsfafa: "sdfsdff",
+    asdfasff: "wefwefw",
+    fefef: "sf sdfs fdsfdsf s dfsfds",
+  },
+  null,
+  "\\t",
+)});
+\`;
+
+// https://github.com/prettier/prettier/issues/821#issue-210557749
+f(
+  \`\${{
+    a: 4,
+    b: 9,
+  }}\`,
+);
+
+// https://github.com/prettier/prettier/issues/1183#issue-220863505
+const makeBody = (store, assets, html) =>
+  \`<!doctype html>\${ReactDOMServer.renderToStaticMarkup(
+    <Html
+      headScripts={compact([assets.javascript.head])}
+      headStyles={compact([assets.styles.body, assets.styles.head])}
+      bodyScripts={compact([assets.javascript.body])}
+      bodyStyles={[]}
+      stringScripts={[
+        \`window.__INITIAL_STATE__ = \${JSON.stringify(
+          store.getState(),
+          null,
+          2,
+        )};\`,
+      ]}
+      content={[
+        { id: "app-container", dangerouslySetInnerHTML: { __html: html } },
+      ]}
+    />,
+  )}\`;
+
+// https://github.com/prettier/prettier/issues/1626#issue-229655106
+const Bar = styled.div\`
+  color: \${(props) =>
+    props.highlight.length > 0
+      ? palette(["text", "dark", "tertiary"])(props)
+      : palette(["text", "dark", "primary"])(props)} !important;
+\`;
 
 ================================================================================
 `;

--- a/tests/format/js/strings/jsfmt.spec.js
+++ b/tests/format/js/strings/jsfmt.spec.js
@@ -1,14 +1,18 @@
+const errors = {
+  acorn: ["non-octal-eight-and-nine.js"],
+  espree: ["non-octal-eight-and-nine.js"],
+};
+
 run_spec(import.meta, ["babel", "flow"], {
   trailingComma: "es5",
-  errors: {
-    acorn: ["non-octal-eight-and-nine.js"],
-    espree: ["non-octal-eight-and-nine.js"],
-  },
+  errors,
 });
 run_spec(import.meta, ["babel", "flow"], {
   trailingComma: "all",
-  errors: {
-    acorn: ["non-octal-eight-and-nine.js"],
-    espree: ["non-octal-eight-and-nine.js"],
-  },
+  errors,
+});
+run_spec(import.meta, ["babel", "flow"], {
+  trailingComma: "all",
+  experimentalOperatorLocation: true,
+  errors,
 });

--- a/tests/format/js/strings/jsfmt.spec.js
+++ b/tests/format/js/strings/jsfmt.spec.js
@@ -13,6 +13,6 @@ run_spec(import.meta, ["babel", "flow"], {
 });
 run_spec(import.meta, ["babel", "flow"], {
   trailingComma: "all",
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
   errors,
 });

--- a/tests/format/js/switch/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/switch/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,142 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`comments.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+switch (true) {
+  case true:
+  // Good luck getting here
+
+  case false:
+}
+
+switch (true) {
+  case true:
+
+  // Good luck getting here
+  case false:
+}
+
+switch(x) {
+  case x: {
+  }
+
+  // other
+
+  case y: {
+  }
+}
+
+switch(x) {
+  default: // comment
+    break;
+}
+
+switch(x) {
+  default: // comment
+    {break;}
+}
+
+switch(x) {
+  default: {// comment
+    break;}
+}
+
+switch(x) {
+  default: /* comment */
+    break;
+}
+
+switch(x) {
+  default: /* comment */
+    {break;}
+}
+
+switch(x) {
+  default: {/* comment */
+    break;}
+}
+
+switch(x) {
+  default: /* comment */ {
+    break;}
+}
+
+=====================================output=====================================
+switch (true) {
+  case true:
+  // Good luck getting here
+
+  case false:
+}
+
+switch (true) {
+  case true:
+
+  // Good luck getting here
+  case false:
+}
+
+switch (x) {
+  case x: {
+  }
+
+  // other
+
+  case y: {
+  }
+}
+
+switch (x) {
+  default: // comment
+    break;
+}
+
+switch (x) {
+  default: {
+    // comment
+    break;
+  }
+}
+
+switch (x) {
+  default: {
+    // comment
+    break;
+  }
+}
+
+switch (x) {
+  default: /* comment */
+    break;
+}
+
+switch (x) {
+  default: /* comment */ {
+    break;
+  }
+}
+
+switch (x) {
+  default: {
+    /* comment */
+    break;
+  }
+}
+
+switch (x) {
+  default: /* comment */ {
+    break;
+  }
+}
+
+================================================================================
+`;
+
 exports[`comments.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -136,6 +273,67 @@ switch (x) {
 ================================================================================
 `;
 
+exports[`comments2.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+switch(1){default: // comment1
+}
+
+switch(2){default: // comment2
+//comment2a
+}
+
+switch(3){default: // comment3
+break;// comment3a
+}
+
+switch(4){default: // comment4
+// comment4a
+break;// comment4b
+}
+
+switch(5){default: // comment5
+// comment5a
+foo();bar();//comment5b
+break;// comment5c
+}
+
+=====================================output=====================================
+switch (1) {
+  default: // comment1
+}
+
+switch (2) {
+  default: // comment2
+  //comment2a
+}
+
+switch (3) {
+  default: // comment3
+    break; // comment3a
+}
+
+switch (4) {
+  default: // comment4
+    // comment4a
+    break; // comment4b
+}
+
+switch (5) {
+  default: // comment5
+    // comment5a
+    foo();
+    bar(); //comment5b
+    break; // comment5c
+}
+
+================================================================================
+`;
+
 exports[`comments2.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -191,6 +389,157 @@ switch (5) {
     foo();
     bar(); //comment5b
     break; // comment5c
+}
+
+================================================================================
+`;
+
+exports[`empty_lines.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+switch (foo) {
+  case "bar":
+    doSomething();
+
+  case "baz":
+    doOtherThing();
+}
+
+switch (foo) {
+
+  case "bar":
+    doSomething();
+
+  case "baz":
+    doOtherThing();
+}
+
+switch (foo) {
+  case "bar":
+    doSomething();
+
+  case "baz":
+    doOtherThing();
+
+}
+
+switch (foo) {
+  case "bar":
+    doSomething();
+
+
+
+  case "baz":
+    doOtherThing();
+}
+
+switch (x) {
+  case y:
+    call();
+
+    break;
+
+  case z:
+    call();
+
+    break;
+}
+
+switch (a) {
+  case b:
+    if (1) {};
+    c;
+}
+
+switch (a) {
+  case x:
+  case y:
+    call();
+
+  case z:
+    call();
+}
+
+switch (a) {
+  case x: case y:
+    call();
+
+  case z:
+    call();
+}
+
+=====================================output=====================================
+switch (foo) {
+  case "bar":
+    doSomething();
+
+  case "baz":
+    doOtherThing();
+}
+
+switch (foo) {
+  case "bar":
+    doSomething();
+
+  case "baz":
+    doOtherThing();
+}
+
+switch (foo) {
+  case "bar":
+    doSomething();
+
+  case "baz":
+    doOtherThing();
+}
+
+switch (foo) {
+  case "bar":
+    doSomething();
+
+  case "baz":
+    doOtherThing();
+}
+
+switch (x) {
+  case y:
+    call();
+
+    break;
+
+  case z:
+    call();
+
+    break;
+}
+
+switch (a) {
+  case b:
+    if (1) {
+    }
+    c;
+}
+
+switch (a) {
+  case x:
+  case y:
+    call();
+
+  case z:
+    call();
+}
+
+switch (a) {
+  case x:
+  case y:
+    call();
+
+  case z:
+    call();
 }
 
 ================================================================================
@@ -346,6 +695,32 @@ switch (a) {
 ================================================================================
 `;
 
+exports[`empty_statement.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+switch (error.code) {
+	case ConfigurationEditingErrorCode.ERROR_INVALID_CONFIGURATION: {
+		nls.localize('errorInvalidConfiguration', "Unable to write into settings. Correct errors/warnings in the file and try again.");
+	};
+}
+
+=====================================output=====================================
+switch (error.code) {
+  case ConfigurationEditingErrorCode.ERROR_INVALID_CONFIGURATION: {
+    nls.localize(
+      "errorInvalidConfiguration",
+      "Unable to write into settings. Correct errors/warnings in the file and try again.",
+    );
+  }
+}
+
+================================================================================
+`;
+
 exports[`empty_statement.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -371,6 +746,26 @@ switch (error.code) {
 ================================================================================
 `;
 
+exports[`empty_switch.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+switch (1) { default:; }
+switch (1) {}
+
+=====================================output=====================================
+switch (1) {
+  default:
+}
+switch (1) {
+}
+
+================================================================================
+`;
+
 exports[`empty_switch.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -385,6 +780,100 @@ switch (1) {
   default:
 }
 switch (1) {
+}
+
+================================================================================
+`;
+
+exports[`switch.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+switch (a) {
+  case 3:
+    alert( '3' );
+    break;
+  case 4:
+    alert( '4' );
+    break;
+  case 5:
+    alert( '5' );
+    break;
+  default:
+    alert( 'default' );
+}
+
+switch (veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong) {
+  case 3:
+    alert( '3' );
+    break;
+  default:
+    alert( 'default' );
+}
+
+switch (veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong > veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong) {
+  case 3:
+    alert( '3' );
+    break;
+  default:
+    alert( 'default' );
+}
+
+switch ($veryLongAndVeryVerboseVariableName && $anotherVeryLongAndVeryVerboseVariableName) {
+}
+
+switch ($longButSlightlyShorterVariableName && $anotherSlightlyShorterVariableName) {
+}
+
+=====================================output=====================================
+switch (a) {
+  case 3:
+    alert("3");
+    break;
+  case 4:
+    alert("4");
+    break;
+  case 5:
+    alert("5");
+    break;
+  default:
+    alert("default");
+}
+
+switch (
+  veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong
+) {
+  case 3:
+    alert("3");
+    break;
+  default:
+    alert("default");
+}
+
+switch (
+  veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong
+  > veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLong
+) {
+  case 3:
+    alert("3");
+    break;
+  default:
+    alert("default");
+}
+
+switch (
+  $veryLongAndVeryVerboseVariableName
+  && $anotherVeryLongAndVeryVerboseVariableName
+) {
+}
+
+switch (
+  $longButSlightlyShorterVariableName
+  && $anotherSlightlyShorterVariableName
+) {
 }
 
 ================================================================================

--- a/tests/format/js/switch/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/switch/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`comments.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`comments.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -273,9 +273,9 @@ switch (x) {
 ================================================================================
 `;
 
-exports[`comments2.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`comments2.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -394,9 +394,9 @@ switch (5) {
 ================================================================================
 `;
 
-exports[`empty_lines.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`empty_lines.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -695,9 +695,9 @@ switch (a) {
 ================================================================================
 `;
 
-exports[`empty_statement.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`empty_statement.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -746,9 +746,9 @@ switch (error.code) {
 ================================================================================
 `;
 
-exports[`empty_switch.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`empty_switch.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -785,9 +785,9 @@ switch (1) {
 ================================================================================
 `;
 
-exports[`switch.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`switch.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/switch/jsfmt.spec.js
+++ b/tests/format/js/switch/jsfmt.spec.js
@@ -1,1 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
+run_spec(import.meta, ["babel", "flow", "typescript"], {
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/switch/jsfmt.spec.js
+++ b/tests/format/js/switch/jsfmt.spec.js
@@ -1,4 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
 run_spec(import.meta, ["babel", "flow", "typescript"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/js/ternaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/ternaries/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`binary.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`binary.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -210,9 +210,9 @@ room = room.map((row, rowIndex) =>
 ================================================================================
 `;
 
-exports[`func-call.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`func-call.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -365,9 +365,9 @@ fn(
 ================================================================================
 `;
 
-exports[`indent.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`indent.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -2019,9 +2019,9 @@ a
 ================================================================================
 `;
 
-exports[`indent-after-paren.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`indent-after-paren.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -5284,9 +5284,9 @@ fn?.[
 ================================================================================
 `;
 
-exports[`nested.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`nested.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -6604,9 +6604,9 @@ showNotification(
 ================================================================================
 `;
 
-exports[`nested-in-condition.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`nested-in-condition.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -7049,9 +7049,9 @@ const value = (
 ================================================================================
 `;
 
-exports[`parenthesis.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`parenthesis.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -7234,9 +7234,9 @@ debug
 ================================================================================
 `;
 
-exports[`test.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`test.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/ternaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/ternaries/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`binary.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const funnelSnapshotCard = (report === MY_OVERVIEW &&
+  !ReportGK.xar_metrics_active_capitol_v2) ||
+  (report === COMPANY_OVERVIEW &&
+    !ReportGK.xar_metrics_active_capitol_v2_company_metrics)
+  ? <ReportMetricsFunnelSnapshotCard metrics={metrics} />
+  : null;
+
+room = room.map((row, rowIndex) => (
+  row.map((col, colIndex) => (
+    (rowIndex === 0 || colIndex === 0 || rowIndex === height || colIndex === width) ? 1 : 0
+  ))
+))
+
+=====================================output=====================================
+const funnelSnapshotCard =
+  (report === MY_OVERVIEW && !ReportGK.xar_metrics_active_capitol_v2)
+  || (report === COMPANY_OVERVIEW
+    && !ReportGK.xar_metrics_active_capitol_v2_company_metrics) ? (
+    <ReportMetricsFunnelSnapshotCard metrics={metrics} />
+  ) : null;
+
+room = room.map((row, rowIndex) =>
+  row.map((col, colIndex) =>
+    rowIndex === 0
+    || colIndex === 0
+    || rowIndex === height
+    || colIndex === width
+      ? 1
+      : 0,
+  ),
+);
+
+================================================================================
+`;
+
 exports[`binary.js - {"tabWidth":4} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -168,6 +210,37 @@ room = room.map((row, rowIndex) =>
 ================================================================================
 `;
 
+exports[`func-call.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+fn(
+  bifornCringerMoshedPerplexSawder,
+  askTrovenaBeenaDependsRowans,
+  glimseGlyphsHazardNoopsTieTie === averredBathersBoxroomBuggyNurl &&
+    anodyneCondosMalateOverateRetinol
+      ? annularCooeedSplicesWalksWayWay
+      : kochabCooieGameOnOboleUnweave
+);
+// TODO(rattrayalex): try to indent consequent/alternate here.
+
+=====================================output=====================================
+fn(
+  bifornCringerMoshedPerplexSawder,
+  askTrovenaBeenaDependsRowans,
+  glimseGlyphsHazardNoopsTieTie === averredBathersBoxroomBuggyNurl
+    && anodyneCondosMalateOverateRetinol
+    ? annularCooeedSplicesWalksWayWay
+    : kochabCooieGameOnOboleUnweave,
+);
+// TODO(rattrayalex): try to indent consequent/alternate here.
+
+================================================================================
+`;
+
 exports[`func-call.js - {"tabWidth":4} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -288,6 +361,336 @@ fn(
     : kochabCooieGameOnOboleUnweave,
 );
 // TODO(rattrayalex): try to indent consequent/alternate here.
+
+================================================================================
+`;
+
+exports[`indent.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+aaaaaaaaaaaaaaa ? bbbbbbbbbbbbbbbbbb : ccccccccccccccc ? ddddddddddddddd : eeeeeeeeeeeeeee ? fffffffffffffff : gggggggggggggggg
+
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+?
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+?
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+?
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+:
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+:
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+:
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+
+a
+    ? {
+        a: 0
+      }
+    : {
+        a: {
+             a: 0
+           }
+            ? {
+                a: 0
+              }
+            : {
+                y: {
+                    a: 0
+                }
+                    ? {
+                        a: 0
+                    }
+                    : {
+                        a: 0
+                    }
+            }
+      }
+
+a
+	? {
+			a: function() {
+				return a
+					? {
+							a: [
+								a
+									? {
+											a: 0,
+											b: [
+												a
+													? [
+															0,
+															1
+													  ]
+													: []
+											]
+									  }
+									: [
+											[
+												0,
+												{
+													a: 0
+												},
+												a
+													? 0
+													: 1
+											],
+											function() {
+												return a
+													? {
+															a: 0
+													  }
+													: [
+															{
+																a: 0
+															},
+															{}
+													  ];
+											}
+									  ]
+							]
+					  }
+					: [
+							a
+								? function() {
+										a
+											? a(
+													a
+														? {
+																a: a(
+																	{
+																		a: 0
+																	}
+																)
+														  }
+														: [
+																0,
+																a(),
+																a(
+																	a(),
+																	{
+																		a: 0
+																	},
+																	a
+																		? a()
+																		: a(
+																				{
+																					a: 0
+																				}
+																		  )
+																),
+																a()
+																	? {
+																			a: a(),
+																			b: []
+																	  }
+																	: {}
+														  ]
+											  ):
+										a(
+											a()
+												? {
+														a: 0
+												  }
+												: (function(a) {
+														return a()
+															? [
+																	{
+																		a: 0,
+																		b: a()
+																	}
+															  ]
+															: a(
+																	[
+																		a
+																			? {
+																					a: 0
+																			  }
+																			: {},
+																		{
+																			a: 0
+																		}
+																	]
+															  );
+												  })(
+														a
+															? function(a) {
+																	return function() {
+																		return 0;
+																	};
+															  }
+															: function(a) {
+																	return function() {
+																		return 1;
+																	}
+															  }
+												  )
+										);
+								  }
+								: function() {
+
+								  }
+					  ];
+			}
+	  }
+    : a;
+
+=====================================output=====================================
+aaaaaaaaaaaaaaa
+  ? bbbbbbbbbbbbbbbbbb
+  : ccccccccccccccc
+  ? ddddddddddddddd
+  : eeeeeeeeeeeeeee
+  ? fffffffffffffff
+  : gggggggggggggggg;
+
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      ? aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+  : aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa;
+
+a
+  ? {
+      a: 0,
+    }
+  : {
+      a: {
+        a: 0,
+      }
+        ? {
+            a: 0,
+          }
+        : {
+            y: {
+              a: 0,
+            }
+              ? {
+                  a: 0,
+                }
+              : {
+                  a: 0,
+                },
+          },
+    };
+
+a
+  ? {
+      a: function () {
+        return a
+          ? {
+              a: [
+                a
+                  ? {
+                      a: 0,
+                      b: [a ? [0, 1] : []],
+                    }
+                  : [
+                      [
+                        0,
+                        {
+                          a: 0,
+                        },
+                        a ? 0 : 1,
+                      ],
+                      function () {
+                        return a
+                          ? {
+                              a: 0,
+                            }
+                          : [
+                              {
+                                a: 0,
+                              },
+                              {},
+                            ];
+                      },
+                    ],
+              ],
+            }
+          : [
+              a
+                ? function () {
+                    a
+                      ? a(
+                          a
+                            ? {
+                                a: a({
+                                  a: 0,
+                                }),
+                              }
+                            : [
+                                0,
+                                a(),
+                                a(
+                                  a(),
+                                  {
+                                    a: 0,
+                                  },
+                                  a
+                                    ? a()
+                                    : a({
+                                        a: 0,
+                                      }),
+                                ),
+                                a()
+                                  ? {
+                                      a: a(),
+                                      b: [],
+                                    }
+                                  : {},
+                              ],
+                        )
+                      : a(
+                          a()
+                            ? {
+                                a: 0,
+                              }
+                            : (function (a) {
+                                return a()
+                                  ? [
+                                      {
+                                        a: 0,
+                                        b: a(),
+                                      },
+                                    ]
+                                  : a([
+                                      a
+                                        ? {
+                                            a: 0,
+                                          }
+                                        : {},
+                                      {
+                                        a: 0,
+                                      },
+                                    ]);
+                              })(
+                                a
+                                  ? function (a) {
+                                      return function () {
+                                        return 0;
+                                      };
+                                    }
+                                  : function (a) {
+                                      return function () {
+                                        return 1;
+                                      };
+                                    },
+                              ),
+                        );
+                  }
+                : function () {},
+            ];
+      },
+    }
+  : a;
 
 ================================================================================
 `;
@@ -1612,6 +2015,659 @@ a
       },
     }
   : a;
+
+================================================================================
+`;
+
+exports[`indent-after-paren.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+foo7 = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz)[Fooooooooooo];
+
+foo8 = (condition ? firstValue : secondValue)[SomeType];
+
+const foo9 = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz)[Fooooooooooo];
+
+function foo10() {
+  return (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)[Fooooooooooo];
+}
+
+function foo11() {
+  throw (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)[Fooooooooooo];
+}
+
+function foo12() {
+  void (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)[Fooooooooooo];
+}
+
+foo13 = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz
+).Fooooooooooo.Fooooooooooo;
+
+foo14 = (condition ? firstValue : secondValue)[SomeType];
+
+const foo15 = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz
+).Fooooooooooo.Fooooooooooo;
+
+function foo16() {
+  return (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+  ).Fooooooooooo.Fooooooooooo;
+}
+
+function foo17() {
+  throw (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+  ).Fooooooooooo.Fooooooooooo;
+}
+
+function foo18() {
+  void (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+  ).Fooooooooooo.Fooooooooooo;
+}
+
+foo19 = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo);
+
+foo20 = (condition ? firstValue : secondValue)[SomeType];
+
+const foo21 = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo);
+
+function foo22() {
+  return (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo);
+}
+
+function foo23() {
+  throw (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo);
+}
+
+function foo24() {
+  void (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo);
+}
+
+foo25 = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz)?.(Fooooooooooo.Fooooooooooo);
+
+foo26 = (condition ? firstValue : secondValue)[SomeType];
+
+const foo27 = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz)?.(Fooooooooooo.Fooooooooooo);
+
+function foo28() {
+  return (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)?.(Fooooooooooo.Fooooooooooo);
+}
+
+function foo29() {
+  throw (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)?.(Fooooooooooo.Fooooooooooo);
+}
+
+function foo30() {
+  void (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)?.(Fooooooooooo.Fooooooooooo);
+}
+
+function* foo31() {
+  yield (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)?.(Fooooooooooo.Fooooooooooo);
+  yield (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz)(Fooooooooooo.Fooooooooooo);
+  yield (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz).Fooooooooooo.Fooooooooooo;
+  yield (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz)[Fooooooooooo.Fooooooooooo];
+}
+
+const foo32 = new (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz
+)(Fooooooooooo.Fooooooooooo);
+
+function foo33() {
+  return new (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+  )(Fooooooooooo.Fooooooooooo);
+}
+
+function foo34() {
+  throw new (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+  )(Fooooooooooo.Fooooooooooo);
+}
+
+function foo35() {
+  void new (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+  )(Fooooooooooo.Fooooooooooo);
+}
+
+foo36 = new (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz
+)(Fooooooooooo.Fooooooooooo);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol)[AnnularCooeedSplicesWalksWayWay]);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0 &&
+  kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol)[AnnularCooeedSplicesWalksWayWay]);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol).Fooooooooooo.Fooooooooooo);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0 &&
+  kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol).Fooooooooooo.Fooooooooooo);
+
+bifornCringerMoshedPerplexSawder =
+    askTrovenaBeenaDependsRowans +
+    ((glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol)(Fooooooooooo.Fooooooooooo));
+
+bifornCringerMoshedPerplexSawder =
+    askTrovenaBeenaDependsRowans +
+    ((glimseGlyphsHazardNoopsTieTie === 0 &&
+    kochabCooieGameOnOboleUnweave === Math.PI
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol)(Fooooooooooo.Fooooooooooo));
+// TODO(rattrayalex): try to fix this case
+
+bifornCringerMoshedPerplexSawder = (
+  glimseGlyphsHazardNoopsTieTie === 0 &&
+  kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).annularCooeedSplicesWalksWayWay
+    .annularCooeedSplicesWalksWayWay(annularCooeedSplicesWalksWayWay)
+    .annularCooeedSplicesWalksWayWay();
+
+foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz)?.()?.()?.();
+
+foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz)()()();
+
+foo =
+  foo.bar.baz[
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ];
+
+const decorated = (arg, ignoreRequestError) => {
+  return (
+    typeof arg === "string" ||
+    (arg && arg.valueOf && typeof arg.valueOf() === "string")
+      ? $delegate(arg, ignoreRequestError)
+      : handleAsyncOperations(arg, ignoreRequestError)
+  ).foo();
+};
+
+bifornCringerMoshedPerplexSawder = fn(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+);
+
+fn(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+)
+
+bifornCringerMoshedPerplexSawder = fn?.(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+);
+
+fn?.(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+)
+
+bifornCringerMoshedPerplexSawder =
+  fn[
+    (glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol
+    ).prop
+  ];
+
+fn[
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+];
+
+bifornCringerMoshedPerplexSawder =
+  fn?.[
+    (glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol
+    ).prop
+  ];
+
+fn?.[
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+];
+
+=====================================output=====================================
+foo7 = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+)[Fooooooooooo];
+
+foo8 = (condition ? firstValue : secondValue)[SomeType];
+
+const foo9 = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+)[Fooooooooooo];
+
+function foo10() {
+  return (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  )[Fooooooooooo];
+}
+
+function foo11() {
+  throw (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  )[Fooooooooooo];
+}
+
+function foo12() {
+  void (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  )[Fooooooooooo];
+}
+
+foo13 = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+).Fooooooooooo.Fooooooooooo;
+
+foo14 = (condition ? firstValue : secondValue)[SomeType];
+
+const foo15 = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+).Fooooooooooo.Fooooooooooo;
+
+function foo16() {
+  return (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ).Fooooooooooo.Fooooooooooo;
+}
+
+function foo17() {
+  throw (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ).Fooooooooooo.Fooooooooooo;
+}
+
+function foo18() {
+  void (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ).Fooooooooooo.Fooooooooooo;
+}
+
+foo19 = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+)(Fooooooooooo.Fooooooooooo);
+
+foo20 = (condition ? firstValue : secondValue)[SomeType];
+
+const foo21 = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+)(Fooooooooooo.Fooooooooooo);
+
+function foo22() {
+  return (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  )(Fooooooooooo.Fooooooooooo);
+}
+
+function foo23() {
+  throw (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  )(Fooooooooooo.Fooooooooooo);
+}
+
+function foo24() {
+  void (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  )(Fooooooooooo.Fooooooooooo);
+}
+
+foo25 = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+)?.(Fooooooooooo.Fooooooooooo);
+
+foo26 = (condition ? firstValue : secondValue)[SomeType];
+
+const foo27 = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+)?.(Fooooooooooo.Fooooooooooo);
+
+function foo28() {
+  return (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  )?.(Fooooooooooo.Fooooooooooo);
+}
+
+function foo29() {
+  throw (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  )?.(Fooooooooooo.Fooooooooooo);
+}
+
+function foo30() {
+  void (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  )?.(Fooooooooooo.Fooooooooooo);
+}
+
+function* foo31() {
+  yield (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  )?.(Fooooooooooo.Fooooooooooo);
+  yield (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  )(Fooooooooooo.Fooooooooooo);
+  yield (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ).Fooooooooooo.Fooooooooooo;
+  yield (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  )[Fooooooooooo.Fooooooooooo];
+}
+
+const foo32 = new (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+)(Fooooooooooo.Fooooooooooo);
+
+function foo33() {
+  return new (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  )(Fooooooooooo.Fooooooooooo);
+}
+
+function foo34() {
+  throw new (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  )(Fooooooooooo.Fooooooooooo);
+}
+
+function foo35() {
+  void new (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  )(Fooooooooooo.Fooooooooooo);
+}
+
+foo36 = new (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+)(Fooooooooooo.Fooooooooooo);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans
+  + (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol)[AnnularCooeedSplicesWalksWayWay];
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans
+  + (glimseGlyphsHazardNoopsTieTie === 0
+  && kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol)[AnnularCooeedSplicesWalksWayWay];
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans
+  + (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).Fooooooooooo.Fooooooooooo;
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans
+  + (glimseGlyphsHazardNoopsTieTie === 0
+  && kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).Fooooooooooo.Fooooooooooo;
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans
+  + (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol)(Fooooooooooo.Fooooooooooo);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans
+  + (glimseGlyphsHazardNoopsTieTie === 0
+    && kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol)(Fooooooooooo.Fooooooooooo);
+// TODO(rattrayalex): try to fix this case
+
+bifornCringerMoshedPerplexSawder = (
+  glimseGlyphsHazardNoopsTieTie === 0
+  && kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+).annularCooeedSplicesWalksWayWay
+  .annularCooeedSplicesWalksWayWay(annularCooeedSplicesWalksWayWay)
+  .annularCooeedSplicesWalksWayWay();
+
+foo = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+)?.()?.()?.();
+
+foo = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+)()()();
+
+foo =
+  foo.bar.baz[
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ];
+
+const decorated = (arg, ignoreRequestError) => {
+  return (
+    typeof arg === "string"
+    || (arg && arg.valueOf && typeof arg.valueOf() === "string")
+      ? $delegate(arg, ignoreRequestError)
+      : handleAsyncOperations(arg, ignoreRequestError)
+  ).foo();
+};
+
+bifornCringerMoshedPerplexSawder = fn(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop,
+);
+
+fn(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop,
+);
+
+bifornCringerMoshedPerplexSawder = fn?.(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop,
+);
+
+fn?.(
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop,
+);
+
+bifornCringerMoshedPerplexSawder =
+  fn[
+    (glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol
+    ).prop
+  ];
+
+fn[
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+];
+
+bifornCringerMoshedPerplexSawder =
+  fn?.[
+    (glimseGlyphsHazardNoopsTieTie === 0
+      ? averredBathersBoxroomBuggyNurl
+      : anodyneCondosMalateOverateRetinol
+    ).prop
+  ];
+
+fn?.[
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).prop
+];
 
 ================================================================================
 `;
@@ -4228,6 +5284,270 @@ fn?.[
 ================================================================================
 `;
 
+exports[`nested.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+let icecream = what == "cone"
+  ? p => !!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`
+  : p => \`here's your \${p} \${what}\`;
+
+const value = condition1
+? value1
+: condition2
+    ? value2
+    : condition3
+        ? value3
+        : value4;
+
+
+const StorybookLoader = ({ match }) => (
+  match.params.storyId === "button"
+    ? <ButtonStorybook />
+    : match.params.storyId === "color"
+    ? <ColorBook />
+    : match.params.storyId === "typography"
+    ? <TypographyBook />
+    : match.params.storyId === "loading"
+    ? <LoaderStorybook />
+    : match.params.storyId === "deal-list"
+    ? <DealListStory />
+    : (
+      <Message>
+        <Title>{'Missing story book'}</Title>
+        <Content>
+          <BackButton/>
+        </Content>
+      </Message>
+    )
+)
+
+const message =
+    i % 3 === 0 && i % 5 === 0 ?
+        'fizzbuzz'
+    : i % 3 === 0 ?
+        'fizz'
+    : i % 5 === 0 ?
+        'buzz'
+    :
+        String(i)
+
+const paymentMessage = state == 'success'
+  ? 'Payment completed successfully'
+
+: state == 'processing'
+  ? 'Payment processing'
+
+: state == 'invalid_cvc'
+  ? 'There was an issue with your CVC number'
+
+: state == 'invalid_expiry'
+  ? 'Expiry must be sometime in the past.'
+
+  : 'There was an issue with the payment.  Please contact support.'
+
+const paymentMessage2 = state == 'success'
+  ? 1 //'Payment completed successfully'
+
+: state == 'processing'
+  ? 2 //'Payment processing'
+
+: state == 'invalid_cvc'
+  ? 3 //'There was an issue with your CVC number'
+
+: true //state == 'invalid_expiry'
+  ? 4 //'Expiry must be sometime in the past.'
+
+  : 5 // 'There was an issue with the payment.  Please contact support.'
+
+const foo = <div className={'match-achievement-medal-type type' + (medals[0].record ? '-record' : (medals[0].unique ? '-unique' : medals[0].type))}>
+	{medals[0].record ? (
+		i18n('Record')
+	) : medals[0].unique ? (
+		i18n('Unique')
+	) : medals[0].type === 0 ? (
+		i18n('Silver')
+	) : medals[0].type === 1 ? (
+		i18n('Gold')
+	) : medals[0].type === 2 ? (
+		i18n('Platinum')
+	) : (
+		i18n('Theme')
+	)}
+</div>
+
+a
+    ? literalline
+    : {
+      123: 12
+    }
+    ? line
+    : softline
+
+const config = {
+    onFailure: onFailure !== undefined ? onFailure :   (
+      error => {
+          notify(
+              typeof error === 'string' ?
+                  error
+              : error.message || 'ra.notification.http_error',
+              'warning',
+              {
+                  _:
+                      typeof error === 'string' ? error
+                      : error && error.message ? error.message
+                      : undefined,
+              }
+          );
+          refresh();
+      }
+    )
+}
+
+showNotification(
+    typeof error === 'string' ? error :   error.message || body,
+    level || 'warning',
+    {
+        messageArgs,
+        undoable: false,
+    }
+)
+=====================================output=====================================
+let icecream =
+  what == "cone"
+    ? (p) => (!!p ? \`here's your \${p} cone\` : \`just the empty cone for you\`)
+    : (p) => \`here's your \${p} \${what}\`;
+
+const value = condition1
+  ? value1
+  : condition2
+  ? value2
+  : condition3
+  ? value3
+  : value4;
+
+const StorybookLoader = ({ match }) =>
+  match.params.storyId === "button" ? (
+    <ButtonStorybook />
+  ) : match.params.storyId === "color" ? (
+    <ColorBook />
+  ) : match.params.storyId === "typography" ? (
+    <TypographyBook />
+  ) : match.params.storyId === "loading" ? (
+    <LoaderStorybook />
+  ) : match.params.storyId === "deal-list" ? (
+    <DealListStory />
+  ) : (
+    <Message>
+      <Title>{"Missing story book"}</Title>
+      <Content>
+        <BackButton />
+      </Content>
+    </Message>
+  );
+
+const message =
+  i % 3 === 0 && i % 5 === 0
+    ? "fizzbuzz"
+    : i % 3 === 0
+    ? "fizz"
+    : i % 5 === 0
+    ? "buzz"
+    : String(i);
+
+const paymentMessage =
+  state == "success"
+    ? "Payment completed successfully"
+    : state == "processing"
+    ? "Payment processing"
+    : state == "invalid_cvc"
+    ? "There was an issue with your CVC number"
+    : state == "invalid_expiry"
+    ? "Expiry must be sometime in the past."
+    : "There was an issue with the payment.  Please contact support.";
+
+const paymentMessage2 =
+  state == "success"
+    ? 1 //'Payment completed successfully'
+    : state == "processing"
+    ? 2 //'Payment processing'
+    : state == "invalid_cvc"
+    ? 3 //'There was an issue with your CVC number'
+    : true //state == 'invalid_expiry'
+    ? 4 //'Expiry must be sometime in the past.'
+    : 5; // 'There was an issue with the payment.  Please contact support.'
+
+const foo = (
+  <div
+    className={
+      "match-achievement-medal-type type"
+      + (medals[0].record
+        ? "-record"
+        : medals[0].unique
+        ? "-unique"
+        : medals[0].type)
+    }
+  >
+    {medals[0].record
+      ? i18n("Record")
+      : medals[0].unique
+      ? i18n("Unique")
+      : medals[0].type === 0
+      ? i18n("Silver")
+      : medals[0].type === 1
+      ? i18n("Gold")
+      : medals[0].type === 2
+      ? i18n("Platinum")
+      : i18n("Theme")}
+  </div>
+);
+
+a
+  ? literalline
+  : {
+      123: 12,
+    }
+  ? line
+  : softline;
+
+const config = {
+  onFailure:
+    onFailure !== undefined
+      ? onFailure
+      : (error) => {
+          notify(
+            typeof error === "string"
+              ? error
+              : error.message || "ra.notification.http_error",
+            "warning",
+            {
+              _:
+                typeof error === "string"
+                  ? error
+                  : error && error.message
+                  ? error.message
+                  : undefined,
+            },
+          );
+          refresh();
+        },
+};
+
+showNotification(
+  typeof error === "string" ? error : error.message || body,
+  level || "warning",
+  {
+    messageArgs,
+    undoable: false,
+  },
+);
+
+================================================================================
+`;
+
 exports[`nested.js - {"tabWidth":4} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -5284,6 +6604,95 @@ showNotification(
 ================================================================================
 `;
 
+exports[`nested-in-condition.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+$var = ($number % 10 >= 2 && ($number % 100 < 10 || $number % 100 >= 20)
+? kochabCooieGameOnOboleUnweave
+: annularCooeedSplicesWalksWayWay)
+  ? anodyneCondosMalateOverateRetinol
+  : averredBathersBoxroomBuggyNurl;
+
+const value = (bifornCringerMoshedPerplexSawder
+? askTrovenaBeenaDependsRowans
+: glimseGlyphsHazardNoopsTieTie)
+  ? true
+    ? true
+    : false
+  : true
+  ? true
+  : false;
+
+(bifornCringerMoshedPerplexSawder ? (
+  askTrovenaBeenaDependsRowans
+) : (
+  glimseGlyphsHazardNoopsTieTie
+)) ? (
+  <Element>
+    <Sub />
+    <Sub />
+    <Sub />
+    <Sub />
+    <Sub />
+    <Sub />
+  </Element>
+) : (
+  <Element2>
+    <Sub />
+    <Sub />
+    <Sub />
+  </Element2>
+);
+
+=====================================output=====================================
+$var = (
+  $number % 10 >= 2 && ($number % 100 < 10 || $number % 100 >= 20)
+    ? kochabCooieGameOnOboleUnweave
+    : annularCooeedSplicesWalksWayWay
+)
+  ? anodyneCondosMalateOverateRetinol
+  : averredBathersBoxroomBuggyNurl;
+
+const value = (
+  bifornCringerMoshedPerplexSawder
+    ? askTrovenaBeenaDependsRowans
+    : glimseGlyphsHazardNoopsTieTie
+)
+  ? true
+    ? true
+    : false
+  : true
+  ? true
+  : false;
+
+(
+  bifornCringerMoshedPerplexSawder
+    ? askTrovenaBeenaDependsRowans
+    : glimseGlyphsHazardNoopsTieTie
+) ? (
+  <Element>
+    <Sub />
+    <Sub />
+    <Sub />
+    <Sub />
+    <Sub />
+    <Sub />
+  </Element>
+) : (
+  <Element2>
+    <Sub />
+    <Sub />
+    <Sub />
+  </Element2>
+);
+
+================================================================================
+`;
+
 exports[`nested-in-condition.js - {"tabWidth":4} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -5640,6 +7049,43 @@ const value = (
 ================================================================================
 `;
 
+exports[`parenthesis.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+debug ? this.state.isVisible ? "partially visible" : "hidden" : null;
+debug ? this.state.isVisible && somethingComplex ? "partially visible" : "hidden" : null;
+
+a => a ? () => {a} : () => {a}
+a => a ? a : a
+a => a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a
+
+=====================================output=====================================
+debug ? (this.state.isVisible ? "partially visible" : "hidden") : null;
+debug
+  ? this.state.isVisible && somethingComplex
+    ? "partially visible"
+    : "hidden"
+  : null;
+
+(a) =>
+  a
+    ? () => {
+        a;
+      }
+    : () => {
+        a;
+      };
+(a) => (a ? a : a);
+(a) =>
+  a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a;
+
+================================================================================
+`;
+
 exports[`parenthesis.js - {"tabWidth":4} format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -5784,6 +7230,66 @@ debug
 (a) => (a ? a : a);
 (a) =>
   a ? aasdasdasdasdasdasdaaasdasdasdasdasdasdasdasdasdasdasdasdasdaaaaaa : a;
+
+================================================================================
+`;
+
+exports[`test.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const obj0 = conditionIsTruthy ? shortThing : otherShortThing
+
+const obj1 = conditionIsTruthy ? { some: 'long', object: 'with', lots: 'of', stuff } : shortThing
+
+const obj2 = conditionIsTruthy ? shortThing : { some: 'long', object: 'with', lots: 'of', stuff }
+
+const obj3 = conditionIsTruthy ? { some: 'eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger', object: 'with', lots: 'of', stuff } : shortThing
+
+const obj4 = conditionIsTruthy ? shortThing : { some: 'eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger', object: 'with', lots: 'of', stuff }
+
+const obj5 = conditionIsTruthy ? { some: 'long', object: 'with', lots: 'of', stuff } : { some: 'eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger', object: 'with', lots: 'of', stuff }
+
+=====================================output=====================================
+const obj0 = conditionIsTruthy ? shortThing : otherShortThing;
+
+const obj1 = conditionIsTruthy
+  ? { some: "long", object: "with", lots: "of", stuff }
+  : shortThing;
+
+const obj2 = conditionIsTruthy
+  ? shortThing
+  : { some: "long", object: "with", lots: "of", stuff };
+
+const obj3 = conditionIsTruthy
+  ? {
+      some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
+      object: "with",
+      lots: "of",
+      stuff,
+    }
+  : shortThing;
+
+const obj4 = conditionIsTruthy
+  ? shortThing
+  : {
+      some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
+      object: "with",
+      lots: "of",
+      stuff,
+    };
+
+const obj5 = conditionIsTruthy
+  ? { some: "long", object: "with", lots: "of", stuff }
+  : {
+      some: "eeeeeeeeeeeeven looooooooooooooooooooooooooooooonger",
+      object: "with",
+      lots: "of",
+      stuff,
+    };
 
 ================================================================================
 `;

--- a/tests/format/js/ternaries/jsfmt.spec.js
+++ b/tests/format/js/ternaries/jsfmt.spec.js
@@ -5,3 +5,6 @@ run_spec(import.meta, ["babel", "flow", "typescript"], {
   useTabs: true,
   tabWidth: 4,
 });
+run_spec(import.meta, ["babel", "flow", "typescript"], {
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/ternaries/jsfmt.spec.js
+++ b/tests/format/js/ternaries/jsfmt.spec.js
@@ -6,5 +6,5 @@ run_spec(import.meta, ["babel", "flow", "typescript"], {
   tabWidth: 4,
 });
 run_spec(import.meta, ["babel", "flow", "typescript"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/js/throw_statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/throw_statement/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,64 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`binaryish.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function f() {
+  throw (
+    property.isIdentifier() &&
+     FUNCTIONS[property.node.name] &&
+     (object.isIdentifier(JEST_GLOBAL) ||
+       (callee.isMemberExpression() && shouldHoistExpression(object))) &&
+    FUNCTIONS[property.node.name](expr.get('arguments'))
+  );
+
+  throw (
+    chalk.bold(
+      'No tests found related to files changed since last commit.\\n',
+    ) +
+    chalk.dim(
+      patternInfo.watch ?
+        'Press \`a\` to run all tests, or run Jest with \`--watchAll\`.' :
+        'Run Jest without \`-o\` to run all tests.',
+    )
+  );
+
+  throw !filePath.includes(coverageDirectory) &&
+    !filePath.endsWith(\`.\${SNAPSHOT_EXTENSION}\`);
+}
+
+=====================================output=====================================
+function f() {
+  throw (
+    property.isIdentifier()
+    && FUNCTIONS[property.node.name]
+    && (object.isIdentifier(JEST_GLOBAL)
+      || (callee.isMemberExpression() && shouldHoistExpression(object)))
+    && FUNCTIONS[property.node.name](expr.get("arguments"))
+  );
+
+  throw (
+    chalk.bold("No tests found related to files changed since last commit.\\n")
+    + chalk.dim(
+      patternInfo.watch
+        ? "Press \`a\` to run all tests, or run Jest with \`--watchAll\`."
+        : "Run Jest without \`-o\` to run all tests.",
+    )
+  );
+
+  throw (
+    !filePath.includes(coverageDirectory)
+    && !filePath.endsWith(\`.\${SNAPSHOT_EXTENSION}\`)
+  );
+}
+
+================================================================================
+`;
+
 exports[`binaryish.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -58,6 +117,63 @@ function f() {
 ================================================================================
 `;
 
+exports[`comment.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function x() {
+  throw func2
+      //comment
+      .bar();
+}
+ 
+function f() {
+  throw (
+    foo
+      // comment
+      .bar()
+  );
+}
+ 
+fn(function f() {
+  throw (
+    foo
+      // comment
+      .bar()
+  );
+});
+
+=====================================output=====================================
+function x() {
+  throw (
+    func2
+      //comment
+      .bar()
+  );
+}
+
+function f() {
+  throw (
+    foo
+      // comment
+      .bar()
+  );
+}
+
+fn(function f() {
+  throw (
+    foo
+      // comment
+      .bar()
+  );
+});
+
+================================================================================
+`;
+
 exports[`comment.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]
@@ -110,6 +226,65 @@ fn(function f() {
       .bar()
   );
 });
+
+================================================================================
+`;
+
+exports[`jsx.js - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function foo() {
+  throw <Bar />;
+}
+
+function foo() {
+  throw <Bar>baz</Bar>;
+}
+
+function foo() {
+  throw <Bar baz={baz} />;
+}
+
+function foo() {
+  throw <Bar baz={baz}>foo</Bar>;
+}
+
+function foo() {
+  throw <></>;
+}
+
+function foo() {
+  throw <>foo</>;
+}
+
+=====================================output=====================================
+function foo() {
+  throw <Bar />;
+}
+
+function foo() {
+  throw <Bar>baz</Bar>;
+}
+
+function foo() {
+  throw <Bar baz={baz} />;
+}
+
+function foo() {
+  throw <Bar baz={baz}>foo</Bar>;
+}
+
+function foo() {
+  throw <></>;
+}
+
+function foo() {
+  throw <>foo</>;
+}
 
 ================================================================================
 `;

--- a/tests/format/js/throw_statement/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/throw_statement/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`binaryish.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`binaryish.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -117,9 +117,9 @@ function f() {
 ================================================================================
 `;
 
-exports[`comment.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`comment.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -230,9 +230,9 @@ fn(function f() {
 ================================================================================
 `;
 
-exports[`jsx.js - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`jsx.js - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["babel", "flow", "typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/js/throw_statement/jsfmt.spec.js
+++ b/tests/format/js/throw_statement/jsfmt.spec.js
@@ -1,1 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
+run_spec(import.meta, ["babel", "flow", "typescript"], {
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/js/throw_statement/jsfmt.spec.js
+++ b/tests/format/js/throw_statement/jsfmt.spec.js
@@ -1,4 +1,4 @@
 run_spec(import.meta, ["babel", "flow", "typescript"]);
 run_spec(import.meta, ["babel", "flow", "typescript"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/jsx/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/jsx/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -234,6 +234,85 @@ const TodoList = ({ todos }) => (
 ================================================================================
 `;
 
+exports[`array-iter.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+const UsersList = ({ users }) => (
+  <section>
+    <h2>Users list</h2>
+    <ul>
+      {users.map(user => (
+        <li key={user.id}>{user.name}</li>
+      ))}
+    </ul>
+  </section>
+)
+
+const TodoList = ({ todos }) => (
+  <div className="TodoList">
+    <ul>{_.map(todos, (todo, i) => <TodoItem key={i} {...todo} />)}</ul>
+  </div>
+);
+
+<div className="search-filter-chips">
+    {scopes
+        .filter(scope => scope.value !== '')
+        .map((scope, i) => (
+            <FilterChip
+                query={this.props.query}
+                onFilterChosen={this.onSearchScopeClicked}
+                key={i}
+                value={scope.value}
+                name={scope.name}
+            />
+        ))}
+</div>
+
+=====================================output=====================================
+const UsersList = ({ users }) => (
+  <section>
+    <h2>Users list</h2>
+    <ul>
+      {users.map((user) => (
+        <li key={user.id}>{user.name}</li>
+      ))}
+    </ul>
+  </section>
+);
+
+const TodoList = ({ todos }) => (
+  <div className='TodoList'>
+    <ul>
+      {_.map(todos, (todo, i) => (
+        <TodoItem key={i} {...todo} />
+      ))}
+    </ul>
+  </div>
+);
+
+<div className='search-filter-chips'>
+  {scopes
+    .filter((scope) => scope.value !== '')
+    .map((scope, i) => (
+      <FilterChip
+        query={this.props.query}
+        onFilterChosen={this.onSearchScopeClicked}
+        key={i}
+        value={scope.value}
+        name={scope.name}
+      />
+    ))}
+</div>;
+
+================================================================================
+`;
+
 exports[`array-iter.js - {"singleQuote":true,"jsxSingleQuote":true} format 1`] = `
 ====================================options=====================================
 jsxSingleQuote: true
@@ -467,6 +546,83 @@ singleQuote: false
 exports[`attr-comments.js - {"singleQuote":true,"jsxSingleQuote":false} format 1`] = `
 ====================================options=====================================
 jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+<Component
+  propFn={
+    // comment
+    function(arg) {
+      fn(arg);
+    }
+  }
+  propArrowFn={
+    // comment
+    arg => fn(arg)
+  }
+  propArrowWithBreak={
+    // comment
+    arg =>
+      fn({
+        makeItBreak
+      })
+  }
+  propArray={
+    // comment
+    [el1, el2]
+  }
+  propObj={
+    // comment
+    { key: val }
+  }
+  propTemplate={
+    // comment
+    \`text\`
+  }
+/>;
+
+=====================================output=====================================
+<Component
+  propFn={
+    // comment
+    function (arg) {
+      fn(arg);
+    }
+  }
+  propArrowFn={
+    // comment
+    (arg) => fn(arg)
+  }
+  propArrowWithBreak={
+    // comment
+    (arg) =>
+      fn({
+        makeItBreak,
+      })
+  }
+  propArray={
+    // comment
+    [el1, el2]
+  }
+  propObj={
+    // comment
+    { key: val }
+  }
+  propTemplate={
+    // comment
+    \`text\`
+  }
+/>;
+
+================================================================================
+`;
+
+exports[`attr-comments.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
 singleQuote: true
@@ -815,6 +971,105 @@ async function testFunction() {
 exports[`await.js - {"singleQuote":true,"jsxSingleQuote":false} format 1`] = `
 ====================================options=====================================
 jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+async function testFunction() {
+  const short = <>
+    {await Promise.all(
+      hierarchyCriticism
+    )}
+    {await hierarchyCriticism.ic.me.oa.p}
+    {await hierarchyCriticism}
+
+    {Promise.all(
+      hierarchyCriticism
+    )}
+    {hierarchyCriticism.ic.me.oa.p}
+    {hierarchyCriticism}
+  </>
+
+  const long = <>
+    {await Promise.all(
+      hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+    )}
+    {await hierarchyCriticism.IncongruousCooperate.MaterialEducation.OriginalArticulate.Parameter}
+    {await hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter}
+
+    {Promise.all(
+      hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+    )}
+    {hierarchyCriticism.IncongruousCooperate.MaterialEducation.OriginalArticulate.Parameter}
+    {hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter}
+  </>
+
+  const jsx = <>
+    {await (<IncongruousCooperate>
+      material education original articulate parameter
+    </IncongruousCooperate>)}
+  </>
+}
+
+=====================================output=====================================
+async function testFunction() {
+  const short = (
+    <>
+      {await Promise.all(hierarchyCriticism)}
+      {await hierarchyCriticism.ic.me.oa.p}
+      {await hierarchyCriticism}
+
+      {Promise.all(hierarchyCriticism)}
+      {hierarchyCriticism.ic.me.oa.p}
+      {hierarchyCriticism}
+    </>
+  );
+
+  const long = (
+    <>
+      {await Promise.all(
+        hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter,
+      )}
+      {
+        await hierarchyCriticism.IncongruousCooperate.MaterialEducation
+          .OriginalArticulate.Parameter
+      }
+      {
+        await hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+      }
+
+      {Promise.all(
+        hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter,
+      )}
+      {
+        hierarchyCriticism.IncongruousCooperate.MaterialEducation
+          .OriginalArticulate.Parameter
+      }
+      {
+        hierarchyCriticismIncongruousCooperateMaterialEducationOriginalArticulateParameter
+      }
+    </>
+  );
+
+  const jsx = (
+    <>
+      {await (
+        <IncongruousCooperate>
+          material education original articulate parameter
+        </IncongruousCooperate>
+      )}
+    </>
+  );
+}
+
+================================================================================
+`;
+
+exports[`await.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
 singleQuote: true
@@ -1959,6 +2214,324 @@ foo ? (
 ================================================================================
 `;
 
+exports[`conditional-expression.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+// There are two ways to print ConditionalExpressions: "normal mode" and
+// "JSX mode". This is normal mode (when breaking):
+//
+//   test
+//     ? consequent
+//     : alternate;
+//
+// And this is JSX mode (when breaking):
+//
+//   test ? (
+//     consequent
+//   ) : (
+//     alternate
+//   );
+//
+// When non-breaking, they look the same:
+//
+//  test ? consequent : alternate;
+//
+// We only print a conditional expression in JSX mode if its test,
+// consequent, or alternate are JSXElements.
+// Otherwise, we print in normal mode.
+
+// This ConditionalExpression has no JSXElements so it prints in normal mode.
+// The line does not break.
+normalModeNonBreaking ? "a" : "b";
+
+// This ConditionalExpression has no JSXElements so it prints in normal mode.
+// Its consequent is very long, so it breaks out to multiple lines.
+normalModeBreaking
+  ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
+  : "c";
+
+// This ConditionalExpression prints in JSX mode because its test is a
+// JSXElement. It is non-breaking.
+// Note: I have never, ever seen someone use a JSXElement as the test in a
+// ConditionalExpression. But this test is included for completeness.
+<div /> ? jsxModeFromElementNonBreaking : "a";
+
+// This ConditionalExpression prints in JSX mode because its consequent is a
+// JSXElement. It is non-breaking.
+jsxModeFromElementNonBreaking ? <div /> : "a";
+
+// This ConditionalExpression prints in JSX mode because its alternate is a
+// JSXElement. It is non-breaking.
+jsxModeFromElementNonBreaking ? "a" : <div />;
+
+// This ConditionalExpression prints in JSX mode because its test is a
+// JSXElement. It is breaking.
+// Note: I have never, ever seen someone use a JSXElement as the test in a
+// ConditionalExpression. But this test is included for completeness.
+<div>
+  <span>thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo</span>
+</div>  ? (
+  "jsx mode from element breaking"
+) : (
+  "a"
+);
+
+// This ConditionalExpression prints in JSX mode because its consequent is a
+// JSXElement. It is breaking.
+jsxModeFromElementBreaking ? (
+  <div>
+    <span>thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo</span>
+  </div>
+) : (
+  "a"
+);
+
+// This ConditionalExpression prints in JSX mode because its alternate is a
+// JSXElement. It is breaking.
+jsxModeFromElementBreaking ? (
+  "a"
+) : (
+  <div>
+    <span>thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo</span>
+  </div>
+);
+
+// This chain of ConditionalExpressions prints in JSX mode because the parent of
+// the outermost ConditionalExpression is a JSXExpressionContainer. It is
+// non-breaking.
+<div>
+  {a ? "a" : b ? "b" : "c"}
+</div>;
+
+// This chain of ConditionalExpressions prints in JSX mode because the parent of
+// the outermost ConditionalExpression is a JSXExpressionContainer. It is
+// breaking.
+<div>
+  {thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo ? "a" : b ? "b" : "c"}
+</div>;
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain. It is non-breaking.
+cable ? "satellite" : isPublic ? "affairs" : network ? <span id="c" /> : "dun";
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain (in this case, at the end). It is
+// breaking; notice the consequents and alternates in the entire chain get
+// wrapped in parens.
+cable ? (
+  "satellite"
+) : isPublic ? (
+  "affairs"
+) : network ? (
+  <div>
+    <span>thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo</span>
+  </div>
+) : "dunno";
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain (in this case, at the beginning). It is
+// breaking; notice the consequents and alternates in the entire chain get
+// wrapped in parens.
+cable ? (
+  <div>
+    <span>thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo</span>
+  </div>
+) : sateline ? (
+  "public"
+) : affairs ? (
+  "network"
+) : "dunno";
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain. It is breaking; notice the consequents
+// and alternates in the entire chain get wrapped in parens.
+<div>
+  {properties.length > 1 ||
+  (properties.length === 1 && properties[0].apps.size > 1) ? (
+    draggingApp == null || newPropertyName == null ? (
+      <MigrationPropertyListItem />
+    ) : (
+      <MigrationPropertyListItem apps={Immutable.List()} />
+    )
+  ) : null}
+</div>;
+
+// #3552
+foo ? <span>loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong jsx</span> :
+undefined
+
+=====================================output=====================================
+// There are two ways to print ConditionalExpressions: "normal mode" and
+// "JSX mode". This is normal mode (when breaking):
+//
+//   test
+//     ? consequent
+//     : alternate;
+//
+// And this is JSX mode (when breaking):
+//
+//   test ? (
+//     consequent
+//   ) : (
+//     alternate
+//   );
+//
+// When non-breaking, they look the same:
+//
+//  test ? consequent : alternate;
+//
+// We only print a conditional expression in JSX mode if its test,
+// consequent, or alternate are JSXElements.
+// Otherwise, we print in normal mode.
+
+// This ConditionalExpression has no JSXElements so it prints in normal mode.
+// The line does not break.
+normalModeNonBreaking ? 'a' : 'b';
+
+// This ConditionalExpression has no JSXElements so it prints in normal mode.
+// Its consequent is very long, so it breaks out to multiple lines.
+normalModeBreaking
+  ? johnJacobJingleHeimerSchmidtHisNameIsMyNameTooWheneverWeGoOutThePeopleAlwaysShoutThereGoesJohnJacobJingleHeimerSchmidtYaDaDaDaDaDaDa
+  : 'c';
+
+// This ConditionalExpression prints in JSX mode because its test is a
+// JSXElement. It is non-breaking.
+// Note: I have never, ever seen someone use a JSXElement as the test in a
+// ConditionalExpression. But this test is included for completeness.
+<div /> ? jsxModeFromElementNonBreaking : 'a';
+
+// This ConditionalExpression prints in JSX mode because its consequent is a
+// JSXElement. It is non-breaking.
+jsxModeFromElementNonBreaking ? <div /> : 'a';
+
+// This ConditionalExpression prints in JSX mode because its alternate is a
+// JSXElement. It is non-breaking.
+jsxModeFromElementNonBreaking ? 'a' : <div />;
+
+// This ConditionalExpression prints in JSX mode because its test is a
+// JSXElement. It is breaking.
+// Note: I have never, ever seen someone use a JSXElement as the test in a
+// ConditionalExpression. But this test is included for completeness.
+<div>
+  <span>
+    thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo
+  </span>
+</div> ? (
+  'jsx mode from element breaking'
+) : (
+  'a'
+);
+
+// This ConditionalExpression prints in JSX mode because its consequent is a
+// JSXElement. It is breaking.
+jsxModeFromElementBreaking ? (
+  <div>
+    <span>
+      thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo
+    </span>
+  </div>
+) : (
+  'a'
+);
+
+// This ConditionalExpression prints in JSX mode because its alternate is a
+// JSXElement. It is breaking.
+jsxModeFromElementBreaking ? (
+  'a'
+) : (
+  <div>
+    <span>
+      thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo
+    </span>
+  </div>
+);
+
+// This chain of ConditionalExpressions prints in JSX mode because the parent of
+// the outermost ConditionalExpression is a JSXExpressionContainer. It is
+// non-breaking.
+<div>{a ? 'a' : b ? 'b' : 'c'}</div>;
+
+// This chain of ConditionalExpressions prints in JSX mode because the parent of
+// the outermost ConditionalExpression is a JSXExpressionContainer. It is
+// breaking.
+<div>
+  {thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo
+    ? 'a'
+    : b
+    ? 'b'
+    : 'c'}
+</div>;
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain. It is non-breaking.
+cable ? 'satellite' : isPublic ? 'affairs' : network ? <span id='c' /> : 'dun';
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain (in this case, at the end). It is
+// breaking; notice the consequents and alternates in the entire chain get
+// wrapped in parens.
+cable ? (
+  'satellite'
+) : isPublic ? (
+  'affairs'
+) : network ? (
+  <div>
+    <span>
+      thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo
+    </span>
+  </div>
+) : (
+  'dunno'
+);
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain (in this case, at the beginning). It is
+// breaking; notice the consequents and alternates in the entire chain get
+// wrapped in parens.
+cable ? (
+  <div>
+    <span>
+      thisIsASongAboutYourPoorSickPenguinHeHasAFeverAndHisToesAreBlueButIfISingToYourPoorSickPenguinHeWillFeelBetterInADayOrTwo
+    </span>
+  </div>
+) : sateline ? (
+  'public'
+) : affairs ? (
+  'network'
+) : (
+  'dunno'
+);
+
+// This chain of ConditionalExpressions prints in JSX mode because there is a
+// JSX element somewhere in the chain. It is breaking; notice the consequents
+// and alternates in the entire chain get wrapped in parens.
+<div>
+  {properties.length > 1
+  || (properties.length === 1 && properties[0].apps.size > 1) ? (
+    draggingApp == null || newPropertyName == null ? (
+      <MigrationPropertyListItem />
+    ) : (
+      <MigrationPropertyListItem apps={Immutable.List()} />
+    )
+  ) : null}
+</div>;
+
+// #3552
+foo ? (
+  <span>
+    loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong jsx
+  </span>
+) : undefined;
+
+================================================================================
+`;
+
 exports[`conditional-expression.js - {"singleQuote":true,"jsxSingleQuote":true} format 1`] = `
 ====================================options=====================================
 jsxSingleQuote: true
@@ -3008,6 +3581,251 @@ singleQuote: true
 ================================================================================
 `;
 
+exports[`expression.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+<View
+  style={
+    {
+      someVeryLongStyle1: "true",
+      someVeryLongStyle2: "true",
+      someVeryLongStyle3: "true",
+      someVeryLongStyle4: "true"
+    }
+  }
+/>;
+
+<View
+  style={
+    [
+      {
+        someVeryLongStyle1: "true",
+        someVeryLongStyle2: "true",
+        someVeryLongStyle3: "true",
+        someVeryLongStyle4: "true"
+      }
+    ]
+  }
+/>;
+
+<Something>
+  {() => (
+    <SomethingElse>
+      <span />
+    </SomethingElse>
+  )}
+</Something>;
+
+<Something>
+  {items.map(item => (
+    <SomethingElse>
+      <span />
+    </SomethingElse>
+  ))}
+</Something>;
+
+<Something>
+  {function() {
+    return (
+      <SomethingElse>
+        <span />
+      </SomethingElse>
+    );
+  }}
+</Something>;
+
+<RadioListItem
+  key={option}
+  imageSource={this.props.veryBigItemImageSourceFunc &&
+    this.props.veryBigItemImageSourceFunc(option)}
+  imageSize={this.props.veryBigItemImageSize}
+  imageView={this.props.veryBigItemImageViewFunc &&
+    this.props.veryBigItemImageViewFunc(option)}
+  heading={this.props.displayTextFunc(option)}
+  value={option}
+/>;
+
+<ParentComponent prop={
+  <Child>
+    test
+  </Child>
+}/>;
+
+<BookingIntroPanel
+  prop="long_string_make_to_force_break"
+  logClick={data => doLogClick("short", "short", data)}
+/>;
+
+<BookingIntroPanel
+  logClick={data =>
+    doLogClick("long_name_long_name_long_name", "long_name_long_name_long_name", data)
+  }
+/>;
+
+<BookingIntroPanel
+  logClick={data => {
+    doLogClick("long_name_long_name_long_name", "long_name_long_name_long_name", data)
+  }}
+/>;
+
+<BookingIntroPanel>
+  {data => doLogClick("short", "short", data)}
+</BookingIntroPanel>;
+
+<BookingIntroPanel>
+  {data =>
+    doLogClick("long_name_long_name_long_name", "long_name_long_name_long_name", data)
+  }
+</BookingIntroPanel>;
+
+<BookingIntroPanel>
+  {data => {
+    doLogClick("long_name_long_name_long_name", "long_name_long_name_long_name", data)
+  }}
+</BookingIntroPanel>;
+
+<SuspendyTree>
+  <div style={{ height: 200, overflow: "scroll" }}>
+    {Array(20)
+      .fill()
+      .map((_, i) => (
+        <h2 key={i}>{i + 1}</h2>
+      ))}
+  </div>
+</SuspendyTree>;
+
+=====================================output=====================================
+<View
+  style={{
+    someVeryLongStyle1: 'true',
+    someVeryLongStyle2: 'true',
+    someVeryLongStyle3: 'true',
+    someVeryLongStyle4: 'true',
+  }}
+/>;
+
+<View
+  style={[
+    {
+      someVeryLongStyle1: 'true',
+      someVeryLongStyle2: 'true',
+      someVeryLongStyle3: 'true',
+      someVeryLongStyle4: 'true',
+    },
+  ]}
+/>;
+
+<Something>
+  {() => (
+    <SomethingElse>
+      <span />
+    </SomethingElse>
+  )}
+</Something>;
+
+<Something>
+  {items.map((item) => (
+    <SomethingElse>
+      <span />
+    </SomethingElse>
+  ))}
+</Something>;
+
+<Something>
+  {function () {
+    return (
+      <SomethingElse>
+        <span />
+      </SomethingElse>
+    );
+  }}
+</Something>;
+
+<RadioListItem
+  key={option}
+  imageSource={
+    this.props.veryBigItemImageSourceFunc
+    && this.props.veryBigItemImageSourceFunc(option)
+  }
+  imageSize={this.props.veryBigItemImageSize}
+  imageView={
+    this.props.veryBigItemImageViewFunc
+    && this.props.veryBigItemImageViewFunc(option)
+  }
+  heading={this.props.displayTextFunc(option)}
+  value={option}
+/>;
+
+<ParentComponent prop={<Child>test</Child>} />;
+
+<BookingIntroPanel
+  prop='long_string_make_to_force_break'
+  logClick={(data) => doLogClick('short', 'short', data)}
+/>;
+
+<BookingIntroPanel
+  logClick={(data) =>
+    doLogClick(
+      'long_name_long_name_long_name',
+      'long_name_long_name_long_name',
+      data,
+    )
+  }
+/>;
+
+<BookingIntroPanel
+  logClick={(data) => {
+    doLogClick(
+      'long_name_long_name_long_name',
+      'long_name_long_name_long_name',
+      data,
+    );
+  }}
+/>;
+
+<BookingIntroPanel>
+  {(data) => doLogClick('short', 'short', data)}
+</BookingIntroPanel>;
+
+<BookingIntroPanel>
+  {(data) =>
+    doLogClick(
+      'long_name_long_name_long_name',
+      'long_name_long_name_long_name',
+      data,
+    )
+  }
+</BookingIntroPanel>;
+
+<BookingIntroPanel>
+  {(data) => {
+    doLogClick(
+      'long_name_long_name_long_name',
+      'long_name_long_name_long_name',
+      data,
+    );
+  }}
+</BookingIntroPanel>;
+
+<SuspendyTree>
+  <div style={{ height: 200, overflow: 'scroll' }}>
+    {Array(20)
+      .fill()
+      .map((_, i) => (
+        <h2 key={i}>{i + 1}</h2>
+      ))}
+  </div>
+</SuspendyTree>;
+
+================================================================================
+`;
+
 exports[`expression.js - {"singleQuote":true,"jsxSingleQuote":true} format 1`] = `
 ====================================options=====================================
 jsxSingleQuote: true
@@ -3324,6 +4142,31 @@ const aDiv = (
 ================================================================================
 `;
 
+exports[`flow_fix_me.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+const aDiv = (
+  /* $FlowFixMe */
+  <div className="foo">
+    Foo bar
+  </div>
+);
+
+=====================================output=====================================
+const aDiv = (
+  /* $FlowFixMe */
+  <div className='foo'>Foo bar</div>
+);
+
+================================================================================
+`;
+
 exports[`flow_fix_me.js - {"singleQuote":true,"jsxSingleQuote":true} format 1`] = `
 ====================================options=====================================
 jsxSingleQuote: true
@@ -3404,6 +4247,27 @@ export default () => <a href="https://foo.bar?q1=foo&q2=bar" />;
 export default () => <a href="https://foo.bar?q1=foo&q2=bar" />;
 
 () => <img src="https://bar.foo?param1=1&param2=2" />;
+
+================================================================================
+`;
+
+exports[`html_escape.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+export default () => <a href="https://foo.bar?q1=foo&q2=bar" />;
+
+() => <img src="https://bar.foo?param1=1&param2=2" />;
+
+=====================================output=====================================
+export default () => <a href='https://foo.bar?q1=foo&q2=bar' />;
+
+() => <img src='https://bar.foo?param1=1&param2=2' />;
 
 ================================================================================
 `;
@@ -3669,6 +4533,89 @@ singleQuote: true
 <div>
   {member.memberName.memberSomething +
     (member.memberDef.memberSomething.signatures ? '()' : '')}
+</div>;
+
+================================================================================
+`;
+
+exports[`hug.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+<div>
+  {__DEV__
+    ? this.renderDevApp()
+    : <div>
+      {routes.map(route => (
+        <MatchAsync
+          key={\`\${route.to}-async\`}
+          pattern={route.to}
+          exactly={route.to === "/"}
+          getComponent={routeES6Modules[route.value]}
+        />
+      ))}
+    </div>}
+</div>;
+
+<div>
+  {__DEV__ && <div>
+    {routes.map(route => (
+      <MatchAsync
+        key={\`\${route.to}-async\`}
+        pattern={route.to}
+        exactly={route.to === "/"}
+        getComponent={routeES6Modules[route.value]}
+      />
+    ))}
+    </div>}
+</div>;
+
+<div>
+  {member.memberName.memberSomething +
+    (member.memberDef.memberSomething.signatures ? '()' : '')}
+</div>
+
+=====================================output=====================================
+<div>
+  {__DEV__ ? (
+    this.renderDevApp()
+  ) : (
+    <div>
+      {routes.map((route) => (
+        <MatchAsync
+          key={\`\${route.to}-async\`}
+          pattern={route.to}
+          exactly={route.to === '/'}
+          getComponent={routeES6Modules[route.value]}
+        />
+      ))}
+    </div>
+  )}
+</div>;
+
+<div>
+  {__DEV__ && (
+    <div>
+      {routes.map((route) => (
+        <MatchAsync
+          key={\`\${route.to}-async\`}
+          pattern={route.to}
+          exactly={route.to === '/'}
+          getComponent={routeES6Modules[route.value]}
+        />
+      ))}
+    </div>
+  )}
+</div>;
+
+<div>
+  {member.memberName.memberSomething
+    + (member.memberDef.memberSomething.signatures ? '()' : '')}
 </div>;
 
 ================================================================================
@@ -3990,6 +4937,85 @@ singleQuote: true
 ================================================================================
 `;
 
+exports[`logical-expression.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+<div>
+  {a || "b"}
+</div>;
+
+<div>
+  {a && "b"}
+</div>;
+
+<div>
+  {a || <span></span>}
+</div>;
+
+<div>
+  {a && <span></span>}
+</div>;
+
+<div>
+  {a && <span>make this text just so long enough to break this to the next line</span>}
+</div>;
+
+<div>
+  {a && b && <span>make this text just so long enough to break this to the next line</span>}
+</div>;
+
+<div>
+  {a && <span>
+    <div>
+      <div></div>
+    </div>
+  </span>}
+</div>;
+
+=====================================output=====================================
+<div>{a || 'b'}</div>;
+
+<div>{a && 'b'}</div>;
+
+<div>{a || <span></span>}</div>;
+
+<div>{a && <span></span>}</div>;
+
+<div>
+  {a && (
+    <span>
+      make this text just so long enough to break this to the next line
+    </span>
+  )}
+</div>;
+
+<div>
+  {a && b && (
+    <span>
+      make this text just so long enough to break this to the next line
+    </span>
+  )}
+</div>;
+
+<div>
+  {a && (
+    <span>
+      <div>
+        <div></div>
+      </div>
+    </span>
+  )}
+</div>;
+
+================================================================================
+`;
+
 exports[`logical-expression.js - {"singleQuote":true,"jsxSingleQuote":true} format 1`] = `
 ====================================options=====================================
 jsxSingleQuote: true
@@ -4188,6 +5214,47 @@ const tabs = [
 ================================================================================
 `;
 
+exports[`object-property.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+const tabs = [
+  {
+    title: "General Info",
+    content: (
+      <GeneralForm
+        long-attribute="i-need-long-value-here"
+        onSave={ onSave }
+        onCancel={ onCancel }
+        countries={ countries }
+      />
+    )
+  }
+];
+
+=====================================output=====================================
+const tabs = [
+  {
+    title: 'General Info',
+    content: (
+      <GeneralForm
+        long-attribute='i-need-long-value-here'
+        onSave={onSave}
+        onCancel={onCancel}
+        countries={countries}
+      />
+    ),
+  },
+];
+
+================================================================================
+`;
+
 exports[`object-property.js - {"singleQuote":true,"jsxSingleQuote":true} format 1`] = `
 ====================================options=====================================
 jsxSingleQuote: true
@@ -4353,6 +5420,51 @@ onClick={() => {
 >
   {header}
   <showSort attr="long long long long long long long long long long long" />
+</td>;
+
+<Foo>{\`    a    very    long    text    that    does    not    break    \`}</Foo>;
+
+================================================================================
+`;
+
+exports[`open-break.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+<td
+onClick={() => {
+  a
+}}>{header}{showSort}</td>;
+
+<td
+onClick={() => {
+  a
+}}>{header}<showSort attr="long long long long long long long long long long long"/></td>;
+
+<Foo>{\`    a    very    long    text    that    does    not    break    \`}</Foo>;
+
+=====================================output=====================================
+<td
+  onClick={() => {
+    a;
+  }}
+>
+  {header}
+  {showSort}
+</td>;
+
+<td
+  onClick={() => {
+    a;
+  }}
+>
+  {header}
+  <showSort attr='long long long long long long long long long long long' />
 </td>;
 
 <Foo>{\`    a    very    long    text    that    does    not    break    \`}</Foo>;
@@ -4545,6 +5657,59 @@ a = [
   <path
     key="1"
     d="M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,"
+  />,
+];
+
+<div {...(foo || foo === null ? { foo } : null)} />;
+
+f?.(<div />);
+(<div />)();
+(<div />)?.();
+
+new Foo(<Component />);
+new Foo(<Component />);
+
+================================================================================
+`;
+
+exports[`parens.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+a = [
+  <path
+    key='0'
+    d='M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,'
+  />,
+  <path
+    key='1'
+    d='M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,'
+  />,
+];
+
+<div {...((foo || foo === null) ? {foo} : null)} />
+
+f?.(<div/>);
+(<div/>)();
+(<div/>)?.();
+
+new Foo(<Component/>);
+new Foo((<Component/>))
+
+=====================================output=====================================
+a = [
+  <path
+    key='0'
+    d='M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,'
+  />,
+  <path
+    key='1'
+    d='M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,M13.6,10.6l,4-2.8L9.5,'
   />,
 ];
 
@@ -4882,6 +6047,97 @@ singleQuote: true
 ================================================================================
 `;
 
+exports[`quotes.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+<div id="&quot;'<>&amp;quot;" />;
+<div id='"&#39;<>&amp;quot;' />;
+<div id={'\\'"&quot;<>&amp;quot;'} />;
+<div id='123' />;
+<div id='&#39;&quot;' />;
+<div id={'\\'\\"\\\\\\''} />;
+<div
+  single='foo'
+  single2={'foo'}
+
+  double="bar"
+  double2={"bar"}
+
+  singleDouble='"'
+  singleDouble2={'"'}
+
+  doubleSingle="'"
+  doubleSingle2={"'"}
+
+  singleEscaped={'\\''}
+  singleEscaped2='&apos;'
+
+  doubleEscaped={"\\""}
+  doubleEscaped2="&quot;"
+
+  singleBothEscaped={'\\'"'}
+  singleBothEscaped2='&apos;"'
+
+  singleBoth='&apos; "'
+  singleBoth2={'\\' "'}
+  singleBoth3='&apos; &apos; "'
+
+  doubleBoth="&quot; '"
+  doubleBoth2={"\\" '"}
+  doubleBoth3="&quot; &apos; '"
+/>;
+
+<p>
+  GitHub Desktop has encountered an unrecoverable error and will need to 1231231
+  restart. This has been reported to the team, but if youencounter this121312331
+  repeatedly please report this issue to the GitHub 12312312312312313{'  '}{' '}
+</p>
+
+=====================================output=====================================
+<div id='"&apos;<>&amp;quot;' />;
+<div id='"&#39;<>&amp;quot;' />;
+<div id={'\\'"&quot;<>&amp;quot;'} />;
+<div id='123' />;
+<div id='&#39;"' />;
+<div id={"'\\"\\\\'"} />;
+<div
+  single='foo'
+  single2={'foo'}
+  double='bar'
+  double2={'bar'}
+  singleDouble='"'
+  singleDouble2={'"'}
+  doubleSingle="'"
+  doubleSingle2={"'"}
+  singleEscaped={"'"}
+  singleEscaped2="'"
+  doubleEscaped={'"'}
+  doubleEscaped2='"'
+  singleBothEscaped={'\\'"'}
+  singleBothEscaped2='&apos;"'
+  singleBoth='&apos; "'
+  singleBoth2={'\\' "'}
+  singleBoth3="' ' &quot;"
+  doubleBoth='" &apos;'
+  doubleBoth2={'" \\''}
+  doubleBoth3="&quot; ' '"
+/>;
+
+<p>
+  GitHub Desktop has encountered an unrecoverable error and will need to 1231231
+  restart. This has been reported to the team, but if youencounter this121312331
+  repeatedly please report this issue to the GitHub 12312312312312313{'  '}{' '}
+</p>;
+
+================================================================================
+`;
+
 exports[`quotes.js - {"singleQuote":true,"jsxSingleQuote":true} format 1`] = `
 ====================================options=====================================
 jsxSingleQuote: true
@@ -5019,6 +6275,29 @@ x = <a>{/w/.test(s)}</a>;
 exports[`regex.js - {"singleQuote":true,"jsxSingleQuote":false} format 1`] = `
 ====================================options=====================================
 jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+x = <div>one</div>, <div>two</div>;
+x = <a>{}</a>
+x = <a>{1/2}</a>
+x = <a>{/w/.test(s)}</a>
+
+=====================================output=====================================
+(x = <div>one</div>), (<div>two</div>);
+x = <a>{}</a>;
+x = <a>{1 / 2}</a>;
+x = <a>{/w/.test(s)}</a>;
+
+================================================================================
+`;
+
+exports[`regex.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
 singleQuote: true
@@ -5402,6 +6681,121 @@ class BreakingClass extends React.component {
 ================================================================================
 `;
 
+exports[`return-statement.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+const NonBreakingArrowExpression = () => <div />;
+
+const BreakingArrowExpression = () => <div>
+  <div>
+    bla bla bla
+  </div>
+</div>;
+
+const NonBreakingArrowExpressionWBody = () => {
+  return (
+    <div />
+  );
+};
+
+const BreakingArrowExpressionWBody = () => {
+  return <div>
+    <div>
+      bla bla bla
+    </div>
+  </div>
+};
+
+const NonBreakingFunction = function() {
+  return (
+    <div />
+  );
+};
+
+const BreakingFunction = function() {
+  return <div>
+    <div>
+      bla bla bla
+    </div>
+  </div>
+};
+
+class NonBreakingClass extends React.component {
+  render() {
+    return (
+      <div />
+    );
+  }
+}
+
+class BreakingClass extends React.component {
+  render() {
+    return <div>
+      <div>
+        bla bla bla
+      </div>
+    </div>;
+  }
+}
+
+=====================================output=====================================
+const NonBreakingArrowExpression = () => <div />;
+
+const BreakingArrowExpression = () => (
+  <div>
+    <div>bla bla bla</div>
+  </div>
+);
+
+const NonBreakingArrowExpressionWBody = () => {
+  return <div />;
+};
+
+const BreakingArrowExpressionWBody = () => {
+  return (
+    <div>
+      <div>bla bla bla</div>
+    </div>
+  );
+};
+
+const NonBreakingFunction = function () {
+  return <div />;
+};
+
+const BreakingFunction = function () {
+  return (
+    <div>
+      <div>bla bla bla</div>
+    </div>
+  );
+};
+
+class NonBreakingClass extends React.component {
+  render() {
+    return <div />;
+  }
+}
+
+class BreakingClass extends React.component {
+  render() {
+    return (
+      <div>
+        <div>bla bla bla</div>
+      </div>
+    );
+  }
+}
+
+================================================================================
+`;
+
 exports[`return-statement.js - {"singleQuote":true,"jsxSingleQuote":true} format 1`] = `
 ====================================options=====================================
 jsxSingleQuote: true
@@ -5570,6 +6964,25 @@ singleQuote: true
 ================================================================================
 `;
 
+exports[`self-closing.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+<Foo></Foo>;
+<Bar />;
+
+=====================================output=====================================
+<Foo></Foo>;
+<Bar />;
+
+================================================================================
+`;
+
 exports[`self-closing.js - {"singleQuote":true,"jsxSingleQuote":true} format 1`] = `
 ====================================options=====================================
 jsxSingleQuote: true
@@ -5671,6 +7084,47 @@ const Labels = {
 exports[`spacing.js - {"singleQuote":true,"jsxSingleQuote":false} format 1`] = `
 ====================================options=====================================
 jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+const Labels = {
+  label1: (
+    <fbt>
+      Label 1
+    </fbt>
+  ),
+
+  label2: (
+    <fbt>
+      Label 2
+    </fbt>
+  ),
+
+  label3: (
+    <fbt>
+      Label 3
+    </fbt>
+  ),
+};
+
+=====================================output=====================================
+const Labels = {
+  label1: <fbt>Label 1</fbt>,
+
+  label2: <fbt>Label 2</fbt>,
+
+  label3: <fbt>Label 3</fbt>,
+};
+
+================================================================================
+`;
+
+exports[`spacing.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
 singleQuote: true
@@ -5844,6 +7298,39 @@ singleQuote: true
 ================================================================================
 `;
 
+exports[`template-literal-in-attr.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+  <div>
+    <div>
+    <div
+          className="js-structured-feedback js-trigger-feedback-negative-reasons item-feedback-button"
+          data-feedback-tags-url={\`/xhr/negative-feedback-tags/\${this.props.item.id}\`}
+        >foo</div>
+</div>
+</div>
+
+=====================================output=====================================
+<div>
+  <div>
+    <div
+      className='js-structured-feedback js-trigger-feedback-negative-reasons item-feedback-button'
+      data-feedback-tags-url={\`/xhr/negative-feedback-tags/\${this.props.item.id}\`}
+    >
+      foo
+    </div>
+  </div>
+</div>;
+
+================================================================================
+`;
+
 exports[`template-literal-in-attr.js - {"singleQuote":true,"jsxSingleQuote":true} format 1`] = `
 ====================================options=====================================
 jsxSingleQuote: true
@@ -5911,6 +7398,23 @@ a == 3 ? (a = <h1>123</h1>) : (a = <h1>abc</h1>);
 exports[`ternary.js - {"singleQuote":true,"jsxSingleQuote":false} format 1`] = `
 ====================================options=====================================
 jsxSingleQuote: false
+parsers: ["flow", "babel", "typescript"]
+printWidth: 80
+singleQuote: true
+                                                                                | printWidth
+=====================================input======================================
+a == 3 ? (a = <h1>123</h1>) : (a = <h1>abc</h1>);
+
+=====================================output=====================================
+a == 3 ? (a = <h1>123</h1>) : (a = <h1>abc</h1>);
+
+================================================================================
+`;
+
+exports[`ternary.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
 singleQuote: true

--- a/tests/format/jsx/jsx/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/jsx/jsx/__snapshots__/jsfmt.spec.js.snap
@@ -234,9 +234,9 @@ const TodoList = ({ todos }) => (
 ================================================================================
 `;
 
-exports[`array-iter.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`array-iter.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
@@ -619,9 +619,9 @@ singleQuote: true
 ================================================================================
 `;
 
-exports[`attr-comments.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`attr-comments.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
@@ -1066,9 +1066,9 @@ async function testFunction() {
 ================================================================================
 `;
 
-exports[`await.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`await.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
@@ -2214,9 +2214,9 @@ foo ? (
 ================================================================================
 `;
 
-exports[`conditional-expression.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`conditional-expression.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
@@ -3581,9 +3581,9 @@ singleQuote: true
 ================================================================================
 `;
 
-exports[`expression.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`expression.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
@@ -4142,9 +4142,9 @@ const aDiv = (
 ================================================================================
 `;
 
-exports[`flow_fix_me.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`flow_fix_me.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
@@ -4251,9 +4251,9 @@ export default () => <a href="https://foo.bar?q1=foo&q2=bar" />;
 ================================================================================
 `;
 
-exports[`html_escape.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`html_escape.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
@@ -4538,9 +4538,9 @@ singleQuote: true
 ================================================================================
 `;
 
-exports[`hug.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`hug.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
@@ -4937,9 +4937,9 @@ singleQuote: true
 ================================================================================
 `;
 
-exports[`logical-expression.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`logical-expression.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
@@ -5214,9 +5214,9 @@ const tabs = [
 ================================================================================
 `;
 
-exports[`object-property.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`object-property.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
@@ -5427,9 +5427,9 @@ onClick={() => {
 ================================================================================
 `;
 
-exports[`open-break.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`open-break.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
@@ -5672,9 +5672,9 @@ new Foo(<Component />);
 ================================================================================
 `;
 
-exports[`parens.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`parens.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
@@ -6047,9 +6047,9 @@ singleQuote: true
 ================================================================================
 `;
 
-exports[`quotes.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`quotes.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
@@ -6294,9 +6294,9 @@ x = <a>{/w/.test(s)}</a>;
 ================================================================================
 `;
 
-exports[`regex.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`regex.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
@@ -6681,9 +6681,9 @@ class BreakingClass extends React.component {
 ================================================================================
 `;
 
-exports[`return-statement.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`return-statement.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
@@ -6964,9 +6964,9 @@ singleQuote: true
 ================================================================================
 `;
 
-exports[`self-closing.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`self-closing.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
@@ -7121,9 +7121,9 @@ const Labels = {
 ================================================================================
 `;
 
-exports[`spacing.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`spacing.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
@@ -7298,9 +7298,9 @@ singleQuote: true
 ================================================================================
 `;
 
-exports[`template-literal-in-attr.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`template-literal-in-attr.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80
@@ -7411,9 +7411,9 @@ a == 3 ? (a = <h1>123</h1>) : (a = <h1>abc</h1>);
 ================================================================================
 `;
 
-exports[`ternary.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorLocation":true} format 1`] = `
+exports[`ternary.js - {"singleQuote":true,"jsxSingleQuote":true,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 jsxSingleQuote: true
 parsers: ["flow", "babel", "typescript"]
 printWidth: 80

--- a/tests/format/jsx/jsx/jsfmt.spec.js
+++ b/tests/format/jsx/jsx/jsfmt.spec.js
@@ -17,5 +17,5 @@ run_spec(import.meta, ["flow", "babel", "typescript"], {
 run_spec(import.meta, ["flow", "babel", "typescript"], {
   singleQuote: true,
   jsxSingleQuote: true,
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/jsx/jsx/jsfmt.spec.js
+++ b/tests/format/jsx/jsx/jsfmt.spec.js
@@ -14,3 +14,8 @@ run_spec(import.meta, ["flow", "babel", "typescript"], {
   singleQuote: true,
   jsxSingleQuote: true,
 });
+run_spec(import.meta, ["flow", "babel", "typescript"], {
+  singleQuote: true,
+  jsxSingleQuote: true,
+  experimentalOperatorLocation: true,
+});

--- a/tests/format/typescript/as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/as/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`array-pattern.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`array-pattern.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -29,9 +29,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`as.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`as.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -268,9 +268,9 @@ const iter2 = createIterator(
 ================================================================================
 `;
 
-exports[`assignment.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`assignment.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -413,9 +413,9 @@ this.intervalID = setInterval(() => {
 ================================================================================
 `;
 
-exports[`assignment2.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`assignment2.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -562,9 +562,9 @@ const originalPrototype = originalConstructor.prototype as TComponent &
 ================================================================================
 `;
 
-exports[`export_default_as.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`export_default_as.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -591,9 +591,9 @@ export default (function log() {} as typeof console.log);
 ================================================================================
 `;
 
-exports[`long-identifiers.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`long-identifiers.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -674,9 +674,9 @@ averredBathersBoxroomBuggyNurl(
 ================================================================================
 `;
 
-exports[`nested-await-and-as.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`nested-await-and-as.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -729,9 +729,9 @@ const getAccountCount = async () =>
 ================================================================================
 `;
 
-exports[`return.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`return.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -778,9 +778,9 @@ function foo() {
 ================================================================================
 `;
 
-exports[`ternary.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`ternary.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/typescript/as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/as/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`array-pattern.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+[x as any] = x;
+
+=====================================output=====================================
+[x as any] = x;
+
+================================================================================
+`;
+
 exports[`array-pattern.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -10,6 +25,140 @@ printWidth: 80
 
 =====================================output=====================================
 [x as any] = x;
+
+================================================================================
+`;
+
+exports[`array-pattern.ts format 2`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+[x as any] = x;
+
+=====================================output=====================================
+[x as any] = x;
+
+================================================================================
+`;
+
+exports[`as.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const name = (description as DescriptionObject).name || (description as string);
+this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
+(originalError ? wrappedError(errMsg, originalError) : Error(errMsg)) as InjectionError;
+'current' in (props.pagination as Object);
+('current' in props.pagination) as Object;
+start + (yearSelectTotal as number);
+(start + yearSelectTotal) as number;
+scrollTop > (visibilityHeight as number);
+(scrollTop > visibilityHeight) as number;
+export default class Column<T> extends (RcTable.Column as React.ComponentClass<ColumnProps<T>,ColumnProps<T>,ColumnProps<T>,ColumnProps<T>>) {}
+export const MobxTypedForm = class extends (Form as { new (): any }) {}
+export abstract class MobxTypedForm1 extends (Form as { new (): any }) {}
+({}) as {};
+function*g() {
+  const test = (yield 'foo') as number;
+}
+async function g1() {
+  const test = (await 'foo') as number;
+}
+({}) as X;
+() => ({}) as X;
+const state = JSON.stringify({
+  next: window.location.href,
+  nonce,
+} as State);
+
+(foo.bar as Baz) = [bar];
+(foo.bar as any)++;
+
+(bValue as boolean) ? 0 : -1;
+<boolean>bValue ? 0 : -1;
+
+const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
+const value2 = thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
+const value3 = thisIsAReallyLongIdentifier as (SomeInterface | SomeOtherInterface);
+const value4 = thisIsAReallyLongIdentifier as { prop1: string, prop2: number, prop3: number }[];
+const value5 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [string, number];
+
+const iter1 = createIterator(this.controller, child, this.tag as SyncFunctionComponent);
+const iter2 = createIterator(self.controller, child, self.tag as SyncFunctionComponent);
+
+=====================================output=====================================
+const name = (description as DescriptionObject).name || (description as string);
+this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
+(originalError
+  ? wrappedError(errMsg, originalError)
+  : Error(errMsg)) as InjectionError;
+"current" in (props.pagination as Object);
+("current" in props.pagination) as Object;
+start + (yearSelectTotal as number);
+(start + yearSelectTotal) as number;
+scrollTop > (visibilityHeight as number);
+(scrollTop > visibilityHeight) as number;
+export default class Column<T> extends (RcTable.Column as React.ComponentClass<
+  ColumnProps<T>,
+  ColumnProps<T>,
+  ColumnProps<T>,
+  ColumnProps<T>
+>) {}
+export const MobxTypedForm = class extends (Form as { new (): any }) {};
+export abstract class MobxTypedForm1 extends (Form as { new (): any }) {}
+({}) as {};
+function* g() {
+  const test = (yield "foo") as number;
+}
+async function g1() {
+  const test = (await "foo") as number;
+}
+({}) as X;
+() => ({} as X);
+const state = JSON.stringify({
+  next: window.location.href,
+  nonce,
+} as State);
+
+(foo.bar as Baz) = [bar];
+(foo.bar as any)++;
+
+(bValue as boolean) ? 0 : -1;
+<boolean>bValue ? 0 : -1;
+
+const value1 =
+  thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
+const value2 =
+  thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
+const value3 = thisIsAReallyLongIdentifier as
+  | SomeInterface
+  | SomeOtherInterface;
+const value4 = thisIsAReallyLongIdentifier as {
+  prop1: string;
+  prop2: number;
+  prop3: number;
+}[];
+const value5 =
+  thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [
+    string,
+    number,
+  ];
+
+const iter1 = createIterator(
+  this.controller,
+  child,
+  this.tag as SyncFunctionComponent,
+);
+const iter2 = createIterator(
+  self.controller,
+  child,
+  self.tag as SyncFunctionComponent,
+);
 
 ================================================================================
 `;
@@ -133,6 +282,198 @@ const iter2 = createIterator(
 ================================================================================
 `;
 
+exports[`as.ts format 2`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const name = (description as DescriptionObject).name || (description as string);
+this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
+(originalError ? wrappedError(errMsg, originalError) : Error(errMsg)) as InjectionError;
+'current' in (props.pagination as Object);
+('current' in props.pagination) as Object;
+start + (yearSelectTotal as number);
+(start + yearSelectTotal) as number;
+scrollTop > (visibilityHeight as number);
+(scrollTop > visibilityHeight) as number;
+export default class Column<T> extends (RcTable.Column as React.ComponentClass<ColumnProps<T>,ColumnProps<T>,ColumnProps<T>,ColumnProps<T>>) {}
+export const MobxTypedForm = class extends (Form as { new (): any }) {}
+export abstract class MobxTypedForm1 extends (Form as { new (): any }) {}
+({}) as {};
+function*g() {
+  const test = (yield 'foo') as number;
+}
+async function g1() {
+  const test = (await 'foo') as number;
+}
+({}) as X;
+() => ({}) as X;
+const state = JSON.stringify({
+  next: window.location.href,
+  nonce,
+} as State);
+
+(foo.bar as Baz) = [bar];
+(foo.bar as any)++;
+
+(bValue as boolean) ? 0 : -1;
+<boolean>bValue ? 0 : -1;
+
+const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
+const value2 = thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
+const value3 = thisIsAReallyLongIdentifier as (SomeInterface | SomeOtherInterface);
+const value4 = thisIsAReallyLongIdentifier as { prop1: string, prop2: number, prop3: number }[];
+const value5 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [string, number];
+
+const iter1 = createIterator(this.controller, child, this.tag as SyncFunctionComponent);
+const iter2 = createIterator(self.controller, child, self.tag as SyncFunctionComponent);
+
+=====================================output=====================================
+const name = (description as DescriptionObject).name || (description as string);
+this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
+(originalError
+  ? wrappedError(errMsg, originalError)
+  : Error(errMsg)) as InjectionError;
+"current" in (props.pagination as Object);
+("current" in props.pagination) as Object;
+start + (yearSelectTotal as number);
+(start + yearSelectTotal) as number;
+scrollTop > (visibilityHeight as number);
+(scrollTop > visibilityHeight) as number;
+export default class Column<T> extends (RcTable.Column as React.ComponentClass<
+  ColumnProps<T>,
+  ColumnProps<T>,
+  ColumnProps<T>,
+  ColumnProps<T>
+>) {}
+export const MobxTypedForm = class extends (Form as { new (): any }) {};
+export abstract class MobxTypedForm1 extends (Form as { new (): any }) {}
+({}) as {};
+function* g() {
+  const test = (yield "foo") as number;
+}
+async function g1() {
+  const test = (await "foo") as number;
+}
+({}) as X;
+() => ({} as X);
+const state = JSON.stringify({
+  next: window.location.href,
+  nonce,
+} as State);
+
+(foo.bar as Baz) = [bar];
+(foo.bar as any)++;
+
+(bValue as boolean) ? 0 : -1;
+<boolean>bValue ? 0 : -1;
+
+const value1 =
+  thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
+const value2 =
+  thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
+const value3 = thisIsAReallyLongIdentifier as
+  | SomeInterface
+  | SomeOtherInterface;
+const value4 = thisIsAReallyLongIdentifier as {
+  prop1: string;
+  prop2: number;
+  prop3: number;
+}[];
+const value5 =
+  thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [
+    string,
+    number,
+  ];
+
+const iter1 = createIterator(
+  this.controller,
+  child,
+  this.tag as SyncFunctionComponent,
+);
+const iter2 = createIterator(
+  self.controller,
+  child,
+  self.tag as SyncFunctionComponent,
+);
+
+================================================================================
+`;
+
+exports[`assignment.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export const LOG_LEVEL = {
+    EMERGENCY: 0,
+    ALERT: 1,
+    CRITICAL: 2,
+    ERROR: 3,
+    WARNING: 4,
+    NOTICE: 5,
+    INFO: 6,
+    DEBUG: 7,
+} as const;
+
+const TYPE_MAP = {
+    'character device': 'special',
+    'character special file': 'special',
+    directory: 'directory',
+    'regular file': 'file',
+    socket: 'socket',
+    'symbolic link': 'link',
+} as Foo;
+
+this.previewPlayerHandle = (setInterval(async () => {
+  if (this.previewIsPlaying) {
+    await this.fetchNextPreviews();
+    this.currentPreviewIndex++;
+  }
+}, this.refreshDelay) as unknown) as number;
+
+this.intervalID = (setInterval(() => {
+  self.step();
+}, 30) as unknown) as number;
+
+=====================================output=====================================
+export const LOG_LEVEL = {
+  EMERGENCY: 0,
+  ALERT: 1,
+  CRITICAL: 2,
+  ERROR: 3,
+  WARNING: 4,
+  NOTICE: 5,
+  INFO: 6,
+  DEBUG: 7,
+} as const;
+
+const TYPE_MAP = {
+  "character device": "special",
+  "character special file": "special",
+  directory: "directory",
+  "regular file": "file",
+  socket: "socket",
+  "symbolic link": "link",
+} as Foo;
+
+this.previewPlayerHandle = setInterval(async () => {
+  if (this.previewIsPlaying) {
+    await this.fetchNextPreviews();
+    this.currentPreviewIndex++;
+  }
+}, this.refreshDelay) as unknown as number;
+
+this.intervalID = setInterval(() => {
+  self.step();
+}, 30) as unknown as number;
+
+================================================================================
+`;
+
 exports[`assignment.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -201,6 +542,153 @@ this.previewPlayerHandle = setInterval(async () => {
 this.intervalID = setInterval(() => {
   self.step();
 }, 30) as unknown as number;
+
+================================================================================
+`;
+
+exports[`assignment.ts format 2`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export const LOG_LEVEL = {
+    EMERGENCY: 0,
+    ALERT: 1,
+    CRITICAL: 2,
+    ERROR: 3,
+    WARNING: 4,
+    NOTICE: 5,
+    INFO: 6,
+    DEBUG: 7,
+} as const;
+
+const TYPE_MAP = {
+    'character device': 'special',
+    'character special file': 'special',
+    directory: 'directory',
+    'regular file': 'file',
+    socket: 'socket',
+    'symbolic link': 'link',
+} as Foo;
+
+this.previewPlayerHandle = (setInterval(async () => {
+  if (this.previewIsPlaying) {
+    await this.fetchNextPreviews();
+    this.currentPreviewIndex++;
+  }
+}, this.refreshDelay) as unknown) as number;
+
+this.intervalID = (setInterval(() => {
+  self.step();
+}, 30) as unknown) as number;
+
+=====================================output=====================================
+export const LOG_LEVEL = {
+  EMERGENCY: 0,
+  ALERT: 1,
+  CRITICAL: 2,
+  ERROR: 3,
+  WARNING: 4,
+  NOTICE: 5,
+  INFO: 6,
+  DEBUG: 7,
+} as const;
+
+const TYPE_MAP = {
+  "character device": "special",
+  "character special file": "special",
+  directory: "directory",
+  "regular file": "file",
+  socket: "socket",
+  "symbolic link": "link",
+} as Foo;
+
+this.previewPlayerHandle = setInterval(async () => {
+  if (this.previewIsPlaying) {
+    await this.fetchNextPreviews();
+    this.currentPreviewIndex++;
+  }
+}, this.refreshDelay) as unknown as number;
+
+this.intervalID = setInterval(() => {
+  self.step();
+}, 30) as unknown as number;
+
+================================================================================
+`;
+
+exports[`assignment2.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const defaultMaskGetter = $parse(attrs[directiveName]) as (
+  scope: ng.IScope
+) => Mask;
+
+(this.configuration as any) = (this.editor as any) = (this
+  .editorBody as any) = undefined;
+
+angular.module("foo").directive("formIsolator", () => {
+  return {
+    name: "form",
+    controller: class FormIsolatorController {
+      $addControl = angular.noop;
+    } as ng.IControllerConstructor,
+  };
+});
+
+(this.selectorElem as any) = this.multiselectWidget = this.initialValues = undefined;
+
+const extraRendererAttrs = ((attrs.rendererAttrs &&
+  this.utils.safeParseJsonString(attrs.rendererAttrs)) ||
+  Object.create(null)) as FieldService.RendererAttributes;
+
+const annotate = (angular.injector as any).$$annotate as (
+  fn: Function
+) => string[];
+
+const originalPrototype = originalConstructor.prototype as TComponent & InjectionTarget,
+  propertyToServiceName = originalPrototype._inject;
+
+=====================================output=====================================
+const defaultMaskGetter = $parse(attrs[directiveName]) as (
+  scope: ng.IScope,
+) => Mask;
+
+(this.configuration as any) =
+  (this.editor as any) =
+  (this.editorBody as any) =
+    undefined;
+
+angular.module("foo").directive("formIsolator", () => {
+  return {
+    name: "form",
+    controller: class FormIsolatorController {
+      $addControl = angular.noop;
+    } as ng.IControllerConstructor,
+  };
+});
+
+(this.selectorElem as any) =
+  this.multiselectWidget =
+  this.initialValues =
+    undefined;
+
+const extraRendererAttrs = ((attrs.rendererAttrs
+  && this.utils.safeParseJsonString(attrs.rendererAttrs))
+  || Object.create(null)) as FieldService.RendererAttributes;
+
+const annotate = (angular.injector as any).$$annotate as (
+  fn: Function,
+) => string[];
+
+const originalPrototype = originalConstructor.prototype as TComponent &
+    InjectionTarget,
+  propertyToServiceName = originalPrototype._inject;
 
 ================================================================================
 `;
@@ -279,6 +767,95 @@ const originalPrototype = originalConstructor.prototype as TComponent &
 ================================================================================
 `;
 
+exports[`assignment2.ts format 2`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const defaultMaskGetter = $parse(attrs[directiveName]) as (
+  scope: ng.IScope
+) => Mask;
+
+(this.configuration as any) = (this.editor as any) = (this
+  .editorBody as any) = undefined;
+
+angular.module("foo").directive("formIsolator", () => {
+  return {
+    name: "form",
+    controller: class FormIsolatorController {
+      $addControl = angular.noop;
+    } as ng.IControllerConstructor,
+  };
+});
+
+(this.selectorElem as any) = this.multiselectWidget = this.initialValues = undefined;
+
+const extraRendererAttrs = ((attrs.rendererAttrs &&
+  this.utils.safeParseJsonString(attrs.rendererAttrs)) ||
+  Object.create(null)) as FieldService.RendererAttributes;
+
+const annotate = (angular.injector as any).$$annotate as (
+  fn: Function
+) => string[];
+
+const originalPrototype = originalConstructor.prototype as TComponent & InjectionTarget,
+  propertyToServiceName = originalPrototype._inject;
+
+=====================================output=====================================
+const defaultMaskGetter = $parse(attrs[directiveName]) as (
+  scope: ng.IScope,
+) => Mask;
+
+(this.configuration as any) =
+  (this.editor as any) =
+  (this.editorBody as any) =
+    undefined;
+
+angular.module("foo").directive("formIsolator", () => {
+  return {
+    name: "form",
+    controller: class FormIsolatorController {
+      $addControl = angular.noop;
+    } as ng.IControllerConstructor,
+  };
+});
+
+(this.selectorElem as any) =
+  this.multiselectWidget =
+  this.initialValues =
+    undefined;
+
+const extraRendererAttrs = ((attrs.rendererAttrs
+  && this.utils.safeParseJsonString(attrs.rendererAttrs))
+  || Object.create(null)) as FieldService.RendererAttributes;
+
+const annotate = (angular.injector as any).$$annotate as (
+  fn: Function,
+) => string[];
+
+const originalPrototype = originalConstructor.prototype as TComponent &
+    InjectionTarget,
+  propertyToServiceName = originalPrototype._inject;
+
+================================================================================
+`;
+
+exports[`export_default_as.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export default (function log() {} as typeof console.log)
+
+=====================================output=====================================
+export default (function log() {} as typeof console.log);
+
+================================================================================
+`;
+
 exports[`export_default_as.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -289,6 +866,62 @@ export default (function log() {} as typeof console.log)
 
 =====================================output=====================================
 export default (function log() {} as typeof console.log);
+
+================================================================================
+`;
+
+exports[`export_default_as.ts format 2`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export default (function log() {} as typeof console.log)
+
+=====================================output=====================================
+export default (function log() {} as typeof console.log);
+
+================================================================================
+`;
+
+exports[`long-identifiers.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans as glimseGlyphsHazardNoopsTieTie;
+
+averredBathersBoxroomBuggyNurl.anodyneCondosMalateOverateRetinol =
+  annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave;
+
+averredBathersBoxroomBuggyNurl = {
+  anodyneCondosMalateOverateRetinol:
+    annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave
+};
+
+averredBathersBoxroomBuggyNurl(
+  anodyneCondosMalateOverateRetinol.annularCooeedSplicesWalksWayWay as
+    kochabCooieGameOnOboleUnweave
+);
+
+=====================================output=====================================
+const bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans as glimseGlyphsHazardNoopsTieTie;
+
+averredBathersBoxroomBuggyNurl.anodyneCondosMalateOverateRetinol =
+  annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave;
+
+averredBathersBoxroomBuggyNurl = {
+  anodyneCondosMalateOverateRetinol:
+    annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave,
+};
+
+averredBathersBoxroomBuggyNurl(
+  anodyneCondosMalateOverateRetinol.annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave,
+);
 
 ================================================================================
 `;
@@ -334,6 +967,75 @@ averredBathersBoxroomBuggyNurl(
 ================================================================================
 `;
 
+exports[`long-identifiers.ts format 2`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans as glimseGlyphsHazardNoopsTieTie;
+
+averredBathersBoxroomBuggyNurl.anodyneCondosMalateOverateRetinol =
+  annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave;
+
+averredBathersBoxroomBuggyNurl = {
+  anodyneCondosMalateOverateRetinol:
+    annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave
+};
+
+averredBathersBoxroomBuggyNurl(
+  anodyneCondosMalateOverateRetinol.annularCooeedSplicesWalksWayWay as
+    kochabCooieGameOnOboleUnweave
+);
+
+=====================================output=====================================
+const bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans as glimseGlyphsHazardNoopsTieTie;
+
+averredBathersBoxroomBuggyNurl.anodyneCondosMalateOverateRetinol =
+  annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave;
+
+averredBathersBoxroomBuggyNurl = {
+  anodyneCondosMalateOverateRetinol:
+    annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave,
+};
+
+averredBathersBoxroomBuggyNurl(
+  anodyneCondosMalateOverateRetinol.annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave,
+);
+
+================================================================================
+`;
+
+exports[`nested-await-and-as.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const getAccountCount = async () =>
+  (await
+    ((await (
+      await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
+    ).findItem("My bookmarks")) as TreeItem
+  ).getChildren()
+  ).length
+
+=====================================output=====================================
+const getAccountCount = async () =>
+  (
+    await (
+      (await (
+        await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
+      ).findItem("My bookmarks")) as TreeItem
+    ).getChildren()
+  ).length;
+
+================================================================================
+`;
+
 exports[`nested-await-and-as.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -361,6 +1063,58 @@ const getAccountCount = async () =>
 ================================================================================
 `;
 
+exports[`nested-await-and-as.ts format 2`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const getAccountCount = async () =>
+  (await
+    ((await (
+      await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
+    ).findItem("My bookmarks")) as TreeItem
+  ).getChildren()
+  ).length
+
+=====================================output=====================================
+const getAccountCount = async () =>
+  (
+    await (
+      (await (
+        await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
+      ).findItem("My bookmarks")) as TreeItem
+    ).getChildren()
+  ).length;
+
+================================================================================
+`;
+
+exports[`return.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function foo() {
+  return {
+    foo: 1,
+    bar: 2,
+  } as Foo;
+}
+
+=====================================output=====================================
+function foo() {
+  return {
+    foo: 1,
+    bar: 2,
+  } as Foo;
+}
+
+================================================================================
+`;
+
 exports[`return.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -381,6 +1135,133 @@ function foo() {
     bar: 2,
   } as Foo;
 }
+
+================================================================================
+`;
+
+exports[`return.ts format 2`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function foo() {
+  return {
+    foo: 1,
+    bar: 2,
+  } as Foo;
+}
+
+=====================================output=====================================
+function foo() {
+  return {
+    foo: 1,
+    bar: 2,
+  } as Foo;
+}
+
+================================================================================
+`;
+
+exports[`ternary.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
+
+foo = (condition ? firstValue : secondValue) as SomeType;
+
+const foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
+
+function foo() {
+  return (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
+}
+
+function foo() {
+  throw (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
+}
+
+function foo() {
+  void ((coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo);
+}
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0 &&
+  kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
+
+=====================================output=====================================
+foo = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+) as Fooooooooooo;
+
+foo = (condition ? firstValue : secondValue) as SomeType;
+
+const foo = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+) as Fooooooooooo;
+
+function foo() {
+  return (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ) as Fooooooooooo;
+}
+
+function foo() {
+  throw (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ) as Fooooooooooo;
+}
+
+function foo() {
+  void ((
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ) as Fooooooooooo);
+}
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans
+  + ((glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans
+  + ((glimseGlyphsHazardNoopsTieTie === 0
+  && kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
 
 ================================================================================
 `;
@@ -481,6 +1362,108 @@ bifornCringerMoshedPerplexSawder =
   askTrovenaBeenaDependsRowans +
   ((glimseGlyphsHazardNoopsTieTie === 0 &&
   kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
+
+================================================================================
+`;
+
+exports[`ternary.ts format 2`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
+
+foo = (condition ? firstValue : secondValue) as SomeType;
+
+const foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
+
+function foo() {
+  return (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
+}
+
+function foo() {
+  throw (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
+}
+
+function foo() {
+  void ((coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo);
+}
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0 &&
+  kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
+
+=====================================output=====================================
+foo = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+) as Fooooooooooo;
+
+foo = (condition ? firstValue : secondValue) as SomeType;
+
+const foo = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+) as Fooooooooooo;
+
+function foo() {
+  return (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ) as Fooooooooooo;
+}
+
+function foo() {
+  throw (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ) as Fooooooooooo;
+}
+
+function foo() {
+  void ((
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ) as Fooooooooooo);
+}
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans
+  + ((glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans
+  + ((glimseGlyphsHazardNoopsTieTie === 0
+  && kochabCooieGameOnOboleUnweave === Math.PI
     ? averredBathersBoxroomBuggyNurl
     : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
 

--- a/tests/format/typescript/as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/as/__snapshots__/jsfmt.spec.js.snap
@@ -29,20 +29,6 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`array-pattern.ts format 2`] = `
-====================================options=====================================
-parsers: ["typescript"]
-printWidth: 80
-                                                                                | printWidth
-=====================================input======================================
-[x as any] = x;
-
-=====================================output=====================================
-[x as any] = x;
-
-================================================================================
-`;
-
 exports[`as.ts - {"experimentalOperatorLocation":true} format 1`] = `
 ====================================options=====================================
 experimentalOperatorLocation: true
@@ -164,125 +150,6 @@ const iter2 = createIterator(
 `;
 
 exports[`as.ts format 1`] = `
-====================================options=====================================
-parsers: ["typescript"]
-printWidth: 80
-                                                                                | printWidth
-=====================================input======================================
-const name = (description as DescriptionObject).name || (description as string);
-this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
-(originalError ? wrappedError(errMsg, originalError) : Error(errMsg)) as InjectionError;
-'current' in (props.pagination as Object);
-('current' in props.pagination) as Object;
-start + (yearSelectTotal as number);
-(start + yearSelectTotal) as number;
-scrollTop > (visibilityHeight as number);
-(scrollTop > visibilityHeight) as number;
-export default class Column<T> extends (RcTable.Column as React.ComponentClass<ColumnProps<T>,ColumnProps<T>,ColumnProps<T>,ColumnProps<T>>) {}
-export const MobxTypedForm = class extends (Form as { new (): any }) {}
-export abstract class MobxTypedForm1 extends (Form as { new (): any }) {}
-({}) as {};
-function*g() {
-  const test = (yield 'foo') as number;
-}
-async function g1() {
-  const test = (await 'foo') as number;
-}
-({}) as X;
-() => ({}) as X;
-const state = JSON.stringify({
-  next: window.location.href,
-  nonce,
-} as State);
-
-(foo.bar as Baz) = [bar];
-(foo.bar as any)++;
-
-(bValue as boolean) ? 0 : -1;
-<boolean>bValue ? 0 : -1;
-
-const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
-const value2 = thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
-const value3 = thisIsAReallyLongIdentifier as (SomeInterface | SomeOtherInterface);
-const value4 = thisIsAReallyLongIdentifier as { prop1: string, prop2: number, prop3: number }[];
-const value5 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [string, number];
-
-const iter1 = createIterator(this.controller, child, this.tag as SyncFunctionComponent);
-const iter2 = createIterator(self.controller, child, self.tag as SyncFunctionComponent);
-
-=====================================output=====================================
-const name = (description as DescriptionObject).name || (description as string);
-this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
-(originalError
-  ? wrappedError(errMsg, originalError)
-  : Error(errMsg)) as InjectionError;
-"current" in (props.pagination as Object);
-("current" in props.pagination) as Object;
-start + (yearSelectTotal as number);
-(start + yearSelectTotal) as number;
-scrollTop > (visibilityHeight as number);
-(scrollTop > visibilityHeight) as number;
-export default class Column<T> extends (RcTable.Column as React.ComponentClass<
-  ColumnProps<T>,
-  ColumnProps<T>,
-  ColumnProps<T>,
-  ColumnProps<T>
->) {}
-export const MobxTypedForm = class extends (Form as { new (): any }) {};
-export abstract class MobxTypedForm1 extends (Form as { new (): any }) {}
-({}) as {};
-function* g() {
-  const test = (yield "foo") as number;
-}
-async function g1() {
-  const test = (await "foo") as number;
-}
-({}) as X;
-() => ({} as X);
-const state = JSON.stringify({
-  next: window.location.href,
-  nonce,
-} as State);
-
-(foo.bar as Baz) = [bar];
-(foo.bar as any)++;
-
-(bValue as boolean) ? 0 : -1;
-<boolean>bValue ? 0 : -1;
-
-const value1 =
-  thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
-const value2 =
-  thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
-const value3 = thisIsAReallyLongIdentifier as
-  | SomeInterface
-  | SomeOtherInterface;
-const value4 = thisIsAReallyLongIdentifier as {
-  prop1: string;
-  prop2: number;
-  prop3: number;
-}[];
-const value5 =
-  thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [
-    string,
-    number,
-  ];
-
-const iter1 = createIterator(
-  this.controller,
-  child,
-  this.tag as SyncFunctionComponent,
-);
-const iter2 = createIterator(
-  self.controller,
-  child,
-  self.tag as SyncFunctionComponent,
-);
-
-================================================================================
-`;
-
-exports[`as.ts format 2`] = `
 ====================================options=====================================
 parsers: ["typescript"]
 printWidth: 80
@@ -546,78 +413,6 @@ this.intervalID = setInterval(() => {
 ================================================================================
 `;
 
-exports[`assignment.ts format 2`] = `
-====================================options=====================================
-parsers: ["typescript"]
-printWidth: 80
-                                                                                | printWidth
-=====================================input======================================
-export const LOG_LEVEL = {
-    EMERGENCY: 0,
-    ALERT: 1,
-    CRITICAL: 2,
-    ERROR: 3,
-    WARNING: 4,
-    NOTICE: 5,
-    INFO: 6,
-    DEBUG: 7,
-} as const;
-
-const TYPE_MAP = {
-    'character device': 'special',
-    'character special file': 'special',
-    directory: 'directory',
-    'regular file': 'file',
-    socket: 'socket',
-    'symbolic link': 'link',
-} as Foo;
-
-this.previewPlayerHandle = (setInterval(async () => {
-  if (this.previewIsPlaying) {
-    await this.fetchNextPreviews();
-    this.currentPreviewIndex++;
-  }
-}, this.refreshDelay) as unknown) as number;
-
-this.intervalID = (setInterval(() => {
-  self.step();
-}, 30) as unknown) as number;
-
-=====================================output=====================================
-export const LOG_LEVEL = {
-  EMERGENCY: 0,
-  ALERT: 1,
-  CRITICAL: 2,
-  ERROR: 3,
-  WARNING: 4,
-  NOTICE: 5,
-  INFO: 6,
-  DEBUG: 7,
-} as const;
-
-const TYPE_MAP = {
-  "character device": "special",
-  "character special file": "special",
-  directory: "directory",
-  "regular file": "file",
-  socket: "socket",
-  "symbolic link": "link",
-} as Foo;
-
-this.previewPlayerHandle = setInterval(async () => {
-  if (this.previewIsPlaying) {
-    await this.fetchNextPreviews();
-    this.currentPreviewIndex++;
-  }
-}, this.refreshDelay) as unknown as number;
-
-this.intervalID = setInterval(() => {
-  self.step();
-}, 30) as unknown as number;
-
-================================================================================
-`;
-
 exports[`assignment2.ts - {"experimentalOperatorLocation":true} format 1`] = `
 ====================================options=====================================
 experimentalOperatorLocation: true
@@ -767,80 +562,6 @@ const originalPrototype = originalConstructor.prototype as TComponent &
 ================================================================================
 `;
 
-exports[`assignment2.ts format 2`] = `
-====================================options=====================================
-parsers: ["typescript"]
-printWidth: 80
-                                                                                | printWidth
-=====================================input======================================
-const defaultMaskGetter = $parse(attrs[directiveName]) as (
-  scope: ng.IScope
-) => Mask;
-
-(this.configuration as any) = (this.editor as any) = (this
-  .editorBody as any) = undefined;
-
-angular.module("foo").directive("formIsolator", () => {
-  return {
-    name: "form",
-    controller: class FormIsolatorController {
-      $addControl = angular.noop;
-    } as ng.IControllerConstructor,
-  };
-});
-
-(this.selectorElem as any) = this.multiselectWidget = this.initialValues = undefined;
-
-const extraRendererAttrs = ((attrs.rendererAttrs &&
-  this.utils.safeParseJsonString(attrs.rendererAttrs)) ||
-  Object.create(null)) as FieldService.RendererAttributes;
-
-const annotate = (angular.injector as any).$$annotate as (
-  fn: Function
-) => string[];
-
-const originalPrototype = originalConstructor.prototype as TComponent & InjectionTarget,
-  propertyToServiceName = originalPrototype._inject;
-
-=====================================output=====================================
-const defaultMaskGetter = $parse(attrs[directiveName]) as (
-  scope: ng.IScope,
-) => Mask;
-
-(this.configuration as any) =
-  (this.editor as any) =
-  (this.editorBody as any) =
-    undefined;
-
-angular.module("foo").directive("formIsolator", () => {
-  return {
-    name: "form",
-    controller: class FormIsolatorController {
-      $addControl = angular.noop;
-    } as ng.IControllerConstructor,
-  };
-});
-
-(this.selectorElem as any) =
-  this.multiselectWidget =
-  this.initialValues =
-    undefined;
-
-const extraRendererAttrs = ((attrs.rendererAttrs
-  && this.utils.safeParseJsonString(attrs.rendererAttrs))
-  || Object.create(null)) as FieldService.RendererAttributes;
-
-const annotate = (angular.injector as any).$$annotate as (
-  fn: Function,
-) => string[];
-
-const originalPrototype = originalConstructor.prototype as TComponent &
-    InjectionTarget,
-  propertyToServiceName = originalPrototype._inject;
-
-================================================================================
-`;
-
 exports[`export_default_as.ts - {"experimentalOperatorLocation":true} format 1`] = `
 ====================================options=====================================
 experimentalOperatorLocation: true
@@ -857,20 +578,6 @@ export default (function log() {} as typeof console.log);
 `;
 
 exports[`export_default_as.ts format 1`] = `
-====================================options=====================================
-parsers: ["typescript"]
-printWidth: 80
-                                                                                | printWidth
-=====================================input======================================
-export default (function log() {} as typeof console.log)
-
-=====================================output=====================================
-export default (function log() {} as typeof console.log);
-
-================================================================================
-`;
-
-exports[`export_default_as.ts format 2`] = `
 ====================================options=====================================
 parsers: ["typescript"]
 printWidth: 80
@@ -967,47 +674,6 @@ averredBathersBoxroomBuggyNurl(
 ================================================================================
 `;
 
-exports[`long-identifiers.ts format 2`] = `
-====================================options=====================================
-parsers: ["typescript"]
-printWidth: 80
-                                                                                | printWidth
-=====================================input======================================
-const bifornCringerMoshedPerplexSawder =
-  askTrovenaBeenaDependsRowans as glimseGlyphsHazardNoopsTieTie;
-
-averredBathersBoxroomBuggyNurl.anodyneCondosMalateOverateRetinol =
-  annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave;
-
-averredBathersBoxroomBuggyNurl = {
-  anodyneCondosMalateOverateRetinol:
-    annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave
-};
-
-averredBathersBoxroomBuggyNurl(
-  anodyneCondosMalateOverateRetinol.annularCooeedSplicesWalksWayWay as
-    kochabCooieGameOnOboleUnweave
-);
-
-=====================================output=====================================
-const bifornCringerMoshedPerplexSawder =
-  askTrovenaBeenaDependsRowans as glimseGlyphsHazardNoopsTieTie;
-
-averredBathersBoxroomBuggyNurl.anodyneCondosMalateOverateRetinol =
-  annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave;
-
-averredBathersBoxroomBuggyNurl = {
-  anodyneCondosMalateOverateRetinol:
-    annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave,
-};
-
-averredBathersBoxroomBuggyNurl(
-  anodyneCondosMalateOverateRetinol.annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave,
-);
-
-================================================================================
-`;
-
 exports[`nested-await-and-as.ts - {"experimentalOperatorLocation":true} format 1`] = `
 ====================================options=====================================
 experimentalOperatorLocation: true
@@ -1063,33 +729,6 @@ const getAccountCount = async () =>
 ================================================================================
 `;
 
-exports[`nested-await-and-as.ts format 2`] = `
-====================================options=====================================
-parsers: ["typescript"]
-printWidth: 80
-                                                                                | printWidth
-=====================================input======================================
-const getAccountCount = async () =>
-  (await
-    ((await (
-      await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
-    ).findItem("My bookmarks")) as TreeItem
-  ).getChildren()
-  ).length
-
-=====================================output=====================================
-const getAccountCount = async () =>
-  (
-    await (
-      (await (
-        await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
-      ).findItem("My bookmarks")) as TreeItem
-    ).getChildren()
-  ).length;
-
-================================================================================
-`;
-
 exports[`return.ts - {"experimentalOperatorLocation":true} format 1`] = `
 ====================================options=====================================
 experimentalOperatorLocation: true
@@ -1116,30 +755,6 @@ function foo() {
 `;
 
 exports[`return.ts format 1`] = `
-====================================options=====================================
-parsers: ["typescript"]
-printWidth: 80
-                                                                                | printWidth
-=====================================input======================================
-function foo() {
-  return {
-    foo: 1,
-    bar: 2,
-  } as Foo;
-}
-
-=====================================output=====================================
-function foo() {
-  return {
-    foo: 1,
-    bar: 2,
-  } as Foo;
-}
-
-================================================================================
-`;
-
-exports[`return.ts format 2`] = `
 ====================================options=====================================
 parsers: ["typescript"]
 printWidth: 80
@@ -1362,108 +977,6 @@ bifornCringerMoshedPerplexSawder =
   askTrovenaBeenaDependsRowans +
   ((glimseGlyphsHazardNoopsTieTie === 0 &&
   kochabCooieGameOnOboleUnweave === Math.PI
-    ? averredBathersBoxroomBuggyNurl
-    : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
-
-================================================================================
-`;
-
-exports[`ternary.ts format 2`] = `
-====================================options=====================================
-parsers: ["typescript"]
-printWidth: 80
-                                                                                | printWidth
-=====================================input======================================
-foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
-    ? baaaaaaaaaaaaaaaaaaaaar
-    : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
-
-foo = (condition ? firstValue : secondValue) as SomeType;
-
-const foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
-  ? baaaaaaaaaaaaaaaaaaaaar
-  : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
-
-function foo() {
-  return (coooooooooooooooooooooooooooooooooooooooooooooooooooond
-    ? baaaaaaaaaaaaaaaaaaaaar
-    : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
-}
-
-function foo() {
-  throw (coooooooooooooooooooooooooooooooooooooooooooooooooooond
-      ? baaaaaaaaaaaaaaaaaaaaar
-      : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
-}
-
-function foo() {
-  void ((coooooooooooooooooooooooooooooooooooooooooooooooooooond
-    ? baaaaaaaaaaaaaaaaaaaaar
-    : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo);
-}
-
-bifornCringerMoshedPerplexSawder =
-  askTrovenaBeenaDependsRowans +
-  ((glimseGlyphsHazardNoopsTieTie === 0
-    ? averredBathersBoxroomBuggyNurl
-    : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
-
-bifornCringerMoshedPerplexSawder =
-  askTrovenaBeenaDependsRowans +
-  ((glimseGlyphsHazardNoopsTieTie === 0 &&
-  kochabCooieGameOnOboleUnweave === Math.PI
-    ? averredBathersBoxroomBuggyNurl
-    : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
-
-=====================================output=====================================
-foo = (
-  coooooooooooooooooooooooooooooooooooooooooooooooooooond
-    ? baaaaaaaaaaaaaaaaaaaaar
-    : baaaaaaaaaaaaaaaaaaaaaz
-) as Fooooooooooo;
-
-foo = (condition ? firstValue : secondValue) as SomeType;
-
-const foo = (
-  coooooooooooooooooooooooooooooooooooooooooooooooooooond
-    ? baaaaaaaaaaaaaaaaaaaaar
-    : baaaaaaaaaaaaaaaaaaaaaz
-) as Fooooooooooo;
-
-function foo() {
-  return (
-    coooooooooooooooooooooooooooooooooooooooooooooooooooond
-      ? baaaaaaaaaaaaaaaaaaaaar
-      : baaaaaaaaaaaaaaaaaaaaaz
-  ) as Fooooooooooo;
-}
-
-function foo() {
-  throw (
-    coooooooooooooooooooooooooooooooooooooooooooooooooooond
-      ? baaaaaaaaaaaaaaaaaaaaar
-      : baaaaaaaaaaaaaaaaaaaaaz
-  ) as Fooooooooooo;
-}
-
-function foo() {
-  void ((
-    coooooooooooooooooooooooooooooooooooooooooooooooooooond
-      ? baaaaaaaaaaaaaaaaaaaaar
-      : baaaaaaaaaaaaaaaaaaaaaz
-  ) as Fooooooooooo);
-}
-
-bifornCringerMoshedPerplexSawder =
-  askTrovenaBeenaDependsRowans
-  + ((glimseGlyphsHazardNoopsTieTie === 0
-    ? averredBathersBoxroomBuggyNurl
-    : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
-
-bifornCringerMoshedPerplexSawder =
-  askTrovenaBeenaDependsRowans
-  + ((glimseGlyphsHazardNoopsTieTie === 0
-  && kochabCooieGameOnOboleUnweave === Math.PI
     ? averredBathersBoxroomBuggyNurl
     : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
 

--- a/tests/format/typescript/as/jsfmt.spec.js
+++ b/tests/format/typescript/as/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(import.meta, ["typescript"]);
+run_spec(import.meta, ["typescript"], { experimentalOperatorLocation: true });

--- a/tests/format/typescript/as/jsfmt.spec.js
+++ b/tests/format/typescript/as/jsfmt.spec.js
@@ -1,2 +1,2 @@
 run_spec(import.meta, ["typescript"]);
-run_spec(import.meta, ["typescript"], { experimentalOperatorLocation: true });
+run_spec(import.meta, ["typescript"], { experimentalOperatorPosition: true });

--- a/tests/format/typescript/conformance/types/functions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/conformance/types/functions/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TSFunctionTypeNoUnnecessaryParentheses.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`TSFunctionTypeNoUnnecessaryParentheses.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -35,9 +35,9 @@ class Foo {
 ================================================================================
 `;
 
-exports[`functionImplementationErrors.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`functionImplementationErrors.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -370,9 +370,9 @@ var f13 = () => {
 ================================================================================
 `;
 
-exports[`functionImplementations.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`functionImplementations.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1067,9 +1067,9 @@ var f12: (x: number) => any = (x) => {
 ================================================================================
 `;
 
-exports[`functionOverloadCompatibilityWithVoid01.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`functionOverloadCompatibilityWithVoid01.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1108,9 +1108,9 @@ function f(x: string): void {
 ================================================================================
 `;
 
-exports[`functionOverloadCompatibilityWithVoid02.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`functionOverloadCompatibilityWithVoid02.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1149,9 +1149,9 @@ function f(x: string): number {
 ================================================================================
 `;
 
-exports[`functionOverloadCompatibilityWithVoid03.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`functionOverloadCompatibilityWithVoid03.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1200,7 +1200,7 @@ exports[`functionOverloadErrorsSyntax.ts [babel-ts] format 1`] = `
   11 |"
 `;
 
-exports[`functionOverloadErrorsSyntax.ts - {"experimentalOperatorLocation":true} [babel-ts] format 1`] = `
+exports[`functionOverloadErrorsSyntax.ts - {"experimentalOperatorPosition":true} [babel-ts] format 1`] = `
 "Rest element must be last element. (9:36)
    7 |
    8 | //Function overload signature with rest param followed by non-optional parameter
@@ -1210,9 +1210,9 @@ exports[`functionOverloadErrorsSyntax.ts - {"experimentalOperatorLocation":true}
   11 |"
 `;
 
-exports[`functionOverloadErrorsSyntax.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`functionOverloadErrorsSyntax.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1275,9 +1275,9 @@ function fn5() {}
 ================================================================================
 `;
 
-exports[`functionTypeTypeParameters.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`functionTypeTypeParameters.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1304,9 +1304,9 @@ type FuncWithTypeParameter = <T, P>() => {};
 ================================================================================
 `;
 
-exports[`parameterInitializersForwardReferencing.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`parameterInitializersForwardReferencing.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/typescript/conformance/types/functions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/conformance/types/functions/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`TSFunctionTypeNoUnnecessaryParentheses.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+class Foo {
+  bar: (() => boolean);
+}
+=====================================output=====================================
+class Foo {
+  bar: () => boolean;
+}
+
+================================================================================
+`;
+
 exports[`TSFunctionTypeNoUnnecessaryParentheses.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -13,6 +31,174 @@ class Foo {
 class Foo {
   bar: () => boolean;
 }
+
+================================================================================
+`;
+
+exports[`functionImplementationErrors.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// @allowUnreachableCode: true
+
+// FunctionExpression with no return type annotation with multiple return statements with unrelated types
+var f1 = function () {
+    return '';
+    return 3;
+};
+var f2 = function x() {
+    return '';
+    return 3;
+};
+var f3 = () => {
+    return '';
+    return 3;
+};
+
+// FunctionExpression with no return type annotation with return branch of number[] and other of string[]
+var f4 = function () {
+    if (true) {
+        return [''];
+    } else {
+        return [1];
+    }
+}
+
+// Function implementation with non -void return type annotation with no return
+function f5(): number {
+}
+
+var m;
+// Function signature with parameter initializer referencing in scope local variable
+function f6(n = m) {
+    var m = 4;
+}
+
+// Function signature with initializer referencing other parameter to the right
+function f7(n = m, m?) {
+}
+
+// FunctionExpression with non -void return type annotation with a throw, no return, and other code
+// Should be error but isn't
+undefined === function (): number {
+    throw undefined;
+    var x = 4;
+};
+
+class Base { private x; }
+class AnotherClass { private y; }
+class Derived1 extends Base { private m; }
+class Derived2 extends Base { private n; }
+function f8() {
+    return new Derived1();
+    return new Derived2();    
+}
+var f9 = function () {
+    return new Derived1();
+    return new Derived2();
+};
+var f10 = () => {
+    return new Derived1();
+    return new Derived2();
+};
+function f11() {
+    return new Base();
+    return new AnotherClass();
+}
+var f12 = function () {
+    return new Base();
+    return new AnotherClass();
+};
+var f13 = () => {
+    return new Base();
+    return new AnotherClass();
+};
+
+=====================================output=====================================
+// @allowUnreachableCode: true
+
+// FunctionExpression with no return type annotation with multiple return statements with unrelated types
+var f1 = function () {
+  return "";
+  return 3;
+};
+var f2 = function x() {
+  return "";
+  return 3;
+};
+var f3 = () => {
+  return "";
+  return 3;
+};
+
+// FunctionExpression with no return type annotation with return branch of number[] and other of string[]
+var f4 = function () {
+  if (true) {
+    return [""];
+  } else {
+    return [1];
+  }
+};
+
+// Function implementation with non -void return type annotation with no return
+function f5(): number {}
+
+var m;
+// Function signature with parameter initializer referencing in scope local variable
+function f6(n = m) {
+  var m = 4;
+}
+
+// Function signature with initializer referencing other parameter to the right
+function f7(n = m, m?) {}
+
+// FunctionExpression with non -void return type annotation with a throw, no return, and other code
+// Should be error but isn't
+undefined
+  === function (): number {
+    throw undefined;
+    var x = 4;
+  };
+
+class Base {
+  private x;
+}
+class AnotherClass {
+  private y;
+}
+class Derived1 extends Base {
+  private m;
+}
+class Derived2 extends Base {
+  private n;
+}
+function f8() {
+  return new Derived1();
+  return new Derived2();
+}
+var f9 = function () {
+  return new Derived1();
+  return new Derived2();
+};
+var f10 = () => {
+  return new Derived1();
+  return new Derived2();
+};
+function f11() {
+  return new Base();
+  return new AnotherClass();
+}
+var f12 = function () {
+  return new Base();
+  return new AnotherClass();
+};
+var f13 = () => {
+  return new Base();
+  return new AnotherClass();
+};
 
 ================================================================================
 `;
@@ -178,6 +364,355 @@ var f12 = function () {
 };
 var f13 = () => {
   return new Base();
+  return new AnotherClass();
+};
+
+================================================================================
+`;
+
+exports[`functionImplementations.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// @allowUnreachableCode: true
+
+// FunctionExpression with no return type annotation and no return statement returns void
+var v: void = function () { } ();
+
+// FunctionExpression f with no return type annotation and directly references f in its body returns any
+var a: any = function f() {
+    return f;
+};
+var a: any = function f() {
+    return f();
+};
+
+// FunctionExpression f with no return type annotation and indirectly references f in its body returns any
+var a: any = function f() {
+    var x = f;
+    return x;
+};
+
+// Two mutually recursive function implementations with no return type annotations
+function rec1() {
+    return rec2();
+}
+function rec2() {
+    return rec1();
+}
+var a = rec1();
+var a = rec2();
+
+// Two mutually recursive function implementations with return type annotation in one
+function rec3(): number {
+    return rec4();
+}
+function rec4() {
+    return rec3();
+}
+var n: number;
+var n = rec3();
+var n = rec4();
+
+// FunctionExpression with no return type annotation and returns a number
+var n = function () {
+    return 3;
+} ();
+
+// FunctionExpression with no return type annotation and returns null
+var nu = null;
+var nu = function () {
+    return null;
+} ();
+
+// FunctionExpression with no return type annotation and returns undefined
+var un = undefined;
+var un = function () {
+    return undefined;
+} ();
+
+// FunctionExpression with no return type annotation and returns a type parameter type
+var n = function <T>(x: T) {
+    return x;
+} (4);
+
+// FunctionExpression with no return type annotation and returns a constrained type parameter type
+var n = function <T extends {}>(x: T) {
+    return x;
+} (4);
+
+// FunctionExpression with no return type annotation with multiple return statements with identical types
+var n = function () {
+    return 3;
+    return 5;
+}();
+
+// Otherwise, the inferred return type is the first of the types of the return statement expressions
+// in the function body that is a supertype of each of the others, 
+// ignoring return statements with no expressions.
+// A compile - time error occurs if no return statement expression has a type that is a supertype of each of the others.
+// FunctionExpression with no return type annotation with multiple return statements with subtype relation between returns
+class Base { private m; }
+class Derived extends Base { private q; }
+var b: Base;
+var b = function () {
+    return new Base(); return new Derived();
+} ();
+
+// FunctionExpression with no return type annotation with multiple return statements with one a recursive call
+var a = function f() {
+    return new Base(); return new Derived(); return f(); // ?
+} ();
+
+// FunctionExpression with non -void return type annotation with a single throw statement
+undefined === function (): number {
+    throw undefined;
+};
+
+// Type of 'this' in function implementation is 'any'
+function thisFunc() {
+    var x = this;
+    var x: any;
+}
+
+// Function signature with optional parameter, no type annotation and initializer has initializer's type
+function opt1(n = 4) {
+    var m = n;
+    var m: number;
+}
+
+// Function signature with optional parameter, no type annotation and initializer has initializer's widened type
+function opt2(n = { x: null, y: undefined }) {
+    var m = n;
+    var m: { x: any; y: any };
+}
+
+// Function signature with initializer referencing other parameter to the left
+function opt3(n: number, m = n) {
+    var y = m;
+    var y: number;
+}
+
+// Function signature with optional parameter has correct codegen 
+// (tested above)
+
+// FunctionExpression with non -void return type annotation return with no expression
+function f6(): number {
+    return;
+}
+
+class Derived2 extends Base { private r: string; }
+class AnotherClass { private x }
+// if f is a contextually typed function expression, the inferred return type is the union type
+// of the types of the return statement expressions in the function body, 
+// ignoring return statements with no expressions.
+var f7: (x: number) => string | number = x => { // should be (x: number) => number | string
+    if (x < 0) { return x; }
+    return x.toString();
+}
+var f8: (x: number) => any = x => { // should be (x: number) => Base
+    return new Base();
+    return new Derived2();
+}
+var f9: (x: number) => any = x => { // should be (x: number) => Base
+    return new Base();
+    return new Derived();
+    return new Derived2();
+}
+var f10: (x: number) => any = x => { // should be (x: number) => Derived | Derived1
+    return new Derived();
+    return new Derived2();
+}
+var f11: (x: number) => any = x => { // should be (x: number) => Base | AnotherClass
+    return new Base();
+    return new AnotherClass();
+}
+var f12: (x: number) => any = x => { // should be (x: number) => Base | AnotherClass
+    return new Base();
+    return; // should be ignored
+    return new AnotherClass();
+}
+
+=====================================output=====================================
+// @allowUnreachableCode: true
+
+// FunctionExpression with no return type annotation and no return statement returns void
+var v: void = (function () {})();
+
+// FunctionExpression f with no return type annotation and directly references f in its body returns any
+var a: any = function f() {
+  return f;
+};
+var a: any = function f() {
+  return f();
+};
+
+// FunctionExpression f with no return type annotation and indirectly references f in its body returns any
+var a: any = function f() {
+  var x = f;
+  return x;
+};
+
+// Two mutually recursive function implementations with no return type annotations
+function rec1() {
+  return rec2();
+}
+function rec2() {
+  return rec1();
+}
+var a = rec1();
+var a = rec2();
+
+// Two mutually recursive function implementations with return type annotation in one
+function rec3(): number {
+  return rec4();
+}
+function rec4() {
+  return rec3();
+}
+var n: number;
+var n = rec3();
+var n = rec4();
+
+// FunctionExpression with no return type annotation and returns a number
+var n = (function () {
+  return 3;
+})();
+
+// FunctionExpression with no return type annotation and returns null
+var nu = null;
+var nu = (function () {
+  return null;
+})();
+
+// FunctionExpression with no return type annotation and returns undefined
+var un = undefined;
+var un = (function () {
+  return undefined;
+})();
+
+// FunctionExpression with no return type annotation and returns a type parameter type
+var n = (function <T>(x: T) {
+  return x;
+})(4);
+
+// FunctionExpression with no return type annotation and returns a constrained type parameter type
+var n = (function <T extends {}>(x: T) {
+  return x;
+})(4);
+
+// FunctionExpression with no return type annotation with multiple return statements with identical types
+var n = (function () {
+  return 3;
+  return 5;
+})();
+
+// Otherwise, the inferred return type is the first of the types of the return statement expressions
+// in the function body that is a supertype of each of the others,
+// ignoring return statements with no expressions.
+// A compile - time error occurs if no return statement expression has a type that is a supertype of each of the others.
+// FunctionExpression with no return type annotation with multiple return statements with subtype relation between returns
+class Base {
+  private m;
+}
+class Derived extends Base {
+  private q;
+}
+var b: Base;
+var b = (function () {
+  return new Base();
+  return new Derived();
+})();
+
+// FunctionExpression with no return type annotation with multiple return statements with one a recursive call
+var a = (function f() {
+  return new Base();
+  return new Derived();
+  return f(); // ?
+})();
+
+// FunctionExpression with non -void return type annotation with a single throw statement
+undefined
+  === function (): number {
+    throw undefined;
+  };
+
+// Type of 'this' in function implementation is 'any'
+function thisFunc() {
+  var x = this;
+  var x: any;
+}
+
+// Function signature with optional parameter, no type annotation and initializer has initializer's type
+function opt1(n = 4) {
+  var m = n;
+  var m: number;
+}
+
+// Function signature with optional parameter, no type annotation and initializer has initializer's widened type
+function opt2(n = { x: null, y: undefined }) {
+  var m = n;
+  var m: { x: any; y: any };
+}
+
+// Function signature with initializer referencing other parameter to the left
+function opt3(n: number, m = n) {
+  var y = m;
+  var y: number;
+}
+
+// Function signature with optional parameter has correct codegen
+// (tested above)
+
+// FunctionExpression with non -void return type annotation return with no expression
+function f6(): number {
+  return;
+}
+
+class Derived2 extends Base {
+  private r: string;
+}
+class AnotherClass {
+  private x;
+}
+// if f is a contextually typed function expression, the inferred return type is the union type
+// of the types of the return statement expressions in the function body,
+// ignoring return statements with no expressions.
+var f7: (x: number) => string | number = (x) => {
+  // should be (x: number) => number | string
+  if (x < 0) {
+    return x;
+  }
+  return x.toString();
+};
+var f8: (x: number) => any = (x) => {
+  // should be (x: number) => Base
+  return new Base();
+  return new Derived2();
+};
+var f9: (x: number) => any = (x) => {
+  // should be (x: number) => Base
+  return new Base();
+  return new Derived();
+  return new Derived2();
+};
+var f10: (x: number) => any = (x) => {
+  // should be (x: number) => Derived | Derived1
+  return new Derived();
+  return new Derived2();
+};
+var f11: (x: number) => any = (x) => {
+  // should be (x: number) => Base | AnotherClass
+  return new Base();
+  return new AnotherClass();
+};
+var f12: (x: number) => any = (x) => {
+  // should be (x: number) => Base | AnotherClass
+  return new Base();
+  return; // should be ignored
   return new AnotherClass();
 };
 
@@ -532,6 +1067,27 @@ var f12: (x: number) => any = (x) => {
 ================================================================================
 `;
 
+exports[`functionOverloadCompatibilityWithVoid01.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function f(x: string): number;
+function f(x: string): void {
+    return;
+} 
+
+=====================================output=====================================
+function f(x: string): number;
+function f(x: string): void {
+  return;
+}
+
+================================================================================
+`;
+
 exports[`functionOverloadCompatibilityWithVoid01.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -552,6 +1108,27 @@ function f(x: string): void {
 ================================================================================
 `;
 
+exports[`functionOverloadCompatibilityWithVoid02.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function f(x: string): void;
+function f(x: string): number {
+    return 0;
+} 
+
+=====================================output=====================================
+function f(x: string): void;
+function f(x: string): number {
+  return 0;
+}
+
+================================================================================
+`;
+
 exports[`functionOverloadCompatibilityWithVoid02.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -567,6 +1144,27 @@ function f(x: string): number {
 function f(x: string): void;
 function f(x: string): number {
   return 0;
+}
+
+================================================================================
+`;
+
+exports[`functionOverloadCompatibilityWithVoid03.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function f(x: string): void;
+function f(x: string): void {
+    return;
+} 
+
+=====================================output=====================================
+function f(x: string): void;
+function f(x: string): void {
+  return;
 }
 
 ================================================================================
@@ -602,6 +1200,49 @@ exports[`functionOverloadErrorsSyntax.ts [babel-ts] format 1`] = `
   11 |"
 `;
 
+exports[`functionOverloadErrorsSyntax.ts - {"experimentalOperatorLocation":true} [babel-ts] format 1`] = `
+"Rest element must be last element. (9:36)
+   7 |
+   8 | //Function overload signature with rest param followed by non-optional parameter
+>  9 | function fn5(x: string, ...y: any[], z: string);
+     |                                    ^
+  10 | function fn5() { }
+  11 |"
+`;
+
+exports[`functionOverloadErrorsSyntax.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+//Function overload signature with optional parameter followed by non-optional parameter
+function fn4a(x?: number, y: string);
+function fn4a() { }
+
+function fn4b(n: string, x?: number, y: string);
+function fn4b() { }
+
+//Function overload signature with rest param followed by non-optional parameter
+function fn5(x: string, ...y: any[], z: string);
+function fn5() { }
+
+=====================================output=====================================
+//Function overload signature with optional parameter followed by non-optional parameter
+function fn4a(x?: number, y: string);
+function fn4a() {}
+
+function fn4b(n: string, x?: number, y: string);
+function fn4b() {}
+
+//Function overload signature with rest param followed by non-optional parameter
+function fn5(x: string, ...y: any[], z: string);
+function fn5() {}
+
+================================================================================
+`;
+
 exports[`functionOverloadErrorsSyntax.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -634,6 +1275,21 @@ function fn5() {}
 ================================================================================
 `;
 
+exports[`functionTypeTypeParameters.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type FuncWithTypeParameter = <T, P>() => {};
+
+=====================================output=====================================
+type FuncWithTypeParameter = <T, P>() => {};
+
+================================================================================
+`;
+
 exports[`functionTypeTypeParameters.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -644,6 +1300,114 @@ type FuncWithTypeParameter = <T, P>() => {};
 
 =====================================output=====================================
 type FuncWithTypeParameter = <T, P>() => {};
+
+================================================================================
+`;
+
+exports[`parameterInitializersForwardReferencing.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+function left(a, b = a, c = b) {
+    a;
+    b;
+}
+
+function right(a = b, b = a) {
+    a;
+    b;
+}
+
+function right2(a = b, b = c, c = a) {
+    a;
+    b;
+    c;
+}
+
+function inside(a = b) {
+    var b;
+}
+
+function outside() {
+    var b;
+    function inside(a = b) { // Still an error because b is declared inside the function
+        var b;
+    }
+}
+
+function defaultArgFunction(a = function () { return b; }, b = 1) { }
+function defaultArgArrow(a = () => () => b, b = 3) { }
+
+class C {
+    constructor(a = b, b = 1) { }
+    method(a = b, b = 1) { }
+}
+
+// Function expressions
+var x = (a = b, b = c, c = d) => { var d; };
+
+// Should not produce errors - can reference later parameters if they occur within a function expression initializer.
+function f(a, b = function () { return c; }, c = b()) {
+}
+
+=====================================output=====================================
+function left(a, b = a, c = b) {
+  a;
+  b;
+}
+
+function right(a = b, b = a) {
+  a;
+  b;
+}
+
+function right2(a = b, b = c, c = a) {
+  a;
+  b;
+  c;
+}
+
+function inside(a = b) {
+  var b;
+}
+
+function outside() {
+  var b;
+  function inside(a = b) {
+    // Still an error because b is declared inside the function
+    var b;
+  }
+}
+
+function defaultArgFunction(
+  a = function () {
+    return b;
+  },
+  b = 1,
+) {}
+function defaultArgArrow(a = () => () => b, b = 3) {}
+
+class C {
+  constructor(a = b, b = 1) {}
+  method(a = b, b = 1) {}
+}
+
+// Function expressions
+var x = (a = b, b = c, c = d) => {
+  var d;
+};
+
+// Should not produce errors - can reference later parameters if they occur within a function expression initializer.
+function f(
+  a,
+  b = function () {
+    return c;
+  },
+  c = b(),
+) {}
 
 ================================================================================
 `;

--- a/tests/format/typescript/conformance/types/functions/jsfmt.spec.js
+++ b/tests/format/typescript/conformance/types/functions/jsfmt.spec.js
@@ -2,6 +2,6 @@ run_spec(import.meta, ["typescript"], {
   errors: { "babel-ts": ["functionOverloadErrorsSyntax.ts"] },
 });
 run_spec(import.meta, ["typescript"], {
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
   errors: { "babel-ts": ["functionOverloadErrorsSyntax.ts"] },
 });

--- a/tests/format/typescript/conformance/types/functions/jsfmt.spec.js
+++ b/tests/format/typescript/conformance/types/functions/jsfmt.spec.js
@@ -1,3 +1,7 @@
 run_spec(import.meta, ["typescript"], {
   errors: { "babel-ts": ["functionOverloadErrorsSyntax.ts"] },
 });
+run_spec(import.meta, ["typescript"], {
+  experimentalOperatorLocation: true,
+  errors: { "babel-ts": ["functionOverloadErrorsSyntax.ts"] },
+});

--- a/tests/format/typescript/instantiation-expression/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/instantiation-expression/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,22 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`basic.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// basic
+const foo = bar<T>;
+
+=====================================output=====================================
+// basic
+const foo = bar<T>;
+
+================================================================================
+`;
+
 exports[`basic.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -16,6 +33,23 @@ const foo = bar<T>;
 ================================================================================
 `;
 
+exports[`binary-expr.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+new A < B >
+C
+
+=====================================output=====================================
+new A<B>();
+C;
+
+================================================================================
+`;
+
 exports[`binary-expr.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -28,6 +62,29 @@ C
 =====================================output=====================================
 new A<B>();
 C;
+
+================================================================================
+`;
+
+exports[`inferface-asi.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+interface Example {
+  (a: number): typeof a
+      
+  <T>(): void
+};
+
+=====================================output=====================================
+interface Example {
+  (a: number): typeof a;
+
+  <T>(): void;
+}
 
 ================================================================================
 `;
@@ -49,6 +106,40 @@ interface Example {
   (a: number): typeof a;
 
   <T>(): void;
+}
+
+================================================================================
+`;
+
+exports[`logical-expr.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export class Foo<T> {
+  message: string;
+}
+
+function sample(error: unknown) {
+  if (!(error instanceof Foo<'some-type'> || error instanceof Error) || !error.message) {
+    return 'something';
+  }
+}
+
+=====================================output=====================================
+export class Foo<T> {
+  message: string;
+}
+
+function sample(error: unknown) {
+  if (
+    !(error instanceof Foo<"some-type"> || error instanceof Error)
+    || !error.message
+  ) {
+    return "something";
+  }
 }
 
 ================================================================================
@@ -87,6 +178,23 @@ function sample(error: unknown) {
 ================================================================================
 `;
 
+exports[`new.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// new
+new A<T>;
+
+=====================================output=====================================
+// new
+new A<T>();
+
+================================================================================
+`;
+
 exports[`new.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -99,6 +207,21 @@ new A<T>;
 =====================================output=====================================
 // new
 new A<T>();
+
+================================================================================
+`;
+
+exports[`typeof.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+let x: typeof y.z<w>;
+
+=====================================output=====================================
+let x: typeof y.z<w>;
 
 ================================================================================
 `;

--- a/tests/format/typescript/instantiation-expression/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/instantiation-expression/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`basic.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`basic.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -33,9 +33,9 @@ const foo = bar<T>;
 ================================================================================
 `;
 
-exports[`binary-expr.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`binary-expr.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -66,9 +66,9 @@ C;
 ================================================================================
 `;
 
-exports[`inferface-asi.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`inferface-asi.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -111,9 +111,9 @@ interface Example {
 ================================================================================
 `;
 
-exports[`logical-expr.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`logical-expr.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -178,9 +178,9 @@ function sample(error: unknown) {
 ================================================================================
 `;
 
-exports[`new.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`new.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -211,9 +211,9 @@ new A<T>();
 ================================================================================
 `;
 
-exports[`typeof.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`typeof.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/typescript/instantiation-expression/jsfmt.spec.js
+++ b/tests/format/typescript/instantiation-expression/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(import.meta, ["typescript"]);
+run_spec(import.meta, ["typescript"], { experimentalOperatorLocation: true });

--- a/tests/format/typescript/instantiation-expression/jsfmt.spec.js
+++ b/tests/format/typescript/instantiation-expression/jsfmt.spec.js
@@ -1,2 +1,2 @@
 run_spec(import.meta, ["typescript"]);
-run_spec(import.meta, ["typescript"], { experimentalOperatorLocation: true });
+run_spec(import.meta, ["typescript"], { experimentalOperatorPosition: true });

--- a/tests/format/typescript/private-fields-in-in/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/private-fields-in-in/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`basic.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`basic.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/typescript/private-fields-in-in/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/private-fields-in-in/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`basic.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+class Person {
+  #name: string;
+  constructor(name: string) {
+    this.#name = name;
+  }
+  
+  equals(other: unknown) {
+    return (
+      other &&
+      typeof other === "object" &&
+      #name in other && // <- this is new!
+      this.#name === other.#name
+    );
+  }
+}
+
+=====================================output=====================================
+class Person {
+  #name: string;
+  constructor(name: string) {
+    this.#name = name;
+  }
+
+  equals(other: unknown) {
+    return (
+      other
+      && typeof other === "object"
+      && #name in other // <- this is new!
+      && this.#name === other.#name
+    );
+  }
+}
+
+================================================================================
+`;
+
 exports[`basic.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/private-fields-in-in/jsfmt.spec.js
+++ b/tests/format/typescript/private-fields-in-in/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(import.meta, ["typescript"]);
+run_spec(import.meta, ["typescript"], { experimentalOperatorLocation: true });

--- a/tests/format/typescript/private-fields-in-in/jsfmt.spec.js
+++ b/tests/format/typescript/private-fields-in-in/jsfmt.spec.js
@@ -1,2 +1,2 @@
 run_spec(import.meta, ["typescript"]);
-run_spec(import.meta, ["typescript"], { experimentalOperatorLocation: true });
+run_spec(import.meta, ["typescript"], { experimentalOperatorPosition: true });

--- a/tests/format/typescript/satisfies-operators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/satisfies-operators/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`argument-expansion.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`argument-expansion.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -188,9 +188,9 @@ const bar5 = [1, 2, 3].reduce((carry, value) => {
 ================================================================================
 `;
 
-exports[`assignment.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`assignment.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -355,9 +355,9 @@ this.intervalID = setInterval(() => {
 ================================================================================
 `;
 
-exports[`basic.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`basic.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -573,9 +573,9 @@ var v = undefined satisfies 1;
 ================================================================================
 `;
 
-exports[`comments.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`comments.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -629,9 +629,9 @@ const t4 = {} /* comment1 */ satisfies /* comment2 */ {};
 ================================================================================
 `;
 
-exports[`comments-unstable.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`comments-unstable.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -706,9 +706,9 @@ Record<string, number>;
 ================================================================================
 `;
 
-exports[`export-default-as.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`export-default-as.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -750,9 +750,9 @@ export default (function log() {} satisfies typeof console.log);
 ================================================================================
 `;
 
-exports[`gt-lt.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`gt-lt.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -800,9 +800,9 @@ x satisfies boolean ?? y; // (x satisfies boolean) ?? y;
 ================================================================================
 `;
 
-exports[`hug-args.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`hug-args.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -868,9 +868,9 @@ window.postMessage({
 ================================================================================
 `;
 
-exports[`lhs.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`lhs.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -951,9 +951,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`nested-await-and-satisfies.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`nested-await-and-satisfies.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1034,9 +1034,9 @@ const getAccountCount = async () =>
 ================================================================================
 `;
 
-exports[`non-null.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`non-null.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1090,9 +1090,9 @@ const el = ReactDOM.findDOMNode(ref);
 ================================================================================
 `;
 
-exports[`satisfies.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`satisfies.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1260,9 +1260,9 @@ foo as unknown satisfies Bar;
 ================================================================================
 `;
 
-exports[`template-literal.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`template-literal.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1355,9 +1355,9 @@ const b = \`\${
 ================================================================================
 `;
 
-exports[`ternary.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`ternary.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -1663,9 +1663,9 @@ bifornCringerMoshedPerplexSawder =
 ================================================================================
 `;
 
-exports[`types-comments.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`types-comments.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/typescript/satisfies-operators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/satisfies-operators/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,68 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`argument-expansion.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const bar1 = [1,2,3].reduce((carry, value) => {
+  return [...carry, value];
+}, ([] satisfies unknown) satisfies number[]);
+
+const bar2 = [1,2,3].reduce((carry, value) => {
+  return [...carry, value];
+}, ([1, 2, 3] satisfies unknown) satisfies number[]);
+
+const bar3 = [1,2,3].reduce((carry, value) => {
+  return {...carry, [value]: true};
+}, ({} satisfies unknown) satisfies {[key: number]: boolean});
+
+const bar4 = [1,2,3].reduce((carry, value) => {
+  return {...carry, [value]: true};
+}, ({1: true} satisfies unknown) satisfies {[key: number]: boolean});
+
+const bar5 = [1,2,3].reduce((carry, value) => {
+  return [...carry, value];
+}, [] satisfies foo);
+
+=====================================output=====================================
+const bar1 = [1, 2, 3].reduce(
+  (carry, value) => {
+    return [...carry, value];
+  },
+  [] satisfies unknown satisfies number[],
+);
+
+const bar2 = [1, 2, 3].reduce(
+  (carry, value) => {
+    return [...carry, value];
+  },
+  [1, 2, 3] satisfies unknown satisfies number[],
+);
+
+const bar3 = [1, 2, 3].reduce(
+  (carry, value) => {
+    return { ...carry, [value]: true };
+  },
+  {} satisfies unknown satisfies { [key: number]: boolean },
+);
+
+const bar4 = [1, 2, 3].reduce(
+  (carry, value) => {
+    return { ...carry, [value]: true };
+  },
+  { 1: true } satisfies unknown satisfies { [key: number]: boolean },
+);
+
+const bar5 = [1, 2, 3].reduce((carry, value) => {
+  return [...carry, value];
+}, [] satisfies foo);
+
+================================================================================
+`;
+
 exports[`argument-expansion.ts - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -125,6 +188,62 @@ const bar5 = [1, 2, 3].reduce((carry, value) => {
 ================================================================================
 `;
 
+exports[`assignment.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const extraRendererAttrs = ((attrs.rendererAttrs &&
+  this.utils.safeParseJsonString(attrs.rendererAttrs)) ||
+  Object.create(null)) satisfies FieldService.RendererAttributes;
+
+const annotate = (angular.injector satisfies any).$$annotate satisfies (
+  fn: Function
+) => string[];
+  
+const originalPrototype = originalConstructor.prototype satisfies TComponent & InjectionTarget,
+  propertyToServiceName = originalPrototype._inject;
+
+this.previewPlayerHandle = (setInterval(async () => {
+  if (this.previewIsPlaying) {
+    await this.fetchNextPreviews();
+    this.currentPreviewIndex++;
+  }
+}, this.refreshDelay) satisfies unknown) satisfies number;
+
+this.intervalID = (setInterval(() => {
+  self.step();
+}, 30) satisfies unknown) satisfies number;
+
+=====================================output=====================================
+const extraRendererAttrs = ((attrs.rendererAttrs
+  && this.utils.safeParseJsonString(attrs.rendererAttrs))
+  || Object.create(null)) satisfies FieldService.RendererAttributes;
+
+const annotate = (angular.injector satisfies any).$$annotate satisfies (
+  fn: Function,
+) => string[];
+
+const originalPrototype = originalConstructor.prototype satisfies TComponent &
+    InjectionTarget,
+  propertyToServiceName = originalPrototype._inject;
+
+this.previewPlayerHandle = setInterval(async () => {
+  if (this.previewIsPlaying) {
+    await this.fetchNextPreviews();
+    this.currentPreviewIndex++;
+  }
+}, this.refreshDelay) satisfies unknown satisfies number;
+
+this.intervalID = setInterval(() => {
+  self.step();
+}, 30) satisfies unknown satisfies number;
+
+================================================================================
+`;
+
 exports[`assignment.ts - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -232,6 +351,79 @@ this.previewPlayerHandle = setInterval(async () => {
 this.intervalID = setInterval(() => {
   self.step();
 }, 30) satisfies unknown satisfies number;
+
+================================================================================
+`;
+
+exports[`basic.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const t1 = { a: 1 } satisfies I1;
+const t2 = { a: 1, b: 1 } satisfies I1;
+const t3 = { } satisfies I1;
+const t4: T1 = { a: "a" } satisfies T1;
+const t5 = (m => m.substring(0)) satisfies T2;
+const t6 = [1, 2] satisfies [number, number];
+let t7 = { a: 'test' } satisfies A;
+let t8 = { a: 'test', b: 'test' } satisfies A;
+
+const p = {
+  isEven: n => n % 2 === 0,
+  isOdd: n => n % 2 === 1
+} satisfies Predicates;
+
+let obj: { f(s: string): void } & Record<string, unknown> = {
+    f(s) { },
+    g(s) { }
+} satisfies { g(s: string): void } & Record<string, unknown>;
+
+({ f(x) { } }) satisfies { f(s: string): void };
+
+const car = {
+    start() { },
+    move(d) {
+        // d should be number
+    },
+    stop() { }
+} satisfies Movable & Record<string, unknown>;
+
+var v = undefined satisfies 1;
+
+=====================================output=====================================
+const t1 = { a: 1 } satisfies I1;
+const t2 = { a: 1, b: 1 } satisfies I1;
+const t3 = {} satisfies I1;
+const t4: T1 = { a: "a" } satisfies T1;
+const t5 = ((m) => m.substring(0)) satisfies T2;
+const t6 = [1, 2] satisfies [number, number];
+let t7 = { a: "test" } satisfies A;
+let t8 = { a: "test", b: "test" } satisfies A;
+
+const p = {
+  isEven: (n) => n % 2 === 0,
+  isOdd: (n) => n % 2 === 1,
+} satisfies Predicates;
+
+let obj: { f(s: string): void } & Record<string, unknown> = {
+  f(s) {},
+  g(s) {},
+} satisfies { g(s: string): void } & Record<string, unknown>;
+
+({ f(x) {} }) satisfies { f(s: string): void };
+
+const car = {
+  start() {},
+  move(d) {
+    // d should be number
+  },
+  stop() {},
+} satisfies Movable & Record<string, unknown>;
+
+var v = undefined satisfies 1;
 
 ================================================================================
 `;
@@ -381,6 +573,25 @@ var v = undefined satisfies 1;
 ================================================================================
 `;
 
+exports[`comments.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const t2 = {} /* comment */ satisfies {};
+const t3 = {} satisfies /* comment */ {};
+const t4 = {} /* comment1 */ satisfies /* comment2 */ {};
+
+=====================================output=====================================
+const t2 = {} /* comment */ satisfies {};
+const t3 = {} satisfies /* comment */ {};
+const t4 = {} /* comment1 */ satisfies /* comment2 */ {};
+
+================================================================================
+`;
+
 exports[`comments.ts - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -414,6 +625,32 @@ const t4 = {} /* comment1 */ satisfies /* comment2 */ {};
 const t2 = {} /* comment */ satisfies {};
 const t3 = {} satisfies /* comment */ {};
 const t4 = {} /* comment1 */ satisfies /* comment2 */ {};
+
+================================================================================
+`;
+
+exports[`comments-unstable.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const t1 = {
+    prop1: 1,
+    prop2: 2,
+    prop3: 3
+} satisfies
+// Comment
+Record<string, number>;
+
+=====================================output=====================================
+const t1 = {
+  prop1: 1,
+  prop2: 2,
+  prop3: 3,
+} satisfies // Comment
+Record<string, number>;
 
 ================================================================================
 `;
@@ -469,6 +706,21 @@ Record<string, number>;
 ================================================================================
 `;
 
+exports[`export-default-as.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export default (function log() {} satisfies typeof console.log)
+
+=====================================output=====================================
+export default (function log() {} satisfies typeof console.log);
+
+================================================================================
+`;
+
 exports[`export-default-as.ts - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -494,6 +746,23 @@ export default (function log() {} satisfies typeof console.log)
 
 =====================================output=====================================
 export default (function log() {} satisfies typeof console.log);
+
+================================================================================
+`;
+
+exports[`gt-lt.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+x satisfies boolean <= y; // (x satisfies boolean) <= y;
+x satisfies boolean ?? y; // (x satisfies boolean) ?? y;
+
+=====================================output=====================================
+(x satisfies boolean) <= y; // (x satisfies boolean) <= y;
+(x satisfies boolean) ?? y; // (x satisfies boolean) ?? y;
 
 ================================================================================
 `;
@@ -527,6 +796,29 @@ x satisfies boolean ?? y; // (x satisfies boolean) ?? y;
 =====================================output=====================================
 (x satisfies boolean) <= y; // (x satisfies boolean) <= y;
 (x satisfies boolean) ?? y; // (x satisfies boolean) ?? y;
+
+================================================================================
+`;
+
+exports[`hug-args.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+window.postMessage(
+    {
+      context: item.context,
+      topic: item.topic
+    } satisfies IActionMessage
+  );
+
+=====================================output=====================================
+window.postMessage({
+  context: item.context,
+  topic: item.topic,
+} satisfies IActionMessage);
 
 ================================================================================
 `;
@@ -572,6 +864,34 @@ window.postMessage({
   context: item.context,
   topic: item.topic,
 } satisfies IActionMessage);
+
+================================================================================
+`;
+
+exports[`lhs.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+(a satisfies number) = 42;
+({ a: (b satisfies any) = 2000 } = x);
+(this.selectorElem satisfies any) = this.multiselectWidget = this.initialValues = undefined;
+(this.configuration satisfies any) = (this.editor satisfies any) = (this
+  .editorBody satisfies any) = undefined;
+
+=====================================output=====================================
+(a satisfies number) = 42;
+({ a: (b satisfies any) = 2000 } = x);
+(this.selectorElem satisfies any) =
+  this.multiselectWidget =
+  this.initialValues =
+    undefined;
+(this.configuration satisfies any) =
+  (this.editor satisfies any) =
+  (this.editorBody satisfies any) =
+    undefined;
 
 ================================================================================
 `;
@@ -631,6 +951,34 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`nested-await-and-satisfies.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const getAccountCount = async () =>
+  (await
+    ((await (
+      await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
+    ).findItem("My bookmarks")) satisfies TreeItem
+  ).getChildren()
+  ).length
+
+=====================================output=====================================
+const getAccountCount = async () =>
+  (
+    await (
+      (await (
+        await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
+      ).findItem("My bookmarks")) satisfies TreeItem
+    ).getChildren()
+  ).length;
+
+================================================================================
+`;
+
 exports[`nested-await-and-satisfies.ts - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -686,6 +1034,25 @@ const getAccountCount = async () =>
 ================================================================================
 `;
 
+exports[`non-null.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// the 2nd line needs ASI protection
+const el = ReactDOM.findDOMNode(ref)
+;(el satisfies HTMLElement)!.style.cursor = 'pointer'
+
+=====================================output=====================================
+// the 2nd line needs ASI protection
+const el = ReactDOM.findDOMNode(ref);
+(el satisfies HTMLElement)!.style.cursor = "pointer";
+
+================================================================================
+`;
+
 exports[`non-null.ts - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -719,6 +1086,63 @@ const el = ReactDOM.findDOMNode(ref)
 // the 2nd line needs ASI protection
 const el = ReactDOM.findDOMNode(ref);
 (el satisfies HTMLElement)!.style.cursor = "pointer";
+
+================================================================================
+`;
+
+exports[`satisfies.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+({}) satisfies {};
+({}) satisfies X;
+() => ({}) satisfies X;
+this.isTabActionBar((e.target || e.srcElement) satisfies HTMLElement);
+
+'current' in (props.pagination satisfies Object);
+('current' in props.pagination) satisfies Object;
+start + (yearSelectTotal satisfies number);
+(start + yearSelectTotal) satisfies number;
+scrollTop > (visibilityHeight satisfies number);
+(scrollTop > visibilityHeight) satisfies number;
+(bValue satisfies boolean) ? 0 : -1;
+
+async function g1() {
+  const test = (await 'foo') satisfies number;
+}
+
+var x = (v => v) satisfies (x: number) => string;
+
+foo satisfies unknown satisfies Bar;
+foo satisfies unknown as Bar;
+foo as unknown satisfies Bar;
+
+=====================================output=====================================
+({}) satisfies {};
+({}) satisfies X;
+() => ({} satisfies X);
+this.isTabActionBar((e.target || e.srcElement) satisfies HTMLElement);
+
+"current" in (props.pagination satisfies Object);
+("current" in props.pagination) satisfies Object;
+start + (yearSelectTotal satisfies number);
+(start + yearSelectTotal) satisfies number;
+scrollTop > (visibilityHeight satisfies number);
+(scrollTop > visibilityHeight) satisfies number;
+(bValue satisfies boolean) ? 0 : -1;
+
+async function g1() {
+  const test = (await "foo") satisfies number;
+}
+
+var x = ((v) => v) satisfies (x: number) => string;
+
+foo satisfies unknown satisfies Bar;
+foo satisfies unknown as Bar;
+foo as unknown satisfies Bar;
 
 ================================================================================
 `;
@@ -836,6 +1260,38 @@ foo as unknown satisfies Bar;
 ================================================================================
 `;
 
+exports[`template-literal.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const a = \`\${(foo + bar) satisfies baz}\`;
+const b = \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + bar) satisfies baz}\`;
+const b = \`\${(foo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) satisfies baz}\`;
+const b = \`\${(foo + bar) satisfies veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}\`;
+const b = \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) satisfies veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}\`;
+
+=====================================output=====================================
+const a = \`\${(foo + bar) satisfies baz}\`;
+const b = \`\${
+  (veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + bar) satisfies baz
+}\`;
+const b = \`\${
+  (foo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) satisfies baz
+}\`;
+const b = \`\${
+  (foo + bar) satisfies veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz
+}\`;
+const b = \`\${
+  (veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo
+    + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) satisfies veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz
+}\`;
+
+================================================================================
+`;
+
 exports[`template-literal.ts - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -895,6 +1351,109 @@ const b = \`\${
   (veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo +
     veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) satisfies veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz
 }\`;
+
+================================================================================
+`;
+
+exports[`ternary.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz) satisfies Fooooooooooo;
+
+foo = (condition ? firstValue : secondValue) satisfies SomeType;
+
+const foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz) satisfies Fooooooooooo;
+
+function foo() {
+  return (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz) satisfies Fooooooooooo;
+}
+
+function foo() {
+  throw (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz) satisfies Fooooooooooo;
+}
+
+function foo() {
+  void ((coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz) satisfies Fooooooooooo);
+}
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol) satisfies AnnularCooeedSplicesWalksWayWay);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0 &&
+  kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol) satisfies AnnularCooeedSplicesWalksWayWay);
+
+=====================================output=====================================
+foo = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+) satisfies Fooooooooooo;
+
+foo = (condition ? firstValue : secondValue) satisfies SomeType;
+
+const foo = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+) satisfies Fooooooooooo;
+
+function foo() {
+  return (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ) satisfies Fooooooooooo;
+}
+
+function foo() {
+  throw (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ) satisfies Fooooooooooo;
+}
+
+function foo() {
+  void ((
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ) satisfies Fooooooooooo);
+}
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans
+  + ((glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol) satisfies AnnularCooeedSplicesWalksWayWay);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans
+  + ((glimseGlyphsHazardNoopsTieTie === 0
+  && kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol) satisfies AnnularCooeedSplicesWalksWayWay);
 
 ================================================================================
 `;
@@ -1100,6 +1659,25 @@ bifornCringerMoshedPerplexSawder =
   kochabCooieGameOnOboleUnweave === Math.PI
     ? averredBathersBoxroomBuggyNurl
     : anodyneCondosMalateOverateRetinol) satisfies AnnularCooeedSplicesWalksWayWay);
+
+================================================================================
+`;
+
+exports[`types-comments.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+(() => {
+  // swallow error and fallback to using directory as path
+}) satisfies string[];
+
+=====================================output=====================================
+(() => {
+  // swallow error and fallback to using directory as path
+}) satisfies string[];
 
 ================================================================================
 `;

--- a/tests/format/typescript/satisfies-operators/jsfmt.spec.js
+++ b/tests/format/typescript/satisfies-operators/jsfmt.spec.js
@@ -1,3 +1,3 @@
 run_spec(import.meta, ["typescript"]);
 run_spec(import.meta, ["typescript"], { semi: false });
-run_spec(import.meta, ["typescript"], { experimentalOperatorLocation: true });
+run_spec(import.meta, ["typescript"], { experimentalOperatorPosition: true });

--- a/tests/format/typescript/satisfies-operators/jsfmt.spec.js
+++ b/tests/format/typescript/satisfies-operators/jsfmt.spec.js
@@ -1,2 +1,3 @@
 run_spec(import.meta, ["typescript"]);
 run_spec(import.meta, ["typescript"], { semi: false });
+run_spec(import.meta, ["typescript"], { experimentalOperatorLocation: true });

--- a/tests/format/typescript/template-literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/template-literals/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`as-expression.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`as-expression.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth
@@ -63,9 +63,9 @@ const b = \`\${
 ================================================================================
 `;
 
-exports[`expressions.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`expressions.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/typescript/template-literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/template-literals/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`as-expression.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const a = \`\${(foo + bar) as baz}\`;
+const b = \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + bar) as baz}\`;
+const b = \`\${(foo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) as baz}\`;
+const b = \`\${(foo + bar) as veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}\`;
+const b = \`\${(veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) as veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz}\`;
+
+=====================================output=====================================
+const a = \`\${(foo + bar) as baz}\`;
+const b = \`\${
+  (veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo + bar) as baz
+}\`;
+const b = \`\${
+  (foo + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) as baz
+}\`;
+const b = \`\${
+  (foo + bar) as veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz
+}\`;
+const b = \`\${
+  (veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo
+    + veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) as veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz
+}\`;
+
+================================================================================
+`;
+
 exports[`as-expression.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
@@ -27,6 +59,20 @@ const b = \`\${
   (veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongFoo +
     veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBar) as veryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongBaz
 }\`;
+
+================================================================================
+`;
+
+exports[`expressions.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const bar = tag<number>\`but where will prettier wrap such a long tagged template literal? \${foo.bar.baz} long long long long long long long long long long long long long long\`;
+=====================================output=====================================
+const bar = tag<number>\`but where will prettier wrap such a long tagged template literal? \${foo.bar.baz} long long long long long long long long long long long long long long\`;
 
 ================================================================================
 `;

--- a/tests/format/typescript/template-literals/jsfmt.spec.js
+++ b/tests/format/typescript/template-literals/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(import.meta, ["typescript"]);
+run_spec(import.meta, ["typescript"], { experimentalOperatorLocation: true });

--- a/tests/format/typescript/template-literals/jsfmt.spec.js
+++ b/tests/format/typescript/template-literals/jsfmt.spec.js
@@ -1,2 +1,2 @@
 run_spec(import.meta, ["typescript"]);
-run_spec(import.meta, ["typescript"], { experimentalOperatorLocation: true });
+run_spec(import.meta, ["typescript"], { experimentalOperatorPosition: true });

--- a/tests/format/typescript/ternaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/ternaries/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`indent.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`indent.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/typescript/ternaries/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/ternaries/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,128 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`indent.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+foo = (callNode.parent?.type === AST_NODE_TYPES.ChainExpression
+  ? callNode.parent.parent
+  : callNode.parent
+).TSESTree!.BinaryExpression;
+
+foo = (callNode.parent?.type === AST_NODE_TYPES.ChainExpression
+  ? callNode.parent.parent
+  : callNode.parent
+).TSESTree!.BinaryExpression;
+
+bifornCringerMoshedPerplexSawder = (glimseGlyphsHazardNoopsTieTie === 0 &&
+kochabCooieGameOnOboleUnweave === Math.PI
+  ? averredBathersBoxroomBuggyNurl
+  : anodyneCondosMalateOverateRetinol
+).annularCooeedSplicesWalksWayWay
+  .annularCooeedSplicesWalksWayWay(annularCooeedSplicesWalksWayWay)!
+  .annularCooeedSplicesWalksWayWay();
+
+foo = (callNode.parent?.type === AST_NODE_TYPES.ChainExpression
+  ? callNode.parent.parent
+  : callNode.parent
+).TSESTree!.BinaryExpression!;
+
+foo = (callNode.parent?.type === AST_NODE_TYPES.ChainExpression
+  ? callNode.parent.parent
+  : callNode.parent
+).TSESTree!.BinaryExpression!;
+
+bifornCringerMoshedPerplexSawder = (glimseGlyphsHazardNoopsTieTie === 0 &&
+kochabCooieGameOnOboleUnweave === Math.PI
+  ? averredBathersBoxroomBuggyNurl
+  : anodyneCondosMalateOverateRetinol
+).annularCooeedSplicesWalksWayWay
+  .annularCooeedSplicesWalksWayWay(annularCooeedSplicesWalksWayWay)!
+  .annularCooeedSplicesWalksWayWay()!;
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).Foo!.foo;
+
+foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz)!;
+
+foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz)!!!!!;
+
+=====================================output=====================================
+foo = (
+  callNode.parent?.type === AST_NODE_TYPES.ChainExpression
+    ? callNode.parent.parent
+    : callNode.parent
+).TSESTree!.BinaryExpression;
+
+foo = (
+  callNode.parent?.type === AST_NODE_TYPES.ChainExpression
+    ? callNode.parent.parent
+    : callNode.parent
+).TSESTree!.BinaryExpression;
+
+bifornCringerMoshedPerplexSawder = (
+  glimseGlyphsHazardNoopsTieTie === 0
+  && kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+).annularCooeedSplicesWalksWayWay
+  .annularCooeedSplicesWalksWayWay(annularCooeedSplicesWalksWayWay)!
+  .annularCooeedSplicesWalksWayWay();
+
+foo = (
+  callNode.parent?.type === AST_NODE_TYPES.ChainExpression
+    ? callNode.parent.parent
+    : callNode.parent
+).TSESTree!.BinaryExpression!;
+
+foo = (
+  callNode.parent?.type === AST_NODE_TYPES.ChainExpression
+    ? callNode.parent.parent
+    : callNode.parent
+).TSESTree!.BinaryExpression!;
+
+bifornCringerMoshedPerplexSawder = (
+  glimseGlyphsHazardNoopsTieTie === 0
+  && kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+).annularCooeedSplicesWalksWayWay
+  .annularCooeedSplicesWalksWayWay(annularCooeedSplicesWalksWayWay)!
+  .annularCooeedSplicesWalksWayWay()!;
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans
+  + (glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol
+  ).Foo!.foo;
+
+foo = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+)!;
+
+foo = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+)!!!!!;
+
+================================================================================
+`;
+
 exports[`indent.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/ternaries/jsfmt.spec.js
+++ b/tests/format/typescript/ternaries/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(import.meta, ["typescript"]);
+run_spec(import.meta, ["typescript"], { experimentalOperatorLocation: true });

--- a/tests/format/typescript/ternaries/jsfmt.spec.js
+++ b/tests/format/typescript/ternaries/jsfmt.spec.js
@@ -1,2 +1,2 @@
 run_spec(import.meta, ["typescript"]);
-run_spec(import.meta, ["typescript"], { experimentalOperatorLocation: true });
+run_spec(import.meta, ["typescript"], { experimentalOperatorPosition: true });

--- a/tests/format/typescript/webhost/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/webhost/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,231 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`webtsc.ts - {"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+/// <reference path='..\\..\\src\\compiler\\tsc.ts'/>
+
+namespace TypeScript.WebTsc {
+
+    declare var RealActiveXObject: { new (s: string): any };
+
+    function getWScriptSystem() {
+        const fso = new RealActiveXObject("Scripting.FileSystemObject");
+
+        const fileStream = new ActiveXObject("ADODB.Stream");
+        fileStream.Type = 2 /*text*/;
+
+        const args: string[] = [];
+        for (let i = 0; i < WScript.Arguments.length; i++) {
+            args[i] = WScript.Arguments.Item(i);
+        }
+        return {
+            args: args,
+            newLine: "\\r\\n",
+            write(s: string): void {
+                WScript.StdOut.Write(s);
+            },
+            writeErr(s: string): void {
+                WScript.StdErr.Write(s);
+            },
+            readFile(fileName: string, encoding?: string): string {
+                if (!fso.FileExists(fileName)) {
+                    return undefined;
+                }
+                fileStream.Open();
+                try {
+                    if (encoding) {
+                        fileStream.Charset = encoding;
+                        fileStream.LoadFromFile(fileName);
+                    }
+                    else {
+                        // Load file and read the first two bytes into a string with no interpretation
+                        fileStream.Charset = "x-ansi";
+                        fileStream.LoadFromFile(fileName);
+                        const bom = fileStream.ReadText(2) || "";
+                        // Position must be at 0 before encoding can be changed
+                        fileStream.Position = 0;
+                        // [0xFF,0xFE] and [0xFE,0xFF] mean utf-16 (little or big endian), otherwise default to utf-8
+                        fileStream.Charset = bom.length >= 2 && (bom.charCodeAt(0) === 0xFF && bom.charCodeAt(1) === 0xFE || bom.charCodeAt(0) === 0xFE && bom.charCodeAt(1) === 0xFF) ? "unicode" : "utf-8";
+                    }
+                    // ReadText method always strips byte order mark from resulting string
+                    return fileStream.ReadText();
+                }
+                catch (e) {
+                    throw e;
+                }
+                finally {
+                    fileStream.Close();
+                }
+            },
+            writeFile(fileName: string, data: string): boolean {
+                const f = fso.CreateTextFile(fileName, true);
+                f.Write(data);
+                f.Close();
+                return true;
+            },
+            resolvePath(path: string): string {
+                return fso.GetAbsolutePathName(path);
+            },
+            fileExists(path: string): boolean {
+                return fso.FileExists(path);
+            },
+            directoryExists(path: string) {
+                return fso.FolderExists(path);
+            },
+            createDirectory(directoryName: string) {
+                if (!this.directoryExists(directoryName)) {
+                    fso.CreateFolder(directoryName);
+                }
+            },
+            getExecutingFilePath() {
+                return WScript.ScriptFullName;
+            },
+            getCurrentDirectory() {
+                return "";
+            },
+            getMemoryUsage() {
+                return 0;
+            },
+            exit(exitCode?: number): void {
+                WScript.Quit(exitCode);
+            },
+            useCaseSensitiveFileNames: false
+        };
+    }
+
+    export function prepareCompiler(currentDir: string, stdOut: ITextWriter, stdErr: ITextWriter) {
+        const shell = new RealActiveXObject("WScript.Shell");
+        shell.CurrentDirectory = currentDir;
+        WScript.ScriptFullName = currentDir + "\\\\tc.js";
+        WScript.StdOut = stdOut;
+        WScript.StdErr = stdErr;
+        sys = getWScriptSystem();
+
+        return (commandLine: string) => {
+            ts.executeCommandLine(commandLine.split(" "));
+        };
+    }
+}
+
+=====================================output=====================================
+/// <reference path='..\\..\\src\\compiler\\tsc.ts'/>
+
+namespace TypeScript.WebTsc {
+  declare var RealActiveXObject: { new (s: string): any };
+
+  function getWScriptSystem() {
+    const fso = new RealActiveXObject("Scripting.FileSystemObject");
+
+    const fileStream = new ActiveXObject("ADODB.Stream");
+    fileStream.Type = 2 /*text*/;
+
+    const args: string[] = [];
+    for (let i = 0; i < WScript.Arguments.length; i++) {
+      args[i] = WScript.Arguments.Item(i);
+    }
+    return {
+      args: args,
+      newLine: "\\r\\n",
+      write(s: string): void {
+        WScript.StdOut.Write(s);
+      },
+      writeErr(s: string): void {
+        WScript.StdErr.Write(s);
+      },
+      readFile(fileName: string, encoding?: string): string {
+        if (!fso.FileExists(fileName)) {
+          return undefined;
+        }
+        fileStream.Open();
+        try {
+          if (encoding) {
+            fileStream.Charset = encoding;
+            fileStream.LoadFromFile(fileName);
+          } else {
+            // Load file and read the first two bytes into a string with no interpretation
+            fileStream.Charset = "x-ansi";
+            fileStream.LoadFromFile(fileName);
+            const bom = fileStream.ReadText(2) || "";
+            // Position must be at 0 before encoding can be changed
+            fileStream.Position = 0;
+            // [0xFF,0xFE] and [0xFE,0xFF] mean utf-16 (little or big endian), otherwise default to utf-8
+            fileStream.Charset =
+              bom.length >= 2
+              && ((bom.charCodeAt(0) === 0xff && bom.charCodeAt(1) === 0xfe)
+                || (bom.charCodeAt(0) === 0xfe && bom.charCodeAt(1) === 0xff))
+                ? "unicode"
+                : "utf-8";
+          }
+          // ReadText method always strips byte order mark from resulting string
+          return fileStream.ReadText();
+        } catch (e) {
+          throw e;
+        } finally {
+          fileStream.Close();
+        }
+      },
+      writeFile(fileName: string, data: string): boolean {
+        const f = fso.CreateTextFile(fileName, true);
+        f.Write(data);
+        f.Close();
+        return true;
+      },
+      resolvePath(path: string): string {
+        return fso.GetAbsolutePathName(path);
+      },
+      fileExists(path: string): boolean {
+        return fso.FileExists(path);
+      },
+      directoryExists(path: string) {
+        return fso.FolderExists(path);
+      },
+      createDirectory(directoryName: string) {
+        if (!this.directoryExists(directoryName)) {
+          fso.CreateFolder(directoryName);
+        }
+      },
+      getExecutingFilePath() {
+        return WScript.ScriptFullName;
+      },
+      getCurrentDirectory() {
+        return "";
+      },
+      getMemoryUsage() {
+        return 0;
+      },
+      exit(exitCode?: number): void {
+        WScript.Quit(exitCode);
+      },
+      useCaseSensitiveFileNames: false,
+    };
+  }
+
+  export function prepareCompiler(
+    currentDir: string,
+    stdOut: ITextWriter,
+    stdErr: ITextWriter,
+  ) {
+    const shell = new RealActiveXObject("WScript.Shell");
+    shell.CurrentDirectory = currentDir;
+    WScript.ScriptFullName = currentDir + "\\\\tc.js";
+    WScript.StdOut = stdOut;
+    WScript.StdErr = stdErr;
+    sys = getWScriptSystem();
+
+    return (commandLine: string) => {
+      ts.executeCommandLine(commandLine.split(" "));
+    };
+  }
+}
+
+================================================================================
+`;
+
 exports[`webtsc.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/webhost/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/webhost/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`webtsc.ts - {"experimentalOperatorLocation":true} format 1`] = `
+exports[`webtsc.ts - {"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/typescript/webhost/jsfmt.spec.js
+++ b/tests/format/typescript/webhost/jsfmt.spec.js
@@ -1,1 +1,2 @@
 run_spec(import.meta, ["typescript"]);
+run_spec(import.meta, ["typescript"], { experimentalOperatorLocation: true });

--- a/tests/format/typescript/webhost/jsfmt.spec.js
+++ b/tests/format/typescript/webhost/jsfmt.spec.js
@@ -1,2 +1,2 @@
 run_spec(import.meta, ["typescript"]);
-run_spec(import.meta, ["typescript"], { experimentalOperatorLocation: true });
+run_spec(import.meta, ["typescript"], { experimentalOperatorPosition: true });

--- a/tests/format/vue/vue/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/vue/vue/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,372 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`attributes.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<template>
+<div
+  v-for="({ longLongProp, longLongProp }, index) of longLongLongLongLongLongLongLongList"
+  v-for="({ longLongProp=42, longLongProp='Hello, World!' }, index) of longLongLongLongLongLongLongLongList"
+  v-for="({ longLongProp, longLongProp }) of longLongLongLongLongLongLongLongList"
+  v-for="({ longLongProp, longLongProp, anotherLongLongProp, yetAnotherLongLongProp }, index) of longLongLongLongLongLongLongLongList"
+  v-for="({ longLongProp, longLongProp, anotherLongLongProp, yetAnotherLongLongProp }) of longLongLongLongLongLongLongLongList"
+  v-for="([longLongProp, longLongProp, anotherLongLongProp, yetAnotherLongLongProp], index) of longLongLongLongLongLongLongLongList"
+  v-for="([longLongProp, longLongProp=42, anotherLongLongProp, yetAnotherLongLongProp='Hello, World!'], index) of longLongLongLongLongLongLongLongList"
+  v-for="([longLongProp, longLongProp, [longLongProp, longLongProp, [longLongProp, longLongProp, anotherLongLongProp, yetAnotherLongLongProp], yetAnotherLongLongProp], yetAnotherLongLongProp], index) of longLongLongLongLongLongLongLongList"
+  v-for="([longLongProp, longLongProp, [longLongProp, longLongProp='Hello, Prettier!', [longLongProp, longLongProp, anotherLongLongProp=[longLongProp, longLongProp, anotherLongLongProp, yetAnotherLongLongProp], yetAnotherLongLongProp], yetAnotherLongLongProp], yetAnotherLongLongProp], index) of longLongLongLongLongLongLongLongList"
+  v-for="([{ longLongProp, longLongProp }, { longLongProp, longLongProp }, [{ longLongProp, longLongProp, anotherLongLongProp, yetAnotherLongLongProp }, longLongProp], yetAnotherLongLongProp], index) of longLongLongLongLongLongLongLongList"
+  v-for="({firstValue, secondValue: { longLongProp, longLongProp, anotherLongLongProp, yetAnotherLongLongProp }}, objectKey, index) in objectWithAVeryVeryVeryVeryLongName"
+  v-for="({firstValue={ longLongProp, longLongProp }, secondValue}, objectKey, index) in objectWithAVeryVeryVeryVeryLongName"
+  v-for="({firstValue, secondValue, thirdValue, fourthValue}, objectKey, index) in objectWithAVeryVeryVeryVeryLongName"
+  v-for="({firstValue, secondValue, thirdValue, fourthValue}, objectKey, index) in objectWithAVeryVeryVeryVeryLongName"
+  v-for="({firstValue, secondValue, thirdValue, fourthValue, fifthValue: { longLongProp, longLongProp, anotherLongLongProp, yetAnotherLongLongProp }, sixthValue, seventhValue}, objectKey, index) in objectWithAVeryVeryVeryVeryLongName"
+  v-for="({firstValue, secondValue, thirdValue, fourthValue, fifthValue: { longLongProp, longLongProp, anotherLongLongProp, yetAnotherLongLongProp }, sixthValue: {firstValue, secondValue, thirdValue, fourthValue, fifthValue: { longLongProp, longLongProp, anotherLongLongProp, yetAnotherLongLongProp }, sixthValue, seventhValue}, seventhValue}, objectKey, index) in objectWithAVeryVeryVeryVeryLongName"
+  v-for="({firstValue, secondValue, thirdValue, fourthValue, fifthValue: { longLongProp, longLongProp, anotherLongLongProp={ longLongProp, longLongProp, anotherLongLongProp, yetAnotherLongLongProp }, yetAnotherLongLongProp }, sixthValue, seventhValue}, objectKey, index) in objectWithAVeryVeryVeryVeryLongName"
+  v-for="  item  in  items "
+  v-for="  item  of  items "
+  v-for="(    item    , index)    in    items"
+  v-for="value    in     object"
+  v-for="(value,    key)    in    object"
+  v-for="(value,    key)    of    object"
+  v-for="(value  ,   key,   index)    in   object"
+  v-for="   n    in   evenNumbers"
+  v-for=" n in even   ( numbers) "
+  v-for=" n    in    10"
+  v-for=" { a }    in    [0].map(()=>({a:1}))   "
+  v-for=" ({ a }, [c  ])    in    [0].map(()=>1)   "
+  v-for=" n in items.map(x => { return x }) "
+  @click="  /* hello */   "
+  @click="   /* 1 */ $emit( /* 2 */ 'click' /* 3 */ ) /* 4 */ ; /* 5 */   "
+  @click="   $emit(   'click'   )   "
+  @click="   $emit(   'click'   )  ;"
+  @click="   $emit(   'click'   )  ;if(something){for(let i=j;i<100;i++){}}else{}"
+  slot-scope="     foo"
+  slot-scope="     {row   }"
+  slot-scope="{destructuring:{   a:{b}}}"
+  #default="     foo"
+  #default="     {row   }"
+  #default="{destructuring:{   a:{b}}}"
+  v-slot="     foo"
+  v-slot="     {row   }"
+  v-slot="{destructuring:{   a:{b}}}"
+  v-slot:name="     foo"
+  v-slot:name="     {row   }"
+  v-slot:name="{destructuring:{   a:{b}}}"
+  :class="{ longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true }"
+  :class="(() => { return 'hello' })()"
+  :key="index /* hello */ "
+  :key="index // hello "
+  @click="() => {console.log(test)}"
+  @click="
+    () => {
+      console.log(test);
+    }
+  "
+  @click="doSomething()"
+  @click="doSomething;"
+  @click="a.b;"
+  @click="a[1];"
+  @click="a['b'];"
+  @click="a[null];"
+  #default="{foo:{bar:{baz}}}"
+></div>
+</template>
+
+=====================================output=====================================
+<template>
+  <div
+    v-for="(
+      { longLongProp, longLongProp }, index
+    ) of longLongLongLongLongLongLongLongList"
+    v-for="(
+      { longLongProp = 42, longLongProp = 'Hello, World!' }, index
+    ) of longLongLongLongLongLongLongLongList"
+    v-for="{
+      longLongProp,
+      longLongProp,
+    } of longLongLongLongLongLongLongLongList"
+    v-for="(
+      {
+        longLongProp,
+        longLongProp,
+        anotherLongLongProp,
+        yetAnotherLongLongProp,
+      },
+      index
+    ) of longLongLongLongLongLongLongLongList"
+    v-for="{
+      longLongProp,
+      longLongProp,
+      anotherLongLongProp,
+      yetAnotherLongLongProp,
+    } of longLongLongLongLongLongLongLongList"
+    v-for="(
+      [longLongProp, longLongProp, anotherLongLongProp, yetAnotherLongLongProp],
+      index
+    ) of longLongLongLongLongLongLongLongList"
+    v-for="(
+      [
+        longLongProp,
+        longLongProp = 42,
+        anotherLongLongProp,
+        yetAnotherLongLongProp = 'Hello, World!',
+      ],
+      index
+    ) of longLongLongLongLongLongLongLongList"
+    v-for="(
+      [
+        longLongProp,
+        longLongProp,
+        [
+          longLongProp,
+          longLongProp,
+          [
+            longLongProp,
+            longLongProp,
+            anotherLongLongProp,
+            yetAnotherLongLongProp,
+          ],
+          yetAnotherLongLongProp,
+        ],
+        yetAnotherLongLongProp,
+      ],
+      index
+    ) of longLongLongLongLongLongLongLongList"
+    v-for="(
+      [
+        longLongProp,
+        longLongProp,
+        [
+          longLongProp,
+          longLongProp = 'Hello, Prettier!',
+          [
+            longLongProp,
+            longLongProp,
+            anotherLongLongProp = [
+              longLongProp,
+              longLongProp,
+              anotherLongLongProp,
+              yetAnotherLongLongProp,
+            ],
+            yetAnotherLongLongProp,
+          ],
+          yetAnotherLongLongProp,
+        ],
+        yetAnotherLongLongProp,
+      ],
+      index
+    ) of longLongLongLongLongLongLongLongList"
+    v-for="(
+      [
+        { longLongProp, longLongProp },
+        { longLongProp, longLongProp },
+        [
+          {
+            longLongProp,
+            longLongProp,
+            anotherLongLongProp,
+            yetAnotherLongLongProp,
+          },
+          longLongProp,
+        ],
+        yetAnotherLongLongProp,
+      ],
+      index
+    ) of longLongLongLongLongLongLongLongList"
+    v-for="(
+      {
+        firstValue,
+        secondValue: {
+          longLongProp,
+          longLongProp,
+          anotherLongLongProp,
+          yetAnotherLongLongProp,
+        },
+      },
+      objectKey,
+      index
+    ) in objectWithAVeryVeryVeryVeryLongName"
+    v-for="(
+      { firstValue = { longLongProp, longLongProp }, secondValue },
+      objectKey,
+      index
+    ) in objectWithAVeryVeryVeryVeryLongName"
+    v-for="(
+      { firstValue, secondValue, thirdValue, fourthValue }, objectKey, index
+    ) in objectWithAVeryVeryVeryVeryLongName"
+    v-for="(
+      { firstValue, secondValue, thirdValue, fourthValue }, objectKey, index
+    ) in objectWithAVeryVeryVeryVeryLongName"
+    v-for="(
+      {
+        firstValue,
+        secondValue,
+        thirdValue,
+        fourthValue,
+        fifthValue: {
+          longLongProp,
+          longLongProp,
+          anotherLongLongProp,
+          yetAnotherLongLongProp,
+        },
+        sixthValue,
+        seventhValue,
+      },
+      objectKey,
+      index
+    ) in objectWithAVeryVeryVeryVeryLongName"
+    v-for="(
+      {
+        firstValue,
+        secondValue,
+        thirdValue,
+        fourthValue,
+        fifthValue: {
+          longLongProp,
+          longLongProp,
+          anotherLongLongProp,
+          yetAnotherLongLongProp,
+        },
+        sixthValue: {
+          firstValue,
+          secondValue,
+          thirdValue,
+          fourthValue,
+          fifthValue: {
+            longLongProp,
+            longLongProp,
+            anotherLongLongProp,
+            yetAnotherLongLongProp,
+          },
+          sixthValue,
+          seventhValue,
+        },
+        seventhValue,
+      },
+      objectKey,
+      index
+    ) in objectWithAVeryVeryVeryVeryLongName"
+    v-for="(
+      {
+        firstValue,
+        secondValue,
+        thirdValue,
+        fourthValue,
+        fifthValue: {
+          longLongProp,
+          longLongProp,
+          anotherLongLongProp = {
+            longLongProp,
+            longLongProp,
+            anotherLongLongProp,
+            yetAnotherLongLongProp,
+          },
+          yetAnotherLongLongProp,
+        },
+        sixthValue,
+        seventhValue,
+      },
+      objectKey,
+      index
+    ) in objectWithAVeryVeryVeryVeryLongName"
+    v-for="item in items"
+    v-for="item of items"
+    v-for="(item, index) in items"
+    v-for="value in object"
+    v-for="(value, key) in object"
+    v-for="(value, key) of object"
+    v-for="(value, key, index) in object"
+    v-for="n in evenNumbers"
+    v-for="n in even(numbers)"
+    v-for="n in 10"
+    v-for="{ a } in [0].map(() => ({ a: 1 }))"
+    v-for="({ a }, [c]) in [0].map(() => 1)"
+    v-for="n in items.map((x) => {
+      return x
+    })"
+    @click="/* hello */"
+    @click="/* 1 */ $emit(/* 2 */ 'click' /* 3 */) /* 4 */ /* 5 */"
+    @click="$emit('click')"
+    @click="$emit('click')"
+    @click="
+      $emit('click')
+      if (something) {
+        for (let i = j; i < 100; i++) {}
+      } else {
+      }
+    "
+    slot-scope="foo"
+    slot-scope="{ row }"
+    slot-scope="{
+      destructuring: {
+        a: { b },
+      },
+    }"
+    #default="foo"
+    #default="{ row }"
+    #default="{
+      destructuring: {
+        a: { b },
+      },
+    }"
+    v-slot="foo"
+    v-slot="{ row }"
+    v-slot="{
+      destructuring: {
+        a: { b },
+      },
+    }"
+    v-slot:name="foo"
+    v-slot:name="{ row }"
+    v-slot:name="{
+      destructuring: {
+        a: { b },
+      },
+    }"
+    :class="{
+      longlonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglonglong: true,
+    }"
+    :class="
+      (() => {
+        return 'hello'
+      })()
+    "
+    :key="index /* hello */"
+    :key="
+      index // hello
+    "
+    @click="
+      () => {
+        console.log(test)
+      }
+    "
+    @click="
+      () => {
+        console.log(test)
+      }
+    "
+    @click="doSomething()"
+    @click="doSomething;"
+    @click="a.b;"
+    @click="a[1];"
+    @click="a['b'];"
+    @click="a[null]"
+    #default="{
+      foo: {
+        bar: { baz },
+      },
+    }"
+  ></div>
+</template>
+
+================================================================================
+`;
+
 exports[`attributes.vue - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["vue"]
@@ -1098,6 +1465,173 @@ trailingComma: "none"
 ================================================================================
 `;
 
+exports[`board_card.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<script>
+import './issue_card_inner';
+import eventHub from '../eventhub';
+
+const Store = gl.issueBoards.BoardsStore;
+
+export default {
+  name: 'BoardsIssueCard',
+  components: {
+    'issue-card-inner': gl.issueBoards.IssueCardInner,
+  },
+  props: {
+    list: Object,
+    issue: Object,
+    issueLinkBase: String,
+    disabled: Boolean,
+    index: Number,
+    rootPath: String,
+  },
+  data() {
+    return {
+      showDetail: false,
+      detailIssue: Store.detail,
+    };
+  },
+  computed: {
+    issueDetailVisible() {
+      return (
+        this.detailIssue.issue && this.detailIssue.issue.id === this.issue.id
+      );
+    },
+  },
+  methods: {
+    mouseDown() {
+      this.showDetail = true;
+    },
+    mouseMove() {
+      this.showDetail = false;
+    },
+    showIssue(e) {
+      if (e.target.classList.contains('js-no-trigger')) return;
+
+      if (this.showDetail) {
+        this.showDetail = false;
+
+        if (Store.detail.issue && Store.detail.issue.id === this.issue.id) {
+          eventHub.$emit('clearDetailIssue');
+        } else {
+          eventHub.$emit('newDetailIssue', this.issue);
+          Store.detail.list = this.list;
+        }
+      }
+    },
+  },
+};
+</script>
+
+<template>
+  <li class="card"
+    :class="{ 'user-can-drag': !disabled && issue.id, 'is-disabled': disabled || !issue.id, 'is-active': issueDetailVisible }"
+    :index="index"
+    :data-issue-id="issue.id"
+    @mousedown="mouseDown"
+    @mousemove="mouseMove"
+    @mouseup="showIssue($event)">
+    <issue-card-inner
+      :list="list"
+      :issue="issue"
+      :issue-link-base="issueLinkBase"
+      :root-path="rootPath"
+      :update-filters="true" />
+  </li>
+</template>
+
+=====================================output=====================================
+<script>
+import "./issue_card_inner"
+import eventHub from "../eventhub"
+
+const Store = gl.issueBoards.BoardsStore
+
+export default {
+  name: "BoardsIssueCard",
+  components: {
+    "issue-card-inner": gl.issueBoards.IssueCardInner,
+  },
+  props: {
+    list: Object,
+    issue: Object,
+    issueLinkBase: String,
+    disabled: Boolean,
+    index: Number,
+    rootPath: String,
+  },
+  data() {
+    return {
+      showDetail: false,
+      detailIssue: Store.detail,
+    }
+  },
+  computed: {
+    issueDetailVisible() {
+      return (
+        this.detailIssue.issue && this.detailIssue.issue.id === this.issue.id
+      )
+    },
+  },
+  methods: {
+    mouseDown() {
+      this.showDetail = true
+    },
+    mouseMove() {
+      this.showDetail = false
+    },
+    showIssue(e) {
+      if (e.target.classList.contains("js-no-trigger")) return
+
+      if (this.showDetail) {
+        this.showDetail = false
+
+        if (Store.detail.issue && Store.detail.issue.id === this.issue.id) {
+          eventHub.$emit("clearDetailIssue")
+        } else {
+          eventHub.$emit("newDetailIssue", this.issue)
+          Store.detail.list = this.list
+        }
+      }
+    },
+  },
+}
+</script>
+
+<template>
+  <li
+    class="card"
+    :class="{
+      'user-can-drag': !disabled && issue.id,
+      'is-disabled': disabled || !issue.id,
+      'is-active': issueDetailVisible,
+    }"
+    :index="index"
+    :data-issue-id="issue.id"
+    @mousedown="mouseDown"
+    @mousemove="mouseMove"
+    @mouseup="showIssue($event)"
+  >
+    <issue-card-inner
+      :list="list"
+      :issue="issue"
+      :issue-link-base="issueLinkBase"
+      :root-path="rootPath"
+      :update-filters="true"
+    />
+  </li>
+</template>
+
+================================================================================
+`;
+
 exports[`board_card.vue - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["vue"]
@@ -1596,6 +2130,26 @@ export default {
 ================================================================================
 `;
 
+exports[`case-sensitive-tags.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<template>
+	<Input></Input>
+</template>
+
+=====================================output=====================================
+<template>
+  <Input></Input>
+</template>
+
+================================================================================
+`;
+
 exports[`case-sensitive-tags.vue - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["vue"]
@@ -1649,6 +2203,37 @@ trailingComma: "none"
 <template>
   <Input></Input>
 </template>
+
+================================================================================
+`;
+
+exports[`custom-block.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<i18n>
+  en:
+    one: One
+    two: Two
+</i18n>
+
+<html><head></head><body></body></html>
+
+=====================================output=====================================
+<i18n>
+  en:
+    one: One
+    two: Two
+</i18n>
+
+<html>
+  <head></head>
+  <body></body>
+</html>
 
 ================================================================================
 `;
@@ -1739,6 +2324,81 @@ trailingComma: "none"
   <head></head>
   <body></body>
 </html>
+
+================================================================================
+`;
+
+exports[`expression-binding.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<!-- #7396 -->
+<template>
+<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`"/>
+</template>
+<template>
+<MyComponent :attr="\`\${first} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`
++\`\${second} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`"/>
+</template>
+<template>
+<MyComponent :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo +               bar} template literal value\`"/>
+</template>
+<template>
+<MyComponent :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value'"/>
+</template>
+<template>
+<MyComponent :src="'first loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog' + 'second loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog'"/>
+</template>
+<template>
+<MyComponent :src="100000000000000000000000000000000000000000000000000000000000000000000000000"/>
+</template>
+
+=====================================output=====================================
+<!-- #7396 -->
+<template>
+  <MyComponent
+    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${foo} template literal value\`"
+  />
+</template>
+<template>
+  <MyComponent
+    :attr="
+      \`\${first} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`
+      + \`\${second} loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${template} \${literal}\`
+    "
+  />
+</template>
+<template>
+  <MyComponent
+    :attr="\`loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog \${
+      foo + bar
+    } template literal value\`"
+  />
+</template>
+<template>
+  <MyComponent
+    :src="'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog literal string value'"
+  />
+</template>
+<template>
+  <MyComponent
+    :src="
+      'first loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog'
+      + 'second loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog'
+    "
+  />
+</template>
+<template>
+  <MyComponent
+    :src="
+      100000000000000000000000000000000000000000000000000000000000000000000000000
+    "
+  />
+</template>
 
 ================================================================================
 `;
@@ -1965,6 +2625,65 @@ trailingComma: "none"
 ================================================================================
 `;
 
+exports[`filter.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<!-- vue filters are only allowed in v-bind and interpolation -->
+<template>
+  <div class="allowed">{{value | thisIsARealSuperLongFilterPipe("arg1", arg2) | anotherPipeLongJustForFun | pipeTheThird}}</div>
+  <div class="allowed" v-bind:something='value | thisIsARealSuperLongFilterPipe("arg1", arg2) | anotherPipeLongJustForFun | pipeTheThird'></div>
+  <div class="allowed" :class='value | thisIsARealSuperLongFilterPipe("arg1", arg2) | anotherPipeLongJustForFun | pipeTheThird'></div>
+  <div class="not-allowed" v-if='value | thisIsARealSuperLongFilterPipe("arg1", arg2) | anotherPipeLongJustForFun | pipeTheThird'></div>
+</template>
+
+=====================================output=====================================
+<!-- vue filters are only allowed in v-bind and interpolation -->
+<template>
+  <div class="allowed">
+    {{
+      value
+        | thisIsARealSuperLongFilterPipe("arg1", arg2)
+        | anotherPipeLongJustForFun
+        | pipeTheThird
+    }}
+  </div>
+  <div
+    class="allowed"
+    v-bind:something="
+      value
+        | thisIsARealSuperLongFilterPipe('arg1', arg2)
+        | anotherPipeLongJustForFun
+        | pipeTheThird
+    "
+  ></div>
+  <div
+    class="allowed"
+    :class="
+      value
+        | thisIsARealSuperLongFilterPipe('arg1', arg2)
+        | anotherPipeLongJustForFun
+        | pipeTheThird
+    "
+  ></div>
+  <div
+    class="not-allowed"
+    v-if="
+      value
+        | thisIsARealSuperLongFilterPipe('arg1', arg2)
+        | anotherPipeLongJustForFun
+        | pipeTheThird
+    "
+  ></div>
+</template>
+
+================================================================================
+`;
+
 exports[`filter.vue - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["vue"]
@@ -2134,6 +2853,138 @@ trailingComma: "none"
         pipeTheThird
     "
   ></div>
+</template>
+
+================================================================================
+`;
+
+exports[`interpolations.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<template>
+<div>Fuga magnam facilis. Voluptatem quaerat porro.{{
+
+
+x => {
+    const hello = 'world'
+    return hello;
+}
+
+
+
+}} Magni consectetur in et molestias neque esse voluptatibus voluptas. {{  
+    
+    
+    some_variable 
+
+
+
+}} Eum quia nihil nulla esse. Dolorem asperiores vero est error {{
+
+                    preserve
+
+                    invalid
+                    
+                    interpolation
+
+}} reprehenderit voluptates minus {{console.log(  short_interpolation )}} nemo.</div>
+
+<script type="text/jsx">
+  export default {
+    render (h) {
+      return (
+        <ul
+          class={{
+            'a': b,
+            'c': d,
+            "e": f
+          }}
+        >
+          { this.xyz }
+        </ul>
+    )
+  };
+</script>
+
+<div>
+  1234567890123456789012345678901234567890123456789012345678901234567890{{ something }}1234567890
+</div>
+<div>
+  1234567890123456789012345678901234567890123456789012345678901234567890 {{ something }}1234567890
+</div>
+<div>
+  1234567890123456789012345678901234567890123456789012345678901234567890{{ something }} 1234567890
+</div>
+<div>
+  1234567890123456789012345678901234567890123456789012345678901234567890 {{ something }} 1234567890
+</div>
+</template>
+
+=====================================output=====================================
+<template>
+  <div>
+    Fuga magnam facilis. Voluptatem quaerat porro.{{
+      (x) => {
+        const hello = "world"
+        return hello
+      }
+    }}
+    Magni consectetur in et molestias neque esse voluptatibus voluptas.
+    {{ some_variable }} Eum quia nihil nulla esse. Dolorem asperiores vero est
+    error
+    {{
+
+                    preserve
+
+                    invalid
+                    
+                    interpolation
+
+    }}
+    reprehenderit voluptates minus {{ console.log(short_interpolation) }} nemo.
+  </div>
+
+  <script type="text/jsx">
+    export default {
+      render (h) {
+        return (
+          <ul
+            class={{
+              'a': b,
+              'c': d,
+              "e": f
+            }}
+          >
+            { this.xyz }
+          </ul>
+      )
+    };
+  </script>
+
+  <div>
+    1234567890123456789012345678901234567890123456789012345678901234567890{{
+      something
+    }}1234567890
+  </div>
+  <div>
+    1234567890123456789012345678901234567890123456789012345678901234567890
+    {{ something }}1234567890
+  </div>
+  <div>
+    1234567890123456789012345678901234567890123456789012345678901234567890{{
+      something
+    }}
+    1234567890
+  </div>
+  <div>
+    1234567890123456789012345678901234567890123456789012345678901234567890
+    {{ something }} 1234567890
+  </div>
 </template>
 
 ================================================================================
@@ -2532,6 +3383,30 @@ x => {
 ================================================================================
 `;
 
+exports[`multiple-template1.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<template></template>
+<template lang=unknown>
+<a>
+</template>
+cloned.
+
+=====================================output=====================================
+<template></template>
+<template lang="unknown">
+<a>
+</template>
+cloned.
+
+================================================================================
+`;
+
 exports[`multiple-template1.vue - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["vue"]
@@ -2601,6 +3476,30 @@ cloned.
 ================================================================================
 `;
 
+exports[`multiple-template2.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<template></template>
+<template lang=unknown>
+<a>
+</template>
+<template></template >
+
+=====================================output=====================================
+<template></template>
+<template lang="unknown">
+<a>
+</template>
+<template></template>
+
+================================================================================
+`;
+
 exports[`multiple-template2.vue - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["vue"]
@@ -2666,6 +3565,38 @@ trailingComma: "none"
 <a>
 </template>
 <template></template>
+
+================================================================================
+`;
+
+exports[`nested-template.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<template>
+  <div>
+      <template>
+        <div></div>
+      </template>
+      <div>
+               Do not go out, you'll got yourself cloned by bad bad people.
+      </div>
+  </div>
+</template>
+
+=====================================output=====================================
+<template>
+  <div>
+    <template>
+      <div></div>
+    </template>
+    <div>Do not go out, you'll got yourself cloned by bad bad people.</div>
+  </div>
+</template>
 
 ================================================================================
 `;
@@ -2763,6 +3694,25 @@ trailingComma: "none"
 ================================================================================
 `;
 
+exports[`one-line-template1.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<template><p>foo</p><div>foo</div></template>
+
+=====================================output=====================================
+<template>
+  <p>foo</p>
+  <div>foo</div>
+</template>
+
+================================================================================
+`;
+
 exports[`one-line-template1.vue - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["vue"]
@@ -2812,6 +3762,27 @@ trailingComma: "none"
 <template>
   <p>foo</p>
   <div>foo</div>
+</template>
+
+================================================================================
+`;
+
+exports[`one-line-template2.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<template><div><p>foo</p><div>bar</div></div></template>
+
+=====================================output=====================================
+<template>
+  <div>
+    <p>foo</p>
+    <div>bar</div>
+  </div>
 </template>
 
 ================================================================================
@@ -2872,6 +3843,113 @@ trailingComma: "none"
     <p>foo</p>
     <div>bar</div>
   </div>
+</template>
+
+================================================================================
+`;
+
+exports[`pre-child.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<template>
+<!-- copied from https://github.com/gitlabhq/gitlabhq/blob/master/app/assets/javascripts/ide/components/jobs/detail.vue -->
+<pre
+  ref="buildTrace"
+  class="build-trace mb-0 h-100"
+  @scroll="scrollBuildLog"
+>
+  <code
+    v-show="!detailJob.isLoading"
+    class="bash"
+    v-html="jobOutput"
+  >
+  </code>
+  <div
+    v-show="detailJob.isLoading"
+    class="build-loader-animation"
+  >
+    <div class="dot"></div>
+    <div class="dot"></div>
+    <div class="dot"></div>
+  </div>
+</pre>
+</template>
+
+<!-- copied from https://github.com/gitlabhq/gitlabhq/blob/master/app/assets/javascripts/vue_shared/components/code_block.vue -->
+<template>
+  <pre class="code-block rounded">
+    <code class="d-block">{{ code }}</code>
+  </pre>
+</template>
+
+<template>
+<pre class='woot'>
+  {{ stuff }}
+  </pre>
+</template>
+
+<template>
+<pre class='woot'>
+  123{{ wqeqwwqwqweqweqwewwq || wqeqwwqwqweqweqwewwq || wqeqwwqwqweqweqwewwq || wqeqwwqwqweqweqwewwq }}123
+  123{{ wqeqwwqwqweqweqwewwq || wqeqwwqwqweqweqwewwq || wqeqwwqwqweqweqwewwq || wqeqwwqwqweqweqwewwq }}123
+    </pre>
+</template>
+
+=====================================output=====================================
+<template>
+  <!-- copied from https://github.com/gitlabhq/gitlabhq/blob/master/app/assets/javascripts/ide/components/jobs/detail.vue -->
+  <pre ref="buildTrace" class="build-trace mb-0 h-100" @scroll="scrollBuildLog">
+  <code
+    v-show="!detailJob.isLoading"
+    class="bash"
+    v-html="jobOutput"
+  >
+  </code>
+  <div
+    v-show="detailJob.isLoading"
+    class="build-loader-animation"
+  >
+    <div class="dot"></div>
+    <div class="dot"></div>
+    <div class="dot"></div>
+  </div>
+</pre>
+</template>
+
+<!-- copied from https://github.com/gitlabhq/gitlabhq/blob/master/app/assets/javascripts/vue_shared/components/code_block.vue -->
+<template>
+  <pre class="code-block rounded">
+    <code class="d-block">{{ code }}</code>
+  </pre>
+</template>
+
+<template>
+  <pre class="woot">
+  {{ stuff }}
+  </pre>
+</template>
+
+<template>
+  <pre class="woot">
+  123{{
+      wqeqwwqwqweqweqwewwq
+      || wqeqwwqwqweqweqwewwq
+      || wqeqwwqwqweqweqwewwq
+      || wqeqwwqwqweqweqwewwq
+    }}123
+  123{{
+      wqeqwwqwqweqweqwewwq
+      || wqeqwwqwqweqweqwewwq
+      || wqeqwwqwqweqweqwewwq
+      || wqeqwwqwqweqweqwewwq
+    }}123
+    </pre
+  >
 </template>
 
 ================================================================================
@@ -3195,6 +4273,24 @@ trailingComma: "none"
 ================================================================================
 `;
 
+exports[`script_src.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<script src="https://www.gstatic.com/firebasejs/4.10.1/firebase.js"></script>
+<script src="https://www.gstatic.com/firebasejs/4.10.1/firebase-firestore.js"></script>
+
+=====================================output=====================================
+<script src="https://www.gstatic.com/firebasejs/4.10.1/firebase.js"></script>
+<script src="https://www.gstatic.com/firebasejs/4.10.1/firebase-firestore.js"></script>
+
+================================================================================
+`;
+
 exports[`script_src.vue - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["vue"]
@@ -3242,6 +4338,62 @@ trailingComma: "none"
 =====================================output=====================================
 <script src="https://www.gstatic.com/firebasejs/4.10.1/firebase.js"></script>
 <script src="https://www.gstatic.com/firebasejs/4.10.1/firebase-firestore.js"></script>
+
+================================================================================
+`;
+
+exports[`self_closing.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<template>
+  <div />
+</template>
+
+<script>
+foo( )
+</script>
+
+<template>
+<div class="container">
+  <HomeH />
+  <HomeA />
+  <HomeX />
+  <HomeY />
+</div>
+</template>
+
+<template>
+  <Foo><Bar
+         attr
+                                     /></Foo>
+</template>
+
+=====================================output=====================================
+<template>
+  <div />
+</template>
+
+<script>
+foo()
+</script>
+
+<template>
+  <div class="container">
+    <HomeH />
+    <HomeA />
+    <HomeX />
+    <HomeY />
+  </div>
+</template>
+
+<template>
+  <Foo><Bar attr /></Foo>
+</template>
 
 ================================================================================
 `;
@@ -3411,6 +4563,30 @@ foo();
 ================================================================================
 `;
 
+exports[`self_closing_style.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<template>
+  <span :class="$style.root"><slot /></span>
+</template>
+
+<style src="./style.css" module />
+
+=====================================output=====================================
+<template>
+  <span :class="$style.root"><slot /></span>
+</template>
+
+<style src="./style.css" module />
+
+================================================================================
+`;
+
 exports[`self_closing_style.vue - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["vue"]
@@ -3476,6 +4652,114 @@ trailingComma: "none"
 </template>
 
 <style src="./style.css" module />
+
+================================================================================
+`;
+
+exports[`style.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<script>
+</script>
+
+<style>
+#foo1{ color: #f00;
+}
+</style>
+<style scoped>
+#foo2{ color: #f00;
+}
+</style>
+
+<style lang="css">
+#foo3{ color: #f00;
+}
+</style>
+<style lang="css" scoped>
+#foo4{ color: #f00;
+}
+</style>
+
+<style lang="less">
+#foo5{ color: #f00;
+}
+</style>
+<style lang="less" scoped>
+#foo6{ 
+         @color: #f00;
+  color: @color;
+}
+</style>
+
+
+<style lang="scss">
+#foo8{ 
+         $color: #f00;
+  color: $color;
+}
+</style>
+<style lang="scss" scoped>
+#foo8{ 
+         $color: #f00;
+  color: $color;
+}
+</style>
+
+
+=====================================output=====================================
+<script></script>
+
+<style>
+#foo1 {
+  color: #f00;
+}
+</style>
+<style scoped>
+#foo2 {
+  color: #f00;
+}
+</style>
+
+<style lang="css">
+#foo3 {
+  color: #f00;
+}
+</style>
+<style lang="css" scoped>
+#foo4 {
+  color: #f00;
+}
+</style>
+
+<style lang="less">
+#foo5 {
+  color: #f00;
+}
+</style>
+<style lang="less" scoped>
+#foo6 {
+  @color: #f00;
+  color: @color;
+}
+</style>
+
+<style lang="scss">
+#foo8 {
+  $color: #f00;
+  color: $color;
+}
+</style>
+<style lang="scss" scoped>
+#foo8 {
+  $color: #f00;
+  color: $color;
+}
+</style>
 
 ================================================================================
 `;
@@ -3801,6 +5085,26 @@ trailingComma: "none"
 ================================================================================
 `;
 
+exports[`tag-name.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<template>
+  <Table></Table>
+</template>
+
+=====================================output=====================================
+<template>
+  <Table></Table>
+</template>
+
+================================================================================
+`;
+
 exports[`tag-name.vue - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["vue"]
@@ -3853,6 +5157,71 @@ trailingComma: "none"
 =====================================output=====================================
 <template>
   <Table></Table>
+</template>
+
+================================================================================
+`;
+
+exports[`template.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<!--copied from https://github.com/gitlabhq/gitlabhq/blob/master/app/assets/javascripts/vue_shared/components/content_viewer/viewers/image_viewer.vue-->
+<template>
+  <div class="file-container">
+    <div class="file-content image_file">
+      <img
+        ref="contentImg"
+        :class="{ 'is-zoomable': isZoomable, 'is-zoomed': isZoomed }"
+        :src="path"
+        :alt="path"
+        @load="onImgLoad"
+        @click="onImgClick"/>
+      <p
+        v-if="renderInfo"
+        class="file-info prepend-top-10">
+        <template v-if="fileSize>0">
+          {{ fileSizeReadable }}
+        </template>
+        <template v-if="fileSize>0 && width && height">
+          |
+        </template>
+        <template v-if="width && height">
+          W: {{ width }} | H: {{ height }}
+        </template>
+      </p>
+    </div>
+  </div>
+</template>
+
+=====================================output=====================================
+<!--copied from https://github.com/gitlabhq/gitlabhq/blob/master/app/assets/javascripts/vue_shared/components/content_viewer/viewers/image_viewer.vue-->
+<template>
+  <div class="file-container">
+    <div class="file-content image_file">
+      <img
+        ref="contentImg"
+        :class="{ 'is-zoomable': isZoomable, 'is-zoomed': isZoomed }"
+        :src="path"
+        :alt="path"
+        @load="onImgLoad"
+        @click="onImgClick"
+      />
+      <p v-if="renderInfo" class="file-info prepend-top-10">
+        <template v-if="fileSize > 0">
+          {{ fileSizeReadable }}
+        </template>
+        <template v-if="fileSize > 0 && width && height"> | </template>
+        <template v-if="width && height">
+          W: {{ width }} | H: {{ height }}
+        </template>
+      </p>
+    </div>
+  </div>
 </template>
 
 ================================================================================
@@ -4050,6 +5419,39 @@ trailingComma: "none"
 ================================================================================
 `;
 
+exports[`template-dom.html - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<!DOCTYPE html><html>
+  <body>
+    <div v-if="foo ===    'foo'">
+
+</div>
+    <script>
+new Vue({el: '#app'})
+    </script>
+  </body>
+</html>
+
+=====================================output=====================================
+<!doctype html>
+<html>
+  <body>
+    <div v-if="foo === 'foo'"></div>
+    <script>
+      new Vue({ el: "#app" })
+    </script>
+  </body>
+</html>
+
+================================================================================
+`;
+
 exports[`template-dom.html - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["vue"]
@@ -4142,6 +5544,88 @@ new Vue({el: '#app'})
     </script>
   </body>
 </html>
+
+================================================================================
+`;
+
+exports[`template-lang.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<template lang="pug">
+  .test
+    #foo
+  .bla
+</template>
+
+<template 
+
+
+   
+   lang='pug'>
+  .test
+    #foo
+  .bla
+</template>
+
+<template lang="unknown">
+  #container
+    some-component(tag='<some-tag>')
+</template>
+
+<template lang="">
+  <v-app-bar>
+    <v-menu offset-y>
+      <template></template>
+    </v-menu>
+  </v-app-bar>
+</template>
+
+<template lang>
+  <v-app-bar>
+    <v-menu offset-y>
+      <template></template>
+    </v-menu>
+  </v-app-bar>
+</template>
+
+=====================================output=====================================
+<template lang="pug">
+  .test
+    #foo
+  .bla
+</template>
+
+<template lang="pug">
+  .test
+    #foo
+  .bla
+</template>
+
+<template lang="unknown">
+  #container
+    some-component(tag='<some-tag>')
+</template>
+
+<template lang="">
+  <v-app-bar>
+    <v-menu offset-y>
+      <template></template>
+    </v-menu>
+  </v-app-bar>
+</template>
+
+<template lang>
+  <v-app-bar>
+    <v-menu offset-y>
+      <template></template>
+    </v-menu>
+  </v-app-bar>
+</template>
 
 ================================================================================
 `;
@@ -4389,6 +5873,39 @@ trailingComma: "none"
 ================================================================================
 `;
 
+exports[`test.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<script>
+</script>
+
+<template>
+  <br />
+  <footer>
+    foo
+    <br/>
+  </footer>
+</template>
+
+=====================================output=====================================
+<script></script>
+
+<template>
+  <br />
+  <footer>
+    foo
+    <br />
+  </footer>
+</template>
+
+================================================================================
+`;
+
 exports[`test.vue - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["vue"]
@@ -4480,6 +5997,118 @@ trailingComma: "none"
     foo
     <br />
   </footer>
+</template>
+
+================================================================================
+`;
+
+exports[`v-if.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+====================================options=====================================
+experimentalOperatorLocation: true
+parsers: ["vue"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+<template>
+<root>
+  <and v-if="
+long_long_long_long_long_long_long_condition_1 && long_long_long_long_long_long_long_condition_2 && short_1 && short_2 &&
+long_long_long_long_long_long_long_condition_3 &&
+long_long_long_long_long_long_long_condition_4
+"></and>
+  <and v-if="
+(long_long_long_long_long_long_long_condition_1 && long_long_long_long_long_long_long_condition_2 && (short_1 && short_2) ) &&
+long_long_long_long_long_long_long_condition_3 &&
+long_long_long_long_long_long_long_condition_4
+"></and>
+  <or v-if="
+long_long_long_long_long_long_long_condition_1 || long_long_long_long_long_long_long_condition_2 ||short_1 || short_2 ||
+long_long_long_long_long_long_long_condition_3 ||
+long_long_long_long_long_long_long_condition_4
+"></or>
+  <or v-if="
+(long_long_long_long_long_long_long_condition_1 || long_long_long_long_long_long_long_condition_2 || (short_1 || short_2) ||
+long_long_long_long_long_long_long_condition_3) ||
+long_long_long_long_long_long_long_condition_4
+"></or>
+  <mixed v-if="
+long_long_long_long_long_long_long_condition_1 && long_long_long_long_long_long_long_condition_2 ||  ((short_1 && short_2) &&
+long_long_long_long_long_long_long_condition_3 &&
+long_long_long_long_long_long_long_condition_4)
+"></mixed>
+  <mixed v-if="
+long_long_long_long_long_long_long_condition_1 && long_long_long_long_long_long_long_condition_2 || short_1 && short_2 &&
+long_long_long_long_long_long_long_condition_3 ||
+long_long_long_long_long_long_long_condition_4
+"></mixed>
+</root>
+</template>
+
+=====================================output=====================================
+<template>
+  <root>
+    <and
+      v-if="
+        long_long_long_long_long_long_long_condition_1
+        && long_long_long_long_long_long_long_condition_2
+        && short_1
+        && short_2
+        && long_long_long_long_long_long_long_condition_3
+        && long_long_long_long_long_long_long_condition_4
+      "
+    ></and>
+    <and
+      v-if="
+        long_long_long_long_long_long_long_condition_1
+        && long_long_long_long_long_long_long_condition_2
+        && short_1
+        && short_2
+        && long_long_long_long_long_long_long_condition_3
+        && long_long_long_long_long_long_long_condition_4
+      "
+    ></and>
+    <or
+      v-if="
+        long_long_long_long_long_long_long_condition_1
+        || long_long_long_long_long_long_long_condition_2
+        || short_1
+        || short_2
+        || long_long_long_long_long_long_long_condition_3
+        || long_long_long_long_long_long_long_condition_4
+      "
+    ></or>
+    <or
+      v-if="
+        long_long_long_long_long_long_long_condition_1
+        || long_long_long_long_long_long_long_condition_2
+        || short_1
+        || short_2
+        || long_long_long_long_long_long_long_condition_3
+        || long_long_long_long_long_long_long_condition_4
+      "
+    ></or>
+    <mixed
+      v-if="
+        (long_long_long_long_long_long_long_condition_1
+          && long_long_long_long_long_long_long_condition_2)
+        || (short_1
+          && short_2
+          && long_long_long_long_long_long_long_condition_3
+          && long_long_long_long_long_long_long_condition_4)
+      "
+    ></mixed>
+    <mixed
+      v-if="
+        (long_long_long_long_long_long_long_condition_1
+          && long_long_long_long_long_long_long_condition_2)
+        || (short_1
+          && short_2
+          && long_long_long_long_long_long_long_condition_3)
+        || long_long_long_long_long_long_long_condition_4
+      "
+    ></mixed>
+  </root>
 </template>
 
 ================================================================================

--- a/tests/format/vue/vue/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/vue/vue/__snapshots__/jsfmt.spec.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`attributes.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`attributes.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -1465,9 +1465,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`board_card.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`board_card.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -2130,9 +2130,9 @@ export default {
 ================================================================================
 `;
 
-exports[`case-sensitive-tags.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`case-sensitive-tags.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -2207,9 +2207,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`custom-block.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`custom-block.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -2328,9 +2328,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`expression-binding.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`expression-binding.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -2625,9 +2625,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`filter.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`filter.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -2858,9 +2858,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`interpolations.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`interpolations.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -3383,9 +3383,9 @@ x => {
 ================================================================================
 `;
 
-exports[`multiple-template1.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`multiple-template1.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -3476,9 +3476,9 @@ cloned.
 ================================================================================
 `;
 
-exports[`multiple-template2.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`multiple-template2.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -3569,9 +3569,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`nested-template.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`nested-template.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -3694,9 +3694,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`one-line-template1.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`one-line-template1.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -3767,9 +3767,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`one-line-template2.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`one-line-template2.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -3848,9 +3848,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`pre-child.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`pre-child.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -4273,9 +4273,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`script_src.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`script_src.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -4342,9 +4342,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`self_closing.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`self_closing.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -4563,9 +4563,9 @@ foo();
 ================================================================================
 `;
 
-exports[`self_closing_style.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`self_closing_style.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -4656,9 +4656,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`style.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`style.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -5085,9 +5085,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`tag-name.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`tag-name.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -5162,9 +5162,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`template.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`template.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -5419,9 +5419,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`template-dom.html - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`template-dom.html - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -5548,9 +5548,9 @@ new Vue({el: '#app'})
 ================================================================================
 `;
 
-exports[`template-lang.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`template-lang.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -5873,9 +5873,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`test.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`test.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false
@@ -6002,9 +6002,9 @@ trailingComma: "none"
 ================================================================================
 `;
 
-exports[`v-if.vue - {"semi":false,"experimentalOperatorLocation":true} format 1`] = `
+exports[`v-if.vue - {"semi":false,"experimentalOperatorPosition":true} format 1`] = `
 ====================================options=====================================
-experimentalOperatorLocation: true
+experimentalOperatorPosition: true
 parsers: ["vue"]
 printWidth: 80
 semi: false

--- a/tests/format/vue/vue/jsfmt.spec.js
+++ b/tests/format/vue/vue/jsfmt.spec.js
@@ -3,5 +3,5 @@ run_spec(import.meta, ["vue"], { trailingComma: "es5" });
 run_spec(import.meta, ["vue"], { semi: false });
 run_spec(import.meta, ["vue"], {
   semi: false,
-  experimentalOperatorLocation: true,
+  experimentalOperatorPosition: true,
 });

--- a/tests/format/vue/vue/jsfmt.spec.js
+++ b/tests/format/vue/vue/jsfmt.spec.js
@@ -1,3 +1,7 @@
 run_spec(import.meta, ["vue"], { trailingComma: "none" });
 run_spec(import.meta, ["vue"], { trailingComma: "es5" });
 run_spec(import.meta, ["vue"], { semi: false });
+run_spec(import.meta, ["vue"], {
+  semi: false,
+  experimentalOperatorLocation: true,
+});

--- a/tests/integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests/integration/__tests__/__snapshots__/early-exit.js.snap
@@ -71,7 +71,7 @@ Format options:
   --end-of-line <lf|crlf|cr|auto>
                            Which end of line characters to apply.
                            Defaults to lf.
-  --experimental-operator-location
+  --experimental-operator-position
                            Use experimental formatting for breaking lines before binary operators
                            Defaults to false.
   --html-whitespace-sensitivity <css|strict|ignore>
@@ -249,7 +249,7 @@ Format options:
   --end-of-line <lf|crlf|cr|auto>
                            Which end of line characters to apply.
                            Defaults to lf.
-  --experimental-operator-location
+  --experimental-operator-position
                            Use experimental formatting for breaking lines before binary operators
                            Defaults to false.
   --html-whitespace-sensitivity <css|strict|ignore>

--- a/tests/integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests/integration/__tests__/__snapshots__/early-exit.js.snap
@@ -71,6 +71,9 @@ Format options:
   --end-of-line <lf|crlf|cr|auto>
                            Which end of line characters to apply.
                            Defaults to lf.
+  --experimental-operator-location
+                           Use experimental formatting for breaking lines before binary operators
+                           Defaults to false.
   --html-whitespace-sensitivity <css|strict|ignore>
                            How to handle whitespaces in HTML.
                            Defaults to css.
@@ -246,6 +249,9 @@ Format options:
   --end-of-line <lf|crlf|cr|auto>
                            Which end of line characters to apply.
                            Defaults to lf.
+  --experimental-operator-location
+                           Use experimental formatting for breaking lines before binary operators
+                           Defaults to false.
   --html-whitespace-sensitivity <css|strict|ignore>
                            How to handle whitespaces in HTML.
                            Defaults to css.

--- a/tests/integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/help-options.js.snap
@@ -206,6 +206,19 @@ Default: lf
 
 exports[`show detailed usage with --help end-of-line (write) 1`] = `[]`;
 
+exports[`show detailed usage with --help experimental-operator-location (stderr) 1`] = `""`;
+
+exports[`show detailed usage with --help experimental-operator-location (stdout) 1`] = `
+"--experimental-operator-location
+
+  Use experimental formatting for breaking lines before binary operators
+
+Default: false
+"
+`;
+
+exports[`show detailed usage with --help experimental-operator-location (write) 1`] = `[]`;
+
 exports[`show detailed usage with --help file-info (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help file-info (stdout) 1`] = `

--- a/tests/integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/help-options.js.snap
@@ -206,10 +206,10 @@ Default: lf
 
 exports[`show detailed usage with --help end-of-line (write) 1`] = `[]`;
 
-exports[`show detailed usage with --help experimental-operator-location (stderr) 1`] = `""`;
+exports[`show detailed usage with --help experimental-operator-position (stderr) 1`] = `""`;
 
-exports[`show detailed usage with --help experimental-operator-location (stdout) 1`] = `
-"--experimental-operator-location
+exports[`show detailed usage with --help experimental-operator-position (stdout) 1`] = `
+"--experimental-operator-position
 
   Use experimental formatting for breaking lines before binary operators
 
@@ -217,7 +217,7 @@ Default: false
 "
 `;
 
-exports[`show detailed usage with --help experimental-operator-location (write) 1`] = `[]`;
+exports[`show detailed usage with --help experimental-operator-position (write) 1`] = `[]`;
 
 exports[`show detailed usage with --help file-info (stderr) 1`] = `""`;
 

--- a/tests/integration/__tests__/__snapshots__/plugin-options-string.js.snap
+++ b/tests/integration/__tests__/__snapshots__/plugin-options-string.js.snap
@@ -18,12 +18,12 @@ exports[`show external options with \`--help\` 1`] = `
 - First value
 + Second value
 
-@@ -22,16 +22,18 @@
-                             Control how Prettier formats quoted code embedded in the file.
-                             Defaults to auto.
-    --end-of-line <lf|crlf|cr|auto>
+@@ -25,16 +25,18 @@
                              Which end of line characters to apply.
                              Defaults to lf.
+    --experimental-operator-location
+                             Use experimental formatting for breaking lines before binary operators
+                             Defaults to false.
 +   --foo-string <string>    foo description
 +                            Defaults to bar.
     --html-whitespace-sensitivity <css|strict|ignore>

--- a/tests/integration/__tests__/__snapshots__/plugin-options-string.js.snap
+++ b/tests/integration/__tests__/__snapshots__/plugin-options-string.js.snap
@@ -21,7 +21,7 @@ exports[`show external options with \`--help\` 1`] = `
 @@ -25,16 +25,18 @@
                              Which end of line characters to apply.
                              Defaults to lf.
-    --experimental-operator-location
+    --experimental-operator-position
                              Use experimental formatting for breaking lines before binary operators
                              Defaults to false.
 +   --foo-string <string>    foo description

--- a/tests/integration/__tests__/__snapshots__/plugin-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/plugin-options.js.snap
@@ -61,12 +61,12 @@ exports[`show external options with \`--help\` 1`] = `
 - First value
 + Second value
 
-@@ -22,16 +22,18 @@
-                             Control how Prettier formats quoted code embedded in the file.
-                             Defaults to auto.
-    --end-of-line <lf|crlf|cr|auto>
+@@ -25,16 +25,18 @@
                              Which end of line characters to apply.
                              Defaults to lf.
+    --experimental-operator-location
+                             Use experimental formatting for breaking lines before binary operators
+                             Defaults to false.
 +   --foo-option <bar|baz>   foo description
 +                            Defaults to bar.
     --html-whitespace-sensitivity <css|strict|ignore>

--- a/tests/integration/__tests__/__snapshots__/plugin-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/plugin-options.js.snap
@@ -64,7 +64,7 @@ exports[`show external options with \`--help\` 1`] = `
 @@ -25,16 +25,18 @@
                              Which end of line characters to apply.
                              Defaults to lf.
-    --experimental-operator-location
+    --experimental-operator-position
                              Use experimental formatting for breaking lines before binary operators
                              Defaults to false.
 +   --foo-option <bar|baz>   foo description

--- a/tests/integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests/integration/__tests__/__snapshots__/schema.js.snap
@@ -89,6 +89,11 @@ This option cannot be used with --range-start and --range-end.",
             },
           ],
         },
+        "experimentalOperatorLocation": {
+          "default": false,
+          "description": "Use experimental formatting for breaking lines before binary operators",
+          "type": "boolean",
+        },
         "filepath": {
           "default": undefined,
           "description": "Specify the input filepath. This will be used to do parser inference.",

--- a/tests/integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests/integration/__tests__/__snapshots__/schema.js.snap
@@ -89,7 +89,7 @@ This option cannot be used with --range-start and --range-end.",
             },
           ],
         },
-        "experimentalOperatorLocation": {
+        "experimentalOperatorPosition": {
           "default": false,
           "description": "Use experimental formatting for breaking lines before binary operators",
           "type": "boolean",

--- a/tests/integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests/integration/__tests__/__snapshots__/support-info.js.snap
@@ -130,6 +130,10 @@ exports[`API getSupportInfo() 1`] = `
       "default": "lf",
       "type": "choice",
     },
+    "experimentalOperatorLocation": {
+      "default": false,
+      "type": "boolean",
+    },
     "filepath": {
       "default": undefined,
       "type": "path",
@@ -852,6 +856,14 @@ exports[`CLI --support-info (stdout) 1`] = `
       "name": "endOfLine",
       "pluginDefaults": {},
       "type": "choice"
+    },
+    {
+      "category": "Experimental",
+      "default": false,
+      "description": "Use experimental formatting for breaking lines before binary operators",
+      "name": "experimentalOperatorLocation",
+      "pluginDefaults": {},
+      "type": "boolean"
     },
     {
       "category": "Special",

--- a/tests/integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests/integration/__tests__/__snapshots__/support-info.js.snap
@@ -130,7 +130,7 @@ exports[`API getSupportInfo() 1`] = `
       "default": "lf",
       "type": "choice",
     },
-    "experimentalOperatorLocation": {
+    "experimentalOperatorPosition": {
       "default": false,
       "type": "boolean",
     },
@@ -861,7 +861,7 @@ exports[`CLI --support-info (stdout) 1`] = `
       "category": "Experimental",
       "default": false,
       "description": "Use experimental formatting for breaking lines before binary operators",
-      "name": "experimentalOperatorLocation",
+      "name": "experimentalOperatorPosition",
       "pluginDefaults": {},
       "type": "boolean"
     },


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Closes #7111

This PR differs from #7111 in the following:
- Base branch is `next`.
-  Enabled when `experimentalOperatorPosition` is `true`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
