### PR TITLE
Allow decorator on private members and class expressions

### DIFF
--- a/changelog_unreleased/typescript/14548.md
+++ b/changelog_unreleased/typescript/14548.md
@@ -1,0 +1,24 @@
+#### Allow decorators on private members (#14548 by @fisker)
+
+<!-- prettier-ignore -->
+```ts
+// Input
+class A {
+  @decorator()
+  #privateMethod () {}
+}
+
+// Prettier stable
+SyntaxError: Decorators are not valid here. (2:3)
+  1 | class A {
+> 2 |   @decorator()
+    |   ^^^^^^^^^^^^
+  3 |   #privateMethod () {}
+  4 | }
+
+// Prettier main
+class A {
+  @decorator()
+  #privateMethod() {}
+}
+```

--- a/changelog_unreleased/typescript/14548.md
+++ b/changelog_unreleased/typescript/14548.md
@@ -1,4 +1,4 @@
-#### Allow decorators on private members (#14548 by @fisker)
+#### Allow decorators on private members and class expressions (#14548 by @fisker)
 
 <!-- prettier-ignore -->
 ```ts

--- a/tests/format/js/decorators/class-expression/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/decorators/class-expression/__snapshots__/jsfmt.spec.js.snap
@@ -24,14 +24,6 @@ exports[`arguments.js [flow] format 1`] = `
   3 |"
 `;
 
-exports[`arguments.js [typescript] format 1`] = `
-"Decorators are not valid here. (1:13)
-> 1 | console.log(@deco class Foo {})
-    |             ^^^^^
-  2 | console.log(@deco class {})
-  3 |"
-`;
-
 exports[`arguments.js - {"semi":false} [acorn] format 1`] = `
 "Unexpected character '@' (1:13)
 > 1 | console.log(@deco class Foo {})
@@ -52,14 +44,6 @@ exports[`arguments.js - {"semi":false} [flow] format 1`] = `
 "Unexpected token \`@\` (1:13)
 > 1 | console.log(@deco class Foo {})
     |             ^
-  2 | console.log(@deco class {})
-  3 |"
-`;
-
-exports[`arguments.js - {"semi":false} [typescript] format 1`] = `
-"Decorators are not valid here. (1:13)
-> 1 | console.log(@deco class Foo {})
-    |             ^^^^^
   2 | console.log(@deco class {})
   3 |"
 `;
@@ -144,15 +128,6 @@ exports[`class-expression.js [flow] format 1`] = `
   4 | (@deco class Foo {});"
 `;
 
-exports[`class-expression.js [typescript] format 1`] = `
-"Decorators are not valid here. (1:13)
-> 1 | const a1 = (@deco class Foo {});
-    |             ^^^^^
-  2 | const a2 = (@deco class {});
-  3 |
-  4 | (@deco class Foo {});"
-`;
-
 exports[`class-expression.js - {"semi":false} [acorn] format 1`] = `
 "Unexpected character '@' (1:13)
 > 1 | const a1 = (@deco class Foo {});
@@ -175,15 +150,6 @@ exports[`class-expression.js - {"semi":false} [flow] format 1`] = `
 "Unexpected token \`@\` (1:13)
 > 1 | const a1 = (@deco class Foo {});
     |             ^
-  2 | const a2 = (@deco class {});
-  3 |
-  4 | (@deco class Foo {});"
-`;
-
-exports[`class-expression.js - {"semi":false} [typescript] format 1`] = `
-"Decorators are not valid here. (1:13)
-> 1 | const a1 = (@deco class Foo {});
-    |             ^^^^^
   2 | const a2 = (@deco class {});
   3 |
   4 | (@deco class Foo {});"
@@ -336,14 +302,6 @@ exports[`member-expression.js [flow] format 1`] = `
   3 |"
 `;
 
-exports[`member-expression.js [typescript] format 1`] = `
-"Decorators are not valid here. (1:2)
-> 1 | (@deco class Foo {}).name;
-    |  ^^^^^
-  2 | (@deco class {}).name;
-  3 |"
-`;
-
 exports[`member-expression.js - {"semi":false} [acorn] format 1`] = `
 "Unexpected character '@' (1:2)
 > 1 | (@deco class Foo {}).name;
@@ -364,14 +322,6 @@ exports[`member-expression.js - {"semi":false} [flow] format 1`] = `
 "Unexpected token \`@\` (1:2)
 > 1 | (@deco class Foo {}).name;
     |  ^
-  2 | (@deco class {}).name;
-  3 |"
-`;
-
-exports[`member-expression.js - {"semi":false} [typescript] format 1`] = `
-"Decorators are not valid here. (1:2)
-> 1 | (@deco class Foo {}).name;
-    |  ^^^^^
   2 | (@deco class {}).name;
   3 |"
 `;
@@ -448,15 +398,6 @@ exports[`super-class.js [flow] format 1`] = `
   4 |"
 `;
 
-exports[`super-class.js [typescript] format 1`] = `
-"Decorators are not valid here. (1:20)
-> 1 | class Foo extends (@deco class Foo {}){}
-    |                    ^^^^^
-  2 |
-  3 | class Foo extends (@deco class {}){}
-  4 |"
-`;
-
 exports[`super-class.js - {"semi":false} [acorn] format 1`] = `
 "Unexpected character '@' (1:20)
 > 1 | class Foo extends (@deco class Foo {}){}
@@ -479,15 +420,6 @@ exports[`super-class.js - {"semi":false} [flow] format 1`] = `
 "Unexpected token \`@\` (1:20)
 > 1 | class Foo extends (@deco class Foo {}){}
     |                    ^
-  2 |
-  3 | class Foo extends (@deco class {}){}
-  4 |"
-`;
-
-exports[`super-class.js - {"semi":false} [typescript] format 1`] = `
-"Decorators are not valid here. (1:20)
-> 1 | class Foo extends (@deco class Foo {}){}
-    |                    ^^^^^
   2 |
   3 | class Foo extends (@deco class {}){}
   4 |"

--- a/tests/format/js/decorators/class-expression/jsfmt.spec.js
+++ b/tests/format/js/decorators/class-expression/jsfmt.spec.js
@@ -1,6 +1,5 @@
 const errors = {
   flow: true,
-  typescript: true,
   acorn: true,
   espree: true,
 };

--- a/tests/format/typescript/decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/decorators/__snapshots__/jsfmt.spec.js.snap
@@ -497,6 +497,48 @@ class MyContainerComponent {
 ================================================================================
 `;
 
+exports[`legacy.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+[
+  @decorator() class {},
+  @decorator() class A {},
+];
+
+class A {
+  @decorator() accessor #field;
+}
+
+class B {
+  @decorator() #field () {}
+}
+
+=====================================output=====================================
+[
+  (
+    @decorator()
+    class {}
+  ),
+  (
+    @decorator()
+    class A {}
+  ),
+];
+
+class A {
+  @decorator() accessor #field;
+}
+
+class B {
+  @decorator() #field() {}
+}
+
+================================================================================
+`;
+
 exports[`mobx.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/decorators/legacy.ts
+++ b/tests/format/typescript/decorators/legacy.ts
@@ -1,0 +1,12 @@
+[
+  @decorator() class {},
+  @decorator() class A {},
+];
+
+class A {
+  @decorator() accessor #field;
+}
+
+class B {
+  @decorator() #field () {}
+}

--- a/tests/format/typescript/type-arguments-bit-shift-left-like/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/type-arguments-bit-shift-left-like/__snapshots__/jsfmt.spec.js.snap
@@ -49,7 +49,7 @@ exports[`3.ts [typescript] format 1`] = `
   2 |"
 `;
 
-exports[`4.ts [babel-ts] format 1`] = `
+exports[`4.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
 printWidth: 80
@@ -64,13 +64,6 @@ printWidth: 80
 );
 
 ================================================================================
-`;
-
-exports[`4.ts [typescript] format 1`] = `
-"Decorators are not valid here. (1:2)
-> 1 | (@f<<T>(v: T) => void>() class {});
-    |  ^^^^^^^^^^^^^^^^^^^^^^^
-  2 |"
 `;
 
 exports[`5.tsx [babel-ts] format 1`] = `

--- a/tests/format/typescript/type-arguments-bit-shift-left-like/jsfmt.spec.js
+++ b/tests/format/typescript/type-arguments-bit-shift-left-like/jsfmt.spec.js
@@ -1,3 +1,3 @@
 run_spec(__dirname, ["typescript"], {
-  errors: { typescript: ["3.ts", "4.ts", "5.tsx"] },
+  errors: { typescript: ["3.ts", "5.tsx"] },
 });


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #14547

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
