### PR TITLE
Remove dead code

### DIFF
--- a/src/language-js/print/flow.js
+++ b/src/language-js/print/flow.js
@@ -4,7 +4,6 @@ import assert from "node:assert";
 import printString from "../../utils/print-string.js";
 import printNumber from "../../utils/print-number.js";
 import { replaceEndOfLine } from "../../document/utils.js";
-import UnexpectedNodeError from "../../utils/unexpected-node-error.js";
 import {
   isFunctionNotation,
   isGetterOrSetter,
@@ -252,25 +251,6 @@ function printFlow(path, options, print) {
       return "%checks";
     case "DeclaredPredicate":
       return ["%checks(", print("value"), ")"];
-
-    // These types are unprintable because they serve as abstract
-    // supertypes for other (printable) types.
-    case "Node":
-    case "Printable":
-    case "SourceLocation":
-    case "Position":
-    case "Statement":
-    case "Function":
-    case "Pattern":
-    case "Expression":
-    case "Declaration":
-    case "Specifier":
-    case "NamedSpecifier":
-    case "Comment":
-    case "MemberTypeAnnotation": // Flow
-    case "Type":
-      /* c8 ignore next */
-      throw new UnexpectedNodeError(node, "Flow");
   }
 }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

We have full list of `VistorKeys`, those types won't pass to `print` even they exists.

[These lines are added in 2014 in recast repo.](https://github.com/benjamn/recast/commit/b98bb8d1dbefdd7436a0794236a2118b5d2def8f)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
