### PR TITLE
Allow multiple decorators on same getter/setter

### DIFF
--- a/changelog_unreleased/typescript/14584.md
+++ b/changelog_unreleased/typescript/14584.md
@@ -1,0 +1,31 @@
+#### Allow multiple decorators on same getter/setter (#14584 by @fisker)
+
+<!-- prettier-ignore -->
+```ts
+// Input
+class A {
+  @decorator()
+  get foo () {}
+  
+  @decorator()
+  set foo (value) {}
+}
+
+// Prettier stable
+SyntaxError: Decorators cannot be applied to multiple get/set accessors of the same name. (5:3)
+  3 |   get foo () {}
+  4 |   
+> 5 |   @decorator()
+    |   ^^^^^^^^^^^^
+  6 |   set foo (value) {}
+  7 | }
+
+// Prettier main
+class A {
+  @decorator()
+  get foo() {}
+
+  @decorator()
+  set foo(value) {}
+}
+```

--- a/src/language-js/parse/postprocess/typescript.js
+++ b/src/language-js/parse/postprocess/typescript.js
@@ -57,40 +57,19 @@ function throwErrorForInvalidDecorator(node) {
 
   const { SyntaxKind } = ts;
   for (const modifier of modifiers) {
-    if (ts.isDecorator(modifier)) {
-      if (!nodeCanBeDecorated(node)) {
-        if (
-          node.kind === SyntaxKind.MethodDeclaration &&
-          // @ts-expect-error -- internal?
-          !ts.nodeIsPresent(node.body)
-        ) {
-          throwErrorOnTsNode(
-            modifier,
-            "A decorator can only decorate a method implementation, not an overload."
-          );
-        } else {
-          throwErrorOnTsNode(modifier, "Decorators are not valid here.");
-        }
-      } else if (
-        node.kind === SyntaxKind.GetAccessor ||
-        node.kind === SyntaxKind.SetAccessor
-      ) {
+    if (ts.isDecorator(modifier) && !nodeCanBeDecorated(node)) {
+      if (
+        node.kind === SyntaxKind.MethodDeclaration &&
         // @ts-expect-error -- internal?
-        const accessors = ts.getAllAccessorDeclarations(
-          node.parent.members,
-          node
+        !ts.nodeIsPresent(node.body)
+      ) {
+        throwErrorOnTsNode(
+          modifier,
+          "A decorator can only decorate a method implementation, not an overload."
         );
-        if (
-          // @ts-expect-error -- internal?
-          ts.hasDecorators(accessors.firstAccessor) &&
-          node === accessors.secondAccessor
-        ) {
-          throwErrorOnTsNode(
-            modifier,
-            "Decorators cannot be applied to multiple get/set accessors of the same name."
-          );
-        }
       }
+
+      throwErrorOnTsNode(modifier, "Decorators are not valid here.");
     }
   }
 }

--- a/tests/format/typescript/decorators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/decorators/__snapshots__/jsfmt.spec.js.snap
@@ -30,7 +30,7 @@ exports[`abstract-method.ts [typescript] format 1`] = `
   5 |"
 `;
 
-exports[`accessor.ts [babel-ts] format 1`] = `
+exports[`accessor.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]
 printWidth: 80
@@ -54,17 +54,6 @@ class A {
 }
 
 ================================================================================
-`;
-
-exports[`accessor.ts [typescript] format 1`] = `
-"Decorators cannot be applied to multiple get/set accessors of the same name. (4:5)
-  2 |     @foo()
-  3 |     get a() {return 1}
-> 4 |     @bar()
-    |     ^^^^^^
-  5 |     set a(v) {}
-  6 | }
-  7 |"
 `;
 
 exports[`argument-list-preserve-line.ts format 1`] = `

--- a/tests/format/typescript/decorators/jsfmt.spec.js
+++ b/tests/format/typescript/decorators/jsfmt.spec.js
@@ -1,3 +1,3 @@
 run_spec(__dirname, ["typescript"], {
-  errors: { typescript: ["abstract-method.ts", "accessor.ts"] },
+  errors: { typescript: ["abstract-method.ts"] },
 });


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
