### PR TITLE
`lint-changelog` should warn for second template comment

### DIFF
--- a/scripts/lint-changelog.mjs
+++ b/scripts/lint-changelog.mjs
@@ -4,6 +4,7 @@ import path from "node:path";
 import fs from "node:fs";
 import { outdent } from "outdent";
 import createEsmUtils from "esm-utils";
+import { LinesAndColumns } from "lines-and-columns";
 import { CHANGELOG_CATEGORIES } from "./utils/changelog-categories.mjs";
 
 const { __dirname } = createEsmUtils(import.meta);
@@ -45,7 +46,7 @@ const template = fs.readFileSync(
   path.join(CHANGELOG_ROOT, TEMPLATE_FILE),
   "utf8"
 );
-const [templateComment1, templateComment2] = template.match(/<!--.*?-->/gs);
+const templateComments = template.match(/<!--.*?-->/gs);
 const [templateAuthorLink] = template.match(authorRegex);
 const checkedFiles = new Map();
 
@@ -94,11 +95,15 @@ for (const category of CHANGELOG_CATEGORIES) {
     if (!authorRegex.test(content)) {
       showErrorMessage(`[${displayPath}]: Author link is missing.`);
     }
-    if (
-      content.includes(templateComment1) ||
-      content.includes(templateComment2)
-    ) {
-      showErrorMessage(`[${displayPath}]: Please remove template comments`);
+    for (const comment of templateComments) {
+      if (comment !== "<!-- prettier-ignore -->" && content.includes(comment)) {
+        showErrorMessage(
+          `[${displayPath}]: Please remove ${getCommentDescription(
+            content,
+            comment
+          )}`
+        );
+      }
     }
     if (content.includes(templateAuthorLink)) {
       showErrorMessage(
@@ -135,4 +140,19 @@ for (const category of CHANGELOG_CATEGORIES) {
       );
     }
   }
+}
+
+function getCommentDescription(content, comment) {
+  const start = content.indexOf(comment);
+  const end = start + comment.length;
+  const linesAndColumns = new LinesAndColumns(content);
+  const [startLine, endLine] = [start, end].map(
+    (index) => linesAndColumns.locationForIndex(index).line + 1
+  );
+
+  if (startLine === endLine) {
+    return `template comment "${comment}" on line ${startLine}`;
+  }
+
+  return `template comment on line ${startLine}-${endLine}`;
 }

--- a/scripts/lint-changelog.mjs
+++ b/scripts/lint-changelog.mjs
@@ -45,7 +45,7 @@ const template = fs.readFileSync(
   path.join(CHANGELOG_ROOT, TEMPLATE_FILE),
   "utf8"
 );
-const [templateComment] = template.match(/<!--.*?-->/s);
+const [templateComment1, templateComment2] = template.match(/<!--.*?-->/gs);
 const [templateAuthorLink] = template.match(authorRegex);
 const checkedFiles = new Map();
 
@@ -94,10 +94,11 @@ for (const category of CHANGELOG_CATEGORIES) {
     if (!authorRegex.test(content)) {
       showErrorMessage(`[${displayPath}]: Author link is missing.`);
     }
-    if (content.includes(templateComment)) {
-      showErrorMessage(
-        `[${displayPath}]: Please remove template comments at top.`
-      );
+    if (
+      content.includes(templateComment1) ||
+      content.includes(templateComment2)
+    ) {
+      showErrorMessage(`[${displayPath}]: Please remove template comments`);
     }
     if (content.includes(templateAuthorLink)) {
       showErrorMessage(

--- a/website/blog/2021-05-09-2.3.0.md
+++ b/website/blog/2021-05-09-2.3.0.md
@@ -1064,8 +1064,6 @@ interface Foo {
 
 #### Fix missing semicolon in `declare export * from …` ([#9767](https://github.com/prettier/prettier/pull/9767) by [@fisker](https://github.com/fisker))
 
-<!-- Optional description if it makes sense. -->
-
 <!-- prettier-ignore -->
 ```jsx
 // Input


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

https://github.com/prettier/prettier/pull/13436#issuecomment-1483890362

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
