### PR TITLE
Fix playground down

### DIFF
--- a/website/static/service-worker.js
+++ b/website/static/service-worker.js
@@ -9,8 +9,11 @@ importScripts(
 
 const plugins = [
   ...new Set(Object.values(parsersLocation).map((file) => `lib/${file}`)),
-  "lib/plugins/estree.js",
 ];
+// TODO: Remove after release v3
+if (self.location.hostname !== "prettier.io") {
+  plugins.push("lib/plugins/estree.js");
+}
 
 toolbox.precache([
   // Scripts

--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -9,7 +9,10 @@ importScripts("lib/standalone.js");
 for (const file of new Set(Object.values(parsersLocation))) {
   importScripts(`lib/${file}`);
 }
-importScripts("lib/plugins/estree.js");
+// TODO: Remove after release v3
+if (self.location.hostname !== "prettier.io") {
+  importScripts("lib/plugins/estree.js");
+}
 
 const docExplorerPlugin = {
   parsers: {


### PR DESCRIPTION
## Description

This is cased by merging `next` to `main`. 

Fixes #14607

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
