### PR TITLE
Whitelist keys when build package.json file

### DIFF
--- a/scripts/build/build-package-json.js
+++ b/scripts/build/build-package-json.js
@@ -15,7 +15,6 @@ const keysToKeep = [
   "funding",
   "homepage",
   "author",
-  "type",
   "license",
   "main",
   "browser",
@@ -36,7 +35,6 @@ async function buildPackageJson({ file, files }) {
 
   const overrides = {
     bin: `./${bin}`,
-    type: "commonjs",
     main: "./index.cjs",
     engines: {
       ...packageJson.engines,

--- a/scripts/build/build-package-json.js
+++ b/scripts/build/build-package-json.js
@@ -6,6 +6,25 @@ import {
   writeJson,
 } from "../utils/index.mjs";
 
+const keysToKeep = [
+  "name",
+  "version",
+  "description",
+  "bin",
+  "repository",
+  "funding",
+  "homepage",
+  "author",
+  "type",
+  "license",
+  "main",
+  "browser",
+  "unpkg",
+  "exports",
+  "engines",
+  "files",
+];
+
 async function buildPackageJson({ file, files }) {
   const packageJson = await readJson(path.join(PROJECT_ROOT, file.input));
 
@@ -15,73 +34,83 @@ async function buildPackageJson({ file, files }) {
       path.join(PROJECT_ROOT, file.input)
   ).output.file;
 
-  packageJson.bin = `./${bin}`;
-  packageJson.main = "./index.cjs";
-  packageJson.exports = {
-    ".": {
-      require: "./index.cjs",
-      types: "./index.d.ts",
-      default: "./index.mjs",
+  const overrides = {
+    bin: `./${bin}`,
+    type: "commonjs",
+    main: "./index.cjs",
+    engines: {
+      ...packageJson.engines,
+      // https://github.com/prettier/prettier/pull/13118#discussion_r922708068
+      // Don't delete, comment out if we don't want override
+      node: ">=14",
     },
-    "./*": "./*",
-    ...Object.fromEntries(
-      files
-        .filter((file) => file.output.format === "umd")
-        .map((file) => {
-          const basename = path.basename(file.output.file, ".js");
-          return [
-            file.isPlugin ? `./plugins/${basename}` : `./${basename}`,
-            {
-              require: `./${file.output.file}`,
-              types: `./${file.output.file.replace(/\.js$/, ".d.ts")}`,
-              default: `./${file.output.file.replace(/\.js$/, ".mjs")}`,
-            },
-          ];
-        })
-    ),
-    // Legacy entries
-    // TODO: Remove bellow in v4
-    "./esm/standalone.mjs": "./standalone.mjs",
-    ...Object.fromEntries(
-      files
-        .filter(
-          (file) =>
-            file.isPlugin &&
-            file.output.format === "umd" &&
-            file.output.file !== "plugins/estree.js"
-        )
-        .flatMap((file) => {
-          let basename = path.basename(file.output.file, ".js");
-          if (basename === "acorn") {
-            basename = "espree";
-          }
-          return [
-            [`./parser-${basename}`, `./${file.output.file}`],
-            [`./parser-${basename}.js`, `./${file.output.file}`],
-            [
-              `./esm/parser-${basename}.mjs`,
-              `./${file.output.file.replace(/\.js$/, ".mjs")}`,
-            ],
-          ];
-        })
-    ),
+    exports: {
+      ".": {
+        require: "./index.cjs",
+        types: "./index.d.ts",
+        default: "./index.mjs",
+      },
+      "./*": "./*",
+      ...Object.fromEntries(
+        files
+          .filter((file) => file.output.format === "umd")
+          .map((file) => {
+            const basename = path.basename(file.output.file, ".js");
+            return [
+              file.isPlugin ? `./plugins/${basename}` : `./${basename}`,
+              {
+                require: `./${file.output.file}`,
+                types: `./${file.output.file.replace(/\.js$/, ".d.ts")}`,
+                default: `./${file.output.file.replace(/\.js$/, ".mjs")}`,
+              },
+            ];
+          })
+      ),
+      // Legacy entries
+      // TODO: Remove bellow in v4
+      "./esm/standalone.mjs": "./standalone.mjs",
+      ...Object.fromEntries(
+        files
+          .filter(
+            (file) =>
+              file.isPlugin &&
+              file.output.format === "umd" &&
+              file.output.file !== "plugins/estree.js"
+          )
+          .flatMap((file) => {
+            let basename = path.basename(file.output.file, ".js");
+            if (basename === "acorn") {
+              basename = "espree";
+            }
+            return [
+              [`./parser-${basename}`, `./${file.output.file}`],
+              [`./parser-${basename}.js`, `./${file.output.file}`],
+              [
+                `./esm/parser-${basename}.mjs`,
+                `./${file.output.file.replace(/\.js$/, ".mjs")}`,
+              ],
+            ];
+          })
+      ),
+    },
+    scripts: {
+      prepublishOnly:
+        "node -e \"assert.equal(require('.').version, require('..').version)\"",
+    },
+    files: files.map(({ output: { file } }) => file).sort(),
   };
-  // https://github.com/prettier/prettier/pull/13118#discussion_r922708068
-  packageJson.engines.node = ">=14";
-  delete packageJson.dependencies;
-  delete packageJson.devDependencies;
-  delete packageJson.browserslist;
-  delete packageJson.type;
-  delete packageJson.c8;
-  delete packageJson.packageManager;
-  delete packageJson.resolutions;
-  packageJson.scripts = {
-    prepublishOnly:
-      "node -e \"assert.equal(require('.').version, require('..').version)\"",
-  };
-  packageJson.files = files.map(({ output: { file } }) => file).sort();
 
-  await writeJson(path.join(DIST_DIR, file.output.file), packageJson);
+  await writeJson(
+    path.join(DIST_DIR, file.output.file),
+    Object.assign(pick(packageJson, keysToKeep), overrides)
+  );
+}
+
+function pick(object, keys) {
+  keys = new Set(keys);
+  return Object.fromEntries(
+    Object.entries(object).filter(([key]) => keys.has(key))
+  );
 }
 
 export default buildPackageJson;

--- a/scripts/build/build-package-json.js
+++ b/scripts/build/build-package-json.js
@@ -93,11 +93,11 @@ async function buildPackageJson({ file, files }) {
           })
       ),
     },
+    files: files.map(({ output: { file } }) => file).sort(),
     scripts: {
       prepublishOnly:
         "node -e \"assert.equal(require('.').version, require('..').version)\"",
     },
-    files: files.map(({ output: { file } }) => file).sort(),
   };
 
   await writeJson(


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

~To indicate `.js` files are not in ESM. (Only `.mjs` files are in ESM, `.js` files are UMD)~ I forget that The default is `commonjs`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
