### PR TITLE
Remove `showInternal` option from `getSupportInfo()`

### DIFF
--- a/src/cli/options/get-context-options.js
+++ b/src/cli/options/get-context-options.js
@@ -67,7 +67,6 @@ function supportInfoToContextOptions({ options: supportOptions, languages }) {
 async function getContextOptions(plugins, pluginSearchDirs) {
   const supportInfo = await getSupportInfo({
     showDeprecated: true,
-    showInternal: true,
     plugins,
     pluginSearchDirs,
   });
@@ -76,7 +75,7 @@ async function getContextOptions(plugins, pluginSearchDirs) {
 }
 
 function getContextOptionsWithoutPlugins() {
-  const supportInfo = getSupportInfoWithoutPlugins({ showInternal: true });
+  const supportInfo = getSupportInfoWithoutPlugins();
   return supportInfoToContextOptions(supportInfo);
 }
 

--- a/src/cli/print-support-info.js
+++ b/src/cli/print-support-info.js
@@ -1,14 +1,19 @@
 import stringify from "fast-json-stable-stringify";
 import { getSupportInfo, format } from "../index.js";
-import { printToScreen } from "./utils.js";
+import { printToScreen, omit } from "./utils.js";
 
 const sortByName = (array) =>
   array.sort((a, b) => a.name.localeCompare(b.name));
 
 async function printSupportInfo() {
-  const supportInfo = await getSupportInfo();
-  sortByName(supportInfo.languages);
-  sortByName(supportInfo.options);
+  const { languages, options } = await getSupportInfo();
+  const supportInfo = {
+    languages: sortByName(languages),
+    options: sortByName(options).map((option) =>
+      omit(option, ["cliName", "cliCategory", "cliDescription"])
+    ),
+  };
+
   printToScreen(await format(stringify(supportInfo), { parser: "json" }));
 }
 

--- a/src/cli/utils.js
+++ b/src/cli/utils.js
@@ -4,8 +4,6 @@ import sdbm from "sdbm";
 // @ts-expect-error
 import { __internal as sharedWithCli } from "../index.js";
 
-const { arrayify, isNonEmptyArray, partition } = sharedWithCli.utils;
-
 // eslint-disable-next-line no-console
 const printToScreen = console.log.bind(console);
 
@@ -91,10 +89,9 @@ const normalizeToPosix =
     ? (filepath) => filepath.replaceAll("\\", "/")
     : (filepath) => filepath;
 
+export const { arrayify, isNonEmptyArray, partition, omit } =
+  sharedWithCli.utils;
 export {
-  arrayify,
-  isNonEmptyArray,
-  partition,
   printToScreen,
   groupBy,
   pick,

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ import normalizeOptions from "./main/normalize-options.js";
 import arrayify from "./utils/arrayify.js";
 import partition from "./utils/partition.js";
 import isNonEmptyArray from "./utils/is-non-empty-array.js";
+import omit from "./utils/object-omit.js"
 
 /**
  * @param {*} fn
@@ -94,6 +95,7 @@ const sharedWithCli = {
     arrayify,
     isNonEmptyArray,
     partition,
+    omit,
   },
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ import normalizeOptions from "./main/normalize-options.js";
 import arrayify from "./utils/arrayify.js";
 import partition from "./utils/partition.js";
 import isNonEmptyArray from "./utils/is-non-empty-array.js";
-import omit from "./utils/object-omit.js"
+import omit from "./utils/object-omit.js";
 
 /**
  * @param {*} fn

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -1,4 +1,3 @@
-import arrayify from "../utils/arrayify.js";
 import omit from "../utils/object-omit.js";
 import { options as coreOptions } from "./core-options.evaluate.js";
 
@@ -25,7 +24,7 @@ function getSupportInfo({
   const languages = plugins.flatMap((plugin) => plugin.languages ?? []);
 
   const options = [];
-  for (const originalOption of arrayify(
+  for (const [name, originalOption] of Object.entries(
     Object.assign({}, ...plugins.map(({ options }) => options), coreOptions),
     "name"
   )) {
@@ -36,6 +35,8 @@ function getSupportInfo({
     const option = showInternal
       ? { ...originalOption }
       : omit(originalOption, ["cliName", "cliCategory", "cliDescription"]);
+
+    option.name = name;
 
     // This work this way because we used support `[{value: [], since: '0.0.0'}]`
     if (Array.isArray(option.default)) {

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -19,8 +19,7 @@ function getSupportInfo({ plugins = [], showDeprecated = false } = {}) {
 
   const options = [];
   for (const [name, originalOption] of Object.entries(
-    Object.assign({}, ...plugins.map(({ options }) => options), coreOptions),
-    "name"
+    Object.assign({}, ...plugins.map(({ options }) => options), coreOptions)
   )) {
     if (!showDeprecated && originalOption.deprecated) {
       continue;

--- a/src/main/support.js
+++ b/src/main/support.js
@@ -1,4 +1,3 @@
-import omit from "../utils/object-omit.js";
 import { options as coreOptions } from "./core-options.evaluate.js";
 
 /**
@@ -13,14 +12,9 @@ import { options as coreOptions } from "./core-options.evaluate.js";
  * @param {(string | object)[]=} param0.plugins Strings are resolved by `withPlugins`.
  * @param {string[]=} param0.pluginSearchDirs Added by `withPlugins`.
  * @param {boolean=} param0.showDeprecated
- * @param {boolean=} param0.showInternal
  * @return {{ languages: Array<any>, options: Array<NamedOptionInfo> }}
  */
-function getSupportInfo({
-  plugins = [],
-  showDeprecated = false,
-  showInternal = false,
-} = {}) {
+function getSupportInfo({ plugins = [], showDeprecated = false } = {}) {
   const languages = plugins.flatMap((plugin) => plugin.languages ?? []);
 
   const options = [];
@@ -32,11 +26,7 @@ function getSupportInfo({
       continue;
     }
 
-    const option = showInternal
-      ? { ...originalOption }
-      : omit(originalOption, ["cliName", "cliCategory", "cliDescription"]);
-
-    option.name = name;
+    const option = { name, ...originalOption };
 
     // This work this way because we used support `[{value: [], since: '0.0.0'}]`
     if (Array.isArray(option.default)) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

This option only hide `cli*` value from options, API user should not care about it, only hide them when run CLI with `--support-info` .

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
