### PR TITLE
Add support for nested Markdown code blocks with backticks and tildes (#14624)

### DIFF
--- a/src/language-markdown/embed.js
+++ b/src/language-markdown/embed.js
@@ -14,7 +14,7 @@ function embed(path, options) {
       return async (textToDoc) => {
         const styleUnit = options.__inJsTemplate ? "~" : "`";
         const style = styleUnit.repeat(
-          Math.max(3, getMaxContinuousCount(node.value, styleUnit) + 1)
+          Math.max(3, getMaxContinuousCount(node.value, "`") + 1, getMaxContinuousCount(node.value, "~") + 1)
         );
         const newOptions = { parser };
         if (node.lang === "tsx") {

--- a/tests/format/markdown/code/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/markdown/code/__snapshots__/jsfmt.spec.js.snap
@@ -272,6 +272,32 @@ proseWrap: "always"
 ================================================================================
 `;
 
+exports[`nested-code.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+printWidth: 80
+proseWrap: "always"
+                                                                                | printWidth
+=====================================input======================================
+\`\`\`markdown
+This is markdown
+
+~~~json
+["json", "in", "markdown", "in", "markdown"]
+~~~
+\`\`\`
+=====================================output=====================================
+\`\`\`\`markdown
+This is markdown
+
+\`\`\`json
+["json", "in", "markdown", "in", "markdown"]
+\`\`\`
+\`\`\`\`
+
+================================================================================
+`;
+
 exports[`simple.md - {"proseWrap":"always"} format 1`] = `
 ====================================options=====================================
 parsers: ["markdown"]

--- a/tests/format/markdown/code/nested-code.md
+++ b/tests/format/markdown/code/nested-code.md
@@ -1,0 +1,7 @@
+```markdown
+This is markdown
+
+~~~json
+["json", "in", "markdown", "in", "markdown"]
+~~~
+```


### PR DESCRIPTION
## Description

With this change the following code will now format correctly:

````markdown
```markdown
This is markdown

~~~json
["json", "in", "markdown", "in", "markdown"]
~~~
```
````

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~~
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

## Open questions:

- RE "If the change is user-facing". Does this warrant an update to the CHANGELOG? I'm happy to write one if it does.
- Would you like any more tests cases from me?

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
