### PR TITLE
Put `types` first in `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "unpkg": "./standalone.js",
   "exports": {
     ".": {
-      "require": "./src/index.cjs",
       "types": "./src/index.d.ts",
+      "require": "./src/index.cjs",
       "default": "./src/index.js"
     },
     "./*": "./*"

--- a/scripts/build/build-package-json.js
+++ b/scripts/build/build-package-json.js
@@ -39,8 +39,8 @@ async function buildPackageJson({ file, files }) {
     },
     exports: {
       ".": {
-        require: "./index.cjs",
         types: "./index.d.ts",
+        require: "./index.cjs",
         default: "./index.mjs",
       },
       "./*": "./*",
@@ -52,8 +52,8 @@ async function buildPackageJson({ file, files }) {
             return [
               file.isPlugin ? `./plugins/${basename}` : `./${basename}`,
               {
-                require: `./${file.output.file}`,
                 types: `./${file.output.file.replace(/\.js$/, ".d.ts")}`,
+                require: `./${file.output.file}`,
                 default: `./${file.output.file.replace(/\.js$/, ".mjs")}`,
               },
             ];


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Not sure if it's necessary, but https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing

> The "types" condition should always come first in "exports".




## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
