### PR TITLE
Improve doc printer when `printWidth: Infinity`

### DIFF
--- a/src/document/printer.js
+++ b/src/document/printer.js
@@ -201,6 +201,10 @@ function fits(
   groupModeMap,
   mustBeFlat
 ) {
+  if (width === Number.POSITIVE_INFINITY) {
+    return true;
+  }
+
   let restIdx = restCommands.length;
   /** @type {Array<Omit<Command, 'ind'>>} */
   const cmds = [next];


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Ref: https://github.com/prettier/prettier/issues/14514#issuecomment-1471000708

In #14634, maybe we should also print the doc with `printWidth: Infinity` and check the printed string instead?

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
