### PR TITLE
Fix incorrect formatting of member chains where last call has a single template literal argument

### DIFF
--- a/changelog_unreleased/javascript/14639.md
+++ b/changelog_unreleased/javascript/14639.md
@@ -1,0 +1,27 @@
+#### Fix incorrect formatting of member chains where last call has a single template literal arguement (#14639 by @solarized-fox)
+
+<!-- Optional description if it makes sense. -->
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+foo("long" + "set").bar("of" + "arguments").baz("will" + "break")
+.qux(`
+    template literal
+`)
+
+// Prettier stable
+foo("long" + "set")
+  .bar("of" + "arguments")
+  .baz("will" + "break").qux(`
+    template literal
+`);
+
+// Prettier main
+foo("long" + "set")
+  .bar("of" + "arguments")
+  .baz("will" + "break")
+  .qux(`
+    template literal
+`);
+```

--- a/changelog_unreleased/javascript/14639.md
+++ b/changelog_unreleased/javascript/14639.md
@@ -1,7 +1,5 @@
 #### Fix incorrect formatting of member chains where last call has a single template literal argument (#14639 by @solarized-fox)
 
-<!-- Optional description if it makes sense. -->
-
 <!-- prettier-ignore -->
 ```jsx
 // Input
@@ -10,12 +8,20 @@ foo("long" + "set").bar("of" + "arguments").baz("will" + "break")
     template literal
 `)
 
+insertRule(`*, *:before, *:after {
+  box-sizing: inherit;
+}`);
+
 // Prettier stable
 foo("long" + "set")
   .bar("of" + "arguments")
   .baz("will" + "break").qux(`
     template literal
 `);
+
+insertRule(`*, *:before, *:after {
+   box-sizing: inherit;
+}`);
 
 // Prettier main
 foo("long" + "set")
@@ -24,4 +30,9 @@ foo("long" + "set")
   .qux(`
     template literal
 `);
+
+insertRule(
+   `*, *:before, *:after {
+   box-sizing: inherit;
+ }`);
 ```

--- a/changelog_unreleased/javascript/14639.md
+++ b/changelog_unreleased/javascript/14639.md
@@ -1,4 +1,4 @@
-#### Fix incorrect formatting of member chains where last call has a single template literal arguement (#14639 by @solarized-fox)
+#### Fix incorrect formatting of member chains where last call has a single template literal argument (#14639 by @solarized-fox)
 
 <!-- Optional description if it makes sense. -->
 

--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -22,6 +22,7 @@ import {
   isTSTypeExpression,
   isArrayOrTupleExpression,
   isObjectOrRecordExpression,
+  isTemplateOnItsOwnLine,
 } from "../utils/index.js";
 
 import {
@@ -160,13 +161,18 @@ function printCallArguments(path, options, print) {
     ]);
   }
 
-  const contents = [
-    "(",
-    indent([softline, ...printedArguments]),
-    ifBreak(maybeTrailingComma),
-    softline,
-    ")",
-  ];
+  const isTemplateLiteralSingleArg =
+    args.length === 1 && isTemplateOnItsOwnLine(args[0], options.originalText);
+  const inner = isTemplateLiteralSingleArg
+    ? [indent(printedArguments)]
+    : [
+        indent([softline, ...printedArguments]),
+        ifBreak(maybeTrailingComma),
+        softline,
+      ];
+
+  const contents = ["(", ...inner, ")"];
+
   if (isLongCurriedCallExpression(path)) {
     // By not wrapping the arguments in a group, the printer prioritizes
     // breaking up these arguments rather than the args of the parent call.

--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -178,8 +178,8 @@ function printCallArguments(path, options, print) {
     const closingString = quasis.at(-1).value.raw;
     //if the string begins or ends with whitespace (and/or brackets), inline the respective delimiter
     //by omitting newlines
-    const openingNewline = /^[({\[]*\s*?\n/.test(openingString)
-    const closingNewline = /\n\s*[)}\]]*$/.test(closingString);
+    const openingNewline = /^[([{]*\s*?\n/.test(openingString);
+    const closingNewline = /\n\s*[)\]}]*$/.test(closingString);
 
     inner = [
       indent([openingNewline ? "" : ifBreak(softline), printedArguments]),

--- a/src/language-js/print/call-expression.js
+++ b/src/language-js/print/call-expression.js
@@ -5,7 +5,6 @@ import {
   isCallExpression,
   isMemberish,
   isStringLiteral,
-  isTemplateOnItsOwnLine,
   isTestCall,
   iterateCallArgumentsPath,
 } from "../utils/index.js";
@@ -21,28 +20,24 @@ function printCallExpression(path, options, print) {
   const optional = printOptionalToken(path);
   const args = getCallArguments(node);
 
-  const isTemplateLiteralSingleArg =
-    args.length === 1 && isTemplateOnItsOwnLine(args[0], options.originalText);
-
   if (
-    isTemplateLiteralSingleArg ||
     // Dangling comments are not handled, all these special cases should have arguments #9668
-    (args.length > 0 &&
-      !isNew &&
-      !isDynamicImport &&
-      // We want to keep CommonJS- and AMD-style require calls, and AMD-style
-      // define calls, as a unit.
-      // e.g. `define(["some/lib"], (lib) => {`
-      (isCommonsJsOrAmdCall(node, parent) ||
-        // Keep test declarations on a single line
-        // e.g. `it('long name', () => {`
-        isTestCall(node, parent)))
+    args.length > 0 &&
+    !isNew &&
+    !isDynamicImport &&
+    // We want to keep CommonJS- and AMD-style require calls, and AMD-style
+    // define calls, as a unit.
+    // e.g. `define(["some/lib"], (lib) => {`
+    (isCommonsJsOrAmdCall(node, parent) ||
+      // Keep test declarations on a single line
+      // e.g. `it('long name', () => {`
+      isTestCall(node, parent))
   ) {
     const printed = [];
     iterateCallArgumentsPath(path, () => {
       printed.push(print());
     });
-    if (!(isTemplateLiteralSingleArg && printed[0].label?.embed)) {
+    if (!printed[0].label?.embed) {
       return [
         isNew ? "new " : "",
         print("callee"),

--- a/tests/format/js/assignment/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/assignment/__snapshots__/jsfmt.spec.js.snap
@@ -731,7 +731,8 @@ if (true) {
   );
 }
 
-const bifornCringerMoshedPerplexSawderGlyphsHb = someBigFunctionName(\`foo
+const bifornCringerMoshedPerplexSawderGlyphsHb = someBigFunctionName(
+  \`foo
 \`)("bar");
 
 ================================================================================

--- a/tests/format/js/template-literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/template-literals/__snapshots__/jsfmt.spec.js.snap
@@ -22,6 +22,54 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`chain-ending-with-single-argument.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+foo("long" + "set").bar("of" + "arguments").baz("will" + "break")
+.qux(\`
+    template literal
+\`)
+
+foo("long" + "set").bar("of" + "arguments").baz("will" + "break")
+.qux(\`
+    template literal
+\`).toString()
+
+foo().bar().baz().qux(\`
+  template literal
+  template literal
+\`)
+
+=====================================output=====================================
+foo("long" + "set")
+  .bar("of" + "arguments")
+  .baz("will" + "break")
+  .qux(\`
+    template literal
+\`);
+
+foo("long" + "set")
+  .bar("of" + "arguments")
+  .baz("will" + "break")
+  .qux(\`
+    template literal
+\`)
+  .toString();
+
+foo()
+  .bar()
+  .baz()
+  .qux(\`
+  template literal
+  template literal
+\`);
+
+================================================================================
+`;
+
 exports[`conditional-expressions.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/format/js/template-literals/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/template-literals/__snapshots__/jsfmt.spec.js.snap
@@ -43,6 +43,22 @@ foo().bar().baz().qux(\`
   template literal
 \`)
 
+foo()
+  .bar()
+  .baz()
+  .qux(
+    \`
+    template literal
+\`,
+  );
+
+foo()
+  .bar()
+  .baz()
+  .qux(\`
+    template literal
+\`);
+
 =====================================output=====================================
 foo("long" + "set")
   .bar("of" + "arguments")
@@ -65,6 +81,20 @@ foo()
   .qux(\`
   template literal
   template literal
+\`);
+
+foo()
+  .bar()
+  .baz()
+  .qux(\`
+    template literal
+\`);
+
+foo()
+  .bar()
+  .baz()
+  .qux(\`
+    template literal
 \`);
 
 ================================================================================

--- a/tests/format/js/template-literals/chain-ending-with-single-argument.js
+++ b/tests/format/js/template-literals/chain-ending-with-single-argument.js
@@ -12,3 +12,19 @@ foo().bar().baz().qux(`
   template literal
   template literal
 `)
+
+foo()
+  .bar()
+  .baz()
+  .qux(
+    `
+    template literal
+`,
+  );
+
+foo()
+  .bar()
+  .baz()
+  .qux(`
+    template literal
+`);

--- a/tests/format/js/template-literals/chain-ending-with-single-argument.js
+++ b/tests/format/js/template-literals/chain-ending-with-single-argument.js
@@ -1,0 +1,14 @@
+foo("long" + "set").bar("of" + "arguments").baz("will" + "break")
+.qux(`
+    template literal
+`)
+
+foo("long" + "set").bar("of" + "arguments").baz("will" + "break")
+.qux(`
+    template literal
+`).toString()
+
+foo().bar().baz().qux(`
+  template literal
+  template literal
+`)

--- a/tests/format/js/template/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/template/__snapshots__/jsfmt.spec.js.snap
@@ -46,7 +46,8 @@ new Error(formatErrorMessage\`
 \`);
 
 =====================================output=====================================
-insertRule(\`*, *:before, *:after {
+insertRule(
+  \`*, *:before, *:after {
   box-sizing: inherit;
 }\`);
 


### PR DESCRIPTION
## Description

Fixes #13533

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
