### PR TITLE
index.d.ts: Printer: add missing getCommentChildNodes

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -497,6 +497,16 @@ export interface Printer<T = any> {
   printComment?:
     | ((commentPath: AstPath<T>, options: ParserOptions<T>) => Doc)
     | undefined;
+  /**
+   * By default, Prettier searches all object properties (except for a few predefined ones) of each node recursively.
+   * This function can be provided to override that behavior.
+   * @param node The node whose children should be returned.
+   * @param options Current options.
+   * @returns `[]` if the node has no children or `undefined` to fall back on the default behavior.
+   */
+  getCommentChildNodes?:
+    | ((node: T, options: ParserOptions<T>) => T[] | undefined)
+    | undefined;
   handleComments?:
     | {
         ownLine?:


### PR DESCRIPTION
## Description

index.d.ts: Printer: add missing getCommentChildNodes

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [X] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

This is already documented in the docs #12502 .

Does this count as "user-facing" considering it only affects plugin authors?

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
