### PR TITLE
Remove `/vendors` and `/scripts/vendors` from `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,3 @@ package-lock.json
 .node-version
 # When installing software on gitpod.io, `core.*` files are generated
 /core.*
-
-# Temporarily ignore these files to avoid conflicts between next and main branch
-/vendors
-/scripts/vendors


### PR DESCRIPTION
## Description

Vendors dir is now unnecessary

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
