### PR TITLE
Add a `writeFormattedFile` to mock

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -325,7 +325,7 @@ module.exports = {
                 path.resolve(__dirname, "src/**"),
                 `!${path.resolve(__dirname, "src/cli/**")}`,
                 `!${path.resolve(__dirname, "src/index.js")}`,
-                `!${path.resolve(__dirname, "src/common/third-party.js")}`,
+                `!${path.resolve(__dirname, "src/common/mockable.js")}`,
               ],
               message: "Don't use code from other directory.",
             },

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -489,8 +489,8 @@ const nodejsFiles = [
     replaceModule: [replaceDiffPackageEntry("lib/patch/create.js")],
   },
   {
-    input: "src/common/third-party.js",
-    outputBaseName: "internal/third-party",
+    input: "src/common/mockable.js",
+    outputBaseName: "internal/internal",
     replaceModule: [
       // cosmiconfig@6 -> import-fresh can't find parentModule, since module is bundled
       {

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -12,7 +12,7 @@ import findCacheFile from "./find-cache-file.js";
 import FormatResultsCache from "./format-results-cache.js";
 import { statSafe, normalizeToPosix } from "./utils.js";
 
-const { getStdin } = thirdParty;
+const { getStdin, writeFormattedFile } = thirdParty;
 
 function diff(a, b) {
   return createTwoFilesPatch("", "", a, b, "", "", { context: 2 });
@@ -425,7 +425,7 @@ async function formatFiles(context) {
         }
 
         try {
-          await fs.writeFile(filename, output, "utf8");
+          await writeFormattedFile(filename, output);
 
           // Set cache if format succeeds
           shouldSetCache = true;

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -3,7 +3,7 @@ import path from "node:path";
 import chalk from "chalk";
 import { createTwoFilesPatch } from "diff";
 import * as prettier from "../index.js";
-import thirdParty from "../common/third-party.js";
+import mockable from "../common/mockable.js";
 import { createIsIgnoredFunction, errors } from "./prettier-internal.js";
 import { expandPatterns } from "./expand-patterns.js";
 import getOptionsForFile from "./options/get-options-for-file.js";
@@ -12,7 +12,7 @@ import findCacheFile from "./find-cache-file.js";
 import FormatResultsCache from "./format-results-cache.js";
 import { statSafe, normalizeToPosix } from "./utils.js";
 
-const { getStdin, writeFormattedFile } = thirdParty;
+const { getStdin, writeFormattedFile } = mockable;
 
 function diff(a, b) {
   return createTwoFilesPatch("", "", a, b, "", "", { context: 2 });

--- a/src/cli/is-tty.js
+++ b/src/cli/is-tty.js
@@ -1,8 +1,8 @@
-import thirdParty from "../common/third-party.js";
+import mockable from "../common/mockable.js";
 
 // Some CI pipelines incorrectly report process.stdout.isTTY status,
 // which causes unwanted lines in the output. An additional check for isCI() helps.
 // See https://github.com/prettier/prettier/issues/5801
 export default function isTTY() {
-  return process.stdout.isTTY && !thirdParty.isCI();
+  return process.stdout.isTTY && !mockable.isCI();
 }

--- a/src/common/mockable.js
+++ b/src/common/mockable.js
@@ -8,7 +8,7 @@ function writeFormattedFile(file, data) {
   return fs.writeFile(file, data);
 }
 
-const thirdParty = {
+const mockable = {
   cosmiconfig,
   findParentDir,
   getStdin,
@@ -16,4 +16,4 @@ const thirdParty = {
   writeFormattedFile,
 };
 
-export default thirdParty;
+export default mockable;

--- a/src/common/third-party.js
+++ b/src/common/third-party.js
@@ -1,13 +1,19 @@
+import fs from "node:fs/promises";
 import { cosmiconfig } from "cosmiconfig";
 import { sync as findParentDir } from "find-parent-dir";
 import getStdin from "get-stdin";
 import { isCI } from "ci-info";
+
+function writeFormattedFile(file, data) {
+  return fs.writeFile(file, data);
+}
 
 const thirdParty = {
   cosmiconfig,
   findParentDir,
   getStdin,
   isCI: () => isCI,
+  writeFormattedFile,
 };
 
 export default thirdParty;

--- a/src/config/get-prettier-config-explorer.js
+++ b/src/config/get-prettier-config-explorer.js
@@ -1,10 +1,10 @@
 import { pathToFileURL } from "node:url";
 import parseToml from "@iarna/toml/parse-async.js";
 import parseJson5 from "json5/lib/parse.js";
-import thirdParty from "../common/third-party.js";
+import mockable from "../common/mockable.js";
 import loadExternalConfig from "./load-external-config.js";
 
-const { cosmiconfig } = thirdParty;
+const { cosmiconfig } = mockable;
 
 const searchPlaces = [
   "package.json",

--- a/src/main/plugins/search-plugins.js
+++ b/src/main/plugins/search-plugins.js
@@ -3,13 +3,13 @@ import { fileURLToPath } from "node:url";
 import mem, { memClear } from "mem";
 import fastGlob from "fast-glob";
 import isDirectory from "../../utils/is-directory.js";
-import thirdParty from "../../common/third-party.js";
+import mockable from "../../common/mockable.js";
 import { loadPluginFromDirectory } from "./load-plugin.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const findNodeModules = mem((directory) =>
-  thirdParty.findParentDir(directory, "node_modules")
+  mockable.findParentDir(directory, "node_modules")
 );
 
 const findPluginsInNodeModules = mem(async (nodeModulesDir) => {

--- a/tests/integration/__tests__/mockable.js
+++ b/tests/integration/__tests__/mockable.js
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import createEsmUtils from "esm-utils";
-import { thirdParty } from "../env.js";
+import { mockable } from "../env.js";
 
 const { __dirname } = createEsmUtils(import.meta);
 
@@ -12,7 +12,7 @@ describe("cosmiconfig", () => {
   beforeAll(async () => {
     ({
       default: { cosmiconfig },
-    } = await import(pathToFileURL(thirdParty)));
+    } = await import(pathToFileURL(mockable)));
   });
 
   const configs = [
@@ -57,6 +57,6 @@ describe("cosmiconfig", () => {
 test("isCI", async () => {
   const {
     default: { isCI },
-  } = await import(pathToFileURL(thirdParty));
+  } = await import(pathToFileURL(mockable));
   expect(typeof isCI()).toBe("boolean");
 });

--- a/tests/integration/cli-worker.js
+++ b/tests/integration/cli-worker.js
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import url from "node:url";
 import { cosmiconfig } from "cosmiconfig";
-import { prettierCli, thirdParty as thirdPartyModuleFile } from "./env.js";
+import { prettierCli, mockable as mockableModuleFile } from "./env.js";
 
 const normalizeToPosix =
   path.sep === "\\"
@@ -43,24 +43,24 @@ async function run() {
   process.stdin.isTTY = Boolean(options.isTTY);
   process.stdout.isTTY = Boolean(options.stdoutIsTTY);
 
-  const { default: thirdParty } = await import(
-    url.pathToFileURL(thirdPartyModuleFile)
+  const { default: mockable } = await import(
+    url.pathToFileURL(mockableModuleFile)
   );
 
   // We cannot use `jest.setMock("get-stream", impl)` here, because in the
   // production build everything is bundled into one file so there is no
   // "get-stream" module to mock.
   // eslint-disable-next-line require-await
-  thirdParty.getStdin = async () => options.input || "";
-  thirdParty.isCI = () => Boolean(options.ci);
-  thirdParty.cosmiconfig = (moduleName, options) =>
+  mockable.getStdin = async () => options.input || "";
+  mockable.isCI = () => Boolean(options.ci);
+  mockable.cosmiconfig = (moduleName, options) =>
     cosmiconfig(moduleName, {
       ...options,
       stopDir: url.fileURLToPath(new URL("./cli", import.meta.url)),
     });
-  thirdParty.findParentDir = () => process.cwd();
+  mockable.findParentDir = () => process.cwd();
   // eslint-disable-next-line require-await
-  thirdParty.writeFormattedFile = async (filename, content) => {
+  mockable.writeFormattedFile = async (filename, content) => {
     filename = normalizeToPosix(path.relative(process.cwd(), filename));
     if (
       options.mockWriteFileErrors &&

--- a/tests/integration/env.js
+++ b/tests/integration/env.js
@@ -11,10 +11,10 @@ const prettierCli = path.join(
   typeof bin === "object" ? bin.prettier : bin
 );
 
-const thirdParty = isProduction
-  ? path.join(PRETTIER_DIR, "./internal/third-party.mjs")
-  : path.join(PRETTIER_DIR, "./src/common/third-party.js");
+const mockable = isProduction
+  ? path.join(PRETTIER_DIR, "./internal/internal.mjs")
+  : path.join(PRETTIER_DIR, "./src/common/mockable.js");
 
 const projectRoot = path.join(__dirname, "../..");
 
-export { isProduction, thirdParty, prettierCli, projectRoot };
+export { isProduction, mockable, prettierCli, projectRoot };


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Mock `thirdParty.writeFormattedFile` instead of `fs.writeFile`, so other files like cache file can write normally even if it use `fs.promises.writeFile` in future.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
