### PR TITLE
Remove outdated visitor key for `TSAbstractMethodDefinition`

### DIFF
--- a/src/language-js/traverse/visitor-keys.evaluate.js
+++ b/src/language-js/traverse/visitor-keys.evaluate.js
@@ -26,8 +26,6 @@ const additionalVisitorKeys = {
   TSJSDocUnknownType: [],
   TSJSDocNullableType: ["typeAnnotation"],
   TSJSDocNonNullableType: ["typeAnnotation"],
-  // This one maybe invalid, need investigate
-  TSAbstractMethodDefinition: ["decorators"],
 
   // Flow
   ClassProperty: ["variance"],

--- a/src/language-js/traverse/visitor-keys.evaluate.js
+++ b/src/language-js/traverse/visitor-keys.evaluate.js
@@ -53,6 +53,7 @@ const additionalVisitorKeys = {
 const excludeKeys = {
   // From `tsVisitorKeys`
   MethodDefinition: ["typeParameters"],
+  TSPropertySignature: ["initializer"],
 
   // From `flowVisitorKeys`
   ArrowFunctionExpression: ["id"],
@@ -66,9 +67,6 @@ const excludeKeys = {
   // From `babelVisitorKeys`
   DeclareInterface: ["mixins", "implements"],
   InterfaceDeclaration: ["mixins", "implements"],
-
-  // TypeScript
-  TSPropertySignature: ["initializer"],
 };
 
 const visitorKeys = Object.fromEntries(

--- a/tests/unit/__snapshots__/visitor-keys.js.snap
+++ b/tests/unit/__snapshots__/visitor-keys.js.snap
@@ -673,7 +673,6 @@ exports[`visitor keys estree 1`] = `
   "TSAbstractMethodDefinition": [
     "key",
     "value",
-    "decorators",
   ],
   "TSAbstractPropertyDefinition": [
     "decorators",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
