### PR TITLE
Don't apply plugin default options from unused plugins

### DIFF
--- a/src/main/normalize-format-options.js
+++ b/src/main/normalize-format-options.js
@@ -71,17 +71,13 @@ async function normalizeFormatOptions(options, opts = {}) {
 
   rawOptions.printer = printer;
 
-  const pluginDefaults = Object.fromEntries(
-    supportOptions
-      .filter(
-        (optionInfo) =>
-          optionInfo.pluginDefaults?.[printerPlugin.name] !== undefined
+  const pluginDefaults = printerPlugin.defaultOptions
+    ? Object.fromEntries(
+        Object.entries(printerPlugin.defaultOptions).filter(
+          ([, value]) => value !== undefined
+        )
       )
-      .map((optionInfo) => [
-        optionInfo.name,
-        optionInfo.pluginDefaults[printerPlugin.name],
-      ])
-  );
+    : {};
 
   const mixedDefaults = { ...defaults, ...pluginDefaults };
 

--- a/tests/integration/__tests__/printer-and-parser.js
+++ b/tests/integration/__tests__/printer-and-parser.js
@@ -25,3 +25,21 @@ test("Should use printer and parser from the same plugin", async () => {
   );
   expect(result).toEqual({ parsedBy: "plugin B", printedBy: "plugin B" });
 });
+
+test("Should not apply default options from unused plugin", async () => {
+  const pluginA = { defaultOptions: { tabWidth: 10 } };
+  const pluginB = {
+    parsers: { foo: { parse: () => ({}), astFormat: "foo" } },
+    printers: {
+      foo: {
+        print: (path, options) =>
+          JSON.stringify({ tabWidth: options.tabWidth }),
+      },
+    },
+  };
+
+  const result = JSON.parse(
+    await prettier.format("_", { plugins: [pluginA, pluginB], parser: "foo" })
+  );
+  expect(result).toEqual({ tabWidth: 2 });
+});


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
