### PR TITLE
Line breaking after `extends` in type parameters

### DIFF
--- a/changelog_unreleased/typescript/14672.md
+++ b/changelog_unreleased/typescript/14672.md
@@ -1,0 +1,20 @@
+#### Line breaking after `extends` in type parameters (#14672 by @sosukesuzuki)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+export type OuterType2<
+  LongerLongerLongerLongerInnerType extends LongerLongerLongerLongerLongerLongerLongerLongerOtherType
+> = { a: 1 };
+
+// Prettier stable
+export type OuterType2<
+  LongerLongerLongerLongerInnerType extends LongerLongerLongerLongerLongerLongerLongerLongerOtherType
+> = { a: 1 };
+
+// Prettier main
+export type OuterType2<
+  LongerLongerLongerLongerInnerType extends
+    LongerLongerLongerLongerLongerLongerLongerLongerOtherType,
+> = { a: 1 };
+```

--- a/src/language-js/print/type-parameters.js
+++ b/src/language-js/print/type-parameters.js
@@ -112,6 +112,10 @@ function printDanglingCommentsForInline(path, options) {
 
 function printTypeParameter(path, options, print) {
   const { node, parent } = path;
+
+  /**
+   * @type {import("../../document/builders.js").Doc[]}
+   */
   const parts = [node.type === "TSTypeParameter" && node.const ? "const " : ""];
 
   const name = node.type === "TSTypeParameter" ? print("name") : node.name;
@@ -160,14 +164,14 @@ function printTypeParameter(path, options, print) {
   }
 
   if (node.constraint) {
-    parts.push(" extends ", print("constraint"));
+    parts.push(" extends", indent([line, print("constraint")]));
   }
 
   if (node.default) {
     parts.push(" = ", print("default"));
   }
 
-  return parts;
+  return group(parts);
 }
 
 export { printTypeParameter, printTypeParameters, getTypeParametersGroupId };

--- a/tests/format/typescript/typeparams/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/typeparams/__snapshots__/jsfmt.spec.js.snap
@@ -362,6 +362,54 @@ class _ {
 ================================================================================
 `;
 
+exports[`line-breaking-after-extends.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+export type OuterType1<
+  LongerLongerLongerLongerInnerType extends LongerLongerLongerLongerOtherType<OneMoreType>
+> = { a: 1 };
+
+export type OuterType2<
+  LongerLongerLongerLongerInnerType extends LongerLongerLongerLongerLongerLongerLongerLongerOtherType
+> = { a: 1 };
+
+export type OuterType3<
+  LongerLongerLongerLongerInnerType extends LongerLongerLongerLongerLongerLo.ngerLongerLongerOtherType
+> = { a: 1 };
+
+export type OuterType4<
+  LongerLongerLongerLongerInnerType extends
+    | LongerLongerLongerLongerLongerLo
+    | ngerLongerLongerOtherType
+> = { a: 1 };
+
+=====================================output=====================================
+export type OuterType1<
+  LongerLongerLongerLongerInnerType extends
+    LongerLongerLongerLongerOtherType<OneMoreType>,
+> = { a: 1 };
+
+export type OuterType2<
+  LongerLongerLongerLongerInnerType extends
+    LongerLongerLongerLongerLongerLongerLongerLongerOtherType,
+> = { a: 1 };
+
+export type OuterType3<
+  LongerLongerLongerLongerInnerType extends
+    LongerLongerLongerLongerLongerLo.ngerLongerLongerOtherType,
+> = { a: 1 };
+
+export type OuterType4<
+  LongerLongerLongerLongerInnerType extends
+    LongerLongerLongerLongerLongerLo | ngerLongerLongerOtherType,
+> = { a: 1 };
+
+================================================================================
+`;
+
 exports[`long-function-arg.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/typeparams/line-breaking-after-extends.ts
+++ b/tests/format/typescript/typeparams/line-breaking-after-extends.ts
@@ -1,0 +1,17 @@
+export type OuterType1<
+  LongerLongerLongerLongerInnerType extends LongerLongerLongerLongerOtherType<OneMoreType>
+> = { a: 1 };
+
+export type OuterType2<
+  LongerLongerLongerLongerInnerType extends LongerLongerLongerLongerLongerLongerLongerLongerOtherType
+> = { a: 1 };
+
+export type OuterType3<
+  LongerLongerLongerLongerInnerType extends LongerLongerLongerLongerLongerLo.ngerLongerLongerOtherType
+> = { a: 1 };
+
+export type OuterType4<
+  LongerLongerLongerLongerInnerType extends
+    | LongerLongerLongerLongerLongerLo
+    | ngerLongerLongerOtherType
+> = { a: 1 };


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #14666 

Adds a newline and indent after `extends` in the type param to respect `printWidth`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
