### PR TITLE
Bundle actual cjs entry

### DIFF
--- a/scripts/build/build-javascript-module.js
+++ b/scripts/build/build-javascript-module.js
@@ -158,7 +158,6 @@ function getEsbuildOptions({ file, files, shouldCollectLicenses, cliOptions }) {
     );
     // External other bundled files
     replaceModule.push(...replacements);
-    console.log(replacements);
   } else {
     replaceModule.push(
       // When running build script with `--no-minify`, `esbuildPluginNodeModulePolyfills` shim `module` module incorrectly

--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -472,9 +472,7 @@ const nodejsFiles = [
       },
       replaceDiffPackageEntry("lib/diff/array.js"),
     ],
-  },
-  {
-    input: "src/index.cjs",
+    formats: ["esm", "cjs"],
   },
   {
     input: "bin/prettier.cjs",
@@ -504,15 +502,16 @@ const nodejsFiles = [
         path: path.join(dirname, "./shims/parent-module.cjs"),
       },
     ],
+    formats: ["esm", "cjs"],
   },
 ].flatMap((file) => {
-  let { input, output, outputBaseName, ...buildOptions } = file;
+  let { input, output, outputBaseName, formats, ...buildOptions } = file;
+  formats ??= [input.endsWith(".cjs") ? "cjs" : "esm"];
 
-  const format = input.endsWith(".cjs") ? "cjs" : "esm";
   outputBaseName ??= path.basename(input, path.extname(input));
 
   return [
-    {
+    ...formats.map((format) => ({
       input,
       output: {
         format,
@@ -522,7 +521,7 @@ const nodejsFiles = [
       buildOptions,
       build: buildJavascriptModule,
       kind: "javascript",
-    },
+    })),
     getTypesFileConfig({ input, outputBaseName }),
   ];
 });

--- a/scripts/build/esbuild-plugins/evaluate.js
+++ b/scripts/build/esbuild-plugins/evaluate.js
@@ -8,8 +8,6 @@ export default function esbuildPluginEvaluate() {
   return {
     name: "evaluate",
     setup(build) {
-      const { format } = build.initialOptions;
-
       build.onLoad({ filter: /\.evaluate\.c?js$/ }, async ({ path }) => {
         const module = await importModule(path);
         const text = Object.entries(module)

--- a/scripts/build/esbuild-plugins/evaluate.js
+++ b/scripts/build/esbuild-plugins/evaluate.js
@@ -17,20 +17,17 @@ export default function esbuildPluginEvaluate() {
             value = serialize(value, { space: 2 });
 
             if (specifier === "default") {
-              return format === "cjs"
-                ? `module.exports = ${value};`
-                : `export default ${value};`;
+              return `export default ${value};`;
             }
 
             if (!isValidIdentifier(specifier)) {
               throw new Error(`${specifier} is not a valid specifier`);
             }
 
-            return format === "cjs"
-              ? `exports.${specifier} = ${value};`
-              : `export const ${specifier} = ${value};`;
+            return `export const ${specifier} = ${value};`;
           })
           .join("\n");
+
         return { contents: text };
       });
     },

--- a/tests/integration/__tests__/bundle.js
+++ b/tests/integration/__tests__/bundle.js
@@ -116,9 +116,11 @@ test("Commonjs version", () => {
   );
   expect(typeof prettierCommonjsVersion.util.getStringWidth).toBe("function");
 
-  expect(Object.keys(prettierCommonjsVersion.__debug).sort()).toEqual(
-    Object.keys(prettier.__debug).sort()
-  );
+  expect(
+    Object.keys(prettierCommonjsVersion.__debug)
+      .filter((key) => key !== "default")
+      .sort()
+  ).toEqual(Object.keys(prettier.__debug).sort());
   expect(typeof prettierCommonjsVersion.__debug.parse).toBe("function");
 
   expect(prettierCommonjsVersion.version).toBe(prettier.version);

--- a/tests/integration/__tests__/bundle.js
+++ b/tests/integration/__tests__/bundle.js
@@ -102,9 +102,7 @@ test("Commonjs version", () => {
   ));
 
   expect(Object.keys(prettierCommonjsVersion).sort()).toEqual(
-    Object.keys(prettier)
-      .filter((key) => key !== "__internal")
-      .sort()
+    Object.keys(prettier).sort()
   );
   expect(typeof prettierCommonjsVersion.format).toBe("function");
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

VSCode extention can't use cjs proxy to `import()` esm version, try to bundle CommonJS version of index.cjs

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
