### PR TITLE
"browser" field in exports["."] for standalone entrypoint (fixes #14765)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     ".": {
       "types": "./src/index.d.ts",
       "require": "./src/index.cjs",
+      "browser": "./src/standalone.mjs",
       "default": "./src/index.js"
     },
     "./*": "./*"


### PR DESCRIPTION
## Description

Attempt to fix #14765. Seems to help, but I'm not 100% sure if it's a safe change for everyone (should it be `standalone.js` and not `standalone.mjs`?).

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
