### PR TITLE
fix incorrect formatting of attribute selectors with url protocols

### DIFF
--- a/tests/format/css/attribute/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/css/attribute/__snapshots__/jsfmt.spec.js.snap
@@ -280,6 +280,10 @@ href
 *=
 'example'
 ] {}
+a[ href ^= 'http://example.com' ] {}
+a[ href $= 'https://example.com' ] {}
+a[ href *= 'tel:0123456789' ] {}
+a[ href *= 'mailto:a-n-other@example.com' ] {}
 input[ type = 'radio' i ] {}
 input[  type  =  'radio'  i  ] {}
 input[ type ~= 'radio' i ] {}
@@ -410,6 +414,16 @@ a[href*='example'] {
 }
 a[href*='example'] {
 }
+a[ href ^= 'http://example.com' ]
+{
+}
+a[ href $= 'https://example.com' ]
+{
+}
+a[href*='tel:0123456789'] {
+}
+a[href*='mailto:a-n-other@example.com'] {
+}
 input[type='radio' i] {
 }
 input[type='radio' i] {
@@ -521,6 +535,10 @@ href
 *=
 'example'
 ] {}
+a[ href ^= 'http://example.com' ] {}
+a[ href $= 'https://example.com' ] {}
+a[ href *= 'tel:0123456789' ] {}
+a[ href *= 'mailto:a-n-other@example.com' ] {}
 input[ type = 'radio' i ] {}
 input[  type  =  'radio'  i  ] {}
 input[ type ~= 'radio' i ] {}
@@ -650,6 +668,16 @@ a[href$=".cn"] {
 a[href*="example"] {
 }
 a[href*="example"] {
+}
+a[ href ^= 'http://example.com' ]
+{
+}
+a[ href $= 'https://example.com' ]
+{
+}
+a[href*="tel:0123456789"] {
+}
+a[href*="mailto:a-n-other@example.com"] {
 }
 input[type="radio" i] {
 }

--- a/tests/format/css/attribute/spaces.css
+++ b/tests/format/css/attribute/spaces.css
@@ -39,6 +39,10 @@ href
 *=
 'example'
 ] {}
+a[ href ^= 'http://example.com' ] {}
+a[ href $= 'https://example.com' ] {}
+a[ href *= 'tel:0123456789' ] {}
+a[ href *= 'mailto:a-n-other@example.com' ] {}
 input[ type = 'radio' i ] {}
 input[  type  =  'radio'  i  ] {}
 input[ type ~= 'radio' i ] {}


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Attribute selectors with url protocols are incorrectly formatted :

```css
a[href^='http://example.com'] {
}

/* becomes */

a[href^='http://example.com']
{
}
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] ~~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~~
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
