### PR TITLE
Boolean checks should not be inverted

### DIFF
--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -510,7 +510,7 @@ function handleFunctionNameComments({
 }
 
 function handleCommentAfterArrowParams({ comment, enclosingNode, text }) {
-  if (!(enclosingNode?.type === "ArrowFunctionExpression")) {
+  if (enclosingNode?.type !== "ArrowFunctionExpression") {
     return false;
   }
 


### PR DESCRIPTION
Hey there, I've found this small issue.

By the way, this is a great project! I've been using it since its beginning :)

## Description

It is needlessly complex to invert the result of a boolean comparison. The opposite comparison should be made instead.

In other words, instead of `!(a === b)` use `a !== b`.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
