### PR TITLE
TypeScript: Fix issue with double semicolon caused by `// prettier-ignore` on a call signature line

### DIFF
--- a/changelog_unreleased/typescript/14830.md
+++ b/changelog_unreleased/typescript/14830.md
@@ -1,0 +1,22 @@
+#### Fix issue with double semicolon caused by `// prettier-ignore` on a call signature line (#14830 by @ot07)
+
+<!-- prettier-ignore -->
+```ts
+// Input
+type Foo = {
+  (): void; // prettier-ignore
+  second: string;
+};
+
+// Prettier stable
+type Foo = {
+  (): void;; // prettier-ignore
+  second: string;
+};
+
+// Prettier main
+type Foo = {
+  (): void; // prettier-ignore
+  second: string;
+};
+```

--- a/src/language-js/print/object.js
+++ b/src/language-js/print/object.js
@@ -118,7 +118,8 @@ function printObject(path, options, print) {
     if (
       (prop.node.type === "TSPropertySignature" ||
         prop.node.type === "TSMethodSignature" ||
-        prop.node.type === "TSConstructSignatureDeclaration") &&
+        prop.node.type === "TSConstructSignatureDeclaration" ||
+        prop.node.type === "TSCallSignatureDeclaration") &&
       hasComment(prop.node, CommentCheckFlags.PrettierIgnore)
     ) {
       separatorParts.shift();

--- a/tests/format/typescript/call-signature/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/call-signature/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,91 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`call-signature.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type T = {
+  (): void;
+  second: string;
+};
+
+type T = {
+  (): void; // prettier-ignore
+  second: string;
+};
+
+type T = {
+  first: string;
+  (): void;
+};
+
+type T = {
+  first: string;
+  (): void; // prettier-ignore
+};
+
+interface I {
+  (): void;
+  second: string;
+}
+
+interface I {
+  (): void; // prettier-ignore
+  second: string;
+}
+
+interface I {
+  first: string;
+  (): void;
+}
+
+interface I {
+  first: string;
+  (): void; // prettier-ignore
+}
+
+=====================================output=====================================
+type T = {
+  (): void;
+  second: string;
+};
+
+type T = {
+  (): void; // prettier-ignore
+  second: string;
+};
+
+type T = {
+  first: string;
+  (): void;
+};
+
+type T = {
+  first: string;
+  (): void; // prettier-ignore
+};
+
+interface I {
+  (): void;
+  second: string;
+}
+
+interface I {
+  (): void; // prettier-ignore
+  second: string;
+}
+
+interface I {
+  first: string;
+  (): void;
+}
+
+interface I {
+  first: string;
+  (): void; // prettier-ignore
+}
+
+================================================================================
+`;

--- a/tests/format/typescript/call-signature/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/call-signature/__snapshots__/jsfmt.spec.js.snap
@@ -17,6 +17,11 @@ type T = {
 };
 
 type T = {
+  (): void; // comment
+  second: string;
+};
+
+type T = {
   first: string;
   (): void;
 };
@@ -26,6 +31,11 @@ type T = {
   (): void; // prettier-ignore
 };
 
+type T = {
+  first: string;
+  (): void; // comment
+};
+
 interface I {
   (): void;
   second: string;
@@ -37,6 +47,11 @@ interface I {
 }
 
 interface I {
+  (): void; // comment
+  second: string;
+}
+
+interface I {
   first: string;
   (): void;
 }
@@ -44,6 +59,11 @@ interface I {
 interface I {
   first: string;
   (): void; // prettier-ignore
+}
+
+interface I {
+  first: string;
+  (): void; // comment
 }
 
 =====================================output=====================================
@@ -58,6 +78,11 @@ type T = {
 };
 
 type T = {
+  (): void; // comment
+  second: string;
+};
+
+type T = {
   first: string;
   (): void;
 };
@@ -67,6 +92,11 @@ type T = {
   (): void; // prettier-ignore
 };
 
+type T = {
+  first: string;
+  (): void; // comment
+};
+
 interface I {
   (): void;
   second: string;
@@ -78,6 +108,11 @@ interface I {
 }
 
 interface I {
+  (): void; // comment
+  second: string;
+}
+
+interface I {
   first: string;
   (): void;
 }
@@ -85,6 +120,11 @@ interface I {
 interface I {
   first: string;
   (): void; // prettier-ignore
+}
+
+interface I {
+  first: string;
+  (): void; // comment
 }
 
 ================================================================================

--- a/tests/format/typescript/call-signature/call-signature.ts
+++ b/tests/format/typescript/call-signature/call-signature.ts
@@ -1,0 +1,39 @@
+type T = {
+  (): void;
+  second: string;
+};
+
+type T = {
+  (): void; // prettier-ignore
+  second: string;
+};
+
+type T = {
+  first: string;
+  (): void;
+};
+
+type T = {
+  first: string;
+  (): void; // prettier-ignore
+};
+
+interface I {
+  (): void;
+  second: string;
+}
+
+interface I {
+  (): void; // prettier-ignore
+  second: string;
+}
+
+interface I {
+  first: string;
+  (): void;
+}
+
+interface I {
+  first: string;
+  (): void; // prettier-ignore
+}

--- a/tests/format/typescript/call-signature/call-signature.ts
+++ b/tests/format/typescript/call-signature/call-signature.ts
@@ -9,6 +9,11 @@ type T = {
 };
 
 type T = {
+  (): void; // comment
+  second: string;
+};
+
+type T = {
   first: string;
   (): void;
 };
@@ -18,6 +23,11 @@ type T = {
   (): void; // prettier-ignore
 };
 
+type T = {
+  first: string;
+  (): void; // comment
+};
+
 interface I {
   (): void;
   second: string;
@@ -29,6 +39,11 @@ interface I {
 }
 
 interface I {
+  (): void; // comment
+  second: string;
+}
+
+interface I {
   first: string;
   (): void;
 }
@@ -36,4 +51,9 @@ interface I {
 interface I {
   first: string;
   (): void; // prettier-ignore
+}
+
+interface I {
+  first: string;
+  (): void; // comment
 }

--- a/tests/format/typescript/call-signature/jsfmt.spec.js
+++ b/tests/format/typescript/call-signature/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(import.meta, ["typescript"]);


### PR DESCRIPTION
## Description

Fixes #14786 

Fix to not insert a semicolon at the end of a call signature line with prettier-ignore comment.

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md)

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
