### PR TITLE
Consider Flow type cast expressions when expanding call arguments

### DIFF
--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -281,8 +281,12 @@ function isHopefullyShortCallArgument(node) {
     return isHopefullyShortCallArgument(node.expression);
   }
 
-  if (isTSTypeExpression(node)) {
+  if (isTSTypeExpression(node) || node.type === "TypeCastExpression") {
     let { typeAnnotation } = node;
+    if (typeAnnotation.type === "TypeAnnotation") {
+      typeAnnotation = typeAnnotation.typeAnnotation;
+    }
+
     if (typeAnnotation.type === "TSArrayType") {
       typeAnnotation = typeAnnotation.elementType;
       if (typeAnnotation.type === "TSArrayType") {

--- a/tests/format/flow/type-cast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/type-cast/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`argument-expansion.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const bar1 = [1,2,3].reduce((carry, value) => {
+  return [...carry, value];
+}, ([]: Array<string>));
+
+const bar1 = [1,2,3].reduce((carry, value) => {
+  return {};
+}, ({}: {foo?: string}));
+
+=====================================output=====================================
+const bar1 = [1, 2, 3].reduce((carry, value) => {
+  return [...carry, value];
+}, ([]: Array<string>));
+
+const bar1 = [1, 2, 3].reduce(
+  (carry, value) => {
+    return {};
+  },
+  ({}: { foo?: string }),
+);
+
+================================================================================
+`;
+
 exports[`expression.js format 1`] = `
 ====================================options=====================================
 parsers: ["flow"]

--- a/tests/format/flow/type-cast/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/type-cast/__snapshots__/jsfmt.spec.js.snap
@@ -10,21 +10,10 @@ const bar1 = [1,2,3].reduce((carry, value) => {
   return [...carry, value];
 }, ([]: Array<string>));
 
-const bar1 = [1,2,3].reduce((carry, value) => {
-  return {};
-}, ({}: {foo?: string}));
-
 =====================================output=====================================
 const bar1 = [1, 2, 3].reduce((carry, value) => {
   return [...carry, value];
 }, ([]: Array<string>));
-
-const bar1 = [1, 2, 3].reduce(
-  (carry, value) => {
-    return {};
-  },
-  ({}: { foo?: string }),
-);
 
 ================================================================================
 `;

--- a/tests/format/flow/type-cast/argument-expansion.js
+++ b/tests/format/flow/type-cast/argument-expansion.js
@@ -1,0 +1,3 @@
+const bar1 = [1,2,3].reduce((carry, value) => {
+  return [...carry, value];
+}, ([]: Array<string>));


### PR DESCRIPTION
## Description

Comparing formatting of prettier v2 vs prettier v3 on the Meta codebases i noticed argument expansion no longer works when the second arg is a Flow type cast. My guess is it was related to the changes in #13341 which explicitly handles TS `TSAsExpression` nodes. This change adds similar support for Flow `TypeCastExpression` nodes.

```js
// Input
const bar1 = [1,2,3].reduce((carry, value) => {
  return [...carry, value];
}, ([]: Array<string>));
// Prettier stable
const bar1 = [1,2,3].reduce(
  (carry, value) => {
    return [...carry, value];
  },
  ([]: Array<string>)
);
// Prettier main
const bar1 = [1,2,3].reduce((carry, value) => {
  return [...carry, value];
}, ([]: Array<string>));
```

This change doesn't bring full parity to the current v2.8 logic but it should cover most of the cases and at least match TS behaviour. 

## Checklist

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
