### PR TITLE
Fix playground: AST is massaged for Prettier 2.x

### DIFF
--- a/website/static/worker.js
+++ b/website/static/worker.js
@@ -97,16 +97,28 @@ async function handleFormatMessage(message) {
     },
   };
 
+  const isPrettier2 = prettier.version.startsWith("2.");
+
   for (const key of ["ast", "preprocessedAst"]) {
     if (!message.debug[key]) {
       continue;
     }
+
+    const preprocessForPrint = key === "preprocessedAst";
+
+    if (isPrettier2 && preprocessForPrint) {
+      response.debug[key] = "/* not supported for Prettier 2.x */";
+      continue;
+    }
+
     let ast;
     let errored = false;
     try {
-      const parsed = await prettier.__debug.parse(message.code, options, {
-        preprocessForPrint: key === "preprocessedAst",
-      });
+      const parsed = await prettier.__debug.parse(
+        message.code,
+        options,
+        isPrettier2 ? false : { preprocessForPrint }
+      );
       ast = serializeAst(parsed.ast);
     } catch (e) {
       errored = true;


### PR DESCRIPTION
`prettier.__debug.parse` has different signatures in v2 and v3. Currently the playground on prettier.io uses the v3 signature for v2, that's why AST is shown incomplete (massaged).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
