### PR TITLE
feat: Add name to errors

### DIFF
--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -18,7 +18,9 @@ function diff(a, b) {
   return createTwoFilesPatch("", "", a, b, "", "", { context: 2 });
 }
 
-class DebugError extends Error {}
+class DebugError extends Error {
+  name = "DebugError";
+}
 
 function handleError(context, filename, error, printedFilename) {
   const errorIsUndefinedParseError =

--- a/src/common/errors.js
+++ b/src/common/errors.js
@@ -1,5 +1,13 @@
-class ConfigError extends Error {}
-class UndefinedParserError extends Error {}
-class ArgExpansionBailout extends Error {}
+class ConfigError extends Error {
+  name = "ConfigError";
+}
+
+class UndefinedParserError extends Error {
+  name = "UndefinedParserError";
+}
+
+class ArgExpansionBailout extends Error {
+  name = "ArgExpansionBailout";
+}
 
 export { ConfigError, UndefinedParserError, ArgExpansionBailout };

--- a/tests/unit/errors.js
+++ b/tests/unit/errors.js
@@ -1,0 +1,23 @@
+import {
+  ConfigError,
+  UndefinedParserError,
+  ArgExpansionBailout,
+} from "../../src/common/errors.js";
+
+it("ConfigError", () => {
+  const error = new ConfigError("foo");
+  expect(error.name).toBe("ConfigError");
+  expect(error.message).toBe("foo");
+});
+
+it("UndefinedParserError", () => {
+  const error = new UndefinedParserError("foo");
+  expect(error.name).toBe("UndefinedParserError");
+  expect(error.message).toBe("foo");
+});
+
+it("ArgExpansionBailout", () => {
+  const error = new ArgExpansionBailout("foo");
+  expect(error.name).toBe("ArgExpansionBailout");
+  expect(error.message).toBe("foo");
+});


### PR DESCRIPTION
## Description

When creating a [custom error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error#custom_error_types), it's recommended to set the value of the [`name`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/name) property.

This pull request makes it easier to filter errors:

```JavaScript
try {
    const result = prettier.check(source, config);
    // ...
} catch (err) {
    // CURRENTLY: Need to use ".constructor" for Prettier custom errors.
    // if ("UndefinedParserError" === err.constructor.name) {
    //     console.log("FATAL: No parseri found!");
    // } else if ("SyntaxError" === err.name) {
    //     console.log("FATAL: Syntax error!");
    // }

    // WITH THIS PULL REQUEST: Only use ".name" for all errors.
    if ("UndefinedParserError" === err.name) {
        console.log("FATAL: No parser found!");
    } else if ("SyntaxError" === err.name) {
        console.log("FATAL: Syntax error!");
    }
}
```

My real-life case of using Prettier's API: [Metalint](https://github.com/regseb/metalint/blob/main/src/core/wrapper/prettier.js#L88-L126).

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**