### PR TITLE
Fix typo in function name

### DIFF
--- a/src/plugins/builtin-plugins-proxy.js
+++ b/src/plugins/builtin-plugins-proxy.js
@@ -20,7 +20,7 @@ import markdownLanguages from "../language-markdown/languages.evaluate.js";
 import yamlOptions from "../language-yaml/options.js";
 import yamlLanguages from "../language-yaml/languages.evaluate.js";
 
-function createParsersAndParsers(modules) {
+function createParsersAndPrinters(modules) {
   const parsers = Object.create(null);
   const printers = Object.create(null);
 
@@ -71,7 +71,7 @@ export const languages = [
 ];
 
 // Lazy load the plugins
-export const { parsers, printers } = createParsersAndParsers([
+export const { parsers, printers } = createParsersAndPrinters([
   {
     importPlugin: () => import("./acorn.js"),
     parsers: ["acorn", "espree"],


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
- Fix function name `createParsersAndParsers` to `createParsersAndPrinters`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
