### PR TITLE
Remove space after pipe name

### DIFF
--- a/changelog_unreleased/angular/14961.md
+++ b/changelog_unreleased/angular/14961.md
@@ -20,6 +20,6 @@ For more information on the discussion, please see https://github.com/prettier/p
 
 <!-- Prettier main -->
 <my-component
-  [value]="value | transform : arg1 : arg2 | format : arg3 : arg4"
+  [value]="value | transform: arg1 : arg2 | format: arg3 : arg4"
 ></my-component>
 ```

--- a/changelog_unreleased/angular/14961.md
+++ b/changelog_unreleased/angular/14961.md
@@ -1,4 +1,10 @@
-#### Remove space after pipe name (#13100 by @waterplea)
+#### Remove space after pipe name (#14961 by @waterplea)
+
+We introduced [a new format for pipe in Prettier 2.8](https://prettier.io/blog/2022/11/23/2.8.0.html#insert-spaces-in-pipe-13100httpsgithubcomprettierprettierpull13100-by-sosukesuzukihttpsgithubcomsosukesuzuki), but this was not accepted by the community.
+
+Therefore, we are introducing a new format that reflects community input.
+
+For more information on the discussion, please see https://github.com/prettier/prettier/issues/13887.
 
 <!-- prettier-ignore -->
 ```html

--- a/changelog_unreleased/angular/14961.md
+++ b/changelog_unreleased/angular/14961.md
@@ -1,0 +1,19 @@
+#### Remove space after pipe name (#13100 by @waterplea)
+
+<!-- prettier-ignore -->
+```html
+<!-- Input -->
+<my-component
+  [value]="value | transform: arg1 : arg2 | format: arg3 : arg4"
+></my-component>
+
+<!-- Prettier stable -->
+<my-component
+  [value]="value | transform : arg1 : arg2 | format : arg3 : arg4"
+></my-component>
+
+<!-- Prettier main -->
+<my-component
+  [value]="value | transform : arg1 : arg2 | format : arg3 : arg4"
+></my-component>
+```

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -237,7 +237,7 @@ function printBinaryishExpressions(
     node.type === "NGPipeExpression" && node.arguments.length > 0
       ? group(
           indent([
-            line,
+            softline,
             ": ",
             join(
               [line, ": "],

--- a/tests/format/angular/angular/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/angular/angular/__snapshots__/jsfmt.spec.js.snap
@@ -320,10 +320,10 @@ printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
-    [target]=" a | b : c "
+    bindon-target=" a | b : c:d :e "
+    [(target)]=" a | b : c:d :e "
+    bind-target=" a | b : c:d :e "
+    [target]=" a | b : c:d :e "
     [target]=" a | pipe   "
     [target]=" 0 - 1 "
     [target]=" - 1 "
@@ -436,10 +436,10 @@ printWidth: 80
 
 =====================================output=====================================
 <div
-  bindon-target="a | b : c"
-  [(target)]="a | b : c"
-  bind-target="a | b : c"
-  [target]="a | b : c"
+  bindon-target="a | b: c : d : e"
+  [(target)]="a | b: c : d : e"
+  bind-target="a | b: c : d : e"
+  [target]="a | b: c : d : e"
   [target]="a | pipe"
   [target]="0 - 1"
   [target]="-1"
@@ -599,10 +599,10 @@ printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
-    [target]=" a | b : c "
+    bindon-target=" a | b : c:d :e "
+    [(target)]=" a | b : c:d :e "
+    bind-target=" a | b : c:d :e "
+    [target]=" a | b : c:d :e "
     [target]=" a | pipe   "
     [target]=" 0 - 1 "
     [target]=" - 1 "
@@ -715,10 +715,10 @@ printWidth: 80
 
 =====================================output=====================================
 <div
-  bindon-target="a | b : c"
-  [(target)]="a | b : c"
-  bind-target="a | b : c"
-  [target]="a | b : c"
+  bindon-target="a | b: c : d : e"
+  [(target)]="a | b: c : d : e"
+  bind-target="a | b: c : d : e"
+  [target]="a | b: c : d : e"
   [target]="a | pipe"
   [target]="0 - 1"
   [target]="-1"
@@ -877,10 +877,10 @@ printWidth: 1
  | printWidth
 =====================================input======================================
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
-    [target]=" a | b : c "
+    bindon-target=" a | b : c:d :e "
+    [(target)]=" a | b : c:d :e "
+    bind-target=" a | b : c:d :e "
+    [target]=" a | b : c:d :e "
     [target]=" a | pipe   "
     [target]=" 0 - 1 "
     [target]=" - 1 "
@@ -997,21 +997,29 @@ printWidth: 1
     a
       | b
         : c
+        : d
+        : e
   "
   [(target)]="
     a
       | b
         : c
+        : d
+        : e
   "
   bind-target="
     a
       | b
         : c
+        : d
+        : e
   "
   [target]="
     a
       | b
         : c
+        : d
+        : e
   "
   [target]="
     a
@@ -1496,10 +1504,10 @@ trailingComma: "es5"
                                                                                 | printWidth
 =====================================input======================================
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
-    [target]=" a | b : c "
+    bindon-target=" a | b : c:d :e "
+    [(target)]=" a | b : c:d :e "
+    bind-target=" a | b : c:d :e "
+    [target]=" a | b : c:d :e "
     [target]=" a | pipe   "
     [target]=" 0 - 1 "
     [target]=" - 1 "
@@ -1612,10 +1620,10 @@ trailingComma: "es5"
 
 =====================================output=====================================
 <div
-  bindon-target="a | b : c"
-  [(target)]="a | b : c"
-  bind-target="a | b : c"
-  [target]="a | b : c"
+  bindon-target="a | b: c : d : e"
+  [(target)]="a | b: c : d : e"
+  bind-target="a | b: c : d : e"
+  [target]="a | b: c : d : e"
   [target]="a | pipe"
   [target]="0 - 1"
   [target]="-1"
@@ -1775,10 +1783,10 @@ trailingComma: "none"
                                                                                 | printWidth
 =====================================input======================================
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
-    [target]=" a | b : c "
+    bindon-target=" a | b : c:d :e "
+    [(target)]=" a | b : c:d :e "
+    bind-target=" a | b : c:d :e "
+    [target]=" a | b : c:d :e "
     [target]=" a | pipe   "
     [target]=" 0 - 1 "
     [target]=" - 1 "
@@ -1891,10 +1899,10 @@ trailingComma: "none"
 
 =====================================output=====================================
 <div
-  bindon-target="a | b : c"
-  [(target)]="a | b : c"
-  bind-target="a | b : c"
-  [target]="a | b : c"
+  bindon-target="a | b: c : d : e"
+  [(target)]="a | b: c : d : e"
+  bind-target="a | b: c : d : e"
+  [target]="a | b: c : d : e"
   [target]="a | pipe"
   [target]="0 - 1"
   [target]="-1"
@@ -2598,52 +2606,52 @@ printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute -->
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute bind-target -->
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute [(target)] bind-target -->
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 
 =====================================output=====================================
 <div
-  bindon-target="a | b : c"
-  [(target)]="a | b : c"
-  bind-target="a | b : c"
+  bindon-target="a | b: c : d : e"
+  [(target)]="a | b: c : d : e"
+  bind-target="a | b: c : d : e"
 ></div>
 <!--  prettier-ignore-attribute -->
 <div
-  bindon-target=" a | b : c "
-  [(target)]=" a | b : c "
-  bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute bind-target -->
 <div
-  bindon-target="a | b : c"
-  [(target)]="a | b : c"
-  bind-target=" a | b : c "
+  bindon-target="a | b: c : d : e"
+  [(target)]="a | b: c : d : e"
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute [(target)] bind-target -->
 <div
-  bindon-target="a | b : c"
-  [(target)]=" a | b : c "
-  bind-target=" a | b : c "
+  bindon-target="a | b: c : d : e"
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 
 ================================================================================
@@ -2657,52 +2665,52 @@ printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute -->
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute bind-target -->
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute [(target)] bind-target -->
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 
 =====================================output=====================================
 <div
-  bindon-target="a | b : c"
-  [(target)]="a | b : c"
-  bind-target="a | b : c"
+  bindon-target="a | b: c : d : e"
+  [(target)]="a | b: c : d : e"
+  bind-target="a | b: c : d : e"
 ></div>
 <!--  prettier-ignore-attribute -->
 <div
-  bindon-target=" a | b : c "
-  [(target)]=" a | b : c "
-  bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute bind-target -->
 <div
-  bindon-target="a | b : c"
-  [(target)]="a | b : c"
-  bind-target=" a | b : c "
+  bindon-target="a | b: c : d : e"
+  [(target)]="a | b: c : d : e"
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute [(target)] bind-target -->
 <div
-  bindon-target="a | b : c"
-  [(target)]=" a | b : c "
-  bind-target=" a | b : c "
+  bindon-target="a | b: c : d : e"
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 
 ================================================================================
@@ -2715,27 +2723,27 @@ printWidth: 1
  | printWidth
 =====================================input======================================
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute -->
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute bind-target -->
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute [(target)] bind-target -->
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 
 =====================================output=====================================
@@ -2744,23 +2752,29 @@ printWidth: 1
     a
       | b
         : c
+        : d
+        : e
   "
   [(target)]="
     a
       | b
         : c
+        : d
+        : e
   "
   bind-target="
     a
       | b
         : c
+        : d
+        : e
   "
 ></div>
 <!--  prettier-ignore-attribute -->
 <div
-  bindon-target=" a | b : c "
-  [(target)]=" a | b : c "
-  bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute bind-target -->
 <div
@@ -2768,13 +2782,17 @@ printWidth: 1
     a
       | b
         : c
+        : d
+        : e
   "
   [(target)]="
     a
       | b
         : c
+        : d
+        : e
   "
-  bind-target=" a | b : c "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute [(target)] bind-target -->
 <div
@@ -2782,9 +2800,11 @@ printWidth: 1
     a
       | b
         : c
+        : d
+        : e
   "
-  [(target)]=" a | b : c "
-  bind-target=" a | b : c "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 
 ================================================================================
@@ -2798,52 +2818,52 @@ trailingComma: "es5"
                                                                                 | printWidth
 =====================================input======================================
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute -->
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute bind-target -->
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute [(target)] bind-target -->
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 
 =====================================output=====================================
 <div
-  bindon-target="a | b : c"
-  [(target)]="a | b : c"
-  bind-target="a | b : c"
+  bindon-target="a | b: c : d : e"
+  [(target)]="a | b: c : d : e"
+  bind-target="a | b: c : d : e"
 ></div>
 <!--  prettier-ignore-attribute -->
 <div
-  bindon-target=" a | b : c "
-  [(target)]=" a | b : c "
-  bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute bind-target -->
 <div
-  bindon-target="a | b : c"
-  [(target)]="a | b : c"
-  bind-target=" a | b : c "
+  bindon-target="a | b: c : d : e"
+  [(target)]="a | b: c : d : e"
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute [(target)] bind-target -->
 <div
-  bindon-target="a | b : c"
-  [(target)]=" a | b : c "
-  bind-target=" a | b : c "
+  bindon-target="a | b: c : d : e"
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 
 ================================================================================
@@ -2857,52 +2877,52 @@ trailingComma: "none"
                                                                                 | printWidth
 =====================================input======================================
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute -->
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute bind-target -->
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute [(target)] bind-target -->
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 
 =====================================output=====================================
 <div
-  bindon-target="a | b : c"
-  [(target)]="a | b : c"
-  bind-target="a | b : c"
+  bindon-target="a | b: c : d : e"
+  [(target)]="a | b: c : d : e"
+  bind-target="a | b: c : d : e"
 ></div>
 <!--  prettier-ignore-attribute -->
 <div
-  bindon-target=" a | b : c "
-  [(target)]=" a | b : c "
-  bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute bind-target -->
 <div
-  bindon-target="a | b : c"
-  [(target)]="a | b : c"
-  bind-target=" a | b : c "
+  bindon-target="a | b: c : d : e"
+  [(target)]="a | b: c : d : e"
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute [(target)] bind-target -->
 <div
-  bindon-target="a | b : c"
-  [(target)]=" a | b : c "
-  bind-target=" a | b : c "
+  bindon-target="a | b: c : d : e"
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 
 ================================================================================
@@ -2915,7 +2935,7 @@ parsers: ["angular"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-<div>{{ a | b : c }}</div>
+<div>{{ a | b : c:d :e }}</div>
 <div>{{  a | pipe    }}</div>
 <div>{{ 0 - 1 }}</div>
 <div>{{ - 1 }}</div>
@@ -2984,7 +3004,7 @@ printWidth: 80
 <p>{{ {a:a?b:{} } }}</p>
 
 =====================================output=====================================
-<div>{{ a | b : c }}</div>
+<div>{{ a | b: c : d : e }}</div>
 <div>{{ a | pipe }}</div>
 <div>{{ 0 - 1 }}</div>
 <div>{{ -1 }}</div>
@@ -3013,31 +3033,31 @@ printWidth: 80
 <div>{{ a // hello }}</div>
 <label for="transmissionLayoutRadioButton">{{
   "SearchSelection.transmissionLayoutRadioButton"
-    | localize : localizationSection
+    | localize: localizationSection
 }}</label>
 <label
   for="transmissionLayoutRadioButtontransmissionLayoutRadioButtontransmissionLayoutRadioButtontransmissionLayoutRadioButton"
   >{{
     "SearchSelection.transmissionLayoutRadioButton"
-      | localize : localizationSection
+      | localize: localizationSection
   }}</label
 >
 <label for="transmissionLayoutRadioButton"
   >{{
     "SearchSelection.transmissionLayoutRadioButton"
-      | localize : localizationSection
+      | localize: localizationSection
   }}
 </label>
 <label for="transmissionLayoutRadioButton">
   {{
     "SearchSelection.transmissionLayoutRadioButton"
-      | localize : localizationSection
+      | localize: localizationSection
   }}</label
 >
 <label for="transmissionLayoutRadioButton">
   {{
     "SearchSelection.transmissionLayoutRadioButton"
-      | localize : localizationSection
+      | localize: localizationSection
   }}
 </label>
 <div class="Nemo possimus non voluptates dicta accusamus id quia">
@@ -3064,7 +3084,7 @@ printWidth: 80
 <p>
   {{
     "delete"
-      | translate : {what: ("entities" | translate : ({count: array.length}))}
+      | translate: {what: ("entities" | translate: ({count: array.length}))}
   }}
 </p>
 <p>{{ {a: 1 + ({})} }}</p>
@@ -3082,7 +3102,7 @@ parsers: ["angular"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
-<div>{{ a | b : c }}</div>
+<div>{{ a | b : c:d :e }}</div>
 <div>{{  a | pipe    }}</div>
 <div>{{ 0 - 1 }}</div>
 <div>{{ - 1 }}</div>
@@ -3151,7 +3171,7 @@ printWidth: 80
 <p>{{ {a:a?b:{} } }}</p>
 
 =====================================output=====================================
-<div>{{ a | b : c }}</div>
+<div>{{ a | b: c : d : e }}</div>
 <div>{{ a | pipe }}</div>
 <div>{{ 0 - 1 }}</div>
 <div>{{ -1 }}</div>
@@ -3181,7 +3201,7 @@ printWidth: 80
 <label for="transmissionLayoutRadioButton">
   {{
     "SearchSelection.transmissionLayoutRadioButton"
-      | localize : localizationSection
+      | localize: localizationSection
   }}
 </label>
 <label
@@ -3189,25 +3209,25 @@ printWidth: 80
 >
   {{
     "SearchSelection.transmissionLayoutRadioButton"
-      | localize : localizationSection
+      | localize: localizationSection
   }}
 </label>
 <label for="transmissionLayoutRadioButton">
   {{
     "SearchSelection.transmissionLayoutRadioButton"
-      | localize : localizationSection
+      | localize: localizationSection
   }}
 </label>
 <label for="transmissionLayoutRadioButton">
   {{
     "SearchSelection.transmissionLayoutRadioButton"
-      | localize : localizationSection
+      | localize: localizationSection
   }}
 </label>
 <label for="transmissionLayoutRadioButton">
   {{
     "SearchSelection.transmissionLayoutRadioButton"
-      | localize : localizationSection
+      | localize: localizationSection
   }}
 </label>
 <div class="Nemo possimus non voluptates dicta accusamus id quia">
@@ -3236,7 +3256,7 @@ printWidth: 80
 <p>
   {{
     "delete"
-      | translate : { what: ("entities" | translate : { count: array.length }) }
+      | translate: { what: ("entities" | translate: { count: array.length }) }
   }}
 </p>
 <p>{{ { a: 1 + {} } }}</p>
@@ -3253,7 +3273,7 @@ parsers: ["angular"]
 printWidth: 1
  | printWidth
 =====================================input======================================
-<div>{{ a | b : c }}</div>
+<div>{{ a | b : c:d :e }}</div>
 <div>{{  a | pipe    }}</div>
 <div>{{ 0 - 1 }}</div>
 <div>{{ - 1 }}</div>
@@ -3327,6 +3347,8 @@ printWidth: 1
     a
       | b
         : c
+        : d
+        : e
   }}
 </div>
 <div>
@@ -3626,7 +3648,7 @@ printWidth: 80
 trailingComma: "es5"
                                                                                 | printWidth
 =====================================input======================================
-<div>{{ a | b : c }}</div>
+<div>{{ a | b : c:d :e }}</div>
 <div>{{  a | pipe    }}</div>
 <div>{{ 0 - 1 }}</div>
 <div>{{ - 1 }}</div>
@@ -3695,7 +3717,7 @@ trailingComma: "es5"
 <p>{{ {a:a?b:{} } }}</p>
 
 =====================================output=====================================
-<div>{{ a | b : c }}</div>
+<div>{{ a | b: c : d : e }}</div>
 <div>{{ a | pipe }}</div>
 <div>{{ 0 - 1 }}</div>
 <div>{{ -1 }}</div>
@@ -3724,31 +3746,31 @@ trailingComma: "es5"
 <div>{{ a // hello }}</div>
 <label for="transmissionLayoutRadioButton">{{
   "SearchSelection.transmissionLayoutRadioButton"
-    | localize : localizationSection
+    | localize: localizationSection
 }}</label>
 <label
   for="transmissionLayoutRadioButtontransmissionLayoutRadioButtontransmissionLayoutRadioButtontransmissionLayoutRadioButton"
   >{{
     "SearchSelection.transmissionLayoutRadioButton"
-      | localize : localizationSection
+      | localize: localizationSection
   }}</label
 >
 <label for="transmissionLayoutRadioButton"
   >{{
     "SearchSelection.transmissionLayoutRadioButton"
-      | localize : localizationSection
+      | localize: localizationSection
   }}
 </label>
 <label for="transmissionLayoutRadioButton">
   {{
     "SearchSelection.transmissionLayoutRadioButton"
-      | localize : localizationSection
+      | localize: localizationSection
   }}</label
 >
 <label for="transmissionLayoutRadioButton">
   {{
     "SearchSelection.transmissionLayoutRadioButton"
-      | localize : localizationSection
+      | localize: localizationSection
   }}
 </label>
 <div class="Nemo possimus non voluptates dicta accusamus id quia">
@@ -3775,7 +3797,7 @@ trailingComma: "es5"
 <p>
   {{
     "delete"
-      | translate : { what: ("entities" | translate : { count: array.length }) }
+      | translate: { what: ("entities" | translate: { count: array.length }) }
   }}
 </p>
 <p>{{ { a: 1 + {} } }}</p>
@@ -3793,7 +3815,7 @@ printWidth: 80
 trailingComma: "none"
                                                                                 | printWidth
 =====================================input======================================
-<div>{{ a | b : c }}</div>
+<div>{{ a | b : c:d :e }}</div>
 <div>{{  a | pipe    }}</div>
 <div>{{ 0 - 1 }}</div>
 <div>{{ - 1 }}</div>
@@ -3862,7 +3884,7 @@ trailingComma: "none"
 <p>{{ {a:a?b:{} } }}</p>
 
 =====================================output=====================================
-<div>{{ a | b : c }}</div>
+<div>{{ a | b: c : d : e }}</div>
 <div>{{ a | pipe }}</div>
 <div>{{ 0 - 1 }}</div>
 <div>{{ -1 }}</div>
@@ -3891,31 +3913,31 @@ trailingComma: "none"
 <div>{{ a // hello }}</div>
 <label for="transmissionLayoutRadioButton">{{
   "SearchSelection.transmissionLayoutRadioButton"
-    | localize : localizationSection
+    | localize: localizationSection
 }}</label>
 <label
   for="transmissionLayoutRadioButtontransmissionLayoutRadioButtontransmissionLayoutRadioButtontransmissionLayoutRadioButton"
   >{{
     "SearchSelection.transmissionLayoutRadioButton"
-      | localize : localizationSection
+      | localize: localizationSection
   }}</label
 >
 <label for="transmissionLayoutRadioButton"
   >{{
     "SearchSelection.transmissionLayoutRadioButton"
-      | localize : localizationSection
+      | localize: localizationSection
   }}
 </label>
 <label for="transmissionLayoutRadioButton">
   {{
     "SearchSelection.transmissionLayoutRadioButton"
-      | localize : localizationSection
+      | localize: localizationSection
   }}</label
 >
 <label for="transmissionLayoutRadioButton">
   {{
     "SearchSelection.transmissionLayoutRadioButton"
-      | localize : localizationSection
+      | localize: localizationSection
   }}
 </label>
 <div class="Nemo possimus non voluptates dicta accusamus id quia">
@@ -3942,7 +3964,7 @@ trailingComma: "none"
 <p>
   {{
     "delete"
-      | translate : { what: ("entities" | translate : { count: array.length }) }
+      | translate: { what: ("entities" | translate: { count: array.length }) }
   }}
 </p>
 <p>{{ { a: 1 + {} } }}</p>
@@ -5359,17 +5381,17 @@ bindon-ngModel
 </div>
 
 <!-- pipe with configuration argument => "February 25, 1970" -->
-<div>Birthdate: {{ currentHero?.birthdate | date : "longDate" }}</div>
+<div>Birthdate: {{ currentHero?.birthdate | date: "longDate" }}</div>
 
 <div>{{ currentHero | json }}</div>
 
 <div>
-  Birthdate: {{ currentHero?.birthdate | date : "longDate" | uppercase }}
+  Birthdate: {{ currentHero?.birthdate | date: "longDate" | uppercase }}
 </div>
 
 <div>
   <!-- pipe price to USD and display the $ symbol -->
-  <label>Price: </label>{{ product.price | currency : "USD" : true }}
+  <label>Price: </label>{{ product.price | currency: "USD" : true }}
 </div>
 
 <a class="to-toc" href="#toc">top</a>
@@ -7011,18 +7033,18 @@ bindon-ngModel
 </div>
 
 <!-- pipe with configuration argument => "February 25, 1970" -->
-<div>Birthdate: {{ currentHero?.birthdate | date : "longDate" }}</div>
+<div>Birthdate: {{ currentHero?.birthdate | date: "longDate" }}</div>
 
 <div>{{ currentHero | json }}</div>
 
 <div>
-  Birthdate: {{ currentHero?.birthdate | date : "longDate" | uppercase }}
+  Birthdate: {{ currentHero?.birthdate | date: "longDate" | uppercase }}
 </div>
 
 <div>
   <!-- pipe price to USD and display the $ symbol -->
   <label>Price:</label>
-  {{ product.price | currency : "USD" : true }}
+  {{ product.price | currency: "USD" : true }}
 </div>
 
 <a class="to-toc" href="#toc">top</a>
@@ -11974,17 +11996,17 @@ bindon-ngModel
 </div>
 
 <!-- pipe with configuration argument => "February 25, 1970" -->
-<div>Birthdate: {{ currentHero?.birthdate | date : "longDate" }}</div>
+<div>Birthdate: {{ currentHero?.birthdate | date: "longDate" }}</div>
 
 <div>{{ currentHero | json }}</div>
 
 <div>
-  Birthdate: {{ currentHero?.birthdate | date : "longDate" | uppercase }}
+  Birthdate: {{ currentHero?.birthdate | date: "longDate" | uppercase }}
 </div>
 
 <div>
   <!-- pipe price to USD and display the $ symbol -->
-  <label>Price: </label>{{ product.price | currency : "USD" : true }}
+  <label>Price: </label>{{ product.price | currency: "USD" : true }}
 </div>
 
 <a class="to-toc" href="#toc">top</a>
@@ -13501,17 +13523,17 @@ bindon-ngModel
 </div>
 
 <!-- pipe with configuration argument => "February 25, 1970" -->
-<div>Birthdate: {{ currentHero?.birthdate | date : "longDate" }}</div>
+<div>Birthdate: {{ currentHero?.birthdate | date: "longDate" }}</div>
 
 <div>{{ currentHero | json }}</div>
 
 <div>
-  Birthdate: {{ currentHero?.birthdate | date : "longDate" | uppercase }}
+  Birthdate: {{ currentHero?.birthdate | date: "longDate" | uppercase }}
 </div>
 
 <div>
   <!-- pipe price to USD and display the $ symbol -->
-  <label>Price: </label>{{ product.price | currency : "USD" : true }}
+  <label>Price: </label>{{ product.price | currency: "USD" : true }}
 </div>
 
 <a class="to-toc" href="#toc">top</a>

--- a/tests/format/angular/angular/attributes.component.html
+++ b/tests/format/angular/angular/attributes.component.html
@@ -1,8 +1,8 @@
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
-    [target]=" a | b : c "
+    bindon-target=" a | b : c:d :e "
+    [(target)]=" a | b : c:d :e "
+    bind-target=" a | b : c:d :e "
+    [target]=" a | b : c:d :e "
     [target]=" a | pipe   "
     [target]=" 0 - 1 "
     [target]=" - 1 "

--- a/tests/format/angular/angular/ignore-attribute.component.html
+++ b/tests/format/angular/angular/ignore-attribute.component.html
@@ -1,23 +1,23 @@
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute -->
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute bind-target -->
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>
 <!--  prettier-ignore-attribute [(target)] bind-target -->
 <div
-    bindon-target=" a | b : c "
-    [(target)]=" a | b : c "
-    bind-target=" a | b : c "
+  bindon-target=" a | b : c:d :e "
+  [(target)]=" a | b : c:d :e "
+  bind-target=" a | b : c:d :e "
 ></div>

--- a/tests/format/angular/angular/interpolation.component.html
+++ b/tests/format/angular/angular/interpolation.component.html
@@ -1,4 +1,4 @@
-<div>{{ a | b : c }}</div>
+<div>{{ a | b : c:d :e }}</div>
 <div>{{  a | pipe    }}</div>
 <div>{{ 0 - 1 }}</div>
 <div>{{ - 1 }}</div>

--- a/tests/format/angular/bracket-same-line/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/angular/bracket-same-line/__snapshots__/jsfmt.spec.js.snap
@@ -28,7 +28,7 @@ printWidth: 80
 =====================================output=====================================
 <div
   ng-if="$ctrl.shouldShowWarning && !$ctrl.loading"
-  bindon-target="a | b : c"
+  bindon-target="a | b: c"
   (event)="(foo == $event)"
   *ngIf="something ? true : false"
   [(ngModel)]="canSave"
@@ -37,7 +37,7 @@ printWidth: 80
 </div>
 <span
   ng-if="$ctrl.shouldShowWarning && !$ctrl.loading"
-  bindon-target="a | b : c"
+  bindon-target="a | b: c"
   (event)="(foo == $event)"
   *ngIf="something ? true : false"
   [(ngModel)]="canSave"
@@ -45,7 +45,7 @@ printWidth: 80
 >
 <img
   ng-if="$ctrl.shouldShowWarning && !$ctrl.loading"
-  bindon-target="a | b : c"
+  bindon-target="a | b: c"
   (event)="(foo == $event)"
   *ngIf="something ? true : false"
   [(ngModel)]="canSave"
@@ -93,7 +93,7 @@ printWidth: 80
 =====================================output=====================================
 <div
   ng-if="$ctrl.shouldShowWarning && !$ctrl.loading"
-  bindon-target="a | b : c"
+  bindon-target="a | b: c"
   (event)="(foo == $event)"
   *ngIf="something ? true : false"
   [(ngModel)]="canSave">
@@ -101,7 +101,7 @@ printWidth: 80
 </div>
 <span
   ng-if="$ctrl.shouldShowWarning && !$ctrl.loading"
-  bindon-target="a | b : c"
+  bindon-target="a | b: c"
   (event)="(foo == $event)"
   *ngIf="something ? true : false"
   [(ngModel)]="canSave"
@@ -109,7 +109,7 @@ printWidth: 80
 >
 <img
   ng-if="$ctrl.shouldShowWarning && !$ctrl.loading"
-  bindon-target="a | b : c"
+  bindon-target="a | b: c"
   (event)="(foo == $event)"
   *ngIf="something ? true : false"
   [(ngModel)]="canSave" />

--- a/tests/format/angular/interpolation/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/angular/interpolation/__snapshots__/jsfmt.spec.js.snap
@@ -88,10 +88,10 @@ trailingComma: "none"
 
 =====================================output=====================================
 [
-  a ? (b | c : d) : (e | f : g),
+  a ? (b | c: d) : (e | f: g),
   a | b | c | d,
   a | b | c | d,
-  a | b : (c | d),
+  a | b: (c | d),
   { a: b | c },
   a + b | c,
   (a | b) + c,
@@ -100,22 +100,22 @@ trailingComma: "none"
   a[b | c],
   ($students | async).items,
   ($students | async)(),
-  myData | myPipe : "arg1" : "arg2" : "arg3",
+  myData | myPipe: "arg1" : "arg2" : "arg3",
   value
     | pipeA
       : {
           keyA: reallySuperLongValue,
-          keyB: shortValue | pipeB | pipeC : valueToPipeC
+          keyB: shortValue | pipeB | pipeC: valueToPipeC
         }
       : {
           keyA: reallySuperLongValue,
-          keyB: shortValue | pipeB | pipeC : valueToPipeC
+          keyB: shortValue | pipeB | pipeC: valueToPipeC
         }
     | aaa,
   (hideLinqPanel
     ? "ReportSelection.HideShowLabel_Show.String"
     : "ReportSelection.HideShowLabel_Hide.String"
-  ) | localize : localizationSection
+  ) | localize: localizationSection
 ]
 ================================================================================
 `;


### PR DESCRIPTION
## Description

As per discussion in the linked issue, the most desired format was to keep spaces around semicolon separating pipe arguments, but remove space after pipe name.

Closes #13887 

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
