### PR TITLE
Fix infinite recursion issue for new Array nodes

### DIFF
--- a/src/language-js/print/array.js
+++ b/src/language-js/print/array.js
@@ -178,7 +178,7 @@ function isLineAfterElementEmpty({ node }, { originalText: text }) {
     return false;
   }
 
-  const length = text.length;
+  const { length } = text;
   while (currentIdx < length) {
     if (text[currentIdx] === ",") {
       break;


### PR DESCRIPTION
## Description

In the js language printer, when an array is printed the `printArrayElements` util will take each its elements and call `isLineAfterElementEmpty`. This checks the elements `locEnd` position and uses a recursive function to walk through the file to find its related ",". For cases where the node is dynamically created the location will not match the source text (often range will just be set to `[1, 1]`). In some rare cases the file source text will not contain a "," at all which will cause the function to infinitely recurse through each char position until it its the maximum stack size. I understand the codemod/loc not matching source case is not expected to be supported by prettier but this case does tend to work well today and this specific fix does not add much complexity or overhead so would be nice to include it.

Specific changes:
- Changed recursive `skipToComma` function to be iterative, since even in a normal case this could add a good amount of overhead as it walks through the text one char at a time.
- Additionally i added a backstop to the iteration so it does not walk past the end of the file.
- Inline `skipComment` logic, no need for the function overhead here.
- To guard against the codemod use cases i abort if the node has a 0 size loc, this should not be possible outside this use case.

## Checklist

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
