### PR TITLE
add git-diff option

### DIFF
--- a/src/cli/cli-options.evaluate.js
+++ b/src/cli/cli-options.evaluate.js
@@ -157,6 +157,12 @@ const options = {
     default: 0,
     type: "int",
   },
+  gitDiff: {
+    default: false,
+    description:
+      "Show git diff of changed file. Can only be used with --check.",
+    type: "boolean",
+  },
   editorconfig: {
     category: optionCategories.CATEGORY_CONFIG,
     default: true,

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -1,5 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { execSync } from "node:child_process";
 import chalk from "chalk";
 import { createTwoFilesPatch } from "diff";
 import * as prettier from "../index.js";
@@ -462,6 +463,25 @@ async function formatFiles(context) {
 
     if (isDifferent) {
       if (context.argv.check) {
+        if (context.argv.gitDiff) {
+          const tmpFileName = `${filename}-prettier`;
+
+          await fs.writeFile(tmpFileName, output);
+
+          try {
+            execSync(`git diff --no-index ${filename} ${tmpFileName}`, {
+              shell: true,
+              stdio: "inherit",
+            });
+          } catch (e) {
+            if (!("status" in e) || e.status > 1) {
+              console.log(`git diff error for ${filename}`);
+            }
+          }
+
+          await fs.unlink(tmpFileName);
+        }
+
         context.logger.warn(fileNameToDisplay);
       } else if (context.argv.listDifferent) {
         context.logger.log(fileNameToDisplay);

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -38,6 +38,10 @@ async function run(rawArguments) {
 async function main(context) {
   context.logger.debug(`normalized argv: ${JSON.stringify(context.argv)}`);
 
+  if (context.argv.gitDiff && !context.argv.check) {
+    throw new Error("Cannot use --git-diff without --check.");
+  }
+
   if (context.argv.check && context.argv.listDifferent) {
     throw new Error("Cannot use --check and --list-different together.");
   }

--- a/tests/integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests/integration/__tests__/__snapshots__/early-exit.js.snap
@@ -129,6 +129,8 @@ Other options:
   --file-info <path>       Extract the following info (as JSON) for a given file path. Reported fields:
                            * ignored (boolean) - true if file path is filtered by --ignore-path
                            * inferredParser (string | null) - name of parser inferred from file path
+  --git-diff               Show git diff of changed file. Can only be used with --check.
+                           Defaults to false.
   -h, --help <flag>        Show CLI usage, or details about the given flag.
                            Example: --help write
   -u, --ignore-unknown     Ignore unknown files.
@@ -294,6 +296,8 @@ Other options:
   --file-info <path>       Extract the following info (as JSON) for a given file path. Reported fields:
                            * ignored (boolean) - true if file path is filtered by --ignore-path
                            * inferredParser (string | null) - name of parser inferred from file path
+  --git-diff               Show git diff of changed file. Can only be used with --check.
+                           Defaults to false.
   -h, --help <flag>        Show CLI usage, or details about the given flag.
                            Example: --help write
   -u, --ignore-unknown     Ignore unknown files.

--- a/tests/integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/help-options.js.snap
@@ -214,6 +214,18 @@ exports[`show detailed usage with --help find-config-path (stdout) 1`] = `
 
 exports[`show detailed usage with --help find-config-path (write) 1`] = `[]`;
 
+exports[`show detailed usage with --help git-diff (stderr) 1`] = `""`;
+
+exports[`show detailed usage with --help git-diff (stdout) 1`] = `
+"--git-diff
+
+  Show git diff of changed file. Can only be used with --check.
+
+Default: false"
+`;
+
+exports[`show detailed usage with --help git-diff (write) 1`] = `[]`;
+
 exports[`show detailed usage with --help help (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help help (stdout) 1`] = `


### PR DESCRIPTION
## Description

Add --git-diff option to show git diff. Can only be used with --check.
Nothing fancy but I think thats what people at [#6885](https://github.com/prettier/prettier/issues/6885) have been requesting?

I can add tests/docs, is it an alright solution to the problem?

<img width="793" alt="Screenshot 2023-06-25 at 22 44 12" src="https://github.com/prettier/prettier/assets/33291143/f1524115-7d6e-416a-9ea1-8e4961d0d083">

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
