### PR TITLE
Update integrating-with-linters.md to match stylelint v15

### DIFF
--- a/docs/integrating-with-linters.md
+++ b/docs/integrating-with-linters.md
@@ -8,7 +8,6 @@ Linters usually contain not only code quality rules, but also stylistic rules. M
 Luckily it’s easy to turn off rules that conflict or are unnecessary with Prettier, by using these pre-made configs:
 
 - [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier)
-- [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier)
 
 Check out the above links for instructions on how to install and set things up.
 

--- a/website/versioned_docs/version-stable/integrating-with-linters.md
+++ b/website/versioned_docs/version-stable/integrating-with-linters.md
@@ -9,7 +9,6 @@ Linters usually contain not only code quality rules, but also stylistic rules. M
 Luckily it’s easy to turn off rules that conflict or are unnecessary with Prettier, by using these pre-made configs:
 
 - [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier)
-- [stylelint-config-prettier](https://github.com/prettier/stylelint-config-prettier)
 
 Check out the above links for instructions on how to install and set things up.
 


### PR DESCRIPTION
removed recommendation to use `stylelint-config-prettier` since it is not needed in v15 and above. 

more information here:
https://stylelint.io/migration-guide/to-15/

- [ V ] I’ve added tests to confirm my change works.
- [ V  ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
