### PR TITLE
Expand arrow function passed as argument that returns a constructor

### DIFF
--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -10,7 +10,6 @@ import {
   getCallArguments,
   iterateCallArgumentsPath,
   isNextLineEmpty,
-  isCallExpression,
   isStringLiteral,
   isObjectProperty,
   getCallArgumentSelector,
@@ -210,7 +209,7 @@ function couldExpandArg(arg, arrowChainRecursion = false) {
         isObjectOrRecordExpression(arg.body) ||
         isArrayOrTupleExpression(arg.body) ||
         (!arrowChainRecursion &&
-          (isCallExpression(arg.body) ||
+          (isCallLikeExpression(arg.body) ||
             arg.body.type === "ConditionalExpression")) ||
         isJsxElement(arg.body))) ||
     arg.type === "DoExpression" ||

--- a/tests/format/js/arrow-call/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/arrow-call/__snapshots__/jsfmt.spec.js.snap
@@ -303,6 +303,93 @@ promise.then((result) =>
 ================================================================================
 `;
 
+exports[`call-like.js - {"arrowParens":"always"} format 1`] = `
+====================================options=====================================
+arrowParens: "always"
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+myFunction((someArgument) => looooooooooooooooooooooooooooooooooongFunctionCall())
+
+myFunction((someArgument) => new loooooooooooooooooooooooooooooongNewExpression())
+
+myFunction((someArgument) => import('looooooooooooooo/oooooooooooooooong/import'))
+
+=====================================output=====================================
+myFunction((someArgument) =>
+  looooooooooooooooooooooooooooooooooongFunctionCall(),
+);
+
+myFunction((someArgument) =>
+  new loooooooooooooooooooooooooooooongNewExpression(),
+);
+
+myFunction((someArgument) =>
+  import("looooooooooooooo/oooooooooooooooong/import"),
+);
+
+================================================================================
+`;
+
+exports[`call-like.js - {"trailingComma":"all"} format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+trailingComma: "all"
+                                                                                | printWidth
+=====================================input======================================
+myFunction((someArgument) => looooooooooooooooooooooooooooooooooongFunctionCall())
+
+myFunction((someArgument) => new loooooooooooooooooooooooooooooongNewExpression())
+
+myFunction((someArgument) => import('looooooooooooooo/oooooooooooooooong/import'))
+
+=====================================output=====================================
+myFunction((someArgument) =>
+  looooooooooooooooooooooooooooooooooongFunctionCall(),
+);
+
+myFunction((someArgument) =>
+  new loooooooooooooooooooooooooooooongNewExpression(),
+);
+
+myFunction((someArgument) =>
+  import("looooooooooooooo/oooooooooooooooong/import"),
+);
+
+================================================================================
+`;
+
+exports[`call-like.js - {"trailingComma":"es5"} format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+trailingComma: "es5"
+                                                                                | printWidth
+=====================================input======================================
+myFunction((someArgument) => looooooooooooooooooooooooooooooooooongFunctionCall())
+
+myFunction((someArgument) => new loooooooooooooooooooooooooooooongNewExpression())
+
+myFunction((someArgument) => import('looooooooooooooo/oooooooooooooooong/import'))
+
+=====================================output=====================================
+myFunction((someArgument) =>
+  looooooooooooooooooooooooooooooooooongFunctionCall()
+);
+
+myFunction((someArgument) =>
+  new loooooooooooooooooooooooooooooongNewExpression()
+);
+
+myFunction((someArgument) =>
+  import("looooooooooooooo/oooooooooooooooong/import")
+);
+
+================================================================================
+`;
+
 exports[`class-property.js - {"arrowParens":"always"} format 1`] = `
 ====================================options=====================================
 arrowParens: "always"

--- a/tests/format/js/arrow-call/call-like.js
+++ b/tests/format/js/arrow-call/call-like.js
@@ -1,0 +1,5 @@
+myFunction((someArgument) => looooooooooooooooooooooooooooooooooongFunctionCall())
+
+myFunction((someArgument) => new loooooooooooooooooooooooooooooongNewExpression())
+
+myFunction((someArgument) => import('looooooooooooooo/oooooooooooooooong/import'))


### PR DESCRIPTION
## Description

Fixes https://github.com/prettier/prettier/issues/15027
Also fixes broken behavior of `import` expression with `acorn` parser - [playground (bug)](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEB6VACCBrAOlAWwE8AxAVyjBgEtoAKOgZwgLgEEAnAczNdgEoMAXgB8GADYQp0mbLnz5ULuUo1oAYQCG48XX798+dBigQYWPIVIUqtKA2atOPPjEGiTcAO4SFf-9JKAHLeAKIAHgAOHHCMjHZ6BlBGmKbmOPjEKrb0TCzs3LwIbsJi1ASREBwwdADkkgHSqI0ySqjlldW1+iAANCAQkWpQjMigmhwcEF4AChMIoyjaXppEo-0ARhyaYNhwMADKmqwAMtRQcMgAZtqMcJvbu-sHkTvnXMgwHGT3IHcE1E+31+8SU4jgAEUyGZLkgbuI7v0AFaMcIHd7gqEw663X4AR2h8BmU0iixAmkYAFoLnAACZ0vogL6aajid7qFgETTIck6RmgrjgtgwL7UDZkIlwDhnC44hG-AAWMAI4gA6grqPBGK8wHADgtNdQAG6aog8sBxRlGn4ASSg9NgBzAHGoQzY9oOMCI4LliJA0Qgd1V20iPOisSlRsu-XOd2qxM0XC5vt+rw4cZ5OyqUEZ0XOMFV1FpMAVyAAHAAGfoxAnUGIJpPcuG4-owTQbQvF0tIABM-TIdwAKu3FvC-XACBs6fTaSdNEoyIm4CQqlyRe9MxKICAAL47oA)

`isCallLikeExpression` just adds nodes with types `NewExpression` and `ImportExpression` to the `isCallExpression`

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
