### PR TITLE
Add parenthesis around leading multiline comment in return statement

### DIFF
--- a/changelog_unreleased/javascript/15037.md
+++ b/changelog_unreleased/javascript/15037.md
@@ -1,0 +1,29 @@
+#### Add parenthesis around leading multiline comment in return statement (#15037 by @auvred)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+function fn() {
+  return (
+    /**
+     * @type {...}
+     */ expresssion
+  )
+}
+
+// Prettier stable
+function fn() {
+  return /**
+   * @type {...}
+   */ expresssion;
+}
+
+// Prettier main
+function fn() {
+  return (
+    /**
+     * @type {...}
+     */ expresssion
+  );
+}
+```

--- a/src/language-js/print/function.js
+++ b/src/language-js/print/function.js
@@ -19,6 +19,8 @@ import {
   hasNakedLeftSide,
   getLeftSide,
 } from "../utils/index.js";
+import hasNewlineInRange from "../../utils/has-newline-in-range.js";
+import { locEnd, locStart } from "../loc.js";
 import {
   printFunctionParameters,
   shouldGroupFunctionParameters,
@@ -290,7 +292,11 @@ function returnArgumentHasLeadingComment(options, argument) {
   if (
     hasLeadingOwnLineComment(options.originalText, argument) ||
     (hasComment(argument, CommentCheckFlags.Leading, (comment) =>
-      comment.value.includes("\n"),
+      hasNewlineInRange(
+        options.originalText,
+        locStart(comment),
+        locEnd(comment),
+      ),
     ) &&
       !isJsxElement(argument))
   ) {

--- a/src/language-js/print/function.js
+++ b/src/language-js/print/function.js
@@ -11,6 +11,7 @@ import {
   getFunctionParameters,
   hasLeadingOwnLineComment,
   isBinaryish,
+  isJsxElement,
   hasComment,
   CommentCheckFlags,
   isCallExpression,
@@ -286,7 +287,13 @@ function printThrowStatement(path, options, print) {
 // (the leftmost leaf node) and, if it (or its parents) has any
 // leadingComments, returns true (so it can be wrapped in parens).
 function returnArgumentHasLeadingComment(options, argument) {
-  if (hasLeadingOwnLineComment(options.originalText, argument)) {
+  if (
+    hasLeadingOwnLineComment(options.originalText, argument) ||
+    (hasComment(argument, CommentCheckFlags.Leading, (comment) =>
+      comment.value.includes("\n"),
+    ) &&
+      !isJsxElement(argument))
+  ) {
     return true;
   }
 

--- a/tests/format/js/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/comments/__snapshots__/jsfmt.spec.js.snap
@@ -4733,6 +4733,53 @@ function inlineComment() {
   ) || 42
 }
 
+function multilineBlockSameLine() {
+  return (
+    /**
+    * @type {string}
+    */ 'result'
+  )
+}
+
+function multilineBlockNextLine() {
+  return (
+    /**
+    * @type {string}
+    */ 
+    'result'
+  )
+}
+
+function multilineBlockSameLineJsx() {
+  return (
+    /**
+    * JSX Same line
+    */ <div></div>
+  )
+}
+
+function multilineBlockNextLineJsx() {
+  return (
+    /**
+    * JSX Next line
+    */
+    <div></div>
+  )
+}
+
+function singleLineBlockSameLine() {
+  return (
+    /** Result -> */ 'result'
+  )
+}
+
+function singleLineBlockNextLine() {
+  return (
+    /** Result below */ 
+    'result'
+  )
+}
+
 =====================================output=====================================
 function jsx() {
   return (
@@ -4862,6 +4909,51 @@ function taggedTemplate() {
 
 function inlineComment() {
   return /* hi */ 42 || 42
+}
+
+function multilineBlockSameLine() {
+  return (
+    /**
+     * @type {string}
+     */ "result"
+  )
+}
+
+function multilineBlockNextLine() {
+  return (
+    /**
+     * @type {string}
+     */
+    "result"
+  )
+}
+
+function multilineBlockSameLineJsx() {
+  return (
+    /**
+     * JSX Same line
+     */ <div></div>
+  )
+}
+
+function multilineBlockNextLineJsx() {
+  return (
+    /**
+     * JSX Next line
+     */
+    <div></div>
+  )
+}
+
+function singleLineBlockSameLine() {
+  return /** Result -> */ "result"
+}
+
+function singleLineBlockNextLine() {
+  return (
+    /** Result below */
+    "result"
+  )
 }
 
 ================================================================================
@@ -4995,6 +5087,53 @@ function inlineComment() {
   ) || 42
 }
 
+function multilineBlockSameLine() {
+  return (
+    /**
+    * @type {string}
+    */ 'result'
+  )
+}
+
+function multilineBlockNextLine() {
+  return (
+    /**
+    * @type {string}
+    */ 
+    'result'
+  )
+}
+
+function multilineBlockSameLineJsx() {
+  return (
+    /**
+    * JSX Same line
+    */ <div></div>
+  )
+}
+
+function multilineBlockNextLineJsx() {
+  return (
+    /**
+    * JSX Next line
+    */
+    <div></div>
+  )
+}
+
+function singleLineBlockSameLine() {
+  return (
+    /** Result -> */ 'result'
+  )
+}
+
+function singleLineBlockNextLine() {
+  return (
+    /** Result below */ 
+    'result'
+  )
+}
+
 =====================================output=====================================
 function jsx() {
   return (
@@ -5124,6 +5263,51 @@ function taggedTemplate() {
 
 function inlineComment() {
   return /* hi */ 42 || 42;
+}
+
+function multilineBlockSameLine() {
+  return (
+    /**
+     * @type {string}
+     */ "result"
+  );
+}
+
+function multilineBlockNextLine() {
+  return (
+    /**
+     * @type {string}
+     */
+    "result"
+  );
+}
+
+function multilineBlockSameLineJsx() {
+  return (
+    /**
+     * JSX Same line
+     */ <div></div>
+  );
+}
+
+function multilineBlockNextLineJsx() {
+  return (
+    /**
+     * JSX Next line
+     */
+    <div></div>
+  );
+}
+
+function singleLineBlockSameLine() {
+  return /** Result -> */ "result";
+}
+
+function singleLineBlockNextLine() {
+  return (
+    /** Result below */
+    "result"
+  );
 }
 
 ================================================================================

--- a/tests/format/js/comments/return-statement.js
+++ b/tests/format/js/comments/return-statement.js
@@ -119,3 +119,50 @@ function inlineComment() {
     /* hi */ 42
   ) || 42
 }
+
+function multilineBlockSameLine() {
+  return (
+    /**
+    * @type {string}
+    */ 'result'
+  )
+}
+
+function multilineBlockNextLine() {
+  return (
+    /**
+    * @type {string}
+    */ 
+    'result'
+  )
+}
+
+function multilineBlockSameLineJsx() {
+  return (
+    /**
+    * JSX Same line
+    */ <div></div>
+  )
+}
+
+function multilineBlockNextLineJsx() {
+  return (
+    /**
+    * JSX Next line
+    */
+    <div></div>
+  )
+}
+
+function singleLineBlockSameLine() {
+  return (
+    /** Result -> */ 'result'
+  )
+}
+
+function singleLineBlockNextLine() {
+  return (
+    /** Result below */ 
+    'result'
+  )
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/prettier/prettier/issues/15013

There is no such problem with JSX ([playground](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAzArlMMCW0AEqUAFAJT7AA6U++ATnDOnTcdbbQPQBU37H3fACkAygA1+tbp3wAeACY4AbgD5ZnRav6lqAXxAAaEBAAOuaAGdkoAIZ06EAO4AFOwisobAG0c2AnlZGAEZ0NmAA1owiNgC2cAAyOFBwyKjeFnDBoRFRJmFJAObIMHTomSAZMTjFpeUWhV5wAIroEPCp6eUAVhYAHiINza3tSGleGUYAjsNwzg4mHiA2FgC0yXDyG4YgJTY4XoUAwhAxMTbIS15e2-VQBY0AgjAlOEHo8M5wdInJHePlAAsYDEvAB1AE4eAWPJgOAidyQ5SQvwXMAWQIgJRlACSUE2sBEYDoODMDzxIhgfkafwmIBMDgyoNCJgu9LgGToShSRiSHJgcxsBTONPKeToHIuQRsQTg1yM9KSMFBOHkMAByAAHAAGIwMaY4BgCoXnUadIwwaXK1XqpAAJiM6AyABVpR4xrS4DEZfJNvJ4jY7uhBXAAGIQOhnZ6FC42d4QEC6XRAA)), so I excluded it from the condition to avoid duplicate parenthesis

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
