### PR TITLE
docs: Add `.gitignore` to the default ignore path

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -114,7 +114,7 @@ If you don’t have a configuration file, or want to ignore it if it does exist,
 
 ## `--ignore-path`
 
-Path to a file containing patterns that describe files to ignore. By default, Prettier looks for `./.prettierignore`.\
+Path to a file containing patterns that describe files to ignore. By default, Prettier looks for `./.gitignore` and `./.prettierignore`.\
 Multiple values are accepted.
 
 ## `--list-different`


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Add `.gitignore` to the default in the docs of `--ignore-path` CLI option.
ref: #14731

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
