### PR TITLE
Consistently keep comments after colon in conditional expression

### DIFF
--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -343,8 +343,16 @@ function handleConditionalExpressionComments({
     precedingNode &&
     !hasNewlineInRange(text, locEnd(precedingNode), locStart(comment));
 
+  const nextCharacterAfterPrecedingIndex =
+    precedingNode &&
+    getNextNonSpaceNonCommentCharacterIndex(text, locEnd(precedingNode));
+  const isAfterColon =
+    nextCharacterAfterPrecedingIndex !== false &&
+    text.charAt(nextCharacterAfterPrecedingIndex) === ":" &&
+    nextCharacterAfterPrecedingIndex < locStart(comment);
+
   if (
-    (!precedingNode || !isSameLineAsPrecedingNode) &&
+    (!precedingNode || !isSameLineAsPrecedingNode || isAfterColon) &&
     (enclosingNode?.type === "ConditionalExpression" ||
       enclosingNode?.type === "TSConditionalType") &&
     followingNode

--- a/tests/format/js/conditional/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/conditional/__snapshots__/jsfmt.spec.js.snap
@@ -129,6 +129,24 @@ test
 test ? test /* c
 c */? foo : bar : bar;
 
+test ?
+  foo : // comment
+  bar
+
+test ?
+  // comment 1
+  foo /** comment 2 */ : /** comment 3 */
+  /** comment 4 */
+  bar
+
+test ?
+  \`
+         template string 1
+  \`: // comment
+  \`
+         template string 2
+  \`
+
 =====================================output=====================================
 var inspect =
   4 === util.inspect.length
@@ -231,12 +249,13 @@ test
 // It is at least possible to delete the extra newline that was
 // unfortunately added before the second condition above:
 test
-  ? foo /* comment
+  ? foo
+  : /* comment
          comment
      comment
            comment
     */
-  : test
+  test
   ? foo
   : /* comment
   comment
@@ -252,6 +271,27 @@ c */
     ? foo
     : bar
   : bar;
+
+test
+  ? foo
+  : // comment
+    bar;
+
+test
+  ? // comment 1
+    foo /** comment 2 */
+  : /** comment 3 */
+    /** comment 4 */
+    bar;
+
+test
+  ? \`
+         template string 1
+  \`
+  : // comment
+    \`
+         template string 2
+  \`;
 
 ================================================================================
 `;

--- a/tests/format/js/conditional/comments.js
+++ b/tests/format/js/conditional/comments.js
@@ -120,3 +120,21 @@ test
 
 test ? test /* c
 c */? foo : bar : bar;
+
+test ?
+  foo : // comment
+  bar
+
+test ?
+  // comment 1
+  foo /** comment 2 */ : /** comment 3 */
+  /** comment 4 */
+  bar
+
+test ?
+  `
+         template string 1
+  `: // comment
+  `
+         template string 2
+  `


### PR DESCRIPTION
## Description

Fixes https://github.com/prettier/prettier/issues/14944

The issue occurs when the consequent branch of conditional expression, colon and comment are placed in one line:
```jsx
a ?
  b : // here  
  c
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
