### PR TITLE
Glimmer: don't format <pre> and <style> tags

### DIFF
--- a/changelog_unreleased/handlebars/15068.md
+++ b/changelog_unreleased/handlebars/15068.md
@@ -1,0 +1,43 @@
+#### Glimmer: don't format <pre> and <style> tags (#15068 by @jurgenwerk)
+
+<!-- prettier-ignore -->
+```handlebars
+// Input
+<pre>
+  cd ~
+  ls
+  echo "hey"
+</pre>
+
+<style>
+  .red { color: red }
+
+  .blue {
+    color: red
+  }
+</style>
+
+// Prettier stable
+<pre>
+  cd ~ ls echo "hey"
+</pre>
+
+<style>
+  .red { color: red } .blue { color: blue }
+</style>
+
+// Prettier main
+<pre>
+  cd ~
+  ls
+  echo "hey"
+</pre>
+
+<style>
+  .red { color: red }
+
+  .blue {
+    color: red
+  }
+</style>
+```

--- a/tests/format/handlebars/whitespace/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/handlebars/whitespace/__snapshots__/jsfmt.spec.js.snap
@@ -330,6 +330,60 @@ printWidth: 40
 ================================================================================
 `;
 
+exports[`whitespace-sensitive-tags.hbs - {"printWidth":40} format 1`] = `
+====================================options=====================================
+parsers: ["glimmer"]
+printWidth: 40
+                                        | printWidth
+=====================================input======================================
+<pre>
+  this
+
+  should not
+
+
+
+  be formatted - it should stay exactly as it is
+
+  .this-code-should-stay-as-it-is {
+    color: red;
+  }
+</pre>
+
+
+<style>
+  .this-code-should-also-stay-as-it-is {
+    color: red;
+  }
+
+  .should-not-change-this-either { color: red; }
+</style>
+
+=====================================output=====================================
+<pre>
+  this
+
+  should not
+
+
+
+  be formatted - it should stay exactly as it is
+
+  .this-code-should-stay-as-it-is {
+    color: red;
+  }
+</pre>
+
+<style>
+  .this-code-should-also-stay-as-it-is {
+    color: red;
+  }
+
+  .should-not-change-this-either { color: red; }
+</style>
+================================================================================
+`;
+
 exports[`preserved-spaces-and-breaks.hbs - {"printWidth":40} format 1`] = `
 ====================================options=====================================
 parsers: ["glimmer"]

--- a/tests/format/handlebars/whitespace/whitespace-sensitive-tags.hbs
+++ b/tests/format/handlebars/whitespace/whitespace-sensitive-tags.hbs
@@ -1,0 +1,22 @@
+<pre>
+  this
+
+  should not
+
+
+
+  be formatted - it should stay exactly as it is
+
+  .this-code-should-stay-as-it-is {
+    color: red;
+  }
+</pre>
+
+
+<style>
+  .this-code-should-also-stay-as-it-is {
+    color: red;
+  }
+
+  .should-not-change-this-either { color: red; }
+</style>


### PR DESCRIPTION
## Description

This PR fixes the bug described in issue https://github.com/prettier/prettier/issues/14261

As mentioned in the issue, In addition to `<pre>`, `<style>` is also causing problems - the printer is collapsing CSS code into one line.

Ideally, we should also properly format the `<style>` content but I suppose that would have to be implemented - I was looking at how html printer is formatting that and I don't see an easy way of reusing that here. 

In hopes of finding support for formatting CSS in the glimmer printer was also checking the printer from the glimmer source code that this printer was based on (https://github.com/glimmerjs/glimmer-vm/blob/master/packages/%40glimmer/syntax/lib/generation/printer.ts) but it looks like it was rewritten entirely (in an incompatible manner). 

So for now I think ignoring the `<style>` content is still an improvement over the current behaviour. 

## Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
