### PR TITLE
Update Node.js versions in v3 blog post

### DIFF
--- a/website/blog/2023-07-05-3.0.0.md
+++ b/website/blog/2023-07-05-3.0.0.md
@@ -309,9 +309,9 @@ SyntaxError: Syntax Error: Unexpected Name "B". (1:26)
 
 ### API
 
-#### Drop support for Node.js 10 and 12 ([#11830](https://github.com/prettier/prettier/pull/11830) by [@fisker](https://github.com/fisker), [#13118](https://github.com/prettier/prettier/pull/13118) by [@sosukesuzuki](https://github.com/sosukesuzuki))
+#### Drop support for Node.js 10, 12 and 14 ([#11830](https://github.com/prettier/prettier/pull/11830) by [@fisker](https://github.com/fisker), [#13118](https://github.com/prettier/prettier/pull/13118) by [@sosukesuzuki](https://github.com/sosukesuzuki)), [#13439](https://github.com/prettier/prettier/pull/13439) by [@sosukesuzuki](https://github.com/sosukesuzuki))
 
-The minimal required Node.js version is v14
+The minimal required Node.js version is v16
 
 #### Change public APIs to asynchronous ([#12574](https://github.com/prettier/prettier/pull/12574), [#12788](https://github.com/prettier/prettier/pull/12788), [#12790](https://github.com/prettier/prettier/pull/12790), [#13265](https://github.com/prettier/prettier/pull/13265) by [@fisker](https://github.com/fisker))
 


### PR DESCRIPTION
## Description

The PR https://github.com/prettier/prettier/pull/13439 featured as part of v3.0.0 meaning that Prettier can no longer be installed under Node.js v14 and errors if you try. This PR updates the v3 blog post to highlight this.
<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
