### PR TITLE
Use `rimraf` instead of `rm -rf`, which is not available in Windows

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "webpack --mode=production && docusaurus-build",
     "start": "concurrently \"docusaurus-start\" \"webpack --mode=development --watch\"",
-    "update-stable-docs": "rm -rf ./versioned_docs ./versions.json && docusaurus-version stable"
+    "update-stable-docs": "rimraf ./versioned_docs ./versions.json && docusaurus-version stable"
   },
   "dependencies": {
     "clipboard": "2.0.11",
@@ -22,6 +22,7 @@
     "concurrently": "8.2.0",
     "docusaurus": "1.14.7",
     "js-yaml": "4.1.0",
+    "rimraf": "5.0.1",
     "webpack": "5.88.1",
     "webpack-cli": "5.1.4"
   }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -1469,6 +1469,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@isaacs/cliui@npm:^8.0.2":
+  version: 8.0.2
+  resolution: "@isaacs/cliui@npm:8.0.2"
+  dependencies:
+    string-width: ^5.1.2
+    string-width-cjs: "npm:string-width@^4.2.0"
+    strip-ansi: ^7.0.1
+    strip-ansi-cjs: "npm:strip-ansi@^6.0.1"
+    wrap-ansi: ^8.1.0
+    wrap-ansi-cjs: "npm:wrap-ansi@^7.0.0"
+  checksum: 4a473b9b32a7d4d3cfb7a614226e555091ff0c5a29a1734c28c72a182c2f6699b26fc6b5c2131dfd841e86b185aea714c72201d7c98c2fba5f17709333a67aeb
+  languageName: node
+  linkType: hard
+
 "@jridgewell/gen-mapping@npm:^0.3.0, @jridgewell/gen-mapping@npm:^0.3.2":
   version: 0.3.3
   resolution: "@jridgewell/gen-mapping@npm:0.3.3"
@@ -1578,6 +1592,13 @@ __metadata:
     "@nodelib/fs.scandir": 2.1.5
     fastq: ^1.6.0
   checksum: 190c643f156d8f8f277bf2a6078af1ffde1fd43f498f187c2db24d35b4b4b5785c02c7dc52e356497b9a1b65b13edc996de08de0b961c32844364da02986dc53
+  languageName: node
+  linkType: hard
+
+"@pkgjs/parseargs@npm:^0.11.0":
+  version: 0.11.0
+  resolution: "@pkgjs/parseargs@npm:0.11.0"
+  checksum: 6ad6a00fc4f2f2cfc6bff76fb1d88b8ee20bc0601e18ebb01b6d4be583733a860239a521a7fbca73b612e66705078809483549d2b18f370eb346c5155c8e4a0f
   languageName: node
   linkType: hard
 
@@ -2020,6 +2041,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ansi-regex@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "ansi-regex@npm:6.0.1"
+  checksum: 1ff8b7667cded1de4fa2c9ae283e979fc87036864317da86a2e546725f96406746411d0d85e87a2d12fa5abd715d90006de7fa4fa0477c92321ad3b4c7d4e169
+  languageName: node
+  linkType: hard
+
 "ansi-styles@npm:^2.2.1":
   version: 2.2.1
   resolution: "ansi-styles@npm:2.2.1"
@@ -2042,6 +2070,13 @@ __metadata:
   dependencies:
     color-convert: ^2.0.1
   checksum: 513b44c3b2105dd14cc42a19271e80f386466c4be574bccf60b627432f9198571ebf4ab1e4c3ba17347658f4ee1711c163d574248c0c1cdc2d5917a0ad582ec4
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^6.1.0":
+  version: 6.2.1
+  resolution: "ansi-styles@npm:6.2.1"
+  checksum: ef940f2f0ced1a6347398da88a91da7930c33ecac3c77b72c5905f8b8fe402c52e6fde304ff5347f616e27a742da3f1dc76de98f6866c69251ad0b07a66776d9
   languageName: node
   linkType: hard
 
@@ -2568,6 +2603,15 @@ __metadata:
     balanced-match: ^1.0.0
     concat-map: 0.0.1
   checksum: faf34a7bb0c3fcf4b59c7808bc5d2a96a40988addf2e7e09dfbb67a2251800e0d14cd2bfc1aa79174f2f5095c54ff27f46fb1289fe2d77dac755b5eb3434cc07
+  languageName: node
+  linkType: hard
+
+"brace-expansion@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "brace-expansion@npm:2.0.1"
+  dependencies:
+    balanced-match: ^1.0.0
+  checksum: a61e7cd2e8a8505e9f0036b3b6108ba5e926b4b55089eeb5550cd04a471fe216c96d4fe7e4c7f995c728c554ae20ddfc4244cad10aef255e72b62930afd233d1
   languageName: node
   linkType: hard
 
@@ -3324,7 +3368,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:7.0.3, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:7.0.3, cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:
@@ -4075,6 +4119,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eastasianwidth@npm:^0.2.0":
+  version: 0.2.0
+  resolution: "eastasianwidth@npm:0.2.0"
+  checksum: 7d00d7cd8e49b9afa762a813faac332dee781932d6f2c848dc348939c4253f1d4564341b7af1d041853bc3f32c2ef141b58e0a4d9862c17a7f08f68df1e0f1ed
+  languageName: node
+  linkType: hard
+
 "ecc-jsbn@npm:~0.1.1":
   version: 0.1.2
   resolution: "ecc-jsbn@npm:0.1.2"
@@ -4103,6 +4154,13 @@ __metadata:
   version: 8.0.0
   resolution: "emoji-regex@npm:8.0.0"
   checksum: d4c5c39d5a9868b5fa152f00cada8a936868fd3367f33f71be515ecee4c803132d11b31a6222b2571b1e5f7e13890156a94880345594d0ce7e3c9895f560f192
+  languageName: node
+  linkType: hard
+
+"emoji-regex@npm:^9.2.2":
+  version: 9.2.2
+  resolution: "emoji-regex@npm:9.2.2"
+  checksum: 8487182da74aabd810ac6d6f1994111dfc0e331b01271ae01ec1eb0ad7b5ecc2bbbbd2f053c05cb55a1ac30449527d819bbfbf0e3de1023db308cbcb47f86601
   languageName: node
   linkType: hard
 
@@ -4951,6 +5009,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"foreground-child@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "foreground-child@npm:3.1.1"
+  dependencies:
+    cross-spawn: ^7.0.0
+    signal-exit: ^4.0.1
+  checksum: 139d270bc82dc9e6f8bc045fe2aae4001dc2472157044fdfad376d0a3457f77857fa883c1c8b21b491c6caade9a926a4bed3d3d2e8d3c9202b151a4cbbd0bcd5
+  languageName: node
+  linkType: hard
+
 "forever-agent@npm:~0.6.1":
   version: 0.6.1
   resolution: "forever-agent@npm:0.6.1"
@@ -5235,6 +5303,21 @@ __metadata:
   version: 0.4.1
   resolution: "glob-to-regexp@npm:0.4.1"
   checksum: e795f4e8f06d2a15e86f76e4d92751cf8bbfcf0157cea5c2f0f35678a8195a750b34096b1256e436f0cebc1883b5ff0888c47348443e69546a5a87f9e1eb1167
+  languageName: node
+  linkType: hard
+
+"glob@npm:^10.2.5":
+  version: 10.3.3
+  resolution: "glob@npm:10.3.3"
+  dependencies:
+    foreground-child: ^3.1.0
+    jackspeak: ^2.0.3
+    minimatch: ^9.0.1
+    minipass: ^5.0.0 || ^6.0.2 || ^7.0.0
+    path-scurry: ^1.10.1
+  bin:
+    glob: dist/cjs/src/bin.js
+  checksum: 29190d3291f422da0cb40b77a72fc8d2c51a36524e99b8bf412548b7676a6627489528b57250429612b6eec2e6fe7826d328451d3e694a9d15e575389308ec53
   languageName: node
   linkType: hard
 
@@ -6465,6 +6548,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jackspeak@npm:^2.0.3":
+  version: 2.2.1
+  resolution: "jackspeak@npm:2.2.1"
+  dependencies:
+    "@isaacs/cliui": ^8.0.2
+    "@pkgjs/parseargs": ^0.11.0
+  dependenciesMeta:
+    "@pkgjs/parseargs":
+      optional: true
+  checksum: e29291c0d0f280a063fa18fbd1e891ab8c2d7519fd34052c0ebde38538a15c603140d60c2c7f432375ff7ee4c5f1c10daa8b2ae19a97c3d4affe308c8360c1df
+  languageName: node
+  linkType: hard
+
 "jest-worker@npm:^27.4.5":
   version: 27.5.1
   resolution: "jest-worker@npm:27.5.1"
@@ -7034,6 +7130,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^9.1.1 || ^10.0.0":
+  version: 10.0.0
+  resolution: "lru-cache@npm:10.0.0"
+  checksum: 18f101675fe283bc09cda0ef1e3cc83781aeb8373b439f086f758d1d91b28730950db785999cd060d3c825a8571c03073e8c14512b6655af2188d623031baf50
+  languageName: node
+  linkType: hard
+
 "lz-string@npm:1.5.0":
   version: 1.5.0
   resolution: "lz-string@npm:1.5.0"
@@ -7276,6 +7379,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"minimatch@npm:^9.0.1":
+  version: 9.0.3
+  resolution: "minimatch@npm:9.0.3"
+  dependencies:
+    brace-expansion: ^2.0.1
+  checksum: 253487976bf485b612f16bf57463520a14f512662e592e95c571afdab1442a6a6864b6c88f248ce6fc4ff0b6de04ac7aa6c8bb51e868e99d1d65eb0658a708b5
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:~3.0.2":
   version: 3.0.8
   resolution: "minimatch@npm:3.0.8"
@@ -7289,6 +7401,13 @@ __metadata:
   version: 1.2.8
   resolution: "minimist@npm:1.2.8"
   checksum: 75a6d645fb122dad29c06a7597bddea977258957ed88d7a6df59b5cd3fe4a527e253e9bbf2e783e4b73657f9098b96a5fe96ab8a113655d4109108577ecf85b0
+  languageName: node
+  linkType: hard
+
+"minipass@npm:^5.0.0 || ^6.0.2 || ^7.0.0":
+  version: 7.0.2
+  resolution: "minipass@npm:7.0.2"
+  checksum: 46776de732eb7cef2c7404a15fb28c41f5c54a22be50d47b03c605bf21f5c18d61a173c0a20b49a97e7a65f78d887245066410642551e45fffe04e9ac9e325bc
   languageName: node
   linkType: hard
 
@@ -7928,6 +8047,16 @@ __metadata:
   version: 1.0.7
   resolution: "path-parse@npm:1.0.7"
   checksum: 49abf3d81115642938a8700ec580da6e830dde670be21893c62f4e10bd7dd4c3742ddc603fe24f898cba7eb0c6bc1777f8d9ac14185d34540c6d4d80cd9cae8a
+  languageName: node
+  linkType: hard
+
+"path-scurry@npm:^1.10.1":
+  version: 1.10.1
+  resolution: "path-scurry@npm:1.10.1"
+  dependencies:
+    lru-cache: ^9.1.1 || ^10.0.0
+    minipass: ^5.0.0 || ^6.0.2 || ^7.0.0
+  checksum: e2557cff3a8fb8bc07afdd6ab163a92587884f9969b05bbbaf6fe7379348bfb09af9ed292af12ed32398b15fb443e81692047b786d1eeb6d898a51eb17ed7d90
   languageName: node
   linkType: hard
 
@@ -9158,6 +9287,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rimraf@npm:5.0.1":
+  version: 5.0.1
+  resolution: "rimraf@npm:5.0.1"
+  dependencies:
+    glob: ^10.2.5
+  bin:
+    rimraf: dist/cjs/src/bin.js
+  checksum: bafce85391349a2d960847980bf9b5caa2a8887f481af630f1ea27e08288217293cec72d75e9a2ba35495c212789f66a7f3d23366ba6197026ab71c535126857
+  languageName: node
+  linkType: hard
+
 "root-workspace-0b6124@workspace:.":
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
@@ -9175,6 +9315,7 @@ __metadata:
     prop-types: 15.8.1
     react: 18.2.0
     react-dom: 18.2.0
+    rimraf: 5.0.1
     webpack: 5.88.1
     webpack-cli: 5.1.4
   languageName: unknown
@@ -9533,6 +9674,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"signal-exit@npm:^4.0.1":
+  version: 4.0.2
+  resolution: "signal-exit@npm:4.0.2"
+  checksum: 41f5928431cc6e91087bf0343db786a6313dd7c6fd7e551dbc141c95bb5fb26663444fd9df8ea47c5d7fc202f60aa7468c3162a9365cbb0615fc5e1b1328fe31
+  languageName: node
+  linkType: hard
+
 "simple-swizzle@npm:^0.2.2":
   version: 0.2.2
   resolution: "simple-swizzle@npm:0.2.2"
@@ -9809,7 +9957,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
+"string-width-cjs@npm:string-width@^4.2.0, string-width@npm:^4.1.0, string-width@npm:^4.2.0, string-width@npm:^4.2.3":
   version: 4.2.3
   resolution: "string-width@npm:4.2.3"
   dependencies:
@@ -9817,6 +9965,17 @@ __metadata:
     is-fullwidth-code-point: ^3.0.0
     strip-ansi: ^6.0.1
   checksum: e52c10dc3fbfcd6c3a15f159f54a90024241d0f149cf8aed2982a2d801d2e64df0bf1dc351cf8e95c3319323f9f220c16e740b06faecd53e2462df1d2b5443fb
+  languageName: node
+  linkType: hard
+
+"string-width@npm:^5.0.1, string-width@npm:^5.1.2":
+  version: 5.1.2
+  resolution: "string-width@npm:5.1.2"
+  dependencies:
+    eastasianwidth: ^0.2.0
+    emoji-regex: ^9.2.2
+    strip-ansi: ^7.0.1
+  checksum: 7369deaa29f21dda9a438686154b62c2c5f661f8dda60449088f9f980196f7908fc39fdd1803e3e01541970287cf5deae336798337e9319a7055af89dafa7193
   languageName: node
   linkType: hard
 
@@ -9878,6 +10037,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1, strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "strip-ansi@npm:6.0.1"
+  dependencies:
+    ansi-regex: ^5.0.1
+  checksum: f3cd25890aef3ba6e1a74e20896c21a46f482e93df4a06567cebf2b57edabb15133f1f94e57434e0a958d61186087b1008e89c94875d019910a213181a14fc8c
+  languageName: node
+  linkType: hard
+
 "strip-ansi@npm:6.0.0":
   version: 6.0.0
   resolution: "strip-ansi@npm:6.0.0"
@@ -9896,12 +10064,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strip-ansi@npm:^6.0.0, strip-ansi@npm:^6.0.1":
-  version: 6.0.1
-  resolution: "strip-ansi@npm:6.0.1"
+"strip-ansi@npm:^7.0.1":
+  version: 7.1.0
+  resolution: "strip-ansi@npm:7.1.0"
   dependencies:
-    ansi-regex: ^5.0.1
-  checksum: f3cd25890aef3ba6e1a74e20896c21a46f482e93df4a06567cebf2b57edabb15133f1f94e57434e0a958d61186087b1008e89c94875d019910a213181a14fc8c
+    ansi-regex: ^6.0.1
+  checksum: 859c73fcf27869c22a4e4d8c6acfe690064659e84bef9458aa6d13719d09ca88dcfd40cbf31fd0be63518ea1a643fe070b4827d353e09533a5b0b9fd4553d64d
   languageName: node
   linkType: hard
 
@@ -10855,7 +11023,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"wrap-ansi@npm:^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0, wrap-ansi@npm:^7.0.0":
   version: 7.0.0
   resolution: "wrap-ansi@npm:7.0.0"
   dependencies:
@@ -10863,6 +11031,17 @@ __metadata:
     string-width: ^4.1.0
     strip-ansi: ^6.0.0
   checksum: a790b846fd4505de962ba728a21aaeda189b8ee1c7568ca5e817d85930e06ef8d1689d49dbf0e881e8ef84436af3a88bc49115c2e2788d841ff1b8b5b51a608b
+  languageName: node
+  linkType: hard
+
+"wrap-ansi@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "wrap-ansi@npm:8.1.0"
+  dependencies:
+    ansi-styles: ^6.1.0
+    string-width: ^5.0.1
+    strip-ansi: ^7.0.1
+  checksum: 371733296dc2d616900ce15a0049dca0ef67597d6394c57347ba334393599e800bab03c41d4d45221b6bc967b8c453ec3ae4749eff3894202d16800fdfe0e238
   languageName: node
   linkType: hard
 


### PR DESCRIPTION

## Description

<!-- Please provide a brief summary of your changes: -->

In Windows, `yarn build:website` for `$PULL_REQUEST = "true"` fails bacause `rm` doesn't exist in Windows.

```
PS> $env:PULL_REQUEST = "true"
PS> yarn build:website
Building prettier...
 Building packages
index.mjs.............................................................. SKIPPED
 index.d.ts............................................................ SKIPPED
 index.cjs............................................................. SKIPPED
 index.d.ts............................................................ SKIPPED
bin/prettier.cjs....................................................... SKIPPED
internal/cli.mjs....................................................... SKIPPED
internal/internal.mjs.................................................. SKIPPED
doc.mjs................................................................ SKIPPED
 doc.js................................................................ SKIPPED
 doc.d.ts.............................................................. SKIPPED
standalone.mjs......................................................... SKIPPED
 standalone.js.........................................................   DONE
 standalone.d.ts....................................................... SKIPPED
plugins/estree.mjs..................................................... SKIPPED
 plugins/estree.js.....................................................   DONE
 plugins/estree.d.ts................................................... SKIPPED
plugins/babel.mjs...................................................... SKIPPED
 plugins/babel.js......................................................   DONE
 plugins/babel.d.ts.................................................... SKIPPED
plugins/flow.mjs....................................................... SKIPPED
 plugins/flow.js.......................................................   DONE
 plugins/flow.d.ts..................................................... SKIPPED
plugins/typescript.mjs................................................. SKIPPED
 plugins/typescript.js.................................................   DONE
 plugins/typescript.d.ts............................................... SKIPPED
plugins/acorn.mjs...................................................... SKIPPED
 plugins/acorn.js......................................................   DONE
 plugins/acorn.d.ts.................................................... SKIPPED
plugins/meriyah.mjs.................................................... SKIPPED
 plugins/meriyah.js....................................................   DONE
 plugins/meriyah.d.ts.................................................. SKIPPED
plugins/angular.mjs.................................................... SKIPPED
 plugins/angular.js....................................................   DONE
 plugins/angular.d.ts.................................................. SKIPPED
plugins/postcss.mjs.................................................... SKIPPED
 plugins/postcss.js....................................................   DONE
 plugins/postcss.d.ts.................................................. SKIPPED
plugins/graphql.mjs.................................................... SKIPPED
 plugins/graphql.js....................................................   DONE
 plugins/graphql.d.ts.................................................. SKIPPED
plugins/markdown.mjs................................................... SKIPPED
 plugins/markdown.js...................................................   DONE
 plugins/markdown.d.ts................................................. SKIPPED
plugins/glimmer.mjs.................................................... SKIPPED
 plugins/glimmer.js....................................................   DONE
 plugins/glimmer.d.ts.................................................. SKIPPED
plugins/html.mjs....................................................... SKIPPED
 plugins/html.js.......................................................   DONE
 plugins/html.d.ts..................................................... SKIPPED
plugins/yaml.mjs....................................................... SKIPPED
 plugins/yaml.js.......................................................   DONE
 plugins/yaml.d.ts..................................................... SKIPPED
package.json........................................................... SKIPPED
README.md.............................................................. SKIPPED
LICENSE................................................................ SKIPPED
Preparing files for playground...
Installing website dependencies...
➤ YN0000: ┌ Resolution step
➤ YN0002: │ docusaurus@npm:1.14.7 doesn't provide webpack (p1b3b0), requested by react-dev-utils
➤ YN0002: │ root-workspace-0b6124@workspace:. doesn't provide @codemirror/language (p884aa), requested by codemirror-graphql
➤ YN0002: │ root-workspace-0b6124@workspace:. doesn't provide codemirror (p0ec4c), requested by codemirror-graphql
➤ YN0002: │ root-workspace-0b6124@workspace:. doesn't provide graphql (p8c9d6), requested by codemirror-graphql
➤ YN0000: │ Some peer dependencies are incorrectly met; run yarn explain peer-requirements <hash> for details, where <hash> is the six-letter p-prefixed code
➤ YN0000: └ Completed
➤ YN0000: ┌ Fetch step
➤ YN0000: └ Completed in 0s 396ms
➤ YN0000: ┌ Link step
➤ YN0000: └ Completed in 1s 537ms
➤ YN0000: Done with warnings in 2s 275ms
Synchronizing docs...
'rm' は、内部コマンドまたは外部コマンド、
操作可能なプログラムまたはバッチ ファイルとして認識されていません。
command not found: rm
I:\prettier\website\static\lib\plugins\flow.js:4
`),x.js_error)throw x.js_error}}else throw x}function tZ(){var x=l0.process;x&&x.on?x.on("uncaughtException",function(r,e){DK(r),x.exit(2)}):l0.addEventListener&&l0.addEventListener("error",function(r){r.error&&DK(r.error)})}tZ();function l(x,r){return(x.l>=0?x.l:x.l=x.length)==1?x(r):Ds(x,[r])}function p(x,r,e){return(x.l>=0?x.l:x.l=x.length)==2?x(r,e):Ds(x,[r,e])}function G0(x,r,e,t){return(x.l>=0?x.l:x.l=x.length)==3?x(r,e,t):Ds(x,[r,e,t])}function oe(x,r,e,t,u){return(x.l>=0?x.l:x.l=x.length)==4?x(r,e,t,u):Ds(x,[r,e,t,u])}function Je(x,r,e,t,u,i){return(x.l>=0?x.l:x.l=x.length)==5?x(r,e,t,u,i):Ds(x,[r,e,t,u,i])}function nZ(x,r,e,t,u,i,f,o){return(x.l>=0?x.l:x.l=x.length)==7?x(r,e,t,u,i,f,o):Ds(x,[r,e,t,u,i,f,o])}var HC=[Qr,jz,-1],jK=[Qr,az,-2],mn=[Qr,H_,-3],qC=[Qr,rz,-4],w2=[Qr,dD,-7],zK=[Qr,Ij,-8],KK=[Qr,aj,-9],Tr=[Qr,YU,-11],Il=[Qr,Dj,-12],uZ=[4,0,0,0,[12,45,[4,0,0,0,0]]],GC=[0,[11,'File "',[2,0,[11,'", line ',[4,0,0,0,[11,ij,[4,0,0,0,[12,45,[4,0,0,0,[11,": ",[2,0,0]]]]]]]]]],'File "%s", line %d, characters %d-%d: %s'],Ja=[0,0,[0,0,0],[0,0,0]],Pl=[0,0,0,0,1,0,0,0],JK=[0,"first_leading","last_trailing"],YK=[0,hf,gf,ni,l7,Af,Ii,yu,uc,O7,zi,Nf,un,Ku,sc,Le,E7,Q7,rf,Bf,T7,ci,Xc,hc,Gn,uf,j7,ku,ji,Qi,Jc,B7,Tu,yi,bi,_i,fi,Ff,Xi,nu,s7,Bc,K7,Wu,mc,vi,tf,Wf,Wn,ic,oc,Fi,Ce,Re,Mu,lf,dc,Mi,y7,Pf,ju,Gf,sf,ec,Tf,_c,Ai,ce,Ri,qn,ff,Hi,_u,e7,Iu,Li,xf,kc,cc,gu,Uu,ef,p7,$n,_f,v7,zf,z7,Q1,pi,Zu,Zn,J7,o7,Cf,df,V7,xu,Ci,Ru,wu,iu,Vu,xc,F7,jn,nc,d7,Yn,R7,Qu,Fu,If,Gu,af,zn,ki,jc,Yi,lu,mi,ou,Su,It,k7,t7,_7,R2,di,eu,Du,c7,of,cu,jf,A7,F2,Hu,Qn,Mf,Di,uu,Wc,G7,au,F1,Ui,Ju,Sc,tc,x7,yf,du,xi,Mc,ui,C7,n7,q7,Vn,Zf,Vf,$i,qf,L7,Ou,Bn,Ni,P7,Kn,tu,qi,xr,u7,ii,Cu,yc,$u,i7,Cc,Nc,zu,Ac,Y7,mf,g7,Pi,Of,Yf,ru,Wi,Dc,nf,Oc,r7,ti,kf,ei,bf,si,H7,Qf,bn,Yu,Sf,pn,Pc,Au,D7,vc,wc,S7,X7,Lu,f7,a7,Oi,Nu,fc,$f,b7,Df,zc,mu,Uf,ac,su,je,pc,fu,Pu,pu,Zi,I7,Me,lc,Xu,N7,Tc,Ji,Bi,m7,Gi,Ke,Eu,Z7,Rf,pf,gc,Si,wf,ze,Kc,cf,Ki,hu,rc,Xn,Fn,hi,Kf,li,Rc,h7,Lc,ai,Jn,M7,Ti,Xf,Jf,$7,w7,U7,oi,Bu,Ec,Hn,W7,qu,Yc,Ei,L2,Lf,vf,ri,U2],kn=[0,0,0];Dt(11,Il,Dj),Dt(10,Tr,YU),Dt(9,[Qr,TD,PM],TD),Dt(8,KK,aj),Dt(7,zK,Ij),Dt(6,w2,dD),Dt(5,[Qr,qM,-6],qM),Dt(4,[Qr,tM,-5],tM),Dt(3,qC,rz),Dt(2,mn,H_),Dt(1,jK,az),Dt(0,HC,jz);var iZ="output_substring",fZ=Hf,cZ=Ts,sZ=As,oZ="CamlinternalLazy.Undefined",vZ=mz,aZ="\\'",lZ="\\b",pZ="\\t",yZ="\\n",dZ="\\r",mZ="List.iter2",kZ="tl",hZ="hd",_Z="String.blit / Bytes.blit_string",wZ="Bytes.blit",TZ="String.sub / Bytes.sub",SZ="Array.blit",EZ="Array.sub",AZ="Map.remove_min_elt",gZ=[0,0,0,0],NZ=[0,"map.ml",400,10],IZ=[0,0,0],PZ=K4,CZ=K4,RZ=K4,OZ=K4,LZ="Stdlib.Queue.Empty",UZ="Buffer.add_substring/add_subbytes",MZ="Buffer.add: cannot grow buffer",DZ=[0,GU,93,2],jZ=[0,GU,94,2],zZ="Buffer.sub",KZ="%c",JZ="%s",YZ=DU,BZ=dz,XZ=vD,WZ=Uz,VZ="%f",ZZ="%B",$Z="%{",FZ="%}",QZ="%(",HZ="%)",qZ=CD,GZ="%t",bZ="%?",x$="%r",r$="%_r",e$=[0,i2,850,23],t$=[0,i2,814,21],n$=[0,i2,815,21],u$=[0,i2,818,21],i$=[0,i2,819,21],f$=[0,i2,822,19],c$=[0,i2,823,19],s$=[0,i2,826,22],o$=[0,i2,827,22],v$=[0,i2,831,30],a$=[0,i2,832,30],l$=[0,i2,836,26],p$=[0,i2,837,26],y$=[0,i2,846,28],d$=[0,i2,847,28],m$=[0,i2,851,23],k$=[0,i2,1558,4],h$="Printf: bad conversion %[",_$=[0,i2,1626,39],w$=[0,i2,1649,31],T$=[0,i2,1650,31],S$="Printf: bad conversion %_",E$=Oj,A$=aD,g$=Oj,N$=aD,I$=[0,[11,"invalid box description ",[3,0,0]],"invalid box description %S"],P$=[0,0,4],C$=Dk,R$="neg_infinity",O$=_D,L$=Hf,U$=[0,tt],M$="%+nd",D$="% nd",j$="%+ni",z$="% ni",K$="%nx",J$="%#nx",Y$="%nX",B$="%#nX",X$="%no",W$="%#no",V$="%nd",Z$=vD,$$="%nu",F$="%+ld",Q$="% ld",H$="%+li",q$="% li",G$="%lx",b$="%#lx",xF="%lX",rF="%#lX",eF="%lo",tF="%#lo",nF="%ld",uF=dz,iF="%lu",fF="%+Ld",cF="% Ld",sF="%+Li",oF="% Li",vF="%Lx",aF="%#Lx",lF="%LX",pF="%#LX",yF="%Lo",dF="%#Lo",mF="%Ld",kF=Uz,hF="%Lu",_F="%+d",wF="% d",TF="%+i",SF="% i",EF="%x",AF="%#x",gF="%X",NF="%#X",IF="%o",PF="%#o",CF=hl,RF=DU,OF=qD,LF=oa,UF="@}",MF="@?",DF=`@
                                     ^

Error: Command failed with exit code 127: yarn update-stable-docs
    at makeError (file:///I:/prettier/node_modules/execa/lib/error.js:59:11)
    at handlePromise (file:///I:/prettier/node_modules/execa/index.js:124:26)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async file:///I:/prettier/scripts/build-website.js:108:3 {
  shortMessage: 'Command failed with exit code 127: yarn update-stable-docs',
  command: 'yarn update-stable-docs',
  escapedCommand: 'yarn update-stable-docs',
  exitCode: 127,
  signal: undefined,
  signalDescription: undefined,
  stdout: undefined,
  stderr: undefined,
  failed: true,
  timedOut: false,
  isCanceled: false,
  killed: false
}

Node.js v18.14.0
```

A classic solution is to use `rimraf` instead of `rm -rf`. Alternative one is to use `fs.rmSync('foo/', { recursive: true, force: true })` (available since v14).

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
