### PR TITLE
fix: add missing `printer.preprocess` definition

### DIFF
--- a/changelog_unreleased/api/15123.md
+++ b/changelog_unreleased/api/15123.md
@@ -1,0 +1,3 @@
+#### fix: add missing `printer.preprocess` definition (#15123 by @so1ve)
+
+Adds missing types for `printer.preprocess`.

--- a/changelog_unreleased/api/15123.md
+++ b/changelog_unreleased/api/15123.md
@@ -5,7 +5,7 @@ Adds missing types for `printer.preprocess`.
 ```diff
 export interface Printer<T = any> {
 +  preprocess?:
-    | ((ast: T, options: ParserOptions<T>) => T | Promise<T>)
-    | undefined;
++    | ((ast: T, options: ParserOptions<T>) => T | Promise<T>)
++    | undefined;
 }
 ```

--- a/changelog_unreleased/api/15123.md
+++ b/changelog_unreleased/api/15123.md
@@ -1,3 +1,3 @@
-#### fix: add missing `printer.preprocess` definition (#15123 by @so1ve)
+#### Add missing type definition for `printer.preprocess` (#15123 by @so1ve)
 
 Adds missing types for `printer.preprocess`.

--- a/changelog_unreleased/api/15123.md
+++ b/changelog_unreleased/api/15123.md
@@ -1,88 +1,10 @@
 #### Add missing type definition for `printer.preprocess` (#15123 by @so1ve)
 
-Adds missing types for `printer.preprocess`.
-
 ```diff
 export interface Printer<T = any> {
-  print(
-    path: AstPath<T>,
-    options: ParserOptions<T>,
-    print: (path: AstPath<T>) => Doc,
-    args?: unknown,
-  ): Doc;
-  embed?:
-    | ((
-        path: AstPath,
-        options: Options,
-      ) =>
-        | ((
-            textToDoc: (text: string, options: Options) => Promise<Doc>,
-            print: (
-              selector?: string | number | Array<string | number> | AstPath,
-            ) => Doc,
-            path: AstPath,
-            options: Options,
-          ) => Promise<Doc | undefined> | Doc | undefined)
-        | Doc
-        | null)
-    | undefined;
-+  preprocess?:
-+    | ((ast: T, options: ParserOptions<T>) => T | Promise<T>)
-+    | undefined;
-  insertPragma?: (text: string) => string;
-  /**
-   * @returns `null` if you want to remove this node
-   * @returns `void` if you want to use modified newNode
-   * @returns anything if you want to replace the node with it
-   */
-  massageAstNode?: ((node: any, newNode: any, parent: any) => any) | undefined;
-  hasPrettierIgnore?: ((path: AstPath<T>) => boolean) | undefined;
-  canAttachComment?: ((node: T) => boolean) | undefined;
-  isBlockComment?: ((node: T) => boolean) | undefined;
-  willPrintOwnComments?: ((path: AstPath<T>) => boolean) | undefined;
-  printComment?:
-    | ((commentPath: AstPath<T>, options: ParserOptions<T>) => Doc)
-    | undefined;
-  /**
-   * By default, Prettier searches all object properties (except for a few predefined ones) of each node recursively.
-   * This function can be provided to override that behavior.
-   * @param node The node whose children should be returned.
-   * @param options Current options.
-   * @returns `[]` if the node has no children or `undefined` to fall back on the default behavior.
-   */
-  getCommentChildNodes?:
-    | ((node: T, options: ParserOptions<T>) => T[] | undefined)
-    | undefined;
-  handleComments?:
-    | {
-        ownLine?:
-          | ((
-              commentNode: any,
-              text: string,
-              options: ParserOptions<T>,
-              ast: T,
-              isLastComment: boolean,
-            ) => boolean)
-          | undefined;
-        endOfLine?:
-          | ((
-              commentNode: any,
-              text: string,
-              options: ParserOptions<T>,
-              ast: T,
-              isLastComment: boolean,
-            ) => boolean)
-          | undefined;
-        remaining?:
-          | ((
-              commentNode: any,
-              text: string,
-              options: ParserOptions<T>,
-              ast: T,
-              isLastComment: boolean,
-            ) => boolean)
-          | undefined;
-      }
-    | undefined;
+  // ...
++ preprocess?:
++   | ((ast: T, options: ParserOptions<T>) => T | Promise<T>)
++   | undefined;
 }
 ```

--- a/changelog_unreleased/api/15123.md
+++ b/changelog_unreleased/api/15123.md
@@ -1,3 +1,11 @@
 #### Add missing type definition for `printer.preprocess` (#15123 by @so1ve)
 
 Adds missing types for `printer.preprocess`.
+
+```diff
+export interface Printer<T = any> {
++  preprocess?:
+    | ((ast: T, options: ParserOptions<T>) => T | Promise<T>)
+    | undefined;
+}
+```

--- a/changelog_unreleased/api/15123.md
+++ b/changelog_unreleased/api/15123.md
@@ -4,8 +4,85 @@ Adds missing types for `printer.preprocess`.
 
 ```diff
 export interface Printer<T = any> {
+  print(
+    path: AstPath<T>,
+    options: ParserOptions<T>,
+    print: (path: AstPath<T>) => Doc,
+    args?: unknown,
+  ): Doc;
+  embed?:
+    | ((
+        path: AstPath,
+        options: Options,
+      ) =>
+        | ((
+            textToDoc: (text: string, options: Options) => Promise<Doc>,
+            print: (
+              selector?: string | number | Array<string | number> | AstPath,
+            ) => Doc,
+            path: AstPath,
+            options: Options,
+          ) => Promise<Doc | undefined> | Doc | undefined)
+        | Doc
+        | null)
+    | undefined;
 +  preprocess?:
 +    | ((ast: T, options: ParserOptions<T>) => T | Promise<T>)
 +    | undefined;
+  insertPragma?: (text: string) => string;
+  /**
+   * @returns `null` if you want to remove this node
+   * @returns `void` if you want to use modified newNode
+   * @returns anything if you want to replace the node with it
+   */
+  massageAstNode?: ((node: any, newNode: any, parent: any) => any) | undefined;
+  hasPrettierIgnore?: ((path: AstPath<T>) => boolean) | undefined;
+  canAttachComment?: ((node: T) => boolean) | undefined;
+  isBlockComment?: ((node: T) => boolean) | undefined;
+  willPrintOwnComments?: ((path: AstPath<T>) => boolean) | undefined;
+  printComment?:
+    | ((commentPath: AstPath<T>, options: ParserOptions<T>) => Doc)
+    | undefined;
+  /**
+   * By default, Prettier searches all object properties (except for a few predefined ones) of each node recursively.
+   * This function can be provided to override that behavior.
+   * @param node The node whose children should be returned.
+   * @param options Current options.
+   * @returns `[]` if the node has no children or `undefined` to fall back on the default behavior.
+   */
+  getCommentChildNodes?:
+    | ((node: T, options: ParserOptions<T>) => T[] | undefined)
+    | undefined;
+  handleComments?:
+    | {
+        ownLine?:
+          | ((
+              commentNode: any,
+              text: string,
+              options: ParserOptions<T>,
+              ast: T,
+              isLastComment: boolean,
+            ) => boolean)
+          | undefined;
+        endOfLine?:
+          | ((
+              commentNode: any,
+              text: string,
+              options: ParserOptions<T>,
+              ast: T,
+              isLastComment: boolean,
+            ) => boolean)
+          | undefined;
+        remaining?:
+          | ((
+              commentNode: any,
+              text: string,
+              options: ParserOptions<T>,
+              ast: T,
+              isLastComment: boolean,
+            ) => boolean)
+          | undefined;
+      }
+    | undefined;
 }
 ```

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -458,7 +458,7 @@ export interface Parser<T = any> {
   locStart: (node: T) => number;
   locEnd: (node: T) => number;
   preprocess?:
-    | ((text: string, options: ParserOptions<T>) => string)
+    | ((text: string, options: ParserOptions<T>) => string | Promise<string>)
     | undefined;
 }
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -485,7 +485,9 @@ export interface Printer<T = any> {
         | Doc
         | null)
     | undefined;
-  preprocess?: ((ast: T, options: ParserOptions<T>) => T | Promise<T>) | undefined;
+  preprocess?:
+    | ((ast: T, options: ParserOptions<T>) => T | Promise<T>)
+    | undefined;
   insertPragma?: (text: string) => string;
   /**
    * @returns `null` if you want to remove this node

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -458,7 +458,7 @@ export interface Parser<T = any> {
   locStart: (node: T) => number;
   locEnd: (node: T) => number;
   preprocess?:
-    | ((text: string, options: ParserOptions<T>) => string | Promise<string>)
+    | ((text: string, options: ParserOptions<T>) => string)
     | undefined;
 }
 
@@ -485,6 +485,7 @@ export interface Printer<T = any> {
         | Doc
         | null)
     | undefined;
+  preprocess?: ((ast: T, options: ParserOptions<T>) => T | Promise<T>) | undefined;
   insertPragma?: (text: string) => string;
   /**
    * @returns `null` if you want to remove this node


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

> Also, the preprocess method of a printer can return a promise now.

In the blog, preprocess in allowed to return a promise now. However the types are wrong.

I guess the blog is wrong too because preprocess belongs to parser?

Maybe address #12683

(I'm unable to provide a changelog now but soon)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
