### PR TITLE
Update editors.md

### DIFF
--- a/docs/editors.md
+++ b/docs/editors.md
@@ -41,7 +41,7 @@ See the [WebStorm setup guide](webstorm.md).
 
 ## Visual Studio
 
-Install the [JavaScript Prettier extension](https://github.com/madskristensen/JavaScriptPrettier).
+Install the [JavaScript Prettier extension](https://github.com/madskristensen/JavaScriptPrettier). [Pre VS2022 only](https://github.com/madskristensen/JavaScriptPrettier/issues/36)
 
 ## Atom
 


### PR DESCRIPTION
visual studio add-in does not work on VS2022

## Description

Note that add-in does not work in Visual Studio 2022

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
