### PR TITLE
Add missing 'getVisitorKeys' method type definition for 'Printer'

### DIFF
--- a/changelog_unreleased/api/15125.md
+++ b/changelog_unreleased/api/15125.md
@@ -1,4 +1,4 @@
-#### Add missing 'getVisitorKeys' method type definition for 'Printer' (#15125 by @auvred)
+#### Add missing `getVisitorKeys` method type definition for `Printer` (#15125 by @auvred)
 
 ```tsx
 const printer: Printer = {

--- a/changelog_unreleased/api/15125.md
+++ b/changelog_unreleased/api/15125.md
@@ -5,7 +5,6 @@ const printer: Printer = {
   print: () => [],
   getVisitorKeys(node, nonTraversableKeys) {
     return ["body"];
-  }
-}
+  },
+};
 ```
-

--- a/changelog_unreleased/api/15125.md
+++ b/changelog_unreleased/api/15125.md
@@ -1,0 +1,11 @@
+#### Add missing 'getVisitorKeys' method type definition for 'Printer' (#15125 by @auvred)
+
+```tsx
+const printer: Printer = {
+  print: () => [],
+  getVisitorKeys(node, nonTraversableKeys) {
+    return ["body"];
+  }
+}
+```
+

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -540,6 +540,9 @@ export interface Printer<T = any> {
           | undefined;
       }
     | undefined;
+  getVisitorKeys?:
+    | ((node: T, nonTraversableKeys: Set<string>) => string[])
+    | undefined;
 }
 
 export interface CursorOptions extends Options {


### PR DESCRIPTION
## Description

Closes #15121

Reference: https://prettier.io/docs/en/plugins.html#optional-getvisitorkeys

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
