### PR TITLE
Support `as` and `satisfies` expressions for Flow

### DIFF
--- a/changelog_unreleased/flow/15130.md
+++ b/changelog_unreleased/flow/15130.md
@@ -1,0 +1,13 @@
+#### Support `as` and `satisfies` expressions for Flow (#15130 by @gkz)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+const x = y as T;
+
+// Prettier stable
+// <error: unsupported>
+
+// Prettier main
+const x = y as T;
+```

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -11,7 +11,7 @@ import {
   isCallExpression,
   isMemberExpression,
   isObjectProperty,
-  isTSTypeExpression,
+  isBinaryCastExpression,
   isArrayOrTupleExpression,
   isObjectOrRecordExpression,
   createTypeCheckFunction,
@@ -310,19 +310,25 @@ function needsParens(path, options) {
     case "TSTypeAssertion":
     case "TSAsExpression":
     case "TSSatisfiesExpression":
+    case "AsExpression":
+    case "AsConstExpression":
+    case "SatisfiesExpression":
     case "LogicalExpression":
       switch (parent.type) {
         case "TSAsExpression":
         case "TSSatisfiesExpression":
+        case "AsExpression":
+        case "AsConstExpression":
+        case "SatisfiesExpression":
           // examples:
           //   foo as unknown as Bar
           //   foo satisfies unknown satisfies Bar
           //   foo satisfies unknown as Bar
           //   foo as unknown satisfies Bar
-          return !isTSTypeExpression(node);
+          return !isBinaryCastExpression(node);
 
         case "ConditionalExpression":
-          return isTSTypeExpression(node);
+          return isBinaryCastExpression(node);
 
         case "CallExpression":
         case "NewExpression":
@@ -352,7 +358,7 @@ function needsParens(path, options) {
         case "AssignmentPattern":
           return (
             key === "left" &&
-            (node.type === "TSTypeAssertion" || isTSTypeExpression(node))
+            (node.type === "TSTypeAssertion" || isBinaryCastExpression(node))
           );
 
         case "LogicalExpression":
@@ -443,6 +449,9 @@ function needsParens(path, options) {
         case "TSAsExpression":
         case "TSSatisfiesExpression":
         case "TSNonNullExpression":
+        case "AsExpression":
+        case "AsConstExpression":
+        case "SatisfiesExpression":
         case "BindExpression":
           return true;
 
@@ -747,6 +756,9 @@ function needsParens(path, options) {
         case "TypeCastExpression":
         case "TSAsExpression":
         case "TSSatisfiesExpression":
+        case "AsExpression":
+        case "AsConstExpression":
+        case "SatisfiesExpression":
         case "TSNonNullExpression":
           return true;
 
@@ -795,6 +807,9 @@ function needsParens(path, options) {
 
         case "TSAsExpression":
         case "TSSatisfiesExpression":
+        case "AsExpression":
+        case "AsConstExpression":
+        case "SatisfiesExpression":
         case "TSNonNullExpression":
         case "BindExpression":
         case "TaggedTemplateExpression":

--- a/src/language-js/print/call-arguments.js
+++ b/src/language-js/print/call-arguments.js
@@ -19,7 +19,7 @@ import {
   isRegExpLiteral,
   isSimpleType,
   isCallLikeExpression,
-  isTSTypeExpression,
+  isBinaryCastExpression,
   isArrayOrTupleExpression,
   isObjectOrRecordExpression,
 } from "../utils/index.js";
@@ -185,7 +185,7 @@ function couldExpandArg(arg, arrowChainRecursion = false) {
     (isArrayOrTupleExpression(arg) &&
       (arg.elements.length > 0 || hasComment(arg))) ||
     (arg.type === "TSTypeAssertion" && couldExpandArg(arg.expression)) ||
-    (isTSTypeExpression(arg) && couldExpandArg(arg.expression)) ||
+    (isBinaryCastExpression(arg) && couldExpandArg(arg.expression)) ||
     arg.type === "FunctionExpression" ||
     (arg.type === "ArrowFunctionExpression" &&
       // we want to avoid breaking inside composite return types but not simple keywords
@@ -281,7 +281,7 @@ function isHopefullyShortCallArgument(node) {
     return isHopefullyShortCallArgument(node.expression);
   }
 
-  if (isTSTypeExpression(node) || node.type === "TypeCastExpression") {
+  if (isBinaryCastExpression(node) || node.type === "TypeCastExpression") {
     let { typeAnnotation } = node;
     if (typeAnnotation.type === "TypeAnnotation") {
       typeAnnotation = typeAnnotation.typeAnnotation;

--- a/src/language-js/print/cast-expression.js
+++ b/src/language-js/print/cast-expression.js
@@ -1,0 +1,36 @@
+import { softline, group, indent } from "../../document/builders.js";
+import { isCallExpression, isMemberExpression } from "../utils/index.js";
+
+function printBinaryCastExpression(path, options, print) {
+  const { parent, node } = path;
+  let parts = [];
+  switch (node.type) {
+    case "AsConstExpression":
+      parts = [print("expression"), " as const"];
+      break;
+    case "AsExpression":
+    case "TSAsExpression":
+      parts = [print("expression"), " ", "as", " ", print("typeAnnotation")];
+      break;
+    case "SatisfiesExpression":
+    case "TSSatisfiesExpression":
+      parts = [
+        print("expression"),
+        " ",
+        "satisfies",
+        " ",
+        print("typeAnnotation"),
+      ];
+      break;
+  }
+
+  if (
+    (isCallExpression(parent) && parent.callee === node) ||
+    (isMemberExpression(parent) && parent.object === node)
+  ) {
+    return group([indent([softline, ...parts]), softline]);
+  }
+  return parts;
+}
+
+export { printBinaryCastExpression };

--- a/src/language-js/print/flow.js
+++ b/src/language-js/print/flow.js
@@ -10,6 +10,7 @@ import {
   rawText,
 } from "../utils/index.js";
 import isFlowKeywordType from "../utils/is-flow-keyword-type.js";
+import { printBinaryCastExpression } from "./cast-expression.js";
 import { printClass } from "./class.js";
 import {
   printOpaqueType,
@@ -276,6 +277,11 @@ function printFlow(path, options, print) {
           ? ["(", print("value"), ")"]
           : []),
       ];
+
+    case "AsExpression":
+    case "AsConstExpression":
+    case "SatisfiesExpression":
+      return printBinaryCastExpression(path, options, print);
   }
 }
 

--- a/src/language-js/print/template-literal.js
+++ b/src/language-js/print/template-literal.js
@@ -18,7 +18,7 @@ import {
   isSimpleTemplateLiteral,
   hasComment,
   isMemberExpression,
-  isTSTypeExpression,
+  isBinaryCastExpression,
 } from "../utils/index.js";
 
 function printTemplateLiteral(path, print, options) {
@@ -89,7 +89,7 @@ function printTemplateLiteral(path, print, options) {
         isMemberExpression(expression) ||
         expression.type === "ConditionalExpression" ||
         expression.type === "SequenceExpression" ||
-        isTSTypeExpression(expression) ||
+        isBinaryCastExpression(expression) ||
         isBinaryish(expression)
       ) {
         expressionDoc = [indent([softline, expressionDoc]), softline];

--- a/src/language-js/print/ternary.js
+++ b/src/language-js/print/ternary.js
@@ -3,7 +3,7 @@ import {
   isJsxElement,
   isCallExpression,
   isMemberExpression,
-  isTSTypeExpression,
+  isBinaryCastExpression,
   hasComment,
 } from "../utils/index.js";
 import { locStart, locEnd } from "../loc.js";
@@ -163,7 +163,7 @@ function shouldExtraIndentForConditionalExpression(path) {
 
     if (
       (node.type === "NewExpression" && node.callee === child) ||
-      (isTSTypeExpression(node) && node.expression === child)
+      (isBinaryCastExpression(node) && node.expression === child)
     ) {
       parent = path.getParentNode(ancestorCount + 1);
       child = node;

--- a/src/language-js/print/typescript.js
+++ b/src/language-js/print/typescript.js
@@ -10,8 +10,6 @@ import UnexpectedNodeError from "../../utils/unexpected-node-error.js";
 import {
   isStringLiteral,
   shouldPrintComma,
-  isCallExpression,
-  isMemberExpression,
   isArrayOrTupleExpression,
   isObjectOrRecordExpression,
 } from "../utils/index.js";
@@ -37,6 +35,7 @@ import { printPropertyKey } from "./property.js";
 import { printFunction, printMethodValue } from "./function.js";
 import { printInterface } from "./interface.js";
 import { printBlock } from "./block.js";
+import { printBinaryCastExpression } from "./cast-expression.js";
 import {
   printTypeAlias,
   printIntersectionType,
@@ -145,18 +144,9 @@ function printTypescript(path, options, print) {
     case "TSTypeParameter":
       return printTypeParameter(path, options, print);
     case "TSAsExpression":
-    case "TSSatisfiesExpression": {
-      const operator = node.type === "TSAsExpression" ? "as" : "satisfies";
-      parts.push(print("expression"), ` ${operator} `, print("typeAnnotation"));
-      const { parent } = path;
-      if (
-        (isCallExpression(parent) && parent.callee === node) ||
-        (isMemberExpression(parent) && parent.object === node)
-      ) {
-        return group([indent([softline, ...parts]), softline]);
-      }
-      return parts;
-    }
+    case "TSSatisfiesExpression":
+      return printBinaryCastExpression(path, options, print);
+
     case "TSArrayType":
       return printArrayType(print);
     case "TSPropertySignature":

--- a/src/language-js/traverse/visitor-keys.evaluate.js
+++ b/src/language-js/traverse/visitor-keys.evaluate.js
@@ -40,6 +40,9 @@ const additionalVisitorKeys = {
   TypePredicate: ["asserts"],
   UndefinedTypeAnnotation: [],
   UnknownTypeAnnotation: [],
+  AsExpression: ["expression", "typeAnnotation"],
+  AsConstExpression: ["expression"],
+  SatisfiesExpression: ["expression", "typeAnnotation"],
 };
 
 const excludeKeys = {

--- a/src/language-js/types/estree.d.ts
+++ b/src/language-js/types/estree.d.ts
@@ -25,7 +25,18 @@ export type Comment = (
   leading?: boolean;
 };
 
-export type Node = (ESTree.Node | Babel.Node | TSESTree.Node | NGTree.NGNode) &
+type FlowAdditionalNode =
+  | { type: "AsExpression"; expression: Node; typeAnnotation: Node }
+  | { type: "AsConstExpression"; expression: Node }
+  | { type: "SatisfiesExpression"; expression: Node; typeAnnotation: Node };
+
+export type Node = (
+  | ESTree.Node
+  | Babel.Node
+  | TSESTree.Node
+  | NGTree.NGNode
+  | FlowAdditionalNode
+) &
   AdditionalFields;
 
 export type TemplateLiteral = (

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -55,7 +55,7 @@ function hasNakedLeftSide(node) {
     node.type === "TaggedTemplateExpression" ||
     node.type === "BindExpression" ||
     (node.type === "UpdateExpression" && !node.prefix) ||
-    isTSTypeExpression(node) ||
+    isBinaryCastExpression(node) ||
     node.type === "TSNonNullExpression" ||
     node.type === "ChainExpression"
   );
@@ -795,6 +795,9 @@ function startsWithNoLookaheadToken(node, predicate) {
     case "TSSatisfiesExpression":
     case "TSAsExpression":
     case "TSNonNullExpression":
+    case "AsExpression":
+    case "AsConstExpression":
+    case "SatisfiesExpression":
       return startsWithNoLookaheadToken(node.expression, predicate);
     default:
       return predicate(node);
@@ -1101,9 +1104,14 @@ const markerForIfWithoutBlockAndSameLineComment = Symbol(
   "ifWithoutBlockAndSameLineComment",
 );
 
-const isTSTypeExpression = createTypeCheckFunction([
+const isBinaryCastExpression = createTypeCheckFunction([
+  // TS
   "TSAsExpression",
   "TSSatisfiesExpression",
+  // Flow
+  "AsExpression",
+  "AsConstExpression",
+  "SatisfiesExpression",
 ]);
 
 export {
@@ -1161,7 +1169,7 @@ export {
   getComments,
   CommentCheckFlags,
   markerForIfWithoutBlockAndSameLineComment,
-  isTSTypeExpression,
+  isBinaryCastExpression,
   isArrayOrTupleExpression,
   isObjectOrRecordExpression,
   createTypeCheckFunction,

--- a/tests/format/flow/as-satisfies-expression/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/as-satisfies-expression/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,544 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`as.js [babel-flow] format 1`] = `
+"Unexpected token, expected "," (3:27)
+  1 | // @flow
+  2 |
+> 3 | const name = (description as Description).name || (description as string);
+    |                           ^
+  4 | this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
+  5 | (originalError ? wrappedError(errMsg, originalError) : Error(errMsg)) as InjectionError;
+  6 | 'current' in (props.pagination as {...});"
+`;
+
+exports[`as.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+const name = (description as Description).name || (description as string);
+this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
+(originalError ? wrappedError(errMsg, originalError) : Error(errMsg)) as InjectionError;
+'current' in (props.pagination as {...});
+('current' in props.pagination) as {...};
+start + (yearSelectTotal as number);
+(start + yearSelectTotal) as number;
+scrollTop > (visibilityHeight as number);
+(scrollTop > visibilityHeight) as number;
+export default class Column<T> extends (RcTable.Column as Long.Thing<ColumnProps<T>,ColumnProps<T>,ColumnProps<T>,ColumnProps<T>>) {}
+({}) as {};
+function*g() {
+  const test = (yield 'foo') as number;
+}
+async function g1() {
+  const test = (await 'foo') as number;
+}
+({}) as X;
+() => ({}) as X;
+const state = JSON.stringify({
+  next: window.location.href,
+  nonce,
+} as State);
+
+(bValue as boolean) ? 0 : -1;
+
+const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
+const value2 = thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
+const value3 = thisIsAReallyLongIdentifier as (SomeInterface | SomeOtherInterface);
+const value4 = thisIsAReallyLongIdentifier as { prop1: string, prop2: number, prop3: number }[];
+const value5 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [string, number];
+
+const iter1 = createIterator(this.controller, child, this.tag as BlahFunctionComponent);
+const iter2 = createIterator(self.controller, child, self.tag as BlahFunctionComponent);
+
+x as any as T;
+
+=====================================output=====================================
+// @flow
+
+const name = (description as Description).name || (description as string);
+this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
+(originalError
+  ? wrappedError(errMsg, originalError)
+  : Error(errMsg)) as InjectionError;
+"current" in (props.pagination as { ... });
+("current" in props.pagination) as { ... };
+start + (yearSelectTotal as number);
+(start + yearSelectTotal) as number;
+scrollTop > (visibilityHeight as number);
+(scrollTop > visibilityHeight) as number;
+export default class Column<T> extends (RcTable.Column as Long.Thing<
+  ColumnProps<T>,
+  ColumnProps<T>,
+  ColumnProps<T>,
+  ColumnProps<T>,
+>) {}
+({}) as {};
+function* g() {
+  const test = (yield "foo") as number;
+}
+async function g1() {
+  const test = (await "foo") as number;
+}
+({}) as X;
+() => ({}) as X;
+const state = JSON.stringify({
+  next: window.location.href,
+  nonce,
+} as State);
+
+(bValue as boolean) ? 0 : -1;
+
+const value1 =
+  thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
+const value2 =
+  thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
+const value3 = thisIsAReallyLongIdentifier as
+  | SomeInterface
+  | SomeOtherInterface;
+const value4 = thisIsAReallyLongIdentifier as {
+  prop1: string,
+  prop2: number,
+  prop3: number,
+}[];
+const value5 =
+  thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [
+    string,
+    number,
+  ];
+
+const iter1 = createIterator(
+  this.controller,
+  child,
+  this.tag as BlahFunctionComponent,
+);
+const iter2 = createIterator(
+  self.controller,
+  child,
+  self.tag as BlahFunctionComponent,
+);
+
+x as any as T;
+
+================================================================================
+`;
+
+exports[`as-const.js [babel-flow] format 1`] = `
+"Unexpected token (12:11)
+  10 |     INFO: 6,
+  11 |     DEBUG: 7,
+> 12 | } as const;
+     |           ^
+  13 |"
+`;
+
+exports[`as-const.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+export const LOG_LEVEL = {
+    EMERGENCY: 0,
+    ALERT: 1,
+    CRITICAL: 2,
+    ERROR: 3,
+    WARNING: 4,
+    NOTICE: 5,
+    INFO: 6,
+    DEBUG: 7,
+} as const;
+
+=====================================output=====================================
+// @flow
+
+export const LOG_LEVEL = {
+  EMERGENCY: 0,
+  ALERT: 1,
+  CRITICAL: 2,
+  ERROR: 3,
+  WARNING: 4,
+  NOTICE: 5,
+  INFO: 6,
+  DEBUG: 7,
+} as const;
+
+================================================================================
+`;
+
+exports[`assignment.js [babel-flow] format 1`] = `
+"Unexpected token, expected "," (17:23)
+  15 |     this.currentPreviewIndex++;
+  16 |   }
+> 17 | }, this.refreshDelay) as any);
+     |                       ^
+  18 |
+  19 | this.intervalID = (setInterval(() => {
+  20 |   self.step();"
+`;
+
+exports[`assignment.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+const TYPE_MAP = {
+    'character device': 'special',
+    'character special file': 'special',
+    directory: 'directory',
+    'regular file': 'file',
+    socket: 'socket',
+    'symbolic link': 'link',
+} as Foo;
+
+this.previewPlayerHandle = (setInterval(async () => {
+  if (this.previewIsPlaying) {
+    await this.fetchNextPreviews();
+    this.currentPreviewIndex++;
+  }
+}, this.refreshDelay) as any);
+
+this.intervalID = (setInterval(() => {
+  self.step();
+}, 30) as any);
+
+=====================================output=====================================
+// @flow
+
+const TYPE_MAP = {
+  "character device": "special",
+  "character special file": "special",
+  directory: "directory",
+  "regular file": "file",
+  socket: "socket",
+  "symbolic link": "link",
+} as Foo;
+
+this.previewPlayerHandle = setInterval(async () => {
+  if (this.previewIsPlaying) {
+    await this.fetchNextPreviews();
+    this.currentPreviewIndex++;
+  }
+}, this.refreshDelay) as any;
+
+this.intervalID = setInterval(() => {
+  self.step();
+}, 30) as any;
+
+================================================================================
+`;
+
+exports[`export_default_as.js [babel-flow] format 1`] = `
+"Unexpected token, expected "," (3:35)
+  1 | // @flow
+  2 |
+> 3 | export default (function log() {} as typeof console.log)
+    |                                   ^
+  4 |"
+`;
+
+exports[`export_default_as.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+export default (function log() {} as typeof console.log)
+
+=====================================output=====================================
+// @flow
+
+export default (function log() {} as typeof console.log);
+
+================================================================================
+`;
+
+exports[`long-identifiers.js [babel-flow] format 1`] = `
+"Unexpected token, expected "," (11:37)
+   9 | averredBathersBoxroomBuggyNurl = {
+  10 |   anodyneCondosMalateOverateRetinol:
+> 11 |     annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave
+     |                                     ^
+  12 | };
+  13 |
+  14 | averredBathersBoxroomBuggyNurl("
+`;
+
+exports[`long-identifiers.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+const bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans as glimseGlyphsHazardNoopsTieTie;
+
+averredBathersBoxroomBuggyNurl.anodyneCondosMalateOverateRetinol =
+  annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave;
+
+averredBathersBoxroomBuggyNurl = {
+  anodyneCondosMalateOverateRetinol:
+    annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave
+};
+
+averredBathersBoxroomBuggyNurl(
+  anodyneCondosMalateOverateRetinol.annularCooeedSplicesWalksWayWay as
+    kochabCooieGameOnOboleUnweave
+);
+
+=====================================output=====================================
+// @flow
+
+const bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans as glimseGlyphsHazardNoopsTieTie;
+
+averredBathersBoxroomBuggyNurl.anodyneCondosMalateOverateRetinol =
+  annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave;
+
+averredBathersBoxroomBuggyNurl = {
+  anodyneCondosMalateOverateRetinol:
+    annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave,
+};
+
+averredBathersBoxroomBuggyNurl(
+  anodyneCondosMalateOverateRetinol.annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave,
+);
+
+================================================================================
+`;
+
+exports[`nested-await-and-as.js [babel-flow] format 1`] = `
+"Unexpected token, expected "," (7:33)
+   5 |     ((await (
+   6 |       await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
+>  7 |     ).findItem("My bookmarks")) as TreeItem
+     |                                 ^
+   8 |   ).getChildren()
+   9 |   ).length
+  10 |"
+`;
+
+exports[`nested-await-and-as.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+const getAccountCount = async () =>
+  (await
+    ((await (
+      await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
+    ).findItem("My bookmarks")) as TreeItem
+  ).getChildren()
+  ).length
+
+=====================================output=====================================
+// @flow
+
+const getAccountCount = async () =>
+  (
+    await (
+      (await (
+        await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
+      ).findItem("My bookmarks")) as TreeItem
+    ).getChildren()
+  ).length;
+
+================================================================================
+`;
+
+exports[`return.js [babel-flow] format 1`] = `
+"Missing semicolon. (7:4)
+  5 |     foo: 1,
+  6 |     bar: 2,
+> 7 |   } as Foo;
+    |    ^
+  8 | }
+  9 |"
+`;
+
+exports[`return.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+function foo() {
+  return {
+    foo: 1,
+    bar: 2,
+  } as Foo;
+}
+
+=====================================output=====================================
+// @flow
+
+function foo() {
+  return {
+    foo: 1,
+    bar: 2,
+  } as Foo;
+}
+
+================================================================================
+`;
+
+exports[`satisfies.js [babel-flow] format 1`] = `
+"Missing semicolon. (3:12)
+  1 | // @flow
+  2 |
+> 3 | const x = y satisfies T;
+    |            ^
+  4 |"
+`;
+
+exports[`satisfies.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+const x = y satisfies T;
+
+=====================================output=====================================
+// @flow
+
+const x = y satisfies T;
+
+================================================================================
+`;
+
+exports[`ternary.js [babel-flow] format 1`] = `
+"Unexpected token, expected "," (28:32)
+  26 |   void ((coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  27 |     ? baaaaaaaaaaaaaaaaaaaaar
+> 28 |     : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo);
+     |                                ^
+  29 | }
+  30 |
+  31 | bifornCringerMoshedPerplexSawder ="
+`;
+
+exports[`ternary.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// @flow
+
+foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
+
+foo = (condition ? firstValue : secondValue) as SomeType;
+
+const foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
+
+function foo() {
+  return (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
+}
+
+function foo() {
+  throw (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
+}
+
+function foo() {
+  void ((coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo);
+}
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0 &&
+  kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
+
+=====================================output=====================================
+// @flow
+
+foo = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+) as Fooooooooooo;
+
+foo = (condition ? firstValue : secondValue) as SomeType;
+
+const foo = (
+  coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz
+) as Fooooooooooo;
+
+function foo() {
+  return (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ) as Fooooooooooo;
+}
+
+function foo() {
+  throw (
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ) as Fooooooooooo;
+}
+
+function foo() {
+  void ((
+    coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz
+  ) as Fooooooooooo);
+}
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0 &&
+  kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
+
+================================================================================
+`;

--- a/tests/format/flow/as-satisfies-expression/as-const.js
+++ b/tests/format/flow/as-satisfies-expression/as-const.js
@@ -1,0 +1,12 @@
+// @flow
+
+export const LOG_LEVEL = {
+    EMERGENCY: 0,
+    ALERT: 1,
+    CRITICAL: 2,
+    ERROR: 3,
+    WARNING: 4,
+    NOTICE: 5,
+    INFO: 6,
+    DEBUG: 7,
+} as const;

--- a/tests/format/flow/as-satisfies-expression/as.js
+++ b/tests/format/flow/as-satisfies-expression/as.js
@@ -1,0 +1,38 @@
+// @flow
+
+const name = (description as Description).name || (description as string);
+this.isTabActionBar((e.target || e.srcElement) as HTMLElement);
+(originalError ? wrappedError(errMsg, originalError) : Error(errMsg)) as InjectionError;
+'current' in (props.pagination as {...});
+('current' in props.pagination) as {...};
+start + (yearSelectTotal as number);
+(start + yearSelectTotal) as number;
+scrollTop > (visibilityHeight as number);
+(scrollTop > visibilityHeight) as number;
+export default class Column<T> extends (RcTable.Column as Long.Thing<ColumnProps<T>,ColumnProps<T>,ColumnProps<T>,ColumnProps<T>>) {}
+({}) as {};
+function*g() {
+  const test = (yield 'foo') as number;
+}
+async function g1() {
+  const test = (await 'foo') as number;
+}
+({}) as X;
+() => ({}) as X;
+const state = JSON.stringify({
+  next: window.location.href,
+  nonce,
+} as State);
+
+(bValue as boolean) ? 0 : -1;
+
+const value1 = thisIsAReallyReallyReallyReallyReallyLongIdentifier as SomeInterface;
+const value2 = thisIsAnIdentifier as thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyReallyLongInterface;
+const value3 = thisIsAReallyLongIdentifier as (SomeInterface | SomeOtherInterface);
+const value4 = thisIsAReallyLongIdentifier as { prop1: string, prop2: number, prop3: number }[];
+const value5 = thisIsAReallyReallyReallyReallyReallyReallyReallyReallyReallyLongIdentifier as [string, number];
+
+const iter1 = createIterator(this.controller, child, this.tag as BlahFunctionComponent);
+const iter2 = createIterator(self.controller, child, self.tag as BlahFunctionComponent);
+
+x as any as T;

--- a/tests/format/flow/as-satisfies-expression/assignment.js
+++ b/tests/format/flow/as-satisfies-expression/assignment.js
@@ -1,0 +1,21 @@
+// @flow
+
+const TYPE_MAP = {
+    'character device': 'special',
+    'character special file': 'special',
+    directory: 'directory',
+    'regular file': 'file',
+    socket: 'socket',
+    'symbolic link': 'link',
+} as Foo;
+
+this.previewPlayerHandle = (setInterval(async () => {
+  if (this.previewIsPlaying) {
+    await this.fetchNextPreviews();
+    this.currentPreviewIndex++;
+  }
+}, this.refreshDelay) as any);
+
+this.intervalID = (setInterval(() => {
+  self.step();
+}, 30) as any);

--- a/tests/format/flow/as-satisfies-expression/export_default_as.js
+++ b/tests/format/flow/as-satisfies-expression/export_default_as.js
@@ -1,0 +1,3 @@
+// @flow
+
+export default (function log() {} as typeof console.log)

--- a/tests/format/flow/as-satisfies-expression/jsfmt.spec.js
+++ b/tests/format/flow/as-satisfies-expression/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(import.meta, ["flow"], { errors: { "babel-flow": true } });

--- a/tests/format/flow/as-satisfies-expression/long-identifiers.js
+++ b/tests/format/flow/as-satisfies-expression/long-identifiers.js
@@ -1,0 +1,17 @@
+// @flow
+
+const bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans as glimseGlyphsHazardNoopsTieTie;
+
+averredBathersBoxroomBuggyNurl.anodyneCondosMalateOverateRetinol =
+  annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave;
+
+averredBathersBoxroomBuggyNurl = {
+  anodyneCondosMalateOverateRetinol:
+    annularCooeedSplicesWalksWayWay as kochabCooieGameOnOboleUnweave
+};
+
+averredBathersBoxroomBuggyNurl(
+  anodyneCondosMalateOverateRetinol.annularCooeedSplicesWalksWayWay as
+    kochabCooieGameOnOboleUnweave
+);

--- a/tests/format/flow/as-satisfies-expression/nested-await-and-as.js
+++ b/tests/format/flow/as-satisfies-expression/nested-await-and-as.js
@@ -1,0 +1,9 @@
+// @flow
+
+const getAccountCount = async () =>
+  (await
+    ((await (
+      await focusOnSection(BOOKMARKED_PROJECTS_SECTION_NAME)
+    ).findItem("My bookmarks")) as TreeItem
+  ).getChildren()
+  ).length

--- a/tests/format/flow/as-satisfies-expression/return.js
+++ b/tests/format/flow/as-satisfies-expression/return.js
@@ -1,0 +1,8 @@
+// @flow
+
+function foo() {
+  return {
+    foo: 1,
+    bar: 2,
+  } as Foo;
+}

--- a/tests/format/flow/as-satisfies-expression/satisfies.js
+++ b/tests/format/flow/as-satisfies-expression/satisfies.js
@@ -1,0 +1,3 @@
+// @flow
+
+const x = y satisfies T;

--- a/tests/format/flow/as-satisfies-expression/ternary.js
+++ b/tests/format/flow/as-satisfies-expression/ternary.js
@@ -1,0 +1,42 @@
+// @flow
+
+foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
+
+foo = (condition ? firstValue : secondValue) as SomeType;
+
+const foo = (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+  ? baaaaaaaaaaaaaaaaaaaaar
+  : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
+
+function foo() {
+  return (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
+}
+
+function foo() {
+  throw (coooooooooooooooooooooooooooooooooooooooooooooooooooond
+      ? baaaaaaaaaaaaaaaaaaaaar
+      : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo;
+}
+
+function foo() {
+  void ((coooooooooooooooooooooooooooooooooooooooooooooooooooond
+    ? baaaaaaaaaaaaaaaaaaaaar
+    : baaaaaaaaaaaaaaaaaaaaaz) as Fooooooooooo);
+}
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);
+
+bifornCringerMoshedPerplexSawder =
+  askTrovenaBeenaDependsRowans +
+  ((glimseGlyphsHazardNoopsTieTie === 0 &&
+  kochabCooieGameOnOboleUnweave === Math.PI
+    ? averredBathersBoxroomBuggyNurl
+    : anodyneCondosMalateOverateRetinol) as AnnularCooeedSplicesWalksWayWay);

--- a/tests/unit/__snapshots__/visitor-keys.js.snap
+++ b/tests/unit/__snapshots__/visitor-keys.js.snap
@@ -28,6 +28,13 @@ exports[`visitor keys estree 1`] = `
     "typeParameters",
     "predicate",
   ],
+  "AsConstExpression": [
+    "expression",
+  ],
+  "AsExpression": [
+    "expression",
+    "typeAnnotation",
+  ],
   "AssignmentExpression": [
     "left",
     "right",
@@ -655,6 +662,10 @@ exports[`visitor keys estree 1`] = `
   ],
   "ReturnStatement": [
     "argument",
+  ],
+  "SatisfiesExpression": [
+    "expression",
+    "typeAnnotation",
   ],
   "SequenceExpression": [
     "expressions",


### PR DESCRIPTION
## Description

Adds support for  printing `as` and `satisfies` expressions in Flow.
```
const x = y as T;
```

This is accomplished first by factoring out TypeScript's logic and using/extending that.

Tests are mostly copied from TS's tests. I did a `diff` of Flow's and TS's snapshot file to confirm that that differences were expected (from input change).

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
