### PR TITLE
Do not add trailing comma for grouped scss comments

### DIFF
--- a/changelog_unreleased/scss/15217.md
+++ b/changelog_unreleased/scss/15217.md
@@ -1,0 +1,25 @@
+#### Do not add trailing comma for grouped scss comments (#15217 by @auvred)
+
+<!-- prettier-ignore -->
+```scss
+/* Input */
+$foo: (
+	'property': (),
+	// comment 1
+	// comment 2
+)
+
+/* Prettier stable */
+$foo: (
+  "property": (),
+  // comment 1
+  // comment 2,
+);
+
+/* Prettier main */
+$foo: (
+  "property": (),
+  // comment 1
+  // comment 2
+);
+```

--- a/src/language-css/print/parenthesized-value-group.js
+++ b/src/language-css/print/parenthesized-value-group.js
@@ -40,6 +40,10 @@ function printTrailingComma(path, options) {
 
   if (
     path.node.type !== "value-comment" &&
+    !(
+      path.node.type === "value-comma_group" &&
+      path.node.groups.every((group) => group.type === "value-comment")
+    ) &&
     shouldPrintTrailingComma(options) &&
     path.callParent(() => isSCSSMapItemNode(path, options))
   ) {

--- a/tests/format/scss/scss/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/scss/scss/__snapshots__/jsfmt.spec.js.snap
@@ -1558,6 +1558,17 @@ label {
 div {
   margin: - pow(2, 2) * 100px;
 }
+
+$foo: (
+    'property1': (),
+    // comment 1
+    // comment 2
+
+    'property2': 1,
+    /** comment 1 */
+    /* comment 2 */
+);
+
 =====================================output=====================================
 @media #{$g-breakpoint-tiny} {
 }
@@ -2630,6 +2641,14 @@ label {
 div {
   margin: - pow(2, 2) * 100px;
 }
+
+$foo: (
+  "property1": (),
+  // comment 1
+  // comment 2
+  "property2": 1,
+  /** comment 1 */ /* comment 2 */
+);
 
 ================================================================================
 `;
@@ -3732,6 +3751,17 @@ label {
 div {
   margin: - pow(2, 2) * 100px;
 }
+
+$foo: (
+    'property1': (),
+    // comment 1
+    // comment 2
+
+    'property2': 1,
+    /** comment 1 */
+    /* comment 2 */
+);
+
 =====================================output=====================================
 @media #{$g-breakpoint-tiny} {
 }
@@ -4804,6 +4834,14 @@ label {
 div {
   margin: - pow(2, 2) * 100px;
 }
+
+$foo: (
+  "property1": (),
+  // comment 1
+  // comment 2
+  "property2": 1,
+  /** comment 1 */ /* comment 2 */
+);
 
 ================================================================================
 `;

--- a/tests/format/scss/scss/scss.scss
+++ b/tests/format/scss/scss/scss.scss
@@ -1089,3 +1089,13 @@ label {
 div {
   margin: - pow(2, 2) * 100px;
 }
+
+$foo: (
+    'property1': (),
+    // comment 1
+    // comment 2
+
+    'property2': 1,
+    /** comment 1 */
+    /* comment 2 */
+);


### PR DESCRIPTION
## Description

Fixes https://github.com/prettier/prettier/issues/15193

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
