### PR TITLE
State that the supported version of MDX is 1 until #12209 is fixed

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,7 @@ Prettier is an opinionated code formatter with support for:
 - [Ember/Handlebars](https://handlebarsjs.com/)
 - [JSON](https://json.org/)
 - [GraphQL](https://graphql.org/)
-- [Markdown](https://commonmark.org/), including [GFM](https://github.github.com/gfm/) and [MDX](https://mdxjs.com/)
+- [Markdown](https://commonmark.org/), including [GFM](https://github.github.com/gfm/) and [MDX v1](https://mdxjs.com/)
 - [YAML](https://yaml.org/)
 
 It removes all original styling[\*](#footnotes) and ensures that all outputted code conforms to a consistent style. (See this [blog post](https://jlongster.com/A-Prettier-Formatter))

--- a/website/data/languages.yml
+++ b/website/data/languages.yml
@@ -33,7 +33,7 @@
   variants:
     - "[CommonMark](https://commonmark.org)"
     - "[GitHub-Flavored Markdown](https://github.github.com/gfm/)"
-    - "[MDX](https://mdxjs.com)"
+    - "[MDX v1](https://mdxjs.com)"
 - name: YAML
   nameLink: https://yaml.org
   showName: true

--- a/website/versioned_docs/version-stable/index.md
+++ b/website/versioned_docs/version-stable/index.md
@@ -17,7 +17,7 @@ Prettier is an opinionated code formatter with support for:
 - [Ember/Handlebars](https://handlebarsjs.com/)
 - [JSON](https://json.org/)
 - [GraphQL](https://graphql.org/)
-- [Markdown](https://commonmark.org/), including [GFM](https://github.github.com/gfm/) and [MDX](https://mdxjs.com/)
+- [Markdown](https://commonmark.org/), including [GFM](https://github.github.com/gfm/) and [MDX v1](https://mdxjs.com/)
 - [YAML](https://yaml.org/)
 
 It removes all original styling[\*](#footnotes) and ensures that all outputted code conforms to a consistent style. (See this [blog post](https://jlongster.com/A-Prettier-Formatter))


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Not a few people misunderstand Prettier supports MDX v2. We see a non-negligible number of issues based on misinterpretations of the MDX version. This PR will state that Prettier only supports v1 and prevents them from misunderstanding the supported version until #12209 is fixed.
I may have to change the link to <https://v1.mdxjs.com/>.
After it is fixed, the "v1" that has been added can be changed to "v2" or simply removed.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
