### PR TITLE
Fix type annotations for config docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,7 +37,7 @@ JS(ESM):
 ```js
 // prettier.config.js, .prettierrc.js, prettier.config.mjs, or .prettierrc.mjs
 
-/** @type {import("prettier").Options} */
+/** @type {import("prettier").Config} */
 const config = {
   trailingComma: "es5",
   tabWidth: 4,
@@ -53,7 +53,7 @@ JS(CommonJS):
 ```js
 // prettier.config.js, .prettierrc.js, prettier.config.cjs, or .prettierrc.cjs
 
-/** @type {import("prettier").Options} */
+/** @type {import("prettier").Config} */
 const config = {
   trailingComma: "es5",
   tabWidth: 4,

--- a/website/versioned_docs/version-stable/configuration.md
+++ b/website/versioned_docs/version-stable/configuration.md
@@ -38,7 +38,7 @@ JS(ESM):
 ```js
 // prettier.config.js, .prettierrc.js, prettier.config.mjs, or .prettierrc.mjs
 
-/** @type {import("prettier").Options} */
+/** @type {import("prettier").Config} */
 const config = {
   trailingComma: "es5",
   tabWidth: 4,
@@ -54,7 +54,7 @@ JS(CommonJS):
 ```js
 // prettier.config.js, .prettierrc.js, prettier.config.cjs, or .prettierrc.cjs
 
-/** @type {import("prettier").Options} */
+/** @type {import("prettier").Config} */
 const config = {
   trailingComma: "es5",
   tabWidth: 4,


### PR DESCRIPTION
This lets VSCode validate the `overrides` property.

## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
