### PR TITLE
Support shared config that forbids `require()`

### DIFF
--- a/changelog_unreleased/api/15233.md
+++ b/changelog_unreleased/api/15233.md
@@ -4,6 +4,6 @@ If an external shared config package is used, and the package `exports` don't ha
 
 In Prettier stable Prettier fails when attempt to `require()` the package, and throws an error
 
-```js
+```text
 Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in <packageName>/package.json
 ```

--- a/changelog_unreleased/api/15233.md
+++ b/changelog_unreleased/api/15233.md
@@ -2,7 +2,7 @@
 
 If an external shared config package is used, and the package `exports` don't have `require` or `default` export.
 
-In Prettier stable Prettier fails when attempt to `require()` the package, and throws an error
+In Prettier stable Prettier fails when attempt to `require()` the package, and throws an error.
 
 ```text
 Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in <packageName>/package.json

--- a/changelog_unreleased/api/15233.md
+++ b/changelog_unreleased/api/15233.md
@@ -1,0 +1,9 @@
+#### Support shared config that forbids `require()` (#15233 by @fisker)
+
+If an external shared config package is used, and the package `exports` don't have `require` or `default` export.
+
+In Prettier stable Prettier fails when attempt to `require()` the package, and throws an error
+
+```js
+Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in <packageName>/package.json
+```

--- a/src/config/load-external-config.js
+++ b/src/config/load-external-config.js
@@ -1,6 +1,11 @@
 import requireFromFile from "../utils/require-from-file.js";
 import importFromFile from "../utils/import-from-file.js";
 
+const requireErrorCodesShouldBeIgnored = new Set([
+  "MODULE_NOT_FOUND",
+  "ERR_REQUIRE_ESM",
+  "ERR_PACKAGE_PATH_NOT_EXPORTED",
+]);
 async function loadExternalConfig(config, filepath) {
   /*
   Try `require()` first, this is how it works in Prettier v2.
@@ -12,10 +17,7 @@ async function loadExternalConfig(config, filepath) {
   try {
     return requireFromFile(config, filepath);
   } catch (/** @type {any} */ error) {
-    if (
-      error?.code !== "MODULE_NOT_FOUND" &&
-      error?.code !== "ERR_REQUIRE_ESM"
-    ) {
+    if (!requireErrorCodesShouldBeIgnored.has(error?.code)) {
       throw error;
     }
   }

--- a/tests/integration/__tests__/config-resolution.js
+++ b/tests/integration/__tests__/config-resolution.js
@@ -361,3 +361,15 @@ test(".json5 config file(invalid)", async () => {
   const error = /JSON5: invalid end of input at 2:1/;
   await expect(prettier.resolveConfig(file)).rejects.toThrow(error);
 });
+
+test("support external module with `module` only `exports`", async () => {
+  const directory = path.join(
+    __dirname,
+    "../cli/config/external-config/esm-package-forbids-require",
+  );
+  const file = path.join(directory, "index.js");
+
+  await expect(prettier.resolveConfig(file)).resolves.toMatchObject({
+    printWidth: 79,
+  });
+});

--- a/tests/integration/cli/config/external-config/esm-package-forbids-require/index.js
+++ b/tests/integration/cli/config/external-config/esm-package-forbids-require/index.js
@@ -1,0 +1,1 @@
+console.log("should have no semi");

--- a/tests/integration/cli/config/external-config/esm-package-forbids-require/node_modules/prettier-config-forbids-require/index.js
+++ b/tests/integration/cli/config/external-config/esm-package-forbids-require/node_modules/prettier-config-forbids-require/index.js
@@ -1,0 +1,1 @@
+export default { printWidth: 79 }

--- a/tests/integration/cli/config/external-config/esm-package-forbids-require/node_modules/prettier-config-forbids-require/package.json
+++ b/tests/integration/cli/config/external-config/esm-package-forbids-require/node_modules/prettier-config-forbids-require/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "prettier-config-forbids-require",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "exports": {
+    "import": "./index.js"
+  }
+}

--- a/tests/integration/cli/config/external-config/esm-package-forbids-require/package.json
+++ b/tests/integration/cli/config/external-config/esm-package-forbids-require/package.json
@@ -1,0 +1,3 @@
+{
+  "prettier": "prettier-config-forbids-require"
+}


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #15195

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
