### PR TITLE
Missing types

### DIFF
--- a/src/document/public.d.ts
+++ b/src/document/public.d.ts
@@ -38,6 +38,7 @@ export namespace builders {
 
   interface Group {
     type: "group";
+    id?: symbol;
     contents: Doc;
     break: boolean;
     expandedStates: Doc[];
@@ -64,6 +65,8 @@ export namespace builders {
 
   interface Label {
     type: "label";
+    label: any;
+    contents: Doc;
   }
 
   interface Line {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -870,10 +870,19 @@ export namespace util {
     options?: SkipOptions | undefined,
   ): boolean;
 
+  function getNextNonSpaceNonCommentCharacterIndex(
+    text: string,
+    startIndex: number,
+  ): number | false;
+
   function getNextNonSpaceNonCommentCharacter(
     text: string,
     startIndex: number,
   ): string;
+
+  function isNextLineEmpty(text: string, startIndex: number): boolean;
+
+  function isPreviousLineEmpty(text: string, startIndex: number): boolean;
 
   function makeString(
     rawText: string,


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
When working on migrating `prettier-plugin-solidity` to typescript I discovered some missing details in the types exported by Prettier.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
