### PR TITLE
Minor refactor to `expandPatterns`

### DIFF
--- a/src/cli/expand-patterns.js
+++ b/src/cli/expand-patterns.js
@@ -84,12 +84,10 @@ async function* expandPatternsInternal(context) {
           it returns files like 'src/../index.js'
         */
         const relativePath = path.relative(cwd, absolutePath) || ".";
+        const prefix = escapePathForGlob(fixWindowsSlashes(relativePath));
         entries.push({
           type: "dir",
-          glob:
-            escapePathForGlob(fixWindowsSlashes(relativePath)) +
-            "/" +
-            getSupportedFilesGlob(),
+          glob: getSupportedFilesGlob().map((pattern) => `${prefix}/**/${pattern}`),
           input: pattern,
         });
       }
@@ -135,10 +133,10 @@ async function* expandPatternsInternal(context) {
       const filenames = context.languages.flatMap(
         (lang) => lang.filenames || [],
       );
-      supportedFilesGlob = `**/{${[
+      supportedFilesGlob = [
         ...extensions.map((ext) => "*" + (ext[0] === "." ? ext : "." + ext)),
         ...filenames,
-      ]}}`;
+      ];
     }
     return supportedFilesGlob;
   }

--- a/src/cli/expand-patterns.js
+++ b/src/cli/expand-patterns.js
@@ -87,7 +87,9 @@ async function* expandPatternsInternal(context) {
         const prefix = escapePathForGlob(fixWindowsSlashes(relativePath));
         entries.push({
           type: "dir",
-          glob: getSupportedFilesGlob().map((pattern) => `${prefix}/**/${pattern}`),
+          glob: getSupportedFilesGlob().map(
+            (pattern) => `${prefix}/**/${pattern}`,
+          ),
           input: pattern,
         });
       }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

I found that `fast-glob` can't glob any file with `**/{*.js}` (single extension), the original code works because we always have many `extensions` and `filenames` in `languages`.
I guess better pass an array to `fast-glob` instead to be safer.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
