### PR TITLE
Use `process.exitCode` instead of `process.exit()`

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -82,8 +82,9 @@ async function main(context) {
     await logFileInfoOrDie(context);
   } else if (useStdin) {
     if (context.argv.cache) {
+      process.exitCode = 2;
       context.logger.error("`--cache` cannot be used with stdin.");
-      process.exit(2);
+      return;
     }
     await formatStdin(context);
   } else if (hasFilePatterns) {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
