### PR TITLE
Fix `--stdin-file-path`

### DIFF
--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -74,7 +74,7 @@ async function main(context) {
 
   const hasFilePatterns = context.filePatterns.length > 0;
   const useStdin =
-    !hasFilePatterns && (!process.stdin.isTTY || context.argv.filePath);
+    !hasFilePatterns && (!process.stdin.isTTY || context.argv.filepath);
 
   if (context.argv.findConfigPath) {
     await logResolvedConfigPathOrDie(context);

--- a/tests/integration/__tests__/stdin-filepath.js
+++ b/tests/integration/__tests__/stdin-filepath.js
@@ -1,5 +1,6 @@
 import { isCI } from "ci-info";
 import { outdent } from "outdent";
+
 describe("format correctly if stdin content compatible with stdin-filepath", () => {
   runCli(
     "cli",
@@ -133,5 +134,16 @@ describe("output file as-is if stdin-filepath matched patterns in ignore-path", 
   }).test({
     stdout: "hello_world( );",
     status: 0,
+  });
+});
+
+describe("Should format stdin even if it's empty", () => {
+  runCli("cli", ["--stdin-filepath", "example.js"], {
+    isTTY: true,
+  }).test({
+    stdout: "",
+    status: 0,
+    stderr: "",
+    write: [],
   });
 });


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

There is no `context.argv.filePath`, only `context.argv.filepath`.
`

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
