### PR TITLE
Move `--cache-strategy` check into `index.js`

### DIFF
--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -306,18 +306,10 @@ async function formatFiles(context) {
       cacheFilePath,
       context.argv.cacheStrategy || "content",
     );
-  } else {
-    if (context.argv.cacheStrategy) {
-      context.logger.error(
-        "`--cache-strategy` cannot be used without `--cache`.",
-      );
-      process.exit(2);
-    }
-    if (!context.argv.cacheLocation) {
-      const stat = await statSafe(cacheFilePath);
-      if (stat) {
-        await fs.unlink(cacheFilePath);
-      }
+  } else if (!context.argv.cacheLocation) {
+    const stat = await statSafe(cacheFilePath);
+    if (stat) {
+      await fs.unlink(cacheFilePath);
     }
   }
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -54,6 +54,10 @@ async function main(context) {
     throw new Error("Cannot use --file-info with multiple files");
   }
 
+  if (!context.argv.cache && context.argv.cacheStrategy) {
+    throw new Error("`--cache-strategy` cannot be used without `--cache`.");
+  }
+
   if (context.argv.version) {
     printToScreen(prettier.version);
     return;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Move it together with other conflict flags check. `exitCode` changed to `1`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
