### PR TITLE
docs: marked `pretty-quick` as "not actively maintained" in precommit section and recommended `lint-staged` instead

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -19,7 +19,9 @@ This will install [husky](https://github.com/typicode/husky) and [lint-staged](h
 
 Read more at the [lint-staged](https://github.com/okonet/lint-staged#configuration) repo.
 
-## Option 2. [pretty-quick](https://github.com/azz/pretty-quick)
+## Option 2. [pretty-quick](https://github.com/azz/pretty-quick) **(Not actively maintained)**
+
+> This project is **not actively maintained** and its latest version ([`v3.1.3`](https://github.com/azz/pretty-quick/releases/tag/v3.1.3)) does not work with prettier `v3` and above. Please use **[lint-staged](#option-1-lint-staged)** instead.
 
 **Use Case:** Great for when you want an entire file formatting on your changed/staged files.
 


### PR DESCRIPTION
Marked `pretty-quick` as "not actively maintained" in precommit section and recommended `lint-staged` instead

## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
