### PR TITLE
Missing attributes in ParserOptions type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -441,6 +441,8 @@ export interface ParserOptions<T = any> extends RequiredOptions {
   locStart: (node: T) => number;
   locEnd: (node: T) => number;
   originalText: string;
+  astFormat: string;
+  printer: Printer<T>;
 }
 
 export interface Plugin<T = any> {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

found these missing attributes in the ParserOptions type while working on the typescript migration in our plugin.

I based this from `src/main/normalize-format-options.js`

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
