### PR TITLE
Fix empty Prettier config file create command

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -29,7 +29,7 @@ pnpm add --save-dev --save-exact prettier
 Then, create an empty config file to let editors and other tools know you are using Prettier:
 
 ```bash
-node -e "fs.writeFileSync('.prettierrc.json', '{}\n')"
+node -e "fs.writeFileSync('.prettierrc.json','{}\n')"
 ```
 
 Next, create a [.prettierignore](ignore.md) file to let the Prettier CLI and editors know which files to _not_ format. Here’s an example:

--- a/docs/install.md
+++ b/docs/install.md
@@ -31,7 +31,7 @@ Then, create an empty config file to let editors and other tools know you are us
 <!--
 Note:
 - `echo "{}" > .prettierrc` would result in `"{}"<SPACE>` on Windows.
-- `echo {}> .prettierrc` would result the file in UTF-16LE encoding.
+- `echo {}> .prettierrc` would result the file in UTF-16LE encoding in PowerShell.
 The below version works in cmd.exe, bash, zsh, fish, powershell.exe.
 -->
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -32,7 +32,7 @@ Then, create an empty config file to let editors and other tools know you are us
 Note:
 - `echo "{}" > .prettierrc` would result in `"{}"<SPACE>` on Windows.
 - `echo {}> .prettierrc` would result the file in UTF-16LE encoding in PowerShell.
-The below version works in cmd.exe, bash, zsh, fish, powershell.exe.
+The below version works in cmd.exe, bash, zsh, fish, PowerShell.
 -->
 
 ```bash

--- a/docs/install.md
+++ b/docs/install.md
@@ -36,7 +36,7 @@ The below version works in cmd.exe, bash, zsh, fish, powershell.exe.
 -->
 
 ```bash
-node -e "fs.writeFileSync('.prettierrc.json','{}\n')"
+node --eval "fs.writeFileSync('.prettierrc','{}\n')"
 ```
 
 Next, create a [.prettierignore](ignore.md) file to let the Prettier CLI and editors know which files to _not_ format. Here’s an example:

--- a/docs/install.md
+++ b/docs/install.md
@@ -28,10 +28,8 @@ pnpm add --save-dev --save-exact prettier
 
 Then, create an empty config file to let editors and other tools know you are using Prettier:
 
-<!-- Note: `echo "{}" > .prettierrc.json` would result in `"{}"<SPACE>` on Windows. The below version works in cmd.exe, bash, zsh, fish. -->
-
 ```bash
-echo {}> .prettierrc.json
+node -e "require('fs').writeFileSync('.prettierrc.json', '{}\n')"
 ```
 
 Next, create a [.prettierignore](ignore.md) file to let the Prettier CLI and editors know which files to _not_ format. Here’s an example:

--- a/docs/install.md
+++ b/docs/install.md
@@ -29,7 +29,7 @@ pnpm add --save-dev --save-exact prettier
 Then, create an empty config file to let editors and other tools know you are using Prettier:
 
 ```bash
-node -e "require('fs').writeFileSync('.prettierrc.json', '{}\n')"
+node -e "fs.writeFileSync('.prettierrc.json', '{}\n')"
 ```
 
 Next, create a [.prettierignore](ignore.md) file to let the Prettier CLI and editors know which files to _not_ format. Here’s an example:

--- a/docs/install.md
+++ b/docs/install.md
@@ -30,8 +30,8 @@ Then, create an empty config file to let editors and other tools know you are us
 
 <!--
 Note:
-- `echo "{}" > .prettierrc.json` would result in `"{}"<SPACE>` on Windows.
-- `echo {}> .prettierrc.json` would result `.prettierrc.json` file in UTF-16LE encoding.
+- `echo "{}" > .prettierrc` would result in `"{}"<SPACE>` on Windows.
+- `echo {}> .prettierrc` would result `.prettierrc.json` file in UTF-16LE encoding.
 The below version works in cmd.exe, bash, zsh, fish, powershell.exe.
 -->
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -28,6 +28,13 @@ pnpm add --save-dev --save-exact prettier
 
 Then, create an empty config file to let editors and other tools know you are using Prettier:
 
+<!--
+Note:
+- `echo "{}" > .prettierrc.json` would result in `"{}"<SPACE>` on Windows.
+- `echo {}> .prettierrc.json` would result `.prettierrc.json` file in UTF-16LE encoding.
+The below version works in cmd.exe, bash, zsh, fish, powershell.exe.
+-->
+
 ```bash
 node -e "fs.writeFileSync('.prettierrc.json','{}\n')"
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -31,7 +31,7 @@ Then, create an empty config file to let editors and other tools know you are us
 <!--
 Note:
 - `echo "{}" > .prettierrc` would result in `"{}"<SPACE>` on Windows.
-- `echo {}> .prettierrc` would result `.prettierrc.json` file in UTF-16LE encoding.
+- `echo {}> .prettierrc` would result the file in UTF-16LE encoding.
 The below version works in cmd.exe, bash, zsh, fish, powershell.exe.
 -->
 

--- a/website/versioned_docs/version-stable/install.md
+++ b/website/versioned_docs/version-stable/install.md
@@ -29,10 +29,15 @@ pnpm add --save-dev --save-exact prettier
 
 Then, create an empty config file to let editors and other tools know you are using Prettier:
 
-<!-- Note: `echo "{}" > .prettierrc.json` would result in `"{}"<SPACE>` on Windows. The below version works in cmd.exe, bash, zsh, fish. -->
+<!--
+Note:
+- `echo "{}" > .prettierrc` would result in `"{}"<SPACE>` on Windows.
+- `echo {}> .prettierrc` would result the file in UTF-16LE encoding in PowerShell.
+The below version works in cmd.exe, bash, zsh, fish, PowerShell.
+-->
 
 ```bash
-echo {}> .prettierrc.json
+node --eval "fs.writeFileSync('.prettierrc','{}\n')"
 ```
 
 Next, create a [.prettierignore](ignore.md) file to let the Prettier CLI and editors know which files to _not_ format. Here’s an example:


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Tested on `cmd`, `powershell`, work as expected.

```console
node --eval "fs.writeFileSync('.prettierrc','{}\n')" && node -p "JSON.stringify(fs.readFileSync('.prettierrc','utf8'))"
# "{}\n"
```

Fixes #13926
Fixes #11751
Closes #11692

Note to myself: copy to stable version after we decide what to use.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
