### PR TITLE
Add `node.source.end.offset` back

### DIFF
--- a/src/language-css/loc.js
+++ b/src/language-css/loc.js
@@ -26,6 +26,11 @@ function calculateLocEnd(node, text) {
     return skipEverythingButNewLine(text, node.source.startOffset);
   }
 
+  // `postcss>=8`
+  if (typeof node.source?.end?.offset === "number") {
+    return node.source.end.offset;
+  }
+
   if (node.source) {
     if (node.source.end) {
       return lineColumnToIndex(node.source.end, text);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Accidently removed it in #15345 when fixing the offset.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
