### PR TITLE
Do not split call of scss function with leading dash

### DIFF
--- a/changelog_unreleased/scss/15370.md
+++ b/changelog_unreleased/scss/15370.md
@@ -1,0 +1,19 @@
+#### Do not split call of scss function with leading dash (#15370 by @auvred)
+
+<!-- prettier-ignore -->
+```scss
+/* Input */
+div {
+  width: -double(-double(3));
+}
+
+/* Prettier stable */
+div {
+  width: -double(- double(3));
+}
+
+/* Prettier main */
+div {
+  width: -double(-double(3));
+}
+```

--- a/src/language-css/print/comma-separated-value-group.js
+++ b/src/language-css/print/comma-separated-value-group.js
@@ -270,7 +270,7 @@ function printCommaSeparatedValueGroup(path, options, print) {
       isMathOperator &&
       iNode.value === "-" &&
       iNextNode.type === "value-func" &&
-      locEnd(iNode) !== locStart(iNextNode)
+      (options.parser !== "scss" || locEnd(iNode) !== locStart(iNextNode))
     ) {
       parts.push(" ");
       continue;

--- a/src/language-css/print/comma-separated-value-group.js
+++ b/src/language-css/print/comma-separated-value-group.js
@@ -269,7 +269,8 @@ function printCommaSeparatedValueGroup(path, options, print) {
       options.parser === "scss" &&
       isMathOperator &&
       iNode.value === "-" &&
-      iNextNode.type === "value-func"
+      iNextNode.type === "value-func" &&
+      locEnd(iNode) !== locStart(iNextNode)
     ) {
       parts.push(" ");
       continue;

--- a/src/language-css/print/comma-separated-value-group.js
+++ b/src/language-css/print/comma-separated-value-group.js
@@ -270,7 +270,7 @@ function printCommaSeparatedValueGroup(path, options, print) {
       isMathOperator &&
       iNode.value === "-" &&
       iNextNode.type === "value-func" &&
-      (options.parser !== "scss" || locEnd(iNode) !== locStart(iNextNode))
+      locEnd(iNode) !== locStart(iNextNode)
     ) {
       parts.push(" ");
       continue;

--- a/tests/format/scss/scss/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/scss/scss/__snapshots__/jsfmt.spec.js.snap
@@ -1561,6 +1561,8 @@ div {
 
 div {
   margin: -double(-double(1em));
+  margin: -double(- double(1em));
+  margin: - double(-double(1em));
 }
 
 @function asdf() {
@@ -2654,6 +2656,8 @@ div {
 
 div {
   margin: -double(-double(1em));
+  margin: -double(- double(1em));
+  margin: - double(-double(1em));
 }
 
 @function asdf() {
@@ -3772,6 +3776,8 @@ div {
 
 div {
   margin: -double(-double(1em));
+  margin: -double(- double(1em));
+  margin: - double(-double(1em));
 }
 
 @function asdf() {
@@ -4865,6 +4871,8 @@ div {
 
 div {
   margin: -double(-double(1em));
+  margin: -double(- double(1em));
+  margin: - double(-double(1em));
 }
 
 @function asdf() {

--- a/tests/format/scss/scss/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/scss/scss/__snapshots__/jsfmt.spec.js.snap
@@ -1565,8 +1565,8 @@ div {
   margin: - double(-double(1em));
 }
 
-@function asdf() {
-  @return width: -double(1em);
+@function -double($value) {
+  @return $value * 2;
 }
 
 $foo: (
@@ -2658,8 +2658,8 @@ div {
   margin: - double(-double(1em));
 }
 
-@function asdf() {
-  @return width: -double(1em);
+@function -double($value) {
+  @return $value * 2;
 }
 
 $foo: (
@@ -3778,8 +3778,8 @@ div {
   margin: - double(-double(1em));
 }
 
-@function asdf() {
-  @return width: -double(1em);
+@function -double($value) {
+  @return $value * 2;
 }
 
 $foo: (
@@ -4871,8 +4871,8 @@ div {
   margin: - double(-double(1em));
 }
 
-@function asdf() {
-  @return width: -double(1em);
+@function -double($value) {
+  @return $value * 2;
 }
 
 $foo: (

--- a/tests/format/scss/scss/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/scss/scss/__snapshots__/jsfmt.spec.js.snap
@@ -1559,6 +1559,16 @@ div {
   margin: - pow(2, 2) * 100px;
 }
 
+div {
+  margin: -double(-double(1em));
+}
+
+@function asdf() {
+  @return (
+    width: -double(1em);
+  )
+}
+
 $foo: (
     'property1': (),
     // comment 1
@@ -2640,6 +2650,14 @@ label {
 // #5636
 div {
   margin: - pow(2, 2) * 100px;
+}
+
+div {
+  margin: -double(-double(1em));
+}
+
+@function asdf() {
+  @return (width: -double(1em) ;);
 }
 
 $foo: (
@@ -3752,6 +3770,16 @@ div {
   margin: - pow(2, 2) * 100px;
 }
 
+div {
+  margin: -double(-double(1em));
+}
+
+@function asdf() {
+  @return (
+    width: -double(1em);
+  )
+}
+
 $foo: (
     'property1': (),
     // comment 1
@@ -4833,6 +4861,14 @@ label {
 // #5636
 div {
   margin: - pow(2, 2) * 100px;
+}
+
+div {
+  margin: -double(-double(1em));
+}
+
+@function asdf() {
+  @return (width: -double(1em) ;);
 }
 
 $foo: (

--- a/tests/format/scss/scss/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/scss/scss/__snapshots__/jsfmt.spec.js.snap
@@ -1566,9 +1566,7 @@ div {
 }
 
 @function asdf() {
-  @return (
-    width: -double(1em);
-  )
+  @return width: -double(1em);
 }
 
 $foo: (
@@ -2661,7 +2659,7 @@ div {
 }
 
 @function asdf() {
-  @return (width: -double(1em) ;);
+  @return width: -double(1em);
 }
 
 $foo: (
@@ -3781,9 +3779,7 @@ div {
 }
 
 @function asdf() {
-  @return (
-    width: -double(1em);
-  )
+  @return width: -double(1em);
 }
 
 $foo: (
@@ -4876,7 +4872,7 @@ div {
 }
 
 @function asdf() {
-  @return (width: -double(1em) ;);
+  @return width: -double(1em);
 }
 
 $foo: (

--- a/tests/format/scss/scss/scss.scss
+++ b/tests/format/scss/scss/scss.scss
@@ -1096,8 +1096,8 @@ div {
   margin: - double(-double(1em));
 }
 
-@function asdf() {
-  @return width: -double(1em);
+@function -double($value) {
+  @return $value * 2;
 }
 
 $foo: (

--- a/tests/format/scss/scss/scss.scss
+++ b/tests/format/scss/scss/scss.scss
@@ -1090,6 +1090,16 @@ div {
   margin: - pow(2, 2) * 100px;
 }
 
+div {
+  margin: -double(-double(1em));
+}
+
+@function asdf() {
+  @return (
+    width: -double(1em);
+  )
+}
+
 $foo: (
     'property1': (),
     // comment 1

--- a/tests/format/scss/scss/scss.scss
+++ b/tests/format/scss/scss/scss.scss
@@ -1092,6 +1092,8 @@ div {
 
 div {
   margin: -double(-double(1em));
+  margin: -double(- double(1em));
+  margin: - double(-double(1em));
 }
 
 @function asdf() {

--- a/tests/format/scss/scss/scss.scss
+++ b/tests/format/scss/scss/scss.scss
@@ -1097,9 +1097,7 @@ div {
 }
 
 @function asdf() {
-  @return (
-    width: -double(1em);
-  )
+  @return width: -double(1em);
 }
 
 $foo: (


### PR DESCRIPTION
## Description

Fixes https://github.com/prettier/prettier/issues/15369

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
