### PR TITLE
Update docs for pre-commit with plugins

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -69,6 +69,8 @@ Copy the following config into your `.pre-commit-config.yaml` file:
 
 Read more at [mirror of prettier package for pre-commit](https://github.com/pre-commit/mirrors-prettier) and the [pre-commit](https://pre-commit.com) website.
 
+If you use Prettier 3.0 or later with plugins, you need to write the path to plugins in `.prettierrc.js`. See https://github.com/sosukesuzuki/prettier-precommit-with-plugins-example for details.
+
 ## Option 4. [Husky.Net](https://github.com/alirezanet/Husky.Net)
 
 **Use Case:** A dotnet solution to use Prettier along with other code quality tools (e.g. dotnet-format, ESLint, Stylelint, etc.). It supports multiple file states (staged - last-commit, git-files etc.)


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Closes https://github.com/prettier/prettier/issues/15388

Since 3.0, we need to write plugin paths to `.prettierrc.js` for pre-commit with plugins. So I think we should mention about it in docs.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
