### PR TITLE
Move editorconfig-to-prettier package into repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "diff": "5.1.0",
     "eastasianwidth": "0.2.0",
     "editorconfig": "0.15.3",
-    "editorconfig-to-prettier": "1.0.0",
     "emoji-regex": "10.2.1",
     "escape-string-regexp": "5.0.0",
     "espree": "9.6.1",

--- a/src/config/editorconfig-to-prettier.js
+++ b/src/config/editorconfig-to-prettier.js
@@ -1,0 +1,75 @@
+module.exports = editorConfigToPrettier;
+
+function removeUnset(editorConfig) {
+  const result = {};
+  const keys = Object.keys(editorConfig);
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    if (editorConfig[key] === "unset") {
+      continue;
+    }
+    result[key] = editorConfig[key];
+  }
+  return result;
+}
+
+function editorConfigToPrettier(editorConfig) {
+  if (!editorConfig) {
+    return null;
+  }
+
+  editorConfig = removeUnset(editorConfig);
+
+  if (Object.keys(editorConfig).length === 0) {
+    return null;
+  }
+
+  const result = {};
+
+  if (editorConfig.indent_style) {
+    result.useTabs = editorConfig.indent_style === "tab";
+  }
+
+  if (editorConfig.indent_size === "tab") {
+    result.useTabs = true;
+  }
+
+  if (result.useTabs && editorConfig.tab_width) {
+    result.tabWidth = editorConfig.tab_width;
+  } else if (
+    editorConfig.indent_style === "space" &&
+    editorConfig.indent_size &&
+    editorConfig.indent_size !== "tab"
+  ) {
+    result.tabWidth = editorConfig.indent_size;
+  } else if (editorConfig.tab_width !== undefined) {
+    result.tabWidth = editorConfig.tab_width;
+  }
+
+  if (editorConfig.max_line_length) {
+    if (editorConfig.max_line_length === "off") {
+      result.printWidth = Number.POSITIVE_INFINITY;
+    } else {
+      result.printWidth = editorConfig.max_line_length;
+    }
+  }
+
+  if (editorConfig.quote_type === "single") {
+    result.singleQuote = true;
+  } else if (editorConfig.quote_type === "double") {
+    result.singleQuote = false;
+  }
+
+  if (["cr", "crlf", "lf"].indexOf(editorConfig.end_of_line) !== -1) {
+    result.endOfLine = editorConfig.end_of_line;
+  }
+
+  if (
+    editorConfig.insert_final_newline === false ||
+    editorConfig.insert_final_newline === true
+  ) {
+    result.insertFinalNewline = editorConfig.insert_final_newline;
+  }
+
+  return result;
+}

--- a/src/config/editorconfig-to-prettier.js
+++ b/src/config/editorconfig-to-prettier.js
@@ -1,5 +1,3 @@
-module.exports = editorConfigToPrettier;
-
 function removeUnset(editorConfig) {
   const result = {};
   const keys = Object.keys(editorConfig);
@@ -73,3 +71,5 @@ function editorConfigToPrettier(editorConfig) {
 
   return result;
 }
+
+export default editorConfigToPrettier;

--- a/src/config/editorconfig-to-prettier.js
+++ b/src/config/editorconfig-to-prettier.js
@@ -58,7 +58,7 @@ function editorConfigToPrettier(editorConfig) {
     result.singleQuote = false;
   }
 
-  if (["cr", "crlf", "lf"].indexOf(editorConfig.end_of_line) !== -1) {
+  if (["cr", "crlf", "lf"].includes(editorConfig.end_of_line)) {
     result.endOfLine = editorConfig.end_of_line;
   }
 

--- a/src/config/resolve-editorconfig.js
+++ b/src/config/resolve-editorconfig.js
@@ -1,6 +1,6 @@
 import path from "node:path";
 import editorconfig from "editorconfig";
-import editorConfigToPrettier from "editorconfig-to-prettier";
+import editorConfigToPrettier from "./editorconfig-to-prettier.js";
 import findProjectRoot from "./find-project-root.js";
 
 async function loadEditorConfig(filePath) {

--- a/src/config/resolve-editorconfig.js
+++ b/src/config/resolve-editorconfig.js
@@ -1,6 +1,6 @@
 import path from "node:path";
 import editorconfig from "editorconfig";
-const editorConfigToPrettier = require("./editorconfig-to-prettier.js");
+import editorConfigToPrettier from "./editorconfig-to-prettier.js";
 import findProjectRoot from "./find-project-root.js";
 
 async function loadEditorConfig(filePath) {

--- a/src/config/resolve-editorconfig.js
+++ b/src/config/resolve-editorconfig.js
@@ -1,6 +1,6 @@
 import path from "node:path";
 import editorconfig from "editorconfig";
-import editorConfigToPrettier from "./editorconfig-to-prettier.js";
+const editorConfigToPrettier = require("./editorconfig-to-prettier.js");
 import findProjectRoot from "./find-project-root.js";
 
 async function loadEditorConfig(filePath) {

--- a/tests/unit/editorconfig-to-prettier.js
+++ b/tests/unit/editorconfig-to-prettier.js
@@ -1,0 +1,160 @@
+import assert from "node:assert/strict";
+import editorconfigToPrettier from "./index.js";
+
+assert.deepEqual(
+  editorconfigToPrettier({
+    indent_style: "tab",
+    tab_width: 8,
+    indent_size: 2,
+    max_line_length: 100,
+  }),
+  {
+    useTabs: true,
+    tabWidth: 8,
+    printWidth: 100,
+  },
+);
+
+assert.deepEqual(
+  editorconfigToPrettier({
+    indent_style: "space",
+    tab_width: 8,
+    indent_size: 2,
+    max_line_length: 100,
+  }),
+  {
+    useTabs: false,
+    tabWidth: 2,
+    printWidth: 100,
+  },
+);
+
+assert.deepEqual(
+  editorconfigToPrettier({
+    indent_style: "space",
+    tab_width: 8,
+    indent_size: 8,
+    max_line_length: 100,
+  }),
+  {
+    useTabs: false,
+    tabWidth: 8,
+    printWidth: 100,
+  },
+);
+
+assert.deepEqual(
+  editorconfigToPrettier({
+    tab_width: 4,
+    indent_size: "tab",
+  }),
+  {
+    tabWidth: 4,
+    useTabs: true,
+  },
+);
+
+assert.deepEqual(
+  editorconfigToPrettier({
+    indent_size: "tab",
+  }),
+  {
+    useTabs: true,
+  },
+);
+
+assert.deepEqual(
+  editorconfigToPrettier({
+    tab_width: 0,
+    indent_size: 0,
+  }),
+  {
+    tabWidth: 0,
+  },
+);
+
+assert.deepEqual(
+  editorconfigToPrettier({
+    quote_type: "single",
+  }),
+  {
+    singleQuote: true,
+  },
+);
+
+assert.deepEqual(
+  editorconfigToPrettier({
+    quote_type: "double",
+  }),
+  {
+    singleQuote: false,
+  },
+);
+
+assert.deepEqual(
+  editorconfigToPrettier({
+    quote_type: "double",
+    max_line_length: "off",
+  }),
+  {
+    printWidth: Number.POSITIVE_INFINITY,
+    singleQuote: false,
+  },
+);
+
+assert.deepEqual(
+  editorconfigToPrettier({
+    end_of_line: "cr",
+  }),
+  {
+    endOfLine: "cr",
+  },
+);
+
+assert.deepEqual(
+  editorconfigToPrettier({
+    end_of_line: "crlf",
+  }),
+  {
+    endOfLine: "crlf",
+  },
+);
+
+assert.deepEqual(
+  editorconfigToPrettier({
+    end_of_line: "lf",
+  }),
+  {
+    endOfLine: "lf",
+  },
+);
+
+assert.deepEqual(
+  editorconfigToPrettier({
+    endOfLine: 123,
+  }),
+  {},
+);
+
+assert.deepEqual(
+  editorconfigToPrettier({
+    indent_style: "space",
+    indent_size: 2,
+    max_line_length: "unset",
+  }),
+  {
+    useTabs: false,
+    tabWidth: 2,
+  },
+);
+
+assert.deepEqual(editorconfigToPrettier({ insert_final_newline: false }), {
+  insertFinalNewline: false,
+});
+
+assert.deepEqual(editorconfigToPrettier({ insert_final_newline: true }), {
+  insertFinalNewline: true,
+});
+
+assert.deepEqual(editorconfigToPrettier({}), null);
+assert.deepEqual(editorconfigToPrettier(null), null);

--- a/tests/unit/editorconfig-to-prettier.js
+++ b/tests/unit/editorconfig-to-prettier.js
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import editorconfigToPrettier from "./index.js";
+import editorconfigToPrettier from "../../src/config/editorconfig-to-prettier.js";
 
 assert.deepEqual(
   editorconfigToPrettier({

--- a/tests/unit/editorconfig-to-prettier.js
+++ b/tests/unit/editorconfig-to-prettier.js
@@ -29,7 +29,7 @@ test('editorconfigToPrettier', () => {
 
   expect(
     editorconfigToPrettier({
-      // indent_style: "space",
+      indent_style: "space",
       tab_width: 8,
       indent_size: 8,
       max_line_length: 100,

--- a/tests/unit/editorconfig-to-prettier.js
+++ b/tests/unit/editorconfig-to-prettier.js
@@ -29,7 +29,7 @@ test('editorconfigToPrettier', () => {
 
   expect(
     editorconfigToPrettier({
-      indent_style: "space",
+      // indent_style: "space",
       tab_width: 8,
       indent_size: 8,
       max_line_length: 100,

--- a/tests/unit/editorconfig-to-prettier.js
+++ b/tests/unit/editorconfig-to-prettier.js
@@ -1,145 +1,147 @@
 import editorconfigToPrettier from "../../src/config/editorconfig-to-prettier.js";
 
-expect(
-  editorconfigToPrettier({
-    indent_style: "tab",
-    tab_width: 8,
-    indent_size: 2,
-    max_line_length: 100,
-  }),
-).toStrictEqual({
-  useTabs: true,
-  tabWidth: 8,
-  printWidth: 100,
+test('editorconfigToPrettier', () => {
+  expect(
+    editorconfigToPrettier({
+      indent_style: "tab",
+      tab_width: 8,
+      indent_size: 2,
+      max_line_length: 100,
+    }),
+  ).toStrictEqual({
+    useTabs: true,
+    tabWidth: 8,
+    printWidth: 100,
+  });
+
+  expect(
+    editorconfigToPrettier({
+      indent_style: "space",
+      tab_width: 8,
+      indent_size: 2,
+      max_line_length: 100,
+    }),
+  ).toStrictEqual({
+    useTabs: false,
+    tabWidth: 2,
+    printWidth: 100,
+  });
+
+  expect(
+    editorconfigToPrettier({
+      indent_style: "space",
+      tab_width: 8,
+      indent_size: 8,
+      max_line_length: 100,
+    }),
+  ).toStrictEqual({
+    useTabs: false,
+    tabWidth: 8,
+    printWidth: 100,
+  });
+
+  expect(
+    editorconfigToPrettier({
+      tab_width: 4,
+      indent_size: "tab",
+    }),
+  ).toStrictEqual({
+    tabWidth: 4,
+    useTabs: true,
+  });
+
+  expect(
+    editorconfigToPrettier({
+      indent_size: "tab",
+    }),
+  ).toStrictEqual({
+    useTabs: true,
+  });
+
+  expect(
+    editorconfigToPrettier({
+      tab_width: 0,
+      indent_size: 0,
+    }),
+  ).toStrictEqual({
+    tabWidth: 0,
+  });
+
+  expect(
+    editorconfigToPrettier({
+      quote_type: "single",
+    }),
+  ).toStrictEqual({
+    singleQuote: true,
+  });
+
+  expect(
+    editorconfigToPrettier({
+      quote_type: "double",
+    }),
+  ).toStrictEqual({
+    singleQuote: false,
+  });
+
+  expect(
+    editorconfigToPrettier({
+      quote_type: "double",
+      max_line_length: "off",
+    }),
+  ).toStrictEqual({
+    printWidth: Number.POSITIVE_INFINITY,
+    singleQuote: false,
+  });
+
+  expect(
+    editorconfigToPrettier({
+      end_of_line: "cr",
+    }),
+  ).toStrictEqual({
+    endOfLine: "cr",
+  });
+
+  expect(
+    editorconfigToPrettier({
+      end_of_line: "crlf",
+    }),
+  ).toStrictEqual({
+    endOfLine: "crlf",
+  });
+
+  expect(
+    editorconfigToPrettier({
+      end_of_line: "lf",
+    }),
+  ).toStrictEqual({
+    endOfLine: "lf",
+  });
+
+  expect(
+    editorconfigToPrettier({
+      endOfLine: 123,
+    }),
+  ).toStrictEqual({});
+
+  expect(
+    editorconfigToPrettier({
+      indent_style: "space",
+      indent_size: 2,
+      max_line_length: "unset",
+    }),
+  ).toStrictEqual({
+    useTabs: false,
+    tabWidth: 2,
+  });
+
+  expect(editorconfigToPrettier({ insert_final_newline: false })).toStrictEqual({
+    insertFinalNewline: false,
+  });
+
+  expect(editorconfigToPrettier({ insert_final_newline: true })).toStrictEqual({
+    insertFinalNewline: true,
+  });
+
+  expect(editorconfigToPrettier({})).toBeNull();
+  expect(editorconfigToPrettier(null)).toBeNull();
 });
-
-expect(
-  editorconfigToPrettier({
-    indent_style: "space",
-    tab_width: 8,
-    indent_size: 2,
-    max_line_length: 100,
-  }),
-).toStrictEqual({
-  useTabs: false,
-  tabWidth: 2,
-  printWidth: 100,
-});
-
-expect(
-  editorconfigToPrettier({
-    indent_style: "space",
-    tab_width: 8,
-    indent_size: 8,
-    max_line_length: 100,
-  }),
-).toStrictEqual({
-  useTabs: false,
-  tabWidth: 8,
-  printWidth: 100,
-});
-
-expect(
-  editorconfigToPrettier({
-    tab_width: 4,
-    indent_size: "tab",
-  }),
-).toStrictEqual({
-  tabWidth: 4,
-  useTabs: true,
-});
-
-expect(
-  editorconfigToPrettier({
-    indent_size: "tab",
-  }),
-).toStrictEqual({
-  useTabs: true,
-});
-
-expect(
-  editorconfigToPrettier({
-    tab_width: 0,
-    indent_size: 0,
-  }),
-).toStrictEqual({
-  tabWidth: 0,
-});
-
-expect(
-  editorconfigToPrettier({
-    quote_type: "single",
-  }),
-).toStrictEqual({
-  singleQuote: true,
-});
-
-expect(
-  editorconfigToPrettier({
-    quote_type: "double",
-  }),
-).toStrictEqual({
-  singleQuote: false,
-});
-
-expect(
-  editorconfigToPrettier({
-    quote_type: "double",
-    max_line_length: "off",
-  }),
-).toStrictEqual({
-  printWidth: Number.POSITIVE_INFINITY,
-  singleQuote: false,
-});
-
-expect(
-  editorconfigToPrettier({
-    end_of_line: "cr",
-  }),
-).toStrictEqual({
-  endOfLine: "cr",
-});
-
-expect(
-  editorconfigToPrettier({
-    end_of_line: "crlf",
-  }),
-).toStrictEqual({
-  endOfLine: "crlf",
-});
-
-expect(
-  editorconfigToPrettier({
-    end_of_line: "lf",
-  }),
-).toStrictEqual({
-  endOfLine: "lf",
-});
-
-expect(
-  editorconfigToPrettier({
-    endOfLine: 123,
-  }),
-).toStrictEqual({});
-
-expect(
-  editorconfigToPrettier({
-    indent_style: "space",
-    indent_size: 2,
-    max_line_length: "unset",
-  }),
-).toStrictEqual({
-  useTabs: false,
-  tabWidth: 2,
-});
-
-expect(editorconfigToPrettier({ insert_final_newline: false })).toStrictEqual({
-  insertFinalNewline: false,
-});
-
-expect(editorconfigToPrettier({ insert_final_newline: true })).toStrictEqual({
-  insertFinalNewline: true,
-});
-
-expect(editorconfigToPrettier({})).toBeNull();
-expect(editorconfigToPrettier(null)).toBeNull();

--- a/tests/unit/editorconfig-to-prettier.js
+++ b/tests/unit/editorconfig-to-prettier.js
@@ -1,160 +1,145 @@
-import assert from "node:assert/strict";
 import editorconfigToPrettier from "../../src/config/editorconfig-to-prettier.js";
 
-assert.deepEqual(
+expect(
   editorconfigToPrettier({
     indent_style: "tab",
     tab_width: 8,
     indent_size: 2,
     max_line_length: 100,
   }),
-  {
-    useTabs: true,
-    tabWidth: 8,
-    printWidth: 100,
-  },
-);
+).toStrictEqual({
+  useTabs: true,
+  tabWidth: 8,
+  printWidth: 100,
+});
 
-assert.deepEqual(
+expect(
   editorconfigToPrettier({
     indent_style: "space",
     tab_width: 8,
     indent_size: 2,
     max_line_length: 100,
   }),
-  {
-    useTabs: false,
-    tabWidth: 2,
-    printWidth: 100,
-  },
-);
+).toStrictEqual({
+  useTabs: false,
+  tabWidth: 2,
+  printWidth: 100,
+});
 
-assert.deepEqual(
+expect(
   editorconfigToPrettier({
     indent_style: "space",
     tab_width: 8,
     indent_size: 8,
     max_line_length: 100,
   }),
-  {
-    useTabs: false,
-    tabWidth: 8,
-    printWidth: 100,
-  },
-);
+).toStrictEqual({
+  useTabs: false,
+  tabWidth: 8,
+  printWidth: 100,
+});
 
-assert.deepEqual(
+expect(
   editorconfigToPrettier({
     tab_width: 4,
     indent_size: "tab",
   }),
-  {
-    tabWidth: 4,
-    useTabs: true,
-  },
-);
+).toStrictEqual({
+  tabWidth: 4,
+  useTabs: true,
+});
 
-assert.deepEqual(
+expect(
   editorconfigToPrettier({
     indent_size: "tab",
   }),
-  {
-    useTabs: true,
-  },
-);
+).toStrictEqual({
+  useTabs: true,
+});
 
-assert.deepEqual(
+expect(
   editorconfigToPrettier({
     tab_width: 0,
     indent_size: 0,
   }),
-  {
-    tabWidth: 0,
-  },
-);
+).toStrictEqual({
+  tabWidth: 0,
+});
 
-assert.deepEqual(
+expect(
   editorconfigToPrettier({
     quote_type: "single",
   }),
-  {
-    singleQuote: true,
-  },
-);
+).toStrictEqual({
+  singleQuote: true,
+});
 
-assert.deepEqual(
+expect(
   editorconfigToPrettier({
     quote_type: "double",
   }),
-  {
-    singleQuote: false,
-  },
-);
+).toStrictEqual({
+  singleQuote: false,
+});
 
-assert.deepEqual(
+expect(
   editorconfigToPrettier({
     quote_type: "double",
     max_line_length: "off",
   }),
-  {
-    printWidth: Number.POSITIVE_INFINITY,
-    singleQuote: false,
-  },
-);
+).toStrictEqual({
+  printWidth: Number.POSITIVE_INFINITY,
+  singleQuote: false,
+});
 
-assert.deepEqual(
+expect(
   editorconfigToPrettier({
     end_of_line: "cr",
   }),
-  {
-    endOfLine: "cr",
-  },
-);
+).toStrictEqual({
+  endOfLine: "cr",
+});
 
-assert.deepEqual(
+expect(
   editorconfigToPrettier({
     end_of_line: "crlf",
   }),
-  {
-    endOfLine: "crlf",
-  },
-);
+).toStrictEqual({
+  endOfLine: "crlf",
+});
 
-assert.deepEqual(
+expect(
   editorconfigToPrettier({
     end_of_line: "lf",
   }),
-  {
-    endOfLine: "lf",
-  },
-);
+).toStrictEqual({
+  endOfLine: "lf",
+});
 
-assert.deepEqual(
+expect(
   editorconfigToPrettier({
     endOfLine: 123,
   }),
-  {},
-);
+).toStrictEqual({});
 
-assert.deepEqual(
+expect(
   editorconfigToPrettier({
     indent_style: "space",
     indent_size: 2,
     max_line_length: "unset",
   }),
-  {
-    useTabs: false,
-    tabWidth: 2,
-  },
-);
+).toStrictEqual({
+  useTabs: false,
+  tabWidth: 2,
+});
 
-assert.deepEqual(editorconfigToPrettier({ insert_final_newline: false }), {
+expect(editorconfigToPrettier({ insert_final_newline: false })).toStrictEqual({
   insertFinalNewline: false,
 });
 
-assert.deepEqual(editorconfigToPrettier({ insert_final_newline: true }), {
+expect(editorconfigToPrettier({ insert_final_newline: true })).toStrictEqual({
   insertFinalNewline: true,
 });
 
-assert.deepEqual(editorconfigToPrettier({}), null);
-assert.deepEqual(editorconfigToPrettier(null), null);
+expect(editorconfigToPrettier({})).toBeNull();
+expect(editorconfigToPrettier(null)).toBeNull();

--- a/tests/unit/editorconfig-to-prettier.js
+++ b/tests/unit/editorconfig-to-prettier.js
@@ -1,6 +1,6 @@
 import editorconfigToPrettier from "../../src/config/editorconfig-to-prettier.js";
 
-test('editorconfigToPrettier', () => {
+test("editorconfigToPrettier", () => {
   expect(
     editorconfigToPrettier({
       indent_style: "tab",
@@ -134,9 +134,11 @@ test('editorconfigToPrettier', () => {
     tabWidth: 2,
   });
 
-  expect(editorconfigToPrettier({ insert_final_newline: false })).toStrictEqual({
-    insertFinalNewline: false,
-  });
+  expect(editorconfigToPrettier({ insert_final_newline: false })).toStrictEqual(
+    {
+      insertFinalNewline: false,
+    },
+  );
 
   expect(editorconfigToPrettier({ insert_final_newline: true })).toStrictEqual({
     insertFinalNewline: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3244,13 +3244,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"editorconfig-to-prettier@npm:1.0.0":
-  version: 1.0.0
-  resolution: "editorconfig-to-prettier@npm:1.0.0"
-  checksum: 8054f8593c2f93abca9f3c6db91030fbd80a15fd36b076a5f3fbeb246267173e290817adfb3389d9066026bcc85822e72b7635596e9dda6e74927ae110cbc474
-  languageName: node
-  linkType: hard
-
 "editorconfig@npm:0.15.3":
   version: 0.15.3
   resolution: "editorconfig@npm:0.15.3"
@@ -7176,7 +7169,6 @@ __metadata:
     diff: 5.1.0
     eastasianwidth: 0.2.0
     editorconfig: 0.15.3
-    editorconfig-to-prettier: 1.0.0
     emoji-regex: 10.2.1
     enquirer: 2.4.1
     esbuild: 0.19.2


### PR DESCRIPTION
I'd like to vendor/upstream this code because it's been the topic of a handful of issues in its repo over the years, including https://github.com/josephfrazier/editorconfig-to-prettier/issues/9, https://github.com/josephfrazier/editorconfig-to-prettier/issues/21, and most recently https://github.com/josephfrazier/editorconfig-to-prettier/issues/24, and I feel that having it in-repo would be more appropriate (not to mention [the issues in _this_ repo that pertain to editorconfig parsing](https://github.com/search?q=repo%3Aprettier%2Fprettier+editorconfig++&type=issues&state=open)). I've elaborated on my thoughts in https://github.com/josephfrazier/editorconfig-to-prettier/issues/24#issuecomment-1718405985, which I'll quote below:

> hey @Drakmyth, thanks for continuing this conversation! I appreciate all the links you've provided that indicate existing intention and implementations of parsing non-standard/custom properties. It seems like this question might not be as simple as I thought it was previously.
> 
> @fisker, thanks for chiming in as well!
> 
> As you (@fisker) mentioned in [#16 (comment)](https://github.com/josephfrazier/editorconfig-to-prettier/pull/16#issuecomment-1486130040), this package was originally intended for use by Prettier, and while there are some other dependents (according to [github](https://github.com/josephfrazier/editorconfig-to-prettier/network/dependents?dependent_type=PACKAGE) and [npm](https://www.npmjs.com/package/editorconfig-to-prettier?activeTab=dependents)), Prettier is still the vast majority of the usage this package sees.
> 
> Given that, I think it might make sense for this package's code/functionality to move into the Prettier repository, so that any issues relating to it can be discussed where it's used. Personally, I don't use `.editorconfig` with Prettier, so I don't feel especially well-positioned to make decisions on how things should work, especially when [the output of this package is subsequently modified by Prettier](https://github.com/prettier/prettier/blob/7c512651f8814924a042034ff821190c68ef409d/src/config/resolve-editorconfig.js#L13-L16) (I think you had also [mentioned](https://github.com/prettier/prettier/issues/14514#issuecomment-1471056464) this previously, @fisker), indicating that its behavior is already divergent from the intended use case.
> 
> What do y'all think of that proposal? If we have https://github.com/prettier/prettier/ vendor this repository's code, then I can archive this repo and direct people to discuss functionality in the Prettier issues.

This also implements @fisker's suggested change to ES module syntax from https://github.com/josephfrazier/editorconfig-to-prettier/pull/16/, as it's required for lint/test etc to pass.

Once this is merged, I'll likely archive the https://github.com/josephfrazier/editorconfig-to-prettier/ repo after adding a note directing any visitors here instead.