### PR TITLE
cleanup EditorConfig handling: Remove unused parsing/ignoring of `insert_final_newline` to `insertFinalNewline`

### DIFF
--- a/src/config/editorconfig-to-prettier.js
+++ b/src/config/editorconfig-to-prettier.js
@@ -62,13 +62,6 @@ function editorConfigToPrettier(editorConfig) {
     result.endOfLine = editorConfig.end_of_line;
   }
 
-  if (
-    editorConfig.insert_final_newline === false ||
-    editorConfig.insert_final_newline === true
-  ) {
-    result.insertFinalNewline = editorConfig.insert_final_newline;
-  }
-
   return result;
 }
 

--- a/src/config/resolve-editorconfig.js
+++ b/src/config/resolve-editorconfig.js
@@ -10,11 +10,6 @@ async function loadEditorConfig(filePath) {
 
   const config = editorConfigToPrettier(editorConfig);
 
-  if (config) {
-    // We are not using this option
-    delete config.insertFinalNewline;
-  }
-
   return config;
 }
 

--- a/tests/unit/editorconfig-to-prettier.js
+++ b/tests/unit/editorconfig-to-prettier.js
@@ -134,16 +134,6 @@ test("editorconfigToPrettier", () => {
     tabWidth: 2,
   });
 
-  expect(editorconfigToPrettier({ insert_final_newline: false })).toStrictEqual(
-    {
-      insertFinalNewline: false,
-    },
-  );
-
-  expect(editorconfigToPrettier({ insert_final_newline: true })).toStrictEqual({
-    insertFinalNewline: true,
-  });
-
   expect(editorconfigToPrettier({})).toBeNull();
   expect(editorconfigToPrettier(null)).toBeNull();
 });


### PR DESCRIPTION
Now that https://github.com/prettier/prettier/pull/15394 has been
merged, this addresses https://github.com/prettier/prettier/issues/14514#issuecomment-1471056464

_EDIT: Note that this is just a code cleanup, and does not change the behavior of Prettier_