### PR TITLE
Support embedded formatting in template literals annotated with `as const`

### DIFF
--- a/changelog_unreleased/typescript/15408.md
+++ b/changelog_unreleased/typescript/15408.md
@@ -1,0 +1,21 @@
+#### Support embedded formatting in template literals annotated with `as const` (#15408 by @sosukesuzuki)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+const GQL_QUERY_WITH_CONST = /* GraphQL */ `
+  query S { shop }
+` as const;
+
+// Prettier stable
+const GQL_QUERY_WITH_CONST = /* GraphQL */ `
+  query S { shop }
+` as const;
+
+// Prettier main
+const GQL_QUERY_WITH_CONST = /* GraphQL */ `
+  query S {
+    shop
+  }
+` as const;
+```

--- a/src/language-js/embed/graphql.js
+++ b/src/language-js/embed/graphql.js
@@ -3,7 +3,7 @@ import {
   escapeTemplateCharacters,
   printTemplateExpressions,
 } from "../print/template-literal.js";
-import { hasLanguageComment, isAsConstExpression } from "./utils.js";
+import { hasLanguageComment } from "./utils.js";
 
 async function printEmbedGraphQL(textToDoc, print, path /*, options*/) {
   const { node } = path;
@@ -107,10 +107,7 @@ function printGraphqlComments(lines) {
  */
 function isGraphQL({ node, parent }) {
   return (
-    hasLanguageComment(node, "GraphQL") ||
-    (parent &&
-      isAsConstExpression(parent) &&
-      hasLanguageComment(parent, "GraphQL")) ||
+    hasLanguageComment({ node, parent }, "GraphQL") ||
     (parent &&
       ((parent.type === "TaggedTemplateExpression" &&
         ((parent.tag.type === "MemberExpression" &&

--- a/src/language-js/embed/graphql.js
+++ b/src/language-js/embed/graphql.js
@@ -3,7 +3,7 @@ import {
   escapeTemplateCharacters,
   printTemplateExpressions,
 } from "../print/template-literal.js";
-import { hasLanguageComment } from "./utils.js";
+import { hasLanguageComment, isAsConstExpression } from "./utils.js";
 
 async function printEmbedGraphQL(textToDoc, print, path /*, options*/) {
   const { node } = path;
@@ -108,6 +108,9 @@ function printGraphqlComments(lines) {
 function isGraphQL({ node, parent }) {
   return (
     hasLanguageComment(node, "GraphQL") ||
+    (parent &&
+      isAsConstExpression(parent) &&
+      hasLanguageComment(parent, "GraphQL")) ||
     (parent &&
       ((parent.type === "TaggedTemplateExpression" &&
         ((parent.tag.type === "MemberExpression" &&

--- a/src/language-js/embed/html.js
+++ b/src/language-js/embed/html.js
@@ -10,7 +10,11 @@ import {
   printTemplateExpressions,
   uncookTemplateElementValue,
 } from "../print/template-literal.js";
-import { isAngularComponentTemplate, hasLanguageComment } from "./utils.js";
+import {
+  isAngularComponentTemplate,
+  hasLanguageComment,
+  isAsConstExpression,
+} from "./utils.js";
 
 // The counter is needed to distinguish nested embeds.
 let htmlTemplateLiteralCounter = 0;
@@ -103,6 +107,9 @@ async function printEmbedHtmlLike(parser, textToDoc, print, path, options) {
 function isHtml(path) {
   return (
     hasLanguageComment(path.node, "HTML") ||
+    (path.parent &&
+      isAsConstExpression(path.parent) &&
+      hasLanguageComment(path.parent, "HTML")) ||
     path.match(
       (node) => node.type === "TemplateLiteral",
       (node, name) =>

--- a/src/language-js/embed/html.js
+++ b/src/language-js/embed/html.js
@@ -10,11 +10,7 @@ import {
   printTemplateExpressions,
   uncookTemplateElementValue,
 } from "../print/template-literal.js";
-import {
-  isAngularComponentTemplate,
-  hasLanguageComment,
-  isAsConstExpression,
-} from "./utils.js";
+import { isAngularComponentTemplate, hasLanguageComment } from "./utils.js";
 
 // The counter is needed to distinguish nested embeds.
 let htmlTemplateLiteralCounter = 0;
@@ -106,10 +102,7 @@ async function printEmbedHtmlLike(parser, textToDoc, print, path, options) {
  */
 function isHtml(path) {
   return (
-    hasLanguageComment(path.node, "HTML") ||
-    (path.parent &&
-      isAsConstExpression(path.parent) &&
-      hasLanguageComment(path.parent, "HTML")) ||
+    hasLanguageComment(path, "HTML") ||
     path.match(
       (node) => node.type === "TemplateLiteral",
       (node, name) =>

--- a/src/language-js/embed/utils.js
+++ b/src/language-js/embed/utils.js
@@ -68,10 +68,11 @@ function hasLanguageComment(node, languageName) {
 
 function isAsConstExpression(node) {
   return (
-    node.type === "TSAsExpression" &&
-    node.typeAnnotation.type === "TSTypeReference" &&
-    node.typeAnnotation.typeName.type === "Identifier" &&
-    node.typeAnnotation.typeName.name === "const"
+    node.type === "AsConstExpression" ||
+    (node.type === "TSAsExpression" &&
+      node.typeAnnotation.type === "TSTypeReference" &&
+      node.typeAnnotation.typeName.type === "Identifier" &&
+      node.typeAnnotation.typeName.name === "const")
   );
 }
 

--- a/src/language-js/embed/utils.js
+++ b/src/language-js/embed/utils.js
@@ -66,8 +66,18 @@ function hasLanguageComment(node, languageName) {
   );
 }
 
+function isAsConstExpression(node) {
+  return (
+    node.type === "TSAsExpression" &&
+    node.typeAnnotation.type === "TSTypeReference" &&
+    node.typeAnnotation.typeName.type === "Identifier" &&
+    node.typeAnnotation.typeName.name === "const"
+  );
+}
+
 export {
   isAngularComponentStyles,
   isAngularComponentTemplate,
   hasLanguageComment,
+  isAsConstExpression,
 };

--- a/src/language-js/embed/utils.js
+++ b/src/language-js/embed/utils.js
@@ -53,7 +53,7 @@ function isAngularComponentTemplate(path) {
   );
 }
 
-function hasLanguageComment(node, languageName) {
+function hasLeadingBlockCommentWithName(node, languageName) {
   // This checks for a leading comment that is exactly `/* GraphQL */`
   // In order to be in line with other implementations of this comment tag
   // we will not trim the comment value and we will expect exactly one space on
@@ -63,6 +63,13 @@ function hasLanguageComment(node, languageName) {
     node,
     CommentCheckFlags.Block | CommentCheckFlags.Leading,
     ({ value }) => value === ` ${languageName} `,
+  );
+}
+function hasLanguageComment({ node, parent }, languageName) {
+  return (
+    hasLeadingBlockCommentWithName(node, languageName) ||
+    (isAsConstExpression(parent) &&
+      hasLeadingBlockCommentWithName(parent, languageName))
   );
 }
 

--- a/tests/format/flow/as-const/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/as-const/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`embedded.js [babel-flow] format 1`] = `
+"Unexpected token (3:11)
+  1 | const GQL_QUERY_WITH_CONST = /* GraphQL */ \`
+  2 |   query S { shop }
+> 3 | \` as const;
+    |           ^
+  4 |
+  5 | const HTML_WITH_CONST = /* HTML */ \`
+  6 | <div>"
+`;
+
+exports[`embedded.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const GQL_QUERY_WITH_CONST = /* GraphQL */ \`
+  query S { shop }
+\` as const;
+
+const HTML_WITH_CONST = /* HTML */ \`
+<div>
+<h1>foo</h1>
+  <p>foo</p>
+</div>
+\` as const;
+
+=====================================output=====================================
+const GQL_QUERY_WITH_CONST = /* GraphQL */ \`
+  query S {
+    shop
+  }
+\` as const;
+
+const HTML_WITH_CONST = /* HTML */ \`
+  <div>
+    <h1>foo</h1>
+    <p>foo</p>
+  </div>
+\` as const;
+
+================================================================================
+`;

--- a/tests/format/flow/as-const/embedded.js
+++ b/tests/format/flow/as-const/embedded.js
@@ -1,0 +1,10 @@
+const GQL_QUERY_WITH_CONST = /* GraphQL */ `
+  query S { shop }
+` as const;
+
+const HTML_WITH_CONST = /* HTML */ `
+<div>
+<h1>foo</h1>
+  <p>foo</p>
+</div>
+` as const;

--- a/tests/format/flow/as-const/jsfmt.spec.js
+++ b/tests/format/flow/as-const/jsfmt.spec.js
@@ -1,0 +1,5 @@
+run_spec(import.meta, ["flow"], {
+  errors: {
+    "babel-flow": ["embedded.js"],
+  },
+});

--- a/tests/format/typescript/as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/as/__snapshots__/jsfmt.spec.js.snap
@@ -133,6 +133,40 @@ const iter2 = createIterator(
 ================================================================================
 `;
 
+exports[`as-const-embedded.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const GQL_QUERY_WITH_CONST = /* GraphQL */ \`
+  query S { shop }
+\` as const;
+
+const HTML_WITH_CONST = /* HTML */ \`
+<div>
+<h1>foo</h1>
+  <p>foo</p>
+</div>
+\` as const;
+
+=====================================output=====================================
+const GQL_QUERY_WITH_CONST = /* GraphQL */ \`
+  query S {
+    shop
+  }
+\` as const;
+
+const HTML_WITH_CONST = /* HTML */ \`
+  <div>
+    <h1>foo</h1>
+    <p>foo</p>
+  </div>
+\` as const;
+
+================================================================================
+`;
+
 exports[`assignment.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/as/as-const-embedded.ts
+++ b/tests/format/typescript/as/as-const-embedded.ts
@@ -1,0 +1,10 @@
+const GQL_QUERY_WITH_CONST = /* GraphQL */ `
+  query S { shop }
+` as const;
+
+const HTML_WITH_CONST = /* HTML */ `
+<div>
+<h1>foo</h1>
+  <p>foo</p>
+</div>
+` as const;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #15315

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
