### PR TITLE
Fix printing comment for the last operand of union types

### DIFF
--- a/changelog_unreleased/typescript/15409.md
+++ b/changelog_unreleased/typescript/15409.md
@@ -1,0 +1,36 @@
+#### Fix printing comment for the last operand of union types (#15409 by @sosukesuzuki)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+type Foo1 = (
+  | "thing1" // Comment1
+  | "thing2" // Comment2
+)[]; // Final comment1
+type Foo2 = (
+  | "thing1" // Comment1
+  | "thing2" // Comment2
+) & Bar; // Final comment2
+
+// Prettier stable
+type Foo1 = (
+  | "thing1" // Comment1
+  | "thing2"
+)[]; // Comment2 // Final comment1
+type Foo2 = (
+  | "thing1" // Comment1
+  | "thing2"
+) & // Comment2
+  Bar; // Final comment2
+
+// Prettier main
+type Foo1 = (
+  | "thing1" // Comment1
+  | "thing2" // Comment2
+)[]; // Final comment1
+type Foo2 = (
+  | "thing1" // Comment1
+  | "thing2" // Comment2
+) &
+  Bar; // Final comment2
+```

--- a/tests/format/flow/union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/union/__snapshots__/jsfmt.spec.js.snap
@@ -22,6 +22,37 @@ const myValue = (callcallcallcallcallcall(
 ================================================================================
 `;
 
+exports[`comments.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type Foo = (
+  | "thing1" // Comment1
+  | "thing2" // Comment2
+)[]; // Final comment1
+
+type Foo = (
+  | "thing1" // Comment1
+  | "thing2" // Comment2
+) & Bar; // Final comment2
+
+=====================================output=====================================
+type Foo = (
+  | "thing1" // Comment1
+  | "thing2" // Comment2
+)[]; // Final comment1
+
+type Foo = (
+  | "thing1" // Comment1
+  | "thing2" // Comment2
+) &
+  Bar; // Final comment2
+
+================================================================================
+`;
+
 exports[`union.js format 1`] = `
 ====================================options=====================================
 parsers: ["flow"]

--- a/tests/format/flow/union/comments.js
+++ b/tests/format/flow/union/comments.js
@@ -1,0 +1,9 @@
+type Foo = (
+  | "thing1" // Comment1
+  | "thing2" // Comment2
+)[]; // Final comment1
+
+type Foo = (
+  | "thing1" // Comment1
+  | "thing2" // Comment2
+) & Bar; // Final comment2

--- a/tests/format/typescript/union/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/union/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,36 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`comments.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type Foo = (
+  | "thing1" // Comment1
+  | "thing2" // Comment2
+)[]; // Final comment1
+
+type Foo = (
+  | "thing1" // Comment1
+  | "thing2" // Comment2
+) & Bar; // Final comment2
+
+=====================================output=====================================
+type Foo = (
+  | "thing1" // Comment1
+  | "thing2" // Comment2
+)[]; // Final comment1
+
+type Foo = (
+  | "thing1" // Comment1
+  | "thing2" // Comment2
+) &
+  Bar; // Final comment2
+
+================================================================================
+`;
+
 exports[`inlining.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/union/comments.ts
+++ b/tests/format/typescript/union/comments.ts
@@ -1,0 +1,9 @@
+type Foo = (
+  | "thing1" // Comment1
+  | "thing2" // Comment2
+)[]; // Final comment1
+
+type Foo = (
+  | "thing1" // Comment1
+  | "thing2" // Comment2
+) & Bar; // Final comment2


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #11910

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
