### PR TITLE
Improve browserslist in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -205,8 +205,7 @@
   },
   "browserslist": [
     ">0.5%",
-    "not ie 11",
-    "not safari 5.1",
+    "not dead",
     "not op_mini all"
   ],
   "preferUnplugged": true,


### PR DESCRIPTION
## Description

- `not dead` includes `not ie 11`.
  > dead: browsers without official support or updates for 24 months. Right now it is IE 11, IE_Mob 11, BlackBerry 10, BlackBerry 7, Samsung 4, OperaMobile 12.1 and all versions of Baidu.
- `not safari 5.1` is obsolete.

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
