### PR TITLE
language-css fix exception in `insideURLFunctionInImportAtRuleNode`

### DIFF
--- a/src/language-css/utils/index.js
+++ b/src/language-css/utils/index.js
@@ -95,7 +95,7 @@ function insideAtRuleNode(path, atRuleNameOrAtRuleNames) {
 function insideURLFunctionInImportAtRuleNode(path) {
   const { node } = path;
   return (
-    node.groups[0].value === "url" &&
+    node.groups?.[0].value === "url" &&
     node.groups.length === 2 &&
     path.findAncestor((node) => node.type === "css-atrule")?.name === "import"
   );


### PR DESCRIPTION
## Description

This fixes an exception when `node.groups` is empty in `insideURLFunctionInImportAtRuleNode`

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
