### PR TITLE
Support type arguments after `typeof`

### DIFF
--- a/changelog_unreleased/flow/15466.md
+++ b/changelog_unreleased/flow/15466.md
@@ -1,0 +1,8 @@
+#### Support type arguments after `typeof` (#15466 by @sosukesuzuki)
+
+Supports type arguments after `typeof` syntax supported since [Flow v0.127.0](https://github.com/facebook/flow/blob/HEAD/Changelog.md#02170):
+
+<!-- prettier-ignore -->
+```jsx
+type Foo = typeof MyGenericClass<string, number>;
+```

--- a/src/language-js/print/type-annotation.js
+++ b/src/language-js/print/type-annotation.js
@@ -521,12 +521,11 @@ function printArrayType(print) {
 - `TypeofTypeAnnotation`
 */
 function printTypeQuery({ node }, print) {
-  return [
-    "typeof ",
-    ...(node.type === "TSTypeQuery"
-      ? [print("exprName"), print("typeParameters")]
-      : [print("argument")]),
-  ];
+  const argumentPropertyName =
+    node.type === "TSTypeQuery" ? "exprName" : "argument";
+  const typeArgsPropertyName =
+    node.type === "TSTypeQuery" ? "typeParameters" : "typeArguments";
+  return ["typeof ", print(argumentPropertyName), print(typeArgsPropertyName)];
 }
 
 function printTypePredicate(path, print) {

--- a/src/language-js/traverse/visitor-keys.evaluate.js
+++ b/src/language-js/traverse/visitor-keys.evaluate.js
@@ -43,6 +43,7 @@ const additionalVisitorKeys = {
   AsExpression: ["expression", "typeAnnotation"],
   AsConstExpression: ["expression"],
   SatisfiesExpression: ["expression", "typeAnnotation"],
+  TypeofTypeAnnotation: ["argument", "typeArguments"],
 };
 
 const excludeKeys = {

--- a/tests/format/flow/typeof/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/typeof/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`typeof-with-type-arguments.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type Foo = typeof MyGenericClass<string, number>;
+
+=====================================output=====================================
+type Foo = typeof MyGenericClass<string, number>;
+
+================================================================================
+`;

--- a/tests/format/flow/typeof/jsfmt.spec.js
+++ b/tests/format/flow/typeof/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(import.meta, ["flow"]);

--- a/tests/format/flow/typeof/typeof-with-type-arguments.js
+++ b/tests/format/flow/typeof/typeof-with-type-arguments.js
@@ -1,0 +1,1 @@
+type Foo = typeof MyGenericClass<string, number>;

--- a/tests/unit/__snapshots__/visitor-keys.js.snap
+++ b/tests/unit/__snapshots__/visitor-keys.js.snap
@@ -1043,6 +1043,7 @@ exports[`visitor keys estree 1`] = `
   ],
   "TypeofTypeAnnotation": [
     "argument",
+    "typeArguments",
   ],
   "UnaryExpression": [
     "argument",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Flow now supports `typeof MyGenericClass<string, number>` syntax (ref: https://github.com/prettier/prettier/pull/15455 )

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
