### PR TITLE
Show `(unchanged)` keyword for accessibility in CLI `--write`

### DIFF
--- a/changelog_unreleased/cli/15467.md
+++ b/changelog_unreleased/cli/15467.md
@@ -1,0 +1,19 @@
+#### Show `(unchanged)` keyword for accessibility in CLI `--write` (#15467 by @ADTC)
+
+Previously, the only distinction between a changed file and an unchanged file was the grey color of the file name. In the example below, we can't distinguish between `a.js` and `b.js` as the color is missing. This issue is fixed by adding the `(unchanged)` keyword which makes the distinction accessible without color.
+
+<!-- prettier-ignore -->
+```sh
+# Input
+prettier --write .
+
+# Prettier stable
+a.js 0ms
+b.js 0ms
+c.js 0ms (cached)
+
+# Prettier main
+a.js 0ms
+b.js 0ms (unchanged)
+c.js 0ms (unchanged) (cached)
+```

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -439,9 +439,9 @@ async function formatFiles(context) {
           Date.now() - start
         }ms (unchanged)`;
         if (isCacheExists) {
-          context.logger.debug(`${message} (cached)`);
+          context.logger.log(`${message} (cached)`);
         } else {
-          context.logger.debug(message);
+          context.logger.log(message);
         }
       }
     } else if (context.argv.debugCheck) {

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -435,14 +435,11 @@ async function formatFiles(context) {
           process.exitCode = 2;
         }
       } else if (!context.argv.check && !context.argv.listDifferent) {
-        const message = `${chalk.grey(fileNameToDisplay)} ${
-          Date.now() - start
-        }ms`;
-        if (isCacheExists) {
-          context.logger.log(`${message} (cached)`);
-        } else {
-          context.logger.log(message);
-        }
+        context.logger.debug(
+          `${chalk.grey(fileNameToDisplay)} ${
+            Date.now() - start
+          }ms (unchanged)${isCacheExists ? " (cached)" : ""}`,
+        );
       }
     } else if (context.argv.debugCheck) {
       if (result.filepath) {

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -435,11 +435,14 @@ async function formatFiles(context) {
           process.exitCode = 2;
         }
       } else if (!context.argv.check && !context.argv.listDifferent) {
-        context.logger.debug(
-          `${chalk.grey(fileNameToDisplay)} ${
-            Date.now() - start
-          }ms (unchanged)${isCacheExists ? " (cached)" : ""}`,
-        );
+        const message = `${chalk.grey(fileNameToDisplay)} ${
+          Date.now() - start
+        }ms (unchanged)`;
+        if (isCacheExists) {
+          context.logger.debug(`${message} (cached)`);
+        } else {
+          context.logger.debug(message);
+        }
       }
     } else if (context.argv.debugCheck) {
       if (result.filepath) {

--- a/tests/integration/__tests__/__snapshots__/line-after-filepath-with-errors.js.snap
+++ b/tests/integration/__tests__/__snapshots__/line-after-filepath-with-errors.js.snap
@@ -83,7 +83,7 @@ invalid-2.unknown
 [[called readline.clearLine(process.stdout)]]
 valid-1.js
 [[called readline.clearLine(process.stdout)]]
-valid-1.js 0ms"
+valid-1.js 0ms (unchanged)"
 `;
 
 exports[`Line breaking after filepath with errors (write) 1`] = `[]`;

--- a/tests/integration/__tests__/__snapshots__/write.js.snap
+++ b/tests/integration/__tests__/__snapshots__/write.js.snap
@@ -2,7 +2,7 @@
 
 exports[`do not write file with --write + formatted file (stderr) 1`] = `""`;
 
-exports[`do not write file with --write + formatted file (stdout) 1`] = `"formatted.js 0ms"`;
+exports[`do not write file with --write + formatted file (stdout) 1`] = `"formatted.js 0ms (unchanged)"`;
 
 exports[`do not write file with --write + invalid file (stderr) 1`] = `
 "[error] invalid.js: SyntaxError: Unexpected token (1:17)

--- a/tests/integration/__tests__/cache.js
+++ b/tests/integration/__tests__/cache.js
@@ -133,7 +133,7 @@ describe("--cache option", () => {
       expect(firstStdout.split("\n")).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\)$/),
         ]),
       );
 
@@ -146,8 +146,8 @@ describe("--cache option", () => {
       ]);
       expect(secondStdout.split("\n")).toEqual(
         expect.arrayContaining([
-          expect.stringMatching(/^a\.js .+ms \(cached\)$/),
-          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+          expect.stringMatching(/^a\.js .+ms \(unchanged\) \(cached\)$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\) \(cached\)$/),
         ]),
       );
     });
@@ -167,7 +167,7 @@ describe("--cache option", () => {
       expect(firstStdout.split("\n")).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\)$/),
         ]),
       );
 
@@ -182,7 +182,7 @@ describe("--cache option", () => {
         // the cache of `b.js` is only available.
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\) \(cached\)$/),
         ]),
       );
     });
@@ -202,7 +202,7 @@ describe("--cache option", () => {
       expect(firstStdout.split("\n")).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\)$/),
         ]),
       );
 
@@ -218,7 +218,7 @@ describe("--cache option", () => {
         // the cache of `b.js` is only available.
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\) \(cached\)$/),
         ]),
       );
     });
@@ -234,7 +234,7 @@ describe("--cache option", () => {
       expect(firstStdout.split("\n")).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\)$/),
         ]),
       );
 
@@ -250,7 +250,7 @@ describe("--cache option", () => {
       expect(secondStdout.split("\n")).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\)$/),
         ]),
       );
     });
@@ -273,7 +273,7 @@ describe("--cache option", () => {
       expect(secondStdout.split("\n")).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\) \(cached\)$/),
         ]),
       );
     });
@@ -309,7 +309,7 @@ describe("--cache option", () => {
       expect(thirdStdout.split("\n")).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\) \(cached\)$/),
         ]),
       );
     });
@@ -336,7 +336,7 @@ describe("--cache option", () => {
       expect(firstStdout.split("\n")).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\)$/),
         ]),
       );
 
@@ -394,7 +394,7 @@ describe("--cache option", () => {
       expect(firstStdout.split("\n")).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\)$/),
         ]),
       );
 
@@ -404,8 +404,8 @@ describe("--cache option", () => {
       );
       expect(secondStdout.split("\n")).toEqual(
         expect.arrayContaining([
-          expect.stringMatching(/^a\.js .+ms \(cached\)$/),
-          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+          expect.stringMatching(/^a\.js .+ms \(unchanged\) \(cached\)$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\) \(cached\)$/),
         ]),
       );
     });
@@ -425,7 +425,7 @@ describe("--cache option", () => {
       expect(firstStdout.split("\n")).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\)$/),
         ]),
       );
 
@@ -440,7 +440,7 @@ describe("--cache option", () => {
         // the cache of `b.js` is only available.
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\) \(cached\)$/),
         ]),
       );
     });
@@ -460,7 +460,7 @@ describe("--cache option", () => {
       expect(firstStdout.split("\n")).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\)$/),
         ]),
       );
 
@@ -474,8 +474,8 @@ describe("--cache option", () => {
       );
       expect(secondStdout.split("\n")).toEqual(
         expect.arrayContaining([
-          expect.stringMatching(/^a\.js .+ms \(cached\)$/),
-          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+          expect.stringMatching(/^a\.js .+ms \(unchanged\) \(cached\)$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\) \(cached\)$/),
         ]),
       );
     });
@@ -491,7 +491,7 @@ describe("--cache option", () => {
       expect(firstStdout.split("\n")).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\)$/),
         ]),
       );
 
@@ -507,7 +507,7 @@ describe("--cache option", () => {
       expect(secondStdout.split("\n")).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\)$/),
         ]),
       );
     });
@@ -530,7 +530,7 @@ describe("--cache option", () => {
       expect(secondStdout.split("\n")).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\) \(cached\)$/),
         ]),
       );
     });
@@ -566,7 +566,7 @@ describe("--cache option", () => {
       expect(thirdStdout.split("\n")).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\) \(cached\)$/),
         ]),
       );
     });
@@ -593,7 +593,7 @@ describe("--cache option", () => {
       expect(firstStdout.split("\n")).toEqual(
         expect.arrayContaining([
           expect.stringMatching(/^a\.js .+ms$/),
-          expect.stringMatching(/^b\.js .+ms$/),
+          expect.stringMatching(/^b\.js .+ms \(unchanged\)$/),
         ]),
       );
 
@@ -677,7 +677,7 @@ describe("--cache option", () => {
         expect(firstStdout.split("\n")).toEqual(
           expect.arrayContaining([
             expect.stringMatching(/^a\.js .+ms$/),
-            expect.stringMatching(/^b\.js .+ms$/),
+            expect.stringMatching(/^b\.js .+ms \(unchanged\)$/),
           ]),
         );
 
@@ -687,8 +687,8 @@ describe("--cache option", () => {
         );
         expect(secondStdout.split("\n")).toEqual(
           expect.arrayContaining([
-            expect.stringMatching(/^a\.js .+ms \(cached\)$/),
-            expect.stringMatching(/^b\.js .+ms \(cached\)$/),
+            expect.stringMatching(/^a\.js .+ms \(unchanged\) \(cached\)$/),
+            expect.stringMatching(/^b\.js .+ms \(unchanged\) \(cached\)$/),
           ]),
         );
       });


### PR DESCRIPTION
## Description

Fixes #15396.

As described in the issue, this:

* resolves the accessibility concern by distinguishing unchanged files from changed files using the keyword `(unchanged)` instead of merely using grey color.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve ~added~ updated tests to confirm my change works.
- [x] _(No update needed)_ (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
