### PR TITLE
Disambiguate unary expr in instanceof and in

### DIFF
--- a/changelog_unreleased/javascript/15468.md
+++ b/changelog_unreleased/javascript/15468.md
@@ -1,4 +1,4 @@
-#### Disambiguate unary expressions on left hand side of instanceof and in (#15466 by @lucacasonato)
+#### Disambiguate unary expressions on left hand side of instanceof and in (#15468 by @lucacasonato)
 
 Parentheses are now added around unary expression on the left hand side of
 `instanceof` and `in` expressions, to disambiguate the unary on the left hand

--- a/changelog_unreleased/javascript/15468.md
+++ b/changelog_unreleased/javascript/15468.md
@@ -1,0 +1,24 @@
+#### Disambiguate unary expressions on left hand side of instanceof and in (#15466 by @lucacasonato)
+
+Parentheses are now added around unary expression on the left hand side of
+`instanceof` and `in` expressions, to disambiguate the unary on the left hand
+side with a unary applying to the entire binary expression.
+
+This helps catch a common mistake where a user intends to write `!("x" in y)`
+but instead writes `!"x" in y`, which is really parsed as the nonsensical
+`(!"x") in y`.
+
+<!-- prettier-ignore -->
+```js
+// Input
+!"x" in y;
+!("x" in y);
+
+// Prettier stable
+!"x" in y;
+!("x" in y);
+
+// Prettier main
+(!"x") in y;
+!("x" in y);
+```

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -241,6 +241,19 @@ function needsParens(path, options) {
         return true;
       }
       break;
+
+    // A user typing `!foo instanceof Bar` probably intended
+    // `!(foo instanceof Bar)`, so format to `(!foo) instance Bar` to what is
+    // really happening
+    case "BinaryExpression":
+      if (
+        key === "left" &&
+        (parent.operator === "in" || parent.operator === "instanceof") &&
+        node.type === "UnaryExpression"
+      ) {
+        return true;
+      }
+      break;
   }
 
   switch (node.type) {

--- a/tests/format/flow-repo/binary/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow-repo/binary/__snapshots__/jsfmt.spec.js.snap
@@ -97,7 +97,7 @@ let tests = [
   // bogus stuff on LHS
   function () {
     null in {}; // error
-    void 0 in {}; // error
+    (void 0) in {}; // error
     ({}) in {}; // error
     [] in {}; // error
     false in []; // error
@@ -107,7 +107,7 @@ let tests = [
   function () {
     if ("foo" in 123) {
     } // error
-    if (!"foo" in {}) {
+    if ((!"foo") in {}) {
     } // error, !'foo' is a boolean
     if (!("foo" in {})) {
     }

--- a/tests/format/js/binary-expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/binary-expressions/__snapshots__/jsfmt.spec.js.snap
@@ -440,17 +440,70 @@ printWidth: 80
 !(foo instanceof Bar);
 (!foo) instanceof Bar;
 
+~foo in bar;
+(~foo in bar); 
+~(foo in bar);
+(~foo) in bar;
+
+~foo instanceof Bar;
+(~foo instanceof Bar);
+~(foo instanceof Bar);
+(~foo) instanceof Bar;
+
++foo in bar;
+(+foo in bar); 
++(foo in bar);
+(+foo) in bar;
+
++foo instanceof Bar;
+(+foo instanceof Bar);
++(foo instanceof Bar);
+(+foo) instanceof Bar;
+
+-foo in bar;
+(-foo in bar); 
+-(foo in bar);
+(-foo) in bar;
+
+-foo instanceof Bar;
+(-foo instanceof Bar);
+-(foo instanceof Bar);
+(-foo) instanceof Bar;
+
 void 0 in bar;
 (void 0 in bar);
 void (0 in bar);
 (void 0) in bar;
 
-+x in bar;
-(+x in bar);
-+(x in bar);
-(+x) in bar;
+void 0 instanceof bar;
+(void 0 instanceof bar);
+void (0 instanceof bar);
+(void 0) instanceof bar;
+
+delete 0 in bar;
+(delete 0 in bar);
+delete (0 in bar);
+(delete 0) in bar;
+
+delete 0 instanceof bar;
+(delete 0 instanceof bar);
+delete (0 instanceof bar);
+(delete 0) instanceof bar;
+
+typeof 0 in bar;
+(typeof 0 in bar);
+typeof (0 in bar);
+(typeof 0) in bar;
+
+typeof 0 instanceof bar;
+(typeof 0 instanceof bar);
+typeof (0 instanceof bar);
+(typeof 0) instanceof bar;
 
 ++x instanceof bar; // not ambiguous, because ++(x instanceof bar) is obviously invalid
+
+!!foo instanceof Bar;
+
 =====================================output=====================================
 (!foo) in bar;
 (!foo) in bar;
@@ -462,17 +515,69 @@ void (0 in bar);
 !(foo instanceof Bar);
 (!foo) instanceof Bar;
 
+(~foo) in bar;
+(~foo) in bar;
+~(foo in bar);
+(~foo) in bar;
+
+(~foo) instanceof Bar;
+(~foo) instanceof Bar;
+~(foo instanceof Bar);
+(~foo) instanceof Bar;
+
+(+foo) in bar;
+(+foo) in bar;
++(foo in bar);
+(+foo) in bar;
+
+(+foo) instanceof Bar;
+(+foo) instanceof Bar;
++(foo instanceof Bar);
+(+foo) instanceof Bar;
+
+(-foo) in bar;
+(-foo) in bar;
+-(foo in bar);
+(-foo) in bar;
+
+(-foo) instanceof Bar;
+(-foo) instanceof Bar;
+-(foo instanceof Bar);
+(-foo) instanceof Bar;
+
 (void 0) in bar;
 (void 0) in bar;
 void (0 in bar);
 (void 0) in bar;
 
-(+x) in bar;
-(+x) in bar;
-+(x in bar);
-(+x) in bar;
+(void 0) instanceof bar;
+(void 0) instanceof bar;
+void (0 instanceof bar);
+(void 0) instanceof bar;
+
+(delete 0) in bar;
+(delete 0) in bar;
+delete (0 in bar);
+(delete 0) in bar;
+
+(delete 0) instanceof bar;
+(delete 0) instanceof bar;
+delete (0 instanceof bar);
+(delete 0) instanceof bar;
+
+(typeof 0) in bar;
+(typeof 0) in bar;
+typeof (0 in bar);
+(typeof 0) in bar;
+
+(typeof 0) instanceof bar;
+(typeof 0) instanceof bar;
+typeof (0 instanceof bar);
+(typeof 0) instanceof bar;
 
 ++x instanceof bar; // not ambiguous, because ++(x instanceof bar) is obviously invalid
+
+(!!foo) instanceof Bar;
 
 ================================================================================
 `;

--- a/tests/format/js/binary-expressions/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/binary-expressions/__snapshots__/jsfmt.spec.js.snap
@@ -424,6 +424,59 @@ if (
 ================================================================================
 `;
 
+exports[`in_instanceof.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+!foo in bar;
+(!foo in bar); 
+!(foo in bar);
+(!foo) in bar;
+
+!foo instanceof Bar;
+(!foo instanceof Bar);
+!(foo instanceof Bar);
+(!foo) instanceof Bar;
+
+void 0 in bar;
+(void 0 in bar);
+void (0 in bar);
+(void 0) in bar;
+
++x in bar;
+(+x in bar);
++(x in bar);
+(+x) in bar;
+
+++x instanceof bar; // not ambiguous, because ++(x instanceof bar) is obviously invalid
+=====================================output=====================================
+(!foo) in bar;
+(!foo) in bar;
+!(foo in bar);
+(!foo) in bar;
+
+(!foo) instanceof Bar;
+(!foo) instanceof Bar;
+!(foo instanceof Bar);
+(!foo) instanceof Bar;
+
+(void 0) in bar;
+(void 0) in bar;
+void (0 in bar);
+(void 0) in bar;
+
+(+x) in bar;
+(+x) in bar;
++(x in bar);
+(+x) in bar;
+
+++x instanceof bar; // not ambiguous, because ++(x instanceof bar) is obviously invalid
+
+================================================================================
+`;
+
 exports[`inline-jsx.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "flow", "typescript"]

--- a/tests/format/js/binary-expressions/in_instanceof.js
+++ b/tests/format/js/binary-expressions/in_instanceof.js
@@ -8,14 +8,66 @@
 !(foo instanceof Bar);
 (!foo) instanceof Bar;
 
+~foo in bar;
+(~foo in bar); 
+~(foo in bar);
+(~foo) in bar;
+
+~foo instanceof Bar;
+(~foo instanceof Bar);
+~(foo instanceof Bar);
+(~foo) instanceof Bar;
+
++foo in bar;
+(+foo in bar); 
++(foo in bar);
+(+foo) in bar;
+
++foo instanceof Bar;
+(+foo instanceof Bar);
++(foo instanceof Bar);
+(+foo) instanceof Bar;
+
+-foo in bar;
+(-foo in bar); 
+-(foo in bar);
+(-foo) in bar;
+
+-foo instanceof Bar;
+(-foo instanceof Bar);
+-(foo instanceof Bar);
+(-foo) instanceof Bar;
+
 void 0 in bar;
 (void 0 in bar);
 void (0 in bar);
 (void 0) in bar;
 
-+x in bar;
-(+x in bar);
-+(x in bar);
-(+x) in bar;
+void 0 instanceof bar;
+(void 0 instanceof bar);
+void (0 instanceof bar);
+(void 0) instanceof bar;
+
+delete 0 in bar;
+(delete 0 in bar);
+delete (0 in bar);
+(delete 0) in bar;
+
+delete 0 instanceof bar;
+(delete 0 instanceof bar);
+delete (0 instanceof bar);
+(delete 0) instanceof bar;
+
+typeof 0 in bar;
+(typeof 0 in bar);
+typeof (0 in bar);
+(typeof 0) in bar;
+
+typeof 0 instanceof bar;
+(typeof 0 instanceof bar);
+typeof (0 instanceof bar);
+(typeof 0) instanceof bar;
 
 ++x instanceof bar; // not ambiguous, because ++(x instanceof bar) is obviously invalid
+
+!!foo instanceof Bar;

--- a/tests/format/js/binary-expressions/in_instanceof.js
+++ b/tests/format/js/binary-expressions/in_instanceof.js
@@ -1,0 +1,21 @@
+!foo in bar;
+(!foo in bar); 
+!(foo in bar);
+(!foo) in bar;
+
+!foo instanceof Bar;
+(!foo instanceof Bar);
+!(foo instanceof Bar);
+(!foo) instanceof Bar;
+
+void 0 in bar;
+(void 0 in bar);
+void (0 in bar);
+(void 0) in bar;
+
++x in bar;
+(+x in bar);
++(x in bar);
+(+x) in bar;
+
+++x instanceof bar; // not ambiguous, because ++(x instanceof bar) is obviously invalid


### PR DESCRIPTION
## Description

Fixes https://github.com/prettier/prettier/issues/15434

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
