### PR TITLE
Fix name case of selectors in styled components interpolation

### DIFF
--- a/changelog_unreleased/javascript/15472.md
+++ b/changelog_unreleased/javascript/15472.md
@@ -1,0 +1,40 @@
+#### Fix name case of selectors in styled components interpolation ([#15472](https://github.com/prettier/prettier/pull/15472) by [@lucasols](https://github.com/lucasols))
+
+<!-- prettier-ignore -->
+```js
+// Input
+const StyledComponent = styled.div`
+  margin-right: -4px;
+
+  ${Container}.isExpanded & {
+    transform: rotate(-180deg);
+  }
+`;
+
+const StyledComponent2 = styled.div`
+  margin-right: -4px;
+
+  ${abc}.camelCase + ${def}.camelCase & {
+    transform: rotate(-180deg);
+  }
+`;
+
+// Prettier stable
+const StyledComponent = styled.div`
+  margin-right: -4px;
+
+  ${Container}.isexpanded & {
+    transform: rotate(-180deg);
+  }
+`;
+
+const StyledComponent2 = styled.div`
+  margin-right: -4px;
+
+  ${abc}.camelcase + ${def}.camelCase & {
+    transform: rotate(-180deg);
+  }
+`;
+
+// Prettier main -- same as input
+```

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -224,7 +224,7 @@ function genericPrint(path, options, print) {
         // If a Less file ends up being parsed with the SCSS parser, Less
         // variable declarations will be parsed as at-rules with names ending
         // with a colon, so keep the original case then.
-        isDetachedRulesetCallNode(node) || node.name.endsWith(":")
+        isDetachedRulesetCallNode(node) || node.name.endsWith(":") || isTemplatePlaceholderNode(node)
           ? node.name
           : maybeToLowerCase(node.name),
         node.params

--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -224,7 +224,9 @@ function genericPrint(path, options, print) {
         // If a Less file ends up being parsed with the SCSS parser, Less
         // variable declarations will be parsed as at-rules with names ending
         // with a colon, so keep the original case then.
-        isDetachedRulesetCallNode(node) || node.name.endsWith(":") || isTemplatePlaceholderNode(node)
+        isDetachedRulesetCallNode(node) ||
+        node.name.endsWith(":") ||
+        isTemplatePlaceholderNode(node)
           ? node.name
           : maybeToLowerCase(node.name),
         node.params

--- a/tests/format/js/multiparser-css/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/multiparser-css/__snapshots__/jsfmt.spec.js.snap
@@ -363,6 +363,48 @@ export const Group = styled.div\`
 ================================================================================
 `;
 
+exports[`issue-8352.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const StyledComponent = styled.div\`
+  margin-right: -4px;
+
+  \${Container}.isExpanded & {
+    transform: rotate(-180deg);
+  }
+\`;
+
+const StyledComponent2 = styled.div\`
+  margin-right: -4px;
+
+  \${abc}.camelCase + \${def}.camelCase & {
+    transform: rotate(-180deg);
+  }
+\`;
+
+=====================================output=====================================
+const StyledComponent = styled.div\`
+  margin-right: -4px;
+
+  \${Container}.isExpanded & {
+    transform: rotate(-180deg);
+  }
+\`;
+
+const StyledComponent2 = styled.div\`
+  margin-right: -4px;
+
+  \${abc}.camelCase + \${def}.camelCase & {
+    transform: rotate(-180deg);
+  }
+\`;
+
+================================================================================
+`;
+
 exports[`issue-9072.js format 1`] = `
 ====================================options=====================================
 parsers: ["babel", "typescript", "flow"]

--- a/tests/format/js/multiparser-css/issue-8352.js
+++ b/tests/format/js/multiparser-css/issue-8352.js
@@ -1,0 +1,15 @@
+const StyledComponent = styled.div`
+  margin-right: -4px;
+
+  ${Container}.isExpanded & {
+    transform: rotate(-180deg);
+  }
+`;
+
+const StyledComponent2 = styled.div`
+  margin-right: -4px;
+
+  ${abc}.camelCase + ${def}.camelCase & {
+    transform: rotate(-180deg);
+  }
+`;


### PR DESCRIPTION
## Description

Fixes #8352 

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
