### PR TITLE
Support `(type) satisfies never;`

### DIFF
--- a/changelog_unreleased/typescript/15514.md
+++ b/changelog_unreleased/typescript/15514.md
@@ -1,0 +1,15 @@
+#### Keep required parenthesis around some specific keyword like identifiers in expression statement of satisfies / as expression (#15514 by @seiyab)
+
+<!-- prettier-ignore -->
+```ts
+// Input
+(type) satisfies never;
+
+
+// Prettier stable
+type satisfies never;
+
+
+// Prettier main
+(type) satisfies never;
+```

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -114,7 +114,9 @@ function needsParens(path, options) {
     if (
       key === "expression" &&
       (parent.type === "TSSatisfiesExpression" ||
-        parent.type === "TSAsExpression") &&
+        parent.type === "SatisfiesExpression" ||
+        parent.type === "TSAsExpression" ||
+        parent.type === "AsExpression") &&
       path.grandparent?.type === "ExpressionStatement" &&
       [
         "await",

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -111,25 +111,32 @@ function needsParens(path, options) {
     }
 
     // `(type) satisfies never;` and similar cases
-    if (
-      key === "expression" &&
-      path.grandparent?.type === "ExpressionStatement"
-    ) {
-      switch (parent.type) {
-        case "TSSatisfiesExpression":
-        case "SatisfiesExpression":
-        case "TSAsExpression":
-        case "AsExpression":
-          switch (node.name) {
-            case "await":
-            case "interface":
-            case "module":
-            case "using":
-            case "yield":
-            case "let":
-            case "type":
-              return true;
-          }
+    if (key === "expression") {
+      const ancestorNeitherAsNorSatisfies = path.findAncestor((node) => {
+        switch (node.type) {
+          case "TSSatisfiesExpression":
+          case "SatisfiesExpression":
+          case "TSAsExpression":
+          case "AsExpression":
+            return false;
+          default:
+            return true;
+        }
+      });
+      if (
+        ancestorNeitherAsNorSatisfies !== parent &&
+        ancestorNeitherAsNorSatisfies.type === "ExpressionStatement"
+      ) {
+        switch (node.name) {
+          case "await":
+          case "interface":
+          case "module":
+          case "using":
+          case "yield":
+          case "let":
+          case "type":
+            return true;
+        }
       }
     }
 

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -110,6 +110,25 @@ function needsParens(path, options) {
       }
     }
 
+    // `(type) satisfies never;` and similar cases
+    if (
+      key === "expression" &&
+      (parent.type === "TSSatisfiesExpression" ||
+        parent.type === "TSAsExpression") &&
+      path.grandparent?.type === "ExpressionStatement" &&
+      [
+        "await",
+        "interface",
+        "module",
+        "using",
+        "yield",
+        "let",
+        "type",
+      ].includes(node.name)
+    ) {
+      return true;
+    }
+
     return false;
   }
 

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -112,31 +112,23 @@ function needsParens(path, options) {
 
     // `(type) satisfies never;` and similar cases
     if (key === "expression") {
-      const ancestorNeitherAsNorSatisfies = path.findAncestor((node) => {
-        switch (node.type) {
-          case "TSSatisfiesExpression":
-          case "SatisfiesExpression":
-          case "TSAsExpression":
-          case "AsExpression":
-          case "AsConstExpression":
-            return false;
-          default:
+      switch (node.name) {
+        case "await":
+        case "interface":
+        case "module":
+        case "using":
+        case "yield":
+        case "let":
+        case "type": {
+          const ancestorNeitherAsNorSatisfies = path.findAncestor(
+            (node) => !isBinaryCastExpression(node),
+          );
+          if (
+            ancestorNeitherAsNorSatisfies !== parent &&
+            ancestorNeitherAsNorSatisfies.type === "ExpressionStatement"
+          ) {
             return true;
-        }
-      });
-      if (
-        ancestorNeitherAsNorSatisfies !== parent &&
-        ancestorNeitherAsNorSatisfies.type === "ExpressionStatement"
-      ) {
-        switch (node.name) {
-          case "await":
-          case "interface":
-          case "module":
-          case "using":
-          case "yield":
-          case "let":
-          case "type":
-            return true;
+          }
         }
       }
     }

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -113,22 +113,24 @@ function needsParens(path, options) {
     // `(type) satisfies never;` and similar cases
     if (
       key === "expression" &&
-      (parent.type === "TSSatisfiesExpression" ||
-        parent.type === "SatisfiesExpression" ||
-        parent.type === "TSAsExpression" ||
-        parent.type === "AsExpression") &&
-      path.grandparent?.type === "ExpressionStatement" &&
-      [
-        "await",
-        "interface",
-        "module",
-        "using",
-        "yield",
-        "let",
-        "type",
-      ].includes(node.name)
+      path.grandparent?.type === "ExpressionStatement"
     ) {
-      return true;
+      switch (parent.type) {
+        case "TSSatisfiesExpression":
+        case "SatisfiesExpression":
+        case "TSAsExpression":
+        case "AsExpression":
+          switch (node.name) {
+            case "await":
+            case "interface":
+            case "module":
+            case "using":
+            case "yield":
+            case "let":
+            case "type":
+              return true;
+          }
+      }
     }
 
     return false;

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -118,6 +118,7 @@ function needsParens(path, options) {
           case "SatisfiesExpression":
           case "TSAsExpression":
           case "AsExpression":
+          case "AsConstExpression":
             return false;
           default:
             return true;

--- a/tests/format/flow/as-satisfies-expression/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/as-satisfies-expression/__snapshots__/jsfmt.spec.js.snap
@@ -56,6 +56,8 @@ const iter2 = createIterator(self.controller, child, self.tag as BlahFunctionCom
 
 x as any as T;
 
+(type) as T;
+
 =====================================output=====================================
 // @flow
 
@@ -122,6 +124,8 @@ const iter2 = createIterator(
 );
 
 x as any as T;
+
+(type) as T;
 
 ================================================================================
 `;
@@ -400,12 +404,14 @@ function foo() {
 `;
 
 exports[`satisfies.js [babel-flow] format 1`] = `
-"Missing semicolon. (3:12)
-  1 | // @flow
-  2 |
-> 3 | const x = y satisfies T;
-    |            ^
-  4 |"
+"Unexpected token, expected "type" (32:8)
+  30 | satisfies satisfies mixed;
+  31 | as satisfies mixed;
+> 32 | opaque satisfies mixed;
+     |        ^
+  33 |
+  34 | abc satisfies mixed; // not a keyword
+  35 | }"
 `;
 
 exports[`satisfies.js format 1`] = `
@@ -418,10 +424,83 @@ printWidth: 80
 
 const x = y satisfies T;
 
+// demonstrating how "satisfies" expression can be practically used as expression statement.
+const _ = (type: 'foo' | 'bar') => {
+switch (type) {
+  case 'foo':
+    return 1;
+  case 'bar':
+    return 2;
+  default:
+    // exhaustiveness check idiom
+    (type) satisfies empty;
+    throw new Error('unreachable');
+}
+}
+
+function needParens() {
+(let) satisfies mixed;
+(interface) satisfies mixed;
+(module) satisfies mixed;
+(using) satisfies mixed;
+(yield) satisfies mixed;
+(await) satisfies mixed;
+}
+
+function noNeedParens() {
+async satisfies mixed;
+satisfies satisfies mixed;
+as satisfies mixed;
+opaque satisfies mixed;
+
+abc satisfies mixed; // not a keyword
+}
+
+function satisfiesChain() {
+satisfies satisfies satisfies satisfies satisfies;
+}
+
+
 =====================================output=====================================
 // @flow
 
 const x = y satisfies T;
+
+// demonstrating how "satisfies" expression can be practically used as expression statement.
+const _ = (type: "foo" | "bar") => {
+  switch (type) {
+    case "foo":
+      return 1;
+    case "bar":
+      return 2;
+    default:
+      // exhaustiveness check idiom
+      (type) satisfies empty;
+      throw new Error("unreachable");
+  }
+};
+
+function needParens() {
+  (let) satisfies mixed;
+  (interface) satisfies mixed;
+  (module) satisfies mixed;
+  (using) satisfies mixed;
+  (yield) satisfies mixed;
+  (await) satisfies mixed;
+}
+
+function noNeedParens() {
+  async satisfies mixed;
+  satisfies satisfies mixed;
+  as satisfies mixed;
+  opaque satisfies mixed;
+
+  abc satisfies mixed; // not a keyword
+}
+
+function satisfiesChain() {
+  satisfies satisfies satisfies satisfies satisfies;
+}
 
 ================================================================================
 `;

--- a/tests/format/flow/as-satisfies-expression/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/as-satisfies-expression/__snapshots__/jsfmt.spec.js.snap
@@ -467,7 +467,6 @@ satisfies satisfies satisfies satisfies satisfies;
 (type) satisfies empty satisfies mixed;
 }
 
-
 =====================================output=====================================
 // @flow
 

--- a/tests/format/flow/as-satisfies-expression/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/as-satisfies-expression/__snapshots__/jsfmt.spec.js.snap
@@ -458,6 +458,7 @@ abc satisfies mixed; // not a keyword
 
 function satisfiesChain() {
 satisfies satisfies satisfies satisfies satisfies;
+(type) satisfies empty satisfies mixed;
 }
 
 
@@ -500,6 +501,7 @@ function noNeedParens() {
 
 function satisfiesChain() {
   satisfies satisfies satisfies satisfies satisfies;
+  (type) satisfies empty satisfies mixed;
 }
 
 ================================================================================

--- a/tests/format/flow/as-satisfies-expression/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/as-satisfies-expression/__snapshots__/jsfmt.spec.js.snap
@@ -136,7 +136,9 @@ exports[`as-const.js [babel-flow] format 1`] = `
   11 |     DEBUG: 7,
 > 12 | } as const;
      |           ^
-  13 |"
+  13 |
+  14 | (type) as const;
+  15 |"
 `;
 
 exports[`as-const.js format 1`] = `
@@ -158,6 +160,8 @@ export const LOG_LEVEL = {
     DEBUG: 7,
 } as const;
 
+(type) as const;
+
 =====================================output=====================================
 // @flow
 
@@ -171,6 +175,8 @@ export const LOG_LEVEL = {
   INFO: 6,
   DEBUG: 7,
 } as const;
+
+(type) as const;
 
 ================================================================================
 `;

--- a/tests/format/flow/as-satisfies-expression/as-const.js
+++ b/tests/format/flow/as-satisfies-expression/as-const.js
@@ -10,3 +10,5 @@ export const LOG_LEVEL = {
     INFO: 6,
     DEBUG: 7,
 } as const;
+
+(type) as const;

--- a/tests/format/flow/as-satisfies-expression/as.js
+++ b/tests/format/flow/as-satisfies-expression/as.js
@@ -36,3 +36,5 @@ const iter1 = createIterator(this.controller, child, this.tag as BlahFunctionCom
 const iter2 = createIterator(self.controller, child, self.tag as BlahFunctionComponent);
 
 x as any as T;
+
+(type) as T;

--- a/tests/format/flow/as-satisfies-expression/satisfies.js
+++ b/tests/format/flow/as-satisfies-expression/satisfies.js
@@ -1,3 +1,40 @@
 // @flow
 
 const x = y satisfies T;
+
+// demonstrating how "satisfies" expression can be practically used as expression statement.
+const _ = (type: 'foo' | 'bar') => {
+switch (type) {
+  case 'foo':
+    return 1;
+  case 'bar':
+    return 2;
+  default:
+    // exhaustiveness check idiom
+    (type) satisfies empty;
+    throw new Error('unreachable');
+}
+}
+
+function needParens() {
+(let) satisfies mixed;
+(interface) satisfies mixed;
+(module) satisfies mixed;
+(using) satisfies mixed;
+(yield) satisfies mixed;
+(await) satisfies mixed;
+}
+
+function noNeedParens() {
+async satisfies mixed;
+satisfies satisfies mixed;
+as satisfies mixed;
+opaque satisfies mixed;
+
+abc satisfies mixed; // not a keyword
+}
+
+function satisfiesChain() {
+satisfies satisfies satisfies satisfies satisfies;
+}
+

--- a/tests/format/flow/as-satisfies-expression/satisfies.js
+++ b/tests/format/flow/as-satisfies-expression/satisfies.js
@@ -38,4 +38,3 @@ function satisfiesChain() {
 satisfies satisfies satisfies satisfies satisfies;
 (type) satisfies empty satisfies mixed;
 }
-

--- a/tests/format/flow/as-satisfies-expression/satisfies.js
+++ b/tests/format/flow/as-satisfies-expression/satisfies.js
@@ -36,5 +36,6 @@ abc satisfies mixed; // not a keyword
 
 function satisfiesChain() {
 satisfies satisfies satisfies satisfies satisfies;
+(type) satisfies empty satisfies mixed;
 }
 

--- a/tests/format/typescript/as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/as/__snapshots__/jsfmt.spec.js.snap
@@ -327,6 +327,26 @@ export default (function log() {} as typeof console.log);
 ================================================================================
 `;
 
+exports[`expression-statement.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// expression statemnt of "as" expression hardly ever makes sense, but it's still valid.
+const [type, x] = [0, 0];
+(type) as unknown;
+x as unknown;
+
+=====================================output=====================================
+// expression statemnt of "as" expression hardly ever makes sense, but it's still valid.
+const [type, x] = [0, 0];
+type as unknown;
+x as unknown;
+
+================================================================================
+`;
+
 exports[`long-identifiers.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/as/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/as/__snapshots__/jsfmt.spec.js.snap
@@ -341,7 +341,7 @@ x as unknown;
 =====================================output=====================================
 // expression statemnt of "as" expression hardly ever makes sense, but it's still valid.
 const [type, x] = [0, 0];
-type as unknown;
+(type) as unknown;
 x as unknown;
 
 ================================================================================

--- a/tests/format/typescript/as/expression-statement.ts
+++ b/tests/format/typescript/as/expression-statement.ts
@@ -1,0 +1,4 @@
+// expression statemnt of "as" expression hardly ever makes sense, but it's still valid.
+const [type, x] = [0, 0];
+(type) as unknown;
+x as unknown;

--- a/tests/format/typescript/satisfies-operators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/satisfies-operators/__snapshots__/jsfmt.spec.js.snap
@@ -556,18 +556,18 @@ const _ = () => {
       return 2
     default:
       // exhaustiveness check idiom
-      type satisfies never
+      ;(type) satisfies never
       throw new Error("unreachable")
   }
 }
 
 function needParens() {
-  let satisfies unknown
-  interface satisfies unknown
-  module satisfies unknown
-  using satisfies unknown
-  yield satisfies unknown
-  await satisfies unknown
+  ;(let) satisfies unknown
+  ;(interface) satisfies unknown
+  ;(module) satisfies unknown
+  ;(using) satisfies unknown
+  ;(yield) satisfies unknown
+  ;(await) satisfies unknown
 }
 
 function noNeedParens() {
@@ -642,18 +642,18 @@ const _ = () => {
       return 2;
     default:
       // exhaustiveness check idiom
-      type satisfies never;
+      (type) satisfies never;
       throw new Error("unreachable");
   }
 };
 
 function needParens() {
-  let satisfies unknown;
-  interface satisfies unknown;
-  module satisfies unknown;
-  using satisfies unknown;
-  yield satisfies unknown;
-  await satisfies unknown;
+  (let) satisfies unknown;
+  (interface) satisfies unknown;
+  (module) satisfies unknown;
+  (using) satisfies unknown;
+  (yield) satisfies unknown;
+  (await) satisfies unknown;
 }
 
 function noNeedParens() {

--- a/tests/format/typescript/satisfies-operators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/satisfies-operators/__snapshots__/jsfmt.spec.js.snap
@@ -541,6 +541,7 @@ abc satisfies unknown; // not a keyword
 
 function satisfiesChain() {
 satisfies satisfies satisfies satisfies satisfies;
+(type) satisfies never satisfies unknown;
 }
 
 
@@ -580,6 +581,7 @@ function noNeedParens() {
 
 function satisfiesChain() {
   satisfies satisfies satisfies satisfies satisfies
+  ;(type) satisfies never satisfies unknown
 }
 
 ================================================================================
@@ -627,6 +629,7 @@ abc satisfies unknown; // not a keyword
 
 function satisfiesChain() {
 satisfies satisfies satisfies satisfies satisfies;
+(type) satisfies never satisfies unknown;
 }
 
 
@@ -666,6 +669,7 @@ function noNeedParens() {
 
 function satisfiesChain() {
   satisfies satisfies satisfies satisfies satisfies;
+  (type) satisfies never satisfies unknown;
 }
 
 ================================================================================

--- a/tests/format/typescript/satisfies-operators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/satisfies-operators/__snapshots__/jsfmt.spec.js.snap
@@ -498,6 +498,179 @@ export default (function log() {} satisfies typeof console.log);
 ================================================================================
 `;
 
+exports[`expression-statement.ts - {"semi":false} format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+
+let type: 'foo' | 'bar' = 'foo';
+
+// demonstrating how "satisfies" expression can be practically used as expression statement.
+const _ = () => {
+switch (type) {
+  case 'foo':
+    return 1;
+  case 'bar':
+    return 2;
+  default:
+    // exhaustiveness check idiom
+    (type) satisfies never;
+    throw new Error('unreachable');
+}
+}
+
+function needParens() {
+(let) satisfies unknown;
+(interface) satisfies unknown;
+(module) satisfies unknown;
+(using) satisfies unknown;
+(yield) satisfies unknown;
+(await) satisfies unknown;
+}
+
+function noNeedParens() {
+async satisfies unknown;
+satisfies satisfies unknown;
+as satisfies unknown;
+
+abc satisfies unknown; // not a keyword
+}
+
+function satisfiesChain() {
+satisfies satisfies satisfies satisfies satisfies;
+}
+
+
+=====================================output=====================================
+let type: "foo" | "bar" = "foo"
+
+// demonstrating how "satisfies" expression can be practically used as expression statement.
+const _ = () => {
+  switch (type) {
+    case "foo":
+      return 1
+    case "bar":
+      return 2
+    default:
+      // exhaustiveness check idiom
+      type satisfies never
+      throw new Error("unreachable")
+  }
+}
+
+function needParens() {
+  let satisfies unknown
+  interface satisfies unknown
+  module satisfies unknown
+  using satisfies unknown
+  yield satisfies unknown
+  await satisfies unknown
+}
+
+function noNeedParens() {
+  async satisfies unknown
+  satisfies satisfies unknown
+  as satisfies unknown
+
+  abc satisfies unknown // not a keyword
+}
+
+function satisfiesChain() {
+  satisfies satisfies satisfies satisfies satisfies
+}
+
+================================================================================
+`;
+
+exports[`expression-statement.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+
+let type: 'foo' | 'bar' = 'foo';
+
+// demonstrating how "satisfies" expression can be practically used as expression statement.
+const _ = () => {
+switch (type) {
+  case 'foo':
+    return 1;
+  case 'bar':
+    return 2;
+  default:
+    // exhaustiveness check idiom
+    (type) satisfies never;
+    throw new Error('unreachable');
+}
+}
+
+function needParens() {
+(let) satisfies unknown;
+(interface) satisfies unknown;
+(module) satisfies unknown;
+(using) satisfies unknown;
+(yield) satisfies unknown;
+(await) satisfies unknown;
+}
+
+function noNeedParens() {
+async satisfies unknown;
+satisfies satisfies unknown;
+as satisfies unknown;
+
+abc satisfies unknown; // not a keyword
+}
+
+function satisfiesChain() {
+satisfies satisfies satisfies satisfies satisfies;
+}
+
+
+=====================================output=====================================
+let type: "foo" | "bar" = "foo";
+
+// demonstrating how "satisfies" expression can be practically used as expression statement.
+const _ = () => {
+  switch (type) {
+    case "foo":
+      return 1;
+    case "bar":
+      return 2;
+    default:
+      // exhaustiveness check idiom
+      type satisfies never;
+      throw new Error("unreachable");
+  }
+};
+
+function needParens() {
+  let satisfies unknown;
+  interface satisfies unknown;
+  module satisfies unknown;
+  using satisfies unknown;
+  yield satisfies unknown;
+  await satisfies unknown;
+}
+
+function noNeedParens() {
+  async satisfies unknown;
+  satisfies satisfies unknown;
+  as satisfies unknown;
+
+  abc satisfies unknown; // not a keyword
+}
+
+function satisfiesChain() {
+  satisfies satisfies satisfies satisfies satisfies;
+}
+
+================================================================================
+`;
+
 exports[`gt-lt.ts - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/satisfies-operators/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/satisfies-operators/__snapshots__/jsfmt.spec.js.snap
@@ -544,7 +544,6 @@ satisfies satisfies satisfies satisfies satisfies;
 (type) satisfies never satisfies unknown;
 }
 
-
 =====================================output=====================================
 let type: "foo" | "bar" = "foo"
 
@@ -631,7 +630,6 @@ function satisfiesChain() {
 satisfies satisfies satisfies satisfies satisfies;
 (type) satisfies never satisfies unknown;
 }
-
 
 =====================================output=====================================
 let type: "foo" | "bar" = "foo";

--- a/tests/format/typescript/satisfies-operators/expression-statement.ts
+++ b/tests/format/typescript/satisfies-operators/expression-statement.ts
@@ -36,4 +36,3 @@ function satisfiesChain() {
 satisfies satisfies satisfies satisfies satisfies;
 (type) satisfies never satisfies unknown;
 }
-

--- a/tests/format/typescript/satisfies-operators/expression-statement.ts
+++ b/tests/format/typescript/satisfies-operators/expression-statement.ts
@@ -1,0 +1,38 @@
+
+let type: 'foo' | 'bar' = 'foo';
+
+// demonstrating how "satisfies" expression can be practically used as expression statement.
+const _ = () => {
+switch (type) {
+  case 'foo':
+    return 1;
+  case 'bar':
+    return 2;
+  default:
+    // exhaustiveness check idiom
+    (type) satisfies never;
+    throw new Error('unreachable');
+}
+}
+
+function needParens() {
+(let) satisfies unknown;
+(interface) satisfies unknown;
+(module) satisfies unknown;
+(using) satisfies unknown;
+(yield) satisfies unknown;
+(await) satisfies unknown;
+}
+
+function noNeedParens() {
+async satisfies unknown;
+satisfies satisfies unknown;
+as satisfies unknown;
+
+abc satisfies unknown; // not a keyword
+}
+
+function satisfiesChain() {
+satisfies satisfies satisfies satisfies satisfies;
+}
+

--- a/tests/format/typescript/satisfies-operators/expression-statement.ts
+++ b/tests/format/typescript/satisfies-operators/expression-statement.ts
@@ -34,5 +34,6 @@ abc satisfies unknown; // not a keyword
 
 function satisfiesChain() {
 satisfies satisfies satisfies satisfies satisfies;
+(type) satisfies never satisfies unknown;
 }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/prettier/prettier/issues/15491.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] ~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
