### PR TITLE
Allow setting arbitrary Prettier options via .editorconfig

### DIFF
--- a/changelog_unreleased/misc/15531.md
+++ b/changelog_unreleased/misc/15531.md
@@ -1,0 +1,3 @@
+#### Support all Prettier options in EditorConfig files (#15531 by @benblank)
+
+Any Prettier option can be set via `.editorconfig` by converting its name to snake case and prefixing it with `prettier/`. For example, the option `--trailing-comma none` / `{ trailingComma: "none" }` can be translated to `prettier/trailing_comma = none`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,7 +200,9 @@ If you’d like a JSON schema to validate your configuration, one is available h
 
 ## EditorConfig
 
-If `options.editorconfig` is `true` and an [`.editorconfig` file](https://editorconfig.org/) is in your project, Prettier will parse it and convert its properties to the corresponding Prettier configuration. This configuration will be overridden by `.prettierrc`, etc.
+If `options.editorconfig` is `true` and an [`.editorconfig` file](https://editorconfig.org/) is in your project, Prettier will parse it and convert its properties to the corresponding Prettier configuration. Prettier supports several common EditorConfig properties, as well as custom ones — prefixed with `prettier/` and converted to snake case — for all Prettier options. This can prevent the need for separate `.editorconfig` and `.prettierrc`, etc. files.
+
+If the EditorConfig property corresponding to a Prettier option and the prefixed version of that option are both present (e.g. both `quote_type = single` and `prettier/single_quote = true`), the prefixed version will take precedence in the case of a conflict. Similarly, any options present in `.prettierrc`, etc. override anything set via `.editorconfig`. To avoid confusion and accidental conflicts, it is best to ensure that each Prettier option is only set once.
 
 Here’s an annotated description of how different properties map to Prettier’s behavior:
 
@@ -209,18 +211,24 @@ Here’s an annotated description of how different properties map to Prettier’
 # root = true
 
 [*]
-# Non-configurable Prettier behaviors
+# Common properties corresponding to Prettier behaviors which can't be changed
 charset = utf-8
 insert_final_newline = true
 # Caveat: Prettier won’t trim trailing whitespace inside template strings, but your editor might.
 # trim_trailing_whitespace = true
 
-# Configurable Prettier behaviors
+# Common properties corresponding to Prettier options
 # (change these if your Prettier config differs)
 end_of_line = lf
 indent_style = space
 indent_size = 2
 max_line_length = 80
+
+# Custom properties for Prettier options
+prettier/semi = false
+prettier/trailing_comma = none
+# Don't do this; use max_line_length instead, so other tools understand it, too.
+# prettier/print_width = 80
 ```
 
 Here’s a copy+paste-ready `.editorconfig` file if you use the default options:

--- a/src/config/editorconfig-to-prettier.js
+++ b/src/config/editorconfig-to-prettier.js
@@ -1,3 +1,10 @@
+// Matches numbers with digits before or after the decimal point (or both) and
+// numbers without a decimal point. A leading sign is recognized, as are leading
+// and trailing zeroes.
+const NUMBER_PATTERN = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)$/;
+
+const PREFIX = "prettier/";
+
 function removeUnset(editorConfig) {
   const result = {};
   const keys = Object.keys(editorConfig);
@@ -60,6 +67,27 @@ function editorConfigToPrettier(editorConfig) {
 
   if (["cr", "crlf", "lf"].includes(editorConfig.end_of_line)) {
     result.endOfLine = editorConfig.end_of_line;
+  }
+
+  const prefixed = Object.entries(editorConfig).filter(([key]) =>
+    key.startsWith(PREFIX),
+  );
+
+  for (const [rawKey, rawValue] of prefixed) {
+    const key = rawKey
+      .slice(PREFIX.length)
+      .replace(/_([a-z])/, (match) => match[1].toUpperCase());
+
+    const value =
+      rawValue === "true"
+        ? true
+        : rawValue === "false"
+        ? false
+        : NUMBER_PATTERN.test(rawValue)
+        ? Number.parseInt(rawValue, 10)
+        : rawValue;
+
+    result[key] = value;
   }
 
   return result;

--- a/tests/unit/editorconfig-to-prettier.js
+++ b/tests/unit/editorconfig-to-prettier.js
@@ -134,6 +134,16 @@ test("editorconfigToPrettier", () => {
     tabWidth: 2,
   });
 
+  expect(
+    editorconfigToPrettier({
+      "prettier/prose_wrap": "always",
+      something_unrecognized: 1000,
+      "another_prefix/a_different_setting": false,
+    }),
+  ).toStrictEqual({
+    proseWrap: "always",
+  });
+
   expect(editorconfigToPrettier({})).toBeNull();
   expect(editorconfigToPrettier(null)).toBeNull();
 });


### PR DESCRIPTION
### Description

This is a potential implementation of the feature request in #15530.

When reading key-value pairs from an EditorConfig file, any key starting with `prettier/` is translated into an equivalently-named Prettier option, e.g. `prettier/prose_wrap = always` becomes `{ proseWrap: "always" }`. Values which appear to represent booleans (i.e. `true` and `false`) or numbers (e.g. `7` or `-.5`[^1]) are parsed as such. All other values remain strings.

[^1]: While Prettier itself doesn't use floating-point or negative numbers, they are supported here for the benefit of Prettier plugins which may need them.

Prefixed keys are not restricted to those which correspond to Prettier options, so that Prettier plugins can be configured via this mechanism as well. It also creates the potential for the same option to be set via both a common key (e.g. `max_line_length`) and a prefixed key (e.g. `prettier/print_width`), but the documentation warns against doing so. In the case of a conflict, the prefixed key takes precedence.

The slash character was chosen to separate the `prettier` "namespace" from the setting name because, while there doesn't seem to be any real consensus among EditorConfig plugins on what character to use, I felt the slash was at least nicely visually distinct and that using a character other than an underscore reduces the likelihood of accidentally conflicting with other EditorConfig plugins' custom keys or future versions of the EditorConfig spec. I'm very open to selecting a different character (or entire prefix) if another would be preferable.

### Checklist

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
