### PR TITLE
Add support for dynamic tag names in html template literals

### DIFF
--- a/src/language-js/embed/html.js
+++ b/src/language-js/embed/html.js
@@ -19,8 +19,21 @@ async function printEmbedHtmlLike(parser, textToDoc, print, path, options) {
   const counter = htmlTemplateLiteralCounter;
   htmlTemplateLiteralCounter = (htmlTemplateLiteralCounter + 1) >>> 0;
 
-  const composePlaceholder = (index) =>
-    `PRETTIER_HTML_PLACEHOLDER_${index}_${counter}_IN_JS`;
+  const variableNameIndexLookup = {};
+  const composePlaceholder = (index) => {
+    let placeholder = index;
+
+    const nextExpression = node.expressions[index];
+    if (nextExpression && nextExpression.type === "Identifier") {
+      if (Object.hasOwn(variableNameIndexLookup, nextExpression.name)) {
+        placeholder = variableNameIndexLookup[nextExpression.name];
+      } else {
+        variableNameIndexLookup[nextExpression.name] = index;
+      }
+    }
+
+    return `PRETTIER_HTML_PLACEHOLDER_${placeholder}_${counter}_IN_JS`;
+  };
 
   const text = node.quasis
     .map((quasi, index, quasis) =>

--- a/tests/format/js/multiparser-html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/multiparser-html/__snapshots__/jsfmt.spec.js.snap
@@ -346,6 +346,11 @@ html\`
     
     x-attr="\${replace}" .prop="\${replace}">
     </\${staticTagName}>
+    <\${this.staticTagName}
+    >
+    <\${this.a.staticTagName}></\${this.a.staticTagName}>
+    </\${this.staticTagName}
+    >
 </div>
 \`
 
@@ -489,6 +494,9 @@ const staticTagName = "static-tag-name";
 html\`
   <div>
     <\${staticTagName} x-attr="\${replace}" .prop="\${replace}"></\${staticTagName}>
+    <\${this.staticTagName}>
+      <\${this.a.staticTagName}></\${this.a.staticTagName}>
+    </\${this.staticTagName}>
   </div>
 \`;
 
@@ -612,6 +620,11 @@ html\`
     
     x-attr="\${replace}" .prop="\${replace}">
     </\${staticTagName}>
+    <\${this.staticTagName}
+    >
+    <\${this.a.staticTagName}></\${this.a.staticTagName}>
+    </\${this.staticTagName}
+    >
 </div>
 \`
 
@@ -716,6 +729,9 @@ html\`
   <div>
     <\${staticTagName} x-attr="\${replace}" .prop="\${replace}">
     </\${staticTagName}>
+    <\${this.staticTagName}>
+      <\${this.a.staticTagName}></\${this.a.staticTagName}>
+    </\${this.staticTagName}>
   </div>
 \`;
 

--- a/tests/format/js/multiparser-html/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/multiparser-html/__snapshots__/jsfmt.spec.js.snap
@@ -338,6 +338,17 @@ html\`<div style="   color : red;
             display    :inline ">
   </div>\`
 
+const staticTagName = 'static-tag-name';
+
+html\`
+  <div>
+    <\${staticTagName}
+    
+    x-attr="\${replace}" .prop="\${replace}">
+    </\${staticTagName}>
+</div>
+\`
+
 =====================================output=====================================
 import { LitElement, html } from "@polymer/lit-element";
 
@@ -473,6 +484,14 @@ html\`
   ></div>
 \`;
 
+const staticTagName = "static-tag-name";
+
+html\`
+  <div>
+    <\${staticTagName} x-attr="\${replace}" .prop="\${replace}"></\${staticTagName}>
+  </div>
+\`;
+
 ================================================================================
 `;
 
@@ -585,6 +604,17 @@ html\`<div style="   color : red;
             display    :inline ">
   </div>\`
 
+const staticTagName = 'static-tag-name';
+
+html\`
+  <div>
+    <\${staticTagName}
+    
+    x-attr="\${replace}" .prop="\${replace}">
+    </\${staticTagName}>
+</div>
+\`
+
 =====================================output=====================================
 import { LitElement, html } from "@polymer/lit-element";
 
@@ -679,6 +709,15 @@ html\`<div
 \${foo}:\${bar};
             display    :inline "
 ></div>\`;
+
+const staticTagName = "static-tag-name";
+
+html\`
+  <div>
+    <\${staticTagName} x-attr="\${replace}" .prop="\${replace}">
+    </\${staticTagName}>
+  </div>
+\`;
 
 ================================================================================
 `;

--- a/tests/format/js/multiparser-html/lit-html.js
+++ b/tests/format/js/multiparser-html/lit-html.js
@@ -100,3 +100,14 @@ html`<div style="   color : red;
 ${ foo}:${bar};
             display    :inline ">
   </div>`
+
+const staticTagName = 'static-tag-name';
+
+html`
+  <div>
+    <${staticTagName}
+    
+    x-attr="${replace}" .prop="${replace}">
+    </${staticTagName}>
+</div>
+`

--- a/tests/format/js/multiparser-html/lit-html.js
+++ b/tests/format/js/multiparser-html/lit-html.js
@@ -109,5 +109,10 @@ html`
     
     x-attr="${replace}" .prop="${replace}">
     </${staticTagName}>
+    <${this.staticTagName}
+    >
+    <${this.a.staticTagName}></${this.a.staticTagName}>
+    </${this.staticTagName}
+    >
 </div>
 `


### PR DESCRIPTION
## Description

Fixes #5922 by reusing the placeholder index on variables and member expressions that match each other.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
