### PR TITLE
Switch `kRegex` to use RegExp with `u` directly

### DIFF
--- a/src/language-markdown/constants.evaluate.js
+++ b/src/language-markdown/constants.evaluate.js
@@ -21,10 +21,6 @@ const cjkPattern = `(?:${cjkRegex
   Block: ["Variation_Selectors", "Variation_Selectors_Supplement"],
 }).toString()})?`;
 
-const kRegex = unicodeRegex({ Script: ["Hangul"] })
-  .union(unicodeRegex({ Script_Extensions: ["Hangul"] }))
-  .toRegExp();
-
 // http://spec.commonmark.org/0.25/#ascii-punctuation-character
 const asciiPunctuationCharset =
   /* prettier-ignore */ regexpUtil.charset(
@@ -50,4 +46,4 @@ const punctuationCharset = unicodeRegex({
 
 const punctuationPattern = punctuationCharset.toString();
 
-export { cjkPattern, kRegex, punctuationPattern };
+export { cjkPattern, punctuationPattern };

--- a/src/language-markdown/utils.js
+++ b/src/language-markdown/utils.js
@@ -37,8 +37,8 @@ const KIND_CJ_LETTER = "cj-letter";
 const KIND_K_LETTER = "k-letter";
 const KIND_CJK_PUNCTUATION = "cjk-punctuation";
 
-const isKLetter = (character) =>
-  /^\p{Script_Extensions=Hangul}$/u.test(character);
+const K_REGEXP = /^\p{Script_Extensions=Hangul}$/u;
+const isKLetter = (character) => K_REGEXP.test(character);
 
 /**
  * @typedef {" " | "\n" | ""} WhitespaceValue

--- a/src/language-markdown/utils.js
+++ b/src/language-markdown/utils.js
@@ -1,10 +1,6 @@
 import assert from "node:assert";
 import { locStart, locEnd } from "./loc.js";
-import {
-  cjkPattern,
-  kRegex,
-  punctuationPattern,
-} from "./constants.evaluate.js";
+import { cjkPattern, punctuationPattern } from "./constants.evaluate.js";
 
 const INLINE_NODE_TYPES = new Set([
   "liquidNode",
@@ -40,6 +36,9 @@ const KIND_NON_CJK = "non-cjk";
 const KIND_CJ_LETTER = "cj-letter";
 const KIND_K_LETTER = "k-letter";
 const KIND_CJK_PUNCTUATION = "cjk-punctuation";
+
+const isKLetter = (character) =>
+  /^\p{Script_Extensions=Hangul}$/u.test(character);
 
 /**
  * @typedef {" " | "\n" | ""} WhitespaceValue
@@ -122,7 +121,7 @@ function splitText(text) {
               type: "word",
               value: innerToken,
               // Korean uses space to divide words, but Chinese & Japanese do not
-              kind: kRegex.test(innerToken) ? KIND_K_LETTER : KIND_CJ_LETTER,
+              kind: isKLetter(innerToken) ? KIND_K_LETTER : KIND_CJ_LETTER,
               hasLeadingPunctuation: false,
               hasTrailingPunctuation: false,
             },

--- a/src/language-markdown/utils.js
+++ b/src/language-markdown/utils.js
@@ -37,7 +37,7 @@ const KIND_CJ_LETTER = "cj-letter";
 const KIND_K_LETTER = "k-letter";
 const KIND_CJK_PUNCTUATION = "cjk-punctuation";
 
-const K_REGEXP = /^\p{Script_Extensions=Hangul}$/u;
+const K_REGEXP = /^\p{Script_Extensions=Hangul}$/gu;
 const isKLetter = (character) => K_REGEXP.test(character);
 
 /**

--- a/src/language-markdown/utils.js
+++ b/src/language-markdown/utils.js
@@ -37,7 +37,7 @@ const KIND_CJ_LETTER = "cj-letter";
 const KIND_K_LETTER = "k-letter";
 const KIND_CJK_PUNCTUATION = "cjk-punctuation";
 
-const K_REGEXP = /p{Script_Extensions=Hangul}/g;
+const K_REGEXP = /\p{Script_Extensions=Hangul}/u;
 
 /**
  * @typedef {" " | "\n" | ""} WhitespaceValue

--- a/src/language-markdown/utils.js
+++ b/src/language-markdown/utils.js
@@ -37,8 +37,7 @@ const KIND_CJ_LETTER = "cj-letter";
 const KIND_K_LETTER = "k-letter";
 const KIND_CJK_PUNCTUATION = "cjk-punctuation";
 
-const K_REGEXP = /^\p{Script_Extensions=Hangul}$/gu;
-const isKLetter = (character) => K_REGEXP.test(character);
+const K_REGEXP = /p{Script_Extensions=Hangul}/g;
 
 /**
  * @typedef {" " | "\n" | ""} WhitespaceValue
@@ -121,7 +120,7 @@ function splitText(text) {
               type: "word",
               value: innerToken,
               // Korean uses space to divide words, but Chinese & Japanese do not
-              kind: isKLetter(innerToken) ? KIND_K_LETTER : KIND_CJ_LETTER,
+              kind: K_REGEXP.test(innerToken) ? KIND_K_LETTER : KIND_CJ_LETTER,
               hasLeadingPunctuation: false,
               hasTrailingPunctuation: false,
             },


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
