### PR TITLE
Switch `PUNCTUATION_REGEXP` to use RegExp with `u` directly

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "postcss-scss": "4.0.9",
     "postcss-selector-parser": "2.2.3",
     "postcss-values-parser": "2.0.1",
-    "regexp-util": "2.0.0",
     "remark-footnotes": "2.0.0",
     "remark-math": "3.0.1",
     "remark-parse": "8.0.3",

--- a/src/language-markdown/constants.evaluate.js
+++ b/src/language-markdown/constants.evaluate.js
@@ -1,10 +1,10 @@
-import * as cjkRegex from "cjk-regex";
+import { all as getCjkCharset } from "cjk-regex";
 import escapeStringRegexp from "escape-string-regexp";
 import { Charset } from "regexp-util";
 import unicodeRegex from "unicode-regex";
 
 const cjkCharset = new Charset(
-  cjkRegex.all(),
+  getCjkCharset(),
   unicodeRegex({
     Script_Extensions: ["Han", "Katakana", "Hiragana", "Hangul", "Bopomofo"],
     General_Category: [

--- a/src/language-markdown/constants.evaluate.js
+++ b/src/language-markdown/constants.evaluate.js
@@ -1,4 +1,5 @@
 import { all as getCjkCharset } from "cjk-regex";
+import escapeStringRegexp from "escape-string-regexp";
 import { Charset } from "regexp-util";
 import unicodeRegex from "unicode-regex";
 
@@ -24,32 +25,61 @@ const CJK_REGEXP = new RegExp(
   `(?:${cjkCharset.toString()})(?:${variationSelectorsCharset.toString()})?`,
 );
 
-// http://spec.commonmark.org/0.25/#ascii-punctuation-character
-const asciiPunctuationCharset =
-  /* prettier-ignore */ new Charset(
-  "!", '"', "#",  "$", "%", "&", "'", "(", ")", "*",
-  "+", ",", "-",  ".", "/", ":", ";", "<", "=", ">",
-  "?", "@", "[", "\\", "]", "^", "_", "`", "{", "|",
-  "}", "~"
-);
+const asciiPunctuationCharacters = [
+  "!",
+  '"',
+  "#",
+  "$",
+  "%",
+  "&",
+  "'",
+  "(",
+  ")",
+  "*",
+  "+",
+  ",",
+  "-",
+  ".",
+  "/",
+  ":",
+  ";",
+  "<",
+  "=",
+  ">",
+  "?",
+  "@",
+  "[",
+  "\\",
+  "]",
+  "^",
+  "_",
+  "`",
+  "{",
+  "|",
+  "}",
+  "~",
+];
 
 // http://spec.commonmark.org/0.25/#punctuation-character
-const unicodePunctuationCharset = unicodeRegex({
-  // http://unicode.org/Public/5.1.0/ucd/UCD.html#General_Category_Values
-  General_Category: [
-    /* Pc */ "Connector_Punctuation",
-    /* Pd */ "Dash_Punctuation",
-    /* Pe */ "Close_Punctuation",
-    /* Pf */ "Final_Punctuation",
-    /* Pi */ "Initial_Punctuation",
-    /* Po */ "Other_Punctuation",
-    /* Ps */ "Open_Punctuation",
-  ],
-});
+// http://unicode.org/Public/5.1.0/ucd/UCD.html#General_Category_Values
+const unicodePunctuationClasses = [
+  /* Pc */ "Connector_Punctuation",
+  /* Pd */ "Dash_Punctuation",
+  /* Pe */ "Close_Punctuation",
+  /* Pf */ "Final_Punctuation",
+  /* Pi */ "Initial_Punctuation",
+  /* Po */ "Other_Punctuation",
+  /* Ps */ "Open_Punctuation",
+];
 
-const PUNCTUATION_REGEXP = new Charset(
-  asciiPunctuationCharset,
-  unicodePunctuationCharset,
-).toRegExp();
+const PUNCTUATION_REGEXP = new RegExp(
+  [
+    ...asciiPunctuationCharacters.map((character) =>
+      escapeStringRegexp(character),
+    ),
+    ...unicodePunctuationClasses.map((charset) => `\\p{${charset}}`),
+  ].join("|"),
+  "u",
+);
 
 export { CJK_REGEXP, PUNCTUATION_REGEXP };

--- a/src/language-markdown/constants.evaluate.js
+++ b/src/language-markdown/constants.evaluate.js
@@ -1,5 +1,4 @@
 import { all as getCjkCharset } from "cjk-regex";
-import escapeStringRegexp from "escape-string-regexp";
 import { Charset } from "regexp-util";
 import unicodeRegex from "unicode-regex";
 
@@ -73,14 +72,12 @@ const unicodePunctuationClasses = [
 ];
 
 const PUNCTUATION_REGEXP = new RegExp(
-  [
-    ...asciiPunctuationCharacters.map((character) =>
-      escapeStringRegexp(character),
-    ),
+  `(?:${[
+    new Charset(...asciiPunctuationCharacters).toRegExp().source,
     ...unicodePunctuationClasses.map(
       (charset) => `\\p{General_Category=${charset}}`,
     ),
-  ].join("|"),
+  ].join("|")})`,
   "u",
 );
 

--- a/src/language-markdown/constants.evaluate.js
+++ b/src/language-markdown/constants.evaluate.js
@@ -60,8 +60,8 @@ const asciiPunctuationCharacters = [
   "~",
 ];
 
-// http://spec.commonmark.org/0.25/#punctuation-character
-// http://unicode.org/Public/5.1.0/ucd/UCD.html#General_Category_Values
+// https://spec.commonmark.org/0.25/#punctuation-character
+// https://unicode.org/Public/5.1.0/ucd/UCD.html#General_Category_Values
 const unicodePunctuationClasses = [
   /* Pc */ "Connector_Punctuation",
   /* Pd */ "Dash_Punctuation",
@@ -77,7 +77,9 @@ const PUNCTUATION_REGEXP = new RegExp(
     ...asciiPunctuationCharacters.map((character) =>
       escapeStringRegexp(character),
     ),
-    ...unicodePunctuationClasses.map((charset) => `\\p{${charset}}`),
+    ...unicodePunctuationClasses.map(
+      (charset) => `\\p{General_Category=${charset}}`,
+    ),
   ].join("|"),
   "u",
 );

--- a/src/language-markdown/constants.evaluate.js
+++ b/src/language-markdown/constants.evaluate.js
@@ -1,10 +1,10 @@
-import { all as getCjkCharset } from "cjk-regex";
+import * as cjkRegex from "cjk-regex";
 import escapeStringRegexp from "escape-string-regexp";
 import { Charset } from "regexp-util";
 import unicodeRegex from "unicode-regex";
 
 const cjkCharset = new Charset(
-  getCjkCharset(),
+  cjkRegex.all(),
   unicodeRegex({
     Script_Extensions: ["Han", "Katakana", "Hiragana", "Hangul", "Bopomofo"],
     General_Category: [

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -95,7 +95,7 @@ function genericPrint(path, options, print) {
               `(^|${PUNCTUATION_REGEXP.source})(_+)`,
               `(_+)(${PUNCTUATION_REGEXP.source}|$)`,
             ].join("|"),
-            "g",
+            "gu",
           ),
           (_, text1, underscore1, underscore2, text2) =>
             (underscore1

--- a/src/language-markdown/utils.js
+++ b/src/language-markdown/utils.js
@@ -236,11 +236,8 @@ function isAutolink(node) {
 }
 
 export {
-  getFencedCodeBlockValue,
-  getOrderedListItemInfo,
   hasGitDiffFriendlyOrderedList,
   INLINE_NODE_TYPES,
-  INLINE_NODE_WRAPPER_TYPES,
   isAutolink,
   KIND_CJ_LETTER,
   KIND_CJK_PUNCTUATION,

--- a/src/language-markdown/utils.js
+++ b/src/language-markdown/utils.js
@@ -236,8 +236,11 @@ function isAutolink(node) {
 }
 
 export {
+  getFencedCodeBlockValue,
+  getOrderedListItemInfo,
   hasGitDiffFriendlyOrderedList,
   INLINE_NODE_TYPES,
+  INLINE_NODE_WRAPPER_TYPES,
   isAutolink,
   KIND_CJ_LETTER,
   KIND_CJK_PUNCTUATION,

--- a/yarn.lock
+++ b/yarn.lock
@@ -7423,7 +7423,6 @@ __metadata:
     postcss-values-parser: "npm:2.0.1"
     prettier: "npm:3.3.2"
     pretty-bytes: "npm:6.1.1"
-    regexp-util: "npm:2.0.0"
     remark-footnotes: "npm:2.0.0"
     remark-math: "npm:3.0.1"
     remark-parse: "npm:8.0.3"
@@ -7631,7 +7630,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regexp-util@npm:2.0.0, regexp-util@npm:^2.0.0":
+"regexp-util@npm:^2.0.0":
   version: 2.0.0
   resolution: "regexp-util@npm:2.0.0"
   dependencies:


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
