### PR TITLE
Revert "Switch `kRegex` to use RegExp with `u` directly"

### DIFF
--- a/src/language-markdown/constants.evaluate.js
+++ b/src/language-markdown/constants.evaluate.js
@@ -21,6 +21,10 @@ const cjkPattern = `(?:${cjkRegex
   Block: ["Variation_Selectors", "Variation_Selectors_Supplement"],
 }).toString()})?`;
 
+const kRegex = unicodeRegex({ Script: ["Hangul"] })
+  .union(unicodeRegex({ Script_Extensions: ["Hangul"] }))
+  .toRegExp();
+
 // http://spec.commonmark.org/0.25/#ascii-punctuation-character
 const asciiPunctuationCharset =
   /* prettier-ignore */ regexpUtil.charset(
@@ -46,4 +50,4 @@ const punctuationCharset = unicodeRegex({
 
 const punctuationPattern = punctuationCharset.toString();
 
-export { cjkPattern, punctuationPattern };
+export { cjkPattern, kRegex, punctuationPattern };

--- a/src/language-markdown/utils.js
+++ b/src/language-markdown/utils.js
@@ -1,6 +1,10 @@
 import assert from "node:assert";
 import { locStart, locEnd } from "./loc.js";
-import { cjkPattern, punctuationPattern } from "./constants.evaluate.js";
+import {
+  cjkPattern,
+  kRegex,
+  punctuationPattern,
+} from "./constants.evaluate.js";
 
 const INLINE_NODE_TYPES = new Set([
   "liquidNode",
@@ -36,8 +40,6 @@ const KIND_NON_CJK = "non-cjk";
 const KIND_CJ_LETTER = "cj-letter";
 const KIND_K_LETTER = "k-letter";
 const KIND_CJK_PUNCTUATION = "cjk-punctuation";
-
-const K_REGEXP = /\p{Script_Extensions=Hangul}/u;
 
 /**
  * @typedef {" " | "\n" | ""} WhitespaceValue
@@ -120,7 +122,7 @@ function splitText(text) {
               type: "word",
               value: innerToken,
               // Korean uses space to divide words, but Chinese & Japanese do not
-              kind: K_REGEXP.test(innerToken) ? KIND_K_LETTER : KIND_CJ_LETTER,
+              kind: kRegex.test(innerToken) ? KIND_K_LETTER : KIND_CJ_LETTER,
               hasLeadingPunctuation: false,
               hasTrailingPunctuation: false,
             },


### PR DESCRIPTION
Reverts prettier/prettier#15584

Looks like it's not supported in browsers targeted. https://github.com/prettier/prettier/actions/runs/6841921595/job/18602833438?pr=15630#step:5:46