### PR TITLE
Add `replaceTextEndOfLine` back

### DIFF
--- a/src/document/utils.js
+++ b/src/document/utils.js
@@ -407,9 +407,14 @@ function normalizeDoc(doc) {
 function replaceEndOfLine(doc, replacement = literalline) {
   return mapDoc(doc, (currentDoc) =>
     typeof currentDoc === "string"
-      ? join(replacement, currentDoc.split("\n"))
+      ? replaceTextEndOfLine(currentDoc, replacement)
       : currentDoc,
   );
+}
+
+// Strings are docs too, but use it can avoid bundling `mapDoc`
+function replaceTextEndOfLine(text, replacement = literalline) {
+  return join(replacement, text.split("\n"));
 }
 
 function canBreakFn(doc) {
@@ -441,6 +446,7 @@ export {
   normalizeDoc,
   cleanDoc,
   replaceEndOfLine,
+  replaceTextEndOfLine,
   canBreak,
   getDocType,
   inheritLabel,

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -9,7 +9,7 @@ import {
   line,
   softline,
 } from "../document/builders.js";
-import { replaceEndOfLine } from "../document/utils.js";
+import { replaceTextEndOfLine } from "../document/utils.js";
 import getPreferredQuote from "../utils/get-preferred-quote.js";
 import isNonEmptyArray from "../utils/is-non-empty-array.js";
 import UnexpectedNodeError from "../utils/unexpected-node-error.js";
@@ -194,7 +194,7 @@ function print(path, options, print) {
           ];
         }
 
-        return replaceEndOfLine(text);
+        return replaceTextEndOfLine(text);
       }
 
       const isWhitespaceOnly = htmlWhitespaceUtils.isWhitespaceOnly(text);

--- a/src/language-html/embed/angular-interpolation.js
+++ b/src/language-html/embed/angular-interpolation.js
@@ -1,5 +1,5 @@
 import { group, indent, line } from "../../document/builders.js";
-import { replaceEndOfLine } from "../../document/utils.js";
+import { replaceTextEndOfLine } from "../../document/utils.js";
 import { formatAttributeValue } from "./utils.js";
 
 const interpolationRegex = /{{(.+?)}}/s;
@@ -8,7 +8,7 @@ async function printAngularInterpolation(text, textToDoc) {
   const parts = [];
   for (const [index, part] of text.split(interpolationRegex).entries()) {
     if (index % 2 === 0) {
-      parts.push(replaceEndOfLine(part));
+      parts.push(replaceTextEndOfLine(part));
     } else {
       try {
         parts.push(
@@ -27,7 +27,7 @@ async function printAngularInterpolation(text, textToDoc) {
           ]),
         );
       } catch {
-        parts.push("{{", replaceEndOfLine(part), "}}");
+        parts.push("{{", replaceTextEndOfLine(part), "}}");
       }
     }
   }

--- a/src/language-html/print/children.js
+++ b/src/language-html/print/children.js
@@ -6,7 +6,7 @@ import {
   softline,
   hardline,
 } from "../../document/builders.js";
-import { replaceEndOfLine } from "../../document/utils.js";
+import { replaceTextEndOfLine } from "../../document/utils.js";
 import { locStart, locEnd } from "../loc.js";
 import {
   forceBreakChildren,
@@ -31,7 +31,7 @@ function printChild(childPath, options, print) {
   if (hasPrettierIgnore(child)) {
     return [
       printOpeningTagPrefix(child, options),
-      replaceEndOfLine(
+      replaceTextEndOfLine(
         options.originalText.slice(
           locStart(child) +
             (child.prev && needsToBorrowNextOpeningTagStartMarker(child.prev)

--- a/src/language-html/print/element.js
+++ b/src/language-html/print/element.js
@@ -8,7 +8,7 @@ import {
   line,
   softline,
 } from "../../document/builders.js";
-import { replaceEndOfLine } from "../../document/utils.js";
+import { replaceTextEndOfLine } from "../../document/utils.js";
 import getNodeContent from "../get-node-content.js";
 import {
   shouldPreserveContent,
@@ -33,7 +33,7 @@ function printElement(path, options, print) {
     return [
       printOpeningTagPrefix(node, options),
       group(printOpeningTag(path, options, print)),
-      replaceEndOfLine(getNodeContent(node, options)),
+      replaceTextEndOfLine(getNodeContent(node, options)),
       ...printClosingTag(node, options),
       printClosingTagSuffix(node, options),
     ];

--- a/src/language-html/print/tag.js
+++ b/src/language-html/print/tag.js
@@ -11,7 +11,7 @@ import {
   softline,
   hardline,
 } from "../../document/builders.js";
-import { replaceEndOfLine } from "../../document/utils.js";
+import { replaceTextEndOfLine } from "../../document/utils.js";
 import { locStart, locEnd } from "../loc.js";
 import {
   isTextLikeNode,
@@ -240,7 +240,7 @@ function printAttributes(path, options, print) {
   const printedAttributes = path.map(
     ({ node: attribute }) =>
       hasPrettierIgnoreAttribute(attribute)
-        ? replaceEndOfLine(
+        ? replaceTextEndOfLine(
             options.originalText.slice(locStart(attribute), locEnd(attribute)),
           )
         : print(),

--- a/src/language-html/printer-html.js
+++ b/src/language-html/printer-html.js
@@ -3,7 +3,7 @@
  */
 
 import { fill, group, hardline } from "../document/builders.js";
-import { cleanDoc, replaceEndOfLine } from "../document/utils.js";
+import { cleanDoc, replaceTextEndOfLine } from "../document/utils.js";
 import UnexpectedNodeError from "../utils/unexpected-node-error.js";
 import getPreferredQuote from "../utils/get-preferred-quote.js";
 import htmlWhitespaceUtils from "../utils/html-whitespace-utils.js";
@@ -32,7 +32,7 @@ function genericPrint(path, options, print) {
 
   switch (node.type) {
     case "front-matter":
-      return replaceEndOfLine(node.raw);
+      return replaceTextEndOfLine(node.raw);
     case "root":
       if (options.__onHtmlRoot) {
         options.__onHtmlRoot(node);
@@ -66,7 +66,10 @@ function genericPrint(path, options, print) {
         const value = hasTrailingNewline
           ? node.value.replace(trailingNewlineRegex, "")
           : node.value;
-        return [replaceEndOfLine(value), hasTrailingNewline ? hardline : ""];
+        return [
+          replaceTextEndOfLine(value),
+          hasTrailingNewline ? hardline : "",
+        ];
       }
 
       const printed = cleanDoc([
@@ -93,7 +96,7 @@ function genericPrint(path, options, print) {
     case "comment":
       return [
         printOpeningTagPrefix(node, options),
-        replaceEndOfLine(
+        replaceTextEndOfLine(
           options.originalText.slice(locStart(node), locEnd(node)),
         ),
         printClosingTagSuffix(node, options),
@@ -109,7 +112,7 @@ function genericPrint(path, options, print) {
         node.rawName,
         "=",
         quote,
-        replaceEndOfLine(
+        replaceTextEndOfLine(
           quote === '"'
             ? value.replaceAll('"', "&quot;")
             : value.replaceAll("'", "&apos;"),

--- a/src/language-html/utils/index.js
+++ b/src/language-html/utils/index.js
@@ -5,7 +5,7 @@
 import isFrontMatter from "../../utils/front-matter/is-front-matter.js";
 import inferParser from "../../utils/infer-parser.js";
 import { line, hardline, join } from "../../document/builders.js";
-import { replaceEndOfLine } from "../../document/utils.js";
+import { replaceTextEndOfLine } from "../../document/utils.js";
 import {
   CSS_DISPLAY_TAGS,
   CSS_DISPLAY_DEFAULT,
@@ -609,8 +609,8 @@ function isVueSfcBindingsAttribute(attribute, options) {
 function getTextValueParts(node, value = node.value) {
   return node.parent.isWhitespaceSensitive
     ? node.parent.isIndentationSensitive
-      ? replaceEndOfLine(value)
-      : replaceEndOfLine(
+      ? replaceTextEndOfLine(value)
+      : replaceTextEndOfLine(
           dedentString(htmlTrimPreserveIndentation(value)),
           hardline,
         )

--- a/src/language-js/embed/css.js
+++ b/src/language-js/embed/css.js
@@ -1,6 +1,10 @@
 import isNonEmptyArray from "../../utils/is-non-empty-array.js";
 import { indent, hardline, softline } from "../../document/builders.js";
-import { mapDoc, replaceEndOfLine, cleanDoc } from "../../document/utils.js";
+import {
+  mapDoc,
+  replaceTextEndOfLine,
+  cleanDoc,
+} from "../../document/utils.js";
 import { printTemplateExpressions } from "../print/template-literal.js";
 import { isAngularComponentStyles } from "./utils.js";
 
@@ -49,7 +53,7 @@ function replacePlaceholders(quasisDoc, expressionDocs) {
     return doc.split(/@prettier-placeholder-(\d+)-id/).map((component, idx) => {
       // The placeholder is always at odd indices
       if (idx % 2 === 0) {
-        return replaceEndOfLine(component);
+        return replaceTextEndOfLine(component);
       }
 
       // The component will always be a number at odd index

--- a/src/language-js/print/comment.js
+++ b/src/language-js/print/comment.js
@@ -1,5 +1,5 @@
 import { join, hardline } from "../../document/builders.js";
-import { replaceEndOfLine } from "../../document/utils.js";
+import { replaceTextEndOfLine } from "../../document/utils.js";
 
 import { isLineComment } from "../utils/index.js";
 import { locStart, locEnd } from "../loc.js";
@@ -21,7 +21,7 @@ function printComment(commentPath, options) {
       return printIndentableBlockComment(comment);
     }
 
-    return ["/*", replaceEndOfLine(comment.value), "*/"];
+    return ["/*", replaceTextEndOfLine(comment.value), "*/"];
   }
 
   /* c8 ignore next */

--- a/src/language-js/print/estree.js
+++ b/src/language-js/print/estree.js
@@ -8,7 +8,7 @@ import {
   group,
   indent,
 } from "../../document/builders.js";
-import { replaceEndOfLine } from "../../document/utils.js";
+import { replaceTextEndOfLine } from "../../document/utils.js";
 import UnexpectedNodeError from "../../utils/unexpected-node-error.js";
 
 import {
@@ -620,7 +620,7 @@ function printEstree(path, options, print, args) {
     case "AccessorProperty":
       return printClassProperty(path, options, print);
     case "TemplateElement":
-      return replaceEndOfLine(node.value.raw);
+      return replaceTextEndOfLine(node.value.raw);
     case "TemplateLiteral":
       return printTemplateLiteral(path, print, options);
     case "TaggedTemplateExpression":

--- a/src/language-js/print/flow.js
+++ b/src/language-js/print/flow.js
@@ -3,7 +3,7 @@
 import assert from "node:assert";
 import printString from "../../utils/print-string.js";
 import printNumber from "../../utils/print-number.js";
-import { replaceEndOfLine } from "../../document/utils.js";
+import { replaceTextEndOfLine } from "../../document/utils.js";
 import {
   isFunctionNotation,
   isGetterOrSetter,
@@ -241,7 +241,7 @@ function printFlow(path, options, print) {
     case "BooleanLiteralTypeAnnotation":
       return String(node.value);
     case "StringLiteralTypeAnnotation":
-      return replaceEndOfLine(printString(rawText(node), options));
+      return replaceTextEndOfLine(printString(rawText(node), options));
     case "NumberLiteralTypeAnnotation":
       return printNumber(node.raw ?? node.extra.raw);
     case "BigIntLiteralTypeAnnotation":

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -15,7 +15,7 @@ import {
   join,
   cursor,
 } from "../../document/builders.js";
-import { willBreak, replaceEndOfLine } from "../../document/utils.js";
+import { willBreak, replaceTextEndOfLine } from "../../document/utils.js";
 import UnexpectedNodeError from "../../utils/unexpected-node-error.js";
 import getPreferredQuote from "../../utils/get-preferred-quote.js";
 import WhitespaceUtils from "../../utils/whitespace-utils.js";
@@ -505,7 +505,11 @@ function printJsxAttribute(path, options, print) {
           : final.replaceAll("'", "&apos;");
       res = path.call(
         () =>
-          printComments(path, replaceEndOfLine(quote + final + quote), options),
+          printComments(
+            path,
+            replaceTextEndOfLine(quote + final + quote),
+            options,
+          ),
         "value",
       );
     } else {

--- a/src/language-js/print/literal.js
+++ b/src/language-js/print/literal.js
@@ -1,6 +1,6 @@
 import printString from "../../utils/print-string.js";
 import printNumber from "../../utils/print-number.js";
-import { replaceEndOfLine } from "../../document/utils.js";
+import { replaceTextEndOfLine } from "../../document/utils.js";
 
 /**
  * @typedef {import("../types/estree.js").Node} Node
@@ -17,7 +17,7 @@ function printLiteral(path, options /*, print*/) {
     case "NumericLiteral": // Babel 6 Literal split
       return printNumber(node.extra.raw);
     case "StringLiteral": // Babel 6 Literal split
-      return replaceEndOfLine(printString(node.extra.raw, options));
+      return replaceTextEndOfLine(printString(node.extra.raw, options));
     case "NullLiteral": // Babel 6 Literal split
       return "null";
     case "BooleanLiteral": // Babel 6 Literal split
@@ -48,7 +48,7 @@ function printLiteral(path, options /*, print*/) {
       if (typeof value === "string") {
         return isDirective(path)
           ? printDirective(node.raw, options)
-          : replaceEndOfLine(printString(node.raw, options));
+          : replaceTextEndOfLine(printString(node.raw, options));
       }
       return String(value);
     }

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -18,7 +18,7 @@ import {
   group,
   hardlineWithoutBreakParent,
 } from "../document/builders.js";
-import { normalizeDoc, replaceEndOfLine } from "../document/utils.js";
+import { normalizeDoc, replaceTextEndOfLine } from "../document/utils.js";
 import { printDocToString } from "../document/printer.js";
 import UnexpectedNodeError from "../utils/unexpected-node-error.js";
 import embed from "./embed.js";
@@ -236,7 +236,7 @@ function genericPrint(path, options, print) {
         const alignment = " ".repeat(4);
         return align(alignment, [
           alignment,
-          replaceEndOfLine(node.value, hardline),
+          replaceTextEndOfLine(node.value, hardline),
         ]);
       }
 
@@ -250,7 +250,7 @@ function genericPrint(path, options, print) {
         node.lang || "",
         node.meta ? " " + node.meta : "",
         hardline,
-        replaceEndOfLine(
+        replaceTextEndOfLine(
           getFencedCodeBlockValue(node, options.originalText),
           hardline,
         ),
@@ -264,7 +264,7 @@ function genericPrint(path, options, print) {
         parent.type === "root" && isLast ? node.value.trimEnd() : node.value;
       const isHtmlComment = /^<!--.*-->$/s.test(value);
 
-      return replaceEndOfLine(
+      return replaceTextEndOfLine(
         value,
         // @ts-expect-error
         isHtmlComment ? hardline : markAsRoot(literalline),
@@ -410,7 +410,7 @@ function genericPrint(path, options, print) {
         ? ["  ", markAsRoot(literalline)]
         : ["\\", hardline];
     case "liquidNode":
-      return replaceEndOfLine(node.value, hardline);
+      return replaceTextEndOfLine(node.value, hardline);
     // MDX
     // fallback to the original text if multiparser failed
     // or `embeddedLanguageFormatting: "off"`
@@ -424,7 +424,9 @@ function genericPrint(path, options, print) {
       return [
         "$$",
         hardline,
-        node.value ? [replaceEndOfLine(node.value, hardline), hardline] : "",
+        node.value
+          ? [replaceTextEndOfLine(node.value, hardline), hardline]
+          : "",
         "$$",
       ];
     case "inlineMath":

--- a/src/language-yaml/printer-yaml.js
+++ b/src/language-yaml/printer-yaml.js
@@ -9,7 +9,7 @@ import {
   line,
   lineSuffix,
 } from "../document/builders.js";
-import { replaceEndOfLine } from "../document/utils.js";
+import { replaceTextEndOfLine } from "../document/utils.js";
 import isPreviousLineEmpty from "../utils/is-previous-line-empty.js";
 import UnexpectedNodeError from "../utils/unexpected-node-error.js";
 import { insertPragma, isPragma } from "./pragma.js";
@@ -97,7 +97,7 @@ function genericPrint(path, options, print) {
 
   if (hasPrettierIgnore(path)) {
     parts.push(
-      replaceEndOfLine(
+      replaceTextEndOfLine(
         options.originalText
           .slice(node.position.start.offset, node.position.end.offset)
           .trimEnd(),


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

It was removed in https://github.com/prettier/prettier/pull/13343, it doesn't matter before because we bundle all print logic in code, but now the print logic lives in plugins, use this version can reduce size.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
