### PR TITLE
Update contributing.md to mention options philosophy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ To debug Prettier locally, you can either debug it in Node (recommended) or the 
 
 ## No New Options
 
-Prettier is an opinionated styler and is not accepting pull requests that add new formatting options. You can [read more about our options philosophy here](docs/option-philosophy.md).
+Prettier is an opinionated formatter and is not accepting pull requests that add new formatting options. You can [read more about our options philosophy here](docs/option-philosophy.md).
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ To debug Prettier locally, you can either debug it in Node (recommended) or the 
 
 ## No New Options
 
-Prettier is an opinionated styler and is not accepting pull requests that add new formatting options.  You can [read more about our options philosophy here](docs/option-philosophy.md).
+Prettier is an opinionated styler and is not accepting pull requests that add new formatting options. You can [read more about our options philosophy here](docs/option-philosophy.md).
 
 ## Pull requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,10 @@ To debug Prettier locally, you can either debug it in Node (recommended) or the 
 - The easiest way to debug it in Node is to create a local test file with some example code you want formatted and either run it in an editor like VS Code or run it directly via `./bin/prettier.js <your_test_file>`.
 - The easiest way to debug it in the browser is to build Prettier's website locally (see [`website/README.md`](website/README.md)).
 
+## No New Options
+
+Prettier is an opinionated styler and is not accepting pull requests that add new formatting options.  You can [read more about our options philosophy here](docs/option-philosophy.md).
+
 ## Pull requests
 
 The project uses ESLint for linting and Prettier for formatting. If your editor isn't set up to work with them, you can lint and format all files from the command line using `yarn fix`.


### PR DESCRIPTION
`CONTRIBUTING.md` now briefly discusses the option philosophy and links to `docs/options-philosophy.md`.

