### PR TITLE
Improve `getVisitorKeys` runtime performance

### DIFF
--- a/src/utils/create-get-visitor-keys.js
+++ b/src/utils/create-get-visitor-keys.js
@@ -7,7 +7,7 @@ function createGetVisitorKeys(visitorKeys, typeProperty = "type") {
     const type = node[typeProperty];
 
     /* c8 ignore next 5 */
-    if (process.env.NODE_ENV !== "production" && type === undefined) {
+    if (type === undefined && process.env.NODE_ENV !== "production") {
       throw new Error(
         `Can't get node type, you must pass the wrong typeProperty '${typeProperty}'`,
       );


### PR DESCRIPTION
## Description

After profiling Prettier against a large repo like [mui/material-ui](https://github.com/mui/material-ui), the `getVisitorKeys` function is flagged as the function with the highest self-time. 

<img width="891" alt="Screenshot 2023-11-13 at 06 31 52" src="https://github.com/prettier/prettier/assets/2567083/2431a59c-bcc6-4a69-bc21-9c09a8098ee0">

After drilling into the file, it becomes clear that most of the time is spent checking `process.env.NODE_ENV`. This PR improves `getVisitorKeys` runtime performance by swapping the two conditions in the if branch. The `undefined`  check is cheaper than the `process.env.NODE_ENV` property lookup and the string comparison. 

Rerunning Prettier against the material-ui repo shows a ~1% performance improvement.

**Before:**

<img width="789" alt="Screenshot 2023-11-13 at 06 32 46" src="https://github.com/prettier/prettier/assets/2567083/c18fb74c-ecfb-48be-8380-baf689db0045">

**After:**

<img width="888" alt="Screenshot 2023-11-13 at 06 36 33" src="https://github.com/prettier/prettier/assets/2567083/5d895ba2-0ed7-48ef-9eb3-efd8e3f9fc9d">

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
