### PR TITLE
Remove unused `findParentDir` from mockable

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
     "fast-json-stable-stringify": "2.1.0",
     "file-entry-cache": "7.0.1",
     "find-cache-dir": "5.0.0",
-    "find-parent-dir": "0.3.1",
     "flow-parser": "0.221.0",
     "get-east-asian-width": "1.2.0",
     "get-stdin": "9.0.0",

--- a/src/common/mockable.js
+++ b/src/common/mockable.js
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import { lilconfig } from "lilconfig";
-import { sync as findParentDir } from "find-parent-dir";
 import getStdin from "get-stdin";
 import { isCI } from "ci-info";
 
@@ -10,7 +9,6 @@ function writeFormattedFile(file, data) {
 
 const mockable = {
   lilconfig,
-  findParentDir,
   getStdin,
   isCI: () => isCI,
   writeFormattedFile,

--- a/tests/integration/cli-worker.js
+++ b/tests/integration/cli-worker.js
@@ -71,7 +71,6 @@ async function run() {
       ...options,
       stopDir: url.fileURLToPath(new URL("./cli", import.meta.url)),
     });
-  mockable.findParentDir = () => process.cwd();
   // eslint-disable-next-line require-await
   mockable.writeFormattedFile = async (filename, content) => {
     filename = normalizeToPosix(path.relative(process.cwd(), filename));

--- a/yarn.lock
+++ b/yarn.lock
@@ -4145,13 +4145,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-parent-dir@npm:0.3.1":
-  version: 0.3.1
-  resolution: "find-parent-dir@npm:0.3.1"
-  checksum: 55e722584760cfbc6611901c7ced5081345cf629e2ecd6a4f6704b13b5a1876c8d9d9db5fd4965ba23e1ecbc24a8b62af40379cfef1ffa0231719b9d924eebdd
-  languageName: node
-  linkType: hard
-
 "find-up@npm:^4.0.0, find-up@npm:^4.1.0":
   version: 4.1.0
   resolution: "find-up@npm:4.1.0"
@@ -7202,7 +7195,6 @@ __metadata:
     fast-json-stable-stringify: 2.1.0
     file-entry-cache: 7.0.1
     find-cache-dir: 5.0.0
-    find-parent-dir: 0.3.1
     flow-parser: 0.221.0
     get-east-asian-width: 1.2.0
     get-stdin: 9.0.0


### PR DESCRIPTION
## Description

It appears that the `findParentDir` method `mockable.js` isn't used anywhere in the code base. I suspect that this code wasn't cleaned after a refactor, but I wasn't able the specific commit in the history.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
