### PR TITLE
Fix spelling issue in ternaries blog post

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -43,7 +43,6 @@
         "Cheung",
         "chrzosel",
         "Clemmons",
-        "clammering",
         "cliify",
         "cmds",
         "codebases",

--- a/website/blog/2023-11-13-curious-ternaries.md
+++ b/website/blog/2023-11-13-curious-ternaries.md
@@ -65,7 +65,7 @@ Another developer had this to say:
 
 So we felt we had a winning formula, but we knew it could be a jarring introduction to the community.
 
-As a result, we decided to put this new formatting behind a temporary `--experimental-ternaries` option for a few months, and in the meantime go ahead and ship what the community has been clammering for: [indented ternaries](https://github.com/prettier/prettier/pull/9559).
+As a result, we decided to put this new formatting behind a temporary `--experimental-ternaries` option for a few months, and in the meantime go ahead and ship what the community has been clamoring for: [indented ternaries](https://github.com/prettier/prettier/pull/9559).
 
 ## Styling Overview
 


### PR DESCRIPTION
## Description

This PR fixes the spelling of "clamoring" in the latest release blog post.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
