### PR TITLE
Mock `stopDir` instead of the whole `lilconfig` package

### DIFF
--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -583,6 +583,11 @@ const nodejsFiles = [
         module: getPackageFile("js-yaml/dist/js-yaml.mjs"),
         path: getPackageFile("js-yaml/lib/loader.js"),
       },
+      {
+        module: require.resolve("lilconfig"),
+        find: "exports.lilconfigSync = lilconfigSync;",
+        replacement: "",
+      },
     ],
     addDefaultExport: true,
   },
@@ -610,13 +615,6 @@ const nodejsFiles = [
   {
     input: "src/common/mockable.js",
     outputBaseName: "internal/internal",
-    replaceModule: [
-      {
-        module: require.resolve("lilconfig"),
-        find: "exports.lilconfigSync = lilconfigSync;",
-        replacement: "",
-      },
-    ],
   },
 ].flatMap((file) => {
   let { input, output, outputBaseName, ...buildOptions } = file;

--- a/src/common/mockable.js
+++ b/src/common/mockable.js
@@ -7,7 +7,8 @@ function writeFormattedFile(file, data) {
 }
 
 const mockable = {
-  getLilconfigStopDirectory() {},
+  // eslint-disable-next-line unicorn/no-useless-undefined
+  getLilconfigStopDirectory: () => undefined,
   getStdin,
   isCI: () => isCI,
   writeFormattedFile,

--- a/src/common/mockable.js
+++ b/src/common/mockable.js
@@ -1,5 +1,4 @@
 import fs from "node:fs/promises";
-import { lilconfig } from "lilconfig";
 import getStdin from "get-stdin";
 import { isCI } from "ci-info";
 
@@ -8,7 +7,7 @@ function writeFormattedFile(file, data) {
 }
 
 const mockable = {
-  lilconfig,
+  getLilconfigStopDirectory() {},
   getStdin,
   isCI: () => isCI,
   writeFormattedFile,

--- a/src/config/get-prettier-config-explorer.js
+++ b/src/config/get-prettier-config-explorer.js
@@ -1,12 +1,11 @@
 import { pathToFileURL } from "node:url";
+import { lilconfig } from "lilconfig";
 import parseToml from "@iarna/toml/parse-async.js";
 import parseJson5 from "json5/lib/parse.js";
 import yaml from "js-yaml";
 import parseJson from "parse-json";
 import mockable from "../common/mockable.js";
 import loadExternalConfig from "./load-external-config.js";
-
-const { lilconfig } = mockable;
 
 const searchPlaces = [
   "package.json",
@@ -106,7 +105,8 @@ async function transform(result) {
  * @return {ReturnType<import("lilconfig").lilconfig>}
  */
 function getExplorer() {
-  return lilconfig("prettier", { searchPlaces, loaders, transform });
+  const stopDir = mockable.getLilconfigStopDirectory();
+  return lilconfig("prettier", { searchPlaces, loaders, transform, stopDir });
 }
 
 export default getExplorer;

--- a/tests/integration/__tests__/mockable.js
+++ b/tests/integration/__tests__/mockable.js
@@ -1,56 +1,5 @@
-import path from "node:path";
 import { pathToFileURL } from "node:url";
-import createEsmUtils from "esm-utils";
 import { mockable } from "../env.js";
-
-const { __dirname } = createEsmUtils(import.meta);
-
-// This don't has to be the same result as `prettier.resolveConfig`,
-// Because we are testing with default `lilconfigOptions`
-describe("lilconfig", () => {
-  let lilconfig;
-  beforeAll(async () => {
-    ({
-      default: { lilconfig },
-    } = await import(pathToFileURL(mockable)));
-  });
-
-  const configs = [
-    {
-      title: "prettier.config.cjs",
-      dirname: path.join(__dirname, "../cli/config/js/"),
-      file: path.join(__dirname, "../cli/config/js/prettier.config.cjs"),
-      value: {
-        endOfLine: "auto",
-        tabWidth: 8,
-      },
-    },
-    {
-      title: "package.json",
-      dirname: path.join(__dirname, "../cli/config/package/"),
-      file: path.join(__dirname, "../cli/config/package/package.json"),
-      value: {
-        tabWidth: 3,
-        overrides: [
-          {
-            files: "*.ts",
-            options: {
-              tabWidth: 5,
-            },
-          },
-        ],
-      },
-    },
-  ];
-
-  for (const { title, dirname, file, value } of configs) {
-    test(`async version ${title}`, async () => {
-      const { config, filepath } = await lilconfig("prettier").search(dirname);
-      expect(config).toEqual(value);
-      expect(filepath).toBe(file);
-    });
-  }
-});
 
 test("isCI", async () => {
   const {

--- a/tests/integration/cli-worker.js
+++ b/tests/integration/cli-worker.js
@@ -3,7 +3,6 @@ import fs from "node:fs";
 import path from "node:path";
 import url from "node:url";
 import readline from "node:readline";
-import { lilconfig } from "lilconfig";
 import { prettierCli, mockable as mockableModuleFile } from "./env.js";
 
 const normalizeToPosix =
@@ -66,11 +65,8 @@ async function run() {
   // eslint-disable-next-line require-await
   mockable.getStdin = async () => options.input || "";
   mockable.isCI = () => Boolean(options.ci);
-  mockable.lilconfig = (moduleName, options) =>
-    lilconfig(moduleName, {
-      ...options,
-      stopDir: url.fileURLToPath(new URL("./cli", import.meta.url)),
-    });
+  mockable.getLilconfigStopDirectory = () =>
+    url.fileURLToPath(new URL("./cli", import.meta.url));
   // eslint-disable-next-line require-await
   mockable.writeFormattedFile = async (filename, content) => {
     filename = normalizeToPosix(path.relative(process.cwd(), filename));


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
