### PR TITLE
Fix unstable and ugly formatting for comments in destructuring patterns

### DIFF
--- a/changelog_unreleased/typescript/15708.md
+++ b/changelog_unreleased/typescript/15708.md
@@ -1,0 +1,31 @@
+#### Fix unstable and ugly formatting for comments in destructuring patterns (#15708 by @sosukesuzuki)
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+const {
+  foo,
+  // bar
+  // baz
+}: Foo = expr;
+
+// Prettier stable
+const {
+  foo1,
+} // bar
+// baz
+: Foo = expr;
+
+// Prettier stable second output
+const {
+  foo1, // bar
+} // baz
+: Foo = expr;
+
+// Prettier main
+const {
+  foo1,
+  // bar
+  // baz
+}: Foo = expr;
+```

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -62,7 +62,7 @@ function handleOwnLineComment(context) {
     handleLabeledStatementComments,
     handleBreakAndContinueStatementComments,
     handleNestedConditionalExpressionComments,
-    handleCommentsInPattern,
+    handleCommentsInDestructuringPattern,
   ].some((fn) => fn(context));
 }
 
@@ -991,7 +991,7 @@ function handleLastUnionElementInExpression({
  * }: Foo = foo();
  *
  */
-function handleCommentsInPattern({
+function handleCommentsInDestructuringPattern({
   comment,
   enclosingNode,
   precedingNode,

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -62,6 +62,7 @@ function handleOwnLineComment(context) {
     handleLabeledStatementComments,
     handleBreakAndContinueStatementComments,
     handleNestedConditionalExpressionComments,
+    handleCommentsInPattern,
   ].some((fn) => fn(context));
 }
 
@@ -974,6 +975,36 @@ function handleLastUnionElementInExpression({
     return true;
   }
   return false;
+}
+
+/**
+ * const [
+ *   foo,
+ *   // bar
+ *   // baz
+ * ]: Foo = foo();
+ *
+ * const {
+ *   foo,
+ *   // bar
+ *   // baz
+ * }: Foo = foo();
+ *
+ */
+function handleCommentsInPattern({
+  comment,
+  enclosingNode,
+  precedingNode,
+  followingNode,
+}) {
+  if (
+    (enclosingNode?.type === "ObjectPattern" ||
+      enclosingNode?.type === "ArrayPattern") &&
+    followingNode?.type === "TSTypeAnnotation"
+  ) {
+    addTrailingComment(precedingNode, comment);
+    return true;
+  }
 }
 
 /**

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -1002,7 +1002,15 @@ function handleCommentsInDestructuringPattern({
       enclosingNode?.type === "ArrayPattern") &&
     followingNode?.type === "TSTypeAnnotation"
   ) {
-    addTrailingComment(precedingNode, comment);
+    if (precedingNode) {
+      addTrailingComment(precedingNode, comment);
+    } else {
+      // const {
+      //   // bar
+      //   // baz
+      // }: Foo = expr;
+      addDanglingComment(enclosingNode, comment);
+    }
     return true;
   }
 }

--- a/tests/format/typescript/comments/15707.ts
+++ b/tests/format/typescript/comments/15707.ts
@@ -1,0 +1,45 @@
+const {
+  foo,
+  // bar
+  // baz
+}: Foo = expr;
+
+const {
+  foo1,
+  // bar
+  foo2,
+  // baz
+}: Foo = expr;
+
+const [
+  foo,
+  // bar
+  // baz
+]: Foo = expr;
+
+const [
+  foo1,
+  // bar
+  foo2,
+  // baz
+]: Foo = expr;
+
+function method({
+  foo,
+  // bar = "bar",
+  // bazz = "bazz",
+}: Foo) {}
+
+function method({
+  foo1,
+  // bar = "bar",
+  foo2
+  // bazz = "bazz",
+}: Foo) {}
+
+function method([
+  foo,
+  // bar = "bar",
+  foo2
+  // bazz = "bazz",
+]: Foo) {}

--- a/tests/format/typescript/comments/15707.ts
+++ b/tests/format/typescript/comments/15707.ts
@@ -43,3 +43,13 @@ function method([
   foo2
   // bazz = "bazz",
 ]: Foo) {}
+
+const {
+  // bar
+  // baz
+}: Foo = expr;
+
+const [
+  // bar
+  // baz
+]: Foo = expr;

--- a/tests/format/typescript/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/comments/__snapshots__/jsfmt.spec.js.snap
@@ -1,5 +1,107 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`15707.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const {
+  foo,
+  // bar
+  // baz
+}: Foo = expr;
+
+const {
+  foo1,
+  // bar
+  foo2,
+  // baz
+}: Foo = expr;
+
+const [
+  foo,
+  // bar
+  // baz
+]: Foo = expr;
+
+const [
+  foo1,
+  // bar
+  foo2,
+  // baz
+]: Foo = expr;
+
+function method({
+  foo,
+  // bar = "bar",
+  // bazz = "bazz",
+}: Foo) {}
+
+function method({
+  foo1,
+  // bar = "bar",
+  foo2
+  // bazz = "bazz",
+}: Foo) {}
+
+function method([
+  foo,
+  // bar = "bar",
+  foo2
+  // bazz = "bazz",
+]: Foo) {}
+
+=====================================output=====================================
+const {
+  foo,
+  // bar
+  // baz
+}: Foo = expr;
+
+const {
+  foo1,
+  // bar
+  foo2,
+  // baz
+}: Foo = expr;
+
+const [
+  foo,
+  // bar
+  // baz
+]: Foo = expr;
+
+const [
+  foo1,
+  // bar
+  foo2,
+  // baz
+]: Foo = expr;
+
+function method({
+  foo,
+  // bar = "bar",
+  // bazz = "bazz",
+}: Foo) {}
+
+function method({
+  foo1,
+  // bar = "bar",
+  foo2,
+  // bazz = "bazz",
+}: Foo) {}
+
+function method([
+  foo,
+  // bar = "bar",
+  foo2,
+  // bazz = "bazz",
+]: Foo) {}
+
+================================================================================
+`;
+
 exports[`abstract_class.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]

--- a/tests/format/typescript/comments/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/typescript/comments/__snapshots__/jsfmt.spec.js.snap
@@ -52,6 +52,16 @@ function method([
   // bazz = "bazz",
 ]: Foo) {}
 
+const {
+  // bar
+  // baz
+}: Foo = expr;
+
+const [
+  // bar
+  // baz
+]: Foo = expr;
+
 =====================================output=====================================
 const {
   foo,
@@ -98,6 +108,16 @@ function method([
   foo2,
   // bazz = "bazz",
 ]: Foo) {}
+
+const {
+  // bar
+  // baz
+}: Foo = expr;
+
+const [
+  // bar
+  // baz
+]: Foo = expr;
 
 ================================================================================
 `;


### PR DESCRIPTION
## Description

Fixes #15707

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
