### PR TITLE
Reduce how much text needs to be diffed when computing cursor positions

### DIFF
--- a/src/document/printer.js
+++ b/src/document/printer.js
@@ -648,8 +648,8 @@ function printDocToString(doc, options) {
 
     return {
       formatted: beforeCursor + aroundCursor + afterCursor,
-      cursorNodeStart: beforeCursor.length,
-      cursorNodeText: aroundCursor,
+      cursorRegionStart: beforeCursor.length,
+      cursorRegionText: aroundCursor,
     };
   }
 

--- a/src/document/public.d.ts
+++ b/src/document/public.d.ts
@@ -192,8 +192,8 @@ export namespace printer {
     options: Options,
   ): {
     formatted: string;
-    cursorNodeStart?: number | undefined;
-    cursorNodeText?: string | undefined;
+    cursorRegionStart?: number | undefined;
+    cursorRegionText?: string | undefined;
   };
   interface Options {
     /**

--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -244,14 +244,28 @@ function printJsxElementInternal(path, options, print) {
     : group(multilineChildren, { shouldBreak: true });
 
   /*
-  `printJsxChildren` won't call `print` on `JSXText`
-  When the cursorNode is inside `cursor` won't get print.
+  `printJsxChildren` won't call `print` on `JSXText`, so when the cursorNode,
+  nodeBeforeCursor, or nodeAfterCursor is inside, `cursor` won't get printed.
+  This logic fixes that:
   */
-  if (
-    options.cursorNode?.type === "JSXText" &&
-    node.children.includes(options.cursorNode)
-  ) {
-    content = [cursor, content, cursor];
+  if (options.cursorLocation) {
+    const { cursorNode, nodeBeforeCursor, nodeAfterCursor } =
+      options.cursorLocation;
+    if (cursorNode?.type === "JSXText" && node.children.includes(cursorNode)) {
+      content = [cursor, content, cursor];
+    }
+    if (
+      nodeBeforeCursor?.type === "JSXText" &&
+      node.children.includes(nodeBeforeCursor)
+    ) {
+      content = [cursor, content];
+    }
+    if (
+      nodeAfterCursor?.type === "JSXText" &&
+      node.children.includes(nodeAfterCursor)
+    ) {
+      content = [content, cursor];
+    }
   }
 
   if (isMdxBlock) {

--- a/src/main/ast-to-doc.js
+++ b/src/main/ast-to-doc.js
@@ -51,6 +51,19 @@ async function printAstToDoc(ast, options) {
 
   ensureAllCommentsPrinted(options);
 
+  if (
+    options.cursorLocation?.nodeAfterCursor &&
+    !options.cursorLocation.nodeBeforeCursor
+  ) {
+    return [cursor, doc];
+  }
+  if (
+    options.cursorLocation?.nodeBeforeCursor &&
+    !options.cursorLocation.nodeAfterCursor
+  ) {
+    return [doc, cursor];
+  }
+
   return doc;
 
   function mainPrint(selector, args) {
@@ -106,8 +119,20 @@ function callPluginPrintFunction(path, options, printPath, args, embeds) {
     doc = printer.print(path, options, printPath, args);
   }
 
-  if (node === options.cursorNode) {
-    doc = inheritLabel(doc, (doc) => [cursor, doc, cursor]);
+  if (options.cursorLocation) {
+    const { cursorNode, nodeBeforeCursor, nodeAfterCursor } =
+      options.cursorLocation;
+    switch (node) {
+      case cursorNode:
+        doc = inheritLabel(doc, (doc) => [cursor, doc, cursor]);
+        break;
+      case nodeBeforeCursor:
+        doc = inheritLabel(doc, (doc) => [doc, cursor]);
+        break;
+      case nodeAfterCursor:
+        doc = inheritLabel(doc, (doc) => [cursor, doc]);
+        break;
+    }
   }
 
   // We let JSXElement print its comments itself because it adds () around

--- a/src/main/get-cursor-node.js
+++ b/src/main/get-cursor-node.js
@@ -1,23 +1,81 @@
-import { getDescendants } from "../utils/ast-utils.js";
+import { getChildren, getDescendants, isLeaf } from "../utils/ast-utils.js";
 import createGetVisitorKeysFunction from "./create-get-visitor-keys-function.js";
 
-function getCursorNode(ast, options) {
+/**
+ * Find the location of the cursor in the AST, represented in one of the
+ * following ways:
+ * 
+ *   { "cursorNode": <node> } - the cursor is WITHIN <node>
+ 
+ *   { "nodeBeforeCursor": <node1> | undefined,
+ *     "nodeAfterCursor": <node2> | undefined }
+ *   - the cursor is BETWEEN <node1> and <node2>. `undefined` represents the
+ *     beginning or end of the document.
+ * 
+ * This function will return whichever of the above possibilities most
+ * precisely identifies the cursor's location. This means returning a
+ * "cursorNode" when the cursor lies within a leaf node of the AST, and one of
+ * the other possibilities otherwise.
+ */
+function getCursorLocation(ast, options) {
   const { cursorOffset, locStart, locEnd } = options;
   const getVisitorKeys = createGetVisitorKeysFunction(
     options.printer.getVisitorKeys,
   );
+  
   const nodeContainsCursor = (node) =>
     locStart(node) <= cursorOffset && locEnd(node) >= cursorOffset;
 
   let cursorNode = ast;
+  const nodesContainingCursor = [ast];
+
   for (const node of getDescendants(ast, {
     getVisitorKeys,
     filter: nodeContainsCursor,
   })) {
+    nodesContainingCursor.push(node);
     cursorNode = node;
   }
 
-  return cursorNode;
+  if (isLeaf(cursorNode, {getVisitorKeys})) {
+    return { cursorNode }
+  }
+
+  // We've established that the cursor is NOT contained in a leaf node of the
+  // AST. We instead need to find two nodes (which needn't necessarily be
+  // leaves) of the AST that the cursor lies *between*.
+
+  let nodeBeforeCursor;
+  let nodeAfterCursor;
+  let nodeBeforeCursorEndIndex = -1;
+  let nodeAfterCursorStartIndex = Number.POSITIVE_INFINITY;
+
+  while (nodesContainingCursor.length > 0 && (nodeBeforeCursor === undefined || nodeAfterCursor === undefined)) {
+    cursorNode = nodesContainingCursor.pop();
+    const foundBeforeNode = nodeBeforeCursor !== undefined;
+    const foundAfterNode = nodeAfterCursor !== undefined;
+    for (const node of getChildren(cursorNode, {getVisitorKeys})) {
+      if (!foundBeforeNode) {
+        const nodeEnd = locEnd(node)
+        if (nodeEnd <= cursorOffset && nodeEnd > nodeBeforeCursorEndIndex) {
+          nodeBeforeCursor = node;
+          nodeBeforeCursorEndIndex = nodeEnd;
+        }
+      }
+      if (!foundAfterNode) {
+        const nodeStart = locStart(node)
+        if (nodeStart >= cursorOffset && nodeStart < nodeAfterCursorStartIndex) {
+          nodeAfterCursor = node;
+          nodeAfterCursorStartIndex = nodeStart;
+        }
+      }
+    }
+  }
+
+  return {
+    nodeBeforeCursor,
+    nodeAfterCursor
+  }
 }
 
-export default getCursorNode;
+export default getCursorLocation;

--- a/src/utils/ast-utils.js
+++ b/src/utils/ast-utils.js
@@ -47,6 +47,17 @@ function* getDescendants(node, options) {
 
 /**
  * @param {Node} node
+ * @param {{getVisitorKeys: GetVisitorKeys}}
+ */
+function isLeaf(node, options) {
+  for (const _ of getChildren(node, options)) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * @param {Node} node
  * @param {{getVisitorKeys: GetVisitorKeys, predicate: Predicate}} options
  */
 function hasDescendant(node, { getVisitorKeys, predicate }) {
@@ -59,4 +70,4 @@ function hasDescendant(node, { getVisitorKeys, predicate }) {
   return false;
 }
 
-export { hasDescendant, getDescendants, getChildren };
+export { hasDescendant, getDescendants, getChildren, isLeaf };

--- a/tests/unit/print-doc-to-string.js
+++ b/tests/unit/print-doc-to-string.js
@@ -24,7 +24,7 @@ test("Should properly trim with cursor", () => {
     ),
   ).toEqual({
     formatted: "Prettier\n",
-    cursorNodeStart: 0,
-    cursorNodeText: "Prettier",
+    cursorRegionStart: 0,
+    cursorRegionText: "Prettier",
   });
 });


### PR DESCRIPTION
## Description

This implements roughly the tactic I proposed at https://github.com/prettier/prettier/issues/4801#issuecomment-1816869699.

It's a draft for now. I have a bunch of outstanding concerns I want to dig into before it's ready for review (in addition to the stuff in the PR template checklist), many of which probably require tweaks to the logic here:

- [ ] I've changed the signatures of a bunch of functions. Are any of them part of the package's API, meant to be used either by end users of Prettier or authors of third-party plugins? I don't have a clear idea yet of what's an internal implementation detail vs part of the interface for plugin authors vs part of the interface for end users.
  - [ ] In particular: I removed `opts.cursorNode`, but perhaps that's something that third party plugins might use or modify, in which case I've broken them?
- [ ] I seem to have broken a couple of the tests that combine cursor positioning with formatting only a target range. I am a bit confused about why those tests exist because the Pretter CLI `--help` text specifically says that those two features can't be used together. (I also have no idea why my changes broke that scenario in particular.) I guess I should investigate...
- [ ] I've added some logic to `printAstToDoc` to insert the `cursor` symbol at beginning or end of the doc in the scenario where the cursor is located before the first AST node. But what happens when there are embedded docs, or when `printAstToDoc` gets called from the multiparser (are these the same scenario?)? Since I didn't consider these scenarios at all when writing the code, I presume the behaviour of my code in them is currently broken.
- [ ] Have I introduced a possible scenario where only one cursor placeholder gets printed in `printDocToString` (e.g. because the other is part of a group that doesn't get printed at all for some reason)? If this happens it will cause `printDocToString` to throw, so I need to either ensure it's impossible or modify `printDocToString` to handle it when it happens.
- [ ] What happens when the `nodeBeforeCursor` ends up _after_ `nodeAfterCursor` in the formatted doc, e.g. because some sort of sorting plugin for Prettier was used like https://github.com/trivago/prettier-plugin-sort-imports? This obviously breaks the intended logic for computing the cursor position, and right now I don't detect it or recover from it.
- [ ] Wherever it makes sense, I should add tests exploring the precise doubts I list above
  
## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
