### PR TITLE
fix: allow disabling Angular 17's control flow syntax formatting

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -430,6 +430,10 @@ export interface RequiredOptions extends doc.printer.Options {
    * @default false
    */
   singleAttributePerLine: boolean;
+  /**
+   * Control whether Prettier formats Angular's control flow syntax.
+   */
+  angularControlFlowSyntax: boolean;
 }
 
 export interface ParserOptions<T = any> extends RequiredOptions {

--- a/src/language-html/options.js
+++ b/src/language-html/options.js
@@ -32,6 +32,12 @@ const options = {
     default: false,
     description: "Indent script and style tags in Vue files.",
   },
+  angularControlFlowSyntax: {
+    category: CATEGORY_HTML,
+    type: "boolean",
+    default: true,
+    description: "Format Angular's control flow syntax.",
+  },
 };
 
 export default options;

--- a/src/language-html/parser-html.js
+++ b/src/language-html/parser-html.js
@@ -91,7 +91,7 @@ function ngHtmlParser(input, parseOptions, options) {
       ? (...args) =>
           shouldParseAsRawText(...args) ? TagContentType.RAW_TEXT : undefined
       : undefined,
-    tokenizeAngularBlocks: name === "angular" ? true : undefined,
+    tokenizeAngularBlocks: name === "angular" ? options.angularControlFlowSyntax : undefined,
   });
 
   if (name === "vue") {

--- a/tests/format/angular/icu/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/angular/icu/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`icu.component.html - {"angularControlFlowSyntax":false} format 1`] = `
+====================================options=====================================
+angularControlFlowSyntax: false
+parsers: ["angular"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<span i18n>Updated {minutes, plural, =0 {just now} =1 {one minute ago} other {{{minutes}} minutes ago}}</span>
+<span i18n>The author is {gender, select, male {male} female {female} other {other}}</span>
+<span i18n>Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other {{{minutes}} minutes ago by {gender, select, male {male} female {female} other {other}}}}</span>
+
+=====================================output=====================================
+<span i18n
+  >Updated {minutes, plural, =0 {just now} =1 {one minute ago} other
+  {{{minutes}} minutes ago}}</span
+>
+<span i18n
+  >The author is {gender, select, male {male} female {female} other
+  {other}}</span
+>
+<span i18n
+  >Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other
+  {{{minutes}} minutes ago by {gender, select, male {male} female {female} other
+  {other}}}}</span
+>
+
+================================================================================
+`;

--- a/tests/format/angular/icu/icu.component.html
+++ b/tests/format/angular/icu/icu.component.html
@@ -1,0 +1,3 @@
+<span i18n>Updated {minutes, plural, =0 {just now} =1 {one minute ago} other {{{minutes}} minutes ago}}</span>
+<span i18n>The author is {gender, select, male {male} female {female} other {other}}</span>
+<span i18n>Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other {{{minutes}} minutes ago by {gender, select, male {male} female {female} other {other}}}}</span>

--- a/tests/format/angular/icu/jsfmt.spec.js
+++ b/tests/format/angular/icu/jsfmt.spec.js
@@ -1,0 +1,4 @@
+// The ICU component can be moved to the angular/angular tests when ICU parsing
+// with control flow syntax has been fixed, but until then this component will
+// not work with {angularControlFlowSyntax: true} (the default).
+run_spec(import.meta, ["angular"], { angularControlFlowSyntax: false });


### PR DESCRIPTION
## Description

This change leaves Angular's new control flow syntax on by default, but allows disabling it as the current implementation does not handle formatting ICU expressions correctly and the provided ICU component crashes the test runner when `{angularControlFlowSyntax: false}` is not provided.

work around for: https://github.com/prettier/prettier/issues/15650

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
