### PR TITLE
`prettier.__internal.inferParser` for new CLI

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import {
   getSupportInfo as getSupportInfoWithoutPlugins,
   normalizeOptionSettings,
 } from "./main/support.js";
+import inferParserWithoutPlugins from "./utils/infer-parser.js";
 import getFileInfoWithoutPlugins from "./common/get-file-info.js";
 import {
   loadBuiltinPlugins,
@@ -89,6 +90,11 @@ const sharedWithCli = {
   normalizeOptions,
   getSupportInfoWithoutPlugins,
   normalizeOptionSettings,
+  inferParser: withPlugins(
+    (file, options) =>
+      options?.parser ??
+      inferParserWithoutPlugins(options, { physicalFile: file }),
+  ),
   vnopts: {
     ChoiceSchema: vnopts.ChoiceSchema,
     apiDescriptor: vnopts.apiDescriptor,

--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,10 @@ const getFileInfo = withPlugins(getFileInfoWithoutPlugins);
 /** @type {typeof getSupportInfoWithoutPlugins} */
 const getSupportInfo = withPlugins(getSupportInfoWithoutPlugins, 0);
 
+const inferParser = withPlugins((file, options) =>
+  inferParserWithoutPlugins(options, { physicalFile: file }),
+);
+
 // Internal shared with cli
 const sharedWithCli = {
   errors,
@@ -90,11 +94,8 @@ const sharedWithCli = {
   normalizeOptions,
   getSupportInfoWithoutPlugins,
   normalizeOptionSettings,
-  inferParser: withPlugins(
-    (file, options) =>
-      options?.parser ??
-      inferParserWithoutPlugins(options, { physicalFile: file }),
-  ),
+  inferParser: (file, options) =>
+    Promise.resolve(options?.parser ?? inferParser(file, options)),
   vnopts: {
     ChoiceSchema: vnopts.ChoiceSchema,
     apiDescriptor: vnopts.apiDescriptor,


### PR DESCRIPTION
## Description

```
> p=await import('./index.js')
> await p.__internal.inferParser('package.json',{})
'json-stringify'
> await p.__internal.inferParser('.prettierrc',{})
'yaml'
> await p.__internal.inferParser('node_modules/.bin/acorn',{})
'babel'
> await p.__internal.inferParser('node_modules/.bin/acorn',{parser:'yaml'})
'yaml'
> await p.__internal.inferParser('foo.java', {plugins:["prettier-plugin-java"]})
'java'
> await p.__internal.inferParser('foo.java', {plugins:["prettier-plugin-java1"]})
Uncaught:
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'prettier-plugin-java1',,,
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
