### PR TITLE
documenting the `hardline` within an `ifBreak` odd behaviour

### DIFF
--- a/commands.md
+++ b/commands.md
@@ -97,6 +97,10 @@ ifBreak(";", " ");
 
 `groupId` can be used to check another _already printed_ group instead of the current group.
 
+If a [`hardline`](#hardline) is present within the possible contents, the group containing the `ifBreak` command will be broken regardless of said content being printed, which might not be desireable. This behaviour is a design limitation and probably hints that the same printed result could be achieved in a different way.
+
+In the rare case that `hardline` is definitely needed, consider using [`hardlineWithoutBreakParent`](#hardlinewithoutbreakparent-and-literallinewithoutbreakparent) instead to avoid an unwanted group break propagation.
+
 ### `breakParent`
 
 ```ts

--- a/commands.md
+++ b/commands.md
@@ -97,7 +97,7 @@ ifBreak(";", " ");
 
 `groupId` can be used to check another _already printed_ group instead of the current group.
 
-If a [`hardline`](#hardline) is present within the possible contents, the group containing the `ifBreak` command will be broken regardless of said content being printed, which might not be desireable. This behaviour is a design limitation and probably hints that the same printed result could be achieved in a different way.
+If a [`hardline`](#hardline) or [`breakParent`](#breakParent) is present within the possible contents, the parent groups will be broken regardless of said content being printed, which might not be desireable. This behaviour is a design limitation. Usually the desired result can be achieved in a different way.
 
 In the rare case that `hardline` is definitely needed, consider using [`hardlineWithoutBreakParent`](#hardlinewithoutbreakparent-and-literallinewithoutbreakparent) instead to avoid an unwanted group break propagation.
 


### PR DESCRIPTION
## Description

closes #15710
<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
