### PR TITLE
fix example to fit the actual experimentalTernaries behaviour

### DIFF
--- a/website/blog/2023-11-13-curious-ternaries.md
+++ b/website/blog/2023-11-13-curious-ternaries.md
@@ -80,8 +80,7 @@ const animalName =
     pet.isScary() ?
       'wolf'
     : 'dog'
-  : pet.canMeow() ?
-    'cat'
+  : pet.canMeow() ? 'cat'
   : 'probably a bunny';
 ```
 


### PR DESCRIPTION
## Description

The blogpost shows one of the experimental ternaries examples written a way that doesn't match the actual format that prettier chooses.

It might be there though for illustrational purposes though. Up to you if you decide to merge this.
<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
