### PR TITLE
Fix expect call in dts test

### DIFF
--- a/tests/dts/unit/run.js
+++ b/tests/dts/unit/run.js
@@ -29,6 +29,18 @@ describe("Unit tests for dts files", () => {
     /** @type {import("typescript").Diagnostic[]} */
     const diagnostics = ts.getPreEmitDiagnostics(program);
 
-    expect(diagnostics).toEqual([]);
+    expect(diagnostics.map(formatDiagnostic)).toEqual([]);
   });
 });
+
+/**
+ * @param {import("typescript").Diagnostic} diagnostic
+ */
+function formatDiagnostic({ file, start, code, messageText }) {
+  let location = "";
+  if (file) {
+    const { line, character } = ts.getLineAndCharacterOfPosition(file, start);
+    location = `${file.fileName}:${line + 1}:${character + 1} `;
+  }
+  return `${location}TS${code}: ${messageText}`;
+}


### PR DESCRIPTION
## Description

Jest's `expect` iterates all the properties of diagnostic objects triggering a deprecation error in a getter. That's why now it gets an array of formatted messages instead. Also formatted messages are easier to understand when the test fails.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
