### PR TITLE
fix: handle parsing of angular ICU expressions

### DIFF
--- a/changelog_unreleased/angular/15773.md
+++ b/changelog_unreleased/angular/15773.md
@@ -1,0 +1,42 @@
+<!--
+
+1. Choose a folder based on which language your PR is for.
+
+   - For JavaScript, choose `javascript/` etc.
+   - For TypeScript specific syntax, choose `typescript/`.
+   - If your PR applies to multiple languages, such as TypeScript/Flow, choose one folder and mention which languages it applies to.
+
+2. In your chosen folder, create a file with your PR number: `XXXX.md`. For example: `typescript/6728.md`.
+
+3. Copy the content below and paste it in your new file.
+
+4. Fill in a title, the PR number and your user name.
+
+5. Optionally write a description. Many times it’s enough with just sample code.
+
+6. Change ```jsx to your language. For example, ```yaml.
+
+7. Change the `// Input` and `// Prettier` comments to the comment syntax of your language. For example, `# Input`.
+
+8. Choose some nice input example code. Paste it along with the output before and after your PR.
+
+-->
+
+#### fix: handle parsing of angular ICU expressions (#15773 by @mattlewis92)
+
+<!-- Optional description if it makes sense. -->
+
+<!-- prettier-ignore -->
+```html
+<!-- Input -->
+<span i18n>Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other {{{minutes}} minutes ago}}</span>
+
+<!-- Prettier stable -->
+Error is thrown: "SyntaxError: Unexpected closing block. The block may have been closed earlier. If you meant to write the } character, you should use the "&#125;" HTML entity instead. (1:51)"
+
+<!-- Prettier main -->
+<span i18n
+>Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other
+  {{{minutes}} minutes ago}}</span
+>
+```

--- a/src/language-html/parser-html.js
+++ b/src/language-html/parser-html.js
@@ -68,6 +68,19 @@ function normalizeAngularControlFlowBlock(node) {
 }
 
 /**
+ * Converts an angular ICU expression to a text node so it can be printed as text.
+ */
+function convertAngularIcuExpressionToTextNode(node) {
+  if (node.type === "plural" || node.type === "select") {
+    node.type = "text";
+    node.value = node.sourceSpan.start.file.content.slice(
+      node.sourceSpan.start.offset,
+      node.sourceSpan.end.offset,
+    );
+  }
+}
+
+/**
  * @param {string} input
  * @param {ParseOptions} parseOptions
  * @param {Options} options
@@ -374,6 +387,7 @@ function parse(
     }
 
     normalizeAngularControlFlowBlock(node);
+    convertAngularIcuExpressionToTextNode(node);
   });
 
   return ast;

--- a/tests/format/angular/angular/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/angular/angular/__snapshots__/jsfmt.spec.js.snap
@@ -2599,6 +2599,245 @@ trailingComma: "none"
 ================================================================================
 `;
 
+exports[`icu.html - {"bracketSpacing":false} format 1`] = `
+====================================options=====================================
+bracketSpacing: false
+parsers: ["angular"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<span i18n>Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other {{{minutes}} minutes ago}}</span>
+<span i18n>The author is {gender, select, male {male} female {female} other {other}}</span>
+
+@if (condition) {
+    <span i18n>Updated: {minutes, plural,
+      =0 {just now}
+      =1 {one minute ago}
+      other {{{minutes}} minutes ago by {gender, select, male {male} female {female} other {other}}}}
+    </span>
+}
+
+=====================================output=====================================
+<span i18n
+  >Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other
+  {{{minutes}} minutes ago}}</span
+>
+<span i18n
+  >The author is {gender, select, male {male} female {female} other
+  {other}}</span
+>
+
+@if (condition) {
+  <span i18n
+    >Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other
+    {{{minutes}} minutes ago by {gender, select, male {male} female {female}
+    other {other}}}}
+  </span>
+}
+
+================================================================================
+`;
+
+exports[`icu.html - {"htmlWhitespaceSensitivity":"ignore"} format 1`] = `
+====================================options=====================================
+htmlWhitespaceSensitivity: "ignore"
+parsers: ["angular"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<span i18n>Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other {{{minutes}} minutes ago}}</span>
+<span i18n>The author is {gender, select, male {male} female {female} other {other}}</span>
+
+@if (condition) {
+    <span i18n>Updated: {minutes, plural,
+      =0 {just now}
+      =1 {one minute ago}
+      other {{{minutes}} minutes ago by {gender, select, male {male} female {female} other {other}}}}
+    </span>
+}
+
+=====================================output=====================================
+<span i18n>
+  Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other
+  {{{minutes}} minutes ago}}
+</span>
+<span i18n>
+  The author is {gender, select, male {male} female {female} other {other}}
+</span>
+
+@if (condition) {
+  <span i18n>
+    Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other
+    {{{minutes}} minutes ago by {gender, select, male {male} female {female}
+    other {other}}}}
+  </span>
+}
+
+================================================================================
+`;
+
+exports[`icu.html - {"printWidth":1} format 1`] = `
+====================================options=====================================
+parsers: ["angular"]
+printWidth: 1
+ | printWidth
+=====================================input======================================
+<span i18n>Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other {{{minutes}} minutes ago}}</span>
+<span i18n>The author is {gender, select, male {male} female {female} other {other}}</span>
+
+@if (condition) {
+    <span i18n>Updated: {minutes, plural,
+      =0 {just now}
+      =1 {one minute ago}
+      other {{{minutes}} minutes ago by {gender, select, male {male} female {female} other {other}}}}
+    </span>
+}
+
+=====================================output=====================================
+<span
+  i18n
+  >Updated:
+  {minutes,
+  plural,
+  =0
+  {just
+  now}
+  =1
+  {one
+  minute
+  ago}
+  other
+  {{{minutes}}
+  minutes
+  ago}}</span
+>
+<span
+  i18n
+  >The
+  author
+  is
+  {gender,
+  select,
+  male
+  {male}
+  female
+  {female}
+  other
+  {other}}</span
+>
+
+@if (
+  condition
+) {
+  <span
+    i18n
+    >Updated:
+    {minutes,
+    plural,
+    =0
+    {just
+    now}
+    =1
+    {one
+    minute
+    ago}
+    other
+    {{{minutes}}
+    minutes
+    ago
+    by
+    {gender,
+    select,
+    male
+    {male}
+    female
+    {female}
+    other
+    {other}}}}
+  </span>
+}
+
+================================================================================
+`;
+
+exports[`icu.html - {"trailingComma":"es5"} format 1`] = `
+====================================options=====================================
+parsers: ["angular"]
+printWidth: 80
+trailingComma: "es5"
+                                                                                | printWidth
+=====================================input======================================
+<span i18n>Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other {{{minutes}} minutes ago}}</span>
+<span i18n>The author is {gender, select, male {male} female {female} other {other}}</span>
+
+@if (condition) {
+    <span i18n>Updated: {minutes, plural,
+      =0 {just now}
+      =1 {one minute ago}
+      other {{{minutes}} minutes ago by {gender, select, male {male} female {female} other {other}}}}
+    </span>
+}
+
+=====================================output=====================================
+<span i18n
+  >Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other
+  {{{minutes}} minutes ago}}</span
+>
+<span i18n
+  >The author is {gender, select, male {male} female {female} other
+  {other}}</span
+>
+
+@if (condition) {
+  <span i18n
+    >Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other
+    {{{minutes}} minutes ago by {gender, select, male {male} female {female}
+    other {other}}}}
+  </span>
+}
+
+================================================================================
+`;
+
+exports[`icu.html - {"trailingComma":"none"} format 1`] = `
+====================================options=====================================
+parsers: ["angular"]
+printWidth: 80
+trailingComma: "none"
+                                                                                | printWidth
+=====================================input======================================
+<span i18n>Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other {{{minutes}} minutes ago}}</span>
+<span i18n>The author is {gender, select, male {male} female {female} other {other}}</span>
+
+@if (condition) {
+    <span i18n>Updated: {minutes, plural,
+      =0 {just now}
+      =1 {one minute ago}
+      other {{{minutes}} minutes ago by {gender, select, male {male} female {female} other {other}}}}
+    </span>
+}
+
+=====================================output=====================================
+<span i18n
+  >Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other
+  {{{minutes}} minutes ago}}</span
+>
+<span i18n
+  >The author is {gender, select, male {male} female {female} other
+  {other}}</span
+>
+
+@if (condition) {
+  <span i18n
+    >Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other
+    {{{minutes}} minutes ago by {gender, select, male {male} female {female}
+    other {other}}}}
+  </span>
+}
+
+================================================================================
+`;
+
 exports[`ignore-attribute.component.html - {"bracketSpacing":false} format 1`] = `
 ====================================options=====================================
 bracketSpacing: false

--- a/tests/format/angular/angular/icu.html
+++ b/tests/format/angular/angular/icu.html
@@ -1,0 +1,10 @@
+<span i18n>Updated: {minutes, plural, =0 {just now} =1 {one minute ago} other {{{minutes}} minutes ago}}</span>
+<span i18n>The author is {gender, select, male {male} female {female} other {other}}</span>
+
+@if (condition) {
+    <span i18n>Updated: {minutes, plural,
+      =0 {just now}
+      =1 {one minute ago}
+      other {{{minutes}} minutes ago by {gender, select, male {male} female {female} other {other}}}}
+    </span>
+}


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

> [!IMPORTANT]  
> The tests will fail on this PR until https://github.com/prettier/angular-html-parser/pull/38 is released and prettier is updated to use it

Fixes a regression in prettier 3.1 where angular ICU expressions are no longer parsed. We handle them now by parsing them correctly with https://github.com/prettier/angular-html-parser/pull/38 and then changing the node type to text so they are printed as they were before 3.1. Maybe in the future prettier could add support for pretty printing angular ICU expressions, but for now this will restore the previous behaviour.

Fixes #15650

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
