### PR TITLE
Add a bunch more cursor position test cases

### DIFF
--- a/tests/format/html/cursor/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/html/cursor/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,327 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`cursor-0.html format 1`] = `
+====================================options=====================================
+cursorOffset: 354
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<!-- At the time of adding this test, the cursor positioning we end up with
+     here seems clearly wrong.
+     I'm adding the test case anyway to demonstrate the brokenness and ensure
+     that if a future changes fixes it, it'll be obvious from the PR diff that
+     the fix happened.
+     Remove this comment if and when we fix it! -->
+<div>bla bla
+
+
+<|></div>
+
+=====================================output=====================================
+<!-- At the time of adding this test, the cursor positioning we end up with
+     here seems clearly wrong.
+     I'm adding the test case anyway to demonstrate the brokenness and ensure
+     that if a future changes fixes it, it'll be obvious from the PR diff that
+     the fix happened.
+     Remove this comment if and when we fix it! -->
+<div>bla bla</d<|>iv>
+
+================================================================================
+`;
+
+exports[`cursor-1.html format 1`] = `
+====================================options=====================================
+cursorOffset: 354
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<!-- At the time of adding this test, the cursor positioning we end up with
+     here seems clearly wrong.
+     I'm adding the test case anyway to demonstrate the brokenness and ensure
+     that if a future changes fixes it, it'll be obvious from the PR diff that
+     the fix happened.
+     Remove this comment if and when we fix it! -->
+<div>bla bla
+
+
+<|></div>
+<script type="module">
+      import lib from './lib.js';
+  
+        function myFunction() { return 'foo'; }
+  </script>
+
+=====================================output=====================================
+<!-- At the time of adding this test, the cursor positioning we end up with
+     here seems clearly wrong.
+     I'm adding the test case anyway to demonstrate the brokenness and ensure
+     that if a future changes fixes it, it'll be obvious from the PR diff that
+     the fix happened.
+     Remove this comment if and when we fix it! -->
+<div>bla bla</d<|>iv>
+<script type="module">
+  import lib from "./lib.js";
+
+  function myFunction() {
+    return "foo";
+  }
+</script>
+
+================================================================================
+`;
+
+exports[`cursor-2.html format 1`] = `
+====================================options=====================================
+cursorOffset: 48
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<div>bla bla
+
+
+</div>
+<script type="module">
+   <|>   import lib from './lib.js';
+  
+        function myFunction() { return 'foo'; }
+  </script>
+
+=====================================output=====================================
+<div>bla bla</div>
+<script type="module">
+  <|>import lib from "./lib.js";
+
+  function myFunction() {
+    return "foo";
+  }
+</script>
+
+================================================================================
+`;
+
+exports[`cursor-3.html format 1`] = `
+====================================options=====================================
+cursorOffset: 43
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<div>bla bla
+
+
+</div>
+<script type="module"<|>>
+      import lib from './lib.js';
+  
+        function myFunction() { return 'foo'; }
+  </script>
+
+=====================================output=====================================
+<div>bla bla</div>
+<script type="module"<|>>
+  import lib from "./lib.js";
+
+  function myFunction() {
+    return "foo";
+  }
+</script>
+
+================================================================================
+`;
+
+exports[`cursor-4.html format 1`] = `
+====================================options=====================================
+cursorOffset: 399
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<!-- At the time of adding this test, the cursor positioning we end up with
+     here seems wrong, or at least suboptimal.
+     I'm adding the test case anyway to demonstrate the brokenness and ensure
+     that if a future changes fixes it, it'll be obvious from the PR diff that
+     the fix happened.
+     Remove this comment if and when we fix it! -->
+<div>bla bla
+
+
+</div>
+<script type="module"><|>
+      import lib from './lib.js';
+  
+        function myFunction() { return 'foo'; }
+  </script>
+
+=====================================output=====================================
+<!-- At the time of adding this test, the cursor positioning we end up with
+     here seems wrong, or at least suboptimal.
+     I'm adding the test case anyway to demonstrate the brokenness and ensure
+     that if a future changes fixes it, it'll be obvious from the PR diff that
+     the fix happened.
+     Remove this comment if and when we fix it! -->
+<div>bla bla</div>
+<script type="module">
+  <|>import lib from "./lib.js";
+
+  function myFunction() {
+    return "foo";
+  }
+</script>
+
+================================================================================
+`;
+
+exports[`cursor-5.html format 1`] = `
+====================================options=====================================
+cursorOffset: 65
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<div>bla bla
+
+
+</div>
+<script type="module">
+      import lib fro<|>m './lib.js';
+  
+        function myFunction() { return 'foo'; }
+  </script>
+
+=====================================output=====================================
+<div>bla bla</div>
+<script type="module">
+  import lib fro<|>m "./lib.js";
+
+  function myFunction() {
+    return "foo";
+  }
+</script>
+
+================================================================================
+`;
+
+exports[`cursor-6.html format 1`] = `
+====================================options=====================================
+cursorOffset: 660
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<!-- At the time of adding this test, the cursor positioning we end up with
+     here seems clearly wrong.
+     I'm adding the test case anyway to demonstrate the brokenness and ensure
+     that if a future changes fixes it, it'll be obvious from the PR diff that
+     the fix happened.
+     Remove this comment if and when we fix it!
+     A big clue: note that tests/format/js/cursor/cursor-12.js features the
+     same JavaScript code but not in an embedded doc, and we handle cursor
+     positioning just fine in that case! -->
+<div>bla bla
+
+
+</div>
+<script type="module">
+      import lib from './lib.js';
+  
+        function myFunction() { return 'foo'; }<|>
+  </script>
+
+=====================================output=====================================
+<!-- At the time of adding this test, the cursor positioning we end up with
+     here seems clearly wrong.
+     I'm adding the test case anyway to demonstrate the brokenness and ensure
+     that if a future changes fixes it, it'll be obvious from the PR diff that
+     the fix happened.
+     Remove this comment if and when we fix it!
+     A big clue: note that tests/format/js/cursor/cursor-12.js features the
+     same JavaScript code but not in an embedded doc, and we handle cursor
+     positioning just fine in that case! -->
+<div>bla bla</div>
+<script type="module">
+  import lib from "./lib.js";
+
+  function myFunction() {
+    return "foo";<|>
+  }
+</script>
+
+================================================================================
+`;
+
+exports[`cursor-7.html format 1`] = `
+====================================options=====================================
+cursorOffset: 470
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<!-- At the time of adding this test, the cursor positioning we end up with
+     here seems clearly wrong.
+     I'm adding the test case anyway to demonstrate the brokenness and ensure
+     that if a future changes fixes it, it'll be obvious from the PR diff that
+     the fix happened.
+     Remove this comment if and when we fix it! -->
+
+<div>bla bla
+
+
+</div>
+<script type="module">
+      import lib from './lib.js';
+  
+        function myFunction() { return 'foo'; }
+<|>  </script>
+
+=====================================output=====================================
+<!-- At the time of adding this test, the cursor positioning we end up with
+     here seems clearly wrong.
+     I'm adding the test case anyway to demonstrate the brokenness and ensure
+     that if a future changes fixes it, it'll be obvious from the PR diff that
+     the fix happened.
+     Remove this comment if and when we fix it! -->
+
+<div>bla bla</div>
+<script type="module">
+  import lib from "./lib.js";
+
+  function myFunction() {
+    return "foo";
+<|>  }
+</script>
+
+================================================================================
+`;
+
+exports[`cursor-8.html format 1`] = `
+====================================options=====================================
+cursorOffset: 137
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<div>bla bla
+
+
+</div>
+<script type="module">
+      import lib from './lib.js';
+  
+        function myFunction() { return 'foo'; }
+  </scr<|>ipt>
+
+=====================================output=====================================
+<div>bla bla</div>
+<script type="module">
+  import lib from "./lib.js";
+
+  function myFunction() {
+    return "foo";
+  }
+</scr<|>ipt>
+
+================================================================================
+`;

--- a/tests/format/html/cursor/cursor-0.html
+++ b/tests/format/html/cursor/cursor-0.html
@@ -1,0 +1,10 @@
+<!-- At the time of adding this test, the cursor positioning we end up with
+     here seems clearly wrong.
+     I'm adding the test case anyway to demonstrate the brokenness and ensure
+     that if a future changes fixes it, it'll be obvious from the PR diff that
+     the fix happened.
+     Remove this comment if and when we fix it! -->
+<div>bla bla
+
+
+<|></div>

--- a/tests/format/html/cursor/cursor-1.html
+++ b/tests/format/html/cursor/cursor-1.html
@@ -1,0 +1,15 @@
+<!-- At the time of adding this test, the cursor positioning we end up with
+     here seems clearly wrong.
+     I'm adding the test case anyway to demonstrate the brokenness and ensure
+     that if a future changes fixes it, it'll be obvious from the PR diff that
+     the fix happened.
+     Remove this comment if and when we fix it! -->
+<div>bla bla
+
+
+<|></div>
+<script type="module">
+      import lib from './lib.js';
+  
+        function myFunction() { return 'foo'; }
+  </script>

--- a/tests/format/html/cursor/cursor-2.html
+++ b/tests/format/html/cursor/cursor-2.html
@@ -1,0 +1,9 @@
+<div>bla bla
+
+
+</div>
+<script type="module">
+   <|>   import lib from './lib.js';
+  
+        function myFunction() { return 'foo'; }
+  </script>

--- a/tests/format/html/cursor/cursor-3.html
+++ b/tests/format/html/cursor/cursor-3.html
@@ -1,0 +1,9 @@
+<div>bla bla
+
+
+</div>
+<script type="module"<|>>
+      import lib from './lib.js';
+  
+        function myFunction() { return 'foo'; }
+  </script>

--- a/tests/format/html/cursor/cursor-4.html
+++ b/tests/format/html/cursor/cursor-4.html
@@ -1,0 +1,15 @@
+<!-- At the time of adding this test, the cursor positioning we end up with
+     here seems wrong, or at least suboptimal.
+     I'm adding the test case anyway to demonstrate the brokenness and ensure
+     that if a future changes fixes it, it'll be obvious from the PR diff that
+     the fix happened.
+     Remove this comment if and when we fix it! -->
+<div>bla bla
+
+
+</div>
+<script type="module"><|>
+      import lib from './lib.js';
+  
+        function myFunction() { return 'foo'; }
+  </script>

--- a/tests/format/html/cursor/cursor-5.html
+++ b/tests/format/html/cursor/cursor-5.html
@@ -1,0 +1,9 @@
+<div>bla bla
+
+
+</div>
+<script type="module">
+      import lib fro<|>m './lib.js';
+  
+        function myFunction() { return 'foo'; }
+  </script>

--- a/tests/format/html/cursor/cursor-6.html
+++ b/tests/format/html/cursor/cursor-6.html
@@ -1,0 +1,18 @@
+<!-- At the time of adding this test, the cursor positioning we end up with
+     here seems clearly wrong.
+     I'm adding the test case anyway to demonstrate the brokenness and ensure
+     that if a future changes fixes it, it'll be obvious from the PR diff that
+     the fix happened.
+     Remove this comment if and when we fix it!
+     A big clue: note that tests/format/js/cursor/cursor-12.js features the
+     same JavaScript code but not in an embedded doc, and we handle cursor
+     positioning just fine in that case! -->
+<div>bla bla
+
+
+</div>
+<script type="module">
+      import lib from './lib.js';
+  
+        function myFunction() { return 'foo'; }<|>
+  </script>

--- a/tests/format/html/cursor/cursor-7.html
+++ b/tests/format/html/cursor/cursor-7.html
@@ -1,0 +1,16 @@
+<!-- At the time of adding this test, the cursor positioning we end up with
+     here seems clearly wrong.
+     I'm adding the test case anyway to demonstrate the brokenness and ensure
+     that if a future changes fixes it, it'll be obvious from the PR diff that
+     the fix happened.
+     Remove this comment if and when we fix it! -->
+
+<div>bla bla
+
+
+</div>
+<script type="module">
+      import lib from './lib.js';
+  
+        function myFunction() { return 'foo'; }
+<|>  </script>

--- a/tests/format/html/cursor/cursor-8.html
+++ b/tests/format/html/cursor/cursor-8.html
@@ -1,0 +1,9 @@
+<div>bla bla
+
+
+</div>
+<script type="module">
+      import lib from './lib.js';
+  
+        function myFunction() { return 'foo'; }
+  </scr<|>ipt>

--- a/tests/format/html/cursor/jsfmt.spec.js
+++ b/tests/format/html/cursor/jsfmt.spec.js
@@ -1,0 +1,1 @@
+run_spec(import.meta, ["html"]);

--- a/tests/format/js/cursor/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/cursor/__snapshots__/jsfmt.spec.js.snap
@@ -321,11 +321,16 @@ printWidth: 80
 
 exports[`cursor-12.js format 1`] = `
 ====================================options=====================================
-cursorOffset: 53
+cursorOffset: 330
 parsers: ["babel", "typescript", "flow"]
 printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
+// At the time of adding this test, the cursor positioning we end up with
+// here seems clearly wrong.
+// I'm adding the test case anyway to demonstrate the brokenness and ensure
+// that if a future changes fixes it, it'll be obvious from the PR diff that
+// the fix happened.
 [
   [
     [
@@ -340,6 +345,11 @@ printWidth: 80
 ]
 
 =====================================output=====================================
+// At the time of adding this test, the cursor positioning we end up with
+// here seems clearly wrong.
+// I'm adding the test case anyway to demonstrate the brokenness and ensure
+// that if a future changes fixes it, it'll be obvious from the PR diff that
+// the fix happened.
 [
   [
     [

--- a/tests/format/js/cursor/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/cursor/__snapshots__/jsfmt.spec.js.snap
@@ -271,6 +271,113 @@ const y = 5;
 ================================================================================
 `;
 
+exports[`cursor-11.js format 1`] = `
+====================================options=====================================
+cursorOffset: 334
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+// At the time of adding this test, the cursor positioning we end up with
+// here seems clearly wrong.
+// I'm adding the test case anyway to demonstrate the brokenness and ensure
+// that if a future changes fixes it, it'll be obvious from the PR diff that
+// the fix happened.
+[
+  [
+    [
+      [
+        1,
+        2,
+               <|> 3, "looooooooooooooooooooooooooooooooooooooooooooooooooong",
+        "looooooooooooooooooooooooooooooooooooooooooooooooooong",
+      ]
+    ]
+  ]
+]
+
+=====================================output=====================================
+// At the time of adding this test, the cursor positioning we end up with
+// here seems clearly wrong.
+// I'm adding the test case anyway to demonstrate the brokenness and ensure
+// that if a future changes fixes it, it'll be obvious from the PR diff that
+// the fix happened.
+[
+  [
+    [
+      [
+        1,
+        2,
+        3,
+       <|> "looooooooooooooooooooooooooooooooooooooooooooooooooong",
+        "looooooooooooooooooooooooooooooooooooooooooooooooooong",
+      ],
+    ],
+  ],
+];
+
+================================================================================
+`;
+
+exports[`cursor-12.js format 1`] = `
+====================================options=====================================
+cursorOffset: 53
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+[
+  [
+    [
+      [
+        1,
+        2,
+        3  <|>      ,"looooooooooooooooooooooooooooooooooooooooooooooooooong",
+        "looooooooooooooooooooooooooooooooooooooooooooooooooong",
+      ]
+    ]
+  ]
+]
+
+=====================================output=====================================
+[
+  [
+    [
+      [
+        1,
+        2,
+        3,
+  <|>      "looooooooooooooooooooooooooooooooooooooooooooooooooong",
+        "looooooooooooooooooooooooooooooooooooooooooooooooooong",
+      ],
+    ],
+  ],
+];
+
+================================================================================
+`;
+
+exports[`cursor-13.js format 1`] = `
+====================================options=====================================
+cursorOffset: 84
+parsers: ["babel", "typescript", "flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+      import lib from './lib.js';
+  
+        function myFunction() { return 'foo'; }<|>
+
+=====================================output=====================================
+import lib from "./lib.js";
+
+function myFunction() {
+  return "foo";
+}<|>
+
+================================================================================
+`;
+
 exports[`cursor-emoji.js format 1`] = `
 ====================================options=====================================
 cursorOffset: 9

--- a/tests/format/js/cursor/cursor-11.js
+++ b/tests/format/js/cursor/cursor-11.js
@@ -1,0 +1,17 @@
+// At the time of adding this test, the cursor positioning we end up with
+// here seems clearly wrong.
+// I'm adding the test case anyway to demonstrate the brokenness and ensure
+// that if a future changes fixes it, it'll be obvious from the PR diff that
+// the fix happened.
+[
+  [
+    [
+      [
+        1,
+        2,
+               <|> 3, "looooooooooooooooooooooooooooooooooooooooooooooooooong",
+        "looooooooooooooooooooooooooooooooooooooooooooooooooong",
+      ]
+    ]
+  ]
+]

--- a/tests/format/js/cursor/cursor-12.js
+++ b/tests/format/js/cursor/cursor-12.js
@@ -1,0 +1,17 @@
+// At the time of adding this test, the cursor positioning we end up with
+// here seems clearly wrong.
+// I'm adding the test case anyway to demonstrate the brokenness and ensure
+// that if a future changes fixes it, it'll be obvious from the PR diff that
+// the fix happened.
+[
+  [
+    [
+      [
+        1,
+        2,
+        3  <|>      ,"looooooooooooooooooooooooooooooooooooooooooooooooooong",
+        "looooooooooooooooooooooooooooooooooooooooooooooooooong",
+      ]
+    ]
+  ]
+]

--- a/tests/format/js/cursor/cursor-13.js
+++ b/tests/format/js/cursor/cursor-13.js
@@ -1,0 +1,3 @@
+      import lib from './lib.js';
+  
+        function myFunction() { return 'foo'; }<|>


### PR DESCRIPTION
## Description

As a prerequisite for being comfortable putting https://github.com/prettier/prettier/pull/15709 up for review, I wanted more tests of cursor positioning, to convince me that I'm not breaking anything, especially with regard to embedded documents. I've therefore added a bunch of test cases here, including test cases where the cursor position we currently output is clearly perverse. In particular, these tests seem to show that we get cursor position bizarrely wrong a lot of the time when formatting HTML. I do _not_ currently understand whatsoever why that is the case, and my changes in #15709 will not fix it (nor make it worse). I may try to debug it at a later date.

I *do* understand why we get the perverse output in cursor-11.js and cursor-12.js, and it's worth discussing a bit - and here is as good a place as any! #15709 _is_ relevant to those cases; it *mitigates* the risk of encountering the kind of bug shown by those test cases (by reducing in general how big the region we diff with jsdiff is, and therefore reducing in particular how many big runs of whitespace there are in what we diff) but does not remove it entirely, as demonstrated by the fact that on that PR cursor-11.js is fixed but cursor-12.js is still broken. 

Fundamentally the problem in both cursor-11.js and cursor-12.js is one that may show up any time that Prettier reformats some code in a way that removes a big run of whitespace in one place and then adds a big run of whitespace in another place nearby, and then we diff the before and after versions of the whole region to figure out where the cursor should go.

e.g. consider the code below, before and after formatting:

```
[
  [
    [
      [
        1,
        2,
                3, "looooooooooooooooooooooooooooooooooooooooooooooooooong",
        "looooooooooooooooooooooooooooooooooooooooooooooooooong",
      ]
    ]
  ]
]
```

```
[
  [
    [
      [
        1,
        2,
        3,
        "looooooooooooooooooooooooooooooooooooooooooooooooooong",
        "looooooooooooooooooooooooooooooooooooooooooooooooooong",
      ],
    ],
  ],
];
```

The way that a _human_ intuitively thinks about the edit in such a case is to say that the extra indentation before the `3` was *deleted*, and a newline plus indentation was *added* after the 3. Instinctively, we think of what Prettier does as inserting and removing whitespace around the non-whitespace bits of the code, rather than as deleting code and inserting it on the other side of the whitespace. But when we ask a diffing algorithm to find the minimal diff between the original vs formatted code, it doesn't share our intuition; it is looking for the *shortest* possible diff, and a shorter way to make the edit above is to *insert a `3,\n` before the existing run of whitespace*, then *delete the existing `3,`*, essentially preserving the existing excessive indentation and using it as a way to indent the next line. If our *cursor* was inside that block of whitespace that the diff algorithm has creatively preserved, then the diff we get will essentially show that the `3,` has jumped to the other side of our cursor. That's what goes wrong in cursor-11.js.

The fix to *this* class of bug is tweak how we do diffs so that the edit cost of editing long runs of whitespace is reduced. I might work on this at some point.

Anyway, I think it's useful to merge even the tests here that show Prettier doing stupid things, because then when we fix the stupid behaviour, we can see the fix in the diff of the snapshot. I've clearly indicated with comments inside the test cases themselves when I think the current output for a given test case is wrong, though, to avoid confusion. Hopefully you agree with this way of looking at things and don't object to adding test cases whose current output is broken!

## Checklist

- [ ] I’ve added tests to confirm my change works. - N/A
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory). - N/A
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`. - N/A
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
