### PR TITLE
Fix formatDiagnostic in tests/dts/unit/run.js

### DIFF
--- a/tests/dts/unit/run.js
+++ b/tests/dts/unit/run.js
@@ -42,5 +42,29 @@ function formatDiagnostic({ file, start, code, messageText }) {
     const { line, character } = ts.getLineAndCharacterOfPosition(file, start);
     location = `${file.fileName}:${line + 1}:${character + 1} `;
   }
-  return `${location}TS${code}: ${messageText}`;
+  return `${location}TS${code}: ${formatMessageText(messageText)}`;
+}
+
+/**
+ * @param {import("typescript").Diagnostic.messageText} messageText
+ * @param Number indent
+ *
+ * Format the messageText property of a Diagnostic object. This may either
+ * simply be a string, or may be a tree of objects each containing a
+ * `messageText` string and a `next` property pointing to an array of child
+ * nodes. (The tree format gets used when an error is caused by another error.)
+ */
+function formatMessageText(messageText) {
+  if (typeof messageText === "string") {
+    return messageText;
+  }
+  if (messageText.next) {
+    return (
+      messageText.messageText +
+      " (" +
+      messageText.next.map(formatMessageText).join("; ") +
+      ")"
+    );
+  }
+  return messageText.messageText;
 }


### PR DESCRIPTION
## Description

Previously, this failed to handle kinds of objects that `getPreEmitDiagnostics` sometimes returns.

To demonstrate the problem, open `standalone.ts` and replace the line `prettierStandalone.formatWithCursor(" 1", { cursorOffset: 2, parser: "babel" });` with `prettierStandalone.formatWithCursor(" 1", {});`, then run `yarn test dts`.

On main, you'll see this unhelpful output with "object Object":

```
$ yarn test dts
 FAIL  tests/dts/unit/run.js
  Unit tests for dts files
    ✕ no errors (2676 ms)

Unit tests for dts files > no errors
    Error: expect(received).toEqual(expected) // deep equality
    
    - Expected  - 1
    + Received  + 3
    
    - Array []
    + Array [
    +   "/home/mark/prettier/tests/dts/unit/cases/standalone.ts:3:43 TS2345: [object Object]",
    + ]
        at file:///home/mark/prettier/tests/dts/unit/run.js?1702475581997:32:47
        at async Promise.all (index 0)
        at async TestScheduler.scheduleTests (/home/mark/prettier/node_modules/@jest/core/build/index.js:1128:15)
        at async runJest (/home/mark/prettier/node_modules/@jest/core/build/index.js:3390:19)
        at async _run10000 (/home/mark/prettier/node_modules/@jest/core/build/index.js:1513:164)
        at async runCLI (/home/mark/prettier/node_modules/@jest/core/build/index.js:1419:3)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        3.04 s
Ran all test suites matching dts.
```

On this branch, you'll get more helpful output:

```
$ yarn test dts
 FAIL  tests/dts/unit/run.js
  Unit tests for dts files
    ✕ no errors (2674 ms)

Unit tests for dts files > no errors
    Error: expect(received).toEqual(expected) // deep equality
    
    - Expected  - 1
    + Received  + 3
    
    - Array []
    + Array [
    +   "/home/mark/prettier/tests/dts/unit/cases/standalone.ts:3:43 TS2345: Argument of type '{}' is not assignable to parameter of type 'CursorOptions'. (Property 'cursorOffset' is missing in type '{}' but required in type 'CursorOptions'.)",
    + ]
        at file:///home/mark/prettier/tests/dts/unit/run.js?1702475598641:32:47
        at async Promise.all (index 0)
        at async TestScheduler.scheduleTests (/home/mark/prettier/node_modules/@jest/core/build/index.js:1128:15)
        at async runJest (/home/mark/prettier/node_modules/@jest/core/build/index.js:3390:19)
        at async _run10000 (/home/mark/prettier/node_modules/@jest/core/build/index.js:1513:164)
        at async runCLI (/home/mark/prettier/node_modules/@jest/core/build/index.js:1419:3)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        3.026 s
Ran all test suites matching dts.
```

(I basically needed to fix this to help me get https://github.com/prettier/prettier/pull/15789 working, but figured I'd put it in its own PR so the two changes could be reviewed separately.)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
