### PR TITLE
Add `--next` flag to release script

### DIFF
--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -10,9 +10,12 @@ The script has its own `package.json` so we can reinstall the root's `node_modul
 
 ## Flags
 
-- `--manual` Manual run release process instead of publish from GitHub actions
-- `--dry` Dry run
-- `--skip-dependencies-install` Skip dependencies installation
+| Flag                          | Description                                                                             |
+| ----------------------------- | --------------------------------------------------------------------------------------- |
+| `--manual`                    | Manual run release process instead of publish from GitHub actions                       |
+| `--dry`                       | Dry run                                                                                 |
+| `--skip-dependencies-install` | Skip dependencies installation                                                          |
+| `--next`                      | Pre-release such as alpha and beta. It must be run on the `next` branch or it will fail |
 
 ## Credits
 

--- a/scripts/release/parse-arguments.js
+++ b/scripts/release/parse-arguments.js
@@ -8,6 +8,7 @@ function parseArguments() {
       manual = false,
       dry = false,
       "skip-dependencies-install": skipDependenciesInstall = false,
+      next = false,
     },
   } = parseArgs({
     options: {
@@ -26,6 +27,9 @@ function parseArguments() {
       "skip-dependencies-install": {
         type: "boolean",
       },
+      next: {
+        type: "boolean",
+      },
     },
   });
 
@@ -35,6 +39,7 @@ function parseArguments() {
     manual,
     dry,
     skipDependenciesInstall,
+    next,
   };
 }
 

--- a/scripts/release/steps/bump-prettier.js
+++ b/scripts/release/steps/bump-prettier.js
@@ -37,9 +37,9 @@ async function bump({
 }
 
 export default async function bumpPrettier(params) {
-  const { dry, version } = params;
+  const { dry, version, next } = params;
 
-  if (dry) {
+  if (dry || next) {
     return;
   }
 

--- a/scripts/release/steps/check-git-status.js
+++ b/scripts/release/steps/check-git-status.js
@@ -1,6 +1,6 @@
 import { runGit } from "../utils.js";
 
-export default async function checkGitStatus() {
+export default async function checkGitStatus({ next }) {
   const { stdout: status } = await runGit(["status", "--porcelain"]);
 
   if (status) {
@@ -8,5 +8,14 @@ export default async function checkGitStatus() {
       "Uncommitted local changes. " +
         "Please revert or commit all local changes before making a release.",
     );
+  }
+
+  if (next) {
+    const { stdout: branch } = await runGit(["branch", "--show-current"]);
+    if (branch !== "next") {
+      throw new Error(
+        `Expected to be on "next" branch, but currently on "${branch}"`,
+      );
+    }
   }
 }

--- a/scripts/release/steps/post-publish-steps.js
+++ b/scripts/release/steps/post-publish-steps.js
@@ -45,10 +45,10 @@ function twitterAnnouncement() {
   `;
 }
 
-export default async function postPublishSteps({ dry }) {
+export default async function postPublishSteps({ dry, next }) {
   console.log(chalk.bold.green("The script has finished!\n"));
 
-  if (dry) {
+  if (dry || next) {
     return;
   }
 

--- a/scripts/release/steps/show-instructions-after-npm-publish.js
+++ b/scripts/release/steps/show-instructions-after-npm-publish.js
@@ -36,28 +36,32 @@ export function getReleaseUrl(version, previousVersion) {
 export default async function showInstructionsAfterNpmPublish({
   version,
   previousVersion,
+  next,
 }) {
-  const releaseUrl = getReleaseUrl(version, previousVersion);
+  if (next) {
+    console.log(`${chalk.green.bold(`Prettier ${version} published!`)}`);
+  } else {
+    const releaseUrl = getReleaseUrl(version, previousVersion);
+    console.log(
+      outdent`
+        ${chalk.green.bold(`Prettier ${version} published!`)}
 
-  console.log(
-    outdent`
-      ${chalk.green.bold(`Prettier ${version} published!`)}
+        ${chalk.yellow.bold("Some manual steps are necessary.")}
 
-      ${chalk.yellow.bold("Some manual steps are necessary.")}
+        ${chalk.bold.underline("Create a GitHub Release")}
+        - Go to ${chalk.cyan.underline(releaseUrl)}
+        - Press ${chalk.bgGreen.black("Publish release ")}
 
-      ${chalk.bold.underline("Create a GitHub Release")}
-      - Go to ${chalk.cyan.underline(releaseUrl)}
-      - Press ${chalk.bgGreen.black("Publish release ")}
+        ${chalk.bold.underline("Test the new release")}
+        - In a new session, run ${chalk.yellow(
+          "npm i prettier@latest",
+        )} in another directory
+        - Test the API and CLI
 
-      ${chalk.bold.underline("Test the new release")}
-      - In a new session, run ${chalk.yellow(
-        "npm i prettier@latest",
-      )} in another directory
-      - Test the API and CLI
-
-      After that, we can proceed to bump this repo's Prettier dependency.
-    `,
-  );
+        After that, we can proceed to bump this repo's Prettier dependency.
+      `,
+    );
+  }
 
   await waitForEnter();
 }

--- a/scripts/release/steps/show-instructions-after-npm-publish.js
+++ b/scripts/release/steps/show-instructions-after-npm-publish.js
@@ -40,28 +40,30 @@ export default async function showInstructionsAfterNpmPublish({
 }) {
   if (next) {
     console.log(`${chalk.green.bold(`Prettier ${version} published!`)}`);
-  } else {
-    const releaseUrl = getReleaseUrl(version, previousVersion);
-    console.log(
-      outdent`
-        ${chalk.green.bold(`Prettier ${version} published!`)}
-
-        ${chalk.yellow.bold("Some manual steps are necessary.")}
-
-        ${chalk.bold.underline("Create a GitHub Release")}
-        - Go to ${chalk.cyan.underline(releaseUrl)}
-        - Press ${chalk.bgGreen.black("Publish release ")}
-
-        ${chalk.bold.underline("Test the new release")}
-        - In a new session, run ${chalk.yellow(
-          "npm i prettier@latest",
-        )} in another directory
-        - Test the API and CLI
-
-        After that, we can proceed to bump this repo's Prettier dependency.
-      `,
-    );
+    await waitForEnter();
+    return;
   }
+
+  const releaseUrl = getReleaseUrl(version, previousVersion);
+  console.log(
+    outdent`
+      ${chalk.green.bold(`Prettier ${version} published!`)}
+
+      ${chalk.yellow.bold("Some manual steps are necessary.")}
+
+      ${chalk.bold.underline("Create a GitHub Release")}
+      - Go to ${chalk.cyan.underline(releaseUrl)}
+      - Press ${chalk.bgGreen.black("Publish release ")}
+
+      ${chalk.bold.underline("Test the new release")}
+      - In a new session, run ${chalk.yellow(
+        "npm i prettier@latest",
+      )} in another directory
+      - Test the API and CLI
+
+      After that, we can proceed to bump this repo's Prettier dependency.
+    `,
+  );
 
   await waitForEnter();
 }

--- a/scripts/release/steps/update-changelog.js
+++ b/scripts/release/steps/update-changelog.js
@@ -31,8 +31,9 @@ export default async function updateChangelog({
   dry,
   version,
   previousVersion,
+  next,
 }) {
-  if (dry) {
+  if (dry || next) {
     return;
   }
 

--- a/scripts/release/steps/update-dependents-count.js
+++ b/scripts/release/steps/update-dependents-count.js
@@ -71,8 +71,8 @@ function formatNumber(value) {
   return Math.floor(value / 1e5) / 10 + " million";
 }
 
-export default async function updateDependentsCount({ dry }) {
-  if (dry) {
+export default async function updateDependentsCount({ dry, next }) {
+  if (dry || next) {
     return;
   }
 

--- a/scripts/release/steps/update-version.js
+++ b/scripts/release/steps/update-version.js
@@ -1,9 +1,14 @@
 import { runYarn, readJson, writeJson, processFile } from "../utils.js";
 
-export default async function updateVersion({ version }) {
+export default async function updateVersion({ version, next }) {
   const pkg = await readJson("package.json");
   pkg.version = version;
   await writeJson("package.json", pkg);
+
+  // For pre-release, just update package.json
+  if (next) {
+    return;
+  }
 
   // Update github issue templates
   processFile(".github/ISSUE_TEMPLATE/formatting.md", (content) =>

--- a/scripts/release/steps/validate-new-version.js
+++ b/scripts/release/steps/validate-new-version.js
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import semver from "semver";
 
-export default function validateNewVersion({ version, previousVersion }) {
+export default function validateNewVersion({ version, previousVersion, next }) {
   if (!version) {
     throw new Error("'--version' is required");
   }
@@ -15,6 +15,14 @@ export default function validateNewVersion({ version, previousVersion }) {
   if (!semver.gt(version, previousVersion)) {
     throw new Error(
       `Version '${chalk.yellow.underline(version)}' has already been published`,
+    );
+  }
+
+  if (next && semver.prerelease(version) === null) {
+    throw new Error(
+      `Version '${chalk.yellow.underline(
+        version,
+      )}' is not a prerelease version`,
     );
   }
 }

--- a/scripts/release/steps/wait-for-bot-release.js
+++ b/scripts/release/steps/wait-for-bot-release.js
@@ -26,7 +26,7 @@ const sleep = () =>
     setTimeout(resolve, 30_000);
   });
 
-export default async function waitForBotRelease({ dry, version }) {
+export default async function waitForBotRelease({ dry, version, next }) {
   if (dry) {
     return;
   }
@@ -59,20 +59,37 @@ export default async function waitForBotRelease({ dry, version }) {
 
   await waitForEnter();
 
-  console.log(
-    outdent`
-      1. Go to ${chalk.green.underline(
-        "https://github.com/prettier/release-workflow/actions/workflows/release.yml",
-      )}
-      2. Click "${chalk.green(
-        "Run workflow",
-      )}" button, type "${chalk.yellow.underline(
-        version,
-      )}" in "Version to release", uncheck all checkboxes, hit the "${chalk.bgGreen(
-        "Run workflow",
-      )}" button.
-    `,
-  );
+  if (next) {
+    console.log(
+      outdent`
+        1. Go to ${chalk.green.underline(
+          "https://github.com/prettier/release-workflow/actions/workflows/release.yml",
+        )}
+        2. Click "${chalk.green(
+          "Run workflow",
+        )}" button, type "${chalk.yellow.underline(
+          version,
+        )}" in "Version to release", check only "Unstable version", hit the "${chalk.bgGreen(
+          "Run workflow",
+        )}" button.
+      `,
+    );
+  } else {
+    console.log(
+      outdent`
+        1. Go to ${chalk.green.underline(
+          "https://github.com/prettier/release-workflow/actions/workflows/release.yml",
+        )}
+        2. Click "${chalk.green(
+          "Run workflow",
+        )}" button, type "${chalk.yellow.underline(
+          version,
+        )}" in "Version to release", uncheck all checkboxes, hit the "${chalk.bgGreen(
+          "Run workflow",
+        )}" button.
+      `,
+    );
+  }
 
   await waitForEnter();
 

--- a/scripts/release/steps/wait-for-bot-release.js
+++ b/scripts/release/steps/wait-for-bot-release.js
@@ -59,37 +59,20 @@ export default async function waitForBotRelease({ dry, version, next }) {
 
   await waitForEnter();
 
-  if (next) {
-    console.log(
-      outdent`
-        1. Go to ${chalk.green.underline(
-          "https://github.com/prettier/release-workflow/actions/workflows/release.yml",
-        )}
-        2. Click "${chalk.green(
-          "Run workflow",
-        )}" button, type "${chalk.yellow.underline(
-          version,
-        )}" in "Version to release", check only "Unstable version", hit the "${chalk.bgGreen(
-          "Run workflow",
-        )}" button.
-      `,
-    );
-  } else {
-    console.log(
-      outdent`
-        1. Go to ${chalk.green.underline(
-          "https://github.com/prettier/release-workflow/actions/workflows/release.yml",
-        )}
-        2. Click "${chalk.green(
-          "Run workflow",
-        )}" button, type "${chalk.yellow.underline(
-          version,
-        )}" in "Version to release", uncheck all checkboxes, hit the "${chalk.bgGreen(
-          "Run workflow",
-        )}" button.
-      `,
-    );
-  }
+  console.log(
+    outdent`
+      1. Go to ${chalk.green.underline(
+        "https://github.com/prettier/release-workflow/actions/workflows/release.yml",
+      )}
+      2. Click "${chalk.green(
+        "Run workflow",
+      )}" button, type "${chalk.yellow.underline(
+        version,
+      )}" in "Version to release", ${
+        next ? 'check only "Unstable version"' : "uncheck all checkboxes"
+      }, hit the "${chalk.bgGreen("Run workflow")}" button.
+    `,
+  );
 
   await waitForEnter();
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Add the `--next` flag to your release script. When this flag is enabled, we only update the version of `package.json`, add Git tags, and push to GitHub.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
