### PR TITLE
Print angular control flow syntax correctly with prettier ignore comments

### DIFF
--- a/src/language-html/print/angular-control-flow-block.js
+++ b/src/language-html/print/angular-control-flow-block.js
@@ -8,6 +8,7 @@ import {
 } from "../../document/builders.js";
 import ANGULAR_CONTROL_FLOW_BLOCK_SETTINGS from "./angular-control-flow-block-settings.evaluate.js";
 import { printChildren } from "./children.js";
+import { hasPrettierIgnore } from "../utils/index.js";
 
 function printAngularControlFlowBlock(path, options, print) {
   const { node } = path;
@@ -51,7 +52,8 @@ function isPreviousBlockUnClosed(path) {
   const { previous } = path;
   return (
     previous?.type === "angularControlFlowBlock" &&
-    !shouldCloseBlock(path.previous)
+    !shouldCloseBlock(path.previous) &&
+    !hasPrettierIgnore(previous)
   );
 }
 

--- a/tests/format/angular/control-flow/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/angular/control-flow/__snapshots__/jsfmt.spec.js.snap
@@ -426,6 +426,95 @@ topStartToSideStartMaxSize) {
 ================================================================================
 `;
 
+exports[`ignore-comment.html format 1`] = `
+====================================options=====================================
+parsers: ["angular"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<!-- prettier-ignore -->
+@if (condition) {
+  Foo
+} @else {
+  Bar
+}
+
+<!-- prettier-ignore -->
+@for ( item of items; track item) {
+  {{ item }}
+} @empty {
+  No items
+}
+
+<!-- prettier-ignore -->
+@switch (condition) {
+  @case (caseA) {
+    Case A.
+  }
+  @case (caseB) {
+    Case B.
+  }
+  @default {
+    Default case.
+  }
+}
+
+<!-- prettier-ignore -->
+@defer {
+  <large-component />
+} @loading {
+  Loading
+} @placeholder {
+  Placeholder
+} @error {
+  Error
+}
+
+=====================================output=====================================
+<!-- prettier-ignore -->
+@if (condition) {
+  Foo
+}
+@else {
+  Bar
+}
+
+<!-- prettier-ignore -->
+@for ( item of items; track item) {
+  {{ item }}
+}
+@empty {
+  No items
+}
+
+<!-- prettier-ignore -->
+@switch (condition) {
+  @case (caseA) {
+    Case A.
+  }
+  @case (caseB) {
+    Case B.
+  }
+  @default {
+    Default case.
+  }
+}
+
+<!-- prettier-ignore -->
+@defer {
+  <large-component />
+}
+@loading {
+  Loading
+} @placeholder {
+  Placeholder
+} @error {
+  Error
+}
+
+================================================================================
+`;
+
 exports[`mix.html format 1`] = `
 ====================================options=====================================
 parsers: ["angular"]

--- a/tests/format/angular/control-flow/ignore-comment.html
+++ b/tests/format/angular/control-flow/ignore-comment.html
@@ -1,0 +1,37 @@
+<!-- prettier-ignore -->
+@if (condition) {
+  Foo
+} @else {
+  Bar
+}
+
+<!-- prettier-ignore -->
+@for ( item of items; track item) {
+  {{ item }}
+} @empty {
+  No items
+}
+
+<!-- prettier-ignore -->
+@switch (condition) {
+  @case (caseA) {
+    Case A.
+  }
+  @case (caseB) {
+    Case B.
+  }
+  @default {
+    Default case.
+  }
+}
+
+<!-- prettier-ignore -->
+@defer {
+  <large-component />
+} @loading {
+  Loading
+} @placeholder {
+  Placeholder
+} @error {
+  Error
+}


### PR DESCRIPTION
Fixes #15810

## Description

<!-- Please provide a brief summary of your changes: -->

Correctly prints angular control flow syntax blocks when they are preceded by a `<!-- prettier-ignore -->` comment. Previously an extra brace was printed which resulted in invalid syntax.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
