### PR TITLE
Update `esbuild-visualizer` to v0.5.1

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -324,7 +324,6 @@
         "Tparam",
         "Tradeshift",
         "Transloadit",
-        "treemap",
         "trippable",
         "tsbuild",
         "tsep",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "enquirer": "2.4.1",
     "esbuild": "0.19.9",
     "esbuild-plugins-node-modules-polyfill": "1.6.1",
-    "esbuild-visualizer": "0.5.0",
+    "esbuild-visualizer": "0.5.1",
     "eslint": "8.53.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-formatter-friendly": "7.0.0",

--- a/scripts/build/esbuild-plugins/visualizer.js
+++ b/scripts/build/esbuild-plugins/visualizer.js
@@ -1,21 +1,6 @@
 import fs from "node:fs/promises";
 
 import { visualizer as esbuildVisualizer } from "esbuild-visualizer/dist/plugin/index.js";
-import { renderTemplate as esbuildVisualizerRenderTemplate } from "esbuild-visualizer/dist/plugin/render-template.js";
-
-/**
- * @param {import("esbuild-visualizer").Metadata} metafile
- * @param {{title: string, template: import("esbuild-visualizer").TemplateType}} options
- */
-const getReport = async (metafile, options) => {
-  const data = await esbuildVisualizer(metafile);
-  const report = esbuildVisualizerRenderTemplate(options.template, {
-    title: options.title,
-    data,
-  });
-
-  return report;
-};
 
 export default function esbuildPluginVisualizer({ formats }) {
   formats = Object.fromEntries(formats.map((format) => [format, true]));
@@ -48,9 +33,8 @@ export default function esbuildPluginVisualizer({ formats }) {
         }
 
         if (formats.html) {
-          const report = await getReport(metafile, {
+          const report = await esbuildVisualizer(metafile, {
             title: files[0],
-            template: "treemap",
           });
 
           await fs.writeFile(`${esbuildConfig.outfile}.report.html`, report);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3545,16 +3545,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-visualizer@npm:0.5.0":
-  version: 0.5.0
-  resolution: "esbuild-visualizer@npm:0.5.0"
+"esbuild-visualizer@npm:0.5.1":
+  version: 0.5.1
+  resolution: "esbuild-visualizer@npm:0.5.1"
   dependencies:
     open: "npm:^8.4.0"
     picomatch: "npm:^2.3.1"
     yargs: "npm:^17.6.2"
   bin:
     esbuild-visualizer: dist/bin/cli.js
-  checksum: da88c98355068fd1cfd61dae487ff6cde63dc544ad06aeb672c1f7064d745dc487f143a637bf181d545f7f56745db95234747c14a465ac4914e2498bce37c589
+  checksum: 7abbad4fde9f0c228eed3ebf6dc37321f09e1edd76e1409e10d05ae0b03d1209c8191ec68046655c14e962fba8b3889e56db52916a8d8537e658f309a1f6679c
   languageName: node
   linkType: hard
 
@@ -7292,7 +7292,7 @@ __metadata:
     enquirer: "npm:2.4.1"
     esbuild: "npm:0.19.9"
     esbuild-plugins-node-modules-polyfill: "npm:1.6.1"
-    esbuild-visualizer: "npm:0.5.0"
+    esbuild-visualizer: "npm:0.5.1"
     escape-string-regexp: "npm:5.0.0"
     eslint: "npm:8.53.0"
     eslint-config-prettier: "npm:9.1.0"


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

This reverts #15807, since they changed the API back.

https://github.com/btd/esbuild-visualizer/commit/1a3fa4cffa7e34bdf3f29405d9c5f37c3df5bd41

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
