### PR TITLE
Fix `getFileInfo` and `getSupportInfo` type definitions

### DIFF
--- a/changelog_unreleased/api/15854.md
+++ b/changelog_unreleased/api/15854.md
@@ -1,0 +1,11 @@
+#### Fix `getFileInfo` and `getSupportInfo` type definitions (#15854 by @auvred)
+
+```ts
+const plugin: Plugin = {};
+
+prettier.getFileInfo("./file.ext", {
+  plugins: [plugin],
+});
+
+prettier.getSupportInfo({ plugins: [plugin], showDeprecated: true });
+```

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -791,7 +791,7 @@ export interface SupportInfo {
 export interface FileInfoOptions {
   ignorePath?: string | URL | (string | URL)[] | undefined;
   withNodeModules?: boolean | undefined;
-  plugins?: string[] | undefined;
+  plugins?: Array<string | Plugin> | undefined;
   resolveConfig?: boolean | undefined;
 }
 
@@ -805,10 +805,17 @@ export function getFileInfo(
   options?: FileInfoOptions,
 ): Promise<FileInfoResult>;
 
+export interface SupportInfoOptions {
+  plugins?: Array<string | Plugin> | undefined;
+  showDeprecated?: boolean | undefined;
+}
+
 /**
  * Returns an object representing the parsers, languages and file types Prettier supports for the current version.
  */
-export function getSupportInfo(): Promise<SupportInfo>;
+export function getSupportInfo(
+  options?: SupportInfoOptions,
+): Promise<SupportInfo>;
 
 /**
  * `version` field in `package.json`

--- a/tests/dts/unit/cases/index.ts
+++ b/tests/dts/unit/cases/index.ts
@@ -13,6 +13,7 @@ prettier.getFileInfo("./tsconfig.json").then((result) => {
     throw new Error("Bad parser");
   }
 });
+prettier.getFileInfo("path/to/some/file", { plugins: ["my-plugin"] });
 // @ts-expect-error
 prettier.resolveConfig();
 prettier.resolveConfigFile().then((filePath) => {
@@ -27,6 +28,7 @@ prettier.resolveConfigFile("/path").then((filePath) => {
 });
 prettier.clearConfigCache();
 prettier.getSupportInfo();
+prettier.getSupportInfo({ showDeprecated: true, plugins: ["my-plugin"] });
 
 prettier.doc.builders.trim;
 prettier.doc.builders.trim.type;

--- a/tests/dts/unit/cases/plugins.ts
+++ b/tests/dts/unit/cases/plugins.ts
@@ -141,3 +141,5 @@ const plugin: prettier.Plugin<PluginAST> = {
 };
 
 prettier.format("a line!", { parser: "lines", plugins: [plugin] });
+prettier.getFileInfo("path/to/some/file", { plugins: [plugin] });
+prettier.getSupportInfo({ plugins: [plugin] });


### PR DESCRIPTION
## Description

Fixes https://github.com/prettier/prettier/issues/15849

In addition to the `getFileInfo`, I noticed that the `getSupportInfo` type definition is also outdated https://github.com/prettier/prettier/blob/84c169ecc20f6776639d67ed9ab371dacf1db3b8/src/main/support.js#L8-L16

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
