### PR TITLE
Avoid adding colon for `track` in 3rd expression of `for` blocks

### DIFF
--- a/changelog_unreleased/angular/15887.md
+++ b/changelog_unreleased/angular/15887.md
@@ -1,0 +1,13 @@
+#### Avoid adding colon for `track` in 3rd expression of `for` blocks (#15887 by @sosukesuzuki)
+
+<!-- prettier-ignore -->
+```html
+<!-- Input -->
+@for (item of items; let i = $index; track block) {}
+
+<!-- Prettier stable -->
+@for (item of items; let i = $index; track: block) {}
+
+<!-- Prettier main -->
+@for (item of items; let i = $index; track block) {}
+```

--- a/src/language-js/print/angular.js
+++ b/src/language-js/print/angular.js
@@ -66,7 +66,7 @@ function printAngular(path, options, print) {
           (node.key.name === "then" ||
             node.key.name === "else" ||
             node.key.name === "as")) ||
-          (index === 2 &&
+          ((index === 2 || index === 3) &&
             ((node.key.name === "else" &&
               parent.body[index - 1].type === "NGMicrosyntaxKeyedExpression" &&
               parent.body[index - 1].key.name === "then") ||

--- a/tests/format/angular/control-flow/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/angular/control-flow/__snapshots__/jsfmt.spec.js.snap
@@ -287,6 +287,8 @@ item of
 
 <div>
   @for (item of items; let i = $index; track block) {}
+
+  <div *ngFor="item of items; let i = $index; track block"></div>
 </div>
 
 =====================================output=====================================
@@ -338,6 +340,8 @@ item of
 
 <div>
   @for (item of items; let i = $index; track block) {}
+
+  <div *ngFor="item of items; let i = $index; track block"></div>
 </div>
 
 ================================================================================

--- a/tests/format/angular/control-flow/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/angular/control-flow/__snapshots__/jsfmt.spec.js.snap
@@ -285,6 +285,10 @@ item of
   <div *ngFor="item of items; track item"></div>
 </div>
 
+<div>
+  @for (item of items; let i = $index; track block) {}
+</div>
+
 =====================================output=====================================
 <ul>
   @for (let item of items; index as i; trackBy: trackByFn) {
@@ -330,6 +334,10 @@ item of
   @for (item of items; track item) {}
 
   <div *ngFor="item of items; track item"></div>
+</div>
+
+<div>
+  @for (item of items; let i = $index; track block) {}
 </div>
 
 ================================================================================

--- a/tests/format/angular/control-flow/for.html
+++ b/tests/format/angular/control-flow/for.html
@@ -52,3 +52,7 @@ item of
 
   <div *ngFor="item of items; track item"></div>
 </div>
+
+<div>
+  @for (item of items; let i = $index; track block) {}
+</div>

--- a/tests/format/angular/control-flow/for.html
+++ b/tests/format/angular/control-flow/for.html
@@ -55,4 +55,6 @@ item of
 
 <div>
   @for (item of items; let i = $index; track block) {}
+
+  <div *ngFor="item of items; let i = $index; track block"></div>
 </div>


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #15784

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
