### PR TITLE
Fix release notes URL in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 [diff](https://github.com/prettier/prettier/compare/3.1.1...3.2.0)
 
-🔗 [Release Notes](https://prettier.io/blog/2024/01/13/3.2.0.html)
+🔗 [Release Notes](https://prettier.io/blog/2024/01/12/3.2.0.html)
 
 # 3.1.1
 


### PR DESCRIPTION
Fixes typo in https://github.com/prettier/prettier/commit/29f299f73edf9dea28aae9d44a52377a8d12620f#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed

I’ve already updated https://github.com/prettier/prettier/releases/tag/3.2.0. Are there any other places where this link can be broken?