### PR TITLE
Use `ISOString` for `getFormattedDate`

### DIFF
--- a/scripts/release/get-formatted-date.js
+++ b/scripts/release/get-formatted-date.js
@@ -1,8 +1,11 @@
 // TODO: Implement this in `utils.js` when jest.importActual is landed.
 export default function getFormattedDate() {
   const date = new Date();
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, "0");
-  const day = String(date.getDate()).padStart(2, "0");
+  const isoStr = date.toISOString();
+
+  const year = isoStr.slice(0, 4);
+  const month = isoStr.slice(5, 7);
+  const day = isoStr.slice(8, 10);
+
   return { year, month, day };
 }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

https://github.com/prettier/prettier/pull/15913 happened because draft-blog-post uses ISOString and release script uses Date.prototype.getDate()

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
