### PR TITLE
Fix parser inference

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,7 +5,6 @@ overrides:
   - files: "bin/prettier.cjs"
     options:
       trailingComma: none
-  # TODO: Enable this after `jsonc` parser released
-  # - files: ".vscode/*.json"
-  #   options:
-  #     parser: jsonc
+  - files: ".vscode/*.json"
+    options:
+      parser: jsonc

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,6 +3,6 @@
     "esbenp.prettier-vscode",
     "editorconfig.editorconfig",
     "dbaeumer.vscode-eslint",
-    "streetsidesoftware.code-spell-checker"
-  ]
+    "streetsidesoftware.code-spell-checker",
+  ],
 }

--- a/.vscode/settings.example.json
+++ b/.vscode/settings.example.json
@@ -2,14 +2,14 @@
   "[javascript]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
-    "editor.codeActionsOnSave": ["source.fixAll.eslint"]
+    "editor.codeActionsOnSave": ["source.fixAll.eslint"],
   },
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
+    "source.fixAll.eslint": "explicit",
   },
   "prettier.requireConfig": true,
   "eslint.experimental.useFlatConfig": true,
   "files.exclude": {
-    "dist*": true
-  }
+    "dist*": true,
+  },
 }

--- a/changelog_unreleased/api/15927.md
+++ b/changelog_unreleased/api/15927.md
@@ -1,0 +1,12 @@
+#### Fix parser inference (#15927 by @fisker)
+
+<!-- prettier-ignore -->
+```console
+// Prettier stable
+prettier --file-info tsconfig.json
+{ "ignored": false, "inferredParser": "json" }
+
+// Prettier main
+prettier --file-info tsconfig.json
+{ "ignored": false, "inferredParser": "jsonc" }
+```

--- a/src/utils/infer-parser.js
+++ b/src/utils/infer-parser.js
@@ -51,7 +51,7 @@ function getLanguageByInterpreter(languages, file) {
   }
 
   return languages.find(
-    (language) => language.interpreters?.includes(interpreter),
+    ({ interpreters }) => interpreters?.includes(interpreter),
   );
 }
 

--- a/src/utils/infer-parser.js
+++ b/src/utils/infer-parser.js
@@ -21,7 +21,7 @@ function getLanguageByFileName(languages, file) {
   );
 }
 
-function getLanguageByName(languages, languageName) {
+function getLanguageByLanguageName(languages, languageName) {
   if (!languageName) {
     return;
   }
@@ -69,7 +69,7 @@ function inferParser(options, fileInfo) {
   // interpreter in the shebang line, if any; but since this requires FS access,
   // do it last.
   const language =
-    getLanguageByName(languages, fileInfo.language) ??
+    getLanguageByLanguageName(languages, fileInfo.language) ??
     getLanguageByFileName(languages, fileInfo.physicalFile) ??
     getLanguageByFileName(languages, fileInfo.file) ??
     getLanguageByInterpreter(languages, fileInfo.physicalFile);

--- a/src/utils/infer-parser.js
+++ b/src/utils/infer-parser.js
@@ -12,13 +12,11 @@ function getLanguageByFileName(languages, file) {
   const basename = getFileBasename(file).toLowerCase();
 
   return (
-    languages.find(
-      (language) =>
-        language.filenames?.some((name) => name.toLowerCase() === basename),
+    languages.find((language) =>
+      language.filenames?.some((name) => name.toLowerCase() === basename),
     ) ??
-    languages.find(
-      (language) =>
-        language.extensions?.some((extension) => basename.endsWith(extension)),
+    languages.find((language) =>
+      language.extensions?.some((extension) => basename.endsWith(extension)),
     )
   );
 }
@@ -50,8 +48,8 @@ function getLanguageByInterpreter(languages, file) {
     return;
   }
 
-  return languages.find(
-    (language) => language.interpreters?.includes(interpreter),
+  return languages.find((language) =>
+    language.interpreters?.includes(interpreter),
   );
 }
 

--- a/src/utils/infer-parser.js
+++ b/src/utils/infer-parser.js
@@ -12,11 +12,13 @@ function getLanguageByFileName(languages, file) {
   const basename = getFileBasename(file).toLowerCase();
 
   return (
-    languages.find((language) =>
-      language.filenames?.some((name) => name.toLowerCase() === basename),
+    languages.find(
+      ({ filenames }) =>
+        filenames?.some((name) => name.toLowerCase() === basename),
     ) ??
-    languages.find((language) =>
-      language.extensions?.some((extension) => basename.endsWith(extension)),
+    languages.find(
+      ({ extensions }) =>
+        extensions?.some((extension) => basename.endsWith(extension)),
     )
   );
 }
@@ -48,8 +50,8 @@ function getLanguageByInterpreter(languages, file) {
     return;
   }
 
-  return languages.find((language) =>
-    language.interpreters?.includes(interpreter),
+  return languages.find(
+    (language) => language.interpreters?.includes(interpreter),
   );
 }
 

--- a/src/utils/infer-parser.js
+++ b/src/utils/infer-parser.js
@@ -11,10 +11,15 @@ function getLanguageByFileName(languages, file) {
 
   const basename = getFileBasename(file).toLowerCase();
 
-  return languages.find(
-    (language) =>
-      language.extensions?.some((extension) => basename.endsWith(extension)) ||
-      language.filenames?.some((name) => name.toLowerCase() === basename),
+  return (
+    languages.find(
+      (language) =>
+        language.filenames?.some((name) => name.toLowerCase() === basename),
+    ) ??
+    languages.find(
+      (language) =>
+        language.extensions?.some((extension) => basename.endsWith(extension)),
+    )
   );
 }
 
@@ -45,8 +50,8 @@ function getLanguageByInterpreter(languages, file) {
     return;
   }
 
-  return languages.find((language) =>
-    language.interpreters?.includes(interpreter),
+  return languages.find(
+    (language) => language.interpreters?.includes(interpreter),
   );
 }
 

--- a/src/utils/infer-parser.js
+++ b/src/utils/infer-parser.js
@@ -12,13 +12,11 @@ function getLanguageByFileName(languages, file) {
   const basename = getFileBasename(file).toLowerCase();
 
   return (
-    languages.find(
-      ({ filenames }) =>
-        filenames?.some((name) => name.toLowerCase() === basename),
+    languages.find(({ filenames }) =>
+      filenames?.some((name) => name.toLowerCase() === basename),
     ) ??
-    languages.find(
-      ({ extensions }) =>
-        extensions?.some((extension) => basename.endsWith(extension)),
+    languages.find(({ extensions }) =>
+      extensions?.some((extension) => basename.endsWith(extension)),
     )
   );
 }
@@ -50,8 +48,8 @@ function getLanguageByInterpreter(languages, file) {
     return;
   }
 
-  return languages.find(
-    ({ interpreters }) => interpreters?.includes(interpreter),
+  return languages.find(({ interpreters }) =>
+    interpreters?.includes(interpreter),
   );
 }
 

--- a/tests/integration/__tests__/file-info.js
+++ b/tests/integration/__tests__/file-info.js
@@ -130,6 +130,10 @@ test("API getFileInfo with filepath only", async () => {
     ignored: false,
     inferredParser: "markdown",
   });
+  await expect(prettier.getFileInfo("tsconfig.json")).resolves.toEqual({
+    ignored: false,
+    inferredParser: "jsonc",
+  });
 });
 
 describe("API getFileInfo resolveConfig", () => {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Should infer parser by filenames first, then by extensions.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
