### PR TITLE
Improve babel parse error message

### DIFF
--- a/src/language-js/parse/utils/create-babel-parse-error.js
+++ b/src/language-js/parse/utils/create-babel-parse-error.js
@@ -6,7 +6,13 @@ function createBabelParseError(error) {
   let {
     message,
     loc: { line, column },
+    reasonCode,
   } = error;
+
+  if (reasonCode === "MissingPlugin" || reasonCode === "MissingOneOfPlugins") {
+    message = "Unexpected token";
+  }
+
   const suffix = ` (${line}:${column})`;
   if (message.endsWith(suffix)) {
     message = message.slice(0, -suffix.length);

--- a/src/language-json/parser-json.js
+++ b/src/language-json/parser-json.js
@@ -18,16 +18,6 @@ function createJsonParse(options = {}) {
         attachComment: false,
       });
     } catch (/** @type {any} */ error) {
-      if (
-        error?.reasonCode === "MissingPlugin" ||
-        error?.reasonCode === "MissingOneOfPlugins"
-      ) {
-        throw createBabelParseError({
-          message: "Unexpected token",
-          loc: error.loc,
-        });
-      }
-
       throw createBabelParseError(error);
     }
 

--- a/tests/format/misc/errors/babel-missing-plugins/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/babel-missing-plugins/__snapshots__/jsfmt.spec.js.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`snippet: #0 [babel] format 1`] = `
+"This experimental syntax requires enabling one of the following parser plugin(s): "flow", "typescript". (1:8)
+> 1 | export type Foo = number;
+    |        ^
+Cause: This experimental syntax requires enabling one of the following parser plugin(s): "flow", "typescript". (1:7)"
+`;

--- a/tests/format/misc/errors/babel-missing-plugins/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/misc/errors/babel-missing-plugins/__snapshots__/jsfmt.spec.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`snippet: #0 [babel] format 1`] = `
-"This experimental syntax requires enabling one of the following parser plugin(s): "flow", "typescript". (1:8)
+"Unexpected token (1:8)
 > 1 | export type Foo = number;
     |        ^
 Cause: This experimental syntax requires enabling one of the following parser plugin(s): "flow", "typescript". (1:7)"

--- a/tests/format/misc/errors/babel-missing-plugins/jsfmt.spec.js
+++ b/tests/format/misc/errors/babel-missing-plugins/jsfmt.spec.js
@@ -1,0 +1,10 @@
+run_spec(
+  {
+    importMeta: import.meta,
+    snippets: [
+      // https://github.com/babel/babel/commit/a466f9c310ace91484d4087f077ee6d6c8cd8789
+      "export type Foo = number;",
+    ],
+  },
+  ["babel"],
+);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

```
- This experimental syntax requires enabling one of the following parser plugin(s): "flow", "typescript". (1:8)
+ Unexpected token (1:8)
> 1 | export type Foo = number;
    |        ^
```

Similar to #14398, don't show missing plugin in error message.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
