### PR TITLE
fix: tsconfig.json is not jsonc compatible

### DIFF
--- a/src/language-json/languages.evaluate.js
+++ b/src/language-json/languages.evaluate.js
@@ -32,7 +32,6 @@ const languages = [
       "devcontainer.json",
       "jsconfig.json",
       "language-configuration.json",
-      "tsconfig.json",
     ],
   })),
   createLanguage(linguistLanguages.JSON5, () => ({

--- a/tests/integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests/integration/__tests__/__snapshots__/support-info.js.snap
@@ -529,8 +529,7 @@ exports[`CLI --support-info (stdout) 1`] = `
       "filenames": [
         "devcontainer.json",
         "jsconfig.json",
-        "language-configuration.json",
-        "tsconfig.json"
+        "language-configuration.json"
       ],
       "group": "JSON",
       "linguistLanguageId": 423,

--- a/tests/integration/__tests__/file-info.js
+++ b/tests/integration/__tests__/file-info.js
@@ -130,9 +130,13 @@ test("API getFileInfo with filepath only", async () => {
     ignored: false,
     inferredParser: "markdown",
   });
-  await expect(prettier.getFileInfo("tsconfig.json")).resolves.toEqual({
+  await expect(prettier.getFileInfo("devcontainer.json")).resolves.toEqual({
     ignored: false,
     inferredParser: "jsonc",
+  });
+  await expect(prettier.getFileInfo("tsconfig.json")).resolves.toEqual({
+    ignored: false,
+    inferredParser: "json",
   });
 });
 


### PR DESCRIPTION
## Description

tsconfig.json is not compatible with jsonc parsing (comments are tolerated but not trailing commas). See https://github.com/prettier/prettier/issues/15956#issuecomment-1898515499

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
