### PR TITLE
Remove `import/extensions`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -137,7 +137,6 @@ export default [
       ],
 
       // eslint-plugin-import
-      "import/extensions": ["error", "ignorePackages"],
       "import/no-extraneous-dependencies": [
         "error",
         {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Our codebase is now pure ESM, we can't omit extensions, we can write anything that works directly, so we don't need it anymore.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
