### PR TITLE
Prevent splitting of textarea's closing tag

### DIFF
--- a/src/language-html/utils/index.js
+++ b/src/language-html/utils/index.js
@@ -205,6 +205,9 @@ function isTrailingSpaceSensitiveNode(node, options) {
   }
 
   if (isPreLikeNode(node.parent)) {
+    if(node.parent.name == "textarea") {
+      return false;
+    }
     return true;
   }
 

--- a/tests/format/angular/angular/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/angular/angular/__snapshots__/jsfmt.spec.js.snap
@@ -2105,45 +2105,45 @@ printWidth: 80
 <textarea>    {{ generatedDiscountCodes }}</textarea>
 <textarea>
   
-{{ generatedDiscountCodes }}</textarea
->
+{{ generatedDiscountCodes }}
+</textarea>
 <textarea>
   
-    {{ generatedDiscountCodes }}</textarea
->
+    {{ generatedDiscountCodes }}
+</textarea>
 <textarea>{{ generatedDiscountCodes }}123</textarea>
 <textarea>{{ generatedDiscountCodes }}123</textarea>
 <textarea>    {{ generatedDiscountCodes }}123</textarea>
 <textarea>
   
-{{ generatedDiscountCodes }}123</textarea
->
+{{ generatedDiscountCodes }}123
+</textarea>
 <textarea>
   
-    {{ generatedDiscountCodes }}123</textarea
->
+    {{ generatedDiscountCodes }}123
+</textarea>
 <textarea type="text">{{ generatedDiscountCodes }}</textarea>
 <textarea type="text">{{ generatedDiscountCodes }}</textarea>
 <textarea type="text">    {{ generatedDiscountCodes }}</textarea>
 <textarea type="text">
   
-{{ generatedDiscountCodes }}</textarea
->
+{{ generatedDiscountCodes }}
+</textarea>
 <textarea type="text">
   
-    {{ generatedDiscountCodes }}</textarea
->
+    {{ generatedDiscountCodes }}
+</textarea>
 <textarea type="text">{{ generatedDiscountCodes }}123</textarea>
 <textarea type="text">{{ generatedDiscountCodes }}123</textarea>
 <textarea type="text">    {{ generatedDiscountCodes }}123</textarea>
 <textarea type="text">
   
-{{ generatedDiscountCodes }}123</textarea
->
+{{ generatedDiscountCodes }}123
+</textarea>
 <textarea type="text">
   
-    {{ generatedDiscountCodes }}123</textarea
->
+    {{ generatedDiscountCodes }}123
+</textarea>
 
 ================================================================================
 `;
@@ -2198,45 +2198,45 @@ printWidth: 80
 <textarea>    {{ generatedDiscountCodes }}</textarea>
 <textarea>
   
-{{ generatedDiscountCodes }}</textarea
->
+{{ generatedDiscountCodes }}
+</textarea>
 <textarea>
   
-    {{ generatedDiscountCodes }}</textarea
->
+    {{ generatedDiscountCodes }}
+</textarea>
 <textarea>{{ generatedDiscountCodes }}123</textarea>
 <textarea>{{ generatedDiscountCodes }}123</textarea>
 <textarea>    {{ generatedDiscountCodes }}123</textarea>
 <textarea>
   
-{{ generatedDiscountCodes }}123</textarea
->
+{{ generatedDiscountCodes }}123
+</textarea>
 <textarea>
   
-    {{ generatedDiscountCodes }}123</textarea
->
+    {{ generatedDiscountCodes }}123
+</textarea>
 <textarea type="text">{{ generatedDiscountCodes }}</textarea>
 <textarea type="text">{{ generatedDiscountCodes }}</textarea>
 <textarea type="text">    {{ generatedDiscountCodes }}</textarea>
 <textarea type="text">
   
-{{ generatedDiscountCodes }}</textarea
->
+{{ generatedDiscountCodes }}
+</textarea>
 <textarea type="text">
   
-    {{ generatedDiscountCodes }}</textarea
->
+    {{ generatedDiscountCodes }}
+</textarea>
 <textarea type="text">{{ generatedDiscountCodes }}123</textarea>
 <textarea type="text">{{ generatedDiscountCodes }}123</textarea>
 <textarea type="text">    {{ generatedDiscountCodes }}123</textarea>
 <textarea type="text">
   
-{{ generatedDiscountCodes }}123</textarea
->
+{{ generatedDiscountCodes }}123
+</textarea>
 <textarea type="text">
   
-    {{ generatedDiscountCodes }}123</textarea
->
+    {{ generatedDiscountCodes }}123
+</textarea>
 
 ================================================================================
 `;
@@ -2288,127 +2288,127 @@ printWidth: 1
 <textarea
   >{{
     generatedDiscountCodes
-  }}</textarea
->
+  }}
+</textarea>
 <textarea
   >{{
     generatedDiscountCodes
-  }}</textarea
->
+  }}
+</textarea>
 <textarea>
     {{
     generatedDiscountCodes
-  }}</textarea
->
-<textarea>
-  
-{{
-    generatedDiscountCodes
-  }}</textarea
->
-<textarea>
-  
-    {{
-    generatedDiscountCodes
-  }}</textarea
->
-<textarea
-  >{{
-    generatedDiscountCodes
-  }}123</textarea
->
-<textarea
-  >{{
-    generatedDiscountCodes
-  }}123</textarea
->
-<textarea>
-    {{
-    generatedDiscountCodes
-  }}123</textarea
->
+  }}
+</textarea>
 <textarea>
   
 {{
     generatedDiscountCodes
-  }}123</textarea
->
+  }}
+</textarea>
 <textarea>
   
     {{
     generatedDiscountCodes
-  }}123</textarea
->
+  }}
+</textarea>
 <textarea
-  type="text"
   >{{
     generatedDiscountCodes
-  }}</textarea
->
+  }}123
+</textarea>
 <textarea
-  type="text"
   >{{
     generatedDiscountCodes
-  }}</textarea
->
-<textarea
-  type="text"
->
+  }}123
+</textarea>
+<textarea>
     {{
     generatedDiscountCodes
-  }}</textarea
->
-<textarea
-  type="text"
->
+  }}123
+</textarea>
+<textarea>
   
 {{
     generatedDiscountCodes
-  }}</textarea
->
-<textarea
-  type="text"
->
+  }}123
+</textarea>
+<textarea>
   
     {{
     generatedDiscountCodes
-  }}</textarea
->
+  }}123
+</textarea>
 <textarea
   type="text"
   >{{
     generatedDiscountCodes
-  }}123</textarea
->
+  }}
+</textarea>
 <textarea
   type="text"
   >{{
     generatedDiscountCodes
-  }}123</textarea
->
+  }}
+</textarea>
 <textarea
   type="text"
 >
     {{
     generatedDiscountCodes
-  }}123</textarea
->
+  }}
+</textarea>
 <textarea
   type="text"
 >
   
 {{
     generatedDiscountCodes
-  }}123</textarea
->
+  }}
+</textarea>
 <textarea
   type="text"
 >
   
     {{
     generatedDiscountCodes
-  }}123</textarea
+  }}
+</textarea>
+<textarea
+  type="text"
+  >{{
+    generatedDiscountCodes
+  }}123
+</textarea>
+<textarea
+  type="text"
+  >{{
+    generatedDiscountCodes
+  }}123
+</textarea>
+<textarea
+  type="text"
 >
+    {{
+    generatedDiscountCodes
+  }}123
+</textarea>
+<textarea
+  type="text"
+>
+  
+{{
+    generatedDiscountCodes
+  }}123
+</textarea>
+<textarea
+  type="text"
+>
+  
+    {{
+    generatedDiscountCodes
+  }}123
+</textarea>
 
 ================================================================================
 `;
@@ -2463,45 +2463,45 @@ trailingComma: "es5"
 <textarea>    {{ generatedDiscountCodes }}</textarea>
 <textarea>
   
-{{ generatedDiscountCodes }}</textarea
->
+{{ generatedDiscountCodes }}
+</textarea>
 <textarea>
   
-    {{ generatedDiscountCodes }}</textarea
->
+    {{ generatedDiscountCodes }}
+</textarea>
 <textarea>{{ generatedDiscountCodes }}123</textarea>
 <textarea>{{ generatedDiscountCodes }}123</textarea>
 <textarea>    {{ generatedDiscountCodes }}123</textarea>
 <textarea>
   
-{{ generatedDiscountCodes }}123</textarea
->
+{{ generatedDiscountCodes }}123
+</textarea>
 <textarea>
   
-    {{ generatedDiscountCodes }}123</textarea
->
+    {{ generatedDiscountCodes }}123
+</textarea>
 <textarea type="text">{{ generatedDiscountCodes }}</textarea>
 <textarea type="text">{{ generatedDiscountCodes }}</textarea>
 <textarea type="text">    {{ generatedDiscountCodes }}</textarea>
 <textarea type="text">
   
-{{ generatedDiscountCodes }}</textarea
->
+{{ generatedDiscountCodes }}
+</textarea>
 <textarea type="text">
   
-    {{ generatedDiscountCodes }}</textarea
->
+    {{ generatedDiscountCodes }}
+</textarea>
 <textarea type="text">{{ generatedDiscountCodes }}123</textarea>
 <textarea type="text">{{ generatedDiscountCodes }}123</textarea>
 <textarea type="text">    {{ generatedDiscountCodes }}123</textarea>
 <textarea type="text">
   
-{{ generatedDiscountCodes }}123</textarea
->
+{{ generatedDiscountCodes }}123
+</textarea>
 <textarea type="text">
   
-    {{ generatedDiscountCodes }}123</textarea
->
+    {{ generatedDiscountCodes }}123
+</textarea>
 
 ================================================================================
 `;
@@ -2556,45 +2556,45 @@ trailingComma: "none"
 <textarea>    {{ generatedDiscountCodes }}</textarea>
 <textarea>
   
-{{ generatedDiscountCodes }}</textarea
->
+{{ generatedDiscountCodes }}
+</textarea>
 <textarea>
   
-    {{ generatedDiscountCodes }}</textarea
->
+    {{ generatedDiscountCodes }}
+</textarea>
 <textarea>{{ generatedDiscountCodes }}123</textarea>
 <textarea>{{ generatedDiscountCodes }}123</textarea>
 <textarea>    {{ generatedDiscountCodes }}123</textarea>
 <textarea>
   
-{{ generatedDiscountCodes }}123</textarea
->
+{{ generatedDiscountCodes }}123
+</textarea>
 <textarea>
   
-    {{ generatedDiscountCodes }}123</textarea
->
+    {{ generatedDiscountCodes }}123
+</textarea>
 <textarea type="text">{{ generatedDiscountCodes }}</textarea>
 <textarea type="text">{{ generatedDiscountCodes }}</textarea>
 <textarea type="text">    {{ generatedDiscountCodes }}</textarea>
 <textarea type="text">
   
-{{ generatedDiscountCodes }}</textarea
->
+{{ generatedDiscountCodes }}
+</textarea>
 <textarea type="text">
   
-    {{ generatedDiscountCodes }}</textarea
->
+    {{ generatedDiscountCodes }}
+</textarea>
 <textarea type="text">{{ generatedDiscountCodes }}123</textarea>
 <textarea type="text">{{ generatedDiscountCodes }}123</textarea>
 <textarea type="text">    {{ generatedDiscountCodes }}123</textarea>
 <textarea type="text">
   
-{{ generatedDiscountCodes }}123</textarea
->
+{{ generatedDiscountCodes }}123
+</textarea>
 <textarea type="text">
   
-    {{ generatedDiscountCodes }}123</textarea
->
+    {{ generatedDiscountCodes }}123
+</textarea>
 
 ================================================================================
 `;

--- a/tests/format/html/basics/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/html/basics/__snapshots__/jsfmt.spec.js.snap
@@ -737,8 +737,8 @@ e</pre
     >
     <textarea>
  pre-wrap pr
-e-wrap </textarea
-    >
+e-wrap
+    </textarea>
     <span>
       looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline
     </span>
@@ -777,8 +777,8 @@ e</pre
     >
     <textarea>
  pre-wrap pr
-e-wrap </textarea
-    >
+e-wrap
+    </textarea>
     <span>
       looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline
     </span>
@@ -817,8 +817,8 @@ e</pre
     >
     <textarea>
  pre-wrap pr
-e-wrap </textarea
-    >
+e-wrap
+    </textarea>
     <span>
       looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline
     </span>
@@ -857,8 +857,8 @@ e</pre
     >
     <textarea>
  pre-wrap pr
-e-wrap </textarea
-    >
+e-wrap
+    </textarea>
     <span>
       looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline
     </span>
@@ -897,8 +897,8 @@ e</pre
     >
     <textarea>
  pre-wrap pr
-e-wrap </textarea
-    >
+e-wrap
+    </textarea>
     <span>
       looooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooog inline
     </span>

--- a/tests/format/html/tags/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/html/tags/__snapshots__/jsfmt.spec.js.snap
@@ -364,6 +364,87 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`issue-15432.html - {"htmlWhitespaceSensitivity":"ignore"} format 1`] = `
+====================================options=====================================
+htmlWhitespaceSensitivity: "ignore"
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<textarea id="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">foo</textarea>
+
+=====================================output=====================================
+<textarea id="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">
+foo
+</textarea>
+
+================================================================================
+`;
+
+exports[`issue-15432.html - {"htmlWhitespaceSensitivity":"strict"} format 1`] = `
+====================================options=====================================
+htmlWhitespaceSensitivity: "strict"
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<textarea id="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">foo</textarea>
+
+=====================================output=====================================
+<textarea id="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">
+foo
+</textarea>
+
+================================================================================
+`;
+
+exports[`issue-15432.html - {"printWidth":"Infinity"} format 1`] = `
+====================================options=====================================
+parsers: ["html"]
+printWidth: Infinity
+=====================================input======================================
+<textarea id="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">foo</textarea>
+
+=====================================output=====================================
+<textarea id="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">foo</textarea>
+
+================================================================================
+`;
+
+exports[`issue-15432.html - {"printWidth":1} format 1`] = `
+====================================options=====================================
+parsers: ["html"]
+printWidth: 1
+ | printWidth
+=====================================input======================================
+<textarea id="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">foo</textarea>
+
+=====================================output=====================================
+<textarea
+  id="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+>
+foo
+</textarea>
+
+================================================================================
+`;
+
+exports[`issue-15432.html format 1`] = `
+====================================options=====================================
+parsers: ["html"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+<textarea id="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">foo</textarea>
+
+=====================================output=====================================
+<textarea id="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">
+foo
+</textarea>
+
+================================================================================
+`;
+
 exports[`marquee.html - {"htmlWhitespaceSensitivity":"ignore"} format 1`] = `
 ====================================options=====================================
 htmlWhitespaceSensitivity: "ignore"
@@ -5148,8 +5229,8 @@ printWidth: 1
 
 <div>
   <textarea>
-lorem ipsum</textarea
-  >
+lorem ipsum
+  </textarea>
 </div>
 
 ================================================================================

--- a/tests/format/html/tags/issue-15432.html
+++ b/tests/format/html/tags/issue-15432.html
@@ -1,0 +1,1 @@
+<textarea id="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx">foo</textarea>


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
This PR fixes the issue #15432 

Fix #15432 

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
