### PR TITLE
Remove `getDocParts`

### DIFF
--- a/src/document/printer.js
+++ b/src/document/printer.js
@@ -19,7 +19,7 @@ import {
   DOC_TYPE_TRIM,
 } from "./constants.js";
 import InvalidDocError from "./invalid-doc-error.js";
-import { getDocParts, getDocType, propagateBreaks } from "./utils.js";
+import { getDocType, propagateBreaks } from "./utils.js";
 
 /** @typedef {typeof MODE_BREAK | typeof MODE_FLAT} Mode */
 /** @typedef {{ ind: any, doc: any, mode: Mode }} Command */
@@ -222,8 +222,8 @@ function fits(
     }
 
     const { mode, doc } = cmds.pop();
-
-    switch (getDocType(doc)) {
+    const docType = getDocType(doc);
+    switch (docType) {
       case DOC_TYPE_STRING:
         out.push(doc);
         width -= getStringWidth(doc);
@@ -231,7 +231,7 @@ function fits(
 
       case DOC_TYPE_ARRAY:
       case DOC_TYPE_FILL: {
-        const parts = getDocParts(doc);
+        const parts = docType === DOC_TYPE_ARRAY ? doc : doc.parts;
         for (let i = parts.length - 1; i >= 0; i--) {
           cmds.push({ mode, doc: parts[i] });
         }

--- a/src/document/utils.js
+++ b/src/document/utils.js
@@ -20,19 +20,6 @@ import InvalidDocError from "./invalid-doc-error.js";
 import getDocType from "./utils/get-doc-type.js";
 import traverseDoc from "./utils/traverse-doc.js";
 
-const getDocParts = (doc) => {
-  if (Array.isArray(doc)) {
-    return doc;
-  }
-
-  /* c8 ignore next 3 */
-  if (doc.type !== DOC_TYPE_FILL) {
-    throw new Error(`Expect doc to be 'array' or '${DOC_TYPE_FILL}'.`);
-  }
-
-  return doc.parts;
-};
-
 function mapDoc(doc, cb) {
   // Avoid creating `Map`
   if (typeof doc === "string") {
@@ -432,7 +419,6 @@ export {
   canBreak,
   cleanDoc,
   findInDoc,
-  getDocParts,
   getDocType,
   inheritLabel,
   mapDoc,

--- a/src/language-css/print/parenthesized-value-group.js
+++ b/src/language-css/print/parenthesized-value-group.js
@@ -9,7 +9,6 @@ import {
   line,
   softline,
 } from "../../document/builders.js";
-import { getDocParts } from "../../document/utils.js";
 import isNextLineEmpty from "../../utils/is-next-line-empty.js";
 import isNonEmptyArray from "../../utils/is-non-empty-array.js";
 import { locEnd, locStart } from "../loc.js";
@@ -94,7 +93,7 @@ function printParenthesizedValueGroup(path, options, print) {
       child.groups[0].type !== "value-paren_group" &&
       child.groups[2]?.type === "value-paren_group"
     ) {
-      const parts = getDocParts(doc.contents.contents);
+      const { parts } = doc.contents.contents;
       parts[1] = group(parts[1]);
       doc = group(dedent(doc));
     }

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -8,7 +8,7 @@ import {
   softline,
 } from "../../document/builders.js";
 import { DOC_TYPE_FILL, DOC_TYPE_GROUP } from "../../document/constants.js";
-import { cleanDoc, getDocParts } from "../../document/utils.js";
+import { cleanDoc } from "../../document/utils.js";
 import { printComments } from "../../main/comments/print.js";
 import {
   CommentCheckFlags,
@@ -301,8 +301,8 @@ function printBinaryishExpressions(
   if (isNested && hasComment(node)) {
     const printed = cleanDoc(printComments(path, parts, options));
     /* c8 ignore next 3 */
-    if (Array.isArray(printed) || printed.type === DOC_TYPE_FILL) {
-      return getDocParts(printed);
+    if (printed.type === DOC_TYPE_FILL) {
+      return printed.parts;
     }
 
     return [printed];

--- a/src/language-js/print/binaryish.js
+++ b/src/language-js/print/binaryish.js
@@ -305,7 +305,7 @@ function printBinaryishExpressions(
       return printed.parts;
     }
 
-    return [printed];
+    return Array.isArray(printed) ? printed : [printed];
   }
 
   return parts;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

This is a legacy feature, we used have `array`, `concat`, and `fill`.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
