### PR TITLE
perf: Use logical expression instead of regexp for `isUnitTestSetUp`

### DIFF
--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -324,16 +324,21 @@ function isSimpleType(node) {
   );
 }
 
+const unitTestSetUp = new Set([
+  "beforeEach",
+  "beforeAll",
+  "afterEach",
+  "afterAll",
+]);
 /**
  * @param {CallExpression} node
  * @returns {boolean}
  */
 function isUnitTestSetUp(node) {
-  const unitTestSetUpRe = /^(?:before|after)(?:Each|All)$/;
   return (
     node.callee.type === "Identifier" &&
     node.arguments.length === 1 &&
-    unitTestSetUpRe.test(node.callee.name)
+    unitTestSetUp.has(node.callee.name)
   );
 }
 

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -328,10 +328,9 @@ function isSimpleType(node) {
  * @param {CallExpression} node
  * @returns {boolean}
  */
-function isUnitTestSetUp(node) {
+function isUnitTestSetup(node) {
   return (
     node.callee.type === "Identifier" &&
-    node.arguments.length === 1 &&
     (node.callee.name === "beforeEach" ||
       node.callee.name === "beforeAll" ||
       node.callee.name === "afterEach" ||
@@ -379,7 +378,7 @@ function isTestCall(node, parent) {
       return isFunctionOrArrowExpression(node.arguments[0]);
     }
 
-    if (isUnitTestSetUp(node)) {
+    if (isUnitTestSetup(node)) {
       return isAngularTestWrapper(node.arguments[0]);
     }
   } else if (

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -324,12 +324,6 @@ function isSimpleType(node) {
   );
 }
 
-const unitTestSetUp = new Set([
-  "beforeEach",
-  "beforeAll",
-  "afterEach",
-  "afterAll",
-]);
 /**
  * @param {CallExpression} node
  * @returns {boolean}
@@ -338,7 +332,10 @@ function isUnitTestSetUp(node) {
   return (
     node.callee.type === "Identifier" &&
     node.arguments.length === 1 &&
-    unitTestSetUp.has(node.callee.name)
+    (node.callee.name === "beforeEach" ||
+      node.callee.name === "beforeAll" ||
+      node.callee.name === "afterEach" ||
+      node.callee.name === "afterAll")
   );
 }
 

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -325,16 +325,16 @@ function isSimpleType(node) {
 }
 
 /**
- * @param {CallExpression} node
+ * @param {*} node
  * @returns {boolean}
  */
-function isUnitTestSetup(node) {
+function isUnitTestSetupIdentifier(node) {
   return (
-    node.callee.type === "Identifier" &&
-    (node.callee.name === "beforeEach" ||
-      node.callee.name === "beforeAll" ||
-      node.callee.name === "afterEach" ||
-      node.callee.name === "afterAll")
+    node.type === "Identifier" &&
+    (node.name === "beforeEach" ||
+      node.name === "beforeAll" ||
+      node.name === "afterEach" ||
+      node.name === "afterAll")
   );
 }
 
@@ -378,7 +378,7 @@ function isTestCall(node, parent) {
       return isFunctionOrArrowExpression(node.arguments[0]);
     }
 
-    if (isUnitTestSetup(node)) {
+    if (isUnitTestSetupIdentifier(node.callee)) {
       return isAngularTestWrapper(node.arguments[0]);
     }
   } else if (


### PR DESCRIPTION
## Description

The `isUnitTestSetUp` function uses the regular expression `/^(?:before|after)(?:Each|All)$/`. This regex matches the following four strings:

- `beforeEach`
- `beforeAll`
- `afterEach`
- `afterAll`

When the options are limited to about four, using a `Set` is generally faster than performing calculations with a regular expression.

Below are the total execution times of the `isUnitTestSetUp` function against the source code of Babel and Prettier, comparing the `main` branch to this PR:


|repo |  `main` | this PR |
|--------|-------|---|
|prettier | 1.0767030000051818 ms   | 0.8237229999981537 ms |
|babel | 2.696221000274363 ms | 1.9283900000140193 ms |



## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
