### PR TITLE
Fix `getCallArgumentSelector`

### DIFF
--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -1066,6 +1066,7 @@ function iterateCallArgumentsPath(path, iteratee) {
 function getCallArgumentSelector(node, index) {
   const selectors = [];
   if (node.type === "ChainExpression") {
+    node = node.expression;
     selectors.push("expression");
   }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
