### PR TITLE
Fix `isStringKeySafeToUnquote`

### DIFF
--- a/changelog_unreleased/javascript/16058.md
+++ b/changelog_unreleased/javascript/16058.md
@@ -1,0 +1,16 @@
+#### Fix unstable object print (#16058 by @fisker)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+a = {"\a": 1, "b": 2}
+
+// Prettier stable (--quote-props consistent)
+a = { "a": 1, "b": 2 };
+
+// Prettier stable (--quote-props as-needed)
+a = { "a": 1, b: 2 };
+
+// Prettier main
+a = { a: 1, b: 2 };
+```

--- a/src/language-js/print/property.js
+++ b/src/language-js/print/property.js
@@ -44,7 +44,6 @@ function isStringKeySafeToUnquote(node, options) {
     options.parser === "json" ||
     options.parser === "jsonc" ||
     !isStringLiteral(node.key) ||
-    // TODO[@fisker]: Use `printString` instead
     printString(rawText(node.key), options).slice(1, -1) !== node.key.value
   ) {
     return false;

--- a/src/language-js/print/property.js
+++ b/src/language-js/print/property.js
@@ -45,7 +45,7 @@ function isStringKeySafeToUnquote(node, options) {
     options.parser === "jsonc" ||
     !isStringLiteral(node.key) ||
     // TODO[@fisker]: Use `printString` instead
-    rawText(node.key).slice(1, -1) !== node.key.value
+    printString(rawText(node.key), options).slice(1, -1) !== node.key.value
   ) {
     return false;
   }

--- a/tests/format/js/quote-props/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/quote-props/__snapshots__/jsfmt.spec.js.snap
@@ -293,32 +293,32 @@ printWidth: 80
 quoteProps: "as-needed"
                                                                                 | printWidth
 =====================================input======================================
-const a = {
+a = {
   a: "a"
 };
 
-const b = {
+a = {
   'b': "b"
 };
 
-const b2 = {
+a = {
   // Escapes should stay as escapes and not be unquoted.
   '\\u0062': "b",
   '\\u0031': "1"
 };
 
-const c = {
+a = {
   c1: "c1",
   'c2': "c2"
 };
 
-const d = {
+a = {
   d1: "d1",
   'd-2': "d2"
 };
 
 // None of these should become quoted, regardless of the quoteProps value.
-const e = {
+a = {
   NaN: null,
   1: null,
   1.5: null,
@@ -336,7 +336,7 @@ const e = {
   2n: null,
 }
 
-const f = {
+a = {
   // These should be unquoted for quoteProps=as-needed.
   "NaN": null,
   "1": null,
@@ -391,33 +391,38 @@ Object.entries({
   "-1.5": null,
 }
 
+a = {
+  "\\a": 1,
+  "b": 2
+}
+
 =====================================output=====================================
-const a = {
+a = {
   a: "a",
 };
 
-const b = {
+a = {
   b: "b",
 };
 
-const b2 = {
+a = {
   // Escapes should stay as escapes and not be unquoted.
   "\\u0062": "b",
   "\\u0031": "1",
 };
 
-const c = {
+a = {
   c1: "c1",
   c2: "c2",
 };
 
-const d = {
+a = {
   d1: "d1",
   "d-2": "d2",
 };
 
 // None of these should become quoted, regardless of the quoteProps value.
-const e = {
+a = {
   NaN: null,
   1: null,
   1.5: null,
@@ -435,7 +440,7 @@ const e = {
   2n: null,
 };
 
-const f = {
+a = {
   // These should be unquoted for quoteProps=as-needed.
   NaN: null,
   1: null,
@@ -490,6 +495,11 @@ Object.entries({
   "-1.5": null,
 };
 
+a = {
+  a: 1,
+  b: 2,
+};
+
 ================================================================================
 `;
 
@@ -501,32 +511,32 @@ quoteProps: "consistent"
 singleQuote: true
                                                                                 | printWidth
 =====================================input======================================
-const a = {
+a = {
   a: "a"
 };
 
-const b = {
+a = {
   'b': "b"
 };
 
-const b2 = {
+a = {
   // Escapes should stay as escapes and not be unquoted.
   '\\u0062': "b",
   '\\u0031': "1"
 };
 
-const c = {
+a = {
   c1: "c1",
   'c2': "c2"
 };
 
-const d = {
+a = {
   d1: "d1",
   'd-2': "d2"
 };
 
 // None of these should become quoted, regardless of the quoteProps value.
-const e = {
+a = {
   NaN: null,
   1: null,
   1.5: null,
@@ -544,7 +554,7 @@ const e = {
   2n: null,
 }
 
-const f = {
+a = {
   // These should be unquoted for quoteProps=as-needed.
   "NaN": null,
   "1": null,
@@ -599,33 +609,38 @@ Object.entries({
   "-1.5": null,
 }
 
+a = {
+  "\\a": 1,
+  "b": 2
+}
+
 =====================================output=====================================
-const a = {
+a = {
   a: 'a',
 };
 
-const b = {
+a = {
   b: 'b',
 };
 
-const b2 = {
+a = {
   // Escapes should stay as escapes and not be unquoted.
   '\\u0062': 'b',
   '\\u0031': '1',
 };
 
-const c = {
+a = {
   c1: 'c1',
   c2: 'c2',
 };
 
-const d = {
+a = {
   'd1': 'd1',
   'd-2': 'd2',
 };
 
 // None of these should become quoted, regardless of the quoteProps value.
-const e = {
+a = {
   NaN: null,
   1: null,
   1.5: null,
@@ -643,7 +658,7 @@ const e = {
   2n: null,
 };
 
-const f = {
+a = {
   // These should be unquoted for quoteProps=as-needed.
   'NaN': null,
   '1': null,
@@ -698,6 +713,11 @@ Object.entries({
   '-1.5': null,
 };
 
+a = {
+  a: 1,
+  b: 2,
+};
+
 ================================================================================
 `;
 
@@ -708,32 +728,32 @@ printWidth: 80
 quoteProps: "consistent"
                                                                                 | printWidth
 =====================================input======================================
-const a = {
+a = {
   a: "a"
 };
 
-const b = {
+a = {
   'b': "b"
 };
 
-const b2 = {
+a = {
   // Escapes should stay as escapes and not be unquoted.
   '\\u0062': "b",
   '\\u0031': "1"
 };
 
-const c = {
+a = {
   c1: "c1",
   'c2': "c2"
 };
 
-const d = {
+a = {
   d1: "d1",
   'd-2': "d2"
 };
 
 // None of these should become quoted, regardless of the quoteProps value.
-const e = {
+a = {
   NaN: null,
   1: null,
   1.5: null,
@@ -751,7 +771,7 @@ const e = {
   2n: null,
 }
 
-const f = {
+a = {
   // These should be unquoted for quoteProps=as-needed.
   "NaN": null,
   "1": null,
@@ -806,33 +826,38 @@ Object.entries({
   "-1.5": null,
 }
 
+a = {
+  "\\a": 1,
+  "b": 2
+}
+
 =====================================output=====================================
-const a = {
+a = {
   a: "a",
 };
 
-const b = {
+a = {
   b: "b",
 };
 
-const b2 = {
+a = {
   // Escapes should stay as escapes and not be unquoted.
   "\\u0062": "b",
   "\\u0031": "1",
 };
 
-const c = {
+a = {
   c1: "c1",
   c2: "c2",
 };
 
-const d = {
+a = {
   "d1": "d1",
   "d-2": "d2",
 };
 
 // None of these should become quoted, regardless of the quoteProps value.
-const e = {
+a = {
   NaN: null,
   1: null,
   1.5: null,
@@ -850,7 +875,7 @@ const e = {
   2n: null,
 };
 
-const f = {
+a = {
   // These should be unquoted for quoteProps=as-needed.
   "NaN": null,
   "1": null,
@@ -905,6 +930,11 @@ Object.entries({
   "-1.5": null,
 };
 
+a = {
+  a: 1,
+  b: 2,
+};
+
 ================================================================================
 `;
 
@@ -915,32 +945,32 @@ printWidth: 80
 quoteProps: "preserve"
                                                                                 | printWidth
 =====================================input======================================
-const a = {
+a = {
   a: "a"
 };
 
-const b = {
+a = {
   'b': "b"
 };
 
-const b2 = {
+a = {
   // Escapes should stay as escapes and not be unquoted.
   '\\u0062': "b",
   '\\u0031': "1"
 };
 
-const c = {
+a = {
   c1: "c1",
   'c2': "c2"
 };
 
-const d = {
+a = {
   d1: "d1",
   'd-2': "d2"
 };
 
 // None of these should become quoted, regardless of the quoteProps value.
-const e = {
+a = {
   NaN: null,
   1: null,
   1.5: null,
@@ -958,7 +988,7 @@ const e = {
   2n: null,
 }
 
-const f = {
+a = {
   // These should be unquoted for quoteProps=as-needed.
   "NaN": null,
   "1": null,
@@ -1013,33 +1043,38 @@ Object.entries({
   "-1.5": null,
 }
 
+a = {
+  "\\a": 1,
+  "b": 2
+}
+
 =====================================output=====================================
-const a = {
+a = {
   a: "a",
 };
 
-const b = {
+a = {
   "b": "b",
 };
 
-const b2 = {
+a = {
   // Escapes should stay as escapes and not be unquoted.
   "\\u0062": "b",
   "\\u0031": "1",
 };
 
-const c = {
+a = {
   c1: "c1",
   "c2": "c2",
 };
 
-const d = {
+a = {
   d1: "d1",
   "d-2": "d2",
 };
 
 // None of these should become quoted, regardless of the quoteProps value.
-const e = {
+a = {
   NaN: null,
   1: null,
   1.5: null,
@@ -1057,7 +1092,7 @@ const e = {
   2n: null,
 };
 
-const f = {
+a = {
   // These should be unquoted for quoteProps=as-needed.
   "NaN": null,
   "1": null,
@@ -1110,6 +1145,11 @@ Object.entries({
 !{
   "-1": null,
   "-1.5": null,
+};
+
+a = {
+  "a": 1,
+  "b": 2,
 };
 
 ================================================================================

--- a/tests/format/js/quote-props/jsfmt.spec.js
+++ b/tests/format/js/quote-props/jsfmt.spec.js
@@ -1,22 +1,7 @@
-const errors = {};
-
-runFormatTest(import.meta, ["babel"], {
-  quoteProps: "as-needed",
-  errors,
-});
-
-runFormatTest(import.meta, ["babel"], {
-  quoteProps: "preserve",
-  errors,
-});
-
-runFormatTest(import.meta, ["babel"], {
-  quoteProps: "consistent",
-  errors,
-});
-
+runFormatTest(import.meta, ["babel"], { quoteProps: "as-needed" });
+runFormatTest(import.meta, ["babel"], { quoteProps: "preserve" });
+runFormatTest(import.meta, ["babel"], { quoteProps: "consistent" });
 runFormatTest(import.meta, ["babel"], {
   quoteProps: "consistent",
   singleQuote: true,
-  errors,
 });

--- a/tests/format/js/quote-props/objects.js
+++ b/tests/format/js/quote-props/objects.js
@@ -1,29 +1,29 @@
-const a = {
+a = {
   a: "a"
 };
 
-const b = {
+a = {
   'b': "b"
 };
 
-const b2 = {
+a = {
   // Escapes should stay as escapes and not be unquoted.
   '\u0062': "b",
   '\u0031': "1"
 };
 
-const c = {
+a = {
   c1: "c1",
   'c2': "c2"
 };
 
-const d = {
+a = {
   d1: "d1",
   'd-2': "d2"
 };
 
 // None of these should become quoted, regardless of the quoteProps value.
-const e = {
+a = {
   NaN: null,
   1: null,
   1.5: null,
@@ -41,7 +41,7 @@ const e = {
   2n: null,
 }
 
-const f = {
+a = {
   // These should be unquoted for quoteProps=as-needed.
   "NaN": null,
   "1": null,
@@ -94,4 +94,9 @@ Object.entries({
 !{
   "-1": null,
   "-1.5": null,
+}
+
+a = {
+  "\a": 1,
+  "b": 2
 }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fixes #16057

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
