### PR TITLE
Minor tweak to `printPropertyKey`

### DIFF
--- a/src/language-js/print/jsx.js
+++ b/src/language-js/print/jsx.js
@@ -573,7 +573,6 @@ function printJsxOpeningElement(path, options, print) {
   // don't break up opening elements with a single long text attribute
   if (
     node.attributes?.length === 1 &&
-    node.attributes[0].value &&
     isStringLiteral(node.attributes[0].value) &&
     !node.attributes[0].value.value.includes("\n") &&
     // We should break for the following cases:
@@ -601,10 +600,7 @@ function printJsxOpeningElement(path, options, print) {
   // We should print the opening element expanded if any prop value is a
   // string literal with newlines
   const shouldBreak = node.attributes?.some(
-    (attr) =>
-      attr.value &&
-      isStringLiteral(attr.value) &&
-      attr.value.value.includes("\n"),
+    (attr) => isStringLiteral(attr.value) && attr.value.value.includes("\n"),
   );
 
   const attributeLine =

--- a/src/language-js/print/property.js
+++ b/src/language-js/print/property.js
@@ -130,15 +130,9 @@ function printPropertyKey(path, options, print) {
   const { key } = node;
 
   if (options.quoteProps === "consistent" && !needsQuoteProps.has(parent)) {
-    const objectHasStringProp = (
-      parent.properties ||
-      parent.body ||
-      parent.members ||
-      parent.attributes
-    ).some(
+    const objectHasStringProp = path.siblings.some(
       (prop) =>
         !prop.computed &&
-        prop.key &&
         isStringLiteral(prop.key) &&
         !isStringKeySafeToUnquote(prop, options),
     );

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -164,9 +164,10 @@ function isSignedNumericLiteral(node) {
  * @returns {boolean}
  */
 function isStringLiteral(node) {
-  return (
-    node.type === "StringLiteral" ||
-    (node.type === "Literal" && typeof node.value === "string")
+  return Boolean(
+    node &&
+      (node.type === "StringLiteral" ||
+        (node.type === "Literal" && typeof node.value === "string")),
   );
 }
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Simplify with `path.siblings`

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
