### PR TITLE
Add "--write" to the prettier failure output

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -71,7 +71,7 @@ Console output if some of the files require re-formatting:
 Checking formatting...
 [warn] src/fileA.js
 [warn] src/fileB.js
-[warn] Code style issues found in 2 files. Run Prettier to fix.
+[warn] Code style issues found in 2 files. Run Prettier with --write to fix.
 ```
 
 The command will return exit code `1` in the second case, which is helpful inside the CI pipelines.

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -492,7 +492,7 @@ async function formatFiles(context) {
       context.logger.warn(
         context.argv.write
           ? `Code style issues fixed in ${files}.`
-          : `Code style issues found in ${files}. Run Prettier to fix.`,
+          : `Code style issues found in ${files}. Run Prettier with --write to fix.`,
       );
     }
   }

--- a/tests/integration/__tests__/__snapshots__/check.js.snap
+++ b/tests/integration/__tests__/__snapshots__/check.js.snap
@@ -3,7 +3,7 @@
 exports[`--checks should print the number of files that need formatting (stderr) 1`] = `
 "[warn] unformatted.js
 [warn] unformatted2.js
-[warn] Code style issues found in 2 files. Run Prettier to fix."
+[warn] Code style issues found in 2 files. Run Prettier with --write to fix."
 `;
 
 exports[`--checks should print the number of files that need formatting (stdout) 1`] = `"Checking formatting..."`;
@@ -12,12 +12,12 @@ exports[`--checks should print the number of files that need formatting (write) 
 
 exports[`--checks works in CI just as in a non-TTY mode (stderr) 1`] = `
 "[warn] unformatted.js
-[warn] Code style issues found in the above file. Run Prettier to fix."
+[warn] Code style issues found in the above file. Run Prettier with --write to fix."
 `;
 
 exports[`--checks works in CI just as in a non-TTY mode (stderr) 2`] = `
 "[warn] unformatted.js
-[warn] Code style issues found in the above file. Run Prettier to fix."
+[warn] Code style issues found in the above file. Run Prettier with --write to fix."
 `;
 
 exports[`--checks works in CI just as in a non-TTY mode (stdout) 1`] = `"Checking formatting..."`;

--- a/tests/integration/__tests__/__snapshots__/ignore-unknown.js.snap
+++ b/tests/integration/__tests__/__snapshots__/ignore-unknown.js.snap
@@ -26,7 +26,7 @@ override.as-js-file"
 exports[`ignore-unknown check (stderr) 1`] = `
 "[warn] javascript.js
 [warn] override.as-js-file
-[warn] Code style issues found in 2 files. Run Prettier to fix."
+[warn] Code style issues found in 2 files. Run Prettier with --write to fix."
 `;
 
 exports[`ignore-unknown check (stdout) 1`] = `"Checking formatting..."`;

--- a/tests/integration/__tests__/__snapshots__/infer-parser.js.snap
+++ b/tests/integration/__tests__/__snapshots__/infer-parser.js.snap
@@ -3,7 +3,7 @@
 exports[`--check with unknown path and no parser multiple files (stderr) 1`] = `
 "[error] No parser could be inferred for file "<cli>/infer-parser/FOO".
 [warn] foo.js
-[warn] Code style issues found in the above file. Run Prettier to fix."
+[warn] Code style issues found in the above file. Run Prettier with --write to fix."
 `;
 
 exports[`--check with unknown path and no parser multiple files (stdout) 1`] = `"Checking formatting..."`;

--- a/website/blog/2023-07-05-3.0.0.md
+++ b/website/blog/2023-07-05-3.0.0.md
@@ -2060,7 +2060,7 @@ UndefinedParserError: No parser and no file path given, couldn't infer a parser.
 
 #### Updated failure message to be more informative ([#11369](https://github.com/prettier/prettier/pull/11369) by [@webark](https://github.com/webark))
 
-Updated the "Forgot to run Prettier?" to "Run Prettier to fix."
+Updated the "Forgot to run Prettier?" to "Run Prettier with --write to fix."
 
 This keeps the same spirit of the message, but is less likely to be
 misinterpreted as it's a more formal message rather than being

--- a/website/versioned_docs/version-stable/cli.md
+++ b/website/versioned_docs/version-stable/cli.md
@@ -72,7 +72,7 @@ Console output if some of the files require re-formatting:
 Checking formatting...
 [warn] src/fileA.js
 [warn] src/fileB.js
-[warn] Code style issues found in 2 files. Run Prettier to fix.
+[warn] Code style issues found in 2 files. Run Prettier with --write to fix.
 ```
 
 The command will return exit code `1` in the second case, which is helpful inside the CI pipelines.


### PR DESCRIPTION
## Description
- Mention --write in the failure output
  - This will help folks move on quickly without needing to look at docs
  - It also helps with folks who are used to --fix

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
