### PR TITLE
Add newline between markdown footnote definitions

### DIFF
--- a/changelog_unreleased/markdown/16063.md
+++ b/changelog_unreleased/markdown/16063.md
@@ -1,0 +1,18 @@
+#### Add newline between markdown footnote definitions (#16063 by @Atema)
+
+<!-- prettier-ignore -->
+```md
+<!-- Input -->
+[^a]: Footnote A
+
+[^b]: Footnote B
+
+<!-- Prettier stable -->
+[^a]: Footnote A
+[^b]: Footnote B
+
+<!-- Prettier main -->
+[^a]: Footnote A
+
+[^b]: Footnote B
+```

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -41,10 +41,7 @@ import {
  * @typedef {import("../document/builders.js").Doc} Doc
  */
 
-const SIBLING_NODE_TYPES = new Set([
-  "listItem",
-  "definition",
-]);
+const SIBLING_NODE_TYPES = new Set(["listItem", "definition"]);
 
 function genericPrint(path, options, print) {
   const { node } = path;

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -44,7 +44,6 @@ import {
 const SIBLING_NODE_TYPES = new Set([
   "listItem",
   "definition",
-  "footnoteDefinition",
 ]);
 
 function genericPrint(path, options, print) {
@@ -405,7 +404,6 @@ function genericPrint(path, options, print) {
                     isFirst ? group([softline, print()]) : print(),
                 }),
               ),
-              path.next?.type === "footnoteDefinition" ? softline : "",
             ]),
       ];
     }

--- a/tests/format/markdown/footnoteDefinition/__snapshots__/format.test.js.snap
+++ b/tests/format/markdown/footnoteDefinition/__snapshots__/format.test.js.snap
@@ -37,6 +37,7 @@ proseWrap: "never"
 
 =====================================output=====================================
 [^hello]: this is a long long long long long long long long long long long long long paragraph.
+
 [^world]: this is a long long long long long long long long long long long long long paragraph. this is a long long long long long long long long long long long long long paragraph.
 
 ================================================================================
@@ -55,6 +56,7 @@ proseWrap: "preserve"
 
 =====================================output=====================================
 [^hello]: this is a long long long long long long long long long long long long long paragraph.
+
 [^world]:
     this is a long long long long long long long long long long long long long paragraph.
     this is a long long long long long long long long long long long long long paragraph.
@@ -75,6 +77,7 @@ tabWidth: 3
 
 =====================================output=====================================
 [^hello]: this is a long long long long long long long long long long long long long paragraph.
+
 [^world]:
     this is a long long long long long long long long long long long long long paragraph.
     this is a long long long long long long long long long long long long long paragraph.
@@ -352,31 +355,45 @@ proseWrap: "always"
 
 =====================================output=====================================
 [^a]: a
+
 [^a]: a
+
 [^a]: a
+
 [^a]: > 123
+
 [^a]: a
+
 [^a]: > 123
+
 [^a]: a
+
 [^a]: a
+
 [^a]: a
 
 ---
 
 [^a]: a
+
 [^a]: a
+
 [^a]: a
+
 [^a]:
     > 123\\
     > 456
 
 [^a]: a
+
 [^a]:
     > 123\\
     > 456
 
 [^a]: a
+
 [^a]: a
+
 [^a]: a
 
 ================================================================================
@@ -415,31 +432,45 @@ proseWrap: "never"
 
 =====================================output=====================================
 [^a]: a
+
 [^a]: a
+
 [^a]: a
+
 [^a]: > 123
+
 [^a]: a
+
 [^a]: > 123
+
 [^a]: a
+
 [^a]: a
+
 [^a]: a
 
 ---
 
 [^a]: a
+
 [^a]: a
+
 [^a]: a
+
 [^a]:
     > 123\\
     > 456
 
 [^a]: a
+
 [^a]:
     > 123\\
     > 456
 
 [^a]: a
+
 [^a]: a
+
 [^a]: a
 
 ================================================================================
@@ -478,31 +509,45 @@ proseWrap: "preserve"
 
 =====================================output=====================================
 [^a]: a
+
 [^a]: a
+
 [^a]: a
+
 [^a]: > 123
+
 [^a]: a
+
 [^a]: > 123
+
 [^a]: a
+
 [^a]: a
+
 [^a]: a
 
 ---
 
 [^a]: a
+
 [^a]: a
+
 [^a]: a
+
 [^a]:
     > 123\\
     > 456
 
 [^a]: a
+
 [^a]:
     > 123\\
     > 456
 
 [^a]: a
+
 [^a]: a
+
 [^a]: a
 
 ================================================================================
@@ -541,31 +586,45 @@ tabWidth: 3
 
 =====================================output=====================================
 [^a]: a
+
 [^a]: a
+
 [^a]: a
+
 [^a]: > 123
+
 [^a]: a
+
 [^a]: > 123
+
 [^a]: a
+
 [^a]: a
+
 [^a]: a
 
 ---
 
 [^a]: a
+
 [^a]: a
+
 [^a]: a
+
 [^a]:
     > 123\\
     > 456
 
 [^a]: a
+
 [^a]:
     > 123\\
     > 456
 
 [^a]: a
+
 [^a]: a
+
 [^a]: a
 
 ================================================================================


### PR DESCRIPTION
## Description

Ensures there are newlines between markdown footnote definitions, to comply with the standard set by Pandoc (https://pandoc.org/MANUAL.html#footnotes):

> Each footnote should be separated from surrounding content (including other footnotes) by blank lines.

Resolves #8301

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
