### PR TITLE
feat: `declare namespace` printing support for Flow

### DIFF
--- a/changelog_unreleased/flow/16066.md
+++ b/changelog_unreleased/flow/16066.md
@@ -1,4 +1,4 @@
-#### Unquote keys in import attributes (#15888 by @sosukesuzuki)
+#### `declare namespace` printing support for Flow (#16066 by @SamChou19815)
 
 <!-- prettier-ignore -->
 ```jsx

--- a/changelog_unreleased/flow/16066.md
+++ b/changelog_unreleased/flow/16066.md
@@ -1,0 +1,17 @@
+#### Unquote keys in import attributes (#15888 by @sosukesuzuki)
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+declare namespace foo {
+  declare var bar: string;
+}
+
+// Prettier stable
+// does not parse
+
+// Prettier main
+declare namespace foo {
+  declare var bar: string;
+}
+```

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "get-east-asian-width": "1.2.0",
     "get-stdin": "9.0.0",
     "graphql": "16.8.1",
-    "hermes-parser": "0.19.0",
+    "hermes-parser": "0.19.1",
     "html-element-attributes": "3.3.0",
     "html-tag-names": "2.1.0",
     "html-ua-styles": "0.0.5",

--- a/src/language-js/needs-parens.js
+++ b/src/language-js/needs-parens.js
@@ -1004,6 +1004,7 @@ const isStatement = createTypeCheckFunction([
   "DeclareInterface",
   "DeclareModule",
   "DeclareModuleExports",
+  "DeclareNamespace",
   "DeclareVariable",
   "DeclareEnum",
   "DoWhileStatement",

--- a/src/language-js/print/flow.js
+++ b/src/language-js/print/flow.js
@@ -74,6 +74,8 @@ function printFlow(path, options, print) {
         printTypeAnnotationProperty(path, print),
         semi,
       ];
+    case "DeclareNamespace":
+      return ["declare namespace ", print("id"), " ", print("body")];
     case "DeclareVariable":
       return [
         printDeclareToken(path),

--- a/tests/format/flow/type-declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/flow/type-declarations/__snapshots__/jsfmt.spec.js.snap
@@ -29,6 +29,110 @@ declare export default 5;
 ================================================================================
 `;
 
+exports[`declare_module.js - {"semi":false} format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+declare module "foo" {
+  declare var bar: string;
+}
+
+declare module baz {}
+
+=====================================output=====================================
+declare module "foo" {
+  declare var bar: string
+}
+
+declare module baz {
+}
+
+================================================================================
+`;
+
+exports[`declare_module.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+declare module "foo" {
+  declare var bar: string;
+}
+
+declare module baz {}
+
+=====================================output=====================================
+declare module "foo" {
+  declare var bar: string;
+}
+
+declare module baz {
+}
+
+================================================================================
+`;
+
+exports[`declare_namespace.js [babel-flow] format 1`] = `
+"Unexpected token (1:9)
+> 1 | declare namespace foo {
+    |         ^
+  2 |   declare var bar: string;
+  3 | }
+  4 |
+Cause: Unexpected token (1:8)"
+`;
+
+exports[`declare_namespace.js - {"semi":false} [babel-flow] format 1`] = `
+"Unexpected token (1:9)
+> 1 | declare namespace foo {
+    |         ^
+  2 |   declare var bar: string;
+  3 | }
+  4 |
+Cause: Unexpected token (1:8)"
+`;
+
+exports[`declare_namespace.js - {"semi":false} format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+declare namespace foo {
+  declare var bar: string;
+}
+
+=====================================output=====================================
+declare namespace foo {
+  declare var bar: string
+}
+
+================================================================================
+`;
+
+exports[`declare_namespace.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+declare namespace foo {
+  declare var bar: string;
+}
+
+=====================================output=====================================
+declare namespace foo {
+  declare var bar: string;
+}
+
+================================================================================
+`;
+
 exports[`declare_type.js - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["flow"]

--- a/tests/format/flow/type-declarations/declare_module.js
+++ b/tests/format/flow/type-declarations/declare_module.js
@@ -1,0 +1,5 @@
+declare module "foo" {
+  declare var bar: string;
+}
+
+declare module baz {}

--- a/tests/format/flow/type-declarations/declare_namespace.js
+++ b/tests/format/flow/type-declarations/declare_namespace.js
@@ -1,0 +1,3 @@
+declare namespace foo {
+  declare var bar: string;
+}

--- a/tests/format/flow/type-declarations/jsfmt.spec.js
+++ b/tests/format/flow/type-declarations/jsfmt.spec.js
@@ -1,2 +1,11 @@
-runFormatTest(import.meta, ["flow"]);
-runFormatTest(import.meta, ["flow"], { semi: false });
+runFormatTest(import.meta, ["flow"], {
+  errors: {
+    "babel-flow": ["declare_namespace.js"],
+  },
+});
+runFormatTest(import.meta, ["flow"], {
+  semi: false,
+  errors: {
+    "babel-flow": ["declare_namespace.js"],
+  },
+});

--- a/tests/unit/__snapshots__/visitor-keys.js.snap
+++ b/tests/unit/__snapshots__/visitor-keys.js.snap
@@ -200,6 +200,10 @@ exports[`visitor keys estree 1`] = `
   "DeclareModuleExports": [
     "typeAnnotation",
   ],
+  "DeclareNamespace": [
+    "id",
+    "body",
+  ],
   "DeclareOpaqueType": [
     "id",
     "typeParameters",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4765,19 +4765,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hermes-estree@npm:0.19.0":
-  version: 0.19.0
-  resolution: "hermes-estree@npm:0.19.0"
-  checksum: 10/903230b445d5a7d2617add0fcc495a2d4160bf0cdc0f1a19d2338de60755158d082290c222412cc765e66e1fa355a83402a3a5d647d450b9c104bcebfc82e62e
+"hermes-estree@npm:0.19.1":
+  version: 0.19.1
+  resolution: "hermes-estree@npm:0.19.1"
+  checksum: 10/dadafea5cf8fcf7d2c2d3d43740898c73b03db4747d4cc83e3cdb06bfcfbf3ee97f4ee26f077aea455771703f5bd18a4cb40c1ce7af9e38ce541d6c03fc8847a
   languageName: node
   linkType: hard
 
-"hermes-parser@npm:0.19.0":
-  version: 0.19.0
-  resolution: "hermes-parser@npm:0.19.0"
+"hermes-parser@npm:0.19.1":
+  version: 0.19.1
+  resolution: "hermes-parser@npm:0.19.1"
   dependencies:
-    hermes-estree: "npm:0.19.0"
-  checksum: 10/025a0cc15070310411815dfaf6093f8af85bb0cdd1332b1c349469a51602f7733be8f2e36c7d624f4a0b25f7df55e992312ef778201f76ff470a5aff65911584
+    hermes-estree: "npm:0.19.1"
+  checksum: 10/4fd886ce3ab80c79b258fa60085f2915f587aef57bf59e17f6cfe3b0ad2e7b1a1cfff8371b736392f66cff0658a90ece279b608edcb5589f8c56957e799c56f2
   languageName: node
   linkType: hard
 
@@ -7422,7 +7422,7 @@ __metadata:
     get-east-asian-width: "npm:1.2.0"
     get-stdin: "npm:9.0.0"
     graphql: "npm:16.8.1"
-    hermes-parser: "npm:0.19.0"
+    hermes-parser: "npm:0.19.1"
     html-element-attributes: "npm:3.3.0"
     html-tag-names: "npm:2.1.0"
     html-ua-styles: "npm:0.0.5"


### PR DESCRIPTION
## Description

Support `declare namespace` pretty-printing for Flow.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
