### PR TITLE
Add tests of edge cases around liquid

### DIFF
--- a/tests/format/markdown/liquid/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/markdown/liquid/__snapshots__/jsfmt.spec.js.snap
@@ -71,3 +71,171 @@ where does it end }}
 
 ================================================================================
 `;
+
+exports[`unbalanced-mismatched-braces.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+printWidth: 80
+proseWrap: "always"
+                                                                                | printWidth
+=====================================input======================================
+
+Braces {%  doesn't    match so   these   words should not   be   considered as *liquid node* }}
+
+=====================================output=====================================
+Braces {% doesn't match so these words should not be considered as _liquid node_
+}}
+
+================================================================================
+`;
+
+exports[`unbalanced-mismatched-braces.md format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+
+Braces {%  doesn't    match so   these   words should not   be   considered as *liquid node* }}
+
+=====================================output=====================================
+Braces {% doesn't match so these words should not be considered as _liquid node_ }}
+
+================================================================================
+`;
+
+exports[`unbalanced-object-close-only.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+printWidth: 80
+proseWrap: "always"
+                                                                                | printWidth
+=====================================input======================================
+
+
+Following brace doesn't   open  so these words    should not be   considered as *liquid node* }}
+
+=====================================output=====================================
+Following brace doesn't open so these words should not be considered as _liquid
+node_ }}
+
+================================================================================
+`;
+
+exports[`unbalanced-object-close-only.md format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+
+
+Following brace doesn't   open  so these words    should not be   considered as *liquid node* }}
+
+=====================================output=====================================
+Following brace doesn't open so these words should not be considered as _liquid node_ }}
+
+================================================================================
+`;
+
+exports[`unbalanced-object-open-only.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+printWidth: 80
+proseWrap: "always"
+                                                                                | printWidth
+=====================================input======================================
+
+
+This brace {{ doesn't   close  so these words    should not be   considered as *liquid node*
+
+=====================================output=====================================
+This brace {{ doesn't close so these words should not be considered as _liquid
+node_
+
+================================================================================
+`;
+
+exports[`unbalanced-object-open-only.md format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+
+
+This brace {{ doesn't   close  so these words    should not be   considered as *liquid node*
+
+=====================================output=====================================
+This brace {{ doesn't close so these words should not be considered as _liquid node_
+
+================================================================================
+`;
+
+exports[`unbalanced-template-close-only.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+printWidth: 80
+proseWrap: "always"
+                                                                                | printWidth
+=====================================input======================================
+
+
+Following brace doesn't   open  so these words    should not be   considered as *liquid node* %}
+
+=====================================output=====================================
+Following brace doesn't open so these words should not be considered as _liquid
+node_ %}
+
+================================================================================
+`;
+
+exports[`unbalanced-template-close-only.md format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+
+
+Following brace doesn't   open  so these words    should not be   considered as *liquid node* %}
+
+=====================================output=====================================
+Following brace doesn't open so these words should not be considered as _liquid node_ %}
+
+================================================================================
+`;
+
+exports[`unbalanced-template-open-only.md - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+printWidth: 80
+proseWrap: "always"
+                                                                                | printWidth
+=====================================input======================================
+
+
+This brace {% doesn't   close  so these words    should not be   considered as *liquid node*
+
+=====================================output=====================================
+This brace {% doesn't close so these words should not be considered as _liquid
+node_
+
+================================================================================
+`;
+
+exports[`unbalanced-template-open-only.md format 1`] = `
+====================================options=====================================
+parsers: ["markdown"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+
+
+This brace {% doesn't   close  so these words    should not be   considered as *liquid node*
+
+=====================================output=====================================
+This brace {% doesn't close so these words should not be considered as _liquid node_
+
+================================================================================
+`;

--- a/tests/format/markdown/liquid/unbalanced-mismatched-braces.md
+++ b/tests/format/markdown/liquid/unbalanced-mismatched-braces.md
@@ -1,0 +1,2 @@
+
+Braces {%  doesn't    match so   these   words should not   be   considered as *liquid node* }}

--- a/tests/format/markdown/liquid/unbalanced-object-close-only.md
+++ b/tests/format/markdown/liquid/unbalanced-object-close-only.md
@@ -1,0 +1,3 @@
+
+
+Following brace doesn't   open  so these words    should not be   considered as *liquid node* }}

--- a/tests/format/markdown/liquid/unbalanced-object-open-only.md
+++ b/tests/format/markdown/liquid/unbalanced-object-open-only.md
@@ -1,0 +1,3 @@
+
+
+This brace {{ doesn't   close  so these words    should not be   considered as *liquid node*

--- a/tests/format/markdown/liquid/unbalanced-template-close-only.md
+++ b/tests/format/markdown/liquid/unbalanced-template-close-only.md
@@ -1,0 +1,3 @@
+
+
+Following brace doesn't   open  so these words    should not be   considered as *liquid node* %}

--- a/tests/format/markdown/liquid/unbalanced-template-open-only.md
+++ b/tests/format/markdown/liquid/unbalanced-template-open-only.md
@@ -1,0 +1,3 @@
+
+
+This brace {% doesn't   close  so these words    should not be   considered as *liquid node*


### PR DESCRIPTION


## Description
I'm working on #11828 and feel that it's better to have more tests around liquid.
As far as I know, with latest remark-parse, we can't extend syntax with regex as current in-house plugins does. To reduce risk in migration, it should be better to add test in advance.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] ~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~
- [ ] ~(If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
