### PR TITLE
Remove outdated hack for `diff` package

### DIFF
--- a/scripts/build/config.js
+++ b/scripts/build/config.js
@@ -69,18 +69,6 @@ function getTypesFileConfig({ input: jsFileInput, outputBaseName, isPlugin }) {
  * @property {boolean?} addDefaultExport - add default export to bundle
  */
 
-/*
-`diff` use deprecated folder mapping "./" in the "exports" field,
-so we can't `import("diff/lib/diff/array.js")` directly.
-To reduce the bundle size, replace the entry with smaller files.
-
-We can switch to deep import once https://github.com/kpdecker/jsdiff/pull/351 get merged
-*/
-const replaceDiffPackageEntry = (file) => ({
-  module: getPackageFile("diff/lib/index.mjs"),
-  path: getPackageFile(`diff/${file}`),
-});
-
 const extensions = {
   esm: ".mjs",
   umd: ".js",
@@ -517,7 +505,6 @@ const nonPluginUniversalFiles = [
         }),
         path: path.join(dirname, "./shims/chalk.cjs"),
       },
-      replaceDiffPackageEntry("lib/diff/array.js"),
     ],
   },
 ].map((file) => {
@@ -597,7 +584,6 @@ const nodejsFiles = [
         find: "const readBuffer = new Buffer(this.options.readChunk);",
         replacement: "const readBuffer = Buffer.alloc(this.options.readChunk);",
       },
-      replaceDiffPackageEntry("lib/diff/array.js"),
       // `@babel/code-frame` and `@babel/highlight` use compatible `chalk`, but they installed separately
       {
         module: require.resolve("chalk", {
@@ -646,7 +632,6 @@ const nodejsFiles = [
     input: "src/cli/index.js",
     outputBaseName: "internal/cli",
     external: ["benchmark"],
-    replaceModule: [replaceDiffPackageEntry("lib/patch/create.js")],
   },
 ].flatMap((file) => {
   let { input, output, outputBaseName, ...buildOptions } = file;

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -2,7 +2,6 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import chalk from "chalk";
-import { createTwoFilesPatch } from "diff";
 
 import * as prettier from "../index.js";
 import { expandPatterns } from "./expand-patterns.js";
@@ -12,6 +11,7 @@ import isTTY from "./is-tty.js";
 import getOptionsForFile from "./options/get-options-for-file.js";
 import {
   createIsIgnoredFunction,
+  createTwoFilesPatch,
   errors,
   mockable,
 } from "./prettier-internal.js";

--- a/src/cli/prettier-internal.js
+++ b/src/cli/prettier-internal.js
@@ -11,5 +11,6 @@ export const {
   normalizeOptionSettings,
   vnopts,
   fastGlob,
+  createTwoFilesPatch,
   mockable,
 } = sharedWithCli;

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-// "fast-glob" is bundled here since the API uses `micromatch` too
+// "fast-glob" and `createTwoFilesPatch` are bundled here since the API uses `micromatch` and `diff` too
+import { createTwoFilesPatch } from "diff/lib/patch/create.js";
 import fastGlob from "fast-glob";
 import * as vnopts from "vnopts";
 
@@ -96,6 +97,7 @@ const sharedWithCli = {
     apiDescriptor: vnopts.apiDescriptor,
   },
   fastGlob,
+  createTwoFilesPatch,
   utils: {
     isNonEmptyArray,
     partition,

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -1,5 +1,5 @@
 // Use `diff/lib/diff/array.js` instead of `diff` to reduce bundle size
-import diffArrays from "diff/lib/diff/array.js";
+import { diffArrays } from "diff/lib/diff/array.js";
 
 import {
   convertEndOfLineToChars,

--- a/src/main/core.js
+++ b/src/main/core.js
@@ -1,4 +1,5 @@
-import { diffArrays } from "diff";
+// Use `diff/lib/diff/array.js` instead of `diff` to reduce bundle size
+import diffArrays from "diff/lib/diff/array.js";
 
 import {
   convertEndOfLineToChars,


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Revert #12462

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
