### PR TITLE
Exclude optional call from `isTestCall`

### DIFF
--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -368,33 +368,35 @@ function isTestCallCallee(node) {
 
 // eg; `describe("some string", (done) => {})`
 function isTestCall(node, parent) {
-  if (node.type !== "CallExpression") {
+  if (node.type !== "CallExpression" || node.optional) {
     return false;
   }
-  if (node.arguments.length === 1) {
+
+  const args = getCallArguments(node);
+
+  if (args.length === 1) {
     if (isAngularTestWrapper(node) && parent && isTestCall(parent)) {
-      return isFunctionOrArrowExpression(node.arguments[0]);
+      return isFunctionOrArrowExpression(args[0]);
     }
 
     if (isUnitTestSetupIdentifier(node.callee)) {
-      return isAngularTestWrapper(node.arguments[0]);
+      return isAngularTestWrapper(args[0]);
     }
   } else if (
-    (node.arguments.length === 2 || node.arguments.length === 3) &&
-    (node.arguments[0].type === "TemplateLiteral" ||
-      isStringLiteral(node.arguments[0])) &&
+    (args.length === 2 || args.length === 3) &&
+    (args[0].type === "TemplateLiteral" || isStringLiteral(args[0])) &&
     isTestCallCallee(node.callee)
   ) {
     // it("name", () => { ... }, 2500)
-    if (node.arguments[2] && !isNumericLiteral(node.arguments[2])) {
+    if (args[2] && !isNumericLiteral(args[2])) {
       return false;
     }
     return (
-      (node.arguments.length === 2
-        ? isFunctionOrArrowExpression(node.arguments[1])
-        : isFunctionOrArrowExpressionWithBody(node.arguments[1]) &&
-          getFunctionParameters(node.arguments[1]).length <= 1) ||
-      isAngularTestWrapper(node.arguments[1])
+      (args.length === 2
+        ? isFunctionOrArrowExpression(args[1])
+        : isFunctionOrArrowExpressionWithBody(args[1]) &&
+          getFunctionParameters(args[1]).length <= 1) ||
+      isAngularTestWrapper(args[1])
     );
   }
   return false;

--- a/tests/format/js/test-declarations/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/test-declarations/__snapshots__/jsfmt.spec.js.snap
@@ -910,6 +910,41 @@ test.each\`
 ================================================================================
 `;
 
+exports[`optional.js - {"arrowParens":"avoid"} format 1`] = `
+====================================options=====================================
+arrowParens: "avoid"
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+describe?.("some string some string some string some string some string some string some string some string", (done) => {})
+
+=====================================output=====================================
+describe?.(
+  "some string some string some string some string some string some string some string some string",
+  done => {},
+);
+
+================================================================================
+`;
+
+exports[`optional.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "flow", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+describe?.("some string some string some string some string some string some string some string some string", (done) => {})
+
+=====================================output=====================================
+describe?.(
+  "some string some string some string some string some string some string some string some string",
+  (done) => {},
+);
+
+================================================================================
+`;
+
 exports[`test_declarations.js - {"arrowParens":"avoid"} format 1`] = `
 ====================================options=====================================
 arrowParens: "avoid"

--- a/tests/format/js/test-declarations/optional.js
+++ b/tests/format/js/test-declarations/optional.js
@@ -1,0 +1,1 @@
+describe?.("some string some string some string some string some string some string some string some string", (done) => {})


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fix inconsistent between babel and other parser 

Ref: https://github.com/prettier/prettier/pull/16035#issuecomment-1933334644

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
