### PR TITLE
allow linebreaks in member expressions in template interpolations

### DIFF
--- a/changelog_unreleased/javascript/16116.md
+++ b/changelog_unreleased/javascript/16116.md
@@ -1,0 +1,19 @@
+#### Allow linebreaks in member expressions in template interpolations (#16116 by @bakkot)
+
+When there is already a linebreak in a template interpolation, allow it to stay there even if it is a member expression. Note that (as of [#15209](https://github.com/prettier/prettier/pull/15209)) Prettier will not insert a linebreak inside an interpolation when one is not already present.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+`template with ${
+    very.very.very.very.very.very.very.very.very.very.very.long.chain
+}`;
+
+// Prettier stable
+`template with ${very.very.very.very.very.very.very.very.very.very.very.long.chain}`;
+
+// Prettier main
+`template with ${
+  very.very.very.very.very.very.very.very.very.very.very.long.chain
+}`;
+```

--- a/src/language-js/print/template-literal.js
+++ b/src/language-js/print/template-literal.js
@@ -38,7 +38,7 @@ function printTemplateLiteral(path, print, options) {
   }
   const parts = [];
 
-  let expressionDocs = path.map(print, expressionsKey);
+  const expressionDocs = path.map(print, expressionsKey);
 
   parts.push(lineSuffixBoundary, "`");
 

--- a/src/language-js/utils/index.js
+++ b/src/language-js/utils/index.js
@@ -419,68 +419,6 @@ const isMemberExpression = skipChainExpression(
 );
 
 /**
- *
- * @param {any} node
- * @returns {boolean}
- */
-function isSimpleTemplateLiteral(node) {
-  let expressionsKey = "expressions";
-  if (node.type === "TSTemplateLiteralType") {
-    expressionsKey = "types";
-  }
-  const expressions = node[expressionsKey];
-
-  if (expressions.length === 0) {
-    return false;
-  }
-
-  return expressions.every((expr) => {
-    if (isSimpleAtomicExpression(expr) || isSimpleMemberExpression(expr)) {
-      return true;
-    }
-  });
-}
-
-function isSimpleMemberExpression(
-  node,
-  { maxDepth = Number.POSITIVE_INFINITY } = {},
-) {
-  if (hasComment(node)) {
-    return false;
-  }
-  if (node.type === "ChainExpression") {
-    return isSimpleMemberExpression(node.expression, { maxDepth });
-  }
-  if (!isMemberExpression(node)) {
-    return false;
-  }
-
-  let head = node;
-  let depth = 0;
-  while (isMemberExpression(head) && depth++ <= maxDepth) {
-    if (!isSimpleAtomicExpression(head.property)) {
-      return false;
-    }
-    head = head.object;
-    if (hasComment(head)) {
-      return false;
-    }
-  }
-  return isSimpleAtomicExpression(head);
-}
-
-/**
- * This is intended to return true for small expressions
- * which cannot be broken.
- */
-function isSimpleAtomicExpression(node) {
-  if (hasComment(node)) {
-    return false;
-  }
-  return isLiteral(node) || isSingleWordType(node);
-}
-
-/**
  * Attempts to gauge the rough complexity of a node, for example
  * to detect deeply-nested booleans, call expressions with lots of arguments, etc.
  */
@@ -1207,11 +1145,8 @@ export {
   isPrettierIgnoreComment,
   isRegExpLiteral,
   isSignedNumericLiteral,
-  isSimpleAtomicExpression,
   isSimpleCallArgument,
   isSimpleExpressionByNodeCount,
-  isSimpleMemberExpression,
-  isSimpleTemplateLiteral,
   isSimpleType,
   isStringLiteral,
   isTemplateOnItsOwnLine,

--- a/tests/format/js/strings/__snapshots__/jsfmt.spec.js.snap
+++ b/tests/format/js/strings/__snapshots__/jsfmt.spec.js.snap
@@ -415,6 +415,12 @@ and this other one: \${
 which already had a linebreak so can be broken up
 \`;
 
+// https://github.com/prettier/prettier/issues/16114
+message = \`this is a long messsage a simple interpolation without a linebreak \${foo} <- like this\`;
+
+message = \`whereas this messsage has a linebreak in the interpolation \${
+  foo} <- like this\`;
+
 =====================================output=====================================
 foo(
   \`a long string \${1 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3 + 2 + 3} with expr\`,
@@ -537,6 +543,13 @@ and this other one: \${this(
 which already had a linebreak so can be broken up
 \`;
 
+// https://github.com/prettier/prettier/issues/16114
+message = \`this is a long messsage a simple interpolation without a linebreak \${foo} <- like this\`;
+
+message = \`whereas this messsage has a linebreak in the interpolation \${
+  foo
+} <- like this\`;
+
 ================================================================================
 `;
 
@@ -614,6 +627,12 @@ and this other one: \${
 }
 which already had a linebreak so can be broken up
 \`;
+
+// https://github.com/prettier/prettier/issues/16114
+message = \`this is a long messsage a simple interpolation without a linebreak \${foo} <- like this\`;
+
+message = \`whereas this messsage has a linebreak in the interpolation \${
+  foo} <- like this\`;
 
 =====================================output=====================================
 foo(
@@ -736,6 +755,13 @@ and this other one: \${this(
 )}
 which already had a linebreak so can be broken up
 \`;
+
+// https://github.com/prettier/prettier/issues/16114
+message = \`this is a long messsage a simple interpolation without a linebreak \${foo} <- like this\`;
+
+message = \`whereas this messsage has a linebreak in the interpolation \${
+  foo
+} <- like this\`;
 
 ================================================================================
 `;

--- a/tests/format/js/strings/template-literals.js
+++ b/tests/format/js/strings/template-literals.js
@@ -65,3 +65,9 @@ and this other one: ${
 }
 which already had a linebreak so can be broken up
 `;
+
+// https://github.com/prettier/prettier/issues/16114
+message = `this is a long messsage a simple interpolation without a linebreak ${foo} <- like this`;
+
+message = `whereas this messsage has a linebreak in the interpolation ${
+  foo} <- like this`;


### PR DESCRIPTION
## Description

Allow linebreaks in even simple template interpolations when the user already has one there.

Fixes https://github.com/prettier/prettier/issues/16114. This is a followup to https://github.com/prettier/prettier/pull/15209 - now that we have a more flexible heuristic ("treat interpolations as valid places to break only if the user already had linebreak"), we can use it instead of the old "do not break in simple interpolations" heuristic. I mentioned the possibility of doing this in the original PR but no one commented on it either way; now that someone has explicitly requested this I figure we might as well.

Incidentally, it's pretty weird that most expressions _don't_ treat the `${}` as valid places to break. [This is just kinda weird](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEAbOMAEAPTBeTAAxgAsBLAZ00swENNVoBzTCmAJzKhYHczS6UarDjsADhFS0YZaJgAkwADpDMAMwgQAFACNa7AJQqAvoQDcIADQgIYmdArJQ+9hB4AFfQkcpaqHrQAno7WOuy0YADWGADKtAC2cAAyXHDIan4UcKHhUbFiEVxMyBwArtkgWfFkJezl1nDYYqJkibB+ACqiUPpkcD4ZqFnWFEXoAIqlEPDpmRUAVhTYMWNwk9NpSIPDIACOU-DurmI+ILQUALRQcHAAJndWIBy0ZKhFAMIQ8fG0yGeoqEeo246AAgjAOGQdKVDqIUtdZkMKiQYPFUAB1cjwCgFMBwGLefhkABu-ECfzAFBCIGJ5QAklB7rAYmBOHZQYyYjBAuhETsxK4sujwmI-gL+qJiWlrFwsuwYEdaEwfnyKgV2HK-nodHBAdYBVwYOiyLdSMgACwABms7Dg+zItsVyt+Wzm1hgtB0xtNJGQACZrKUsh1PQM3SA4PEdbd7rckrRuKUlXAAGIQdg-CFFP60GEQEDGYxAA). Wouldn't it be better to break there most of the time? I'm happy to include that as well, or do that as a separate PR (it's just a matter of removing [these lines](https://github.com/prettier/prettier/blob/ec0584f83331f69f49a08d445def829887426560/src/language-js/print/template-literal.js#L114-L119).

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
