### PR TITLE
feat: add support for `package.yaml` config

### DIFF
--- a/changelog_unreleased/api/16157.md
+++ b/changelog_unreleased/api/16157.md
@@ -1,19 +1,10 @@
 #### Add support for `package.yaml` config (#16157 by @danielbayley)
 
-Enable support for reading `prettier` configuration directly from [`package.yaml`](https://github.com/pnpm/pnpm/pull/1799).
+Enable support for reading `prettier` configuration from [`package.yaml`](https://github.com/pnpm/pnpm/pull/1799).
 
-<!-- prettier-ignore -->
 ```yaml
 # package.yaml
 prettier:
   semi: false
   singleQuote: true
-```
-
-```js
-// Input
-console.log("pretty");
-
-// Prettier
-console.log("pretty");
 ```

--- a/changelog_unreleased/api/16157.md
+++ b/changelog_unreleased/api/16157.md
@@ -1,0 +1,19 @@
+#### Add support for `package.yaml` config (#16157 by @danielbayley)
+
+Enable support for reading `prettier` configuration directly from [`package.yaml`](https://github.com/pnpm/pnpm/pull/1799).
+
+<!-- prettier-ignore -->
+```yaml
+# package.yaml
+prettier:
+  semi: false
+  singleQuote: true
+```
+
+```js
+// Input
+console.log("pretty");
+
+// Prettier
+console.log("pretty");
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,7 +5,7 @@ title: Configuration File
 
 You can configure Prettier via (in order of precedence):
 
-- A `"prettier"` key in your `package.json` file.
+- A `"prettier"` key in your `package.json`, or [`package.yaml`](https://github.com/pnpm/pnpm/pull/1799) file.
 - A `.prettierrc` file written in JSON or YAML.
 - A `.prettierrc.json`, `.prettierrc.yml`, `.prettierrc.yaml`, or `.prettierrc.json5` file.
 - A `.prettierrc.js`, or `prettier.config.js` file that exports an object using `export default` or `module.exports` (depends on the [`type`](https://nodejs.org/api/packages.html#type) value in your `package.json`).

--- a/src/config/prettier-config/config-searcher.js
+++ b/src/config/prettier-config/config-searcher.js
@@ -1,9 +1,13 @@
 import isFile from "../../utils/is-file.js";
 import Searcher from "../searcher.js";
-import { loadConfigFromPackageJson } from "./loaders.js";
+import {
+  loadConfigFromPackageJson,
+  loadConfigFromPackageYaml,
+} from "./loaders.js";
 
 const CONFIG_FILE_NAMES = [
   "package.json",
+  "package.yaml",
   ".prettierrc",
   ".prettierrc.json",
   ".prettierrc.yaml",
@@ -26,6 +30,14 @@ async function filter({ name, path: file }) {
   if (name === "package.json") {
     try {
       return Boolean(await loadConfigFromPackageJson(file));
+    } catch {
+      return false;
+    }
+  }
+
+  if (name === "package.yaml") {
+    try {
+      return Boolean(await loadConfigFromPackageYaml(file));
     } catch {
       return false;
     }

--- a/src/config/prettier-config/load-config.js
+++ b/src/config/prettier-config/load-config.js
@@ -1,14 +1,19 @@
 import path from "node:path";
 
 import loadExternalConfig from "./load-external-config.js";
-import loaders, { loadConfigFromPackageJson } from "./loaders.js";
+import loaders, {
+  loadConfigFromPackageJson,
+  loadConfigFromPackageYaml,
+} from "./loaders.js";
 
 async function loadConfig(configFile) {
   const { base: fileName, ext: extension } = path.parse(configFile);
   const load =
     fileName === "package.json"
       ? loadConfigFromPackageJson
-      : loaders[extension];
+      : fileName === "package.yaml"
+        ? loadConfigFromPackageYaml
+        : loaders[extension];
 
   if (!load) {
     throw new Error(

--- a/src/config/prettier-config/loaders.js
+++ b/src/config/prettier-config/loaders.js
@@ -27,6 +27,11 @@ async function loadConfigFromPackageJson(file) {
   return prettier;
 }
 
+async function loadConfigFromPackageYaml(file) {
+  const { prettier } = await loadYaml(file);
+  return prettier;
+}
+
 async function loadYaml(file) {
   const content = await readFile(file);
   try {
@@ -67,4 +72,4 @@ const loaders = {
 };
 
 export default loaders;
-export { loadConfigFromPackageJson, readJson };
+export { loadConfigFromPackageJson, loadConfigFromPackageYaml, readJson };

--- a/tests/integration/__tests__/config-resolution.js
+++ b/tests/integration/__tests__/config-resolution.js
@@ -419,3 +419,33 @@ test("Search from directory, not treat file as directory", async () => {
     "directory/.prettierrc",
   );
 });
+
+test("package.json/package.yaml", async () => {
+  await expect(
+    prettier.resolveConfig(
+      new URL("../cli/config/package/file.js", import.meta.url),
+    ),
+  ).resolves.toMatchInlineSnapshot(`
+    {
+      "tabWidth": 3,
+    }
+  `);
+  await expect(
+    prettier.resolveConfig(
+      new URL("../cli/config/package/file.ts", import.meta.url),
+    ),
+  ).resolves.toMatchInlineSnapshot(`
+    {
+      "tabWidth": 5,
+    }
+  `);
+  await expect(
+    prettier.resolveConfig(
+      new URL("../cli/config/package-yaml/file.ts", import.meta.url),
+    ),
+  ).resolves.toMatchInlineSnapshot(`
+    {
+      "printWidth": 101,
+    }
+  `);
+});

--- a/tests/integration/cli/config/package-yaml/package.yaml
+++ b/tests/integration/cli/config/package-yaml/package.yaml
@@ -1,0 +1,4 @@
+name: my-package
+version: 1.0.0
+prettier:
+  printWidth: 101


### PR DESCRIPTION
## Description

Enable support for reading `prettier` configuration directly from [`package.yaml`](https://github.com/pnpm/pnpm/pull/1799).

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
