### PR TITLE
Implement `objectWrap` config option

### DIFF
--- a/changelog_unreleased/javascript/16163.md
+++ b/changelog_unreleased/javascript/16163.md
@@ -1,10 +1,10 @@
-#### Implement `objectWrapping` config option (#16163 by @pauldraper, @sosukesuzuki)
+#### Implement `objectWrap` config option (#16163 by @pauldraper, @sosukesuzuki)
 
 Prettier has historically done semi-manual formatting of multi-line JavaScript object literals.
 
 Namely, an object is kept on multiple lines if there is a newline prior to the first property, even if it could fit on a single line. See [Multi-line objects](rationale.md#multi-line-objects) for more details.
 
-While this behavior continues to be the default, `--object-wrapping=collapse` instead ignores whitespace when formatting object literals.
+While this behavior continues to be the default, `--object-wrap=collapse` instead ignores whitespace when formatting object literals.
 
 <!-- prettier-ignore -->
 ```js

--- a/changelog_unreleased/javascript/16163.md
+++ b/changelog_unreleased/javascript/16163.md
@@ -1,0 +1,32 @@
+#### Implement multilineObject config option (#16163 by @pauldraper)
+
+Prettier has historically done semi-manual formatting of multi-line JavaScript object literals.
+
+Namely, an object is kept on multiple lines if there is a newline prior to the first property, even if it could fit on a single line. See [Multi-line objects](rationale.md#multi-line-objects) for more details.
+
+While this behavior continues to be the default, `--multiline-object=collapse` instead ignores whitespace when formatting object literals.
+
+<!-- prettier-ignore -->
+```js
+// Input
+const obj1 = {
+  name1: "value1", name2: "value2",
+};
+
+const obj2 = { name1: "value1",
+  name2: "value2",
+};
+
+// Prettier stable
+const obj1 = {
+  name1: "value1",
+  name2: "value2",
+};
+
+const obj2 = { name1: "value1", name2: "value2" };
+
+// Prettier main (with `--multiline-object=collapse`)
+const obj1 = { name1: "value1", name2: "value2" };
+
+const obj2 = { name1: "value1", name2: "value2" };
+```

--- a/changelog_unreleased/javascript/16163.md
+++ b/changelog_unreleased/javascript/16163.md
@@ -1,10 +1,10 @@
-#### Implement multilineObject config option (#16163 by @pauldraper)
+#### Implement `objectWrapping` config option (#16163 by @pauldraper)
 
 Prettier has historically done semi-manual formatting of multi-line JavaScript object literals.
 
 Namely, an object is kept on multiple lines if there is a newline prior to the first property, even if it could fit on a single line. See [Multi-line objects](rationale.md#multi-line-objects) for more details.
 
-While this behavior continues to be the default, `--multiline-object=collapse` instead ignores whitespace when formatting object literals.
+While this behavior continues to be the default, `--object-wrapping=collapse` instead ignores whitespace when formatting object literals.
 
 <!-- prettier-ignore -->
 ```js
@@ -25,7 +25,7 @@ const obj1 = {
 
 const obj2 = { name1: "value1", name2: "value2" };
 
-// Prettier main (with `--multiline-object=collapse`)
+// Prettier main (with `--object-wrapping=collapse`)
 const obj1 = { name1: "value1", name2: "value2" };
 
 const obj2 = { name1: "value1", name2: "value2" };

--- a/changelog_unreleased/javascript/16163.md
+++ b/changelog_unreleased/javascript/16163.md
@@ -1,4 +1,4 @@
-#### Implement `objectWrapping` config option (#16163 by @pauldraper)
+#### Implement `objectWrapping` config option (#16163 by @pauldraper, @sosukesuzuki)
 
 Prettier has historically done semi-manual formatting of multi-line JavaScript object literals.
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -163,11 +163,11 @@ Valid options:
 | ------- | ---------------------- | ------------------------ |
 | `true`  | `--no-bracket-spacing` | `bracketSpacing: <bool>` |
 
-## Multi-line Object
+## Object Wrapping
 
 _First available in v3.5.0_
 
-Allow multi-line objects to collapse to a single line.
+Configure how Prettier wraps object literals when they could fit on one line or span multiple lines.
 
 By default, Prettier formats objects as multi-line if there is a newline prior to the first property. Authors can use this heuristic to contextually improve readability, though it has some downsides. See [Multi-line objects](rationale.md#multi-line-objects).
 
@@ -178,7 +178,7 @@ Valid options:
 
 | Default      | CLI Override                                             | API Override                                             |
 | ------------ | -------------------------------------------------------- | -------------------------------------------------------- |
-| `"preserve"` | <code>--multiline-object <preserve&#124;collapse></code> | <code>multilineObject: "<preserve&#124;collapse>"</code> |
+| `"preserve"` | <code>--object-wrapping <preserve&#124;collapse></code>  | <code>objectWrapping: "<preserve&#124;collapse>"</code>  |
 
 ## Bracket Line
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -163,6 +163,23 @@ Valid options:
 | ------- | ---------------------- | ------------------------ |
 | `true`  | `--no-bracket-spacing` | `bracketSpacing: <bool>` |
 
+## Multi-line Object
+
+_First available in v3.5.0_
+
+Allow multi-line objects to collapse to a single line.
+
+By default, Prettier formats objects as multi-line if there is a newline prior to the first property. Authors can use this heuristic to contextually improve readability, though it has some downsides. See [Multi-line objects](rationale.md#multi-line-objects).
+
+Valid options:
+
+- `"preserve"` - Keep as multi-line, if there is a newline between the opening brace and first property.
+- `"collapse"` - Fit to a single line when possible.
+
+| Default      | CLI Override                                             | API Override                                             |
+| ------------ | -------------------------------------------------------- | -------------------------------------------------------- |
+| `"preserve"` | <code>--multiline-object <preserve&#124;collapse></code> | <code>multilineObject: "<preserve&#124;collapse>"</code> |
+
 ## Bracket Line
 
 Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line instead of being alone on the next line (does not apply to self closing elements).

--- a/docs/options.md
+++ b/docs/options.md
@@ -176,8 +176,8 @@ Valid options:
 - `"preserve"` - Keep as multi-line, if there is a newline between the opening brace and first property.
 - `"collapse"` - Fit to a single line when possible.
 
-| Default      | CLI Override                                            | API Override                                            |
-| ------------ | ------------------------------------------------------- | ------------------------------------------------------- |
+| Default      | CLI Override                                        | API Override                                        |
+| ------------ | --------------------------------------------------- | --------------------------------------------------- |
 | `"preserve"` | <code>--object-wrap <preserve&#124;collapse></code> | <code>objectWrap: "<preserve&#124;collapse>"</code> |
 
 ## Bracket Line

--- a/docs/options.md
+++ b/docs/options.md
@@ -176,9 +176,9 @@ Valid options:
 - `"preserve"` - Keep as multi-line, if there is a newline between the opening brace and first property.
 - `"collapse"` - Fit to a single line when possible.
 
-| Default      | CLI Override                                             | API Override                                             |
-| ------------ | -------------------------------------------------------- | -------------------------------------------------------- |
-| `"preserve"` | <code>--object-wrapping <preserve&#124;collapse></code>  | <code>objectWrapping: "<preserve&#124;collapse>"</code>  |
+| Default      | CLI Override                                            | API Override                                            |
+| ------------ | ------------------------------------------------------- | ------------------------------------------------------- |
+| `"preserve"` | <code>--object-wrapping <preserve&#124;collapse></code> | <code>objectWrapping: "<preserve&#124;collapse>"</code> |
 
 ## Bracket Line
 

--- a/docs/options.md
+++ b/docs/options.md
@@ -163,7 +163,7 @@ Valid options:
 | ------- | ---------------------- | ------------------------ |
 | `true`  | `--no-bracket-spacing` | `bracketSpacing: <bool>` |
 
-## Object Wrapping
+## Object Wrap
 
 _First available in v3.5.0_
 
@@ -178,7 +178,7 @@ Valid options:
 
 | Default      | CLI Override                                            | API Override                                            |
 | ------------ | ------------------------------------------------------- | ------------------------------------------------------- |
-| `"preserve"` | <code>--object-wrapping <preserve&#124;collapse></code> | <code>objectWrapping: "<preserve&#124;collapse>"</code> |
+| `"preserve"` | <code>--object-wrap <preserve&#124;collapse></code> | <code>objectWrap: "<preserve&#124;collapse>"</code> |
 
 ## Bracket Line
 

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -31,7 +31,7 @@ It turns out that empty lines are very hard to automatically generate. The appro
 
 By default, Prettier’s printing algorithm prints expressions on a single line if they fit. Objects are used for a lot of different things in JavaScript, though, and sometimes it really helps readability if they stay multiline. See [object lists], [nested configs], [stylesheets] and [keyed methods], for example. We haven’t been able to find a good rule for all those cases, so by default Prettier keeps objects multi-line if there’s a newline between the `{` and the first key in the original source code. Consequently, long single-line objects are automatically expanded, but short multi-line objects are never collapsed.
 
-You can disable this conditional behavior with the [multilineObject](options.md#multi-line-object) option.
+You can disable this conditional behavior with the [`objectWrapping`](options.md#object-wrapping) option.
 
 **Tip:** If you have a multi-line object that you’d like to join up into a single line:
 

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -29,9 +29,11 @@ It turns out that empty lines are very hard to automatically generate. The appro
 
 ### Multi-line objects
 
-By default, Prettier’s printing algorithm prints expressions on a single line if they fit. Objects are used for a lot of different things in JavaScript, though, and sometimes it really helps readability if they stay multiline. See [object lists], [nested configs], [stylesheets] and [keyed methods], for example. We haven’t been able to find a good rule for all those cases, so Prettier instead keeps objects multiline if there’s a newline between the `{` and the first key in the original source code. A consequence of this is that long singleline objects are automatically expanded, but short multiline objects are never collapsed.
+By default, Prettier’s printing algorithm prints expressions on a single line if they fit. Objects are used for a lot of different things in JavaScript, though, and sometimes it really helps readability if they stay multiline. See [object lists], [nested configs], [stylesheets] and [keyed methods], for example. We haven’t been able to find a good rule for all those cases, so by default Prettier keeps objects multi-line if there’s a newline between the `{` and the first key in the original source code. Consequently, long single-line objects are automatically expanded, but short multi-line objects are never collapsed.
 
-**Tip:** If you have a multiline object that you’d like to join up into a single line:
+You can disable this conditional behavior with the [multilineObject](options.md#multi-line-object) option.
+
+**Tip:** If you have a multi-line object that you’d like to join up into a single line:
 
 ```js
 const user = {
@@ -55,7 +57,7 @@ const user = {  name: "John Doe",
 const user = { name: "John Doe", age: 30 };
 ```
 
-And if you’d like to go multiline again, add in a newline after `{`:
+And if you’d like to go multi-line again, add in a newline after `{`:
 
 <!-- prettier-ignore -->
 ```js

--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -31,7 +31,7 @@ It turns out that empty lines are very hard to automatically generate. The appro
 
 By default, Prettier’s printing algorithm prints expressions on a single line if they fit. Objects are used for a lot of different things in JavaScript, though, and sometimes it really helps readability if they stay multiline. See [object lists], [nested configs], [stylesheets] and [keyed methods], for example. We haven’t been able to find a good rule for all those cases, so by default Prettier keeps objects multi-line if there’s a newline between the `{` and the first key in the original source code. Consequently, long single-line objects are automatically expanded, but short multi-line objects are never collapsed.
 
-You can disable this conditional behavior with the [`objectWrapping`](options.md#object-wrapping) option.
+You can disable this conditional behavior with the [`objectWrap`](options.md#object-wrap) option.
 
 **Tip:** If you have a multi-line object that you’d like to join up into a single line:
 

--- a/src/common/common-options.evaluate.js
+++ b/src/common/common-options.evaluate.js
@@ -9,11 +9,11 @@ const options = {
     description: "Print spaces between brackets.",
     oppositeDescription: "Do not print spaces between brackets.",
   },
-  multilineObject: {
+  objectWrapping: {
     category: CATEGORY_COMMON,
     type: "choice",
     default: "preserve",
-    description: "Allow multi-line objects to collapse to a single line.",
+    description: "How to wrap object literals.",
     choices: [
       {
         value: "preserve",

--- a/src/common/common-options.evaluate.js
+++ b/src/common/common-options.evaluate.js
@@ -9,7 +9,7 @@ const options = {
     description: "Print spaces between brackets.",
     oppositeDescription: "Do not print spaces between brackets.",
   },
-  objectWrapping: {
+  objectWrap: {
     category: CATEGORY_COMMON,
     type: "choice",
     default: "preserve",

--- a/src/common/common-options.evaluate.js
+++ b/src/common/common-options.evaluate.js
@@ -9,6 +9,23 @@ const options = {
     description: "Print spaces between brackets.",
     oppositeDescription: "Do not print spaces between brackets.",
   },
+  multilineObject: {
+    category: CATEGORY_COMMON,
+    type: "choice",
+    default: "preserve",
+    description: "Allow multi-line objects to collapse to a single line.",
+    choices: [
+      {
+        value: "preserve",
+        description:
+          "Keep as multi-line, if there is a newline between the opening brace and first property.",
+      },
+      {
+        value: "collapse",
+        description: "Fit to a single line when possible.",
+      },
+    ],
+  },
   singleQuote: {
     category: CATEGORY_COMMON,
     type: "boolean",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -342,10 +342,10 @@ export interface RequiredOptions extends doc.printer.Options {
    */
   bracketSpacing: boolean;
   /**
-   * Allow multi-line objects to collapse to a single line.
+   * How to wrap object literals.
    * @default "preserve"
    */
-  multilineObject: "preserve" | "collapse";
+  objectWrapping: "preserve" | "collapse";
   /**
    * Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line instead of being
    * alone on the next line (does not apply to self closing elements).

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -345,7 +345,7 @@ export interface RequiredOptions extends doc.printer.Options {
    * How to wrap object literals.
    * @default "preserve"
    */
-  objectWrapping: "preserve" | "collapse";
+  objectWrap: "preserve" | "collapse";
   /**
    * Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line instead of being
    * alone on the next line (does not apply to self closing elements).

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -342,6 +342,11 @@ export interface RequiredOptions extends doc.printer.Options {
    */
   bracketSpacing: boolean;
   /**
+   * Allow multi-line objects to collapse to a single line.
+   * @default "preserve"
+   */
+  multilineObject: "preserve" | "collapse";
+  /**
    * Put the `>` of a multi-line HTML (HTML, JSX, Vue, Angular) element at the end of the last line instead of being
    * alone on the next line (does not apply to self closing elements).
    * @default false

--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -21,7 +21,7 @@ const options = {
     ],
   },
   bracketSameLine: commonOptions.bracketSameLine,
-  multilineObject: commonOptions.multilineObject,
+  objectWrapping: commonOptions.objectWrapping,
   bracketSpacing: commonOptions.bracketSpacing,
   jsxBracketSameLine: {
     category: CATEGORY_JAVASCRIPT,

--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -21,7 +21,7 @@ const options = {
     ],
   },
   bracketSameLine: commonOptions.bracketSameLine,
-  objectWrapping: commonOptions.objectWrapping,
+  objectWrap: commonOptions.objectWrap,
   bracketSpacing: commonOptions.bracketSpacing,
   jsxBracketSameLine: {
     category: CATEGORY_JAVASCRIPT,

--- a/src/language-js/options.js
+++ b/src/language-js/options.js
@@ -21,6 +21,7 @@ const options = {
     ],
   },
   bracketSameLine: commonOptions.bracketSameLine,
+  multilineObject: commonOptions.multilineObject,
   bracketSpacing: commonOptions.bracketSpacing,
   jsxBracketSameLine: {
     category: CATEGORY_JAVASCRIPT,

--- a/src/language-js/print/mapped-type.js
+++ b/src/language-js/print/mapped-type.js
@@ -56,7 +56,7 @@ function printTypescriptMappedType(path, options, print) {
   const { node } = path;
   // Break after `{` like `printObject`
   const shouldBreak =
-    options.multilineObject === "preserve" &&
+    options.objectWrapping === "preserve" &&
     hasNewlineInRange(
       options.originalText,
       locStart(node),

--- a/src/language-js/print/mapped-type.js
+++ b/src/language-js/print/mapped-type.js
@@ -56,7 +56,7 @@ function printTypescriptMappedType(path, options, print) {
   const { node } = path;
   // Break after `{` like `printObject`
   const shouldBreak =
-    options.objectWrapping === "preserve" &&
+    options.objectWrap === "preserve" &&
     hasNewlineInRange(
       options.originalText,
       locStart(node),

--- a/src/language-js/print/mapped-type.js
+++ b/src/language-js/print/mapped-type.js
@@ -55,12 +55,14 @@ function printTypeScriptMappedTypeModifier(tokenNode, keyword) {
 function printTypescriptMappedType(path, options, print) {
   const { node } = path;
   // Break after `{` like `printObject`
-  const shouldBreak = hasNewlineInRange(
-    options.originalText,
-    locStart(node),
-    // Ideally, this should be the next token after `{`, but there is no node starts with it.
-    locStart(node.typeParameter),
-  );
+  const shouldBreak =
+    options.multilineObject === "preserve" &&
+    hasNewlineInRange(
+      options.originalText,
+      locStart(node),
+      // Ideally, this should be the next token after `{`, but there is no node starts with it.
+      locStart(node.typeParameter),
+    );
 
   return group(
     [

--- a/src/language-js/print/object.js
+++ b/src/language-js/print/object.js
@@ -94,7 +94,7 @@ function printObject(path, options, print) {
             property.value.type === "ArrayPattern"),
       )) ||
     (node.type !== "ObjectPattern" &&
-      options.objectWrapping === "preserve" &&
+      options.objectWrap === "preserve" &&
       propsAndLoc.length > 0 &&
       hasNewlineInRange(
         options.originalText,

--- a/src/language-js/print/object.js
+++ b/src/language-js/print/object.js
@@ -94,7 +94,7 @@ function printObject(path, options, print) {
             property.value.type === "ArrayPattern"),
       )) ||
     (node.type !== "ObjectPattern" &&
-      options.multilineObject === "preserve" &&
+      options.objectWrapping === "preserve" &&
       propsAndLoc.length > 0 &&
       hasNewlineInRange(
         options.originalText,

--- a/src/language-js/print/object.js
+++ b/src/language-js/print/object.js
@@ -94,6 +94,7 @@ function printObject(path, options, print) {
             property.value.type === "ArrayPattern"),
       )) ||
     (node.type !== "ObjectPattern" &&
+      options.multilineObject === "preserve" &&
       propsAndLoc.length > 0 &&
       hasNewlineInRange(
         options.originalText,

--- a/tests/dts/unit/cases/parsers.ts
+++ b/tests/dts/unit/cases/parsers.ts
@@ -20,7 +20,7 @@ const options: prettier.ParserOptions = {
   bracketSpacing: true,
   bracketSameLine: false,
   htmlWhitespaceSensitivity: "css",
-  objectWrapping: "preserve",
+  objectWrap: "preserve",
   singleAttributePerLine: false,
   vueIndentScriptAndStyle: false,
   arrowParens: "always",

--- a/tests/dts/unit/cases/parsers.ts
+++ b/tests/dts/unit/cases/parsers.ts
@@ -20,7 +20,7 @@ const options: prettier.ParserOptions = {
   bracketSpacing: true,
   bracketSameLine: false,
   htmlWhitespaceSensitivity: "css",
-  multilineObject: "preserve",
+  objectWrapping: "preserve",
   singleAttributePerLine: false,
   vueIndentScriptAndStyle: false,
   arrowParens: "always",

--- a/tests/dts/unit/cases/parsers.ts
+++ b/tests/dts/unit/cases/parsers.ts
@@ -20,6 +20,7 @@ const options: prettier.ParserOptions = {
   bracketSpacing: true,
   bracketSameLine: false,
   htmlWhitespaceSensitivity: "css",
+  multilineObject: "preserve",
   singleAttributePerLine: false,
   vueIndentScriptAndStyle: false,
   arrowParens: "always",

--- a/tests/format/flow/object-multiline/__snapshots__/format.test.js.snap
+++ b/tests/format/flow/object-multiline/__snapshots__/format.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`multiline.js - {"multilineObject":"collapse"} format 1`] = `
+exports[`multiline.js - {"objectWrapping":"collapse"} format 1`] = `
 ====================================options=====================================
-multilineObject: "collapse"
+objectWrapping: "collapse"
 parsers: ["flow"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/flow/object-multiline/__snapshots__/format.test.js.snap
+++ b/tests/format/flow/object-multiline/__snapshots__/format.test.js.snap
@@ -1,0 +1,152 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`multiline.js - {"multilineObject":"collapse"} format 1`] = `
+====================================options=====================================
+multilineObject: "collapse"
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type A = {
+  name1: 'value1',
+  name2: 'value2',
+};
+
+const a: A = {
+  name1: 'value1',
+  name2: 'value2',
+};
+
+type B = { name1: 'value1',
+  name2: 'value2',
+};
+
+const b: B = { name1: 'value1',
+  name2: 'value2',
+};
+
+type C = {
+  name1: 'value1', name2: 'value2',
+};
+
+const c: C = {
+  name1: 'value1', name2: 'value2',
+};
+
+type D = {
+  name1: 'value1', name2: 'value2', };
+
+const d: D = {
+    name1: 'value1', name2: 'value2', };
+
+  type E = { name1: 'value1', name2: 'value2', };
+
+const e: E = { name1: 'value1', name2: 'value2', };
+
+=====================================output=====================================
+type A = { name1: "value1", name2: "value2" };
+
+const a: A = { name1: "value1", name2: "value2" };
+
+type B = { name1: "value1", name2: "value2" };
+
+const b: B = { name1: "value1", name2: "value2" };
+
+type C = { name1: "value1", name2: "value2" };
+
+const c: C = { name1: "value1", name2: "value2" };
+
+type D = { name1: "value1", name2: "value2" };
+
+const d: D = { name1: "value1", name2: "value2" };
+
+type E = { name1: "value1", name2: "value2" };
+
+const e: E = { name1: "value1", name2: "value2" };
+
+================================================================================
+`;
+
+exports[`multiline.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type A = {
+  name1: 'value1',
+  name2: 'value2',
+};
+
+const a: A = {
+  name1: 'value1',
+  name2: 'value2',
+};
+
+type B = { name1: 'value1',
+  name2: 'value2',
+};
+
+const b: B = { name1: 'value1',
+  name2: 'value2',
+};
+
+type C = {
+  name1: 'value1', name2: 'value2',
+};
+
+const c: C = {
+  name1: 'value1', name2: 'value2',
+};
+
+type D = {
+  name1: 'value1', name2: 'value2', };
+
+const d: D = {
+    name1: 'value1', name2: 'value2', };
+
+  type E = { name1: 'value1', name2: 'value2', };
+
+const e: E = { name1: 'value1', name2: 'value2', };
+
+=====================================output=====================================
+type A = {
+  name1: "value1",
+  name2: "value2",
+};
+
+const a: A = {
+  name1: "value1",
+  name2: "value2",
+};
+
+type B = { name1: "value1", name2: "value2" };
+
+const b: B = { name1: "value1", name2: "value2" };
+
+type C = {
+  name1: "value1",
+  name2: "value2",
+};
+
+const c: C = {
+  name1: "value1",
+  name2: "value2",
+};
+
+type D = {
+  name1: "value1",
+  name2: "value2",
+};
+
+const d: D = {
+  name1: "value1",
+  name2: "value2",
+};
+
+type E = { name1: "value1", name2: "value2" };
+
+const e: E = { name1: "value1", name2: "value2" };
+
+================================================================================
+`;

--- a/tests/format/flow/object-multiline/__snapshots__/format.test.js.snap
+++ b/tests/format/flow/object-multiline/__snapshots__/format.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`multiline.js - {"objectWrapping":"collapse"} format 1`] = `
+exports[`multiline.js - {"objectWrap":"collapse"} format 1`] = `
 ====================================options=====================================
-objectWrapping: "collapse"
+objectWrap: "collapse"
 parsers: ["flow"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/flow/object-multiline/format.test.js
+++ b/tests/format/flow/object-multiline/format.test.js
@@ -1,2 +1,2 @@
 runFormatTest(import.meta, ["flow"]);
-runFormatTest(import.meta, ["flow"], { multilineObject: "collapse" });
+runFormatTest(import.meta, ["flow"], { objectWrapping: "collapse" });

--- a/tests/format/flow/object-multiline/format.test.js
+++ b/tests/format/flow/object-multiline/format.test.js
@@ -1,2 +1,2 @@
 runFormatTest(import.meta, ["flow"]);
-runFormatTest(import.meta, ["flow"], { objectWrapping: "collapse" });
+runFormatTest(import.meta, ["flow"], { objectWrap: "collapse" });

--- a/tests/format/flow/object-multiline/format.test.js
+++ b/tests/format/flow/object-multiline/format.test.js
@@ -1,0 +1,2 @@
+runFormatTest(import.meta, ["flow"]);
+runFormatTest(import.meta, ["flow"], { multilineObject: "collapse" });

--- a/tests/format/flow/object-multiline/multiline.js
+++ b/tests/format/flow/object-multiline/multiline.js
@@ -1,0 +1,35 @@
+type A = {
+  name1: 'value1',
+  name2: 'value2',
+};
+
+const a: A = {
+  name1: 'value1',
+  name2: 'value2',
+};
+
+type B = { name1: 'value1',
+  name2: 'value2',
+};
+
+const b: B = { name1: 'value1',
+  name2: 'value2',
+};
+
+type C = {
+  name1: 'value1', name2: 'value2',
+};
+
+const c: C = {
+  name1: 'value1', name2: 'value2',
+};
+
+type D = {
+  name1: 'value1', name2: 'value2', };
+
+const d: D = {
+    name1: 'value1', name2: 'value2', };
+
+  type E = { name1: 'value1', name2: 'value2', };
+
+const e: E = { name1: 'value1', name2: 'value2', };

--- a/tests/format/js/object-multiline/format.spec.js
+++ b/tests/format/js/object-multiline/format.spec.js
@@ -1,2 +1,2 @@
 runFormatTest(import.meta, ["babel"]);
-runFormatTest(import.meta, ["babel"], { objectWrapping: "collapse" });
+runFormatTest(import.meta, ["babel"], { objectWrap: "collapse" });

--- a/tests/format/js/object-multiline/format.spec.js
+++ b/tests/format/js/object-multiline/format.spec.js
@@ -1,0 +1,2 @@
+runFormatTest(import.meta, ["babel"]);
+runFormatTest(import.meta, ["babel"], { multilineObject: "collapse" });

--- a/tests/format/js/object-multiline/format.spec.js
+++ b/tests/format/js/object-multiline/format.spec.js
@@ -1,2 +1,2 @@
 runFormatTest(import.meta, ["babel"]);
-runFormatTest(import.meta, ["babel"], { multilineObject: "collapse" });
+runFormatTest(import.meta, ["babel"], { objectWrapping: "collapse" });

--- a/tests/format/js/object-multiline/multiline.js
+++ b/tests/format/js/object-multiline/multiline.js
@@ -1,0 +1,17 @@
+const a = {
+  name1: 'value1',
+  name2: 'value2',
+};
+
+const b = { name1: 'value1',
+  name2: 'value2',
+};
+
+const c = {
+  name1: 'value1', name2: 'value2',
+};
+
+const d = {
+  name1: 'value1', name2: 'value2', };
+
+const e = { name1: 'value1', name2: 'value2', };

--- a/tests/format/json/json/__snapshots__/format.test.js.snap
+++ b/tests/format/json/json/__snapshots__/format.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`array.json - {"multilineObject":"collapse"} format 1`] = `
+exports[`array.json - {"objectWrapping":"collapse"} format 1`] = `
 ====================================options=====================================
-multilineObject: "collapse"
+objectWrapping: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -158,9 +158,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`boolean.json - {"multilineObject":"collapse"} format 1`] = `
+exports[`boolean.json - {"objectWrapping":"collapse"} format 1`] = `
 ====================================options=====================================
-multilineObject: "collapse"
+objectWrapping: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -247,9 +247,9 @@ true
 ================================================================================
 `;
 
-exports[`json5.json - {"multilineObject":"collapse"} format 1`] = `
+exports[`json5.json - {"objectWrapping":"collapse"} format 1`] = `
 ====================================options=====================================
-multilineObject: "collapse"
+objectWrapping: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -609,9 +609,9 @@ No \\\\n's!",
 ================================================================================
 `;
 
-exports[`json6.json - {"multilineObject":"collapse"} format 1`] = `
+exports[`json6.json - {"objectWrapping":"collapse"} format 1`] = `
 ====================================options=====================================
-multilineObject: "collapse"
+objectWrapping: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -1299,9 +1299,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`key-value.json - {"multilineObject":"collapse"} format 1`] = `
+exports[`key-value.json - {"objectWrapping":"collapse"} format 1`] = `
 ====================================options=====================================
-multilineObject: "collapse"
+objectWrapping: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -1436,9 +1436,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`multi-line.json - {"multilineObject":"collapse"} format 1`] = `
+exports[`multi-line.json - {"objectWrapping":"collapse"} format 1`] = `
 ====================================options=====================================
-multilineObject: "collapse"
+objectWrapping: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -1546,9 +1546,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`null.json - {"multilineObject":"collapse"} format 1`] = `
+exports[`null.json - {"objectWrapping":"collapse"} format 1`] = `
 ====================================options=====================================
-multilineObject: "collapse"
+objectWrapping: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -1635,9 +1635,9 @@ null
 ================================================================================
 `;
 
-exports[`number.json - {"multilineObject":"collapse"} format 1`] = `
+exports[`number.json - {"objectWrapping":"collapse"} format 1`] = `
 ====================================options=====================================
-multilineObject: "collapse"
+objectWrapping: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -1724,9 +1724,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`pass1.json - {"multilineObject":"collapse"} format 1`] = `
+exports[`pass1.json - {"objectWrapping":"collapse"} format 1`] = `
 ====================================options=====================================
-multilineObject: "collapse"
+objectWrapping: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -2524,9 +2524,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`positive-number.json - {"multilineObject":"collapse"} format 1`] = `
+exports[`positive-number.json - {"objectWrapping":"collapse"} format 1`] = `
 ====================================options=====================================
-multilineObject: "collapse"
+objectWrapping: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -2613,9 +2613,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`propertyKey.json - {"multilineObject":"collapse"} format 1`] = `
+exports[`propertyKey.json - {"objectWrapping":"collapse"} format 1`] = `
 ====================================options=====================================
-multilineObject: "collapse"
+objectWrapping: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -2978,9 +2978,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`single-line.json - {"multilineObject":"collapse"} format 1`] = `
+exports[`single-line.json - {"objectWrapping":"collapse"} format 1`] = `
 ====================================options=====================================
-multilineObject: "collapse"
+objectWrapping: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -3082,9 +3082,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`single-quote.json - {"multilineObject":"collapse"} format 1`] = `
+exports[`single-quote.json - {"objectWrapping":"collapse"} format 1`] = `
 ====================================options=====================================
-multilineObject: "collapse"
+objectWrapping: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -3171,9 +3171,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`string.json - {"multilineObject":"collapse"} format 1`] = `
+exports[`string.json - {"objectWrapping":"collapse"} format 1`] = `
 ====================================options=====================================
-multilineObject: "collapse"
+objectWrapping: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/json/json/__snapshots__/format.test.js.snap
+++ b/tests/format/json/json/__snapshots__/format.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`array.json - {"objectWrapping":"collapse"} format 1`] = `
+exports[`array.json - {"objectWrap":"collapse"} format 1`] = `
 ====================================options=====================================
-objectWrapping: "collapse"
+objectWrap: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -158,9 +158,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`boolean.json - {"objectWrapping":"collapse"} format 1`] = `
+exports[`boolean.json - {"objectWrap":"collapse"} format 1`] = `
 ====================================options=====================================
-objectWrapping: "collapse"
+objectWrap: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -247,9 +247,9 @@ true
 ================================================================================
 `;
 
-exports[`json5.json - {"objectWrapping":"collapse"} format 1`] = `
+exports[`json5.json - {"objectWrap":"collapse"} format 1`] = `
 ====================================options=====================================
-objectWrapping: "collapse"
+objectWrap: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -609,9 +609,9 @@ No \\\\n's!",
 ================================================================================
 `;
 
-exports[`json6.json - {"objectWrapping":"collapse"} format 1`] = `
+exports[`json6.json - {"objectWrap":"collapse"} format 1`] = `
 ====================================options=====================================
-objectWrapping: "collapse"
+objectWrap: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -1299,9 +1299,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`key-value.json - {"objectWrapping":"collapse"} format 1`] = `
+exports[`key-value.json - {"objectWrap":"collapse"} format 1`] = `
 ====================================options=====================================
-objectWrapping: "collapse"
+objectWrap: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -1436,9 +1436,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`multi-line.json - {"objectWrapping":"collapse"} format 1`] = `
+exports[`multi-line.json - {"objectWrap":"collapse"} format 1`] = `
 ====================================options=====================================
-objectWrapping: "collapse"
+objectWrap: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -1546,9 +1546,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`null.json - {"objectWrapping":"collapse"} format 1`] = `
+exports[`null.json - {"objectWrap":"collapse"} format 1`] = `
 ====================================options=====================================
-objectWrapping: "collapse"
+objectWrap: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -1635,9 +1635,9 @@ null
 ================================================================================
 `;
 
-exports[`number.json - {"objectWrapping":"collapse"} format 1`] = `
+exports[`number.json - {"objectWrap":"collapse"} format 1`] = `
 ====================================options=====================================
-objectWrapping: "collapse"
+objectWrap: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -1724,9 +1724,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`pass1.json - {"objectWrapping":"collapse"} format 1`] = `
+exports[`pass1.json - {"objectWrap":"collapse"} format 1`] = `
 ====================================options=====================================
-objectWrapping: "collapse"
+objectWrap: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -2524,9 +2524,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`positive-number.json - {"objectWrapping":"collapse"} format 1`] = `
+exports[`positive-number.json - {"objectWrap":"collapse"} format 1`] = `
 ====================================options=====================================
-objectWrapping: "collapse"
+objectWrap: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -2613,9 +2613,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`propertyKey.json - {"objectWrapping":"collapse"} format 1`] = `
+exports[`propertyKey.json - {"objectWrap":"collapse"} format 1`] = `
 ====================================options=====================================
-objectWrapping: "collapse"
+objectWrap: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -2978,9 +2978,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`single-line.json - {"objectWrapping":"collapse"} format 1`] = `
+exports[`single-line.json - {"objectWrap":"collapse"} format 1`] = `
 ====================================options=====================================
-objectWrapping: "collapse"
+objectWrap: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -3082,9 +3082,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`single-quote.json - {"objectWrapping":"collapse"} format 1`] = `
+exports[`single-quote.json - {"objectWrap":"collapse"} format 1`] = `
 ====================================options=====================================
-objectWrapping: "collapse"
+objectWrap: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth
@@ -3171,9 +3171,9 @@ printWidth: 80
 ================================================================================
 `;
 
-exports[`string.json - {"objectWrapping":"collapse"} format 1`] = `
+exports[`string.json - {"objectWrap":"collapse"} format 1`] = `
 ====================================options=====================================
-objectWrapping: "collapse"
+objectWrap: "collapse"
 parsers: ["json"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/json/json/__snapshots__/format.test.js.snap
+++ b/tests/format/json/json/__snapshots__/format.test.js.snap
@@ -1,5 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`array.json - {"multilineObject":"collapse"} format 1`] = `
+====================================options=====================================
+multilineObject: "collapse"
+parsers: ["json"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+[
+  [
+1,null],
+  [1,null,],
+  [null,],
+  [0,],
+  [false,],
+  ['',]
+]
+
+=====================================output=====================================
+[[1, null], [1, null], [null], [0], [false], [""]]
+
+================================================================================
+`;
+
 exports[`array.json - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
 parsers: ["json"]
@@ -135,6 +158,21 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`boolean.json - {"multilineObject":"collapse"} format 1`] = `
+====================================options=====================================
+multilineObject: "collapse"
+parsers: ["json"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+true
+
+=====================================output=====================================
+true
+
+================================================================================
+`;
+
 exports[`boolean.json - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
 parsers: ["json"]
@@ -205,6 +243,66 @@ true
 
 =====================================output=====================================
 true
+
+================================================================================
+`;
+
+exports[`json5.json - {"multilineObject":"collapse"} format 1`] = `
+====================================options=====================================
+multilineObject: "collapse"
+parsers: ["json"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+[
+{
+  '//': 'JSON5 allow \`Infinity\` and \`NaN\`',
+  numbers: [
+    Infinity,
+    -Infinity,
+    NaN,
+  ],
+  Infinity: NaN,
+  NaN: Infinity,
+  NaN: -Infinity,
+},
+{
+  '//': 'JSON5 numbers',
+  hexadecimal: 0xdecaf,
+  leadingDecimalPoint: .8675309, andTrailing: 8675309.,
+  positiveSign: +1,
+},
+{
+  '//': 'JSON5 strings',
+singleQuotes: 'I can use "double quotes" here',
+  lineBreaks: "Look, Mom! \\
+No \\\\n's!",
+}
+]
+
+=====================================output=====================================
+[
+  {
+    "//": "JSON5 allow \`Infinity\` and \`NaN\`",
+    "numbers": [Infinity, -Infinity, NaN],
+    "Infinity": NaN,
+    "NaN": Infinity,
+    "NaN": -Infinity
+  },
+  {
+    "//": "JSON5 numbers",
+    "hexadecimal": 0xdecaf,
+    "leadingDecimalPoint": 0.8675309,
+    "andTrailing": 8675309,
+    "positiveSign": +1
+  },
+  {
+    "//": "JSON5 strings",
+    "singleQuotes": "I can use \\"double quotes\\" here",
+    "lineBreaks": "Look, Mom! \\
+No \\\\n's!"
+  }
+]
 
 ================================================================================
 `;
@@ -506,6 +604,115 @@ No \\\\n's!",
     "singleQuotes": "I can use \\"double quotes\\" here",
     "lineBreaks": "Look, Mom! No \\\\n's!"
   }
+]
+
+================================================================================
+`;
+
+exports[`json6.json - {"multilineObject":"collapse"} format 1`] = `
+====================================options=====================================
+multilineObject: "collapse"
+parsers: ["json"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+[
+{'//': 'Keyword \`undefined\`',
+    "data": [
+      {undefined: undefined},
+      undefined,
+      [undefined, ]
+    ]
+  },
+
+{'//': 'back-tick quoted strings',
+    "data": [
+      \`\`,
+      \`foo\`,
+      \`
+  multiple-line
+\`,
+      \`\\u{1F409}\\\`'"\\\${}\`,
+      {'as-object-value': \`foo\`}
+    ]
+  },
+
+{'//': 'String escapes ',
+    "data": [
+      '\\0', '\\xFF', '\\u00FF', \`\\u{1F409}\`
+    ]
+  },
+
+{'//': 'Numbers',
+    "data": [
+      0o123, 0b101010, 1e5, 123_456, 0xDeeD_Beef,
+      0123,
+      -Infinity, -NaN,
+      +1, -1,
+      +0o123, +0b101010, +1e5, +123_456, +0xDeeD_Beef,
+      -0o123, -0b101010, -1e5, -123_456, -0xDeeD_Beef,
+    ]
+  },
+
+{'//': 'empty members',
+    data: [
+      [,],
+      [1, , 2,,,,],
+      [1, , 2],
+      [1, , 2,]
+    ]
+  }
+]
+
+=====================================output=====================================
+[
+  {
+    "//": "Keyword \`undefined\`",
+    "data": [{ "undefined": undefined }, undefined, [undefined]]
+  },
+
+  {
+    "//": "back-tick quoted strings",
+    "data": [
+      \`\`,
+      \`foo\`,
+      \`
+  multiple-line
+\`,
+      \`\\u{1F409}\\\`'"\\\${}\`,
+      { "as-object-value": \`foo\` }
+    ]
+  },
+
+  { "//": "String escapes ", "data": ["\\0", "\\xFF", "\\u00FF", \`\\u{1F409}\`] },
+
+  {
+    "//": "Numbers",
+    "data": [
+      0o123,
+      0b101010,
+      1e5,
+      123_456,
+      0xdeed_beef,
+      0123,
+      -Infinity,
+      -NaN,
+      +1,
+      -1,
+      +0o123,
+      +0b101010,
+      +1e5,
+      +123_456,
+      +0xdeed_beef,
+      -0o123,
+      -0b101010,
+      -1e5,
+      -123_456,
+      -0xdeed_beef
+    ]
+  },
+
+  { "//": "empty members", "data": [[,], [1, , 2, , , ,], [1, , 2], [1, , 2]] }
 ]
 
 ================================================================================
@@ -1092,6 +1299,29 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`key-value.json - {"multilineObject":"collapse"} format 1`] = `
+====================================options=====================================
+multilineObject: "collapse"
+parsers: ["json"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+{
+    "string": "stringstringstringstringstringstringstringstringstringstringstringstringstringstringstring",
+    "stringstringstringstringstringstringstringstring": "stringstringstringstringstringstringstringstring",
+    "stringstringstringstringstringstringstringstringstringstringstringstringstringstringstring": "string"
+}
+
+=====================================output=====================================
+{
+  "string": "stringstringstringstringstringstringstringstringstringstringstringstringstringstringstring",
+  "stringstringstringstringstringstringstringstring": "stringstringstringstringstringstringstringstring",
+  "stringstringstringstringstringstringstringstringstringstringstringstringstringstringstring": "string"
+}
+
+================================================================================
+`;
+
 exports[`key-value.json - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
 parsers: ["json"]
@@ -1206,6 +1436,22 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`multi-line.json - {"multilineObject":"collapse"} format 1`] = `
+====================================options=====================================
+multilineObject: "collapse"
+parsers: ["json"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+{"key1":[true,false,null],"key2":{"key3":[1,2,"3",
+1e10,1e-3]}}
+
+=====================================output=====================================
+{ "key1": [true, false, null], "key2": { "key3": [1, 2, "3", 1e10, 1e-3] } }
+
+================================================================================
+`;
+
 exports[`multi-line.json - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
 parsers: ["json"]
@@ -1300,6 +1546,21 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`null.json - {"multilineObject":"collapse"} format 1`] = `
+====================================options=====================================
+multilineObject: "collapse"
+parsers: ["json"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+null
+
+=====================================output=====================================
+null
+
+================================================================================
+`;
+
 exports[`null.json - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
 parsers: ["json"]
@@ -1374,6 +1635,21 @@ null
 ================================================================================
 `;
 
+exports[`number.json - {"multilineObject":"collapse"} format 1`] = `
+====================================options=====================================
+multilineObject: "collapse"
+parsers: ["json"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+0
+
+=====================================output=====================================
+0
+
+================================================================================
+`;
+
 exports[`number.json - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
 parsers: ["json"]
@@ -1444,6 +1720,137 @@ printWidth: 80
 
 =====================================output=====================================
 0
+
+================================================================================
+`;
+
+exports[`pass1.json - {"multilineObject":"collapse"} format 1`] = `
+====================================options=====================================
+multilineObject: "collapse"
+parsers: ["json"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+[
+    "JSON Test Pattern pass1",
+    {"object with 1 member":["array with 1 element"]},
+    {},
+    [],
+    -42,
+    true,
+    false,
+    null,
+    {
+        "integer": 1234567890,
+        "real": -9876.543210,
+        "e": 0.123456789e-12,
+        "E": 1.234567890E+34,
+        "":  23456789012E66,
+        "zero": 0,
+        "one": 1,
+        "space": " ",
+        "quote": "\\"",
+        "backslash": "\\\\",
+        "controls": "\\b\\f\\n\\r\\t",
+        "slash": "/ & \\/",
+        "alpha": "abcdefghijklmnopqrstuvwyz",
+        "ALPHA": "ABCDEFGHIJKLMNOPQRSTUVWYZ",
+        "digit": "0123456789",
+        "0123456789": "digit",
+        "special": "\`1~!@#$%^&*()_+-={':[,]}|;.</>?",
+        "hex": "\\u0123\\u4567\\u89AB\\uCDEF\\uabcd\\uef4A",
+        "true": true,
+        "false": false,
+        "null": null,
+        "array":[  ],
+        "object":{  },
+        "address": "50 St. James Street",
+        "url": "http://www.JSON.org/",
+        "comment": "// /* <!-- --",
+        "# -- --> */": " ",
+        " s p a c e d " :[1,2 , 3
+
+,
+
+4 , 5        ,          6           ,7        ],"compact":[1,2,3,4,5,6,7],
+        "jsontext": "{\\"object with 1 member\\":[\\"array with 1 element\\"]}",
+        "quotes": "&#34; \\u0022 %22 0x22 034 &#x22;",
+        "\\/\\\\\\"\\uCAFE\\uBABE\\uAB98\\uFCDE\\ubcda\\uef4A\\b\\f\\n\\r\\t\`1~!@#$%^&*()_+-=[]{}|;:',./<>?"
+: "A key can be any string"
+    },
+    0.5 ,98.6
+,
+99.44
+,
+
+1066,
+1e1,
+0.1e1,
+1e-1,
+1e00,2e+00,2e-00
+,"rosebud"]
+
+=====================================output=====================================
+[
+  "JSON Test Pattern pass1",
+  { "object with 1 member": ["array with 1 element"] },
+  {},
+  [],
+  -42,
+  true,
+  false,
+  null,
+  {
+    "integer": 1234567890,
+    "real": -9876.54321,
+    "e": 0.123456789e-12,
+    "E": 1.23456789e34,
+    "": 23456789012e66,
+    "zero": 0,
+    "one": 1,
+    "space": " ",
+    "quote": "\\"",
+    "backslash": "\\\\",
+    "controls": "\\b\\f\\n\\r\\t",
+    "slash": "/ & \\/",
+    "alpha": "abcdefghijklmnopqrstuvwyz",
+    "ALPHA": "ABCDEFGHIJKLMNOPQRSTUVWYZ",
+    "digit": "0123456789",
+    "0123456789": "digit",
+    "special": "\`1~!@#$%^&*()_+-={':[,]}|;.</>?",
+    "hex": "\\u0123\\u4567\\u89AB\\uCDEF\\uabcd\\uef4A",
+    "true": true,
+    "false": false,
+    "null": null,
+    "array": [],
+    "object": {},
+    "address": "50 St. James Street",
+    "url": "http://www.JSON.org/",
+    "comment": "// /* <!-- --",
+    "# -- --> */": " ",
+    " s p a c e d ": [
+      1, 2, 3,
+
+      4, 5, 6, 7
+    ],
+    "compact": [1, 2, 3, 4, 5, 6, 7],
+    "jsontext": "{\\"object with 1 member\\":[\\"array with 1 element\\"]}",
+    "quotes": "&#34; \\u0022 %22 0x22 034 &#x22;",
+    "\\/\\\\\\"\\uCAFE\\uBABE\\uAB98\\uFCDE\\ubcda\\uef4A\\b\\f\\n\\r\\t\`1~!@#$%^&*()_+-=[]{}|;:',./<>?": "A key can be any string"
+  },
+  0.5,
+  98.6,
+  99.44,
+
+  1066,
+  1e1,
+  0.1e1,
+  1e-1,
+  1,
+  2,
+  2,
+  "rosebud"
+]
 
 ================================================================================
 `;
@@ -2117,6 +2524,21 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`positive-number.json - {"multilineObject":"collapse"} format 1`] = `
+====================================options=====================================
+multilineObject: "collapse"
+parsers: ["json"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
++123
+
+=====================================output=====================================
++123
+
+================================================================================
+`;
+
 exports[`positive-number.json - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
 parsers: ["json"]
@@ -2187,6 +2609,67 @@ printWidth: 80
 
 =====================================output=====================================
 123
+
+================================================================================
+`;
+
+exports[`propertyKey.json - {"multilineObject":"collapse"} format 1`] = `
+====================================options=====================================
+multilineObject: "collapse"
+parsers: ["json"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+{
+    a: '',
+    null: '',
+    true: '',
+    "string": "",
+    0: '',
+    1e2: '',
+    1.0e+2: '',
+    .10e+2: '',
+    1e-2: '',
+    .1e-2: '',
+    0.1e+2: '',
+    1.0: '',
+    1.00000: '',
+    .1: '',
+    .100000: '',
+    0.1: '',
+    0.100000: '',
+    999999999999999999999999999999: '',
+    .000000000000000000000000000001: '',
+    0.000000000000000000000000000001: '',
+    1e999999999999999999999999999999: '',
+    1_2_3: '',
+}
+
+=====================================output=====================================
+{
+  "a": "",
+  "null": "",
+  "true": "",
+  "string": "",
+  "0": "",
+  1e2: "",
+  1.0e2: "",
+  0.1e2: "",
+  1e-2: "",
+  0.1e-2: "",
+  0.1e2: "",
+  1.0: "",
+  1.0: "",
+  "0.1": "",
+  "0.1": "",
+  "0.1": "",
+  "0.1": "",
+  999999999999999999999999999999: "",
+  0.000000000000000000000000000001: "",
+  0.000000000000000000000000000001: "",
+  1e999999999999999999999999999999: "",
+  1_2_3: ""
+}
 
 ================================================================================
 `;
@@ -2495,6 +2978,21 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`single-line.json - {"multilineObject":"collapse"} format 1`] = `
+====================================options=====================================
+multilineObject: "collapse"
+parsers: ["json"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+{"key1":[true,false,null],"key2":{"key3":[1,2,"3",1e10,1e-3]}}
+
+=====================================output=====================================
+{ "key1": [true, false, null], "key2": { "key3": [1, 2, "3", 1e10, 1e-3] } }
+
+================================================================================
+`;
+
 exports[`single-line.json - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
 parsers: ["json"]
@@ -2584,6 +3082,21 @@ printWidth: 80
 ================================================================================
 `;
 
+exports[`single-quote.json - {"multilineObject":"collapse"} format 1`] = `
+====================================options=====================================
+multilineObject: "collapse"
+parsers: ["json"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+'hello'
+
+=====================================output=====================================
+"hello"
+
+================================================================================
+`;
+
 exports[`single-quote.json - {"trailingComma":"all"} format 1`] = `
 ====================================options=====================================
 parsers: ["json"]
@@ -2654,6 +3167,21 @@ printWidth: 80
 
 =====================================output=====================================
 "hello"
+
+================================================================================
+`;
+
+exports[`string.json - {"multilineObject":"collapse"} format 1`] = `
+====================================options=====================================
+multilineObject: "collapse"
+parsers: ["json"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+"string"
+
+=====================================output=====================================
+"string"
 
 ================================================================================
 `;

--- a/tests/format/json/json/format.test.js
+++ b/tests/format/json/json/format.test.js
@@ -1,4 +1,4 @@
-runFormatTest(import.meta, ["json"], { multilineObject: "collapse" });
+runFormatTest(import.meta, ["json"], { objectWrapping: "collapse" });
 runFormatTest(import.meta, ["json"], { trailingComma: "es5" });
 runFormatTest(import.meta, ["json"], { trailingComma: "all" });
 runFormatTest(import.meta, ["json5"], { trailingComma: "es5" });

--- a/tests/format/json/json/format.test.js
+++ b/tests/format/json/json/format.test.js
@@ -1,3 +1,4 @@
+runFormatTest(import.meta, ["json"], { multilineObject: "collapse" });
 runFormatTest(import.meta, ["json"], { trailingComma: "es5" });
 runFormatTest(import.meta, ["json"], { trailingComma: "all" });
 runFormatTest(import.meta, ["json5"], { trailingComma: "es5" });

--- a/tests/format/json/json/format.test.js
+++ b/tests/format/json/json/format.test.js
@@ -1,4 +1,4 @@
-runFormatTest(import.meta, ["json"], { objectWrapping: "collapse" });
+runFormatTest(import.meta, ["json"], { objectWrap: "collapse" });
 runFormatTest(import.meta, ["json"], { trailingComma: "es5" });
 runFormatTest(import.meta, ["json"], { trailingComma: "all" });
 runFormatTest(import.meta, ["json5"], { trailingComma: "es5" });

--- a/tests/format/typescript/object-multiline/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/object-multiline/__snapshots__/format.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`multiline.ts - {"multilineObject":"collapse"} format 1`] = `
+exports[`multiline.ts - {"objectWrapping":"collapse"} format 1`] = `
 ====================================options=====================================
-multilineObject: "collapse"
+objectWrapping: "collapse"
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/typescript/object-multiline/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/object-multiline/__snapshots__/format.test.js.snap
@@ -1,0 +1,152 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`multiline.ts - {"multilineObject":"collapse"} format 1`] = `
+====================================options=====================================
+multilineObject: "collapse"
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type A = {
+  name1: 'value1',
+  name2: 'value2',
+};
+
+const a: A = {
+  name1: 'value1',
+  name2: 'value2',
+};
+
+type B = { name1: 'value1',
+  name2: 'value2',
+};
+
+const b: B = { name1: 'value1',
+  name2: 'value2',
+};
+
+type C = {
+  name1: 'value1', name2: 'value2',
+};
+
+const c: C = {
+  name1: 'value1', name2: 'value2',
+};
+
+type D = {
+  name1: 'value1', name2: 'value2', };
+
+const d: D = {
+    name1: 'value1', name2: 'value2', };
+
+  type E = { name1: 'value1', name2: 'value2', };
+
+const e: E = { name1: 'value1', name2: 'value2', };
+
+=====================================output=====================================
+type A = { name1: "value1"; name2: "value2" };
+
+const a: A = { name1: "value1", name2: "value2" };
+
+type B = { name1: "value1"; name2: "value2" };
+
+const b: B = { name1: "value1", name2: "value2" };
+
+type C = { name1: "value1"; name2: "value2" };
+
+const c: C = { name1: "value1", name2: "value2" };
+
+type D = { name1: "value1"; name2: "value2" };
+
+const d: D = { name1: "value1", name2: "value2" };
+
+type E = { name1: "value1"; name2: "value2" };
+
+const e: E = { name1: "value1", name2: "value2" };
+
+================================================================================
+`;
+
+exports[`multiline.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type A = {
+  name1: 'value1',
+  name2: 'value2',
+};
+
+const a: A = {
+  name1: 'value1',
+  name2: 'value2',
+};
+
+type B = { name1: 'value1',
+  name2: 'value2',
+};
+
+const b: B = { name1: 'value1',
+  name2: 'value2',
+};
+
+type C = {
+  name1: 'value1', name2: 'value2',
+};
+
+const c: C = {
+  name1: 'value1', name2: 'value2',
+};
+
+type D = {
+  name1: 'value1', name2: 'value2', };
+
+const d: D = {
+    name1: 'value1', name2: 'value2', };
+
+  type E = { name1: 'value1', name2: 'value2', };
+
+const e: E = { name1: 'value1', name2: 'value2', };
+
+=====================================output=====================================
+type A = {
+  name1: "value1";
+  name2: "value2";
+};
+
+const a: A = {
+  name1: "value1",
+  name2: "value2",
+};
+
+type B = { name1: "value1"; name2: "value2" };
+
+const b: B = { name1: "value1", name2: "value2" };
+
+type C = {
+  name1: "value1";
+  name2: "value2";
+};
+
+const c: C = {
+  name1: "value1",
+  name2: "value2",
+};
+
+type D = {
+  name1: "value1";
+  name2: "value2";
+};
+
+const d: D = {
+  name1: "value1",
+  name2: "value2",
+};
+
+type E = { name1: "value1"; name2: "value2" };
+
+const e: E = { name1: "value1", name2: "value2" };
+
+================================================================================
+`;

--- a/tests/format/typescript/object-multiline/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/object-multiline/__snapshots__/format.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`multiline.ts - {"objectWrapping":"collapse"} format 1`] = `
+exports[`multiline.ts - {"objectWrap":"collapse"} format 1`] = `
 ====================================options=====================================
-objectWrapping: "collapse"
+objectWrap: "collapse"
 parsers: ["typescript"]
 printWidth: 80
                                                                                 | printWidth

--- a/tests/format/typescript/object-multiline/format.test.js
+++ b/tests/format/typescript/object-multiline/format.test.js
@@ -1,2 +1,2 @@
 runFormatTest(import.meta, ["typescript"]);
-runFormatTest(import.meta, ["typescript"], { multilineObject: "collapse" });
+runFormatTest(import.meta, ["typescript"], { objectWrapping: "collapse" });

--- a/tests/format/typescript/object-multiline/format.test.js
+++ b/tests/format/typescript/object-multiline/format.test.js
@@ -1,2 +1,2 @@
 runFormatTest(import.meta, ["typescript"]);
-runFormatTest(import.meta, ["typescript"], { objectWrapping: "collapse" });
+runFormatTest(import.meta, ["typescript"], { objectWrap: "collapse" });

--- a/tests/format/typescript/object-multiline/format.test.js
+++ b/tests/format/typescript/object-multiline/format.test.js
@@ -1,0 +1,2 @@
+runFormatTest(import.meta, ["typescript"]);
+runFormatTest(import.meta, ["typescript"], { multilineObject: "collapse" });

--- a/tests/format/typescript/object-multiline/multiline.ts
+++ b/tests/format/typescript/object-multiline/multiline.ts
@@ -1,0 +1,35 @@
+type A = {
+  name1: 'value1',
+  name2: 'value2',
+};
+
+const a: A = {
+  name1: 'value1',
+  name2: 'value2',
+};
+
+type B = { name1: 'value1',
+  name2: 'value2',
+};
+
+const b: B = { name1: 'value1',
+  name2: 'value2',
+};
+
+type C = {
+  name1: 'value1', name2: 'value2',
+};
+
+const c: C = {
+  name1: 'value1', name2: 'value2',
+};
+
+type D = {
+  name1: 'value1', name2: 'value2', };
+
+const d: D = {
+    name1: 'value1', name2: 'value2', };
+
+  type E = { name1: 'value1', name2: 'value2', };
+
+const e: E = { name1: 'value1', name2: 'value2', };

--- a/tests/integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests/integration/__tests__/__snapshots__/early-exit.js.snap
@@ -63,7 +63,7 @@ Format options:
                            Defaults to css.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.
-  --object-wrapping <preserve|collapse>
+  --object-wrap <preserve|collapse>
                            How to wrap object literals.
                            Defaults to preserve.
   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|jsonc|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
@@ -234,7 +234,7 @@ Format options:
                            Defaults to css.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.
-  --object-wrapping <preserve|collapse>
+  --object-wrap <preserve|collapse>
                            How to wrap object literals.
                            Defaults to preserve.
   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|jsonc|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>

--- a/tests/integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests/integration/__tests__/__snapshots__/early-exit.js.snap
@@ -63,8 +63,8 @@ Format options:
                            Defaults to css.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.
-  --multiline-object <preserve|collapse>
-                           Allow multi-line objects to collapse to a single line.
+  --object-wrapping <preserve|collapse>
+                           How to wrap object literals.
                            Defaults to preserve.
   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|jsonc|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
                            Which parser to use.
@@ -234,8 +234,8 @@ Format options:
                            Defaults to css.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.
-  --multiline-object <preserve|collapse>
-                           Allow multi-line objects to collapse to a single line.
+  --object-wrapping <preserve|collapse>
+                           How to wrap object literals.
                            Defaults to preserve.
   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|jsonc|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
                            Which parser to use.

--- a/tests/integration/__tests__/__snapshots__/early-exit.js.snap
+++ b/tests/integration/__tests__/__snapshots__/early-exit.js.snap
@@ -63,6 +63,9 @@ Format options:
                            Defaults to css.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.
+  --multiline-object <preserve|collapse>
+                           Allow multi-line objects to collapse to a single line.
+                           Defaults to preserve.
   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|jsonc|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
                            Which parser to use.
   --print-width <int>      The line length where Prettier will try wrap.
@@ -231,6 +234,9 @@ Format options:
                            Defaults to css.
   --jsx-single-quote       Use single quotes in JSX.
                            Defaults to false.
+  --multiline-object <preserve|collapse>
+                           Allow multi-line objects to collapse to a single line.
+                           Defaults to preserve.
   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|jsonc|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
                            Which parser to use.
   --print-width <int>      The line length where Prettier will try wrap.

--- a/tests/integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/help-options.js.snap
@@ -348,23 +348,6 @@ Default: log"
 
 exports[`show detailed usage with --help log-level (write) 1`] = `[]`;
 
-exports[`show detailed usage with --help multiline-object (stderr) 1`] = `""`;
-
-exports[`show detailed usage with --help multiline-object (stdout) 1`] = `
-"--multiline-object <preserve|collapse>
-
-  Allow multi-line objects to collapse to a single line.
-
-Valid options:
-
-  preserve   Keep as multi-line, if there is a newline between the opening brace and first property.
-  collapse   Fit to a single line when possible.
-
-Default: preserve"
-`;
-
-exports[`show detailed usage with --help multiline-object (write) 1`] = `[]`;
-
 exports[`show detailed usage with --help no-bracket-spacing (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help no-bracket-spacing (stdout) 1`] = `
@@ -434,6 +417,23 @@ exports[`show detailed usage with --help no-semi (stdout) 1`] = `
 `;
 
 exports[`show detailed usage with --help no-semi (write) 1`] = `[]`;
+
+exports[`show detailed usage with --help object-wrapping (stderr) 1`] = `""`;
+
+exports[`show detailed usage with --help object-wrapping (stdout) 1`] = `
+"--object-wrapping <preserve|collapse>
+
+  How to wrap object literals.
+
+Valid options:
+
+  preserve   Keep as multi-line, if there is a newline between the opening brace and first property.
+  collapse   Fit to a single line when possible.
+
+Default: preserve"
+`;
+
+exports[`show detailed usage with --help object-wrapping (write) 1`] = `[]`;
 
 exports[`show detailed usage with --help parser (stderr) 1`] = `""`;
 

--- a/tests/integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/help-options.js.snap
@@ -418,10 +418,10 @@ exports[`show detailed usage with --help no-semi (stdout) 1`] = `
 
 exports[`show detailed usage with --help no-semi (write) 1`] = `[]`;
 
-exports[`show detailed usage with --help object-wrapping (stderr) 1`] = `""`;
+exports[`show detailed usage with --help object-wrap (stderr) 1`] = `""`;
 
-exports[`show detailed usage with --help object-wrapping (stdout) 1`] = `
-"--object-wrapping <preserve|collapse>
+exports[`show detailed usage with --help object-wrap (stdout) 1`] = `
+"--object-wrap <preserve|collapse>
 
   How to wrap object literals.
 
@@ -433,7 +433,7 @@ Valid options:
 Default: preserve"
 `;
 
-exports[`show detailed usage with --help object-wrapping (write) 1`] = `[]`;
+exports[`show detailed usage with --help object-wrap (write) 1`] = `[]`;
 
 exports[`show detailed usage with --help parser (stderr) 1`] = `""`;
 

--- a/tests/integration/__tests__/__snapshots__/help-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/help-options.js.snap
@@ -348,6 +348,23 @@ Default: log"
 
 exports[`show detailed usage with --help log-level (write) 1`] = `[]`;
 
+exports[`show detailed usage with --help multiline-object (stderr) 1`] = `""`;
+
+exports[`show detailed usage with --help multiline-object (stdout) 1`] = `
+"--multiline-object <preserve|collapse>
+
+  Allow multi-line objects to collapse to a single line.
+
+Valid options:
+
+  preserve   Keep as multi-line, if there is a newline between the opening brace and first property.
+  collapse   Fit to a single line when possible.
+
+Default: preserve"
+`;
+
+exports[`show detailed usage with --help multiline-object (write) 1`] = `[]`;
+
 exports[`show detailed usage with --help no-bracket-spacing (stderr) 1`] = `""`;
 
 exports[`show detailed usage with --help no-bracket-spacing (stdout) 1`] = `

--- a/tests/integration/__tests__/__snapshots__/plugin-options-string.js.snap
+++ b/tests/integration/__tests__/__snapshots__/plugin-options-string.js.snap
@@ -17,7 +17,7 @@ exports[`show external options with \`--help\` 1`] = `
 - First value
 + Second value
 
-@@ -27,16 +27,18 @@
+@@ -27,19 +27,21 @@
     --experimental-operator-position <start|end>
                              Where to print operators when binary expressions wrap lines.
                              Defaults to end.
@@ -30,6 +30,9 @@ exports[`show external options with \`--help\` 1`] = `
                              Defaults to css.
     --jsx-single-quote       Use single quotes in JSX.
                              Defaults to false.
+    --multiline-object <preserve|collapse>
+                             Allow multi-line objects to collapse to a single line.
+                             Defaults to preserve.
 -   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|jsonc|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
 +   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|jsonc|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc|foo-parser>
                              Which parser to use.

--- a/tests/integration/__tests__/__snapshots__/plugin-options-string.js.snap
+++ b/tests/integration/__tests__/__snapshots__/plugin-options-string.js.snap
@@ -30,7 +30,7 @@ exports[`show external options with \`--help\` 1`] = `
                              Defaults to css.
     --jsx-single-quote       Use single quotes in JSX.
                              Defaults to false.
-    --object-wrapping <preserve|collapse>
+    --object-wrap <preserve|collapse>
                              How to wrap object literals.
                              Defaults to preserve.
 -   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|jsonc|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>

--- a/tests/integration/__tests__/__snapshots__/plugin-options-string.js.snap
+++ b/tests/integration/__tests__/__snapshots__/plugin-options-string.js.snap
@@ -30,8 +30,8 @@ exports[`show external options with \`--help\` 1`] = `
                              Defaults to css.
     --jsx-single-quote       Use single quotes in JSX.
                              Defaults to false.
-    --multiline-object <preserve|collapse>
-                             Allow multi-line objects to collapse to a single line.
+    --object-wrapping <preserve|collapse>
+                             How to wrap object literals.
                              Defaults to preserve.
 -   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|jsonc|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
 +   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|jsonc|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc|foo-parser>

--- a/tests/integration/__tests__/__snapshots__/plugin-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/plugin-options.js.snap
@@ -73,8 +73,8 @@ exports[`show external options with \`--help\` 1`] = `
                              Defaults to css.
     --jsx-single-quote       Use single quotes in JSX.
                              Defaults to false.
-    --multiline-object <preserve|collapse>
-                             Allow multi-line objects to collapse to a single line.
+    --object-wrapping <preserve|collapse>
+                             How to wrap object literals.
                              Defaults to preserve.
 -   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|jsonc|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
 +   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|jsonc|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc|foo-parser>

--- a/tests/integration/__tests__/__snapshots__/plugin-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/plugin-options.js.snap
@@ -60,7 +60,7 @@ exports[`show external options with \`--help\` 1`] = `
 - First value
 + Second value
 
-@@ -27,16 +27,18 @@
+@@ -27,19 +27,21 @@
     --experimental-operator-position <start|end>
                              Where to print operators when binary expressions wrap lines.
                              Defaults to end.
@@ -73,6 +73,9 @@ exports[`show external options with \`--help\` 1`] = `
                              Defaults to css.
     --jsx-single-quote       Use single quotes in JSX.
                              Defaults to false.
+    --multiline-object <preserve|collapse>
+                             Allow multi-line objects to collapse to a single line.
+                             Defaults to preserve.
 -   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|jsonc|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>
 +   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|jsonc|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc|foo-parser>
                              Which parser to use.

--- a/tests/integration/__tests__/__snapshots__/plugin-options.js.snap
+++ b/tests/integration/__tests__/__snapshots__/plugin-options.js.snap
@@ -73,7 +73,7 @@ exports[`show external options with \`--help\` 1`] = `
                              Defaults to css.
     --jsx-single-quote       Use single quotes in JSX.
                              Defaults to false.
-    --object-wrapping <preserve|collapse>
+    --object-wrap <preserve|collapse>
                              How to wrap object literals.
                              Defaults to preserve.
 -   --parser <flow|babel|babel-flow|babel-ts|typescript|acorn|espree|meriyah|css|less|scss|json|json5|jsonc|json-stringify|graphql|markdown|mdx|vue|yaml|glimmer|html|angular|lwc>

--- a/tests/integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests/integration/__tests__/__snapshots__/schema.js.snap
@@ -151,7 +151,7 @@ exports[`schema 1`] = `
           "description": "Use single quotes in JSX.",
           "type": "boolean",
         },
-        "objectWrapping": {
+        "objectWrap": {
           "default": "preserve",
           "description": "How to wrap object literals.",
           "oneOf": [

--- a/tests/integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests/integration/__tests__/__snapshots__/schema.js.snap
@@ -151,9 +151,9 @@ exports[`schema 1`] = `
           "description": "Use single quotes in JSX.",
           "type": "boolean",
         },
-        "multilineObject": {
+        "objectWrapping": {
           "default": "preserve",
-          "description": "Allow multi-line objects to collapse to a single line.",
+          "description": "How to wrap object literals.",
           "oneOf": [
             {
               "description": "Keep as multi-line, if there is a newline between the opening brace and first property.",

--- a/tests/integration/__tests__/__snapshots__/schema.js.snap
+++ b/tests/integration/__tests__/__snapshots__/schema.js.snap
@@ -151,6 +151,24 @@ exports[`schema 1`] = `
           "description": "Use single quotes in JSX.",
           "type": "boolean",
         },
+        "multilineObject": {
+          "default": "preserve",
+          "description": "Allow multi-line objects to collapse to a single line.",
+          "oneOf": [
+            {
+              "description": "Keep as multi-line, if there is a newline between the opening brace and first property.",
+              "enum": [
+                "preserve",
+              ],
+            },
+            {
+              "description": "Fit to a single line when possible.",
+              "enum": [
+                "collapse",
+              ],
+            },
+          ],
+        },
         "parser": {
           "anyOf": [
             {

--- a/tests/integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests/integration/__tests__/__snapshots__/support-info.js.snap
@@ -163,6 +163,14 @@ exports[`API getSupportInfo() 1`] = `
       "default": false,
       "type": "boolean",
     },
+    "multilineObject": {
+      "choices": [
+        "preserve",
+        "collapse",
+      ],
+      "default": "preserve",
+      "type": "choice",
+    },
     "parser": {
       "choices": [
         "flow",
@@ -926,6 +934,24 @@ exports[`CLI --support-info (stdout) 1`] = `
       "name": "jsxSingleQuote",
       "pluginDefaults": {},
       "type": "boolean"
+    },
+    {
+      "category": "Common",
+      "choices": [
+        {
+          "description": "Keep as multi-line, if there is a newline between the opening brace and first property.",
+          "value": "preserve"
+        },
+        {
+          "description": "Fit to a single line when possible.",
+          "value": "collapse"
+        }
+      ],
+      "default": "preserve",
+      "description": "Allow multi-line objects to collapse to a single line.",
+      "name": "multilineObject",
+      "pluginDefaults": {},
+      "type": "choice"
     },
     {
       "category": "Global",

--- a/tests/integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests/integration/__tests__/__snapshots__/support-info.js.snap
@@ -163,7 +163,7 @@ exports[`API getSupportInfo() 1`] = `
       "default": false,
       "type": "boolean",
     },
-    "objectWrapping": {
+    "objectWrap": {
       "choices": [
         "preserve",
         "collapse",
@@ -949,7 +949,7 @@ exports[`CLI --support-info (stdout) 1`] = `
       ],
       "default": "preserve",
       "description": "How to wrap object literals.",
-      "name": "objectWrapping",
+      "name": "objectWrap",
       "pluginDefaults": {},
       "type": "choice"
     },

--- a/tests/integration/__tests__/__snapshots__/support-info.js.snap
+++ b/tests/integration/__tests__/__snapshots__/support-info.js.snap
@@ -163,7 +163,7 @@ exports[`API getSupportInfo() 1`] = `
       "default": false,
       "type": "boolean",
     },
-    "multilineObject": {
+    "objectWrapping": {
       "choices": [
         "preserve",
         "collapse",
@@ -948,8 +948,8 @@ exports[`CLI --support-info (stdout) 1`] = `
         }
       ],
       "default": "preserve",
-      "description": "Allow multi-line objects to collapse to a single line.",
-      "name": "multilineObject",
+      "description": "How to wrap object literals.",
+      "name": "objectWrapping",
       "pluginDefaults": {},
       "type": "choice"
     },

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -36,6 +36,7 @@ const ENABLED_OPTIONS = [
   "singleQuote",
   "bracketSpacing",
   "jsxSingleQuote",
+  "multilineObject",
   "quoteProps",
   "arrowParens",
   "trailingComma",

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -36,7 +36,7 @@ const ENABLED_OPTIONS = [
   "singleQuote",
   "bracketSpacing",
   "jsxSingleQuote",
-  "objectWrapping",
+  "objectWrap",
   "quoteProps",
   "arrowParens",
   "trailingComma",

--- a/website/playground/Playground.js
+++ b/website/playground/Playground.js
@@ -36,7 +36,7 @@ const ENABLED_OPTIONS = [
   "singleQuote",
   "bracketSpacing",
   "jsxSingleQuote",
-  "multilineObject",
+  "objectWrapping",
   "quoteProps",
   "arrowParens",
   "trailingComma",


### PR DESCRIPTION
## Description

Implement `multilineObject` config option to control how multi-line JavaScript objects are formatted.

### Choices

#### "preserve"

This is the default. Objects are kept on multiple lines if there is a newline between the opening brace and the first property key. (I.e. the existing behavior of Prettier.)

#### "collapse"

Objects ignore whitespace-only formatting from the source, and are collapsed to a single line when possible.

### Examples

<details>
<summary>Input</summary>

```js
const obj1 = {
  name1: "value1",
  name2: "value2",
};

const obj2 = {
  name1: "value1", name2: "value2",
};

const obj3 = {
  name1: "value1",
  name2: "value2", };

const obj4 = { name1: "value1",
  name2: "value2",
};

const obj5 = { name1: "value1", name2: "value2", };
```
</details>

<details>
<summary>"preserve"</summary>

```js
const obj1 = {
  name1: "value1",
  name2: "value2",
};

const obj2 = {
  name1: "value1",
  name2: "value2",
};

const obj3 = {
  name1: "value1",
  name2: "value2",
};

const obj4 = { name1: "value1", name2: "value2" };

const obj5 = { name1: "value1", name2: "value2" };
```
</details>

<details>
<summary>"collapse"</summary>

```js
const obj1 = { name1: "value1", name2: "value2" };

const obj2 = { name1: "value1", name2: "value2" };

const obj3 = { name1: "value1", name2: "value2" };

const obj4 = { name1: "value1", name2: "value2" };

const obj5 = { name1: "value1", name2: "value2" };
```
</details>

## Motivation

> By far the biggest reason for adopting Prettier is to stop all the ongoing debates over styles.
>
> https://prettier.io/docs/en/why-prettier

John submits a PR:

```js
const buttonStyles = { background: "#45da09", borderRadius: "4px" };
```

Jessica submits a PR:

```js
const buttonStyles = {
  background: "#45da09",
  borderRadius: "4px"
};
```

Prettier fails to prevent these two contributors from quibbling over the style. The project must publish a style guide to resolve the syntax debate of where and when to use multi-line objects. Moreover, to follow that guide for the single-line object cases, reviewers must now measure characters to see if the object can fit on a single-line without violating line length rules. (Which by itself is a complex task.)

This debate can be settled by using `--multiline-object=collapse`.

The pain of the above situation has been felt by many, many users who expect Prettier to solve this stylistic variation, and is a perennial source of consternation marked by complaints of "instability" and "inconsistency":

* #2068
* #2685 
* #5170
* #5249
* #5803 
* #6424 
* #6596 
* #7794
* #10757 
* #11429 
* #12541 
* #14367
* #11856.

However, the original justifications for the semi-manual formatting still apply. Even though there are many who prefer to Prettier to be opinionated (including myself), it is a non-starter to impose whitespace agnostic object formatting on all Prettier users.

Thus, this change is the only path forward.

## *Aren't we not supposed to add options?*

Normally yes, but this option fundamentally differs from the usual proposals.

### 1. This option makes Prettier *more opinionated*, not less.

Normally, options are eschewed because they contradict Prettier's purpose to be an opinionated formatter.

But today, the single-line vs multi-line is configured not project-by-project, not even file-by-file, but object-literal-by-object-literal. That's literally the most flexibility/least opinionated possible. This change allows users to reign in that flexibility.

Unlike other proposals for adding options, this *does not change the variety of styles that Prettier outputs.* It simply changes how those styles are configured (project-wide vs line-by-line).

### 2. The current behavior is "not a feature"

> The semi-manual formatting for object literals is in fact a workaround, not a feature.
>
> https://prettier.io/docs/en/rationale.html#%EF%B8%8F-a-note-on-formatting-reversibility

This option allows users to opt out of this non-feature workaround.

### 3. Non-reversibility is significantly undesirable

> What does reversible mean? Once an object literal becomes multiline, Prettier won’t collapse it back. If in Prettier-formatted code, we add a property to an object literal, run Prettier, then change our mind, remove the added property, and then run Prettier again, we might end up with a formatting not identical to the initial one. This useless change might even get included in a commit, which is exactly the kind of situation Prettier was created to prevent.
>
> https://prettier.io/docs/en/rationale.html#%EF%B8%8F-a-note-on-formatting-reversibility

This option allows users to make Prettier a reversible formatter.

### 4. Prettier maintainers have invited this change

https://github.com/prettier/prettier/issues/2068#issuecomment-910201889

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [X] I’ve added tests to confirm my change works.
- [X] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [X] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**