### PR TITLE
chore: fix some typos in comments

### DIFF
--- a/website/blog/2017-04-13-1.0.0.md
+++ b/website/blog/2017-04-13-1.0.0.md
@@ -877,7 +877,7 @@ function f(
 ```ts
 // Before
 type UploadState<E, EM, D> =
-  // The upload hasnt begun yet
+  // The upload hasn't begun yet
   | A
   | // The upload timed out
   B
@@ -886,7 +886,7 @@ type UploadState<E, EM, D> =
 
 // After
 type UploadState<E, EM, D> =
-  // The upload hasnt begun yet
+  // The upload hasn't begun yet
   | A
   // The upload timed out
   | B

--- a/website/blog/2018-02-26-1.11.0.md
+++ b/website/blog/2018-02-26-1.11.0.md
@@ -1077,7 +1077,7 @@ This was not intended to be allowed, and has been reverted (in this case, you wo
 
 #### Respect EditorConfig when `--config` is passed ([#3992] by [@josephfrazier])
 
-This is a minor change to the the way `.editorconfig` files are handled. Previously when `--config` was provided, `.editorconfig` was ignored.
+This is a minor change to the way `.editorconfig` files are handled. Previously when `--config` was provided, `.editorconfig` was ignored.
 
 ---
 

--- a/website/blog/2020-03-21-2.0.0.md
+++ b/website/blog/2020-03-21-2.0.0.md
@@ -754,7 +754,7 @@ type A = { [key in B] };
 
 #### Fix edge cases of printing index signatures ([#7228](https://github.com/prettier/prettier/pull/7228) by [@cola119](https://github.com/cola119))
 
-Even though index signatures without type annotations or with multiple parameters aren't valid TypeScript, the TypeScript parser supports this syntax. In line with the [previous error recovery efforts](https://prettier.io/blog/2019/11/09/1.19.0.html#enable-formatting-even-if-there-are-parse-errors-in-some-cases-6816-by-thorn0-and-the-babel-team), Prettier now makes sure its output still can be parsed in these cases. Previous versions produced unparseable code.
+Even though index signatures without type annotations or with multiple parameters aren't valid TypeScript, the TypeScript parser supports this syntax. In line with the [previous error recovery efforts](https://prettier.io/blog/2019/11/09/1.19.0.html#enable-formatting-even-if-there-are-parse-errors-in-some-cases-6816-by-thorn0-and-the-babel-team), Prettier now makes sure its output still can be parsed in these cases. Previous versions produced unparsable code.
 
 <!-- prettier-ignore -->
 ```ts

--- a/website/blog/2020-08-24-2.1.0.md
+++ b/website/blog/2020-08-24-2.1.0.md
@@ -512,7 +512,7 @@ SyntaxError: Unexpected token (1:1)
 // Prettier 2.0
 <div/> < 5;
 
-// Prettier 2.0 second outout
+// Prettier 2.0 second output
 SyntaxError: Adjacent JSX elements must be wrapped in an enclosing tag. Did you want a JSX fragment <>...</>? (1:9)
 > 1 | <div /> < 5;
     |         ^


### PR DESCRIPTION
## Description

 fix some typos in comments

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
