### PR TITLE
docs: `getValue()` replaced with `node`

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -202,7 +202,7 @@ function print(
 
 The `print` function is passed the following parameters:
 
-- **`path`**: An object, which can be used to access nodes in the AST. It’s a stack-like data structure that maintains the current state of the recursion. It is called “path” because it represents the path to the current node from the root of the AST. The current node is returned by `path.getValue()`.
+- **`path`**: An object, which can be used to access nodes in the AST. It’s a stack-like data structure that maintains the current state of the recursion. It is called “path” because it represents the path to the current node from the root of the AST. The current node is returned by `path.node`.
 - **`options`**: A persistent object, which contains global options and which a plugin may mutate to store contextual data.
 - **`print`**: A callback for printing sub-nodes. This function contains the core printing logic that consists of steps whose implementation is provided by plugins. In particular, it calls the printer’s `print` function and passes itself to it. Thus, the two `print` functions – the one from the core and the one from the plugin – call each other while descending down the AST recursively.
 
@@ -214,7 +214,7 @@ import { doc } from "prettier";
 const { group, indent, join, line, softline } = doc.builders;
 
 function print(path, options, print) {
-  const node = path.getValue();
+  const node = path.node;
 
   switch (node.type) {
     case "list":
@@ -281,7 +281,7 @@ For example, a plugin that has nodes with embedded JavaScript might have the fol
 
 ```js
 function embed(path, options) {
-  const node = path.getValue();
+  const node = path.node;
   if (node.type === "javascript") {
     return async (textToDoc) => {
       return [


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
`getValue` function is deprecated.

https://github.com/prettier/prettier/blob/1264a4cdfe11f1c5b5ea6968fedebcb3747ca759/src/index.d.ts#L110-L113

However, [the plugin documentation](https://prettier.io/docs/en/plugins) still uses `getValue` function.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
