### PR TITLE
Remove pre-commit from precommit.md

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -19,22 +19,7 @@ This will install [husky](https://github.com/typicode/husky) and [lint-staged](h
 
 Read more at the [lint-staged](https://github.com/okonet/lint-staged#configuration) repo.
 
-## Option 2. [pre-commit](https://github.com/pre-commit/pre-commit)
-
-**Use Case:** Great when working with multi-language projects.
-
-Copy the following config into your `.pre-commit-config.yaml` file:
-
-```yaml
-- repo: https://github.com/pre-commit/mirrors-prettier
-  rev: "" # Use the sha or tag you want to point at
-  hooks:
-    - id: prettier
-```
-
-Read more at [mirror of prettier package for pre-commit](https://github.com/pre-commit/mirrors-prettier) and the [pre-commit](https://pre-commit.com) website.
-
-## Option 3. [Husky.Net](https://github.com/alirezanet/Husky.Net)
+## Option 2. [Husky.Net](https://github.com/alirezanet/Husky.Net)
 
 **Use Case:** A dotnet solution to use Prettier along with other code quality tools (e.g. dotnet-format, ESLint, Stylelint, etc.). It supports multiple file states (staged - last-commit, git-files etc.)
 
@@ -55,7 +40,7 @@ after installation you can add prettier task to the `task-runner.json`.
 }
 ```
 
-## Option 4. [git-format-staged](https://github.com/hallettj/git-format-staged)
+## Option 3. [git-format-staged](https://github.com/hallettj/git-format-staged)
 
 **Use Case:** Great for when you want to format partially-staged files, and other options do not provide a good fit for your project.
 
@@ -107,7 +92,7 @@ Add or remove file extensions to suit your project. Note that regardless of whic
 
 To read about how git-format-staged works see [Automatic Code Formatting for Partially-Staged Files](https://www.olioapps.com/blog/automatic-code-formatting/).
 
-## Option 5. Shell script
+## Option 4. Shell script
 
 Alternately you can save this script as `.git/hooks/pre-commit` and give it execute permission:
 


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Pre-commit has [archived the prettier package](https://github.com/pre-commit/mirrors-prettier) with the following comment:

> prettier made some changes that breaks plugins entirely

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
