### PR TITLE
docs: Use git add -z and xargs -0 in pre-commit script

### DIFF
--- a/docs/precommit.md
+++ b/docs/precommit.md
@@ -98,14 +98,14 @@ Alternately you can save this script as `.git/hooks/pre-commit` and give it exec
 
 ```sh
 #!/bin/sh
-FILES=$(git diff --cached --name-only --diff-filter=ACMR | sed 's| |\\ |g')
+FILES=$(git diff --cached --name-only --diff-filter=ACMR -z)
 [ -z "$FILES" ] && exit 0
 
 # Prettify all selected files
-echo "$FILES" | xargs ./node_modules/.bin/prettier --ignore-unknown --write
+echo "$FILES" | xargs -0 ./node_modules/.bin/prettier --ignore-unknown --write --
 
 # Add back the modified/prettified files to staging
-echo "$FILES" | xargs git add
+echo "$FILES" | xargs -0 git add --
 
 exit 0
 ```


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
git-add(1) accepts a [`-z` flag] that makes it use NUL characters as pathname separators instead of newlines.
This is suitable with the `-0` flag of xargs(1), and escaping spaces with sed is no longer needed. I also added the `--` flag to both git-add and prettier, to indicate the end of options and the start of input files.

[`-z` flag]: https://git-scm.com/docs/git-diff#Documentation/git-diff.txt--z

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
