### PR TITLE
Use `matchDepNames` instead of `matchPackageNames` in renovate.json5

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,7 +9,7 @@
   prConcurrentLimit: 0,
   packageRules: [
     {
-      matchPackageNames: ["react", "react-dom"],
+      matchDepNames: ["react", "react-dom"],
       groupName: "react",
     },
     {
@@ -25,7 +25,7 @@
       groupName: "glimmer",
     },
     {
-      matchPackageNames: [
+      matchDepNames: [
         "eslint",
         "@eslint/eslintrc",
         "@eslint/js",
@@ -42,7 +42,7 @@
       groupName: "ESLint related dependencies",
     },
     {
-      matchPackageNames: ["@angular/compiler", "angular-estree-parser"],
+      matchDepNames: ["@angular/compiler", "angular-estree-parser"],
       groupName: "Angular Estree",
     },
     {


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Fix warning in 15461

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
