### PR TITLE
Always enable `recordAndTuple`

### DIFF
--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -50,13 +50,11 @@ const parseOptions = {
     "sourcePhaseImports",
     "deferredImportEvaluation",
     ["optionalChainingAssign", { version: "2023-07" }],
+    "recordAndTuple",
   ],
   tokens: true,
   ranges: true,
 };
-
-/** @type {ParserPlugin} */
-const recordAndTuplePlugin = ["recordAndTuple", { syntaxType: "hash" }];
 
 /** @type {ParserPlugin} */
 const v8intrinsicPlugin = "v8intrinsic";
@@ -124,12 +122,6 @@ function createParse({ isExpression = false, optionsCombinations }) {
         ...options,
         sourceType: "script",
       }));
-    }
-
-    if (/#[[{]/.test(text)) {
-      combinations = combinations.map((options) =>
-        appendPlugins([recordAndTuplePlugin], options),
-      );
     }
 
     const shouldEnableV8intrinsicPlugin = /%[A-Z]/.test(text);

--- a/tests/format/misc/errors/js/__snapshots__/format.test.js.snap
+++ b/tests/format/misc/errors/js/__snapshots__/format.test.js.snap
@@ -159,10 +159,10 @@ Cause: Unexpected token (1:6)"
 `;
 
 exports[`snippet: #9 [babel] format 1`] = `
-"Unexpected token (1:2)
+"Tuple expressions starting with '[|' are only allowed when the 'syntaxType' option of the 'recordAndTuple' plugin is set to 'bar'. (1:1)
 > 1 | [| 1 |]
-    |  ^
-Cause: Unexpected token (1:1)"
+    | ^
+Cause: Tuple expressions starting with '[|' are only allowed when the 'syntaxType' option of the 'recordAndTuple' plugin is set to 'bar'. (1:0)"
 `;
 
 exports[`snippet: #10 [babel] format 1`] = `


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Always enable `recordAndTuple` plugin, but removed `syntaxType` https://github.com/babel/babel/pull/16458

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
