### PR TITLE
Flow: add support for inexact tuple types

### DIFF
--- a/changelog_unreleased/flow/16271.md
+++ b/changelog_unreleased/flow/16271.md
@@ -1,0 +1,15 @@
+#### Support Flow's inexact tuple types (#16271 by @gkz)
+
+Adds support for Flow's inexact tuple types.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+type T = [number, ...];
+
+// Prettier stable
+type T = [number];
+
+// Prettier main
+type T = [number, ...];
+```

--- a/tests/format/flow/tuples/__snapshots__/format.test.js.snap
+++ b/tests/format/flow/tuples/__snapshots__/format.test.js.snap
@@ -1,5 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`inexact.js [babel-flow] format 1`] = `
+"Unexpected token (1:15)
+> 1 | type Empty = [...];
+    |               ^
+  2 |
+  3 | type One = [number, ...];
+  4 |
+Cause: Unexpected token (1:14)"
+`;
+
+exports[`inexact.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+type Empty = [...];
+
+type One = [number, ...];
+
+=====================================output=====================================
+type Empty = [...];
+
+type One = [number, ...];
+
+================================================================================
+`;
+
 exports[`labeled.js [babel-flow] format 1`] = `
 "Unexpected token, expected "," (1:12)
 > 1 | type T = [a: string, b: number];

--- a/tests/format/flow/tuples/inexact.js
+++ b/tests/format/flow/tuples/inexact.js
@@ -1,0 +1,3 @@
+type Empty = [...];
+
+type One = [number, ...];


### PR DESCRIPTION
## Description

Inexact tuple types are like inexact object types - they have a trailing `...` in their element list, e.g. `type T = [number, ...]`.

If you have an idea of a better way to add support for this within `print/array.js` let me know.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
