### PR TITLE
Flow: add support for 'implies' type guard variant

### DIFF
--- a/changelog_unreleased/flow/16272.md
+++ b/changelog_unreleased/flow/16272.md
@@ -1,0 +1,15 @@
+#### Support Flow's 'implies' type guard variant (#16272 by @gkz)
+
+Adds support for Flow's `implies` type guard variant. Also updates the `flow-parser` dependency.
+
+<!-- prettier-ignore -->
+```jsx
+// Input
+declare function f(x: mixed): implies x is T;
+
+// Prettier stable
+// error
+
+// Prettier main
+declare function f(x: mixed): implies x is T;
+```

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "fast-json-stable-stringify": "2.1.0",
     "file-entry-cache": "7.0.2",
     "find-cache-dir": "5.0.0",
-    "flow-parser": "0.235.1",
+    "flow-parser": "0.236.0",
     "get-east-asian-width": "1.2.0",
     "get-stdin": "9.0.0",
     "graphql": "16.8.1",

--- a/src/language-js/print/type-annotation.js
+++ b/src/language-js/print/type-annotation.js
@@ -553,10 +553,20 @@ function printTypeQuery({ node }, print) {
   return ["typeof ", print(argumentPropertyName), print(typeArgsPropertyName)];
 }
 
+/*
+- `TSTypePredicate`
+- `TypePredicate`
+*/
 function printTypePredicate(path, print) {
   const { node } = path;
+  const prefix =
+    node.type === "TSTypePredicate" && node.asserts
+      ? "asserts "
+      : node.type === "TypePredicate" && node.kind
+        ? `${node.kind} `
+        : "";
   return [
-    node.asserts ? "asserts " : "",
+    prefix,
     print("parameterName"),
     node.typeAnnotation
       ? [" is ", printTypeAnnotationProperty(path, print)]

--- a/src/language-js/print/type-annotation.js
+++ b/src/language-js/print/type-annotation.js
@@ -542,8 +542,8 @@ function printArrayType(print) {
 }
 
 /*
-- `TSTypeQuery`
-- `TypeofTypeAnnotation`
+- `TSTypeQuery` (TypeScript)
+- `TypeofTypeAnnotation` (flow)
 */
 function printTypeQuery({ node }, print) {
   const argumentPropertyName =
@@ -554,8 +554,8 @@ function printTypeQuery({ node }, print) {
 }
 
 /*
-- `TSTypePredicate`
-- `TypePredicate`
+- `TSTypePredicate` (TypeScript)
+- `TypePredicate` (flow)
 */
 function printTypePredicate(path, print) {
   const { node } = path;

--- a/tests/format/flow/type-guards/__snapshots__/format.test.js.snap
+++ b/tests/format/flow/type-guards/__snapshots__/format.test.js.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test.js [babel-flow] format 1`] = `
+"Missing semicolon. (1:36)
+> 1 | declare function basic(x: mixed): x is string;
+    |                                    ^
+  2 |
+  3 | declare function asserts(x: mixed): asserts x is string;
+  4 |
+Cause: Missing semicolon. (1:35)"
+`;
+
+exports[`test.js format 1`] = `
+====================================options=====================================
+parsers: ["flow"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+declare function basic(x: mixed): x is string;
+
+declare function asserts(x: mixed): asserts x is string;
+
+declare function implies(x: mixed): implies x is string;
+
+=====================================output=====================================
+declare function basic(x: mixed): x is string;
+
+declare function asserts(x: mixed): asserts x is string;
+
+declare function implies(x: mixed): implies x is string;
+
+================================================================================
+`;

--- a/tests/format/flow/type-guards/format.test.js
+++ b/tests/format/flow/type-guards/format.test.js
@@ -1,0 +1,5 @@
+runFormatTest(import.meta, ["flow"], {
+  errors: {
+    "babel-flow": ["test.js"],
+  },
+});

--- a/tests/format/flow/type-guards/test.js
+++ b/tests/format/flow/type-guards/test.js
@@ -1,0 +1,5 @@
+declare function basic(x: mixed): x is string;
+
+declare function asserts(x: mixed): asserts x is string;
+
+declare function implies(x: mixed): implies x is string;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4430,10 +4430,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"flow-parser@npm:0.235.1":
-  version: 0.235.1
-  resolution: "flow-parser@npm:0.235.1"
-  checksum: 10/2c158e940deb2f3312dc91fe0890118295c6dc4823930cf18039bc6facd434504008a7b914a5a5be2f4d30274e0b31f8621d05417e5e4579e4df1f3fdd7cc949
+"flow-parser@npm:0.236.0":
+  version: 0.236.0
+  resolution: "flow-parser@npm:0.236.0"
+  checksum: 10/b556cbe0450659676be80d494f581d11c7e5d83f4a1ae83f28975548c01455aaf06addcd364a1cde427757e4a6f1e373b298acb393bf99dcfdb4f85a3c07b078
   languageName: node
   linkType: hard
 
@@ -7445,7 +7445,7 @@ __metadata:
     fast-json-stable-stringify: "npm:2.1.0"
     file-entry-cache: "npm:7.0.2"
     find-cache-dir: "npm:5.0.0"
-    flow-parser: "npm:0.235.1"
+    flow-parser: "npm:0.236.0"
     get-east-asian-width: "npm:1.2.0"
     get-stdin: "npm:9.0.0"
     graphql: "npm:16.8.1"


### PR DESCRIPTION
## Description

Adds support for Flow's `implies x is T` type guards, along with the basic one and the asserts varient. 

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
