### PR TITLE
feat: support `.prettierrc.jsonc`

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@ You can configure Prettier via (in order of precedence):
 
 - A `"prettier"` key in your `package.json`, or [`package.yaml`](https://github.com/pnpm/pnpm/pull/1799) file.
 - A `.prettierrc` file written in JSON or YAML.
-- A `.prettierrc.json`, `.prettierrc.yml`, `.prettierrc.yaml`, or `.prettierrc.json5` file.
+- A `.prettierrc.json`, `.prettierrc.yml`, `.prettierrc.yaml`, `.prettierrc.json5`, or `.prettierrc.jsonc` file.
 - A `.prettierrc.js`, or `prettier.config.js` file that exports an object using `export default` or `module.exports` (depends on the [`type`](https://nodejs.org/api/packages.html#type) value in your `package.json`).
 - A `.prettierrc.mjs`, or `prettier.config.mjs` file that exports an object using `export default`.
 - A `.prettierrc.cjs`, or `prettier.config.cjs` file that exports an object using `module.exports`.

--- a/src/config/prettier-config/config-searcher.js
+++ b/src/config/prettier-config/config-searcher.js
@@ -13,6 +13,7 @@ const CONFIG_FILE_NAMES = [
   ".prettierrc.yaml",
   ".prettierrc.yml",
   ".prettierrc.json5",
+  ".prettierrc.jsonc",
   ".prettierrc.js",
   ".prettierrc.mjs",
   ".prettierrc.cjs",

--- a/src/config/prettier-config/loaders.js
+++ b/src/config/prettier-config/loaders.js
@@ -42,6 +42,16 @@ async function loadYaml(file) {
   }
 }
 
+async function loadJson5(file) {
+  const content = await readFile(file);
+  try {
+    return json5.parse(content);
+  } catch (/** @type {any} */ error) {
+    error.message = `JSON5 Error in ${file}:\n${error.message}`;
+    throw error;
+  }
+}
+
 const loaders = {
   async ".toml"(file) {
     const content = await readFile(file);
@@ -52,16 +62,9 @@ const loaders = {
       throw error;
     }
   },
-  async ".json5"(file) {
-    const content = await readFile(file);
-    try {
-      return json5.parse(content);
-    } catch (/** @type {any} */ error) {
-      error.message = `JSON5 Error in ${file}:\n${error.message}`;
-      throw error;
-    }
-  },
+  ".json5": loadJson5,
   ".json": readJson,
+  ".jsonc": loadJson5,
   ".js": loadJs,
   ".mjs": loadJs,
   ".cjs": loadJs,

--- a/website/versioned_docs/version-stable/configuration.md
+++ b/website/versioned_docs/version-stable/configuration.md
@@ -8,7 +8,7 @@ You can configure Prettier via (in order of precedence):
 
 - A `"prettier"` key in your `package.json` file.
 - A `.prettierrc` file written in JSON or YAML.
-- A `.prettierrc.json`, `.prettierrc.yml`, `.prettierrc.yaml`, or `.prettierrc.json5` file.
+- A `.prettierrc.json`, `.prettierrc.yml`, `.prettierrc.yaml`, `.prettierrc.json5`, or `.prettierrc.jsonc` file.
 - A `.prettierrc.js`, or `prettier.config.js` file that exports an object using `export default` or `module.exports` (depends on the [`type`](https://nodejs.org/api/packages.html#type) value in your `package.json`).
 - A `.prettierrc.mjs`, or `prettier.config.mjs` file that exports an object using `export default`.
 - A `.prettierrc.cjs`, or `prettier.config.cjs` file that exports an object using `module.exports`.


### PR DESCRIPTION
## Description

Support `.prettierrc.jsonc` as a config file.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
