### PR TITLE
fix(docs): precommit.md pnpm husky init

### DIFF
--- a/website/versioned_docs/version-stable/precommit.md
+++ b/website/versioned_docs/version-stable/precommit.md
@@ -89,7 +89,7 @@ node --eval "fs.writeFileSync('.husky/pre-commit', 'git-format-staged -f \'prett
 <!--pnpm-->
 
 ```bash
-pnpm exec husky-init
+pnpm exec husky init
 pnpm add --save-dev git-format-staged
 node --eval "fs.writeFileSync('.husky/pre-commit', 'git-format-staged -f \'prettier --ignore-unknown --stdin --stdin-filepath \"{}\"\' .\n')"
 ```


### PR DESCRIPTION
## Description

`pnpm exec husky-init` should be `pnpm exec husky init` according to [official documentation](https://typicode.github.io/husky/get-started.html#husky-init-recommended)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
