### PR TITLE
Remove mention of `options.editorconfig` which does not exist.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -202,11 +202,11 @@ You can also switch to the `flow` parser instead of the default `babel` for .js 
 
 ## Configuration Schema
 
-If you’d like a JSON schema to validate your configuration, one is available here: https://json.schemastore.org/prettierrc.
+If you’d like a JSON schema to validate your configuration, one is available here: <https://json.schemastore.org/prettierrc>.
 
 ## EditorConfig
 
-If `options.editorconfig` is `true` and an [`.editorconfig` file](https://editorconfig.org/) is in your project, Prettier will parse it and convert its properties to the corresponding Prettier configuration. This configuration will be overridden by `.prettierrc`, etc.
+If a [`.editorconfig` file](https://editorconfig.org/) is in your project, Prettier will parse it and convert its properties to the corresponding Prettier configuration. This configuration will be overridden by `.prettierrc`, etc.
 
 Here’s an annotated description of how different properties map to Prettier’s behavior:
 


### PR DESCRIPTION
Resolves part of: https://github.com/prettier/prettier/issues/15255

## Description

Docs mention a `options.editorconfig` option that does not exist and merely confuses users.
