### PR TITLE
Fix handlebars path expressions starts with `@`

### DIFF
--- a/changelog_unreleased/handlebars/16358.md
+++ b/changelog_unreleased/handlebars/16358.md
@@ -1,40 +1,13 @@
-<!--
-
-1. Choose a folder based on which language your PR is for.
-
-   - For JavaScript, choose `javascript/` etc.
-   - For TypeScript specific syntax, choose `typescript/`.
-   - If your PR applies to multiple languages, such as TypeScript/Flow, choose one folder and mention which languages it applies to.
-
-2. In your chosen folder, create a file with your PR number: `XXXX.md`. For example: `typescript/6728.md`.
-
-3. Copy the content below and paste it in your new file.
-
-4. Fill in a title, the PR number and your user name.
-
-5. Optionally write a description. Many times it’s enough with just sample code.
-
-6. Change ```jsx to your language. For example, ```yaml.
-
-7. Change the `// Input` and `// Prettier` comments to the comment syntax of your language. For example, `# Input`.
-
-8. Choose some nice input example code. Paste it along with the output before and after your PR.
-
--->
-
-#### fix: changed head to node tail (#16358 by @Princeyadav05)
-
-<!-- Optional description if it makes sense. -->
-added node.tail to head for proper handing of handlebars
+#### Fix handlerbars path expressions starts with `@` (#16358 by @Princeyadav05)
 
 <!-- prettier-ignore -->
 ```hbs
 {{! Input }}
-(foo ?? baz) || baz;
+<div>{{@x.y.z}}</div>
 
 {{! Prettier stable }}
-foo ?? baz || baz;
+<div>{{@x}}</div>
 
 {{! Prettier main }}
-(foo ?? baz) || baz;
+<div>{{@x.y.z}}</div>
 ```

--- a/changelog_unreleased/handlebars/16358.md
+++ b/changelog_unreleased/handlebars/16358.md
@@ -1,4 +1,4 @@
-#### Fix handlerbars path expressions starts with `@` (#16358 by @Princeyadav05)
+#### Fix handlebars path expressions starts with `@` (#16358 by @Princeyadav05)
 
 <!-- prettier-ignore -->
 ```hbs

--- a/changelog_unreleased/handlebars/16358.md
+++ b/changelog_unreleased/handlebars/16358.md
@@ -1,0 +1,40 @@
+<!--
+
+1. Choose a folder based on which language your PR is for.
+
+   - For JavaScript, choose `javascript/` etc.
+   - For TypeScript specific syntax, choose `typescript/`.
+   - If your PR applies to multiple languages, such as TypeScript/Flow, choose one folder and mention which languages it applies to.
+
+2. In your chosen folder, create a file with your PR number: `XXXX.md`. For example: `typescript/6728.md`.
+
+3. Copy the content below and paste it in your new file.
+
+4. Fill in a title, the PR number and your user name.
+
+5. Optionally write a description. Many times it’s enough with just sample code.
+
+6. Change ```jsx to your language. For example, ```yaml.
+
+7. Change the `// Input` and `// Prettier` comments to the comment syntax of your language. For example, `# Input`.
+
+8. Choose some nice input example code. Paste it along with the output before and after your PR.
+
+-->
+
+#### fix: changed head to node tail (#16358 by @Princeyadav05)
+
+<!-- Optional description if it makes sense. -->
+added node.tail to head for proper handing of handlebars
+
+<!-- prettier-ignore -->
+```hbs
+{{! Input }}
+(foo ?? baz) || baz;
+
+{{! Prettier stable }}
+foo ?? baz || baz;
+
+{{! Prettier main }}
+(foo ?? baz) || baz;
+```

--- a/src/language-handlebars/clean.js
+++ b/src/language-handlebars/clean.js
@@ -28,9 +28,8 @@ function clean(original, cloned /*, parent*/) {
     delete cloned.params;
   }
 
-  // `class` is reformatted
-  if (original.type === "AttrNode" && original.name.toLowerCase() === "class") {
-    delete cloned.value;
+  if (original.type === "PathExpression") {
+    cloned.head = original.head.original;
   }
 }
 

--- a/src/language-handlebars/clean.js
+++ b/src/language-handlebars/clean.js
@@ -28,6 +28,11 @@ function clean(original, cloned /*, parent*/) {
     delete cloned.params;
   }
 
+  // `class` is reformatted
+  if (original.type === "AttrNode" && original.name.toLowerCase() === "class") {
+    delete cloned.value;
+  }
+
   if (original.type === "PathExpression") {
     cloned.head = original.head.original;
   }

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -793,7 +793,7 @@ const isPathExpressionPartNeedBrackets = (part, index) =>
   );
 function printPathExpression(node, print) {
   if (node.head.type === "AtHead") {
-    return print("head");
+    return print(node.tail);
   }
 
   if (node.tail.length === 0 && node.original.includes("/")) {

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -366,10 +366,7 @@ function print(path, options, print) {
       ];
     }
     case "PathExpression":
-      return printPathExpression(node, print);
-
-    case "AtHead":
-      return node.name;
+      return printPathExpression(node);
 
     case "BooleanLiteral":
       return String(node.value);
@@ -389,6 +386,7 @@ function print(path, options, print) {
     case "NullLiteral":
       return "null";
 
+    case "AtHead": // Handled in `printPathExpression`
     case "VarHead": // Handled in `printPathExpression`
     case "ThisHead": // Handled in `printPathExpression`
     default:
@@ -784,18 +782,21 @@ const PATH_EXPRESSION_FORBIDDEN_IN_FIRST_PART = new Set([
   "null",
   "undefined",
 ]);
-const isPathExpressionPartNeedBrackets = (part, index) =>
-  (index !== 0 && PATH_EXPRESSION_FORBIDDEN_IN_FIRST_PART.has(part)) ||
-  /\s/.test(part) ||
-  /^\d/.test(part) ||
-  Array.prototype.some.call(part, (character) =>
-    PATH_EXPRESSION_FORBIDDEN_CHARACTERS.has(character),
-  );
-function printPathExpression(node, print) {
-  if (node.head.type === "AtHead") {
-    return join(".", [print("head"), ...node.tail]);
+const isPathExpressionPartNeedBrackets = (part, index) => {
+  if (index === 0 && part.startsWith("@")) {
+    return false;
   }
 
+  return (
+    (index !== 0 && PATH_EXPRESSION_FORBIDDEN_IN_FIRST_PART.has(part)) ||
+    /\s/.test(part) ||
+    /^\d/.test(part) ||
+    Array.prototype.some.call(part, (character) =>
+      PATH_EXPRESSION_FORBIDDEN_CHARACTERS.has(character),
+    )
+  );
+};
+function printPathExpression(node) {
   if (node.tail.length === 0 && node.original.includes("/")) {
     // check if node has data, or
     // check if node is a legacy path expression (and leave it alone)

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -797,9 +797,8 @@ const isPathExpressionPartNeedBrackets = (part, index) => {
   );
 };
 function printPathExpression(node) {
+  // check if node is a legacy path expression and leave it alone
   if (node.tail.length === 0 && node.original.includes("/")) {
-    // check if node has data, or
-    // check if node is a legacy path expression (and leave it alone)
     return node.original;
   }
 

--- a/src/language-handlebars/printer-glimmer.js
+++ b/src/language-handlebars/printer-glimmer.js
@@ -793,7 +793,7 @@ const isPathExpressionPartNeedBrackets = (part, index) =>
   );
 function printPathExpression(node, print) {
   if (node.head.type === "AtHead") {
-    return print(node.tail);
+    return join(".", [print("head"), ...node.tail]);
   }
 
   if (node.tail.length === 0 && node.original.includes("/")) {

--- a/src/language-handlebars/visitor-keys.evaluate.js
+++ b/src/language-handlebars/visitor-keys.evaluate.js
@@ -1,11 +1,1 @@
-import { visitorKeys as glimmerVisitorKeys } from "@glimmer/syntax";
-
-const visitorKeys = {
-  VarHead: [],
-  ThisHead: [],
-  AtHead: [],
-  ...glimmerVisitorKeys,
-  PathExpression: [...glimmerVisitorKeys.PathExpression, "head"],
-};
-
-export default visitorKeys;
+export { visitorKeys as default } from "@glimmer/syntax";

--- a/tests/format/handlebars/path-expressions/__snapshots__/format.test.js.snap
+++ b/tests/format/handlebars/path-expressions/__snapshots__/format.test.js.snap
@@ -42,6 +42,7 @@ printWidth: 80
   {{array.2.[@#].[1]}}
   {{array.2.[a b]}}
   {{this.test}}
+  {{@x.y.z}}
   {{#if @foo}}
   {{/if}}
   <!-- legacy path format, which glimmer does not parse - we don't want to wrap with brackets -->
@@ -54,6 +55,7 @@ printWidth: 80
   {{array.[2].[@#].[1]}}
   {{array.[2].[a b]}}
   {{this.test}}
+  {{@x.y.z}}
   {{#if @foo}}{{/if}}
   <!-- legacy path format, which glimmer does not parse - we don't want to wrap with brackets -->
   {{foo/bar/baz ab=cd}}

--- a/tests/format/handlebars/path-expressions/__snapshots__/format.test.js.snap
+++ b/tests/format/handlebars/path-expressions/__snapshots__/format.test.js.snap
@@ -43,6 +43,9 @@ printWidth: 80
   {{array.2.[a b]}}
   {{this.test}}
   {{@x.y.z}}
+  {{@array.[true]}}
+  {{@array.2.[@#].[1]}}
+  {{@array.2.[a b]}}
   {{#if @foo}}
   {{/if}}
   <!-- legacy path format, which glimmer does not parse - we don't want to wrap with brackets -->
@@ -56,6 +59,9 @@ printWidth: 80
   {{array.[2].[a b]}}
   {{this.test}}
   {{@x.y.z}}
+  {{@array.[true]}}
+  {{@array.[2].[@#].[1]}}
+  {{@array.[2].[a b]}}
   {{#if @foo}}{{/if}}
   <!-- legacy path format, which glimmer does not parse - we don't want to wrap with brackets -->
   {{foo/bar/baz ab=cd}}

--- a/tests/format/handlebars/path-expressions/literal-expressions.hbs
+++ b/tests/format/handlebars/path-expressions/literal-expressions.hbs
@@ -4,6 +4,9 @@
   {{array.2.[a b]}}
   {{this.test}}
   {{@x.y.z}}
+  {{@array.[true]}}
+  {{@array.2.[@#].[1]}}
+  {{@array.2.[a b]}}
   {{#if @foo}}
   {{/if}}
   <!-- legacy path format, which glimmer does not parse - we don't want to wrap with brackets -->

--- a/tests/format/handlebars/path-expressions/literal-expressions.hbs
+++ b/tests/format/handlebars/path-expressions/literal-expressions.hbs
@@ -3,6 +3,7 @@
   {{array.2.[@#].[1]}}
   {{array.2.[a b]}}
   {{this.test}}
+  {{@x.y.z}}
   {{#if @foo}}
   {{/if}}
   <!-- legacy path format, which glimmer does not parse - we don't want to wrap with brackets -->

--- a/tests/unit/__snapshots__/visitor-keys.js.snap
+++ b/tests/unit/__snapshots__/visitor-keys.js.snap
@@ -1165,7 +1165,6 @@ exports[`visitor keys estree-json 1`] = `
 
 exports[`visitor keys glimmer 1`] = `
 {
-  "AtHead": [],
   "AttrNode": [
     "value",
   ],
@@ -1209,9 +1208,7 @@ exports[`visitor keys glimmer 1`] = `
   ],
   "NullLiteral": [],
   "NumberLiteral": [],
-  "PathExpression": [
-    "head",
-  ],
+  "PathExpression": [],
   "StringLiteral": [],
   "SubExpression": [
     "path",
@@ -1222,9 +1219,7 @@ exports[`visitor keys glimmer 1`] = `
     "body",
   ],
   "TextNode": [],
-  "ThisHead": [],
   "UndefinedLiteral": [],
-  "VarHead": [],
 }
 `;
 


### PR DESCRIPTION
## Description

Fixed #16356
Changed print('head') to print(node.tail) as mentioned in the comment: https://github.com/prettier/prettier/issues/16356#issuecomment-2150771806

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
