### PR TITLE
Use prettier version placeholder in `docs/`

### DIFF
--- a/docs/browser.md
+++ b/docs/browser.md
@@ -18,7 +18,7 @@ Required options:
 
 - **[`parser`](options.md#parser) (or [`filepath`](options.md#file-path))**: One of these options has to be specified for Prettier to know which parser to use.
 
-- **`plugins`**: Unlike the `format` function from the [Node.js-based API](api.md#prettierformatsource--options), this function doesn’t load plugins automatically. The `plugins` option is required because all the parsers included in the Prettier package come as plugins (for reasons of file size). These plugins are files in <https://unpkg.com/browse/prettier@3.3.1/plugins/>. Note that `estree` plugin should be loaded when printing JavaScript, TypeScript, Flow, or JSON.
+- **`plugins`**: Unlike the `format` function from the [Node.js-based API](api.md#prettierformatsource--options), this function doesn’t load plugins automatically. The `plugins` option is required because all the parsers included in the Prettier package come as plugins (for reasons of file size). These plugins are files in <https://unpkg.com/browse/prettier@%PRETTIER_VERSION%/plugins/>. Note that `estree` plugin should be loaded when printing JavaScript, TypeScript, Flow, or JSON.
 
   You need to load the ones that you’re going to use and pass them to `prettier.format` using the `plugins` option.
 
@@ -29,8 +29,8 @@ See below for examples.
 ### Global
 
 ```html
-<script src="https://unpkg.com/prettier@3.3.1/standalone.js"></script>
-<script src="https://unpkg.com/prettier@3.3.1/plugins/graphql.js"></script>
+<script src="https://unpkg.com/prettier@%PRETTIER_VERSION%/standalone.js"></script>
+<script src="https://unpkg.com/prettier@%PRETTIER_VERSION%/plugins/graphql.js"></script>
 <script>
   (async () => {
     const formatted = await prettier.format("type Query { hello: String }", {
@@ -47,8 +47,8 @@ Note that the [`unpkg` field](https://unpkg.com/#examples) in Prettier’s `pack
 
 ```html
 <script type="module">
-  import * as prettier from "https://unpkg.com/prettier@3.3.1/standalone.mjs";
-  import prettierPluginGraphql from "https://unpkg.com/prettier@3.3.1/plugins/graphql.mjs";
+  import * as prettier from "https://unpkg.com/prettier@%PRETTIER_VERSION%/standalone.mjs";
+  import prettierPluginGraphql from "https://unpkg.com/prettier@%PRETTIER_VERSION%/plugins/graphql.mjs";
 
   const formatted = await prettier.format("type Query { hello: String }", {
     parser: "graphql",
@@ -61,8 +61,8 @@ Note that the [`unpkg` field](https://unpkg.com/#examples) in Prettier’s `pack
 
 ```js
 define([
-  "https://unpkg.com/prettier@3.3.1/standalone.js",
-  "https://unpkg.com/prettier@3.3.1/plugins/graphql.js",
+  "https://unpkg.com/prettier@%PRETTIER_VERSION%/standalone.js",
+  "https://unpkg.com/prettier@%PRETTIER_VERSION%/plugins/graphql.js",
 ], async (prettier, ...plugins) => {
   const formatted = await prettier.format("type Query { hello: String }", {
     parser: "graphql",
@@ -90,8 +90,8 @@ This syntax doesn’t necessarily work in the browser, but it can be used when b
 ### Worker
 
 ```js
-importScripts("https://unpkg.com/prettier@3.3.1/standalone.js");
-importScripts("https://unpkg.com/prettier@3.3.1/plugins/graphql.js");
+importScripts("https://unpkg.com/prettier@%PRETTIER_VERSION%/standalone.js");
+importScripts("https://unpkg.com/prettier@%PRETTIER_VERSION%/plugins/graphql.js");
 
 (async () => {
   const formatted = await prettier.format("type Query { hello: String }", {
@@ -107,9 +107,9 @@ If you want to format [embedded code](options.md#embedded-language-formatting), 
 
 ```html
 <script type="module">
-  import * as prettier from "https://unpkg.com/prettier@3.3.1/standalone.mjs";
-  import prettierPluginBabel from "https://unpkg.com/prettier@3.3.1/plugins/babel.mjs";
-  import prettierPluginEstree from "https://unpkg.com/prettier@3.3.1/plugins/estree.mjs";
+  import * as prettier from "https://unpkg.com/prettier@%PRETTIER_VERSION%/standalone.mjs";
+  import prettierPluginBabel from "https://unpkg.com/prettier@%PRETTIER_VERSION%/plugins/babel.mjs";
+  import prettierPluginEstree from "https://unpkg.com/prettier@%PRETTIER_VERSION%/plugins/estree.mjs";
 
   console.log(
     await prettier.format("const html=/* HTML */ `<DIV> </DIV>`", {
@@ -125,10 +125,10 @@ The HTML code embedded in JavaScript stays unformatted because the `html` parser
 
 ```html
 <script type="module">
-  import * as prettier from "https://unpkg.com/prettier@3.3.1/standalone.mjs";
-  import prettierPluginBabel from "https://unpkg.com/prettier@3.3.1/plugins/babel.mjs";
-  import prettierPluginEstree from "https://unpkg.com/prettier@3.3.1/plugins/estree.mjs";
-  import prettierPluginHtml from "https://unpkg.com/prettier@3.3.1/plugins/html.mjs";
+  import * as prettier from "https://unpkg.com/prettier@%PRETTIER_VERSION%/standalone.mjs";
+  import prettierPluginBabel from "https://unpkg.com/prettier@%PRETTIER_VERSION%/plugins/babel.mjs";
+  import prettierPluginEstree from "https://unpkg.com/prettier@%PRETTIER_VERSION%/plugins/estree.mjs";
+  import prettierPluginHtml from "https://unpkg.com/prettier@%PRETTIER_VERSION%/plugins/html.mjs";
 
   console.log(
     await prettier.format("const html=/* HTML */ `<DIV> </DIV>`", {

--- a/docs/browser.md
+++ b/docs/browser.md
@@ -91,7 +91,9 @@ This syntax doesn’t necessarily work in the browser, but it can be used when b
 
 ```js
 importScripts("https://unpkg.com/prettier@%PRETTIER_VERSION%/standalone.js");
-importScripts("https://unpkg.com/prettier@%PRETTIER_VERSION%/plugins/graphql.js");
+importScripts(
+  "https://unpkg.com/prettier@%PRETTIER_VERSION%/plugins/graphql.js",
+);
 
 (async () => {
   const formatted = await prettier.format("type Query { hello: String }", {

--- a/scripts/build-website.js
+++ b/scripts/build-website.js
@@ -107,6 +107,7 @@ await runYarn("install", [], { cwd: WEBSITE_DIR });
 
 if (IS_PULL_REQUEST) {
   console.log("Synchronizing docs...");
+  process.env.PRETTIER_VERSION = `999.999.999-pr.${process.env.REVIEW_ID}`;
   await runYarn("update-stable-docs", [], { cwd: WEBSITE_DIR });
 }
 

--- a/scripts/release/steps/update-version.js
+++ b/scripts/release/steps/update-version.js
@@ -17,20 +17,10 @@ export default async function updateVersion({ version, next }) {
   processFile(".github/ISSUE_TEMPLATE/integration.md", (content) =>
     content.replace(/^(- Prettier Version: ).*$/m, `$1${version}`),
   );
-  processFile("docs/install.md", (content) =>
-    content.replace(/^(npx prettier@)\S+/m, `$1${version}`),
-  );
-
-  // Update unpkg link in docs
-  processFile("docs/browser.md", (content) =>
-    content.replaceAll(
-      /(\/\/unpkg\.com\/(?:browse\/)?prettier@).*?\//g,
-      `$1${version}/`,
-    ),
-  );
 
   await runYarn(["install"], { cwd: "./website" });
 
+  process.env.PRETTIER_VERSION = version;
   await runYarn(["update-stable-docs"], {
     cwd: "./website",
   });

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "webpack --mode=production && docusaurus-build",
     "start": "concurrently \"docusaurus-start\" \"webpack --mode=development --watch\"",
-    "update-stable-docs": "rimraf ./versioned_docs ./versions.json && docusaurus-version stable"
+    "update-stable-docs": "rimraf ./versioned_docs ./versions.json && docusaurus-version stable && node ./scripts/replace-version-placeholder.mjs"
   },
   "dependencies": {
     "clipboard": "2.0.11",

--- a/website/scripts/replace-version-placeholder.mjs
+++ b/website/scripts/replace-version-placeholder.mjs
@@ -1,0 +1,22 @@
+import fs from "node:fs/promises";
+
+const DIRECTORY = new URL("../versioned_docs/version-stable/", import.meta.url);
+let version = process.env.PRETTIER_VERSION;
+
+if (!version) {
+  const packageJsonFile = new URL("../../package.json", import.meta.url);
+  const packageJson = JSON.parse(await fs.readFile(packageJsonFile));
+  ({ version } = packageJson);
+}
+
+await Promise.all(
+  ["browser.md"].map(async (file) => {
+    file = new URL(file, DIRECTORY);
+
+    let content = await fs.readFile(file, "utf8");
+
+    content = content.replaceAll("%PRETTIER_VERSION%", version);
+
+    await fs.writeFile(file, content);
+  }),
+);


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

We don't need update files in `docs/` when doing a release.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
