### PR TITLE
Release script: choose version instead of passing argument

### DIFF
--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```sh
-node ./scripts/release/release.js --version NEW_VERSION
+node ./scripts/release/release.js
 ```
 
 The script has its own `package.json` so we can reinstall the root's `node_modules/` while making the release.
@@ -12,6 +12,7 @@ The script has its own `package.json` so we can reinstall the root's `node_modul
 
 | Flag                          | Description                                                                             |
 | ----------------------------- | --------------------------------------------------------------------------------------- |
+| `--version`                   | Version to release                                                                      |
 | `--manual`                    | Manual run release process instead of publish from GitHub actions                       |
 | `--dry`                       | Dry run                                                                                 |
 | `--skip-dependencies-install` | Skip dependencies installation                                                          |

--- a/scripts/release/run.js
+++ b/scripts/release/run.js
@@ -21,6 +21,10 @@ if (semver.parse(previousVersion) === null) {
 
 for (let step of [
   {
+    process: steps.chooseVersion,
+    skip: Boolean(params.version),
+  },
+  {
     name: "Validating new version",
     process: steps.validateNewVersion,
   },

--- a/scripts/release/steps/bump-prettier.js
+++ b/scripts/release/steps/bump-prettier.js
@@ -5,8 +5,7 @@ import semver from "semver";
 import { logPromise, readJson, runGit, runYarn, writeJson } from "../utils.js";
 
 async function format() {
-  await runYarn(["lint:eslint", "--fix"]);
-  await runYarn(["lint:prettier", "--write"]);
+  await runYarn(["fix:prettier"]);
 }
 
 // Only add commit to `.git-blame-ignore-revs` when files except `package.json` and `yarn.lock` changed
@@ -66,6 +65,6 @@ export default async function bumpPrettier(params) {
     "Installing Prettier",
     runYarn(["add", "--dev", `prettier@${version}`]),
   );
-  await logPromise("Updating files", format());
+  await logPromise("Formatting files", format());
   await logPromise("Committing changed files", commit(params));
 }

--- a/scripts/release/steps/choose-version.js
+++ b/scripts/release/steps/choose-version.js
@@ -1,0 +1,34 @@
+import enquirer from "enquirer";
+import semver from "semver";
+
+const SEMVER_INCREMENTS = ["patch", "minor", "major"];
+const CUSTOM_VERSION_VALUE_PLACEHOLDER = "custom-version";
+
+export default async function chooseVersion(params) {
+  let version = await new enquirer.Select({
+    name: "version",
+    message: `Choose a version to release (current: ${params.previousVersion}})`,
+    choices: [
+      ...SEMVER_INCREMENTS.map((type) => {
+        const version = semver.inc(params.previousVersion, type);
+
+        return {
+          message: `${type}: ${version}`,
+          value: version,
+        };
+      }),
+      { role: "separator" },
+      { message: "Other", value: CUSTOM_VERSION_VALUE_PLACEHOLDER },
+    ],
+  }).run();
+
+  if (version === CUSTOM_VERSION_VALUE_PLACEHOLDER) {
+    ({ version } = await enquirer.prompt({
+      type: "input",
+      name: "version",
+      message: `Input version (current: ${params.previousVersion}})`,
+    }));
+  }
+
+  params.version = version;
+}

--- a/scripts/release/steps/choose-version.js
+++ b/scripts/release/steps/choose-version.js
@@ -7,7 +7,7 @@ const CUSTOM_VERSION_VALUE_PLACEHOLDER = "custom-version";
 export default async function chooseVersion(params) {
   let version = await new enquirer.Select({
     name: "version",
-    message: `Choose a version to release (current: ${params.previousVersion}})`,
+    message: `Choose a version to release (current: ${params.previousVersion})`,
     choices: [
       ...SEMVER_INCREMENTS.map((type) => {
         const version = semver.inc(params.previousVersion, type);
@@ -26,7 +26,7 @@ export default async function chooseVersion(params) {
     ({ version } = await enquirer.prompt({
       type: "input",
       name: "version",
-      message: `Input version (current: ${params.previousVersion}})`,
+      message: `Input version (current: ${params.previousVersion})`,
     }));
   }
 

--- a/scripts/release/steps/index.js
+++ b/scripts/release/steps/index.js
@@ -1,5 +1,6 @@
 export { default as bumpPrettier } from "./bump-prettier.js";
 export { default as checkGitStatus } from "./check-git-status.js";
+export { default as chooseVersion } from "./choose-version.js";
 export { default as cleanChangelog } from "./clean-changelog.js";
 export { default as generateBundles } from "./generate-bundles.js";
 export { default as installDependencies } from "./install-dependencies.js";


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

![image](https://github.com/prettier/prettier/assets/172584/aa4df331-d5bc-4e25-9455-3dc7e16ac370)


## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
