### PR TITLE
Add `v` prefix to git tags

### DIFF
--- a/scripts/release/run.js
+++ b/scripts/release/run.js
@@ -5,11 +5,8 @@ import * as steps from "./steps/index.js";
 import { logPromise, readJson, runGit } from "./utils.js";
 
 const params = parseArguments();
-const { stdout: previousVersion } = await runGit([
-  "describe",
-  "--tags",
-  "--abbrev=0",
-]);
+const { stdout: tag } = await runGit(["describe", "--tags", "--abbrev=0"]);
+const previousVersion = tag.startsWith("v") ? tag.slice(1) : tag;
 if (semver.parse(previousVersion) === null) {
   throw new Error(`Unexpected previousVersion: ${previousVersion}`);
 } else {

--- a/scripts/release/steps/push-to-git.js
+++ b/scripts/release/steps/push-to-git.js
@@ -1,8 +1,8 @@
 import { runGit } from "../utils.js";
 
 export default async function pushToGit({ version, repo }) {
-  await runGit(["commit", "-am", `Release ${version}`]);
-  await runGit(["tag", "-a", version, "-m", `Release ${version}`]);
+  await runGit(["commit", "-am", `Release v${version}`]);
+  await runGit(["tag", "-a", `v${version}`, "-m", `Release v${version}`]);
   await runGit(["push", "--repo", repo]);
   await runGit(["push", "--tags", "--repo", repo]);
 }

--- a/scripts/release/steps/show-instructions-after-npm-publish.js
+++ b/scripts/release/steps/show-instructions-after-npm-publish.js
@@ -27,8 +27,8 @@ export function getReleaseUrl(version, previousVersion) {
     });
   }
   const parameters = new URLSearchParams({
-    tag: version,
-    title: version,
+    tag: `v${version}`,
+    title: `v${version}`,
     body,
   });
   return `${RELEASE_URL_BASE}${parameters}`;
@@ -40,7 +40,7 @@ export default async function showInstructionsAfterNpmPublish({
   next,
 }) {
   if (next) {
-    console.log(`${chalk.green.bold(`Prettier ${version} published!`)}`);
+    console.log(`${chalk.green.bold(`Prettier v${version} published!`)}`);
     await waitForEnter();
     return;
   }
@@ -48,7 +48,7 @@ export default async function showInstructionsAfterNpmPublish({
   const releaseUrl = getReleaseUrl(version, previousVersion);
   console.log(
     outdent`
-      ${chalk.green.bold(`Prettier ${version} published!`)}
+      ${chalk.green.bold(`Prettier v${version} published!`)}
 
       ${chalk.yellow.bold("Some manual steps are necessary.")}
 

--- a/scripts/release/tests/publish-to-npm.test.js
+++ b/scripts/release/tests/publish-to-npm.test.js
@@ -23,8 +23,8 @@ describe("publish-to-npm", () => {
       assert.equal(
         result,
         getExpectedReleaseUrl({
-          tag: "2.3.1",
-          title: "2.3.1",
+          tag: "v2.3.1",
+          title: "v2.3.1",
           body: "🔗 [Changelog](https://github.com/prettier/prettier/blob/main/CHANGELOG.md#231)",
         }),
       );
@@ -35,10 +35,10 @@ describe("publish-to-npm", () => {
       assert.equal(
         result,
         getExpectedReleaseUrl({
-          tag: "2.4.0",
-          title: "2.4.0",
+          tag: "v2.4.0",
+          title: "v2.4.0",
           body: [
-            "[diff](https://github.com/prettier/prettier/compare/2.3.0...2.4.0)",
+            "[diff](https://github.com/prettier/prettier/compare/v2.3.0...v2.4.0)",
             `🔗 [Release note](https://prettier.io/blog/${getDateParts().join(
               "/",
             )}/2.4.0.html)`,
@@ -52,10 +52,10 @@ describe("publish-to-npm", () => {
       assert.equal(
         result,
         getExpectedReleaseUrl({
-          tag: "2.3.0",
-          title: "2.3.0",
+          tag: "v2.3.0",
+          title: "v2.3.0",
           body: [
-            "[diff](https://github.com/prettier/prettier/compare/2.2.0...2.3.0)",
+            "[diff](https://github.com/prettier/prettier/compare/v2.2.0...v2.3.0)",
             `🔗 [Release note](https://prettier.io/blog/${getDateParts().join(
               "/",
             )}/2.3.0.html)`,

--- a/scripts/release/utils.js
+++ b/scripts/release/utils.js
@@ -137,7 +137,7 @@ function getBlogPostInfo(version) {
 
 function getChangelogContent({ version, previousVersion, body }) {
   return outdent`
-    [diff](https://github.com/prettier/prettier/compare/${previousVersion}...${version})
+    [diff](https://github.com/prettier/prettier/compare/v${previousVersion}...v${version})
 
     ${body}
   `;


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

It's common to tag the released version as `v1.0.0`, but we missed `v`.

- babel https://github.com/babel/babel/tags
- eslint  https://github.com/eslint/eslint/tags

Question:
1, should we fix it?
2, should we fix the existing tags? (Suggest leave them as it is)

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
