### PR TITLE
Remove `isLastNode` in favor of `AstPath#isLast`

### DIFF
--- a/src/language-css/printer-postcss.js
+++ b/src/language-css/printer-postcss.js
@@ -40,7 +40,6 @@ import {
   isDetachedRulesetCallNode,
   isDetachedRulesetDeclarationNode,
   isKeyframeAtRuleKeywords,
-  isLastNode,
   isMediaAndSupportsKeywords,
   isSCSSControlDirectiveNode,
   isTemplatePlaceholderNode,
@@ -163,7 +162,7 @@ function genericPrint(path, options, print) {
               !parentNode.raws.semicolon &&
               options.originalText[locEnd(node) - 1] !== ";"
             ? ""
-            : options.__isHTMLStyleAttribute && isLastNode(path, node)
+            : options.__isHTMLStyleAttribute && path.isLast
               ? ifBreak(";")
               : ";",
       ];
@@ -301,10 +300,7 @@ function genericPrint(path, options, print) {
       return group(indent(join(line, parts)));
     }
     case "media-query":
-      return [
-        join(" ", path.map(print, "nodes")),
-        isLastNode(path, node) ? "" : ",",
-      ];
+      return [join(" ", path.map(print, "nodes")), path.isLast ? "" : ","];
 
     case "media-type":
       return adjustNumbers(adjustStrings(node.value, options));
@@ -420,7 +416,7 @@ function genericPrint(path, options, print) {
             ? ""
             : line;
 
-        return [leading, node.value, isLastNode(path, node) ? "" : " "];
+        return [leading, node.value, path.isLast ? "" : " "];
       }
 
       const leading = node.value.trim().startsWith("(") ? line : "";

--- a/src/language-css/utils/index.js
+++ b/src/language-css/utils/index.js
@@ -109,11 +109,6 @@ function isVarFunctionNode(node) {
   return node.type === "value-func" && node.value.toLowerCase() === "var";
 }
 
-function isLastNode(path, node) {
-  const nodes = path.parent?.nodes;
-  return nodes && nodes.indexOf(node) === nodes.length - 1;
-}
-
 function isDetachedRulesetDeclarationNode(node) {
   const { selector } = node;
   // If a Less file ends up being parsed with the SCSS parser, Less
@@ -412,7 +407,6 @@ export {
   isKeyInValuePairNode,
   isKeyValuePairInParenGroupNode,
   isKeyValuePairNode,
-  isLastNode,
   isLeftCurlyBraceNode,
   isMathOperatorNode,
   isMediaAndSupportsKeywords,


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
