### PR TITLE
chore: Remove unused Babel parser plugins

### DIFF
--- a/src/language-js/parse/babel.js
+++ b/src/language-js/parse/babel.js
@@ -41,7 +41,6 @@ const parseOptions = {
     "decimal",
     "moduleBlocks",
     "asyncDoExpressions",
-    "regexpUnicodeSets",
     "destructuringPrivate",
     "decoratorAutoAccessors",
     "importReflection",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**

It is now always enabled, and will be removed in the future.
Ref: https://github.com/babel/babel/pull/16572