### PR TITLE
Revert "Pin Node.js v22 version (#16491)"

### DIFF
--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -27,13 +27,13 @@ jobs:
           - "windows-latest"
         node:
           # Latest even version
-          - "22.4.1"
+          - "22"
           # Minimal version for development
           - "18"
         include:
           - os: "ubuntu-latest"
             # Pick a version that is fast (normally highest LTS version)
-            node: "22.4.1"
+            node: "22"
             ENABLE_CODE_COVERAGE: true
             FULL_TEST: true
             CHECK_TEST_PARSERS: true

--- a/.github/workflows/prod-test.yml
+++ b/.github/workflows/prod-test.yml
@@ -56,13 +56,13 @@ jobs:
           - "windows-latest"
         node:
           # Latest even version
-          - "22.4.1"
+          - "22"
           # Minimal version for production
           - "14"
         include:
           - os: "ubuntu-latest"
             # Pick a version that is fast (normally highest LTS version)
-            node: "22.4.1"
+            node: "22"
             FULL_TEST: true
           # Versions not tested on linux, normally only even versions
           # If latest version is an odd number, it can be listed below too


### PR DESCRIPTION
This reverts commit 484ecde4307d3f535256ef83e9b09c5a0445bc77.

## Description

GH Actions supports Node.js 22.5.1 now https://github.com/actions/node-versions/pull/182

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
