### PR TITLE
Rewrite tests for importing JSON

### DIFF
--- a/tests/format/js/import-assertions/__snapshots__/format.test.js.snap
+++ b/tests/format/js/import-assertions/__snapshots__/format.test.js.snap
@@ -109,13 +109,13 @@ Cause: Unexpected token assert"
 `;
 
 exports[`keyword-detect.js [meriyah] format 1`] = `
-"Unexpected token: 'identifier' (1:38)
+"Unexpected token: 'identifier' (1:33)
 > 1 | import "./test.json" /* with */ assert /* with */  { type: "json" }
-    |                                      ^
+    |                                 ^^^^^^
   2 | import {default as b} from "./test.json" /* with */ assert /* with */  { type: "json" }
   3 |
   4 | export {default as e} from "./test.json" /* with */ assert /* with */  { type: "json" }
-Cause: [1:38]: Unexpected token: 'identifier'"
+Cause: [1:32-1:38]: Unexpected token: 'identifier'"
 `;
 
 exports[`keyword-detect.js format 1`] = `

--- a/tests/format/js/import-assertions/__snapshots__/format.test.js.snap
+++ b/tests/format/js/import-assertions/__snapshots__/format.test.js.snap
@@ -88,6 +88,60 @@ import * as baz from "baz.json" /* comment */ assert {};
 ================================================================================
 `;
 
+exports[`keyword-detect.js [acorn] format 1`] = `
+"Unexpected token (1:33)
+> 1 | import "./test.json" /* with */ assert /* with */  { type: "json" }
+    |                                 ^
+  2 | import {default as b} from "./test.json" /* with */ assert /* with */  { type: "json" }
+  3 |
+  4 | export {default as e} from "./test.json" /* with */ assert /* with */  { type: "json" }
+Cause: Unexpected token (1:32)"
+`;
+
+exports[`keyword-detect.js [espree] format 1`] = `
+"Unexpected token assert (1:33)
+> 1 | import "./test.json" /* with */ assert /* with */  { type: "json" }
+    |                                 ^
+  2 | import {default as b} from "./test.json" /* with */ assert /* with */  { type: "json" }
+  3 |
+  4 | export {default as e} from "./test.json" /* with */ assert /* with */  { type: "json" }
+Cause: Unexpected token assert"
+`;
+
+exports[`keyword-detect.js [meriyah] format 1`] = `
+"Unexpected token: 'identifier' (1:38)
+> 1 | import "./test.json" /* with */ assert /* with */  { type: "json" }
+    |                                      ^
+  2 | import {default as b} from "./test.json" /* with */ assert /* with */  { type: "json" }
+  3 |
+  4 | export {default as e} from "./test.json" /* with */ assert /* with */  { type: "json" }
+Cause: [1:38]: Unexpected token: 'identifier'"
+`;
+
+exports[`keyword-detect.js format 1`] = `
+====================================options=====================================
+parsers: ["babel", "typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+import "./test.json" /* with */ assert /* with */  { type: "json" }
+import {default as b} from "./test.json" /* with */ assert /* with */  { type: "json" }
+
+export {default as e} from "./test.json" /* with */ assert /* with */  { type: "json" }
+
+export * from "./test.json" /* with */ assert /* with */  { type: "json" }
+
+=====================================output=====================================
+import "./test.json" /* with */ /* with */ assert { type: "json" };
+import { default as b } from "./test.json" /* with */ /* with */ assert { type: "json" };
+
+export { default as e } from "./test.json" /* with */ /* with */ assert { type: "json" };
+
+export * from "./test.json" /* with */ /* with */ assert { type: "json" };
+
+================================================================================
+`;
+
 exports[`multi-types.js [acorn] format 1`] = `
 "Unexpected token (1:31)
 > 1 | import json from "./foo.json" assert { type: "json", type: "bar" };

--- a/tests/format/js/import-assertions/format.test.js
+++ b/tests/format/js/import-assertions/format.test.js
@@ -8,6 +8,7 @@ runFormatTest(import.meta, ["babel", "typescript"], {
       "re-export.js",
       "without-from.js",
       "non-type.js",
+      "keyword-detect.js",
     ],
     espree: [
       "dynamic-import.js",
@@ -17,6 +18,7 @@ runFormatTest(import.meta, ["babel", "typescript"], {
       "re-export.js",
       "without-from.js",
       "non-type.js",
+      "keyword-detect.js",
     ],
     meriyah: [
       "empty.js",
@@ -25,6 +27,7 @@ runFormatTest(import.meta, ["babel", "typescript"], {
       "re-export.js",
       "without-from.js",
       "non-type.js",
+      "keyword-detect.js",
     ],
   },
 });

--- a/tests/format/js/import-assertions/keyword-detect.js
+++ b/tests/format/js/import-assertions/keyword-detect.js
@@ -1,0 +1,6 @@
+import "./test.json" /* with */ assert /* with */  { type: "json" }
+import {default as b} from "./test.json" /* with */ assert /* with */  { type: "json" }
+
+export {default as e} from "./test.json" /* with */ assert /* with */  { type: "json" }
+
+export * from "./test.json" /* with */ assert /* with */  { type: "json" }

--- a/tests/format/js/import-attributes/__snapshots__/format.test.js.snap
+++ b/tests/format/js/import-attributes/__snapshots__/format.test.js.snap
@@ -105,7 +105,7 @@ exports[`keyword-detect.js [meriyah] format 1`] = `
   2 | import a from "./test.json" /* assert */ with /* assert */  { type: "json" }
   3 |
   4 | export {default as c} from "./test.json" /* assert */ with /* assert */  { type: "json" }
-Cause: [1:69]: Invalid binding in JSON import"
+Cause: [1:68-1:69]: Invalid binding in JSON import"
 `;
 
 exports[`keyword-detect.js format 1`] = `
@@ -234,7 +234,7 @@ exports[`multi-types.js [meriyah] format 1`] = `
 > 1 | import json from "./foo.json" with { type: "json", type: "bar" };
     |                                                                ^
   2 |
-Cause: [1:64]: Duplicate binding 'type'"
+Cause: [1:63-1:64]: Duplicate binding 'type'"
 `;
 
 exports[`multi-types.js format 1`] = `
@@ -299,16 +299,6 @@ exports[`re-export.js [espree] format 1`] = `
   3 | export * as foo3 from "foo.json" with { type: "json" };
   4 |
 Cause: Unexpected token with"
-`;
-
-exports[`re-export.js [meriyah] format 1`] = `
-"Unexpected token: 'with' (1:47)
-> 1 | export { default as foo2 } from "foo.json" with { type: "json" };
-    |                                               ^
-  2 | export * from "foo.json" with { type: "json" };
-  3 | export * as foo3 from "foo.json" with { type: "json" };
-  4 |
-Cause: [1:47]: Unexpected token: 'with'"
 `;
 
 exports[`re-export.js format 1`] = `
@@ -380,7 +370,7 @@ exports[`without-from.js [meriyah] format 1`] = `
 > 1 | import "foo" with { type: "json" }
     |                                  ^
   2 |
-Cause: [1:34]: Invalid binding in JSON import"
+Cause: [1:33-1:34]: Invalid binding in JSON import"
 `;
 
 exports[`without-from.js format 1`] = `

--- a/tests/format/js/import-attributes/__snapshots__/format.test.js.snap
+++ b/tests/format/js/import-attributes/__snapshots__/format.test.js.snap
@@ -82,9 +82,9 @@ exports[`keyword-detect.js [acorn] format 1`] = `
 "Unexpected token (1:35)
 > 1 | import "./test.json" /* assert */ with /* assert */  { type: "json" }
     |                                   ^
-  2 | import {} from "./test.json" /* assert */ with /* assert */  { type: "json" }
-  3 | import "./test.json" /* with */ assert /* with */  { type: "json" }
-  4 | import {} from "./test.json" /* with */ assert /* with */  { type: "json" }
+  2 | import a from "./test.json" /* assert */ with /* assert */  { type: "json" }
+  3 |
+  4 | export {default as c} from "./test.json" /* assert */ with /* assert */  { type: "json" }
 Cause: Unexpected token (1:34)"
 `;
 
@@ -92,9 +92,9 @@ exports[`keyword-detect.js [espree] format 1`] = `
 "Unexpected token with (1:35)
 > 1 | import "./test.json" /* assert */ with /* assert */  { type: "json" }
     |                                   ^
-  2 | import {} from "./test.json" /* assert */ with /* assert */  { type: "json" }
-  3 | import "./test.json" /* with */ assert /* with */  { type: "json" }
-  4 | import {} from "./test.json" /* with */ assert /* with */  { type: "json" }
+  2 | import a from "./test.json" /* assert */ with /* assert */  { type: "json" }
+  3 |
+  4 | export {default as c} from "./test.json" /* assert */ with /* assert */  { type: "json" }
 Cause: Unexpected token with"
 `;
 
@@ -102,10 +102,10 @@ exports[`keyword-detect.js [meriyah] format 1`] = `
 "Invalid binding in JSON import (1:69)
 > 1 | import "./test.json" /* assert */ with /* assert */  { type: "json" }
     |                                                                     ^
-  2 | import {} from "./test.json" /* assert */ with /* assert */  { type: "json" }
-  3 | import "./test.json" /* with */ assert /* with */  { type: "json" }
-  4 | import {} from "./test.json" /* with */ assert /* with */  { type: "json" }
-Cause: [1:68-1:69]: Invalid binding in JSON import"
+  2 | import a from "./test.json" /* assert */ with /* assert */  { type: "json" }
+  3 |
+  4 | export {default as c} from "./test.json" /* assert */ with /* assert */  { type: "json" }
+Cause: [1:69]: Invalid binding in JSON import"
 `;
 
 exports[`keyword-detect.js format 1`] = `
@@ -115,27 +115,19 @@ printWidth: 80
                                                                                 | printWidth
 =====================================input======================================
 import "./test.json" /* assert */ with /* assert */  { type: "json" }
-import {} from "./test.json" /* assert */ with /* assert */  { type: "json" }
-import "./test.json" /* with */ assert /* with */  { type: "json" }
-import {} from "./test.json" /* with */ assert /* with */  { type: "json" }
+import a from "./test.json" /* assert */ with /* assert */  { type: "json" }
 
-export {} from "./test.json" /* assert */ with /* assert */  { type: "json" }
-export {} from "./test.json" /* with */ assert /* with */  { type: "json" }
+export {default as c} from "./test.json" /* assert */ with /* assert */  { type: "json" }
 
 export * from "./test.json" /* assert */ with /* assert */  { type: "json" }
-export * from "./test.json" /* with */ assert /* with */  { type: "json" }
 
 =====================================output=====================================
 import "./test.json" /* assert */ /* assert */ with { type: "json" };
-import {} from "./test.json" /* assert */ /* assert */ with { type: "json" };
-import "./test.json" /* with */ /* with */ assert { type: "json" };
-import {} from "./test.json" /* with */ /* with */ assert { type: "json" };
+import a from "./test.json" /* assert */ /* assert */ with { type: "json" };
 
-export {} from "./test.json" /* assert */ /* assert */ with { type: "json" };
-export {} from "./test.json" /* with */ /* with */ assert { type: "json" };
+export { default as c } from "./test.json" /* assert */ /* assert */ with { type: "json" };
 
 export * from "./test.json" /* assert */ /* assert */ with { type: "json" };
-export * from "./test.json" /* with */ /* with */ assert { type: "json" };
 
 ================================================================================
 `;
@@ -242,7 +234,7 @@ exports[`multi-types.js [meriyah] format 1`] = `
 > 1 | import json from "./foo.json" with { type: "json", type: "bar" };
     |                                                                ^
   2 |
-Cause: [1:63-1:64]: Duplicate binding 'type'"
+Cause: [1:64]: Duplicate binding 'type'"
 `;
 
 exports[`multi-types.js format 1`] = `
@@ -307,6 +299,16 @@ exports[`re-export.js [espree] format 1`] = `
   3 | export * as foo3 from "foo.json" with { type: "json" };
   4 |
 Cause: Unexpected token with"
+`;
+
+exports[`re-export.js [meriyah] format 1`] = `
+"Unexpected token: 'with' (1:47)
+> 1 | export { default as foo2 } from "foo.json" with { type: "json" };
+    |                                               ^
+  2 | export * from "foo.json" with { type: "json" };
+  3 | export * as foo3 from "foo.json" with { type: "json" };
+  4 |
+Cause: [1:47]: Unexpected token: 'with'"
 `;
 
 exports[`re-export.js format 1`] = `
@@ -378,7 +380,7 @@ exports[`without-from.js [meriyah] format 1`] = `
 > 1 | import "foo" with { type: "json" }
     |                                  ^
   2 |
-Cause: [1:33-1:34]: Invalid binding in JSON import"
+Cause: [1:34]: Invalid binding in JSON import"
 `;
 
 exports[`without-from.js format 1`] = `

--- a/tests/format/js/import-attributes/keyword-detect.js
+++ b/tests/format/js/import-attributes/keyword-detect.js
@@ -1,10 +1,6 @@
 import "./test.json" /* assert */ with /* assert */  { type: "json" }
-import {} from "./test.json" /* assert */ with /* assert */  { type: "json" }
-import "./test.json" /* with */ assert /* with */  { type: "json" }
-import {} from "./test.json" /* with */ assert /* with */  { type: "json" }
+import a from "./test.json" /* assert */ with /* assert */  { type: "json" }
 
-export {} from "./test.json" /* assert */ with /* assert */  { type: "json" }
-export {} from "./test.json" /* with */ assert /* with */  { type: "json" }
+export {default as c} from "./test.json" /* assert */ with /* assert */  { type: "json" }
 
 export * from "./test.json" /* assert */ with /* assert */  { type: "json" }
-export * from "./test.json" /* with */ assert /* with */  { type: "json" }


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Doing this because ["JSON modules"](https://github.com/tc39/proposal-json-modules) proposal forbids "named exports".
Meriyah also added support for "import attributes", but not "import assertions".

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
