### PR TITLE
Fix code example for `prettier.resolveConfig`

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -49,7 +49,10 @@ If `options.useCache` is `false`, all caching will be bypassed.
 ```js
 const text = await fs.readFile(filePath, "utf8");
 const options = await prettier.resolveConfig(filePath);
-const formatted = await prettier.format(text, options);
+const formatted = await prettier.format(text, {
+  ...options,
+  filepath: filePath,
+});
 ```
 
 If `options.editorconfig` is `true` and an [`.editorconfig` file](https://editorconfig.org/) is in your project, Prettier will parse it and convert its properties to the corresponding Prettier configuration. This configuration will be overridden by `.prettierrc`, etc. Currently, the following EditorConfig properties are supported:


### PR DESCRIPTION
## Description

The code example for `prettier.resolveConfig` does not works correctly.

```js
const text = await fs.readFile(filePath, "utf8");
const options = await prettier.resolveConfig(filePath);
const formatted = await prettier.format(text, options);
```

When I run the above code, the following error is thrown:

```
UndefinedParserError: No parser and no file path given, couldn't infer a parser.
```

This error occurs because the parser is not specified. To fix this, I changed the code to the following:

```js
const text = await fs.readFile(filePath, "utf8");
const options = await prettier.resolveConfig(filePath);
const formatted = await prettier.format(text, {
  ...options,
  filepath: filePath,
});
```

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
