### PR TITLE
Fix for capitalized fenced code block language

### DIFF
--- a/changelog_unreleased/markdown/16530.md
+++ b/changelog_unreleased/markdown/16530.md
@@ -1,0 +1,20 @@
+#### Fix for capitalized fenced code block language (#16482 by @regseb)
+
+<!-- Optional description if it makes sense. -->
+
+<!-- prettier-ignore -->
+~~~jsx
+// Input
+```JavaScript
+console.log('foo')
+```
+
+// Prettier stable
+```JavaScript
+console.log('foo')
+```
+
+// Prettier main
+```javascript
+console.log("foo");
+```

--- a/src/language-markdown/embed.js
+++ b/src/language-markdown/embed.js
@@ -9,7 +9,7 @@ function embed(path, options) {
   const { node } = path;
 
   if (node.type === "code" && node.lang !== null) {
-    const parser = inferParser(options, { language: node.lang });
+    const parser = inferParser(options, { language: node.lang.toLowerCase() });
     if (parser) {
       return async (textToDoc) => {
         const styleUnit = options.__inJsTemplate ? "~" : "`";
@@ -22,9 +22,12 @@ function embed(path, options) {
         // This is because whether the trailing comma of type parameters
         // should be printed depends on whether it is `*.ts` or `*.tsx`.
         // https://github.com/prettier/prettier/issues/15282
-        if (node.lang === "ts" || node.lang === "typescript") {
+        if (
+          node.lang.toLowerCase() === "ts" ||
+          node.lang.toLowerCase() === "typescript"
+        ) {
           newOptions.filepath = "dummy.ts";
-        } else if (node.lang === "tsx") {
+        } else if (node.lang.toLowerCase() === "tsx") {
           newOptions.filepath = "dummy.tsx";
         }
 
@@ -35,7 +38,7 @@ function embed(path, options) {
 
         return markAsRoot([
           style,
-          node.lang,
+          node.lang.toLowerCase(),
           node.meta ? " " + node.meta : "",
           hardline,
           replaceEndOfLine(doc),

--- a/src/language-markdown/printer-markdown.js
+++ b/src/language-markdown/printer-markdown.js
@@ -252,7 +252,7 @@ function genericPrint(path, options, print) {
       );
       return [
         style,
-        node.lang || "",
+        node.lang ? node.lang.toLowerCase() : "",
         node.meta ? " " + node.meta : "",
         hardline,
         replaceEndOfLine(


### PR DESCRIPTION
## Description

Fixed #16482 

The solution involves converting the language identifier to lowercase before processing it. This ensures that code blocks with capitalized language identifiers are handled consistently.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
