### PR TITLE
Simplify `printMemberChain`

### DIFF
--- a/src/language-js/print/member-chain.js
+++ b/src/language-js/print/member-chain.js
@@ -94,11 +94,11 @@ function printMemberChain(path, options, print) {
     return isNextLineEmpty(node, options);
   }
 
-  function rec(path) {
+  function rec() {
     const { node } = path;
 
     if (node.type === "ChainExpression") {
-      return path.call(() => rec(path), "expression");
+      return path.call(rec, "expression");
     }
 
     if (
@@ -122,7 +122,7 @@ function printMemberChain(path, options, print) {
           hasTrailingEmptyLine ? hardline : "",
         ],
       });
-      path.call((callee) => rec(callee), "callee");
+      path.call(rec, "callee");
     } else if (isMemberish(node)) {
       printedNodes.unshift({
         node,
@@ -135,13 +135,13 @@ function printMemberChain(path, options, print) {
           options,
         ),
       });
-      path.call((object) => rec(object), "object");
+      path.call(rec, "object");
     } else if (node.type === "TSNonNullExpression") {
       printedNodes.unshift({
         node,
         printed: printComments(path, "!", options),
       });
-      path.call((expression) => rec(expression), "expression");
+      path.call(rec, "expression");
     } else {
       printedNodes.unshift({
         node,
@@ -163,7 +163,7 @@ function printMemberChain(path, options, print) {
   });
 
   if (node.callee) {
-    path.call((callee) => rec(callee), "callee");
+    path.call(rec, "callee");
   }
 
   // Once we have a linear list of printed nodes, we want to create groups out


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

`AstPath` is a state machine, don't need pass around.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
