### PR TITLE
docs: document the special treatment of machine-generated files

### DIFF
--- a/docs/rationale.md
+++ b/docs/rationale.md
@@ -346,6 +346,10 @@ If possible, prefer comments that operate on line ranges (e.g. `eslint-disable` 
 
 Prettier is often able to recognize and format non-standard syntax such as ECMAScript early-stage proposals and Markdown syntax extensions not defined by any specification. The support for such syntax is considered best-effort and experimental. Incompatibilities may be introduced in any release and should not be viewed as breaking changes.
 
+## Disclaimer about machine-generated files
+
+Some files, like `package.json` or `composer.lock`, are machine-generated and regularly updated by the package manager. If Prettier were to use the same JSON formatting rules as with other files, it would regularly conflict with these other tools. To avoid this inconvenience, Prettier will use a formatter based on `JSON.stringify` on such files instead. You may notice these differences, such as the removal of vertical whitespace, but this is an intended behavior.
+
 ## What Prettier is _not_ concerned about
 
 Prettier only _prints_ code. It does not transform it. This is to limit the scope of Prettier. Let’s focus on the printing and do it really well!


### PR DESCRIPTION
## Description

Provides documentation under the "Rationale" section explaining that machine-generated files like `package.json` may be handled using a different formatter, and why that is.

Closes #11553

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [X] I’ve added tests to confirm my change works.
    - N/A
- [X] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
    - N/A
- [X] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
    - N/A
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
