### PR TITLE
Add oxford comma to Single Attribute Per Line doc

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -467,7 +467,7 @@ Valid options:
 
 _First available in v2.6.0_
 
-Enforce single attribute per line in HTML, Vue and JSX.
+Enforce single attribute per line in HTML, Vue, and JSX.
 
 Valid options:
 


### PR DESCRIPTION
## Description

I added an Oxford comma because when I read this I got a little confused.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [x] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
