### PR TITLE
[graphql] Support arguments on fragment spreads

### DIFF
--- a/changelog_unreleased/graphql/16571.md
+++ b/changelog_unreleased/graphql/16571.md
@@ -1,0 +1,23 @@
+#### Arguments on FragmentSpread (#16571 by @tobias-tengler)
+
+<!-- prettier-ignore -->
+```graphql
+# Input
+...Fragment(   var: $var   , int: 5, float: 5.6   , bool: true, string: "hello!")
+... Fragment   (var: $thisIsAReallyLongVariableNameRight    , int: 52342342342, float: 5.6,
+  bool: true,
+    string: "hello world this is a very long string!")
+
+# Prettier stable
+Fails to parse
+
+# Prettier main
+...Fragment(var: $var, int: 5, float: 5.6, bool: true, string: "hello!")
+...Fragment(
+  var: $thisIsAReallyLongVariableNameRight
+  int: 52342342342
+  float: 5.6
+  bool: true
+  string: "hello world this is a very long string!"
+)
+```

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "flow-parser": "0.243.0",
     "get-east-asian-width": "1.2.0",
     "get-stdin": "9.0.0",
-    "graphql": "16.9.0",
+    "graphql": "16.9.0-canary.pr.4159.0fa29326c53fcd63c6473c7357c28aa13fa0019d",
     "hermes-parser": "0.23.1",
     "html-element-attributes": "3.4.0",
     "html-tag-names": "2.1.0",

--- a/src/language-graphql/parser-graphql.js
+++ b/src/language-graphql/parser-graphql.js
@@ -17,7 +17,7 @@ function parseComments(ast) {
 }
 
 const parseOptions = {
-  allowLegacyFragmentVariables: true,
+  experimentalFragmentArguments: true,
 };
 
 function createParseError(error) {

--- a/src/language-graphql/printer-graphql.js
+++ b/src/language-graphql/printer-graphql.js
@@ -363,7 +363,25 @@ function genericPrint(path, options, print) {
       return [node.operation, ": ", print("type")];
 
     case "FragmentSpread":
-      return ["...", print("name"), printDirectives(path, print, node)];
+      return [
+        "...",
+        print("name"),
+        node.arguments?.length > 0
+          ? group([
+              "(",
+              indent([
+                softline,
+                join(
+                  [ifBreak("", ", "), softline],
+                  printSequence(path, options, print, "arguments"),
+                ),
+              ]),
+              softline,
+              ")",
+            ])
+          : "",
+        printDirectives(path, print, node),
+      ];
 
     case "InlineFragment":
       return [

--- a/tests/format/graphql/directives/__snapshots__/format.test.js.snap
+++ b/tests/format/graphql/directives/__snapshots__/format.test.js.snap
@@ -13,6 +13,7 @@ query MyQuery @directive(
   @skip(if: true) @nope
   otherField
   ...fragmentSpread, @include(if: ["this isn't even a boolean", "wow, that's really odd",,,,,])
+  ... fragmentSpread2 ( arg:    true) @directive
 }
 
 fragment YouCanHaveDirectivesHereToo on SomeType @yesReally(what: "yes") {
@@ -33,6 +34,7 @@ query MyQuery @directive(arg: 5) {
   otherField
   ...fragmentSpread
     @include(if: ["this isn't even a boolean", "wow, that's really odd"])
+  ...fragmentSpread2(arg: true) @directive
 }
 
 fragment YouCanHaveDirectivesHereToo on SomeType @yesReally(what: "yes") {

--- a/tests/format/graphql/directives/directives.graphql
+++ b/tests/format/graphql/directives/directives.graphql
@@ -5,6 +5,7 @@ query MyQuery @directive(
   @skip(if: true) @nope
   otherField
   ...fragmentSpread, @include(if: ["this isn't even a boolean", "wow, that's really odd",,,,,])
+  ... fragmentSpread2 ( arg:    true) @directive
 }
 
 fragment YouCanHaveDirectivesHereToo on SomeType @yesReally(what: "yes") {

--- a/tests/format/graphql/fragments/__snapshots__/format.test.js.snap
+++ b/tests/format/graphql/fragments/__snapshots__/format.test.js.snap
@@ -15,6 +15,10 @@ printWidth: 80
       noTypeCondition
     }
   }
+  ...BFragment(   var: $var   , int: 5, float: 5.6   , bool: true, string: "hello!")
+  ... CFragment   (var: $thisIsAReallyLongVariableNameRight    , int: 52342342342, float: 5.6,
+   bool: true,
+      string: "hello world this is a very long string!")
 }
 
 fragment XYZ on ABC {
@@ -32,6 +36,14 @@ fragment XYZ on ABC {
       noTypeCondition
     }
   }
+  ...BFragment(var: $var, int: 5, float: 5.6, bool: true, string: "hello!")
+  ...CFragment(
+    var: $thisIsAReallyLongVariableNameRight
+    int: 52342342342
+    float: 5.6
+    bool: true
+    string: "hello world this is a very long string!"
+  )
 }
 
 fragment XYZ on ABC {

--- a/tests/format/graphql/fragments/fragments.graphql
+++ b/tests/format/graphql/fragments/fragments.graphql
@@ -7,6 +7,10 @@
       noTypeCondition
     }
   }
+  ...BFragment(   var: $var   , int: 5, float: 5.6   , bool: true, string: "hello!")
+  ... CFragment   (var: $thisIsAReallyLongVariableNameRight    , int: 52342342342, float: 5.6,
+   bool: true,
+      string: "hello world this is a very long string!")
 }
 
 fragment XYZ on ABC {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4670,10 +4670,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graphql@npm:16.9.0":
-  version: 16.9.0
-  resolution: "graphql@npm:16.9.0"
-  checksum: 10/5833f82bb6c31bec120bbf9cd400eda873e1bb7ef5c17974fa262cd82dc68728fda5d4cb859dc8aaa4c4fe4f6fe1103a9c47efc01a12c02ae5cb581d8e4029e2
+"graphql@npm:16.9.0-canary.pr.4159.0fa29326c53fcd63c6473c7357c28aa13fa0019d":
+  version: 16.9.0-canary.pr.4159.0fa29326c53fcd63c6473c7357c28aa13fa0019d
+  resolution: "graphql@npm:16.9.0-canary.pr.4159.0fa29326c53fcd63c6473c7357c28aa13fa0019d"
+  checksum: 10/dda3b848efd13b304599fc5a91f416a770029d4d2ffd52c62b12ee8699fda68d866fc56b1049d555e233d8c117fc4e027a0e92a01d3732bc2f6cb86b2046fb0f
   languageName: node
   linkType: hard
 
@@ -7359,7 +7359,7 @@ __metadata:
     flow-parser: "npm:0.243.0"
     get-east-asian-width: "npm:1.2.0"
     get-stdin: "npm:9.0.0"
-    graphql: "npm:16.9.0"
+    graphql: "npm:16.9.0-canary.pr.4159.0fa29326c53fcd63c6473c7357c28aa13fa0019d"
     hermes-parser: "npm:0.23.1"
     html-element-attributes: "npm:3.4.0"
     html-tag-names: "npm:2.1.0"


### PR DESCRIPTION
## Description

Support for "fragment variables" on fragment definitions has been added in a [previous PR](https://github.com/prettier/prettier/pull/6016).
This PR adopts the new experimental `experimentalFragmentArguments` parser option to format both the existing fragment arguments on fragment definitions and the new arguments on fragment spreads.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
