### PR TITLE
reorganizing `getPreferredQuote` documentation

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -590,6 +590,11 @@ function hasSpaces(
   options?: SkipOptions,
 ): boolean;
 
+function getPreferredQuote(
+  text: string,
+  preferredQuoteOrPreferSingleQuote: Quote | boolean,
+): Quote;
+
 function makeString(
   rawText: string,
   enclosingQuote: Quote,
@@ -609,11 +614,6 @@ function getNextNonSpaceNonCommentCharacterIndex(
 function isNextLineEmpty(text: string, startIndex: number): boolean;
 
 function isPreviousLineEmpty(text: string, startIndex: number): boolean;
-
-function getPreferredQuote(
-  text: string,
-  preferredQuoteOrPreferSingleQuote: Quote | boolean,
-): Quote;
 ```
 
 ### Tutorials


### PR DESCRIPTION
## Description

`getPreferredQuote` is mainly used to get the quote for `makeString` so it makes more sense to have them close by in the documentation.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [X] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
