### PR TITLE
Preserve a comment between modifier and the decorated property name

### DIFF
--- a/changelog_unreleased/typescript/16578.md
+++ b/changelog_unreleased/typescript/16578.md
@@ -1,0 +1,31 @@
+#### Preserve a comment between modifier and the decorated property name (#16578 by @sosukesuzuki)
+
+There was a bug where block comments between the modifier and the name of a decorated property were being treated as trailing comments of the decorator. This behavior was not only unexpected but also lacked idempotency.
+
+With this change, the position of the block comment between the modifier and the property name is preserved.
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+class Foo {
+  @decorator
+  readonly /* comment */ propertyName;
+}
+
+// Prettier stable
+class Foo {
+  @decorator /* comment */
+  readonly propertyName;
+}
+
+// Prettier stable (second output)
+class Foo {
+  @decorator /* comment */ readonly propertyName;
+}
+
+// Prettier main
+class Foo {
+  @decorator
+  readonly /* comment */ propertyName;
+}
+```

--- a/src/language-js/comments/handle-comments.js
+++ b/src/language-js/comments/handle-comments.js
@@ -528,7 +528,8 @@ function handleMethodNameComments({
   // on the decorator node instead of the method node
   if (
     precedingNode?.type === "Decorator" &&
-    propertyLikeNodeTypes.has(enclosingNode?.type)
+    propertyLikeNodeTypes.has(enclosingNode?.type) &&
+    isLineComment(comment)
   ) {
     addTrailingComment(precedingNode, comment);
     return true;

--- a/tests/format/typescript/comments/16065-2.ts
+++ b/tests/format/typescript/comments/16065-2.ts
@@ -1,0 +1,27 @@
+class Foo {
+  // PropertyDefinition
+  @decorator
+  readonly /* comment */ propertyDefinition;
+
+  // TSAbstractPropertyDefinition
+  @decorator
+  abstract /* comment */ abstractPropertyDefinition;
+
+  // TSAbstractMethodDefinition
+  @decorator
+  abstract /* comment */ abstractMethodDefinition;
+
+  // MethodDefinition
+  @decorator
+  private /* comment */ methodDefinition() {}
+
+  // AccessorProperty
+  @decorator
+  accessor /* comment */ accessorProperty = 3;
+
+  constructor(
+    // TSParameterProperty
+    @decorator
+    readonly /* comment */ parameterProperty,
+  ) {}
+}

--- a/tests/format/typescript/comments/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/comments/__snapshots__/format.test.js.snap
@@ -156,6 +156,72 @@ class Foo {
 ================================================================================
 `;
 
+exports[`16065-2.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+class Foo {
+  // PropertyDefinition
+  @decorator
+  readonly /* comment */ propertyDefinition;
+
+  // TSAbstractPropertyDefinition
+  @decorator
+  abstract /* comment */ abstractPropertyDefinition;
+
+  // TSAbstractMethodDefinition
+  @decorator
+  abstract /* comment */ abstractMethodDefinition;
+
+  // MethodDefinition
+  @decorator
+  private /* comment */ methodDefinition() {}
+
+  // AccessorProperty
+  @decorator
+  accessor /* comment */ accessorProperty = 3;
+
+  constructor(
+    // TSParameterProperty
+    @decorator
+    readonly /* comment */ parameterProperty,
+  ) {}
+}
+
+=====================================output=====================================
+class Foo {
+  // PropertyDefinition
+  @decorator
+  readonly /* comment */ propertyDefinition;
+
+  // TSAbstractPropertyDefinition
+  @decorator
+  abstract /* comment */ abstractPropertyDefinition;
+
+  // TSAbstractMethodDefinition
+  @decorator
+  abstract /* comment */ abstractMethodDefinition;
+
+  // MethodDefinition
+  @decorator
+  private /* comment */ methodDefinition() {}
+
+  // AccessorProperty
+  @decorator
+  accessor /* comment */ accessorProperty = 3;
+
+  constructor(
+    // TSParameterProperty
+    @decorator
+    readonly /* comment */ parameterProperty,
+  ) {}
+}
+
+================================================================================
+`;
+
 exports[`abstract_class.ts format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]


### PR DESCRIPTION
## Description

https://github.com/prettier/prettier/pull/16574#issuecomment-2290621095

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [x] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
