### PR TITLE
correct invalid scss test input

### DIFF
--- a/tests/format/scss/quotes/__snapshots__/format.test.js.snap
+++ b/tests/format/scss/quotes/__snapshots__/format.test.js.snap
@@ -77,7 +77,7 @@ singleQuote: true
 
 @use "library" with (
   $black: #222,
-  $border-radius: 0.1rem
+  $border-radius: 0.1rem,
   $font-family: "Helvetica, sans-serif"
 );
 
@@ -102,7 +102,8 @@ singleQuote: true
 
 @use 'library' with (
   $black: #222,
-  $border-radius: 0.1rem $font-family: 'Helvetica, sans-serif'
+  $border-radius: 0.1rem,
+  $font-family: 'Helvetica, sans-serif'
 );
 
 @use 'library' as *;
@@ -134,7 +135,7 @@ printWidth: 80
 
 @use "library" with (
   $black: #222,
-  $border-radius: 0.1rem
+  $border-radius: 0.1rem,
   $font-family: "Helvetica, sans-serif"
 );
 
@@ -159,7 +160,8 @@ printWidth: 80
 
 @use "library" with (
   $black: #222,
-  $border-radius: 0.1rem $font-family: "Helvetica, sans-serif"
+  $border-radius: 0.1rem,
+  $font-family: "Helvetica, sans-serif"
 );
 
 @use "library" as *;

--- a/tests/format/scss/quotes/quotes.scss
+++ b/tests/format/scss/quotes/quotes.scss
@@ -2,7 +2,7 @@
 
 @use "library" with (
   $black: #222,
-  $border-radius: 0.1rem
+  $border-radius: 0.1rem,
   $font-family: "Helvetica, sans-serif"
 );
 


### PR DESCRIPTION
## Description
Just correct invalid test case. No user facing change.
It resulted syntax error. [Sass playground](https://sass-lang.com/playground/#eJwdyTEOgzAMBdCdU3wFhlYiFcmYqSPXMOCoVgNIdmjF7asyPr0QnocxXJFJSU+Hr9QXbg3QTYXmd0IbY+wv77qweqVFDksYHkF5/Ufet+ozrVLOBDdy+XCVmXoYbeaNVbJr7j+ZvCBm).
```
expected ")".
  ╷
4 │   $font-family: "Helvetica, sans-serif"
  │               ^
  ╵
  - 4:15  root stylesheet
```

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] ~I’ve added tests to confirm my change works.~
- [ ] ~(If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).~
- [ ] ~(If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.~
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
