### PR TITLE
Add debug CLI option to print AST without location information

### DIFF
--- a/src/cli/cli-options.evaluate.js
+++ b/src/cli/cli-options.evaluate.js
@@ -147,6 +147,9 @@ const options = {
   debugPrintAst: {
     type: "boolean",
   },
+  debugPrintLoclessAst: {
+    type: "boolean",
+  },
   debugPrintComments: {
     type: "boolean",
   },

--- a/src/cli/format.js
+++ b/src/cli/format.js
@@ -131,6 +131,58 @@ async function format(context, input, opt) {
     };
   }
 
+  if (context.argv.debugPrintLoclessAst) {
+    const { ast, parser } = await prettier.__debug.parse(input, opt);
+    const locationKeys = new Set();
+    switch (parser) {
+      case "html":
+      case "vue":
+      case "angular":
+      case "lwc": {
+        locationKeys
+          .add("sourceSpan")
+          .add("startSourceSpan")
+          .add("endSourceSpan")
+          .add("nameSpan");
+        break;
+      }
+      case "babel":
+      case "babel-flow":
+      case "babel-ts":
+      case "flow":
+      case "typescript":
+      case "espree":
+      case "meriyah":
+      case "acorn":
+      case "json":
+      case "json5":
+      case "json-stringify":
+      case "graphql": {
+        locationKeys.add("loc").add("tokens");
+        break;
+      }
+      case "css":
+      case "scss":
+      case "less": {
+        locationKeys.add("source");
+        break;
+      }
+      case "markdown":
+      case "mdx":
+      case "yaml": {
+        locationKeys.add("position");
+        break;
+      }
+    }
+    return {
+      formatted: JSON.stringify(ast, (key, value) => {
+        if (!locationKeys.has(key)) {
+          return value;
+        }
+      }),
+    };
+  }
+
   if (context.argv.debugCheck) {
     const pp = await prettier.format(input, opt);
     const pppp = await prettier.format(pp, opt);

--- a/src/main/parse.js
+++ b/src/main/parse.js
@@ -22,7 +22,7 @@ async function parse(originalText, options) {
     handleParseError(error, originalText);
   }
 
-  return { text, ast };
+  return { text, ast, parser: options.parser };
 }
 
 function handleParseError(error, text) {

--- a/tests/integration/__tests__/debug-print-ast.js
+++ b/tests/integration/__tests__/debug-print-ast.js
@@ -11,4 +11,16 @@ test("prints information for debugging AST --debug-print-ast", async () => {
 
   expect(data).toHaveProperty("type", "File");
   expect(data).toHaveProperty("program.type", "Program");
+  expect(data).toHaveProperty("loc", {
+    start: {
+      line: 1,
+      column: 0,
+      index: 0,
+    },
+    end: {
+      line: 1,
+      column: 18,
+      index: 18,
+    },
+  });
 });

--- a/tests/integration/__tests__/debug-print-locless-ast.js
+++ b/tests/integration/__tests__/debug-print-locless-ast.js
@@ -1,0 +1,15 @@
+test("prints information for debugging AST --debug-print-locless-ast", async () => {
+  const { stdout } = await runCli(
+    "cli/with-shebang",
+    ["--debug-print-locless-ast", "--parser", "babel"],
+    {
+      input: "const foo = 'foo';",
+    },
+  );
+
+  const data = JSON.parse(stdout);
+
+  expect(data).toHaveProperty("type", "File");
+  expect(data).toHaveProperty("program.type", "Program");
+  expect(data).not.toHaveProperty("loc");
+});


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

Adds new CLI option `--debug-print-locless-ast`. Which is similar to `--debug-print-ast` but it does not print AST node location information. Location information is useful but it would be annoying if we want to see pure AST structure.

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
