### PR TITLE
Don't print an extra line break for arrow function with type parameter in assignment

### DIFF
--- a/changelog_unreleased/typescript/16586.md
+++ b/changelog_unreleased/typescript/16586.md
@@ -1,0 +1,28 @@
+#### Don't print an extra line break for arrow function with type parameter in assignment (#16586 by @sosukesuzuki)
+
+There was a bug where an extra line was inserted when assigning a chained arrow function with type parameters to a variable if there was a line comment above it.
+
+This change ensures that the extra line is no longer inserted.
+
+<!-- prettier-ignore -->
+```tsx
+// Input
+const foo1 = 
+  // comment
+  <T,>() => () => 1;
+
+// Prettier stable
+const foo1 =
+  // comment
+
+    <T,>() =>
+    () =>
+      1;
+
+// Prettier main
+const foo1 =
+  // comment
+  <T,>() =>
+    () =>
+      1;
+```

--- a/tests/format/typescript/arrow/16067.ts
+++ b/tests/format/typescript/arrow/16067.ts
@@ -1,0 +1,35 @@
+const foo1 = 
+  // comment
+  <T>() => () => 1;
+
+const foo2 = 
+  // comment
+  () => () => 1;
+
+const foo3 = 
+  // comment
+  <T>() => 1;
+
+foo(
+  // comment
+  <T>() => () => 1,
+);
+
+a ||
+  // comment
+  (<T>() => () => 1);
+
+void
+  // comment
+  (<T>() => () => 1);
+
+cond ?
+  // comment
+  <T>() => () => 1
+  :
+  // comment
+  <T>() => () => 1;
+
+foo4 = 
+  // comment
+  <T>() => () => 1;

--- a/tests/format/typescript/arrow/__snapshots__/format.test.js.snap
+++ b/tests/format/typescript/arrow/__snapshots__/format.test.js.snap
@@ -1,5 +1,198 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`16067.ts - {"semi":false} format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+semi: false
+                                                                                | printWidth
+=====================================input======================================
+const foo1 = 
+  // comment
+  <T>() => () => 1;
+
+const foo2 = 
+  // comment
+  () => () => 1;
+
+const foo3 = 
+  // comment
+  <T>() => 1;
+
+foo(
+  // comment
+  <T>() => () => 1,
+);
+
+a ||
+  // comment
+  (<T>() => () => 1);
+
+void
+  // comment
+  (<T>() => () => 1);
+
+cond ?
+  // comment
+  <T>() => () => 1
+  :
+  // comment
+  <T>() => () => 1;
+
+foo4 = 
+  // comment
+  <T>() => () => 1;
+
+=====================================output=====================================
+const foo1 =
+  // comment
+  <T>() =>
+    () =>
+      1
+
+const foo2 =
+  // comment
+  () => () => 1
+
+const foo3 =
+  // comment
+  <T>() => 1
+
+foo(
+  // comment
+  <T>() =>
+    () =>
+      1,
+)
+
+a ||
+  // comment
+  (<T>() =>
+    () =>
+      1)
+
+void (
+  // comment
+  (<T>() =>
+    () =>
+      1)
+)
+
+cond
+  ? // comment
+    <T>() =>
+      () =>
+        1
+  : // comment
+    <T>() =>
+      () =>
+        1
+
+foo4 =
+  // comment
+  <T>() =>
+    () =>
+      1
+
+================================================================================
+`;
+
+exports[`16067.ts format 1`] = `
+====================================options=====================================
+parsers: ["typescript"]
+printWidth: 80
+                                                                                | printWidth
+=====================================input======================================
+const foo1 = 
+  // comment
+  <T>() => () => 1;
+
+const foo2 = 
+  // comment
+  () => () => 1;
+
+const foo3 = 
+  // comment
+  <T>() => 1;
+
+foo(
+  // comment
+  <T>() => () => 1,
+);
+
+a ||
+  // comment
+  (<T>() => () => 1);
+
+void
+  // comment
+  (<T>() => () => 1);
+
+cond ?
+  // comment
+  <T>() => () => 1
+  :
+  // comment
+  <T>() => () => 1;
+
+foo4 = 
+  // comment
+  <T>() => () => 1;
+
+=====================================output=====================================
+const foo1 =
+  // comment
+  <T>() =>
+    () =>
+      1;
+
+const foo2 =
+  // comment
+  () => () => 1;
+
+const foo3 =
+  // comment
+  <T>() => 1;
+
+foo(
+  // comment
+  <T>() =>
+    () =>
+      1,
+);
+
+a ||
+  // comment
+  (<T>() =>
+    () =>
+      1);
+
+void (
+  // comment
+  (<T>() =>
+    () =>
+      1)
+);
+
+cond
+  ? // comment
+    <T>() =>
+      () =>
+        1
+  : // comment
+    <T>() =>
+      () =>
+        1;
+
+foo4 =
+  // comment
+  <T>() =>
+    () =>
+      1;
+
+================================================================================
+`;
+
 exports[`arrow_regression.ts - {"semi":false} format 1`] = `
 ====================================options=====================================
 parsers: ["typescript"]


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->
Fixes #16067

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x] I’ve added tests to confirm my change works.
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
