### PR TITLE
Add `type: "commonjs"` to bundled package.json

### DIFF
--- a/scripts/build/build-package-json.js
+++ b/scripts/build/build-package-json.js
@@ -39,6 +39,7 @@ async function buildPackageJson({ file, files }) {
       // Don't delete, comment out if we don't want override
       node: ">=14",
     },
+    type: "commonjs",
     exports: {
       ".": {
         types: "./index.d.ts",


### PR DESCRIPTION
## Description

<!-- Please provide a brief summary of your changes: -->

We use `.js` extension for UMD modules, let's  make it explicitly mark `.js` files are not ESM. 

Not sure if this will effect [this change](https://nodejs.org/en/blog/release/v22.7.0#module-syntax-detection-is-now-enabled-by-default) in Node.js

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [ ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [ ] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
