### PR TITLE
Feat: Support parsing markdown tagged template literals with interpolation 

### DIFF
--- a/src/language-js/embed/markdown.js
+++ b/src/language-js/embed/markdown.js
@@ -4,26 +4,77 @@ import {
   literalline,
   softline,
 } from "../../document/builders.js";
-import { escapeTemplateCharacters } from "../print/template-literal.js";
+import { mapDoc } from "../../document/utils.js";
+import {
+  escapeTemplateCharacters,
+  printTemplateExpressions,
+} from "../print/template-literal.js";
 
 async function printEmbedMarkdown(textToDoc, print, path /*, options*/) {
   const { node } = path;
-  let text = node.quasis[0].value.raw.replaceAll(
-    /((?:\\\\)*)\\`/gu,
-    (_, backslashes) => "\\".repeat(backslashes.length / 2) + "`",
+  const composePlaceholder = (index) =>
+    `PRETTIER_MD_PLACEHOLDER_${index}_IN_JS`;
+  let hasIndent = false;
+  let indentation;
+  const text = node.quasis
+    .map((quasi, index, quasis) => {
+      let txt = quasi.value.raw.replaceAll(
+        /((?:\\\\)*)\\`/gu,
+        (_, backslashes) => "\\".repeat(backslashes.length / 2) + "`",
+      );
+      if (index === 0) {
+        indentation = getIndentation(txt);
+        hasIndent = getIndentation(txt) !== "";
+      }
+      if (hasIndent) {
+        txt = txt.replaceAll(new RegExp(`^${indentation}`, "gmu"), "");
+      }
+      return index === quasis.length - 1
+        ? txt
+        : txt + composePlaceholder(index);
+    })
+    .join("");
+
+  const expressionDocs = printTemplateExpressions(path, print);
+  const placeholderRegex = new RegExp(
+    composePlaceholder(String.raw`(\d+)`),
+    "gu",
   );
-  const indentation = getIndentation(text);
-  const hasIndent = indentation !== "";
-  if (hasIndent) {
-    text = text.replaceAll(new RegExp(`^${indentation}`, "gmu"), "");
-  }
   const doc = escapeTemplateCharacters(
     await textToDoc(text, { parser: "markdown", __inJsTemplate: true }),
     true,
   );
+
+  const contentDoc = mapDoc(doc, (doc) => {
+    if (typeof doc !== "string") {
+      return doc;
+    }
+
+    const parts = [];
+
+    const components = doc.split(placeholderRegex);
+    for (let i = 0; i < components.length; i++) {
+      const component = components[i];
+
+      if (i % 2 === 0) {
+        if (component) {
+          parts.push(component);
+        }
+        continue;
+      }
+
+      const placeholderIndex = Number(component);
+      parts.push(expressionDocs[placeholderIndex]);
+    }
+
+    return parts;
+  });
+
   return [
     "`",
-    hasIndent ? indent([softline, doc]) : [literalline, dedentToRoot(doc)],
+    hasIndent
+      ? indent([softline, contentDoc])
+      : [literalline, dedentToRoot(contentDoc)],
     softline,
     "`",
   ];
@@ -47,7 +98,7 @@ function printMarkdown(path /*, options*/) {
 function isMarkdown({ node, parent }) {
   return (
     parent?.type === "TaggedTemplateExpression" &&
-    node.quasis.length === 1 &&
+    node.quasis.length > 0 &&
     parent.tag.type === "Identifier" &&
     (parent.tag.name === "md" || parent.tag.name === "markdown")
   );

--- a/tests/format/js/multiparser-comments/__snapshots__/format.test.js.snap
+++ b/tests/format/js/multiparser-comments/__snapshots__/format.test.js.snap
@@ -49,10 +49,12 @@ css\`
 }
 \`;
 
-markdown\`\${
+markdown\`
+\${
       foo
   /* comment */
-}\`;
+}
+\`;
 markdown\`
 \${
       foo

--- a/tests/format/js/multiparser-comments/__snapshots__/format.test.js.snap
+++ b/tests/format/js/multiparser-comments/__snapshots__/format.test.js.snap
@@ -49,12 +49,10 @@ css\`
 }
 \`;
 
-markdown\`
-\${
+markdown\`\${
       foo
   /* comment */
-}
-\`;
+}\`;
 markdown\`
 \${
       foo
@@ -118,10 +116,12 @@ css\`
   }
 \`;
 
-markdown\`\${
+markdown\`
+\${
   foo
   /* comment */
-}\`;
+}
+\`;
 markdown\`
 \${
   foo

--- a/tests/format/js/multiparser-interpolated-markdown/__snapshots__/format.test.js.snap
+++ b/tests/format/js/multiparser-interpolated-markdown/__snapshots__/format.test.js.snap
@@ -1,0 +1,159 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`interpolated-markdown.js - {"proseWrap":"always"} format 1`] = `
+====================================options=====================================
+parsers: ["babel"]
+printWidth: 80
+proseWrap: "always"
+                                                                                | printWidth
+=====================================input======================================
+// og behavior: no interpolations
+md\`By far the biggest reason for adopting Prettier is to stop all the on-going debates over styles. It is generally accepted that having a common style guide is valuable for a project and team but getting there is a very painful and unrewarding process. People get very emotional around particular ways of writing code and nobody likes spending time writing and receiving nits.
+- “We want to free mental threads and end discussions around style. While sometimes fruitful, these discussions are for the most part wasteful.”
+- “Literally had an engineer go through a huge effort of cleaning up all of our code because we were debating ternary style for the longest time and were inconsistent about it. It was dumb, but it was a weird on-going "great debate" that wasted lots of little back and forth bits. It's far easier for us all to agree now: just run Prettier, and go with that style.”
+\`;
+// interpolated markdown should behave the same
+md\`By far the biggest reason for adopting Prettier is to stop all the on-going debates over styles. It is generally accepted that having a common style guide is valuable for a project and team but getting there is a very painful and unrewarding process. People get very emotional around particular ways of writing code and nobody likes spending time writing and receiving nits.
+- “We want to \${free} mental threads and end discussions around style. While sometimes fruitful, these discussions are for the most part wasteful.”
+- “Literally had an engineer go through a huge effort of cleaning up all of our code because we were debating ternary style for the longest time and were inconsistent about it. It was dumb, but it was a weird on-going "great debate" that wasted lots of little back and forth bits. It's far easier for us all to agree now: just run Prettier, and go with that style.”
+\`;
+// leading line breaks should behave the same
+md\`
+By far the biggest reason for adopting Prettier is to stop all the on-going debates over styles. It is generally accepted that having a common style guide is valuable for a project and team but getting there is a very painful and unrewarding process. People get very emotional around particular ways of writing code and nobody likes spending time writing and receiving nits.
+- “We want to \${free} mental threads and end discussions around style. While sometimes fruitful, these discussions are for the most part wasteful.”
+- “Literally had an engineer go through a huge effort of cleaning up all of our code because we were debating ternary style for the longest time and were inconsistent about it. It was dumb, but it was a weird on-going "great debate" that wasted lots of little back and forth bits. It's far easier for us all to agree now: just run Prettier, and go with that style.”
+\`;
+md\`
+
+By far the biggest reason for adopting Prettier is to stop all the on-going debates over styles. It is generally accepted that having a common style guide is valuable for a project and team but getting there is a very painful and unrewarding process. People get very emotional around particular ways of writing code and nobody likes spending time writing and receiving nits.
+- “We want to \${free} mental threads and end discussions around style. While sometimes fruitful, these discussions are for the most part wasteful.”
+- “Literally had an engineer go through a huge effort of cleaning up all of our code because we were debating ternary style for the longest time and were inconsistent about it. It was dumb, but it was a weird on-going "great debate" that wasted lots of little back and forth bits. It's far easier for us all to agree now: just run Prettier, and go with that style.”
+\`;
+// indentation should be stable
+md\`  By far the biggest reason for adopting Prettier is to stop all the on-going debates over styles. It is generally accepted that having a common style guide is valuable for a project and team but getting there is a very painful and unrewarding process. People get very emotional around particular ways of writing code and nobody likes spending time writing and receiving nits.
+- “We want to \${free} mental threads and end discussions around style. While sometimes fruitful, these discussions are for the most part wasteful.”
+- “Literally had an engineer go through a huge effort of cleaning up all of our code because we were debating ternary style for the longest time and were inconsistent about it. It was dumb, but it was a weird on-going "great debate" that wasted lots of little back and forth bits. It's far easier for us all to agree now: just run Prettier, and go with that style.”
+\`;
+md\`
+  By far the biggest reason for adopting Prettier is to stop all the on-going debates over styles. It is generally accepted that having a common style guide is valuable for a project and team but getting there is a very painful and unrewarding process. People get very emotional around particular ways of writing code and nobody likes spending time writing and receiving nits.
+- “We want to \${free} mental threads and end discussions around style. While sometimes fruitful, these discussions are for the most part wasteful.”
+- “Literally had an engineer go through a huge effort of cleaning up all of our code because we were debating ternary style for the longest time and were inconsistent about it. It was dumb, but it was a weird on-going "great debate" that wasted lots of little back and forth bits. It's far easier for us all to agree now: just run Prettier, and go with that style.”
+\`;
+md\`
+  By far the biggest reason for adopting Prettier is to stop all the on-going debates over styles. It is generally accepted that having a common style guide is valuable for a project and team but getting there is a very painful and unrewarding process. People get very emotional around particular ways of writing code and nobody likes spending time writing and receiving nits.
+  - “We want to \${free} mental threads and end discussions around style. While sometimes fruitful, these discussions are for the most part wasteful.”
+  - “Literally had an engineer go through a huge effort of cleaning up all of our code because we were debating ternary style for the longest time and were inconsistent about it. It was dumb, but it was a weird on-going "great debate" that wasted lots of little back and forth bits. It's far easier for us all to agree now: just run Prettier, and go with that style.”
+\`;
+=====================================output=====================================
+// og behavior: no interpolations
+md\`
+By far the biggest reason for adopting Prettier is to stop all the on-going
+debates over styles. It is generally accepted that having a common style guide
+is valuable for a project and team but getting there is a very painful and
+unrewarding process. People get very emotional around particular ways of writing
+code and nobody likes spending time writing and receiving nits.
+
+- “We want to free mental threads and end discussions around style. While
+  sometimes fruitful, these discussions are for the most part wasteful.”
+- “Literally had an engineer go through a huge effort of cleaning up all of our
+  code because we were debating ternary style for the longest time and were
+  inconsistent about it. It was dumb, but it was a weird on-going "great debate"
+  that wasted lots of little back and forth bits. It's far easier for us all to
+  agree now: just run Prettier, and go with that style.”
+\`;
+// interpolated markdown should behave the same
+md\`
+By far the biggest reason for adopting Prettier is to stop all the on-going
+debates over styles. It is generally accepted that having a common style guide
+is valuable for a project and team but getting there is a very painful and
+unrewarding process. People get very emotional around particular ways of writing
+code and nobody likes spending time writing and receiving nits.
+
+- “We want to \${free} mental threads and end discussions around style. While
+  sometimes fruitful, these discussions are for the most part wasteful.”
+- “Literally had an engineer go through a huge effort of cleaning up all of our
+  code because we were debating ternary style for the longest time and were
+  inconsistent about it. It was dumb, but it was a weird on-going "great debate"
+  that wasted lots of little back and forth bits. It's far easier for us all to
+  agree now: just run Prettier, and go with that style.”
+\`;
+// leading line breaks should behave the same
+md\`
+By far the biggest reason for adopting Prettier is to stop all the on-going
+debates over styles. It is generally accepted that having a common style guide
+is valuable for a project and team but getting there is a very painful and
+unrewarding process. People get very emotional around particular ways of writing
+code and nobody likes spending time writing and receiving nits.
+
+- “We want to \${free} mental threads and end discussions around style. While
+  sometimes fruitful, these discussions are for the most part wasteful.”
+- “Literally had an engineer go through a huge effort of cleaning up all of our
+  code because we were debating ternary style for the longest time and were
+  inconsistent about it. It was dumb, but it was a weird on-going "great debate"
+  that wasted lots of little back and forth bits. It's far easier for us all to
+  agree now: just run Prettier, and go with that style.”
+\`;
+md\`
+By far the biggest reason for adopting Prettier is to stop all the on-going
+debates over styles. It is generally accepted that having a common style guide
+is valuable for a project and team but getting there is a very painful and
+unrewarding process. People get very emotional around particular ways of writing
+code and nobody likes spending time writing and receiving nits.
+
+- “We want to \${free} mental threads and end discussions around style. While
+  sometimes fruitful, these discussions are for the most part wasteful.”
+- “Literally had an engineer go through a huge effort of cleaning up all of our
+  code because we were debating ternary style for the longest time and were
+  inconsistent about it. It was dumb, but it was a weird on-going "great debate"
+  that wasted lots of little back and forth bits. It's far easier for us all to
+  agree now: just run Prettier, and go with that style.”
+\`;
+// indentation should be stable
+md\`
+  By far the biggest reason for adopting Prettier is to stop all the on-going
+  debates over styles. It is generally accepted that having a common style guide
+  is valuable for a project and team but getting there is a very painful and
+  unrewarding process. People get very emotional around particular ways of
+  writing code and nobody likes spending time writing and receiving nits.
+
+  - “We want to \${free} mental threads and end discussions around style. While
+    sometimes fruitful, these discussions are for the most part wasteful.”
+  - “Literally had an engineer go through a huge effort of cleaning up all of
+    our code because we were debating ternary style for the longest time and
+    were inconsistent about it. It was dumb, but it was a weird on-going "great
+    debate" that wasted lots of little back and forth bits. It's far easier for
+    us all to agree now: just run Prettier, and go with that style.”
+\`;
+md\`
+  By far the biggest reason for adopting Prettier is to stop all the on-going
+  debates over styles. It is generally accepted that having a common style guide
+  is valuable for a project and team but getting there is a very painful and
+  unrewarding process. People get very emotional around particular ways of
+  writing code and nobody likes spending time writing and receiving nits.
+
+  - “We want to \${free} mental threads and end discussions around style. While
+    sometimes fruitful, these discussions are for the most part wasteful.”
+  - “Literally had an engineer go through a huge effort of cleaning up all of
+    our code because we were debating ternary style for the longest time and
+    were inconsistent about it. It was dumb, but it was a weird on-going "great
+    debate" that wasted lots of little back and forth bits. It's far easier for
+    us all to agree now: just run Prettier, and go with that style.”
+\`;
+md\`
+  By far the biggest reason for adopting Prettier is to stop all the on-going
+  debates over styles. It is generally accepted that having a common style guide
+  is valuable for a project and team but getting there is a very painful and
+  unrewarding process. People get very emotional around particular ways of
+  writing code and nobody likes spending time writing and receiving nits.
+
+  - “We want to \${free} mental threads and end discussions around style. While
+    sometimes fruitful, these discussions are for the most part wasteful.”
+  - “Literally had an engineer go through a huge effort of cleaning up all of
+    our code because we were debating ternary style for the longest time and
+    were inconsistent about it. It was dumb, but it was a weird on-going "great
+    debate" that wasted lots of little back and forth bits. It's far easier for
+    us all to agree now: just run Prettier, and go with that style.”
+\`;
+
+================================================================================
+`;

--- a/tests/format/js/multiparser-interpolated-markdown/format.test.js
+++ b/tests/format/js/multiparser-interpolated-markdown/format.test.js
@@ -1,0 +1,1 @@
+runFormatTest(import.meta, ["babel"], { proseWrap: "always" });

--- a/tests/format/js/multiparser-interpolated-markdown/interpolated-markdown.js
+++ b/tests/format/js/multiparser-interpolated-markdown/interpolated-markdown.js
@@ -1,0 +1,37 @@
+// og behavior: no interpolations
+md`By far the biggest reason for adopting Prettier is to stop all the on-going debates over styles. It is generally accepted that having a common style guide is valuable for a project and team but getting there is a very painful and unrewarding process. People get very emotional around particular ways of writing code and nobody likes spending time writing and receiving nits.
+- “We want to free mental threads and end discussions around style. While sometimes fruitful, these discussions are for the most part wasteful.”
+- “Literally had an engineer go through a huge effort of cleaning up all of our code because we were debating ternary style for the longest time and were inconsistent about it. It was dumb, but it was a weird on-going "great debate" that wasted lots of little back and forth bits. It's far easier for us all to agree now: just run Prettier, and go with that style.”
+`;
+// interpolated markdown should behave the same
+md`By far the biggest reason for adopting Prettier is to stop all the on-going debates over styles. It is generally accepted that having a common style guide is valuable for a project and team but getting there is a very painful and unrewarding process. People get very emotional around particular ways of writing code and nobody likes spending time writing and receiving nits.
+- “We want to ${free} mental threads and end discussions around style. While sometimes fruitful, these discussions are for the most part wasteful.”
+- “Literally had an engineer go through a huge effort of cleaning up all of our code because we were debating ternary style for the longest time and were inconsistent about it. It was dumb, but it was a weird on-going "great debate" that wasted lots of little back and forth bits. It's far easier for us all to agree now: just run Prettier, and go with that style.”
+`;
+// leading line breaks should behave the same
+md`
+By far the biggest reason for adopting Prettier is to stop all the on-going debates over styles. It is generally accepted that having a common style guide is valuable for a project and team but getting there is a very painful and unrewarding process. People get very emotional around particular ways of writing code and nobody likes spending time writing and receiving nits.
+- “We want to ${free} mental threads and end discussions around style. While sometimes fruitful, these discussions are for the most part wasteful.”
+- “Literally had an engineer go through a huge effort of cleaning up all of our code because we were debating ternary style for the longest time and were inconsistent about it. It was dumb, but it was a weird on-going "great debate" that wasted lots of little back and forth bits. It's far easier for us all to agree now: just run Prettier, and go with that style.”
+`;
+md`
+
+By far the biggest reason for adopting Prettier is to stop all the on-going debates over styles. It is generally accepted that having a common style guide is valuable for a project and team but getting there is a very painful and unrewarding process. People get very emotional around particular ways of writing code and nobody likes spending time writing and receiving nits.
+- “We want to ${free} mental threads and end discussions around style. While sometimes fruitful, these discussions are for the most part wasteful.”
+- “Literally had an engineer go through a huge effort of cleaning up all of our code because we were debating ternary style for the longest time and were inconsistent about it. It was dumb, but it was a weird on-going "great debate" that wasted lots of little back and forth bits. It's far easier for us all to agree now: just run Prettier, and go with that style.”
+`;
+// indentation should be stable
+md`  By far the biggest reason for adopting Prettier is to stop all the on-going debates over styles. It is generally accepted that having a common style guide is valuable for a project and team but getting there is a very painful and unrewarding process. People get very emotional around particular ways of writing code and nobody likes spending time writing and receiving nits.
+- “We want to ${free} mental threads and end discussions around style. While sometimes fruitful, these discussions are for the most part wasteful.”
+- “Literally had an engineer go through a huge effort of cleaning up all of our code because we were debating ternary style for the longest time and were inconsistent about it. It was dumb, but it was a weird on-going "great debate" that wasted lots of little back and forth bits. It's far easier for us all to agree now: just run Prettier, and go with that style.”
+`;
+md`
+  By far the biggest reason for adopting Prettier is to stop all the on-going debates over styles. It is generally accepted that having a common style guide is valuable for a project and team but getting there is a very painful and unrewarding process. People get very emotional around particular ways of writing code and nobody likes spending time writing and receiving nits.
+- “We want to ${free} mental threads and end discussions around style. While sometimes fruitful, these discussions are for the most part wasteful.”
+- “Literally had an engineer go through a huge effort of cleaning up all of our code because we were debating ternary style for the longest time and were inconsistent about it. It was dumb, but it was a weird on-going "great debate" that wasted lots of little back and forth bits. It's far easier for us all to agree now: just run Prettier, and go with that style.”
+`;
+md`
+  By far the biggest reason for adopting Prettier is to stop all the on-going debates over styles. It is generally accepted that having a common style guide is valuable for a project and team but getting there is a very painful and unrewarding process. People get very emotional around particular ways of writing code and nobody likes spending time writing and receiving nits.
+  - “We want to ${free} mental threads and end discussions around style. While sometimes fruitful, these discussions are for the most part wasteful.”
+  - “Literally had an engineer go through a huge effort of cleaning up all of our code because we were debating ternary style for the longest time and were inconsistent about it. It was dumb, but it was a weird on-going "great debate" that wasted lots of little back and forth bits. It's far easier for us all to agree now: just run Prettier, and go with that style.”
+`;


### PR DESCRIPTION
## Description

Prettier currently only formats markdown tagged template literals when there is no interpolation. This PR adds the functionality for when interpolations are detected, mimicking the code flow of how interpolations are handled in the html-embed file.

### Change in result in existing test js/multiparser-comments/comment-inside.js

Currently ``md`hello`;`` produces 
```js
md`
hello
`;
```

The existing test has 
```js
markdown`${
      foo
  /* comment */
}`;
```
left verbatim. With this PR, the code above is formatted to
```js
markdown`
${
      foo
  /* comment */
}
`;
```
I believe this is more consistent with Prettier's behavior with non-interpolated markdown template strings.

<!-- Please provide a brief summary of your changes: -->

## Checklist

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->

- [x ] I’ve added tests to confirm my change works.
- [ ] (If changing the API or CLI) I’ve documented the changes I’ve made (in the `docs/` directory).
- [ ] (If the change is user-facing) I’ve added my changes to `changelog_unreleased/*/XXXX.md` file following `changelog_unreleased/TEMPLATE.md`.
- [x] I’ve read the [contributing guidelines](https://github.com/prettier/prettier/blob/main/CONTRIBUTING.md).

<!-- Please DO NOT remove the playground link -->

**✨[Try the playground for this PR](https://prettier.io/playground-redirect)✨**
